### PR TITLE
Fix getting op's parameters as double

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Common/Ops.td
+++ b/include/cudaq/Optimizer/Dialect/Common/Ops.td
@@ -38,7 +38,7 @@ class GenOperator<string mnemonic, list<Trait> traits = []>
     /// If the parameter is known at compilation-time, return its value as a
     /// double.
     llvm::Optional<double> getParameterAsDouble(unsigned i = 0u) {
-      auto param = getParameter();
+      auto param = getParameter(i);
       auto paramDefOp = param.getDefiningOp();
       if (!paramDefOp)
         return std::nullopt;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
Fix to return the correct parameter as double
