### PR TITLE
[quake] OperatorInterface method to get negated controls

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeInterfaces.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeInterfaces.td
@@ -49,6 +49,13 @@ def OperatorInterface : OpInterface<"OperatorInterface"> {
       /*methodBody=*/ "return $_op.getControls();"
     >,
     InterfaceMethod<
+      /*desc=*/ "Returns an array indicating whether controls are negated",
+      /*retType=*/ "std::optional<mlir::ArrayRef<bool>>",
+      /*methodName=*/ "getNegatedControls",
+      /*args=*/ (ins),
+      /*methodBody=*/ "return $_op.getNegatedQubitControls();"
+    >,
+    InterfaceMethod<
       /*desc=*/ "Returns the targets (input) of this operator",
       /*retType=*/ "mlir::Operation::operand_range",
       /*methodName=*/ "getTargets",


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
Add a method to retrieve the information whether controls are negated from the operator interface.
