### PR TITLE
Add reset to kernel_builder in C++ and python.

### DIFF
--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -292,6 +292,13 @@ void bindKernel(py::module &mod) {
           "  kernel, qubit_count = cudaq.make_kernel(int)\n"
           "  # Allocate the variable number of qubits.\n"
           "  qubits = kernel.qalloc(qubit_count)\n")
+      /// @brief Bind the qubit reset method.
+      .def(
+          "reset",
+          [](kernel_builder<> &self, QuakeValue &qubitOrQreg) {
+            self.reset(qubitOrQreg);
+          },
+          "Reset the provide qubit or qubits.")
       /// @brief Allow for JIT compilation of kernel in python via call to
       /// `builder(args)`.
       .def(

--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -298,7 +298,7 @@ void bindKernel(py::module &mod) {
           [](kernel_builder<> &self, QuakeValue &qubitOrQreg) {
             self.reset(qubitOrQreg);
           },
-          "Reset the provide qubit or qubits.")
+          "Reset the provided qubit or qubits.")
       /// @brief Allow for JIT compilation of kernel in python via call to
       /// `builder(args)`.
       .def(

--- a/python/tests/unittests/test_sample.py
+++ b/python/tests/unittests/test_sample.py
@@ -476,6 +476,33 @@ def test_sample_marginalize():
     marginal_result = sample_result.get_marginal_counts([1, 2, 3])
     assert marginal_result.most_probable() == "101"
 
+def test_qubit_reset():
+    """
+    Basic test that we can apply a qubit reset.
+    """
+    kernel = cudaq.make_kernel()
+    qubit = kernel.qalloc()
+    kernel.x(qubit)
+    kernel.reset(qubit)
+    kernel.mz(qubit)
+
+    counts = cudaq.sample(kernel)
+    assert (len(counts) == 1)
+    assert('0' in counts)
+
+def test_qreg_reset():
+    """
+    Basic test that we can apply a qreg reset.
+    """
+    kernel = cudaq.make_kernel()
+    qubits = kernel.qalloc(2)
+    kernel.x(qubits)
+    kernel.reset(qubits)
+    kernel.mz(qubits)
+
+    counts = cudaq.sample(kernel)
+    assert (len(counts) == 1)
+    assert('00' in counts)
 
 # leave for gdb debugging
 if __name__ == "__main__":

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -170,6 +170,8 @@ CUDAQ_DETAILS_MEASURE_DECLARATION(mx)
 CUDAQ_DETAILS_MEASURE_DECLARATION(my)
 CUDAQ_DETAILS_MEASURE_DECLARATION(mz)
 
+void reset(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQreg);
+
 void c_if(ImplicitLocOpBuilder &builder, QuakeValue &conditional,
           std::function<void()> &thenFunctor);
 
@@ -450,6 +452,9 @@ public:
   CUDAQ_BUILDER_ADD_MEASURE(mx)
   CUDAQ_BUILDER_ADD_MEASURE(my)
   CUDAQ_BUILDER_ADD_MEASURE(mz)
+
+  /// @brief Reset the given qubit or qubits.
+  void reset(QuakeValue &qubit) { details::reset(*opBuilder, qubit); }
 
   /// @brief Apply a conditional statement on a
   /// measure result, if true apply the thenFunctor.

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -324,3 +324,33 @@ CUDAQ_TEST(BuilderTester, checkKernelAdjoint) {
   EXPECT_EQ(counts.size(), 1);
   EXPECT_EQ(counts.begin()->first, "1");
 }
+
+CUDAQ_TEST(BuilderTester, checkReset) {
+  {
+    auto entryPoint = cudaq::make_kernel();
+    auto q = entryPoint.qalloc();
+    entryPoint.x(q);
+    entryPoint.reset(q);
+    entryPoint.mz(q);
+    printf("%s\n", entryPoint.to_quake().c_str());
+
+    auto counts = cudaq::sample(entryPoint);
+    counts.dump();
+    EXPECT_EQ(counts.size(), 1);
+    EXPECT_EQ(counts.begin()->first, "0");
+  }
+  {
+    auto entryPoint = cudaq::make_kernel();
+    auto q = entryPoint.qalloc(2);
+    entryPoint.x(q);
+    // For now, don't allow reset on qvec.
+    entryPoint.reset(q);
+    entryPoint.mz(q);
+    printf("%s\n", entryPoint.to_quake().c_str());
+
+    auto counts = cudaq::sample(entryPoint);
+    counts.dump();
+    EXPECT_EQ(counts.size(), 1);
+    EXPECT_EQ(counts.begin()->first, "00");
+  }
+}


### PR DESCRIPTION
We had left off these functions as an oversight. Fix that by adding them here. Tested in both C++ and Python.

Address #2 