### PR TITLE
Fix `QuakeValue` Lifetime Bug and `kernel_builder::to_quake` Handling

### DIFF
--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -39,7 +39,11 @@ void bindMakeKernel(py::module &mod) {
                      "  kernel, qreg = cudaq.make_kernel(cudaq.qreg)\n");
 
   mod.def(
-      "make_kernel", []() { return make_kernel(); },
+      "make_kernel",
+      []() {
+        std::vector<details::KernelBuilderType> empty;
+        return std::make_unique<kernel_builder<>>(empty);
+      },
       "Create and return a :class:`Kernel` that accepts no arguments.\n"
       "\nReturns:\n"
       "  :class:`Kernel` : An empty kernel function to be used for quantum "

--- a/python/tests/unittests/test_bug64_quakevalue_lifetime.py
+++ b/python/tests/unittests/test_bug64_quakevalue_lifetime.py
@@ -1,0 +1,32 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import os
+
+import pytest
+
+import cudaq
+
+def test_QuakeValueLifetimeAndPrint(): 
+    circuit = cudaq.make_kernel()
+    qubitRegister = circuit.qalloc(2)
+    circuit.x(qubitRegister[0])  
+    s = str(circuit)
+    print(s)
+
+    assert s.count('quake.x') == 1
+
+    circuit.x(qubitRegister[0])
+    s = str(circuit)
+    print(s)
+    assert s.count('quake.x') == 2
+
+# leave for gdb debugging
+if __name__ == "__main__":
+    loc = os.path.abspath(__file__)
+    pytest.main([loc, "-rP"])

--- a/python/tests/unittests/test_observe.py
+++ b/python/tests/unittests/test_observe.py
@@ -584,4 +584,4 @@ def test_observe_numpy_array(angles, want_state, want_expectation):
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)
-    pytest.main([loc, "-s", '-k', 'test_validate_list_number_elements'])
+    pytest.main([loc, "-s"])

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <functional>
+#include <map>
 #include <memory>
 
 namespace mlir {
@@ -38,6 +39,9 @@ protected:
   /// to validate that the number of required unique elements
   /// is equal to the number provided as input at runtime.
   bool canValidateVectorNumElements = true;
+
+  std::map<std::size_t, QuakeValue> extractedFromIndex;
+  std::map<void *, QuakeValue> extractedFromValue;
 
 public:
   /// @brief Return the actual MLIR Value

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -17,6 +17,7 @@ class ImplicitLocOpBuilder;
 } // namespace mlir
 
 namespace cudaq {
+class QuakeValue;
 
 /// @brief A QuakeValue is meant to provide a thin
 /// wrapper around an mlir::Value instance. These QuakeValues
@@ -40,15 +41,17 @@ protected:
   /// is equal to the number provided as input at runtime.
   bool canValidateVectorNumElements = true;
 
+  /// @brief Keep track of previously extracted QuakeValues from
+  /// a concrete index value
   std::map<std::size_t, QuakeValue> extractedFromIndex;
+
+  /// @brief Keep track of previously extracted QuakeValues from
+  /// another QuakeValue (represented by its unique opaque pointer)
   std::map<void *, QuakeValue> extractedFromValue;
 
 public:
   /// @brief Return the actual MLIR Value
   mlir::Value getValue() const;
-
-  // Let kernel_builder use getValue()
-  // friend class kernel_builder;
 
   /// @brief The constructor, takes the builder and the value to wrap
   QuakeValue(mlir::ImplicitLocOpBuilder &builder, mlir::Value v);
@@ -78,6 +81,8 @@ public:
   /// starting at the given startIdx and including the following count elements.
   QuakeValue slice(const std::size_t startIdx, const std::size_t count);
 
+  /// @brief For a QuakeValue with type StdVec or QVec, return
+  /// the size QuakeValue.
   QuakeValue size();
 
   /// @brief Return true if this QuakeValue is of type StdVec.
@@ -110,6 +115,8 @@ public:
 
   /// @brief Add this QuakeValue with the given double.
   QuakeValue operator+(const double);
+
+  /// @brief Add this QuakeValue with the given int.
   QuakeValue operator+(const int);
 
   /// @brief Add this QuakeValue with the given QuakeValue
@@ -117,6 +124,8 @@ public:
 
   /// @brief Subtract the given double from this QuakeValue
   QuakeValue operator-(const double);
+
+  /// @brief Subtract the given int from this QuakeValue
   QuakeValue operator-(const int);
 
   /// @brief Subtract the given QuakeValue from this QuakeValue

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -778,10 +778,8 @@ std::string to_quake(ImplicitLocOpBuilder &builder) {
         "cudaq::builder failed to JIT compile the Quake representation.");
 
   std::string printOut;
-  {
-    llvm::raw_string_ostream os(printOut);
-    clonedModule->print(os);
-  }
+  llvm::raw_string_ostream os(printOut);
+  clonedModule->print(os);
   return printOut;
 }
 

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -295,8 +295,8 @@ public:
 } // namespace details
 
 template <class... Ts>
-concept AllAreQuakeValues = sizeof
-...(Ts) < 2 ||
+concept AllAreQuakeValues =
+    sizeof...(Ts) < 2 ||
     (std::conjunction_v<
          std::is_same<std::tuple_element_t<0, std::tuple<Ts...>>, Ts>...> &&
      std::is_same_v<


### PR DESCRIPTION
Fix issue with `QuakeValue` lifetime on instance returned from `QuakeValue::operator[](...)`. Fix issue with `kernel_builder::to_quake()` and multiple calls to print the quake code. 

#64 