### PR TITLE
[CircuitCheck] Run canonicalizer before checking

### DIFF
--- a/utils/CircuitCheck/CMakeLists.txt
+++ b/utils/CircuitCheck/CMakeLists.txt
@@ -17,7 +17,12 @@ target_include_directories(CircuitCheck
 
 target_link_libraries(CircuitCheck
   PRIVATE
-  QuakeDialect
+  MLIRArithDialect
   MLIRMemRefDialect
   MLIRParser
+  MLIRPass
+  MLIRTransforms
+
+  CCDialect
+  QuakeDialect
 )

--- a/utils/CircuitCheck/UnitaryBuilder.cpp
+++ b/utils/CircuitCheck/UnitaryBuilder.cpp
@@ -30,6 +30,9 @@ LogicalResult UnitaryBuilder::build(func::FuncOp func) {
     }
     if (auto optor = dyn_cast<quake::OperatorInterface>(op)) {
       optor.getOperatorMatrix(matrix);
+      // If the operator couldn't produce a matrix, stop the walk.
+      if (matrix.empty())
+        return WalkResult::interrupt();
       applyOperator(matrix, optor.getControls(), optor.getTargets());
       matrix.clear();
     }

--- a/utils/CircuitCheck/UnitaryBuilder.h
+++ b/utils/CircuitCheck/UnitaryBuilder.h
@@ -105,7 +105,7 @@ getGlobalPhaseConjugate(const UnitaryBuilder::UMatrix &matrix, double atol) {
   // Since the matrix uses a column-major storage scheme, it is faster to search
   // for the first nonzero element in the first column.
   for (auto &elt : matrix.col(0)) {
-    if (std::abs(elt) > atol)
+    if (std::abs(elt) < atol)
       continue;
     // Speed up the case for 1 + 0i
     return elt == 1. ? 1. : std::exp(std::complex<double>(0., -std::arg(elt)));


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
CircuitCheck might failed if we don't canonicalize the IR before trying to build the unitary. This step is mainly to guarantee that operators parameters that are known at compilation time are defined by ArithDialect's  constant operation. For example:
```mlir
// CircuitCheck _cannot_ handle:
%cst = arith.constant 3.1415926535897931 : f64
%neg_cst = arith.negf %cst : f64
quake.rx |%neg_cst : f64| (%q0)

// CircuitCheck can handle:
%cst = arith.constant -3.1415926535897931 : f64
quake.rx |%cst : f64| (%q0)
```

This PR also:
- Improves error reporting
- Fixes the computation of global phase