### PR TITLE
Replace the old deallocation pass.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -321,6 +321,14 @@ def cc_CreateLambdaOp : CCOp<"create_lambda",
   let extraClassDeclaration = [{
     using BodyBuilderFn =
         llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)>;
+
+    llvm::ArrayRef<mlir::Type> getResultTypes() {
+      return getType().getSignature().getResults();
+    }
+
+    unsigned getNumResults() {
+      return getType().getSignature().getNumResults();
+    }
   }];
 }
 

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -126,6 +126,7 @@ def LowerToCFG : Pass<"lower-to-cfg", "mlir::func::FuncOp"> {
     Note that it may be the case that converting high-level control flow  Ops
     to CFG form will not be as amenable to lowering to QTX or QTX optimizations.
   }];
+
   let dependentDialects = [ "mlir::cf::ControlFlowDialect" ];
   let constructor = "cudaq::opt::createLowerToCFGPass()";
 }

--- a/lib/Optimizer/Transforms/AddDeallocs.cpp
+++ b/lib/Optimizer/Transforms/AddDeallocs.cpp
@@ -1,79 +1,240 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "cudaq/Todo.h"
-#include "mlir/IR/Dominance.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
+
+#define DEBUG_TYPE "add-deallocs"
 
 using namespace mlir;
 
 namespace {
+// Map from quake.alloca -> bool. `true` means there is a deallocation of the
+// alloca already present in the function.
+using DeallocationMap = llvm::DenseMap<Operation *, bool>;
+using RegionOpSet = llvm::DenseSet<Operation *>;
 
+struct DeallocationAnalysisInfo {
+  DeallocationAnalysisInfo() = default;
+  DeallocationAnalysisInfo(DeallocationMap m, RegionOpSet p)
+      : allocMap(m), parents(p) {}
+
+  bool empty() const { return parents.empty(); }
+
+  // \p op has a Region with a quake.alloca. The alloca may or may not already
+  // be deallocated.
+  bool containsAlloca(Operation *op) const { return parents.count(op); }
+
+  bool needsDeallocations(Operation *op) const {
+    if (!containsAlloca(op))
+      return false;
+    DeallocationMap deallocMap;
+    // Do not use walk() here. We do not want to descend into other regions.
+    for (Region &region : op->getRegions())
+      for (Block &block : region)
+        for (Operation &op : block) {
+          if (auto alloca = dyn_cast<quake::AllocaOp>(op)) {
+            if (!deallocMap.count(&op))
+              deallocMap.insert(std::make_pair(&op, false));
+          } else if (auto dealloc = dyn_cast<quake::DeallocOp>(op)) {
+            auto val = dealloc.getQregOrVec();
+            Operation *alloc = cast<quake::AllocaOp>(val.getDefiningOp());
+            if (deallocMap.count(alloc))
+              deallocMap[alloc] = true;
+            else
+              deallocMap.insert(std::make_pair(alloc, true));
+          }
+        }
+    for (auto &[_, dealloced] : deallocMap)
+      if (!dealloced)
+        return true;
+    // All alloca/dealloc pairs have been added.
+    return false;
+  }
+
+  DeallocationMap allocMap;
+  RegionOpSet parents;
+};
+
+class DeallocationAnalysis {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DeallocationAnalysis)
+
+  DeallocationAnalysis(func::FuncOp op) { performAnalysis(op.getOperation()); }
+
+  bool hasFailed() const { return hasErrors; }
+
+  DeallocationAnalysisInfo getAnalysisInfo() const {
+    if (hasFailed())
+      return {};
+    return {allocMap, parents};
+  }
+
+private:
+  // Perform the analysis on \p func.
+  void performAnalysis(Operation *func) {
+    func->walk([this](Operation *o) {
+      if (isa<cudaq::cc::UnwindBreakOp, cudaq::cc::UnwindContinueOp,
+              cudaq::cc::UnwindReturnOp>(o)) {
+        o->emitError("must run unwind-lowering before quake-add-deallocs.");
+        hasErrors = true;
+      } else if (auto alloc = dyn_cast<quake::AllocaOp>(o)) {
+        auto *op = alloc.getOperation();
+        if (!allocMap.count(op)) {
+          allocMap.insert(std::make_pair(op, /*deallocated=*/false));
+          parents.insert(op->getParentOp());
+          LLVM_DEBUG(llvm::dbgs() << "adding alloca: " << op << " from "
+                                  << op->getParentOp() << '\n');
+        }
+      } else if (auto dealloc = dyn_cast<quake::DeallocOp>(o)) {
+        auto val = dealloc.getQregOrVec();
+        if (auto alloc = val.getDefiningOp<quake::AllocaOp>()) {
+          auto *op = alloc.getOperation();
+          if (allocMap.count(op))
+            allocMap[op] = true;
+          else
+            allocMap.insert(std::make_pair(op, /*deallocated=*/true));
+          LLVM_DEBUG(llvm::dbgs() << "found dealloc of alloca: " << op << '\n');
+        } else {
+          dealloc->emitError("unable to determine associated allocation.");
+          hasErrors = true;
+        }
+      }
+    });
+  }
+
+  DeallocationMap allocMap;
+  RegionOpSet parents;
+  bool hasErrors = false;
+};
+
+// The different rewrite cases involve the same work, but use different types.
+template <typename RET, typename OP>
+LogicalResult addDeallocations(OP wrapper, PatternRewriter &rewriter,
+                               const DeallocationAnalysisInfo &infoMap) {
+  rewriter.startRootUpdate(wrapper);
+  llvm::DenseSet<Operation *> allocs;
+  for (auto &[op, done] : infoMap.allocMap)
+    if ((op->getParentOp() == wrapper.getOperation()) && !done)
+      allocs.insert(op);
+  if (allocs.empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "no deallocations to add\n");
+    return success();
+  }
+
+  // Allocs contains alloca operations to deallocate.
+  LLVM_DEBUG(llvm::dbgs() << "adding deallocations to "
+                          << wrapper.getOperation() << '\n');
+
+  // 1) Create an exit block to stick dealloc operation in.
+  auto *exitBlock = new Block;
+  exitBlock->addArguments(
+      wrapper.getResultTypes(),
+      SmallVector<Location>{wrapper.getNumResults(), wrapper.getLoc()});
+  wrapper.getRegion().push_back(exitBlock);
+
+  // 2) Update all the RET ops (at top level) to branches to the exit block.
+  for (Block &block : wrapper.getRegion())
+    for (Operation &op : block)
+      if (auto ret = dyn_cast<RET>(op)) {
+        rewriter.setInsertionPoint(ret);
+        rewriter.replaceOpWithNewOp<cf::BranchOp>(ret, exitBlock,
+                                                  ret.getOperands());
+      }
+
+  // 3) Create the deallocations.
+  rewriter.setInsertionPointToEnd(exitBlock);
+  for (auto *alloc : allocs)
+    rewriter.create<quake::DeallocOp>(alloc->getLoc(),
+                                      cast<quake::AllocaOp>(alloc));
+  rewriter.create<RET>(wrapper.getLoc(), exitBlock->getArguments());
+
+  rewriter.finalizeRootUpdate(wrapper);
+  LLVM_DEBUG(llvm::dbgs() << "updated " << wrapper.getOperation() << '\n');
+  return success();
+}
+
+template <typename A, typename B>
+struct DeallocPattern : public OpRewritePattern<A> {
+  using Base = OpRewritePattern<A>;
+
+  explicit DeallocPattern(MLIRContext *ctx,
+                          const DeallocationAnalysisInfo &info)
+      : Base(ctx), infoMap(info) {}
+
+  LogicalResult matchAndRewrite(A op,
+                                PatternRewriter &rewriter) const override {
+    return addDeallocations<B>(op, rewriter, infoMap);
+  }
+
+  const DeallocationAnalysisInfo &infoMap;
+};
+
+using FuncDeallocPattern = DeallocPattern<func::FuncOp, func::ReturnOp>;
+using LambdaDeallocPattern =
+    DeallocPattern<cudaq::cc::CreateLambdaOp, cudaq::cc::ReturnOp>;
+using ScopeDeallocPattern =
+    DeallocPattern<cudaq::cc::ScopeOp, cudaq::cc::ContinueOp>;
+
+/// This pass adds quake.dealloc operations to functions and λ expressions to
+/// deallocate any quantum objects as allocated with quake.alloca operations.
+/// Unlike classical objects that are stack allocated, quantum objects must be
+/// explicitly deallocated in final code generation, etc.
+///
+/// It is the responsibility of this pass to add the deallocations in cases
+/// where there is only high-level structured control-flow present.
+/// Specifically, a operations of type func.func, cc.scope, and cc.create_lambda
+/// may have quake.alloca operations which are not paired with quake.dealloc
+/// operations.
+///
+/// This pass should be run <em>after</em> the UnwindLowering pass, which adds
+/// dealloc ops along non-trivial control paths in the presence of global jumps.
+/// DeallocationAnalysis will flag any unwinding jumps as errors.
 class QuakeAddDeallocsPass
     : public cudaq::opt::QuakeAddDeallocsBase<QuakeAddDeallocsPass> {
 public:
-  // TODO: This is currently a very basic pass for inserting the deallocations.
-  // The Buffer Deallocation Pass in mlir/lib/Dialect/Bufferization/Transforms
-  // is a good example of achieving similar results for buffer deallocation.
-  // Currently it is unclear what degree of complexity that we want to support,
-  // and this pass works for all of our current examples. We can expand this
-  // pass as needed to deal with quake qvector allocations in programs with more
-  // sophisticated control flow.
-  //
-  // For example, if we allocate a QVec in an if statement body, then the
-  // returns will not be dominated by the alloc and no dealloc will be
-  // generated by this pass. Following a scope model, the QVec should be
-  // deallocated when the compound statement block exits (along any path).
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
     if (!funcOp || funcOp.empty())
       return;
 
-    DominanceInfo domInfo(funcOp);
-    auto builder = OpBuilder::atBlockBegin(&funcOp.getBody().front());
-    SmallVector<Operation *> termOps;
-    SmallVector<Operation *> allocOps;
-
-    // Find all allocas and returns in the function.
-    for (auto &operation : funcOp.getOps()) {
-      if (isa<quake::AllocaOp>(operation))
-        allocOps.push_back(&operation);
-      else if (isa<func::ReturnOp>(operation))
-        termOps.push_back(&operation);
+    DeallocationAnalysis analysis(funcOp);
+    if (analysis.hasFailed()) {
+      funcOp.emitError("error adding deallocations\n");
+      signalPassFailure();
+      return;
     }
 
-    // Lambda that helps us look and see if the
-    // qreg from an alloca op is already deallocated
-    auto deallocated = [](quake::AllocaOp op) {
-      auto qreg = op.getResult();
-      for (auto user : qreg.getUsers()) {
-        if (isa<quake::DeallocOp>(user)) {
-          return true;
-        }
-      }
-      return false;
-    };
-
-    // Add a dealloc before each return forall allocs that dominate the return.
-    for (auto term : termOps)
-      for (auto alloc : allocOps)
-        if (domInfo.dominates(alloc, term)) {
-          builder.setInsertionPoint(term);
-          auto qAlloc = cast<quake::AllocaOp>(alloc);
-          if (!deallocated(qAlloc)) {
-            builder.create<quake::DeallocOp>(alloc->getLoc(),
-                                             qAlloc.getResult());
-          }
-        }
+    // Analysis was successful, so add the deallocations as needed.
+    auto allocInfo = analysis.getAnalysisInfo();
+    if (allocInfo.empty()) {
+      LLVM_DEBUG(llvm::dbgs() << "no deallocs to add.\n");
+      return;
+    }
+    auto *ctx = funcOp.getContext();
+    RewritePatternSet patterns(ctx);
+    patterns
+        .insert<FuncDeallocPattern, ScopeDeallocPattern, LambdaDeallocPattern>(
+            ctx, allocInfo);
+    ConversionTarget target(*ctx);
+    target.addDynamicallyLegalOp<func::FuncOp, cudaq::cc::ScopeOp,
+                                 cudaq::cc::CreateLambdaOp>(
+        [&](Operation *op) { return !allocInfo.needsDeallocations(op); });
+    target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+    if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
+      funcOp.emitError("error adding deallocations\n");
+      signalPassFailure();
+    }
   }
 };
 

--- a/test/AST-Quake/dealloc.cpp
+++ b/test/AST-Quake/dealloc.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | cudaq-opt --quake-add-deallocs | FileCheck %s
+
+#include <cudaq.h>
+
+__qpu__ void magic_func(int N) {
+  {
+    cudaq::qreg q(N);
+    h(q[0]);
+  }
+  cudaq::qreg w(N);
+  x(w[0]);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_magic_func
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_4:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
+// CHECK:             quake.dealloc(%[[VAL_4]] : !quake.qvec<?>)
+// CHECK:             cc.continue
+// CHECK:           }
+// CHECK:           %[[VAL_10:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
+// CHECK:           quake.dealloc(%[[VAL_10]] : !quake.qvec<?>)
+// CHECK:           return
+// CHECK:         }
+

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -12,8 +12,8 @@
 // CHECK:         %[[VAL_1:.*]] to i64
 // CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_0]])
 // CHECK:         %[[VAL_4:.*]] = tail call %[[VAL_3]]* @__quantum__rt__qubit_allocate_array(i64 2)
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_4]])
+// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
+// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_4]])
 // CHECK:         ret void
 
 // CHECK:         %[[VAL_5:.*]] = tail call %[[VAL_6:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
@@ -29,9 +29,9 @@
 // CHECK: tail call void (i64, void (%Array*, %Qubit*)*, ...) @invokeWithControlQubits(i64 1, void (%Array*, %Qubit*)* nonnull @__quantum__qis__x__ctl, %Qubit* %[[VAL_12]], %Qubit* %[[VAL_15]])
 // CHECK:         tail call void @__quantum__qis__rx(double 4.300000e-01, %[[VAL_11]]* %[[VAL_12]])
 // CHECK:         %[[VAL_16:.*]] = tail call %[[VAL_17:.*]]* @__quantum__qis__mz(%[[VAL_11]]* %[[VAL_12]])
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_5]])
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_7]])
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_8]])
+// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_5]])
+// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_7]])
+// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_8]])
 // CHECK:         ret void
 
 module {


### PR DESCRIPTION
This replaces the old deallocation pass with one that works with the global jump unwinding pass (unwind-lowering) to handle deallocation of quantum objects. This pass deals with deallocations in structured SEME regions such as func.func, cc.scope, and cc.create_lambda. See #14 