### PR TITLE
Build CircuitCheck as part of the build rather than as part of running

### DIFF
--- a/utils/CircuitCheck/CMakeLists.txt
+++ b/utils/CircuitCheck/CMakeLists.txt
@@ -6,7 +6,7 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-add_llvm_utility(CircuitCheck
+add_llvm_executable(CircuitCheck
   CircuitCheck.cpp
   UnitaryBuilder.cpp
 )
@@ -22,4 +22,3 @@ target_link_libraries(CircuitCheck
   MLIRMemRefDialect
   MLIRParser
 )
-


### PR DESCRIPTION
tests. It feels off to have build errors when trying to run the tests.
