### PR TITLE
Fix Issue #126, whereby swap function did not allow ctrl modifier

### DIFF
--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -87,7 +87,7 @@ static ParseResult
 parseRawIndex(OpAsmParser &parser,
               std::optional<OpAsmParser::UnresolvedOperand> &index,
               IntegerAttr &rawIndex) {
-  std::size_t constantIndex;
+  std::size_t constantIndex = 0;
   OptionalParseResult parsedInteger =
       parser.parseOptionalInteger(constantIndex);
   if (parsedInteger.has_value()) {

--- a/runtime/cudaq/algorithms/observe.h
+++ b/runtime/cudaq/algorithms/observe.h
@@ -160,7 +160,7 @@ inline auto distributeComputations(
   for (std::size_t i = 0; auto &asyncResult : asyncResults) {
     auto res = asyncResult.get();
     auto incomingData = res.raw_data();
-    result += incomingData.exp_val_z(spins[i].to_string(false));
+    result += incomingData.exp_val_z();
     data += incomingData;
     i++;
   }

--- a/runtime/cudaq/qis/managers/qir/QIRForwards.h
+++ b/runtime/cudaq/qis/managers/qir/QIRForwards.h
@@ -16,7 +16,7 @@ class Qubit;
 class Result;
 using TuplePtr = int8_t *;
 
-/// QIR QIS Extern Declarations
+/// QIR QIS external declarations
 extern "C" {
 Array *__quantum__rt__array_concatenate(Array *, Array *);
 void __quantum__rt__array_release(Array *);

--- a/runtime/cudaq/qis/managers/qir/QIRForwards.h
+++ b/runtime/cudaq/qis/managers/qir/QIRForwards.h
@@ -67,6 +67,7 @@ void __quantum__qis__r1(double, Qubit *q);
 void __quantum__qis__r1__ctl(double, Array *ctls, Qubit *q);
 
 void __quantum__qis__swap(Qubit *, Qubit *);
+void __quantum__qis__swap__ctl(Array *, Qubit *, Qubit *);
 void __quantum__qis__cphase(double x, Qubit *src, Qubit *tgt);
 
 Result *__quantum__qis__mz(Qubit *);

--- a/runtime/cudaq/qis/managers/qir/QubitQIRExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/qir/QubitQIRExecutionManager.cpp
@@ -100,7 +100,8 @@ private:
            }},
           {"swap",
            [](std::vector<double> d, Array *a, std::vector<Qubit *> &q) {
-             __quantum__qis__swap(q[0], q[1]);
+             a != nullptr ? __quantum__qis__swap__ctl(a, q[0], q[1])
+                          : __quantum__qis__swap(q[0], q[1]);
            }},
           {"cphase",
            [](std::vector<double> d, Array *a, std::vector<Qubit *> &q) {

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -38,10 +38,10 @@ ConcreteQubitOp(h) ConcreteQubitOp(x) ConcreteQubitOp(y) ConcreteQubitOp(z)
 inline QuditInfo qubitToQuditInfo(qubit &q) { return {q.n_levels(), q.id()}; }
 inline bool qubitIsNegative(qubit &q) { return q.is_negative(); }
 
-/// @brief This function will apply the specified QuantumOp. It will check the
-/// modifier template type and if it is base, it will apply the op to any qubits
-/// provided as input. If ctrl, it will take the first N-1 qubits as the
-/// controls and the last qubit as the target.
+/// @brief This function will apply the specified `QuantumOp`. It will check the
+/// modifier template type and if it is `base`, it will apply the operation to
+/// any qubits provided as input. If `ctrl`, it will take the first `N-1` qubits
+/// as the controls and the last qubit as the target.
 template <typename QuantumOp, typename mod = base, typename... QubitArgs>
 void oneQubitApply(QubitArgs &...args) {
   // Get the name of this operation
@@ -66,7 +66,7 @@ void oneQubitApply(QubitArgs &...args) {
     return;
   }
 
-  // If we are here, then mod must be ctrl / adj
+  // If we are here, then `mod` must be control or adjoint
   // Extract the controls and the target
   std::vector<QuditInfo> controls(quditInfos.begin(),
                                   quditInfos.begin() + nArgs - 1);
@@ -176,7 +176,7 @@ void oneQubitSingleParameterApply(ScalarAngle angle, QubitArgs &...args) {
     return;
   }
 
-  // If we are here, then mod must be ctrl / adj
+  // If we are here, then mod must be control or adjoint
   // Extract the controls and the target
   std::vector<QuditInfo> controls(targets.begin(), targets.begin() + nArgs - 1);
 
@@ -219,8 +219,8 @@ void oneQubitSingleParameterControlledRange(ScalarAngle angle,
     oneQubitSingleParameterControlledRange<qubit_op::NAME##Op, mod>(           \
         angle, ctrls, target);                                                 \
   }
-// FIXME add One Qubit Single Param Broadcast over register with an angle for
-// each
+// FIXME add One Qubit Single Parameter Broadcast over register with an angle
+// for each
 
 CUDAQ_QIS_PARAM_ONE_TARGET_(rx)
 CUDAQ_QIS_PARAM_ONE_TARGET_(ry)
@@ -280,18 +280,18 @@ inline void cphase(ScalarAngle angle, qubit &q, qubit &r) {
   getExecutionManager()->apply("cphase", {angle}, {}, arr);
 }
 
-// Measure an individual qubit, return 0,1 as bool
+/// @brief Measure an individual qubit, return 0,1 as `bool`
 inline bool mz(qubit &q) {
   return getExecutionManager()->measure({q.n_levels(), q.id()});
 }
 
-// Measure an individual qubit in x basis, return 0,1 as bool
+/// @brief Measure an individual qubit in `x` basis, return 0,1 as `bool`
 inline bool mx(qubit &q) {
   h(q);
   return getExecutionManager()->measure({q.n_levels(), q.id()});
 }
 
-// Measure an individual qubit in y basis, return 0,1 as bool
+// Measure an individual qubit in `y` basis, return 0,1 as `bool`
 inline bool my(qubit &q) {
   s<adj>(q);
   h(q);
@@ -342,7 +342,7 @@ std::vector<bool> mz(qubit &q, Qs &&...qs) {
 }
 
 namespace support {
-// Helper to initialize a vector<bool> data structure.
+// Helper to initialize a `vector<bool>` data structure.
 extern "C" void __nvqpp_initializer_list_to_vector_bool(std::vector<bool> &,
                                                         char *, std::size_t);
 } // namespace support
@@ -457,7 +457,7 @@ void compute_dag_action(ComputeFunction &&c, ActionFunction &&a) {
   c();
 }
 
-/// Helper function to extract a subvector of a std::vector<T> to be used within
+/// Helper function to extract a slice of a `std::vector<T>` to be used within
 /// CUDA Quantum kernels.
 template <typename T>
   requires(std::is_arithmetic_v<T>)

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -272,6 +272,14 @@ void __quantum__qis__swap(Qubit *q, Qubit *r) {
   cudaq::ScopedTrace trace("NVQIR::swap", qI, rI);
   nvqir::getCircuitSimulatorInternal()->swap(qI, rI);
 }
+
+void __quantum__qis__swap__ctl(Array *ctrls, Qubit *q, Qubit *r) {
+  auto ctrlIdxs = arrayToVectorSizeT(ctrls);
+  auto qI = qubitToSizeT(q);
+  auto rI = qubitToSizeT(r);
+  nvqir::getCircuitSimulatorInternal()->swap(ctrlIdxs, qI, rI);
+}
+
 void __quantum__qis__swap__body(Qubit *q, Qubit *r) {
   __quantum__qis__swap(q, r);
 }

--- a/unittests/integration/ccnot_tester.cpp
+++ b/unittests/integration/ccnot_tester.cpp
@@ -79,3 +79,18 @@ CUDAQ_TEST(CCNOTTester, checkSimple) {
   EXPECT_EQ(1, counts3.size());
   EXPECT_TRUE(counts3.begin()->first == "101");
 }
+
+CUDAQ_TEST(FredkinTester, checkTruth) {
+
+  auto test = []() __qpu__ {
+    cudaq::qubit q, r, s;
+    x(q, s);
+    swap<cudaq::ctrl>(q, r, s);
+    mz(q, r, s);
+  };
+
+  auto counts = cudaq::sample(test);
+  counts.dump();
+  EXPECT_EQ(counts.size(), 1);
+  EXPECT_EQ(counts.begin()->first, "110");
+}


### PR DESCRIPTION
Fix #126. This only applies to library mode since future gate decomposition work will likely be needed for lower ctrl-swap for physical backends. 