### PR TITLE
Adding a dev environment that contains all necessary CUDA and OpenMPI tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"workspaceFolder": "/workspaces/cuda-quantum",
 	"build": {
 		"dockerfile": "../docker/build/cudaqdev.Dockerfile",
-		"args": { "env_tag": "gcc11-main" }
+		"args": { "env_tag": "llvm-main" }
 	},
 	// Getting a browser to e.g. preview docs within the container (optional - uncomment if needed)
 	// "postCreateCommand": "apt update && apt install -y curl && curl -sSL https://dl.google.com/linux/direct/google-chrome-stable_current_$(dpkg --print-architecture).deb -o /tmp/chrome.deb && apt install -y /tmp/chrome.deb",

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -71,12 +71,12 @@ jobs:
       - name: Build cuda-quantum image
         run: |
           docker load --input /tmp/cudaqdev.tar
-          docker build -t ghcr.io/nvidia/cuda-quantum:latest -f docker/release/cudaq.Dockerfile . \
+          docker build -t cuda-quantum:latest -f docker/release/cudaq.Dockerfile . \
             --build-arg dev_image=cuda-quantum-dev --build-arg dev_tag=local
 
       - name: Validate cuda-quantum image
         run: |
-          docker run --rm -dit --name cuda-quantum ghcr.io/nvidia/cuda-quantum:latest
+          docker run --rm -dit --name cuda-quantum cuda-quantum:latest
           docker cp scripts/validate_container.sh cuda-quantum:"/home/cudaq/validate_container.sh"
           docker exec -e TERM=xterm cuda-quantum bash validate_container.sh > /tmp/validation.out
           docker stop cuda-quantum
@@ -84,7 +84,7 @@ jobs:
       - name: Create job summary
         run: |
           echo "## Validation" >> $GITHUB_STEP_SUMMARY
-          echo "The validation for the image ghcr.io/nvidia/cuda-quantum:latest produced the following output:" >> $GITHUB_STEP_SUMMARY
+          echo "The validation of the cuda-quantum image produced the following output:" >> $GITHUB_STEP_SUMMARY
           echo '```text' >> $GITHUB_STEP_SUMMARY
           cat /tmp/validation.out >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -85,9 +85,9 @@ jobs:
         run: |
           echo "## Validation" >> $GITHUB_STEP_SUMMARY
           echo "The validation for the image ghcr.io/nvidia/cuda-quantum:latest produced the following output:" >> $GITHUB_STEP_SUMMARY
-          echo "```text" >> $GITHUB_STEP_SUMMARY
+          echo '```text' >> $GITHUB_STEP_SUMMARY
           cat /tmp/validation.out >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
   documentation:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       json: "${{ steps.read_json.outputs.result }}"
 
     steps:
-      - uses: cloudposse/github-action-matrix-outputs-read@0.3.1
+      - uses: cloudposse/github-action-matrix-outputs-read@0.1.1
         id: read_json
         with:
           matrix-step-name: setup # passed in as job_id above

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,13 @@ jobs:
     with:
       dockerfile: build/devdeps.Dockerfile
       toolchain: ${{ matrix.toolchain }}
-      job_id: setup
+      # needed only for the cloudposse GitHub action
       matrix_key: ${{ matrix.toolchain }}
 
+  # This job is needed only when using the cloudposse GitHub action to read
+  # the output of a matrix job. This is a workaround due to current GitHub
+  # limitations that may not be needed if the work started here concludes:
+  # https://github.com/actions/runner/pull/2477
   config:
     name: Configure build
     runs-on: ubuntu-latest
@@ -41,7 +45,7 @@ jobs:
       - uses: cloudposse/github-action-matrix-outputs-read@0.1.1
         id: read_json
         with:
-          matrix-step-name: setup # passed in as job_id above
+          matrix-step-name: dev_environment
 
   build_and_test:
     name: Build and test
@@ -52,10 +56,7 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/test_in_devenv.yml
     with:
-      # It would be lovely to not hardcode this. 
-      # See if/when the work started here concludes: https://github.com/actions/runner/pull/2477
       devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}', matrix.toolchain)] }}
-      # tar-devdeps-${{ matrix.toolchain }}-${{ github.sha }}
       export_environment: ${{ github.event_name == 'workflow_dispatch' && inputs.export_environment }}
 
   docker_image:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,4 @@ jobs:
     needs: config
     uses: ./.github/workflows/build_packages.yml
     with:
-      devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key.gcc12
+      devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key.gcc12 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         toolchain: [clang16, clang15, gcc12, gcc11]
     uses: ./.github/workflows/dev_environment.yml
     with:
+      dockerfile: build/devdeps.Dockerfile
       toolchain: ${{ matrix.toolchain }}
 
   build_and_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,26 @@ jobs:
     with:
       dockerfile: build/devdeps.Dockerfile
       toolchain: ${{ matrix.toolchain }}
+      #matrix-step-name: ${{ github.job }}
+      matrix_key: ${{ matrix.toolchain }}
+
+  config:
+    name: Configure build
+    runs-on: ubuntu-latest
+    needs: setup
+
+    outputs:
+      json: "${{ steps.read_json.outputs.result }}"
+
+    steps:
+      - uses: cloudposse/github-action-matrix-outputs-read@main
+        id: read_json
+        #with:
+        #  matrix-step-name: setup
 
   build_and_test:
     name: Build and test
-    needs: setup
+    needs: config
     strategy:
       matrix:
         toolchain: [clang16, clang15, gcc12, gcc11]
@@ -38,7 +54,8 @@ jobs:
     with:
       # It would be lovely to not hardcode this. 
       # See if/when the work started here concludes: https://github.com/actions/runner/pull/2477
-      devdeps_cache: tar-devdeps-${{ matrix.toolchain }}-${{ github.sha }}
+      devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}', matrix.toolchain)] }}
+      # tar-devdeps-${{ matrix.toolchain }}-${{ github.sha }}
       export_environment: ${{ github.event_name == 'workflow_dispatch' && inputs.export_environment }}
 
   docker_image:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       dockerfile: build/devdeps.Dockerfile
       toolchain: ${{ matrix.toolchain }}
-      #matrix-step-name: ${{ github.job }}
+      job_id: ${{ github.job }}
       matrix_key: ${{ matrix.toolchain }}
 
   config:
@@ -40,8 +40,8 @@ jobs:
     steps:
       - uses: cloudposse/github-action-matrix-outputs-read@0.3.1
         id: read_json
-        #with:
-        #  matrix-step-name: setup
+        with:
+          matrix-step-name: setup # passed in as job_id above
 
   build_and_test:
     name: Build and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       dockerfile: build/devdeps.Dockerfile
       toolchain: ${{ matrix.toolchain }}
-      job_id: ${{ github.job }}
+      job_id: setup
       matrix_key: ${{ matrix.toolchain }}
 
   config:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         toolchain: [clang16, clang15, gcc12, gcc11]
+      fail-fast: false
     uses: ./.github/workflows/dev_environment.yml
     with:
       dockerfile: build/devdeps.Dockerfile
@@ -32,8 +33,11 @@ jobs:
     strategy:
       matrix:
         toolchain: [clang16, clang15, gcc12, gcc11]
+      fail-fast: false
     uses: ./.github/workflows/test_in_devenv.yml
     with:
+      # It would be lovely to not hardcode this. 
+      # See if/when the work started here concludes: https://github.com/actions/runner/pull/2477
       devdeps_cache: tar-devdeps-${{ matrix.toolchain }}-${{ github.sha }}
       export_environment: ${{ github.event_name == 'workflow_dispatch' && inputs.export_environment }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Load dependencies
     strategy:
       matrix:
-        toolchain: [clang16, clang15, gcc12, gcc11]
+        toolchain: [llvm, clang16, clang15, gcc12, gcc11]
       fail-fast: false
     uses: ./.github/workflows/dev_environment.yml
     with:
@@ -52,7 +52,7 @@ jobs:
     needs: config
     strategy:
       matrix:
-        toolchain: [clang16, clang15, gcc12, gcc11]
+        toolchain: [llvm, clang16, clang15, gcc12, gcc11]
       fail-fast: false
     uses: ./.github/workflows/test_in_devenv.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Load dependencies
     strategy:
       matrix:
-        toolchain: [llvm, clang16, clang15, gcc12, gcc11]
+        toolchain: [llvm, clang16, gcc12]
       fail-fast: false
     uses: ./.github/workflows/dev_environment.yml
     with:
@@ -52,7 +52,7 @@ jobs:
     needs: config
     strategy:
       matrix:
-        toolchain: [llvm, clang16, clang15, gcc12, gcc11]
+        toolchain: [llvm, clang16, gcc12]
       fail-fast: false
     uses: ./.github/workflows/test_in_devenv.yml
     with:
@@ -61,7 +61,7 @@ jobs:
 
   docker_image:
     name: Create Packages
-    needs: setup
+    needs: config
     uses: ./.github/workflows/build_packages.yml
     with:
-      devdeps_cache: tar-devdeps-gcc11-${{ github.sha }}
+      devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key.gcc12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       json: "${{ steps.read_json.outputs.result }}"
 
     steps:
-      - uses: cloudposse/github-action-matrix-outputs-read@main
+      - uses: cloudposse/github-action-matrix-outputs-read@0.3.1
         id: read_json
         #with:
         #  matrix-step-name: setup

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -19,4 +19,4 @@ jobs:
     uses: ./.github/workflows/dev_environment.yml
     with:
       toolchain: ${{ matrix.toolchain }}
-      container_registry: ghcr.io
+      environment: ghcr-deployment

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -18,5 +18,6 @@ jobs:
         toolchain: [clang16, clang15, gcc12, gcc11]
     uses: ./.github/workflows/dev_environment.yml
     with:
+      dockerfile: build/devdeps.Dockerfile
       toolchain: ${{ matrix.toolchain }}
       environment: ghcr-deployment

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -15,9 +15,28 @@ jobs:
   devdeps:
     strategy:
       matrix:
-        toolchain: [clang16, clang15, gcc12, gcc11]
+        toolchain: [clang16, clang15, gcc12]
+      fail-fast: false
     uses: ./.github/workflows/dev_environment.yml
     with:
       dockerfile: build/devdeps.Dockerfile
       toolchain: ${{ matrix.toolchain }}
+      environment: ghcr-deployment
+
+  # FIXME: 
+  # use this instead: https://github.com/marketplace/actions/matrix-outputs-write
+  devdeps_gcc11:
+    uses: ./.github/workflows/dev_environment.yml
+    with:
+      dockerfile: build/devdeps.Dockerfile
+      toolchain: gcc11
+      environment: ghcr-deployment
+
+  extdevdeps:
+    uses: ./.github/workflows/dev_environment.yml
+    if: github.event_name == 'workflow_dispatch'
+    needs: devdeps_gcc11
+    with:
+      dockerfile: build/devdeps.ext.Dockerfile
+      base_image: ${{ needs.devdeps_gcc11.outputs.image_name }}@${{ needs.devdeps_gcc11.outputs.digest }}
       environment: ghcr-deployment

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -15,7 +15,7 @@ jobs:
   devdeps:
     strategy:
       matrix:
-        toolchain: [clang16, clang15, gcc12]
+        toolchain: [llvm, clang16, clang15, gcc12]
       fail-fast: false
     uses: ./.github/workflows/dev_environment.yml
     with:

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -31,6 +31,7 @@ jobs:
   config:
     name: Configure build
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
     needs: devdeps
 
     outputs:

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -15,28 +15,38 @@ jobs:
   devdeps:
     strategy:
       matrix:
-        toolchain: [llvm, clang16, clang15, gcc12]
+        toolchain: [llvm, clang16, clang15, gcc12, gcc11]
       fail-fast: false
     uses: ./.github/workflows/dev_environment.yml
     with:
       dockerfile: build/devdeps.Dockerfile
       toolchain: ${{ matrix.toolchain }}
+      matrix_key: ${{ matrix.toolchain }}
       environment: ghcr-deployment
 
-  # FIXME: 
-  # use this instead: https://github.com/marketplace/actions/matrix-outputs-write
-  devdeps_gcc11:
-    uses: ./.github/workflows/dev_environment.yml
-    with:
-      dockerfile: build/devdeps.Dockerfile
-      toolchain: gcc11
-      environment: ghcr-deployment
+  # This job is needed only when using the cloudposse GitHub action to read
+  # the output of a matrix job. This is a workaround due to current GitHub
+  # limitations that may not be needed if the work started here concludes:
+  # https://github.com/actions/runner/pull/2477
+  config:
+    name: Configure build
+    runs-on: ubuntu-latest
+    needs: devdeps
+
+    outputs:
+      json: "${{ steps.read_json.outputs.result }}"
+
+    steps:
+      - uses: cloudposse/github-action-matrix-outputs-read@0.1.1
+        id: read_json
+        with:
+          matrix-step-name: dev_environment
 
   extdevdeps:
     uses: ./.github/workflows/dev_environment.yml
     if: github.event_name == 'workflow_dispatch'
-    needs: devdeps_gcc11
+    needs: config
     with:
       dockerfile: build/devdeps.ext.Dockerfile
-      base_image: ${{ needs.devdeps_gcc11.outputs.image_name }}@${{ needs.devdeps_gcc11.outputs.digest }}
+      base_image: ${{ fromJson(needs.config.outputs.json).image_name.gcc11 }}@${{ fromJson(needs.config.outputs.json).digest.gcc11 }}
       environment: ghcr-deployment

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -15,7 +15,7 @@ jobs:
   devdeps:
     strategy:
       matrix:
-        toolchain: [llvm, clang16, clang15, gcc12, gcc11]
+        toolchain: [llvm, clang16, gcc12]
       fail-fast: false
     uses: ./.github/workflows/dev_environment.yml
     with:
@@ -49,5 +49,5 @@ jobs:
     needs: config
     with:
       dockerfile: build/devdeps.ext.Dockerfile
-      base_image: ${{ fromJson(needs.config.outputs.json).image_name.gcc11 }}@${{ fromJson(needs.config.outputs.json).digest.gcc11 }}
+      base_image: ${{ fromJson(needs.config.outputs.json).image_name.gcc12 }}@${{ fromJson(needs.config.outputs.json).digest.gcc12 }}
       environment: ghcr-deployment

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -13,19 +13,22 @@ on:
       cache_location:
         required: false
         type: string
+      matrix_key:
+        required: false
+        type: string
       environment:
         required: false
         type: string
     outputs:
       image_name:
         description: "The full name of the built docker image."
-        value: ${{ jobs.metadata.outputs.image_name }}
+        value: ${{ jobs.finalize.outputs.image_name }}
       digest:
         description: "The digest of the docker image, if it was deployed to the registry."
-        value: ${{ jobs.deployment.outputs.digest }}
+        value: ${{ jobs.finalize.outputs.digest }}
       cache_key:
         description: "The cache key to retrieve a tar archive containing the built image(s)."
-        value: ${{ jobs.build.outputs.tar_cache }}
+        value: ${{ jobs.finalize.outputs.tar_cache }}
 
 name: CUDA Quantum cached dev images
 
@@ -190,3 +193,25 @@ jobs:
           gh actions-cache delete ${{ needs.build.outputs.tar_cache }} -R ${{ github.repository }} --confirm
         env:
           GH_TOKEN: ${{ github.token }}
+
+  finalize:
+    name: Finalize
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [metadata, build, deployment]
+
+    outputs:
+      image_name: ${{ fromJson(steps.write_json.outputs.result).image_name }}
+      digest: ${{ fromJson(steps.write_json.outputs.result).digest }}
+      cache_key: ${{ fromJson(steps.write_json.outputs.result).cache_key }}
+
+    steps:        
+      - uses: cloudposse/github-action-matrix-outputs-write@v0.3.1
+        id: write_json
+        with:
+          #matrix-step-name: ${{ inputs.matrix-step-name }}
+          matrix-key: ${{ inputs.matrix_key }}
+          outputs: |-
+            image_name: ${{ needs.metadata.outputs.image_name }}
+            digest: ${{ needs.deployment.outputs.digest }}
+            cache_key: ${{ needs.build.outputs.tar_cache }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -13,9 +13,6 @@ on:
       cache_location:
         required: false
         type: string
-      job_id:
-        required: false
-        type: string
       matrix_key:
         required: false
         type: string
@@ -28,7 +25,7 @@ on:
         value: ${{ jobs.finalize.outputs.image_name }}
       digest:
         description: "The digest of the docker image, if it was deployed to the registry."
-        value: ${{ jobs.deployment.outputs.digest }}
+        value: ${{ jobs.finalize.outputs.digest }}
       cache_key:
         description: "The cache key to retrieve a tar archive containing the built image(s)."
         value: ${{ jobs.finalize.outputs.tar_cache }}
@@ -212,8 +209,9 @@ jobs:
       - uses: cloudposse/github-action-matrix-outputs-write@0.3.0
         id: write_json
         with:
-          matrix-step-name: ${{ inputs.job_id }}
+          matrix-step-name: ${{ inputs.matrix_key && 'dev_environment' }}
           matrix-key: ${{ inputs.matrix_key }}
           outputs: |
             image_name: ${{ needs.metadata.outputs.image_name }}
+            digest: ${{ needs.deployment.outputs.digest }}
             cache_key: ${{ needs.build.outputs.tar_cache }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -209,7 +209,7 @@ jobs:
       cache_key: ${{ fromJson(steps.write_json.outputs.result).cache_key }}
 
     steps:        
-      - uses: cloudposse/github-action-matrix-outputs-write@0.3.1
+      - uses: cloudposse/github-action-matrix-outputs-write@0.3.0
         id: write_json
         with:
           matrix-step-name: ${{ inputs.job_id }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
     inputs:
+      dockerfile:
+        required: true
+        type: string
       toolchain:
         required: true
         type: string
@@ -11,7 +14,7 @@ on:
         required: false
         type: string
 
-name: CUDA Quantum dev environment
+name: CUDA Quantum cached dev images
 
 jobs:
   metadata:
@@ -21,12 +24,15 @@ jobs:
       contents: read
 
     outputs:
+      dockerfile: ${{ steps.build_info.outputs.dockerfile }}
       image_name: ${{ steps.build_info.outputs.image_name }}
+      image_title: ${{ steps.build_info.outputs.image_title }}
       image_tags: ${{ steps.metadata.outputs.tags }}
       image_labels: ${{ steps.metadata.outputs.labels }}
       llvm_commit: ${{ steps.build_info.outputs.llvm_commit }}
       cache_target: ${{ steps.build_info.outputs.cache_target }}
       cache_base: ${{ steps.build_info.outputs.cache_base }}
+      cache_id: ${{ steps.build_info.outputs.cache_id }}
 
     steps:
       - name: Checkout repository
@@ -35,10 +41,14 @@ jobs:
       - name: Determine build arguments
         id: build_info
         run: |
+          image_name=${{ vars.registry || 'ghcr.io' }}/nvidia/cuda-quantum-devdeps
+          echo "image_name=$image_name" >> $GITHUB_OUTPUT
+          echo "image_title=$(basename $image_name)" >> $GITHUB_OUTPUT
+          echo "dockerfile=${{ inputs.dockerfile }}" >> $GITHUB_OUTPUT
           echo "llvm_commit=$(git rev-parse @:./tpls/llvm)" >> $GITHUB_OUTPUT
           echo "cache_base=${{ github.event.pull_request.base.ref || 'main' }}" >> $GITHUB_OUTPUT
           echo "cache_target=${{ inputs.cache_location || github.ref_name  }}" >> $GITHUB_OUTPUT
-          echo "image_name=${{ vars.registry || 'ghcr.io' }}/nvidia/cuda-quantum-devdeps" >> $GITHUB_OUTPUT
+          echo "cache_id=$(basename ${{ inputs.dockerfile }} .Dockerfile)" >> $GITHUB_OUTPUT
 
       - name: Extract metadata for Docker image
         id: metadata
@@ -55,11 +65,11 @@ jobs:
             type=ref,enable=true,prefix=${{ inputs.toolchain }}-pr-,event=pr
             type=ref,enable=true,event=tag
           labels: |
-            org.opencontainers.image.title=cuda-quantum-devdeps
-            org.opencontainers.image.description=Development dependencies for building and testing CUDA Quantum
+            org.opencontainers.image.title=${{ steps.build_info.outputs.image_title }}
+            org.opencontainers.image.description=Dev tools for building and testing CUDA Quantum
 
-  devdeps:
-    name: Dev environment
+  build:
+    name: Cached image
     runs-on: ubuntu-latest
     needs: metadata
     permissions:
@@ -72,12 +82,11 @@ jobs:
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v2
 
-      - name: Build cuda-quantum-devdeps image
-        id: build_devdeps
+      - name: Build ${{ needs.metadata.outputs.image_title }} image
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./docker/build/devdeps.Dockerfile
+          file: ./docker/${{ needs.metadata.outputs.dockerfile }}
           build-args: |
             llvm_commit=${{ needs.metadata.outputs.llvm_commit }}
             toolchain=${{ inputs.toolchain }}
@@ -86,24 +95,24 @@ jobs:
           labels: ${{ needs.metadata.outputs.image_labels }}
           platforms: linux/amd64
           cache-from: |
-            type=gha,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-devdeps-${{ inputs.toolchain }}
-            type=gha,scope=${{ needs.metadata.outputs.cache_base }}-cuda-quantum-devdeps-${{ inputs.toolchain }}
+            type=gha,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}
+            type=gha,scope=${{ needs.metadata.outputs.cache_base }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}
             type=registry,ref=${{ needs.metadata.outputs.image_name }}:${{ inputs.toolchain }}-${{ needs.metadata.outputs.cache_base }}
           cache-to: |
-            type=gha,mode=max,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-devdeps-${{ inputs.toolchain }}
-          outputs: type=docker,dest=/tmp/devdeps.tar
+            type=gha,mode=max,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}
+          outputs: type=docker,dest=/tmp/${{ needs.metadata.outputs.cache_id }}.tar
 
-      - name: Cache cuda-quantum-devdeps image
+      - name: Cache ${{ needs.metadata.outputs.image_title }} image
         uses: actions/cache/save@v3
         with:
-          path: /tmp/devdeps.tar
-          key: tar-devdeps-${{ inputs.toolchain }}-${{ github.sha }}
+          path: /tmp/${{ needs.metadata.outputs.cache_id }}.tar
+          key: tar-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}-${{ github.sha }}
 
   deployment:
-    name: Deploy cuda-quantum-devdeps image
+    name: Deploy ${{ needs.metadata.outputs.image_title }} image
     if: inputs.environment
     runs-on: ubuntu-latest
-    needs: [metadata, devdeps]
+    needs: [metadata, build]
 
     permissions:
       contents: read
@@ -117,8 +126,8 @@ jobs:
       - name: Load tar cache
         uses: actions/cache/restore@v3
         with:
-          path: /tmp/devdeps.tar
-          key: tar-devdeps-${{ inputs.toolchain }}-${{ github.sha }}
+          path: /tmp/${{ needs.metadata.outputs.cache_id }}.tar
+          key: tar-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Log in to the container registry
@@ -131,5 +140,5 @@ jobs:
 
       - name: Push images
         run: |
-          docker load --input /tmp/devdeps.tar
+          docker load --input /tmp/${{ needs.metadata.outputs.cache_id }}.tar
           docker push ${{ needs.metadata.outputs.image_name }} --all-tags

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -40,6 +40,7 @@ jobs:
       dockerfile: ${{ steps.build_info.outputs.dockerfile }}
       image_name: ${{ steps.build_info.outputs.image_name }}
       image_title: ${{ steps.build_info.outputs.image_title }}
+      image_id: ${{ steps.build_info.outputs.image_id }}
       image_tags: ${{ steps.metadata.outputs.tags }}
       image_labels: ${{ steps.metadata.outputs.labels }}
       llvm_commit: ${{ steps.build_info.outputs.llvm_commit }}
@@ -63,6 +64,7 @@ jobs:
 
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
           echo "image_title=$image_title" >> $GITHUB_OUTPUT
+          echo "image_id=$image_id" >> $GITHUB_OUTPUT
           echo "tag_prefix=$tag_prefix" >> $GITHUB_OUTPUT
           echo "tag_suffix=$tag_suffix" >> $GITHUB_OUTPUT
           echo "dockerfile=${{ inputs.dockerfile }}" >> $GITHUB_OUTPUT
@@ -128,7 +130,7 @@ jobs:
             type=registry,ref=${{ needs.metadata.outputs.image_name }}:${{ steps.build_info.outputs.tag_prefix }}${{ needs.metadata.outputs.cache_base }}${{ steps.build_info.outputs.tag_suffix }}
           cache-to: |
             type=gha,mode=max,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}
-          outputs: type=docker,dest=/tmp/devdeps.tar
+          outputs: type=docker,dest=/tmp/${{ needs.metadata.outputs.image_id }}.tar
 
       - name: Create cache location
         id: cache
@@ -138,7 +140,7 @@ jobs:
       - name: Cache ${{ needs.metadata.outputs.image_title }} image
         uses: actions/cache/save@v3
         with:
-          path: /tmp/devdeps.tar
+          path: /tmp/${{ needs.metadata.outputs.image_id }}.tar
           key: ${{ steps.cache.outputs.tar_cache }}
 
   deployment:
@@ -156,7 +158,7 @@ jobs:
       - name: Load tar cache
         uses: actions/cache/restore@v3
         with:
-          path: /tmp/devdeps.tar
+          path: /tmp/${{ needs.metadata.outputs.image_id }}.tar
           key: ${{ needs.build.outputs.tar_cache }}
           fail-on-cache-miss: true
 
@@ -170,7 +172,7 @@ jobs:
 
       - name: Push ${{ needs.metadata.outputs.image_title }} image
         run: |
-          docker load --input /tmp/devdeps.tar
+          docker load --input /tmp/${{ needs.metadata.outputs.image_id }}.tar
           docker push ${{ needs.metadata.outputs.image_name }} --all-tags
 
       - name: Clean up

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -55,9 +55,10 @@ jobs:
       - name: Determine build arguments
         id: build_info
         run: |
+          repo_owner=${{ github.repository_owner }}
           image_id=`basename ${{ inputs.dockerfile }} .Dockerfile`
           image_title=cuda-quantum-`echo $image_id | cut -d "." -f 1`
-          image_name=${{ vars.registry || 'ghcr.io' }}/nvidia/$image_title
+          image_name=${{ vars.registry || 'ghcr.io' }}/${repo_owner,,}/$image_title
           toolchain=${{ inputs.toolchain }}
           tag_prefix=${toolchain:+$toolchain-}
           tag_suffix=`echo $image_id | cut -d "." -f 2- | xargs -I "%" echo .% | tr . -`

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -28,7 +28,7 @@ on:
         value: ${{ jobs.finalize.outputs.image_name }}
       digest:
         description: "The digest of the docker image, if it was deployed to the registry."
-        value: ${{ jobs.finalize.outputs.digest }}
+        value: ${{ jobs.deployment.outputs.digest }}
       cache_key:
         description: "The cache key to retrieve a tar archive containing the built image(s)."
         value: ${{ jobs.finalize.outputs.tar_cache }}
@@ -214,7 +214,6 @@ jobs:
         with:
           matrix-step-name: ${{ inputs.job_id }}
           matrix-key: ${{ inputs.matrix_key }}
-          outputs: |-
+          outputs: |
             image_name: ${{ needs.metadata.outputs.image_name }}
-            digest: ${{ needs.deployment.outputs.digest }}
             cache_key: ${{ needs.build.outputs.tar_cache }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -100,7 +100,6 @@ jobs:
     name: Caching
     runs-on: ubuntu-latest
     needs: metadata
-    timeout-minutes: 600
     permissions:
       contents: read
 

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -206,7 +206,7 @@ jobs:
       cache_key: ${{ fromJson(steps.write_json.outputs.result).cache_key }}
 
     steps:        
-      - uses: cloudposse/github-action-matrix-outputs-write@v0.3.1
+      - uses: cloudposse/github-action-matrix-outputs-write@0.3.1
         id: write_json
         with:
           #matrix-step-name: ${{ inputs.matrix-step-name }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -21,8 +21,8 @@ on:
         description: "The full name of the built docker image."
         value: ${{ jobs.metadata.outputs.image_name }}
       digest:
-        description: "The digest of the built docker image."
-        value: ${{ jobs.build.outputs.digest }}
+        description: "The digest of the docker image, if it was deployed to the registry."
+        value: ${{ jobs.deployment.outputs.digest }}
       cache_key:
         description: "The cache key to retrieve a tar archive containing the built image(s)."
         value: ${{ jobs.build.outputs.tar_cache }}
@@ -101,7 +101,6 @@ jobs:
       contents: read
 
     outputs:
-      digest: ${{ steps.build_image.outputs.digest }}
       tar_cache: ${{ steps.cache.outputs.tar_cache }}
 
     steps:
@@ -151,6 +150,9 @@ jobs:
     needs: [metadata, build]
     permissions: write-all
 
+    outputs:
+      digest: ${{ steps.push_image.outputs.digest }}
+
     environment:
       name: ${{ inputs.environment }}
       url: ${{ vars.deployment_url }}
@@ -172,9 +174,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push ${{ needs.metadata.outputs.image_title }} image
+        id: push_image
         run: |
+          # Note that this may change the digest compared to the digest produced during build
+          # (the saved docker format has its own manifest that doesn't necessarily have the same bit-by-bit format...)
           docker load --input /tmp/${{ needs.metadata.outputs.image_id }}.tar
           docker push ${{ needs.metadata.outputs.image_name }} --all-tags
+          digests=`docker images ${{ needs.metadata.outputs.image_name }} --digests --format '{{.Digest}}'`
+          echo "digest=$digests" >> $GITHUB_OUTPUT
 
       - name: Clean up
         run: |

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -13,6 +13,9 @@ on:
       cache_location:
         required: false
         type: string
+      job_id:
+        required: false
+        type: string
       matrix_key:
         required: false
         type: string
@@ -209,7 +212,7 @@ jobs:
       - uses: cloudposse/github-action-matrix-outputs-write@0.3.1
         id: write_json
         with:
-          #matrix-step-name: ${{ inputs.matrix-step-name }}
+          matrix-step-name: ${{ inputs.job_id }}
           matrix-key: ${{ inputs.matrix_key }}
           outputs: |-
             image_name: ${{ needs.metadata.outputs.image_name }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -4,8 +4,11 @@ on:
       dockerfile:
         required: true
         type: string
+      base_image:
+        required: false
+        type: string
       toolchain:
-        required: true
+        required: false
         type: string
       cache_location:
         required: false
@@ -13,6 +16,16 @@ on:
       environment:
         required: false
         type: string
+    outputs:
+      image_name:
+        description: "The full name of the built docker image."
+        value: ${{ jobs.metadata.outputs.image_name }}
+      digest:
+        description: "The digest of the built docker image."
+        value: ${{ jobs.build.outputs.digest }}
+      cache_key:
+        description: "The cache key to retrieve a tar archive containing the built image(s)."
+        value: ${{ jobs.build.outputs.tar_cache }}
 
 name: CUDA Quantum cached dev images
 
@@ -41,39 +54,52 @@ jobs:
       - name: Determine build arguments
         id: build_info
         run: |
-          image_name=${{ vars.registry || 'ghcr.io' }}/nvidia/cuda-quantum-devdeps
+          image_id=`basename ${{ inputs.dockerfile }} .Dockerfile`
+          image_title=cuda-quantum-`echo $image_id | cut -d "." -f 1`
+          image_name=${{ vars.registry || 'ghcr.io' }}/nvidia/$image_title
+          toolchain=${{ inputs.toolchain }}
+          tag_prefix=${toolchain:+$toolchain-}
+          tag_suffix=`echo $image_id | cut -d "." -f 2- | xargs -I "%" echo .% | tr . -`
+
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
-          echo "image_title=$(basename $image_name)" >> $GITHUB_OUTPUT
+          echo "image_title=$image_title" >> $GITHUB_OUTPUT
+          echo "tag_prefix=$tag_prefix" >> $GITHUB_OUTPUT
+          echo "tag_suffix=$tag_suffix" >> $GITHUB_OUTPUT
           echo "dockerfile=${{ inputs.dockerfile }}" >> $GITHUB_OUTPUT
           echo "llvm_commit=$(git rev-parse @:./tpls/llvm)" >> $GITHUB_OUTPUT
           echo "cache_base=${{ github.event.pull_request.base.ref || 'main' }}" >> $GITHUB_OUTPUT
-          echo "cache_target=${{ inputs.cache_location || github.ref_name  }}" >> $GITHUB_OUTPUT
-          echo "cache_id=$(basename ${{ inputs.dockerfile }} .Dockerfile)" >> $GITHUB_OUTPUT
+          echo "cache_target=${{ inputs.cache_location || github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "cache_id=$(echo $image_id | tr . -)${toolchain:+-$toolchain}" >> $GITHUB_OUTPUT
 
       - name: Extract metadata for Docker image
         id: metadata
         uses: docker/metadata-action@v4
         with:
-          images: ${{ steps.build_info.outputs.image_name  }}
+          images: ${{ steps.build_info.outputs.image_name }}
           flavor: |
             latest=false
-            prefix=${{ inputs.toolchain }}-,onlatest=true
+            prefix=${{ steps.build_info.outputs.tag_prefix }},onlatest=true
+            suffix=${{ steps.build_info.outputs.tag_suffix }},onlatest=true
           tags: |
             # workflow dispatch is covered by these
             type=schedule,enable=true,pattern=nightly
             type=ref,enable=true,event=branch
-            type=ref,enable=true,prefix=${{ inputs.toolchain }}-pr-,event=pr
+            type=ref,enable=true,prefix=${{ steps.build_info.outputs.tag_prefix }}pr-,event=pr
             type=ref,enable=true,event=tag
           labels: |
             org.opencontainers.image.title=${{ steps.build_info.outputs.image_title }}
             org.opencontainers.image.description=Dev tools for building and testing CUDA Quantum
 
   build:
-    name: Cached image
+    name: Caching
     runs-on: ubuntu-latest
     needs: metadata
     permissions:
       contents: read
+
+    outputs:
+      digest: ${{ steps.build_image.outputs.digest }}
+      tar_cache: ${{ steps.cache.outputs.tar_cache }}
 
     steps:
       - name: Checkout repository
@@ -83,40 +109,44 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build ${{ needs.metadata.outputs.image_title }} image
+        id: build_image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./docker/${{ needs.metadata.outputs.dockerfile }}
           build-args: |
-            llvm_commit=${{ needs.metadata.outputs.llvm_commit }}
+            base_image=${{ inputs.base_image }}
             toolchain=${{ inputs.toolchain }}
+            llvm_commit=${{ needs.metadata.outputs.llvm_commit }}
           load: false
           tags: ${{ needs.metadata.outputs.image_tags }}
           labels: ${{ needs.metadata.outputs.image_labels }}
           platforms: linux/amd64
           cache-from: |
-            type=gha,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}
-            type=gha,scope=${{ needs.metadata.outputs.cache_base }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}
-            type=registry,ref=${{ needs.metadata.outputs.image_name }}:${{ inputs.toolchain }}-${{ needs.metadata.outputs.cache_base }}
+            type=gha,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}
+            type=gha,scope=${{ needs.metadata.outputs.cache_base }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}
+            type=registry,ref=${{ needs.metadata.outputs.image_name }}:${{ steps.build_info.outputs.tag_prefix }}${{ needs.metadata.outputs.cache_base }}${{ steps.build_info.outputs.tag_suffix }}
           cache-to: |
-            type=gha,mode=max,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}
+            type=gha,mode=max,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}
           outputs: type=docker,dest=/tmp/${{ needs.metadata.outputs.cache_id }}.tar
+
+      - name: Create cache location
+        id: cache
+        run: |
+          echo "tar_cache=tar-${{ needs.metadata.outputs.cache_id }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Cache ${{ needs.metadata.outputs.image_title }} image
         uses: actions/cache/save@v3
         with:
           path: /tmp/${{ needs.metadata.outputs.cache_id }}.tar
-          key: tar-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}-${{ github.sha }}
+          key: ${{ steps.cache.outputs.tar_cache }}
 
   deployment:
-    name: Deploy ${{ needs.metadata.outputs.image_title }} image
+    name: Deployment
     if: inputs.environment
     runs-on: ubuntu-latest
     needs: [metadata, build]
-
-    permissions:
-      contents: read
-      packages: write
+    permissions: write-all
 
     environment:
       name: ${{ inputs.environment }}
@@ -127,7 +157,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: /tmp/${{ needs.metadata.outputs.cache_id }}.tar
-          key: tar-${{ needs.metadata.outputs.cache_id }}-${{ inputs.toolchain }}-${{ github.sha }}
+          key: ${{ needs.build.outputs.tar_cache }}
           fail-on-cache-miss: true
 
       - name: Log in to the container registry
@@ -138,7 +168,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push images
+      - name: Push ${{ needs.metadata.outputs.image_title }} image
         run: |
           docker load --input /tmp/${{ needs.metadata.outputs.cache_id }}.tar
           docker push ${{ needs.metadata.outputs.image_name }} --all-tags
+
+      - name: Clean up
+        run: |
+          gh extension install actions/gh-actions-cache
+          echo "Deleting cache $key"
+          gh actions-cache delete ${{ needs.build.outputs.tar_cache }} -R ${{ github.repository }} --confirm
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -7,7 +7,7 @@ on:
       cache_location:
         required: false
         type: string
-      container_registry:
+      environment:
         required: false
         type: string
 
@@ -27,7 +27,6 @@ jobs:
       llvm_commit: ${{ steps.build_info.outputs.llvm_commit }}
       cache_target: ${{ steps.build_info.outputs.cache_target }}
       cache_base: ${{ steps.build_info.outputs.cache_base }}
-      output: ${{ steps.build_info.outputs.output }}
 
     steps:
       - name: Checkout repository
@@ -36,17 +35,10 @@ jobs:
       - name: Determine build arguments
         id: build_info
         run: |
-          image_name="${{ inputs.container_registry || 'ghcr.io' }}/nvidia/cuda-quantum-devdeps"
-          if ${{ inputs.container_registry != '' }}; then
-            output="type=registry,name=$image_name"
-          else
-            output="type=docker,dest=/tmp/devdeps.tar"
-          fi
           echo "llvm_commit=$(git rev-parse @:./tpls/llvm)" >> $GITHUB_OUTPUT
           echo "cache_base=${{ github.event.pull_request.base.ref || 'main' }}" >> $GITHUB_OUTPUT
           echo "cache_target=${{ inputs.cache_location || github.ref_name  }}" >> $GITHUB_OUTPUT
-          echo "image_name=$image_name" >> $GITHUB_OUTPUT
-          echo "output=$output" >> $GITHUB_OUTPUT
+          echo "image_name=${{ vars.registry || 'ghcr.io' }}/nvidia/cuda-quantum-devdeps" >> $GITHUB_OUTPUT
 
       - name: Extract metadata for Docker image
         id: metadata
@@ -72,7 +64,6 @@ jobs:
     needs: metadata
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -81,15 +72,7 @@ jobs:
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v2
 
-      - name: Log in to the container registry
-        uses: docker/login-action@v2
-        if: inputs.container_registry != ''
-        with:
-          registry: ${{ inputs.container_registry }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build image and push if requested
+      - name: Build cuda-quantum-devdeps image
         id: build_devdeps
         uses: docker/build-push-action@v4
         with:
@@ -108,11 +91,45 @@ jobs:
             type=registry,ref=${{ needs.metadata.outputs.image_name }}:${{ inputs.toolchain }}-${{ needs.metadata.outputs.cache_base }}
           cache-to: |
             type=gha,mode=max,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-devdeps-${{ inputs.toolchain }}
-          outputs: ${{ needs.metadata.outputs.output }}
+          outputs: type=docker,dest=/tmp/devdeps.tar
 
       - name: Cache cuda-quantum-devdeps image
-        if: inputs.container_registry == ''
         uses: actions/cache/save@v3
         with:
           path: /tmp/devdeps.tar
           key: tar-devdeps-${{ inputs.toolchain }}-${{ github.sha }}
+
+  deployment:
+    name: Deploy cuda-quantum-devdeps image
+    if: inputs.environment
+    runs-on: ubuntu-latest
+    needs: [metadata, devdeps]
+
+    permissions:
+      contents: read
+      packages: write
+
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ vars.deployment_url }}
+
+    steps:
+      - name: Load tar cache
+        uses: actions/cache/restore@v3
+        with:
+          path: /tmp/devdeps.tar
+          key: tar-devdeps-${{ inputs.toolchain }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        if: vars.registry != ''
+        with:
+          registry: ${{ vars.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push images
+        run: |
+          docker load --input /tmp/devdeps.tar
+          docker push ${{ needs.metadata.outputs.image_name }} --all-tags

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -128,7 +128,7 @@ jobs:
             type=registry,ref=${{ needs.metadata.outputs.image_name }}:${{ steps.build_info.outputs.tag_prefix }}${{ needs.metadata.outputs.cache_base }}${{ steps.build_info.outputs.tag_suffix }}
           cache-to: |
             type=gha,mode=max,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}
-          outputs: type=docker,dest=/tmp/${{ needs.metadata.outputs.cache_id }}.tar
+          outputs: type=docker,dest=/tmp/devdeps.tar
 
       - name: Create cache location
         id: cache
@@ -138,7 +138,7 @@ jobs:
       - name: Cache ${{ needs.metadata.outputs.image_title }} image
         uses: actions/cache/save@v3
         with:
-          path: /tmp/${{ needs.metadata.outputs.cache_id }}.tar
+          path: /tmp/devdeps.tar
           key: ${{ steps.cache.outputs.tar_cache }}
 
   deployment:
@@ -156,7 +156,7 @@ jobs:
       - name: Load tar cache
         uses: actions/cache/restore@v3
         with:
-          path: /tmp/${{ needs.metadata.outputs.cache_id }}.tar
+          path: /tmp/devdeps.tar
           key: ${{ needs.build.outputs.tar_cache }}
           fail-on-cache-miss: true
 
@@ -170,7 +170,7 @@ jobs:
 
       - name: Push ${{ needs.metadata.outputs.image_title }} image
         run: |
-          docker load --input /tmp/${{ needs.metadata.outputs.cache_id }}.tar
+          docker load --input /tmp/devdeps.tar
           docker push ${{ needs.metadata.outputs.image_name }} --all-tags
 
       - name: Clean up

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -100,6 +100,7 @@ jobs:
     name: Caching
     runs-on: ubuntu-latest
     needs: metadata
+    timeout-minutes: 600
     permissions:
       contents: read
 

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -61,7 +61,7 @@ jobs:
           image_name=${{ vars.registry || 'ghcr.io' }}/${repo_owner,,}/$image_title
           toolchain=${{ inputs.toolchain }}
           tag_prefix=${toolchain:+$toolchain-}
-          tag_suffix=`echo $image_id | cut -d "." -f 2- | xargs -I "%" echo .% | tr . -`
+          tag_suffix=`echo $image_id | cut -s -d "." -f 2- | xargs -I "%" echo .% | tr . -`
 
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
           echo "image_title=$image_title" >> $GITHUB_OUTPUT

--- a/docker/build/cudaqdev.Dockerfile
+++ b/docker/build/cudaqdev.Dockerfile
@@ -24,6 +24,7 @@
 # or use a suitable build_environment, to enable developing these components.
 ARG build_environment=ghcr.io/nvidia/cuda-quantum-devdeps
 ARG env_tag=llvm-main
+
 FROM $build_environment:$env_tag
 
 ENV CUDAQ_REPO_ROOT=/workspaces/cuda-quantum

--- a/docker/build/devdeps.Dockerfile
+++ b/docker/build/devdeps.Dockerfile
@@ -99,7 +99,7 @@ ENV PATH="$PATH:$LLVM_INSTALL_PREFIX/bin/"
 
 # Install the C++ standard library. We could alternatively build libc++ 
 # as part of the LLVM build and compile against that instead of libstdc++.
-RUN apt-get update && apt-get install -y --no-install-recommends libstdc++-11-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends libstdc++-12-dev \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/c++/11/:/usr/include/x86_64-linux-gnu/c++/11"
 

--- a/docker/build/devdeps.ext.Dockerfile
+++ b/docker/build/devdeps.ext.Dockerfile
@@ -7,8 +7,9 @@
 # ============================================================================ #
 
 # This file extends the CUDA Quantum development dependencies to include the necessary 
-# dependencies for GPU components and backends. This image include a CUDA and OpenMPI
-# installation.
+# dependencies for GPU components and backends. This image include an OpenMPI
+# installation as well as the configured CUDA packages. Which CUDA packages are 
+# included is defined by the cuda_packages argument. 
 #
 # Usage:
 # Must be built from the repo root with:
@@ -278,9 +279,13 @@ ENV LD_LIBRARY_PATH="$CUTENSOR_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
 
 # Install CUDA 11.8.
 
+# cuda-compiler-11-8 cuda-cudart-11-8 cuda-cccl-11-8
+# cuda-cudart-dev-11-8
+# cuda-command-line-tools-11-8n
+ARG cuda_packages=cuda-cudart-11-8
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb \
     && dpkg -i cuda-keyring_1.0-1_all.deb \
-    && apt-get update && apt-get install -y --no-install-recommends cuda-11-8 \
+    && apt-get update && apt-get install -y --no-install-recommends $cuda_packages \
     && rm cuda-keyring_1.0-1_all.deb \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
 

--- a/docker/build/devdeps.ext.Dockerfile
+++ b/docker/build/devdeps.ext.Dockerfile
@@ -12,13 +12,12 @@
 #
 # Usage:
 # Must be built from the repo root with:
-#   docker build -t ghcr.io/nvidia/cuda-quantum-devdeps:${toolchain}-ext-latest -f docker/build/extdevdeps.Dockerfile .
+#   docker build -t ghcr.io/nvidia/cuda-quantum-devdeps:${toolchain}-ext -f docker/build/devdeps.ext.Dockerfile .
 #
 # The variable $toolchain should indicate which compiler toolchain the development environment 
 # which this image extends is configure with; see also docker/build/devdeps.Dockerfile.
 
-ARG devdepsbase=ghcr.io/nvidia/cuda-quantum-devdeps
-ARG devdepsbase_tag=llvm-main
+ARG base_image=ghcr.io/nvidia/cuda-quantum-devdeps:gcc11-main
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as ompibuild
 SHELL ["/bin/bash", "-c"]
@@ -164,7 +163,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 
 # Build the final image that has CUDA Quantum and all its dev dependencies installed, as well as
 # OpenMPI, its dependencies, and additional tools for developing CUDA Quantum backends and extensions.
-FROM $devdepsbase:$devdepsbase_tag
+FROM $base_image
 SHELL ["/bin/bash", "-c"]
 
 # When a dialogue box would be needed during install, assume default configurations.

--- a/docker/build/devdeps.ext.Dockerfile
+++ b/docker/build/devdeps.ext.Dockerfile
@@ -17,7 +17,7 @@
 # The variable $toolchain should indicate which compiler toolchain the development environment 
 # which this image extends is configure with; see also docker/build/devdeps.Dockerfile.
 
-ARG base_image=ghcr.io/nvidia/cuda-quantum-devdeps:gcc11-main
+ARG base_image=ghcr.io/nvidia/cuda-quantum-devdeps:gcc12-main
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as ompibuild
 SHELL ["/bin/bash", "-c"]

--- a/docker/build/extdevdeps.Dockerfile
+++ b/docker/build/extdevdeps.Dockerfile
@@ -1,0 +1,302 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# This file extends the CUDA Quantum development dependencies to include the necessary 
+# dependencies for GPU components and backends. This image include a CUDA and OpenMPI
+# installation.
+#
+# Usage:
+# Must be built from the repo root with:
+#   docker build -t ghcr.io/nvidia/cuda-quantum-devdeps:${toolchain}-ext-latest -f docker/build/extdevdeps.Dockerfile .
+#
+# The variable $toolchain should indicate which compiler toolchain the development environment 
+# which this image extends is configure with; see also docker/build/devdeps.Dockerfile.
+
+ARG devdepsbase=ghcr.io/nvidia/cuda-quantum-devdeps
+ARG devdepsbase_tag=llvm-main
+
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as ompibuild
+SHELL ["/bin/bash", "-c"]
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV CUDA_INSTALL_PREFIX=/usr/local/cuda-11.8
+ENV COMMON_COMPILER_FLAGS="-march=x86-64-v3 -mtune=generic -O2 -pipe"
+
+# 1 - Install basic tools needed for the builds
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc g++ gfortran python3 python3-pip \
+        libcurl4-openssl-dev libssl-dev liblapack-dev libpython3-dev \
+        bzip2 make sudo vim curl git wget \
+    && pip install --no-cache-dir numpy \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# 2 - Install SLURM PMI2 version 21.08.8
+
+ENV PMI_INSTALL_PREFIX=/usr/local/pmi
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-21.08.8.tar.bz2 && \
+    && tar -x -f /var/tmp/slurm-21.08.8.tar.bz2 -C /var/tmp -j && cd /var/tmp/slurm-21.08.8 \
+    &&  CC=gcc CFLAGS="$COMMON_COMPILER_FLAGS" \
+        CXX=g++ CXXFLAGS="$COMMON_COMPILER_FLAGS" \
+        F77=gfortran F90=gfortran FFLAGS="$COMMON_COMPILER_FLAGS" \
+        FC=gfortran FCFLAGS="$COMMON_COMPILER_FLAGS" \
+        LDFLAGS=-Wl,--as-needed \
+        ./configure --prefix="$PMI_INSTALL_PREFIX" \
+    && make -C contribs/pmi2 install \
+    && rm -rf /var/tmp/slurm-21.08.8 /var/tmp/slurm-21.08.8.tar.bz2
+
+# 3 - Install Mellanox OFED version 5.3-1.0.0.1
+
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - \
+    && mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.3-1.0.0.1/ubuntu20.04/mellanox_mlnx_ofed.list \
+    && apt-get update -y && apt-get install -y --no-install-recommends \
+        ibverbs-providers ibverbs-utils \
+        libibmad-dev libibmad5 libibumad-dev libibumad3 \
+        libibverbs-dev libibverbs1 \
+        librdmacm-dev librdmacm1 \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# 4 - Install GDRCOPY version 2.1
+
+ENV GDRCOPY_INSTALL_PREFIX=/usr/local/gdrcopy
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+        autoconf automake \
+        libgcrypt20-dev libnuma-dev libtool \
+    && mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.1.tar.gz \
+    && tar -x -f /var/tmp/v2.1.tar.gz -C /var/tmp -z && cd /var/tmp/gdrcopy-2.1 \
+    && mkdir -p "$GDRCOPY_INSTALL_PREFIX/include" "$GDRCOPY_INSTALL_PREFIX/lib64" \
+    && make PREFIX="$GDRCOPY_INSTALL_PREFIX" lib lib_install \
+    && echo "$GDRCOPY_INSTALL_PREFIX/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
+    && rm -rf /var/tmp/gdrcopy-2.1 /var/tmp/v2.1.tar.gz \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+ENV CPATH="$GDRCOPY_INSTALL_PREFIX/include:$CPATH"
+ENV LIBRARY_PATH="$GDRCOPY_INSTALL_PREFIX/lib64:$LIBRARY_PATH"
+
+# 5 - Install UCX version v1.13.1
+
+ENV UCX_INSTALL_PREFIX=/usr/local/ucx
+RUN mkdir -p /var/tmp && cd /var/tmp \
+    && git clone https://github.com/openucx/ucx.git ucx && cd /var/tmp/ucx \
+    && git checkout v1.13.1 \
+    && ./autogen.sh \
+    &&  CC=gcc CFLAGS="$COMMON_COMPILER_FLAGS" \
+        CXX=g++ CXXFLAGS="$COMMON_COMPILER_FLAGS" \
+        F77=gfortran F90=gfortran FFLAGS="$COMMON_COMPILER_FLAGS" \
+        FC=gfortran FCFLAGS="$COMMON_COMPILER_FLAGS" \
+        LDFLAGS=-Wl,--as-needed \
+        ./configure --prefix="$UCX_INSTALL_PREFIX" \
+            --with-cuda="$CUDA_INSTALL_PREFIX" --with-gdrcopy="$GDRCOPY_INSTALL_PREFIX" \
+            --disable-assertions --disable-backtrace-detail --disable-debug \
+            --disable-params-check --disable-static \
+            --disable-doxygen-doc --disable-logging \
+            --enable-mt \
+    && make -j$(nproc) && make -j$(nproc) install \
+    && rm -rf /var/tmp/ucx
+
+# 6 - Install MUNGE version 0.5.14
+
+ENV MUNGE_INSTALL_PREFIX=/usr/local/munge
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/dun/munge/releases/download/munge-0.5.14/munge-0.5.14.tar.xz \
+    && tar -x -f /var/tmp/munge-0.5.14.tar.xz -C /var/tmp -J && cd /var/tmp/munge-0.5.14 \
+    &&  CC=gcc CFLAGS="$COMMON_COMPILER_FLAGS" \
+        CXX=g++ CXXFLAGS="$COMMON_COMPILER_FLAGS" \
+        F77=gfortran F90=gfortran FFLAGS="$COMMON_COMPILER_FLAGS" \
+        FC=gfortran FCFLAGS="$COMMON_COMPILER_FLAGS" \
+        LDFLAGS=-Wl,--as-needed \
+        ./configure --prefix="$MUNGE_INSTALL_PREFIX" \
+    && make -j$(nproc) && make -j$(nproc) install \
+    && rm -rf /var/tmp/munge-0.5.14 /var/tmp/munge-0.5.14.tar.xz
+
+# 7 - Install PMIX version 3.2.3
+
+ENV PMIX_INSTALL_PREFIX=/usr/local/pmix
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+        hwloc libevent-dev \
+    && mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openpmix/openpmix/releases/download/v3.2.3/pmix-3.2.3.tar.gz \
+    && tar -x -f /var/tmp/pmix-3.2.3.tar.gz -C /var/tmp -z && cd /var/tmp/pmix-3.2.3 \
+    &&  CC=gcc CFLAGS="$COMMON_COMPILER_FLAGS" \
+        CXX=g++ CXXFLAGS="$COMMON_COMPILER_FLAGS" \
+        F77=gfortran F90=gfortran FFLAGS="$COMMON_COMPILER_FLAGS" \
+        FC=gfortran FCFLAGS="$COMMON_COMPILER_FLAGS" \
+        LDFLAGS=-Wl,--as-needed \
+        ./configure --prefix="$PMIX_INSTALL_PREFIX" \
+            --with-munge="$MUNGE_INSTALL_PREFIX" \
+    && make -j$(nproc) && make -j$(nproc) install \
+    && rm -rf /var/tmp/pmix-3.2.3 /var/tmp/pmix-3.2.3.tar.gz \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+ENV CPATH="$PMIX_INSTALL_PREFIX/include:$CPATH" \
+    LD_LIBRARY_PATH="$PMIX_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH" \
+    PATH="$PMIX_INSTALL_PREFIX/bin:$PATH"
+
+# 8 - Install OMPI version 4.1.4
+
+ENV OPENMPI_INSTALL_PREFIX=/usr/local/openmpi
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+        flex openssh-client \
+    && mkdir -p /var/tmp && cd /var/tmp \
+    && git clone https://github.com/open-mpi/ompi.git ompi && cd /var/tmp/ompi \
+    && git checkout v4.1.4 \
+    && ./autogen.pl \
+    &&  CC=gcc CFLAGS="$COMMON_COMPILER_FLAGS" \
+        CXX=g++ CXXFLAGS="$COMMON_COMPILER_FLAGS" \
+        F77=gfortran F90=gfortran FFLAGS="$COMMON_COMPILER_FLAGS" \
+        FC=gfortran FCFLAGS="$COMMON_COMPILER_FLAGS" \
+        LDFLAGS=-Wl,--as-needed \
+        ./configure --prefix="$OPENMPI_INSTALL_PREFIX" \
+            --disable-getpwuid --disable-static \
+            --disable-debug --disable-mem-debug --disable-mem-profile --disable-memchecker \
+            --enable-mca-no-build=btl-uct --enable-mpi1-compatibility --enable-oshmem \
+            --with-cuda="$CUDA_INSTALL_PREFIX" \
+            --with-slurm --with-pmi="$PMI_INSTALL_PREFIX" \
+            --with-pmix="$PMIX_INSTALL_PREFIX" \
+            --with-ucx="$UCX_INSTALL_PREFIX" \
+            --without-verbs \
+    && make -j$(nproc) && make -j$(nproc) install \
+    && rm -rf /var/tmp/ompi \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# Build the final image that has CUDA Quantum and all its dev dependencies installed, as well as
+# OpenMPI, its dependencies, and additional tools for developing CUDA Quantum backends and extensions.
+FROM $devdepsbase:$devdepsbase_tag
+SHELL ["/bin/bash", "-c"]
+
+# When a dialogue box would be needed during install, assume default configurations.
+# Set here to avoid setting it for all install commands. 
+# Given as arg to make sure that this value is only set during build but not in the launched container.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt-get install -y --no-install-recommends \
+        ca-certificates openssl wget \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# Install Mellanox OFED runtime dependencies.
+
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - \
+    && mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.3-1.0.0.1/ubuntu20.04/mellanox_mlnx_ofed.list \
+    && apt-get update -y && apt-get install -y --no-install-recommends \
+        ibverbs-providers ibverbs-utils \
+        libibmad5 libibumad3 libibverbs1 librdmacm1 \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# Copy over SLURM PMI2.
+
+COPY --from=ompibuild /usr/local/pmi /usr/local/pmi
+ENV PMI_INSTALL_PREFIX=/usr/local/pmi
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PMIX_INSTALL_PREFIX/lib"
+
+# Copy over GDRCOPY and install runtime dependencies.
+
+COPY --from=ompibuild /usr/local/gdrcopy /usr/local/gdrcopy
+ENV GDRCOPY_INSTALL_PREFIX=/usr/local/gdrcopy
+ENV CPATH="$GDRCOPY_INSTALL_PREFIX/include:$CPATH"
+ENV LIBRARY_PATH="$GDRCOPY_INSTALL_PREFIX/lib64:$LIBRARY_PATH"
+
+RUN echo "$GDRCOPY_INSTALL_PREFIX/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
+    apt-get update -y && apt-get install -y --no-install-recommends \
+        libgcrypt20 libnuma1 \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# Copy over UCX.
+
+COPY --from=ompibuild /usr/local/ucx /usr/local/ucx
+ENV UCX_INSTALL_PREFIX=/usr/local/ucx
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$UCX_INSTALL_PREFIX/lib"
+
+# Copy over MUNGE.
+
+COPY --from=ompibuild /usr/local/munge /usr/local/munge
+ENV MUNGE_INSTALL_PREFIX=/usr/local/munge
+
+# Copy over PMIX and install runtime dependencies.
+
+COPY --from=pmixbuild /usr/local/pmix /usr/local/pmix
+ENV PMIX_INSTALL_PREFIX=/usr/local/pmix
+ENV PATH="$PMIX_INSTALL_PREFIX/bin:$PATH"
+ENV CPATH="$PMIX_INSTALL_PREFIX/include:$CPATH"
+ENV LD_LIBRARY_PATH="$PMIX_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+        hwloc libevent-dev \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# Copy over OpenMPI and install runtime dependencies.
+
+COPY --from=ompibuild /usr/local/openmpi /usr/local/openmpi
+ENV OPENMPI_INSTALL_PREFIX=/usr/local/openmpi
+ENV MPI_HOME="$OPENMPI_INSTALL_PREFIX"
+ENV MPI_ROOT="$OPENMPI_INSTALL_PREFIX"
+ENV PATH="$PATH:$OPENMPI_INSTALL_PREFIX/bin"
+ENV CPATH="$OPENMPI_INSTALL_PREFIX/include:/usr/local/ofed/5.0-0/include:$CPATH"
+ENV LIBRARY_PATH="/usr/local/ofed/5.0-0/lib:$LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENMPI_INSTALL_PREFIX/lib"
+
+RUN echo "/usr/local/openmpi/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
+    && apt-get update -y && apt-get install -y --no-install-recommends \
+        flex openssh-client \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# Set some configurations in the form of environment variables.
+
+ENV OMPI_MCA_btl=^smcuda,vader,tcp,uct,openib
+ENV OMPI_MCA_pml=ucx
+ENV UCX_IB_PCI_RELAXED_ORDERING=on
+ENV UCX_MAX_RNDV_RAILS=1
+ENV UCX_MEMTYPE_CACHE=n
+ENV UCX_TLS=rc,cuda_copy,cuda_ipc,gdr_copy,sm
+
+# Install cuQuantum libraries.
+
+RUN apt-get update && apt-get install -y --no-install-recommends xz-utils \
+    && wget https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-x86_64/cuquantum-linux-x86_64-22.11.0.13-archive.tar.xz \
+    && tar xf cuquantum-linux-x86_64-22.11.0.13-archive.tar.xz \
+    && mkdir -p /opt/nvidia && mv cuquantum-linux-x86_64-22.11.0.13-archive /opt/nvidia/cuquantum \
+    && cd / && rm -rf cuquantum-linux-x86_64-22.11.0.13-archive.tar.xz \
+    && apt-get remove -y xz-utils \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+ENV CUQUANTUM_INSTALL_PREFIX=/opt/nvidia/cuquantum
+ENV LD_LIBRARY_PATH="$CUQUANTUM_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
+
+# Install cuTensor libraries.
+RUN apt-get update && apt-get install -y --no-install-recommends xz-utils \
+    && wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/libcutensor-linux-x86_64-1.6.2.3-archive.tar.xz \
+    && tar xf libcutensor-linux-x86_64-1.6.2.3-archive.tar.xz && cd libcutensor-linux-x86_64-1.6.2.3-archive \
+    && mkdir -p /opt/nvidia/cutensor && mv include /opt/nvidia/cutensor/ && mv lib/11 /opt/nvidia/cutensor/lib \
+    && cd / && rm -rf libcutensor-linux-x86_64-1.6.2.3-archive* \
+    && apt-get remove -y xz-utils \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+ENV CUTENSOR_INSTALL_PREFIX=/opt/nvidia/cutensor
+ENV LD_LIBRARY_PATH="$CUTENSOR_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
+
+# Install CUDA 11.8.
+
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb \
+    && dpkg -i cuda-keyring_1.0-1_all.deb \
+    && apt-get update && apt-get install -y --no-install-recommends cuda-11-8 \
+    && rm cuda-keyring_1.0-1_all.deb \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# The installation of CUDA above creates files that will be injected upon launching the container
+# with the --gpu=all flag. This creates issues upon container launch. We hence remove these files.
+# As long as the container is launched with the --gpu=all flag, the GPUs remain accessible and CUDA
+# is fully functional. See also https://github.com/NVIDIA/nvidia-docker/issues/1699.
+RUN rm -rf \
+    /usr/lib/x86_64-linux-gnu/libcuda.so* \
+    /usr/lib/x86_64-linux-gnu/libnvcuvid.so* \
+    /usr/lib/x86_64-linux-gnu/libnvidia-*.so* \
+    /usr/lib/firmware \
+    /usr/local/cuda/compat/lib
+
+ENV CUDA_INSTALL_PREFIX=/usr/local/cuda-11.8
+ENV CUDA_HOME="$CUDA_INSTALL_PREFIX"
+ENV CUDA_ROOT="$CUDA_INSTALL_PREFIX"
+ENV CUDA_PATH="$CUDA_INSTALL_PREFIX"
+ENV PATH="${CUDA_INSTALL_PREFIX}/lib64/:${PATH}:${CUDA_INSTALL_PREFIX}/bin"
+ENV LD_LIBRARY_PATH="${CUDA_INSTALL_PREFIX}/lib64:${CUDA_INSTALL_PREFIX}/extras/CUPTI/lib64:${LD_LIBRARY_PATH}"

--- a/docker/build/extdevdeps.Dockerfile
+++ b/docker/build/extdevdeps.Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # 2 - Install SLURM PMI2 version 21.08.8
 
 ENV PMI_INSTALL_PREFIX=/usr/local/pmi
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-21.08.8.tar.bz2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-21.08.8.tar.bz2 \
     && tar -x -f /var/tmp/slurm-21.08.8.tar.bz2 -C /var/tmp -j && cd /var/tmp/slurm-21.08.8 \
     &&  CC=gcc CFLAGS="$COMMON_COMPILER_FLAGS" \
         CXX=g++ CXXFLAGS="$COMMON_COMPILER_FLAGS" \
@@ -177,11 +177,13 @@ RUN apt update && apt-get install -y --no-install-recommends \
 
 # Install Mellanox OFED runtime dependencies.
 
-RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - \
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg \
+    && wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - \
     && mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.3-1.0.0.1/ubuntu20.04/mellanox_mlnx_ofed.list \
     && apt-get update -y && apt-get install -y --no-install-recommends \
         ibverbs-providers ibverbs-utils \
         libibmad5 libibumad3 libibverbs1 librdmacm1 \
+    && apt-get remove -y gnupg \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 # Copy over SLURM PMI2.
@@ -198,7 +200,7 @@ ENV CPATH="$GDRCOPY_INSTALL_PREFIX/include:$CPATH"
 ENV LIBRARY_PATH="$GDRCOPY_INSTALL_PREFIX/lib64:$LIBRARY_PATH"
 
 RUN echo "$GDRCOPY_INSTALL_PREFIX/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
-    apt-get update -y && apt-get install -y --no-install-recommends \
+    && apt-get update -y && apt-get install -y --no-install-recommends \
         libgcrypt20 libnuma1 \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
 
@@ -215,7 +217,7 @@ ENV MUNGE_INSTALL_PREFIX=/usr/local/munge
 
 # Copy over PMIX and install runtime dependencies.
 
-COPY --from=pmixbuild /usr/local/pmix /usr/local/pmix
+COPY --from=ompibuild /usr/local/pmix /usr/local/pmix
 ENV PMIX_INSTALL_PREFIX=/usr/local/pmix
 ENV PATH="$PMIX_INSTALL_PREFIX/bin:$PATH"
 ENV CPATH="$PMIX_INSTALL_PREFIX/include:$CPATH"

--- a/docker/release/cudaq.Dockerfile
+++ b/docker/release/cudaq.Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip libpython3-dev \
-        libstdc++-11-dev \
+        libstdc++-12-dev \
         libcurl4-openssl-dev libssl-dev \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python3 -m pip install --no-cache-dir numpy \

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -84,7 +84,7 @@ if [ -z "${llvm_projects##*lld;*}" ]; then
 fi
 echo "- including general tools and components"
 llvm_components+="cmake-exports;llvm-headers;llvm-libraries;"
-llvm_components+="llvm-config;llc;FileCheck;count;not;"
+llvm_components+="llvm-config;llvm-ar;llc;FileCheck;count;not;"
 
 if [ "$(echo ${projects[*]} | xargs)" != "" ]; then
   echo "- including additional projects "$(echo "${projects[*]}" | xargs | tr ' ' ',')

--- a/scripts/install_toolchain.sh
+++ b/scripts/install_toolchain.sh
@@ -100,6 +100,8 @@ elif [ "$toolchain" = "llvm" ]; then
         temp_install_if_command_unknown g++ g++
         LLVM_INSTALL_PREFIX="$LLVM_INSTALL_PREFIX" bash "$this_file_dir/build_llvm.sh" -s "$LLVM_SOURCE" -c Release -p "clang;lld"
         if [ -d "$llvm_tmp_dir" ]; then
+            echo "The build logs have been moved to $LLVM_INSTALL_PREFIX/logs."
+            mkdir -p "$LLVM_INSTALL_PREFIX/logs" && mv "$llvm_tmp_dir/build/logs"/* "$LLVM_INSTALL_PREFIX/logs/"
             rm -rf "$llvm_tmp_dir"
         fi
     fi
@@ -144,5 +146,6 @@ if [ -x "$(command -v "$CC")" ] && [ -x "$(command -v "$CXX")" ]; then
     fi
 else
     echo "Failed to install $toolchain toolchain."
+    unset CC && unset CXX
     if $is_sourced; then return 10; else exit 10; fi
 fi


### PR DESCRIPTION
### Description

This PR takes care of the second prerequisite for https://github.com/NVIDIA/cuda-quantum/issues/41, as well as the remaining work items for https://github.com/NVIDIA/cuda-quantum/issues/57.

Specifically, it contains the following changes:
- Updates the CUDA Quantum Docker image to use the libstdc++-12.
- Adds llvm to the CI build and removes clang15 and gcc11.
- Adds a dockerfile containing all necessary build dependencies for gpu components, 
  specifically CUDA (runtime only by default, but can be configured), OpenMPI, cuQuantum, and cuTensor
- Adds the option to build and deploy that image upon request from main and release branches 
  (uses the same workflow as the CI and deployment for the more minimal devdeps image)
- Makes the dev_environment workflow generally usable for images that we want to cache as part of our pipelines
- Other minor fixes and cleanup (e.g. to make sure that deployments - to the respective org! - can also be run in forks)
