### PR TITLE
Universally replace the QRef type name with Ref.

### DIFF
--- a/.github/workflows/config/spelling_allowlist.txt
+++ b/.github/workflows/config/spelling_allowlist.txt
@@ -5,6 +5,7 @@ BFGS
 CMake
 COBYLA
 CUDA
+Canonicalizer
 De
 FileCheck
 Fourier
@@ -50,6 +51,7 @@ atol
 auxillary
 backend
 backends
+baz
 bitcode
 bitstring
 bitstrings
@@ -118,10 +120,12 @@ qke
 qpp
 qpu
 qreg
+qtx
 qubit
 qubits
 qudit
 qudits
+rewriter
 rpath
 rtol
 runtime

--- a/docs/sphinx/specification/quake-dialect.md
+++ b/docs/sphinx/specification/quake-dialect.md
@@ -43,8 +43,8 @@ func.func foo(%qvec : !quake.qvec<2>) {
     // Boilerplate to extract each qubit from the vector
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
-    %q0 = quake.qextract %qvec[%c0 : index] : !quake.qvec<2> -> !quake.qref
-    %q1 = quake.qextract %qvec[%c1 : index] : !quake.qvec<2> -> !quake.qref
+    %q0 = quake.qextract %qvec[%c0 : index] : !quake.qvec<2> -> !quake.ref
+    %q1 = quake.qextract %qvec[%c1 : index] : !quake.qvec<2> -> !quake.ref
 
     // We apply some operators to those extracted qubits
     ... bunch of operators using %q0 and %q1 ...

--- a/docs/sphinx/using/advanced/cudaq_ir.rst
+++ b/docs/sphinx/using/advanced/cudaq_ir.rst
@@ -53,7 +53,7 @@ we can look at the IR code that was produced. :code:`simple.qke` contains
            %2 = quake.alloca(%1 : i64) !quake.qvec<?>
            %c0_i32 = arith.constant 0 : i32
            %3 = arith.extsi %c0_i32 : i32 to i64
-           %4 = quake.extract_ref %2[%3] : (!quake.qvec<?>, i64) -> !quake.qref
+           %4 = quake.extract_ref %2[%3] : (!quake.qvec<?>, i64) -> !quake.ref
            quake.h %4 : (!quake.ref) -> ()
            cc.scope {
             %c0_i32_0 = arith.constant 0 : i32
@@ -70,13 +70,13 @@ we can look at the IR code that was produced. :code:`simple.qke` contains
               cc.scope {
                 %6 = memref.load %alloca_1[] : memref<i32>
                 %7 = arith.extsi %6 : i32 to i64
-                %8 = quake.extract_ref %2[%7] : (!quake.qvec<?>, i64) -> !quake.qref
+                %8 = quake.extract_ref %2[%7] : (!quake.qvec<?>, i64) -> !quake.ref
                 %9 = memref.load %alloca_1[] : memref<i32>
                 %c1_i32 = arith.constant 1 : i32
                 %10 = arith.addi %9, %c1_i32 : i32
                 %11 = arith.extsi %10 : i32 to i64
-                %12 = quake.extract_ref %2[%11] : (!quake.qvec<?>, i64) -> !quake.qref
-                quake.x [%8] %12 : (!quake.qref, !quake.qref) -> ()
+                %12 = quake.extract_ref %2[%11] : (!quake.qvec<?>, i64) -> !quake.ref
+                quake.x [%8] %12 : (!quake.ref, !quake.ref) -> ()
               }
               cc.continue
             } step {

--- a/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
@@ -42,9 +42,9 @@ def createAllocaOp : NativeCodeCall<
       "quake::createConstantAlloca($_builder, $_loc, $0, $1)">;
 
 // %2 = constant 10 : i32
-// %3 = quake.alloca (%2 : i32) : !quake.qref<?>
+// %3 = quake.alloca (%2 : i32) : !quake.ref<?>
 // ───────────────────────────────────────────
-// %3 = quake.alloca : !quake.qref<10>
+// %3 = quake.alloca : !quake.ref<10>
 def FuseConstantToAllocaPattern : Pat<
       (quake_AllocaOp:$alloca $optSize), (createAllocaOp $alloca, $optSize),
       [(SizeIsPresentPred $optSize)]>;
@@ -60,13 +60,13 @@ def IsUnknownVec : Constraint<CPred<
 
 // %1 = constant 4 : i64
 // %2 = constant 10 : i64
-// %3 = quake.subvec (%0 : !quake.qref<12>, %1 : i64, %2 : i64) : !quake.qref<?>
+// %3 = quake.subvec (%0 : !quake.ref<12>, %1 : i64, %2 : i64) : !quake.ref<?>
 // ─────────────────────────────────────────────────────────────────────────────
 // %1 = constant 4 : i64
 // %2 = constant 10 : i64
-// %new3 = quake.subvec (%0 : !quake.qref<12>, %1 : i64, %2 : i64) :
-//     !quake.qref<7>
-// %3 = quake.relax_size %new3 : (!quake.qref<7>) -> !quake.qref<?>
+// %new3 = quake.subvec (%0 : !quake.ref<12>, %1 : i64, %2 : i64) :
+//     !quake.ref<7>
+// %3 = quake.relax_size %new3 : (!quake.ref<7>) -> !quake.ref<?>
 def FuseConstantToSubvecPattern : Pat<
       (quake_SubVecOp:$subvec $v, $lo, $hi),
       (createSizedSubVecOp $subvec, $v, $lo, $hi),

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
@@ -60,19 +60,19 @@ void genericOpPrinter(mlir::OpAsmPrinter &_odsPrinter, mlir::Operation *op,
 //===----------------------------------------------------------------------===//
 
 namespace quake {
-/// Returns true if and only if any quantum operand has type `!quake.qref` or
+/// Returns true if and only if any quantum operand has type `!quake.ref` or
 /// `!quake.qvec`.
 inline bool hasReference(mlir::Operation *op) {
   for (mlir::Value opnd : op->getOperands())
-    if (isa<quake::QRefType, quake::QVecType>(opnd.getType()))
+    if (isa<quake::RefType, quake::QVecType>(opnd.getType()))
       return true;
   return false;
 }
 
-/// Returns true if and only if any quantum operand has type `!quake.qref`.
+/// Returns true if and only if any quantum operand has type `!quake.ref`.
 inline bool hasNonVectorReference(mlir::Operation *op) {
   for (mlir::Value opnd : op->getOperands())
-    if (isa<quake::QRefType>(opnd.getType()))
+    if (isa<quake::RefType>(opnd.getType()))
       return true;
   return false;
 }

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -42,7 +42,7 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
     The `alloca` operation allocates either a single wire reference or a vector
     of references to wires. The size of the vector may be provided either
     statically as part of the type or dynamically as an integer-like argument,
-    `size`. The return value will be a quantum reference, type `!quake.qref`,
+    `size`. The return value will be a quantum reference, type `!quake.ref`,
     or a vector of such, type `!quake.qvec<N>`.
 
     All wires are assumed to be initialized to the value `|0>` initially. See
@@ -56,7 +56,7 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
     Examples:
     ```mlir
       // Allocate a single qubit
-      %qubit = quake.alloca !quake.qref
+      %qubit = quake.alloca !quake.ref
 
       // Allocate a qubit register with a size known at compilation time
       %qvec = quake.alloca !quake.qvec<4> {name = "quantum"}
@@ -72,11 +72,11 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
   }];
 
   let arguments = (ins Optional<AnySignlessInteger>:$size);
-  let results = (outs AnyQRefType:$qref_or_vec);
+  let results = (outs AnyRefType:$ref_or_vec);
 
   let builders = [
     OpBuilder<(ins ), [{
-      return build($_builder, $_state, $_builder.getType<QRefType>(), {});
+      return build($_builder, $_state, $_builder.getType<RefType>(), {});
     }]>,
     OpBuilder<(ins "size_t":$size), [{
       return build($_builder, $_state, $_builder.getType<QVecType>(size), {});
@@ -84,7 +84,7 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
   ];
 
   let assemblyFormat = [{
-    (`[` $size^ `:` type($size)`]`)? qualified(type($qref_or_vec)) attr-dict
+    (`[` $size^ `:` type($size)`]`)? qualified(type($ref_or_vec)) attr-dict
   }];
 
   let hasCanonicalizer = 1;
@@ -92,19 +92,19 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
 }
 
 def quake_ConcatOp : QuakeOp<"concat", [Pure]> {
-  let summary = "Construct a qvec from a list of other qref/qvec values.";
+  let summary = "Construct a qvec from a list of other ref/qvec values.";
   let description = [{
     The `concat` operation allows one to concatenate a list of SSA-values of
-    either type QRef or QVec into a new QVec vector.
+    either type Ref or QVec into a new QVec vector.
 
     Example:
     ```mlir
-      %veq = quake.concat %r1, %v1, %r2 : (!quake.qref, !quake.qvec<?>,
-                                           !quake.qref) -> !quake.qvec<?>
+      %veq = quake.concat %r1, %v1, %r2 : (!quake.ref, !quake.qvec<?>,
+                                           !quake.ref) -> !quake.qvec<?>
     ```
   }];
 
-  let arguments = (ins Variadic<AnyQRefType>:$qbits);
+  let arguments = (ins Variadic<AnyRefType>:$qbits);
   let results = (outs QVecType);
 
   let assemblyFormat = [{
@@ -175,7 +175,7 @@ def quake_DeallocOp : QuakeOp<"dealloc"> {
   let summary = "Deallocates a collection of qubits.";
   let description = [{
     The `dealloc` operation deallocates a references to wires. The deallocation
-    can be a single wire, type `!quake.qref`, or a vector of references, type
+    can be a single wire, type `!quake.ref`, or a vector of references, type
     `!quake.qvec<N>`.
 
     Deallocations are automatically inserted by the `QuakeAddDeallocs` and
@@ -192,7 +192,7 @@ def quake_DeallocOp : QuakeOp<"dealloc"> {
   }];
 
   let arguments = (ins
-    Arg<AnyQRefType, "qubit reference (or vector) to deallocate",
+    Arg<AnyRefType, "qubit reference (or vector) to deallocate",
     [MemFree]>:$qreg_or_vec
   );
 
@@ -202,7 +202,7 @@ def quake_DeallocOp : QuakeOp<"dealloc"> {
 }
 
 //===----------------------------------------------------------------------===//
-// QVec, QRef manipulation
+// QVec, Ref manipulation
 //===----------------------------------------------------------------------===//
 
 def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
@@ -217,7 +217,7 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
     Example:
     ```mlir
       %zero = arith.constant 0 : i32
-      %qr = quake.extract_ref %qv[%zero] : (!quake.qvec<?>, i32) -> !quake.qref
+      %qr = quake.extract_ref %qv[%zero] : (!quake.qvec<?>, i32) -> !quake.ref
     ```
   }];
 
@@ -225,7 +225,7 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
     QVecType:$qvec,
     AnySignlessIntegerOrIndex:$index
   );
-  let results = (outs QRefType:$qref);
+  let results = (outs RefType:$ref);
 
   let assemblyFormat = [{
     $qvec `[` $index `]` `:`  functional-type(operands, results) attr-dict
@@ -233,7 +233,7 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$qvec, "mlir::Value":$index), [{
-      return build($_builder, $_state, $_builder.getType<QRefType>(), qvec,
+      return build($_builder, $_state, $_builder.getType<RefType>(), qvec,
                    index);
     }]>,
   ];
@@ -405,14 +405,14 @@ def quake_UnwrapOp : QuakeOp<"unwrap"> {
     example.
 
     ```mlir
-      %0 = ... : !quake.qref
-      %1 = quake.unwrap %0 : (!quake.qref) -> !quake.wire
+      %0 = ... : !quake.ref
+      %1 = quake.unwrap %0 : (!quake.ref) -> !quake.wire
       %2 = quake.rx (%dbl) %1 : (f64, !quake.wire) -> !quake.wire
-      quake.wrap %2 to %0 : !quake.wire, !quake.qref
+      quake.wrap %2 to %0 : !quake.wire, !quake.ref
     ```
   }];
 
-  let arguments = (ins Arg<QRefType,"",[MemRead]>:$ref_value);
+  let arguments = (ins Arg<RefType,"",[MemRead]>:$ref_value);
   let results = (outs WireType);
   let assemblyFormat = [{
     $ref_value `:` functional-type(operands, results) attr-dict
@@ -424,13 +424,13 @@ def quake_WrapOp : QuakeOp<"wrap"> {
   let description = [{
     Each data flow of a volatile wire in a quantum circuit may be associated
     and identified with an invariant and unique quantum reference value of type
-    `!qref`. The wrap operation provides a means of returning a quantum value,
+    `!ref`. The wrap operation provides a means of returning a quantum value,
     a wire, back to the reference value domain.
   }];
 
   let arguments = (ins
     WireType:$wire_value,
-    Arg<QRefType,"",[MemWrite]>:$ref_value
+    Arg<RefType,"",[MemWrite]>:$ref_value
   );
   let assemblyFormat = [{
     $wire_value `to` $ref_value `:` qualified(type(operands)) attr-dict
@@ -1156,12 +1156,12 @@ def quake_ResetOp : QuakeOp<"reset", [QuantumGate,
   let summary = "Reset the wire to the |0> (|0..0>) state.";
   let description = [{
     The `quake.reset` operation resets a wire to the |0> (|0..0>) state. It
-    may take an argument that is either a reference to a wire, type `!qref`,
+    may take an argument that is either a reference to a wire, type `!ref`,
     or a wire, type `!wire`.
 
     Example:
     ```mlir
-      quake.reset %0 : (!quake.qref) -> ()
+      quake.reset %0 : (!quake.ref) -> ()
       %2 = quake.reset %1 : (!quake.wire) -> !quake.wire
     ```
   }];

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -44,7 +44,7 @@ def WireType : QuakeType<"Wire", "wire"> {
       %q3 = quake.gate2 %q2 : (!quake.wire) -> !quake.wire
     ```
 
-    See also the description of the `qref` type.
+    See also the description of the `ref` type.
   }];
 
   let genStorageClass = 0;
@@ -61,21 +61,21 @@ def ControlType : QuakeType<"Control", "control"> {
 }
 
 //===----------------------------------------------------------------------===//
-// QRefType
+// RefType
 //===----------------------------------------------------------------------===//
 
-def QRefType : QuakeType<"QRef", "qref"> {
+def RefType : QuakeType<"Ref", "ref"> {
   let summary = "reference to a wire";
   let description = [{
-    A `qref` represents a reference to a wire.  One can view the values of
+    A `ref` represents a reference to a wire.  One can view the values of
     this type as the horizontal lines in the following a quantum circuit
-    diagram. A value of type `qref` is an SSA-value.
+    diagram. A value of type `ref` is an SSA-value.
 
     ```
     q0 : ─────●────────── <--+
               │              |
             ┌─┴┐  ┌──┐       |
-    q1 : ───┤  ├──┤  ├─── <--+-- `qref`s
+    q1 : ───┤  ├──┤  ├─── <--+-- `ref`s
             └──┘  └──┘
     ```
 
@@ -83,8 +83,8 @@ def QRefType : QuakeType<"QRef", "qref"> {
     (gate1 and gate2 are quantum gates.)
 
     ```mlir
-      %q0 = quake.alloca : !quake.qref
-      %q1 = quake.alloca : !quake.qref
+      %q0 = quake.alloca : !quake.ref
+      %q1 = quake.alloca : !quake.ref
       quake.gate1 [%q0] (%q1)
       quake.gate2 (%q1)
     ```
@@ -101,7 +101,7 @@ def QRefType : QuakeType<"QRef", "qref"> {
     control position in `gate1`, the wire value is not updated.
 
     Not all operations will have side-effects on the referent wire of the
-    reference value of `qref` type.
+    reference value of `ref` type.
   }];
   let genStorageClass = 0;
 }
@@ -113,9 +113,9 @@ def QRefType : QuakeType<"QRef", "qref"> {
 def QVecType : QuakeType<"QVec", "qvec"> {
   let summary = "a aggregate of wire references";
   let description = [{
-    A value of type `qvec` is a (linear) collection of values of type `qref`.
+    A value of type `qvec` is a (linear) collection of values of type `ref`.
     These aggregates are a convenience for referring to an entire group of
-    references to wires. A `qvec` value is a proper SSA-value. `qref` values
+    references to wires. A `qvec` value is a proper SSA-value. `ref` values
     in a `qvec` are not volatile.
   }];
 
@@ -133,11 +133,11 @@ def QVecType : QuakeType<"QVec", "qvec"> {
 }
 
 def AnyQTypeLike : TypeConstraint<Or<[WireType.predicate, QVecType.predicate,
-        ControlType.predicate, QRefType.predicate]>, "quake quantum types">;
+        ControlType.predicate, RefType.predicate]>, "quake quantum types">;
 def AnyQType : Type<AnyQTypeLike.predicate, "quantum type">;
-def AnyQRefTypeLike : TypeConstraint<Or<[QVecType.predicate,
-        QRefType.predicate]>, "quake quantum reference types">;
-def AnyQRefType : Type<AnyQRefTypeLike.predicate, "quantum reference type">;
+def AnyRefTypeLike : TypeConstraint<Or<[QVecType.predicate,
+        RefType.predicate]>, "quake quantum reference types">;
+def AnyRefType : Type<AnyRefTypeLike.predicate, "quantum reference type">;
 def AnyQValueTypeLike : TypeConstraint<Or<[WireType.predicate,
         ControlType.predicate]>, "quake quantum value types">;
 def AnyQValueType : Type<AnyQValueTypeLike.predicate, "quantum value type">;

--- a/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -44,7 +44,7 @@ listReachableFunctions(clang::CallGraphNode *cgn) {
 // Does `ty` refer to a Quake quantum type? This also checks custom recursive
 // types. It does not check builtin recursive types; e.g., `!llvm.ptr<T>`.
 static bool isQubitType(Type ty) {
-  if (ty.isa<quake::QRefType, quake::QVecType>())
+  if (ty.isa<quake::RefType, quake::QVecType>())
     return true;
   if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(ty))
     return isQubitType(vecTy.getElementType());

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -124,7 +124,7 @@ void QuakeBridgeVisitor::addArgumentSymbols(
       auto loc = toLocation(argVal);
       auto parmTy = entryBlock->getArgument(index).getType();
       if (parmTy.isa<cc::LambdaType, cc::StdvecType, LLVM::LLVMStructType,
-                     FunctionType, quake::QRefType, quake::QVecType>()) {
+                     FunctionType, quake::RefType, quake::QVecType>()) {
         symbolTable.insert(name, entryBlock->getArgument(index));
       } else {
         auto memRefTy = MemRefType::get(std::nullopt, parmTy);
@@ -260,8 +260,8 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     return pushValue(qreg);
   }
 
-  if (auto qType = dyn_cast<quake::QRefType>(type)) {
-    // Variable is of !quake.qref type.
+  if (auto qType = dyn_cast<quake::RefType>(type)) {
+    // Variable is of !quake.ref type.
     if (x->hasInit() && !valueStack.empty()) {
       auto val = popValue();
       symbolTable.insert(name, val);

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -142,7 +142,7 @@ bool buildOp(OpBuilder &builder, Location loc, ValueRange operands,
       auto bodyBuilder = [&](OpBuilder &builder, Location loc, Region &,
                              Block &block) {
         Value ref = builder.create<quake::ExtractRefOp>(loc, target,
-                                                         block.getArgument(0));
+                                                        block.getArgument(0));
         builder.create<A>(loc, ValueRange(), ref);
       };
       cudaq::opt::factory::createCountedLoop(builder, loc, rank, bodyBuilder);

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -141,9 +141,9 @@ bool buildOp(OpBuilder &builder, Location loc, ValueRange operands,
       Value rank = builder.create<arith::IndexCastOp>(loc, indexTy, size);
       auto bodyBuilder = [&](OpBuilder &builder, Location loc, Region &,
                              Block &block) {
-        Value qref = builder.create<quake::ExtractRefOp>(loc, target,
+        Value ref = builder.create<quake::ExtractRefOp>(loc, target,
                                                          block.getArgument(0));
-        builder.create<A>(loc, ValueRange(), qref);
+        builder.create<A>(loc, ValueRange(), ref);
       };
       cudaq::opt::factory::createCountedLoop(builder, loc, rank, bodyBuilder);
     } else {
@@ -1008,13 +1008,13 @@ bool QuakeBridgeVisitor::VisitMaterializeTemporaryExpr(
   }
   if (auto structTy = dyn_cast<LLVM::LLVMStructType>(ty);
       structTy && structTy.getName().equals("reference_wrapper")) {
-    assert(isa<quake::QRefType>(peekValue().getType()) ||
+    assert(isa<quake::RefType>(peekValue().getType()) ||
            isa<quake::QVecType>(peekValue().getType()));
     return true;
   }
   if (auto stdvecTy = dyn_cast<cc::StdvecType>(ty);
-      stdvecTy && isa<quake::QRefType>(stdvecTy.getElementType())) {
-    assert(isa<quake::QRefType>(peekValue().getType()) ||
+      stdvecTy && isa<quake::RefType>(stdvecTy.getElementType())) {
+    assert(isa<quake::RefType>(peekValue().getType()) ||
            isa<quake::QVecType>(peekValue().getType()));
     return true;
   }
@@ -1358,7 +1358,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
             reportClangError(x, mangler,
                              "cannot negate an entire register of qubits");
           } else {
-            assert(isa<quake::QRefType>(ctrlValues.getType()));
+            assert(isa<quake::RefType>(ctrlValues.getType()));
             assert(negations.size() == 1 && negations[0] == ctrlValues);
             SmallVector<Value> dummy;
             buildOp<quake::XOp>(builder, loc, ctrlValues, dummy, []() {});
@@ -1682,21 +1682,21 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
   if (size > 0) {
     auto loc = toLocation(x);
     auto last = lastValues(size);
-    bool allQRef = [&]() {
+    bool allRef = [&]() {
       for (auto v : last)
-        if (!isa<quake::QRefType>(v.getType()))
+        if (!isa<quake::RefType>(v.getType()))
           return false;
       return true;
     }();
-    if (allQRef) {
+    if (allRef) {
       if (size > 1) {
         auto qVecTy = quake::QVecType::get(builder.getContext(), size);
         return pushValue(builder.create<quake::ConcatOp>(loc, qVecTy, last));
       }
-      // Pass a one member initialization list as a QRef.
+      // Pass a one member initialization list as a Ref.
       return pushValue(last[0]);
     }
-    TODO_x(loc, x, mangler, "list initialization (not qref)");
+    TODO_x(loc, x, mangler, "list initialization (not ref)");
   }
   return true;
 }

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -51,7 +51,7 @@ public:
 
     // If this alloc is just returning a qubit
     if (auto resultType =
-            alloca.getResult().getType().dyn_cast_or_null<quake::QRefType>()) {
+            alloca.getResult().getType().dyn_cast_or_null<quake::RefType>()) {
 
       StringRef qirQubitAllocate = cudaq::opt::QIRQubitAllocate;
       auto qubitType = cudaq::opt::getQubitType(context);
@@ -107,7 +107,7 @@ public:
 
     auto retType = LLVM::LLVMVoidType::get(context);
 
-    // Could be a dealloc on a qref or a qvec
+    // Could be a dealloc on a ref or a qvec
     StringRef qirQuantumDeallocateFunc;
     Type operandType, qType = dealloc.getOperand().getType();
     if (qType.isa<quake::QVecType>()) {
@@ -503,7 +503,7 @@ public:
       return success();
     }
 
-    // We have 1 control, is it a qvec or a qref?
+    // We have 1 control, is it a qvec or a ref?
     auto control = *instOp.getControls().begin();
     qirFunctionName += "__ctl";
 
@@ -1038,7 +1038,7 @@ public:
     typeConverter.addConversion([&](quake::QVecType type) {
       return cudaq::opt::getArrayType(context);
     });
-    typeConverter.addConversion([&](quake::QRefType type) {
+    typeConverter.addConversion([&](quake::RefType type) {
       return cudaq::opt::getQubitType(context);
     });
     typeConverter.addConversion([&](cudaq::cc::LambdaType type) {

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -1038,9 +1038,8 @@ public:
     typeConverter.addConversion([&](quake::QVecType type) {
       return cudaq::opt::getArrayType(context);
     });
-    typeConverter.addConversion([&](quake::RefType type) {
-      return cudaq::opt::getQubitType(context);
-    });
+    typeConverter.addConversion(
+        [&](quake::RefType type) { return cudaq::opt::getQubitType(context); });
     typeConverter.addConversion([&](cudaq::cc::LambdaType type) {
       return lambdaAsPairOfPointers(type.getContext());
     });

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -270,11 +270,11 @@ void quake::getOperatorEffectsImpl(
         &effects,
     ValueRange controls, ValueRange targets) {
   for (auto v : controls)
-    if (isa<quake::QRefType, quake::QVecType>(v.getType()))
+    if (isa<quake::RefType, quake::QVecType>(v.getType()))
       effects.emplace_back(MemoryEffects::Read::get(), v,
                            SideEffects::DefaultResource::get());
   for (auto v : targets)
-    if (isa<quake::QRefType, quake::QVecType>(v.getType())) {
+    if (isa<quake::RefType, quake::QVecType>(v.getType())) {
       effects.emplace_back(MemoryEffects::Read::get(), v,
                            SideEffects::DefaultResource::get());
       effects.emplace_back(MemoryEffects::Write::get(), v,

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -59,5 +59,5 @@ quake::QVecType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
 //===----------------------------------------------------------------------===//
 
 void quake::QuakeDialect::registerTypes() {
-  addTypes<QVecType, QRefType, WireType, ControlType>();
+  addTypes<QVecType, RefType, WireType, ControlType>();
 }

--- a/lib/Optimizer/Transforms/ExpandMeasurements.cpp
+++ b/lib/Optimizer/Transforms/ExpandMeasurements.cpp
@@ -39,7 +39,7 @@ public:
     // in.
     unsigned numQubits = 0u;
     for (auto v : measureOp.getTargets())
-      if (v.getType().template isa<quake::QRefType>())
+      if (v.getType().template isa<quake::RefType>())
         ++numQubits;
     Value totalToRead =
         rewriter.template create<arith::ConstantIndexOp>(loc, numQubits);
@@ -66,7 +66,7 @@ public:
     Value buffOff = rewriter.template create<arith::ConstantIndexOp>(loc, 0);
     Value one = rewriter.template create<arith::ConstantIndexOp>(loc, 1);
     for (auto v : measureOp.getTargets()) {
-      if (v.getType().template isa<quake::QRefType>()) {
+      if (v.getType().template isa<quake::RefType>()) {
         auto bit = rewriter.template create<A>(loc, i1Ty, v);
         Value offCast =
             rewriter.template create<arith::IndexCastOp>(loc, i64Ty, buffOff);

--- a/lib/Optimizer/Transforms/FuncToQTX.cpp
+++ b/lib/Optimizer/Transforms/FuncToQTX.cpp
@@ -17,7 +17,7 @@ using namespace mlir;
 
 static LogicalResult convertOperation(func::FuncOp funcOp) {
   auto convertType = [](Type type) -> Type {
-    if (type.isa<quake::QRefType>())
+    if (type.isa<quake::RefType>())
       return qtx::WireType::get(type.getContext());
     else if (auto qvec = type.dyn_cast_or_null<quake::QVecType>())
       return qtx::WireArrayType::get(type.getContext(), qvec.getSize(), 0);

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -678,10 +678,10 @@ public:
   // code.
   bool hasLegalType(FunctionType funTy) {
     for (auto ty : funTy.getInputs())
-      if (ty.isa<quake::QRefType, quake::QVecType>())
+      if (ty.isa<quake::RefType, quake::QVecType>())
         return false;
     for (auto ty : funTy.getResults())
-      if (ty.isa<quake::QRefType, quake::QVecType>())
+      if (ty.isa<quake::RefType, quake::QVecType>())
         return false;
     return true;
   }

--- a/lib/Optimizer/Transforms/QTXToQuake.cpp
+++ b/lib/Optimizer/Transforms/QTXToQuake.cpp
@@ -89,8 +89,8 @@ LogicalResult convertOperation(qtx::ArrayBorrowOp qtxOp) {
                                       qtxOp->getAttrDictionary());
 
   for (auto [index, wire] : llvm::zip(adaptor.getIndices(), qtxOp.getWires())) {
-    Value qref = builder.create<quake::ExtractRefOp>(adaptor.getArray(), index);
-    wire.replaceAllUsesWith(qref);
+    Value ref = builder.create<quake::ExtractRefOp>(adaptor.getArray(), index);
+    wire.replaceAllUsesWith(ref);
   }
   qtxOp.getNewArray().replaceAllUsesWith(adaptor.getArray());
   qtxOp.erase();
@@ -210,15 +210,15 @@ LogicalResult convertOperation(Operation &op) {
 //===----------------------------------------------------------------------===//
 
 /// Convert the types of the arguments. Add returns to the function for each
-/// quantum input. Currently this handles only Qrefs and not Qvecs.
+/// quantum input. Currently this handles only Refs and not Qvecs.
 void fixArgumentsAndAddReturns(qtx::CircuitOp circuitOp) {
   auto context = circuitOp->getContext();
-  auto qrefType = quake::QRefType::get(context);
+  auto refType = quake::RefType::get(context);
 
   // Iterate over the target arguments while converting types
   for (auto arg : circuitOp.getTargets()) {
     if (arg.getType().isa<qtx::WireType>()) {
-      arg.setType(qrefType);
+      arg.setType(refType);
       continue;
     }
     auto type = dyn_cast<qtx::WireArrayType>(arg.getType());

--- a/lib/Optimizer/Transforms/QuakeToQTXConverter.h
+++ b/lib/Optimizer/Transforms/QuakeToQTXConverter.h
@@ -22,7 +22,7 @@
 ///
 /// Example: Take the following Quake operation.
 /// ```
-///   quake.x [%q0] %q1 : [!quake.qref] !quake.qref
+///   quake.x [%q0] %q1 : [!quake.ref] !quake.ref
 /// ```
 ///
 /// In QTX, this operation has the form:

--- a/python/tests/compiler/1q.py
+++ b/python/tests/compiler/1q.py
@@ -41,13 +41,13 @@ def test_kernel_non_param_1q():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           quake.y %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           quake.z %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           quake.t %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           quake.s %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           quake.y %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           quake.z %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           quake.t %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           quake.s %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -79,10 +79,10 @@ def test_kernel_param_1q():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
-# CHECK:           quake.ry (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
-# CHECK:           quake.rz (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
+# CHECK:           quake.ry (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
+# CHECK:           quake.rz (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/adjoint.py
+++ b/python/tests/compiler/adjoint.py
@@ -37,8 +37,8 @@ def test_kernel_adjoint_no_args():
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -57,14 +57,14 @@ def test_kernel_adjoint_qubit_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK-SAME:      %[[VAL_0:.*]]: !quake.ref) {
+# CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -99,8 +99,8 @@ def test_kernel_adjoint_qreg_args():
 # CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
-# CHECK:             quake.h %[[VAL_9]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             quake.h %[[VAL_9]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_10:.*]]: index):
@@ -135,9 +135,9 @@ def test_kernel_adjoint_float_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.x %[[VAL_1]] : (!quake.qref) -> ()
-# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -168,8 +168,8 @@ def test_kernel_adjoint_int_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.x %[[VAL_1]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -197,10 +197,10 @@ def test_kernel_adjoint_list_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
-# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -233,17 +233,17 @@ def test_sample_adjoint_qubit():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
-# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
+# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK-SAME:      %[[VAL_0:.*]]: !quake.ref) {
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -288,8 +288,8 @@ def test_sample_adjoint_qreg():
 # CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
-# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.qvec<?>, index) -> !quake.qref
-# CHECK:             quake.x %[[VAL_10]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             quake.x %[[VAL_10]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_9]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_11:.*]]: index):
@@ -304,8 +304,8 @@ def test_sample_adjoint_qreg():
 # CHECK:             cc.condition %[[VAL_16]](%[[VAL_15]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_17:.*]]: index):
-# CHECK:             %[[VAL_18:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_17]]] : (!quake.qvec<?>, index) -> !quake.qref
-# CHECK:             %[[VAL_19:.*]] = quake.mz %[[VAL_18]] : (!quake.qref) -> i1
+# CHECK:             %[[VAL_18:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_17]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             %[[VAL_19:.*]] = quake.mz %[[VAL_18]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_20:.*]] = arith.index_cast %[[VAL_17]] : index to i64
 # CHECK:             %[[VAL_21:.*]] = llvm.getelementptr %[[VAL_13]]{{\[}}%[[VAL_20]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_19]], %[[VAL_21]] : !llvm.ptr<i1>
@@ -329,8 +329,8 @@ def test_sample_adjoint_qreg():
 # CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
-# CHECK:             quake.x %[[VAL_9]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             quake.x %[[VAL_9]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_10:.*]]: index):

--- a/python/tests/compiler/call.py
+++ b/python/tests/compiler/call.py
@@ -35,8 +35,8 @@ def test_kernel_apply_call_no_args():
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -56,14 +56,14 @@ def test_kernel_apply_call_qubit_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.ref) {
+# CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -100,8 +100,8 @@ def test_kernel_apply_call_qreg_args():
 # CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
-# CHECK:             quake.h %[[VAL_9]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             quake.h %[[VAL_9]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_10:.*]]: index):
@@ -134,8 +134,8 @@ def test_kernel_apply_call_float_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -164,7 +164,7 @@ def test_kernel_apply_call_int_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           return
 # CHECK:         }
 
@@ -191,7 +191,7 @@ def test_kernel_apply_call_list_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64,

--- a/python/tests/compiler/conditional.py
+++ b/python/tests/compiler/conditional.py
@@ -52,21 +52,21 @@ def test_kernel_conditional():
 # CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qvec<2>
-# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.qvec<2>, i32) -> !quake.qref
-# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_3]]] : (!quake.qvec<2>, i32) -> !quake.qref
-# CHECK:           quake.x %[[VAL_6]] : (!quake.qref) -> ()
-# CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.qref) -> i1 {registerName = "measurement_"}
+# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_3]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
+# CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> i1 {registerName = "measurement_"}
 # CHECK:           cc.if(%[[VAL_8]]) {
-# CHECK:             quake.x %[[VAL_7]] : (!quake.qref) -> ()
-# CHECK:             %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:             quake.x %[[VAL_7]] : (!quake.ref) -> ()
+# CHECK:             %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           }
 # CHECK:           %[[VAL_10:.*]] = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_13:.*]]: index):
-# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_13]]] : (!quake.qvec<2>, index) -> !quake.qref
-# CHECK:             quake.x %[[VAL_14]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_13]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             quake.x %[[VAL_14]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_13]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_15:.*]]: index):
@@ -74,8 +74,8 @@ def test_kernel_conditional():
 # CHECK:             cc.continue %[[VAL_16]] : index
 # CHECK:           } {counted}
 # CHECK:           cc.if(%[[VAL_8]]) {
-# CHECK:             quake.x %[[VAL_7]] : (!quake.qref) -> ()
-# CHECK:             %[[VAL_17:.*]] = quake.mz %[[VAL_7]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:             quake.x %[[VAL_7]] : (!quake.ref) -> ()
+# CHECK:             %[[VAL_17:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           }
 # CHECK:           return
 # CHECK:         }
@@ -113,11 +113,11 @@ def test_kernel_conditional_with_sample():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           cc.if(%[[VAL_1]]) {
-# CHECK:             quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:             quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -37,14 +37,14 @@ def test_kernel_control_no_args(qubit_count):
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -64,8 +64,8 @@ def test_kernel_control_no_args(qubit_count):
 # CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_7:.*]]: index):
-# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, index) -> !quake.qref
-# CHECK:             quake.x %[[VAL_8]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, index) -> !quake.ref
+# CHECK:             quake.x %[[VAL_8]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_7]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
@@ -98,15 +98,15 @@ def test_kernel_control_float_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, f64) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, f64) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -119,8 +119,8 @@ def test_kernel_control_float_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -146,14 +146,14 @@ def test_kernel_control_int_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, i32) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, i32) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           return
 # CHECK:         }
 
@@ -193,17 +193,17 @@ def test_kernel_control_list_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, !cc.stdvec<f64>) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !cc.stdvec<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
-# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -216,10 +216,10 @@ def test_kernel_control_list_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
-# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.qref) -> ()
+# CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -261,19 +261,19 @@ def test_sample_control_qubit_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
-# CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, !quake.qref) -> ()
-# CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
+# CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK-SAME:      %[[VAL_0:.*]]: !quake.ref) {
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -322,19 +322,19 @@ def test_sample_control_qreg_args():
 # CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 # CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qvec<2>
-# CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.qref
-# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.qvec<2>, i32) -> !quake.qref
-# CHECK:           quake.x %[[VAL_7]] : (!quake.qref) -> ()
-# CHECK:           quake.x %[[VAL_6]] : (!quake.qref) -> ()
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]]] %[[VAL_6]] : (!quake.qvec<2>, !quake.qref) -> ()
+# CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.ref
+# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
+# CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]]] %[[VAL_6]] : (!quake.qvec<2>, !quake.ref) -> ()
 # CHECK:           %[[VAL_8:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
 # CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_12:.*]]: index):
-# CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!quake.qvec<2>, index) -> !quake.qref
-# CHECK:             %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.qref) -> i1
+# CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_15:.*]] = arith.index_cast %[[VAL_12]] : index to i64
 # CHECK:             %[[VAL_16:.*]] = llvm.getelementptr %[[VAL_8]]{{\[}}%[[VAL_15]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_14]], %[[VAL_16]] : !llvm.ptr<i1>
@@ -344,13 +344,13 @@ def test_sample_control_qreg_args():
 # CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_2]] : index
 # CHECK:             cc.continue %[[VAL_18]] : index
 # CHECK:           } {counted}
-# CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_6]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK-SAME:      %[[VAL_0:.*]]: !quake.ref) {
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -394,25 +394,25 @@ def test_sample_apply_call_control():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
-# CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qref, !quake.qref) -> ()
-# CHECK:           quake.h %[[VAL_1]] : (!quake.qref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
+# CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.x %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK-SAME:      %[[VAL_0:.*]]: !quake.ref) {
+# CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-# CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
+# CHECK-SAME:      %[[VAL_0:.*]]: !quake.ref) {
+# CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/measure.py
+++ b/python/tests/compiler/measure.py
@@ -41,14 +41,14 @@ def test_kernel_measure_1q():
 # CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-# CHECK:           %[[VAL_5:.*]] = quake.mx %[[VAL_3]] : (!quake.qref) -> i1 {registerName = ""}
-# CHECK:           %[[VAL_6:.*]] = quake.mx %[[VAL_4]] : (!quake.qref) -> i1 {registerName = ""}
-# CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] : (!quake.qref) -> i1 {registerName = ""}
-# CHECK:           %[[VAL_8:.*]] = quake.my %[[VAL_4]] : (!quake.qref) -> i1 {registerName = ""}
-# CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_3]] : (!quake.qref) -> i1 {registerName = ""}
-# CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_4]] : (!quake.qref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_5:.*]] = quake.mx %[[VAL_3]] : (!quake.ref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_6:.*]] = quake.mx %[[VAL_4]] : (!quake.ref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] : (!quake.ref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_8:.*]] = quake.my %[[VAL_4]] : (!quake.ref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           return
 # CHECK:         }
 
@@ -82,8 +82,8 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
-# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_9]]] : (!quake.qvec<3>, index) -> !quake.qref
-# CHECK:             %[[VAL_11:.*]] = quake.mx %[[VAL_10]] : (!quake.qref) -> i1
+# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_9]]] : (!quake.qvec<3>, index) -> !quake.ref
+# CHECK:             %[[VAL_11:.*]] = quake.mx %[[VAL_10]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_9]] : index to i64
 # CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_11]], %[[VAL_13]] : !llvm.ptr<i1>
@@ -99,8 +99,8 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_19]](%[[VAL_18]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_20:.*]]: index):
-# CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_20]]] : (!quake.qvec<3>, index) -> !quake.qref
-# CHECK:             %[[VAL_22:.*]] = quake.my %[[VAL_21]] : (!quake.qref) -> i1
+# CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_20]]] : (!quake.qvec<3>, index) -> !quake.ref
+# CHECK:             %[[VAL_22:.*]] = quake.my %[[VAL_21]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_23:.*]] = arith.index_cast %[[VAL_20]] : index to i64
 # CHECK:             %[[VAL_24:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_23]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_22]], %[[VAL_24]] : !llvm.ptr<i1>
@@ -116,8 +116,8 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_30]](%[[VAL_29]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_31:.*]]: index):
-# CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_31]]] : (!quake.qvec<3>, index) -> !quake.qref
-# CHECK:             %[[VAL_33:.*]] = quake.mz %[[VAL_32]] : (!quake.qref) -> i1
+# CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_31]]] : (!quake.qvec<3>, index) -> !quake.ref
+# CHECK:             %[[VAL_33:.*]] = quake.mz %[[VAL_32]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_34:.*]] = arith.index_cast %[[VAL_31]] : index to i64
 # CHECK:             %[[VAL_35:.*]] = llvm.getelementptr %[[VAL_27]]{{\[}}%[[VAL_34]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
 # CHECK:             llvm.store %[[VAL_33]], %[[VAL_35]] : !llvm.ptr<i1>

--- a/python/tests/compiler/multi_qubit.py
+++ b/python/tests/compiler/multi_qubit.py
@@ -47,14 +47,14 @@ def test_kernel_2q():
 # CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-# CHECK:           quake.h [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
-# CHECK:           quake.x [%[[VAL_4]]] %[[VAL_3]] : (!quake.qref, !quake.qref) -> ()
-# CHECK:           quake.y [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
-# CHECK:           quake.z [%[[VAL_4]]] %[[VAL_3]] : (!quake.qref, !quake.qref) -> ()
-# CHECK:           quake.t [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
-# CHECK:           quake.s [%[[VAL_4]]] %[[VAL_3]] : (!quake.qref, !quake.qref) -> ()
+# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           quake.h [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.x [%[[VAL_4]]] %[[VAL_3]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.y [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.z [%[[VAL_4]]] %[[VAL_3]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.t [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.s [%[[VAL_4]]] %[[VAL_3]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -89,15 +89,15 @@ def test_kernel_3q():
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<3>
-# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<3>, i32) -> !quake.qref
-# CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<3>, i32) -> !quake.qref
-# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.qvec<3>, i32) -> !quake.qref
-# CHECK:           quake.h [%[[VAL_4]], %[[VAL_5]]] %[[VAL_6]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
-# CHECK:           quake.x [%[[VAL_6]], %[[VAL_4]]] %[[VAL_5]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
-# CHECK:           quake.y [%[[VAL_5]], %[[VAL_6]]] %[[VAL_4]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
-# CHECK:           quake.z [%[[VAL_4]], %[[VAL_5]]] %[[VAL_6]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
-# CHECK:           quake.t [%[[VAL_6]], %[[VAL_4]]] %[[VAL_5]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
-# CHECK:           quake.s [%[[VAL_5]], %[[VAL_6]]] %[[VAL_4]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<3>, i32) -> !quake.ref
+# CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<3>, i32) -> !quake.ref
+# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.qvec<3>, i32) -> !quake.ref
+# CHECK:           quake.h [%[[VAL_4]], %[[VAL_5]]] %[[VAL_6]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
+# CHECK:           quake.x [%[[VAL_6]], %[[VAL_4]]] %[[VAL_5]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
+# CHECK:           quake.y [%[[VAL_5]], %[[VAL_6]]] %[[VAL_4]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
+# CHECK:           quake.z [%[[VAL_4]], %[[VAL_5]]] %[[VAL_6]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
+# CHECK:           quake.t [%[[VAL_6]], %[[VAL_4]]] %[[VAL_5]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
+# CHECK:           quake.s [%[[VAL_5]], %[[VAL_6]]] %[[VAL_4]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/qalloc.py
+++ b/python/tests/compiler/qalloc.py
@@ -29,7 +29,7 @@ def test_kernel_qalloc_empty():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK:           return
 # CHECK:         }
 
@@ -101,7 +101,7 @@ def test_kernel_qalloc_qubit():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK:           return
 # CHECK:         }
 
@@ -119,7 +119,7 @@ def test_kernel_qalloc_qubit_keyword():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/qreg_apply.py
+++ b/python/tests/compiler/qreg_apply.py
@@ -47,8 +47,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_7:.*]]: index):
-# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<2>, index) -> !quake.qref
-# CHECK:             quake.h %[[VAL_8]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             quake.h %[[VAL_8]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_7]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
@@ -60,8 +60,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_13]](%[[VAL_12]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_14:.*]]: index):
-# CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_14]]] : (!quake.qvec<2>, index) -> !quake.qref
-# CHECK:             quake.x %[[VAL_15]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_14]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             quake.x %[[VAL_15]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_14]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_16:.*]]: index):
@@ -73,8 +73,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_20]](%[[VAL_19]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_21:.*]]: index):
-# CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_21]]] : (!quake.qvec<2>, index) -> !quake.qref
-# CHECK:             quake.y %[[VAL_22]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_21]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             quake.y %[[VAL_22]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_21]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_23:.*]]: index):
@@ -86,8 +86,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_27]](%[[VAL_26]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_28:.*]]: index):
-# CHECK:             %[[VAL_29:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_28]]] : (!quake.qvec<2>, index) -> !quake.qref
-# CHECK:             quake.z %[[VAL_29]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_29:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_28]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             quake.z %[[VAL_29]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_28]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_30:.*]]: index):
@@ -99,8 +99,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_34]](%[[VAL_33]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_35:.*]]: index):
-# CHECK:             %[[VAL_36:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_35]]] : (!quake.qvec<2>, index) -> !quake.qref
-# CHECK:             quake.t %[[VAL_36]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_36:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_35]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             quake.t %[[VAL_36]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_35]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_37:.*]]: index):
@@ -112,8 +112,8 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_41]](%[[VAL_40]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_42:.*]]: index):
-# CHECK:             %[[VAL_43:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_42]]] : (!quake.qvec<2>, index) -> !quake.qref
-# CHECK:             quake.s %[[VAL_43]] : (!quake.qref) -> ()
+# CHECK:             %[[VAL_43:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_42]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             quake.s %[[VAL_43]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_42]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_44:.*]]: index):

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -510,7 +510,7 @@ void reset(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQreg) {
     auto bodyBuilder = [&](OpBuilder &builder, Location loc, Region &,
                            Block &block) {
       Value ref = builder.create<quake::ExtractRefOp>(loc, target,
-                                                       block.getArgument(0));
+                                                      block.getArgument(0));
       builder.create<quake::ResetOp>(loc, TypeRange{}, ref);
     };
     cudaq::opt::factory::createCountedLoop(builder, builder.getUnknownLoc(),

--- a/test/AST-Quake/adjoint-2.cpp
+++ b/test/AST-Quake/adjoint-2.cpp
@@ -47,7 +47,7 @@ struct kernel_delta {
 };
 
 // CHECK-LABEL:   func.func private @__nvqpp__mlirgen__kernel_gamma
-// CHECK-SAME:        .adj(%[[VAL_0:.*]]: !quake.qref) {
+// CHECK-SAME:        .adj(%[[VAL_0:.*]]: !quake.ref) {
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_1:.*]] = arith.constant 6 : i32
 // CHECK:             %[[VAL_2:.*]] = memref.alloca() : memref<i32>
@@ -97,7 +97,7 @@ struct kernel_delta {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func private @__nvqpp__mlirgen__kernel_alpha
-// CHECK-SAME:        .adj(%[[VAL_0:.*]]: !quake.qref) {
+// CHECK-SAME:        .adj(%[[VAL_0:.*]]: !quake.ref) {
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_1:.*]] = arith.constant 0 : i32
 // CHECK:             %[[VAL_2:.*]] = memref.alloca() : memref<i32>

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -121,7 +121,7 @@ struct run_circuit {
 // ADJOINT:           %[[VAL_27:.*]] = arith.constant 1 : i32
 // ADJOINT:           %[[VAL_28:.*]] = arith.subi %[[VAL_26]], %[[VAL_27]] : i32
 // ADJOINT:           %[[VAL_29:.*]] = arith.extsi %[[VAL_28]] : i32 to i64
-// ADJOINT:           %[[VAL_30:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_29]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// ADJOINT:           %[[VAL_30:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_29]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // ADJOINT:           cc.scope {
 // ADJOINT:             %[[VAL_31:.*]] = arith.constant 1 : i32
 // ADJOINT:             %[[VAL_32:.*]] = memref.alloca() : memref<i32>
@@ -161,14 +161,14 @@ struct run_circuit {
 // ADJOINT:                 %[[VAL_62:.*]] = arith.constant 1 : i32
 // ADJOINT:                 %[[VAL_63:.*]] = arith.subi %[[VAL_61]], %[[VAL_62]] : i32
 // ADJOINT:                 %[[VAL_64:.*]] = arith.extsi %[[VAL_63]] : i32 to i64
-// ADJOINT:                 %[[VAL_65:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_64]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// ADJOINT:                 %[[VAL_65:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_64]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // ADJOINT:                 %[[VAL_66:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // ADJOINT:                 %[[VAL_67:.*]] = arith.constant 1 : i32
 // ADJOINT:                 %[[VAL_68:.*]] = arith.subi %[[VAL_66]], %[[VAL_67]] : i32
 // ADJOINT:                 %[[VAL_69:.*]] = arith.extsi %[[VAL_68]] : i32 to i64
-// ADJOINT:                 %[[VAL_70:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_69]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// ADJOINT:                 %[[VAL_70:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_69]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // ADJOINT:                 %[[VAL_71:.*]] = arith.negf %[[VAL_60]] : f64
-// ADJOINT:                 quake.ry (%[[VAL_71]]) [%[[VAL_65]]] %[[VAL_70]] : (f64, !quake.qref, !quake.qref) -> ()
+// ADJOINT:                 quake.ry (%[[VAL_71]]) [%[[VAL_65]]] %[[VAL_70]] : (f64, !quake.ref, !quake.ref) -> ()
 // ADJOINT:               }
 // ADJOINT:               cc.continue %[[VAL_50]] : i32
 // ADJOINT:             } step {
@@ -183,7 +183,7 @@ struct run_circuit {
 // ADJOINT:             }
 // ADJOINT:           }
 // ADJOINT:           %[[VAL_78:.*]] = arith.negf %[[VAL_25]] : f64
-// ADJOINT:           quake.ry (%[[VAL_78]]) %[[VAL_30]] : (f64, !quake.qref) -> ()
+// ADJOINT:           quake.ry (%[[VAL_78]]) %[[VAL_30]] : (f64, !quake.ref) -> ()
 // ADJOINT:           %[[VAL_79:.*]] = arith.constant 0 : index
 // ADJOINT:           %[[VAL_80:.*]] = arith.cmpi sgt, %[[VAL_17]], %[[VAL_79]] : index
 // ADJOINT:           %[[VAL_81:.*]] = arith.select %[[VAL_80]], %[[VAL_17]], %[[VAL_79]] : index
@@ -197,8 +197,8 @@ struct run_circuit {
 // ADJOINT:             cc.condition %[[VAL_90]](%[[VAL_87]], %[[VAL_88]] : index, index)
 // ADJOINT:           } do {
 // ADJOINT:           ^bb0(%[[VAL_91:.*]]: index, %[[VAL_92:.*]]: index):
-// ADJOINT:             %[[VAL_93:.*]] = quake.extract_ref %[[VAL_13]][%[[VAL_91]]] : (!quake.qvec<?>, index) -> !quake.qref
-// ADJOINT:             quake.h %[[VAL_93]] : (!quake.qref) -> ()
+// ADJOINT:             %[[VAL_93:.*]] = quake.extract_ref %[[VAL_13]][%[[VAL_91]]] : (!quake.qvec<?>, index) -> !quake.ref
+// ADJOINT:             quake.h %[[VAL_93]] : (!quake.ref) -> ()
 // ADJOINT:             cc.continue %[[VAL_91]], %[[VAL_92]] : index, index
 // ADJOINT:           } step {
 // ADJOINT:           ^bb0(%[[VAL_94:.*]]: index, %[[VAL_95:.*]]: index):
@@ -213,6 +213,6 @@ struct run_circuit {
 
 // ADJOINT-LABEL:   func.func @__nvqpp__mlirgen__run_circuit
 // ADJOINT:               cc.scope {
-// ADJOINT:                 quake.z %{{.*}} : (!quake.qref) -> ()
+// ADJOINT:                 quake.z %{{.*}} : (!quake.ref) -> ()
 // ADJOINT:                 func.call @__nvqpp__mlirgen__statePrep_A.adj(%{{.*}}, %{{.*}}) : (!quake.qvec<?>, f64) -> ()
 // ADJOINT:                 func.call @__nvqpp__mlirgen__QernelZero{{.*}}(%{{[0-9]+}}) :

--- a/test/AST-Quake/bool_literal.cpp
+++ b/test/AST-Quake/bool_literal.cpp
@@ -11,7 +11,7 @@
 
 #include <cudaq.h>
 
-// CHECK: quake.h %[[VAL_0:.*]] : (!quake.qref) -> ()
+// CHECK: quake.h %[[VAL_0:.*]] : (!quake.ref) -> ()
 // CHECK: %false = arith.constant false
 // CHECK: %[[VAL_1:.*]] = memref.alloca() : memref<i1>
 // CHECK: memref.store %false, %[[VAL_1]][] : memref<i1>

--- a/test/AST-Quake/callable-1.cpp
+++ b/test/AST-Quake/callable-1.cpp
@@ -32,15 +32,15 @@ int main() {
 // CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
-// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
-// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_5]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_5]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:           %[[VAL_7:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_8:.*]] = arith.extsi %[[VAL_7]] : i32 to i64
-// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           quake.x [%[[VAL_6]]] %[[VAL_9]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_6]]] %[[VAL_9]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/callable-2.cpp
+++ b/test/AST-Quake/callable-2.cpp
@@ -37,18 +37,18 @@ struct test5_caller {
 };
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__test5_callee
-// CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
+// CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
 // CHECK-SAME:   %[[VAL_1:.*]]: !quake.qvec<?>)
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %
-// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %
-// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           %[[VAL_10:.*]] = quake.extract_ref %
-// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_10]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_10]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           return
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__test5_callable
-// CHECK-SAME:   (%[[VAL_0:.*]]: !quake.qref)
+// CHECK-SAME:   (%[[VAL_0:.*]]: !quake.ref)
 // CHECK:           quake.h %[[VAL_0]]
 // CHECK:           quake.x %[[VAL_0]]
 // CHECK:           quake.z %[[VAL_0]]
@@ -56,34 +56,34 @@ struct test5_caller {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test5_caller
 // CHECK-SAME: () attributes
 // CHECK:           %[[VAL_5:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_6:.*]]: !quake.qref):
-// CHECK:             func.call @__nvqpp__mlirgen__test5_callable{{.*}}(%[[VAL_6]]) : (!quake.qref) -> ()
-// CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__test5_callee{{.*}}(%[[VAL_5]], %{{.*}}) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           ^bb0(%[[VAL_6:.*]]: !quake.ref):
+// CHECK:             func.call @__nvqpp__mlirgen__test5_callable{{.*}}(%[[VAL_6]]) : (!quake.ref) -> ()
+// CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
+// CHECK:           call @__nvqpp__mlirgen__test5_callee{{.*}}(%[[VAL_5]], %{{.*}}) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
 
 // LIFT-LABEL:   func.func @__nvqpp__mlirgen__test5_callee
-// LIFT:           %[[VAL_6:.*]] = cc.callable_func %{{.*}} : (!cc.lambda<(!quake.qref) -> ()>) -> ((!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ())
-// LIFT:           call_indirect %[[VAL_6]](%{{.*}}, %{{.*}}) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
-// LIFT:           %[[VAL_8:.*]] = cc.callable_func %{{.*}} : (!cc.lambda<(!quake.qref) -> ()>) -> ((!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ())
-// LIFT:           call_indirect %[[VAL_8]](%{{.*}}, %{{.*}}) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
-// LIFT:           %[[VAL_10:.*]] = cc.callable_func %{{.*}} : (!cc.lambda<(!quake.qref) -> ()>) -> ((!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ())
-// LIFT:           call_indirect %[[VAL_10]](%{{.*}}, %{{.*}}) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+// LIFT:           %[[VAL_6:.*]] = cc.callable_func %{{.*}} : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())
+// LIFT:           call_indirect %[[VAL_6]](%{{.*}}, %{{.*}}) : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
+// LIFT:           %[[VAL_8:.*]] = cc.callable_func %{{.*}} : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())
+// LIFT:           call_indirect %[[VAL_8]](%{{.*}}, %{{.*}}) : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
+// LIFT:           %[[VAL_10:.*]] = cc.callable_func %{{.*}} : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())
+// LIFT:           call_indirect %[[VAL_10]](%{{.*}}, %{{.*}}) : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // LIFT:           return
 
 // LIFT-LABEL:   func.func @__nvqpp__mlirgen__test5_caller
-// LIFT:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0() : () -> !cc.lambda<(!quake.qref) -> ()>
+// LIFT:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0() : () -> !cc.lambda<(!quake.ref) -> ()>
 // LIFT:           call @__nvqpp__mlirgen__test5_callee{{.*}}(%[[VAL_2]], %
 // LIFT:           return
 
 // LIFT-LABEL:   func.func private @__nvqpp__callable.thunk.lambda.0
-// LIFT-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
-// LIFT-SAME:        %[[VAL_1:.*]]: !quake.qref) {
-// LIFT: call @__nvqpp__lifted.lambda.0(%[[VAL_1]]) : (!quake.qref) -> ()
+// LIFT-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
+// LIFT-SAME:        %[[VAL_1:.*]]: !quake.ref) {
+// LIFT: call @__nvqpp__lifted.lambda.0(%[[VAL_1]]) : (!quake.ref) -> ()
 // LIFT: return
 // LIFT: }
 
 // LIFT-LABEL: func.func private @__nvqpp__lifted.lambda.0
-// LIFT-SAME:   (%[[VAL_0:.*]]: !quake.qref) {
-// LIFT: call @__nvqpp__mlirgen__test5_callable{{.*}}(%[[VAL_0]]) : (!quake.qref) -> ()
+// LIFT-SAME:   (%[[VAL_0:.*]]: !quake.ref) {
+// LIFT: call @__nvqpp__mlirgen__test5_callable{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
 // LIFT: return
 // LIFT: }

--- a/test/AST-Quake/compute_action-2.cpp
+++ b/test/AST-Quake/compute_action-2.cpp
@@ -40,7 +40,7 @@ struct ctrlHeisenberg {
 // CHECK:                 cc.scope {
 // CHECK:                   cc.loop while {
 // CHECK:                   } do {
-// CHECK:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.qref) -> ()
+// CHECK:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.ref) -> ()
 // CHECK:                   } step {
 // CHECK:                   }
 // CHECK:                 }
@@ -48,10 +48,10 @@ struct ctrlHeisenberg {
 // CHECK:                   cc.loop while {
 // CHECK:                   } do {
 // CHECK:                     %[[VAL_28:.*]] = cc.create_lambda {
-// CHECK:                       quake.x [%{{.*}}] %{{.*}} : (!quake.qref, !quake.qref) -> ()
+// CHECK:                       quake.x [%{{.*}}] %{{.*}} : (!quake.ref, !quake.ref) -> ()
 // CHECK:                     } : !cc.lambda<() -> ()>
 // CHECK:                     %[[VAL_36:.*]] = cc.create_lambda {
-// CHECK:                       quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.qref) -> ()
+// CHECK:                       quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.ref) -> ()
 // CHECK:                     } : !cc.lambda<() -> ()>
 // CHECK:                     quake.compute_action %[[VAL_28]], %[[VAL_36]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
 // CHECK:                     cc.continue
@@ -69,11 +69,11 @@ struct ctrlHeisenberg {
 // CHECK-SAME:        %[[VAL_0:.*]]: i32)
 // CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
-// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_1]][] : memref<i32>
 // CHECK:           %[[VAL_4:.*]] = arith.extsi %[[VAL_3]] : i32 to i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca[%[[VAL_4]] : i64] !quake.qvec<?>
-// CHECK:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.qref) -> !quake.qvec<?>
+// CHECK:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.ref) -> !quake.qvec<?>
 // CHECK:           call @__nvqpp__mlirgen__function_magic_func.{{.*}}.ctrl(%[[VAL_6]], %[[VAL_5]]) : (!quake.qvec<?>, !quake.qvec<?>) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -82,12 +82,12 @@ struct ctrlHeisenberg {
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__lifted.lambda.0.adj(
 // LAMBDA-SAME:      %{{[^:]*}}: memref<i32>, %{{[^:]*}}: !quake.qvec<?>) {
-// LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.qref, !quake.qref) -> ()
+// LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.ref, !quake.ref) -> ()
 // LAMBDA:           return
 
 // LAMBDA2-LABEL:   func.func private @__nvqpp__lifted.lambda.1.ctrl(
 // LAMBDA2-SAME:      %[[VAL_0:.*]]: !quake.qvec<?>, %{{.*}}: memref<i32>, %{{.*}}: !quake.qvec<?>) {
-// LAMBDA2:           quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.qref) -> ()
+// LAMBDA2:           quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.ref) -> ()
 // LAMBDA2:           return
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__mlirgen__function_magic_func.
@@ -99,7 +99,7 @@ struct ctrlHeisenberg {
 // LAMBDA:                 cc.scope {
 // LAMBDA:                   cc.loop while {
 // LAMBDA:                   } do {
-// LAMBDA:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.qref) -> ()
+// LAMBDA:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.ref) -> ()
 // LAMBDA:                     cc.continue
 // LAMBDA:                   } step {
 // LAMBDA:                   }
@@ -123,15 +123,15 @@ struct ctrlHeisenberg {
 
 // LAMBDA-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenberg(
 // LAMBDA-SAME:      %{{.*}}: i32)
-// LAMBDA:           %[[VAL_2:.*]] = quake.alloca !quake.qref
-// LAMBDA:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.qref) -> !quake.qvec<?>
+// LAMBDA:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// LAMBDA:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.ref) -> !quake.qvec<?>
 // LAMBDA:           call @__nvqpp__mlirgen__function_magic_func.{{.*}}.ctrl(%[[VAL_6]], %{{.*}}) : (!quake.qvec<?>, !quake.qvec<?>) -> ()
 // LAMBDA:           return
 // LAMBDA:         }
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__lifted.lambda.0(
 // LAMBDA-SAME:      %[[VAL_0:.*]]: memref<i32>, %[[VAL_1:.*]]: !quake.qvec<?>) {
-// LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.qref, !quake.qref) -> ()
+// LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.ref, !quake.ref) -> ()
 // LAMBDA:           return
 // LAMBDA:         }
 

--- a/test/AST-Quake/control.cpp
+++ b/test/AST-Quake/control.cpp
@@ -36,9 +36,9 @@ struct ctrlHeisenberg {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenberg(
 // CHECK-SAME:        %{{.*}}: i32) attributes
-// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
-// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qref
-// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_2]], %[[VAL_3]] : (!quake.qref, !quake.qref) -> !quake.qvec<2>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.ref) -> !quake.qvec<2>
 // CHECK:           quake.apply @__nvqpp__mlirgen__heisenbergU[%[[VAL_8]]] %{{.*}} : (!quake.qvec<2>, !quake.qvec<?>) -> ()
 // CHECK:           return
 
@@ -67,8 +67,8 @@ __qpu__ void qnppx(double theta, cudaq::qubit &q, cudaq::qubit &r,
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__givens(
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qnppx
-// CHECK:           %[[VAL_7:.*]] = quake.concat %{{.*}}, %{{.*}} : (!quake.qref, !quake.qref) -> !quake.qvec<2>
-// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %{{.*}}, %{{.*}} : (!quake.qvec<2>, f64, !quake.qref, !quake.qref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.concat %{{.*}}, %{{.*}} : (!quake.ref, !quake.ref) -> !quake.qvec<2>
+// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %{{.*}}, %{{.*}} : (!quake.qvec<2>, f64, !quake.ref, !quake.ref) -> ()
 // CHECK:           return
 
 __qpu__ void magic_func(cudaq::qreg<> &q) {
@@ -95,7 +95,7 @@ struct ctrlHeisenbergVersion2 {
 // CHECK-SAME:      ._Z[[mangle:[^(]*]](
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenbergVersion2(
-// CHECK:           quake.apply @__nvqpp__mlirgen__function_magic_func._Z[[mangle]]{{\[}}%{{.*}}] %{{.*}} : (!quake.qref, !quake.qvec<?>) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__function_magic_func._Z[[mangle]]{{\[}}%{{.*}}] %{{.*}} : (!quake.ref, !quake.qvec<?>) -> ()
 // CHECK:           return
 
 __qpu__ void qnppx2(double theta, cudaq::qubit &q, cudaq::qubit &r,
@@ -108,11 +108,11 @@ __qpu__ void qnppx2(double theta, cudaq::qubit &q, cudaq::qubit &r,
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qnppx2
-// CHECK-SAME:       %{{[^:]*}}: f64, %[[VAL_1:.*]]: !quake.qref, %[[VAL_2:.*]]: !quake.qref, %[[VAL_3:.*]]: !quake.qref, %[[VAL_4:.*]]: !quake.qref)
-// CHECK:           %[[VAL_7:.*]] = quake.concat %[[VAL_1]], %[[VAL_4]] : (!quake.qref, !quake.qref) -> !quake.qvec<2>
+// CHECK-SAME:       %{{[^:]*}}: f64, %[[VAL_1:.*]]: !quake.ref, %[[VAL_2:.*]]: !quake.ref, %[[VAL_3:.*]]: !quake.ref, %[[VAL_4:.*]]: !quake.ref)
+// CHECK:           %[[VAL_7:.*]] = quake.concat %[[VAL_1]], %[[VAL_4]] : (!quake.ref, !quake.ref) -> !quake.qvec<2>
 // CHECK:           quake.x %[[VAL_4]]
-// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %[[VAL_2]], %[[VAL_3]] : (!quake.qvec<2>, f64, !quake.qref, !quake.qref) -> ()
-// CHECK:           quake.x %[[VAL_4]] : (!quake.qref) -> ()
-// CHECK:           quake.x [%[[VAL_2]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
-// CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %[[VAL_2]], %[[VAL_3]] : (!quake.qvec<2>, f64, !quake.ref, !quake.ref) -> ()
+// CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
+// CHECK:           quake.x [%[[VAL_2]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -138,21 +138,21 @@ struct F {
 // CHECK:             %[[VAL_13:.*]] = func.call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
-// CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.qref
-// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.qref, !quake.qref) -> ()
-// CHECK:             quake.dealloc %[[VAL_14]] : !quake.qref
+// CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.ref
+// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:             quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:             cf.br ^bb8
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.qref,
+// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref,
 // CHECK:             func.call @_Z2g2v() : () -> ()
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:             quake.y %[[VAL_20]] :
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb6:
@@ -162,8 +162,8 @@ struct F {
 // CHECK:               cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:             } do {
 // CHECK:             ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.qref
-// CHECK:               quake.z %[[VAL_25]] : (!quake.qref) -> ()
+// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:               quake.z %[[VAL_25]] : (!quake.ref) -> ()
 // CHECK:               cc.continue %[[VAL_24]] : index
 // CHECK:             } step {
 // CHECK:             ^bb0(%[[VAL_26:.*]]: index):
@@ -208,21 +208,21 @@ struct F {
 // CHECK:             %[[VAL_13:.*]] = func.call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
-// CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.qref
-// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.ref
+// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] :
-// CHECK:             quake.dealloc %[[VAL_14]] : !quake.qref
+// CHECK:             quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:             func.call @_Z2g2v() : () -> ()
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:             quake.y %[[VAL_20]]
 // CHECK:             cf.br ^bb8
 // CHECK:           ^bb6:
@@ -232,8 +232,8 @@ struct F {
 // CHECK:               cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:             } do {
 // CHECK:             ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.qref
-// CHECK:               quake.z %[[VAL_25]] : (!quake.qref) -> ()
+// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:               quake.z %[[VAL_25]] : (!quake.ref) -> ()
 // CHECK:               cc.continue %[[VAL_24]] : index
 // CHECK:             } step {
 // CHECK:             ^bb0(%[[VAL_26:.*]]: index):
@@ -277,21 +277,21 @@ struct F {
 // CHECK:           %[[VAL_13:.*]] = call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.qref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.qref, !quake.qref)
-// CHECK:           quake.dealloc %[[VAL_14]] : !quake.qref
+// CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref)
+// CHECK:           quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:           cf.br ^bb8
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           call @_Z2g2v() : () -> ()
 // CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:           quake.y %[[VAL_20]]
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb6:
@@ -301,7 +301,7 @@ struct F {
 // CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.qref
+// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.ref
 // CHECK:             quake.z %[[VAL_25]]
 // CHECK:             cc.continue %[[VAL_24]] : index
 // CHECK:           } step {
@@ -345,22 +345,22 @@ struct F {
 // CHECK:           %[[VAL_13:.*]] = call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.qref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]]
-// CHECK:           quake.dealloc %[[VAL_14]] : !quake.qref
+// CHECK:           quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]]
 // CHECK:           call @_Z2g2v() : () -> ()
 // CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           quake.y %[[VAL_20]] : (!quake.qref)
+// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           quake.y %[[VAL_20]] : (!quake.ref)
 // CHECK:           cf.br ^bb9
 // CHECK:         ^bb6:
 // CHECK:           call @_Z2g3v() : () -> ()
@@ -369,7 +369,7 @@ struct F {
 // CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.qref
+// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.ref
 // CHECK:             quake.z %[[VAL_25]]
 // CHECK:             cc.continue %[[VAL_24]] : index
 // CHECK:           } step {

--- a/test/AST-Quake/ctor.cpp
+++ b/test/AST-Quake/ctor.cpp
@@ -14,9 +14,9 @@
 using namespace cudaq;
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Teste
-// CHECK-SAME: (%[[VAL_0:.*]]: !quake.qref)
-// CHECK:           quake.h %[[VAL_0]] : (!quake.qref) -> ()
-// CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.qref) -> i1
+// CHECK-SAME: (%[[VAL_0:.*]]: !quake.ref)
+// CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1
 // CHECK:           return
 // CHECK:         }
 
@@ -29,8 +29,8 @@ struct Teste {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Test
 // CHECK-SAME: ()
-// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
-// CHECK:           call @__nvqpp__mlirgen__Teste{{.*}}(%[[VAL_2]]) : (!quake.qref) -> ()
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK:           call @__nvqpp__mlirgen__Teste{{.*}}(%[[VAL_2]]) : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/ctrl_vector.cpp
+++ b/test/AST-Quake/ctrl_vector.cpp
@@ -30,10 +30,10 @@ struct lower_ctrl_as_qreg {
 // CHECK:  %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK:  %[[VAL_5:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:  %[[VAL_6:.*]] = arith.constant 0 : i32
-// CHECK:  %[[VAL_8:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:  quake.h [%[[VAL_2]]] %[[VAL_8]] : (!quake.qvec<?>, !quake.qref) -> ()
+// CHECK:  %[[VAL_8:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:  quake.h [%[[VAL_2]]] %[[VAL_8]] : (!quake.qvec<?>, !quake.ref) -> ()
 // CHECK:  %[[VAL_9:.*]] = arith.constant 1 : i32
-// CHECK:  %[[VAL_11:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:  %[[VAL_11:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:  quake.x [%[[VAL_2]]] %[[VAL_11]] : (
 // clang-format on
 
@@ -53,17 +53,17 @@ struct test_two_control_call {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test_two
 // CHECK-SAME: () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_1:.*]]: !quake.qref):
+// CHECK:           ^bb0(%[[VAL_1:.*]]: !quake.ref):
 // CHECK:             cc.scope {
 // CHECK:               quake.h %[[VAL_1]]
 // CHECK:               quake.x %[[VAL_1]]
 // CHECK:             }
-// CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
+// CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 4 : i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca[%[[VAL_4]] : i64] !quake.qvec<4>
-// CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.qref
-// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test_two_control_call{{.*}}[%[[VAL_5]]] %[[VAL_6]] : (!quake.qvec<4>, !quake.qref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_6]] : (!quake.qref) -> i1
+// CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test_two_control_call{{.*}}[%[[VAL_5]]] %[[VAL_6]] : (!quake.qvec<4>, !quake.ref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> i1
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/empty_step.cpp
+++ b/test/AST-Quake/empty_step.cpp
@@ -41,16 +41,16 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:                 %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:                 %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
-// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_19:.*]] = arith.subi %[[VAL_17]], %[[VAL_18]] : i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_21:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_22:.*]] = arith.extui %[[VAL_21]] : i32 to i64
-// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_22]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:                 func.call @__nvqpp__mlirgen__function_uma._Z3umaRN5cudaq5quditILm2EEES2_S2_(%[[VAL_15]], %[[VAL_20]], %[[VAL_23]]) : (!quake.qref, !quake.qref, !quake.qref) -> ()
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_22]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 func.call @__nvqpp__mlirgen__function_uma._Z3umaRN5cudaq5quditILm2EEES2_S2_(%[[VAL_15]], %[[VAL_20]], %[[VAL_23]]) : (!quake.ref, !quake.ref, !quake.ref) -> ()
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {

--- a/test/AST-Quake/if.cpp
+++ b/test/AST-Quake/if.cpp
@@ -34,10 +34,10 @@ struct kernel {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_9:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
-// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               quake.h [%[[VAL_8]]] %[[VAL_11]] :
 // CHECK:             }
 // CHECK:           }
@@ -69,20 +69,20 @@ struct kernel_else {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_9:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
-// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               quake.h [%[[VAL_8]]] %[[VAL_11]] :
 // CHECK:             }
 // CHECK:           } else {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_12:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               quake.x [%[[VAL_14]]] %[[VAL_17]] :
 // CHECK:             }
 // CHECK:           }

--- a/test/AST-Quake/lambda_instance.cpp
+++ b/test/AST-Quake/lambda_instance.cpp
@@ -24,16 +24,16 @@ struct test0 {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test0
 // CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
-// CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           %[[VAL_12:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test0{{.*}}[%[[VAL_12]]] %[[VAL_15]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
+// CHECK:           %[[VAL_12:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test0{{.*}}[%[[VAL_12]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        5test0
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref)
 // CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return
 // CHECK:         }
@@ -49,16 +49,16 @@ struct test1 {
 // CHECK-SAME:        () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_3:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<2>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
-// CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}5test1{{.*}}[%[[VAL_13]]] %[[VAL_16]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
+// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}5test1{{.*}}[%[[VAL_13]]] %[[VAL_16]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        5test1
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref)
 // CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return
 // CHECK:         }
@@ -86,24 +86,24 @@ struct test2b {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test2b
 // CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
-// CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__instance_test2a{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
+// CHECK:           call @__nvqpp__mlirgen__instance_test2a{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
 // CHECK:           return
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test2a
-// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
+// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           call @__nvqpp__mlirgen__{{.*}}test2b{{.*}}(%[[VAL_4]]) : (!quake.qref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           call @__nvqpp__mlirgen__{{.*}}test2b{{.*}}(%[[VAL_7]]) : (!quake.qref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           call @__nvqpp__mlirgen__{{.*}}test2b{{.*}}(%[[VAL_4]]) : (!quake.ref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           call @__nvqpp__mlirgen__{{.*}}test2b{{.*}}(%[[VAL_7]]) : (!quake.ref) -> ()
 // CHECK:           return
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        6test2b
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref)
 // CHECK:           quake.h %[[VAL_0]] :
-// CHECK:           quake.y %[[VAL_0]] : (!quake.qref) -> ()
+// CHECK:           quake.y %[[VAL_0]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -132,23 +132,23 @@ struct test2c {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test2c
 // CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
-// CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__instance_test2a_c{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
+// CHECK:           call @__nvqpp__mlirgen__instance_test2a_c{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
 // CHECK:           return
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test2a_c
-// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
+// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           call @__nvqpp__mlirgen__{{.*}}test2c{{.*}}(%[[VAL_4]]) : (!quake.qref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           call @__nvqpp__mlirgen__{{.*}}test2c{{.*}}(%[[VAL_7]]) : (!quake.qref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           call @__nvqpp__mlirgen__{{.*}}test2c{{.*}}(%[[VAL_4]]) : (!quake.ref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           call @__nvqpp__mlirgen__{{.*}}test2c{{.*}}(%[[VAL_7]]) : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        6test2c
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref)
 // CHECK:           quake.h %[[VAL_0]]
 // CHECK:           quake.z %[[VAL_0]]
 // CHECK:           quake.h %[[VAL_0]]
@@ -176,16 +176,16 @@ struct test3 {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3a
-// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
+// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_6]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_6]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -195,14 +195,14 @@ struct test3 {
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
 // CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_4:.*]]: !quake.qref):
+// CHECK:           ^bb0(%[[VAL_4:.*]]: !quake.ref):
 // CHECK:             cc.scope {
 // CHECK:               quake.h %[[VAL_4]]
 // CHECK:               quake.z %[[VAL_4]]
 // CHECK:               quake.h %[[VAL_4]]
 // CHECK:             }
-// CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__test3a{{.*}}(%[[VAL_6:.*]], %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
+// CHECK:           call @__nvqpp__mlirgen__test3a{{.*}}(%[[VAL_6:.*]], %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/lambda_variable.cpp
+++ b/test/AST-Quake/lambda_variable.cpp
@@ -35,12 +35,12 @@ struct test3_caller {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_callee
-// CHECK-SAME:     (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
+// CHECK-SAME:     (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
 // CHECK-SAME:      %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -48,13 +48,13 @@ struct test3_caller {
 // CHECK-SAME: () attributes {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.qref):
+// CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.ref):
 // CHECK:             cc.scope {
 // CHECK:               quake.h %[[VAL_5]]
 // CHECK:               quake.y %[[VAL_5]]
 // CHECK:             }
-// CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__test3_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
+// CHECK:           call @__nvqpp__mlirgen__test3_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -87,32 +87,32 @@ struct test4_caller {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = cc.undef !llvm.struct<"test4_callee", ()>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.qref):
+// CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.ref):
 // CHECK:             cc.scope {
 // CHECK:               quake.h %[[VAL_5]] :
-// CHECK:               quake.x %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:               quake.x %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:             }
-// CHECK:           } : !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__instance_test4_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
+// CHECK:           call @__nvqpp__mlirgen__instance_test4_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__instance_test4_callee
-// CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
+// CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
 // CHECK-SAME:    %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           call @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(%[[VAL_4]]) : (!quake.qref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           call @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(%[[VAL_4]]) : (!quake.ref) -> ()
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_6]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           call @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(%[[VAL_7]]) : (!quake.qref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_6]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           call @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(%[[VAL_7]]) : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(
-// CHECK-SAME:                                                                                          %[[VAL_0:.*]]: !quake.qref) attributes {"cudaq-kernel"} {
+// CHECK-SAME:                                                                                          %[[VAL_0:.*]]: !quake.ref) attributes {"cudaq-kernel"} {
 // CHECK:           quake.h %[[VAL_0]] :
 // CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return

--- a/test/AST-Quake/loop_unroll.cpp
+++ b/test/AST-Quake/loop_unroll.cpp
@@ -23,11 +23,11 @@ struct C {
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
 // CHECK-DAG:       %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x i1 : (i64) -> !llvm.ptr<i1>
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<2>, index) -> !quake.qref
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.qref) -> i1
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
 // CHECK:           llvm.store %[[VAL_6]], %[[VAL_4]] : !llvm.ptr<i1>
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<2>, index) -> !quake.qref
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.qref) -> i1
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
 // CHECK:           %[[VAL_9:.*]] = llvm.getelementptr %[[VAL_4]][1] : (!llvm.ptr<i1>) -> !llvm.ptr<i1>
 // CHECK:           llvm.store %[[VAL_8]], %[[VAL_9]] : !llvm.ptr<i1>
 // CHECK:           return

--- a/test/AST-Quake/measure_bell.cpp
+++ b/test/AST-Quake/measure_bell.cpp
@@ -51,15 +51,15 @@ int main() { bell{}(100); }
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_12:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 quake.h %[[VAL_14]] :
 // CHECK:                 %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:                 quake.x [%[[VAL_17]]] %[[VAL_20]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 quake.x [%[[VAL_17]]] %[[VAL_20]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
@@ -152,14 +152,14 @@ struct tinkerbell {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_12:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 quake.h %[[VAL_14]] :
 // CHECK:                 %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 quake.x [%[[VAL_17]]] %[[VAL_20]] : (
 // CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
@@ -216,14 +216,14 @@ struct tinkerbell {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_12:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 quake.h %[[VAL_14]]
 // CHECK:                 %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 quake.x {{\[}}%[[VAL_17]]] %[[VAL_20]] :
 // CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32

--- a/test/AST-Quake/mz.cpp
+++ b/test/AST-Quake/mz.cpp
@@ -38,15 +38,15 @@ struct VectorOfStaticVeq {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorOfStaticVeq() -> !cc.stdvec<i1> attributes {
-// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_1:.*]] = arith.constant 4 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
 // CHECK:           %[[VAL_6:.*]] = quake.alloca[%[[VAL_5]] : i64] !quake.qvec<?>
-// CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.qref
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.ref, !quake.qvec<?>, !quake.qvec<?>, !quake.ref) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = cc.stdvec_size %[[VAL_8]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_11:.*]] = arith.constant 1 : i64
@@ -71,15 +71,15 @@ struct VectorOfDynamicVeq {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_2]][] : memref<i32>
 // CHECK:           %[[VAL_3:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_1]], %[[VAL_3]][] : memref<i32>
-// CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_2]][] : memref<i32>
 // CHECK:           %[[VAL_6:.*]] = arith.extui %[[VAL_5]] : i32 to i64
 // CHECK:           %[[VAL_7:.*]] = quake.alloca[%[[VAL_6]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_8:.*]] = memref.load %[[VAL_3]][] : memref<i32>
 // CHECK:           %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:           %[[VAL_10:.*]] = quake.alloca[%[[VAL_9]] : i64] !quake.qvec<?>
-// CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.qref
-// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.ref, !quake.qvec<?>, !quake.qvec<?>, !quake.ref) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_14:.*]] = cc.stdvec_size %[[VAL_12]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_15:.*]] = arith.constant 1 : i64

--- a/test/AST-Quake/negation.cpp
+++ b/test/AST-Quake/negation.cpp
@@ -24,14 +24,14 @@ struct NegationOperatorTest {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_4:.*]] = arith.extsi %[[VAL_3]] : i32 to i64
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_4]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_4]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:           %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:           %[[VAL_9:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
-// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           quake.x [%[[VAL_5]], %[[VAL_8]] neg [true, false]] %[[VAL_11]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
+// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_5]], %[[VAL_8]] neg [true, false]] %[[VAL_11]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/postfix_ops.cpp
+++ b/test/AST-Quake/postfix_ops.cpp
@@ -41,15 +41,15 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:                 %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:                 %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
-// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_19:.*]] = arith.subi %[[VAL_17]], %[[VAL_18]] : i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_21:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_22:.*]] = arith.extui %[[VAL_21]] : i32 to i64
-// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_22]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_22]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {

--- a/test/AST-Quake/qbit_arg.cpp
+++ b/test/AST-Quake/qbit_arg.cpp
@@ -9,16 +9,16 @@
 // RUN: cudaq-quake --emit-llvm-file %s | FileCheck %s
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__function_testFunc
-// CHECK-SAME:    (%[[VAL_0:.*]]: !quake.qref)
+// CHECK-SAME:    (%[[VAL_0:.*]]: !quake.ref)
 // CHECK: quake.h %[[VAL_0]] :
-// CHECK: %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.qref) -> i1
+// CHECK: %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1
 // CHECK: return
 // CHECK: }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Test
 // CHECK-SAME: () attributes
-// CHECK: %[[VAL_2:.*]] = quake.alloca !quake.qref
-// CHECK: call @__nvqpp__mlirgen__function_testFunc{{.*}}(%[[VAL_2]]) : (!quake.qref) -> ()
+// CHECK: %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK: call @__nvqpp__mlirgen__function_testFunc{{.*}}(%[[VAL_2]]) : (!quake.ref) -> ()
 // CHECK: return
 // CHECK: }
 

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -122,14 +122,14 @@ int main() {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_11:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:                 %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
-// CHECK:                 %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_12]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_12]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_14:.*]] = memref.load %[[VAL_3]][] : memref<i32>
 // CHECK:                 %[[VAL_15:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:                 %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i32
 // CHECK:                 %[[VAL_17:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_18:.*]] = arith.subi %[[VAL_16]], %[[VAL_17]] : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                 quake.swap %[[VAL_13]], %[[VAL_20]] : (
 // CHECK:               }
 // CHECK:               cc.continue
@@ -155,8 +155,8 @@ int main() {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_31:.*]] = memref.load %[[VAL_25]][] : memref<i32>
 // CHECK:                 %[[VAL_32:.*]] = arith.extsi %[[VAL_31]] : i32 to i64
-// CHECK:                 %[[VAL_33:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_32]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:                 quake.h %[[VAL_33]] : (!quake.qref) -> ()
+// CHECK:                 %[[VAL_33:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_32]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 quake.h %[[VAL_33]] : (!quake.ref) -> ()
 // CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_25]][] : memref<i32>
 // CHECK:                 %[[VAL_35:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_36:.*]] = arith.addi %[[VAL_34]], %[[VAL_35]] : i32
@@ -187,11 +187,11 @@ int main() {
 // CHECK:                       %[[VAL_54:.*]] = memref.load %[[VAL_53]][] : memref<f64>
 // CHECK:                       %[[VAL_55:.*]] = memref.load %[[VAL_37]][] : memref<i32>
 // CHECK:                       %[[VAL_56:.*]] = arith.extsi %[[VAL_55]] : i32 to i64
-// CHECK:                       %[[VAL_57:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_56]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:                       %[[VAL_57:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_56]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:                       %[[VAL_58:.*]] = memref.load %[[VAL_39]][] : memref<i32>
 // CHECK:                       %[[VAL_59:.*]] = arith.extsi %[[VAL_58]] : i32 to i64
-// CHECK:                       %[[VAL_60:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_59]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:                       quake.r1 (%[[VAL_54]]) [%[[VAL_57]]] %[[VAL_60]] : (f64, !quake.qref, !quake.qref) -> ()
+// CHECK:                       %[[VAL_60:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_59]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                       quake.r1 (%[[VAL_54]]) [%[[VAL_57]]] %[[VAL_60]] : (f64, !quake.ref, !quake.ref) -> ()
 // CHECK:                     }
 // CHECK:                     cc.continue
 // CHECK:                   } step {
@@ -214,7 +214,7 @@ int main() {
 // CHECK:           %[[VAL_68:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_69:.*]] = arith.subi %[[VAL_67]], %[[VAL_68]] : i32
 // CHECK:           %[[VAL_70:.*]] = arith.extsi %[[VAL_69]] : i32 to i64
-// CHECK:           %[[VAL_71:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_70]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:           %[[VAL_71:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_70]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_71]]
 // CHECK:           return
 // CHECK:         }
@@ -231,8 +231,8 @@ int main() {
 // CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
-// CHECK:             quake.t %[[VAL_9]] : (!quake.qref) -> ()
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
+// CHECK:             quake.t %[[VAL_9]] : (!quake.ref) -> ()
 // CHECK:             cc.continue %[[VAL_8]] : index
 // CHECK:           } step {
 // CHECK:           ^bb0(%[[VAL_10:.*]]: index):
@@ -253,7 +253,7 @@ int main() {
 // CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.qref
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
 // CHECK:             quake.x %[[VAL_9]] :
 // CHECK:             cc.continue %[[VAL_8]] : index
 // CHECK:           } step {
@@ -300,7 +300,7 @@ int main() {
 // CHECK:             cc.condition %[[VAL_30]](%[[VAL_29]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_31:.*]]: index):
-// CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_31]]] : (!quake.qvec<?>, index) -> !quake.qref
+// CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_31]]] : (!quake.qvec<?>, index) -> !quake.ref
 // CHECK:             quake.h %[[VAL_32]] :
 // CHECK:             cc.continue %[[VAL_31]] : index
 // CHECK:           } step {
@@ -336,8 +336,8 @@ int main() {
 // CHECK:                     cc.scope {
 // CHECK:                       %[[VAL_49:.*]] = memref.load %[[VAL_36]][] : memref<i32>
 // CHECK:                       %[[VAL_50:.*]] = arith.extsi %[[VAL_49]] : i32 to i64
-// CHECK:                       %[[VAL_51:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_50]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:                       quake.apply @__nvqpp__mlirgen__tgate[%[[VAL_51]]] %[[VAL_23]] : (!quake.qref, !quake.qvec<?>) -> ()
+// CHECK:                       %[[VAL_51:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_50]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                       quake.apply @__nvqpp__mlirgen__tgate[%[[VAL_51]]] %[[VAL_23]] : (!quake.ref, !quake.qvec<?>) -> ()
 // CHECK:                     }
 // CHECK:                     cc.continue
 // CHECK:                   } step {

--- a/test/AST-Quake/simple.cpp
+++ b/test/AST-Quake/simple.cpp
@@ -20,7 +20,7 @@
 // CHECK-VISIT:     %[[VAL_4:.*]] = quake.alloca(%[[VAL_3]] : i64) : !quake.qvec<?>
 // CHECK-VISIT:     %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK-VISIT:     %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK-VISIT:     %[[VAL_7:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_6]] : i64] : !quake.qvec<?> -> !quake.qref
+// CHECK-VISIT:     %[[VAL_7:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_6]] : i64] : !quake.qvec<?> -> !quake.ref
 // CHECK-VISIT:     quake.h (%[[VAL_7]])
 // CHECK-VISIT:     quake.scope {
 // CHECK-VISIT:       %[[VAL_8:.*]] = arith.constant 0 : i32
@@ -37,12 +37,12 @@
 // CHECK-VISIT:         quake.scope {
 // CHECK-VISIT:           %[[VAL_15:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK-VISIT:           %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK-VISIT:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]] : i64] : !quake.qvec<?> -> !quake.qref
+// CHECK-VISIT:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]] : i64] : !quake.qvec<?> -> !quake.ref
 // CHECK-VISIT:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK-VISIT:           %[[VAL_19:.*]] = arith.constant 1 : i32
 // CHECK-VISIT:           %[[VAL_20:.*]] = arith.addi %[[VAL_18]], %[[VAL_19]] : i32
 // CHECK-VISIT:           %[[VAL_21:.*]] = arith.extsi %[[VAL_20]] : i32 to i64
-// CHECK-VISIT:           %[[VAL_22:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_21]] : i64] : !quake.qvec<?> -> !quake.qref
+// CHECK-VISIT:           %[[VAL_22:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_21]] : i64] : !quake.qvec<?> -> !quake.ref
 // CHECK-VISIT:           quake.x [%[[VAL_17]]] (%[[VAL_22]])
 // CHECK-VISIT:         }
 // CHECK-VISIT:         quake.continue ()
@@ -57,8 +57,8 @@
 // CHECK-VISIT:     %[[VAL_27:.*]] = arith.index_cast %[[VAL_26]] : i64 to index
 // CHECK-VISIT:     %[[VAL_28:.*]] = arith.constant 0 : index
 // CHECK-VISIT:     affine.for %[[VAL_29:.*]] = affine_map<(d0) -> (d0)>(%[[VAL_28]]) to affine_map<(d0) -> (d0)>(%[[VAL_27]]) {
-// CHECK-VISIT:       %[[VAL_30:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_29]] : index] : !quake.qvec<?> -> !quake.qref
-// CHECK-VISIT:       %[[VAL_31:.*]] = quake.mz(%[[VAL_30]] : !quake.qref) : i1
+// CHECK-VISIT:       %[[VAL_30:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_29]] : index] : !quake.qvec<?> -> !quake.ref
+// CHECK-VISIT:       %[[VAL_31:.*]] = quake.mz(%[[VAL_30]] : !quake.ref) : i1
 // CHECK-VISIT:     }
 // CHECK-VISIT:     return
 // CHECK-VISIT:   }

--- a/test/AST-Quake/simple_qarray.cpp
+++ b/test/AST-Quake/simple_qarray.cpp
@@ -51,7 +51,7 @@ int main() {
 // CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<5>
 // CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, i64) -> !quake.qref
+// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_8]] :
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : i32
@@ -66,12 +66,12 @@ int main() {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_14:.*]] = memref.load %[[VAL_10]][] : memref<i32>
 // CHECK:                 %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
-// CHECK:                 %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_15]]] : (!quake.qvec<5>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_15]]] : (!quake.qvec<5>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_17:.*]] = memref.load %[[VAL_10]][] : memref<i32>
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.addi %[[VAL_17]], %[[VAL_18]] : i32
 // CHECK:                 %[[VAL_20:.*]] = arith.extsi %[[VAL_19]] : i32 to i64
-// CHECK:                 %[[VAL_21:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_20]]] : (!quake.qvec<5>, i64) -> !quake.qref
+// CHECK:                 %[[VAL_21:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_20]]] : (!quake.qvec<5>, i64) -> !quake.ref
 // CHECK:                 quake.x [%[[VAL_16]]] %[[VAL_21]] :
 // CHECK:               }
 // CHECK:               cc.continue

--- a/test/AST-Quake/single_qubit_ctor.cpp
+++ b/test/AST-Quake/single_qubit_ctor.cpp
@@ -15,14 +15,14 @@
 // CHECK-SAME: (%[[arg0:.*]]: f64) -> i1
 // CHECK:     %[[V0:.*]] = memref.alloca() : memref<f64>
 // CHECK:     memref.store %[[arg0]], %[[V0]][] : memref<f64>
-// CHECK:     %[[V1:.*]] = quake.alloca !quake.qref
+// CHECK:     %[[V1:.*]] = quake.alloca !quake.ref
 // CHECK:     %[[V2:.*]] = memref.load %[[V0]][] : memref<f64>
 // CHECK:     quake.rx (%[[V2]]) %[[V1]] : (f64,
 // CHECK:     %[[V3:.*]] = memref.load %[[V0]][] : memref<f64>
 // CHECK:     %[[cst:.*]] = arith.constant 2.0{{.*}} : f64
 // CHECK:     %[[V4:.*]] = arith.divf %[[V3]], %[[cst]] : f64
 // CHECK:     quake.ry (%[[V4]]) %[[V1]] : (f64,
-// CHECK:     %[[V5:.*]] = quake.mz %[[V1]] : (!quake.qref) -> i1
+// CHECK:     %[[V5:.*]] = quake.mz %[[V1]] : (!quake.ref) -> i1
 // CHECK:     return %[[V5]] : i1
 // CHECK:   }
 // CHECK: }

--- a/test/AST-Quake/template_lambda.cpp
+++ b/test/AST-Quake/template_lambda.cpp
@@ -32,11 +32,11 @@ int main() {
 // CHECK:           quake.x %{{.*}} :
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test
-// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>)
+// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>)
 // CHECK-NOT:       %[[VAL_0]]
 // CHECK:           %[[VAL_3:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
-// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %{{.*}} : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %{{.*}} : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           quake.apply @__nvqpp__mlirgen__Z4mainE3$_0[%[[VAL_6]]] %[[VAL_9]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %{{.*}} : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %{{.*}} : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           quake.apply @__nvqpp__mlirgen__Z4mainE3$_0[%[[VAL_6]]] %[[VAL_9]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 

--- a/test/AST-Quake/while-1.cpp
+++ b/test/AST-Quake/while-1.cpp
@@ -60,15 +60,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:               %[[VAL_10:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
-// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_13:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_14:.*]] = arith.extui %[[VAL_13]] : i32 to i64
 // CHECK:               %[[VAL_15:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
-// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_19:.*]] = arith.extui %[[VAL_18]] : i32 to i64
-// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           }
@@ -91,15 +91,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i32 to i64
 // CHECK:               %[[VAL_8:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_9:.*]] = arith.subi %[[VAL_7]], %[[VAL_8]] : i64
-// CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_9]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_9]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_11:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:               %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
-// CHECK:               %[[VAL_15:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_15:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
-// CHECK:               %[[VAL_18:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_17]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_18:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_17]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           }
@@ -119,15 +119,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_6:.*]] = arith.extui %[[VAL_5]] : i32 to i64
 // CHECK:               %[[VAL_7:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_8:.*]] = arith.subi %[[VAL_6]], %[[VAL_7]] : i64
-// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_11:.*]] = arith.extui %[[VAL_10]] : i32 to i64
 // CHECK:               %[[VAL_12:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_13:.*]] = arith.subi %[[VAL_11]], %[[VAL_12]] : i64
-// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_15:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_16:.*]] = arith.extui %[[VAL_15]] : i32 to i64
-// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           } while {
@@ -154,15 +154,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:               %[[VAL_10:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
-// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_13:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_14:.*]] = arith.extui %[[VAL_13]] : i32 to i64
 // CHECK:               %[[VAL_15:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
-// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_19:.*]] = arith.extui %[[VAL_18]] : i32 to i64
-// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.qref
+// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           } while {

--- a/test/Conversion/QTXToQuake/qtx-to-quake.mlir
+++ b/test/Conversion/QTXToQuake/qtx-to-quake.mlir
@@ -12,7 +12,7 @@
 module {
 
   // CHECK-LABEL:   func.func @id(
-  // CHECK-SAME:                  %[[VAL_0:.*]]: !quake.qref) {
+  // CHECK-SAME:                  %[[VAL_0:.*]]: !quake.ref) {
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @id(%q0: !qtx.wire) -> (!qtx.wire) {
@@ -20,14 +20,14 @@ module {
   }
 
   // CHECK-LABEL:   func.func @apply_one_target_operators(
-  // CHECK-SAME:                                   %[[VAL_0:.*]]: !quake.qref,
-  // CHECK-SAME:                                   %[[VAL_1:.*]]: !quake.qref) {
-  // CHECK:   quake.h [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
-  // CHECK:   quake.s [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
-  // CHECK:   quake.t [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
-  // CHECK:   quake.x [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
-  // CHECK:   quake.y [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
-  // CHECK:   quake.z [%[[VAL_0]]] %[[VAL_1]] : (!quake.qref, !quake.qref) -> ()
+  // CHECK-SAME:                                   %[[VAL_0:.*]]: !quake.ref,
+  // CHECK-SAME:                                   %[[VAL_1:.*]]: !quake.ref) {
+  // CHECK:   quake.h [%[[VAL_0]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
+  // CHECK:   quake.s [%[[VAL_0]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
+  // CHECK:   quake.t [%[[VAL_0]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
+  // CHECK:   quake.x [%[[VAL_0]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
+  // CHECK:   quake.y [%[[VAL_0]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
+  // CHECK:   quake.z [%[[VAL_0]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @apply_one_target_operators(%q0: !qtx.wire, %q1: !qtx.wire) -> (!qtx.wire, !qtx.wire) {
@@ -42,14 +42,14 @@ module {
 
   // CHECK-LABEL:   func.func @apply_parametrized_one_target_operators() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 3.140000e+00 : f64
-  // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
-  // CHECK: quake.r1 (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.qref, !quake.qref) -> ()
-  // CHECK: quake.rx (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.qref, !quake.qref) -> ()
-  // CHECK: quake.ry (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.qref, !quake.qref) -> ()
-  // CHECK: quake.rz (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.qref, !quake.qref) -> ()
-  // CHECK:           quake.dealloc %[[VAL_1]] : !quake.qref
-  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qref
+  // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+  // CHECK: quake.r1 (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.ref, !quake.ref) -> ()
+  // CHECK: quake.rx (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.ref, !quake.ref) -> ()
+  // CHECK: quake.ry (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.ref, !quake.ref) -> ()
+  // CHECK: quake.rz (%[[VAL_0]]) [%[[VAL_2]]] %[[VAL_1]] : (f64, !quake.ref, !quake.ref) -> ()
+  // CHECK:           quake.dealloc %[[VAL_1]] : !quake.ref
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.ref
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @apply_parametrized_one_target_operators() {
@@ -69,9 +69,9 @@ module {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
   // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK: quake.swap %[[VAL_3]], %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: quake.swap %[[VAL_3]], %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
   // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }
@@ -91,10 +91,10 @@ module {
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
   // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
   // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<3>
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.qvec<3>, i32) -> !quake.qref
-  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<3>, i32) -> !quake.qref
-  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<3>, i32) -> !quake.qref
-  // CHECK: quake.swap [%[[VAL_6]]] %[[VAL_4]], %[[VAL_5]] : (!quake.qref, !quake.qref, !quake.qref) -> ()
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.qvec<3>, i32) -> !quake.ref
+  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<3>, i32) -> !quake.ref
+  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<3>, i32) -> !quake.ref
+  // CHECK: quake.swap [%[[VAL_6]]] %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
   // CHECK:           quake.dealloc %[[VAL_3]] : !quake.qvec<3>
   // CHECK:           return
   // CHECK:         }
@@ -114,10 +114,10 @@ module {
   // CHECK-SAME:                            %[[VAL_0:.*]]: !quake.qvec<2>) {
   // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
-  // CHECK:           quake.x %[[VAL_4]] : (!quake.qref) -> ()
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
+  // CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @return_array(%arg0: !qtx.wire_array<2>) -> (!qtx.wire_array<2>) {
@@ -135,10 +135,10 @@ module {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
   // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK:           quake.reset %[[VAL_3]] : (!quake.qref) -> ()
-  // CHECK:           quake.reset %[[VAL_4]] : (!quake.qref) -> ()
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           quake.reset %[[VAL_3]] : (!quake.ref) -> ()
+  // CHECK:           quake.reset %[[VAL_4]] : (!quake.ref) -> ()
   // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }
@@ -158,15 +158,15 @@ module {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
   // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
-  // CHECK:           quake.x %[[VAL_4]]  : (!quake.qref) -> ()
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
+  // CHECK:           quake.x %[[VAL_4]]  : (!quake.ref) -> ()
   // CHECK:           quake.reset %[[VAL_2]] : (!quake.qvec<2>) -> ()
-  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK:           quake.h %[[VAL_5]] : (!quake.qref) -> ()
-  // CHECK:           quake.x %[[VAL_6]] : (!quake.qref) -> ()
+  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           quake.h %[[VAL_5]] : (!quake.ref) -> ()
+  // CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
   // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }
@@ -191,10 +191,10 @@ module {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
   // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_3]] : (!quake.qref) -> i1
-  // CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_4]] : (!quake.qref) -> i1
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> i1
+  // CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> i1
   // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }
@@ -214,15 +214,15 @@ module {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
   // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
-  // CHECK:           quake.x %[[VAL_4]] : (!quake.qref) -> ()
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
+  // CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
   // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_2]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
-  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK: %[[VAL_7:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.qref
-  // CHECK:           quake.h %[[VAL_6]] : (!quake.qref) -> ()
-  // CHECK:           quake.x %[[VAL_7]] : (!quake.qref) -> ()
+  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_7:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           quake.h %[[VAL_6]] : (!quake.ref) -> ()
+  // CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
   // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
   // CHECK:           return
   // CHECK:         }

--- a/test/Conversion/QuakeToQTX/quake_cc_if.qke
+++ b/test/Conversion/QuakeToQTX/quake_cc_if.qke
@@ -19,21 +19,21 @@ module {
 
     // CHECK:  %[[W0:.*]] = qtx.alloca
     // CHECK:  %[[W1:.*]] = qtx.alloca
-    %q0 = quake.alloca !quake.qref
-    %q1 = quake.alloca !quake.qref
+    %q0 = quake.alloca !quake.ref
+    %q1 = quake.alloca !quake.ref
 
     // CHECK:  %[[W1_1:.*]] = cc.if
     cc.if(%c1) {
       // CHECK:  %[[W1_2:.*]] = qtx.x [%[[W0]]] %[[W1]]
-      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+      quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
       // CHECK:  cc.continue %[[W1_2]]
     } else {
       // CHECK:  %[[W1_3:.*]] = qtx.y [%[[W0]]] %[[W1]]
-      quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+      quake.y [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
       // CHECK:  cc.continue %[[W1_3]]
     }
     // CHECK:  %[[W1_4:.*]] = qtx.z [%[[W0]]] %[[W1_1]]
-    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.z [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     // CHECK: qtx.unrealized_return
     return
   }
@@ -45,21 +45,21 @@ module {
 
     // CHECK:  %[[W0:.*]] = qtx.alloca
     // CHECK:  %[[W1:.*]] = qtx.alloca
-    %q0 = quake.alloca  !quake.qref
-    %q1 = quake.alloca  !quake.qref
+    %q0 = quake.alloca  !quake.ref
+    %q1 = quake.alloca  !quake.ref
 
     // CHECK:  %[[WIRES:.*]]:2 = cc.if
     cc.if(%c1) {
       // CHECK:  %[[W1_1:.*]] = qtx.x [%[[W0]]] %[[W1]]
-      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+      quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
       // CHECK:  cc.continue %[[W1_1]], %[[W0]]
     } else {
       // CHECK:  %[[W0_1:.*]] = qtx.y [%[[W1]]] %[[W0]]
-      quake.y [%q1] %q0 : (!quake.qref, !quake.qref) -> ()
+      quake.y [%q1] %q0 : (!quake.ref, !quake.ref) -> ()
       // CHECK:  cc.continue %[[W1]], %[[W0_1]]
     }
     // CHECK:  %[[W1_2:.*]] = qtx.z [%[[WIRES]]#1] %[[WIRES]]#0
-    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.z [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     // CHECK: qtx.unrealized_return
     return
   }
@@ -68,12 +68,12 @@ module {
   func.func @test03(%c1: i1) {
     // CHECK:  %[[W0:.*]] = qtx.alloca
     // CHECK:  %[[W1:.*]] = qtx.alloca
-    %q0 = quake.alloca  !quake.qref
-    %q1 = quake.alloca  !quake.qref
+    %q0 = quake.alloca  !quake.ref
+    %q1 = quake.alloca  !quake.ref
 
     // CHECK:  %[[W1_1:.*]] = cc.if
     cc.if(%c1) {
-      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+      quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
       // CHECK:  %[[W1_2:.*]] = qtx.x [%[[W0]]] %[[W1]]
       // CHECK:  cc.continue %[[W1_2]]
     }
@@ -81,7 +81,7 @@ module {
     // CHECK:   cc.continue %[[W1]]
 
     // CHECK:  %[[W1_3:.*]] = qtx.y [%[[W0]]] %[[W1_1]]
-    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.y [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     return
   }
 
@@ -90,19 +90,19 @@ module {
     // CHECK:  %[[W0:.*]] = qtx.alloca
     // CHECK:  %[[W1:.*]] = qtx.alloca
     // CHECK:  %[[W2:.*]] = qtx.alloca
-    %q0 = quake.alloca !quake.qref
-    %q1 = quake.alloca !quake.qref
-    %q2 = quake.alloca !quake.qref
+    %q0 = quake.alloca !quake.ref
+    %q1 = quake.alloca !quake.ref
+    %q2 = quake.alloca !quake.ref
 
     // CHECK:  %[[W1_W2:.*]]:2 = cc.if
     cc.if(%c1) {
       // CHECK:  %[[W1_1:.*]] = qtx.h [%[[W0]]] %[[W1]]
-      quake.h [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+      quake.h [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
 
       // CHECK:  %[[W2_2:.*]] = cc.if
       cc.if(%c2) {
         // CHECK:  %[[W2_1:.*]] = qtx.x [%[[W0]]] %[[W2]]
-        quake.x [%q0] %q2 : (!quake.qref, !quake.qref) -> ()
+        quake.x [%q0] %q2 : (!quake.ref, !quake.ref) -> ()
         // CHECK:  cc.continue %[[W2_1]]
       }
       // CHECK: } else {
@@ -115,24 +115,24 @@ module {
 
     // CHECK:  %{{.*}} = qtx.y [%[[W0]]] %[[W1_W2]]#0
     // CHECK:  %{{.*}} = qtx.z [%[[W0]]] %[[W1_W2]]#1
-    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
-    quake.z [%q0] %q2 : (!quake.qref, !quake.qref) -> ()
+    quake.y [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+    quake.z [%q0] %q2 : (!quake.ref, !quake.ref) -> ()
     // CHECK: qtx.unrealized_return
     return
   }
 
   // CHECK-LABEL: func.func @test05
-  func.func @test05(%q0: !quake.qref, %c1: i1) {
+  func.func @test05(%q0: !quake.ref, %c1: i1) {
     // This `cc.if` does not return new wires because %q0 is only used as
     // control and %q1 is locally scoped.
     cc.if(%c1) {
-      %q1 = quake.alloca !quake.qref
+      %q1 = quake.alloca !quake.ref
       // CHECK: %{{.*}} = qtx.x [%[[Q0_W0:.*]]] %{{.*}}
-      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+      quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
       // CHECK-NOT: cc.continue
     }
     // CHECK: %[[Q0_W1:.*]] = qtx.y %[[Q0_W0]]
-    quake.y %q0 : (!quake.qref) -> ()
+    quake.y %q0 : (!quake.ref) -> ()
     // CHECK: qtx.unrealized_return %[[Q0_W1]]
     return
   }
@@ -142,17 +142,17 @@ module {
     %c_0 = arith.constant 0 : i32
 
     // CHECK: %[[W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[INDEX:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
     // CHECK: %[[W0_1:.*]] = qtx.x %[[W0]]
-    quake.x %q0 : (!quake.qref) -> ()
+    quake.x %q0 : (!quake.ref) -> ()
 
     // CHECK: %[[A_3:.*]] = cc.if
     cc.if(%c1) {
       %c_1 = arith.constant 1 : i32
       // CHECK: %[[W1:.*]], %[[A_1:.*]] = qtx.array_borrow %{{.*}} from %[[A_0]]
-      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>, i32) -> !quake.qref
+      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>, i32) -> !quake.ref
       // CHECK: %[[W1_1:.*]] = qtx.y %[[W1]]
-      quake.y %q1 : (!quake.qref) -> ()
+      quake.y %q1 : (!quake.ref) -> ()
       // CHECK: %[[A_2:.*]] = qtx.array_yield %[[W1_1]] to %[[A_1]]
       // CHECK: cc.continue %[[A_2]]
     }
@@ -180,14 +180,14 @@ module {
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[INDEX_0:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
     // CHECK: %[[Q0_W1:.*]] = qtx.x %[[Q0_W0]]
-    quake.x %q0 : (!quake.qref) -> ()
+    quake.x %q0 : (!quake.ref) -> ()
 
     // CHECK: %[[A_Q0:.*]]:2 = cc.if
     cc.if(%c1) {
       // CHECK: %[[Q1_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[INDEX_1:.*]] from %[[A_0]]
-      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>, i32) -> !quake.qref
+      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>, i32) -> !quake.ref
 
       // CHECK: %[[A_Q0_Q1:.*]]:3 = cc.if
       cc.if(%c2) {

--- a/test/Conversion/QuakeToQTX/quake_cc_loop.qke
+++ b/test/Conversion/QuakeToQTX/quake_cc_loop.qke
@@ -17,7 +17,7 @@ module {
     %c42_i64 = arith.constant 42 : i64
 
     // CHECK: %[[Q0_W0:.*]] = qtx.alloca : !qtx.wire
-    %q0 = quake.alloca !quake.qref
+    %q0 = quake.alloca !quake.ref
 
     %alloca = memref.alloca() : memref<i64>
     memref.store %c0_i64, %alloca[] : memref<i64>
@@ -31,7 +31,7 @@ module {
     } do {
       // CHECK: ^bb0(%[[Q0_W2:.*]]: !qtx.wire):
       // CHECK: %[[Q0_W3:.*]] = qtx.x %[[Q0_W2]]
-      quake.x %q0 : (!quake.qref) -> ()
+      quake.x %q0 : (!quake.ref) -> ()
       // CHECK: cc.continue %[[Q0_W3]]
       cc.continue
     } step {
@@ -42,7 +42,7 @@ module {
       // CHECK: cc.continue %[[Q0_W4]]
     }
     // CHECK: %[[Q0_W6:.*]] = qtx.z %[[Q0_W5]]
-    quake.z %q0 : (!quake.qref) -> ()
+    quake.z %q0 : (!quake.ref) -> ()
     return
   }
 
@@ -56,7 +56,7 @@ module {
     %qvec = quake.alloca  !quake.qvec<2>
 
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2> ,i64) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2> ,i64) -> !quake.ref
 
     %alloca = memref.alloca() : memref<i64>
     memref.store %c0_i64, %alloca[] : memref<i64>
@@ -71,7 +71,7 @@ module {
       // CHECK: ^bb0(%[[A_3:.*]]: !qtx.wire_array
       %3 = memref.load %alloca[] : memref<i64>
       // CHECK: %[[QX_W0:.*]], %[[A_4:.*]] = qtx.array_borrow %{{.*}} from %[[A_3]]
-      %4 = quake.extract_ref %qvec[%3] : (!quake.qvec<2> ,i64) -> !quake.qref
+      %4 = quake.extract_ref %qvec[%3] : (!quake.qvec<2> ,i64) -> !quake.ref
 
       // CHECK: %[[A_5:.*]] = qtx.array_yield %[[QX_W0]] to %[[A_4]]
       // CHECK: cc.continue %[[A_5]]

--- a/test/Conversion/QuakeToQTX/quake_cc_scope.qke
+++ b/test/Conversion/QuakeToQTX/quake_cc_scope.qke
@@ -14,41 +14,41 @@ module {
   func.func @one_scope() {
     // CHECK: %[[Q0_W0:.*]] = qtx.alloca
     // CHECK: %[[Q1_W0:.*]] = qtx.alloca
-    %q0 = quake.alloca !quake.qref
-    %q1 = quake.alloca !quake.qref
+    %q0 = quake.alloca !quake.ref
+    %q1 = quake.alloca !quake.ref
 
     // CHECK: %[[Q1_W2:.*]] = cc.scope
     cc.scope {
       // CHECK: %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0]]] %[[Q1_W0]]
-      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+      quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
 
       // CHECK: cc.continue %[[Q1_W1]]
     }
     // CHECK:  %[[Q1_W3:.*]] = qtx.z [%[[Q0_W0]]] %[[Q1_W2:.*]]
-    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.z [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @scope_local_wire
   func.func @scope_local_wire() {
     // CHECK: %[[Q0_W0:.*]] = qtx.alloca
-    %q0 = quake.alloca !quake.qref
+    %q0 = quake.alloca !quake.ref
 
     // CHECK: %[[Q0_W2:.*]] = cc.scope
     cc.scope {
       // CHECK: %[[Q1_W0:.*]] = qtx.alloca
-      %q1 = quake.alloca !quake.qref
+      %q1 = quake.alloca !quake.ref
 
       // CHECK: %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0]]] %[[Q1_W0]]
-      quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+      quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
 
       // CHECK: %[[Q0_W1:.*]] = qtx.y [%[[Q1_W1]]] %[[Q0_W0]]
-      quake.y [%q1] %q0 : (!quake.qref, !quake.qref) -> ()
+      quake.y [%q1] %q0 : (!quake.ref, !quake.ref) -> ()
 
       // TODO: cc.continue %[[Q0_W1]]
     }
     // CHECK: %[[Q0_W3:.*]] = qtx.z %[[Q0_W2]]
-    quake.z %q0 : (!quake.qref) -> ()
+    quake.z %q0 : (!quake.ref) -> ()
     return
   }
 
@@ -57,19 +57,19 @@ module {
     // CHECK: %[[Q0_W0:.*]] = qtx.alloca
     // CHECK: %[[Q1_W0:.*]] = qtx.alloca
     // CHECK: %[[Q2_W0:.*]] = qtx.alloca
-    %q0 = quake.alloca  !quake.qref
-    %q1 = quake.alloca  !quake.qref
-    %q2 = quake.alloca  !quake.qref
+    %q0 = quake.alloca  !quake.ref
+    %q1 = quake.alloca  !quake.ref
+    %q2 = quake.alloca  !quake.ref
 
     // CHECK: %[[Q1_Q2:.*]]:2 = cc.scope
     cc.scope {
       // CHECK: %[[Q1_W1:.*]] = qtx.h [%[[Q0_W0]]] %[[Q1_W0]]
-      quake.h [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+      quake.h [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
 
       // CHECK: %[[Q2_W2:.*]] = cc.scope
       cc.scope {
         // CHECK: %[[Q2_W1:.*]] = qtx.x [%[[Q0_W0]]] %[[Q2_W0]]
-        quake.x [%q0] %q2 : (!quake.qref, !quake.qref) -> ()
+        quake.x [%q0] %q2 : (!quake.ref, !quake.ref) -> ()
         // CHECK: cc.continue %[[Q2_W1]]
       }
 
@@ -77,7 +77,7 @@ module {
     }
 
     // CHECK: %[[Q2_W1:.*]] = qtx.y [%[[Q0_W0]]] %[[Q1_Q2]]#0
-    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.y [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     return
   }
 
@@ -88,15 +88,15 @@ module {
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
 
     // CHECK: %[[A_3:.*]] = cc.scope
     cc.scope {
       // CHECK: %[[Q1_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %{{.*}} from %[[A_0]]
-      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>,i32) -> !quake.qref
+      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>,i32) -> !quake.ref
 
       // CHECK:  %[[Q1_W1:.*]] = qtx.y %[[Q1_W0]]
-      quake.y %q1 : (!quake.qref) -> ()
+      quake.y %q1 : (!quake.ref) -> ()
 
       // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q1_W1]] to %[[A_1]]
       // CHECK: cc.continue %[[A_2]]
@@ -114,7 +114,7 @@ module {
     %c_0 = arith.constant 0 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>,i32) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>,i32) -> !quake.ref
 
     // CHECK: %[[A_Q0_1:.*]]:2 = cc.scope
     cc.scope {
@@ -144,7 +144,7 @@ module {
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>,i32) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>,i32) -> !quake.ref
 
     // CHECK: %[[A_Q0_1:.*]]:2 = cc.scope
     cc.scope {
@@ -152,7 +152,7 @@ module {
       // CHECK: %[[A_Q0:.*]]:2 = cc.scope
       cc.scope {
         // CHECK: %[[Q1_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_0]]
-        %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>,i32) -> !quake.qref
+        %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>,i32) -> !quake.ref
 
         // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q0_W0]], %[[Q1_W0]] to %[[A_1]]
         // CHECK: %[[A_3:.*]] = qtx.reset %[[A_2]]

--- a/test/Conversion/QuakeToQTX/quake_cfg.qke
+++ b/test/Conversion/QuakeToQTX/quake_cfg.qke
@@ -14,75 +14,75 @@ module {
   func.func @test01() {
     // CHECK:  %[[Q0_W0:.*]] = qtx.alloca
     // CHECK:  %[[Q1_W0:.*]] = qtx.alloca
-    %q0 = quake.alloca !quake.qref
-    %q1 = quake.alloca !quake.qref
+    %q0 = quake.alloca !quake.ref
+    %q1 = quake.alloca !quake.ref
 
     // CHECK:  %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0]]] %[[Q1_W0]]
-    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     cf.br ^bb1
 
   ^bb1:
     // CHECK:  %[[Q1_W2:.*]] = qtx.y [%[[Q0_W0]]] %[[Q1_W1]]
-    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.y [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     cf.br ^bb2
 
   ^bb2:
     // CHECK:  %[[Q1_W3:.*]] = qtx.z [%[[Q0_W0]]] %[[Q1_W2]]
-    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.z [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @test02
-  func.func @test02(%q0: !quake.qref, %q1: !quake.qref, %c1: i1) {
+  func.func @test02(%q0: !quake.ref, %q1: !quake.ref, %c1: i1) {
     cf.cond_br %c1, ^bb1, ^bb2
 
   ^bb1:
     // CHECK: %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0:.*]]] %[[Q1_W0:.*]] :
-    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     // CHECK: cf.br ^bb3(%[[Q1_W1]] : !qtx.wire)
     cf.br ^bb3
 
   ^bb2:
     // CHECK: %[[Q1_W2:.*]] = qtx.y [%[[Q0_W0]]] %[[Q1_W0]]
-    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.y [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     // CHECK: cf.br ^bb3(%[[Q1_W2]] : !qtx.wire)
     cf.br ^bb3
 
   // CHECK: ^bb3(%[[Q1_W3:.*]]: !qtx.wire):
   ^bb3:
     // CHECK: %[[Q1_W4:.*]] = qtx.z [%[[Q0_W0]]] %[[Q1_W3]]
-    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.z [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @test03
-  func.func @test03(%q0: !quake.qref, %q1: !quake.qref, %c1: i1) {
+  func.func @test03(%q0: !quake.ref, %q1: !quake.ref, %c1: i1) {
     // TODO: do the checks, I'm unsure about this one.
-    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     cf.br ^bb1
 
   ^bb1:
-    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.y [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     cf.cond_br %c1, ^bb1, ^bb2
 
   ^bb2:
-    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.z [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     return
   }
 
   // CHECK-LABEL: func.func @test04
-  func.func @test04(%q0: !quake.qref, %q1: !quake.qref, %c1: i1) {
+  func.func @test04(%q0: !quake.ref, %q1: !quake.ref, %c1: i1) {
     cf.cond_br %c1, ^bb1, ^bb2
 
   ^bb1:
     // CHECK: %[[Q1_W1:.*]] = qtx.x [%[[Q0_W0:.*]]] %[[Q1_W0:.*]] :
-    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     // CHECK: qtx.unrealized_return %[[Q0_W0]], %[[Q1_W1]]
     return
 
   ^bb2:
     // CHECK: %[[Q1_W2:.*]] = qtx.y [%[[Q0_W0]]] %[[Q1_W0]]
-    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+    quake.y [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     // CHECK: qtx.unrealized_return %[[Q0_W0]], %[[Q1_W2]]
     return
   }
@@ -96,7 +96,7 @@ module {
 
   ^bb1:
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
     // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_1]]
     // CHECK: cf.br ^bb3(%[[A_2]] : !qtx.wire_array<2>)
     cf.br ^bb3
@@ -120,13 +120,13 @@ module {
     // CHECK: %[[A_0:.*]] = qtx.alloc
     %qvec = quake.alloca !quake.qvec<2>
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
 
     cf.cond_br %c1, ^bb1, ^bb4
 
   ^bb1:
     // CHECK: %[[Q1_W0:.*]], %[[A_2:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_1]]
-    %q1 = quake.extract_ref %qvec[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.qref
+    %q1 = quake.extract_ref %qvec[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.ref
     cf.cond_br %c1, ^bb2, ^bb3
 
   ^bb2:
@@ -141,7 +141,7 @@ module {
 
   ^bb4:
     // CHECK: %[[Q1_W1:.*]], %[[A_5:.*]] = qtx.array_borrow %[[IDX_1]] from %[[A_1]]
-    %q2 = quake.extract_ref %qvec[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.qref
+    %q2 = quake.extract_ref %qvec[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.ref
     // CHECK: %[[A_6:.*]] = qtx.array_yield %[[Q1_W1]] to %[[A_5]]
     // CHECK: cf.br ^bb5(%[[A_6]] : !qtx.wire_array<2, dead = 1>)
     cf.br ^bb5
@@ -162,13 +162,13 @@ module {
     // CHECK: %[[A_0:.*]] = qtx.alloc
     %qvec = quake.alloca !quake.qvec<2>
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
 
     cf.cond_br %c1, ^bb1, ^bb2
 
   ^bb1:
     // CHECK: %[[Q1_W0:.*]], %[[A_2:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_1]]
-    %q1 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
+    %q1 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
     // CHECK: %[[A_3:.*]] = qtx.array_yield %[[Q1_W0]] to %[[A_2]]
     // CHECK: cf.br ^bb3(%[[A_3]], %[[Q0_W0]] : !qtx.wire_array<2, dead = 1>, !qtx.wire)
     cf.br ^bb3

--- a/test/Conversion/QuakeToQTX/straightline.qke
+++ b/test/Conversion/QuakeToQTX/straightline.qke
@@ -11,9 +11,9 @@
 module {
 
   // CHECK-LABEL: func.func @id_qubit(
-  // CHECK-SAME:                      %[[Q0:.*]]: !quake.qref
-  func.func @id_qubit(%q0: !quake.qref) {
-    // CHECK: %[[Q0_W0:.*]] = builtin.unrealized_conversion_cast %[[Q0]] : !quake.qref to !qtx.wire
+  // CHECK-SAME:                      %[[Q0:.*]]: !quake.ref
+  func.func @id_qubit(%q0: !quake.ref) {
+    // CHECK: %[[Q0_W0:.*]] = builtin.unrealized_conversion_cast %[[Q0]] : !quake.ref to !qtx.wire
     // CHECK: qtx.unrealized_return %[[Q0_W0]] : !qtx.wire
     return
   }
@@ -37,40 +37,40 @@ module {
     return %reg1 : !cc.stdvec<i1>
   }
 
-  // CHECK-LABEL: func.func @alloc_dealloc_qref_and_qvec
+  // CHECK-LABEL: func.func @alloc_dealloc_ref_and_qvec
   // CHECK:           %[[Q0_W0:.*]] = qtx.alloca : !qtx.wire
   // CHECK:           %[[A_0:.*]] = qtx.alloca : !qtx.wire_array
   // CHECK:           qtx.dealloc %[[Q0_W0]]
   // CHECK:           qtx.dealloc %[[A_0]]
   // CHECK:           qtx.unrealized_return
-  func.func @alloc_dealloc_qref_and_qvec() {
-    %q0 = quake.alloca  !quake.qref
+  func.func @alloc_dealloc_ref_and_qvec() {
+    %q0 = quake.alloca  !quake.ref
     %qvec = quake.alloca  !quake.qvec<2>
-    quake.dealloc %q0 : !quake.qref
+    quake.dealloc %q0 : !quake.ref
     quake.dealloc %qvec : !quake.qvec<2>
     return
   }
 
-  // CHECK-LABEL: func.func @alloc_dealloc_qvec_with_extracted_qrefs
+  // CHECK-LABEL: func.func @alloc_dealloc_qvec_with_extracted_refs
   // CHECK:           %[[A_0:.*]] = qtx.alloca : !qtx.wire_array
   // CHECK:           %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %{{.*}} from %[[A_0]]
   // CHECK:           %[[A_2:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_1]]
   // CHECK:           qtx.dealloc %[[A_2]]
   // CHECK-NOT:       %{{.*}}, %{{.*}} = array_borrow
   // CHECK:           qtx.unrealized_return
-  func.func @alloc_dealloc_qvec_with_extracted_qrefs() {
+  func.func @alloc_dealloc_qvec_with_extracted_refs() {
     %c_0 = arith.constant 0 : i32
     %qvec = quake.alloca  !quake.qvec<2>
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
+    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
     quake.dealloc %qvec : !quake.qvec<2>
     return
   }
 
   // CHECK-LABEL: func.func @apply_one_target_operators(
-  // CHECK-SAME:                                        %[[Q0:.*]]: !quake.qref,
-  // CHECK-SAME:                                        %[[Q1:.*]]: !quake.qref
-  // CHECK:           %[[Q0_W0:.*]] = builtin.unrealized_conversion_cast %[[Q0]] : !quake.qref to !qtx.wire
-  // CHECK:           %[[Q1_W0:.*]] = builtin.unrealized_conversion_cast %[[Q1]] : !quake.qref to !qtx.wire
+  // CHECK-SAME:                                        %[[Q0:.*]]: !quake.ref,
+  // CHECK-SAME:                                        %[[Q1:.*]]: !quake.ref
+  // CHECK:           %[[Q0_W0:.*]] = builtin.unrealized_conversion_cast %[[Q0]] : !quake.ref to !qtx.wire
+  // CHECK:           %[[Q1_W0:.*]] = builtin.unrealized_conversion_cast %[[Q1]] : !quake.ref to !qtx.wire
   // CHECK:           %[[Q1_W1:.*]] = qtx.h [%[[Q0_W0]]] %[[Q1_W0]]
   // CHECK:           %[[Q1_W2:.*]] = qtx.s [%[[Q0_W0]]] %[[Q1_W1]]
   // CHECK:           %[[Q1_W3:.*]] = qtx.t [%[[Q0_W0]]] %[[Q1_W2]]
@@ -78,13 +78,13 @@ module {
   // CHECK:           %[[Q1_W5:.*]] = qtx.y [%[[Q0_W0]]] %[[Q1_W4]]
   // CHECK:           %[[Q1_W6:.*]] = qtx.z [%[[Q0_W0]]] %[[Q1_W5]]
   // CHECK:           qtx.unrealized_return %[[Q0_W0]], %[[Q1_W6]]
-  func.func @apply_one_target_operators(%q0: !quake.qref, %q1: !quake.qref) {
-    quake.h [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
-    quake.s [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
-    quake.t [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
-    quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
-    quake.y [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
-    quake.z [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+  func.func @apply_one_target_operators(%q0: !quake.ref, %q1: !quake.ref) {
+    quake.h [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+    quake.s [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+    quake.t [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+    quake.y [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+    quake.z [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
     return
   }
 
@@ -98,12 +98,12 @@ module {
   // CHECK:           qtx.unrealized_return
   func.func @apply_parametrized_one_target_operators() {
     %angle = arith.constant 3.14 : f64
-    %q0 = quake.alloca  !quake.qref
-    %q1 = quake.alloca  !quake.qref
-    quake.r1 (%angle) [%q1] %q0 : (f64, !quake.qref, !quake.qref) -> ()
-    quake.rx (%angle) [%q1] %q0 : (f64, !quake.qref, !quake.qref) -> ()
-    quake.ry (%angle) [%q1] %q0 : (f64, !quake.qref, !quake.qref) -> ()
-    quake.rz (%angle) [%q1] %q0 : (f64, !quake.qref, !quake.qref) -> ()
+    %q0 = quake.alloca  !quake.ref
+    %q1 = quake.alloca  !quake.ref
+    quake.r1 (%angle) [%q1] %q0 : (f64, !quake.ref, !quake.ref) -> ()
+    quake.rx (%angle) [%q1] %q0 : (f64, !quake.ref, !quake.ref) -> ()
+    quake.ry (%angle) [%q1] %q0 : (f64, !quake.ref, !quake.ref) -> ()
+    quake.rz (%angle) [%q1] %q0 : (f64, !quake.ref, !quake.ref) -> ()
     return
   }
 
@@ -119,15 +119,15 @@ module {
     %c_1 = arith.constant 1 : i32
     %c_2 = arith.constant 2 : i32
     %0 = quake.alloca !quake.qvec<3>
-    %q0 = quake.extract_ref %0 [%c_0] : (!quake.qvec<3>,i32) -> !quake.qref
-    %q1 = quake.extract_ref %0 [%c_1] : (!quake.qvec<3>,i32) -> !quake.qref
-    %q2 = quake.extract_ref %0 [%c_2] : (!quake.qvec<3>,i32) -> !quake.qref
-    quake.swap [%q2] %q0, %q1 : (!quake.qref,!quake.qref,!quake.qref) -> ()
+    %q0 = quake.extract_ref %0 [%c_0] : (!quake.qvec<3>,i32) -> !quake.ref
+    %q1 = quake.extract_ref %0 [%c_1] : (!quake.qvec<3>,i32) -> !quake.ref
+    %q2 = quake.extract_ref %0 [%c_2] : (!quake.qvec<3>,i32) -> !quake.ref
+    quake.swap [%q2] %q0, %q1 : (!quake.ref,!quake.ref,!quake.ref) -> ()
     return
   }
 
-  // CHECK-LABEL:   func.func @mz_and_reset_qvec_with_extracted_qrefs
-  func.func @mz_and_reset_qvec_with_extracted_qrefs() {
+  // CHECK-LABEL:   func.func @mz_and_reset_qvec_with_extracted_refs
+  func.func @mz_and_reset_qvec_with_extracted_refs() {
     %c_0 = arith.constant 0 : i32
     %c_1 = arith.constant 1 : i32
 
@@ -136,8 +136,8 @@ module {
 
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
     // CHECK: %[[Q1_W0:.*]], %[[A_2:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_1]]
-    %q0 = quake.extract_ref %0[%c_0] : (!quake.qvec<2>, i32) -> !quake.qref
-    %q1 = quake.extract_ref %0[%c_1] : (!quake.qvec<2>, i32) -> !quake.qref
+    %q0 = quake.extract_ref %0[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
+    %q1 = quake.extract_ref %0[%c_1] : (!quake.qvec<2>, i32) -> !quake.ref
 
     // CHECK: %[[A_3:.*]] = qtx.array_yield %[[Q0_W0]], %[[Q1_W0]] to %[[A_2]]
     // CHECK: %{{.*}}, %[[A_4:.*]] = qtx.mz %[[A_3]]

--- a/test/Conversion/QuakeToQTX/unable_to_convert.qke
+++ b/test/Conversion/QuakeToQTX/unable_to_convert.qke
@@ -44,18 +44,18 @@ func.func @return_mz(%qvec: !quake.qvec<2>, %size: i64) -> !cc.stdvec<i1> {
 // expected-warning@+1 {{couldn't convert kernel to QTX}}
 func.func @too_many_qextracts(%a: i64, %b: i64, %c: i64) {
   %0 = quake.alloca !quake.qvec<2>
-  %qa = quake.extract_ref %0[%a] : (!quake.qvec<2>, i64) -> !quake.qref
-  %qb = quake.extract_ref %0[%b] : (!quake.qvec<2>, i64) -> !quake.qref
-  %qc = quake.extract_ref %0[%c] : (!quake.qvec<2>, i64) -> !quake.qref
+  %qa = quake.extract_ref %0[%a] : (!quake.qvec<2>, i64) -> !quake.ref
+  %qb = quake.extract_ref %0[%b] : (!quake.qvec<2>, i64) -> !quake.ref
+  %qc = quake.extract_ref %0[%c] : (!quake.qvec<2>, i64) -> !quake.ref
   return
 }
 
 // CHECK-LABEL:   func.func @too_many_qextracts(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64) {
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:           return
 // CHECK:         }
 
@@ -68,8 +68,8 @@ func.func @for_loop_with_extracted_vector() {
   %c1_i64 = arith.constant 1 : i64
 
   %0 = quake.alloca  !quake.qvec<2>
-  %1 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.qref
-  %2 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.qref
+  %1 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
+  %2 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.ref
 
   %alloca = memref.alloca() : memref<i64>
   memref.store %c0_i64, %alloca[] : memref<i64>
@@ -79,8 +79,8 @@ func.func @for_loop_with_extracted_vector() {
     cc.condition %5
   } do {
     %4 = memref.load %alloca[] : memref<i64>
-    %5 = quake.extract_ref %0[%4] : (!quake.qvec<2>, i64) -> !quake.qref
-    quake.x %5 : (!quake.qref) -> ()
+    %5 = quake.extract_ref %0[%4] : (!quake.qvec<2>, i64) -> !quake.ref
+    quake.x %5 : (!quake.ref) -> ()
     cc.continue
   } step {
     %4 = memref.load %alloca[] : memref<i64>
@@ -95,8 +95,8 @@ func.func @for_loop_with_extracted_vector() {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i64>
 // CHECK:           memref.store %[[VAL_1]], %[[VAL_6]][] : memref<i64>
 // CHECK:           cc.loop while {
@@ -105,8 +105,8 @@ func.func @for_loop_with_extracted_vector() {
 // CHECK:             cc.condition %[[VAL_8]]
 // CHECK:           } do {
 // CHECK:             %[[VAL_9:.*]] = memref.load %[[VAL_6]][] : memref<i64>
-// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             quake.x %[[VAL_10]] : (!quake.qref) -> ()
+// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             quake.x %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:             cc.continue
 // CHECK:           } step {
 // CHECK:             %[[VAL_11:.*]] = memref.load %[[VAL_6]][] : memref<i64>

--- a/test/Quake-QIR/allocaNoOperand.qke
+++ b/test/Quake-QIR/allocaNoOperand.qke
@@ -56,46 +56,46 @@ module {
     %0 = quake.alloca !quake.qvec<4>
     %1 = memref.alloc() : memref<4xi1>
     %c0 = arith.constant 0 : index
-    %2 = quake.extract_ref %0[%c0] : (!quake.qvec<4>, index) -> !quake.qref
-    quake.x %2 : (!quake.qref) -> ()
+    %2 = quake.extract_ref %0[%c0] : (!quake.qvec<4>, index) -> !quake.ref
+    quake.x %2 : (!quake.ref) -> ()
     %c1 = arith.constant 1 : index
-    %3 = quake.extract_ref %0[%c1] : (!quake.qvec<4>, index) -> !quake.qref
-    quake.x %3 : (!quake.qref) -> ()
+    %3 = quake.extract_ref %0[%c1] : (!quake.qvec<4>, index) -> !quake.ref
+    quake.x %3 : (!quake.ref) -> ()
     %c3 = arith.constant 3 : index
-    %4 = quake.extract_ref %0[%c3] : (!quake.qvec<4>, index) -> !quake.qref
-    quake.h %4 : (!quake.qref) -> ()
+    %4 = quake.extract_ref %0[%c3] : (!quake.qvec<4>, index) -> !quake.ref
+    quake.h %4 : (!quake.ref) -> ()
     %c2 = arith.constant 2 : index
-    %5 = quake.extract_ref %0[%c2] : (!quake.qvec<4>, index) -> !quake.qref
-    quake.x [%5] %4 : (!quake.qref, !quake.qref) -> ()
-    quake.t %2 : (!quake.qref) -> ()
-    quake.t %3 : (!quake.qref) -> ()
-    quake.t %5 : (!quake.qref) -> ()
-    quake.t<adj> %4 : (!quake.qref) -> ()
-    quake.x [%2] %3 : (!quake.qref, !quake.qref) -> ()
-    quake.x [%5] %4 : (!quake.qref, !quake.qref) -> ()
-    quake.x [%4] %2 : (!quake.qref, !quake.qref) -> ()
-    quake.x [%3] %5 : (!quake.qref, !quake.qref) -> ()
-    quake.x [%2] %3 : (!quake.qref, !quake.qref) -> ()
-    quake.x [%5] %4 : (!quake.qref, !quake.qref) -> ()
-    quake.t<adj> %2 : (!quake.qref) -> ()
-    quake.t<adj> %3 : (!quake.qref) -> ()
-    quake.t<adj> %5 : (!quake.qref) -> ()
-    quake.t %4 : (!quake.qref) -> ()
-    quake.x [%2] %3 : (!quake.qref, !quake.qref) -> ()
-    quake.x [%5] %4 : (!quake.qref, !quake.qref) -> ()
-    quake.s %4 : (!quake.qref) -> ()
-    quake.x [%4] %2 : (!quake.qref, !quake.qref) -> ()
-    quake.h %4 : (!quake.qref) -> ()
-    %6 = quake.mz %2 : (!quake.qref) -> i1
+    %5 = quake.extract_ref %0[%c2] : (!quake.qvec<4>, index) -> !quake.ref
+    quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
+    quake.t %2 : (!quake.ref) -> ()
+    quake.t %3 : (!quake.ref) -> ()
+    quake.t %5 : (!quake.ref) -> ()
+    quake.t<adj> %4 : (!quake.ref) -> ()
+    quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%4] %2 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%3] %5 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
+    quake.t<adj> %2 : (!quake.ref) -> ()
+    quake.t<adj> %3 : (!quake.ref) -> ()
+    quake.t<adj> %5 : (!quake.ref) -> ()
+    quake.t %4 : (!quake.ref) -> ()
+    quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
+    quake.s %4 : (!quake.ref) -> ()
+    quake.x [%4] %2 : (!quake.ref, !quake.ref) -> ()
+    quake.h %4 : (!quake.ref) -> ()
+    %6 = quake.mz %2 : (!quake.ref) -> i1
     %c0_0 = arith.constant 0 : index
     memref.store %6, %1[%c0_0] : memref<4xi1>
-    %7 = quake.mz %3 : (!quake.qref) -> i1
+    %7 = quake.mz %3 : (!quake.ref) -> i1
     %c1_1 = arith.constant 1 : index
     memref.store %7, %1[%c1_1] : memref<4xi1>
-    %8 = quake.mz %5 : (!quake.qref) -> i1
+    %8 = quake.mz %5 : (!quake.ref) -> i1
     %c2_2 = arith.constant 2 : index
     memref.store %8, %1[%c2_2] : memref<4xi1>
-    %9 = quake.mz %4 : (!quake.qref) -> i1
+    %9 = quake.mz %4 : (!quake.ref) -> i1
     %c3_3 = arith.constant 3 : index
     memref.store %9, %1[%c3_3] : memref<4xi1>
     return

--- a/test/Quake-QIR/base-profile-2.qke
+++ b/test/Quake-QIR/base-profile-2.qke
@@ -16,8 +16,8 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"}}
     %1 = quake.alloca [%c2_i64 : i64] !quake.qvec<2>
     %c1_i32 = arith.constant 1 : i32
     %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.qvec<2>,i64) -> !quake.qref
-    %4 = quake.mz %3 : (!quake.qref) -> i1
+    %3 = quake.extract_ref %1[%2] : (!quake.qvec<2>,i64) -> !quake.ref
+    %4 = quake.mz %3 : (!quake.ref) -> i1
     return
   }
 }

--- a/test/Quake-QIR/base-profile-3.qke
+++ b/test/Quake-QIR/base-profile-3.qke
@@ -16,8 +16,8 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"}}
     %1 = quake.alloca[%c2_i64 : i64] !quake.qvec<2>
     %c1_i32 = arith.constant 1 : i32
     %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.qvec<2>,i64) -> !quake.qref
-    %4 = quake.mz %3 : (!quake.qref) -> i1 { registerName = "Bob" }
+    %3 = quake.extract_ref %1[%2] : (!quake.qvec<2>,i64) -> !quake.ref
+    %4 = quake.mz %3 : (!quake.ref) -> i1 { registerName = "Bob" }
     return
   }
 }

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -53,17 +53,17 @@ module {
       %1 = quake.alloca [%two : i32] !quake.qvec<2>
       %2 = quake.alloca [%one : i32] !quake.qvec<?>
       
-      %qr1 = quake.extract_ref %0[%zero] : (!quake.qvec<?>,i32) -> !quake.qref
-      %qr2 = quake.extract_ref %1[%one]  : (!quake.qvec<2>,i32) -> !quake.qref
+      %qr1 = quake.extract_ref %0[%zero] : (!quake.qvec<?>,i32) -> !quake.ref
+      %qr2 = quake.extract_ref %1[%one]  : (!quake.qvec<2>,i32) -> !quake.ref
 
       %fl = arith.constant 0.43 : f64
       %fl2 = arith.constant 0.33 : f64
       %fl3 = arith.constant 0.73 : f64
-      quake.h %qr1 : (!quake.qref) -> ()  
-      quake.x [%qr1] %qr2 : (!quake.qref, !quake.qref) -> ()
-      quake.rx (%fl) %qr1 : (f64, !quake.qref) -> ()
+      quake.h %qr1 : (!quake.ref) -> ()  
+      quake.x [%qr1] %qr2 : (!quake.ref, !quake.ref) -> ()
+      quake.rx (%fl) %qr1 : (f64, !quake.ref) -> ()
 
-      quake.mz %qr1 : (!quake.qref) -> i1
+      quake.mz %qr1 : (!quake.ref) -> i1
       return 
     }
 }

--- a/test/Quake-QIR/ghz.qke
+++ b/test/Quake-QIR/ghz.qke
@@ -40,16 +40,16 @@ module {
         %c0 = arith.constant 0 : i32
         %one = arith.constant 1 : i32
         %q = quake.alloca [%arg0 : i32] !quake.qvec<?>
-        %q0 = quake.extract_ref %q [%c0] : (!quake.qvec<?>,i32) -> !quake.qref
-        quake.h %q0 : (!quake.qref) -> ()
+        %q0 = quake.extract_ref %q [%c0] : (!quake.qvec<?>,i32) -> !quake.ref
+        quake.h %q0 : (!quake.ref) -> ()
         %size_m_1 = arith.subi %arg0, %one : i32
         %upper = arith.index_cast %size_m_1 : i32 to index
         affine.for %i = 0 to %upper {
             %i_int = arith.index_cast %i : index to i32
             %ip1 = arith.addi %i_int, %one : i32
-            %qi = quake.extract_ref %q [%i] : (!quake.qvec<?>,index) -> !quake.qref
-            %qi1 = quake.extract_ref %q [%ip1] : (!quake.qvec<?>,i32) -> !quake.qref
-            quake.x [%qi] %qi1 : (!quake.qref,!quake.qref) -> ()
+            %qi = quake.extract_ref %q [%i] : (!quake.qvec<?>,index) -> !quake.ref
+            %qi1 = quake.extract_ref %q [%ip1] : (!quake.qvec<?>,i32) -> !quake.ref
+            quake.x [%qi] %qi1 : (!quake.ref,!quake.ref) -> ()
         }
         return
     }

--- a/test/Quake-QIR/measure.qke
+++ b/test/Quake-QIR/measure.qke
@@ -15,11 +15,11 @@ module {
     %two = arith.constant 2 : i32
     %0 = quake.alloca [%two : i32] !quake.qvec<?>
 
-    %qr1 = quake.extract_ref %0[%zero] : (!quake.qvec<?>,i32) -> !quake.qref
-    %qr2 = quake.extract_ref %0[%one] : (!quake.qvec<?>,i32) -> !quake.qref
+    %qr1 = quake.extract_ref %0[%zero] : (!quake.qvec<?>,i32) -> !quake.ref
+    %qr2 = quake.extract_ref %0[%one] : (!quake.qvec<?>,i32) -> !quake.ref
 
-    quake.mx %qr1 : (!quake.qref) -> i1
-    quake.my %qr1 : (!quake.qref) -> i1
+    quake.mx %qr1 : (!quake.ref) -> i1
+    quake.my %qr1 : (!quake.ref) -> i1
     return 
   }
 }

--- a/test/Quake-QIR/testBaseProfile.qke
+++ b/test/Quake-QIR/testBaseProfile.qke
@@ -30,17 +30,17 @@ module {
     %c0 = arith.constant 0 : index
     %c3_i32 = arith.constant 3 : i32
     %0 = quake.alloca[%c3_i32 : i32] !quake.qvec<3>
-    %1 = quake.extract_ref %0[%c0_i32] : (!quake.qvec<3>,i32) -> !quake.qref
-    quake.h %1 : (!quake.qref) -> ()
-    %2 = quake.extract_ref %0[%c0] : (!quake.qvec<3>, index) -> !quake.qref
-    %3 = quake.extract_ref %0[%c1_i32] : (!quake.qvec<3>,i32) -> !quake.qref
-    quake.x [%2] %3 : (!quake.qref, !quake.qref) -> ()
-    %4 = quake.extract_ref %0[%c1] : (!quake.qvec<3>,index) -> !quake.qref
-    %5 = quake.extract_ref %0[%c2_i32] : (!quake.qvec<3>,i32) -> !quake.qref
-    quake.x [%4] %5 : (!quake.qref, !quake.qref) -> ()
-    %6 = quake.mz %1 : (!quake.qref) -> i1
-    %7 = quake.mz %3 : (!quake.qref) -> i1
-    %8 = quake.mz %5 : (!quake.qref) -> i1
+    %1 = quake.extract_ref %0[%c0_i32] : (!quake.qvec<3>,i32) -> !quake.ref
+    quake.h %1 : (!quake.ref) -> ()
+    %2 = quake.extract_ref %0[%c0] : (!quake.qvec<3>, index) -> !quake.ref
+    %3 = quake.extract_ref %0[%c1_i32] : (!quake.qvec<3>,i32) -> !quake.ref
+    quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
+    %4 = quake.extract_ref %0[%c1] : (!quake.qvec<3>,index) -> !quake.ref
+    %5 = quake.extract_ref %0[%c2_i32] : (!quake.qvec<3>,i32) -> !quake.ref
+    quake.x [%4] %5 : (!quake.ref, !quake.ref) -> ()
+    %6 = quake.mz %1 : (!quake.ref) -> i1
+    %7 = quake.mz %3 : (!quake.ref) -> i1
+    %8 = quake.mz %5 : (!quake.ref) -> i1
     return
   }
   // CHECK: attributes #0 = { "EntryPoint" "requiredQubits"="3" "requiredResults"="3" }

--- a/test/Quake/adjoint-1.qke
+++ b/test/Quake/adjoint-1.qke
@@ -17,22 +17,22 @@ module {
     %c0_i32 = arith.constant 0 : i32
     %0 = quake.alloca !quake.qvec<2>
     cc.if(%arg0) {
-      %3 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-      %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-      quake.h [%3] %4 : (!quake.qref, !quake.qref) -> ()
-      quake.x %4 : (!quake.qref) -> ()
-      quake.y [%3] %4 : (!quake.qref, !quake.qref) -> ()
+      %3 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+      %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+      quake.h [%3] %4 : (!quake.ref, !quake.ref) -> ()
+      quake.x %4 : (!quake.ref) -> ()
+      quake.y [%3] %4 : (!quake.ref, !quake.ref) -> ()
     }
     %dead = cc.loop while ((%iter = %c0_i32) -> (i32)) {
       %5 = arith.cmpi slt, %iter, %arg2 : i32
       cc.condition %5 (%iter : i32)
     } do {
       ^bb1(%iter : i32):
-        %3 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-        %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-        quake.x [%3] %4 : (!quake.qref, !quake.qref) -> ()
-        quake.y %4 : (!quake.qref) -> ()
-        quake.z [%3] %4 : (!quake.qref, !quake.qref) -> ()
+        %3 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+        %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+        quake.x [%3] %4 : (!quake.ref, !quake.ref) -> ()
+        quake.y %4 : (!quake.ref) -> ()
+        quake.z [%3] %4 : (!quake.ref, !quake.ref) -> ()
         cc.continue %iter : i32
     } step {
       ^bb2(%iter : i32):
@@ -45,11 +45,11 @@ module {
       cc.continue %arg1 : i1
     }
     cc.if(%b3) {
-      %3 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-      %4 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-      quake.y %4 : (!quake.qref) -> ()
-      quake.z [%3] %4 : (!quake.qref, !quake.qref) -> ()
-      quake.h %4 : (!quake.qref) -> ()
+      %3 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+      %4 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+      quake.y %4 : (!quake.ref) -> ()
+      quake.z [%3] %4 : (!quake.ref, !quake.ref) -> ()
+      quake.h %4 : (!quake.ref) -> ()
     }
     return
   }
@@ -74,8 +74,8 @@ module {
 // CHECK:             cc.continue %[[VAL_1]] : i1
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_9:.*]]) {
-// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:             quake.h %[[VAL_11]] :
 // CHECK:             quake.z [%[[VAL_10]]] %[[VAL_11]] :
 // CHECK:             quake.y %[[VAL_11]] :
@@ -88,8 +88,8 @@ module {
 // CHECK:             cc.condition %[[VAL_18]](%[[VAL_16]], %[[VAL_17]] : i32, i32)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_19:.*]]: i32, %[[VAL_20:.*]]: i32):
-// CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:             quake.z [%[[VAL_21]]] %[[VAL_22]] :
 // CHECK:             quake.y %[[VAL_22]] :
 // CHECK:             quake.x [%[[VAL_21]]] %[[VAL_22]] :
@@ -101,8 +101,8 @@ module {
 // CHECK:             cc.continue %[[VAL_25]], %[[VAL_26]] : i32, i32
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_0]]) {
-// CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             %[[VAL_28:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_28:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:             quake.y [%[[VAL_27]]] %[[VAL_28]] :
 // CHECK:             quake.x %[[VAL_28]] :
 // CHECK:             quake.h [%[[VAL_27]]] %[[VAL_28]] :

--- a/test/Quake/adjoint-2.qke
+++ b/test/Quake/adjoint-2.qke
@@ -10,14 +10,14 @@
 
 module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__kernel_alpha = "_ZN12kernel_alphaclERN4cudaq5quditILm2EEE", __nvqpp__mlirgen__kernel_beta = "_ZN11kernel_betaclEv"}} {
   // expected-error @+1 {{cannot make adjoint of kernel with a measurement}}
-  func.func @__nvqpp__mlirgen__kernel_alpha(%arg0: !quake.qref) attributes {"cudaq-kernel"} {
-    %0 = quake.mx %arg0 : (!quake.qref) -> i1
+  func.func @__nvqpp__mlirgen__kernel_alpha(%arg0: !quake.ref) attributes {"cudaq-kernel"} {
+    %0 = quake.mx %arg0 : (!quake.ref) -> i1
     return
   }
   func.func @__nvqpp__mlirgen__kernel_beta() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-    %0 = quake.alloca !quake.qref
+    %0 = quake.alloca !quake.ref
     %1 = cc.undef !llvm.struct<"kernel_alpha", ()>
-    quake.apply<adj> @__nvqpp__mlirgen__kernel_alpha %0 : (!quake.qref) -> ()
+    quake.apply<adj> @__nvqpp__mlirgen__kernel_alpha %0 : (!quake.ref) -> ()
     return
   }
 }

--- a/test/Quake/apply-1.qke
+++ b/test/Quake/apply-1.qke
@@ -11,22 +11,22 @@
 // Test specialization of a user-defined kernel (@test) for both
 // adjoint and control forms.
 
-  func.func @test(%arg : !quake.qref) {
-    quake.t %arg : (!quake.qref) -> ()
-    quake.h %arg : (!quake.qref) -> ()
+  func.func @test(%arg : !quake.ref) {
+    quake.t %arg : (!quake.ref) -> ()
+    quake.h %arg : (!quake.ref) -> ()
     %1 = arith.constant 1.0 : f32
-    quake.rx (%1) %arg : (f32, !quake.qref) -> ()
-    quake.x %arg : (!quake.qref) -> ()
+    quake.rx (%1) %arg : (f32, !quake.ref) -> ()
+    quake.x %arg : (!quake.ref) -> ()
     return
   }
   
-  func.func @do_apply(%arg : !quake.qref, %brg : !quake.qref) {
-    quake.apply <adj> @test [%brg] %arg : (!quake.qref,!quake.qref) -> ()
+  func.func @do_apply(%arg : !quake.ref, %brg : !quake.ref) {
+    quake.apply <adj> @test [%brg] %arg : (!quake.ref,!quake.ref) -> ()
     return
   }
 
 // CHECK-LABEL: func.func private @test.adj.ctrl(
-// CHECK-SAME:     %[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: !quake.qref) {
+// CHECK-SAME:     %[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: !quake.ref) {
 // CHECK:         %[[VAL_2:.*]] = arith.constant 1.0{{.*}} : f32
 // CHECK-DAG:     quake.x [%[[VAL_0]]] %[[VAL_1]] :
 // CHECK-DAG:     %[[VAL_3:.*]] = arith.negf %[[VAL_2]] : f32
@@ -40,7 +40,7 @@
 // testing it is not strictly required here.
 
 // CHECK-LABEL:   func.func private @test.ctrl(
-// CHECK-SAME:       %[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: !quake.qref) {
+// CHECK-SAME:       %[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: !quake.ref) {
 // CHECK:           quake.t [%[[VAL_0]]] %[[VAL_1]]
 // CHECK:           quake.h [%[[VAL_0]]] %[[VAL_1]]
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1.000000e+00 : f32
@@ -50,7 +50,7 @@
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !quake.qref) {
+// CHECK-SAME:                    %[[VAL_0:.*]]: !quake.ref) {
 // CHECK:           quake.t %[[VAL_0]] :
 // CHECK:           quake.h %[[VAL_0]] :
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1.000000e+00 : f32
@@ -60,9 +60,9 @@
 // CHECK:         }
 
 // CHECK-LABEL: func.func @do_apply(
-// CHECK-SAME:     %[[VAL_0:.*]]: !quake.qref, %[[VAL_1:.*]]: !quake.qref) {
-// CHECK:         %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.qref) -> !quake.qvec<?>
-// CHECK:         call @test.adj.ctrl(%[[VAL_2]], %[[VAL_0]]) : (!quake.qvec<?>, !quake.qref) -> ()
+// CHECK-SAME:     %[[VAL_0:.*]]: !quake.ref, %[[VAL_1:.*]]: !quake.ref) {
+// CHECK:         %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.ref) -> !quake.qvec<?>
+// CHECK:         call @test.adj.ctrl(%[[VAL_2]], %[[VAL_0]]) : (!quake.qvec<?>, !quake.ref) -> ()
 // CHECK:         return
 // CHECK:       }
 

--- a/test/Quake/apply-2.qke
+++ b/test/Quake/apply-2.qke
@@ -12,14 +12,14 @@
 // adjoint and control forms.
 
 module {
-  func.func @test(%arg : !quake.qref) {
-    quake.t %arg : (!quake.qref) -> ()
-    quake.h %arg : (!quake.qref) -> ()
-    quake.x %arg : (!quake.qref) -> ()
+  func.func @test(%arg : !quake.ref) {
+    quake.t %arg : (!quake.ref) -> ()
+    quake.h %arg : (!quake.ref) -> ()
+    quake.x %arg : (!quake.ref) -> ()
     return
   }
-  func.func @do_apply(%arg : !quake.qref, %brg : !quake.qref) {
-    quake.apply <adj> @test [%brg] %arg : (!quake.qref, !quake.qref) -> ()
+  func.func @do_apply(%arg : !quake.ref, %brg : !quake.ref) {
+    quake.apply <adj> @test [%brg] %arg : (!quake.ref, !quake.ref) -> ()
     return
   }
 }

--- a/test/Quake/basic.qke
+++ b/test/Quake/basic.qke
@@ -11,8 +11,8 @@
 // CHECK-LABEL: func @alloc(
 // CHECK-SAME: %[[SIZE:.*]]: i32
 func.func @alloc(%size : i32) {
-  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.qref
-  %qubit = quake.alloca !quake.qref
+  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.ref
+  %qubit = quake.alloca !quake.ref
   // CHECK: %[[QREG0:.*]] = quake.alloca[%[[SIZE]] : i32] !quake.qvec<?>
   %qvec0 = quake.alloca [%size : i32] !quake.qvec<?>
   // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<4>
@@ -22,8 +22,8 @@ func.func @alloc(%size : i32) {
 
 // CHECK-LABEL: func @alloc_qubit
 func.func @alloc_qubit() {
-  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.qref
-  %qubit = quake.alloca !quake.qref
+  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.ref
+  %qubit = quake.alloca !quake.ref
   return
 }
 
@@ -35,17 +35,17 @@ func.func @alloc_qreg() {
 }
 
 // CHECK-LABEL: func @args(
-// CHECK-SAME: %{{.*}}: !quake.qref, %{{.*}}: !quake.qvec<2>)
-func.func @args(%qubit: !quake.qref, %qvec: !quake.qvec<2>) {
+// CHECK-SAME: %{{.*}}: !quake.ref, %{{.*}}: !quake.qvec<2>)
+func.func @args(%qubit: !quake.ref, %qvec: !quake.qvec<2>) {
   return
 }
 
 // CHECK-LABEL: func @reset
 func.func @reset() {
-  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.qref
-  %qubit = quake.alloca !quake.qref
-  // CHECK: quake.reset %[[QUBIT]] : (!quake.qref) -> ()
-  quake.reset %qubit : (!quake.qref) -> ()
+  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.ref
+  %qubit = quake.alloca !quake.ref
+  // CHECK: quake.reset %[[QUBIT]] : (!quake.ref) -> ()
+  quake.reset %qubit : (!quake.ref) -> ()
   // CHECK: %[[QREG:.*]] = quake.alloca !quake.qvec<2>
   %qreg = quake.alloca !quake.qvec<2>
   // CHECK: quake.reset %[[QREG]] : (!quake.qvec<2>) -> ()
@@ -55,9 +55,9 @@ func.func @reset() {
 
 // CHECK-LABEL: func @apply_x
 func.func @apply_x() {
-  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.qref
-  %qubit = quake.alloca !quake.qref
-  quake.x %qubit : (!quake.qref) -> ()
+  // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.ref
+  %qubit = quake.alloca !quake.ref
+  quake.x %qubit : (!quake.ref) -> ()
   return
 }
 
@@ -67,9 +67,9 @@ func.func @apply_cx() {
   %c1 = arith.constant 1 : index
   // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<2>
   %qvec = quake.alloca  !quake.qvec<2>
-  %q0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<2>,index) -> !quake.qref
-  %q1 = quake.extract_ref %qvec[%c1] : (!quake.qvec<2>,index) -> !quake.qref
-  quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
+  %q0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<2>,index) -> !quake.ref
+  %q1 = quake.extract_ref %qvec[%c1] : (!quake.qvec<2>,index) -> !quake.ref
+  quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
   return
 }
 
@@ -78,12 +78,12 @@ func.func @apply_cx_v() {
   %c1 = arith.constant 1 : index
   // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<2>
   %qvec = quake.alloca  !quake.qvec<2>
-  %q0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<2>,index) -> !quake.qref
-  %q1 = quake.extract_ref %qvec[%c1] : (!quake.qvec<2>,index) -> !quake.qref
-  %q2 = quake.unwrap %q0 : (!quake.qref) -> !quake.wire
-  %q3 = quake.unwrap %q1 : (!quake.qref) -> !quake.wire
+  %q0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<2>,index) -> !quake.ref
+  %q1 = quake.extract_ref %qvec[%c1] : (!quake.qvec<2>,index) -> !quake.ref
+  %q2 = quake.unwrap %q0 : (!quake.ref) -> !quake.wire
+  %q3 = quake.unwrap %q1 : (!quake.ref) -> !quake.wire
   // CHECK: %{{.*}} = quake.x [%{{.*}}] %{{.*}} : (!quake.wire, !quake.wire) -> !quake.wire
   %q5 = quake.x [%q2] %q3 : (!quake.wire, !quake.wire) -> !quake.wire
-  quake.wrap %q5 to %q1 : !quake.wire, !quake.qref
+  quake.wrap %q5 to %q1 : !quake.wire, !quake.ref
   return
 }

--- a/test/Quake/bell.qke
+++ b/test/Quake/bell.qke
@@ -12,25 +12,25 @@ module {
     // CHECK: %[[C0:.*]] = arith.constant 0 : i32
     // CHECK: %[[C1:.*]] = arith.constant 1 : i32
     // CHECK: %0 = quake.alloca !quake.qvec<2>
-    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-    // CHECK: %2 = quake.extract_ref %0[%[[C1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+    // CHECK: %2 = quake.extract_ref %0[%[[C1]]] : (!quake.qvec<2>, i32) -> !quake.ref
     // CHECK: quake.h %1
     // CHECK: quake.x [%1] %2 :
-    // CHECK: %3 = quake.mz %1 : (!quake.qref) -> i1
-    // CHECK: %4 = quake.mz %2 : (!quake.qref) -> i1
+    // CHECK: %3 = quake.mz %1 : (!quake.ref) -> i1
+    // CHECK: %4 = quake.mz %2 : (!quake.ref) -> i1
     // CHECK: return
     func.func @bell() {
         %0 = arith.constant 2 : i32
         %c_0 = arith.constant 0 : i32
         %c_1 = arith.constant 1 : i32
         %qubits = quake.alloca [%0 : i32] !quake.qvec<?>
-        %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>,i32) -> !quake.qref
-        %q1 = quake.extract_ref %qubits[%c_1] : (!quake.qvec<?>,i32) -> !quake.qref
+        %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>,i32) -> !quake.ref
+        %q1 = quake.extract_ref %qubits[%c_1] : (!quake.qvec<?>,i32) -> !quake.ref
 
-        quake.h %q0 : (!quake.qref) -> ()
-        quake.x [%q0] %q1 : (!quake.qref, !quake.qref) -> ()
-        quake.mz %q0 : (!quake.qref) -> i1
-        quake.mz %q1 : (!quake.qref) -> i1
+        quake.h %q0 : (!quake.ref) -> ()
+        quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+        quake.mz %q0 : (!quake.ref) -> i1
+        quake.mz %q1 : (!quake.ref) -> i1
         return
     }
 }

--- a/test/Quake/canonical-1.qke
+++ b/test/Quake/canonical-1.qke
@@ -19,8 +19,8 @@ func.func @test2() {
   // relax_size must be inserted here
   %2 = call @test1(%1) : (!quake.qvec<?>) -> i1
   %3 = arith.constant 1 : i64
-  %4 = quake.extract_ref %1[%3] : (!quake.qvec<?>,i64) -> !quake.qref
-  quake.h %4 : (!quake.qref) -> ()
+  %4 = quake.extract_ref %1[%3] : (!quake.qvec<?>,i64) -> !quake.ref
+  quake.h %4 : (!quake.ref) -> ()
   return
 }
 
@@ -29,7 +29,7 @@ func.func @test2() {
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<10>
 // CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.qvec<10>) -> !quake.qvec<?>
 // CHECK:           %[[VAL_3:.*]] = call @test1(%[[VAL_2]]) : (!quake.qvec<?>) -> i1
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_0]]] : (!quake.qvec<10>, i64) -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_0]]] : (!quake.qvec<10>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_4]]
 // CHECK:           return
 // CHECK:         }
@@ -42,8 +42,8 @@ func.func @test3() {
   // This subvec qvec<?> can be reified to qvec<4>
   %4 = quake.subvec %1, %2, %3 : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
   %5 = arith.constant 2 : i64
-  %6 = quake.extract_ref %4[%5] : (!quake.qvec<?>,i64) -> !quake.qref
-  quake.h %6 : (!quake.qref) -> ()
+  %6 = quake.extract_ref %4[%5] : (!quake.qvec<?>,i64) -> !quake.ref
+  quake.h %6 : (!quake.ref) -> ()
   return
 }
 
@@ -53,8 +53,8 @@ func.func @test3() {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 4 : i64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<10>
 // CHECK:           %[[VAL_4:.*]] = quake.subvec %[[VAL_3]], %[[VAL_2]], %[[VAL_1]] : (!quake.qvec<10>, i64, i64) -> !quake.qvec<4>
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_0]]] : (!quake.qvec<4>, i64) -> !quake.qref
-// CHECK:           quake.h %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_0]]] : (!quake.qvec<4>, i64) -> !quake.ref
+// CHECK:           quake.h %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -62,13 +62,13 @@ func.func @test_qextract_1() {
     %c0 = arith.constant 0 : i64
     %c2 = arith.constant 2 : i64
     %qvec = quake.alloca [%c2 : i64] !quake.qvec<?>
-    %0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>, i64) -> !quake.qref
-    quake.h %0 : (!quake.qref) -> ()
+    %0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>, i64) -> !quake.ref
+    quake.h %0 : (!quake.ref) -> ()
     %c0_0 = arith.constant 0 : i64
     %c1 = arith.constant 1 : i64
-    %1 = quake.extract_ref %qvec[%c0_0] : (!quake.qvec<?>, i64) -> !quake.qref
-    %2 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>, i64) -> !quake.qref
-    quake.x [%1] %2 : (!quake.qref, !quake.qref) -> ()
+    %1 = quake.extract_ref %qvec[%c0_0] : (!quake.qvec<?>, i64) -> !quake.ref
+    %2 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>, i64) -> !quake.ref
+    quake.x [%1] %2 : (!quake.ref, !quake.ref) -> ()
     return
 }
 
@@ -76,10 +76,10 @@ func.func @test_qextract_1() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           quake.h %[[VAL_3]] : (!quake.qref) -> ()
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -88,18 +88,18 @@ func.func @test_qextract_2(%arg0: i1) {
     %c2 = arith.constant 2 : i64
     %c1 = arith.constant 1 : i64
     %qvec = quake.alloca[%c2 : i64]  !quake.qvec<?>
-    %0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.qref
-    quake.h %0 : (!quake.qref) -> ()
+    %0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.ref
+    quake.h %0 : (!quake.ref) -> ()
     cc.if(%arg0) {
       cc.scope {
-        %1 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.qref
-        %2 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>,i64) -> !quake.qref
-        quake.x [%1] %2 : (!quake.qref,!quake.qref) -> ()
+        %1 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.ref
+        %2 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>,i64) -> !quake.ref
+        quake.x [%1] %2 : (!quake.ref,!quake.ref) -> ()
       }
     }
-    %3 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.qref
-    %4 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>,i64) -> !quake.qref
-    quake.x [%3] %4 : (!quake.qref,!quake.qref) -> ()
+    %3 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.ref
+    %4 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>,i64) -> !quake.ref
+    quake.x [%3] %4 : (!quake.ref,!quake.ref) -> ()
     return
 }
 
@@ -108,14 +108,14 @@ func.func @test_qextract_2(%arg0: i1) {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_4]] :
 // CHECK:           cc.if(%[[VAL_0]]) {
-// CHECK:             %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.qref
-// CHECK:             %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:             %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_5]]] %[[VAL_6]] :
 // CHECK:           }
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.qref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_4]]] %[[VAL_7]] :
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/canonical-2.qke
+++ b/test/Quake/canonical-2.qke
@@ -20,7 +20,7 @@
     %5 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
     %c1_i64_0 = arith.constant 1 : i64
     %6 = arith.subi %5, %c1_i64_0 : i64
-    %7 = quake.extract_ref %arg0[%6] : (!quake.qvec<?>,i64) -> !quake.qref
+    %7 = quake.extract_ref %arg0[%6] : (!quake.qvec<?>,i64) -> !quake.ref
     %8 = cc.create_lambda {
       cc.scope {
         %c0 = arith.constant 0 : index
@@ -28,14 +28,14 @@
         %10 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
         %11 = arith.index_cast %10 : i64 to index
         scf.for %arg1 = %c0 to %11 step %c1 {
-          %12 = quake.extract_ref %arg0[%arg1] : (!quake.qvec<?>,index) -> !quake.qref
-          quake.h %12 : (!quake.qref) -> ()
+          %12 = quake.extract_ref %arg0[%arg1] : (!quake.qvec<?>,index) -> !quake.ref
+          quake.h %12 : (!quake.ref) -> ()
         }
       }
     } : !cc.lambda<() -> ()>
     %9 = cc.create_lambda {
       cc.scope {
-        quake.z [%4] %7 : (!quake.qvec<?>, !quake.qref) -> ()
+        quake.z [%4] %7 : (!quake.qvec<?>, !quake.ref) -> ()
       }
     } : !cc.lambda<() -> ()>
     quake.compute_action %8, %9 : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>

--- a/test/Quake/ccnot.qke
+++ b/test/Quake/ccnot.qke
@@ -11,7 +11,7 @@
 module {
 
     // CHECK-LABEL: func.func @apply_x(
-    // CHECK-SAME: %[[arg0:.*]]: !quake.qref) {
+    // CHECK-SAME: %[[arg0:.*]]: !quake.ref) {
     // CHECK:   quake.x %[[arg0]] :
     // CHECK:   return
     // CHECK: }
@@ -20,16 +20,16 @@ module {
     // CHECK:   %[[C1:.*]] = arith.constant 1 : i32
     // CHECK:   %[[a0:.*]] = quake.alloca !quake.qvec<3>
     // CHECK:   affine.for %[[arg0:.*]] = 0 to 3 {
-    // CHECK:     %[[a2:.*]] = quake.extract_ref %[[a0]][%[[arg0]]] : (!quake.qvec<3>, index) -> !quake.qref
+    // CHECK:     %[[a2:.*]] = quake.extract_ref %[[a0]][%[[arg0]]] : (!quake.qvec<3>, index) -> !quake.ref
     // CHECK:     quake.x %[[a2]] :
     // CHECK:   }
-    // CHECK:   %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.qvec<3>, i32) -> !quake.qref
+    // CHECK:   %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.qvec<3>, i32) -> !quake.ref
     // CHECK:   quake.x %[[a1]] :
     // CHECK:   return
     // CHECK: }
     
-    func.func @apply_x(%q : !quake.qref) {
-        quake.x %q : (!quake.qref) -> ()
+    func.func @apply_x(%q : !quake.ref) {
+        quake.x %q : (!quake.ref) -> ()
         return
     }
 
@@ -41,12 +41,12 @@ module {
         %qubits = quake.alloca [ %c_3 : i32 ] !quake.qvec<?>
         %c_3_idx = arith.index_cast %c_3 : i32 to index
         affine.for %i = 0 to %c_3_idx {
-            %q0 = quake.extract_ref %qubits [%i] : (!quake.qvec<?>, index) -> !quake.qref
-            quake.x %q0 : (!quake.qref) -> ()
+            %q0 = quake.extract_ref %qubits [%i] : (!quake.qvec<?>, index) -> !quake.ref
+            quake.x %q0 : (!quake.ref) -> ()
         }
 
-        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>, i32) -> !quake.qref
-        func.call @apply_x(%q1) : (!quake.qref) -> ()
+        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>, i32) -> !quake.ref
+        func.call @apply_x(%q1) : (!quake.ref) -> ()
 
         return
     }

--- a/test/Quake/compute_action.qke
+++ b/test/Quake/compute_action.qke
@@ -25,20 +25,20 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
       cc.scope {
         %c0_i32 = arith.constant 0 : i32
         %4 = arith.extsi %c0_i32 : i32 to i64
-        %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.qref
-        quake.t %5 : (!quake.qref) -> ()
+        %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.ref
+        quake.t %5 : (!quake.ref) -> ()
         %c1_i32 = arith.constant 1 : i32
         %6 = arith.extsi %c1_i32 : i32 to i64
-        %7 = quake.extract_ref %1[%6] : (!quake.qvec<?>,i64) -> !quake.qref
-        quake.x %7 : (!quake.qref) -> ()
+        %7 = quake.extract_ref %1[%6] : (!quake.qvec<?>,i64) -> !quake.ref
+        quake.x %7 : (!quake.ref) -> ()
       }
     } : !cc.lambda<() -> ()>
     %3 = cc.create_lambda {
       cc.scope {
         %c2_i32 = arith.constant 2 : i32
         %4 = arith.extsi %c2_i32 : i32 to i64
-        %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.qref
-        quake.h %5 : (!quake.qref) -> ()
+        %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.ref
+        quake.h %5 : (!quake.ref) -> ()
       }
     } : !cc.lambda<() -> ()>
     quake.compute_action %2, %3 : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
@@ -49,10 +49,10 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
 // CHECK-LABEL:   func.func private @__nvqpp__lifted.lambda.{{[01]}}.adj(
 // CHECK-SAME:            %[[VAL_0:.*]]: !quake.qvec<5>,
 // CHECK-SAME:            %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64) {
-// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.qvec<5>, i64) -> !quake.qref
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<5>, i64) -> !quake.qref
-// CHECK:           quake.x %[[VAL_4]] : (!quake.qref) -> ()
-// CHECK:           quake.t<adj> %[[VAL_3]] : (!quake.qref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.qvec<5>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<5>, i64) -> !quake.ref
+// CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
+// CHECK:           quake.t<adj> %[[VAL_3]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/cse.qke
+++ b/test/Quake/cse.qke
@@ -20,25 +20,25 @@ module {
     %c2_i64 = arith.constant 2 : i64
     %cst = arith.constant -1.000000e+00 : f64
     %0 = quake.alloca  !quake.qvec<3>
-    %1 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<3>,i64) -> !quake.qref
-    quake.x %1 : (!quake.qref) -> ()
+    %1 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<3>,i64) -> !quake.ref
+    quake.x %1 : (!quake.ref) -> ()
     %2 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
     %3 = llvm.load %2 : !llvm.ptr<f64>
-    %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<3>,i64) -> !quake.qref
-    quake.ry (%3) %4 : (f64, !quake.qref) -> ()
+    %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<3>,i64) -> !quake.ref
+    quake.ry (%3) %4 : (f64, !quake.ref) -> ()
     %5 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
     %6 = llvm.getelementptr %5[1] : (!llvm.ptr<f64>) -> !llvm.ptr<f64>
     %7 = llvm.load %6 : !llvm.ptr<f64>
-    %8 = quake.extract_ref %0[%c2_i64] : (!quake.qvec<3>, i64) -> !quake.qref
-    quake.ry (%7) %8 : (f64, !quake.qref) -> ()
-    quake.x [%8] %1 : (!quake.qref, !quake.qref) -> ()
-    quake.x [%1] %4 : (!quake.qref, !quake.qref) -> ()
+    %8 = quake.extract_ref %0[%c2_i64] : (!quake.qvec<3>, i64) -> !quake.ref
+    quake.ry (%7) %8 : (f64, !quake.ref) -> ()
+    quake.x [%8] %1 : (!quake.ref, !quake.ref) -> ()
+    quake.x [%1] %4 : (!quake.ref, !quake.ref) -> ()
     %9 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
     %10 = llvm.load %9 : !llvm.ptr<f64>
     %11 = arith.mulf %10, %cst : f64
-    quake.ry (%11) %4 : (f64, !quake.qref) -> ()
-    quake.x [%1] %4   : (!quake.qref, !quake.qref) -> ()
-    quake.x [%4] %1   : (!quake.qref, !quake.qref) -> ()
+    quake.ry (%11) %4 : (f64, !quake.ref) -> ()
+    quake.x [%1] %4   : (!quake.ref, !quake.ref) -> ()
+    quake.x [%4] %1   : (!quake.ref, !quake.ref) -> ()
     return
   }
 }

--- a/test/Quake/deuteron.qke
+++ b/test/Quake/deuteron.qke
@@ -13,13 +13,13 @@
 // CHECK:    %[[C0:.*]] = arith.constant 0 : i32
 // CHECK:    %[[C1:.*]] = arith.constant 1 : i32
 // CHECK:    %[[a0:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:    %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C0]]] : (!quake.qvec<2>, i32) -> !quake.qref
-// CHECK:    %[[a2:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.qvec<2>, i32) -> !quake.qref
+// CHECK:    %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+// CHECK:    %[[a2:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.qvec<2>, i32) -> !quake.ref
 // CHECK:    quake.x %[[a1]]
-// CHECK:    quake.ry (%[[arg0]]) %[[a2]] : (f64, !quake.qref) -> ()
-// CHECK:    quake.x [%[[a2]]] %[[a1]] : (!quake.qref, !quake.qref) -> ()
-// CHECK:    %[[a3:.*]] = quake.mz %[[a1]] : (!quake.qref) -> i1
-// CHECK:    %[[a4:.*]] = quake.mz %[[a2]] : (!quake.qref) -> i1
+// CHECK:    quake.ry (%[[arg0]]) %[[a2]] : (f64, !quake.ref) -> ()
+// CHECK:    quake.x [%[[a2]]] %[[a1]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:    %[[a3:.*]] = quake.mz %[[a1]] : (!quake.ref) -> i1
+// CHECK:    %[[a4:.*]] = quake.mz %[[a2]] : (!quake.ref) -> i1
 // CHECK:    return
 // CHECK:  }
 
@@ -30,14 +30,14 @@ module {
         %c_1 = arith.constant 1 : i32
         %c_angle = arith.constant 0.59 : f64
         %qubits = quake.alloca [ %0 : i32 ] !quake.qvec<?>
-        %q0 = quake.extract_ref %qubits [%c_0] : (!quake.qvec<?>,i32) -> !quake.qref
-        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>,i32) -> !quake.qref
+        %q0 = quake.extract_ref %qubits [%c_0] : (!quake.qvec<?>,i32) -> !quake.ref
+        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>,i32) -> !quake.ref
 
-        quake.x %q0 : (!quake.qref) -> ()
-        quake.ry (%theta) %q1  : (f64, !quake.qref) -> ()
-        quake.x [%q1] %q0 : (!quake.qref, !quake.qref) -> ()
-        %measurements0 = quake.mz %q0 : (!quake.qref) -> i1
-        %measurements1 = quake.mz %q1 : (!quake.qref) -> i1
+        quake.x %q0 : (!quake.ref) -> ()
+        quake.ry (%theta) %q1  : (f64, !quake.ref) -> ()
+        quake.x [%q1] %q0 : (!quake.ref, !quake.ref) -> ()
+        %measurements0 = quake.mz %q0 : (!quake.ref) -> i1
+        %measurements1 = quake.mz %q1 : (!quake.ref) -> i1
         return
     }
 }

--- a/test/Quake/dummy.qke
+++ b/test/Quake/dummy.qke
@@ -16,8 +16,8 @@
 // CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
 // CHECK:     %1 = quake.alloca[%[[C22]] : i64] !quake.qvec<?>
 // CHECK:     %2 = quake.alloca[%[[C1]] : i32] !quake.qvec<?>
-// CHECK:     %3 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:     %4 = quake.extract_ref %1[%[[C1]]] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:     %3 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     %4 = quake.extract_ref %1[%[[C1]]] : (!quake.qvec<?>, i32) -> !quake.ref
 // CHECK:     quake.h %3 :
 // CHECK:     quake.x [%3] %4 :
 // CHECK:     return
@@ -31,10 +31,10 @@ func.func @bar() {
   %qr22 = quake.alloca[ %1 : i64 ]  !quake.qvec<?>
   %q = quake.alloca [%one : i32]  !quake.qvec<?>
 
-  %r = quake.extract_ref %qr2[%3] : (!quake.qvec<?>,i32) -> !quake.qref
-  %q1 = quake.extract_ref %qr22[%one] : (!quake.qvec<?> ,i32) -> !quake.qref
+  %r = quake.extract_ref %qr2[%3] : (!quake.qvec<?>,i32) -> !quake.ref
+  %q1 = quake.extract_ref %qr22[%one] : (!quake.qvec<?> ,i32) -> !quake.ref
 
-  quake.h %r : (!quake.qref) -> ()
-  quake.x[%r] %q1 : (!quake.qref,!quake.qref) -> ()
+  quake.h %r : (!quake.ref) -> ()
+  quake.x[%r] %q1 : (!quake.ref,!quake.ref) -> ()
   return
 }

--- a/test/Quake/ghz.qke
+++ b/test/Quake/ghz.qke
@@ -12,16 +12,16 @@ module {
     // CHECK: %[[C0:.*]] = arith.constant 0 : i32
     // CHECK: %[[C1:.*]] = arith.constant 1 : i32
     // CHECK: %0 = quake.alloca[%[[arg0]] : i32] !quake.qvec<?>
-    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
+    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
     // CHECK: quake.h %1 :
     // CHECK: %2 = arith.subi %arg0, %[[C1]] : i32
     // CHECK: %3 = arith.index_cast %2 : i32 to index
     // CHECK: affine.for %arg1 = 0 to %3 {
     // CHECK:   %4 = arith.index_cast %arg1 : index to i32
     // CHECK:   %5 = arith.addi %4, %[[C1]] : i32
-    // CHECK:   %6 = quake.extract_ref %0[%arg1] : (!quake.qvec<?>, index) -> !quake.qref
-    // CHECK:   %7 = quake.extract_ref %0[%5] : (!quake.qvec<?>, i32) -> !quake.qref
-    // CHECK:   quake.x [%6] %7 : (!quake.qref, !quake.qref) -> ()
+    // CHECK:   %6 = quake.extract_ref %0[%arg1] : (!quake.qvec<?>, index) -> !quake.ref
+    // CHECK:   %7 = quake.extract_ref %0[%5] : (!quake.qvec<?>, i32) -> !quake.ref
+    // CHECK:   quake.x [%6] %7 : (!quake.ref, !quake.ref) -> ()
     // CHECK: }
     // CHECK: return
     // CHECK: }
@@ -30,16 +30,16 @@ module {
         %c0 = arith.constant 0 : i32
         %one = arith.constant 1 : i32
         %q = quake.alloca [%arg0 : i32] !quake.qvec<?>
-        %q0 = quake.extract_ref %q[%c0] : (!quake.qvec<?>, i32) -> !quake.qref
-        quake.h %q0 : (!quake.qref) -> ()
+        %q0 = quake.extract_ref %q[%c0] : (!quake.qvec<?>, i32) -> !quake.ref
+        quake.h %q0 : (!quake.ref) -> ()
         %size_m_1 = arith.subi %arg0, %one : i32
         %upper = arith.index_cast %size_m_1 : i32 to index
         affine.for %i = 0 to %upper {
             %i_int = arith.index_cast %i : index to i32
             %ip1 = arith.addi %i_int, %one : i32
-            %qi = quake.extract_ref %q[%i] : (!quake.qvec<?>, index) -> !quake.qref
-            %qi1 = quake.extract_ref %q[%ip1] : (!quake.qvec<?>, i32) -> !quake.qref
-            quake.x [%qi] %qi1 : (!quake.qref, !quake.qref) -> ()
+            %qi = quake.extract_ref %q[%i] : (!quake.qvec<?>, index) -> !quake.ref
+            %qi1 = quake.extract_ref %q[%ip1] : (!quake.qvec<?>, i32) -> !quake.ref
+            quake.x [%qi] %qi1 : (!quake.ref, !quake.ref) -> ()
         }
         return
     }

--- a/test/Quake/inline.qke
+++ b/test/Quake/inline.qke
@@ -12,29 +12,29 @@
 // RUN: cudaq-opt --apply-op-specialization --inline --canonicalize %s | FileCheck %s
 
 func.func @__nvqpp__mlirgen____nvqppBuilderKernel_202375922897() {
-  %0 = quake.alloca  !quake.qref
-  %1 = quake.alloca  !quake.qref
-  call @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%0) : (!quake.qref) -> ()
-  quake.h %1 : (!quake.qref) -> ()
-  quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127[%1] %0 : (!quake.qref, !quake.qref) -> ()
-  quake.h %1 : (!quake.qref) -> ()
-  %2 = quake.mz %1 : (!quake.qref) -> i1 {registerName = ""}
+  %0 = quake.alloca  !quake.ref
+  %1 = quake.alloca  !quake.ref
+  call @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%0) : (!quake.ref) -> ()
+  quake.h %1 : (!quake.ref) -> ()
+  quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127[%1] %0 : (!quake.ref, !quake.ref) -> ()
+  quake.h %1 : (!quake.ref) -> ()
+  %2 = quake.mz %1 : (!quake.ref) -> i1 {registerName = ""}
   return
 }
-func.func @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%arg0: !quake.qref) {
-  quake.x %arg0 : (!quake.qref) -> ()
+func.func @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%arg0: !quake.ref) {
+  quake.x %arg0 : (!quake.ref) -> ()
   return
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_202375922897() {
-// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.x %[[VAL_0]]
 // CHECK:           quake.h %[[VAL_1]]
-// CHECK:           %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.qref) -> !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.ref) -> !quake.qvec<?>
 // CHECK:           quake.x [%[[VAL_2]]] %[[VAL_0]] :
 // CHECK:           quake.h %[[VAL_1]] :
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.qref) -> i1 {registerName = ""}
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1 {registerName = ""}
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/iqft.qke
+++ b/test/Quake/iqft.qke
@@ -50,14 +50,14 @@
 // CHECK:       %7 = arith.index_cast %arg1 : index to i32
 // CHECK:       %8 = arith.subi %1, %7 : i32
 // CHECK:       %9 = arith.subi %8, %[[C1]] : i32
-// CHECK:       %10 = quake.extract_ref %arg0[%7] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:       %11 = quake.extract_ref %arg0[%9] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:       quake.swap %10, %11 : (!quake.qref, !quake.qref) -> ()
+// CHECK:       %10 = quake.extract_ref %arg0[%7] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:       %11 = quake.extract_ref %arg0[%9] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:       quake.swap %10, %11 : (!quake.ref, !quake.ref) -> ()
 // CHECK:     }
 // CHECK:     affine.for %arg1 = 0 to %3 {
 // CHECK:       %7 = arith.index_cast %arg1 : index to i32
-// CHECK:       %8 = quake.extract_ref %arg0[%7] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:       quake.h %8 : (!quake.qref) -> ()
+// CHECK:       %8 = quake.extract_ref %arg0[%7] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:       quake.h %8 : (!quake.ref) -> ()
 // CHECK:       %9 = arith.addi %7, %[[C1]] : i32
 // CHECK:       affine.for %arg2 = #map(%arg1) to 1 {
 // CHECK:         %10 = arith.index_cast %arg2 : index to i32
@@ -66,13 +66,13 @@
 // CHECK:         %13 = arith.sitofp %12 : i32 to f64
 // CHECK:         %14 = math.powf %[[CF0]], %13 : f64
 // CHECK:         %15 = arith.divf %[[CF1]], %14 : f64
-// CHECK:         %16 = quake.extract_ref %arg0[%9] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:         %17 = quake.extract_ref %arg0[%11] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:         quake.r1 (%15) [%16] %17 : (f64, !quake.qref, !quake.qref) -> ()
+// CHECK:         %16 = quake.extract_ref %arg0[%9] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:         %17 = quake.extract_ref %arg0[%11] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:         quake.r1 (%15) [%16] %17 : (f64, !quake.ref, !quake.ref) -> ()
 // CHECK:       }
 // CHECK:     }
-// CHECK:     %6 = quake.extract_ref %arg0[%2] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:     quake.h %6 : (!quake.qref) -> ()
+// CHECK:     %6 = quake.extract_ref %arg0[%2] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     quake.h %6 : (!quake.ref) -> ()
 // CHECK:     return
 // CHECK:   }
 // CHECK: }
@@ -99,15 +99,15 @@ module {
             %7 = arith.index_cast %arg2 : index to i32
             %9 = arith.subi %n, %7 : i32
             %10 = arith.subi %9, %c1 : i32
-            %qi = quake.extract_ref %arg0 [%7] : (!quake.qvec<?>,i32) -> !quake.qref
-            %qi1 = quake.extract_ref %arg0 [%10] : (!quake.qvec<?>,i32) -> !quake.qref
-            quake.swap %qi, %qi1 : (!quake.qref, !quake.qref) -> ()
+            %qi = quake.extract_ref %arg0 [%7] : (!quake.qvec<?>,i32) -> !quake.ref
+            %qi1 = quake.extract_ref %arg0 [%10] : (!quake.qvec<?>,i32) -> !quake.ref
+            quake.swap %qi, %qi1 : (!quake.ref, !quake.ref) -> ()
         }
 
         affine.for %arg3 = 0 to %nm1idx {
             %11 = arith.index_cast %arg3 : index to i32
-            %qi = quake.extract_ref %arg0[%11] : (!quake.qvec<?>, i32) -> !quake.qref
-            quake.h %qi : (!quake.qref) -> ()
+            %qi = quake.extract_ref %arg0[%11] : (!quake.qvec<?>, i32) -> !quake.ref
+            quake.h %qi : (!quake.ref) -> ()
             %13 = arith.addi %11, %c1 : i32
             %12 = memref.alloca() : memref<i32>
             memref.store %13, %12[] : memref<i32>
@@ -125,13 +125,13 @@ module {
                 %s2f = arith.sitofp %jmy : i32 to f64
                 %denom = math.powf %c2f, %s2f : f64
                 %24 = arith.divf %16, %denom : f64
-                %qj = quake.extract_ref %arg0[%13] : (!quake.qvec<?>, i32) -> !quake.qref
-                %qy = quake.extract_ref %arg0[%15] : (!quake.qvec<?>, i32) -> !quake.qref
-                quake.r1 (%24)[%qj] %qy : (f64,!quake.qref,!quake.qref) -> ()
+                %qj = quake.extract_ref %arg0[%13] : (!quake.qvec<?>, i32) -> !quake.ref
+                %qy = quake.extract_ref %arg0[%15] : (!quake.qvec<?>, i32) -> !quake.ref
+                quake.r1 (%24)[%qj] %qy : (f64,!quake.ref,!quake.ref) -> ()
             }
         }
-        %qnm1 = quake.extract_ref %arg0[%nm1] : (!quake.qvec<?>,i32) -> !quake.qref
-        quake.h %qnm1 : (!quake.qref) -> ()
+        %qnm1 = quake.extract_ref %arg0[%nm1] : (!quake.qvec<?>,i32) -> !quake.ref
+        quake.h %qnm1 : (!quake.ref) -> ()
         return
     }
 }

--- a/test/Quake/kernel_exec.qke
+++ b/test/Quake/kernel_exec.qke
@@ -20,8 +20,8 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
     %3 = quake.alloca[%2 : i64] !quake.qvec<?>
     %c0_i32 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32 : i32 to i64
-    %5 = quake.extract_ref %3[%4] : (!quake.qvec<?>,i64) -> !quake.qref
-    quake.h %5 : (!quake.qref) -> ()
+    %5 = quake.extract_ref %3[%4] : (!quake.qvec<?>,i64) -> !quake.ref
+    quake.h %5 : (!quake.ref) -> ()
     cc.scope {
       %7 = memref.alloca() : memref<i32>
       memref.store %c0_i32, %7[] : memref<i32>
@@ -38,12 +38,12 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
       } do {
       ^bb1 (%arg11 : index):
         %18 = arith.index_cast %arg11 : index to i64
-        %19 = quake.extract_ref %3[%18] : (!quake.qvec<?>,i64) -> !quake.qref
+        %19 = quake.extract_ref %3[%18] : (!quake.qvec<?>,i64) -> !quake.ref
         %20 = arith.trunci %18 : i64 to i32
         %21 = arith.addi %20, %c1_i32 : i32
         %22 = arith.extsi %21 : i32 to i64
-        %23 = quake.extract_ref %3[%22] : (!quake.qvec<?>,i64) -> !quake.qref
-        quake.x [%19] %23 : (!quake.qref, !quake.qref) -> ()
+        %23 = quake.extract_ref %3[%22] : (!quake.qvec<?>,i64) -> !quake.ref
+        quake.x [%19] %23 : (!quake.ref, !quake.ref) -> ()
 	cc.continue %arg11 : index
       } step {
       ^bb2 (%arg21 : index):
@@ -61,8 +61,8 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
 	cc.condition %cond (%argx1 : index)
     } do {
     ^bb1 (%arg31 : index):
-      %18 = quake.extract_ref %3[%arg31] : (!quake.qvec<?>,index) -> !quake.qref
-      %19 = quake.mz %18 : (!quake.qref) -> i1
+      %18 = quake.extract_ref %3[%arg31] : (!quake.qvec<?>,index) -> !quake.ref
+      %19 = quake.mz %18 : (!quake.ref) -> i1
       cc.continue %arg31 : index
     } step {
     ^bb1 (%arg32 : index):

--- a/test/Quake/lambda_kernel_exec.qke
+++ b/test/Quake/lambda_kernel_exec.qke
@@ -21,12 +21,12 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
     %1 = quake.alloca[%0 : i64]  !quake.qvec<?>
     %c0_i32 = arith.constant 0 : i32
     %2 = arith.extsi %c0_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.qvec<?>,i64) -> !quake.qref
-    quake.h %3 : (!quake.qref) -> ()
+    %3 = quake.extract_ref %1[%2] : (!quake.qvec<?>,i64) -> !quake.ref
+    quake.h %3 : (!quake.ref) -> ()
     %c0_i32_0 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32_0 : i32 to i64
-    %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>, i64) -> !quake.qref
-    %6 = quake.mz %5 : (!quake.qref)->i1 {registerName = "b"} 
+    %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>, i64) -> !quake.ref
+    %6 = quake.mz %5 : (!quake.ref)->i1 {registerName = "b"} 
     %alloca = memref.alloca() : memref<i1>
     memref.store %6, %alloca[] : memref<i1>
     %7 = memref.load %alloca[] : memref<i1>
@@ -34,14 +34,14 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
       cc.scope {
         %c1_i32_1 = arith.constant 1 : i32
         %11 = arith.extsi %c1_i32_1 : i32 to i64
-        %12 = quake.extract_ref %1[%11] : (!quake.qvec<?>,i64) -> !quake.qref
-        quake.x %12 : (!quake.qref) -> ()
+        %12 = quake.extract_ref %1[%11] : (!quake.qvec<?>,i64) -> !quake.ref
+        quake.x %12 : (!quake.ref) -> ()
       }
     }
     %c1_i32 = arith.constant 1 : i32
     %8 = arith.extsi %c1_i32 : i32 to i64
-    %9 = quake.extract_ref %1[%8] : (!quake.qvec<?>,i64) -> !quake.qref
-    %10 = quake.mz %9 : (!quake.qref) -> i1
+    %9 = quake.extract_ref %1[%8] : (!quake.qvec<?>,i64) -> !quake.ref
+    %10 = quake.mz %9 : (!quake.ref) -> i1
     return
   }
 
@@ -55,12 +55,12 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
     %1 = quake.alloca[%0 : i64] !quake.qvec<?>
     %c0_i32 = arith.constant 0 : i32
     %2 = arith.extsi %c0_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.qvec<?>,i64) -> !quake.qref
-    quake.h %3 : (!quake.qref) -> ()
+    %3 = quake.extract_ref %1[%2] : (!quake.qvec<?>,i64) -> !quake.ref
+    quake.h %3 : (!quake.ref) -> ()
     %c0_i32_0 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32_0 : i32 to i64
-    %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.qref
-    %6 = quake.mz %5 : (!quake.qref) ->i1 {registerName = "b"} 
+    %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.ref
+    %6 = quake.mz %5 : (!quake.ref) ->i1 {registerName = "b"} 
     %alloca = memref.alloca() : memref<i1>
     memref.store %6, %alloca[] : memref<i1>
     %7 = memref.load %alloca[] : memref<i1>
@@ -68,14 +68,14 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
       cc.scope {
         %c1_i32_1 = arith.constant 1 : i32
         %11 = arith.extsi %c1_i32_1 : i32 to i64
-        %12 = quake.extract_ref %1[%11] : (!quake.qvec<?>, i64) -> !quake.qref
-        quake.x %12 : (!quake.qref) -> ()
+        %12 = quake.extract_ref %1[%11] : (!quake.qvec<?>, i64) -> !quake.ref
+        quake.x %12 : (!quake.ref) -> ()
       }
     }
     %c1_i32 = arith.constant 1 : i32
     %8 = arith.extsi %c1_i32 : i32 to i64
-    %9 = quake.extract_ref %1[%8] : (!quake.qvec<?>,i64) -> !quake.qref
-    %10 = quake.mz %9 : (!quake.qref) -> i1
+    %9 = quake.extract_ref %1[%8] : (!quake.qvec<?>,i64) -> !quake.ref
+    %10 = quake.mz %9 : (!quake.ref) -> i1
     return
   }
 }

--- a/test/Quake/lambda_variable-1.qke
+++ b/test/Quake/lambda_variable-1.qke
@@ -13,15 +13,15 @@
 // constructing the QTX circuit.
 
 module attributes{ qtx.mangled_name_map = { __nvqpp__mlirgen__test3_callee = "_ZN12test3_calleeclEOSt8functionIFvRN4cudaq5quditILm2EEEEERNS1_4qregILm18446744073709551615ELm2EEE", __nvqpp__mlirgen__test3_caller = "_ZN12test3_callerclEv"}} {
-  func.func @__nvqpp__mlirgen__test3_callee(%arg0: !cc.lambda<(!quake.qref) -> ()>, %arg1: !quake.qvec<?>) attributes {"cudaq-kernel"} {
+  func.func @__nvqpp__mlirgen__test3_callee(%arg0: !cc.lambda<(!quake.ref) -> ()>, %arg1: !quake.qvec<?>) attributes {"cudaq-kernel"} {
     %c0_i32 = arith.constant 0 : i32
     %0 = arith.extsi %c0_i32 : i32 to i64
-    %1 = quake.extract_ref %arg1[%0] : (!quake.qvec<?>,i64) -> !quake.qref
-    cc.call_callable %arg0, %1 : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+    %1 = quake.extract_ref %arg1[%0] : (!quake.qvec<?>,i64) -> !quake.ref
+    cc.call_callable %arg0, %1 : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
     %c1_i32 = arith.constant 1 : i32
     %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.extract_ref %arg1[%2] : (!quake.qvec<?>,i64) -> !quake.qref
-    cc.call_callable %arg0, %3 : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+    %3 = quake.extract_ref %arg1[%2] : (!quake.qvec<?>,i64) -> !quake.ref
+    cc.call_callable %arg0, %3 : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
     return
   }
   func.func @__nvqpp__mlirgen__test3_caller() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
@@ -30,42 +30,42 @@ module attributes{ qtx.mangled_name_map = { __nvqpp__mlirgen__test3_callee = "_Z
     %1 = quake.alloca[%0 : i64] !quake.qvec<?>
     %2 = cc.undef !llvm.struct<"test3_callee", ()>
     %3 = cc.create_lambda {
-    ^bb0(%arg0: !quake.qref):
+    ^bb0(%arg0: !quake.ref):
       cc.scope {
-        quake.h %arg0 : (!quake.qref) -> ()
-        quake.y %arg0 : (!quake.qref) -> ()
+        quake.h %arg0 : (!quake.ref) -> ()
+        quake.y %arg0 : (!quake.ref) -> ()
       }
-    } : !cc.lambda<(!quake.qref) -> ()>
-    call @__nvqpp__mlirgen__test3_callee(%3, %1) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
+    } : !cc.lambda<(!quake.ref) -> ()>
+    call @__nvqpp__mlirgen__test3_callee(%3, %1) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
     return
   }
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_callee(
-// CHECK-SAME:        %[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
+// CHECK-SAME:        %[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           %[[VAL_5:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.qref) -> ()>) -> ((!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ())
-// CHECK:           call_indirect %[[VAL_5]](%[[VAL_0]], %[[VAL_4]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
-// CHECK:            %[[VAL_6:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_2]]] : (!quake.qvec<?>, i64) -> !quake.qref
-// CHECK:           %[[VAL_7:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.qref) -> ()>) -> ((!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ())
-// CHECK:           call_indirect %[[VAL_7]](%[[VAL_0]], %[[VAL_6]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_5:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())
+// CHECK:           call_indirect %[[VAL_5]](%[[VAL_0]], %[[VAL_4]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
+// CHECK:            %[[VAL_6:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_2]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_7:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())
+// CHECK:           call_indirect %[[VAL_7]](%[[VAL_0]], %[[VAL_6]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_caller()
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<2>
 // CHECK:           %[[VAL_1:.*]] = quake.relax_size %[[VAL_0]] : (!quake.qvec<2>) -> !quake.qvec<?>
-// CHECK:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0() : () -> !cc.lambda<(!quake.qref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__test3_callee(%[[VAL_2]], %[[VAL_1]]) : (!cc.lambda<(!quake.qref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0() : () -> !cc.lambda<(!quake.ref) -> ()>
+// CHECK:           call @__nvqpp__mlirgen__test3_callee(%[[VAL_2]], %[[VAL_1]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
 
 // CHECK-LABEL:   func.func private @__nvqpp__callable.thunk.lambda.0(
-// CHECK-SAME:        %[[VAL_0:.*]]: !cc.lambda<(!quake.qref) -> ()>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qref) {
-// CHECK:           call @__nvqpp__lifted.lambda.0(%[[VAL_1]]) : (!quake.qref) -> ()
+// CHECK-SAME:        %[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.ref) {
+// CHECK:           call @__nvqpp__lifted.lambda.0(%[[VAL_1]]) : (!quake.ref) -> ()
 
 // CHECK-LABEL:   func.func private @__nvqpp__lifted.lambda.0(
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qref) {
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref) {
 // CHECK:           quake.h %[[VAL_0]] :
 // CHECK:           quake.y %[[VAL_0]] :
 

--- a/test/Quake/lambda_variable-2.qke
+++ b/test/Quake/lambda_variable-2.qke
@@ -43,7 +43,7 @@
 // CHECK:             } do {
 // CHECK:               %[[VAL_7:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_8:.*]] = arith.extsi %[[VAL_7]] : i32 to i64
-// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<4>, i64) -> !quake.qref
+// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<4>, i64) -> !quake.ref
 // CHECK:               quake.h %[[VAL_9]] :
 // CHECK:               cc.continue
 // CHECK:             } step {
@@ -91,8 +91,8 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__kernel_a = "_ZN8ker
           } do {
             %6 = memref.load %alloca[] : memref<i32>
             %7 = arith.extsi %6 : i32 to i64
-            %8 = quake.extract_ref %1[%7] : (!quake.qvec<4>, i64) -> !quake.qref
-            quake.h %8 : (!quake.qref) -> ()
+            %8 = quake.extract_ref %1[%7] : (!quake.qvec<4>, i64) -> !quake.ref
+            quake.h %8 : (!quake.ref) -> ()
             cc.continue
           } step {
             %6 = memref.load %alloca[] : memref<i32>

--- a/test/Quake/mz.qke
+++ b/test/Quake/mz.qke
@@ -9,39 +9,39 @@
 // RUN: cudaq-opt %s | cudaq-opt | FileCheck %s
 
 func.func @static.mz_test() {
-  %0 = quake.alloca  !quake.qref
+  %0 = quake.alloca  !quake.ref
   %1 = quake.alloca  !quake.qvec<4>
   %2 = quake.alloca  !quake.qvec<2>
-  %3 = quake.alloca  !quake.qref
-  quake.mz %0, %1, %2, %3 : (!quake.qref, !quake.qvec<4>, !quake.qvec<2>, !quake.qref) -> !cc.stdvec<i1>
+  %3 = quake.alloca  !quake.ref
+  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.qvec<4>, !quake.qvec<2>, !quake.ref) -> !cc.stdvec<i1>
   return
 }
 
 // CHECK-LABEL:   func.func @static.mz_test() {
-// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<4>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qref
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!quake.qref, !quake.qvec<4>, !quake.qvec<2>, !quake.qref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.qvec<4>, !quake.qvec<2>, !quake.ref) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 
 func.func @dynamic.mz_test(%arg0 : i32, %arg1 : i32) {
-  %0 = quake.alloca  !quake.qref
+  %0 = quake.alloca  !quake.ref
   %1 = quake.alloca[%arg0 : i32]  !quake.qvec<?>
   %2 = quake.alloca [%arg1 : i32] !quake.qvec<?>
-  %3 = quake.alloca  !quake.qref
-  quake.mz %0, %1, %2, %3 : (!quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) -> !cc.stdvec<i1>
+  %3 = quake.alloca  !quake.ref
+  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.qvec<?>, !quake.qvec<?>, !quake.ref) -> !cc.stdvec<i1>
   return
 }
 
 // CHECK-LABEL:   func.func @dynamic.mz_test(
 // CHECK-SAME:        %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) {
-// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
 // CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_1]] : i32] !quake.qvec<?>
-// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qref
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (!quake.qref, !quake.qvec<?>, !quake.qvec<?>, !quake.qref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.qvec<?>, !quake.qvec<?>, !quake.ref) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/observeAnsatz.qke
+++ b/test/Quake/observeAnsatz.qke
@@ -15,19 +15,19 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ansatz = "_ZN6ansat
     %0 = memref.alloca() : memref<f64>
     memref.store %arg0, %0[] : memref<f64>
     %1 = quake.alloca  !quake.qvec<2>
-    %2 = quake.extract_ref %1[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-    quake.x %2 : (!quake.qref) -> ()
+    %2 = quake.extract_ref %1[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+    quake.x %2 : (!quake.ref) -> ()
     %3 = memref.load %0[] : memref<f64>
-    %4 = quake.extract_ref %1[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-    quake.ry (%3) %4 : (f64, !quake.qref) -> ()
-    %5 = quake.extract_ref %1[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-    %6 = quake.extract_ref %1[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.qref
-    quake.x [%5] %6 : (!quake.qref,!quake.qref) -> ()
+    %4 = quake.extract_ref %1[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+    quake.ry (%3) %4 : (f64, !quake.ref) -> ()
+    %5 = quake.extract_ref %1[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+    %6 = quake.extract_ref %1[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+    quake.x [%5] %6 : (!quake.ref,!quake.ref) -> ()
     return
   }
 }
 
 // CHECK: quake.h %[[VAL_4:.*]]
 // CHECK: quake.h %[[VAL_5:.*]]
-// CHECK: %[[VAL_0:.*]] = quake.mz %[[VAL_1:.*]] : (!quake.qref) -> i1
-// CHECK: %[[VAL_2:.*]] = quake.mz %[[VAL_3:.*]] : (!quake.qref) -> i1
+// CHECK: %[[VAL_0:.*]] = quake.mz %[[VAL_1:.*]] : (!quake.ref) -> i1
+// CHECK: %[[VAL_2:.*]] = quake.mz %[[VAL_3:.*]] : (!quake.ref) -> i1

--- a/test/Quake/qpe.qke
+++ b/test/Quake/qpe.qke
@@ -8,27 +8,27 @@
 
 // RUN: cudaq-opt %s --canonicalize | FileCheck %s
 
-// CHECK:   func.func @ctrl_t_gate(%arg0: !quake.qref) {
+// CHECK:   func.func @ctrl_t_gate(%arg0: !quake.ref) {
 // CHECK:     quake.t %arg0 :
 // CHECK:     return
 // CHECK:   }
-// CHECK:   func.func @qpe_test_callable(%arg0: i32, %arg1: i32, %arg2: (!quake.qvec<?>) -> !quake.qvec<?>, %arg3: (!quake.qref) -> ()) {
+// CHECK:   func.func @qpe_test_callable(%arg0: i32, %arg1: i32, %arg2: (!quake.qvec<?>) -> !quake.qvec<?>, %arg3: (!quake.ref) -> ()) {
 // CHECK:     %[[C0:.*]] = arith.constant 0 : i32
 // CHECK:     %0 = quake.alloca[%arg0 : i32] !quake.qvec<?>
-// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:     call_indirect %arg3(%1) : (!quake.qref) -> ()
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     call_indirect %arg3(%1) : (!quake.ref) -> ()
 // CHECK:     return
 // CHECK:   }
 
-func.func @ctrl_t_gate(%q : !quake.qref) -> () {
-  quake.t %q : (!quake.qref) -> () 
+func.func @ctrl_t_gate(%q : !quake.ref) -> () {
+  quake.t %q : (!quake.ref) -> () 
   return
 }
 
-func.func @qpe_test_callable(%nq : i32, %nc : i32, %state_prep : (!quake.qvec<?>)->(!quake.qvec<?>), %oracle : (!quake.qref)->()) {
+func.func @qpe_test_callable(%nq : i32, %nc : i32, %state_prep : (!quake.qvec<?>)->(!quake.qvec<?>), %oracle : (!quake.ref)->()) {
   %0 = arith.constant 0 : i32
   %qubits = quake.alloca[%nq : i32] !quake.qvec<?>
-  %q = quake.extract_ref %qubits[%0] : (!quake.qvec<?>,i32) -> !quake.qref
-  func.call_indirect %oracle(%q) : (!quake.qref)->()
+  %q = quake.extract_ref %qubits[%0] : (!quake.qvec<?>,i32) -> !quake.ref
+  func.call_indirect %oracle(%q) : (!quake.ref)->()
   return
 }

--- a/test/Quake/quake-ops.qke
+++ b/test/Quake/quake-ops.qke
@@ -15,58 +15,58 @@ func.func private @apply_kernel(%0 : i32, %1 : !quake.qvec<?>)
 // Test roundtripping on the various quake ops.
 func.func @quantum_ops() {
   // Allocations
-  %0 = quake.alloca !quake.qref
-  quake.dealloc %0 : !quake.qref
+  %0 = quake.alloca !quake.ref
+  quake.dealloc %0 : !quake.ref
   %v0 = quake.alloca !quake.qvec<5>
   quake.dealloc %v0 : !quake.qvec<5>
   %1 = quake.alloca !quake.qvec<4>
   %2 = arith.constant 2 : i32
   %3 = quake.alloca[%2 : i32] !quake.qvec<?>
-  %4 = quake.alloca !quake.qref
+  %4 = quake.alloca !quake.ref
 
   // Vectors of references
   %zero = arith.constant 0 : i32
   %i = arith.constant 3    : i64
-  %5 = quake.concat %3, %4 : (!quake.qvec<?>, !quake.qref) -> !quake.qvec<?>
-  %6 = quake.concat %4, %1 : (!quake.qref, !quake.qvec<4>) -> !quake.qvec<5>
-  %7 = quake.extract_ref %5[%zero] : (!quake.qvec<?>, i32) -> !quake.qref
-  %8 = quake.extract_ref %6[%i]    : (!quake.qvec<5>, i64) -> !quake.qref
+  %5 = quake.concat %3, %4 : (!quake.qvec<?>, !quake.ref) -> !quake.qvec<?>
+  %6 = quake.concat %4, %1 : (!quake.ref, !quake.qvec<4>) -> !quake.qvec<5>
+  %7 = quake.extract_ref %5[%zero] : (!quake.qvec<?>, i32) -> !quake.ref
+  %8 = quake.extract_ref %6[%i]    : (!quake.qvec<5>, i64) -> !quake.ref
   %9 = quake.relax_size %6         : (!quake.qvec<5>) -> !quake.qvec<?>
   %z = arith.constant 0 : index
   %10 = quake.subvec %5, %z, %i : (!quake.qvec<?>, index, i64) -> !quake.qvec<?>
   %11 = quake.vec_size %5 : (!quake.qvec<?>) -> index
 
   // Reference/dereference
-  quake.reset %4 : (!quake.qref) -> ()
+  quake.reset %4 : (!quake.ref) -> ()
   %12 = quake.null_wire
-  %13 = quake.unwrap %4 : (!quake.qref) -> !quake.wire
+  %13 = quake.unwrap %4 : (!quake.ref) -> !quake.wire
   %18 = quake.reset %13 : (!quake.wire) -> !quake.wire
-  quake.wrap %18 to %4 : !quake.wire, !quake.qref
+  quake.wrap %18 to %4 : !quake.wire, !quake.ref
 
   // Control type conversion
   %14 = quake.convert_ctrl %12 : (!quake.wire) -> !quake.control
 
   // Quantum operations, reference form
-  quake.x %4 : (!quake.qref) -> ()
-  quake.y %4 : (!quake.qref) -> ()
-  quake.z %4 : (!quake.qref) -> ()
-  quake.h %4 : (!quake.qref) -> ()
-  quake.s %4 : (!quake.qref) -> ()
-  quake.t %4 : (!quake.qref) -> ()
-  quake.swap %4, %7 : (!quake.qref, !quake.qref) -> ()
+  quake.x %4 : (!quake.ref) -> ()
+  quake.y %4 : (!quake.ref) -> ()
+  quake.z %4 : (!quake.ref) -> ()
+  quake.h %4 : (!quake.ref) -> ()
+  quake.s %4 : (!quake.ref) -> ()
+  quake.t %4 : (!quake.ref) -> ()
+  quake.swap %4, %7 : (!quake.ref, !quake.ref) -> ()
 
   %f = arith.constant 12.0 : f32
-  quake.r1 (%f) %7 : (f32, !quake.qref) -> ()
-  quake.rx (%f) %7 : (f32, !quake.qref) -> ()
+  quake.r1 (%f) %7 : (f32, !quake.ref) -> ()
+  quake.rx (%f) %7 : (f32, !quake.ref) -> ()
   %g = arith.constant 23.0 : f32
-  quake.phased_rx (%f, %g) %7 : (f32, f32, !quake.qref) -> ()
-  quake.ry (%f) %7 : (f32, !quake.qref) -> ()
-  quake.rz (%f) %7 : (f32, !quake.qref) -> ()
-  quake.u2 (%f, %g) %7 : (f32, f32, !quake.qref) -> ()
+  quake.phased_rx (%f, %g) %7 : (f32, f32, !quake.ref) -> ()
+  quake.ry (%f) %7 : (f32, !quake.ref) -> ()
+  quake.rz (%f) %7 : (f32, !quake.ref) -> ()
+  quake.u2 (%f, %g) %7 : (f32, f32, !quake.ref) -> ()
   %h = arith.constant 34.0 : f32
-  quake.u3 (%f, %g, %h) %7 : (f32, f32, f32, !quake.qref) -> ()
+  quake.u3 (%f, %g, %h) %7 : (f32, f32, f32, !quake.ref) -> ()
 
-  %15 = quake.mx %4 : (!quake.qref) -> i1
+  %15 = quake.mx %4 : (!quake.ref) -> i1
   %16 = quake.my %5 : (!quake.qvec<?>) -> !cc.stdvec<i1>
   %17 = quake.mz %6 : (!quake.qvec<5>) -> !cc.stdvec<i1>
 
@@ -97,13 +97,13 @@ func.func @quantum_ops() {
   %39 = quake.mz %36 : (!quake.wire) -> i1
 
   // CUDA Quantum model support
-  %40 = quake.alloca !quake.qref { apply_variants = true }
+  %40 = quake.alloca !quake.ref { apply_variants = true }
   %41 = quake.alloca !quake.qvec<2>
   %42 = arith.constant 0 : i32
-  %43 = quake.alloca !quake.qref
-  quake.apply @apply_kernel %42, %43 : (i32, !quake.qref) -> ()
-  quake.apply @apply_kernel [%40, %41] %42, %43 : (!quake.qref, !quake.qvec<2>, i32, !quake.qref) -> ()
-  quake.apply<adj> @apply_kernel [%40, %41] %42, %43 : (!quake.qref, !quake.qvec<2>, i32, !quake.qref) -> ()
+  %43 = quake.alloca !quake.ref
+  quake.apply @apply_kernel %42, %43 : (i32, !quake.ref) -> ()
+  quake.apply @apply_kernel [%40, %41] %42, %43 : (!quake.ref, !quake.qvec<2>, i32, !quake.ref) -> ()
+  quake.apply<adj> @apply_kernel [%40, %41] %42, %43 : (!quake.ref, !quake.qvec<2>, i32, !quake.ref) -> ()
 
   %44 = cc.undef !cc.lambda<() -> ()> { compute_action = true }
   %45 = cc.undef !cc.lambda<() -> ()>
@@ -112,81 +112,81 @@ func.func @quantum_ops() {
 
   // Adjoint modifier
   %47 = cc.undef f64 { adjoint = true }
-  quake.s<adj> %4 : (!quake.qref) -> ()
-  quake.t<adj> %4 : (!quake.qref) -> ()
+  quake.s<adj> %4 : (!quake.ref) -> ()
+  quake.t<adj> %4 : (!quake.ref) -> ()
 
-  quake.r1<adj> (%f) %7 : (f32, !quake.qref) -> ()
-  quake.rx<adj> (%f) %7 : (f32, !quake.qref) -> ()
-  quake.phased_rx<adj> (%f, %g) %7 : (f32, f32, !quake.qref) -> ()
-  quake.ry<adj> (%f) %7 : (f32, !quake.qref) -> ()
-  quake.rz<adj> (%f) %7 : (f32, !quake.qref) -> ()
-  quake.u2<adj> (%f, %g) %7 : (f32, f32, !quake.qref) -> ()
-  quake.u3<adj> (%f, %g, %h) %7 : (f32, f32, f32, !quake.qref) -> ()
+  quake.r1<adj> (%f) %7 : (f32, !quake.ref) -> ()
+  quake.rx<adj> (%f) %7 : (f32, !quake.ref) -> ()
+  quake.phased_rx<adj> (%f, %g) %7 : (f32, f32, !quake.ref) -> ()
+  quake.ry<adj> (%f) %7 : (f32, !quake.ref) -> ()
+  quake.rz<adj> (%f) %7 : (f32, !quake.ref) -> ()
+  quake.u2<adj> (%f, %g) %7 : (f32, f32, !quake.ref) -> ()
+  quake.u3<adj> (%f, %g, %h) %7 : (f32, f32, f32, !quake.ref) -> ()
 
   // Control modifier
   %46 = quake.alloca !quake.qvec<3> {control = true}
-  quake.x [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
-  quake.y [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
-  quake.z [%7] %4 : (!quake.qref, !quake.qref) -> ()
-  quake.h [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
-  quake.s [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
-  quake.t [%46] %4 : (!quake.qvec<3>, !quake.qref) -> ()
-  quake.swap [%46] %4, %7 : (!quake.qvec<3>, !quake.qref, !quake.qref) -> ()
+  quake.x [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
+  quake.y [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
+  quake.z [%7] %4 : (!quake.ref, !quake.ref) -> ()
+  quake.h [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
+  quake.s [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
+  quake.t [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
+  quake.swap [%46] %4, %7 : (!quake.qvec<3>, !quake.ref, !quake.ref) -> ()
 
-  quake.r1 (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.qref) -> ()
-  quake.rx (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.qref) -> ()
-  quake.phased_rx (%f, %g) [%46] %7 : (f32, f32, !quake.qvec<3>, !quake.qref) -> ()
-  quake.ry (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.qref) -> ()
-  quake.rz (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.qref) -> ()
-  quake.u2 (%f, %g) [%46] %7 : (f32, f32, !quake.qvec<3>, !quake.qref) -> ()
-  quake.u3 (%f, %g, %47) [%46] %7 : (f32, f32, f64, !quake.qvec<3>, !quake.qref) -> ()
+  quake.r1 (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.ref) -> ()
+  quake.rx (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.ref) -> ()
+  quake.phased_rx (%f, %g) [%46] %7 : (f32, f32, !quake.qvec<3>, !quake.ref) -> ()
+  quake.ry (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.ref) -> ()
+  quake.rz (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.ref) -> ()
+  quake.u2 (%f, %g) [%46] %7 : (f32, f32, !quake.qvec<3>, !quake.ref) -> ()
+  quake.u3 (%f, %g, %47) [%46] %7 : (f32, f32, f64, !quake.qvec<3>, !quake.ref) -> ()
 
   return
 }
 
 // CHECK-LABEL:   func.func @quantum_ops() {
-// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qref
-// CHECK:           quake.dealloc %[[VAL_0]] : !quake.qref
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
 // CHECK:           quake.dealloc %[[VAL_1]] : !quake.qvec<5>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<4>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_4:.*]] = quake.alloca{{\[}}%[[VAL_3]] : i32] !quake.qvec<?>
-// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qref
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_4]], %[[VAL_5]] : (!quake.qvec<?>, !quake.qref) -> !quake.qvec<?>
-// CHECK:           %[[VAL_9:.*]] = quake.concat %[[VAL_5]], %[[VAL_2]] : (!quake.qref, !quake.qvec<4>) -> !quake.qvec<5>
-// CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_6]]] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, i64) -> !quake.qref
+// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_4]], %[[VAL_5]] : (!quake.qvec<?>, !quake.ref) -> !quake.qvec<?>
+// CHECK:           %[[VAL_9:.*]] = quake.concat %[[VAL_5]], %[[VAL_2]] : (!quake.ref, !quake.qvec<4>) -> !quake.qvec<5>
+// CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_6]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, i64) -> !quake.ref
 // CHECK:           %[[VAL_12:.*]] = quake.relax_size %[[VAL_9]] : (!quake.qvec<5>) -> !quake.qvec<?>
 // CHECK:           %[[VAL_13:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_14:.*]] = quake.subvec %[[VAL_8]], %[[VAL_13]], %[[VAL_7]] : (!quake.qvec<?>, index, i64) -> !quake.qvec<?>
 // CHECK:           %[[VAL_15:.*]] = quake.vec_size %[[VAL_8]] : (!quake.qvec<?>) -> index
-// CHECK:           quake.reset %[[VAL_5]] : (!quake.qref) -> ()
+// CHECK:           quake.reset %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_16:.*]] = quake.null_wire
-// CHECK:           %[[VAL_17:.*]] = quake.unwrap %[[VAL_5]] : (!quake.qref) -> !quake.wire
+// CHECK:           %[[VAL_17:.*]] = quake.unwrap %[[VAL_5]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[VAL_18:.*]] = quake.reset %[[VAL_17]] : (!quake.wire) -> !quake.wire
-// CHECK:           quake.wrap %[[VAL_18]] to %[[VAL_5]] : !quake.wire, !quake.qref
+// CHECK:           quake.wrap %[[VAL_18]] to %[[VAL_5]] : !quake.wire, !quake.ref
 // CHECK:           %[[VAL_19:.*]] = quake.convert_ctrl %[[VAL_16]] : (!quake.wire) -> !quake.control
-// CHECK:           quake.x %[[VAL_5]] : (!quake.qref) -> ()
-// CHECK:           quake.y %[[VAL_5]] : (!quake.qref) -> ()
-// CHECK:           quake.z %[[VAL_5]] : (!quake.qref) -> ()
-// CHECK:           quake.h %[[VAL_5]] : (!quake.qref) -> ()
-// CHECK:           quake.s %[[VAL_5]] : (!quake.qref) -> ()
-// CHECK:           quake.t %[[VAL_5]] : (!quake.qref) -> ()
-// CHECK:           quake.swap %[[VAL_5]], %[[VAL_10]] : (!quake.qref, !quake.qref) -> ()
+// CHECK:           quake.x %[[VAL_5]] : (!quake.ref) -> ()
+// CHECK:           quake.y %[[VAL_5]] : (!quake.ref) -> ()
+// CHECK:           quake.z %[[VAL_5]] : (!quake.ref) -> ()
+// CHECK:           quake.h %[[VAL_5]] : (!quake.ref) -> ()
+// CHECK:           quake.s %[[VAL_5]] : (!quake.ref) -> ()
+// CHECK:           quake.t %[[VAL_5]] : (!quake.ref) -> ()
+// CHECK:           quake.swap %[[VAL_5]], %[[VAL_10]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           %[[VAL_20:.*]] = arith.constant 1.200000e+01 : f32
-// CHECK:           quake.r1 (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
-// CHECK:           quake.rx (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
+// CHECK:           quake.r1 (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.ref) -> ()
+// CHECK:           quake.rx (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.ref) -> ()
 // CHECK:           %[[VAL_21:.*]] = arith.constant 2.300000e+01 : f32
-// CHECK:           quake.phased_rx (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.qref) -> ()
-// CHECK:           quake.ry (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
-// CHECK:           quake.rz (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
-// CHECK:           quake.u2 (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.qref) -> ()
+// CHECK:           quake.phased_rx (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.ref) -> ()
+// CHECK:           quake.ry (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.ref) -> ()
+// CHECK:           quake.rz (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.ref) -> ()
+// CHECK:           quake.u2 (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.ref) -> ()
 // CHECK:           %[[VAL_22:.*]] = arith.constant 3.400000e+01 : f32
-// CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.qref) -> ()
-// CHECK:           %[[VAL_23:.*]] = quake.mx %[[VAL_5]] : (!quake.qref) -> i1
+// CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.ref) -> ()
+// CHECK:           %[[VAL_23:.*]] = quake.mx %[[VAL_5]] : (!quake.ref) -> i1
 // CHECK:           %[[VAL_24:.*]] = quake.my %[[VAL_8]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_25:.*]] = quake.mz %[[VAL_9]] : (!quake.qvec<5>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_26:.*]] = cc.undef i32 {wires = true}
@@ -210,42 +210,42 @@ func.func @quantum_ops() {
 // CHECK:           %[[VAL_44:.*]] = quake.mx %[[VAL_36]]#0 : (!quake.wire) -> i1
 // CHECK:           %[[VAL_45:.*]] = quake.my %[[VAL_27]] : (!quake.wire) -> i1
 // CHECK:           %[[VAL_46:.*]] = quake.mz %[[VAL_43]] : (!quake.wire) -> i1
-// CHECK:           %[[VAL_47:.*]] = quake.alloca !quake.qref {apply_variants = true}
+// CHECK:           %[[VAL_47:.*]] = quake.alloca !quake.ref {apply_variants = true}
 // CHECK:           %[[VAL_48:.*]] = quake.alloca !quake.qvec<2>
 // CHECK:           %[[VAL_49:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_50:.*]] = quake.alloca !quake.qref
-// CHECK:           quake.apply @apply_kernel %[[VAL_49]], %[[VAL_50]] : (i32, !quake.qref) -> ()
-// CHECK:           quake.apply @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.qref, !quake.qvec<2>, i32, !quake.qref) -> ()
-// CHECK:           quake.apply<adj> @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.qref, !quake.qvec<2>, i32, !quake.qref) -> ()
+// CHECK:           %[[VAL_50:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.apply @apply_kernel %[[VAL_49]], %[[VAL_50]] : (i32, !quake.ref) -> ()
+// CHECK:           quake.apply @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.qvec<2>, i32, !quake.ref) -> ()
+// CHECK:           quake.apply<adj> @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.qvec<2>, i32, !quake.ref) -> ()
 // CHECK:           %[[VAL_51:.*]] = cc.undef !cc.lambda<() -> ()> {compute_action = true}
 // CHECK:           %[[VAL_52:.*]] = cc.undef !cc.lambda<() -> ()>
 // CHECK:           quake.compute_action %[[VAL_51]], %[[VAL_52]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
 // CHECK:           quake.compute_action<dag> %[[VAL_51]], %[[VAL_52]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
 // CHECK:           %[[VAL_53:.*]] = cc.undef f64 {adjoint = true}
-// CHECK:           quake.s<adj> %[[VAL_5]] : (!quake.qref) -> ()
-// CHECK:           quake.t<adj> %[[VAL_5]] : (!quake.qref) -> ()
-// CHECK:           quake.r1<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
-// CHECK:           quake.rx<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
-// CHECK:           quake.phased_rx<adj> (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.qref) -> ()
-// CHECK:           quake.ry<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
-// CHECK:           quake.rz<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.qref) -> ()
-// CHECK:           quake.u2<adj> (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.qref) -> ()
-// CHECK:           quake.u3<adj> (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.qref) -> ()
+// CHECK:           quake.s<adj> %[[VAL_5]] : (!quake.ref) -> ()
+// CHECK:           quake.t<adj> %[[VAL_5]] : (!quake.ref) -> ()
+// CHECK:           quake.r1<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.ref) -> ()
+// CHECK:           quake.rx<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.ref) -> ()
+// CHECK:           quake.phased_rx<adj> (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.ref) -> ()
+// CHECK:           quake.ry<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.ref) -> ()
+// CHECK:           quake.rz<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.ref) -> ()
+// CHECK:           quake.u2<adj> (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.ref) -> ()
+// CHECK:           quake.u3<adj> (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.ref) -> ()
 // CHECK:           %[[VAL_54:.*]] = quake.alloca !quake.qvec<3> {control = true}
-// CHECK:           quake.x {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.y {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.z {{\[}}%[[VAL_10]]] %[[VAL_5]] : (!quake.qref, !quake.qref) -> ()
-// CHECK:           quake.h {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.s {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.t {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.swap {{\[}}%[[VAL_54]]] %[[VAL_5]], %[[VAL_10]] : (!quake.qvec<3>, !quake.qref, !quake.qref) -> ()
-// CHECK:           quake.r1 (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.rx (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.phased_rx (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.ry (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.rz (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.u2 (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.qvec<3>, !quake.qref) -> ()
-// CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_53]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, f64, !quake.qvec<3>, !quake.qref) -> ()
+// CHECK:           quake.x {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.y {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.z {{\[}}%[[VAL_10]]] %[[VAL_5]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.h {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.s {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.t {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.swap {{\[}}%[[VAL_54]]] %[[VAL_5]], %[[VAL_10]] : (!quake.qvec<3>, !quake.ref, !quake.ref) -> ()
+// CHECK:           quake.r1 (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.rx (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.phased_rx (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.ry (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.rz (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.u2 (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_53]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, f64, !quake.qvec<3>, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -611,17 +611,19 @@ func.func @wire_type() -> !quake.wire {
 }
 
 // CHECK-LABEL:   func.func @unwrap_wrap(
-// CHECK-SAME:      %[[VAL_0:.*]]: !quake.qref) {
-// CHECK:           %[[VAL_1:.*]] = quake.unwrap %[[VAL_0]] : (!quake.qref) -> !quake.wire
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.ref) {
+// CHECK:           %[[VAL_1:.*]] = quake.unwrap %[[VAL_0]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[VAL_2:.*]] = quake.null_wire
 // CHECK:           %[[VAL_3:.*]] = quake.x [%[[VAL_2]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> !quake.wire
-// CHECK:           quake.wrap %[[VAL_3]] to %[[VAL_0]] : !quake.wire, !quake.qref
+// CHECK:           quake.wrap %[[VAL_3]] to %[[VAL_0]] : !quake.wire, !quake.ref
+// CHECK:           return
+// CHECK:         }
 
-func.func @unwrap_wrap(%0 : !quake.qref) {
-  %1 = quake.unwrap %0 : (!quake.qref) -> !quake.wire
+func.func @unwrap_wrap(%0 : !quake.ref) {
+  %1 = quake.unwrap %0 : (!quake.ref) -> !quake.wire
   %3 = quake.null_wire
   %2 = quake.x [%3] %1 : (!quake.wire, !quake.wire) -> !quake.wire
-  quake.wrap %2 to %0 : !quake.wire, !quake.qref
+  quake.wrap %2 to %0 : !quake.wire, !quake.ref
   return
 }
 

--- a/test/Quake/test_add_dealloc.qke
+++ b/test/Quake/test_add_dealloc.qke
@@ -15,8 +15,8 @@ func.func @ghz(%arg0 : i32) {
   %one = arith.constant 1 : i32
   // CHECK: %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
   %q = quake.alloca[%arg0 : i32] !quake.qvec<?>
-  %q0 = quake.extract_ref %q[%c0] : (!quake.qvec<?>, i32) -> !quake.qref
-  quake.h %q0 : (!quake.qref) -> () 
+  %q0 = quake.extract_ref %q[%c0] : (!quake.qvec<?>, i32) -> !quake.ref
+  quake.h %q0 : (!quake.ref) -> () 
   // CHECK: quake.dealloc %[[VAL_3]] : !quake.qvec<?>
   return
 }

--- a/test/Quake/test_inline_simpify.qke
+++ b/test/Quake/test_inline_simpify.qke
@@ -8,7 +8,7 @@
 
 // RUN: cudaq-opt %s | FileCheck %s
 // CHECK: module {
-// CHECK:   func.func @apply_x(%arg0: !quake.qref) {
+// CHECK:   func.func @apply_x(%arg0: !quake.ref) {
 // CHECK:     quake.x %arg0 :
 // CHECK:     return
 // CHECK:   }
@@ -18,20 +18,20 @@
 // CHECK:     %0 = quake.alloca[%[[C3]] : i32] !quake.qvec<?>
 // CHECK:     %1 = arith.index_cast %[[C3]] : i32 to index
 // CHECK:     affine.for %arg0 = 0 to %1 {
-// CHECK:       %3 = quake.extract_ref %0[%arg0] : (!quake.qvec<?>, index) -> !quake.qref
+// CHECK:       %3 = quake.extract_ref %0[%arg0] : (!quake.qvec<?>, index) -> !quake.ref
 // CHECK:       quake.x %3 :
 // CHECK:     }
-// CHECK:     %2 = quake.extract_ref %0[%[[C1]]] : (!quake.qvec<?>, i32) -> !quake.qref
-// CHECK:     call @apply_x(%2) : (!quake.qref) -> ()
+// CHECK:     %2 = quake.extract_ref %0[%[[C1]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     call @apply_x(%2) : (!quake.ref) -> ()
 // CHECK:     return
 // CHECK:   }
 // CHECK: }
 
 module {
     // Any function that takes quantum memory as input
-    // must return the same, e.g. (!quake.qref) -> (!quake.qref)
-    func.func @apply_x(%q : !quake.qref) -> () {
-        quake.x %q : (!quake.qref) -> ()
+    // must return the same, e.g. (!quake.ref) -> (!quake.ref)
+    func.func @apply_x(%q : !quake.ref) -> () {
+        quake.x %q : (!quake.ref) -> ()
         return
     }
 
@@ -41,12 +41,12 @@ module {
         %qubits = quake.alloca [%c_3 : i32 ] !quake.qvec<?>
         %c_3_idx = arith.index_cast %c_3 : i32 to index
         affine.for %i = 0 to %c_3_idx {
-            %q0 = quake.extract_ref %qubits [%i] :( !quake.qvec<?>,index) -> !quake.qref
-            quake.x %q0 : (!quake.qref) -> ()
+            %q0 = quake.extract_ref %qubits [%i] :( !quake.qvec<?>,index) -> !quake.ref
+            quake.x %q0 : (!quake.ref) -> ()
         }
 
-        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>, i32) -> !quake.qref
-        func.call @apply_x(%q1) : (!quake.qref) -> ()
+        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>, i32) -> !quake.ref
+        func.call @apply_x(%q1) : (!quake.ref) -> ()
         
         return
     }

--- a/test/Quake/test_merge_rotation.qke
+++ b/test/Quake/test_merge_rotation.qke
@@ -12,11 +12,11 @@
 // CHECK:     %[[C2:.*]] = arith.constant 2 : i32
 // CHECK:     %[[C0:.*]] = arith.constant 0 : i32
 // CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
-// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
 // CHECK:     %[[CF:.*]] = arith.constant 5.900000e-01 : f64
 // CHECK:     quake.rx (%[[CF]]) %1 : (f64,
 // CHECK:     quake.rx (%[[CF]]) %1 : (f64,
-// CHECK:     %2 = quake.mz %1 : (!quake.qref) -> i1
+// CHECK:     %2 = quake.mz %1 : (!quake.ref) -> i1
 // CHECK:     return
 // CHECK:   }
 
@@ -24,11 +24,11 @@ func.func @duplicate_rotation_check() {
   %0 = arith.constant 2 : i32
   %c_0 = arith.constant 0 : i32
   %qubits = quake.alloca [ %0 : i32 ] !quake.qvec<?>
-  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>,i32) -> !quake.qref
+  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>,i32) -> !quake.ref
   %c_angle = arith.constant 0.59 : f64
-  quake.rx (%c_angle) %q0: (f64, !quake.qref) -> ()
-  quake.rx (%c_angle) %q0 : (f64, !quake.qref) -> ()
-  %measurements0 = quake.mz %q0 : (!quake.qref) -> i1
+  quake.rx (%c_angle) %q0: (f64, !quake.ref) -> ()
+  quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
+  %measurements0 = quake.mz %q0 : (!quake.ref) -> i1
   return
 }
 
@@ -36,26 +36,26 @@ func.func @duplicate_rotation_check() {
 // CHECK:     %[[C2]] = arith.constant 2 : i32
 // CHECK:     %[[C0]] = arith.constant 0 : i32
 // CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
-// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
 // CHECK:     %[[CF:.*]] = arith.constant 5.900000e-01 : f64
 // CHECK:     %[[CF2:.*]] = arith.constant 2.300000e-01 : f64
 // CHECK:     quake.rx (%[[CF]]) %1 : (f64,
 // CHECK:     quake.rx (%[[CF]]) %1 : (f64,
 // CHECK:     quake.rx (%[[CF2]]) %1 : (f64,
-// CHECK:     %2 = quake.mz %1 : (!quake.qref) -> i1
+// CHECK:     %2 = quake.mz %1 : (!quake.ref) -> i1
 // CHECK:     return
 // CHECK: }
 func.func @duplicate_rotation_check2() {
   %0 = arith.constant 2 : i32
   %c_0 = arith.constant 0 : i32
   %qubits = quake.alloca [ %0 : i32] !quake.qvec<?>
-  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>, i32) -> !quake.qref
+  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>, i32) -> !quake.ref
   %c_angle = arith.constant 0.59 : f64
   %c_angle2 = arith.constant 0.23 : f64
-  quake.rx (%c_angle) %q0 : (f64, !quake.qref) -> ()
-  quake.rx (%c_angle) %q0 : (f64, !quake.qref) -> ()
-  quake.rx (%c_angle2) %q0 : (f64, !quake.qref) -> ()
-  %measurement = quake.mz %q0 : (!quake.qref) -> i1
+  quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
+  quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
+  quake.rx (%c_angle2) %q0 : (f64, !quake.ref) -> ()
+  %measurement = quake.mz %q0 : (!quake.ref) -> i1
   return
 }
 
@@ -72,7 +72,7 @@ func.func @returns_angle(%arg0 : f64, %arg1 : f64) -> (f64) {
 // CHECK:     %[[C2:.*]] = arith.constant 2 : i32
 // CHECK:     %[[C0:.*]] = arith.constant 0 : i32
 // CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
-// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.qref
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
 // CHECK:     %[[CF:.*]] = arith.constant 5.900000e-01 : f64
 // CHECK:     %[[CF2:.*]] = arith.constant 2.300000e-01 : f64
 // CHECK:     %[[CF3:.*]] = arith.constant 6.400000e-01 : f64
@@ -81,22 +81,22 @@ func.func @returns_angle(%arg0 : f64, %arg1 : f64) -> (f64) {
 // CHECK:     quake.rx (%cst) %1 :
 // CHECK:     quake.rx (%3) %1 :
 // CHECK:     quake.rx (%2) %1 :
-// CHECK:     %4 = quake.mz %1 : (!quake.qref) -> i1
+// CHECK:     %4 = quake.mz %1 : (!quake.ref) -> i1
 // CHECK:     return
 // CHECK: }
 func.func @duplicate_rotation_check3() {
   %0 = arith.constant 2 : i32
   %c_0 = arith.constant 0 : i32
   %qubits = quake.alloca [ %0 : i32 ] !quake.qvec<?>
-  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>, i32) -> !quake.qref
+  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>, i32) -> !quake.ref
   %c_angle = arith.constant 0.59 : f64
   %c_angle2 = arith.constant 0.23 : f64
   %c_angle3 = arith.constant 0.64 : f64
   %new_angle = call @returns_angle(%c_angle, %c_angle2) : (f64, f64) -> (f64) 
   %new_angle2 = call @returns_angle(%c_angle3, %c_angle2) : (f64, f64) -> (f64)
-  quake.rx (%c_angle) %q0 : (f64, !quake.qref) -> ()
-  quake.rx (%new_angle2) %q0 : (f64, !quake.qref) -> ()
-  quake.rx (%new_angle) %q0 : (f64, !quake.qref) -> ()
-  %measurement = quake.mz %q0 : (!quake.qref) -> i1
+  quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
+  quake.rx (%new_angle2) %q0 : (f64, !quake.ref) -> ()
+  quake.rx (%new_angle) %q0 : (f64, !quake.ref) -> ()
+  %measurement = quake.mz %q0 : (!quake.ref) -> i1
   return
 }

--- a/utils/CircuitCheck/UnitaryBuilder.cpp
+++ b/utils/CircuitCheck/UnitaryBuilder.cpp
@@ -16,7 +16,7 @@ using namespace mlir;
 LogicalResult UnitaryBuilder::build(func::FuncOp func) {
   for (auto arg : func.getArguments()) {
     auto type = arg.getType();
-    if (type.isa<quake::QRefType>() || type.isa<quake::QVecType>())
+    if (type.isa<quake::RefType>() || type.isa<quake::QVecType>())
       if (allocateQubits(arg) == WalkResult::interrupt())
         return failure();
   }


### PR DESCRIPTION
Since the type is prefixed with `!quake` the extra `q` doesn't add any new information.
