### PR TITLE
Fix bug 69, no expval attached to `observe_result` when shots aren't provided

### DIFF
--- a/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
+++ b/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
@@ -84,7 +84,7 @@ public:
             sum += term.get_term_coefficient(0).real();
           else {
             auto [exp, data] = cudaq::measure(term);
-            results.emplace_back(data.to_map(), term.to_string(false));
+            results.emplace_back(data.to_map(), term.to_string(false), exp);
             sum += term.get_term_coefficient(0).real() * exp;
           }
         });

--- a/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
+++ b/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
@@ -91,7 +91,7 @@ public:
           else {
 
             auto [exp, data] = cudaq::measure(term);
-            results.emplace_back(data.to_map(), term.to_string());
+            results.emplace_back(data.to_map(), term.to_string(), exp);
             sum += term.get_term_coefficient(0).real() * exp;
           }
         });


### PR DESCRIPTION
#69