### PR TITLE
Pushing the build caches for main and release branches to ghcr instead to the gha cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     needs: build_caches
     strategy:
       matrix:
-        toolchain: [llvm, clang16, gcc12]
+        toolchain: [clang16, gcc12]
       fail-fast: false
     uses: ./.github/workflows/dev_environment.yml
     with:
@@ -39,6 +39,17 @@ jobs:
       toolchain: ${{ matrix.toolchain }}
       # needed only for the cloudposse GitHub action
       matrix_key: ${{ matrix.toolchain }}
+
+  # split out to make the llvm build optional for now
+  setup_llvm:
+    name: Load dependencies (llvm)
+    needs: build_caches
+    uses: ./.github/workflows/dev_environment.yml
+    with:
+      dockerfile: build/devdeps.Dockerfile
+      additional_build_caches: |
+        ${{ needs.build_caches.outputs.build_cache }}
+      toolchain: llvm
 
   # This job is needed only when using the cloudposse GitHub action to read
   # the output of a matrix job. This is a workaround due to current GitHub
@@ -63,11 +74,19 @@ jobs:
     needs: config
     strategy:
       matrix:
-        toolchain: [llvm, clang16, gcc12]
+        toolchain: [clang16, gcc12]
       fail-fast: false
     uses: ./.github/workflows/test_in_devenv.yml
     with:
       devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}', matrix.toolchain)] }}
+      export_environment: ${{ github.event_name == 'workflow_dispatch' && inputs.export_environment }}
+
+  build_and_test_llvm:
+    name: Build and test (llvm)
+    needs: setup_llvm
+    uses: ./.github/workflows/test_in_devenv.yml
+    with:
+      devdeps_cache: ${{ needs.setup_llvm.outputs.cache_key }}
       export_environment: ${{ github.event_name == 'workflow_dispatch' && inputs.export_environment }}
 
   docker_image:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build_caches:
+    name: Load build caches
+    uses: ./.github/workflows/dev_environment.yml
+    with:
+      dockerfile: build/devdeps.Dockerfile
+      build_target: doxygenbuild
+      build_cache_only: true
+
   setup:
     name: Load dependencies
+    needs: build_caches
     strategy:
       matrix:
         toolchain: [llvm, clang16, gcc12]
@@ -25,6 +34,8 @@ jobs:
     uses: ./.github/workflows/dev_environment.yml
     with:
       dockerfile: build/devdeps.Dockerfile
+      additional_build_caches: |
+        ${{ needs.build_caches.outputs.build_cache }}
       toolchain: ${{ matrix.toolchain }}
       # needed only for the cloudposse GitHub action
       matrix_key: ${{ matrix.toolchain }}

--- a/.github/workflows/clean_caches.yml
+++ b/.github/workflows/clean_caches.yml
@@ -46,7 +46,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   pr_cleanup:
-    name: Clean up PR related build caches
+    name: Clean up PR related GitHub caches
     if: github.event_name == 'pull_request_target'
     permissions: write-all
     runs-on: ubuntu-latest

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -24,7 +24,7 @@ jobs:
     needs: doxygen
     strategy:
       matrix:
-        toolchain: [llvm, clang16, gcc12]
+        toolchain: [clang16, gcc12]
       fail-fast: false
     uses: ./.github/workflows/dev_environment.yml
     with:
@@ -33,6 +33,17 @@ jobs:
         ${{ needs.doxygen.outputs.build_cache }}
       toolchain: ${{ matrix.toolchain }}
       matrix_key: ${{ matrix.toolchain }}
+      environment: ghcr-deployment
+
+  # split out so that it is not required to finish to proceed with other jobs
+  devdeps_llvm:
+    needs: doxygen
+    uses: ./.github/workflows/dev_environment.yml
+    with:
+      dockerfile: build/devdeps.Dockerfile
+      additional_build_caches: |
+        ${{ needs.doxygen.outputs.build_cache }}
+      toolchain: llvm
       environment: ghcr-deployment
 
   # This job is needed only when using the cloudposse GitHub action to read

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -12,7 +12,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  doxygen:
+    uses: ./.github/workflows/dev_environment.yml
+    with:
+      dockerfile: build/devdeps.Dockerfile
+      build_target: doxygenbuild
+      build_cache_only: true
+      environment: ghcr-deployment
+
   devdeps:
+    needs: doxygen
     strategy:
       matrix:
         toolchain: [llvm, clang16, gcc12]
@@ -20,6 +29,8 @@ jobs:
     uses: ./.github/workflows/dev_environment.yml
     with:
       dockerfile: build/devdeps.Dockerfile
+      additional_build_caches: |
+        ${{ needs.doxygen.outputs.build_cache }}
       toolchain: ${{ matrix.toolchain }}
       matrix_key: ${{ matrix.toolchain }}
       environment: ghcr-deployment

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -118,9 +118,11 @@ jobs:
           cache_target=${{ inputs.cache_location || github.ref_name }}
           cache_base=${{ github.event.pull_request.base.ref || 'main' }}
           registry_cache=ghcr.io/${{ needs.metadata.outputs.owner }}/buildcache-cuda-quantum
+          nvidia_registry_cache=ghcr.io/nvidia/buildcache-cuda-quantum
 
           cache_from_gha="type=gha,scope=${cache_target}-cuda-quantum-${cache_id}"
           cache_from_registry="type=registry,ref=${registry_cache}-${cache_id}:${cache_base}"
+          cache_from_nvidia_registry=registry,ref=${nvidia_registry_cache}-${cache_id}:${cache_base}"
           if ${{ inputs.environment == 'ghcr-deployment' }}; then
             cache_to_destination="type=registry,mode=max,ref=${registry_cache}-${cache_id}:${cache_target}"
           else
@@ -129,6 +131,7 @@ jobs:
 
           echo "cache_from_gha=$cache_from_gha" >> $GITHUB_OUTPUT
           echo "cache_from_registry=$cache_from_registry" >> $GITHUB_OUTPUT
+          echo "cache_from_nvidia_registry=$cache_from_nvidia_registry" >> $GITHUB_OUTPUT
           echo "cache_to_destination=$cache_to_destination" >> $GITHUB_OUTPUT
           echo "tar_cache=tar-${cache_id}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
@@ -157,6 +160,7 @@ jobs:
           cache-from: |
             ${{ steps.cache.outputs.cache_from_gha }}
             ${{ steps.cache.outputs.cache_from_registry }}
+            ${{ steps.cache.outputs.cache_from_nvidia_registry }}
           cache-to: |
             ${{ steps.cache.outputs.cache_to_destination }}
           outputs: type=docker,dest=/tmp/${{ needs.metadata.outputs.image_id }}.tar

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -4,6 +4,16 @@ on:
       dockerfile:
         required: true
         type: string
+      build_target:
+        required: false
+        type: string
+      additional_build_caches:
+        required: false
+        type: string
+      build_cache_only:
+        required: false
+        type: boolean
+        default: false
       base_image:
         required: false
         type: string
@@ -29,6 +39,9 @@ on:
       cache_key:
         description: "The cache key to retrieve a tar archive containing the built image(s)."
         value: ${{ jobs.finalize.outputs.tar_cache }}
+      build_cache:
+        description: "The location from which the build cache can be loaded in subsequent builds."
+        value: ${{ jobs.finalize.outputs.build_cache }}
 
 name: CUDA Quantum cached dev images
 
@@ -57,7 +70,8 @@ jobs:
         id: build_info
         run: |
           repo_owner=${{ github.repository_owner }}
-          image_id=`basename ${{ inputs.dockerfile }} .Dockerfile`
+          build_target=${{ inputs.build_target }}
+          image_id=`basename ${{ inputs.dockerfile }} .Dockerfile`${build_target:+.$build_target}
           image_title=cuda-quantum-`echo $image_id | cut -d "." -f 1`
           image_name=${{ vars.registry || 'ghcr.io' }}/${repo_owner,,}/$image_title
           toolchain=${{ inputs.toolchain }}
@@ -103,6 +117,7 @@ jobs:
 
     outputs:
       tar_cache: ${{ steps.cache.outputs.tar_cache }}
+      build_cache: ${{ steps.cache.outputs.cache_to_destination }}
 
     steps:
       - name: Checkout repository
@@ -124,16 +139,18 @@ jobs:
           cache_from_registry="type=registry,ref=${registry_cache}-${cache_id}:${cache_base}"
           cache_from_nvidia_registry="type=registry,ref=${nvidia_registry_cache}-${cache_id}:${cache_base}"
           if ${{ inputs.environment == 'ghcr-deployment' }}; then
-            cache_to_destination="type=registry,mode=max,ref=${registry_cache}-${cache_id}:${cache_target}"
+            cache_to_destination="type=registry,ref=${registry_cache}-${cache_id}:${cache_target}"
           else
-            cache_to_destination="type=gha,mode=max,scope=${cache_target}-cuda-quantum-${cache_id}"
+            cache_to_destination="type=gha,scope=${cache_target}-cuda-quantum-${cache_id}"
           fi
 
           echo "cache_from_gha=$cache_from_gha" >> $GITHUB_OUTPUT
           echo "cache_from_registry=$cache_from_registry" >> $GITHUB_OUTPUT
           echo "cache_from_nvidia_registry=$cache_from_nvidia_registry" >> $GITHUB_OUTPUT
           echo "cache_to_destination=$cache_to_destination" >> $GITHUB_OUTPUT
-          echo "tar_cache=tar-${cache_id}-${{ github.sha }}" >> $GITHUB_OUTPUT
+          if ${{ ! inputs.build_cache_only }}; then
+            echo "tar_cache=tar-${cache_id}-${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Log in to GitHub CR
         uses: docker/login-action@v2
@@ -149,6 +166,7 @@ jobs:
         with:
           context: .
           file: ./docker/${{ needs.metadata.outputs.dockerfile }}
+          target: ${{ inputs.build_target }}
           build-args: |
             base_image=${{ inputs.base_image }}
             toolchain=${{ inputs.toolchain }}
@@ -161,19 +179,21 @@ jobs:
             ${{ steps.cache.outputs.cache_from_gha }}
             ${{ steps.cache.outputs.cache_from_registry }}
             ${{ steps.cache.outputs.cache_from_nvidia_registry }}
+            ${{ inputs.additional_build_caches }}
           cache-to: |
-            ${{ steps.cache.outputs.cache_to_destination }}
+            ${{ steps.cache.outputs.cache_to_destination }},mode=max
           outputs: type=docker,dest=/tmp/${{ needs.metadata.outputs.image_id }}.tar
 
       - name: Cache ${{ needs.metadata.outputs.image_title }} image
         uses: actions/cache/save@v3
+        if: ! inputs.build_cache_only
         with:
           path: /tmp/${{ needs.metadata.outputs.image_id }}.tar
           key: ${{ steps.cache.outputs.tar_cache }}
 
   deployment:
     name: Deployment
-    if: inputs.environment
+    if: inputs.environment && ! inputs.build_cache_only
     runs-on: ubuntu-latest
     needs: [metadata, build]
     permissions: write-all
@@ -229,6 +249,7 @@ jobs:
       image_name: ${{ fromJson(steps.write_json.outputs.result).image_name }}
       digest: ${{ fromJson(steps.write_json.outputs.result).digest }}
       cache_key: ${{ fromJson(steps.write_json.outputs.result).cache_key }}
+      build_cache: ${{ fromJson(steps.write_json.outputs.result).build_cache }}
 
     steps:        
       - uses: cloudposse/github-action-matrix-outputs-write@0.3.0
@@ -240,3 +261,4 @@ jobs:
             image_name: ${{ needs.metadata.outputs.image_name }}
             digest: ${{ needs.deployment.outputs.digest }}
             cache_key: ${{ needs.build.outputs.tar_cache }}
+            build_cache: ${{ needs.build.outputs.build_cache }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -122,7 +122,7 @@ jobs:
 
           cache_from_gha="type=gha,scope=${cache_target}-cuda-quantum-${cache_id}"
           cache_from_registry="type=registry,ref=${registry_cache}-${cache_id}:${cache_base}"
-          cache_from_nvidia_registry=registry,ref=${nvidia_registry_cache}-${cache_id}:${cache_base}"
+          cache_from_nvidia_registry="type=registry,ref=${nvidia_registry_cache}-${cache_id}:${cache_base}"
           if ${{ inputs.environment == 'ghcr-deployment' }}; then
             cache_to_destination="type=registry,mode=max,ref=${registry_cache}-${cache_id}:${cache_target}"
           else

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -41,15 +41,13 @@ jobs:
 
     outputs:
       dockerfile: ${{ steps.build_info.outputs.dockerfile }}
+      owner: ${{ steps.build_info.outputs.owner }}
       image_name: ${{ steps.build_info.outputs.image_name }}
       image_title: ${{ steps.build_info.outputs.image_title }}
       image_id: ${{ steps.build_info.outputs.image_id }}
       image_tags: ${{ steps.metadata.outputs.tags }}
       image_labels: ${{ steps.metadata.outputs.labels }}
       llvm_commit: ${{ steps.build_info.outputs.llvm_commit }}
-      cache_target: ${{ steps.build_info.outputs.cache_target }}
-      cache_base: ${{ steps.build_info.outputs.cache_base }}
-      cache_id: ${{ steps.build_info.outputs.cache_id }}
 
     steps:
       - name: Checkout repository
@@ -72,10 +70,8 @@ jobs:
           echo "tag_prefix=$tag_prefix" >> $GITHUB_OUTPUT
           echo "tag_suffix=$tag_suffix" >> $GITHUB_OUTPUT
           echo "dockerfile=${{ inputs.dockerfile }}" >> $GITHUB_OUTPUT
+          echo "owner=${repo_owner,,}" >> $GITHUB_OUTPUT
           echo "llvm_commit=$(git rev-parse @:./tpls/llvm)" >> $GITHUB_OUTPUT
-          echo "cache_base=${{ github.event.pull_request.base.ref || 'main' }}" >> $GITHUB_OUTPUT
-          echo "cache_target=${{ inputs.cache_location || github.ref_name }}" >> $GITHUB_OUTPUT
-          echo "cache_id=$(echo $image_id | tr . -)${toolchain:+-$toolchain}" >> $GITHUB_OUTPUT
 
       - name: Extract metadata for Docker image
         id: metadata
@@ -103,6 +99,7 @@ jobs:
     timeout-minutes: 600
     permissions:
       contents: read
+      packages: write
 
     outputs:
       tar_cache: ${{ steps.cache.outputs.tar_cache }}
@@ -113,6 +110,35 @@ jobs:
 
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v2
+
+      - name: Create cache locations
+        id: cache
+        run: |
+          cache_id=$(echo ${{ needs.metadata.outputs.image_id }} | tr . -)${toolchain:+-$toolchain}
+          cache_target=${{ inputs.cache_location || github.ref_name }}
+          cache_base=${{ github.event.pull_request.base.ref || 'main' }}
+          registry_cache=ghcr.io/${{ needs.metadata.outputs.owner }}/buildcache-cuda-quantum
+
+          cache_from_gha="type=gha,scope=${cache_target}-cuda-quantum-${cache_id}"
+          cache_from_registry="type=registry,ref=${registry_cache}-${cache_id}:${cache_base}"
+          if ${{ inputs.environment == 'ghcr-deployment' }}; then
+            cache_to_destination="type=registry,mode=max,ref=${registry_cache}-${cache_id}:${cache_target}"
+          else
+            cache_to_destination="type=gha,mode=max,scope=${cache_target}-cuda-quantum-${cache_id}"
+          fi
+
+          echo "cache_from_gha=$cache_from_gha" >> $GITHUB_OUTPUT
+          echo "cache_from_registry=$cache_from_registry" >> $GITHUB_OUTPUT
+          echo "cache_to_destination=$cache_to_destination" >> $GITHUB_OUTPUT
+          echo "tar_cache=tar-${cache_id}-${{ github.sha }}" >> $GITHUB_OUTPUT
+
+      - name: Log in to GitHub CR
+        uses: docker/login-action@v2
+        if: inputs.environment == 'ghcr-deployment'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ${{ needs.metadata.outputs.image_title }} image
         id: build_image
@@ -129,17 +155,11 @@ jobs:
           labels: ${{ needs.metadata.outputs.image_labels }}
           platforms: linux/amd64
           cache-from: |
-            type=gha,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}
-            type=gha,scope=${{ needs.metadata.outputs.cache_base }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}
-            type=registry,ref=${{ needs.metadata.outputs.image_name }}:${{ steps.build_info.outputs.tag_prefix }}${{ needs.metadata.outputs.cache_base }}${{ steps.build_info.outputs.tag_suffix }}
+            ${{ steps.cache.outputs.cache_from_gha }}
+            ${{ steps.cache.outputs.cache_from_registry }}
           cache-to: |
-            type=gha,mode=max,scope=${{ needs.metadata.outputs.cache_target }}-cuda-quantum-${{ needs.metadata.outputs.cache_id }}
+            ${{ steps.cache.outputs.cache_to_destination }}
           outputs: type=docker,dest=/tmp/${{ needs.metadata.outputs.image_id }}.tar
-
-      - name: Create cache location
-        id: cache
-        run: |
-          echo "tar_cache=tar-${{ needs.metadata.outputs.cache_id }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Cache ${{ needs.metadata.outputs.image_title }} image
         uses: actions/cache/save@v3

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -186,14 +186,14 @@ jobs:
 
       - name: Cache ${{ needs.metadata.outputs.image_title }} image
         uses: actions/cache/save@v3
-        if: ! inputs.build_cache_only
+        if: ${{ ! inputs.build_cache_only }}
         with:
           path: /tmp/${{ needs.metadata.outputs.image_id }}.tar
           key: ${{ steps.cache.outputs.tar_cache }}
 
   deployment:
     name: Deployment
-    if: inputs.environment && ! inputs.build_cache_only
+    if: inputs.environment && ${{ ! inputs.build_cache_only }}
     runs-on: ubuntu-latest
     needs: [metadata, build]
     permissions: write-all

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -193,7 +193,7 @@ jobs:
 
   deployment:
     name: Deployment
-    if: inputs.environment && ${{ ! inputs.build_cache_only }}
+    if: ${{ inputs.environment && ! inputs.build_cache_only }}
     runs-on: ubuntu-latest
     needs: [metadata, build]
     permissions: write-all


### PR DESCRIPTION
This should ensure that there is always an existing build cache for main and release branches. Caches created as part of CI will continue to be pushed to the gha cache.

This PR also creates a separate cache for the doxygen build, since otherwise doxygen is rebuilt in each matrix job when there are changes to the rest of the image.