### PR TITLE
Revert change to disable jump branching.

### DIFF
--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -7,7 +7,6 @@
  *******************************************************************************/
 
 // RUN: cudaq-quake %s | cudaq-opt --unwind-lowering --canonicalize | FileCheck %s
-// XFAIL: *
 
 #include <cudaq.h>
 

--- a/test/AST-Quake/if_return.cpp
+++ b/test/AST-Quake/if_return.cpp
@@ -7,7 +7,6 @@
  *******************************************************************************/
 
 // RUN: cudaq-quake %s | cudaq-opt --canonicalize | FileCheck %s
-// XFAIL: *
 
 #include <cudaq.h>
 

--- a/test/AST-Quake/while-2.cpp
+++ b/test/AST-Quake/while-2.cpp
@@ -8,7 +8,6 @@
 
 // RUN: cudaq-quake %s | FileCheck --check-prefixes=EARLY %s
 // RUN: cudaq-quake %s | cudaq-opt --canonicalize | FileCheck %s
-// XFAIL: *
 
 #include <cudaq.h>
 


### PR DESCRIPTION
Previous change introduced regressions on main. We don't want the regressions in the development branch.

I have read the Contributor License Agreement and I hereby accept the Terms.