### PR TITLE
Add overload to handle the case when the user writes:

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -111,9 +111,9 @@ inline std::string getQodaKernelName(const std::string &tag) {
   return runtime::cudaqGenPrefixName + tag;
 }
 
-/// Creates the tag name for a quantum kernel. The tag name is a name by which one
-/// can lookup a kernel at runtime. This name does not include the nvq++ prefix
-/// nor the unique (C++ mangled) suffix.
+/// Creates the tag name for a quantum kernel. The tag name is a name by which
+/// one can lookup a kernel at runtime. This name does not include the nvq++
+/// prefix nor the unique (C++ mangled) suffix.
 std::string getTagNameOfFunctionDecl(const clang::FunctionDecl *func,
                                      clang::ItaniumMangleContext *mangler);
 
@@ -227,18 +227,21 @@ public:
   // Expr nodes to lower to Quake.
   //===--------------------------------------------------------------------===//
 
+  bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *x);
   bool TraverseBinaryOperator(clang::BinaryOperator *x,
                               DataRecursionQueue *q = nullptr);
-  bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *x);
   bool VisitBinaryOperator(clang::BinaryOperator *x);
-  bool VisitConditionalOperator(clang::ConditionalOperator *x);
   bool VisitCallExpr(clang::CallExpr *x);
+  bool VisitConditionalOperator(clang::ConditionalOperator *x);
   bool VisitCXXConstructExpr(clang::CXXConstructExpr *x);
+  bool VisitCXXTemporaryObjectExpr(clang::CXXTemporaryObjectExpr *x);
+  bool WalkUpFromCXXTemporaryObjectExpr(clang::CXXTemporaryObjectExpr *x);
   bool VisitCXXOperatorCallExpr(clang::CXXOperatorCallExpr *x);
   bool WalkUpFromCXXOperatorCallExpr(clang::CXXOperatorCallExpr *x);
   bool VisitDeclRefExpr(clang::DeclRefExpr *x);
   bool VisitFloatingLiteral(clang::FloatingLiteral *x);
   bool VisitImplicitCastExpr(clang::ImplicitCastExpr *x);
+  bool VisitInitListExpr(clang::InitListExpr *x);
   bool VisitIntegerLiteral(clang::IntegerLiteral *x);
   bool VisitCXXBoolLiteralExpr(clang::CXXBoolLiteralExpr *x);
   bool TraverseLambdaExpr(clang::LambdaExpr *x,
@@ -246,6 +249,8 @@ public:
   bool VisitMaterializeTemporaryExpr(clang::MaterializeTemporaryExpr *x);
   bool VisitUnaryOperator(clang::UnaryOperator *x);
   bool VisitStringLiteral(clang::StringLiteral *x);
+
+  bool isVectorOfQubitRefs(clang::CXXConstructExpr *x);
 
   //===--------------------------------------------------------------------===//
   // Type nodes to lower to Quake.
@@ -428,8 +433,8 @@ private:
   /// Get the ASTContext.
   clang::ASTContext *getContext() const { return astContext; }
 
-  /// Calls should be to C++ mangled names unless this is a known entry point. In
-  /// the latter case, use the entry point name.
+  /// Calls should be to C++ mangled names unless this is a known entry point.
+  /// In the latter case, use the entry point name.
   std::string genLoweredName(clang::FunctionDecl *x, mlir::FunctionType funcTy);
 
   /// Return a FuncOp for the specified function, given a name and signature. If

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -113,10 +113,10 @@ def quake_ComputeActionOp : QuakeOp<"compute_action",
     [MemoryEffects<[MemRead, MemWrite]>]> {
   let summary = "Captures the compute/action/uncompute high-level idiom.";
   let description = [{
-    CUDA Quantum supports the high-level compute/action/uncompute idiom by providing
-    a custom template function (class) that takes pure kernels (a callable like
-    a λ) as arguments. This operation captures uses of the idiom and can
-    be systematically expanded into a quantum circuit via successive
+    CUDA Quantum supports the high-level compute/action/uncompute idiom by
+    providing a custom template function (class) that takes pure kernels (a
+    callable like a λ) as arguments. This operation captures uses of the idiom
+    and can be systematically expanded into a quantum circuit via successive
     transformations.
   }];
 

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1,4 +1,4 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
@@ -998,24 +998,40 @@ bool QuakeBridgeVisitor::VisitMaterializeTemporaryExpr(
     clang::MaterializeTemporaryExpr *x) {
   if (typeMode)
     return true;
+  auto loc = toLocation(x->getSourceRange());
+  auto ty = genType(x->getType());
+  
+  // The following cases are λ expressions and quantum data. In those cases,
+  // there is nothing to materialize, so we can just pass the Value on the top
+  // of the stack.
+  if (isa<cc::LambdaType>(ty)) {
+    assert(isa<cc::LambdaType>(peekValue().getType()));
+    return true;
+  }
+  if (isa<quake::QVecType>(ty)) {
+    assert(isa<quake::QVecType>(peekValue().getType()));
+    return true;
+  }
+  if (auto structTy = dyn_cast<LLVM::LLVMStructType>(ty);
+      structTy && structTy.getName().equals("reference_wrapper")) {
+    assert(isa<quake::QRefType>(peekValue().getType()) ||
+           isa<quake::QVecType>(peekValue().getType()));
+    return true;
+  }
+  if (auto stdvecTy = dyn_cast<cc::StdvecType>(ty);
+      stdvecTy && isa<quake::QRefType>(stdvecTy.getElementType())) {
+    assert(isa<quake::QRefType>(peekValue().getType()) ||
+           isa<quake::QVecType>(peekValue().getType()));
+    return true;
+  }
+  
+  // Is the Value on the top of the stack is already materialized?
+  if (peekValue().getType() == ty)
+    return true;
+
   // FIXME: this implementation is a hack. The temporary should be some object
   // allocated on the stack, not an undefined value. Need to fix reference and
   // pointer arguments first.
-  auto loc = toLocation(x->getSourceRange());
-  auto ty = genType(x->getType());
-  if (ty.isa<cc::LambdaType>()) {
-    assert(peekValue().getType().isa<cc::LambdaType>());
-    return true;
-  }
-  if (ty.isa<quake::QVecType>()) {
-    assert(peekValue().getType().isa<quake::QVecType>());
-    return true;
-  }
-  if (peekValue().getType() == ty) {
-    // emitWarning(loc, "assumed expression was materialized, passing value");
-    return true;
-  }
-
   // emitWarning(loc, "materialized expression as undefined");
   return pushValue(builder.create<cc::UndefOp>(loc, ty));
 }
@@ -1550,91 +1566,154 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
   return true;
 }
 
+bool QuakeBridgeVisitor::isVectorOfQubitRefs(clang::CXXConstructExpr *x) {
+  if (auto *ctor = x->getConstructor();
+      ctor && isInNamespace(ctor, "std") && ctor->getNameAsString() == "vector")
+    if (Value v = peekValue(); v && isa<quake::QVecType>(v.getType()))
+      return true;
+  return false;
+}
+
+bool QuakeBridgeVisitor::WalkUpFromCXXTemporaryObjectExpr(
+    clang::CXXTemporaryObjectExpr *x) {
+  if (isVectorOfQubitRefs(x))
+    VisitCXXTemporaryObjectExpr(x);
+  return WalkUpFromCXXConstructExpr(x) && VisitCXXTemporaryObjectExpr(x);
+}
+
+bool QuakeBridgeVisitor::VisitCXXTemporaryObjectExpr(
+    clang::CXXTemporaryObjectExpr *x) {
+  if (typeMode)
+    return true;
+  if (isVectorOfQubitRefs(x)) {
+    assert(isa<quake::QVecType>(peekValue().getType()));
+    return true;
+  }
+  return true;
+}
+
+bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
+  if (typeMode)
+    return true;
+  if (x->isSyntacticForm())
+    return true;
+  auto size = x->getNumInits();
+  if (size > 0) {
+    auto loc = toLocation(x);
+    auto last = lastValues(size);
+    bool allQRef = [&]() {
+      for (auto v : last)
+        if (!isa<quake::QRefType>(v.getType()))
+          return false;
+      return true;
+    }();
+    if (allQRef) {
+      if (size > 1) {
+        auto qVecTy = quake::QVecType::get(builder.getContext(), size);
+        return pushValue(builder.create<quake::ConcatOp>(loc, qVecTy, last));
+      }
+      // Pass a one member initialization list as a QRef.
+      return pushValue(last[0]);
+    }
+    TODO_x(loc, x, mangler, "list initialization (not qref)");
+  }
+  return true;
+}
+
 bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
   if (typeMode)
     return true;
   if (x->isElidable())
     return true;
+
   auto loc = toLocation(x);
   if (auto *ctor = x->getConstructor()) {
     auto ctorName = ctor->getNameAsString();
-    if (isInNamespace(ctor, "cudaq") &&
-        (ctorName == "qreg" || ctorName == "qspan")) {
-      // This is a qreg q(N);
-      auto regTy = genType(x->getType()).cast<quake::QVecType>();
-      if (x->getNumArgs() == 1) {
-        assert(!regTy.hasSpecifiedSize());
-        auto sizeVal = popValue();
-        if (sizeVal.getType().isa<quake::QVecType>())
-          return pushValue(sizeVal);
-        return pushValue(builder.create<quake::AllocaOp>(loc, regTy, sizeVal));
+    if (isInNamespace(ctor, "cudaq")) {
+      if (ctorName == "qreg" || ctorName == "qspan") {
+        // This is a qreg q(N);
+        auto regTy = genType(x->getType()).cast<quake::QVecType>();
+        if (x->getNumArgs() == 1) {
+          assert(!regTy.hasSpecifiedSize());
+          auto sizeVal = popValue();
+          if (isa<quake::QVecType>(sizeVal.getType()))
+            return pushValue(sizeVal);
+          return pushValue(
+              builder.create<quake::AllocaOp>(loc, regTy, sizeVal));
+        }
+        auto qregSizeVal = builder.create<arith::ConstantIntOp>(
+            loc, regTy.getSize(), builder.getIntegerType(64));
+        return pushValue(
+            builder.create<quake::AllocaOp>(loc, regTy, qregSizeVal));
       }
-      auto qregSizeVal = builder.create<arith::ConstantIntOp>(
-          loc, regTy.getSize(), builder.getIntegerType(64));
-      return pushValue(
-          builder.create<quake::AllocaOp>(loc, regTy, qregSizeVal));
-    }
-    if (isInNamespace(ctor, "cudaq") && ctorName == "qudit") {
-      // This is a "cudaq::qudit/qubit q;"
-      return pushValue(builder.create<quake::AllocaOp>(loc));
-    }
-    if (isInNamespace(ctor, "std") && ctorName == "function") {
-      // Are we converting a lambda expr to a std::function?
-      auto backTy = peekValue().getType();
-      if (backTy.isa<cc::LambdaType>()) {
-        // Skip this constructor (for now).
+      if (ctorName == "qudit") {
+        // This is a "cudaq::qudit/qubit q;"
+        return pushValue(builder.create<quake::AllocaOp>(loc));
+      }
+    } else if (isInNamespace(ctor, "std")) {
+      if (isVectorOfQubitRefs(x)) {
+        assert(isa<quake::QVecType>(peekValue().getType()));
         return true;
       }
-      if (auto stTy = backTy.dyn_cast_or_null<LLVM::LLVMStructType>()) {
-        if (!stTy.getBody().empty()) {
-          // TODO: We don't support a callable class with data members yet.
-          TODO_loc(loc, "callable class with data members");
-        }
-        // Constructor generated as degenerate reference to call operator.
-        auto *fromTy = x->getArg(0)->getType().getTypePtr();
-        // FIXME: May need to peel off more than one layer of sugar?
-        if (auto *elabTy = dyn_cast<clang::ElaboratedType>(fromTy))
-          fromTy = elabTy->desugar().getTypePtr();
-        auto *fromDecl = dyn_cast_or_null<clang::RecordType>(fromTy)->getDecl();
-        if (!fromDecl)
-          TODO_loc(loc, "recovering record type for a callable");
-        auto *objDecl = dyn_cast_or_null<clang::CXXRecordDecl>(fromDecl);
-        if (!objDecl)
-          TODO_loc(loc, "recovering C++ declaration for callable");
-        auto *callOperDecl = findCallOperator(objDecl);
-        if (!callOperDecl) {
-          auto &de = mangler->getASTContext().getDiagnostics();
-          auto id = de.getCustomDiagID(
-              clang::DiagnosticsEngine::Error,
-              "std::function initializer must be a callable");
-          de.Report(x->getBeginLoc(), id);
+      if (ctorName == "function") {
+        // Are we converting a lambda expr to a std::function?
+        auto backTy = peekValue().getType();
+        if (backTy.isa<cc::LambdaType>()) {
+          // Skip this constructor (for now).
           return true;
         }
-        auto kernelCallTy = getFunctionType(callOperDecl);
-        auto kernelName = generateQodaKernelName(callOperDecl);
-        return pushValue(builder.create<cc::CreateLambdaOp>(
-            loc, cc::LambdaType::get(kernelCallTy),
-            [&](OpBuilder &builder, Location loc) {
-              auto args = builder.getBlock()->getArguments();
-              auto call = builder.create<func::CallOp>(
-                  loc, kernelCallTy.getResults(), kernelName, args);
-              builder.create<cc::ReturnOp>(loc, call.getResults());
-            }));
+        if (auto stTy = backTy.dyn_cast_or_null<LLVM::LLVMStructType>()) {
+          if (!stTy.getBody().empty()) {
+            // TODO: We don't support a callable class with data members yet.
+            TODO_loc(loc, "callable class with data members");
+          }
+          // Constructor generated as degenerate reference to call operator.
+          auto *fromTy = x->getArg(0)->getType().getTypePtr();
+          // FIXME: May need to peel off more than one layer of sugar?
+          if (auto *elabTy = dyn_cast<clang::ElaboratedType>(fromTy))
+            fromTy = elabTy->desugar().getTypePtr();
+          auto *fromDecl =
+              dyn_cast_or_null<clang::RecordType>(fromTy)->getDecl();
+          if (!fromDecl)
+            TODO_loc(loc, "recovering record type for a callable");
+          auto *objDecl = dyn_cast_or_null<clang::CXXRecordDecl>(fromDecl);
+          if (!objDecl)
+            TODO_loc(loc, "recovering C++ declaration for callable");
+          auto *callOperDecl = findCallOperator(objDecl);
+          if (!callOperDecl) {
+            auto &de = mangler->getASTContext().getDiagnostics();
+            auto id = de.getCustomDiagID(
+                clang::DiagnosticsEngine::Error,
+                "std::function initializer must be a callable");
+            de.Report(x->getBeginLoc(), id);
+            return true;
+          }
+          auto kernelCallTy = getFunctionType(callOperDecl);
+          auto kernelName = generateQodaKernelName(callOperDecl);
+          return pushValue(builder.create<cc::CreateLambdaOp>(
+              loc, cc::LambdaType::get(kernelCallTy),
+              [&](OpBuilder &builder, Location loc) {
+                auto args = builder.getBlock()->getArguments();
+                auto call = builder.create<func::CallOp>(
+                    loc, kernelCallTy.getResults(), kernelName, args);
+                builder.create<cc::ReturnOp>(loc, call.getResults());
+              }));
+        }
       }
     }
 
     // TODO: remove this when we can handle ctors more generally.
     if (!ctor->isDefaultConstructor()) {
-      LLVM_DEBUG(llvm::dbgs() << "unhandled ctor: " << x << '\n');
+      LLVM_DEBUG(llvm::dbgs() << "unhandled ctor:\n"; x->dump());
       TODO_loc(loc, "C++ ctor (not-default)");
     }
 
     // A regular C++ class constructor lowers as:
-    //  1) A unique object must be created, so the type must have a minimum of
-    //     one byte.
-    //   2) Allocate a new object.
-    //   3) Call the constructor passing the address of the allocation as
-    //   `this`.
+    //
+    // 1) A unique object must be created, so the type must have a minimum of
+    //    one byte.
+    // 2) Allocate a new object.
+    // 3) Call the constructor passing the address of the allocation as `this`.
 
     // FIXME: As this is now, the stack space isn't correctly sized. The next
     // line should be something like:

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1000,7 +1000,7 @@ bool QuakeBridgeVisitor::VisitMaterializeTemporaryExpr(
     return true;
   auto loc = toLocation(x->getSourceRange());
   auto ty = genType(x->getType());
-  
+
   // The following cases are λ expressions and quantum data. In those cases,
   // there is nothing to materialize, so we can just pass the Value on the top
   // of the stack.
@@ -1024,9 +1024,9 @@ bool QuakeBridgeVisitor::VisitMaterializeTemporaryExpr(
            isa<quake::QVecType>(peekValue().getType()));
     return true;
   }
-  
-  // Is the Value on the top of the stack is already materialized?
-  if (peekValue().getType() == ty)
+
+  // Is the Value on the top of the stack already materialized?
+  if (!valueStack.empty() && (peekValue().getType() == ty))
     return true;
 
   // FIXME: this implementation is a hack. The temporary should be some object

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -433,6 +433,22 @@ void control(QuantumKernel &&kernel, QuantumRegister &&ctrl_qubits,
   getExecutionManager()->endCtrlRegion(ctrls.size());
 }
 
+// Control the given cudaq kernel on the given list of references to control
+// qubits.
+template <typename QuantumKernel, typename... Args>
+  requires isCallableVoidKernel<QuantumKernel, Args...>
+void control(QuantumKernel &&kernel,
+             std::vector<std::reference_wrapper<qubit>> &&ctrl_qubits,
+             Args &&...args) {
+  std::vector<std::size_t> ctrls;
+  for (auto &cq : ctrl_qubits) {
+    ctrls.push_back(cq.get().id());
+  }
+  getExecutionManager()->startCtrlRegion(ctrls);
+  kernel(std::forward<Args>(args)...);
+  getExecutionManager()->endCtrlRegion(ctrls.size());
+}
+
 // Apply the adjoint of the given cudaq kernel
 template <typename QuantumKernel, typename... Args>
   requires isCallableVoidKernel<QuantumKernel, Args...>

--- a/test/AST-Quake/control.cpp
+++ b/test/AST-Quake/control.cpp
@@ -14,7 +14,6 @@ struct heisenbergU {
   void operator()(cudaq::qreg<> &q) __qpu__ {
     auto nQubits = q.size();
     for (int step = 0; step < 100; ++step) {
-      // Fixme need a way to apply ar Rn to all qubits
       for (int j = 0; j < nQubits; j++)
         rx(-.01, q[j]);
       for (int i = 0; i < nQubits - 1; i++) {

--- a/test/AST-Quake/control.cpp
+++ b/test/AST-Quake/control.cpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | FileCheck %s
+
+#include <cudaq.h>
+
+struct heisenbergU {
+  void operator()(cudaq::qreg<> &q) __qpu__ {
+    auto nQubits = q.size();
+    for (int step = 0; step < 100; ++step) {
+      // Fixme need a way to apply ar Rn to all qubits
+      for (int j = 0; j < nQubits; j++)
+        rx(-.01, q[j]);
+      for (int i = 0; i < nQubits - 1; i++) {
+        cudaq::compute_action([&]() { x<cudaq::ctrl>(q[i], q[i + 1]); },
+                              [&]() { rz(-.01, q[i + 1]); });
+      }
+    }
+  }
+};
+
+struct ctrlHeisenberg {
+  void operator()(int nQubits) __qpu__ {
+    cudaq::qubit ctrl1, ctrl2;
+    cudaq::qreg q(nQubits);
+    cudaq::control(heisenbergU{}, {ctrl1, ctrl2}, q);
+  }
+};
+
+int main() { ctrlHeisenberg{}(5); }
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__heisenbergU(
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenberg(
+// CHECK-SAME:        %{{.*}}: i32) attributes
+// CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qref
+// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_2]], %[[VAL_3]] : (!quake.qref, !quake.qref) -> !quake.qvec<2>
+// CHECK:           quake.apply @__nvqpp__mlirgen__heisenbergU[%[[VAL_8]] : !quake.qvec<2>] %{{.*}} : (!quake.qvec<?>) -> ()
+// CHECK:           return
+

--- a/test/AST-Quake/control.cpp
+++ b/test/AST-Quake/control.cpp
@@ -32,8 +32,6 @@ struct ctrlHeisenberg {
   }
 };
 
-int main() { ctrlHeisenberg{}(5); }
-
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__heisenbergU(
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenberg(
@@ -44,3 +42,32 @@ int main() { ctrlHeisenberg{}(5); }
 // CHECK:           quake.apply @__nvqpp__mlirgen__heisenbergU[%[[VAL_8]] : !quake.qvec<2>] %{{.*}} : (!quake.qvec<?>) -> ()
 // CHECK:           return
 
+
+struct givens {
+  void operator()(double lambda, cudaq::qubit &q, cudaq::qubit &r) __qpu__ {
+    ry(M_PI_2, q);
+    ry(M_PI_2, r);
+    z<cudaq::ctrl>(q, r);
+    ry(lambda, q);
+    ry(-lambda, r);
+    z<cudaq::ctrl>(q, r);
+    ry(-M_PI_2, q);
+    ry(-M_PI_2, r);
+  }
+};
+
+__qpu__ void qnppx(double theta, cudaq::qubit &q, cudaq::qubit &r,
+                   cudaq::qubit &s, cudaq::qubit &t) {
+  x<cudaq::ctrl>(r, q);
+  x<cudaq::ctrl>(s, t);
+  cudaq::control(givens{}, {q, t}, theta, r, s);
+  x<cudaq::ctrl>(r, q);
+  x<cudaq::ctrl>(s, t);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__givens(
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qnppx
+// CHECK:           %[[VAL_7:.*]] = quake.concat %{{.*}}, %{{.*}} : (!quake.qref, !quake.qref) -> !quake.qvec<2>
+// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]] : !quake.qvec<2>] %{{.*}}, %{{.*}}, %{{.*}} : (f64, !quake.qref, !quake.qref) -> ()
+// CHECK:           return


### PR DESCRIPTION
```c++
  cudaq::control(Kernel{}, {ctrl1, ctrl2}, args...);
```
Get vector<reference_wrapper<qubit>> through the bridge.

Add simple test.