### PR TITLE
Convert the quake dialect ops to support both memory and register forms.

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/DecompositionGateSetMapping.h
+++ b/include/cudaq/Optimizer/CodeGen/DecompositionGateSetMapping.h
@@ -22,7 +22,7 @@ inline mlir::Value createFloatConstant(mlir::PatternRewriter &builder,
                                                       ty);
 }
 
-inline mlir::Value createRx(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createRx(mlir::PatternRewriter &builder, mlir::Location loc,
                             mlir::UnitAttr adj, mlir::Value theta,
                             mlir::Value ctrl, mlir::ValueRange targ,
                             mlir::DenseBoolArrayAttr neg) {
@@ -45,11 +45,11 @@ inline mlir::Value createRx(mlir::PatternRewriter &builder, mlir::Location loc,
   auto negHalfPi = builder.create<mlir::arith::NegFOp>(loc, halfPi);
   builder.create<quake::RzOp>(loc, adj, mlir::ValueRange{negHalfPi},
                               mlir::ValueRange{}, targ, neg);
-  return {};
+  return 0;
 }
 
 template <typename A>
-mlir::Value createR_(mlir::PatternRewriter &builder, mlir::Location loc,
+std::size_t createR_(mlir::PatternRewriter &builder, mlir::Location loc,
                      mlir::UnitAttr adj, mlir::Value theta, mlir::Value ctrl,
                      mlir::ValueRange targ, mlir::DenseBoolArrayAttr neg) {
   auto two = createFloatConstant(builder, loc,
@@ -64,24 +64,24 @@ mlir::Value createR_(mlir::PatternRewriter &builder, mlir::Location loc,
                     mlir::ValueRange{}, targ, neg);
   builder.create<quake::XOp>(loc, adj, mlir::ValueRange{},
                              mlir::ValueRange{ctrl}, targ, neg);
-  return {};
+  return 0;
 }
 
-inline mlir::Value createRy(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createRy(mlir::PatternRewriter &builder, mlir::Location loc,
                             mlir::UnitAttr adj, mlir::Value theta,
                             mlir::Value ctrl, mlir::ValueRange targ,
                             mlir::DenseBoolArrayAttr neg) {
   return createR_<quake::RyOp>(builder, loc, adj, theta, ctrl, targ, neg);
 }
 
-inline mlir::Value createRz(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createRz(mlir::PatternRewriter &builder, mlir::Location loc,
                             mlir::UnitAttr adj, mlir::Value theta,
                             mlir::Value ctrl, mlir::ValueRange targ,
                             mlir::DenseBoolArrayAttr neg) {
   return createR_<quake::RzOp>(builder, loc, adj, theta, ctrl, targ, neg);
 }
 
-inline mlir::Value createR1(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createR1(mlir::PatternRewriter &builder, mlir::Location loc,
                             mlir::UnitAttr adj, mlir::Value theta,
                             mlir::Value ctrl, mlir::ValueRange targ,
                             mlir::DenseBoolArrayAttr neg) {
@@ -92,7 +92,7 @@ inline mlir::Value createR1(mlir::PatternRewriter &builder, mlir::Location loc,
   auto halfTheta = builder.create<mlir::arith::DivFOp>(loc, theta, two);
   builder.create<quake::RzOp>(loc, adj, mlir::ValueRange{halfTheta},
                               mlir::ValueRange{}, mlir::ValueRange{ctrl}, neg);
-  return {};
+  return 0;
 }
 
 } // namespace cudaq::decomposition

--- a/include/cudaq/Optimizer/CodeGen/IQMGateSetMapping.h
+++ b/include/cudaq/Optimizer/CodeGen/IQMGateSetMapping.h
@@ -23,7 +23,7 @@ inline mlir::Value createFloatConstant(mlir::PatternRewriter &builder,
                                                       ty);
 }
 
-inline mlir::Value createTripleR(mlir::PatternRewriter &builder,
+inline std::size_t createTripleR(mlir::PatternRewriter &builder,
                                  mlir::Location loc, mlir::UnitAttr adj,
                                  mlir::FloatType ty, mlir::ValueRange ctrl,
                                  mlir::ValueRange targ,
@@ -37,10 +37,10 @@ inline mlir::Value createTripleR(mlir::PatternRewriter &builder,
   builder.create<quake::PhasedRxOp>(loc, adj, middle, ctrl, targ, neg);
   builder.create<quake::PhasedRxOp>(
       loc, adj, mlir::ArrayRef<mlir::Value>{negHalfPi, zero}, ctrl, targ, neg);
-  return {};
+  return 0;
 }
 
-inline mlir::Value createRZ(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createRZ(mlir::PatternRewriter &builder, mlir::Location loc,
                             mlir::UnitAttr adj, mlir::Value theta,
                             mlir::ValueRange ctrl, mlir::ValueRange targ,
                             mlir::DenseBoolArrayAttr neg) {
@@ -52,14 +52,14 @@ inline mlir::Value createRZ(mlir::PatternRewriter &builder, mlir::Location loc,
                        mlir::ArrayRef<mlir::Value>{negTheta, halfPi});
 }
 
-inline mlir::Value createR1(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createR1(mlir::PatternRewriter &builder, mlir::Location loc,
                             mlir::UnitAttr adj, mlir::Value theta,
                             mlir::ValueRange ctrl, mlir::ValueRange targ,
                             mlir::DenseBoolArrayAttr neg) {
   return createRZ(builder, loc, adj, theta, ctrl, targ, neg);
 }
 
-inline mlir::Value createH(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createH(mlir::PatternRewriter &builder, mlir::Location loc,
                            mlir::UnitAttr adj, mlir::ValueRange parm,
                            mlir::ValueRange ctrl, mlir::ValueRange targ,
                            mlir::DenseBoolArrayAttr neg) {
@@ -71,10 +71,10 @@ inline mlir::Value createH(mlir::PatternRewriter &builder, mlir::Location loc,
       loc, adj, mlir::ArrayRef<mlir::Value>{halfPi, halfPi}, ctrl, targ, neg);
   builder.create<quake::PhasedRxOp>(
       loc, adj, mlir::ArrayRef<mlir::Value>{pi, zero}, ctrl, targ, neg);
-  return {};
+  return 0;
 }
 
-inline mlir::Value createX(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createX(mlir::PatternRewriter &builder, mlir::Location loc,
                            mlir::UnitAttr adj, mlir::ValueRange parm,
                            mlir::ValueRange ctrl, mlir::ValueRange targ,
                            mlir::DenseBoolArrayAttr neg) {
@@ -83,10 +83,10 @@ inline mlir::Value createX(mlir::PatternRewriter &builder, mlir::Location loc,
   auto zero = createFloatConstant(builder, loc, dubTy, 0.0);
   builder.create<quake::PhasedRxOp>(
       loc, adj, mlir::ArrayRef<mlir::Value>{pi, zero}, ctrl, targ, neg);
-  return {};
+  return 0;
 }
 
-inline mlir::Value createY(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createY(mlir::PatternRewriter &builder, mlir::Location loc,
                            mlir::UnitAttr adj, mlir::ValueRange parm,
                            mlir::ValueRange ctrl, mlir::ValueRange targ,
                            mlir::DenseBoolArrayAttr neg) {
@@ -95,10 +95,10 @@ inline mlir::Value createY(mlir::PatternRewriter &builder, mlir::Location loc,
   auto pi = createFloatConstant(builder, loc, dubTy, M_PI);
   builder.create<quake::PhasedRxOp>(
       loc, adj, mlir::ArrayRef<mlir::Value>{pi, halfPi}, ctrl, targ, neg);
-  return {};
+  return 0;
 }
 
-inline mlir::Value createZ(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createZ(mlir::PatternRewriter &builder, mlir::Location loc,
                            mlir::UnitAttr adj, mlir::ValueRange parm,
                            mlir::ValueRange ctrl, mlir::ValueRange targ,
                            mlir::DenseBoolArrayAttr neg) {
@@ -110,7 +110,7 @@ inline mlir::Value createZ(mlir::PatternRewriter &builder, mlir::Location loc,
                        mlir::ArrayRef<mlir::Value>{negPi, halfPi});
 }
 
-inline mlir::Value createS(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createS(mlir::PatternRewriter &builder, mlir::Location loc,
                            mlir::UnitAttr adj, mlir::ValueRange parm,
                            mlir::ValueRange ctrl, mlir::ValueRange targ,
                            mlir::DenseBoolArrayAttr neg) {
@@ -121,7 +121,7 @@ inline mlir::Value createS(mlir::PatternRewriter &builder, mlir::Location loc,
                        mlir::ArrayRef<mlir::Value>{negHalfPi, halfPi});
 }
 
-inline mlir::Value createT(mlir::PatternRewriter &builder, mlir::Location loc,
+inline std::size_t createT(mlir::PatternRewriter &builder, mlir::Location loc,
                            mlir::UnitAttr adj, mlir::ValueRange parm,
                            mlir::ValueRange ctrl, mlir::ValueRange targ,
                            mlir::DenseBoolArrayAttr neg) {

--- a/include/cudaq/Optimizer/CodeGen/IQMGateSetMapping.td
+++ b/include/cudaq/Optimizer/CodeGen/IQMGateSetMapping.td
@@ -31,12 +31,12 @@ def IsNotNull : Constraint<CPred<"$0 ? true : false">>;
 // phased_r(θ, 0, ...)
 
 def CreateRX : NativeCodeCall<
-    "[&]() -> mlir::Value {"
+    "[&]() -> std::size_t {"
     "  auto zero = cudaq::iqm::createFloatConstant($_builder, $_loc,"
     "    $1.front().getType().cast<mlir::FloatType>(), 0.0);"
     "  $_builder.create<quake::PhasedRxOp>($_loc, $0,"
     "    mlir::ArrayRef<mlir::Value>{$1.front(), zero}, $2, $3, $4);"
-    "  return {}; }()">;
+    "  return 0; }()">;
 
 def IQMRxPattern : Pat<
       (RxOp $adj, $parm, $ctrl, $targ, $neg),
@@ -48,12 +48,12 @@ def IQMRxPattern : Pat<
 // phased_r(θ, π / 2, ...)
 
 def CreateRY : NativeCodeCall<
-    "[&]() -> mlir::Value {"
+    "[&]() -> std::size_t {"
     "  auto halfPi = cudaq::iqm::createFloatConstant($_builder, $_loc, "
     "    $1.front().getType().cast<mlir::FloatType>(), M_PI_2);"
     "  $_builder.create<quake::PhasedRxOp>($_loc, $0,"
     "    mlir::ArrayRef<mlir::Value>{$1.front(), halfPi}, $2, $3, $4);"
-    "  return {}; }()">;
+    "  return 0; }()">;
 
 def IQMRyPattern : Pat<
       (RyOp $adj, $parm, $ctrl, $targ, $neg),
@@ -182,11 +182,11 @@ def IQMR1Pattern : Pat<
 // quake.h j
 
 def CreateXctrl : NativeCodeCall<
-    "[&]() -> mlir::Value {"
+    "[&]() -> std::size_t {"
     "  $_builder.create<quake::HOp>($_loc, mlir::ValueRange{}, $3);"
     "  $_builder.create<quake::ZOp>($_loc, $2, $3);"
     "  $_builder.create<quake::HOp>($_loc, mlir::ValueRange{}, $3);"
-    "  return {}; }()">;
+    "  return 0; }()">;
 
 def IQMXctrlPattern : Pat<
       (XOp $adj, $parm, $ctrl, $targ, $neg),

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -190,6 +190,8 @@ def cc_LoopOp : CCOp<"loop",
 
     mlir::OperandRange
     getSuccessorEntryOperands(std::optional<unsigned> index);
+
+    bool hasBreakInBody();
   }];
 }
 

--- a/include/cudaq/Optimizer/Dialect/Common/Traits.h
+++ b/include/cudaq/Optimizer/Dialect/Common/Traits.h
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/****************************************************************-*- C++ -*-****
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 #pragma once
 
@@ -13,10 +13,38 @@
 namespace cudaq {
 
 template <typename ConcreteType>
-class Hermitian : public mlir::OpTrait::TraitBase<ConcreteType, Hermitian> {};
+class Hermitian : public mlir::OpTrait::TraitBase<ConcreteType, Hermitian> {
+public:
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    if (cast<ConcreteType>(op).isAdj())
+      return op->emitOpError("may not be adjoint");
+    return mlir::success();
+  }
+};
 
 template <typename ConcreteType>
 class QuantumGate : public mlir::OpTrait::TraitBase<ConcreteType, QuantumGate> {
+public:
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    return mlir::success();
+  }
+};
+
+template <typename ConcreteType>
+class Rotation : public mlir::OpTrait::TraitBase<ConcreteType, Rotation> {
+public:
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    return mlir::success();
+  }
+};
+
+template <typename ConcreteType>
+class QuantumMeasure
+    : public mlir::OpTrait::TraitBase<ConcreteType, QuantumMeasure> {
+public:
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    return mlir::success();
+  }
 };
 
 } // namespace cudaq

--- a/include/cudaq/Optimizer/Dialect/Common/Traits.td
+++ b/include/cudaq/Optimizer/Dialect/Common/Traits.td
@@ -1,10 +1,10 @@
-/********************************************************** -*- tablegen -*- ***
+/***********************************************************-*- tablegen -*-****
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 #ifndef CUDAQ_OPTIMIZER_DIALECT_COMMON_TRAITS
 #define CUDAQ_OPTIMIZER_DIALECT_COMMON_TRAITS
@@ -20,6 +20,14 @@ def QuantumGate : NativeOpTrait<"QuantumGate"> {
 }
 
 def Hermitian : NativeOpTrait<"Hermitian"> {
+  let cppNamespace = "::cudaq";
+}
+
+def Rotation : NativeOpTrait<"Rotation"> {
+  let cppNamespace = "::cudaq";
+}
+
+def QuantumMeasure : NativeOpTrait<"QuantumMeasure"> {
   let cppNamespace = "::cudaq";
 }
 

--- a/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
@@ -4,7 +4,7 @@
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 #ifndef NVQPP_OPTIMIZER_DIALECT_QUAKE_CANONICAL
 #define NVQPP_OPTIMIZER_DIALECT_QUAKE_CANONICAL

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
@@ -78,10 +78,10 @@ inline bool hasNonVectorReference(mlir::Operation *op) {
 }
 
 /// Returns true if and only if all quantum operands do not have type
-/// `!quake.wire` or `!quake.qcontrol`.
+/// `!quake.wire` or `!quake.control`.
 inline bool isAllReferences(mlir::Operation *op) {
   for (mlir::Value opnd : op->getOperands())
-    if (isa<quake::WireType, quake::QControlType>(opnd.getType()))
+    if (isa<quake::WireType, quake::ControlType>(opnd.getType()))
       return false;
   return true;
 }

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -142,8 +142,26 @@ def quake_ComputeActionOp : QuakeOp<"compute_action"> {
 }
 
 def quake_ConvertControlOp : QuakeOp<"convert_ctrl"> {
+  let summary = "Convert a wire value to a control value.";
+  let description = [{
+    This operation should be considered experimental. It is currently not used.
+
+    This operation makes the conversion of a wire value to a control value
+    explicit in the quake IR. These values have different semantics in the IR.
+    Ensuring these semantics via the type system may (or may not) prove to be
+    advantageous.
+
+    A value of type control is (nearly) an SSA-value. Once defined, via the
+    `convert_ctrl` operation, it can be used as an argument to other operations.
+    These uses are qualified. They must be in control argument positions and
+    these operations must dominate any second use of the `qubit` argument to
+    the `convert_ctrl`. The operand value and result value of a `convert_ctrl`
+    may not be used as arguments to the exact same subsequent operation.
+  }];
+
   let arguments = (ins WireType:$qubit);
-  let results = (outs QControlType);
+  let results = (outs ControlType);
+
   let assemblyFormat = [{
     $qubit `:` functional-type(operands, results) attr-dict
   }];

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -1,10 +1,10 @@
-/********************************************************** -*- tablegen -*- ***
+/***********************************************************-*- tablegen -*-****
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 #ifndef CUDAQ_OPTIMIZER_DIALECT_QUAKE_OPS
 #define CUDAQ_OPTIMIZER_DIALECT_QUAKE_OPS
@@ -37,39 +37,42 @@ class QuakeOp<string mnemonic, list<Trait> traits = []> :
 //===----------------------------------------------------------------------===//
 
 def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
-  let summary = "Allocates a collection of qubits.";
+  let summary = "Allocates a reference or collection of references to wires.";
   let description = [{
-    The operation allocates either a single qubit or a register of qubits
-    depending whether a size operand is provided.  The return value will be
-    either a qubit, `!quake.qref`, or an vector of qubits, `!quake.qvec<...>`,
-    that represents references to qubit(s).
+    The `alloca` operation allocates either a single wire reference or a vector
+    of references to wires. The size of the vector may be provided either
+    statically as part of the type or dynamically as an integer-like argument,
+    `size`. The return value will be a quantum reference, type `!quake.qref`,
+    or a vector of such, type `!quake.qvec<N>`.
 
-    In Quake, all qubits must be explicitly deallocated within the _same_ scope
-    of their allocation.  There is a pass that automatically adds deallocations.
+    All wires are assumed to be initialized to the value `|0>` initially. See
+    the `null_wire` op.
+
+    The `QuakeAddDeallocs` and `UnwindLowering` passes will insert deallocation
+    ops for the scopes in which allocations appear automatically. This is
+    helpful for generating code for targets such as QIR, which require
+    allocation/deallocation pairs.
 
     Examples:
-
     ```mlir
-    // Allocate a single qubit
-    %qubit = quake.alloca : !quake.qref
+      // Allocate a single qubit
+      %qubit = quake.alloca !quake.qref
 
-    // Allocate a qubit register with a size known at compilation time
-    %qvec = quake.qalloca : !quake.qvec<4>
+      // Allocate a qubit register with a size known at compilation time
+      %qvec = quake.alloca !quake.qvec<4> {name = "quantum"}
 
-    // Allocate a qubit register with a size known at runtime time
-    %qvec = quake.qalloca(%size : i32) : !quake.qvec<?>
+      // Allocate a qubit register with a size known at runtime time
+      %qvec = quake.alloca(%size : i32) !quake.qvec<?>
     ```
 
-    Note:  The parameter of the returned type is populated when the
-    canonicalizer for this operation is run, and the value of the size is known.
-    ```mlir
-    %four = arith.constant 4 : i32
-    %0 = quake.alloca(%four : i32) : !quake.qvec<4>
-    ```
+    Canonicalization for this op will fold constant vector sizes directly into
+    the type.
+
+    See DeallocOp.
   }];
 
   let arguments = (ins Optional<AnySignlessInteger>:$size);
-  let results = (outs AnyQType:$qref_or_vec);
+  let results = (outs AnyQRefType:$qref_or_vec);
 
   let builders = [
     OpBuilder<(ins ), [{
@@ -81,7 +84,7 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
   ];
 
   let assemblyFormat = [{
-    (`(` $size^ `:` type($size)`)`)? attr-dict `:` qualified(type($qref_or_vec))
+    (`[` $size^ `:` type($size)`]`)? qualified(type($qref_or_vec)) attr-dict
   }];
 
   let hasCanonicalizer = 1;
@@ -91,14 +94,17 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
 def quake_ConcatOp : QuakeOp<"concat", [Pure]> {
   let summary = "Construct a qvec from a list of other qref/qvec values.";
   let description = [{
-    The `quake.concat` operation allows one to group a list of values of type
-    QRef and/or QVec into a new QVec aggregate.
-    ```
-    %veq = quake.concat %r1, %v1, %r2 : (!quake.qref, !quake.qvec<?>, !quake.qref) -> !quake.qvec<?>
+    The `concat` operation allows one to concatenate a list of SSA-values of
+    either type QRef or QVec into a new QVec vector.
+
+    Example:
+    ```mlir
+      %veq = quake.concat %r1, %v1, %r2 : (!quake.qref, !quake.qvec<?>,
+                                           !quake.qref) -> !quake.qvec<?>
     ```
   }];
 
-  let arguments = (ins Variadic<AnyQType>:$qbits);
+  let arguments = (ins Variadic<AnyQRefType>:$qbits);
   let results = (outs QVecType);
 
   let assemblyFormat = [{
@@ -106,31 +112,40 @@ def quake_ConcatOp : QuakeOp<"concat", [Pure]> {
   }];
 }
 
-// A ComputeActionOp is marked as having memory effects to prevent the MLIR
-// optimizer from eliding it as dead code. It will be transformed into a series
-// of CallOps.
-def quake_ComputeActionOp : QuakeOp<"compute_action",
-    [MemoryEffects<[MemRead, MemWrite]>]> {
+// A ComputeActionOp will be transformed into a series of CallOps.
+def quake_ComputeActionOp : QuakeOp<"compute_action"> {
   let summary = "Captures the compute/action/uncompute high-level idiom.";
   let description = [{
-    CUDA Quantum supports the high-level compute/action/uncompute idiom by
+    CUDA Quantum supports the high-level compute, action, uncompute idiom by
     providing a custom template function (class) that takes pure kernels (a
     callable like a λ) as arguments. This operation captures uses of the idiom
     and can be systematically expanded into a quantum circuit via successive
     transformations.
+
+    The `is_dagger` attribute can be used to "reverse" this idiom to one of
+    uncompute, action, compute.
+
+    The uncompute step is generated automatically by generating the adjoint of
+    the compute kernel.
   }];
 
-  // FIXME: The compute and action can be other sorts of Callable instances and
-  // need not be inline λ expressions.
   let arguments = (ins
     UnitAttr:$is_dagger,
     cc_LambdaType:$compute,
     cc_LambdaType:$action
   );
-  
+
   let assemblyFormat = [{
-    (`<` `dag` $is_dagger^ `>`)? $compute `,` $action attr-dict
-    `:` qualified(type(operands))
+    (`<` `dag` $is_dagger^ `>`)? $compute `,` $action `:`
+      qualified(type(operands)) attr-dict
+  }];
+}
+
+def quake_ConvertControlOp : QuakeOp<"convert_ctrl"> {
+  let arguments = (ins WireType:$qubit);
+  let results = (outs QControlType);
+  let assemblyFormat = [{
+    $qubit `:` functional-type(operands, results) attr-dict
   }];
 }
 
@@ -141,20 +156,30 @@ def quake_ComputeActionOp : QuakeOp<"compute_action",
 def quake_DeallocOp : QuakeOp<"dealloc"> {
   let summary = "Deallocates a collection of qubits.";
   let description = [{
-    This operation is used to deallocate a collection of qubits, which is 
-    represented in quake as a `quake.qvec<?>` parameterized type. 
-    Quake DeallocOps are added using the -quake-add-deallocs pass. 
+    The `dealloc` operation deallocates a references to wires. The deallocation
+    can be a single wire, type `!quake.qref`, or a vector of references, type
+    `!quake.qvec<N>`.
+
+    Deallocations are automatically inserted by the `QuakeAddDeallocs` and
+    `UnwindLowering` passes.
+
+    Example:
+    ```mlir
+      %1 = quake.alloca !quake.qvec<4>
+      ...
+      quake.dealloc %1 : !quake.qvec<4>
     ```
-    %four = arith.constant 4 : i32
-    %0 = quake.alloca(%four : i32) : !quake.qvec<?>
-    quake.dealloc(%0)
-    ```
+
+    See AllocaOp.
   }];
+
   let arguments = (ins
-    Arg<AnyQType, "qubit reference (or vector) to deallocate",
-    [MemFree]>:$qreg_or_vec);
+    Arg<AnyQRefType, "qubit reference (or vector) to deallocate",
+    [MemFree]>:$qreg_or_vec
+  );
+
   let assemblyFormat = [{
-    `(` $qreg_or_vec `:` qualified(type($qreg_or_vec)) `)` attr-dict 
+    $qreg_or_vec `:` qualified(type($qreg_or_vec)) attr-dict
   }];
 }
 
@@ -162,40 +187,53 @@ def quake_DeallocOp : QuakeOp<"dealloc"> {
 // QVec, QRef manipulation
 //===----------------------------------------------------------------------===//
 
-def quake_QExtractOp : QuakeOp<"qextract", [Pure]> {
-  let summary = "Get a reference to a single qubit.";
+def quake_QExtractOp : QuakeOp<"extract_ref", [Pure]> {
+  let summary = "Get a reference to a single wire.";
   let description = [{
-    The `quake.qextract` operation extracts qubit references from a vector.
+    The `extract_ref` operation extracts a quantum reference from a vector of
+    quantum references.
+
+    The following example extracts the quantum reference at position 0 from a
+    vector of references. The vector, in this case, has unknown size.
+
+    Example:
+    ```mlir
+      %zero = arith.constant 0 : i32
+      %qr = quake.qextract %qv[%zero] : (!quake.qvec<?>, i32) -> !quake.qref
     ```
-    %zero = arith.constant 0 : i32
-    %qr = quake.qextract %qv[%zero] : !quake.qvec<?>[i32] -> !quake.qref
-    ```
-    The produced SSA value is then used for all operations on the 0'th qubit
-    of the `%qv` vector of qubits.
   }];
+
   let arguments = (ins
     QVecType:$qvec,
     AnySignlessIntegerOrIndex:$index
   );
+  let results = (outs QRefType:$qref);
+
+  let assemblyFormat = [{
+    $qvec `[` $index `]` `:`  functional-type(operands, results) attr-dict
+  }];
+
   let builders = [
     OpBuilder<(ins "mlir::Value":$qvec, "mlir::Value":$index), [{
       return build($_builder, $_state, $_builder.getType<QRefType>(), qvec,
                    index);
     }]>,
   ];
-  let results = (outs QRefType:$qref);
-  let assemblyFormat = [{
-    $qvec `[` $index `]` attr-dict
-    `:`  qualified(type($qvec)) `[` type($index) `]` `->` qualified(type($qref))
-  }];
   let hasFolder = 1;
 }
 
 def quake_RelaxSizeOp : QuakeOp<"relax_size", [Pure]> {
   let summary = "Relax the constant size on a !qvec to be unknown.";
   let description = [{
-    At times, the IR needs to forget the length of a `!qvec<n>` and demote it
-    to a `!qvec<?>` in order to preserve a strongly-typed IR.
+    At times, the IR needs to forget the length of an SSA-value of type
+    `!quake.qvec<N>` and demote it to type `!quake.qvec<?>` where the size is
+    said to be unknown. This demotion is required to preserve a valid,
+    strongly-typed IR.
+
+    Example:
+    ```mlir
+      %uqv = quake.relax_size %qv : (!quake.qvec<4>) -> !quake.qvec<?>
+    ```
   }];
 
   let arguments = (ins QVecType:$inputVec);
@@ -212,21 +250,28 @@ def quake_RelaxSizeOp : QuakeOp<"relax_size", [Pure]> {
 def quake_SubVecOp : QuakeOp<"subvec", [Pure]> {
   let summary = "Extract a subvector from a qvec reference value.";
   let description = [{
-    The `quake.subvec` operation gets a subvector reference from a qvec.
+    The `subvec` operation returns a subvector of references, type
+    `!quake.qvec<N>` from a vector of references, type `!quake.qvec<M>`, where
+    `M >= N`.
+
+    In the following example, the operation produces an SSA-value with 5
+    references. These references may be indexed from 0 to 4 via `%qr` and are
+    the same references as those from 2 to 6 indexed via `%qv`. Specifically,
+    the returned vector, `%qr`, is not a constructor and does not own the
+    references; it simply makes a copy as a new (shorter) vector. Therefore,
+    subvectors need never be deallocated.
+
+    Example:
+    ```mlir
+      %0 = arith.constant 2 : i32
+      %1 = arith.constant 6 : i32
+      %qr = quake.subvec %qv, %0, %1 : (!quake.qvec<?>, i32, i32) ->
+                                        !quake.qvec<5>
     ```
-    %zero = arith.constant 0 : i32
-    %four = arith.constant 4 : i32
-    %qr = quake.subvec %qv, %zero, %four : (!quake.qvec<?>, i32, i32) -> !quake.qvec<5>
-    ```
-    The produced SSA value is then used for all operations on the zeroth through
-    the fourth (inclusive, total of 5) qubit of the `%qv` vector of qubits. The
-    returned vector is not a constructor and is non-owning. The subvector of
-    qubits are the same qubits as in the original `%qv`. (This is identical to
-    the semantics of the `qextract` op.)
   }];
 
   let arguments = (ins
-    QVecType:$qvec, 
+    QVecType:$qvec,
     AnySignlessIntegerOrIndex:$low,
     AnySignlessIntegerOrIndex:$high
   );
@@ -243,13 +288,22 @@ def quake_SubVecOp : QuakeOp<"subvec", [Pure]> {
 // QVecSizeOp
 //===----------------------------------------------------------------------===//
 
-def quake_QVecSizeOp : QuakeOp<"qvec_size", [Pure]> {
-  let summary = "Get size of a qvec.";
+def quake_QVecSizeOp : QuakeOp<"vec_size", [Pure]> {
+  let summary = "Return the size of a qvec.";
   let description = [{
-    Get the size of a qvec. 
-    ```
-    %0 = quake.alloca(%four : i32) : !quake.qvec<4>
-    %s = quake.qvec_size (%0 : !quake.qvec<?>) : i64
+    Returns the size of a value of type `!quake.qvec<n>`. If the vector has a
+    static size, the static size is returned (effectively as a constant). If
+    the size of the vector is dynamic, the size value will be an SSA-value.
+
+    Examples:
+    ```mlir
+      %0 = quake.alloca !quake.qvec<4>
+      // %1 will be 4 with canonicalization.
+      %1 = quake.qvec_size %0 : (!quake.qvec<4>) -> i64
+      
+      %2 = ... : !quake.qvec<?>
+      // %3 may not be computed until runtime.
+      %3 = quake.qvec_size %2 : (!quake.qvec<?>) -> i64
     ```
   }];
 
@@ -257,49 +311,10 @@ def quake_QVecSizeOp : QuakeOp<"qvec_size", [Pure]> {
   let results = (outs AnySignlessIntegerOrIndex:$size);
 
   let assemblyFormat = [{
-    $qvec attr-dict `:` functional-type(operands, results)
+    $qvec `:` functional-type(operands, results) attr-dict
   }];
 
   let hasCanonicalizer = 1;
-}
-
-//===----------------------------------------------------------------------===//
-// Measurements and resets
-//===----------------------------------------------------------------------===//
-
-class Measurement<string mnemonic> : QuakeOp<mnemonic> {
-  let arguments = (ins
-    Arg<Variadic<AnyQType>,
-      "qubit reference(s) (or vector(s)) to measure",
-      [MemRead, MemWrite]>:$targets,
-    OptionalAttr<StrAttr>:$registerName
-  );
-  let results = (outs AnyTypeOf<[I1, StdvecOf<[I1]>]>:$bits);
-  let assemblyFormat = [{
-    `(` $targets `:` type($targets) `)` attr-dict `:` type($bits)
-  }];
-  let hasVerifier = 1;
-}
-
-def quake_ResetOp : QuakeOp<"reset"> {
-  let summary = "Reset the qubit (qreg) to the |0> (|0..0>) state";
-  let description = [{
-    The `quake.reset` operation resets a qubit (qreg) to the |0> (|0..0>) state.
-
-    Example:
-    ```mlir
-    quake.reset(%0 : !quake.qref)
-    ```
-  }];
-
-  let arguments = (ins
-    Arg<AnyQType,
-      "qubit reference (or vector) to reset", [MemRead, MemWrite]>:$targets
-  );
-  let results = (outs);
-  let assemblyFormat = [{
-    `(` $targets `:` type($targets) `)` attr-dict
-  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -326,8 +341,8 @@ def quake_ApplyOp : QuakeOp<"apply",
   let results = (outs Variadic<AnyType>);
 
   let assemblyFormat = [{
-    (`<` `adj` $is_adj^ `>`)? $callee (`[` $controls^ `:` type($controls) `]`)?
-      $args attr-dict `:` functional-type($args,results)
+    (`<` `adj` $is_adj^ `>`)? $callee (`[` $controls^ `]`)? $args `:`
+      functional-type(operands,results) attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -402,6 +417,8 @@ def quake_WrapOp : QuakeOp<"wrap"> {
   let assemblyFormat = [{
     $wire_value `to` $ref_value `:` qualified(type(operands)) attr-dict
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def quake_NullWireOp : QuakeOp<"null_wire", [Pure]> {
@@ -416,34 +433,46 @@ def quake_NullWireOp : QuakeOp<"null_wire", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
-// Base quantum instructions
+// Base quantum operations
 //===----------------------------------------------------------------------===//
 
-// The following classes factor out some class declarations common to quantum
-// instruction operations.  For example, it enable us to easily modify the
-// arguments, results and assembly format for all instructions in one place.
-
-class Operator<string mnemonic, list<Trait> traits = []>
+class QuakeOperator<string mnemonic, list<Trait> traits = []>
     : QuakeOp<mnemonic,
-        !listconcat([AttrSizedOperandSegments, OperatorInterface], traits)> {
+        !listconcat([QuantumGate, AttrSizedOperandSegments, OperatorInterface,
+          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>], traits)> {
 
   let arguments = (ins
     UnitAttr:$is_adj,
     Variadic<AnyFloat>:$parameters,
-    Arg<Variadic<AnyQType>,
-      "qubit reference(s) (or vector(s)) used as control(s)",
-      [MemRead]>:$controls,
-    Arg<Variadic<QRefType>,
-      "qubit reference(s) to target", [MemRead, MemWrite]>:$targets,
+    Variadic<AnyQType>:$controls,
+    Variadic<AnyQType>:$targets,
     OptionalAttr<DenseBoolArrayAttr>:$negated_qubit_controls
   );
+  let results = (outs Variadic<WireType>);
+
   let builders = [
+    OpBuilder<(ins "mlir::UnitAttr":$is_adj,
+                   "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::DenseBoolArrayAttr":$negates), [{
+      return build($_builder, $_state, mlir::TypeRange{}, is_adj, parameters,
+                   controls, targets, negates);
+    }]>,
+    OpBuilder<(ins "bool":$is_adj,
+                   "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::DenseBoolArrayAttr":$negates), [{
+      return build($_builder, $_state, mlir::TypeRange{}, is_adj, parameters,
+                   controls, targets, negates);
+    }]>,
     OpBuilder<(ins "bool":$is_adj,
                    "mlir::ValueRange":$parameters,
                    "mlir::ValueRange":$controls,
                    "mlir::ValueRange":$targets), [{
-      return build($_builder, $_state, is_adj, parameters, controls,
-                   targets, {});
+      return build($_builder, $_state, is_adj, parameters, controls, targets,
+                   {});
     }]>,
     OpBuilder<(ins "mlir::ValueRange":$parameters,
                    "mlir::ValueRange":$controls,
@@ -459,19 +488,726 @@ class Operator<string mnemonic, list<Trait> traits = []>
       return build($_builder, $_state, mlir::ValueRange{}, targets);
     }]>
   ];
+
   let assemblyFormat = [{
-    (`<` `adj` $is_adj^ `>`)?
-    (`[` $controls^ (`neg` $negated_qubit_controls^ )? `:` type($controls) `]`)?
-    custom<Parameters>($parameters, type($parameters))
-    `(` $targets `)` attr-dict
+    ( `<` `adj` $is_adj^ `>` )? ( `(` $parameters^ `)` )?
+    (`[` $controls^ (`neg` $negated_qubit_controls^ )? `]`)?
+    $targets `:` functional-type(operands, results) attr-dict
   }];
-  code OperatorExtraClassDeclaration = "";
+
+  code OpBaseDeclaration = [{
+    void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::EffectInstance<
+      mlir::MemoryEffects::Effect>> &effects) {
+      quake::getOperatorEffectsImpl(effects, getControls(), getTargets());
+    }
+
+    //===------------------------------------------------------------------===//
+    // Properties
+    //===------------------------------------------------------------------===//
+
+    bool isAdj() { return getIsAdj(); }
+
+    //===------------------------------------------------------------------===//
+    // Element Access
+    //===------------------------------------------------------------------===//
+
+    mlir::Value getParameter(unsigned i = 0u) { return getParameters()[i]; }
+
+    /// If the parameter is known at compilation-time, return its value as a
+    /// double.
+    std::optional<double> getParameterAsDouble(unsigned i = 0u) {
+      auto param = getParameter();
+      auto paramDefOp = param.getDefiningOp();
+      if (!paramDefOp)
+        return std::nullopt;
+      auto constOp = mlir::dyn_cast<mlir::arith::ConstantOp>(paramDefOp);
+      if (!constOp)
+        return std::nullopt;
+      if (auto value = dyn_cast<mlir::FloatAttr>(constOp.getValue())) {
+        return value.getValueAsDouble();
+      }
+      return std::nullopt;
+    }
+
+    mlir::Value getTarget(unsigned i = 0u) { return getTargets()[i]; }
+  }];
+}
+
+class OneTargetOp<string mnemonic, list<Trait> traits = []> :
+    QuakeOperator<mnemonic, !listconcat([NumParameters<0>, NumTargets<1>],
+                traits)>;
+
+class OneTargetParamOp<string mnemonic, list<Trait> traits = []> :
+    QuakeOperator<mnemonic, !listconcat([NumParameters<1>, NumTargets<1>],
+                traits)>;
+
+class TwoTargetOp<string mnemonic, list<Trait> traits = []> :
+    QuakeOperator<mnemonic, !listconcat([NumParameters<0>, NumTargets<2>],
+                traits)>;
+
+//===----------------------------------------------------------------------===//
+// Pauli instructions
+//===----------------------------------------------------------------------===//
+
+def XOp : OneTargetOp<"x", [Hermitian]> {
+  let summary = "Pauli-X operation (aka, NOT)";
+  let description = [{
+    Matrix representation:
+    ```
+    X = | 0  1 |
+        | 1  0 |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌───┐
+    q0: ┤ X ├
+        └───┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array.
+    void getOperatorMatrix(Matrix &matrix) {
+      matrix.assign({0, 1, 1, 0});
+    }
+
+    bool isClifford() {
+      return getControls().size() < 2;
+    }
+  }];
+}
+
+def YOp : OneTargetOp<"y", [Hermitian]> {
+  let summary = "Pauli-Y operation";
+  let description = [{
+    Matrix representation:
+    ```
+    Y = | 0  -i |
+        | i   0 |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌───┐
+    q0: ┤ Y ├
+        └───┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array.
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace std::complex_literals;
+      matrix.assign({0, 1i, -1i, 0});
+    }
+
+    bool isClifford() {
+      return getControls().size() < 2;
+    }
+  }];
+}
+
+def ZOp : OneTargetOp<"z", [Hermitian]> {
+  let summary = "Pauli-Z operation.";
+  let description = [{
+    Matrix representation:
+    ```
+    Z = | 1   0 |
+        | 0  -1 |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌───┐
+    q0: ┤ Z ├
+        └───┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array.
+    void getOperatorMatrix(Matrix &matrix) {
+      matrix.assign({1, 0, 0, -1});
+    }
+
+    bool isClifford() {
+      return getControls().size() < 2;
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
-// Common instructions
+// Clifford+T instructions (Pauli's are also part of the Clifford group)
 //===----------------------------------------------------------------------===//
 
-include "cudaq/Optimizer/Dialect/Common/Ops.td"
+def HOp : OneTargetOp<"h", [Hermitian]> {
+  let summary = "Hadamard operation";
+  let description = [{
+    This is a pi rotation about the X+Z axis, and has the effect of changing
+    computation basis from |0> (|1>) to |+> (|->) and vice-versa.  Meaning that
+    it enables one to create a superposition of basis states.
+
+    Matrix representation:
+    ```
+    H = (1 / sqrt(2)) * | 1   1 |
+                        | 1  -1 |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌───┐
+    q0: ┤ H ├
+        └───┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array.
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace llvm::numbers;
+      matrix.assign({inv_sqrt2, inv_sqrt2, inv_sqrt2, -inv_sqrt2});
+    }
+
+    bool isClifford() {
+      return getControls().size() == 0;
+    }
+  }];
+}
+
+def SOp : OneTargetOp<"s"> {
+  let summary = "S operation (aka, P or Sqrt(Z))";
+  let description = [{
+    This operation applies to its target a pi/2 rotation about the Z axis.
+
+    Matrix representation:
+    ```
+    S = | 1   0 |
+        | 0   i |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌───┐
+    q0: ┤ S ├
+        └───┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array.
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace llvm::numbers;
+      using namespace std::complex_literals;
+      if (getIsAdj())
+        matrix.assign({1, 0, 0, -1i});
+      else
+        matrix.assign({1, 0, 0, 1i});
+    }
+
+    bool isClifford() {
+      return getControls().size() == 0;
+    }
+  }];
+}
+
+def TOp : OneTargetOp<"t"> {
+  let summary = "T operation";
+  let description = [{
+    This operation applies to its target a pi/4 rotation about the Z axis.
+
+    Matrix representation:
+    ```
+    T = | 1   0 |
+        | 0  exp(i pi / 4) |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌───┐
+    q0: ┤ T ├
+        └───┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array.
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace llvm::numbers;
+      if (getIsAdj())
+        matrix.assign({1, 0, 0, {inv_sqrt2, -inv_sqrt2}});
+      else
+        matrix.assign({1, 0, 0, {inv_sqrt2, inv_sqrt2}});
+    }
+  }];
+}
+
+def SwapOp : TwoTargetOp<"swap", [Hermitian]> {
+  let summary = "Swap operation";
+  let description = [{
+    This operation swaps the states of two wires.
+
+    Matrix representation:
+    ```
+    Swap = | 1 0 0 0 |
+           | 0 0 1 0 |
+           | 0 1 0 0 |
+           | 0 0 0 1 |
+    ```
+
+    Circuit symbol:
+    ```
+    q0: ─X─
+         │
+    q1: ─X─
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array.
+    void getOperatorMatrix(Matrix &matrix) {
+      matrix.assign({1, 0, 0, 0,
+                     0, 0, 1, 0,
+                     0, 1, 0, 0,
+                     0, 0, 0, 1});
+    }
+
+    bool isClifford() {
+      return getControls().size() == 0;
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Arbitrary rotation instructions
+//===----------------------------------------------------------------------===//
+
+def R1Op : OneTargetParamOp<"r1", [Rotation]> {
+  let summary = "an arbitrary rotation about the |1> state";
+  let description = [{
+    Matrix representation:
+    ```
+    R1(t) = | 1  0 |
+            | 0  exp(i * t)|
+    ```
+
+    Circuit symbol:
+    ```
+        ┌────┐
+    q0: ┤ R1 ├
+        └────┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array if
+    /// it can be computed at compilation time, i.e., if the parameter is a
+    /// compile-time constant.
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace std::complex_literals;
+      auto theta = getParameterAsDouble();
+      if (!theta)
+        return;
+      if (getIsAdj())
+        *theta *= -1;
+      matrix.assign({1, 0, 0, std::exp(*theta * 1i)});
+    }
+  }];
+}
+
+def RxOp : OneTargetParamOp<"rx", [Rotation]> {
+  let summary = "an arbitrary rotation about the X axis";
+  let description = [{
+    Matrix representation:
+    ```
+    Rx(t) =  exp(-(i * t/2) * X) |  cos(t/2)  -isin(t/2) |
+                                 | -isin(t/2)  cos(t/2)  |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌────┐
+    q0: ┤ Rx ├
+        └────┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array if
+    /// it can be computed at compilation time, i.e., if the parameter is a
+    /// compile-time constant.
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace std::complex_literals;
+      auto theta = getParameterAsDouble();
+      if (!theta)
+        return;
+      if (getIsAdj())
+        *theta *= -1;
+      matrix.assign({      std::cos(*theta / 2.), -1i * std::sin(*theta / 2.),
+                     -1i * std::sin(*theta / 2.), std::cos(*theta / 2.)});
+    }
+  }];
+}
+
+def PhasedRxOp : QuakeOperator<"phased_rx",
+                   [NumParameters<2>, NumTargets<1>, Rotation]> {
+  let summary = "Phased rx gate. Two parameters and one target qubit.";
+  let description = [{
+    Matrix representation:
+    ```
+    PhasedRx(ϴ,φ) =
+               | cos(ϴ/2)                  -exp(i(pi/2-φ) * sin(ϴ/2)   |
+               | exp(i(φ-pi/2)) * sin(ϴ/2)          cos(ϴ/2)           |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌──────────┐
+    q0: ┤ PhasedRx ├
+        └──────────┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace std::complex_literals;
+      auto theta = getParameterAsDouble(0);
+      auto rxPhi = getParameterAsDouble(1);
+      if (!theta || !rxPhi)
+        return;
+      if (getIsAdj()) {
+        *theta *= -1;
+      }
+      auto phi = *rxPhi - M_PI_2;
+      auto lambda = -(*rxPhi) + M_PI_2;
+      matrix.assign({
+        std::cos(*theta / 2.),
+        std::exp(phi * 1i) * std::sin(*theta / 2.),
+        -std::exp(lambda * 1i) * std::sin(*theta / 2.),
+        std::exp(1i * (phi + lambda)) * std::cos(*theta / 2.)
+      });
+    }
+  }];
+}
+
+def RyOp : OneTargetParamOp<"ry", [Rotation]> {
+  let summary = "an arbitrary rotation about the Y axis";
+  let description = [{
+    Matrix representation:
+    ```
+    Ry(t) =  exp(-(i * t/2) * Y) | cos(t/2)  -sin(t/2) |
+                                 | sin(t/2)   cos(t/2) |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌────┐
+    q0: ┤ Ry ├
+        └────┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array if
+    /// it can be computed at compilation time, i.e., if the parameter is a
+    /// compile-time constant.
+    void getOperatorMatrix(Matrix &matrix) {
+      auto theta = getParameterAsDouble();
+      if (!theta)
+        return;
+      if (getIsAdj())
+        *theta *= -1;
+      matrix.assign({std::cos(*theta / 2.), -std::sin(*theta / 2.),
+                     std::sin(*theta / 2.), std::cos(*theta / 2.)});
+    }
+  }];
+}
+
+def RzOp : OneTargetParamOp<"rz", [Rotation]> {
+  let summary = "an arbitrary rotation about the Z axis";
+  let description = [{
+    Matrix representation:
+    ```
+    Rz(t) =  exp(-(i * t/2) * Z) | exp(-i*t/2)      0      |
+                                 |     0       exp(i*t/2), |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌────┐
+    q0: ┤ Rz ├
+        └────┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array if
+    /// it can be computed at compilation time, i.e., if the parameter is a
+    /// compile-time constant.
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace std::complex_literals;
+      auto theta = getParameterAsDouble();
+      if (!theta)
+        return;
+      if (getIsAdj())
+        *theta *= -1;
+      matrix.assign({std::exp( -1i * (*theta) / 2.), 0,
+                     0, std::exp(1i * (*theta) / 2.)});
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Universal intructions
+//===----------------------------------------------------------------------===//
+
+def U2Op : QuakeOperator<"u2", [NumParameters<2>, NumTargets<1>, Rotation]> {
+  let summary = "generic rotation about the X+Z axis";
+  let description = [{
+    The two parameters are Euler angles: φ and λ.
+
+    Matrix representation:
+    ```
+    U2(φ,λ) = 1/sqrt(2) | 1        -exp(iλ)       |
+                        | exp(iφ)   exp(i(λ + φ)) |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌────┐
+    q0: ┤ U2 ├
+        └────┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array if
+    /// it can be computed at compilation time, i.e., if the parameter is a
+    /// compile-time constant.
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace llvm::numbers;
+      using namespace std::complex_literals;
+      auto phi = getParameterAsDouble(0);
+      auto lambda = getParameterAsDouble(1);
+      if (!phi || lambda)
+        return;
+      if (getIsAdj()) {
+        *phi *= -1;
+        *lambda *= -1;
+      }
+      matrix.assign({
+        inv_sqrt2,
+        inv_sqrt2 * std::exp(*phi * 1i),
+        -inv_sqrt2 * std::exp(*lambda * 1i),
+        inv_sqrt2 * std::exp(1i * (*phi + *lambda))
+      });
+    }
+  }];
+}
+
+def U3Op : QuakeOperator<"u3", [NumParameters<3>, NumTargets<1>, Rotation]> {
+  let summary = "the universal three-parameters operator";
+  let description = [{
+    The three parameters are Euler angles: ϴ, φ, and λ.
+
+    NOTE: U3 is a generalization of U2 that covers all single-qubit rotations.
+
+    Matrix representation:
+    ```
+    U3(ϴ,φ,λ) = | cos(ϴ/2)            -exp(iλ) * sin(ϴ/2)       |
+                | exp(iφ) * sin(ϴ/2)   exp(i(λ + φ)) * cos(ϴ/2) |
+    ```
+
+    Circuit symbol:
+    ```
+        ┌────┐
+    q0: ┤ U3 ├
+        └────┘
+    ```
+  }];
+  let extraClassDeclaration = OpBaseDeclaration # [{
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    /// Set `matrix` to the operator's unitary matrix as a column-major array if
+    /// it can be computed at compilation time, i.e., if the parameter is a
+    /// compile-time constant.
+    void getOperatorMatrix(Matrix &matrix) {
+      using namespace std::complex_literals;
+      auto theta = getParameterAsDouble(0);
+      auto phi = getParameterAsDouble(1);
+      auto lambda = getParameterAsDouble(2);
+      if (!theta || !phi || lambda)
+        return;
+      if (getIsAdj()) {
+        *theta *= -1;
+        *phi *= -1;
+        *lambda *= -1;
+      }
+      matrix.assign({
+        std::cos(*theta / 2.),
+        std::exp(*phi * 1i) * std::sin(*theta / 2.),
+        -std::exp(*lambda * 1i) * std::sin(*theta / 2.),
+        std::exp(1i * (*phi + *lambda)) * std::cos(*theta / 2.)
+      });
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Reset
+//===----------------------------------------------------------------------===//
+
+def quake_ResetOp : QuakeOp<"reset", [QuantumGate,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "Reset the wire to the |0> (|0..0>) state.";
+  let description = [{
+    The `quake.reset` operation resets a wire to the |0> (|0..0>) state. It
+    may take an argument that is either a reference to a wire, type `!qref`,
+    or a wire, type `!wire`.
+
+    Example:
+    ```mlir
+      quake.reset %0 : (!quake.qref) -> ()
+      %2 = quake.reset %1 : (!quake.wire) -> !quake.wire
+    ```
+  }];
+
+  let arguments = (ins AnyQType:$targets);
+  let results = (outs Variadic<WireType>);
+  let assemblyFormat = [{
+     $targets `:` functional-type(operands, results) attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::
+        EffectInstance<mlir::MemoryEffects::Effect>> &effects) {
+      quake::getOperatorEffectsImpl(effects, {}, getTargets());
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Measurements
+//===----------------------------------------------------------------------===//
+
+class Measurement<string mnemonic> : QuakeOp<mnemonic,
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, QuantumMeasure]> {
+  let arguments = (ins
+    Variadic<AnyQType>:$targets,
+    OptionalAttr<StrAttr>:$registerName
+  );
+  let results = (outs AnyTypeOf<[I1, StdvecOf<[I1]>]>:$bits);
+
+  let assemblyFormat = [{
+    $targets `:` functional-type(operands, results) attr-dict
+  }];
+
+  code OpBaseDeclaration = [{
+    void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::EffectInstance<
+      mlir::MemoryEffects::Effect>> &effects) {
+      quake::getOperatorEffectsImpl(effects, {}, getTargets());
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
+def MxOp : Measurement<"mx"> {
+  let summary = "Measure a single qubit along the x-axis";
+  let description = [{
+    The `mx` operation measures the state of qubits into classical bits
+    represented by a `i1` (or a vector of `i1`), along the x-axis.
+
+    The state of the qubits is collapsed into one of the computational basis
+    states, i.e., either |0> or |1>.  A `reset` operation can guarantee that the
+    qubit returns to a |0> state, and thus it can be used for further
+    computation.  Another option is to deallocate the qubit using `dealloc`.
+  }];
+  let extraClassDeclaration = OpBaseDeclaration;
+}
+
+def MyOp : Measurement<"my"> {
+  let summary = "Measure a single qubit along the y-axis";
+  let description = [{
+    The `mx` operation measures the state of qubits into classical bits
+    represented by a `i1` (or a vector of `i1`), along the y-axis.
+
+    The state of the qubit is collapsed into one of the computational basis
+    states, i.e., either |0> or |1>.  A `reset` operation can guarantee that the
+    qubit returns to a |0> state, and thus it can be used for further
+    computation.  Another option is to deallocate the qubit using `dealloc`.
+  }];
+  let extraClassDeclaration = OpBaseDeclaration;
+}
+
+def MzOp : Measurement<"mz"> {
+  let summary = "Measure a single qubit along the z-axis";
+  let description = [{
+    The `mz` operation measures the state of qubits into a classical bits
+    represented by a `i1` (or a vector of `i1`), along the z-axis---the
+    so-called computational basis.
+
+    The state of the qubit is collapsed into one of the computational basis
+    states, i.e., either |0> or |1>.  A `reset` operation can guarantee that the
+    qubit returns to a |0> state, and thus it can be used for further
+    computation.  Another option is to deallocate the qubit using `dealloc`.
+  }];
+  let extraClassDeclaration = OpBaseDeclaration;
+}
 
 #endif // CUDAQ_OPTIMIZER_DIALECT_QUAKE_OPS

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -50,9 +50,9 @@ def WireType : QuakeType<"Wire", "wire"> {
   let genStorageClass = 0;
 }
 
-def QControlType : QuakeType<"QControl", "qcontrol"> {
+def ControlType : QuakeType<"Control", "control"> {
   let description = [{
-    A qubit of type qcontrol is a value of type wire used in a control position.
+    A qubit of type control is a value of type wire used in a control position.
     Using a qubit in a control position means the qubit is an SSA-value. It is
     defined once and can be used multiple times (in multiple control positions)
     without changing value.
@@ -133,13 +133,13 @@ def QVecType : QuakeType<"QVec", "qvec"> {
 }
 
 def AnyQTypeLike : TypeConstraint<Or<[WireType.predicate, QVecType.predicate,
-        QControlType.predicate, QRefType.predicate]>, "quake quantum types">;
+        ControlType.predicate, QRefType.predicate]>, "quake quantum types">;
 def AnyQType : Type<AnyQTypeLike.predicate, "quantum type">;
 def AnyQRefTypeLike : TypeConstraint<Or<[QVecType.predicate,
         QRefType.predicate]>, "quake quantum reference types">;
 def AnyQRefType : Type<AnyQRefTypeLike.predicate, "quantum reference type">;
 def AnyQValueTypeLike : TypeConstraint<Or<[WireType.predicate,
-        QControlType.predicate]>, "quake quantum value types">;
+        ControlType.predicate]>, "quake quantum value types">;
 def AnyQValueType : Type<AnyQValueTypeLike.predicate, "quantum value type">;
 
 def IsStdvecTypePred : CPred<"$_self.isa<::cudaq::cc::StdvecType>()">;

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -1,10 +1,10 @@
-/********************************************************** -*- tablegen -*- ***
+/***********************************************************-*- tablegen -*-****
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 #ifndef CUDAQ_OPTIMIZER_DIALECT_QUAKE_TYPES
 #define CUDAQ_OPTIMIZER_DIALECT_QUAKE_TYPES
@@ -47,6 +47,16 @@ def WireType : QuakeType<"Wire", "wire"> {
     See also the description of the `qref` type.
   }];
 
+  let genStorageClass = 0;
+}
+
+def QControlType : QuakeType<"QControl", "qcontrol"> {
+  let description = [{
+    A qubit of type qcontrol is a value of type wire used in a control position.
+    Using a qubit in a control position means the qubit is an SSA-value. It is
+    defined once and can be used multiple times (in multiple control positions)
+    without changing value.
+  }];
   let genStorageClass = 0;
 }
 
@@ -123,8 +133,14 @@ def QVecType : QuakeType<"QVec", "qvec"> {
 }
 
 def AnyQTypeLike : TypeConstraint<Or<[WireType.predicate, QVecType.predicate,
-        QRefType.predicate]>, "quake quantum types">;
+        QControlType.predicate, QRefType.predicate]>, "quake quantum types">;
 def AnyQType : Type<AnyQTypeLike.predicate, "quantum type">;
+def AnyQRefTypeLike : TypeConstraint<Or<[QVecType.predicate,
+        QRefType.predicate]>, "quake quantum reference types">;
+def AnyQRefType : Type<AnyQRefTypeLike.predicate, "quantum reference type">;
+def AnyQValueTypeLike : TypeConstraint<Or<[WireType.predicate,
+        QControlType.predicate]>, "quake quantum value types">;
+def AnyQValueType : Type<AnyQValueTypeLike.predicate, "quantum value type">;
 
 def IsStdvecTypePred : CPred<"$_self.isa<::cudaq::cc::StdvecType>()">;
 

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1296,7 +1296,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
     if (funcName.equals("reset")) {
       if (!negations.empty())
         reportNegateError();
-      return builder.create<quake::ResetOp>(loc, args[0]);
+      return builder.create<quake::ResetOp>(loc, TypeRange{}, args[0]);
     }
     if (funcName.equals("swap")) {
       const auto size = args.size();

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -59,5 +59,5 @@ quake::QVecType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
 //===----------------------------------------------------------------------===//
 
 void quake::QuakeDialect::registerTypes() {
-  addTypes<QVecType, QRefType, WireType>();
+  addTypes<QVecType, QRefType, WireType, QControlType>();
 }

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -59,5 +59,5 @@ quake::QVecType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
 //===----------------------------------------------------------------------===//
 
 void quake::QuakeDialect::registerTypes() {
-  addTypes<QVecType, QRefType, WireType, QControlType>();
+  addTypes<QVecType, QRefType, WireType, ControlType>();
 }

--- a/lib/Optimizer/Transforms/QTXToQuake.cpp
+++ b/lib/Optimizer/Transforms/QTXToQuake.cpp
@@ -59,7 +59,7 @@ LogicalResult convertOperation(qtx::ResetOp qtxOp) {
   for (auto [operand, result] :
        llvm::zip(qtxOp.getOperands(), qtxOp.getResults())) {
     result.replaceAllUsesWith(operand);
-    builder.create<quake::ResetOp>(operand);
+    builder.create<quake::ResetOp>(TypeRange{}, operand);
   }
   qtxOp.erase();
   return success();

--- a/python/tests/compiler/1q.py
+++ b/python/tests/compiler/1q.py
@@ -41,13 +41,13 @@ def test_kernel_non_param_1q():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.h (%[[VAL_0]])
-# CHECK:           quake.x (%[[VAL_0]])
-# CHECK:           quake.y (%[[VAL_0]])
-# CHECK:           quake.z (%[[VAL_0]])
-# CHECK:           quake.t (%[[VAL_0]])
-# CHECK:           quake.s (%[[VAL_0]])
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           quake.y %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           quake.z %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           quake.t %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           quake.s %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -79,10 +79,10 @@ def test_kernel_param_1q():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.rx |%[[VAL_0]] : f64|(%[[VAL_1]])
-# CHECK:           quake.ry |%[[VAL_0]] : f64|(%[[VAL_1]])
-# CHECK:           quake.rz |%[[VAL_0]] : f64|(%[[VAL_1]])
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           quake.ry (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           quake.rz (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/adjoint.py
+++ b/python/tests/compiler/adjoint.py
@@ -32,7 +32,7 @@ def test_kernel_adjoint_no_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}  : () -> ()
+# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} : () -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -92,7 +92,7 @@ def test_kernel_adjoint_qreg_args():
 # CHECK-SAME:      %[[VAL_0:.*]]: !quake.qvec<?>) {
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+# CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 # CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 # CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
@@ -243,7 +243,7 @@ def test_sample_adjoint_qubit():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -281,7 +281,7 @@ def test_sample_adjoint_qreg():
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
 # CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
-# CHECK:           %[[VAL_4:.*]] = quake.qvec_size %[[VAL_3]] : (!quake.qvec<?>) -> i64
+# CHECK:           %[[VAL_4:.*]] = quake.vec_size %[[VAL_3]] : (!quake.qvec<?>) -> i64
 # CHECK:           %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : i64 to index
 # CHECK:           %[[VAL_6:.*]] = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_5]] : index
@@ -289,7 +289,7 @@ def test_sample_adjoint_qreg():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
 # CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.qvec<?>, index) -> !quake.qref
-# CHECK:             quake.x %[[VAL_10]] : (!quake.ref) -> ()
+# CHECK:             quake.x %[[VAL_10]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_9]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_11:.*]]: index):
@@ -322,7 +322,7 @@ def test_sample_adjoint_qreg():
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.qvec<?>) {
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+# CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 # CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 # CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
@@ -330,7 +330,7 @@ def test_sample_adjoint_qreg():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
 # CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
-# CHECK:             quake.x %[[VAL_9]] : (!quake.ref) -> ()
+# CHECK:             quake.x %[[VAL_9]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_10:.*]]: index):

--- a/python/tests/compiler/adjoint.py
+++ b/python/tests/compiler/adjoint.py
@@ -233,7 +233,7 @@ def test_sample_adjoint_qubit():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 # CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
 # CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.qref) -> ()
@@ -280,7 +280,7 @@ def test_sample_adjoint_qreg():
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.alloca(%[[VAL_0]] : i32) !quake.qvec<?>
+# CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
 # CHECK:           %[[VAL_4:.*]] = quake.qvec_size %[[VAL_3]] : (!quake.qvec<?>) -> i64
 # CHECK:           %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : i64 to index
 # CHECK:           %[[VAL_6:.*]] = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_2]]) -> (index)) {

--- a/python/tests/compiler/adjoint.py
+++ b/python/tests/compiler/adjoint.py
@@ -37,8 +37,8 @@ def test_kernel_adjoint_no_args():
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.x (%[[VAL_0]])
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -57,14 +57,14 @@ def test_kernel_adjoint_qubit_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 # CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.h (%[[VAL_0]])
+# CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -83,7 +83,7 @@ def test_kernel_adjoint_qreg_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qvec<5>
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<5>
 # CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.qvec<5>) -> ()
 # CHECK:           return
 # CHECK:         }
@@ -99,8 +99,8 @@ def test_kernel_adjoint_qreg_args():
 # CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-# CHECK:             %[[VAL_9:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_8]]] : !quake.qvec<?>[index] -> !quake.qref
-# CHECK:             quake.h (%[[VAL_9]])
+# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
+# CHECK:             quake.h %[[VAL_9]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_10:.*]]: index):
@@ -135,9 +135,9 @@ def test_kernel_adjoint_float_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.x (%[[VAL_1]])
-# CHECK:           quake.rx |%[[VAL_0]] : f64|(%[[VAL_1]])
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.x %[[VAL_1]] : (!quake.qref) -> ()
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -168,8 +168,8 @@ def test_kernel_adjoint_int_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.x (%[[VAL_1]])
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.x %[[VAL_1]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -197,10 +197,10 @@ def test_kernel_adjoint_list_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
-# CHECK:           quake.rx |%[[VAL_3]] : f64|(%[[VAL_1]])
+# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -234,16 +234,16 @@ def test_sample_adjoint_qubit():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.x (%[[VAL_0]])
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
 # CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           %[[VAL_1:.*]] = quake.mz(%[[VAL_0]] : !quake.qref) {registerName = ""} : i1
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.x (%[[VAL_0]])
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -280,7 +280,7 @@ def test_sample_adjoint_qreg():
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.alloca(%[[VAL_0]] : i32) : !quake.qvec<?>
+# CHECK:           %[[VAL_3:.*]] = quake.alloca(%[[VAL_0]] : i32) !quake.qvec<?>
 # CHECK:           %[[VAL_4:.*]] = quake.qvec_size %[[VAL_3]] : (!quake.qvec<?>) -> i64
 # CHECK:           %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : i64 to index
 # CHECK:           %[[VAL_6:.*]] = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_2]]) -> (index)) {
@@ -288,8 +288,8 @@ def test_sample_adjoint_qreg():
 # CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
-# CHECK:             %[[VAL_10:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_9]]] : !quake.qvec<?>[index] -> !quake.qref
-# CHECK:             quake.x (%[[VAL_10]])
+# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.qvec<?>, index) -> !quake.qref
+# CHECK:             quake.x %[[VAL_10]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_9]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_11:.*]]: index):
@@ -304,8 +304,8 @@ def test_sample_adjoint_qreg():
 # CHECK:             cc.condition %[[VAL_16]](%[[VAL_15]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_17:.*]]: index):
-# CHECK:             %[[VAL_18:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_17]]] : !quake.qvec<?>[index] -> !quake.qref
-# CHECK:             %[[VAL_19:.*]] = quake.mz(%[[VAL_18]] : !quake.qref) : i1
+# CHECK:             %[[VAL_18:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_17]]] : (!quake.qvec<?>, index) -> !quake.qref
+# CHECK:             %[[VAL_19:.*]] = quake.mz %[[VAL_18]] : (!quake.qref) -> i1
 # CHECK:             %[[VAL_20:.*]] = arith.index_cast %[[VAL_17]] : index to i64
 # CHECK:             %[[VAL_21:.*]] = llvm.getelementptr %[[VAL_13]]{{\[}}%[[VAL_20]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_19]], %[[VAL_21]] : !llvm.ptr<i1>
@@ -329,8 +329,8 @@ def test_sample_adjoint_qreg():
 # CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-# CHECK:             %[[VAL_9:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_8]]] : !quake.qvec<?>[index] -> !quake.qref
-# CHECK:             quake.x (%[[VAL_9]])
+# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
+# CHECK:             quake.x %[[VAL_9]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_10:.*]]: index):

--- a/python/tests/compiler/call.py
+++ b/python/tests/compiler/call.py
@@ -35,8 +35,8 @@ def test_kernel_apply_call_no_args():
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.x (%[[VAL_0]])
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -56,14 +56,14 @@ def test_kernel_apply_call_qubit_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.h (%[[VAL_0]])
+# CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -83,7 +83,7 @@ def test_kernel_apply_call_qreg_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qvec<5>
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<5>
 # CHECK:           %[[VAL_1:.*]] = quake.relax_size %[[VAL_0]] : (!quake.qvec<5>) -> !quake.qvec<?>
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_1]]) : (!quake.qvec<?>) -> ()
 # CHECK:           return
@@ -100,8 +100,8 @@ def test_kernel_apply_call_qreg_args():
 # CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-# CHECK:             %[[VAL_9:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_8]]] : !quake.qvec<?>[index] -> !quake.qref
-# CHECK:             quake.h (%[[VAL_9]])
+# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
+# CHECK:             quake.h %[[VAL_9]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_10:.*]]: index):
@@ -134,8 +134,8 @@ def test_kernel_apply_call_float_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.rx |%[[VAL_0]] : f64|(%[[VAL_1]])
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -164,7 +164,7 @@ def test_kernel_apply_call_int_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           return
 # CHECK:         }
 
@@ -191,7 +191,7 @@ def test_kernel_apply_call_list_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
 # CHECK:           quake.rx |%[[VAL_3]] : f64|(%[[VAL_1]])

--- a/python/tests/compiler/call.py
+++ b/python/tests/compiler/call.py
@@ -36,7 +36,7 @@ def test_kernel_apply_call_no_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -63,7 +63,7 @@ def test_kernel_apply_call_qubit_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -93,7 +93,7 @@ def test_kernel_apply_call_qreg_args():
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.qvec<?>) {
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+# CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 # CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 # CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
@@ -101,7 +101,7 @@ def test_kernel_apply_call_qreg_args():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
 # CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
-# CHECK:             quake.h %[[VAL_9]] : (!quake.ref) -> ()
+# CHECK:             quake.h %[[VAL_9]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_10:.*]]: index):
@@ -135,7 +135,7 @@ def test_kernel_apply_call_float_args():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/call.py
+++ b/python/tests/compiler/call.py
@@ -194,7 +194,7 @@ def test_kernel_apply_call_list_args():
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
-# CHECK:           quake.rx |%[[VAL_3]] : f64|(%[[VAL_1]])
+# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64,
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/conditional.py
+++ b/python/tests/compiler/conditional.py
@@ -51,22 +51,22 @@ def test_kernel_conditional():
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_5:.*]] = quake.alloca : !quake.qvec<2>
-# CHECK:           %[[VAL_6:.*]] = quake.qextract %[[VAL_5]]{{\[}}%[[VAL_4]]] : !quake.qvec<2>[i32] -> !quake.qref
-# CHECK:           %[[VAL_7:.*]] = quake.qextract %[[VAL_5]]{{\[}}%[[VAL_3]]] : !quake.qvec<2>[i32] -> !quake.qref
-# CHECK:           quake.x (%[[VAL_6]])
-# CHECK:           %[[VAL_8:.*]] = quake.mz(%[[VAL_6]] : !quake.qref) {registerName = "measurement_"} : i1
+# CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qvec<2>
+# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.qvec<2>, i32) -> !quake.qref
+# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_3]]] : (!quake.qvec<2>, i32) -> !quake.qref
+# CHECK:           quake.x %[[VAL_6]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.qref) -> i1 {registerName = "measurement_"}
 # CHECK:           cc.if(%[[VAL_8]]) {
-# CHECK:             quake.x (%[[VAL_7]])
-# CHECK:             %[[VAL_9:.*]] = quake.mz(%[[VAL_7]] : !quake.qref) {registerName = ""} : i1
+# CHECK:             quake.x %[[VAL_7]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           }
 # CHECK:           %[[VAL_10:.*]] = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_13:.*]]: index):
-# CHECK:             %[[VAL_14:.*]] = quake.qextract %[[VAL_5]]{{\[}}%[[VAL_13]]] : !quake.qvec<2>[index] -> !quake.qref
-# CHECK:             quake.x (%[[VAL_14]])
+# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_13]]] : (!quake.qvec<2>, index) -> !quake.qref
+# CHECK:             quake.x %[[VAL_14]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_13]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_15:.*]]: index):
@@ -74,8 +74,8 @@ def test_kernel_conditional():
 # CHECK:             cc.continue %[[VAL_16]] : index
 # CHECK:           } {counted}
 # CHECK:           cc.if(%[[VAL_8]]) {
-# CHECK:             quake.x (%[[VAL_7]])
-# CHECK:             %[[VAL_17:.*]] = quake.mz(%[[VAL_7]] : !quake.qref) {registerName = ""} : i1
+# CHECK:             quake.x %[[VAL_7]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_17:.*]] = quake.mz %[[VAL_7]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           }
 # CHECK:           return
 # CHECK:         }
@@ -113,11 +113,11 @@ def test_kernel_conditional_with_sample():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.x (%[[VAL_0]])
-# CHECK:           %[[VAL_1:.*]] = quake.mz(%[[VAL_0]] : !quake.qref) {registerName = ""} : i1
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           cc.if(%[[VAL_1]]) {
-# CHECK:             quake.x (%[[VAL_0]])
+# CHECK:             quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -397,7 +397,7 @@ def test_sample_apply_call_control():
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
-# CHECK:           quake.h (%[[VAL_1]])
+# CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, !quake.qref) -> ()
 # CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
 # CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -37,19 +37,19 @@ def test_kernel_control_no_args(qubit_count):
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]] : !quake.qref]  : () -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.x (%[[VAL_0]])
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qvec<5>
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<5>
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]] : !quake.qvec<5>]  : () -> ()
 # CHECK:           return
 # CHECK:         }
@@ -64,8 +64,8 @@ def test_kernel_control_no_args(qubit_count):
 # CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_7:.*]]: index):
-# CHECK:             %[[VAL_8:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_7]]] : !quake.qvec<5>[index] -> !quake.qref
-# CHECK:             quake.x (%[[VAL_8]])
+# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, index) -> !quake.qref
+# CHECK:             quake.x %[[VAL_8]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_7]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
@@ -98,29 +98,29 @@ def test_kernel_control_float_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (f64) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.rx |%[[VAL_0]] : f64|(%[[VAL_1]])
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qvec<5>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qvec<5>] %[[VAL_0]] : (f64) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
-# CHECK:           quake.rx |%[[VAL_0]] : f64|(%[[VAL_1]])
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -146,27 +146,27 @@ def test_kernel_control_int_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (i32) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qvec<5>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qvec<5>] %[[VAL_0]] : (i32) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qvec<5>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
 # CHECK:           return
 # CHECK:         }
 
@@ -193,33 +193,33 @@ def test_kernel_control_list_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (!cc.stdvec<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
-# CHECK:           quake.rx |%[[VAL_3]] : f64|(%[[VAL_1]])
+# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qvec<5>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qvec<5>] %[[VAL_0]] : (!cc.stdvec<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
-# CHECK:           quake.rx |%[[VAL_3]] : f64|(%[[VAL_1]])
+# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -261,19 +261,19 @@ def test_sample_control_qubit_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
 # CHECK:           quake.h (%[[VAL_1]])
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           quake.h (%[[VAL_1]])
-# CHECK:           %[[VAL_2:.*]] = quake.mz(%[[VAL_1]] : !quake.qref) {registerName = ""} : i1
+# CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.x (%[[VAL_0]])
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -321,11 +321,11 @@ def test_sample_control_qreg_args():
 # CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 # CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_5:.*]] = quake.alloca : !quake.qvec<2>
-# CHECK:           %[[VAL_6:.*]] = quake.alloca : !quake.qref
-# CHECK:           %[[VAL_7:.*]] = quake.qextract %[[VAL_5]]{{\[}}%[[VAL_4]]] : !quake.qvec<2>[i32] -> !quake.qref
-# CHECK:           quake.x (%[[VAL_7]])
-# CHECK:           quake.x (%[[VAL_6]])
+# CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qvec<2>
+# CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.qvec<2>, i32) -> !quake.qref
+# CHECK:           quake.x %[[VAL_7]] : (!quake.qref) -> ()
+# CHECK:           quake.x %[[VAL_6]] : (!quake.qref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]] : !quake.qvec<2>] %[[VAL_6]] : (!quake.qref) -> ()
 # CHECK:           %[[VAL_8:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
 # CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_3]]) -> (index)) {
@@ -333,8 +333,8 @@ def test_sample_control_qreg_args():
 # CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_12:.*]]: index):
-# CHECK:             %[[VAL_13:.*]] = quake.qextract %[[VAL_5]]{{\[}}%[[VAL_12]]] : !quake.qvec<2>[index] -> !quake.qref
-# CHECK:             %[[VAL_14:.*]] = quake.mz(%[[VAL_13]] : !quake.qref) : i1
+# CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!quake.qvec<2>, index) -> !quake.qref
+# CHECK:             %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.qref) -> i1
 # CHECK:             %[[VAL_15:.*]] = arith.index_cast %[[VAL_12]] : index to i64
 # CHECK:             %[[VAL_16:.*]] = llvm.getelementptr %[[VAL_8]]{{\[}}%[[VAL_15]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_14]], %[[VAL_16]] : !llvm.ptr<i1>
@@ -344,13 +344,13 @@ def test_sample_control_qreg_args():
 # CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_2]] : index
 # CHECK:             cc.continue %[[VAL_18]] : index
 # CHECK:           } {counted}
-# CHECK:           %[[VAL_19:.*]] = quake.mz(%[[VAL_6]] : !quake.qref) {registerName = ""} : i1
+# CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_6]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.x (%[[VAL_0]])
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -394,25 +394,25 @@ def test_sample_apply_call_control():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
 # CHECK:           quake.h (%[[VAL_1]])
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           quake.h (%[[VAL_1]])
-# CHECK:           %[[VAL_2:.*]] = quake.mz(%[[VAL_1]] : !quake.qref) {registerName = ""} : i1
+# CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.x (%[[VAL_0]])
+# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.h (%[[VAL_0]])
+# CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -264,8 +264,8 @@ def test_sample_control_qubit_args():
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
-# CHECK:           quake.h (%[[VAL_1]])
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, !quake.qref) -> ()
+# CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, !quake.qref) -> ()
 # CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
 # CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           return

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -38,7 +38,7 @@ def test_kernel_control_no_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]] : !quake.qref]  : () -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]]] : (!quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -50,7 +50,7 @@ def test_kernel_control_no_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]] : !quake.qvec<5>]  : () -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]]] : (!quake.qvec<5>) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -99,7 +99,7 @@ def test_kernel_control_float_args(qubit_count):
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (f64) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, f64) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -113,7 +113,7 @@ def test_kernel_control_float_args(qubit_count):
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qvec<5>] %[[VAL_0]] : (f64) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qvec<5>, f64) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -147,7 +147,7 @@ def test_kernel_control_int_args(qubit_count):
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (i32) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, i32) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -160,7 +160,7 @@ def test_kernel_control_int_args(qubit_count):
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qvec<5>] %[[VAL_0]] : (i32) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qvec<5>, i32) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -194,7 +194,7 @@ def test_kernel_control_list_args(qubit_count):
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (!cc.stdvec<f64>) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, !cc.stdvec<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -210,7 +210,7 @@ def test_kernel_control_list_args(qubit_count):
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qvec<5>] %[[VAL_0]] : (!cc.stdvec<f64>) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qvec<5>, !cc.stdvec<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -265,7 +265,7 @@ def test_sample_control_qubit_args():
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
 # CHECK:           quake.h (%[[VAL_1]])
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, !quake.qref) -> ()
 # CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
 # CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           return
@@ -326,7 +326,7 @@ def test_sample_control_qreg_args():
 # CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.qvec<2>, i32) -> !quake.qref
 # CHECK:           quake.x %[[VAL_7]] : (!quake.qref) -> ()
 # CHECK:           quake.x %[[VAL_6]] : (!quake.qref) -> ()
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]] : !quake.qvec<2>] %[[VAL_6]] : (!quake.qref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]]] %[[VAL_6]] : (!quake.qvec<2>, !quake.qref) -> ()
 # CHECK:           %[[VAL_8:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
 # CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_0]] : index
@@ -398,7 +398,7 @@ def test_sample_apply_call_control():
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
 # CHECK:           quake.h (%[[VAL_1]])
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]] : !quake.qref] %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, !quake.qref) -> ()
 # CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
 # CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           return

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -58,7 +58,7 @@ def test_kernel_control_no_args(qubit_count):
 # CHECK:           %[[VAL_0:.*]] = arith.constant 5 : index
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qvec<5>
+# CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<5>
 # CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : index)

--- a/python/tests/compiler/measure.py
+++ b/python/tests/compiler/measure.py
@@ -40,15 +40,17 @@ def test_kernel_measure_1q():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qvec<2>
-# CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-# CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i32] -> !quake.qref
-# CHECK:           %[[VAL_5:.*]] = quake.mx(%[[VAL_3]] : !quake.qref) {registerName = ""} : i1
-# CHECK:           %[[VAL_6:.*]] = quake.mx(%[[VAL_4]] : !quake.qref) {registerName = ""} : i1
-# CHECK:           %[[VAL_7:.*]] = quake.my(%[[VAL_3]] : !quake.qref) {registerName = ""} : i1
-# CHECK:           %[[VAL_8:.*]] = quake.my(%[[VAL_4]] : !quake.qref) {registerName = ""} : i1
-# CHECK:           %[[VAL_9:.*]] = quake.mz(%[[VAL_3]] : !quake.qref) {registerName = ""} : i1
-# CHECK:           %[[VAL_10:.*]] = quake.mz(%[[VAL_4]] : !quake.qref) {registerName = ""} : i1
+# CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+# CHECK:           %[[VAL_5:.*]] = quake.mx %[[VAL_3]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_6:.*]] = quake.mx %[[VAL_4]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_8:.*]] = quake.my %[[VAL_4]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_3]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:        
+# CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_4]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:        
 # CHECK:           return
 # CHECK:         }
 
@@ -75,15 +77,15 @@ def test_kernel_measure_qreg():
 # CHECK:           %[[VAL_1:.*]] = arith.constant 3 : i64
 # CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_4:.*]] = quake.alloca : !quake.qvec<3>
+# CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.qvec<3>
 # CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
 # CHECK:           %[[VAL_6:.*]] = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
-# CHECK:             %[[VAL_10:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_9]]] : !quake.qvec<3>[index] -> !quake.qref
-# CHECK:             %[[VAL_11:.*]] = quake.mx(%[[VAL_10]] : !quake.qref) : i1
+# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_9]]] : (!quake.qvec<3>, index) -> !quake.qref
+# CHECK:             %[[VAL_11:.*]] = quake.mx %[[VAL_10]] : (!quake.qref) -> i1
 # CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_9]] : index to i64
 # CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_11]], %[[VAL_13]] : !llvm.ptr<i1>
@@ -99,8 +101,8 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_19]](%[[VAL_18]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_20:.*]]: index):
-# CHECK:             %[[VAL_21:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_20]]] : !quake.qvec<3>[index] -> !quake.qref
-# CHECK:             %[[VAL_22:.*]] = quake.my(%[[VAL_21]] : !quake.qref) : i1
+# CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_20]]] : (!quake.qvec<3>, index) -> !quake.qref
+# CHECK:             %[[VAL_22:.*]] = quake.my %[[VAL_21]] : (!quake.qref) -> i1
 # CHECK:             %[[VAL_23:.*]] = arith.index_cast %[[VAL_20]] : index to i64
 # CHECK:             %[[VAL_24:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_23]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_22]], %[[VAL_24]] : !llvm.ptr<i1>
@@ -116,8 +118,8 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_30]](%[[VAL_29]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_31:.*]]: index):
-# CHECK:             %[[VAL_32:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_31]]] : !quake.qvec<3>[index] -> !quake.qref
-# CHECK:             %[[VAL_33:.*]] = quake.mz(%[[VAL_32]] : !quake.qref) : i1
+# CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_31]]] : (!quake.qvec<3>, index) -> !quake.qref
+# CHECK:             %[[VAL_33:.*]] = quake.mz %[[VAL_32]] : (!quake.qref) -> i1
 # CHECK:             %[[VAL_34:.*]] = arith.index_cast %[[VAL_31]] : index to i64
 # CHECK:             %[[VAL_35:.*]] = llvm.getelementptr %[[VAL_27]]{{\[}}%[[VAL_34]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_33]], %[[VAL_35]] : !llvm.ptr<i1>

--- a/python/tests/compiler/measure.py
+++ b/python/tests/compiler/measure.py
@@ -48,9 +48,7 @@ def test_kernel_measure_1q():
 # CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           %[[VAL_8:.*]] = quake.my %[[VAL_4]] : (!quake.qref) -> i1 {registerName = ""}
 # CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_3]] : (!quake.qref) -> i1 {registerName = ""}
-# CHECK:        
 # CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_4]] : (!quake.qref) -> i1 {registerName = ""}
-# CHECK:        
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/multi_qubit.py
+++ b/python/tests/compiler/multi_qubit.py
@@ -46,15 +46,15 @@ def test_kernel_2q():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qvec<2>
-# CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-# CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i32] -> !quake.qref
-# CHECK:           quake.h {{\[}}%[[VAL_3]] : !quake.qref] (%[[VAL_4]])
-# CHECK:           quake.x {{\[}}%[[VAL_4]] : !quake.qref] (%[[VAL_3]])
-# CHECK:           quake.y {{\[}}%[[VAL_3]] : !quake.qref] (%[[VAL_4]])
-# CHECK:           quake.z {{\[}}%[[VAL_4]] : !quake.qref] (%[[VAL_3]])
-# CHECK:           quake.t {{\[}}%[[VAL_3]] : !quake.qref] (%[[VAL_4]])
-# CHECK:           quake.s {{\[}}%[[VAL_4]] : !quake.qref] (%[[VAL_3]])
+# CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+# CHECK:           quake.h [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
+# CHECK:           quake.x [%[[VAL_4]]] %[[VAL_3]] : (!quake.qref, !quake.qref) -> ()
+# CHECK:           quake.y [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
+# CHECK:           quake.z [%[[VAL_4]]] %[[VAL_3]] : (!quake.qref, !quake.qref) -> ()
+# CHECK:           quake.t [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
+# CHECK:           quake.s [%[[VAL_4]]] %[[VAL_3]] : (!quake.qref, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -88,16 +88,16 @@ def test_kernel_3q():
 # CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i32
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qvec<3>
-# CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_2]]] : !quake.qvec<3>[i32] -> !quake.qref
-# CHECK:           %[[VAL_5:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_1]]] : !quake.qvec<3>[i32] -> !quake.qref
-# CHECK:           %[[VAL_6:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_0]]] : !quake.qvec<3>[i32] -> !quake.qref
-# CHECK:           quake.h {{\[}}%[[VAL_4]], %[[VAL_5]] : !quake.qref, !quake.qref] (%[[VAL_6]])
-# CHECK:           quake.x {{\[}}%[[VAL_6]], %[[VAL_4]] : !quake.qref, !quake.qref] (%[[VAL_5]])
-# CHECK:           quake.y {{\[}}%[[VAL_5]], %[[VAL_6]] : !quake.qref, !quake.qref] (%[[VAL_4]])
-# CHECK:           quake.z {{\[}}%[[VAL_4]], %[[VAL_5]] : !quake.qref, !quake.qref] (%[[VAL_6]])
-# CHECK:           quake.t {{\[}}%[[VAL_6]], %[[VAL_4]] : !quake.qref, !quake.qref] (%[[VAL_5]])
-# CHECK:           quake.s {{\[}}%[[VAL_5]], %[[VAL_6]] : !quake.qref, !quake.qref] (%[[VAL_4]])
+# CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<3>
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<3>, i32) -> !quake.qref
+# CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<3>, i32) -> !quake.qref
+# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.qvec<3>, i32) -> !quake.qref
+# CHECK:           quake.h [%[[VAL_4]], %[[VAL_5]]] %[[VAL_6]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
+# CHECK:           quake.x [%[[VAL_6]], %[[VAL_4]]] %[[VAL_5]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
+# CHECK:           quake.y [%[[VAL_5]], %[[VAL_6]]] %[[VAL_4]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
+# CHECK:           quake.z [%[[VAL_4]], %[[VAL_5]]] %[[VAL_6]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
+# CHECK:           quake.t [%[[VAL_6]], %[[VAL_4]]] %[[VAL_5]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
+# CHECK:           quake.s [%[[VAL_5]], %[[VAL_6]]] %[[VAL_4]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/qalloc.py
+++ b/python/tests/compiler/qalloc.py
@@ -29,7 +29,7 @@ def test_kernel_qalloc_empty():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 # CHECK:           return
 # CHECK:         }
 
@@ -47,7 +47,7 @@ def test_kernel_qalloc_qreg():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qvec<10>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<10>
 # CHECK:           return
 # CHECK:         }
 
@@ -65,7 +65,7 @@ def test_kernel_qalloc_qreg_keyword():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qvec<10>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<10>
 # CHECK:           return
 # CHECK:         }
 
@@ -83,7 +83,7 @@ def test_kernel_qalloc_quake_val():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca(%[[VAL_0]] : i32) : !quake.qvec<?>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca(%[[VAL_0]] : i32) !quake.qvec<?>
 # CHECK:           return
 # CHECK:         }
 
@@ -101,7 +101,7 @@ def test_kernel_qalloc_qubit():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 # CHECK:           return
 # CHECK:         }
 
@@ -119,7 +119,7 @@ def test_kernel_qalloc_qubit_keyword():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/qalloc.py
+++ b/python/tests/compiler/qalloc.py
@@ -83,7 +83,7 @@ def test_kernel_qalloc_quake_val():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca(%[[VAL_0]] : i32) !quake.qvec<?>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/qreg_apply.py
+++ b/python/tests/compiler/qreg_apply.py
@@ -41,14 +41,14 @@ def test_kernel_qreg():
 # CHECK:           %[[VAL_0:.*]] = arith.constant 2 : index
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qvec<2>
+# CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
 # CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_7:.*]]: index):
-# CHECK:             %[[VAL_8:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_7]]] : !quake.qvec<2>[index] -> !quake.qref
-# CHECK:             quake.h (%[[VAL_8]])
+# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<2>, index) -> !quake.qref
+# CHECK:             quake.h %[[VAL_8]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_7]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
@@ -60,8 +60,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_13]](%[[VAL_12]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_14:.*]]: index):
-# CHECK:             %[[VAL_15:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_14]]] : !quake.qvec<2>[index] -> !quake.qref
-# CHECK:             quake.x (%[[VAL_15]])
+# CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_14]]] : (!quake.qvec<2>, index) -> !quake.qref
+# CHECK:             quake.x %[[VAL_15]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_14]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_16:.*]]: index):
@@ -73,8 +73,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_20]](%[[VAL_19]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_21:.*]]: index):
-# CHECK:             %[[VAL_22:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_21]]] : !quake.qvec<2>[index] -> !quake.qref
-# CHECK:             quake.y (%[[VAL_22]])
+# CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_21]]] : (!quake.qvec<2>, index) -> !quake.qref
+# CHECK:             quake.y %[[VAL_22]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_21]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_23:.*]]: index):
@@ -86,8 +86,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_27]](%[[VAL_26]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_28:.*]]: index):
-# CHECK:             %[[VAL_29:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_28]]] : !quake.qvec<2>[index] -> !quake.qref
-# CHECK:             quake.z (%[[VAL_29]])
+# CHECK:             %[[VAL_29:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_28]]] : (!quake.qvec<2>, index) -> !quake.qref
+# CHECK:             quake.z %[[VAL_29]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_28]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_30:.*]]: index):
@@ -99,8 +99,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_34]](%[[VAL_33]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_35:.*]]: index):
-# CHECK:             %[[VAL_36:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_35]]] : !quake.qvec<2>[index] -> !quake.qref
-# CHECK:             quake.t (%[[VAL_36]])
+# CHECK:             %[[VAL_36:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_35]]] : (!quake.qvec<2>, index) -> !quake.qref
+# CHECK:             quake.t %[[VAL_36]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_35]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_37:.*]]: index):
@@ -112,8 +112,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_41]](%[[VAL_40]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_42:.*]]: index):
-# CHECK:             %[[VAL_43:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_42]]] : !quake.qvec<2>[index] -> !quake.qref
-# CHECK:             quake.s (%[[VAL_43]])
+# CHECK:             %[[VAL_43:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_42]]] : (!quake.qvec<2>, index) -> !quake.qref
+# CHECK:             quake.s %[[VAL_43]] : (!quake.qref) -> ()
 # CHECK:             cc.continue %[[VAL_42]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_44:.*]]: index):

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -497,7 +497,7 @@ QuakeValue mz(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQreg,
 void reset(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQreg) {
   auto value = qubitOrQreg.getValue();
   if (isa<quake::QRefType>(value.getType())) {
-    builder.create<quake::ResetOp>(value);
+    builder.create<quake::ResetOp>(TypeRange{}, value);
     return;
   }
 
@@ -511,7 +511,7 @@ void reset(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQreg) {
                            Block &block) {
       Value qref =
           builder.create<quake::QExtractOp>(loc, target, block.getArgument(0));
-      builder.create<quake::ResetOp>(loc, qref);
+      builder.create<quake::ResetOp>(loc, TypeRange{}, qref);
     };
     cudaq::opt::factory::createCountedLoop(builder, builder.getUnknownLoc(),
                                            rank, bodyBuilder);

--- a/test/AST-Quake/adjoint-1.cpp
+++ b/test/AST-Quake/adjoint-1.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -20,9 +20,9 @@ struct k {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__k
 // CHECK-SAME: (%[[VAL_0:.*]]: !quake.qvec<?>)
-// CHECK:           quake.h (%{{.*}})
-// CHECK:           quake.ry |%{{.*}} : f64|(%{{.*}})
-// CHECK:           quake.t (%{{.*}})
+// CHECK:           quake.h %{{.*}}
+// CHECK:           quake.ry (%{{.*}}) %{{.*}}
+// CHECK:           quake.t %{{.*}}
 // CHECK:           return
 
 struct ep {
@@ -34,7 +34,7 @@ struct ep {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ep()
 // CHECK:           %[[VAL_2:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca(%[[VAL_2]] : i64) : !quake.qvec<3>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<3>
 // CHECK:           %[[VAL_4:.*]] = quake.relax_size %[[VAL_3]] : (!quake.qvec<3>) -> !quake.qvec<?>
 // CHECK:           quake.apply<adj> @__nvqpp__mlirgen__k %[[VAL_4]] : (!quake.qvec<?>) -> ()
 // CHECK:           return

--- a/test/AST-Quake/adjoint-2.cpp
+++ b/test/AST-Quake/adjoint-2.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | cudaq-opt --apply-op-specialization | FileCheck %s
 
@@ -77,9 +77,9 @@ struct kernel_delta {
 // CHECK:             } do {
 // CHECK:             ^bb0(%[[VAL_24:.*]]: i32):
 // CHECK:               cc.scope {
-// CHECK:                 quake.y (%[[VAL_0]])
-// CHECK:                 quake.x (%[[VAL_0]])
-// CHECK:                 quake.h (%[[VAL_0]])
+// CHECK:                 quake.y %[[VAL_0]]
+// CHECK:                 quake.x %[[VAL_0]]
+// CHECK:                 quake.h %[[VAL_0]]
 // CHECK:               }
 // CHECK:               cc.continue %[[VAL_24]] : i32
 // CHECK:             } step {
@@ -123,9 +123,9 @@ struct kernel_delta {
 // CHECK:             } do {
 // CHECK:             ^bb0(%[[VAL_20:.*]]: i32):
 // CHECK:               cc.scope {
-// CHECK:                 quake.z (%[[VAL_0]])
-// CHECK:                 quake.y (%[[VAL_0]])
-// CHECK:                 quake.x (%[[VAL_0]])
+// CHECK:                 quake.z %[[VAL_0]]
+// CHECK:                 quake.y %[[VAL_0]]
+// CHECK:                 quake.x %[[VAL_0]]
 // CHECK:               }
 // CHECK:               cc.continue %[[VAL_20]] : i32
 // CHECK:             } step {

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 // RUN: cudaq-quake %s | cudaq-opt --apply-op-specialization | FileCheck --check-prefixes=ADJOINT %s
@@ -48,7 +48,7 @@ struct QernelZero {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__run_circuit
 // CHECK-SAME:        (%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: f64)
 // CHECK:           %[[VAL_5:.*]] = memref.alloca() : memref<f64>
-// CHECK:           %[[VAL_10:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_10:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_16:.*]] = memref.load %[[VAL_5]][] : memref<f64>
 // CHECK:           call @__nvqpp__mlirgen__statePrep_A{{.*}}(%[[VAL_10]], %[[VAL_16]]) : (!quake.qvec<?>, f64) -> ()
 // CHECK:           cc.scope {
@@ -56,7 +56,7 @@ struct QernelZero {
 // CHECK:               cc.condition %{{.*}}
 // CHECK:             } do {
 // CHECK:               cc.scope {
-// CHECK:                 quake.z (%{{.*}})
+// CHECK:                 quake.z %{{.*}}
 // CHECK:                 %[[VAL_23:.*]] = memref.load %[[VAL_5]][] : memref<f64>
 // CHECK:                 quake.apply<adj> @__nvqpp__mlirgen__statePrep_A{{.*}} %[[VAL_10]], %[[VAL_23]] : (!quake.qvec<?>, f64) -> ()
 // CHECK:                 func.call @__nvqpp__mlirgen__statePrep_A{{.*}}(%[[VAL_10]], %{{.*}}) : (!quake.qvec<?>, f64) -> ()
@@ -93,7 +93,7 @@ struct run_circuit {
 // ADJOINT-SAME:        .adj(%[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: f64) {
 // ADJOINT:           %[[VAL_2:.*]] = memref.alloca() : memref<f64>
 // ADJOINT:           memref.store %[[VAL_1]], %[[VAL_2]][] : memref<f64>
-// ADJOINT:           %[[VAL_3:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// ADJOINT:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // ADJOINT:           %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : i64 to i32
 // ADJOINT:           %[[VAL_5:.*]] = memref.alloca() : memref<i32>
 // ADJOINT:           memref.store %[[VAL_4]], %[[VAL_5]][] : memref<i32>
@@ -105,7 +105,7 @@ struct run_circuit {
 // ADJOINT:           %[[VAL_11:.*]] = arith.constant 1 : i64
 // ADJOINT:           %[[VAL_12:.*]] = arith.subi %[[VAL_9]], %[[VAL_11]] : i64
 // ADJOINT:           %[[VAL_13:.*]] = quake.subvec %[[VAL_0]], %[[VAL_10]], %[[VAL_12]] : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
-// ADJOINT:           %[[VAL_16:.*]] = quake.qvec_size %[[VAL_13]] : (!quake.qvec<?>) -> i64
+// ADJOINT:           %[[VAL_16:.*]] = quake.vec_size %[[VAL_13]] : (!quake.qvec<?>) -> i64
 // ADJOINT:           %[[VAL_17:.*]] = arith.index_cast %[[VAL_16]] : i64 to index
 // ADJOINT:           %[[VAL_14:.*]] = arith.constant 0 : index
 // ADJOINT:           %[[VAL_15:.*]] = arith.constant 1 : index
@@ -121,7 +121,7 @@ struct run_circuit {
 // ADJOINT:           %[[VAL_27:.*]] = arith.constant 1 : i32
 // ADJOINT:           %[[VAL_28:.*]] = arith.subi %[[VAL_26]], %[[VAL_27]] : i32
 // ADJOINT:           %[[VAL_29:.*]] = arith.extsi %[[VAL_28]] : i32 to i64
-// ADJOINT:           %[[VAL_30:.*]] = quake.qextract %[[VAL_0]][%[[VAL_29]]] : !quake.qvec<?>[i64] -> !quake.qref
+// ADJOINT:           %[[VAL_30:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_29]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // ADJOINT:           cc.scope {
 // ADJOINT:             %[[VAL_31:.*]] = arith.constant 1 : i32
 // ADJOINT:             %[[VAL_32:.*]] = memref.alloca() : memref<i32>
@@ -161,14 +161,14 @@ struct run_circuit {
 // ADJOINT:                 %[[VAL_62:.*]] = arith.constant 1 : i32
 // ADJOINT:                 %[[VAL_63:.*]] = arith.subi %[[VAL_61]], %[[VAL_62]] : i32
 // ADJOINT:                 %[[VAL_64:.*]] = arith.extsi %[[VAL_63]] : i32 to i64
-// ADJOINT:                 %[[VAL_65:.*]] = quake.qextract %[[VAL_0]][%[[VAL_64]]] : !quake.qvec<?>[i64] -> !quake.qref
+// ADJOINT:                 %[[VAL_65:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_64]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // ADJOINT:                 %[[VAL_66:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // ADJOINT:                 %[[VAL_67:.*]] = arith.constant 1 : i32
 // ADJOINT:                 %[[VAL_68:.*]] = arith.subi %[[VAL_66]], %[[VAL_67]] : i32
 // ADJOINT:                 %[[VAL_69:.*]] = arith.extsi %[[VAL_68]] : i32 to i64
-// ADJOINT:                 %[[VAL_70:.*]] = quake.qextract %[[VAL_0]][%[[VAL_69]]] : !quake.qvec<?>[i64] -> !quake.qref
+// ADJOINT:                 %[[VAL_70:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_69]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // ADJOINT:                 %[[VAL_71:.*]] = arith.negf %[[VAL_60]] : f64
-// ADJOINT:                 quake.ry {{\[}}%[[VAL_65]] : !quake.qref] |%[[VAL_71]] : f64|(%[[VAL_70]])
+// ADJOINT:                 quake.ry (%[[VAL_71]]) [%[[VAL_65]]] %[[VAL_70]] : (f64, !quake.qref, !quake.qref) -> ()
 // ADJOINT:               }
 // ADJOINT:               cc.continue %[[VAL_50]] : i32
 // ADJOINT:             } step {
@@ -183,7 +183,7 @@ struct run_circuit {
 // ADJOINT:             }
 // ADJOINT:           }
 // ADJOINT:           %[[VAL_78:.*]] = arith.negf %[[VAL_25]] : f64
-// ADJOINT:           quake.ry |%[[VAL_78]] : f64|(%[[VAL_30]])
+// ADJOINT:           quake.ry (%[[VAL_78]]) %[[VAL_30]] : (f64, !quake.qref) -> ()
 // ADJOINT:           %[[VAL_79:.*]] = arith.constant 0 : index
 // ADJOINT:           %[[VAL_80:.*]] = arith.cmpi sgt, %[[VAL_17]], %[[VAL_79]] : index
 // ADJOINT:           %[[VAL_81:.*]] = arith.select %[[VAL_80]], %[[VAL_17]], %[[VAL_79]] : index
@@ -197,8 +197,8 @@ struct run_circuit {
 // ADJOINT:             cc.condition %[[VAL_90]](%[[VAL_87]], %[[VAL_88]] : index, index)
 // ADJOINT:           } do {
 // ADJOINT:           ^bb0(%[[VAL_91:.*]]: index, %[[VAL_92:.*]]: index):
-// ADJOINT:             %[[VAL_93:.*]] = quake.qextract %[[VAL_13]]{{\[}}%[[VAL_91]]] : !quake.qvec<?>[index] -> !quake.qref
-// ADJOINT:             quake.h (%[[VAL_93]])
+// ADJOINT:             %[[VAL_93:.*]] = quake.extract_ref %[[VAL_13]][%[[VAL_91]]] : (!quake.qvec<?>, index) -> !quake.qref
+// ADJOINT:             quake.h %[[VAL_93]] : (!quake.qref) -> ()
 // ADJOINT:             cc.continue %[[VAL_91]], %[[VAL_92]] : index, index
 // ADJOINT:           } step {
 // ADJOINT:           ^bb0(%[[VAL_94:.*]]: index, %[[VAL_95:.*]]: index):
@@ -213,6 +213,6 @@ struct run_circuit {
 
 // ADJOINT-LABEL:   func.func @__nvqpp__mlirgen__run_circuit
 // ADJOINT:               cc.scope {
-// ADJOINT:                 quake.z (%{{.*}})
+// ADJOINT:                 quake.z %{{.*}} : (!quake.qref) -> ()
 // ADJOINT:                 func.call @__nvqpp__mlirgen__statePrep_A.adj(%{{.*}}, %{{.*}}) : (!quake.qvec<?>, f64) -> ()
 // ADJOINT:                 func.call @__nvqpp__mlirgen__QernelZero{{.*}}(%{{[0-9]+}}) :

--- a/test/AST-Quake/auto_kernel-1.cpp
+++ b/test/AST-Quake/auto_kernel-1.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -23,7 +23,7 @@ struct ak1 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ak1
 // CHECK-SAME:        (%[[VAL_0:.*]]: i32) -> i1 attributes {
-// CHECK:           %[[VAL_13:.*]] = quake.mz(%{{.*}} : !quake.qvec<?>) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
 // CHECK:           %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_13]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>

--- a/test/AST-Quake/auto_kernel-2.cpp
+++ b/test/AST-Quake/auto_kernel-2.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -22,7 +22,7 @@ struct ak2 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ak2
 // CHECK-SAME: () -> !cc.stdvec<i1> attributes {
-// CHECK:           %[[VAL_19:.*]] = quake.mz(%{{.*}} : !quake.qvec<5>) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_19:.*]] = quake.mz %{{.*}} : (!quake.qvec<5>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_19]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_21:.*]] = cc.stdvec_size %[[VAL_19]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_22:.*]] = arith.constant 1 : i64

--- a/test/AST-Quake/bool_literal.cpp
+++ b/test/AST-Quake/bool_literal.cpp
@@ -1,17 +1,17 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
 
 #include <cudaq.h>
 
-// CHECK: quake.h (%[[VAL_0:.*]])
+// CHECK: quake.h %[[VAL_0:.*]] : (!quake.qref) -> ()
 // CHECK: %false = arith.constant false
 // CHECK: %[[VAL_1:.*]] = memref.alloca() : memref<i1>
 // CHECK: memref.store %false, %[[VAL_1]][] : memref<i1>

--- a/test/AST-Quake/callable-1.cpp
+++ b/test/AST-Quake/callable-1.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -32,15 +32,15 @@ int main() {
 // CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
-// CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_0]][%[[VAL_2]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:           quake.h (%[[VAL_3]])
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
-// CHECK:           %[[VAL_6:.*]] = quake.qextract %[[VAL_0]][%[[VAL_5]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_5]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           %[[VAL_7:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_8:.*]] = arith.extsi %[[VAL_7]] : i32 to i64
-// CHECK:           %[[VAL_9:.*]] = quake.qextract %[[VAL_0]][%[[VAL_8]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:           quake.x [%[[VAL_6]] : !quake.qref] (%[[VAL_9]])
+// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           quake.x [%[[VAL_6]]] %[[VAL_9]] : (!quake.qref, !quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -48,7 +48,7 @@ int main() {
 // CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.qvec<?>) -> ()>) attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca(%[[VAL_2]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<?>
 // CHECK:           call @__nvqpp__mlirgen__Z4mainE3$_0(%[[VAL_3]]) : (!quake.qvec<?>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/callable-2.cpp
+++ b/test/AST-Quake/callable-2.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 // RUN: cudaq-quake %s | cudaq-opt --lambda-lifting --canonicalize | FileCheck --check-prefixes=LIFT %s
@@ -39,19 +39,19 @@ struct test5_caller {
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__test5_callee
 // CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
 // CHECK-SAME:   %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.qextract %
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
-// CHECK:           %[[VAL_10:.*]] = quake.qextract %
+// CHECK:           %[[VAL_10:.*]] = quake.extract_ref %
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_10]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
 // CHECK:           return
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__test5_callable
 // CHECK-SAME:   (%[[VAL_0:.*]]: !quake.qref)
-// CHECK:           quake.h (%[[VAL_0]])
-// CHECK:           quake.x (%[[VAL_0]])
-// CHECK:           quake.z (%[[VAL_0]])
+// CHECK:           quake.h %[[VAL_0]]
+// CHECK:           quake.x %[[VAL_0]]
+// CHECK:           quake.z %[[VAL_0]]
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test5_caller
 // CHECK-SAME: () attributes

--- a/test/AST-Quake/compute_action-1.cpp
+++ b/test/AST-Quake/compute_action-1.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 // RUN: cudaq-quake -D DAGGER %s | FileCheck --check-prefixes=DAGGER %s
@@ -27,11 +27,11 @@ void t() __qpu__ {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_t
 // CHECK-SAME: () attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
-// CHECK:               quake.t (%{{.*}})
-// CHECK:               quake.x (%{{.*}})
+// CHECK:               quake.t %{{.*}}
+// CHECK:               quake.x %{{.*}}
 // CHECK:           }
 // CHECK:           %[[VAL_10:.*]] = cc.create_lambda {
-// CHECK:               quake.h (%{{.*}})
+// CHECK:               quake.h %{{.*}}
 // CHECK:           }
 // CHECK:           quake.compute_action %[[VAL_3]], %[[VAL_10]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
 // CHECK:           return
@@ -40,11 +40,11 @@ void t() __qpu__ {
 // DAGGER-LABEL:   func.func @__nvqpp__mlirgen__function_t
 // DAGGER-SAME: () attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
 // DAGGER:           %[[VAL_3:.*]] = cc.create_lambda {
-// DAGGER:               quake.t (%{{.*}})
-// DAGGER:               quake.x (%{{.*}})
+// DAGGER:               quake.t %{{.*}}
+// DAGGER:               quake.x %{{.*}}
 // DAGGER:           }
 // DAGGER:           %[[VAL_10:.*]] = cc.create_lambda {
-// DAGGER:               quake.h (%{{.*}})
+// DAGGER:               quake.h %{{.*}}
 // DAGGER:           }
 // DAGGER:           quake.compute_action<dag> %[[VAL_3]], %[[VAL_10]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
 // DAGGER:           return

--- a/test/AST-Quake/compute_action-2.cpp
+++ b/test/AST-Quake/compute_action-2.cpp
@@ -40,7 +40,7 @@ struct ctrlHeisenberg {
 // CHECK:                 cc.scope {
 // CHECK:                   cc.loop while {
 // CHECK:                   } do {
-// CHECK:                     quake.rx [%[[VAL_0]] : !quake.qvec<?>] |%{{.*}} : f64|(%{{.*}})
+// CHECK:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.qref) -> ()
 // CHECK:                   } step {
 // CHECK:                   }
 // CHECK:                 }
@@ -48,10 +48,10 @@ struct ctrlHeisenberg {
 // CHECK:                   cc.loop while {
 // CHECK:                   } do {
 // CHECK:                     %[[VAL_28:.*]] = cc.create_lambda {
-// CHECK:                       quake.x [%{{.*}} : !quake.qref] (%{{.*}})
+// CHECK:                       quake.x [%{{.*}}] %{{.*}} : (!quake.qref, !quake.qref) -> ()
 // CHECK:                     } : !cc.lambda<() -> ()>
 // CHECK:                     %[[VAL_36:.*]] = cc.create_lambda {
-// CHECK:                       quake.rz [%[[VAL_0]] : !quake.qvec<?>] |%{{.*}} : f64|(%{{.*}})
+// CHECK:                       quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.qref) -> ()
 // CHECK:                     } : !cc.lambda<() -> ()>
 // CHECK:                     quake.compute_action %[[VAL_28]], %[[VAL_36]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
 // CHECK:                     cc.continue
@@ -69,10 +69,10 @@ struct ctrlHeisenberg {
 // CHECK-SAME:        %[[VAL_0:.*]]: i32)
 // CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qref
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
 // CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_1]][] : memref<i32>
 // CHECK:           %[[VAL_4:.*]] = arith.extsi %[[VAL_3]] : i32 to i64
-// CHECK:           %[[VAL_5:.*]] = quake.alloca(%[[VAL_4]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_5:.*]] = quake.alloca[%[[VAL_4]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.qref) -> !quake.qvec<?>
 // CHECK:           call @__nvqpp__mlirgen__function_magic_func.{{.*}}.ctrl(%[[VAL_6]], %[[VAL_5]]) : (!quake.qvec<?>, !quake.qvec<?>) -> ()
 // CHECK:           return
@@ -82,12 +82,12 @@ struct ctrlHeisenberg {
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__lifted.lambda.0.adj(
 // LAMBDA-SAME:      %{{[^:]*}}: memref<i32>, %{{[^:]*}}: !quake.qvec<?>) {
-// LAMBDA:           quake.x [%{{.*}} : !quake.qref] (%{{.*}})
+// LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.qref, !quake.qref) -> ()
 // LAMBDA:           return
 
 // LAMBDA2-LABEL:   func.func private @__nvqpp__lifted.lambda.1.ctrl(
 // LAMBDA2-SAME:      %[[VAL_0:.*]]: !quake.qvec<?>, %{{.*}}: memref<i32>, %{{.*}}: !quake.qvec<?>) {
-// LAMBDA2:           quake.rz [%[[VAL_0]] : !quake.qvec<?>] |%{{.*}} : f64|(%{{.*}})
+// LAMBDA2:           quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.qref) -> ()
 // LAMBDA2:           return
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__mlirgen__function_magic_func.
@@ -99,7 +99,7 @@ struct ctrlHeisenberg {
 // LAMBDA:                 cc.scope {
 // LAMBDA:                   cc.loop while {
 // LAMBDA:                   } do {
-// LAMBDA:                     quake.rx [%[[VAL_0]] : !quake.qvec<?>] |%{{.*}} : f64|(%{{.*}})
+// LAMBDA:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.qref) -> ()
 // LAMBDA:                     cc.continue
 // LAMBDA:                   } step {
 // LAMBDA:                   }
@@ -123,7 +123,7 @@ struct ctrlHeisenberg {
 
 // LAMBDA-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenberg(
 // LAMBDA-SAME:      %{{.*}}: i32)
-// LAMBDA:           %[[VAL_2:.*]] = quake.alloca : !quake.qref
+// LAMBDA:           %[[VAL_2:.*]] = quake.alloca !quake.qref
 // LAMBDA:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.qref) -> !quake.qvec<?>
 // LAMBDA:           call @__nvqpp__mlirgen__function_magic_func.{{.*}}.ctrl(%[[VAL_6]], %{{.*}}) : (!quake.qvec<?>, !quake.qvec<?>) -> ()
 // LAMBDA:           return
@@ -131,7 +131,7 @@ struct ctrlHeisenberg {
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__lifted.lambda.0(
 // LAMBDA-SAME:      %[[VAL_0:.*]]: memref<i32>, %[[VAL_1:.*]]: !quake.qvec<?>) {
-// LAMBDA:           quake.x [%{{.*}} : !quake.qref] (%{{.*}})
+// LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.qref, !quake.qref) -> ()
 // LAMBDA:           return
 // LAMBDA:         }
 

--- a/test/AST-Quake/control.cpp
+++ b/test/AST-Quake/control.cpp
@@ -36,10 +36,10 @@ struct ctrlHeisenberg {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenberg(
 // CHECK-SAME:        %{{.*}}: i32) attributes
-// CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qref
-// CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qref
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qref
 // CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_2]], %[[VAL_3]] : (!quake.qref, !quake.qref) -> !quake.qvec<2>
-// CHECK:           quake.apply @__nvqpp__mlirgen__heisenbergU[%[[VAL_8]] : !quake.qvec<2>] %{{.*}} : (!quake.qvec<?>) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__heisenbergU[%[[VAL_8]]] %{{.*}} : (!quake.qvec<2>, !quake.qvec<?>) -> ()
 // CHECK:           return
 
 struct givens {
@@ -68,7 +68,7 @@ __qpu__ void qnppx(double theta, cudaq::qubit &q, cudaq::qubit &r,
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qnppx
 // CHECK:           %[[VAL_7:.*]] = quake.concat %{{.*}}, %{{.*}} : (!quake.qref, !quake.qref) -> !quake.qvec<2>
-// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]] : !quake.qvec<2>] %{{.*}}, %{{.*}}, %{{.*}} : (f64, !quake.qref, !quake.qref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %{{.*}}, %{{.*}} : (!quake.qvec<2>, f64, !quake.qref, !quake.qref) -> ()
 // CHECK:           return
 
 __qpu__ void magic_func(cudaq::qreg<> &q) {
@@ -95,7 +95,7 @@ struct ctrlHeisenbergVersion2 {
 // CHECK-SAME:      ._Z[[mangle:[^(]*]](
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenbergVersion2(
-// CHECK:           quake.apply @__nvqpp__mlirgen__function_magic_func._Z[[mangle]]{{\[}}%{{.*}} : !quake.qref] %{{.*}} : (!quake.qvec<?>) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__function_magic_func._Z[[mangle]]{{\[}}%{{.*}}] %{{.*}} : (!quake.qref, !quake.qvec<?>) -> ()
 // CHECK:           return
 
 __qpu__ void qnppx2(double theta, cudaq::qubit &q, cudaq::qubit &r,
@@ -110,9 +110,9 @@ __qpu__ void qnppx2(double theta, cudaq::qubit &q, cudaq::qubit &r,
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qnppx2
 // CHECK-SAME:       %{{[^:]*}}: f64, %[[VAL_1:.*]]: !quake.qref, %[[VAL_2:.*]]: !quake.qref, %[[VAL_3:.*]]: !quake.qref, %[[VAL_4:.*]]: !quake.qref)
 // CHECK:           %[[VAL_7:.*]] = quake.concat %[[VAL_1]], %[[VAL_4]] : (!quake.qref, !quake.qref) -> !quake.qvec<2>
-// CHECK:           quake.x (%[[VAL_4]])
-// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]] : !quake.qvec<2>] %{{.*}}, %[[VAL_2]], %[[VAL_3]] : (f64, !quake.qref, !quake.qref) -> ()
-// CHECK:           quake.x (%[[VAL_4]])
-// CHECK:           quake.x [%[[VAL_2]] : !quake.qref] (%[[VAL_1]])
-// CHECK:           quake.x [%[[VAL_3]] : !quake.qref] (%[[VAL_4]])
+// CHECK:           quake.x %[[VAL_4]]
+// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %[[VAL_2]], %[[VAL_3]] : (!quake.qvec<2>, f64, !quake.qref, !quake.qref) -> ()
+// CHECK:           quake.x %[[VAL_4]] : (!quake.qref) -> ()
+// CHECK:           quake.x [%[[VAL_2]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
 // CHECK:           return

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | cudaq-opt --unwind-lowering --canonicalize | FileCheck %s
 
@@ -123,7 +123,7 @@ struct F {
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca : !quake.qvec<2>
+// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.qvec<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_9:.*]] = memref.alloca() : memref<i32>
@@ -138,22 +138,22 @@ struct F {
 // CHECK:             %[[VAL_13:.*]] = func.call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
-// CHECK:             %[[VAL_14:.*]] = quake.alloca : !quake.qref
-// CHECK:             %[[VAL_15:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.x {{\[}}%[[VAL_14]] : !quake.qref] (%[[VAL_15]])
-// CHECK:             quake.dealloc(%[[VAL_14]] : !quake.qref)
+// CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.qref
+// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:             quake.dealloc %[[VAL_14]] : !quake.qref
 // CHECK:             cf.br ^bb8
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             %[[VAL_17:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.x {{\[}}%[[VAL_16]] : !quake.qref] (%[[VAL_17]])
+// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.qref,
 // CHECK:             func.call @_Z2g2v() : () -> ()
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.y (%[[VAL_20]])
+// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.y %[[VAL_20]] :
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb6:
 // CHECK:             func.call @_Z2g3v() : () -> ()
@@ -162,8 +162,8 @@ struct F {
 // CHECK:               cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:             } do {
 // CHECK:             ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:               %[[VAL_25:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_24]]] : !quake.qvec<2>[index] -> !quake.qref
-// CHECK:               quake.z (%[[VAL_25]])
+// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.qref
+// CHECK:               quake.z %[[VAL_25]] : (!quake.qref) -> ()
 // CHECK:               cc.continue %[[VAL_24]] : index
 // CHECK:             } step {
 // CHECK:             ^bb0(%[[VAL_26:.*]]: index):
@@ -180,7 +180,7 @@ struct F {
 // CHECK:             cc.continue
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz(%[[VAL_8]] : !quake.qvec<2>) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 
@@ -193,7 +193,7 @@ struct F {
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca : !quake.qvec<2>
+// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.qvec<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_9:.*]] = memref.alloca() : memref<i32>
@@ -208,22 +208,22 @@ struct F {
 // CHECK:             %[[VAL_13:.*]] = func.call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
-// CHECK:             %[[VAL_14:.*]] = quake.alloca : !quake.qref
-// CHECK:             %[[VAL_15:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.x {{\[}}%[[VAL_14]] : !quake.qref] (%[[VAL_15]])
-// CHECK:             quake.dealloc(%[[VAL_14]] : !quake.qref)
+// CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.qref
+// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] :
+// CHECK:             quake.dealloc %[[VAL_14]] : !quake.qref
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             %[[VAL_17:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.x {{\[}}%[[VAL_16]] : !quake.qref] (%[[VAL_17]])
+// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.qref, !quake.qref) -> ()
 // CHECK:             func.call @_Z2g2v() : () -> ()
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.y (%[[VAL_20]])
+// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.y %[[VAL_20]]
 // CHECK:             cf.br ^bb8
 // CHECK:           ^bb6:
 // CHECK:             func.call @_Z2g3v() : () -> ()
@@ -232,8 +232,8 @@ struct F {
 // CHECK:               cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:             } do {
 // CHECK:             ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:               %[[VAL_25:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_24]]] : !quake.qvec<2>[index] -> !quake.qref
-// CHECK:               quake.z (%[[VAL_25]])
+// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.qref
+// CHECK:               quake.z %[[VAL_25]] : (!quake.qref) -> ()
 // CHECK:               cc.continue %[[VAL_24]] : index
 // CHECK:             } step {
 // CHECK:             ^bb0(%[[VAL_26:.*]]: index):
@@ -250,7 +250,7 @@ struct F {
 // CHECK:             cc.continue
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz(%[[VAL_8]] : !quake.qvec<2>) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 
@@ -263,7 +263,7 @@ struct F {
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca : !quake.qvec<2>
+// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.qvec<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           %[[VAL_9:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_7]], %[[VAL_9]][] : memref<i32>
@@ -277,22 +277,22 @@ struct F {
 // CHECK:           %[[VAL_13:.*]] = call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_14:.*]] = quake.alloca : !quake.qref
-// CHECK:           %[[VAL_15:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.x {{\[}}%[[VAL_14]] : !quake.qref] (%[[VAL_15]])
-// CHECK:           quake.dealloc(%[[VAL_14]] : !quake.qref)
+// CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.qref, !quake.qref)
+// CHECK:           quake.dealloc %[[VAL_14]] : !quake.qref
 // CHECK:           cf.br ^bb8
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           %[[VAL_17:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.x {{\[}}%[[VAL_16]] : !quake.qref] (%[[VAL_17]])
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.qref, !quake.qref) -> ()
 // CHECK:           call @_Z2g2v() : () -> ()
 // CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.y (%[[VAL_20]])
+// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.y %[[VAL_20]]
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb6:
 // CHECK:           call @_Z2g3v() : () -> ()
@@ -301,8 +301,8 @@ struct F {
 // CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_24]]] : !quake.qvec<2>[index] -> !quake.qref
-// CHECK:             quake.z (%[[VAL_25]])
+// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.qref
+// CHECK:             quake.z %[[VAL_25]]
 // CHECK:             cc.continue %[[VAL_24]] : index
 // CHECK:           } step {
 // CHECK:           ^bb0(%[[VAL_26:.*]]: index):
@@ -315,10 +315,10 @@ struct F {
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb7:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz(%[[VAL_8]] : !quake.qvec<2>) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
 // CHECK:           cf.br ^bb8
 // CHECK:         ^bb8:
-// CHECK:           quake.dealloc(%[[VAL_8]] : !quake.qvec<2>)
+// CHECK:           quake.dealloc %[[VAL_8]] : !quake.qvec<2>
 // CHECK:           return
 // CHECK:         }
 
@@ -331,7 +331,7 @@ struct F {
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca : !quake.qvec<2>
+// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.qvec<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           %[[VAL_9:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_7]], %[[VAL_9]][] : memref<i32>
@@ -345,22 +345,22 @@ struct F {
 // CHECK:           %[[VAL_13:.*]] = call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_14:.*]] = quake.alloca : !quake.qref
-// CHECK:           %[[VAL_15:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.x {{\[}}%[[VAL_14]] : !quake.qref] (%[[VAL_15]])
-// CHECK:           quake.dealloc(%[[VAL_14]] : !quake.qref)
+// CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]]
+// CHECK:           quake.dealloc %[[VAL_14]] : !quake.qref
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           %[[VAL_17:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.x {{\[}}%[[VAL_16]] : !quake.qref] (%[[VAL_17]])
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]]
 // CHECK:           call @_Z2g2v() : () -> ()
 // CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.y (%[[VAL_20]])
+// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.y %[[VAL_20]] : (!quake.qref)
 // CHECK:           cf.br ^bb9
 // CHECK:         ^bb6:
 // CHECK:           call @_Z2g3v() : () -> ()
@@ -369,8 +369,8 @@ struct F {
 // CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = quake.qextract %[[VAL_8]]{{\[}}%[[VAL_24]]] : !quake.qvec<2>[index] -> !quake.qref
-// CHECK:             quake.z (%[[VAL_25]])
+// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.qref
+// CHECK:             quake.z %[[VAL_25]]
 // CHECK:             cc.continue %[[VAL_24]] : index
 // CHECK:           } step {
 // CHECK:           ^bb0(%[[VAL_26:.*]]: index):
@@ -385,10 +385,10 @@ struct F {
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb8:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz(%[[VAL_8]] : !quake.qvec<2>) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
 // CHECK:           cf.br ^bb9
 // CHECK:         ^bb9:
-// CHECK:           quake.dealloc(%[[VAL_8]] : !quake.qvec<2>)
+// CHECK:           quake.dealloc %[[VAL_8]] : !quake.qvec<2>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/ctor.cpp
+++ b/test/AST-Quake/ctor.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake --emit-llvm-file %s | FileCheck %s
 
@@ -15,8 +15,8 @@ using namespace cudaq;
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Teste
 // CHECK-SAME: (%[[VAL_0:.*]]: !quake.qref)
-// CHECK:           quake.h (%[[VAL_0]])
-// CHECK:           %[[VAL_1:.*]] = quake.mz(%[[VAL_0]] : !quake.qref) : i1
+// CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
+// CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.qref) -> i1
 // CHECK:           return
 // CHECK:         }
 
@@ -29,7 +29,7 @@ struct Teste {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Test
 // CHECK-SAME: ()
-// CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qref
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
 // CHECK:           call @__nvqpp__mlirgen__Teste{{.*}}(%[[VAL_2]]) : (!quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/ctrl_vector.cpp
+++ b/test/AST-Quake/ctrl_vector.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -26,15 +26,15 @@ struct lower_ctrl_as_qreg {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__lower_ctrl_as_qreg
 // CHECK-SAME: () attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
 // CHECK:  %[[VAL_0:.*]] = arith.constant 4 : i32
-// CHECK:  %[[VAL_2:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
+// CHECK:  %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:  %[[VAL_3:.*]] = arith.constant 2 : i32
-// CHECK:  %[[VAL_5:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
+// CHECK:  %[[VAL_5:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:  %[[VAL_6:.*]] = arith.constant 0 : i32
-// CHECK:  %[[VAL_8:.*]] = quake.qextract %[[VAL_5]][%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:  quake.h [%[[VAL_2]] : !quake.qvec<?>] (%[[VAL_8]])
+// CHECK:  %[[VAL_8:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:  quake.h [%[[VAL_2]]] %[[VAL_8]] : (!quake.qvec<?>, !quake.qref) -> ()
 // CHECK:  %[[VAL_9:.*]] = arith.constant 1 : i32
-// CHECK:  %[[VAL_11:.*]] = quake.qextract %[[VAL_5]][%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:  quake.x [%[[VAL_2]] : !quake.qvec<?>] (%[[VAL_11]])
+// CHECK:  %[[VAL_11:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:  quake.x [%[[VAL_2]]] %[[VAL_11]] : (
 // clang-format on
 
 struct test_two_control_call {
@@ -55,15 +55,15 @@ struct test_two_control_call {
 // CHECK:           %[[VAL_0:.*]] = cc.create_lambda {
 // CHECK:           ^bb0(%[[VAL_1:.*]]: !quake.qref):
 // CHECK:             cc.scope {
-// CHECK:               quake.h (%[[VAL_1]])
-// CHECK:               quake.x (%[[VAL_1]])
+// CHECK:               quake.h %[[VAL_1]]
+// CHECK:               quake.x %[[VAL_1]]
 // CHECK:             }
 // CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_5:.*]] = quake.alloca(%[[VAL_4]] : i64) : !quake.qvec<4>
-// CHECK:           %[[VAL_6:.*]] = quake.alloca : !quake.qref
-// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test_two_control_call{{.*}}[%[[VAL_5]] : !quake.qvec<4>] %[[VAL_6]] : (!quake.qref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.mz(%[[VAL_6]] : !quake.qref) : i1
+// CHECK:           %[[VAL_5:.*]] = quake.alloca[%[[VAL_4]] : i64] !quake.qvec<4>
+// CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.qref
+// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test_two_control_call{{.*}}[%[[VAL_5]]] %[[VAL_6]] : (!quake.qvec<4>, !quake.qref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_6]] : (!quake.qref) -> i1
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/dealloc.cpp
+++ b/test/AST-Quake/dealloc.cpp
@@ -21,12 +21,12 @@ __qpu__ void magic_func(int N) {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_magic_func
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_4:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
-// CHECK:             quake.dealloc(%[[VAL_4]] : !quake.qvec<?>)
+// CHECK:             %[[VAL_4:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:             quake.dealloc %[[VAL_4]] : !quake.qvec<?>
 // CHECK:             cc.continue
 // CHECK:           }
-// CHECK:           %[[VAL_10:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
-// CHECK:           quake.dealloc(%[[VAL_10]] : !quake.qvec<?>)
+// CHECK:           %[[VAL_10:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:           quake.dealloc %[[VAL_10]] : !quake.qvec<?>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/empty_step.cpp
+++ b/test/AST-Quake/empty_step.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -22,7 +22,7 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_2:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // CHECK:             %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:             %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:             memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -41,15 +41,15 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:                 %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:                 %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
-// CHECK:                 %[[VAL_15:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_14]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                 %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_19:.*]] = arith.subi %[[VAL_17]], %[[VAL_18]] : i64
-// CHECK:                 %[[VAL_20:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_19]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                 %[[VAL_21:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_22:.*]] = arith.extui %[[VAL_21]] : i32 to i64
-// CHECK:                 %[[VAL_23:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_22]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_22]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                 func.call @__nvqpp__mlirgen__function_uma._Z3umaRN5cudaq5quditILm2EEES2_S2_(%[[VAL_15]], %[[VAL_20]], %[[VAL_23]]) : (!quake.qref, !quake.qref, !quake.qref) -> ()
 // CHECK:               }
 // CHECK:               cc.continue

--- a/test/AST-Quake/if.cpp
+++ b/test/AST-Quake/if.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
 
@@ -28,17 +28,17 @@ struct kernel {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i1>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca(%[[VAL_3]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_1]][] : memref<i1>
 // CHECK:           cc.if(%[[VAL_5]]) {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:               %[[VAL_8:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_7]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_9:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
-// CHECK:               %[[VAL_11:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_10]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:               quake.h [%[[VAL_8]] : !quake.qref] (%[[VAL_11]])
+// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               quake.h [%[[VAL_8]]] %[[VAL_11]] :
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[VAL_12:.*]] = arith.constant 0 : i32
@@ -63,27 +63,27 @@ struct kernel_else {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i1>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca(%[[VAL_3]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_1]][] : memref<i1>
 // CHECK:           cc.if(%[[VAL_5]]) {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:               %[[VAL_8:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_7]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_9:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
-// CHECK:               %[[VAL_11:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_10]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:               quake.h [%[[VAL_8]] : !quake.qref] (%[[VAL_11]])
+// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               quake.h [%[[VAL_8]]] %[[VAL_11]] :
 // CHECK:             }
 // CHECK:           } else {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_12:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:               %[[VAL_14:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_13]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:               %[[VAL_17:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_16]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:               quake.x [%[[VAL_14]] : !quake.qref] (%[[VAL_17]])
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               quake.x [%[[VAL_14]]] %[[VAL_17]] :
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[VAL_18:.*]] = arith.constant 0 : i32

--- a/test/AST-Quake/lambda_instance.cpp
+++ b/test/AST-Quake/lambda_instance.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -22,19 +22,19 @@ struct test0 {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test0
-// CHECK:           %[[VAL_2:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
 // CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           %[[VAL_12:.*]] = quake.qextract %[[VAL_2]][%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:           %[[VAL_15:.*]] = quake.qextract %[[VAL_2]][%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test0{{.*}}[%[[VAL_12]] : !quake.qref] %[[VAL_15]] : (!quake.qref) -> ()
+// CHECK:           %[[VAL_12:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test0{{.*}}[%[[VAL_12]]] %[[VAL_15]] : (!quake.qref, !quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        5test0
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref)
-// CHECK:           quake.x (%[[VAL_0]])
+// CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return
 // CHECK:         }
 
@@ -47,19 +47,19 @@ struct test1 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test1
 // CHECK-SAME:        () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_3:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<2>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<2>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
 // CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           %[[VAL_13:.*]] = quake.qextract %[[VAL_3]][%{{.*}}] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           %[[VAL_16:.*]] = quake.qextract %[[VAL_3]][%{{.*}}] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}5test1{{.*}}[%[[VAL_13]] : !quake.qref] %[[VAL_16]] : (!quake.qref) -> ()
+// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}5test1{{.*}}[%[[VAL_13]]] %[[VAL_16]] : (!quake.qref, !quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        5test1
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref)
-// CHECK:           quake.x (%[[VAL_0]])
+// CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return
 // CHECK:         }
 
@@ -84,7 +84,7 @@ struct test2b {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test2b
-// CHECK:           %[[VAL_2:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
 // CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
 // CHECK:           call @__nvqpp__mlirgen__instance_test2a{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
@@ -93,17 +93,17 @@ struct test2b {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test2a
 // CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_1]][%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2b{{.*}}(%[[VAL_4]]) : (!quake.qref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.qextract %[[VAL_1]][%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2b{{.*}}(%[[VAL_7]]) : (!quake.qref) -> ()
 // CHECK:           return
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        6test2b
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref)
-// CHECK:           quake.h (%[[VAL_0]])
-// CHECK:           quake.y (%[[VAL_0]])
+// CHECK:           quake.h %[[VAL_0]] :
+// CHECK:           quake.y %[[VAL_0]] : (!quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -130,7 +130,7 @@ struct test2c {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test2c
-// CHECK:           %[[VAL_2:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
 // CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
 // CHECK:           call @__nvqpp__mlirgen__instance_test2a_c{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
@@ -139,9 +139,9 @@ struct test2c {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test2a_c
 // CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_1]][%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2c{{.*}}(%[[VAL_4]]) : (!quake.qref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.qextract %[[VAL_1]][%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2c{{.*}}(%[[VAL_7]]) : (!quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -149,9 +149,9 @@ struct test2c {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        6test2c
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref)
-// CHECK:           quake.h (%[[VAL_0]])
-// CHECK:           quake.z (%[[VAL_0]])
-// CHECK:           quake.h (%[[VAL_0]])
+// CHECK:           quake.h %[[VAL_0]]
+// CHECK:           quake.z %[[VAL_0]]
+// CHECK:           quake.h %[[VAL_0]]
 // CHECK:           return
 // CHECK:         }
 
@@ -180,11 +180,11 @@ struct test3 {
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_3]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK:           %[[VAL_7:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_6]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_6]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -193,13 +193,13 @@ struct test3 {
 // CHECK-SAME:        () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca(%[[VAL_1]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
 // CHECK:           ^bb0(%[[VAL_4:.*]]: !quake.qref):
 // CHECK:             cc.scope {
-// CHECK:               quake.h (%[[VAL_4]])
-// CHECK:               quake.z (%[[VAL_4]])
-// CHECK:               quake.h (%[[VAL_4]])
+// CHECK:               quake.h %[[VAL_4]]
+// CHECK:               quake.z %[[VAL_4]]
+// CHECK:               quake.h %[[VAL_4]]
 // CHECK:             }
 // CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
 // CHECK:           call @__nvqpp__mlirgen__test3a{{.*}}(%[[VAL_6:.*]], %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
@@ -252,8 +252,8 @@ struct test4x8 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:    7test4x4
-// CHECK:           quake.h (%
-// CHECK:           quake.y (%
+// CHECK:           quake.h %
+// CHECK:           quake.y %
 // CHECK:           return
 // CHECK:         }
 
@@ -271,9 +271,9 @@ struct test4x8 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:    7test4x8
-// CHECK:           quake.h (%
-// CHECK:           quake.z (%
-// CHECK:           quake.h (%
+// CHECK:           quake.h %
+// CHECK:           quake.z %
+// CHECK:           quake.h %
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/lambda_variable.cpp
+++ b/test/AST-Quake/lambda_variable.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -37,21 +37,21 @@ struct test3_caller {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_callee
 // CHECK-SAME:     (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
 // CHECK-SAME:      %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %{{.*}}[%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.qextract %{{.*}}[%{{.*}}] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_caller
 // CHECK-SAME: () attributes {
-// CHECK:           %[[VAL_2:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.qref):
 // CHECK:             cc.scope {
-// CHECK:               quake.h (%[[VAL_5]])
-// CHECK:               quake.y (%[[VAL_5]])
+// CHECK:               quake.h %[[VAL_5]]
+// CHECK:               quake.y %[[VAL_5]]
 // CHECK:             }
 // CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
 // CHECK:           call @__nvqpp__mlirgen__test3_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
@@ -84,13 +84,13 @@ struct test4_caller {
 // CHECK-SAME: () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca(%[[VAL_1]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = cc.undef !llvm.struct<"test4_callee", ()>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.qref):
 // CHECK:             cc.scope {
-// CHECK:               quake.h (%[[VAL_5]])
-// CHECK:               quake.x (%[[VAL_5]])
+// CHECK:               quake.h %[[VAL_5]] :
+// CHECK:               quake.x %[[VAL_5]] : (!quake.qref) -> ()
 // CHECK:             }
 // CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
 // CHECK:           call @__nvqpp__mlirgen__instance_test4_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
@@ -102,18 +102,18 @@ struct test4_caller {
 // CHECK-SAME:    %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_3]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           call @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(%[[VAL_4]]) : (!quake.qref) -> ()
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK:           %[[VAL_7:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_6]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_6]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           call @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(%[[VAL_7]]) : (!quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(
 // CHECK-SAME:                                                                                          %[[VAL_0:.*]]: !quake.qref) attributes {"cudaq-kernel"} {
-// CHECK:           quake.h (%[[VAL_0]])
-// CHECK:           quake.x (%[[VAL_0]])
+// CHECK:           quake.h %[[VAL_0]] :
+// CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/loop_unroll.cpp
+++ b/test/AST-Quake/loop_unroll.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | cudaq-opt --pass-pipeline='builtin.module(expand-measurements,canonicalize,cc-loop-unroll,canonicalize)' | FileCheck %s
 
@@ -21,13 +21,13 @@ struct C {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca : !quake.qvec<2>
+// CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
 // CHECK-DAG:       %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x i1 : (i64) -> !llvm.ptr<i1>
-// CHECK:           %[[VAL_5:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[index] -> !quake.qref
-// CHECK:           %[[VAL_6:.*]] = quake.mz(%[[VAL_5]] : !quake.qref) : i1
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<2>, index) -> !quake.qref
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.qref) -> i1
 // CHECK:           llvm.store %[[VAL_6]], %[[VAL_4]] : !llvm.ptr<i1>
-// CHECK:           %[[VAL_7:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[index] -> !quake.qref
-// CHECK:           %[[VAL_8:.*]] = quake.mz(%[[VAL_7]] : !quake.qref) : i1
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<2>, index) -> !quake.qref
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.qref) -> i1
 // CHECK:           %[[VAL_9:.*]] = llvm.getelementptr %[[VAL_4]][1] : (!llvm.ptr<i1>) -> !llvm.ptr<i1>
 // CHECK:           llvm.store %[[VAL_8]], %[[VAL_9]] : !llvm.ptr<i1>
 // CHECK:           return

--- a/test/AST-Quake/measure_bell.cpp
+++ b/test/AST-Quake/measure_bell.cpp
@@ -1,4 +1,4 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
@@ -34,7 +34,7 @@ int main() { bell{}(100); }
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca(%[[VAL_3]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_5]], %[[VAL_6]][] : memref<i32>
@@ -51,16 +51,16 @@ int main() { bell{}(100); }
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_12:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:                 %[[VAL_14:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_13]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                 quake.h (%[[VAL_14]])
+// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 quake.h %[[VAL_14]] :
 // CHECK:                 %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:                 %[[VAL_17:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_16]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_19]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                 quake.x {{\[}}%[[VAL_17]] : !quake.qref] (%[[VAL_20]])
-// CHECK:                 %[[VAL_21:.*]] = quake.mz(%[[VAL_4]] : !quake.qvec<?>) : !cc.stdvec<i1>
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 quake.x [%[[VAL_17]]] %[[VAL_20]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
 // CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
@@ -135,7 +135,7 @@ struct tinkerbell {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca(%[[VAL_3]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_5]], %[[VAL_6]][] : memref<i32>
@@ -152,16 +152,16 @@ struct tinkerbell {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_12:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:                 %[[VAL_14:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_13]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                 quake.h (%[[VAL_14]])
+// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 quake.h %[[VAL_14]] :
 // CHECK:                 %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:                 %[[VAL_17:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_16]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_19]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                 quake.x {{\[}}%[[VAL_17]] : !quake.qref] (%[[VAL_20]])
-// CHECK:                 %[[VAL_21:.*]] = quake.mz(%[[VAL_4]] : !quake.qvec<?>) : !cc.stdvec<i1>
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 quake.x [%[[VAL_17]]] %[[VAL_20]] : (
+// CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
 // CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
@@ -199,7 +199,7 @@ struct tinkerbell {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca(%[[VAL_3]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_5]], %[[VAL_6]][] : memref<i32>
@@ -216,16 +216,16 @@ struct tinkerbell {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_12:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:                 %[[VAL_14:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_13]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                 quake.h (%[[VAL_14]])
+// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 quake.h %[[VAL_14]]
 // CHECK:                 %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:                 %[[VAL_17:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_16]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_19]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                 quake.x {{\[}}%[[VAL_17]] : !quake.qref] (%[[VAL_20]])
-// CHECK:                 %[[VAL_21:.*]] = quake.mz(%[[VAL_4]] : !quake.qvec<?>) : !cc.stdvec<i1>
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 quake.x {{\[}}%[[VAL_17]]] %[[VAL_20]] :
+// CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
 // CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>

--- a/test/AST-Quake/mz.cpp
+++ b/test/AST-Quake/mz.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -21,8 +21,8 @@ struct S {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__S() attributes
 // CHECK:           %[[VAL_0:.*]] = arith.constant 20 : i32
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca(%[[VAL_1]] : i64) : !quake.qvec<?>
-// CHECK:           %[[VAL_18:.*]] = quake.mz(%[[VAL_2]] : !quake.qvec<?>) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_2]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -38,15 +38,15 @@ struct VectorOfStaticVeq {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorOfStaticVeq() -> !cc.stdvec<i1> attributes {
-// CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
 // CHECK:           %[[VAL_1:.*]] = arith.constant 4 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca(%[[VAL_2]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
-// CHECK:           %[[VAL_6:.*]] = quake.alloca(%[[VAL_5]] : i64) : !quake.qvec<?>
-// CHECK:           %[[VAL_7:.*]] = quake.alloca : !quake.qref
-// CHECK:           %[[VAL_8:.*]] = quake.mz(%[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : !quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_6:.*]] = quake.alloca[%[[VAL_5]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = cc.stdvec_size %[[VAL_8]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_11:.*]] = arith.constant 1 : i64
@@ -71,15 +71,15 @@ struct VectorOfDynamicVeq {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_2]][] : memref<i32>
 // CHECK:           %[[VAL_3:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_1]], %[[VAL_3]][] : memref<i32>
-// CHECK:           %[[VAL_4:.*]] = quake.alloca : !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.qref
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_2]][] : memref<i32>
 // CHECK:           %[[VAL_6:.*]] = arith.extui %[[VAL_5]] : i32 to i64
-// CHECK:           %[[VAL_7:.*]] = quake.alloca(%[[VAL_6]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_7:.*]] = quake.alloca[%[[VAL_6]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_8:.*]] = memref.load %[[VAL_3]][] : memref<i32>
 // CHECK:           %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
-// CHECK:           %[[VAL_10:.*]] = quake.alloca(%[[VAL_9]] : i64) : !quake.qvec<?>
-// CHECK:           %[[VAL_11:.*]] = quake.alloca : !quake.qref
-// CHECK:           %[[VAL_12:.*]] = quake.mz(%[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : !quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_10:.*]] = quake.alloca[%[[VAL_9]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_14:.*]] = cc.stdvec_size %[[VAL_12]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_15:.*]] = arith.constant 1 : i64

--- a/test/AST-Quake/negation.cpp
+++ b/test/AST-Quake/negation.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -21,17 +21,17 @@ struct NegationOperatorTest {
 // CHECK-SAME: () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 3 : i32
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca(%[[VAL_1]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_4:.*]] = arith.extsi %[[VAL_3]] : i32 to i64
-// CHECK:           %[[VAL_5:.*]] = quake.qextract %[[VAL_2]][%[[VAL_4]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_4]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:           %[[VAL_8:.*]] = quake.qextract %[[VAL_2]][%[[VAL_7]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           %[[VAL_9:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
-// CHECK:           %[[VAL_11:.*]] = quake.qextract %[[VAL_2]][%[[VAL_10]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:           quake.x [%[[VAL_5]], %[[VAL_8]] neg [true, false] : !quake.qref, !quake.qref] (%[[VAL_11]])
+// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           quake.x [%[[VAL_5]], %[[VAL_8]] neg [true, false]] %[[VAL_11]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/passQregNToQSpan.cpp
+++ b/test/AST-Quake/passQregNToQSpan.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -28,7 +28,7 @@ struct entry {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__entry() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_1:.*]] = quake.alloca(%[[VAL_0]] : i64) : !quake.qvec<3>
+// CHECK:           %[[VAL_1:.*]] = quake.alloca[%[[VAL_0]] : i64] !quake.qvec<3>
 // CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.qvec<3>) -> !quake.qvec<?>
 // CHECK:           call @__nvqpp__mlirgen__function_mcx._Z3mcxN5cudaq5qspan{{.*}}(%[[VAL_2]]) : (!quake.qvec<?>) -> ()
 // CHECK:           return

--- a/test/AST-Quake/postfix_ops.cpp
+++ b/test/AST-Quake/postfix_ops.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -22,7 +22,7 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>,
 // CHECK-SAME:         %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_2:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // CHECK:             %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:             %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:             memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -41,15 +41,15 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:                 %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:                 %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
-// CHECK:                 %[[VAL_15:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_14]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                 %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_19:.*]] = arith.subi %[[VAL_17]], %[[VAL_18]] : i64
-// CHECK:                 %[[VAL_20:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_19]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                 %[[VAL_21:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_22:.*]] = arith.extui %[[VAL_21]] : i32 to i64
-// CHECK:                 %[[VAL_23:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_22]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_22]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {

--- a/test/AST-Quake/qbit_arg.cpp
+++ b/test/AST-Quake/qbit_arg.cpp
@@ -1,23 +1,23 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake --emit-llvm-file %s | FileCheck %s
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__function_testFunc
 // CHECK-SAME:    (%[[VAL_0:.*]]: !quake.qref)
-// CHECK: quake.h (%[[VAL_0]])
-// CHECK: %[[VAL_1:.*]] = quake.mz(%[[VAL_0]] : !quake.qref) : i1
+// CHECK: quake.h %[[VAL_0]] :
+// CHECK: %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.qref) -> i1
 // CHECK: return
 // CHECK: }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Test
 // CHECK-SAME: () attributes
-// CHECK: %[[VAL_2:.*]] = quake.alloca : !quake.qref
+// CHECK: %[[VAL_2:.*]] = quake.alloca !quake.qref
 // CHECK: call @__nvqpp__mlirgen__function_testFunc{{.*}}(%[[VAL_2]]) : (!quake.qref) -> ()
 // CHECK: return
 // CHECK: }

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -103,7 +103,7 @@ int main() {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_iqft
 // CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
-// CHECK:           %[[VAL_1:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_1:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // CHECK:           %[[VAL_2:.*]] = arith.trunci %[[VAL_1]] : i64 to i32
 // CHECK:           %[[VAL_3:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_2]], %[[VAL_3]][] : memref<i32>
@@ -122,15 +122,15 @@ int main() {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_11:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:                 %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
-// CHECK:                 %[[VAL_13:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_12]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_12]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                 %[[VAL_14:.*]] = memref.load %[[VAL_3]][] : memref<i32>
 // CHECK:                 %[[VAL_15:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:                 %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i32
 // CHECK:                 %[[VAL_17:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_18:.*]] = arith.subi %[[VAL_16]], %[[VAL_17]] : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_19]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                 quake.swap (%[[VAL_13]], %[[VAL_20]])
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 quake.swap %[[VAL_13]], %[[VAL_20]] : (
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
@@ -155,8 +155,8 @@ int main() {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_31:.*]] = memref.load %[[VAL_25]][] : memref<i32>
 // CHECK:                 %[[VAL_32:.*]] = arith.extsi %[[VAL_31]] : i32 to i64
-// CHECK:                 %[[VAL_33:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_32]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                 quake.h (%[[VAL_33]])
+// CHECK:                 %[[VAL_33:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_32]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 quake.h %[[VAL_33]] : (!quake.qref) -> ()
 // CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_25]][] : memref<i32>
 // CHECK:                 %[[VAL_35:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_36:.*]] = arith.addi %[[VAL_34]], %[[VAL_35]] : i32
@@ -187,11 +187,11 @@ int main() {
 // CHECK:                       %[[VAL_54:.*]] = memref.load %[[VAL_53]][] : memref<f64>
 // CHECK:                       %[[VAL_55:.*]] = memref.load %[[VAL_37]][] : memref<i32>
 // CHECK:                       %[[VAL_56:.*]] = arith.extsi %[[VAL_55]] : i32 to i64
-// CHECK:                       %[[VAL_57:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_56]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:                       %[[VAL_57:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_56]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:                       %[[VAL_58:.*]] = memref.load %[[VAL_39]][] : memref<i32>
 // CHECK:                       %[[VAL_59:.*]] = arith.extsi %[[VAL_58]] : i32 to i64
-// CHECK:                       %[[VAL_60:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_59]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                       quake.r1 {{\[}}%[[VAL_57]] : !quake.qref] |%[[VAL_54]] : f64|(%[[VAL_60]])
+// CHECK:                       %[[VAL_60:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_59]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                       quake.r1 (%[[VAL_54]]) [%[[VAL_57]]] %[[VAL_60]] : (f64, !quake.qref, !quake.qref) -> ()
 // CHECK:                     }
 // CHECK:                     cc.continue
 // CHECK:                   } step {
@@ -214,15 +214,15 @@ int main() {
 // CHECK:           %[[VAL_68:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_69:.*]] = arith.subi %[[VAL_67]], %[[VAL_68]] : i32
 // CHECK:           %[[VAL_70:.*]] = arith.extsi %[[VAL_69]] : i32 to i64
-// CHECK:           %[[VAL_71:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_70]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:           quake.h (%[[VAL_71]])
+// CHECK:           %[[VAL_71:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_70]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           quake.h %[[VAL_71]]
 // CHECK:           return
 // CHECK:         }
 
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__tgate
 // CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>) attributes
-// CHECK:           %[[VAL_3:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
@@ -231,8 +231,8 @@ int main() {
 // CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-// CHECK:             %[[VAL_9:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_8]]] : !quake.qvec<?>[index] -> !quake.qref
-// CHECK:             quake.t (%[[VAL_9]])
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
+// CHECK:             quake.t %[[VAL_9]] : (!quake.qref) -> ()
 // CHECK:             cc.continue %[[VAL_8]] : index
 // CHECK:           } step {
 // CHECK:           ^bb0(%[[VAL_10:.*]]: index):
@@ -244,7 +244,7 @@ int main() {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Z4mainE3$_0
 // CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_3:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
@@ -253,8 +253,8 @@ int main() {
 // CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-// CHECK:             %[[VAL_9:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_8]]] : !quake.qvec<?>[index] -> !quake.qref
-// CHECK:             quake.x (%[[VAL_9]])
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
+// CHECK:             quake.x %[[VAL_9]] :
 // CHECK:             cc.continue %[[VAL_8]] : index
 // CHECK:           } step {
 // CHECK:           ^bb0(%[[VAL_10:.*]]: index):
@@ -276,7 +276,7 @@ int main() {
 // CHECK:           %[[VAL_7:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           %[[VAL_9:.*]] = arith.extsi %[[VAL_8]] : i32 to i64
-// CHECK:           %[[VAL_10:.*]] = quake.alloca(%[[VAL_9]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_10:.*]] = quake.alloca[%[[VAL_9]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_11:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:           %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
 // CHECK:           %[[VAL_13:.*]] = arith.constant 0 : i64
@@ -285,13 +285,13 @@ int main() {
 // CHECK:           %[[VAL_16:.*]] = quake.subvec %[[VAL_10]], %[[VAL_13]], %[[VAL_15]] : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
 // CHECK:           %[[VAL_17:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:           %[[VAL_18:.*]] = arith.extsi %[[VAL_17]] : i32 to i64
-// CHECK:           %[[VAL_19:.*]] = quake.qvec_size %[[VAL_10]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_19:.*]] = quake.vec_size %[[VAL_10]] : (!quake.qvec<?>) -> i64
 // CHECK:           %[[VAL_20:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_21:.*]] = arith.subi %[[VAL_19]], %[[VAL_20]] : i64
 // CHECK:           %[[VAL_22:.*]] = arith.subi %[[VAL_19]], %[[VAL_18]] : i64
 // CHECK:           %[[VAL_23:.*]] = quake.subvec %[[VAL_10]], %[[VAL_22]], %[[VAL_21]] : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
 // CHECK:           call @__nvqpp__mlirgen__Z4mainE3$_0(%[[VAL_23]]) : (!quake.qvec<?>) -> ()
-// CHECK:           %[[VAL_24:.*]] = quake.qvec_size %[[VAL_16]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_24:.*]] = quake.vec_size %[[VAL_16]] : (!quake.qvec<?>) -> i64
 // CHECK:           %[[VAL_25:.*]] = arith.index_cast %[[VAL_24]] : i64 to index
 // CHECK:           %[[VAL_26:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_27:.*]] = arith.constant 1 : index
@@ -300,8 +300,8 @@ int main() {
 // CHECK:             cc.condition %[[VAL_30]](%[[VAL_29]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_31:.*]]: index):
-// CHECK:             %[[VAL_32:.*]] = quake.qextract %[[VAL_16]]{{\[}}%[[VAL_31]]] : !quake.qvec<?>[index] -> !quake.qref
-// CHECK:             quake.h (%[[VAL_32]])
+// CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_31]]] : (!quake.qvec<?>, index) -> !quake.qref
+// CHECK:             quake.h %[[VAL_32]] :
 // CHECK:             cc.continue %[[VAL_31]] : index
 // CHECK:           } step {
 // CHECK:           ^bb0(%[[VAL_33:.*]]: index):
@@ -336,8 +336,8 @@ int main() {
 // CHECK:                     cc.scope {
 // CHECK:                       %[[VAL_49:.*]] = memref.load %[[VAL_36]][] : memref<i32>
 // CHECK:                       %[[VAL_50:.*]] = arith.extsi %[[VAL_49]] : i32 to i64
-// CHECK:                       %[[VAL_51:.*]] = quake.qextract %[[VAL_16]]{{\[}}%[[VAL_50]]] : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:                       quake.apply @__nvqpp__mlirgen__tgate{{\[}}%[[VAL_51]] : !quake.qref] %[[VAL_23]] : (!quake.qvec<?>) -> ()
+// CHECK:                       %[[VAL_51:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_50]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                       quake.apply @__nvqpp__mlirgen__tgate[%[[VAL_51]]] %[[VAL_23]] : (!quake.qref, !quake.qvec<?>) -> ()
 // CHECK:                     }
 // CHECK:                     cc.continue
 // CHECK:                   } step {
@@ -357,6 +357,6 @@ int main() {
 // CHECK:             }
 // CHECK:           }
 // CHECK:           call @__nvqpp__mlirgen__function_iqft{{.*}}(%[[VAL_16]]) : (!quake.qvec<?>) -> ()
-// CHECK:           %[[VAL_68:.*]] = quake.mz(%[[VAL_16]] : !quake.qvec<?>) :  !cc.stdvec<i1>
+// CHECK:           %[[VAL_68:.*]] = quake.mz %[[VAL_16]] : (!quake.qvec<?>) ->  !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/simple.cpp
+++ b/test/AST-Quake/simple.cpp
@@ -20,7 +20,7 @@
 // CHECK-VISIT:     %[[VAL_4:.*]] = quake.alloca(%[[VAL_3]] : i64) : !quake.qvec<?>
 // CHECK-VISIT:     %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK-VISIT:     %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK-VISIT:     %[[VAL_7:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_6]] : i64] : !quake.qvec<?> -> !quake.qref
+// CHECK-VISIT:     %[[VAL_7:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_6]] : i64] : !quake.qvec<?> -> !quake.qref
 // CHECK-VISIT:     quake.h (%[[VAL_7]])
 // CHECK-VISIT:     quake.scope {
 // CHECK-VISIT:       %[[VAL_8:.*]] = arith.constant 0 : i32
@@ -37,12 +37,12 @@
 // CHECK-VISIT:         quake.scope {
 // CHECK-VISIT:           %[[VAL_15:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK-VISIT:           %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK-VISIT:           %[[VAL_17:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_16]] : i64] : !quake.qvec<?> -> !quake.qref
+// CHECK-VISIT:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]] : i64] : !quake.qvec<?> -> !quake.qref
 // CHECK-VISIT:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK-VISIT:           %[[VAL_19:.*]] = arith.constant 1 : i32
 // CHECK-VISIT:           %[[VAL_20:.*]] = arith.addi %[[VAL_18]], %[[VAL_19]] : i32
 // CHECK-VISIT:           %[[VAL_21:.*]] = arith.extsi %[[VAL_20]] : i32 to i64
-// CHECK-VISIT:           %[[VAL_22:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_21]] : i64] : !quake.qvec<?> -> !quake.qref
+// CHECK-VISIT:           %[[VAL_22:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_21]] : i64] : !quake.qvec<?> -> !quake.qref
 // CHECK-VISIT:           quake.x [%[[VAL_17]]] (%[[VAL_22]])
 // CHECK-VISIT:         }
 // CHECK-VISIT:         quake.continue ()
@@ -53,11 +53,11 @@
 // CHECK-VISIT:         memref.store %[[VAL_25]], %[[VAL_9]][] : memref<i32>
 // CHECK-VISIT:       }
 // CHECK-VISIT:     }
-// CHECK-VISIT:     %[[VAL_26:.*]] = quake.qvec_size(%[[VAL_4]] : !quake.qvec<?>) : i64
+// CHECK-VISIT:     %[[VAL_26:.*]] = quake.vec_size(%[[VAL_4]] : !quake.qvec<?>) : i64
 // CHECK-VISIT:     %[[VAL_27:.*]] = arith.index_cast %[[VAL_26]] : i64 to index
 // CHECK-VISIT:     %[[VAL_28:.*]] = arith.constant 0 : index
 // CHECK-VISIT:     affine.for %[[VAL_29:.*]] = affine_map<(d0) -> (d0)>(%[[VAL_28]]) to affine_map<(d0) -> (d0)>(%[[VAL_27]]) {
-// CHECK-VISIT:       %[[VAL_30:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_29]] : index] : !quake.qvec<?> -> !quake.qref
+// CHECK-VISIT:       %[[VAL_30:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_29]] : index] : !quake.qvec<?> -> !quake.qref
 // CHECK-VISIT:       %[[VAL_31:.*]] = quake.mz(%[[VAL_30]] : !quake.qref) : i1
 // CHECK-VISIT:     }
 // CHECK-VISIT:     return

--- a/test/AST-Quake/simple_qarray.cpp
+++ b/test/AST-Quake/simple_qarray.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // Simple test to make sure the tool is built and has basic functionality.
 
@@ -48,11 +48,11 @@ int main() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ghz
 // CHECK-SAME: ()
 // CHECK:           %[[VAL_2:.*]] = arith.constant 5 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca(%[[VAL_2]] : i64) : !quake.qvec<5>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<5>
 // CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:           %[[VAL_8:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_7]]] : !quake.qvec<5>[i64] -> !quake.qref
-// CHECK:           quake.h (%[[VAL_8]])
+// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, i64) -> !quake.qref
+// CHECK:           quake.h %[[VAL_8]] :
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : i32
 // CHECK:             %[[VAL_10:.*]] = memref.alloca() : memref<i32>
@@ -66,13 +66,13 @@ int main() {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_14:.*]] = memref.load %[[VAL_10]][] : memref<i32>
 // CHECK:                 %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
-// CHECK:                 %[[VAL_16:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_15]]] : !quake.qvec<5>[i64] -> !quake.qref
+// CHECK:                 %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_15]]] : (!quake.qvec<5>, i64) -> !quake.qref
 // CHECK:                 %[[VAL_17:.*]] = memref.load %[[VAL_10]][] : memref<i32>
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.addi %[[VAL_17]], %[[VAL_18]] : i32
 // CHECK:                 %[[VAL_20:.*]] = arith.extsi %[[VAL_19]] : i32 to i64
-// CHECK:                 %[[VAL_21:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_20]]] : !quake.qvec<5>[i64] -> !quake.qref
-// CHECK:                 quake.x [%[[VAL_16]] : !quake.qref] (%[[VAL_21]])
+// CHECK:                 %[[VAL_21:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_20]]] : (!quake.qvec<5>, i64) -> !quake.qref
+// CHECK:                 quake.x [%[[VAL_16]]] %[[VAL_21]] :
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
@@ -82,7 +82,7 @@ int main() {
 // CHECK:               memref.store %[[VAL_24]], %[[VAL_10]][] : memref<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_33:.*]] = quake.mz(%[[VAL_3]] : !quake.qvec<5>) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_33:.*]] = quake.mz %[[VAL_3]] : (!quake.qvec<5>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/single_qubit_ctor.cpp
+++ b/test/AST-Quake/single_qubit_ctor.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -15,14 +15,14 @@
 // CHECK-SAME: (%[[arg0:.*]]: f64) -> i1
 // CHECK:     %[[V0:.*]] = memref.alloca() : memref<f64>
 // CHECK:     memref.store %[[arg0]], %[[V0]][] : memref<f64>
-// CHECK:     %[[V1:.*]] = quake.alloca : !quake.qref
+// CHECK:     %[[V1:.*]] = quake.alloca !quake.qref
 // CHECK:     %[[V2:.*]] = memref.load %[[V0]][] : memref<f64>
-// CHECK:     quake.rx |%[[V2]] : f64|(%[[V1]])
+// CHECK:     quake.rx (%[[V2]]) %[[V1]] : (f64,
 // CHECK:     %[[V3:.*]] = memref.load %[[V0]][] : memref<f64>
 // CHECK:     %[[cst:.*]] = arith.constant 2.0{{.*}} : f64
 // CHECK:     %[[V4:.*]] = arith.divf %[[V3]], %[[cst]] : f64
-// CHECK:     quake.ry |%[[V4]] : f64|(%[[V1]])
-// CHECK:     %[[V5:.*]] = quake.mz(%[[V1]] : !quake.qref) : i1
+// CHECK:     quake.ry (%[[V4]]) %[[V1]] : (f64,
+// CHECK:     %[[V5:.*]] = quake.mz %[[V1]] : (!quake.qref) -> i1
 // CHECK:     return %[[V5]] : i1
 // CHECK:   }
 // CHECK: }

--- a/test/AST-Quake/slice.cpp
+++ b/test/AST-Quake/slice.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -24,7 +24,7 @@ struct SliceTest {
 // CHECK-SAME:      (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) attributes {
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : i32
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
-// CHECK:           %[[VAL_6:.*]] = quake.alloca(%[[VAL_5]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_6:.*]] = quake.alloca[%[[VAL_5]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_11:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_12:.*]] = arith.addi %{{.*}}, %{{.*}} : i64
 // CHECK:           %[[VAL_13:.*]] = arith.subi %[[VAL_12]], %[[VAL_11]] : i64

--- a/test/AST-Quake/template_lambda.cpp
+++ b/test/AST-Quake/template_lambda.cpp
@@ -29,14 +29,14 @@ int main() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__thisWorks
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Z4mainE3$_0(
-// CHECK:           quake.x (%{{.*}})
+// CHECK:           quake.x %{{.*}} :
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test
 // CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>)
 // CHECK-NOT:       %[[VAL_0]]
-// CHECK:           %[[VAL_3:.*]] = quake.alloca(%{{.*}} : i64) : !quake.qvec<?>
-// CHECK:           %[[VAL_6:.*]] = quake.qextract %{{.*}} : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:           %[[VAL_9:.*]] = quake.qextract %{{.*}} : !quake.qvec<?>[i64] -> !quake.qref
-// CHECK:           quake.apply @__nvqpp__mlirgen__Z4mainE3$_0[%[[VAL_6]] : !quake.qref] %[[VAL_9]] : (!quake.qref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %{{.*}} : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %{{.*}} : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           quake.apply @__nvqpp__mlirgen__Z4mainE3$_0[%[[VAL_6]]] %[[VAL_9]] : (!quake.qref, !quake.qref) -> ()
 // CHECK:           return
 

--- a/test/AST-Quake/vector_bool.cpp
+++ b/test/AST-Quake/vector_bool.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -22,7 +22,7 @@ struct t1 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__t1
 // CHECK-SAME:        (%[[VAL_0:.*]]: !cc.stdvec<f64>) -> i1 attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
-// CHECK:           %[[VAL_13:.*]] = quake.mz(%{{.*}} : !quake.qvec<?>) : !cc.stdvec<i1>
+// CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
 // CHECK:           %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_13]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>

--- a/test/AST-Quake/while-1.cpp
+++ b/test/AST-Quake/while-1.cpp
@@ -1,10 +1,10 @@
-/*************************************************************** -*- C++ -*- ***
+/*******************************************************************************
  * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
 
@@ -45,7 +45,7 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test1
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_2:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -60,15 +60,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:               %[[VAL_10:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
-// CHECK:               %[[VAL_12:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_11]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_13:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_14:.*]] = arith.extui %[[VAL_13]] : i32 to i64
 // CHECK:               %[[VAL_15:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
-// CHECK:               %[[VAL_17:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_16]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_19:.*]] = arith.extui %[[VAL_18]] : i32 to i64
-// CHECK:               %[[VAL_20:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_19]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           }
@@ -78,7 +78,7 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test2
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_2:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -91,15 +91,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i32 to i64
 // CHECK:               %[[VAL_8:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_9:.*]] = arith.subi %[[VAL_7]], %[[VAL_8]] : i64
-// CHECK:               %[[VAL_10:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_9]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_9]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_11:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:               %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
-// CHECK:               %[[VAL_15:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_14]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_15:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
-// CHECK:               %[[VAL_18:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_17]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_18:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_17]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           }
@@ -109,7 +109,7 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test3
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_2:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -119,15 +119,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_6:.*]] = arith.extui %[[VAL_5]] : i32 to i64
 // CHECK:               %[[VAL_7:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_8:.*]] = arith.subi %[[VAL_6]], %[[VAL_7]] : i64
-// CHECK:               %[[VAL_9:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_8]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_11:.*]] = arith.extui %[[VAL_10]] : i32 to i64
 // CHECK:               %[[VAL_12:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_13:.*]] = arith.subi %[[VAL_11]], %[[VAL_12]] : i64
-// CHECK:               %[[VAL_14:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_13]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_15:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_16:.*]] = arith.extui %[[VAL_15]] : i32 to i64
-// CHECK:               %[[VAL_17:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_16]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           } while {
@@ -140,7 +140,7 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test4
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>) -> f64
-// CHECK:           %[[VAL_2:.*]] = quake.qvec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -154,15 +154,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:               %[[VAL_10:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
-// CHECK:               %[[VAL_12:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_11]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_13:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_14:.*]] = arith.extui %[[VAL_13]] : i32 to i64
 // CHECK:               %[[VAL_15:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
-// CHECK:               %[[VAL_17:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_16]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_19:.*]] = arith.extui %[[VAL_18]] : i32 to i64
-// CHECK:               %[[VAL_20:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_19]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           } while {

--- a/test/Conversion/QTXToQuake/qtx-to-quake.mlir
+++ b/test/Conversion/QTXToQuake/qtx-to-quake.mlir
@@ -20,14 +20,14 @@ module {
   }
 
   // CHECK-LABEL:   func.func @apply_one_target_operators(
-  // CHECK-SAME:                                          %[[VAL_0:.*]]: !quake.qref,
-  // CHECK-SAME:                                          %[[VAL_1:.*]]: !quake.qref) {
-  // CHECK:           quake.h {{\[}}%[[VAL_0]] : !quake.qref] (%[[VAL_1]])
-  // CHECK:           quake.s {{\[}}%[[VAL_0]] : !quake.qref] (%[[VAL_1]])
-  // CHECK:           quake.t {{\[}}%[[VAL_0]] : !quake.qref] (%[[VAL_1]])
-  // CHECK:           quake.x {{\[}}%[[VAL_0]] : !quake.qref] (%[[VAL_1]])
-  // CHECK:           quake.y {{\[}}%[[VAL_0]] : !quake.qref] (%[[VAL_1]])
-  // CHECK:           quake.z {{\[}}%[[VAL_0]] : !quake.qref] (%[[VAL_1]])
+  // CHECK-SAME:                                   %[[VAL_0:.*]]: !quake.qref,
+  // CHECK-SAME:                                   %[[VAL_1:.*]]: !quake.qref) {
+  // CHECK:   quake.h [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
+  // CHECK:   quake.s [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
+  // CHECK:   quake.t [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
+  // CHECK:   quake.x [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
+  // CHECK:   quake.y [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
+  // CHECK:   quake.z [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @apply_one_target_operators(%q0: !qtx.wire, %q1: !qtx.wire) -> (!qtx.wire, !qtx.wire) {
@@ -42,14 +42,14 @@ module {
 
   // CHECK-LABEL:   func.func @apply_parametrized_one_target_operators() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 3.140000e+00 : f64
-  // CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qref
-  // CHECK:           quake.r1 {{\[}}%[[VAL_2]] : !quake.qref] |%[[VAL_0]] : f64|(%[[VAL_1]])
-  // CHECK:           quake.rx {{\[}}%[[VAL_2]] : !quake.qref] |%[[VAL_0]] : f64|(%[[VAL_1]])
-  // CHECK:           quake.ry {{\[}}%[[VAL_2]] : !quake.qref] |%[[VAL_0]] : f64|(%[[VAL_1]])
-  // CHECK:           quake.rz {{\[}}%[[VAL_2]] : !quake.qref] |%[[VAL_0]] : f64|(%[[VAL_1]])
-  // CHECK:           quake.dealloc(%[[VAL_1]] : !quake.qref)
-  // CHECK:           quake.dealloc(%[[VAL_2]] : !quake.qref)
+  // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
+  // CHECK: quake.r1 (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.qref, !quake.qref) -> ()
+  // CHECK: quake.rx (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.qref, !quake.qref) -> ()
+  // CHECK: quake.ry (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.qref, !quake.qref) -> ()
+  // CHECK: quake.rz (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.qref, !quake.qref) -> ()
+  // CHECK:           quake.dealloc %[[VAL_1]] : !quake.qref
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qref
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @apply_parametrized_one_target_operators() {
@@ -68,11 +68,11 @@ module {
   // CHECK-LABEL:   func.func @qextract_and_apply_two_targets_operator() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qvec<2>
-  // CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           quake.swap (%[[VAL_3]], %[[VAL_4]])
-  // CHECK:           quake.dealloc(%[[VAL_2]] : !quake.qvec<2>)
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK: quake.swap %[[VAL_3]], %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @qextract_and_apply_two_targets_operator() {
@@ -90,12 +90,12 @@ module {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
   // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
-  // CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qvec<3>
-  // CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_0]]] : !quake.qvec<3>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_5:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_1]]] : !quake.qvec<3>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_6:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_2]]] : !quake.qvec<3>[i32] -> !quake.qref
-  // CHECK:           quake.swap {{\[}}%[[VAL_6]] : !quake.qref] (%[[VAL_4]], %[[VAL_5]])
-  // CHECK:           quake.dealloc(%[[VAL_3]] : !quake.qvec<3>)
+  // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<3>
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.qvec<3>, i32) -> !quake.qref
+  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<3>, i32) -> !quake.qref
+  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<3>, i32) -> !quake.qref
+  // CHECK: quake.swap [%[[VAL_6]]] %[[VAL_4]], %[[VAL_5]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
+  // CHECK:           quake.dealloc %[[VAL_3]] : !quake.qvec<3>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @qextract_and_apply_controlled_two_targets_operator() {
@@ -114,10 +114,10 @@ module {
   // CHECK-SAME:                            %[[VAL_0:.*]]: !quake.qvec<2>) {
   // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           quake.h (%[[VAL_3]])
-  // CHECK:           quake.x (%[[VAL_4]])
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
+  // CHECK:           quake.x %[[VAL_4]] : (!quake.qref) -> ()
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @return_array(%arg0: !qtx.wire_array<2>) -> (!qtx.wire_array<2>) {
@@ -134,12 +134,12 @@ module {
   // CHECK-LABEL:   func.func @reset_wires() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qvec<2>
-  // CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           quake.reset(%[[VAL_3]] : !quake.qref)
-  // CHECK:           quake.reset(%[[VAL_4]] : !quake.qref)
-  // CHECK:           quake.dealloc(%[[VAL_2]] : !quake.qvec<2>)
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK:           quake.reset %[[VAL_3]] : (!quake.qref) -> ()
+  // CHECK:           quake.reset %[[VAL_4]] : (!quake.qref) -> ()
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @reset_wires() {
@@ -157,17 +157,17 @@ module {
   // CHECK-LABEL:   func.func @reset_array() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qvec<2>
-  // CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           quake.h (%[[VAL_3]])
-  // CHECK:           quake.x (%[[VAL_4]])
-  // CHECK:           quake.reset(%[[VAL_2]] : !quake.qvec<2>)
-  // CHECK:           %[[VAL_5:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_6:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           quake.h (%[[VAL_5]])
-  // CHECK:           quake.x (%[[VAL_6]])
-  // CHECK:           quake.dealloc(%[[VAL_2]] : !quake.qvec<2>)
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
+  // CHECK:           quake.x %[[VAL_4]]  : (!quake.qref) -> ()
+  // CHECK:           quake.reset %[[VAL_2]] : (!quake.qvec<2>) -> ()
+  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK:           quake.h %[[VAL_5]] : (!quake.qref) -> ()
+  // CHECK:           quake.x %[[VAL_6]] : (!quake.qref) -> ()
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @reset_array() {
@@ -190,12 +190,12 @@ module {
   // CHECK-LABEL:   func.func @mz_wires() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qvec<2>
-  // CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_5:.*]] = quake.mz(%[[VAL_3]] : !quake.qref) : i1
-  // CHECK:           %[[VAL_6:.*]] = quake.mz(%[[VAL_4]] : !quake.qref) : i1
-  // CHECK:           quake.dealloc(%[[VAL_2]] : !quake.qvec<2>)
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_3]] : (!quake.qref) -> i1
+  // CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_4]] : (!quake.qref) -> i1
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @mz_wires() {
@@ -213,17 +213,17 @@ module {
   // CHECK-LABEL:   func.func @mz_array() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qvec<2>
-  // CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           quake.h (%[[VAL_3]])
-  // CHECK:           quake.x (%[[VAL_4]])
-  // CHECK:           %[[VAL_5:.*]] = quake.mz(%[[VAL_2]] : !quake.qvec<2>) : !cc.stdvec<i1>
-  // CHECK:           %[[VAL_6:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           %[[VAL_7:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i32] -> !quake.qref
-  // CHECK:           quake.h (%[[VAL_6]])
-  // CHECK:           quake.x (%[[VAL_7]])
-  // CHECK:           quake.dealloc(%[[VAL_2]] : !quake.qvec<2>)
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
+  // CHECK:           quake.x %[[VAL_4]] : (!quake.qref) -> ()
+  // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_2]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
+  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK: %[[VAL_7:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+  // CHECK:           quake.h %[[VAL_6]] : (!quake.qref) -> ()
+  // CHECK:           quake.x %[[VAL_7]] : (!quake.qref) -> ()
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @mz_array() {

--- a/test/Conversion/QuakeToQTX/quake_cc_if.qke
+++ b/test/Conversion/QuakeToQTX/quake_cc_if.qke
@@ -19,21 +19,21 @@ module {
 
     // CHECK:  %[[W0:.*]] = qtx.alloca
     // CHECK:  %[[W1:.*]] = qtx.alloca
-    %q0 = quake.alloca : !quake.qref
-    %q1 = quake.alloca : !quake.qref
+    %q0 = quake.alloca !quake.qref
+    %q1 = quake.alloca !quake.qref
 
     // CHECK:  %[[W1_1:.*]] = cc.if
     cc.if(%c1) {
       // CHECK:  %[[W1_2:.*]] = qtx.x [%[[W0]]] %[[W1]]
-      quake.x [%q0: !quake.qref] (%q1)
+      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
       // CHECK:  cc.continue %[[W1_2]]
     } else {
       // CHECK:  %[[W1_3:.*]] = qtx.y [%[[W0]]] %[[W1]]
-      quake.y [%q0: !quake.qref] (%q1)
+      quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
       // CHECK:  cc.continue %[[W1_3]]
     }
     // CHECK:  %[[W1_4:.*]] = qtx.z [%[[W0]]] %[[W1_1]]
-    quake.z [%q0: !quake.qref] (%q1)
+    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     // CHECK: qtx.unrealized_return
     return
   }
@@ -45,21 +45,21 @@ module {
 
     // CHECK:  %[[W0:.*]] = qtx.alloca
     // CHECK:  %[[W1:.*]] = qtx.alloca
-    %q0 = quake.alloca : !quake.qref
-    %q1 = quake.alloca : !quake.qref
+    %q0 = quake.alloca  !quake.qref
+    %q1 = quake.alloca  !quake.qref
 
     // CHECK:  %[[WIRES:.*]]:2 = cc.if
     cc.if(%c1) {
       // CHECK:  %[[W1_1:.*]] = qtx.x [%[[W0]]] %[[W1]]
-      quake.x [%q0: !quake.qref] (%q1)
+      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
       // CHECK:  cc.continue %[[W1_1]], %[[W0]]
     } else {
       // CHECK:  %[[W0_1:.*]] = qtx.y [%[[W1]]] %[[W0]]
-      quake.y [%q1: !quake.qref] (%q0)
+      quake.y [%q1] %q0 : (!quake.qref, !quake.qref) -> ()
       // CHECK:  cc.continue %[[W1]], %[[W0_1]]
     }
     // CHECK:  %[[W1_2:.*]] = qtx.z [%[[WIRES]]#1] %[[WIRES]]#0
-    quake.z [%q0: !quake.qref] (%q1)
+    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     // CHECK: qtx.unrealized_return
     return
   }
@@ -68,12 +68,12 @@ module {
   func.func @test03(%c1: i1) {
     // CHECK:  %[[W0:.*]] = qtx.alloca
     // CHECK:  %[[W1:.*]] = qtx.alloca
-    %q0 = quake.alloca : !quake.qref
-    %q1 = quake.alloca : !quake.qref
+    %q0 = quake.alloca  !quake.qref
+    %q1 = quake.alloca  !quake.qref
 
     // CHECK:  %[[W1_1:.*]] = cc.if
     cc.if(%c1) {
-      quake.x [%q0: !quake.qref] (%q1)
+      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
       // CHECK:  %[[W1_2:.*]] = qtx.x [%[[W0]]] %[[W1]]
       // CHECK:  cc.continue %[[W1_2]]
     }
@@ -81,7 +81,7 @@ module {
     // CHECK:   cc.continue %[[W1]]
 
     // CHECK:  %[[W1_3:.*]] = qtx.y [%[[W0]]] %[[W1_1]]
-    quake.y [%q0: !quake.qref] (%q1)
+    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     return
   }
 
@@ -90,19 +90,19 @@ module {
     // CHECK:  %[[W0:.*]] = qtx.alloca
     // CHECK:  %[[W1:.*]] = qtx.alloca
     // CHECK:  %[[W2:.*]] = qtx.alloca
-    %q0 = quake.alloca : !quake.qref
-    %q1 = quake.alloca : !quake.qref
-    %q2 = quake.alloca : !quake.qref
+    %q0 = quake.alloca !quake.qref
+    %q1 = quake.alloca !quake.qref
+    %q2 = quake.alloca !quake.qref
 
     // CHECK:  %[[W1_W2:.*]]:2 = cc.if
     cc.if(%c1) {
       // CHECK:  %[[W1_1:.*]] = qtx.h [%[[W0]]] %[[W1]]
-      quake.h [%q0: !quake.qref] (%q1)
+      quake.h [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
 
       // CHECK:  %[[W2_2:.*]] = cc.if
       cc.if(%c2) {
         // CHECK:  %[[W2_1:.*]] = qtx.x [%[[W0]]] %[[W2]]
-        quake.x [%q0: !quake.qref] (%q2)
+        quake.x [%q0] %q2 : (!quake.qref, !quake.qref) -> ()
         // CHECK:  cc.continue %[[W2_1]]
       }
       // CHECK: } else {
@@ -115,8 +115,8 @@ module {
 
     // CHECK:  %{{.*}} = qtx.y [%[[W0]]] %[[W1_W2]]#0
     // CHECK:  %{{.*}} = qtx.z [%[[W0]]] %[[W1_W2]]#1
-    quake.y [%q0: !quake.qref] (%q1)
-    quake.z [%q0: !quake.qref] (%q2)
+    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.z [%q0] %q2 : (!quake.qref, !quake.qref) -> ()
     // CHECK: qtx.unrealized_return
     return
   }
@@ -126,13 +126,13 @@ module {
     // This `cc.if` does not return new wires because %q0 is only used as
     // control and %q1 is locally scoped.
     cc.if(%c1) {
-      %q1 = quake.alloca : !quake.qref
+      %q1 = quake.alloca !quake.qref
       // CHECK: %{{.*}} = qtx.x [%[[Q0_W0:.*]]] %{{.*}}
-      quake.x [%q0: !quake.qref] (%q1)
+      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
       // CHECK-NOT: cc.continue
     }
     // CHECK: %[[Q0_W1:.*]] = qtx.y %[[Q0_W0]]
-    quake.y (%q0)
+    quake.y %q0 : (!quake.qref) -> ()
     // CHECK: qtx.unrealized_return %[[Q0_W1]]
     return
   }
@@ -142,17 +142,17 @@ module {
     %c_0 = arith.constant 0 : i32
 
     // CHECK: %[[W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[INDEX:.*]] from %{{.*}}
-    %q0 = quake.qextract %qvec[%c_0] : !quake.qvec<2>[i32] -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
     // CHECK: %[[W0_1:.*]] = qtx.x %[[W0]]
-    quake.x (%q0)
+    quake.x %q0 : (!quake.qref) -> ()
 
     // CHECK: %[[A_3:.*]] = cc.if
     cc.if(%c1) {
       %c_1 = arith.constant 1 : i32
       // CHECK: %[[W1:.*]], %[[A_1:.*]] = qtx.array_borrow %{{.*}} from %[[A_0]]
-      %q1 = quake.qextract %qvec[%c_1] : !quake.qvec<2>[i32] -> !quake.qref
+      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>, i32) -> !quake.qref
       // CHECK: %[[W1_1:.*]] = qtx.y %[[W1]]
-      quake.y (%q1)
+      quake.y %q1 : (!quake.qref) -> ()
       // CHECK: %[[A_2:.*]] = qtx.array_yield %[[W1_1]] to %[[A_1]]
       // CHECK: cc.continue %[[A_2]]
     }
@@ -164,7 +164,7 @@ module {
 
     // CHECK: %[[A_4:.*]] = qtx.array_yield %[[W0_1]] to %[[A_3]]
     // CHECK: %{{.*}}, %[[A_5:.*]] = qtx.mz %[[A_4]]
-    %reg = quake.mz (%qvec : !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
 
     // We reborrow the wires after the measurement
 
@@ -180,14 +180,14 @@ module {
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[INDEX_0:.*]] from %{{.*}}
-    %q0 = quake.qextract %qvec[%c_0] : !quake.qvec<2>[i32] -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
     // CHECK: %[[Q0_W1:.*]] = qtx.x %[[Q0_W0]]
-    quake.x (%q0)
+    quake.x %q0 : (!quake.qref) -> ()
 
     // CHECK: %[[A_Q0:.*]]:2 = cc.if
     cc.if(%c1) {
       // CHECK: %[[Q1_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[INDEX_1:.*]] from %[[A_0]]
-      %q1 = quake.qextract %qvec[%c_1] : !quake.qvec<2>[i32] -> !quake.qref
+      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>, i32) -> !quake.qref
 
       // CHECK: %[[A_Q0_Q1:.*]]:3 = cc.if
       cc.if(%c2) {
@@ -196,7 +196,7 @@ module {
         // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q0_W1]], %[[Q1_W0]] to %[[A_1]]
 
         // CHECK: %[[A_3:.*]] = qtx.reset %[[A_2]]
-        quake.reset (%qvec : !quake.qvec<2>)
+        quake.reset %qvec : (!quake.qvec<2>) -> ()
 
         // We reborrow the wires, and return a new wire that corresponds to %q0
         // and a new array that corresponds to %qvec
@@ -218,7 +218,7 @@ module {
     // CHECK: %[[A_6:.*]] = qtx.array_yield %[[A_Q0]]#1 to %[[A_Q0]]#0
 
     // CHECK: %{{.*}}, %[[A_7:.*]] = qtx.mz %[[A_6]]
-    %reg = quake.mz (%qvec : !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
 
     // CHECK: %[[Q0_W2:.*]], %[[A_8:.*]] = qtx.array_borrow %[[INDEX_0:.*]] from %[[A_7]]
     // CHECK: %[[A_9:.*]] = qtx.array_yield %[[Q0_W2]] to %[[A_8]]

--- a/test/Conversion/QuakeToQTX/quake_cc_loop.qke
+++ b/test/Conversion/QuakeToQTX/quake_cc_loop.qke
@@ -17,7 +17,7 @@ module {
     %c42_i64 = arith.constant 42 : i64
 
     // CHECK: %[[Q0_W0:.*]] = qtx.alloca : !qtx.wire
-    %q0 = quake.alloca : !quake.qref
+    %q0 = quake.alloca !quake.qref
 
     %alloca = memref.alloca() : memref<i64>
     memref.store %c0_i64, %alloca[] : memref<i64>
@@ -31,7 +31,7 @@ module {
     } do {
       // CHECK: ^bb0(%[[Q0_W2:.*]]: !qtx.wire):
       // CHECK: %[[Q0_W3:.*]] = qtx.x %[[Q0_W2]]
-      quake.x (%q0)
+      quake.x %q0 : (!quake.qref) -> ()
       // CHECK: cc.continue %[[Q0_W3]]
       cc.continue
     } step {
@@ -42,7 +42,7 @@ module {
       // CHECK: cc.continue %[[Q0_W4]]
     }
     // CHECK: %[[Q0_W6:.*]] = qtx.z %[[Q0_W5]]
-    quake.z (%q0)
+    quake.z %q0 : (!quake.qref) -> ()
     return
   }
 
@@ -53,10 +53,10 @@ module {
     %c2_i64 = arith.constant 2 : i64
 
     // CHECK: %[[A_0:.*]] = qtx.alloca
-    %qvec = quake.alloca : !quake.qvec<2>
+    %qvec = quake.alloca  !quake.qvec<2>
 
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.qextract %qvec[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2> ,i64) -> !quake.qref
 
     %alloca = memref.alloca() : memref<i64>
     memref.store %c0_i64, %alloca[] : memref<i64>
@@ -71,7 +71,7 @@ module {
       // CHECK: ^bb0(%[[A_3:.*]]: !qtx.wire_array
       %3 = memref.load %alloca[] : memref<i64>
       // CHECK: %[[QX_W0:.*]], %[[A_4:.*]] = qtx.array_borrow %{{.*}} from %[[A_3]]
-      %4 = quake.qextract %qvec[%3] : !quake.qvec<2>[i64] -> !quake.qref
+      %4 = quake.extract_ref %qvec[%3] : (!quake.qvec<2> ,i64) -> !quake.qref
 
       // CHECK: %[[A_5:.*]] = qtx.array_yield %[[QX_W0]] to %[[A_4]]
       // CHECK: cc.continue %[[A_5]]
@@ -86,7 +86,7 @@ module {
     // CHECK: %[[A_8:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_7]]
     // CHECK: %{{.*}}, %[[A_9:.*]] = qtx.mz %[[A_8]]
     // CHECK: %{{.*}}, %{{.*}} = qtx.array_borrow %[[IDX_0]] from %[[A_9]]
-    %2 = quake.mz (%qvec : !quake.qvec<2>) : !cc.stdvec<i1>
+    %2 = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
     return
   }
 

--- a/test/Conversion/QuakeToQTX/quake_cc_scope.qke
+++ b/test/Conversion/QuakeToQTX/quake_cc_scope.qke
@@ -14,41 +14,41 @@ module {
   func.func @one_scope() {
     // CHECK: %[[Q0_W0:.*]] = qtx.alloca
     // CHECK: %[[Q1_W0:.*]] = qtx.alloca
-    %q0 = quake.alloca : !quake.qref
-    %q1 = quake.alloca : !quake.qref
+    %q0 = quake.alloca !quake.qref
+    %q1 = quake.alloca !quake.qref
 
     // CHECK: %[[Q1_W2:.*]] = cc.scope
     cc.scope {
       // CHECK: %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0]]] %[[Q1_W0]]
-      quake.x [%q0: !quake.qref] (%q1)
+      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
 
       // CHECK: cc.continue %[[Q1_W1]]
     }
     // CHECK:  %[[Q1_W3:.*]] = qtx.z [%[[Q0_W0]]] %[[Q1_W2:.*]]
-    quake.z [%q0: !quake.qref] (%q1)
+    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @scope_local_wire
   func.func @scope_local_wire() {
     // CHECK: %[[Q0_W0:.*]] = qtx.alloca
-    %q0 = quake.alloca : !quake.qref
+    %q0 = quake.alloca !quake.qref
 
     // CHECK: %[[Q0_W2:.*]] = cc.scope
     cc.scope {
       // CHECK: %[[Q1_W0:.*]] = qtx.alloca
-      %q1 = quake.alloca : !quake.qref
+      %q1 = quake.alloca !quake.qref
 
       // CHECK: %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0]]] %[[Q1_W0]]
-      quake.x [%q0: !quake.qref] (%q1)
+      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
 
       // CHECK: %[[Q0_W1:.*]] = qtx.y [%[[Q1_W1]]] %[[Q0_W0]]
-      quake.y [%q1: !quake.qref] (%q0)
+      quake.y [%q1] %q0 : (!quake.qref, !quake.qref) -> ()
 
       // TODO: cc.continue %[[Q0_W1]]
     }
     // CHECK: %[[Q0_W3:.*]] = qtx.z %[[Q0_W2]]
-    quake.z (%q0)
+    quake.z %q0 : (!quake.qref) -> ()
     return
   }
 
@@ -57,19 +57,19 @@ module {
     // CHECK: %[[Q0_W0:.*]] = qtx.alloca
     // CHECK: %[[Q1_W0:.*]] = qtx.alloca
     // CHECK: %[[Q2_W0:.*]] = qtx.alloca
-    %q0 = quake.alloca : !quake.qref
-    %q1 = quake.alloca : !quake.qref
-    %q2 = quake.alloca : !quake.qref
+    %q0 = quake.alloca  !quake.qref
+    %q1 = quake.alloca  !quake.qref
+    %q2 = quake.alloca  !quake.qref
 
     // CHECK: %[[Q1_Q2:.*]]:2 = cc.scope
     cc.scope {
       // CHECK: %[[Q1_W1:.*]] = qtx.h [%[[Q0_W0]]] %[[Q1_W0]]
-      quake.h [%q0: !quake.qref] (%q1)
+      quake.h [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
 
       // CHECK: %[[Q2_W2:.*]] = cc.scope
       cc.scope {
         // CHECK: %[[Q2_W1:.*]] = qtx.x [%[[Q0_W0]]] %[[Q2_W0]]
-        quake.x [%q0: !quake.qref] (%q2)
+        quake.x [%q0] %q2 : (!quake.qref, !quake.qref) -> ()
         // CHECK: cc.continue %[[Q2_W1]]
       }
 
@@ -77,7 +77,7 @@ module {
     }
 
     // CHECK: %[[Q2_W1:.*]] = qtx.y [%[[Q0_W0]]] %[[Q1_Q2]]#0
-    quake.y [%q0: !quake.qref] (%q1)
+    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     return
   }
 
@@ -88,15 +88,15 @@ module {
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %{{.*}}
-    %q0 = quake.qextract %qvec[%c_0] : !quake.qvec<2>[i32] -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
 
     // CHECK: %[[A_3:.*]] = cc.scope
     cc.scope {
       // CHECK: %[[Q1_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %{{.*}} from %[[A_0]]
-      %q1 = quake.qextract %qvec[%c_1] : !quake.qvec<2>[i32] -> !quake.qref
+      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>,i32) -> !quake.qref
 
       // CHECK:  %[[Q1_W1:.*]] = qtx.y %[[Q1_W0]]
-      quake.y (%q1)
+      quake.y %q1 : (!quake.qref) -> ()
 
       // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q1_W1]] to %[[A_1]]
       // CHECK: cc.continue %[[A_2]]
@@ -105,7 +105,7 @@ module {
     // CHECK: %[[A_4:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_3]]
     // CHECK: %{{.*}}, %[[A_5:.*]] = qtx.mz %[[A_4]]
     // CHECK: %{{.*}}, %{{.*}} = qtx.array_borrow %[[IDX_0]] from %[[A_5]]
-    %reg = quake.mz (%qvec : !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
     return
   }
 
@@ -114,7 +114,7 @@ module {
     %c_0 = arith.constant 0 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %{{.*}}
-    %q0 = quake.qextract %qvec[%c_0] : !quake.qvec<2>[i32] -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>,i32) -> !quake.qref
 
     // CHECK: %[[A_Q0_1:.*]]:2 = cc.scope
     cc.scope {
@@ -124,7 +124,7 @@ module {
         // CHECK: %[[A_1:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_0]]
         // CHECK: %[[A_2:.*]] = qtx.reset %[[A_1]]
         // CHECK: %[[Q0_W1:.*]], %[[A_3:.*]] = qtx.array_borrow %[[IDX_0]] from %[[A_2]]
-        quake.reset (%qvec : !quake.qvec<2>)
+        quake.reset %qvec : (!quake.qvec<2>)-> ()
 
         // CHECK: cc.continue %[[A_3]], %[[Q0_W1]]
       }
@@ -134,7 +134,7 @@ module {
     // CHECK: %[[A_4:.*]] = qtx.array_yield %[[A_Q0_1]]#1 to %[[A_Q0_1]]#0
     // CHECK: %{{.*}}, %[[A_5:.*]] = qtx.mz %[[A_4]]
     // CHECK: %{{.*}}, %[[A_6:.*]] = qtx.array_borrow %[[IDX_0]] from %[[A_5]]
-    %reg = quake.mz (%qvec : !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
     return
   }
 
@@ -144,7 +144,7 @@ module {
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %{{.*}}
-    %q0 = quake.qextract %qvec[%c_0] : !quake.qvec<2>[i32] -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>,i32) -> !quake.qref
 
     // CHECK: %[[A_Q0_1:.*]]:2 = cc.scope
     cc.scope {
@@ -152,12 +152,12 @@ module {
       // CHECK: %[[A_Q0:.*]]:2 = cc.scope
       cc.scope {
         // CHECK: %[[Q1_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_0]]
-        %q1 = quake.qextract %qvec[%c_1] : !quake.qvec<2>[i32] -> !quake.qref
+        %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>,i32) -> !quake.qref
 
         // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q0_W0]], %[[Q1_W0]] to %[[A_1]]
         // CHECK: %[[A_3:.*]] = qtx.reset %[[A_2]]
         // CHECK: %[[Q0_Q1:.*]]:2, %[[A_4:.*]] = qtx.array_borrow %[[IDX_0]], %[[IDX_1]] from %[[A_3]]
-        quake.reset (%qvec : !quake.qvec<2>)
+        quake.reset %qvec : (!quake.qvec<2>) -> ()
 
         // CHECK: %[[A_5:.*]] = qtx.array_yield %[[Q0_Q1]]#1 to %[[A_4]]
         // CHECK: cc.continue %[[A_5]], %[[Q0_Q1]]#0
@@ -168,7 +168,7 @@ module {
     // CHECK: %[[A_6:.*]] = qtx.array_yield %[[A_Q0_1]]#1 to %[[A_Q0_1]]#0
     // CHECK: %{{.*}}, %[[A_7:.*]] = qtx.mz %[[A_6]]
     // CHECK: %{{.*}}, %[[A_8:.*]] = qtx.array_borrow %[[IDX_0]] from %[[A_7]]
-    %reg = quake.mz (%qvec : !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
     return
   }
 }

--- a/test/Conversion/QuakeToQTX/quake_cfg.qke
+++ b/test/Conversion/QuakeToQTX/quake_cfg.qke
@@ -14,21 +14,21 @@ module {
   func.func @test01() {
     // CHECK:  %[[Q0_W0:.*]] = qtx.alloca
     // CHECK:  %[[Q1_W0:.*]] = qtx.alloca
-    %q0 = quake.alloca : !quake.qref
-    %q1 = quake.alloca : !quake.qref
+    %q0 = quake.alloca !quake.qref
+    %q1 = quake.alloca !quake.qref
 
     // CHECK:  %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0]]] %[[Q1_W0]]
-    quake.x [%q0: !quake.qref] (%q1)
+    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     cf.br ^bb1
 
   ^bb1:
     // CHECK:  %[[Q1_W2:.*]] = qtx.y [%[[Q0_W0]]] %[[Q1_W1]]
-    quake.y [%q0: !quake.qref] (%q1)
+    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     cf.br ^bb2
 
   ^bb2:
     // CHECK:  %[[Q1_W3:.*]] = qtx.z [%[[Q0_W0]]] %[[Q1_W2]]
-    quake.z [%q0: !quake.qref] (%q1)
+    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     return
   }
 
@@ -38,35 +38,35 @@ module {
 
   ^bb1:
     // CHECK: %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0:.*]]] %[[Q1_W0:.*]] :
-    quake.x [%q0: !quake.qref] (%q1)
+    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     // CHECK: cf.br ^bb3(%[[Q1_W1]] : !qtx.wire)
     cf.br ^bb3
 
   ^bb2:
     // CHECK: %[[Q1_W2:.*]] = qtx.y [%[[Q0_W0]]] %[[Q1_W0]]
-    quake.y [%q0: !quake.qref] (%q1)
+    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     // CHECK: cf.br ^bb3(%[[Q1_W2]] : !qtx.wire)
     cf.br ^bb3
 
   // CHECK: ^bb3(%[[Q1_W3:.*]]: !qtx.wire):
   ^bb3:
     // CHECK: %[[Q1_W4:.*]] = qtx.z [%[[Q0_W0]]] %[[Q1_W3]]
-    quake.z [%q0: !quake.qref] (%q1)
+    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @test03
   func.func @test03(%q0: !quake.qref, %q1: !quake.qref, %c1: i1) {
     // TODO: do the checks, I'm unsure about this one.
-    quake.x [%q0: !quake.qref] (%q1)
+    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     cf.br ^bb1
 
   ^bb1:
-    quake.y [%q0: !quake.qref] (%q1)
+    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     cf.cond_br %c1, ^bb1, ^bb2
 
   ^bb2:
-    quake.z [%q0: !quake.qref] (%q1)
+    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     return
   }
 
@@ -76,13 +76,13 @@ module {
 
   ^bb1:
     // CHECK: %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0:.*]]] %[[Q1_W0:.*]] :
-    quake.x [%q0: !quake.qref] (%q1)
+    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     // CHECK: qtx.unrealized_return %[[Q0_W0]], %[[Q1_W1]]
     return
 
   ^bb2:
     // CHECK: %[[Q1_W2:.*]] = qtx.y [%[[Q0_W0]]] %[[Q1_W0]]
-    quake.y [%q0: !quake.qref] (%q1)
+    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     // CHECK: qtx.unrealized_return %[[Q0_W0]], %[[Q1_W2]]
     return
   }
@@ -91,12 +91,12 @@ module {
     %c0_i64 = arith.constant 0 : i64
 
     // CHECK: %[[A_0:.*]] = qtx.alloc
-    %qvec = quake.alloca : !quake.qvec<2>
+    %qvec = quake.alloca !quake.qvec<2>
     cf.cond_br %c1, ^bb1, ^bb2
 
   ^bb1:
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.qextract %qvec[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
     // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_1]]
     // CHECK: cf.br ^bb3(%[[A_2]] : !qtx.wire_array<2>)
     cf.br ^bb3
@@ -108,7 +108,7 @@ module {
   // CHECK: ^bb3(%[[A_3:.*]]: !qtx.wire_array<2>):
   ^bb3:
     // CHECK: %{{.*}}, %{{.*}} = qtx.mz %[[A_3]]
-    %reg = quake.mz (%qvec: !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %qvec: (!quake.qvec<2>) -> !cc.stdvec<i1>
     return
   }
 
@@ -118,15 +118,15 @@ module {
     %c1_i64 = arith.constant 1 : i64
 
     // CHECK: %[[A_0:.*]] = qtx.alloc
-    %qvec = quake.alloca : !quake.qvec<2>
+    %qvec = quake.alloca !quake.qvec<2>
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.qextract %qvec[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
 
     cf.cond_br %c1, ^bb1, ^bb4
 
   ^bb1:
     // CHECK: %[[Q1_W0:.*]], %[[A_2:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_1]]
-    %q1 = quake.qextract %qvec[%c1_i64] : !quake.qvec<2>[i64] -> !quake.qref
+    %q1 = quake.extract_ref %qvec[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.qref
     cf.cond_br %c1, ^bb2, ^bb3
 
   ^bb2:
@@ -141,7 +141,7 @@ module {
 
   ^bb4:
     // CHECK: %[[Q1_W1:.*]], %[[A_5:.*]] = qtx.array_borrow %[[IDX_1]] from %[[A_1]]
-    %q2 = quake.qextract %qvec[%c1_i64] : !quake.qvec<2>[i64] -> !quake.qref
+    %q2 = quake.extract_ref %qvec[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.qref
     // CHECK: %[[A_6:.*]] = qtx.array_yield %[[Q1_W1]] to %[[A_5]]
     // CHECK: cf.br ^bb5(%[[A_6]] : !qtx.wire_array<2, dead = 1>)
     cf.br ^bb5
@@ -150,7 +150,7 @@ module {
   ^bb5:
     // CHECK: %[[A_8:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_7]]
     // CHECK: %{{.*}}, %{{.*}} = qtx.mz %[[A_8]]
-    %reg = quake.mz (%qvec: !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %qvec: (!quake.qvec<2>)-> !cc.stdvec<i1>
     return
   }
 
@@ -160,15 +160,15 @@ module {
     %c1_i64 = arith.constant 1 : i64
 
     // CHECK: %[[A_0:.*]] = qtx.alloc
-    %qvec = quake.alloca : !quake.qvec<2>
+    %qvec = quake.alloca !quake.qvec<2>
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.qextract %qvec[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
 
     cf.cond_br %c1, ^bb1, ^bb2
 
   ^bb1:
     // CHECK: %[[Q1_W0:.*]], %[[A_2:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_1]]
-    %q1 = quake.qextract %qvec[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
+    %q1 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
     // CHECK: %[[A_3:.*]] = qtx.array_yield %[[Q1_W0]] to %[[A_2]]
     // CHECK: cf.br ^bb3(%[[A_3]], %[[Q0_W0]] : !qtx.wire_array<2, dead = 1>, !qtx.wire)
     cf.br ^bb3
@@ -176,7 +176,7 @@ module {
   ^bb2:
     // CHECK: %[[A_4:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_1]]
     // CHECK: %[[A_5:.*]] = qtx.reset %[[A_4]]
-    quake.reset (%qvec: !quake.qvec<2>)
+    quake.reset %qvec: (!quake.qvec<2>)->()
     // CHECK: %[[Q0_W1:.*]], %[[A_6:.*]] = qtx.array_borrow %[[IDX_0]] from %[[A_5]]
     // CHECK: cf.br ^bb3(%[[A_6]], %[[Q0_W1]] : !qtx.wire_array<2, dead = 1>, !qtx.wire)
     cf.br ^bb3
@@ -185,7 +185,7 @@ module {
   ^bb3:
     // CHECK: %[[A_8:.*]] = qtx.array_yield %[[Q0_W2]] to %[[A_7]]
     // CHECK: %{{.*}}, %{{.*}} = qtx.mz %[[A_8]]
-    %reg = quake.mz (%qvec: !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %qvec: (!quake.qvec<2>) -> !cc.stdvec<i1>
     return
   }
 }

--- a/test/Conversion/QuakeToQTX/straightline.qke
+++ b/test/Conversion/QuakeToQTX/straightline.qke
@@ -31,7 +31,7 @@ module {
   func.func @return_mz(%qvec: !quake.qvec<2>) -> !cc.stdvec<i1> {
     // CHECK: %[[ARRAY:.*]] = builtin.unrealized_conversion_cast %[[QVEC]] : !quake.qvec<2> to !qtx.wire_array<2>
     // CHECK: %[[REG:.*]], %[[ARRAY_1:.*]] = qtx.mz %[[ARRAY]]
-    %reg = quake.mz(%qvec : !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
     // CHXXXECK: qtx.unrealized_return <%[[REG]]> %[[ARRAY_1]] : <!cc.stdvec<i1>> !qtx.wire_array<2>
     %reg1 = cc.undef !cc.stdvec<i1>
     return %reg1 : !cc.stdvec<i1>
@@ -44,10 +44,10 @@ module {
   // CHECK:           qtx.dealloc %[[A_0]]
   // CHECK:           qtx.unrealized_return
   func.func @alloc_dealloc_qref_and_qvec() {
-    %q0 = quake.alloca : !quake.qref
-    %qvec = quake.alloca : !quake.qvec<2>
-    quake.dealloc (%q0 : !quake.qref)
-    quake.dealloc (%qvec : !quake.qvec<2>)
+    %q0 = quake.alloca  !quake.qref
+    %qvec = quake.alloca  !quake.qvec<2>
+    quake.dealloc %q0 : !quake.qref
+    quake.dealloc %qvec : !quake.qvec<2>
     return
   }
 
@@ -60,9 +60,9 @@ module {
   // CHECK:           qtx.unrealized_return
   func.func @alloc_dealloc_qvec_with_extracted_qrefs() {
     %c_0 = arith.constant 0 : i32
-    %qvec = quake.alloca : !quake.qvec<2>
-    %q0 = quake.qextract %qvec[%c_0] : !quake.qvec<2>[i32] -> !quake.qref
-    quake.dealloc (%qvec : !quake.qvec<2>)
+    %qvec = quake.alloca  !quake.qvec<2>
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
+    quake.dealloc %qvec : !quake.qvec<2>
     return
   }
 
@@ -79,12 +79,12 @@ module {
   // CHECK:           %[[Q1_W6:.*]] = qtx.z [%[[Q0_W0]]] %[[Q1_W5]]
   // CHECK:           qtx.unrealized_return %[[Q0_W0]], %[[Q1_W6]]
   func.func @apply_one_target_operators(%q0: !quake.qref, %q1: !quake.qref) {
-    quake.h [%q0: !quake.qref] (%q1)
-    quake.s [%q0: !quake.qref] (%q1)
-    quake.t [%q0: !quake.qref] (%q1)
-    quake.x [%q0: !quake.qref] (%q1)
-    quake.y [%q0: !quake.qref] (%q1)
-    quake.z [%q0: !quake.qref] (%q1)
+    quake.h [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.s [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.t [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
     return
   }
 
@@ -98,12 +98,12 @@ module {
   // CHECK:           qtx.unrealized_return
   func.func @apply_parametrized_one_target_operators() {
     %angle = arith.constant 3.14 : f64
-    %q0 = quake.alloca : !quake.qref
-    %q1 = quake.alloca : !quake.qref
-    quake.r1 [%q1 : !quake.qref] |%angle : f64| (%q0)
-    quake.rx [%q1 : !quake.qref] |%angle : f64| (%q0)
-    quake.ry [%q1 : !quake.qref] |%angle : f64| (%q0)
-    quake.rz [%q1 : !quake.qref] |%angle : f64| (%q0)
+    %q0 = quake.alloca  !quake.qref
+    %q1 = quake.alloca  !quake.qref
+    quake.r1 (%angle) [%q1] %q0 : (f64, !quake.qref, !quake.qref) -> ()
+    quake.rx (%angle) [%q1] %q0 : (f64, !quake.qref, !quake.qref) -> ()
+    quake.ry (%angle) [%q1] %q0 : (f64, !quake.qref, !quake.qref) -> ()
+    quake.rz (%angle) [%q1] %q0 : (f64, !quake.qref, !quake.qref) -> ()
     return
   }
 
@@ -118,11 +118,11 @@ module {
     %c_0 = arith.constant 0 : i32
     %c_1 = arith.constant 1 : i32
     %c_2 = arith.constant 2 : i32
-    %0 = quake.alloca : !quake.qvec<3>
-    %q0 = quake.qextract %0 [%c_0] : !quake.qvec<3>[i32] -> !quake.qref
-    %q1 = quake.qextract %0 [%c_1] : !quake.qvec<3>[i32] -> !quake.qref
-    %q2 = quake.qextract %0 [%c_2] : !quake.qvec<3>[i32] -> !quake.qref
-    quake.swap [%q2 : !quake.qref] (%q0, %q1)
+    %0 = quake.alloca !quake.qvec<3>
+    %q0 = quake.extract_ref %0 [%c_0] : (!quake.qvec<3>,i32) -> !quake.qref
+    %q1 = quake.extract_ref %0 [%c_1] : (!quake.qvec<3>,i32) -> !quake.qref
+    %q2 = quake.extract_ref %0 [%c_2] : (!quake.qvec<3>,i32) -> !quake.qref
+    quake.swap [%q2] %q0, %q1 : (!quake.qref,!quake.qref,!quake.qref) -> ()
     return
   }
 
@@ -132,23 +132,23 @@ module {
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[A_0:.*]] = qtx.alloca
-    %0 = quake.alloca : !quake.qvec<2>
+    %0 = quake.alloca !quake.qvec<2>
 
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
     // CHECK: %[[Q1_W0:.*]], %[[A_2:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_1]]
-    %q0 = quake.qextract %0[%c_0] : !quake.qvec<2>[i32] -> !quake.qref
-    %q1 = quake.qextract %0[%c_1] : !quake.qvec<2>[i32] -> !quake.qref
+    %q0 = quake.extract_ref %0[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
+    %q1 = quake.extract_ref %0[%c_1] : (!quake.qvec<2>, i32) -> !quake.qref
 
     // CHECK: %[[A_3:.*]] = qtx.array_yield %[[Q0_W0]], %[[Q1_W0]] to %[[A_2]]
     // CHECK: %{{.*}}, %[[A_4:.*]] = qtx.mz %[[A_3]]
     // CHECK: %[[Q0_Q1:.*]]:2, %[[A_5:.*]] = qtx.array_borrow %[[IDX_0]], %[[IDX_1]] from %[[A_4]]
-    %reg = quake.mz (%0 : !quake.qvec<2>) : !cc.stdvec<i1>
+    %reg = quake.mz %0 : (!quake.qvec<2>) -> !cc.stdvec<i1>
 
 
     // CHECK: %[[A_6:.*]] = qtx.array_yield %[[Q0_Q1]]#0, %[[Q0_Q1]]#1 to %[[A_5]]
     // CHECK: %[[A_7:.*]] = qtx.reset %[[A_6]]
     // CHECK: %{{.*}}:2, %[[A_8:.*]] = qtx.array_borrow %[[IDX_0]], %[[IDX_1]] from %[[A_7]]
-    quake.reset (%0 : !quake.qvec<2>)
+    quake.reset %0 : (!quake.qvec<2>) -> ()
 
     // CHECK: qtx.unrealized_return
     return

--- a/test/Conversion/QuakeToQTX/unable_to_convert.qke
+++ b/test/Conversion/QuakeToQTX/unable_to_convert.qke
@@ -26,16 +26,16 @@ func.func @unknown_size_qvec(%qvec: !quake.qvec<?>) {
 
 // expected-warning@+1 {{couldn't convert kernel to QTX}}
 func.func @return_mz(%qvec: !quake.qvec<2>, %size: i64) -> !cc.stdvec<i1> {
-  %reg = quake.mz(%qvec : !quake.qvec<2>) : !cc.stdvec<i1>
-  %error = quake.alloca(%size : i64) : !quake.qvec<?>
+  %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
+  %error = quake.alloca [%size : i64]  !quake.qvec<?>
   return %reg : !cc.stdvec<i1>
 }
 
 // CHECK-LABEL:   func.func @return_mz(
 // CHECK-SAME:                         %[[VAL_0:.*]]: !quake.qvec<2>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: i64) -> !cc.stdvec<i1> {
-// CHECK:           %[[VAL_2:.*]] = quake.mz(%[[VAL_0]] : !quake.qvec<2>) : !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = quake.alloca(%[[VAL_1]] : i64) : !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_0]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
 // CHECK:           return %[[VAL_2]] : !cc.stdvec<i1>
 // CHECK:         }
 
@@ -43,19 +43,19 @@ func.func @return_mz(%qvec: !quake.qvec<2>, %size: i64) -> !cc.stdvec<i1> {
 
 // expected-warning@+1 {{couldn't convert kernel to QTX}}
 func.func @too_many_qextracts(%a: i64, %b: i64, %c: i64) {
-  %0 = quake.alloca : !quake.qvec<2>
-  %qa = quake.qextract %0[%a] : !quake.qvec<2>[i64] -> !quake.qref
-  %qb = quake.qextract %0[%b] : !quake.qvec<2>[i64] -> !quake.qref
-  %qc = quake.qextract %0[%c] : !quake.qvec<2>[i64] -> !quake.qref
+  %0 = quake.alloca !quake.qvec<2>
+  %qa = quake.extract_ref %0[%a] : (!quake.qvec<2>, i64) -> !quake.qref
+  %qb = quake.extract_ref %0[%b] : (!quake.qvec<2>, i64) -> !quake.qref
+  %qc = quake.extract_ref %0[%c] : (!quake.qvec<2>, i64) -> !quake.qref
   return
 }
 
 // CHECK-LABEL:   func.func @too_many_qextracts(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64) {
-// CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qvec<2>
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           %[[VAL_5:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           %[[VAL_6:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
 // CHECK:           return
 // CHECK:         }
 
@@ -67,9 +67,9 @@ func.func @for_loop_with_extracted_vector() {
   %c0_i64 = arith.constant 0 : i64
   %c1_i64 = arith.constant 1 : i64
 
-  %0 = quake.alloca : !quake.qvec<2>
-  %1 = quake.qextract %0[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
-  %2 = quake.qextract %0[%c1_i64] : !quake.qvec<2>[i64] -> !quake.qref
+  %0 = quake.alloca  !quake.qvec<2>
+  %1 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
+  %2 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.qref
 
   %alloca = memref.alloca() : memref<i64>
   memref.store %c0_i64, %alloca[] : memref<i64>
@@ -79,8 +79,8 @@ func.func @for_loop_with_extracted_vector() {
     cc.condition %5
   } do {
     %4 = memref.load %alloca[] : memref<i64>
-    %5 = quake.qextract %0[%4] : !quake.qvec<2>[i64] -> !quake.qref
-    quake.x (%5)
+    %5 = quake.extract_ref %0[%4] : (!quake.qvec<2>, i64) -> !quake.qref
+    quake.x %5 : (!quake.qref) -> ()
     cc.continue
   } step {
     %4 = memref.load %alloca[] : memref<i64>
@@ -94,9 +94,9 @@ func.func @for_loop_with_extracted_vector() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qvec<2>
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           %[[VAL_5:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
 // CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i64>
 // CHECK:           memref.store %[[VAL_1]], %[[VAL_6]][] : memref<i64>
 // CHECK:           cc.loop while {
@@ -105,8 +105,8 @@ func.func @for_loop_with_extracted_vector() {
 // CHECK:             cc.condition %[[VAL_8]]
 // CHECK:           } do {
 // CHECK:             %[[VAL_9:.*]] = memref.load %[[VAL_6]][] : memref<i64>
-// CHECK:             %[[VAL_10:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_9]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.x (%[[VAL_10]])
+// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.x %[[VAL_10]] : (!quake.qref) -> ()
 // CHECK:             cc.continue
 // CHECK:           } step {
 // CHECK:             %[[VAL_11:.*]] = memref.load %[[VAL_6]][] : memref<i64>

--- a/test/QTX/Transforms/op_cancellation.mlir
+++ b/test/QTX/Transforms/op_cancellation.mlir
@@ -18,9 +18,9 @@ module {
     %w2 = x %w1 : !qtx.wire
 
     // Corner case that we might not run into.  Since `h` is Hermitian the
-    // `adj` property should not make a differnce.
+    // `adj` property is not allowed.
     %w3 = h %w2 : !qtx.wire
-    %w4 = h<adj> %w3 : !qtx.wire
+    %w4 = h %w3 : !qtx.wire
 
     %w5 = t %w4 : !qtx.wire
     %w6 = t<adj> %w5 : !qtx.wire

--- a/test/Quake-QIR/allocaNoOperand.qke
+++ b/test/Quake-QIR/allocaNoOperand.qke
@@ -53,49 +53,49 @@ module {
 // CHECK:         %[[VAL_19:.*]] = tail call %[[VAL_16]]* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_11]])
 // CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
 // CHECK:         ret void
-    %0 = quake.alloca : !quake.qvec<4>
+    %0 = quake.alloca !quake.qvec<4>
     %1 = memref.alloc() : memref<4xi1>
     %c0 = arith.constant 0 : index
-    %2 = quake.qextract %0[%c0] : !quake.qvec<4>[index] -> !quake.qref
-    quake.x (%2)
+    %2 = quake.extract_ref %0[%c0] : (!quake.qvec<4>, index) -> !quake.qref
+    quake.x %2 : (!quake.qref) -> ()
     %c1 = arith.constant 1 : index
-    %3 = quake.qextract %0[%c1] : !quake.qvec<4>[index] -> !quake.qref
-    quake.x (%3)
+    %3 = quake.extract_ref %0[%c1] : (!quake.qvec<4>, index) -> !quake.qref
+    quake.x %3 : (!quake.qref) -> ()
     %c3 = arith.constant 3 : index
-    %4 = quake.qextract %0[%c3] : !quake.qvec<4>[index] -> !quake.qref
-    quake.h (%4)
+    %4 = quake.extract_ref %0[%c3] : (!quake.qvec<4>, index) -> !quake.qref
+    quake.h %4 : (!quake.qref) -> ()
     %c2 = arith.constant 2 : index
-    %5 = quake.qextract %0[%c2] : !quake.qvec<4>[index] -> !quake.qref
-    quake.x [%5 : !quake.qref] (%4)
-    quake.t (%2)
-    quake.t (%3)
-    quake.t (%5)
-    quake.t<adj> (%4)
-    quake.x [%2 : !quake.qref] (%3)
-    quake.x [%5 : !quake.qref] (%4)
-    quake.x [%4 : !quake.qref] (%2)
-    quake.x [%3 : !quake.qref] (%5)
-    quake.x [%2 : !quake.qref] (%3)
-    quake.x [%5 : !quake.qref] (%4)
-    quake.t<adj> (%2)
-    quake.t<adj> (%3)
-    quake.t<adj> (%5)
-    quake.t (%4)
-    quake.x [%2 : !quake.qref] (%3)
-    quake.x [%5 : !quake.qref] (%4)
-    quake.s (%4)
-    quake.x [%4 : !quake.qref] (%2)
-    quake.h (%4)
-    %6 = quake.mz(%2 : !quake.qref) : i1
+    %5 = quake.extract_ref %0[%c2] : (!quake.qvec<4>, index) -> !quake.qref
+    quake.x [%5] %4 : (!quake.qref, !quake.qref) -> ()
+    quake.t %2 : (!quake.qref) -> ()
+    quake.t %3 : (!quake.qref) -> ()
+    quake.t %5 : (!quake.qref) -> ()
+    quake.t<adj> %4 : (!quake.qref) -> ()
+    quake.x [%2] %3 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%5] %4 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%4] %2 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%3] %5 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%2] %3 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%5] %4 : (!quake.qref, !quake.qref) -> ()
+    quake.t<adj> %2 : (!quake.qref) -> ()
+    quake.t<adj> %3 : (!quake.qref) -> ()
+    quake.t<adj> %5 : (!quake.qref) -> ()
+    quake.t %4 : (!quake.qref) -> ()
+    quake.x [%2] %3 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%5] %4 : (!quake.qref, !quake.qref) -> ()
+    quake.s %4 : (!quake.qref) -> ()
+    quake.x [%4] %2 : (!quake.qref, !quake.qref) -> ()
+    quake.h %4 : (!quake.qref) -> ()
+    %6 = quake.mz %2 : (!quake.qref) -> i1
     %c0_0 = arith.constant 0 : index
     memref.store %6, %1[%c0_0] : memref<4xi1>
-    %7 = quake.mz(%3 : !quake.qref) : i1
+    %7 = quake.mz %3 : (!quake.qref) -> i1
     %c1_1 = arith.constant 1 : index
     memref.store %7, %1[%c1_1] : memref<4xi1>
-    %8 = quake.mz(%5 : !quake.qref) : i1
+    %8 = quake.mz %5 : (!quake.qref) -> i1
     %c2_2 = arith.constant 2 : index
     memref.store %8, %1[%c2_2] : memref<4xi1>
-    %9 = quake.mz(%4 : !quake.qref) : i1
+    %9 = quake.mz %4 : (!quake.qref) -> i1
     %c3_3 = arith.constant 3 : index
     memref.store %9, %1[%c3_3] : memref<4xi1>
     return

--- a/test/Quake-QIR/base-profile-2.qke
+++ b/test/Quake-QIR/base-profile-2.qke
@@ -13,11 +13,11 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"}}
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
     %c2_i64 = arith.constant 2 : i64
-    %1 = quake.alloca(%c2_i64 : i64) : !quake.qvec<2>
+    %1 = quake.alloca [%c2_i64 : i64] !quake.qvec<2>
     %c1_i32 = arith.constant 1 : i32
     %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.qextract %1[%2] : !quake.qvec<2>[i64] -> !quake.qref
-    %4 = quake.mz(%3 : !quake.qref) : i1
+    %3 = quake.extract_ref %1[%2] : (!quake.qvec<2>,i64) -> !quake.qref
+    %4 = quake.mz %3 : (!quake.qref) -> i1
     return
   }
 }

--- a/test/Quake-QIR/base-profile-3.qke
+++ b/test/Quake-QIR/base-profile-3.qke
@@ -13,11 +13,11 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"}}
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
     %c2_i64 = arith.constant 2 : i64
-    %1 = quake.alloca(%c2_i64 : i64) : !quake.qvec<2>
+    %1 = quake.alloca[%c2_i64 : i64] !quake.qvec<2>
     %c1_i32 = arith.constant 1 : i32
     %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.qextract %1[%2] : !quake.qvec<2>[i64] -> !quake.qref
-    %4 = quake.mz(%3 : !quake.qref) {registerName = "Bob"} : i1
+    %3 = quake.extract_ref %1[%2] : (!quake.qvec<2>,i64) -> !quake.qref
+    %4 = quake.mz %3 : (!quake.qref) -> i1 { registerName = "Bob" }
     return
   }
 }

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -36,9 +36,9 @@
 
 module {
      func.func @test_func(%p : i32) {
-          %qv = quake.alloca(%p : i32) : !quake.qvec<?>
+          %qv = quake.alloca [%p : i32] !quake.qvec<?>
           %t = arith.constant 2 : i32
-          %v = quake.alloca(%t : i32) : !quake.qvec<?>
+          %v = quake.alloca [%t : i32] !quake.qvec<?>
           return
      }
 
@@ -48,22 +48,22 @@ module {
       %one = arith.constant 1 : i32
       %neg = arith.constant -5 : i32
       %two = arith.constant 2 : i32
-      %0 = quake.alloca(%two : i32) : !quake.qvec<?>
+      %0 = quake.alloca [%two : i32] !quake.qvec<?>
      
-      %1 = quake.alloca(%two : i32) : !quake.qvec<2>
-      %2 = quake.alloca(%one : i32) : !quake.qvec<?>
+      %1 = quake.alloca [%two : i32] !quake.qvec<2>
+      %2 = quake.alloca [%one : i32] !quake.qvec<?>
       
-      %qr1 = quake.qextract %0[%zero] : !quake.qvec<?>[i32] -> !quake.qref
-      %qr2 = quake.qextract %1[%one] : !quake.qvec<2>[i32] -> !quake.qref
+      %qr1 = quake.extract_ref %0[%zero] : (!quake.qvec<?>,i32) -> !quake.qref
+      %qr2 = quake.extract_ref %1[%one]  : (!quake.qvec<2>,i32) -> !quake.qref
 
       %fl = arith.constant 0.43 : f64
       %fl2 = arith.constant 0.33 : f64
       %fl3 = arith.constant 0.73 : f64
-      quake.h (%qr1)  
-      quake.x [%qr1 : !quake.qref] (%qr2)
-      quake.rx |%fl : f64|(%qr1)
+      quake.h %qr1 : (!quake.qref) -> ()  
+      quake.x [%qr1] %qr2 : (!quake.qref, !quake.qref) -> ()
+      quake.rx (%fl) %qr1 : (f64, !quake.qref) -> ()
 
-      quake.mz(%qr1 : !quake.qref) : i1
+      quake.mz %qr1 : (!quake.qref) -> i1
       return 
     }
 }

--- a/test/Quake-QIR/ghz.qke
+++ b/test/Quake-QIR/ghz.qke
@@ -39,17 +39,17 @@ module {
     func.func @ghz(%arg0 : i32) {
         %c0 = arith.constant 0 : i32
         %one = arith.constant 1 : i32
-        %q = quake.alloca(%arg0 : i32) : !quake.qvec<?>
-        %q0 = quake.qextract %q [%c0] : !quake.qvec<?>[i32] -> !quake.qref
-        quake.h (%q0) 
+        %q = quake.alloca [%arg0 : i32] !quake.qvec<?>
+        %q0 = quake.extract_ref %q [%c0] : (!quake.qvec<?>,i32) -> !quake.qref
+        quake.h %q0 : (!quake.qref) -> ()
         %size_m_1 = arith.subi %arg0, %one : i32
         %upper = arith.index_cast %size_m_1 : i32 to index
         affine.for %i = 0 to %upper {
             %i_int = arith.index_cast %i : index to i32
             %ip1 = arith.addi %i_int, %one : i32
-            %qi = quake.qextract %q [%i] : !quake.qvec<?>[index] -> !quake.qref
-            %qi1 = quake.qextract %q [%ip1] : !quake.qvec<?>[i32] -> !quake.qref
-            quake.x [%qi : !quake.qref] (%qi1)
+            %qi = quake.extract_ref %q [%i] : (!quake.qvec<?>,index) -> !quake.qref
+            %qi1 = quake.extract_ref %q [%ip1] : (!quake.qvec<?>,i32) -> !quake.qref
+            quake.x [%qi] %qi1 : (!quake.qref,!quake.qref) -> ()
         }
         return
     }

--- a/test/Quake-QIR/measure.qke
+++ b/test/Quake-QIR/measure.qke
@@ -13,13 +13,13 @@ module {
     %zero = arith.constant 0 : i32
     %one = arith.constant 1 : i32
     %two = arith.constant 2 : i32
-    %0 = quake.alloca(%two : i32) : !quake.qvec<?>
+    %0 = quake.alloca [%two : i32] !quake.qvec<?>
 
-    %qr1 = quake.qextract %0[%zero] : !quake.qvec<?>[i32] -> !quake.qref
-    %qr2 = quake.qextract %0[%one] : !quake.qvec<?>[i32] -> !quake.qref
+    %qr1 = quake.extract_ref %0[%zero] : (!quake.qvec<?>,i32) -> !quake.qref
+    %qr2 = quake.extract_ref %0[%one] : (!quake.qvec<?>,i32) -> !quake.qref
 
-    quake.mx(%qr1 : !quake.qref) : i1
-    quake.my(%qr1 : !quake.qref) : i1
+    quake.mx %qr1 : (!quake.qref) -> i1
+    quake.my %qr1 : (!quake.qref) -> i1
     return 
   }
 }

--- a/test/Quake-QIR/testBaseProfile.qke
+++ b/test/Quake-QIR/testBaseProfile.qke
@@ -29,18 +29,18 @@ module {
     %c0_i32 = arith.constant 0 : i32
     %c0 = arith.constant 0 : index
     %c3_i32 = arith.constant 3 : i32
-    %0 = quake.alloca(%c3_i32 : i32) : !quake.qvec<3>
-    %1 = quake.qextract %0[%c0_i32] : !quake.qvec<3>[i32] -> !quake.qref
-    quake.h (%1)
-    %2 = quake.qextract %0[%c0] : !quake.qvec<3>[index] -> !quake.qref
-    %3 = quake.qextract %0[%c1_i32] : !quake.qvec<3>[i32] -> !quake.qref
-    quake.x [%2 : !quake.qref] (%3)
-    %4 = quake.qextract %0[%c1] : !quake.qvec<3>[index] -> !quake.qref
-    %5 = quake.qextract %0[%c2_i32] : !quake.qvec<3>[i32] -> !quake.qref
-    quake.x [%4 : !quake.qref] (%5)
-    %6 = quake.mz (%1 : !quake.qref) : i1
-    %7 = quake.mz (%3 : !quake.qref) : i1
-    %8 = quake.mz (%5 : !quake.qref) : i1
+    %0 = quake.alloca[%c3_i32 : i32] !quake.qvec<3>
+    %1 = quake.extract_ref %0[%c0_i32] : (!quake.qvec<3>,i32) -> !quake.qref
+    quake.h %1 : (!quake.qref) -> ()
+    %2 = quake.extract_ref %0[%c0] : (!quake.qvec<3>, index) -> !quake.qref
+    %3 = quake.extract_ref %0[%c1_i32] : (!quake.qvec<3>,i32) -> !quake.qref
+    quake.x [%2] %3 : (!quake.qref, !quake.qref) -> ()
+    %4 = quake.extract_ref %0[%c1] : (!quake.qvec<3>,index) -> !quake.qref
+    %5 = quake.extract_ref %0[%c2_i32] : (!quake.qvec<3>,i32) -> !quake.qref
+    quake.x [%4] %5 : (!quake.qref, !quake.qref) -> ()
+    %6 = quake.mz %1 : (!quake.qref) -> i1
+    %7 = quake.mz %3 : (!quake.qref) -> i1
+    %8 = quake.mz %5 : (!quake.qref) -> i1
     return
   }
   // CHECK: attributes #0 = { "EntryPoint" "requiredQubits"="3" "requiredResults"="3" }

--- a/test/Quake/adjoint-1.qke
+++ b/test/Quake/adjoint-1.qke
@@ -15,24 +15,24 @@ module {
     %c0_i64 = arith.constant 0 : i64
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
-    %0 = quake.alloca : !quake.qvec<2>
+    %0 = quake.alloca !quake.qvec<2>
     cc.if(%arg0) {
-      %3 = quake.qextract %0[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
-      %4 = quake.qextract %0[%c1_i64] : !quake.qvec<2>[i64] -> !quake.qref
-      quake.h [%3 : !quake.qref] (%4)
-      quake.x (%4)
-      quake.y [%3 : !quake.qref] (%4)
+      %3 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+      %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+      quake.h [%3] %4 : (!quake.qref, !quake.qref) -> ()
+      quake.x %4 : (!quake.qref) -> ()
+      quake.y [%3] %4 : (!quake.qref, !quake.qref) -> ()
     }
     %dead = cc.loop while ((%iter = %c0_i32) -> (i32)) {
       %5 = arith.cmpi slt, %iter, %arg2 : i32
       cc.condition %5 (%iter : i32)
     } do {
       ^bb1(%iter : i32):
-        %3 = quake.qextract %0[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
-        %4 = quake.qextract %0[%c1_i64] : !quake.qvec<2>[i64] -> !quake.qref
-        quake.x [%3 : !quake.qref] (%4)
-        quake.y (%4)
-        quake.z [%3 : !quake.qref] (%4)
+        %3 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+        %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+        quake.x [%3] %4 : (!quake.qref, !quake.qref) -> ()
+        quake.y %4 : (!quake.qref) -> ()
+        quake.z [%3] %4 : (!quake.qref, !quake.qref) -> ()
         cc.continue %iter : i32
     } step {
       ^bb2(%iter : i32):
@@ -45,11 +45,11 @@ module {
       cc.continue %arg1 : i1
     }
     cc.if(%b3) {
-      %3 = quake.qextract %0[%c1_i64] : !quake.qvec<2>[i64] -> !quake.qref
-      %4 = quake.qextract %0[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
-      quake.y (%4)
-      quake.z [%3 : !quake.qref] (%4)
-      quake.h (%4)
+      %3 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+      %4 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+      quake.y %4 : (!quake.qref) -> ()
+      quake.z [%3] %4 : (!quake.qref, !quake.qref) -> ()
+      quake.h %4 : (!quake.qref) -> ()
     }
     return
   }
@@ -67,18 +67,18 @@ module {
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_7:.*]] = quake.alloca : !quake.qvec<2>
+// CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.qvec<2>
 // CHECK:           %[[VAL_8:.*]] = cc.if(%[[VAL_0]]) -> i1 {
 // CHECK:             cc.continue %[[VAL_0]] : i1
 // CHECK:           } else {
 // CHECK:             cc.continue %[[VAL_1]] : i1
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_9:.*]]) {
-// CHECK:             %[[VAL_10:.*]] = quake.qextract %[[VAL_7]]{{\[}}%[[VAL_3]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             %[[VAL_11:.*]] = quake.qextract %[[VAL_7]]{{\[}}%[[VAL_4]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.h (%[[VAL_11]])
-// CHECK:             quake.z {{\[}}%[[VAL_10]] : !quake.qref] (%[[VAL_11]])
-// CHECK:             quake.y (%[[VAL_11]])
+// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.h %[[VAL_11]] :
+// CHECK:             quake.z [%[[VAL_10]]] %[[VAL_11]] :
+// CHECK:             quake.y %[[VAL_11]] :
 // CHECK:           }
 // CHECK:           %[[VAL_12:.*]] = arith.cmpi sgt, %[[VAL_2]], %[[VAL_6]] : i32
 // CHECK:           %[[VAL_13:.*]] = arith.select %[[VAL_12]], %[[VAL_2]], %[[VAL_6]] : i32
@@ -88,11 +88,11 @@ module {
 // CHECK:             cc.condition %[[VAL_18]](%[[VAL_16]], %[[VAL_17]] : i32, i32)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_19:.*]]: i32, %[[VAL_20:.*]]: i32):
-// CHECK:             %[[VAL_21:.*]] = quake.qextract %[[VAL_7]]{{\[}}%[[VAL_4]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             %[[VAL_22:.*]] = quake.qextract %[[VAL_7]]{{\[}}%[[VAL_3]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.z {{\[}}%[[VAL_21]] : !quake.qref] (%[[VAL_22]])
-// CHECK:             quake.y (%[[VAL_22]])
-// CHECK:             quake.x {{\[}}%[[VAL_21]] : !quake.qref] (%[[VAL_22]])
+// CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.z [%[[VAL_21]]] %[[VAL_22]] :
+// CHECK:             quake.y %[[VAL_22]] :
+// CHECK:             quake.x [%[[VAL_21]]] %[[VAL_22]] :
 // CHECK:             cc.continue %[[VAL_19]], %[[VAL_20]] : i32, i32
 // CHECK:           } step {
 // CHECK:           ^bb0(%[[VAL_23:.*]]: i32, %[[VAL_24:.*]]: i32):
@@ -101,11 +101,11 @@ module {
 // CHECK:             cc.continue %[[VAL_25]], %[[VAL_26]] : i32, i32
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_0]]) {
-// CHECK:             %[[VAL_27:.*]] = quake.qextract %[[VAL_7]]{{\[}}%[[VAL_4]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             %[[VAL_28:.*]] = quake.qextract %[[VAL_7]]{{\[}}%[[VAL_3]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.y {{\[}}%[[VAL_27]] : !quake.qref] (%[[VAL_28]])
-// CHECK:             quake.x (%[[VAL_28]])
-// CHECK:             quake.h {{\[}}%[[VAL_27]] : !quake.qref] (%[[VAL_28]])
+// CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_28:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.y [%[[VAL_27]]] %[[VAL_28]] :
+// CHECK:             quake.x %[[VAL_28]] :
+// CHECK:             quake.h [%[[VAL_27]]] %[[VAL_28]] :
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/adjoint-2.qke
+++ b/test/Quake/adjoint-2.qke
@@ -11,11 +11,11 @@
 module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__kernel_alpha = "_ZN12kernel_alphaclERN4cudaq5quditILm2EEE", __nvqpp__mlirgen__kernel_beta = "_ZN11kernel_betaclEv"}} {
   // expected-error @+1 {{cannot make adjoint of kernel with a measurement}}
   func.func @__nvqpp__mlirgen__kernel_alpha(%arg0: !quake.qref) attributes {"cudaq-kernel"} {
-    %0 = quake.mx(%arg0 : !quake.qref) : i1
+    %0 = quake.mx %arg0 : (!quake.qref) -> i1
     return
   }
   func.func @__nvqpp__mlirgen__kernel_beta() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-    %0 = quake.alloca : !quake.qref
+    %0 = quake.alloca !quake.qref
     %1 = cc.undef !llvm.struct<"kernel_alpha", ()>
     quake.apply<adj> @__nvqpp__mlirgen__kernel_alpha %0 : (!quake.qref) -> ()
     return

--- a/test/Quake/apply-1.qke
+++ b/test/Quake/apply-1.qke
@@ -11,29 +11,28 @@
 // Test specialization of a user-defined kernel (@test) for both
 // adjoint and control forms.
 
-module {
   func.func @test(%arg : !quake.qref) {
-    quake.t (%arg)
-    quake.h (%arg)
+    quake.t %arg : (!quake.qref) -> ()
+    quake.h %arg : (!quake.qref) -> ()
     %1 = arith.constant 1.0 : f32
-    quake.rx |%1 : f32| (%arg)
-    quake.x (%arg)
+    quake.rx (%1) %arg : (f32, !quake.qref) -> ()
+    quake.x %arg : (!quake.qref) -> ()
     return
   }
+  
   func.func @do_apply(%arg : !quake.qref, %brg : !quake.qref) {
-    quake.apply <adj> @test [%brg : !quake.qref] %arg : (!quake.qref) -> ()
+    quake.apply <adj> @test [%brg] %arg : (!quake.qref,!quake.qref) -> ()
     return
   }
-}
 
 // CHECK-LABEL: func.func private @test.adj.ctrl(
 // CHECK-SAME:     %[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: !quake.qref) {
-// CHECK:         %[[VAL_2:.*]] = arith.constant 1.000000e+00 : f32
-// CHECK-DAG:     quake.x {{\[}}%[[VAL_0]] : !quake.qvec<?>] (%[[VAL_1]])
+// CHECK:         %[[VAL_2:.*]] = arith.constant 1.0{{.*}} : f32
+// CHECK-DAG:     quake.x [%[[VAL_0]]] %[[VAL_1]] :
 // CHECK-DAG:     %[[VAL_3:.*]] = arith.negf %[[VAL_2]] : f32
-// CHECK:         quake.rx {{\[}}%[[VAL_0]] : !quake.qvec<?>] |%[[VAL_3]] : f32|(%[[VAL_1]])
-// CHECK:         quake.h {{\[}}%[[VAL_0]] : !quake.qvec<?>] (%[[VAL_1]])
-// CHECK:         quake.t<adj> {{\[}}%[[VAL_0]] : !quake.qvec<?>] (%[[VAL_1]])
+// CHECK:         quake.rx (%[[VAL_3]]) [%[[VAL_0]]] %[[VAL_1]] :
+// CHECK:         quake.h [%[[VAL_0]]] %[[VAL_1]] :
+// CHECK:         quake.t<adj> [%[[VAL_0]]] %[[VAL_1]] : (!quake.qvec<?>,
 // CHECK:         return
 // CHECK:       }
 
@@ -42,21 +41,21 @@ module {
 
 // CHECK-LABEL:   func.func private @test.ctrl(
 // CHECK-SAME:       %[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: !quake.qref) {
-// CHECK:           quake.t {{\[}}%[[VAL_0]] : !quake.qvec<?>] (%[[VAL_1]])
-// CHECK:           quake.h {{\[}}%[[VAL_0]] : !quake.qvec<?>] (%[[VAL_1]])
+// CHECK:           quake.t [%[[VAL_0]]] %[[VAL_1]]
+// CHECK:           quake.h [%[[VAL_0]]] %[[VAL_1]]
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1.000000e+00 : f32
-// CHECK:           quake.rx {{\[}}%[[VAL_0]] : !quake.qvec<?>] |%[[VAL_2]] : f32|(%[[VAL_1]])
-// CHECK:           quake.x {{\[}}%[[VAL_0]] : !quake.qvec<?>] (%[[VAL_1]])
+// CHECK:           quake.rx (%[[VAL_2]]) [%[[VAL_0]]] %[[VAL_1]]
+// CHECK:           quake.x [%[[VAL_0]]] %[[VAL_1]]
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !quake.qref) {
-// CHECK:           quake.t (%[[VAL_0]])
-// CHECK:           quake.h (%[[VAL_0]])
+// CHECK:           quake.t %[[VAL_0]] :
+// CHECK:           quake.h %[[VAL_0]] :
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1.000000e+00 : f32
-// CHECK:           quake.rx |%[[VAL_1]] : f32|(%[[VAL_0]])
-// CHECK:           quake.x (%[[VAL_0]])
+// CHECK:           quake.rx (%[[VAL_1]]) %[[VAL_0]] :
+// CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/apply-2.qke
+++ b/test/Quake/apply-2.qke
@@ -13,13 +13,13 @@
 
 module {
   func.func @test(%arg : !quake.qref) {
-    quake.t (%arg)
-    quake.h (%arg)
-    quake.x (%arg)
+    quake.t %arg : (!quake.qref) -> ()
+    quake.h %arg : (!quake.qref) -> ()
+    quake.x %arg : (!quake.qref) -> ()
     return
   }
   func.func @do_apply(%arg : !quake.qref, %brg : !quake.qref) {
-    quake.apply <adj> @test [%brg : !quake.qref] %arg : (!quake.qref) -> ()
+    quake.apply <adj> @test [%brg] %arg : (!quake.qref, !quake.qref) -> ()
     return
   }
 }

--- a/test/Quake/basic.qke
+++ b/test/Quake/basic.qke
@@ -8,69 +8,82 @@
 
 // RUN: cudaq-opt %s | cudaq-opt | FileCheck %s
 
-module {
-  // CHECK-LABEL: func @alloc(
-  // CHECK-SAME: %[[SIZE:.*]]: i32
-  func.func @alloc(%size : i32) {
-    // CHECK: %[[QUBIT:.*]] = quake.alloca : !quake.qref
-    %qubit = quake.alloca : !quake.qref
-    // CHECK: %[[QREG0:.*]] = quake.alloca(%[[SIZE]] : i32) : !quake.qvec<?>
-    %qvec0 = quake.alloca(%size : i32) : !quake.qvec<?>
-    // CHECK: %[[QREG1:.*]] = quake.alloca : !quake.qvec<4>
-    %qvec1 = quake.alloca : !quake.qvec<4>
-    return
-  }
-
-  // CHECK-LABEL: func @alloc_qubit
-  func.func @alloc_qubit() {
-    // CHECK: %[[QUBIT:.*]] = quake.alloca : !quake.qref
-    %qubit = quake.alloca : !quake.qref
-    return
-  }
-
-  // CHECK-LABEL: func @alloc_qreg
-  func.func @alloc_qreg() {
-    // CHECK: %[[QREG1:.*]] = quake.alloca : !quake.qvec<2>
-    %qvec = quake.alloca : !quake.qvec<2>
-    return
-  }
-
-  // CHECK: func @args
-  func.func @args(%qubit: !quake.qref, %qvec: !quake.qvec<2>) {
-    return
-  }
-
-  // CHECK-LABEL: func @reset
-  func.func @reset() {
-    // CHECK: %[[QUBIT:.*]] = quake.alloca : !quake.qref
-    %qubit = quake.alloca : !quake.qref
-    // CHECK: quake.reset(%[[QUBIT]] : !quake.qref)
-    quake.reset(%qubit : !quake.qref)
-    // CHECK: %[[QREG:.*]] = quake.alloca : !quake.qvec<2>
-    %qreg = quake.alloca : !quake.qvec<2>
-    // CHECK: quake.reset(%[[QREG]] : !quake.qvec<2>)
-    quake.reset(%qreg : !quake.qvec<2>)
-    return
-  }
-
-  // CHECK-LABEL: func @apply_x
-  func.func @apply_x() {
-    // CHECK: %[[QUBIT:.*]] = quake.alloca : !quake.qref
-    %qubit = quake.alloca : !quake.qref
-    quake.x(%qubit)
-    return
-  }
-
-  // CHECK-LABEL: func @apply_cx
-  func.func @apply_cx() {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    // CHECK: %[[QREG1:.*]] = quake.alloca : !quake.qvec<2>
-    %qvec = quake.alloca : !quake.qvec<2>
-    %q0 = quake.qextract %qvec[%c0] : !quake.qvec<2>[index] -> !quake.qref
-    %q1 = quake.qextract %qvec[%c1] : !quake.qvec<2>[index] -> !quake.qref
-    quake.x[%q0 : !quake.qref](%q1)
-    return
-  }
+// CHECK-LABEL: func @alloc(
+// CHECK-SAME: %[[SIZE:.*]]: i32
+func.func @alloc(%size : i32) {
+  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.qref
+  %qubit = quake.alloca !quake.qref
+  // CHECK: %[[QREG0:.*]] = quake.alloca[%[[SIZE]] : i32] !quake.qvec<?>
+  %qvec0 = quake.alloca [%size : i32] !quake.qvec<?>
+  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<4>
+  %qvec1 = quake.alloca !quake.qvec<4>
+  return
 }
 
+// CHECK-LABEL: func @alloc_qubit
+func.func @alloc_qubit() {
+  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.qref
+  %qubit = quake.alloca !quake.qref
+  return
+}
+
+// CHECK-LABEL: func @alloc_qreg
+func.func @alloc_qreg() {
+  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<2>
+  %qvec = quake.alloca !quake.qvec<2>
+  return
+}
+
+// CHECK-LABEL: func @args(
+// CHECK-SAME: %{{.*}}: !quake.qref, %{{.*}}: !quake.qvec<2>)
+func.func @args(%qubit: !quake.qref, %qvec: !quake.qvec<2>) {
+  return
+}
+
+// CHECK-LABEL: func @reset
+func.func @reset() {
+  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.qref
+  %qubit = quake.alloca !quake.qref
+  // CHECK: quake.reset %[[QUBIT]] : (!quake.qref) -> ()
+  quake.reset %qubit : (!quake.qref) -> ()
+  // CHECK: %[[QREG:.*]] = quake.alloca !quake.qvec<2>
+  %qreg = quake.alloca !quake.qvec<2>
+  // CHECK: quake.reset %[[QREG]] : (!quake.qvec<2>) -> ()
+  quake.reset %qreg : (!quake.qvec<2>) -> ()
+  return
+}
+
+// CHECK-LABEL: func @apply_x
+func.func @apply_x() {
+  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.qref
+  %qubit = quake.alloca !quake.qref
+  quake.x %qubit : (!quake.qref) -> ()
+  return
+}
+
+// CHECK-LABEL: func @apply_cx
+func.func @apply_cx() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<2>
+  %qvec = quake.alloca  !quake.qvec<2>
+  %q0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<2>,index) -> !quake.qref
+  %q1 = quake.extract_ref %qvec[%c1] : (!quake.qvec<2>,index) -> !quake.qref
+  quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+  return
+}
+
+func.func @apply_cx_v() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<2>
+  %qvec = quake.alloca  !quake.qvec<2>
+  %q0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<2>,index) -> !quake.qref
+  %q1 = quake.extract_ref %qvec[%c1] : (!quake.qvec<2>,index) -> !quake.qref
+  %q2 = quake.unwrap %q0 : (!quake.qref) -> !quake.wire
+  %q3 = quake.unwrap %q1 : (!quake.qref) -> !quake.wire
+  // CHECK: %{{.*}} = quake.x [%{{.*}}] %{{.*}} : (!quake.wire, !quake.wire) -> !quake.wire
+  %q5 = quake.x [%q2] %q3 : (!quake.wire, !quake.wire) -> !quake.wire
+  quake.wrap %q5 to %q1 : !quake.wire, !quake.qref
+  return
+}

--- a/test/Quake/bell.qke
+++ b/test/Quake/bell.qke
@@ -11,26 +11,26 @@ module {
     // CHECK-LABEL: func @bell()
     // CHECK: %[[C0:.*]] = arith.constant 0 : i32
     // CHECK: %[[C1:.*]] = arith.constant 1 : i32
-    // CHECK: %0 = quake.alloca : !quake.qvec<2>
-    // CHECK: %1 = quake.qextract %0[%[[C0]]] : !quake.qvec<2>[i32] -> !quake.qref
-    // CHECK: %2 = quake.qextract %0[%[[C1]]] : !quake.qvec<2>[i32] -> !quake.qref
-    // CHECK: quake.h (%1)
-    // CHECK: quake.x [%1 : !quake.qref] (%2)
-    // CHECK: %3 = quake.mz(%1 : !quake.qref) : i1
-    // CHECK: %4 = quake.mz(%2 : !quake.qref) : i1
+    // CHECK: %0 = quake.alloca !quake.qvec<2>
+    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+    // CHECK: %2 = quake.extract_ref %0[%[[C1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+    // CHECK: quake.h %1
+    // CHECK: quake.x [%1] %2 :
+    // CHECK: %3 = quake.mz %1 : (!quake.qref) -> i1
+    // CHECK: %4 = quake.mz %2 : (!quake.qref) -> i1
     // CHECK: return
     func.func @bell() {
         %0 = arith.constant 2 : i32
         %c_0 = arith.constant 0 : i32
         %c_1 = arith.constant 1 : i32
-        %qubits = quake.alloca ( %0 : i32 ) : !quake.qvec<?>
-        %q0 = quake.qextract %qubits[%c_0] : !quake.qvec<?>[i32] -> !quake.qref
-        %q1 = quake.qextract %qubits[%c_1] : !quake.qvec<?>[i32] -> !quake.qref
+        %qubits = quake.alloca [%0 : i32] !quake.qvec<?>
+        %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>,i32) -> !quake.qref
+        %q1 = quake.extract_ref %qubits[%c_1] : (!quake.qvec<?>,i32) -> !quake.qref
 
-        quake.h (%q0)
-        quake.x [%q0 : !quake.qref] (%q1)
-        quake.mz(%q0 : !quake.qref) : i1
-        quake.mz(%q1 : !quake.qref) : i1
+        quake.h %q0 : (!quake.qref) -> ()
+        quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+        quake.mz %q0 : (!quake.qref) -> i1
+        quake.mz %q1 : (!quake.qref) -> i1
         return
     }
 }

--- a/test/Quake/canonical-1.qke
+++ b/test/Quake/canonical-1.qke
@@ -15,35 +15,35 @@ func.func @test1(%arg0 : !quake.qvec<?>) -> i1 {
 
 func.func @test2() {
   %0 = arith.constant 10 : i64
-  %1 = quake.alloca(%0 : i64) : !quake.qvec<?>
+  %1 = quake.alloca[%0 : i64] !quake.qvec<?>
   // relax_size must be inserted here
   %2 = call @test1(%1) : (!quake.qvec<?>) -> i1
   %3 = arith.constant 1 : i64
-  %4 = quake.qextract %1[%3] : !quake.qvec<?>[i64] -> !quake.qref
-  quake.h (%4)
+  %4 = quake.extract_ref %1[%3] : (!quake.qvec<?>,i64) -> !quake.qref
+  quake.h %4 : (!quake.qref) -> ()
   return
 }
 
 // CHECK-LABEL:   func.func @test2() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qvec<10>
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<10>
 // CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.qvec<10>) -> !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = call @test1(%[[VAL_2]]) : (!quake.qvec<?>) -> i1
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_1]]{{\[}}%[[VAL_0]]] : !quake.qvec<10>[i64] -> !quake.qref
-// CHECK:           quake.h (%[[VAL_4]])
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_0]]] : (!quake.qvec<10>, i64) -> !quake.qref
+// CHECK:           quake.h %[[VAL_4]]
 // CHECK:           return
 // CHECK:         }
 
 func.func @test3() {
   %0 = arith.constant 10 : i64
-  %1 = quake.alloca(%0 : i64) : !quake.qvec<?>
+  %1 = quake.alloca [%0 : i64] !quake.qvec<?>
   %2 = arith.constant 4 : i64
   %3 = arith.constant 7 : i64
   // This subvec qvec<?> can be reified to qvec<4>
   %4 = quake.subvec %1, %2, %3 : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
   %5 = arith.constant 2 : i64
-  %6 = quake.qextract %4[%5] : !quake.qvec<?>[i64] -> !quake.qref
-  quake.h (%6)
+  %6 = quake.extract_ref %4[%5] : (!quake.qvec<?>,i64) -> !quake.qref
+  quake.h %6 : (!quake.qref) -> ()
   return
 }
 
@@ -51,35 +51,35 @@ func.func @test3() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 7 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qvec<10>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<10>
 // CHECK:           %[[VAL_4:.*]] = quake.subvec %[[VAL_3]], %[[VAL_2]], %[[VAL_1]] : (!quake.qvec<10>, i64, i64) -> !quake.qvec<4>
-// CHECK:           %[[VAL_5:.*]] = quake.qextract %[[VAL_4]]{{\[}}%[[VAL_0]]] : !quake.qvec<4>[i64] -> !quake.qref
-// CHECK:           quake.h (%[[VAL_5]])
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_0]]] : (!quake.qvec<4>, i64) -> !quake.qref
+// CHECK:           quake.h %[[VAL_5]] : (!quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 func.func @test_qextract_1() {
     %c0 = arith.constant 0 : i64
     %c2 = arith.constant 2 : i64
-    %qvec = quake.alloca(%c2 : i64) : !quake.qvec<?>
-    %0 = quake.qextract %qvec[%c0] : !quake.qvec<?>[i64] -> !quake.qref
-    quake.h (%0)
+    %qvec = quake.alloca [%c2 : i64] !quake.qvec<?>
+    %0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>, i64) -> !quake.qref
+    quake.h %0 : (!quake.qref) -> ()
     %c0_0 = arith.constant 0 : i64
     %c1 = arith.constant 1 : i64
-    %1 = quake.qextract %qvec[%c0_0] : !quake.qvec<?>[i64] -> !quake.qref
-    %2 = quake.qextract %qvec[%c1] : !quake.qvec<?>[i64] -> !quake.qref
-    quake.x [%1 : !quake.qref] (%2)
+    %1 = quake.extract_ref %qvec[%c0_0] : (!quake.qvec<?>, i64) -> !quake.qref
+    %2 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>, i64) -> !quake.qref
+    quake.x [%1] %2 : (!quake.qref, !quake.qref) -> ()
     return
 }
 
 // CHECK-LABEL:   func.func @test_qextract_1() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qvec<2>
-// CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.h (%[[VAL_3]])
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_2]]{{\[}}%[[VAL_0]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.x {{\[}}%[[VAL_3]] : !quake.qref] (%[[VAL_4]])
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -87,19 +87,19 @@ func.func @test_qextract_2(%arg0: i1) {
     %c0 = arith.constant 0 : i64
     %c2 = arith.constant 2 : i64
     %c1 = arith.constant 1 : i64
-    %qvec = quake.alloca(%c2 : i64) : !quake.qvec<?>
-    %0 = quake.qextract %qvec[%c0] : !quake.qvec<?>[i64] -> !quake.qref
-    quake.h (%0)
+    %qvec = quake.alloca[%c2 : i64]  !quake.qvec<?>
+    %0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.qref
+    quake.h %0 : (!quake.qref) -> ()
     cc.if(%arg0) {
       cc.scope {
-        %1 = quake.qextract %qvec[%c0] : !quake.qvec<?>[i64] -> !quake.qref
-        %2 = quake.qextract %qvec[%c1] : !quake.qvec<?>[i64] -> !quake.qref
-        quake.x [%1 : !quake.qref] (%2)
+        %1 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.qref
+        %2 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>,i64) -> !quake.qref
+        quake.x [%1] %2 : (!quake.qref,!quake.qref) -> ()
       }
     }
-    %3 = quake.qextract %qvec[%c0] : !quake.qvec<?>[i64] -> !quake.qref
-    %4 = quake.qextract %qvec[%c1] : !quake.qvec<?>[i64] -> !quake.qref
-    quake.x [%3 : !quake.qref] (%4)
+    %3 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.qref
+    %4 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>,i64) -> !quake.qref
+    quake.x [%3] %4 : (!quake.qref,!quake.qref) -> ()
     return
 }
 
@@ -107,15 +107,15 @@ func.func @test_qextract_2(%arg0: i1) {
 // CHECK-SAME:                               %[[VAL_0:.*]]: i1) {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qvec<2>
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.h (%[[VAL_4]])
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.h %[[VAL_4]] :
 // CHECK:           cc.if(%[[VAL_0]]) {
-// CHECK:             %[[VAL_5:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_1]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             %[[VAL_6:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:             quake.x {{\[}}%[[VAL_5]] : !quake.qref] (%[[VAL_6]])
+// CHECK:             %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             quake.x [%[[VAL_5]]] %[[VAL_6]] :
 // CHECK:           }
-// CHECK:           %[[VAL_7:.*]] = quake.qextract %[[VAL_3]]{{\[}}%[[VAL_2]]] : !quake.qvec<2>[i64] -> !quake.qref
-// CHECK:           quake.x {{\[}}%[[VAL_4]] : !quake.qref] (%[[VAL_7]])
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           quake.x [%[[VAL_4]]] %[[VAL_7]] :
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/canonical-2.qke
+++ b/test/Quake/canonical-2.qke
@@ -9,7 +9,7 @@
 // RUN: cudaq-opt -canonicalize %s | FileCheck %s
 
   func.func @__nvqpp__mlirgen__reflect_about_uniform(%arg0: !quake.qvec<?>) attributes {"cudaq-kernel"} {
-    %0 = quake.qvec_size %arg0 : (!quake.qvec<?>) -> i64
+    %0 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
     %c1_i32 = arith.constant 1 : i32
     %1 = arith.extsi %c1_i32 : i32 to i64
     %2 = arith.subi %0, %1 : i64
@@ -17,25 +17,25 @@
     %c1_i64 = arith.constant 1 : i64
     %3 = arith.subi %2, %c1_i64 : i64
     %4 = quake.subvec %arg0, %c0_i64, %3 : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
-    %5 = quake.qvec_size %arg0 : (!quake.qvec<?>) -> i64
+    %5 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
     %c1_i64_0 = arith.constant 1 : i64
     %6 = arith.subi %5, %c1_i64_0 : i64
-    %7 = quake.qextract %arg0[%6] : !quake.qvec<?>[i64] -> !quake.qref
+    %7 = quake.extract_ref %arg0[%6] : (!quake.qvec<?>,i64) -> !quake.qref
     %8 = cc.create_lambda {
       cc.scope {
         %c0 = arith.constant 0 : index
         %c1 = arith.constant 1 : index
-        %10 = quake.qvec_size %arg0 : (!quake.qvec<?>) -> i64
+        %10 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
         %11 = arith.index_cast %10 : i64 to index
         scf.for %arg1 = %c0 to %11 step %c1 {
-          %12 = quake.qextract %arg0[%arg1] : !quake.qvec<?>[index] -> !quake.qref
-          quake.h (%12)
+          %12 = quake.extract_ref %arg0[%arg1] : (!quake.qvec<?>,index) -> !quake.qref
+          quake.h %12 : (!quake.qref) -> ()
         }
       }
     } : !cc.lambda<() -> ()>
     %9 = cc.create_lambda {
       cc.scope {
-        quake.z [%4 : !quake.qvec<?>] (%7)
+        quake.z [%4] %7 : (!quake.qvec<?>, !quake.qref) -> ()
       }
     } : !cc.lambda<() -> ()>
     quake.compute_action %8, %9 : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
@@ -45,16 +45,16 @@
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__reflect_about_uniform(
 // CHECK:           %[[VAL_12:.*]] = cc.create_lambda {
 // CHECK-NOT:       cc.scope
-// CHECK:             %[[VAL_13:.*]] = quake.qvec_size %{{.*}} : (!quake.qvec<?>) -> i64
+// CHECK:             %[[VAL_13:.*]] = quake.vec_size %{{.*}} : (!quake.qvec<?>) -> i64
 // CHECK:             %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : i64 to index
 // CHECK:             scf.for %[[VAL_15:.*]] = %{{.*}} to %[[VAL_14]] step %
-// CHECK:               %[[VAL_16:.*]] = quake.qextract
-// CHECK:               quake.h (%[[VAL_16]])
+// CHECK:               %[[VAL_16:.*]] = quake.extract_ref
+// CHECK:               quake.h %[[VAL_16]]
 // CHECK:             }
 // CHECK:           } : !cc.lambda<() -> ()>
 // CHECK:           %[[VAL_17:.*]] = cc.create_lambda {
 // CHECK-NOT:       cc.scope
-// CHECK:             quake.z [%{{.*}} : !quake.qvec<?>] (%{{.*}})
+// CHECK:             quake.z [%{{.*}}] %{{.*}} :
 // CHECK:           } : !cc.lambda<() -> ()>
 // CHECK:           quake.compute_action
 // CHECK:           return

--- a/test/Quake/ccnot.qke
+++ b/test/Quake/ccnot.qke
@@ -12,23 +12,24 @@ module {
 
     // CHECK-LABEL: func.func @apply_x(
     // CHECK-SAME: %[[arg0:.*]]: !quake.qref) {
-    // CHECK:   quake.x (%[[arg0]])
+    // CHECK:   quake.x %[[arg0]] :
     // CHECK:   return
     // CHECK: }
+    
     // CHECK-LABEL: func.func @ccnot() {
     // CHECK:   %[[C1:.*]] = arith.constant 1 : i32
-    // CHECK:   %[[a0:.*]] = quake.alloca : !quake.qvec<3>
+    // CHECK:   %[[a0:.*]] = quake.alloca !quake.qvec<3>
     // CHECK:   affine.for %[[arg0:.*]] = 0 to 3 {
-    // CHECK:     %[[a2:.*]] = quake.qextract %[[a0]][%[[arg0]]] : !quake.qvec<3>[index] -> !quake.qref
-    // CHECK:     quake.x (%[[a2]])
+    // CHECK:     %[[a2:.*]] = quake.extract_ref %[[a0]][%[[arg0]]] : (!quake.qvec<3>, index) -> !quake.qref
+    // CHECK:     quake.x %[[a2]] :
     // CHECK:   }
-    // CHECK:   %[[a1:.*]] = quake.qextract %[[a0]][%[[C1]]] : !quake.qvec<3>[i32] -> !quake.qref
-    // CHECK:   quake.x (%[[a1]])
+    // CHECK:   %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.qvec<3>, i32) -> !quake.qref
+    // CHECK:   quake.x %[[a1]] :
     // CHECK:   return
     // CHECK: }
     
     func.func @apply_x(%q : !quake.qref) {
-        quake.x (%q)
+        quake.x %q : (!quake.qref) -> ()
         return
     }
 
@@ -37,14 +38,14 @@ module {
         %c_0 = arith.constant 0 : i32
         %c_1 = arith.constant 1 : i32
         %c_2 = arith.constant 2 : i32
-        %qubits = quake.alloca ( %c_3 : i32 ) : !quake.qvec<?>
+        %qubits = quake.alloca [ %c_3 : i32 ] !quake.qvec<?>
         %c_3_idx = arith.index_cast %c_3 : i32 to index
         affine.for %i = 0 to %c_3_idx {
-            %q0 = quake.qextract %qubits [%i] : !quake.qvec<?>[index] -> !quake.qref
-            quake.x (%q0)
+            %q0 = quake.extract_ref %qubits [%i] : (!quake.qvec<?>, index) -> !quake.qref
+            quake.x %q0 : (!quake.qref) -> ()
         }
 
-        %q1 = quake.qextract %qubits [%c_1] : !quake.qvec<?>[i32] -> !quake.qref
+        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>, i32) -> !quake.qref
         func.call @apply_x(%q1) : (!quake.qref) -> ()
 
         return

--- a/test/Quake/compute_action.qke
+++ b/test/Quake/compute_action.qke
@@ -20,25 +20,25 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
   func.func @__nvqpp__mlirgen__t() attributes {"cudaq-entrypoint"} {
     %c5_i32 = arith.constant 5 : i32
     %0 = arith.extsi %c5_i32 : i32 to i64
-    %1 = quake.alloca(%0 : i64) : !quake.qvec<?>
+    %1 = quake.alloca[%0 : i64] !quake.qvec<?>
     %2 = cc.create_lambda {
       cc.scope {
         %c0_i32 = arith.constant 0 : i32
         %4 = arith.extsi %c0_i32 : i32 to i64
-        %5 = quake.qextract %1[%4] : !quake.qvec<?>[i64] -> !quake.qref
-        quake.t (%5)
+        %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.qref
+        quake.t %5 : (!quake.qref) -> ()
         %c1_i32 = arith.constant 1 : i32
         %6 = arith.extsi %c1_i32 : i32 to i64
-        %7 = quake.qextract %1[%6] : !quake.qvec<?>[i64] -> !quake.qref
-        quake.x (%7)
+        %7 = quake.extract_ref %1[%6] : (!quake.qvec<?>,i64) -> !quake.qref
+        quake.x %7 : (!quake.qref) -> ()
       }
     } : !cc.lambda<() -> ()>
     %3 = cc.create_lambda {
       cc.scope {
         %c2_i32 = arith.constant 2 : i32
         %4 = arith.extsi %c2_i32 : i32 to i64
-        %5 = quake.qextract %1[%4] : !quake.qvec<?>[i64] -> !quake.qref
-        quake.h (%5)
+        %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.qref
+        quake.h %5 : (!quake.qref) -> ()
       }
     } : !cc.lambda<() -> ()>
     quake.compute_action %2, %3 : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
@@ -49,10 +49,10 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
 // CHECK-LABEL:   func.func private @__nvqpp__lifted.lambda.{{[01]}}.adj(
 // CHECK-SAME:            %[[VAL_0:.*]]: !quake.qvec<5>,
 // CHECK-SAME:            %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64) {
-// CHECK:           %[[VAL_3:.*]] = quake.qextract %[[VAL_0]][%[[VAL_1]]] : !quake.qvec<5>[i64] -> !quake.qref
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_0]][%[[VAL_2]]] : !quake.qvec<5>[i64] -> !quake.qref
-// CHECK:           quake.x (%[[VAL_4]])
-// CHECK:           quake.t<adj> (%[[VAL_3]])
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.qvec<5>, i64) -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<5>, i64) -> !quake.qref
+// CHECK:           quake.x %[[VAL_4]] : (!quake.qref) -> ()
+// CHECK:           quake.t<adj> %[[VAL_3]] : (!quake.qref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -60,7 +60,7 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qvec<5>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<5>
 // CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]], %[[VAL_2]], %[[VAL_1]]) : (!quake.qvec<5>, i64, i64) -> ()
 // CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]], %[[VAL_0]]) : (!quake.qvec<5>, i64) -> ()
 // CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}.adj(%[[VAL_3]], %[[VAL_2]], %[[VAL_1]]) : (!quake.qvec<5>, i64, i64) -> ()

--- a/test/Quake/cse.qke
+++ b/test/Quake/cse.qke
@@ -19,26 +19,26 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %c2_i64 = arith.constant 2 : i64
     %cst = arith.constant -1.000000e+00 : f64
-    %0 = quake.alloca : !quake.qvec<3>
-    %1 = quake.qextract %0[%c0_i64] : !quake.qvec<3>[i64] -> !quake.qref
-    quake.x (%1)
+    %0 = quake.alloca  !quake.qvec<3>
+    %1 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<3>,i64) -> !quake.qref
+    quake.x %1 : (!quake.qref) -> ()
     %2 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
     %3 = llvm.load %2 : !llvm.ptr<f64>
-    %4 = quake.qextract %0[%c1_i64] : !quake.qvec<3>[i64] -> !quake.qref
-    quake.ry |%3 : f64|(%4)
+    %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<3>,i64) -> !quake.qref
+    quake.ry (%3) %4 : (f64, !quake.qref) -> ()
     %5 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
     %6 = llvm.getelementptr %5[1] : (!llvm.ptr<f64>) -> !llvm.ptr<f64>
     %7 = llvm.load %6 : !llvm.ptr<f64>
-    %8 = quake.qextract %0[%c2_i64] : !quake.qvec<3>[i64] -> !quake.qref
-    quake.ry |%7 : f64|(%8)
-    quake.x [%8 : !quake.qref] (%1)
-    quake.x [%1 : !quake.qref] (%4)
+    %8 = quake.extract_ref %0[%c2_i64] : (!quake.qvec<3>, i64) -> !quake.qref
+    quake.ry (%7) %8 : (f64, !quake.qref) -> ()
+    quake.x [%8] %1 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%1] %4 : (!quake.qref, !quake.qref) -> ()
     %9 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
     %10 = llvm.load %9 : !llvm.ptr<f64>
     %11 = arith.mulf %10, %cst : f64
-    quake.ry |%11 : f64|(%4)
-    quake.x [%1 : !quake.qref] (%4)
-    quake.x [%4 : !quake.qref] (%1)
+    quake.ry (%11) %4 : (f64, !quake.qref) -> ()
+    quake.x [%1] %4   : (!quake.qref, !quake.qref) -> ()
+    quake.x [%4] %1   : (!quake.qref, !quake.qref) -> ()
     return
   }
 }

--- a/test/Quake/deuteron.qke
+++ b/test/Quake/deuteron.qke
@@ -12,14 +12,14 @@
 // CHECK-SAME: %[[arg0:.*]]: f64) {
 // CHECK:    %[[C0:.*]] = arith.constant 0 : i32
 // CHECK:    %[[C1:.*]] = arith.constant 1 : i32
-// CHECK:    %[[a0:.*]] = quake.alloca : !quake.qvec<2>
-// CHECK:    %[[a1:.*]] = quake.qextract %[[a0]][%[[C0]]] : !quake.qvec<2>[i32] -> !quake.qref
-// CHECK:    %[[a2:.*]] = quake.qextract %[[a0]][%[[C1]]] : !quake.qvec<2>[i32] -> !quake.qref
-// CHECK:    quake.x (%[[a1]])
-// CHECK:    quake.ry |%[[arg0]] : f64|(%[[a2]])
-// CHECK:    quake.x [%[[a2]] : !quake.qref] (%[[a1]])
-// CHECK:    %[[a3:.*]] = quake.mz(%[[a1]] : !quake.qref) : i1
-// CHECK:    %[[a4:.*]] = quake.mz(%[[a2]] : !quake.qref) : i1
+// CHECK:    %[[a0:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:    %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C0]]] : (!quake.qvec<2>, i32) -> !quake.qref
+// CHECK:    %[[a2:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+// CHECK:    quake.x %[[a1]]
+// CHECK:    quake.ry (%[[arg0]]) %[[a2]] : (f64, !quake.qref) -> ()
+// CHECK:    quake.x [%[[a2]]] %[[a1]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:    %[[a3:.*]] = quake.mz %[[a1]] : (!quake.qref) -> i1
+// CHECK:    %[[a4:.*]] = quake.mz %[[a2]] : (!quake.qref) -> i1
 // CHECK:    return
 // CHECK:  }
 
@@ -29,15 +29,15 @@ module {
         %c_0 = arith.constant 0 : i32
         %c_1 = arith.constant 1 : i32
         %c_angle = arith.constant 0.59 : f64
-        %qubits = quake.alloca ( %0 : i32 ) : !quake.qvec<?>
-        %q0 = quake.qextract %qubits [%c_0] : !quake.qvec<?>[i32] -> !quake.qref
-        %q1 = quake.qextract %qubits [%c_1] : !quake.qvec<?>[i32] -> !quake.qref
+        %qubits = quake.alloca [ %0 : i32 ] !quake.qvec<?>
+        %q0 = quake.extract_ref %qubits [%c_0] : (!quake.qvec<?>,i32) -> !quake.qref
+        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>,i32) -> !quake.qref
 
-        quake.x (%q0)
-        quake.ry |%theta : f64|(%q1)
-        quake.x [%q1 : !quake.qref] (%q0)
-        %measurements0 = quake.mz(%q0 : !quake.qref) : i1
-        %measurements1 = quake.mz(%q1 : !quake.qref) : i1
+        quake.x %q0 : (!quake.qref) -> ()
+        quake.ry (%theta) %q1  : (f64, !quake.qref) -> ()
+        quake.x [%q1] %q0 : (!quake.qref, !quake.qref) -> ()
+        %measurements0 = quake.mz %q0 : (!quake.qref) -> i1
+        %measurements1 = quake.mz %q1 : (!quake.qref) -> i1
         return
     }
 }

--- a/test/Quake/dummy.qke
+++ b/test/Quake/dummy.qke
@@ -7,35 +7,34 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt %s | FileCheck %s
-module {
+
 // CHECK: func.func @bar() {
-// CHECK:     %[[C0:.*]] = arith.constant 0 : i32
-// CHECK:     %[[C2:.*]] = arith.constant 2 : i32
-// CHECK:     %[[C1:.*]] = arith.constant 1 : i32
-// CHECK:     %[[C22:.*]] = arith.constant 22 : i64
-// CHECK:     %0 = quake.alloca(%[[C2]] : i32) : !quake.qvec<?>
-// CHECK:     %1 = quake.alloca(%[[C22]] : i64) : !quake.qvec<?>
-// CHECK:     %2 = quake.alloca(%[[C1]] : i32) : !quake.qvec<?>
-// CHECK:     %3 = quake.qextract %0[%[[C0]]] : !quake.qvec<?>[i32] -> !quake.qref
-// CHECK:     %4 = quake.qextract %1[%[[C1]]] : !quake.qvec<?>[i32] -> !quake.qref
-// CHECK:     quake.h (%3)
-// CHECK:     quake.x [%3 : !quake.qref] (%4)
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : i32
+// CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : i32
+// CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:     %[[C22:.*]] = arith.constant 22 : i64
+// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
+// CHECK:     %1 = quake.alloca[%[[C22]] : i64] !quake.qvec<?>
+// CHECK:     %2 = quake.alloca[%[[C1]] : i32] !quake.qvec<?>
+// CHECK:     %3 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:     %4 = quake.extract_ref %1[%[[C1]]] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:     quake.h %3 :
+// CHECK:     quake.x [%3] %4 :
 // CHECK:     return
 // CHECK: }
-    func.func @bar() {
-        %3 = arith.constant 0 : i32
-        %0 = arith.constant 2 : i32
-        %one = arith.constant 1 : i32
-        %1 = arith.constant 22 : i64
-        %qr2 = quake.alloca ( %0 : i32 ) : !quake.qvec<?>
-        %qr22 = quake.alloca ( %1 : i64 ) : !quake.qvec<?>
-        %q = quake.alloca (%one : i32) : !quake.qvec<?>
+func.func @bar() {
+  %3 = arith.constant 0 : i32
+  %0 = arith.constant 2 : i32
+  %one = arith.constant 1 : i32
+  %1 = arith.constant 22 : i64
+  %qr2 = quake.alloca [ %0 : i32 ]  !quake.qvec<?>
+  %qr22 = quake.alloca[ %1 : i64 ]  !quake.qvec<?>
+  %q = quake.alloca [%one : i32]  !quake.qvec<?>
 
-        %r = quake.qextract %qr2[%3] : !quake.qvec<?>[i32] -> !quake.qref
-        %q1 = quake.qextract %qr22[%one] : !quake.qvec<?>[i32] -> !quake.qref
+  %r = quake.extract_ref %qr2[%3] : (!quake.qvec<?>,i32) -> !quake.qref
+  %q1 = quake.extract_ref %qr22[%one] : (!quake.qvec<?> ,i32) -> !quake.qref
 
-        quake.h (%r)
-        quake.x[%r : !quake.qref] (%q1)
-        return
-    }
+  quake.h %r : (!quake.qref) -> ()
+  quake.x[%r] %q1 : (!quake.qref,!quake.qref) -> ()
+  return
 }

--- a/test/Quake/ghz.qke
+++ b/test/Quake/ghz.qke
@@ -8,20 +8,20 @@
 
 // RUN: cudaq-opt %s --canonicalize | FileCheck %s
 module {
-    // CHECK: func.func @ghz(%arg0: i32) {
+    // CHECK: func.func @ghz(%[[arg0:.*]]: i32) {
     // CHECK: %[[C0:.*]] = arith.constant 0 : i32
     // CHECK: %[[C1:.*]] = arith.constant 1 : i32
-    // CHECK: %0 = quake.alloca(%arg0 : i32) : !quake.qvec<?>
-    // CHECK: %1 = quake.qextract %0[%[[C0]]] : !quake.qvec<?>[i32] -> !quake.qref
-    // CHECK: quake.h (%1)
+    // CHECK: %0 = quake.alloca[%[[arg0]] : i32] !quake.qvec<?>
+    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
+    // CHECK: quake.h %1 :
     // CHECK: %2 = arith.subi %arg0, %[[C1]] : i32
     // CHECK: %3 = arith.index_cast %2 : i32 to index
     // CHECK: affine.for %arg1 = 0 to %3 {
     // CHECK:   %4 = arith.index_cast %arg1 : index to i32
     // CHECK:   %5 = arith.addi %4, %[[C1]] : i32
-    // CHECK:   %6 = quake.qextract %0[%arg1] : !quake.qvec<?>[index] -> !quake.qref
-    // CHECK:   %7 = quake.qextract %0[%5] : !quake.qvec<?>[i32] -> !quake.qref
-    // CHECK:   quake.x [%6 : !quake.qref] (%7)
+    // CHECK:   %6 = quake.extract_ref %0[%arg1] : (!quake.qvec<?>, index) -> !quake.qref
+    // CHECK:   %7 = quake.extract_ref %0[%5] : (!quake.qvec<?>, i32) -> !quake.qref
+    // CHECK:   quake.x [%6] %7 : (!quake.qref, !quake.qref) -> ()
     // CHECK: }
     // CHECK: return
     // CHECK: }
@@ -29,17 +29,17 @@ module {
         // %size = arith.constant 3 : i32
         %c0 = arith.constant 0 : i32
         %one = arith.constant 1 : i32
-        %q = quake.alloca(%arg0 : i32) : !quake.qvec<?>
-        %q0 = quake.qextract %q[%c0] : !quake.qvec<?>[i32] -> !quake.qref
-        quake.h (%q0) 
+        %q = quake.alloca [%arg0 : i32] !quake.qvec<?>
+        %q0 = quake.extract_ref %q[%c0] : (!quake.qvec<?>, i32) -> !quake.qref
+        quake.h %q0 : (!quake.qref) -> ()
         %size_m_1 = arith.subi %arg0, %one : i32
         %upper = arith.index_cast %size_m_1 : i32 to index
         affine.for %i = 0 to %upper {
             %i_int = arith.index_cast %i : index to i32
             %ip1 = arith.addi %i_int, %one : i32
-            %qi = quake.qextract %q[%i] : !quake.qvec<?>[index] -> !quake.qref
-            %qi1 = quake.qextract %q[%ip1] : !quake.qvec<?>[i32] -> !quake.qref
-            quake.x [%qi : !quake.qref] (%qi1)
+            %qi = quake.extract_ref %q[%i] : (!quake.qvec<?>, index) -> !quake.qref
+            %qi1 = quake.extract_ref %q[%ip1] : (!quake.qvec<?>, i32) -> !quake.qref
+            quake.x [%qi] %qi1 : (!quake.qref, !quake.qref) -> ()
         }
         return
     }

--- a/test/Quake/inline.qke
+++ b/test/Quake/inline.qke
@@ -12,29 +12,29 @@
 // RUN: cudaq-opt --apply-op-specialization --inline --canonicalize %s | FileCheck %s
 
 func.func @__nvqpp__mlirgen____nvqppBuilderKernel_202375922897() {
-  %0 = quake.alloca : !quake.qref
-  %1 = quake.alloca : !quake.qref
+  %0 = quake.alloca  !quake.qref
+  %1 = quake.alloca  !quake.qref
   call @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%0) : (!quake.qref) -> ()
-  quake.h (%1)
-  quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127[%1 : !quake.qref] %0 : (!quake.qref) -> ()
-  quake.h (%1)
-  %2 = quake.mz(%1 : !quake.qref) {registerName = ""} : i1
+  quake.h %1 : (!quake.qref) -> ()
+  quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127[%1] %0 : (!quake.qref, !quake.qref) -> ()
+  quake.h %1 : (!quake.qref) -> ()
+  %2 = quake.mz %1 : (!quake.qref) -> i1 {registerName = ""}
   return
 }
 func.func @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%arg0: !quake.qref) {
-  quake.x (%arg0)
+  quake.x %arg0 : (!quake.qref) -> ()
   return
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_202375922897() {
-// CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-// CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qref
-// CHECK:           quake.x (%[[VAL_0]])
-// CHECK:           quake.h (%[[VAL_1]])
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+// CHECK:           quake.x %[[VAL_0]]
+// CHECK:           quake.h %[[VAL_1]]
 // CHECK:           %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.qref) -> !quake.qvec<?>
-// CHECK:           quake.x [%[[VAL_2]] : !quake.qvec<?>] (%[[VAL_0]])
-// CHECK:           quake.h (%[[VAL_1]])
-// CHECK:           %[[VAL_3:.*]] = quake.mz(%[[VAL_1]] : !quake.qref) {registerName = ""} : i1
+// CHECK:           quake.x [%[[VAL_2]]] %[[VAL_0]] :
+// CHECK:           quake.h %[[VAL_1]] :
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/iqft.qke
+++ b/test/Quake/iqft.qke
@@ -40,7 +40,7 @@
 // CHECK:     %[[C1:.*]] = arith.constant 1 : i32
 // CHECK:     %[[C2:.*]] = arith.constant 2 : i32
 // CHECK:     %c-1_i32 = arith.constant -1 : i32
-// CHECK:     %0 = quake.qvec_size %arg0 : (!quake.qvec<?>) -> i64
+// CHECK:     %0 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
 // CHECK:     %1 = arith.trunci %0 : i64 to i32
 // CHECK:     %2 = arith.subi %1, %[[C1]] : i32
 // CHECK:     %3 = arith.index_cast %2 : i32 to index
@@ -50,14 +50,14 @@
 // CHECK:       %7 = arith.index_cast %arg1 : index to i32
 // CHECK:       %8 = arith.subi %1, %7 : i32
 // CHECK:       %9 = arith.subi %8, %[[C1]] : i32
-// CHECK:       %10 = quake.qextract %arg0[%7] : !quake.qvec<?>[i32] -> !quake.qref
-// CHECK:       %11 = quake.qextract %arg0[%9] : !quake.qvec<?>[i32] -> !quake.qref
-// CHECK:       quake.swap (%10, %11)
+// CHECK:       %10 = quake.extract_ref %arg0[%7] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:       %11 = quake.extract_ref %arg0[%9] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:       quake.swap %10, %11 : (!quake.qref, !quake.qref) -> ()
 // CHECK:     }
 // CHECK:     affine.for %arg1 = 0 to %3 {
 // CHECK:       %7 = arith.index_cast %arg1 : index to i32
-// CHECK:       %8 = quake.qextract %arg0[%7] : !quake.qvec<?>[i32] -> !quake.qref
-// CHECK:       quake.h (%8)
+// CHECK:       %8 = quake.extract_ref %arg0[%7] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:       quake.h %8 : (!quake.qref) -> ()
 // CHECK:       %9 = arith.addi %7, %[[C1]] : i32
 // CHECK:       affine.for %arg2 = #map(%arg1) to 1 {
 // CHECK:         %10 = arith.index_cast %arg2 : index to i32
@@ -66,13 +66,13 @@
 // CHECK:         %13 = arith.sitofp %12 : i32 to f64
 // CHECK:         %14 = math.powf %[[CF0]], %13 : f64
 // CHECK:         %15 = arith.divf %[[CF1]], %14 : f64
-// CHECK:         %16 = quake.qextract %arg0[%9] : !quake.qvec<?>[i32] -> !quake.qref
-// CHECK:         %17 = quake.qextract %arg0[%11] : !quake.qvec<?>[i32] -> !quake.qref
-// CHECK:         quake.r1 [%16 : !quake.qref] |%15 : f64|(%17)
+// CHECK:         %16 = quake.extract_ref %arg0[%9] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:         %17 = quake.extract_ref %arg0[%11] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:         quake.r1 (%15) [%16] %17 : (f64, !quake.qref, !quake.qref) -> ()
 // CHECK:       }
 // CHECK:     }
-// CHECK:     %6 = quake.qextract %arg0[%2] : !quake.qvec<?>[i32] -> !quake.qref
-// CHECK:     quake.h (%6)
+// CHECK:     %6 = quake.extract_ref %arg0[%2] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:     quake.h %6 : (!quake.qref) -> ()
 // CHECK:     return
 // CHECK:   }
 // CHECK: }
@@ -86,7 +86,7 @@ module {
         %c0 = arith.constant 0 : i32
         %c2 = arith.constant 2 : i32
         %cn1 = arith.constant -1 : i32
-        %nn = quake.qvec_size %arg0 : (!quake.qvec<?>) -> i64
+        %nn = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
         %n = arith.trunci %nn : i64 to i32
         %nm1 = arith.subi %n, %c1 : i32
         %nm1idx = arith.index_cast %nm1 : i32 to index
@@ -99,15 +99,15 @@ module {
             %7 = arith.index_cast %arg2 : index to i32
             %9 = arith.subi %n, %7 : i32
             %10 = arith.subi %9, %c1 : i32
-            %qi = quake.qextract %arg0 [%7] : !quake.qvec<?>[i32] -> !quake.qref
-            %qi1 = quake.qextract %arg0 [%10] : !quake.qvec<?>[i32] -> !quake.qref
-            quake.swap (%qi, %qi1)
+            %qi = quake.extract_ref %arg0 [%7] : (!quake.qvec<?>,i32) -> !quake.qref
+            %qi1 = quake.extract_ref %arg0 [%10] : (!quake.qvec<?>,i32) -> !quake.qref
+            quake.swap %qi, %qi1 : (!quake.qref, !quake.qref) -> ()
         }
 
         affine.for %arg3 = 0 to %nm1idx {
             %11 = arith.index_cast %arg3 : index to i32
-            %qi = quake.qextract %arg0[%11] : !quake.qvec<?>[i32] -> !quake.qref
-            quake.h (%qi)
+            %qi = quake.extract_ref %arg0[%11] : (!quake.qvec<?>, i32) -> !quake.qref
+            quake.h %qi : (!quake.qref) -> ()
             %13 = arith.addi %11, %c1 : i32
             %12 = memref.alloca() : memref<i32>
             memref.store %13, %12[] : memref<i32>
@@ -125,13 +125,13 @@ module {
                 %s2f = arith.sitofp %jmy : i32 to f64
                 %denom = math.powf %c2f, %s2f : f64
                 %24 = arith.divf %16, %denom : f64
-                %qj = quake.qextract %arg0[%13] : !quake.qvec<?>[i32] -> !quake.qref
-                %qy = quake.qextract %arg0[%15] : !quake.qvec<?>[i32] -> !quake.qref
-                quake.r1 [%qj : !quake.qref] |%24 : f64|(%qy)
+                %qj = quake.extract_ref %arg0[%13] : (!quake.qvec<?>, i32) -> !quake.qref
+                %qy = quake.extract_ref %arg0[%15] : (!quake.qvec<?>, i32) -> !quake.qref
+                quake.r1 (%24)[%qj] %qy : (f64,!quake.qref,!quake.qref) -> ()
             }
         }
-        %qnm1 = quake.qextract %arg0[%nm1] : !quake.qvec<?>[i32] -> !quake.qref
-        quake.h (%qnm1)
+        %qnm1 = quake.extract_ref %arg0[%nm1] : (!quake.qvec<?>,i32) -> !quake.qref
+        quake.h %qnm1 : (!quake.qref) -> ()
         return
     }
 }

--- a/test/Quake/kernel_exec.qke
+++ b/test/Quake/kernel_exec.qke
@@ -17,11 +17,11 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
     memref.store %arg0, %0[] : memref<i32>
     %1 = memref.load %0[] : memref<i32>
     %2 = arith.extsi %1 : i32 to i64
-    %3 = quake.alloca(%2 : i64) : !quake.qvec<?>
+    %3 = quake.alloca[%2 : i64] !quake.qvec<?>
     %c0_i32 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32 : i32 to i64
-    %5 = quake.qextract %3[%4] : !quake.qvec<?>[i64] -> !quake.qref
-    quake.h (%5)
+    %5 = quake.extract_ref %3[%4] : (!quake.qvec<?>,i64) -> !quake.qref
+    quake.h %5 : (!quake.qref) -> ()
     cc.scope {
       %7 = memref.alloca() : memref<i32>
       memref.store %c0_i32, %7[] : memref<i32>
@@ -38,12 +38,12 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
       } do {
       ^bb1 (%arg11 : index):
         %18 = arith.index_cast %arg11 : index to i64
-        %19 = quake.qextract %3[%18] : !quake.qvec<?>[i64] -> !quake.qref
+        %19 = quake.extract_ref %3[%18] : (!quake.qvec<?>,i64) -> !quake.qref
         %20 = arith.trunci %18 : i64 to i32
         %21 = arith.addi %20, %c1_i32 : i32
         %22 = arith.extsi %21 : i32 to i64
-        %23 = quake.qextract %3[%22] : !quake.qvec<?>[i64] -> !quake.qref
-        quake.x [%19 : !quake.qref] (%23)
+        %23 = quake.extract_ref %3[%22] : (!quake.qvec<?>,i64) -> !quake.qref
+        quake.x [%19] %23 : (!quake.qref, !quake.qref) -> ()
 	cc.continue %arg11 : index
       } step {
       ^bb2 (%arg21 : index):
@@ -52,7 +52,7 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
         cc.continue %incr : index
       }
     }
-    %15 = quake.qvec_size %3 : (!quake.qvec<?>) -> i64
+    %15 = quake.vec_size %3 : (!quake.qvec<?>) -> i64
     %16 = arith.index_cast %15 : i64 to index
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -61,8 +61,8 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
 	cc.condition %cond (%argx1 : index)
     } do {
     ^bb1 (%arg31 : index):
-      %18 = quake.qextract %3[%arg31] : !quake.qvec<?>[index] -> !quake.qref
-      %19 = quake.mz(%18 : !quake.qref) : i1
+      %18 = quake.extract_ref %3[%arg31] : (!quake.qvec<?>,index) -> !quake.qref
+      %19 = quake.mz %18 : (!quake.qref) -> i1
       cc.continue %arg31 : index
     } step {
     ^bb1 (%arg32 : index):

--- a/test/Quake/lambda_kernel_exec.qke
+++ b/test/Quake/lambda_kernel_exec.qke
@@ -18,15 +18,15 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
   func.func @__nvqpp__mlirgen__lambda.main.test() attributes {"cudaq-entrypoint"} {
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
-    %1 = quake.alloca(%0 : i64) : !quake.qvec<?>
+    %1 = quake.alloca[%0 : i64]  !quake.qvec<?>
     %c0_i32 = arith.constant 0 : i32
     %2 = arith.extsi %c0_i32 : i32 to i64
-    %3 = quake.qextract %1[%2] : !quake.qvec<?>[i64] -> !quake.qref
-    quake.h (%3)
+    %3 = quake.extract_ref %1[%2] : (!quake.qvec<?>,i64) -> !quake.qref
+    quake.h %3 : (!quake.qref) -> ()
     %c0_i32_0 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32_0 : i32 to i64
-    %5 = quake.qextract %1[%4] : !quake.qvec<?>[i64] -> !quake.qref
-    %6 = quake.mz(%5 : !quake.qref) {registerName = "b"} : i1
+    %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>, i64) -> !quake.qref
+    %6 = quake.mz %5 : (!quake.qref)->i1 {registerName = "b"} 
     %alloca = memref.alloca() : memref<i1>
     memref.store %6, %alloca[] : memref<i1>
     %7 = memref.load %alloca[] : memref<i1>
@@ -34,14 +34,14 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
       cc.scope {
         %c1_i32_1 = arith.constant 1 : i32
         %11 = arith.extsi %c1_i32_1 : i32 to i64
-        %12 = quake.qextract %1[%11] : !quake.qvec<?>[i64] -> !quake.qref
-        quake.x (%12)
+        %12 = quake.extract_ref %1[%11] : (!quake.qvec<?>,i64) -> !quake.qref
+        quake.x %12 : (!quake.qref) -> ()
       }
     }
     %c1_i32 = arith.constant 1 : i32
     %8 = arith.extsi %c1_i32 : i32 to i64
-    %9 = quake.qextract %1[%8] : !quake.qvec<?>[i64] -> !quake.qref
-    %10 = quake.mz(%9 : !quake.qref) : i1
+    %9 = quake.extract_ref %1[%8] : (!quake.qvec<?>,i64) -> !quake.qref
+    %10 = quake.mz %9 : (!quake.qref) -> i1
     return
   }
 
@@ -52,15 +52,15 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
   func.func @__nvqpp__mlirgen__lambda.main.canHaveMultiple() attributes {"cudaq-entrypoint"} {
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
-    %1 = quake.alloca(%0 : i64) : !quake.qvec<?>
+    %1 = quake.alloca[%0 : i64] !quake.qvec<?>
     %c0_i32 = arith.constant 0 : i32
     %2 = arith.extsi %c0_i32 : i32 to i64
-    %3 = quake.qextract %1[%2] : !quake.qvec<?>[i64] -> !quake.qref
-    quake.h (%3)
+    %3 = quake.extract_ref %1[%2] : (!quake.qvec<?>,i64) -> !quake.qref
+    quake.h %3 : (!quake.qref) -> ()
     %c0_i32_0 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32_0 : i32 to i64
-    %5 = quake.qextract %1[%4] : !quake.qvec<?>[i64] -> !quake.qref
-    %6 = quake.mz(%5 : !quake.qref) {registerName = "b"} : i1
+    %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.qref
+    %6 = quake.mz %5 : (!quake.qref) ->i1 {registerName = "b"} 
     %alloca = memref.alloca() : memref<i1>
     memref.store %6, %alloca[] : memref<i1>
     %7 = memref.load %alloca[] : memref<i1>
@@ -68,14 +68,14 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
       cc.scope {
         %c1_i32_1 = arith.constant 1 : i32
         %11 = arith.extsi %c1_i32_1 : i32 to i64
-        %12 = quake.qextract %1[%11] : !quake.qvec<?>[i64] -> !quake.qref
-        quake.x (%12)
+        %12 = quake.extract_ref %1[%11] : (!quake.qvec<?>, i64) -> !quake.qref
+        quake.x %12 : (!quake.qref) -> ()
       }
     }
     %c1_i32 = arith.constant 1 : i32
     %8 = arith.extsi %c1_i32 : i32 to i64
-    %9 = quake.qextract %1[%8] : !quake.qvec<?>[i64] -> !quake.qref
-    %10 = quake.mz(%9 : !quake.qref) : i1
+    %9 = quake.extract_ref %1[%8] : (!quake.qvec<?>,i64) -> !quake.qref
+    %10 = quake.mz %9 : (!quake.qref) -> i1
     return
   }
 }

--- a/test/Quake/lambda_variable-1.qke
+++ b/test/Quake/lambda_variable-1.qke
@@ -16,24 +16,24 @@ module attributes{ qtx.mangled_name_map = { __nvqpp__mlirgen__test3_callee = "_Z
   func.func @__nvqpp__mlirgen__test3_callee(%arg0: !cc.lambda<(!quake.qref) -> ()>, %arg1: !quake.qvec<?>) attributes {"cudaq-kernel"} {
     %c0_i32 = arith.constant 0 : i32
     %0 = arith.extsi %c0_i32 : i32 to i64
-    %1 = quake.qextract %arg1[%0] : !quake.qvec<?>[i64] -> !quake.qref
+    %1 = quake.extract_ref %arg1[%0] : (!quake.qvec<?>,i64) -> !quake.qref
     cc.call_callable %arg0, %1 : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
     %c1_i32 = arith.constant 1 : i32
     %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.qextract %arg1[%2] : !quake.qvec<?>[i64] -> !quake.qref
+    %3 = quake.extract_ref %arg1[%2] : (!quake.qvec<?>,i64) -> !quake.qref
     cc.call_callable %arg0, %3 : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
     return
   }
   func.func @__nvqpp__mlirgen__test3_caller() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
-    %1 = quake.alloca(%0 : i64) : !quake.qvec<?>
+    %1 = quake.alloca[%0 : i64] !quake.qvec<?>
     %2 = cc.undef !llvm.struct<"test3_callee", ()>
     %3 = cc.create_lambda {
     ^bb0(%arg0: !quake.qref):
       cc.scope {
-        quake.h (%arg0)
-        quake.y (%arg0)
+        quake.h %arg0 : (!quake.qref) -> ()
+        quake.y %arg0 : (!quake.qref) -> ()
       }
     } : !cc.lambda<(!quake.qref) -> ()>
     call @__nvqpp__mlirgen__test3_callee(%3, %1) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
@@ -46,15 +46,15 @@ module attributes{ qtx.mangled_name_map = { __nvqpp__mlirgen__test3_callee = "_Z
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = quake.qextract %[[VAL_1]][%[[VAL_3]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           %[[VAL_5:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.qref) -> ()>) -> ((!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ())
 // CHECK:           call_indirect %[[VAL_5]](%[[VAL_0]], %[[VAL_4]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
-// CHECK:            %[[VAL_6:.*]] = quake.qextract %[[VAL_1]][%[[VAL_2]]] : !quake.qvec<?>[i64] -> !quake.qref
+// CHECK:            %[[VAL_6:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_2]]] : (!quake.qvec<?>, i64) -> !quake.qref
 // CHECK:           %[[VAL_7:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.qref) -> ()>) -> ((!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ())
 // CHECK:           call_indirect %[[VAL_7]](%[[VAL_0]], %[[VAL_6]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_caller()
-// CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qvec<2>
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<2>
 // CHECK:           %[[VAL_1:.*]] = quake.relax_size %[[VAL_0]] : (!quake.qvec<2>) -> !quake.qvec<?>
 // CHECK:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0() : () -> !cc.lambda<(!quake.qref) -> ()>
 // CHECK:           call @__nvqpp__mlirgen__test3_callee(%[[VAL_2]], %[[VAL_1]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
@@ -66,6 +66,6 @@ module attributes{ qtx.mangled_name_map = { __nvqpp__mlirgen__test3_callee = "_Z
 
 // CHECK-LABEL:   func.func private @__nvqpp__lifted.lambda.0(
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref) {
-// CHECK:           quake.h (%[[VAL_0]])
-// CHECK:           quake.y (%[[VAL_0]])
+// CHECK:           quake.h %[[VAL_0]] :
+// CHECK:           quake.y %[[VAL_0]] :
 

--- a/test/Quake/lambda_variable-2.qke
+++ b/test/Quake/lambda_variable-2.qke
@@ -15,9 +15,8 @@
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_a()
-// CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qvec<4>
-// CHECK:           %[[VAL_1:.*]] = quake.relax_size %[[VAL_0]] : (!quake.qvec<4>) -> !quake.qvec<?>
-// CHECK:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0(%[[VAL_1]]) : (!quake.qvec<?>) -> !cc.lambda<() -> ()>
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<4>
+// CHECK:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0(%[[VAL_0]]) : (!quake.qvec<4>) -> !cc.lambda<() -> ()>
 // CHECK:           call @__nvqpp__mlirgen__kernel_b(%[[VAL_2]]) : (!cc.lambda<() -> ()>) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -44,8 +43,8 @@
 // CHECK:             } do {
 // CHECK:               %[[VAL_7:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_8:.*]] = arith.extsi %[[VAL_7]] : i32 to i64
-// CHECK:               %[[VAL_9:.*]] = quake.qextract %[[VAL_0]]{{\[}}%[[VAL_8]]] : !quake.qvec<4>[i64] -> !quake.qref
-// CHECK:               quake.h (%[[VAL_9]])
+// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<4>, i64) -> !quake.qref
+// CHECK:               quake.h %[[VAL_9]] :
 // CHECK:               cc.continue
 // CHECK:             } step {
 // CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_4]][] : memref<i32>
@@ -77,8 +76,7 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__kernel_a = "_ZN8ker
     return
   }
   func.func @__nvqpp__mlirgen__kernel_a() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-    %c4_i64 = arith.constant 4 : i64
-    %1 = quake.alloca(%c4_i64 : i64) : !quake.qvec<4>
+    %1 = quake.alloca !quake.qvec<4>
     %5 = cc.create_lambda {
       cc.scope {
         %alloca = memref.alloca() : memref<i32>
@@ -93,8 +91,8 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__kernel_a = "_ZN8ker
           } do {
             %6 = memref.load %alloca[] : memref<i32>
             %7 = arith.extsi %6 : i32 to i64
-            %8 = quake.qextract %1[%7] : !quake.qvec<4>[i64] -> !quake.qref
-            quake.h (%8)
+            %8 = quake.extract_ref %1[%7] : (!quake.qvec<4>, i64) -> !quake.qref
+            quake.h %8 : (!quake.qref) -> ()
             cc.continue
           } step {
             %6 = memref.load %alloca[] : memref<i32>

--- a/test/Quake/mz.qke
+++ b/test/Quake/mz.qke
@@ -9,28 +9,39 @@
 // RUN: cudaq-opt %s | cudaq-opt | FileCheck %s
 
 func.func @static.mz_test() {
-  %0 = quake.alloca : !quake.qref
-  %1 = quake.alloca : !quake.qvec<4>
-  %2 = quake.alloca : !quake.qvec<2>
-  %3 = quake.alloca : !quake.qref
-  quake.mz (%0, %1, %2, %3 : !quake.qref, !quake.qvec<4>, !quake.qvec<2>, !quake.qref) : !cc.stdvec<i1>
-  cc.return
+  %0 = quake.alloca  !quake.qref
+  %1 = quake.alloca  !quake.qvec<4>
+  %2 = quake.alloca  !quake.qvec<2>
+  %3 = quake.alloca  !quake.qref
+  quake.mz %0, %1, %2, %3 : (!quake.qref, !quake.qvec<4>, !quake.qvec<2>, !quake.qref) -> !cc.stdvec<i1>
+  return
 }
 
 // CHECK-LABEL:   func.func @static.mz_test() {
-// CHECK:           %[[VAL_0:.*]] = quake.alloca : !quake.qref
-// CHECK:           %[[VAL_1:.*]] = quake.alloca : !quake.qvec<4>
-// CHECK:           %[[VAL_2:.*]] = quake.alloca : !quake.qvec<2>
-// CHECK:           %[[VAL_3:.*]] = quake.alloca : !quake.qref
-// CHECK:           %[[VAL_4:.*]] = quake.mz(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : !quake.qref, !quake.qvec<4>, !quake.qvec<2>, !quake.qref) : !cc.stdvec<i1>
-// CHECK:           cc.return
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<4>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!quake.qref, !quake.qvec<4>, !quake.qvec<2>, !quake.qref) -> !cc.stdvec<i1>
+// CHECK:           return
 // CHECK:         }
 
 func.func @dynamic.mz_test(%arg0 : i32, %arg1 : i32) {
-  %0 = quake.alloca : !quake.qref
-  %1 = quake.alloca(%arg0 : i32) : !quake.qvec<?>
-  %2 = quake.alloca(%arg1 : i32) : !quake.qvec<?>
-  %3 = quake.alloca : !quake.qref
-  quake.mz (%0, %1, %2, %3 : !quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) : !cc.stdvec<i1>
-  cc.return
+  %0 = quake.alloca  !quake.qref
+  %1 = quake.alloca[%arg0 : i32]  !quake.qvec<?>
+  %2 = quake.alloca [%arg1 : i32] !quake.qvec<?>
+  %3 = quake.alloca  !quake.qref
+  quake.mz %0, %1, %2, %3 : (!quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) -> !cc.stdvec<i1>
+  return
 }
+
+// CHECK-LABEL:   func.func @dynamic.mz_test(
+// CHECK-SAME:        %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) {
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_1]] : i32] !quake.qvec<?>
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (!quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) -> !cc.stdvec<i1>
+// CHECK:           return
+// CHECK:         }
+

--- a/test/Quake/observeAnsatz.qke
+++ b/test/Quake/observeAnsatz.qke
@@ -14,20 +14,20 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ansatz = "_ZN6ansat
     %c1_i64 = arith.constant 1 : i64
     %0 = memref.alloca() : memref<f64>
     memref.store %arg0, %0[] : memref<f64>
-    %1 = quake.alloca : !quake.qvec<2>
-    %2 = quake.qextract %1[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
-    quake.x (%2)
+    %1 = quake.alloca  !quake.qvec<2>
+    %2 = quake.extract_ref %1[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+    quake.x %2 : (!quake.qref) -> ()
     %3 = memref.load %0[] : memref<f64>
-    %4 = quake.qextract %1[%c1_i64] : !quake.qvec<2>[i64] -> !quake.qref
-    quake.ry |%3 : f64|(%4)
-    %5 = quake.qextract %1[%c1_i64] : !quake.qvec<2>[i64] -> !quake.qref
-    %6 = quake.qextract %1[%c0_i64] : !quake.qvec<2>[i64] -> !quake.qref
-    quake.x [%5 : !quake.qref] (%6)
+    %4 = quake.extract_ref %1[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+    quake.ry (%3) %4 : (f64, !quake.qref) -> ()
+    %5 = quake.extract_ref %1[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+    %6 = quake.extract_ref %1[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
+    quake.x [%5] %6 : (!quake.qref,!quake.qref) -> ()
     return
   }
 }
 
-// CHECK: quake.h (%[[VAL_4:.*]])
-// CHECK: quake.h (%[[VAL_5:.*]])
-// CHECK: %[[VAL_0:.*]] = quake.mz(%[[VAL_1:.*]] : !quake.qref) : i1
-// CHECK: %[[VAL_2:.*]] = quake.mz(%[[VAL_3:.*]] : !quake.qref) : i1
+// CHECK: quake.h %[[VAL_4:.*]]
+// CHECK: quake.h %[[VAL_5:.*]]
+// CHECK: %[[VAL_0:.*]] = quake.mz %[[VAL_1:.*]] : (!quake.qref) -> i1
+// CHECK: %[[VAL_2:.*]] = quake.mz %[[VAL_3:.*]] : (!quake.qref) -> i1

--- a/test/Quake/qpe.qke
+++ b/test/Quake/qpe.qke
@@ -8,30 +8,27 @@
 
 // RUN: cudaq-opt %s --canonicalize | FileCheck %s
 
-// CHECK: module {
 // CHECK:   func.func @ctrl_t_gate(%arg0: !quake.qref) {
-// CHECK:     quake.t (%arg0)
+// CHECK:     quake.t %arg0 :
 // CHECK:     return
 // CHECK:   }
 // CHECK:   func.func @qpe_test_callable(%arg0: i32, %arg1: i32, %arg2: (!quake.qvec<?>) -> !quake.qvec<?>, %arg3: (!quake.qref) -> ()) {
 // CHECK:     %[[C0:.*]] = arith.constant 0 : i32
-// CHECK:     %0 = quake.alloca(%arg0 : i32) : !quake.qvec<?>
-// CHECK:     %1 = quake.qextract %0[%[[C0]]] : !quake.qvec<?>[i32] -> !quake.qref
+// CHECK:     %0 = quake.alloca[%arg0 : i32] !quake.qvec<?>
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
 // CHECK:     call_indirect %arg3(%1) : (!quake.qref) -> ()
 // CHECK:     return
 // CHECK:   }
-// CHECK: }
-module {
-    func.func @ctrl_t_gate(%q : !quake.qref) -> () {
-        quake.t (%q) 
-        return
-    }
 
-    func.func @qpe_test_callable(%nq : i32, %nc : i32, %state_prep : (!quake.qvec<?>)->(!quake.qvec<?>), %oracle : (!quake.qref)->()) {
-        %0 = arith.constant 0 : i32
-        %qubits = quake.alloca(%nq : i32) : !quake.qvec<?>
-        %q = quake.qextract %qubits[%0] : !quake.qvec<?>[i32] -> !quake.qref
-        func.call_indirect %oracle(%q) : (!quake.qref)->()
-        return
-    }
+func.func @ctrl_t_gate(%q : !quake.qref) -> () {
+  quake.t %q : (!quake.qref) -> () 
+  return
+}
+
+func.func @qpe_test_callable(%nq : i32, %nc : i32, %state_prep : (!quake.qvec<?>)->(!quake.qvec<?>), %oracle : (!quake.qref)->()) {
+  %0 = arith.constant 0 : i32
+  %qubits = quake.alloca[%nq : i32] !quake.qvec<?>
+  %q = quake.extract_ref %qubits[%0] : (!quake.qvec<?>,i32) -> !quake.qref
+  func.call_indirect %oracle(%q) : (!quake.qref)->()
+  return
 }

--- a/test/Quake/quake-errors.qke
+++ b/test/Quake/quake-errors.qke
@@ -330,11 +330,11 @@ func.func @test() {
 
 %neg = arith.constant -5 : i32
 // expected-error @+1 {{expected a non-negative integer size}}
-%0 = quake.alloca(%neg : i32) : !quake.qvec<?>
+%0 = quake.alloca[%neg : i32] !quake.qvec<?>
 
 // -----
 
 %two = arith.constant 2 : i32
 // expected-error @+1 {{expected operand size to match QVecType size}}
-%0 = quake.alloca(%two : i32) : !quake.qvec<4>
+%0 = quake.alloca[%two : i32] !quake.qvec<4>
      

--- a/test/Quake/quake-ops.qke
+++ b/test/Quake/quake-ops.qke
@@ -10,6 +10,245 @@
 
 // RUN: cudaq-opt %s | cudaq-opt | FileCheck %s
 
+func.func private @apply_kernel(%0 : i32, %1 : !quake.qvec<?>)
+
+// Test roundtripping on the various quake ops.
+func.func @quantum_ops() {
+  // Allocations
+  %0 = quake.alloca !quake.qref
+  quake.dealloc %0 : !quake.qref
+  %v0 = quake.alloca !quake.qvec<5>
+  quake.dealloc %v0 : !quake.qvec<5>
+  %1 = quake.alloca !quake.qvec<4>
+  %2 = arith.constant 2 : i32
+  %3 = quake.alloca[%2 : i32] !quake.qvec<?>
+  %4 = quake.alloca !quake.qref
+
+  // Vectors of references
+  %zero = arith.constant 0 : i32
+  %i = arith.constant 3    : i64
+  %5 = quake.concat %3, %4 : (!quake.qvec<?>, !quake.qref) -> !quake.qvec<?>
+  %6 = quake.concat %4, %1 : (!quake.qref, !quake.qvec<4>) -> !quake.qvec<5>
+  %7 = quake.extract_ref %5[%zero] : (!quake.qvec<?>, i32) -> !quake.qref
+  %8 = quake.extract_ref %6[%i]    : (!quake.qvec<5>, i64) -> !quake.qref
+  %9 = quake.relax_size %6         : (!quake.qvec<5>) -> !quake.qvec<?>
+  %z = arith.constant 0 : index
+  %10 = quake.subvec %5, %z, %i : (!quake.qvec<?>, index, i64) -> !quake.qvec<?>
+  %11 = quake.vec_size %5 : (!quake.qvec<?>) -> index
+
+  // Reference/dereference
+  quake.reset %4 : (!quake.qref) -> ()
+  %12 = quake.null_wire
+  %13 = quake.unwrap %4 : (!quake.qref) -> !quake.wire
+  %18 = quake.reset %13 : (!quake.wire) -> !quake.wire
+  quake.wrap %18 to %4 : !quake.wire, !quake.qref
+
+  // Control type conversion
+  %14 = quake.convert_ctrl %12 : (!quake.wire) -> !quake.qcontrol
+
+  // Quantum operations, reference form
+  quake.x %4 : (!quake.qref) -> ()
+  quake.y %4 : (!quake.qref) -> ()
+  quake.z %4 : (!quake.qref) -> ()
+  quake.h %4 : (!quake.qref) -> ()
+  quake.s %4 : (!quake.qref) -> ()
+  quake.t %4 : (!quake.qref) -> ()
+  quake.swap %4, %7 : (!quake.qref, !quake.qref) -> ()
+
+  %f = arith.constant 12.0 : f32
+  quake.r1 (%f) %7 : (f32, !quake.qref) -> ()
+  quake.rx (%f) %7 : (f32, !quake.qref) -> ()
+  %g = arith.constant 23.0 : f32
+  quake.phased_rx (%f, %g) %7 : (f32, f32, !quake.qref) -> ()
+  quake.ry (%f) %7 : (f32, !quake.qref) -> ()
+  quake.rz (%f) %7 : (f32, !quake.qref) -> ()
+  quake.u2 (%f, %g) %7 : (f32, f32, !quake.qref) -> ()
+  %h = arith.constant 34.0 : f32
+  quake.u3 (%f, %g, %h) %7 : (f32, f32, f32, !quake.qref) -> ()
+
+  %15 = quake.mx %4 : (!quake.qref) -> i1
+  %16 = quake.my %5 : (!quake.qvec<?>) -> !cc.stdvec<i1>
+  %17 = quake.mz %6 : (!quake.qvec<5>) -> !cc.stdvec<i1>
+
+  // Quantum operations, wire form
+  %19 = cc.undef i32 {wires = true}
+  %20 = quake.null_wire
+  %21 = quake.null_wire
+  %22 = quake.null_wire
+  
+  %23 = quake.x %22 : (!quake.wire) -> !quake.wire
+  %24 = quake.y %23 : (!quake.wire) -> !quake.wire
+  %25 = quake.z %24 : (!quake.wire) -> !quake.wire
+  %26 = quake.h %25 : (!quake.wire) -> !quake.wire
+  %27 = quake.s %26 : (!quake.wire) -> !quake.wire
+  %28 = quake.t %27 : (!quake.wire) -> !quake.wire
+  %29:2 = quake.swap %28, %21 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+
+  %30 = quake.r1 (%f) %29#1 : (f32, !quake.wire) -> !quake.wire
+  %31 = quake.rx (%f) %30 : (f32, !quake.wire) -> !quake.wire
+  %32 = quake.phased_rx (%f, %g) %31 : (f32, f32, !quake.wire) -> !quake.wire
+  %33 = quake.ry (%f) %32 : (f32, !quake.wire) -> !quake.wire
+  %34 = quake.rz (%f) %33 : (f32, !quake.wire) -> !quake.wire
+  %35 = quake.u2 (%f, %g) %34 : (f32, f32, !quake.wire) -> !quake.wire
+  %36 = quake.u3 (%f, %g, %h) %35 : (f32, f32, f32, !quake.wire) -> !quake.wire
+
+  %37 = quake.mx %29#0 : (!quake.wire) -> i1
+  %38 = quake.my %20 : (!quake.wire) -> i1
+  %39 = quake.mz %36 : (!quake.wire) -> i1
+
+  // CUDA Quantum model support
+  %40 = quake.alloca !quake.qref { apply_variants = true }
+  %41 = quake.alloca !quake.qvec<2>
+  %42 = arith.constant 0 : i32
+  %43 = quake.alloca !quake.qref
+  quake.apply @apply_kernel %42, %43 : (i32, !quake.qref) -> ()
+  quake.apply @apply_kernel [%40, %41] %42, %43 : (!quake.qref, !quake.qvec<2>, i32, !quake.qref) -> ()
+  quake.apply<adj> @apply_kernel [%40, %41] %42, %43 : (!quake.qref, !quake.qvec<2>, i32, !quake.qref) -> ()
+
+  %44 = cc.undef !cc.lambda<() -> ()> { compute_action = true }
+  %45 = cc.undef !cc.lambda<() -> ()>
+  quake.compute_action %44, %45 : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
+  quake.compute_action<dag> %44, %45 : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
+
+  // Adjoint modifier
+  %47 = cc.undef f64 { adjoint = true }
+  quake.s<adj> %4 : (!quake.qref) -> ()
+  quake.t<adj> %4 : (!quake.qref) -> ()
+
+  quake.r1<adj> (%f) %7 : (f32, !quake.qref) -> ()
+  quake.rx<adj> (%f) %7 : (f32, !quake.qref) -> ()
+  quake.phased_rx<adj> (%f, %g) %7 : (f32, f32, !quake.qref) -> ()
+  quake.ry<adj> (%f) %7 : (f32, !quake.qref) -> ()
+  quake.rz<adj> (%f) %7 : (f32, !quake.qref) -> ()
+  quake.u2<adj> (%f, %g) %7 : (f32, f32, !quake.qref) -> ()
+  quake.u3<adj> (%f, %g, %h) %7 : (f32, f32, f32, !quake.qref) -> ()
+
+  // Control modifier
+  %46 = quake.alloca !quake.qvec<3> {control = true}
+  quake.x [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
+  quake.y [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
+  quake.z [%7] %4 : (!quake.qref, !quake.qref) -> ()
+  quake.h [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
+  quake.s [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
+  quake.t [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
+  quake.swap [%46] %4, %7 : (!quake.qvec<3>, !quake.qref, !quake.qref) -> ()
+
+  quake.r1 (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.qref) -> ()
+  quake.rx (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.qref) -> ()
+  quake.phased_rx (%f, %g) [%46] %7 : (f32, f32, !quake.qvec<3>, !quake.qref) -> ()
+  quake.ry (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.qref) -> ()
+  quake.rz (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.qref) -> ()
+  quake.u2 (%f, %g) [%46] %7 : (f32, f32, !quake.qvec<3>, !quake.qref) -> ()
+  quake.u3 (%f, %g, %47) [%46] %7 : (f32, f32, f64, !quake.qvec<3>, !quake.qref) -> ()
+
+  return
+}
+
+// CHECK-LABEL:   func.func @quantum_ops() {
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+// CHECK:           quake.dealloc %[[VAL_0]] : !quake.qref
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
+// CHECK:           quake.dealloc %[[VAL_1]] : !quake.qvec<5>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<4>
+// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i32
+// CHECK:           %[[VAL_4:.*]] = quake.alloca{{\[}}%[[VAL_3]] : i32] !quake.qvec<?>
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_7:.*]] = arith.constant 3 : i64
+// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_4]], %[[VAL_5]] : (!quake.qvec<?>, !quake.qref) -> !quake.qvec<?>
+// CHECK:           %[[VAL_9:.*]] = quake.concat %[[VAL_5]], %[[VAL_2]] : (!quake.qref, !quake.qvec<4>) -> !quake.qvec<5>
+// CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_6]]] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, i64) -> !quake.qref
+// CHECK:           %[[VAL_12:.*]] = quake.relax_size %[[VAL_9]] : (!quake.qvec<5>) -> !quake.qvec<?>
+// CHECK:           %[[VAL_13:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_14:.*]] = quake.subvec %[[VAL_8]], %[[VAL_13]], %[[VAL_7]] : (!quake.qvec<?>, index, i64) -> !quake.qvec<?>
+// CHECK:           %[[VAL_15:.*]] = quake.vec_size %[[VAL_8]] : (!quake.qvec<?>) -> index
+// CHECK:           quake.reset %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           %[[VAL_16:.*]] = quake.null_wire
+// CHECK:           %[[VAL_17:.*]] = quake.unwrap %[[VAL_5]] : (!quake.qref) -> !quake.wire
+// CHECK:           %[[VAL_18:.*]] = quake.reset %[[VAL_17]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[VAL_18]] to %[[VAL_5]] : !quake.wire, !quake.qref
+// CHECK:           %[[VAL_19:.*]] = quake.convert_ctrl %[[VAL_16]] : (!quake.wire) -> !quake.qcontrol
+// CHECK:           quake.x %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           quake.y %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           quake.z %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           quake.h %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           quake.s %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           quake.t %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           quake.swap %[[VAL_5]], %[[VAL_10]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           %[[VAL_20:.*]] = arith.constant 1.200000e+01 : f32
+// CHECK:           quake.r1 (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
+// CHECK:           quake.rx (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
+// CHECK:           %[[VAL_21:.*]] = arith.constant 2.300000e+01 : f32
+// CHECK:           quake.phased_rx (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.qref) -> ()
+// CHECK:           quake.ry (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
+// CHECK:           quake.rz (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
+// CHECK:           quake.u2 (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.qref) -> ()
+// CHECK:           %[[VAL_22:.*]] = arith.constant 3.400000e+01 : f32
+// CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.qref) -> ()
+// CHECK:           %[[VAL_23:.*]] = quake.mx %[[VAL_5]] : (!quake.qref) -> i1
+// CHECK:           %[[VAL_24:.*]] = quake.my %[[VAL_8]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_25:.*]] = quake.mz %[[VAL_9]] : (!quake.qvec<5>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_26:.*]] = cc.undef i32 {wires = true}
+// CHECK:           %[[VAL_27:.*]] = quake.null_wire
+// CHECK:           %[[VAL_28:.*]] = quake.null_wire
+// CHECK:           %[[VAL_29:.*]] = quake.null_wire
+// CHECK:           %[[VAL_30:.*]] = quake.x %[[VAL_29]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_31:.*]] = quake.y %[[VAL_30]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_32:.*]] = quake.z %[[VAL_31]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_33:.*]] = quake.h %[[VAL_32]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_34:.*]] = quake.s %[[VAL_33]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_35:.*]] = quake.t %[[VAL_34]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_36:.*]]:2 = quake.swap %[[VAL_35]], %[[VAL_28]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_37:.*]] = quake.r1 (%[[VAL_20]]) %[[VAL_36]]#1 : (f32, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_38:.*]] = quake.rx (%[[VAL_20]]) %[[VAL_37]] : (f32, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_39:.*]] = quake.phased_rx (%[[VAL_20]], %[[VAL_21]]) %[[VAL_38]] : (f32, f32, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_40:.*]] = quake.ry (%[[VAL_20]]) %[[VAL_39]] : (f32, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_41:.*]] = quake.rz (%[[VAL_20]]) %[[VAL_40]] : (f32, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_42:.*]] = quake.u2 (%[[VAL_20]], %[[VAL_21]]) %[[VAL_41]] : (f32, f32, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_43:.*]] = quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_42]] : (f32, f32, f32, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_44:.*]] = quake.mx %[[VAL_36]]#0 : (!quake.wire) -> i1
+// CHECK:           %[[VAL_45:.*]] = quake.my %[[VAL_27]] : (!quake.wire) -> i1
+// CHECK:           %[[VAL_46:.*]] = quake.mz %[[VAL_43]] : (!quake.wire) -> i1
+// CHECK:           %[[VAL_47:.*]] = quake.alloca !quake.qref {apply_variants = true}
+// CHECK:           %[[VAL_48:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_49:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_50:.*]] = quake.alloca !quake.qref
+// CHECK:           quake.apply @apply_kernel %[[VAL_49]], %[[VAL_50]] : (i32, !quake.qref) -> ()
+// CHECK:           quake.apply @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.qref, !quake.qvec<2>, i32, !quake.qref) -> ()
+// CHECK:           quake.apply<adj> @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.qref, !quake.qvec<2>, i32, !quake.qref) -> ()
+// CHECK:           %[[VAL_51:.*]] = cc.undef !cc.lambda<() -> ()> {compute_action = true}
+// CHECK:           %[[VAL_52:.*]] = cc.undef !cc.lambda<() -> ()>
+// CHECK:           quake.compute_action %[[VAL_51]], %[[VAL_52]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
+// CHECK:           quake.compute_action<dag> %[[VAL_51]], %[[VAL_52]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
+// CHECK:           %[[VAL_53:.*]] = cc.undef f64 {adjoint = true}
+// CHECK:           quake.s<adj> %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           quake.t<adj> %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           quake.r1<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
+// CHECK:           quake.rx<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
+// CHECK:           quake.phased_rx<adj> (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.qref) -> ()
+// CHECK:           quake.ry<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
+// CHECK:           quake.rz<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
+// CHECK:           quake.u2<adj> (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.qref) -> ()
+// CHECK:           quake.u3<adj> (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.qref) -> ()
+// CHECK:           %[[VAL_54:.*]] = quake.alloca !quake.qvec<3> {control = true}
+// CHECK:           quake.x {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.y {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.z {{\[}}%[[VAL_10]]] %[[VAL_5]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           quake.h {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.s {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.t {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.swap {{\[}}%[[VAL_54]]] %[[VAL_5]], %[[VAL_10]] : (!quake.qvec<3>, !quake.qref, !quake.qref) -> ()
+// CHECK:           quake.r1 (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.rx (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.phased_rx (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.ry (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.rz (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.u2 (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_53]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, f64, !quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           return
+// CHECK:         }
+
 // CHECK-LABEL:   func.func @quake_op1(
 // CHECK-SAME:        %[[VAL_0:.*]]: !llvm.ptr<f64>, %[[VAL_1:.*]]: i64) -> i64 {
 // CHECK:           %[[VAL_2:.*]] = cc.stdvec_init %[[VAL_0]], %[[VAL_1]] : (!llvm.ptr<f64>, i64) -> !cc.stdvec<f64>
@@ -304,6 +543,15 @@ func.func @cc_op8_continue_test() -> f64 {
 // CHECK:           return
 // CHECK:         }
 
+func.func @cc.scope_result() {
+  %0 = cc.scope -> i32 {
+    %x = cc.alloca i32 : () -> !cc.ptr<i32>
+    %0 = cc.undef i32
+    cc.continue %0 : i32
+  }
+  return
+}
+
 // CHECK-LABEL:   func.func @cc.scope_blocks() {
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_0:.*]] = cc.alloca i32 : () -> !cc.ptr<i32>
@@ -321,15 +569,6 @@ func.func @cc_op8_continue_test() -> f64 {
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }
-
-func.func @cc.scope_result() {
-  %0 = cc.scope -> i32 {
-    %x = cc.alloca i32 : () -> !cc.ptr<i32>
-    %0 = cc.undef i32
-    cc.continue %0 : i32
-  }
-  return
-}
 
 // scope with an embedded primitive CFG
 func.func @cc.scope_blocks() {
@@ -365,13 +604,15 @@ func.func @wire_type() -> !quake.wire {
 // CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
 // CHECK:           %[[VAL_1:.*]] = quake.unwrap %[[VAL_0]] : (!quake.qref) -> !quake.wire
 // CHECK:           %[[VAL_2:.*]] = quake.null_wire
-// CHECK:           quake.wrap %[[VAL_2]] to %[[VAL_0]] : !quake.wire, !quake.qref
+// CHECK:           %[[VAL_3:.*]] = quake.x [%[[VAL_2]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[VAL_3]] to %[[VAL_0]] : !quake.wire, !quake.qref
 // CHECK:           return
 // CHECK:         }
 
 func.func @unwrap_wrap(%0 : !quake.qref) {
   %1 = quake.unwrap %0 : (!quake.qref) -> !quake.wire
-  %2 = quake.null_wire
+  %3 = quake.null_wire
+  %2 = quake.x [%3] %1 : (!quake.wire, !quake.wire) -> !quake.wire
   quake.wrap %2 to %0 : !quake.wire, !quake.qref
   return
 }

--- a/test/Quake/quake-ops.qke
+++ b/test/Quake/quake-ops.qke
@@ -44,7 +44,7 @@ func.func @quantum_ops() {
   quake.wrap %18 to %4 : !quake.wire, !quake.qref
 
   // Control type conversion
-  %14 = quake.convert_ctrl %12 : (!quake.wire) -> !quake.qcontrol
+  %14 = quake.convert_ctrl %12 : (!quake.wire) -> !quake.control
 
   // Quantum operations, reference form
   quake.x %4 : (!quake.qref) -> ()
@@ -168,7 +168,7 @@ func.func @quantum_ops() {
 // CHECK:           %[[VAL_17:.*]] = quake.unwrap %[[VAL_5]] : (!quake.qref) -> !quake.wire
 // CHECK:           %[[VAL_18:.*]] = quake.reset %[[VAL_17]] : (!quake.wire) -> !quake.wire
 // CHECK:           quake.wrap %[[VAL_18]] to %[[VAL_5]] : !quake.wire, !quake.qref
-// CHECK:           %[[VAL_19:.*]] = quake.convert_ctrl %[[VAL_16]] : (!quake.wire) -> !quake.qcontrol
+// CHECK:           %[[VAL_19:.*]] = quake.convert_ctrl %[[VAL_16]] : (!quake.wire) -> !quake.control
 // CHECK:           quake.x %[[VAL_5]] : (!quake.qref) -> ()
 // CHECK:           quake.y %[[VAL_5]] : (!quake.qref) -> ()
 // CHECK:           quake.z %[[VAL_5]] : (!quake.qref) -> ()

--- a/test/Quake/test_add_dealloc.qke
+++ b/test/Quake/test_add_dealloc.qke
@@ -7,18 +7,16 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt %s --quake-add-deallocs | FileCheck %s
-module {
+
 // CHECK-LABEL:   func.func @ghz(
 // CHECK-SAME:                   %[[VAL_0:.*]]: i32) {
-    func.func @ghz(%arg0 : i32) {
-        %c0 = arith.constant 0 : i32
-        %one = arith.constant 1 : i32
-// CHECK:           %[[VAL_3:.*]] = quake.alloca(%[[VAL_0]] : i32) : !quake.qvec<?>
-        %q = quake.alloca(%arg0 : i32) : !quake.qvec<?>
-        %q0 = quake.qextract %q[%c0] : !quake.qvec<?>[i32] -> !quake.qref
-        quake.h (%q0) 
-// CHECK:           quake.dealloc(%[[VAL_3]] : !quake.qvec<?>)
-        return
-    }
+func.func @ghz(%arg0 : i32) {
+  %c0 = arith.constant 0 : i32
+  %one = arith.constant 1 : i32
+  // CHECK: %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
+  %q = quake.alloca[%arg0 : i32] !quake.qvec<?>
+  %q0 = quake.extract_ref %q[%c0] : (!quake.qvec<?>, i32) -> !quake.qref
+  quake.h %q0 : (!quake.qref) -> () 
+  // CHECK: quake.dealloc %[[VAL_3]] : !quake.qvec<?>
+  return
 }
-

--- a/test/Quake/test_inline_simpify.qke
+++ b/test/Quake/test_inline_simpify.qke
@@ -9,19 +9,19 @@
 // RUN: cudaq-opt %s | FileCheck %s
 // CHECK: module {
 // CHECK:   func.func @apply_x(%arg0: !quake.qref) {
-// CHECK:     quake.x (%arg0)
+// CHECK:     quake.x %arg0 :
 // CHECK:     return
 // CHECK:   }
 // CHECK:   func.func @ccnot() {
 // CHECK:     %[[C3:.*]] = arith.constant 3 : i32
 // CHECK:     %[[C1:.*]] = arith.constant 1 : i32
-// CHECK:     %0 = quake.alloca(%[[C3]] : i32) : !quake.qvec<?>
+// CHECK:     %0 = quake.alloca[%[[C3]] : i32] !quake.qvec<?>
 // CHECK:     %1 = arith.index_cast %[[C3]] : i32 to index
 // CHECK:     affine.for %arg0 = 0 to %1 {
-// CHECK:       %3 = quake.qextract %0[%arg0] : !quake.qvec<?>[index] -> !quake.qref
-// CHECK:       quake.x (%3)
+// CHECK:       %3 = quake.extract_ref %0[%arg0] : (!quake.qvec<?>, index) -> !quake.qref
+// CHECK:       quake.x %3 :
 // CHECK:     }
-// CHECK:     %2 = quake.qextract %0[%[[C1]]] : !quake.qvec<?>[i32] -> !quake.qref
+// CHECK:     %2 = quake.extract_ref %0[%[[C1]]] : (!quake.qvec<?>, i32) -> !quake.qref
 // CHECK:     call @apply_x(%2) : (!quake.qref) -> ()
 // CHECK:     return
 // CHECK:   }
@@ -31,21 +31,21 @@ module {
     // Any function that takes quantum memory as input
     // must return the same, e.g. (!quake.qref) -> (!quake.qref)
     func.func @apply_x(%q : !quake.qref) -> () {
-        quake.x (%q)
+        quake.x %q : (!quake.qref) -> ()
         return
     }
 
     func.func @ccnot() {
         %c_3 = arith.constant 3 : i32
         %c_1 = arith.constant 1 : i32
-        %qubits = quake.alloca ( %c_3 : i32 ) : !quake.qvec<?>
+        %qubits = quake.alloca [%c_3 : i32 ] !quake.qvec<?>
         %c_3_idx = arith.index_cast %c_3 : i32 to index
         affine.for %i = 0 to %c_3_idx {
-            %q0 = quake.qextract %qubits [%i] : !quake.qvec<?>[index] -> !quake.qref
-            quake.x (%q0)
+            %q0 = quake.extract_ref %qubits [%i] :( !quake.qvec<?>,index) -> !quake.qref
+            quake.x %q0 : (!quake.qref) -> ()
         }
 
-        %q1 = quake.qextract %qubits [%c_1] : !quake.qvec<?>[i32] -> !quake.qref
+        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>, i32) -> !quake.qref
         func.call @apply_x(%q1) : (!quake.qref) -> ()
         
         return

--- a/test/Quake/test_merge_rotation.qke
+++ b/test/Quake/test_merge_rotation.qke
@@ -11,95 +11,92 @@
 // CHECK: func.func @duplicate_rotation_check() {
 // CHECK:     %[[C2:.*]] = arith.constant 2 : i32
 // CHECK:     %[[C0:.*]] = arith.constant 0 : i32
-// CHECK:     %0 = quake.alloca(%[[C2]] : i32) : !quake.qvec<?>
-// CHECK:     %1 = quake.qextract %0[%[[C0]]] : !quake.qvec<?>[i32] -> !quake.qref
+// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
 // CHECK:     %[[CF:.*]] = arith.constant 5.900000e-01 : f64
-// CHECK:     quake.rx |%[[CF]] : f64|(%1)
-// CHECK:     quake.rx |%[[CF]] : f64|(%1)
-// CHECK:     %2 = quake.mz(%1 : !quake.qref) : i1
+// CHECK:     quake.rx (%[[CF]]) %1 : (f64,
+// CHECK:     quake.rx (%[[CF]]) %1 : (f64,
+// CHECK:     %2 = quake.mz %1 : (!quake.qref) -> i1
 // CHECK:     return
 // CHECK:   }
 
-module {
-    func.func @duplicate_rotation_check() {
-        %0 = arith.constant 2 : i32
-        %c_0 = arith.constant 0 : i32
-        %qubits = quake.alloca ( %0 : i32 ) : !quake.qvec<?>
-        %q0 = quake.qextract %qubits[%c_0] : !quake.qvec<?>[i32] -> !quake.qref
-        %c_angle = arith.constant 0.59 : f64
-        quake.rx |%c_angle : f64|(%q0)
-        quake.rx |%c_angle : f64|(%q0)
-        %measurements0 = quake.mz(%q0 : !quake.qref) : i1
-        return
-    }
+func.func @duplicate_rotation_check() {
+  %0 = arith.constant 2 : i32
+  %c_0 = arith.constant 0 : i32
+  %qubits = quake.alloca [ %0 : i32 ] !quake.qvec<?>
+  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>,i32) -> !quake.qref
+  %c_angle = arith.constant 0.59 : f64
+  quake.rx (%c_angle) %q0: (f64, !quake.qref) -> ()
+  quake.rx (%c_angle) %q0 : (f64, !quake.qref) -> ()
+  %measurements0 = quake.mz %q0 : (!quake.qref) -> i1
+  return
+}
 
 // CHECK: func.func @duplicate_rotation_check2() {
 // CHECK:     %[[C2]] = arith.constant 2 : i32
 // CHECK:     %[[C0]] = arith.constant 0 : i32
-// CHECK:     %0 = quake.alloca(%[[C2]] : i32) : !quake.qvec<?>
-// CHECK:     %1 = quake.qextract %0[%[[C0]]] : !quake.qvec<?>[i32] -> !quake.qref
+// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
 // CHECK:     %[[CF:.*]] = arith.constant 5.900000e-01 : f64
 // CHECK:     %[[CF2:.*]] = arith.constant 2.300000e-01 : f64
-// CHECK:     quake.rx |%[[CF]] : f64|(%1)
-// CHECK:     quake.rx |%[[CF]] : f64|(%1)
-// CHECK:     quake.rx |%[[CF2]] : f64|(%1)
-// CHECK:     %2 = quake.mz(%1 : !quake.qref) : i1
+// CHECK:     quake.rx (%[[CF]]) %1 : (f64,
+// CHECK:     quake.rx (%[[CF]]) %1 : (f64,
+// CHECK:     quake.rx (%[[CF2]]) %1 : (f64,
+// CHECK:     %2 = quake.mz %1 : (!quake.qref) -> i1
 // CHECK:     return
 // CHECK: }
-    func.func @duplicate_rotation_check2() {
-        %0 = arith.constant 2 : i32
-        %c_0 = arith.constant 0 : i32
-        %qubits = quake.alloca ( %0 : i32 ) : !quake.qvec<?>
-        %q0 = quake.qextract %qubits[%c_0] : !quake.qvec<?>[i32] -> !quake.qref
-        %c_angle = arith.constant 0.59 : f64
-        %c_angle2 = arith.constant 0.23 : f64
-        quake.rx |%c_angle : f64|(%q0)
-        quake.rx |%c_angle : f64|(%q0)
-        quake.rx |%c_angle2 : f64|(%q0)
-        %measurement = quake.mz(%q0 : !quake.qref) : i1
-        return
-    }
+func.func @duplicate_rotation_check2() {
+  %0 = arith.constant 2 : i32
+  %c_0 = arith.constant 0 : i32
+  %qubits = quake.alloca [ %0 : i32] !quake.qvec<?>
+  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>, i32) -> !quake.qref
+  %c_angle = arith.constant 0.59 : f64
+  %c_angle2 = arith.constant 0.23 : f64
+  quake.rx (%c_angle) %q0 : (f64, !quake.qref) -> ()
+  quake.rx (%c_angle) %q0 : (f64, !quake.qref) -> ()
+  quake.rx (%c_angle2) %q0 : (f64, !quake.qref) -> ()
+  %measurement = quake.mz %q0 : (!quake.qref) -> i1
+  return
+}
 
 // CHECK:  func.func @returns_angle(%arg0: f64, %arg1: f64) -> f64 {
 // CHECK:    %0 = arith.divf %arg0, %arg1 : f64
 // CHECK:    return %0 : f64
 // CHECK:  }
-    func.func @returns_angle(%arg0 : f64, %arg1 : f64) -> (f64) {
-        %0 = arith.divf %arg0, %arg1 : f64
-        return %0 : f64
-    }
+func.func @returns_angle(%arg0 : f64, %arg1 : f64) -> (f64) {
+  %0 = arith.divf %arg0, %arg1 : f64
+  return %0 : f64
+}
 
 // CHECK: func.func @duplicate_rotation_check3() {
 // CHECK:     %[[C2:.*]] = arith.constant 2 : i32
 // CHECK:     %[[C0:.*]] = arith.constant 0 : i32
-// CHECK:     %0 = quake.alloca(%[[C2]] : i32) : !quake.qvec<?>
-// CHECK:     %1 = quake.qextract %0[%[[C0]]] : !quake.qvec<?>[i32] -> !quake.qref
+// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
 // CHECK:     %[[CF:.*]] = arith.constant 5.900000e-01 : f64
 // CHECK:     %[[CF2:.*]] = arith.constant 2.300000e-01 : f64
 // CHECK:     %[[CF3:.*]] = arith.constant 6.400000e-01 : f64
 // CHECK:     %2 = call @returns_angle(%[[CF]], %[[CF2]]) : (f64, f64) -> f64
 // CHECK:     %3 = call @returns_angle(%[[CF3]], %[[CF2]]) : (f64, f64) -> f64
-// CHECK:     quake.rx |%cst : f64|(%1)
-// CHECK:     quake.rx |%3 : f64|(%1)
-// CHECK:     quake.rx |%2 : f64|(%1)
-// CHECK:     %4 = quake.mz(%1 : !quake.qref) : i1
+// CHECK:     quake.rx (%cst) %1 :
+// CHECK:     quake.rx (%3) %1 :
+// CHECK:     quake.rx (%2) %1 :
+// CHECK:     %4 = quake.mz %1 : (!quake.qref) -> i1
 // CHECK:     return
 // CHECK: }
-    func.func @duplicate_rotation_check3() {
-        %0 = arith.constant 2 : i32
-        %c_0 = arith.constant 0 : i32
-        %qubits = quake.alloca ( %0 : i32 ) : !quake.qvec<?>
-        %q0 = quake.qextract %qubits[%c_0] : !quake.qvec<?>[i32] -> !quake.qref
-        %c_angle = arith.constant 0.59 : f64
-        %c_angle2 = arith.constant 0.23 : f64
-        %c_angle3 = arith.constant 0.64 : f64
-        %new_angle = call @returns_angle(%c_angle, %c_angle2) : (f64, f64) -> (f64) 
-        %new_angle2 = call @returns_angle(%c_angle3, %c_angle2) : (f64, f64) -> (f64)
-        quake.rx |%c_angle : f64|(%q0)
-        quake.rx |%new_angle2 : f64|(%q0)
-        quake.rx |%new_angle : f64|(%q0)
-        %measurement = quake.mz(%q0 : !quake.qref) : i1
-        return
-    }
-
+func.func @duplicate_rotation_check3() {
+  %0 = arith.constant 2 : i32
+  %c_0 = arith.constant 0 : i32
+  %qubits = quake.alloca [ %0 : i32 ] !quake.qvec<?>
+  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>, i32) -> !quake.qref
+  %c_angle = arith.constant 0.59 : f64
+  %c_angle2 = arith.constant 0.23 : f64
+  %c_angle3 = arith.constant 0.64 : f64
+  %new_angle = call @returns_angle(%c_angle, %c_angle2) : (f64, f64) -> (f64) 
+  %new_angle2 = call @returns_angle(%c_angle3, %c_angle2) : (f64, f64) -> (f64)
+  quake.rx (%c_angle) %q0 : (f64, !quake.qref) -> ()
+  quake.rx (%new_angle2) %q0 : (f64, !quake.qref) -> ()
+  quake.rx (%new_angle) %q0 : (f64, !quake.qref) -> ()
+  %measurement = quake.mz %q0 : (!quake.qref) -> i1
+  return
 }


### PR DESCRIPTION
This unifies the quantum gate definitions into a single Op and eliminates the overhead of supporting parallel dialects for the same operations. See issue #98 for more.

A large portion of these changes involves converting the tests to support a new syntax in which types are mandatory on quantum operations and more uniformly follow the MLIR default functional notation.

Modify some specific points in the existing code to use the new op builder routines. Also begin the work of phasing out the Common directory, which will become obsolete after this refactoring is complete.

