### PR TITLE
Minor fixes for markdown link check

### DIFF
--- a/.github/workflows/config/mlc_config.json
+++ b/.github/workflows/config/mlc_config.json
@@ -10,5 +10,10 @@
           "Accept-Encoding": "zstd, br, gzip, deflate"
         }
       }
+    ],
+    "ignorePatterns": [
+      {
+        "pattern": "^https://www.gnu.org/prep/standards/standards.html"
+      }
     ]
 }

--- a/.github/workflows/link_and_spell_check.yml
+++ b/.github/workflows/link_and_spell_check.yml
@@ -4,6 +4,10 @@ on:
     branches:
     - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 name: "Check spelling, linting and links"
 
 jobs:
@@ -11,27 +15,31 @@ jobs:
     runs-on: ubuntu-latest
     name: "Check spelling, linting and links"
     steps:
-    - uses: actions/checkout@v3
-    - name: markdownlint-cli
-      # cspell:words nosborn
-      uses: nosborn/github-action-markdown-cli@v3.2.0
-      with:
-        files: .
-        config_file: '.github/workflows/config/md_lint_config.yml'
-    - name: Markdown link check
-      # cspell:words gaurav
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-verbose-mode: "yes"
-        config_file: ".github/workflows/config/mlc_config.json"        
-      if: ${{ success() || failure() }}
-    - name: "Check spelling in changed files"
-      # cspell:words streetsidesoftware
-      uses: streetsidesoftware/cspell-action@v1.2.4
-      with:
-        inline: warning
-        # Only warn on spelling errors, since there's likely a lot of false
-        # positives with terminology in quantum computing.
-        strict: false
-        incremental_files_only: true
-        config: '.github/workflows/config/spelling_allowlist.json'
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: markdownlint-cli
+        # cspell:words nosborn
+        uses: nosborn/github-action-markdown-cli@v3.2.0
+        with:
+          files: .
+          config_file: '.github/workflows/config/md_lint_config.yml'
+
+      - name: Markdown link check
+        # cspell:words gaurav
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-verbose-mode: "yes"
+          config-file: ".github/workflows/config/mlc_config.json"        
+        if: ${{ success() || failure() }}
+
+      - name: "Check spelling in changed files"
+        # cspell:words streetsidesoftware
+        uses: streetsidesoftware/cspell-action@v1.2.4
+        with:
+          inline: warning
+          # Only warn on spelling errors, since there's likely a lot of false
+          # positives with terminology in quantum computing.
+          strict: false
+          incremental_files_only: true
+          config: '.github/workflows/config/spelling_allowlist.json'


### PR DESCRIPTION
This PR
- fixes a typo that caused the config file to be ignored,
- adds a particularly flaky link to the list of links to ignore,
- makes it so that the check is cancelled when new changes are pushed