### PR TITLE
Universal conversion of QVec to Veq.

### DIFF
--- a/.github/workflows/config/spelling_allowlist.txt
+++ b/.github/workflows/config/spelling_allowlist.txt
@@ -33,6 +33,7 @@ OpenQASM
 Optimizers
 Pauli
 Paulis
+Pimpl
 QAOA
 QIR
 QIS
@@ -43,10 +44,13 @@ Quake
 Toffoli
 VQE
 Vazirani
+Veq
 Wl
 adjoint
 al
 ansatz
+args
+arith
 atol
 auxillary
 backend
@@ -113,6 +117,7 @@ natively
 nlopt
 nullary
 nvq
+pre
 precompute
 precomputed
 qir
@@ -136,6 +141,7 @@ subclass
 subclassed
 subclasses
 subclassing
+subscriptable
 subtype
 subtypes
 subtyping

--- a/docs/sphinx/specification/quake-dialect.md
+++ b/docs/sphinx/specification/quake-dialect.md
@@ -39,19 +39,19 @@ Let's see an example to clarify the distinction between the models.  Take the
 following Quake implementation of some toy quantum computation:
 
 ```cpp
-func.func foo(%qvec : !quake.qvec<2>) {
+func.func foo(%veq : !quake.veq<2>) {
     // Boilerplate to extract each qubit from the vector
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
-    %q0 = quake.qextract %qvec[%c0 : index] : !quake.qvec<2> -> !quake.ref
-    %q1 = quake.qextract %qvec[%c1 : index] : !quake.qvec<2> -> !quake.ref
+    %q0 = quake.qextract %veq[%c0 : index] : !quake.veq<2> -> !quake.ref
+    %q1 = quake.qextract %veq[%c1 : index] : !quake.veq<2> -> !quake.ref
 
     // We apply some operators to those extracted qubits
     ... bunch of operators using %q0 and %q1 ...
     quake.h (%q0)
 
     // We decide to measure the vector
-    %result = quake.mz (%qvec) : vector<2xi1>
+    %result = quake.mz (%veq) : vector<2xi1>
 
     // And then apply another Hadamard to %q0
     quake.h (%q0)
@@ -72,7 +72,7 @@ other on the same qubit---visually:
 Where `I` is the identity operator. Now note that a naive implemention of
 this optimization for Quake would optimize away both `quake.h` operators
 being applied to `%q0`.  Such an implementation would have missed the fact
-that a measurement is being applied to the vector, `%qvec`, which contains
+that a measurement is being applied to the vector, `%veq`, which contains
 `%q0`.
 
 Of course it is possible to correctly implement this optimization for Quake.

--- a/docs/sphinx/using/advanced/cudaq_ir.rst
+++ b/docs/sphinx/using/advanced/cudaq_ir.rst
@@ -50,10 +50,10 @@ we can look at the IR code that was produced. :code:`simple.qke` contains
            memref.store %arg0, %alloca[] : memref<i32>
            %0 = memref.load %alloca[] : memref<i32>
            %1 = arith.extsi %0 : i32 to i64
-           %2 = quake.alloca(%1 : i64) !quake.qvec<?>
+           %2 = quake.alloca(%1 : i64) !quake.veq<?>
            %c0_i32 = arith.constant 0 : i32
            %3 = arith.extsi %c0_i32 : i32 to i64
-           %4 = quake.extract_ref %2[%3] : (!quake.qvec<?>, i64) -> !quake.ref
+           %4 = quake.extract_ref %2[%3] : (!quake.veq<?>, i64) -> !quake.ref
            quake.h %4 : (!quake.ref) -> ()
            cc.scope {
             %c0_i32_0 = arith.constant 0 : i32
@@ -70,12 +70,12 @@ we can look at the IR code that was produced. :code:`simple.qke` contains
               cc.scope {
                 %6 = memref.load %alloca_1[] : memref<i32>
                 %7 = arith.extsi %6 : i32 to i64
-                %8 = quake.extract_ref %2[%7] : (!quake.qvec<?>, i64) -> !quake.ref
+                %8 = quake.extract_ref %2[%7] : (!quake.veq<?>, i64) -> !quake.ref
                 %9 = memref.load %alloca_1[] : memref<i32>
                 %c1_i32 = arith.constant 1 : i32
                 %10 = arith.addi %9, %c1_i32 : i32
                 %11 = arith.extsi %10 : i32 to i64
-                %12 = quake.extract_ref %2[%11] : (!quake.qvec<?>, i64) -> !quake.ref
+                %12 = quake.extract_ref %2[%11] : (!quake.veq<?>, i64) -> !quake.ref
                 quake.x [%8] %12 : (!quake.ref, !quake.ref) -> ()
               }
               cc.continue
@@ -86,7 +86,7 @@ we can look at the IR code that was produced. :code:`simple.qke` contains
                 memref.store %7, %alloca_1[] : memref<i32>
             }
             }
-            %5 = quake.mz %2 : (!quake.qvec<?>) -> !cc.stdvec<i1>
+            %5 = quake.mz %2 : (!quake.veq<?>) -> !cc.stdvec<i1>
             return
         }
     }

--- a/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
@@ -15,24 +15,24 @@ include "mlir/Dialect/Arith/IR/ArithOps.td"
 include "cudaq/Optimizer/Dialect/Quake/QuakeOps.td"
 
 def KnownSizePred : Constraint<
-      CPred<"$0.getType().isa<quake::QVecType>() && "
-            "$0.getType().cast<quake::QVecType>().hasSpecifiedSize()">>;
+      CPred<"$0.getType().isa<quake::VeqType>() && "
+            "$0.getType().cast<quake::VeqType>().hasSpecifiedSize()">>;
 
 def UnknownSizePred : Constraint<
-      CPred<"$0.getType().isa<quake::QVecType>() && "
-            "!$0.getType().cast<quake::QVecType>().hasSpecifiedSize()">>;
+      CPred<"$0.getType().isa<quake::VeqType>() && "
+            "!$0.getType().cast<quake::VeqType>().hasSpecifiedSize()">>;
 
 def createConstantOp : NativeCodeCall<
       "$_builder.create<mlir::arith::ConstantOp>($_loc, $0.getType(),"
       "  $_builder.getIntegerAttr($0.getType(),"
-      "   $1.getType().cast<quake::QVecType>().getSize()))">;
+      "   $1.getType().cast<quake::VeqType>().getSize()))">;
 
-// %4 = quake.qvec_size(%3 : !quake.qvec<10>) : 164
+// %4 = quake.veq_size(%3 : !quake.veq<10>) : 164
 // ────────────────────────────────────────────────
 // %4 = constant 10 : i64
-def ForwardConstantQVecSizePattern : Pat<
-      (quake_QVecSizeOp:$res $qvec), (createConstantOp $res, $qvec),
-      [(KnownSizePred $qvec)]>;
+def ForwardConstantVeqSizePattern : Pat<
+      (quake_VeqSizeOp:$res $veq), (createConstantOp $res, $veq),
+      [(KnownSizePred $veq)]>;
 
 def SizeIsPresentPred : Constraint<CPred<
       "$0.size() == 1 &&"

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
@@ -61,10 +61,10 @@ void genericOpPrinter(mlir::OpAsmPrinter &_odsPrinter, mlir::Operation *op,
 
 namespace quake {
 /// Returns true if and only if any quantum operand has type `!quake.ref` or
-/// `!quake.qvec`.
+/// `!quake.veq`.
 inline bool hasReference(mlir::Operation *op) {
   for (mlir::Value opnd : op->getOperands())
-    if (isa<quake::RefType, quake::QVecType>(opnd.getType()))
+    if (isa<quake::RefType, quake::VeqType>(opnd.getType()))
       return true;
   return false;
 }

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -43,7 +43,7 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
     of references to wires. The size of the vector may be provided either
     statically as part of the type or dynamically as an integer-like argument,
     `size`. The return value will be a quantum reference, type `!quake.ref`,
-    or a vector of such, type `!quake.qvec<N>`.
+    or a vector of such, type `!quake.veq<N>`.
 
     All wires are assumed to be initialized to the value `|0>` initially. See
     the `null_wire` op.
@@ -59,10 +59,10 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
       %qubit = quake.alloca !quake.ref
 
       // Allocate a qubit register with a size known at compilation time
-      %qvec = quake.alloca !quake.qvec<4> {name = "quantum"}
+      %veq = quake.alloca !quake.veq<4> {name = "quantum"}
 
       // Allocate a qubit register with a size known at runtime time
-      %qvec = quake.alloca(%size : i32) !quake.qvec<?>
+      %veq = quake.alloca(%size : i32) !quake.veq<?>
     ```
 
     Canonicalization for this op will fold constant vector sizes directly into
@@ -79,7 +79,7 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
       return build($_builder, $_state, $_builder.getType<RefType>(), {});
     }]>,
     OpBuilder<(ins "size_t":$size), [{
-      return build($_builder, $_state, $_builder.getType<QVecType>(size), {});
+      return build($_builder, $_state, $_builder.getType<VeqType>(size), {});
     }]>
   ];
 
@@ -92,20 +92,20 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
 }
 
 def quake_ConcatOp : QuakeOp<"concat", [Pure]> {
-  let summary = "Construct a qvec from a list of other ref/qvec values.";
+  let summary = "Construct a veq from a list of other ref/veq values.";
   let description = [{
     The `concat` operation allows one to concatenate a list of SSA-values of
-    either type Ref or QVec into a new QVec vector.
+    either type Ref or Veq into a new Veq vector.
 
     Example:
     ```mlir
-      %veq = quake.concat %r1, %v1, %r2 : (!quake.ref, !quake.qvec<?>,
-                                           !quake.ref) -> !quake.qvec<?>
+      %veq = quake.concat %r1, %v1, %r2 : (!quake.ref, !quake.veq<?>,
+                                           !quake.ref) -> !quake.veq<?>
     ```
   }];
 
   let arguments = (ins Variadic<AnyRefType>:$qbits);
-  let results = (outs QVecType);
+  let results = (outs VeqType);
 
   let assemblyFormat = [{
     $qbits attr-dict `:` functional-type(operands, results)
@@ -176,16 +176,16 @@ def quake_DeallocOp : QuakeOp<"dealloc"> {
   let description = [{
     The `dealloc` operation deallocates a references to wires. The deallocation
     can be a single wire, type `!quake.ref`, or a vector of references, type
-    `!quake.qvec<N>`.
+    `!quake.veq<N>`.
 
     Deallocations are automatically inserted by the `QuakeAddDeallocs` and
     `UnwindLowering` passes.
 
     Example:
     ```mlir
-      %1 = quake.alloca !quake.qvec<4>
+      %1 = quake.alloca !quake.veq<4>
       ...
-      quake.dealloc %1 : !quake.qvec<4>
+      quake.dealloc %1 : !quake.veq<4>
     ```
 
     See AllocaOp.
@@ -202,7 +202,7 @@ def quake_DeallocOp : QuakeOp<"dealloc"> {
 }
 
 //===----------------------------------------------------------------------===//
-// QVec, Ref manipulation
+// Veq, Ref manipulation
 //===----------------------------------------------------------------------===//
 
 def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
@@ -217,23 +217,23 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
     Example:
     ```mlir
       %zero = arith.constant 0 : i32
-      %qr = quake.extract_ref %qv[%zero] : (!quake.qvec<?>, i32) -> !quake.ref
+      %qr = quake.extract_ref %qv[%zero] : (!quake.veq<?>, i32) -> !quake.ref
     ```
   }];
 
   let arguments = (ins
-    QVecType:$qvec,
+    VeqType:$veq,
     AnySignlessIntegerOrIndex:$index
   );
   let results = (outs RefType:$ref);
 
   let assemblyFormat = [{
-    $qvec `[` $index `]` `:`  functional-type(operands, results) attr-dict
+    $veq `[` $index `]` `:`  functional-type(operands, results) attr-dict
   }];
 
   let builders = [
-    OpBuilder<(ins "mlir::Value":$qvec, "mlir::Value":$index), [{
-      return build($_builder, $_state, $_builder.getType<RefType>(), qvec,
+    OpBuilder<(ins "mlir::Value":$veq, "mlir::Value":$index), [{
+      return build($_builder, $_state, $_builder.getType<RefType>(), veq,
                    index);
     }]>,
   ];
@@ -241,21 +241,21 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
 }
 
 def quake_RelaxSizeOp : QuakeOp<"relax_size", [Pure]> {
-  let summary = "Relax the constant size on a !qvec to be unknown.";
+  let summary = "Relax the constant size on a !veq to be unknown.";
   let description = [{
     At times, the IR needs to forget the length of an SSA-value of type
-    `!quake.qvec<N>` and demote it to type `!quake.qvec<?>` where the size is
+    `!quake.veq<N>` and demote it to type `!quake.veq<?>` where the size is
     said to be unknown. This demotion is required to preserve a valid,
     strongly-typed IR.
 
     Example:
     ```mlir
-      %uqv = quake.relax_size %qv : (!quake.qvec<4>) -> !quake.qvec<?>
+      %uqv = quake.relax_size %qv : (!quake.veq<4>) -> !quake.veq<?>
     ```
   }];
 
-  let arguments = (ins QVecType:$inputVec);
-  let results = (outs QVecType);
+  let arguments = (ins VeqType:$inputVec);
+  let results = (outs VeqType);
 
   let assemblyFormat = [{
     $inputVec `:` functional-type(operands, results) attr-dict
@@ -266,10 +266,10 @@ def quake_RelaxSizeOp : QuakeOp<"relax_size", [Pure]> {
 }
 
 def quake_SubVecOp : QuakeOp<"subvec", [Pure]> {
-  let summary = "Extract a subvector from a qvec reference value.";
+  let summary = "Extract a subvector from a veq reference value.";
   let description = [{
     The `subvec` operation returns a subvector of references, type
-    `!quake.qvec<N>` from a vector of references, type `!quake.qvec<M>`, where
+    `!quake.veq<N>` from a vector of references, type `!quake.veq<M>`, where
     `M >= N`.
 
     In the following example, the operation produces an SSA-value with 5
@@ -283,17 +283,17 @@ def quake_SubVecOp : QuakeOp<"subvec", [Pure]> {
     ```mlir
       %0 = arith.constant 2 : i32
       %1 = arith.constant 6 : i32
-      %qr = quake.subvec %qv, %0, %1 : (!quake.qvec<?>, i32, i32) ->
-                                        !quake.qvec<5>
+      %qr = quake.subvec %qv, %0, %1 : (!quake.veq<?>, i32, i32) ->
+                                        !quake.veq<5>
     ```
   }];
 
   let arguments = (ins
-    QVecType:$qvec,
+    VeqType:$veq,
     AnySignlessIntegerOrIndex:$low,
     AnySignlessIntegerOrIndex:$high
   );
-  let results = (outs QVecType:$qsub);
+  let results = (outs VeqType:$qsub);
 
   let assemblyFormat = [{
     operands attr-dict `:` functional-type(operands, results)
@@ -303,33 +303,33 @@ def quake_SubVecOp : QuakeOp<"subvec", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
-// QVecSizeOp
+// VeqSizeOp
 //===----------------------------------------------------------------------===//
 
-def quake_QVecSizeOp : QuakeOp<"vec_size", [Pure]> {
-  let summary = "Return the size of a qvec.";
+def quake_VeqSizeOp : QuakeOp<"vec_size", [Pure]> {
+  let summary = "Return the size of a veq.";
   let description = [{
-    Returns the size of a value of type `!quake.qvec<n>`. If the vector has a
+    Returns the size of a value of type `!quake.veq<n>`. If the vector has a
     static size, the static size is returned (effectively as a constant). If
     the size of the vector is dynamic, the size value will be an SSA-value.
 
     Examples:
     ```mlir
-      %0 = quake.alloca !quake.qvec<4>
+      %0 = quake.alloca !quake.veq<4>
       // %1 will be 4 with canonicalization.
-      %1 = quake.qvec_size %0 : (!quake.qvec<4>) -> i64
+      %1 = quake.veq_size %0 : (!quake.veq<4>) -> i64
       
-      %2 = ... : !quake.qvec<?>
+      %2 = ... : !quake.veq<?>
       // %3 may not be computed until runtime.
-      %3 = quake.qvec_size %2 : (!quake.qvec<?>) -> i64
+      %3 = quake.veq_size %2 : (!quake.veq<?>) -> i64
     ```
   }];
 
-  let arguments = (ins QVecType:$qvec);
+  let arguments = (ins VeqType:$veq);
   let results = (outs AnySignlessIntegerOrIndex:$size);
 
   let assemblyFormat = [{
-    $qvec `:` functional-type(operands, results) attr-dict
+    $veq `:` functional-type(operands, results) attr-dict
   }];
 
   let hasCanonicalizer = 1;

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -107,16 +107,16 @@ def RefType : QuakeType<"Ref", "ref"> {
 }
 
 //===----------------------------------------------------------------------===//
-// QVecType
+// VeqType
 //===----------------------------------------------------------------------===//
 
-def QVecType : QuakeType<"QVec", "qvec"> {
+def VeqType : QuakeType<"Veq", "veq"> {
   let summary = "a aggregate of wire references";
   let description = [{
-    A value of type `qvec` is a (linear) collection of values of type `ref`.
+    A value of type `veq` is a (linear) collection of values of type `ref`.
     These aggregates are a convenience for referring to an entire group of
-    references to wires. A `qvec` value is a proper SSA-value. `ref` values
-    in a `qvec` are not volatile.
+    references to wires. A `veq` value is a proper SSA-value. `ref` values
+    in a `veq` are not volatile.
   }];
 
   let parameters = (ins "std::size_t":$size);
@@ -126,16 +126,16 @@ def QVecType : QuakeType<"QVec", "qvec"> {
   
   let extraClassDeclaration = [{
     bool hasSpecifiedSize() const { return getSize(); }
-    static QVecType getUnsized(mlir::MLIRContext *ctx) {
-      return QVecType::get(ctx, 0);
+    static VeqType getUnsized(mlir::MLIRContext *ctx) {
+      return VeqType::get(ctx, 0);
     }
   }];
 }
 
-def AnyQTypeLike : TypeConstraint<Or<[WireType.predicate, QVecType.predicate,
+def AnyQTypeLike : TypeConstraint<Or<[WireType.predicate, VeqType.predicate,
         ControlType.predicate, RefType.predicate]>, "quake quantum types">;
 def AnyQType : Type<AnyQTypeLike.predicate, "quantum type">;
-def AnyRefTypeLike : TypeConstraint<Or<[QVecType.predicate,
+def AnyRefTypeLike : TypeConstraint<Or<[VeqType.predicate,
         RefType.predicate]>, "quake quantum reference types">;
 def AnyRefType : Type<AnyRefTypeLike.predicate, "quantum reference type">;
 def AnyQValueTypeLike : TypeConstraint<Or<[WireType.predicate,

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -67,7 +67,7 @@ def ApplySpecialization : Pass<"apply-op-specialization", "mlir::ModuleOp"> {
   let description = [{
     The quake.apply op allows quake kernels to be called with implicit
     specialization of the function itself. For example, a user-defined kernel
-    can be called with an optional qvec of control qubits. These extra control
+    can be called with an optional veq of control qubits. These extra control
     qubits implicitly create a new and distinct function that threads these
     control qubits to each quantum op in the function.
 
@@ -244,7 +244,7 @@ def CCMemToReg : Pass<"cc-mem2reg", "mlir::func::FuncOp"> {
 def ExpandMeasurements : Pass<"expand-measurements"> {
   let summary = "Expand multi-ref measurements to series on single refs.";
   let description = [{
-    The `mx`, `my`, `mz` ops can take a list of qubits and/or qvec arguments.
+    The `mx`, `my`, `mz` ops can take a list of qubits and/or veq arguments.
     The target may only support measuring a single qubit however. This pass
     expands these ops in list format into a series of measurements (including
     loops) on individual qubits and into a single `std::vector<bool>` result.

--- a/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -44,7 +44,7 @@ listReachableFunctions(clang::CallGraphNode *cgn) {
 // Does `ty` refer to a Quake quantum type? This also checks custom recursive
 // types. It does not check builtin recursive types; e.g., `!llvm.ptr<T>`.
 static bool isQubitType(Type ty) {
-  if (ty.isa<quake::RefType, quake::QVecType>())
+  if (ty.isa<quake::RefType, quake::VeqType>())
     return true;
   if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(ty))
     return isQubitType(vecTy.getElementType());

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -124,7 +124,7 @@ void QuakeBridgeVisitor::addArgumentSymbols(
       auto loc = toLocation(argVal);
       auto parmTy = entryBlock->getArgument(index).getType();
       if (parmTy.isa<cc::LambdaType, cc::StdvecType, LLVM::LLVMStructType,
-                     FunctionType, quake::RefType, quake::QVecType>()) {
+                     FunctionType, quake::RefType, quake::VeqType>()) {
         symbolTable.insert(name, entryBlock->getArgument(index));
       } else {
         auto memRefTy = MemRefType::get(std::nullopt, parmTy);
@@ -242,8 +242,8 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
   assert(type && "variable must have a valid type");
   auto loc = toLocation(x->getSourceRange());
   auto name = x->getName();
-  if (auto qType = dyn_cast<quake::QVecType>(type)) {
-    // Variable is of !quake.qvec type.
+  if (auto qType = dyn_cast<quake::VeqType>(type)) {
+    // Variable is of !quake.veq type.
     mlir::Value qreg;
     std::size_t qregSize = qType.getSize();
     if (qregSize == 0 || (x->hasInit() && !valueStack.empty())) {
@@ -272,7 +272,7 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     auto zero = builder.create<mlir::arith::ConstantIntOp>(
         loc, 0, builder.getIntegerType(64));
     auto qregSizeOne = builder.create<quake::AllocaOp>(
-        loc, quake::QVecType::get(builder.getContext(), 1), qregSizeVal);
+        loc, quake::VeqType::get(builder.getContext(), 1), qregSizeVal);
     Value addressTheQubit =
         builder.create<quake::ExtractRefOp>(loc, qregSizeOne, zero);
     symbolTable.insert(name, addressTheQubit);

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -130,8 +130,7 @@ bool buildOp(OpBuilder &builder, Location loc, ValueRange operands,
     builder.create<A>(loc, isAdjoint, params, ctrls, target, negs);
   } else {
     assert(operands.size() >= 1 && "must be at least 1 operand");
-    if ((operands.size() == 1) &&
-        operands[0].getType().isa<quake::VeqType>()) {
+    if ((operands.size() == 1) && operands[0].getType().isa<quake::VeqType>()) {
       auto target = operands[0];
       if (!negations.empty())
         reportNegateError();

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -53,23 +53,23 @@ maybeUnpackOperands(OpBuilder &builder, Location loc, ValueRange operands) {
     return std::make_pair(SmallVector<Value>{operands.take_back()},
                           SmallVector<Value>{operands.drop_back(1)});
   Value target = operands.back();
-  if (target.getType().isa<quake::QVecType>()) {
+  if (target.getType().isa<quake::VeqType>()) {
     // Split the vector. Last one is target, front N-1 are controls.
-    auto vecSize = builder.create<quake::QVecSizeOp>(
+    auto vecSize = builder.create<quake::VeqSizeOp>(
         loc, builder.getIntegerType(64), target);
     auto size = builder.create<arith::IndexCastOp>(loc, builder.getIndexType(),
                                                    vecSize);
     auto one = builder.create<arith::ConstantIndexOp>(loc, 1);
     auto offset = builder.create<arith::SubIOp>(loc, size, one);
-    // Get the last qubit in the qvec: the target.
+    // Get the last qubit in the veq: the target.
     Value qTarg = builder.create<quake::ExtractRefOp>(loc, target, offset);
     auto zero = builder.create<arith::ConstantIndexOp>(loc, 0);
     auto last = builder.create<arith::SubIOp>(loc, offset, one);
     // The canonicalizer will compute a constant size, if possible.
-    auto unsizedQVecTy = quake::QVecType::getUnsized(builder.getContext());
+    auto unsizedVeqTy = quake::VeqType::getUnsized(builder.getContext());
     // Get the subvector of all qubits excluding the last one: controls.
     Value ctrlSubvec =
-        builder.create<quake::SubVecOp>(loc, unsizedQVecTy, target, zero, last);
+        builder.create<quake::SubVecOp>(loc, unsizedVeqTy, target, zero, last);
     return std::make_pair(SmallVector<Value>{qTarg},
                           SmallVector<Value>{ctrlSubvec});
   }
@@ -131,12 +131,12 @@ bool buildOp(OpBuilder &builder, Location loc, ValueRange operands,
   } else {
     assert(operands.size() >= 1 && "must be at least 1 operand");
     if ((operands.size() == 1) &&
-        operands[0].getType().isa<quake::QVecType>()) {
+        operands[0].getType().isa<quake::VeqType>()) {
       auto target = operands[0];
       if (!negations.empty())
         reportNegateError();
       Type indexTy = builder.getIndexType();
-      auto size = builder.create<quake::QVecSizeOp>(
+      auto size = builder.create<quake::VeqSizeOp>(
           loc, builder.getIntegerType(64), target);
       Value rank = builder.create<arith::IndexCastOp>(loc, indexTy, size);
       auto bodyBuilder = [&](OpBuilder &builder, Location loc, Region &,
@@ -347,9 +347,9 @@ static SmallVector<Value> convertKernelArgs(OpBuilder &builder, Location loc,
         result.push_back(load);
         continue;
       }
-    if (auto vVecTy = dyn_cast<quake::QVecType>(vTy))
-      if (auto kVecTy = dyn_cast<quake::QVecType>(kTy)) {
-        // Both are QVec but the QVec are not identical. If the callee has a
+    if (auto vVecTy = dyn_cast<quake::VeqType>(vTy))
+      if (auto kVecTy = dyn_cast<quake::VeqType>(kTy)) {
+        // Both are Veq but the Veq are not identical. If the callee has a
         // dynamic size, we can relax the size from the calling context.
         if (vVecTy.hasSpecifiedSize() && !kVecTy.hasSpecifiedSize()) {
           auto relax = builder.create<quake::RelaxSizeOp>(loc, kVecTy, v);
@@ -619,13 +619,13 @@ bool QuakeBridgeVisitor::VisitImplicitCastExpr(clang::ImplicitCastExpr *x) {
     TODO_loc(loc, "unhandled user defined implicit conversion");
   }
   case clang::CastKind::CK_ConstructorConversion: {
-    // Enable implicit conversion of qreg -> qspan, which are both QVecType.
+    // Enable implicit conversion of qreg -> qspan, which are both VeqType.
     auto toTy = genType(x->getType());
-    if (toTy.isa<quake::QVecType>()) {
+    if (toTy.isa<quake::VeqType>()) {
       auto subExpr = x->getSubExpr();
       if (auto cxxExpr = dyn_cast<clang::CXXConstructExpr>(subExpr);
           cxxExpr->getNumArgs() == 1 &&
-          genType(cxxExpr->getArg(0)->getType()).isa<quake::QVecType>()) {
+          genType(cxxExpr->getArg(0)->getType()).isa<quake::VeqType>()) {
         return true;
       }
     }
@@ -1002,20 +1002,20 @@ bool QuakeBridgeVisitor::VisitMaterializeTemporaryExpr(
     assert(isa<cc::LambdaType>(peekValue().getType()));
     return true;
   }
-  if (isa<quake::QVecType>(ty)) {
-    assert(isa<quake::QVecType>(peekValue().getType()));
+  if (isa<quake::VeqType>(ty)) {
+    assert(isa<quake::VeqType>(peekValue().getType()));
     return true;
   }
   if (auto structTy = dyn_cast<LLVM::LLVMStructType>(ty);
       structTy && structTy.getName().equals("reference_wrapper")) {
     assert(isa<quake::RefType>(peekValue().getType()) ||
-           isa<quake::QVecType>(peekValue().getType()));
+           isa<quake::VeqType>(peekValue().getType()));
     return true;
   }
   if (auto stdvecTy = dyn_cast<cc::StdvecType>(ty);
       stdvecTy && isa<quake::RefType>(stdvecTy.getElementType())) {
     assert(isa<quake::RefType>(peekValue().getType()) ||
-           isa<quake::QVecType>(peekValue().getType()));
+           isa<quake::VeqType>(peekValue().getType()));
     return true;
   }
 
@@ -1159,7 +1159,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       if (auto memberCall = dyn_cast<clang::CXXMemberCallExpr>(x))
         if (memberCall->getImplicitObjectArgument()) {
           auto qregArg = popValue();
-          auto qrSize = builder.create<quake::QVecSizeOp>(
+          auto qrSize = builder.create<quake::VeqSizeOp>(
               loc, builder.getI64Type(), qregArg);
           return pushValue(qrSize);
         }
@@ -1175,7 +1175,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
             auto one = getConstantInt(builder, loc, 1, 64);
             auto offset = builder.create<arith::SubIOp>(loc, qrSize, one);
             auto unsizedVecTy =
-                quake::QVecType::getUnsized(builder.getContext());
+                quake::VeqType::getUnsized(builder.getContext());
             return pushValue(builder.create<quake::SubVecOp>(
                 loc, unsizedVecTy, qregArg, zero, offset));
           }
@@ -1189,7 +1189,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         if (memberCall->getImplicitObjectArgument()) {
           auto actArgs = lastValues(x->getNumArgs());
           auto qregArg = popValue();
-          auto qrSize = builder.create<quake::QVecSizeOp>(
+          auto qrSize = builder.create<quake::VeqSizeOp>(
               loc, builder.getI64Type(), qregArg);
           auto one = getConstantInt(builder, loc, 1, 64);
           auto endOff = builder.create<arith::SubIOp>(loc, qrSize, one);
@@ -1197,7 +1197,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
             auto startOff =
                 builder.create<arith::SubIOp>(loc, qrSize, actArgs.front());
             auto unsizedVecTy =
-                quake::QVecType::getUnsized(builder.getContext());
+                quake::VeqType::getUnsized(builder.getContext());
             return pushValue(builder.create<quake::SubVecOp>(
                 loc, unsizedVecTy, qregArg, startOff, endOff));
           }
@@ -1217,7 +1217,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto one = getConstantInt(builder, loc, 1, 64);
           Value offset = builder.create<arith::AddIOp>(loc, start, count);
           offset = builder.create<arith::SubIOp>(loc, offset, one);
-          auto unsizedVecTy = quake::QVecType::getUnsized(builder.getContext());
+          auto unsizedVecTy = quake::VeqType::getUnsized(builder.getContext());
           return pushValue(builder.create<quake::SubVecOp>(
               loc, unsizedVecTy, qregArg, start, offset));
         }
@@ -1260,7 +1260,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       // Measurements always return a bool or a std::vector<bool>.
       Type resTy = builder.getI1Type();
       if ((args.size() > 1) ||
-          (args.size() == 1 && args[0].getType().isa<quake::QVecType>()))
+          (args.size() == 1 && args[0].getType().isa<quake::VeqType>()))
         resTy = cc::StdvecType::get(builder.getI1Type());
       if (funcName.equals("mx"))
         return pushValue(builder.create<quake::MxOp>(loc, resTy, args));
@@ -1345,7 +1345,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
             for (auto v : concat.getQbits())
               if (std::find(negations.begin(), negations.end(), v) !=
                   negations.end()) {
-                if (isa<quake::QVecType>(v.getType())) {
+                if (isa<quake::VeqType>(v.getType())) {
                   reportClangError(
                       x, mangler, "cannot negate an entire register of qubits");
                 } else {
@@ -1353,7 +1353,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
                   buildOp<quake::XOp>(builder, loc, v, dummy, []() {});
                 }
               }
-          } else if (isa<quake::QVecType>(ctrlValues.getType())) {
+          } else if (isa<quake::VeqType>(ctrlValues.getType())) {
             assert(negations.size() == 1 && negations[0] == ctrlValues);
             reportClangError(x, mangler,
                              "cannot negate an entire register of qubits");
@@ -1650,7 +1650,7 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
 bool QuakeBridgeVisitor::isVectorOfQubitRefs(clang::CXXConstructExpr *x) {
   if (auto *ctor = x->getConstructor();
       ctor && isInNamespace(ctor, "std") && ctor->getNameAsString() == "vector")
-    if (Value v = peekValue(); v && isa<quake::QVecType>(v.getType()))
+    if (Value v = peekValue(); v && isa<quake::VeqType>(v.getType()))
       return true;
   return false;
 }
@@ -1667,7 +1667,7 @@ bool QuakeBridgeVisitor::VisitCXXTemporaryObjectExpr(
   if (typeMode)
     return true;
   if (isVectorOfQubitRefs(x)) {
-    assert(isa<quake::QVecType>(peekValue().getType()));
+    assert(isa<quake::VeqType>(peekValue().getType()));
     return true;
   }
   return true;
@@ -1690,7 +1690,7 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
     }();
     if (allRef) {
       if (size > 1) {
-        auto qVecTy = quake::QVecType::get(builder.getContext(), size);
+        auto qVecTy = quake::VeqType::get(builder.getContext(), size);
         return pushValue(builder.create<quake::ConcatOp>(loc, qVecTy, last));
       }
       // Pass a one member initialization list as a Ref.
@@ -1713,11 +1713,11 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
     if (isInNamespace(ctor, "cudaq")) {
       if (ctorName == "qreg" || ctorName == "qspan") {
         // This is a qreg q(N);
-        auto regTy = genType(x->getType()).cast<quake::QVecType>();
+        auto regTy = genType(x->getType()).cast<quake::VeqType>();
         if (x->getNumArgs() == 1) {
           assert(!regTy.hasSpecifiedSize());
           auto sizeVal = popValue();
-          if (isa<quake::QVecType>(sizeVal.getType()))
+          if (isa<quake::VeqType>(sizeVal.getType()))
             return pushValue(sizeVal);
           return pushValue(
               builder.create<quake::AllocaOp>(loc, regTy, sizeVal));
@@ -1733,7 +1733,7 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
       }
     } else if (isInNamespace(ctor, "std")) {
       if (isVectorOfQubitRefs(x)) {
-        assert(isa<quake::QVecType>(peekValue().getType()));
+        assert(isa<quake::VeqType>(peekValue().getType()));
         return true;
       }
       if (ctorName == "function") {

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -1035,9 +1035,8 @@ public:
     auto *context = getModule().getContext();
     LLVMConversionTarget target{*context};
     LLVMTypeConverter typeConverter(&getContext());
-    typeConverter.addConversion([&](quake::VeqType type) {
-      return cudaq::opt::getArrayType(context);
-    });
+    typeConverter.addConversion(
+        [&](quake::VeqType type) { return cudaq::opt::getArrayType(context); });
     typeConverter.addConversion(
         [&](quake::RefType type) { return cudaq::opt::getQubitType(context); });
     typeConverter.addConversion([&](cudaq::cc::LambdaType type) {

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -187,7 +187,7 @@ void quake::SubVecOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 //===----------------------------------------------------------------------===//
 
 void quake::VeqSizeOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                                    MLIRContext *context) {
+                                                   MLIRContext *context) {
   patterns.add<ForwardConstantVeqSizePattern>(context);
 }
 

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -36,10 +36,10 @@ class QuantumTrait : public OpTrait::TraitBase<ConcreteType, QuantumTrait> {};
 Value quake::createConstantAlloca(PatternRewriter &builder, Location loc,
                                   OpResult result, ValueRange args) {
   auto newAlloca = [&]() {
-    if (result.getType().isa<quake::QVecType>() &&
-        result.getType().cast<quake::QVecType>().hasSpecifiedSize()) {
+    if (result.getType().isa<quake::VeqType>() &&
+        result.getType().cast<quake::VeqType>().hasSpecifiedSize()) {
       return builder.create<quake::AllocaOp>(
-          loc, result.getType().cast<quake::QVecType>().getSize());
+          loc, result.getType().cast<quake::VeqType>().getSize());
     }
     auto constOp = cast<arith::ConstantOp>(args[0].getDefiningOp());
     return builder.create<quake::AllocaOp>(
@@ -47,7 +47,7 @@ Value quake::createConstantAlloca(PatternRewriter &builder, Location loc,
                  constOp.getValue().cast<IntegerAttr>().getInt()));
   }();
   return builder.create<quake::RelaxSizeOp>(
-      loc, quake::QVecType::getUnsized(builder.getContext()), newAlloca);
+      loc, quake::VeqType::getUnsized(builder.getContext()), newAlloca);
 }
 
 void quake::AllocaOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
@@ -56,7 +56,7 @@ void quake::AllocaOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 }
 
 LogicalResult quake::AllocaOp::verify() {
-  auto resultType = dyn_cast<QVecType>(getResult().getType());
+  auto resultType = dyn_cast<VeqType>(getResult().getType());
   if (auto size = getSize()) {
     std::int64_t argSize = 0;
     if (auto cnt = dyn_cast_or_null<arith::ConstantOp>(size.getDefiningOp())) {
@@ -72,9 +72,9 @@ LogicalResult quake::AllocaOp::verify() {
           "must return a vector of qubits since a size was provided.");
     if (resultType.hasSpecifiedSize() &&
         (static_cast<std::size_t>(argSize) != resultType.getSize()))
-      return emitOpError("expected operand size to match QVecType size.");
+      return emitOpError("expected operand size to match VeqType size.");
   } else if (resultType && !resultType.hasSpecifiedSize()) {
-    return emitOpError("must return a qvec with known size.");
+    return emitOpError("must return a veq with known size.");
   }
   return success();
 }
@@ -84,9 +84,9 @@ LogicalResult quake::AllocaOp::verify() {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult quake::ExtractRefOp::fold(FoldAdaptor adaptor) {
-  auto qvec = getQvec();
+  auto veq = getVeq();
   auto op = getOperation();
-  for (auto user : qvec.getUsers()) {
+  for (auto user : veq.getUsers()) {
     if (user == op || op->getBlock() != user->getBlock() ||
         op->isBeforeInBlock(user))
       continue;
@@ -124,14 +124,14 @@ OpFoldResult quake::ExtractRefOp::fold(FoldAdaptor adaptor) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult quake::RelaxSizeOp::verify() {
-  if (cast<quake::QVecType>(getType()).hasSpecifiedSize())
-    emitOpError("return qvec type must not specify a size");
+  if (cast<quake::VeqType>(getType()).hasSpecifiedSize())
+    emitOpError("return veq type must not specify a size");
   return success();
 }
 
 // Forward the argument to a relax_size to the users for all users that are
-// quake operations. All quake ops that take a sized qvec argument are
-// polymorphic on all qvec types. If the op is not a quake op, then maintain
+// quake operations. All quake ops that take a sized veq argument are
+// polymorphic on all veq types. If the op is not a quake op, then maintain
 // strong typing.
 struct ForwardRelaxedSizePattern : public RewritePattern {
   ForwardRelaxedSizePattern(MLIRContext *context)
@@ -164,7 +164,7 @@ void quake::RelaxSizeOp::getCanonicalizationPatterns(
 Value quake::createSizedSubVecOp(PatternRewriter &builder, Location loc,
                                  OpResult result, Value inVec, Value lo,
                                  Value hi) {
-  auto vecTy = result.getType().cast<quake::QVecType>();
+  auto vecTy = result.getType().cast<quake::VeqType>();
   auto *ctx = builder.getContext();
   auto getVal = [&](Value v) {
     auto vCon = cast<arith::ConstantOp>(v.getDefiningOp());
@@ -172,7 +172,7 @@ Value quake::createSizedSubVecOp(PatternRewriter &builder, Location loc,
         vCon.getValue().cast<IntegerAttr>().getInt());
   };
   std::size_t size = getVal(hi) - getVal(lo) + 1u;
-  auto szVecTy = quake::QVecType::get(ctx, size);
+  auto szVecTy = quake::VeqType::get(ctx, size);
   auto subvec = builder.create<quake::SubVecOp>(loc, szVecTy, inVec, lo, hi);
   return builder.create<quake::RelaxSizeOp>(loc, vecTy, subvec);
 }
@@ -183,12 +183,12 @@ void quake::SubVecOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 }
 
 //===----------------------------------------------------------------------===//
-// QVecSizeOp
+// VeqSizeOp
 //===----------------------------------------------------------------------===//
 
-void quake::QVecSizeOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
+void quake::VeqSizeOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                                     MLIRContext *context) {
-  patterns.add<ForwardConstantQVecSizePattern>(context);
+  patterns.add<ForwardConstantVeqSizePattern>(context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -225,7 +225,7 @@ static LogicalResult verifyMeasurements(Operation *const op,
                                         const Type bitsType) {
   bool mustBeStdvec =
       targetsType.size() > 1 ||
-      (targetsType.size() == 1 && targetsType[0].isa<quake::QVecType>());
+      (targetsType.size() == 1 && targetsType[0].isa<quake::VeqType>());
   if (mustBeStdvec) {
     if (!op->getResult(0).getType().isa<cudaq::cc::StdvecType>())
       return op->emitOpError("must return `!cc.stdvec<i1>`, when measuring a "
@@ -270,11 +270,11 @@ void quake::getOperatorEffectsImpl(
         &effects,
     ValueRange controls, ValueRange targets) {
   for (auto v : controls)
-    if (isa<quake::RefType, quake::QVecType>(v.getType()))
+    if (isa<quake::RefType, quake::VeqType>(v.getType()))
       effects.emplace_back(MemoryEffects::Read::get(), v,
                            SideEffects::DefaultResource::get());
   for (auto v : targets)
-    if (isa<quake::RefType, quake::QVecType>(v.getType())) {
+    if (isa<quake::RefType, quake::VeqType>(v.getType())) {
       effects.emplace_back(MemoryEffects::Read::get(), v,
                            SideEffects::DefaultResource::get());
       effects.emplace_back(MemoryEffects::Write::get(), v,

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -22,12 +22,12 @@ using namespace mlir;
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.cpp.inc"
 
 //===----------------------------------------------------------------------===//
-// QVec's custom parser and pretty printing.
+// Veq's custom parser and pretty printing.
 //
-// qvec `<` (`?` | int) `>`
+// veq `<` (`?` | int) `>`
 //===----------------------------------------------------------------------===//
 
-void quake::QVecType::print(AsmPrinter &os) const {
+void quake::VeqType::print(AsmPrinter &os) const {
   os << '<';
   if (hasSpecifiedSize())
     os << getSize();
@@ -36,7 +36,7 @@ void quake::QVecType::print(AsmPrinter &os) const {
   os << '>';
 }
 
-Type quake::QVecType::parse(AsmParser &parser) {
+Type quake::VeqType::parse(AsmParser &parser) {
   if (parser.parseLess())
     return {};
   std::size_t size;
@@ -50,14 +50,14 @@ Type quake::QVecType::parse(AsmParser &parser) {
 }
 
 LogicalResult
-quake::QVecType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
+quake::VeqType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
                         std::size_t size) {
-  // FIXME: Do we want to check the size of the qvec for some bound?
+  // FIXME: Do we want to check the size of the veq for some bound?
   return success();
 }
 
 //===----------------------------------------------------------------------===//
 
 void quake::QuakeDialect::registerTypes() {
-  addTypes<QVecType, RefType, WireType, ControlType>();
+  addTypes<VeqType, RefType, WireType, ControlType>();
 }

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -51,7 +51,7 @@ Type quake::VeqType::parse(AsmParser &parser) {
 
 LogicalResult
 quake::VeqType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
-                        std::size_t size) {
+                       std::size_t size) {
   // FIXME: Do we want to check the size of the veq for some bound?
   return success();
 }

--- a/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -341,7 +341,7 @@ struct ApplyOpPattern : public OpRewritePattern<quake::ApplyOp> {
     auto calleeName = getVariantFunctionName(
         apply, apply.getCallee().getRootReference().str());
     auto *ctx = apply.getContext();
-    auto consTy = quake::QVecType::getUnsized(ctx);
+    auto consTy = quake::VeqType::getUnsized(ctx);
     SmallVector<Value> newArgs;
     if (!apply.getControls().empty()) {
       auto consOp = rewriter.create<quake::ConcatOp>(apply.getLoc(), consTy,
@@ -443,9 +443,9 @@ public:
     // uncompute kernel) without the controls added.
     auto funcName = getCtrlVariantFunctionName(func.getName().str());
     auto funcTy = func.getFunctionType();
-    auto qvecTy = quake::QVecType::getUnsized(ctx);
+    auto veqTy = quake::VeqType::getUnsized(ctx);
     auto loc = func.getLoc();
-    SmallVector<Type> inTys = {qvecTy};
+    SmallVector<Type> inTys = {veqTy};
     inTys.append(funcTy.getInputs().begin(), funcTy.getInputs().end());
     auto newFunc = cudaq::opt::factory::createFunction(
         funcName, funcTy.getResults(), inTys, module);
@@ -453,7 +453,7 @@ public:
     IRMapping mapping;
     func.getBody().cloneInto(&newFunc.getBody(), mapping);
     auto controlNotNeeded = computeActionAnalysis(newFunc);
-    auto newCond = newFunc.getBody().front().insertArgument(0u, qvecTy, loc);
+    auto newCond = newFunc.getBody().front().insertArgument(0u, veqTy, loc);
     newFunc.walk([&](Operation *op) {
       OpBuilder builder(op);
       if (op->hasTrait<cudaq::QuantumGate>()) {

--- a/lib/Optimizer/Transforms/ExpandMeasurements.cpp
+++ b/lib/Optimizer/Transforms/ExpandMeasurements.cpp
@@ -45,9 +45,9 @@ public:
         rewriter.template create<arith::ConstantIndexOp>(loc, numQubits);
     auto idxTy = rewriter.getIndexType();
     for (auto v : measureOp.getTargets())
-      if (v.getType().template isa<quake::QVecType>()) {
+      if (v.getType().template isa<quake::VeqType>()) {
         Value vecSz =
-            rewriter.template create<quake::QVecSizeOp>(loc, idxTy, v);
+            rewriter.template create<quake::VeqSizeOp>(loc, idxTy, v);
         totalToRead =
             rewriter.template create<arith::AddIOp>(loc, totalToRead, vecSz);
       }
@@ -76,7 +76,7 @@ public:
         buffOff = rewriter.template create<arith::AddIOp>(loc, buffOff, one);
       } else {
         Value vecSz =
-            rewriter.template create<quake::QVecSizeOp>(loc, idxTy, v);
+            rewriter.template create<quake::VeqSizeOp>(loc, idxTy, v);
         cudaq::opt::factory::createCountedLoop(
             rewriter, loc, vecSz,
             [&](OpBuilder &builder, Location loc, Region &, Block &block) {

--- a/lib/Optimizer/Transforms/ExpandMeasurements.cpp
+++ b/lib/Optimizer/Transforms/ExpandMeasurements.cpp
@@ -46,8 +46,7 @@ public:
     auto idxTy = rewriter.getIndexType();
     for (auto v : measureOp.getTargets())
       if (v.getType().template isa<quake::VeqType>()) {
-        Value vecSz =
-            rewriter.template create<quake::VeqSizeOp>(loc, idxTy, v);
+        Value vecSz = rewriter.template create<quake::VeqSizeOp>(loc, idxTy, v);
         totalToRead =
             rewriter.template create<arith::AddIOp>(loc, totalToRead, vecSz);
       }
@@ -75,8 +74,7 @@ public:
         rewriter.template create<LLVM::StoreOp>(loc, bit, addr);
         buffOff = rewriter.template create<arith::AddIOp>(loc, buffOff, one);
       } else {
-        Value vecSz =
-            rewriter.template create<quake::VeqSizeOp>(loc, idxTy, v);
+        Value vecSz = rewriter.template create<quake::VeqSizeOp>(loc, idxTy, v);
         cudaq::opt::factory::createCountedLoop(
             rewriter, loc, vecSz,
             [&](OpBuilder &builder, Location loc, Region &, Block &block) {

--- a/lib/Optimizer/Transforms/FuncToQTX.cpp
+++ b/lib/Optimizer/Transforms/FuncToQTX.cpp
@@ -19,8 +19,8 @@ static LogicalResult convertOperation(func::FuncOp funcOp) {
   auto convertType = [](Type type) -> Type {
     if (type.isa<quake::RefType>())
       return qtx::WireType::get(type.getContext());
-    else if (auto qvec = type.dyn_cast_or_null<quake::QVecType>())
-      return qtx::WireArrayType::get(type.getContext(), qvec.getSize(), 0);
+    else if (auto veq = type.dyn_cast_or_null<quake::VeqType>())
+      return qtx::WireArrayType::get(type.getContext(), veq.getSize(), 0);
     return nullptr;
   };
   auto entryBlock = &*funcOp.getBody().begin();

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -66,7 +66,7 @@ public:
     for (auto inTy : funcTy.getInputs()) {
       if (inTy.isa<cudaq::cc::LambdaType, LLVM::LLVMStructType>())
         eleTys.push_back(IntegerType::get(ctx, 64));
-      else if (inTy.isa<cudaq::cc::StdvecType, quake::QVecType>())
+      else if (inTy.isa<cudaq::cc::StdvecType, quake::VeqType>())
         eleTys.push_back(IntegerType::get(ctx, 64));
       else
         eleTys.push_back(inTy);
@@ -123,7 +123,7 @@ public:
       if (auto memrefTy = dyn_cast<cudaq::cc::StdvecType>(inTy))
         inputTys.push_back(cudaq::opt::factory::getPointerType(
             stlVectorType(memrefTy.getElementType())));
-      else if (auto memrefTy = dyn_cast<quake::QVecType>(inTy))
+      else if (auto memrefTy = dyn_cast<quake::VeqType>(inTy))
         inputTys.push_back(cudaq::opt::factory::getPointerType(stlVectorType(
             IntegerType::get(ctx, /*FIXME sizeof a pointer?*/ 64))));
       else
@@ -416,7 +416,7 @@ public:
       if (inTy.isa<cudaq::cc::LambdaType, LLVM::LLVMStructType>()) {
         auto undef = builder.create<cudaq::cc::UndefOp>(loc, inTy);
         args.push_back(undef);
-      } else if (inTy.isa<cudaq::cc::StdvecType, quake::QVecType>()) {
+      } else if (inTy.isa<cudaq::cc::StdvecType, quake::VeqType>()) {
         Type eleTy = IntegerType::get(ctx, /*FIXME sizeof a pointer?*/ 64);
         if (auto memrefTy = dyn_cast<cudaq::cc::StdvecType>(inTy))
           eleTy = memrefTy.getElementType();
@@ -678,10 +678,10 @@ public:
   // code.
   bool hasLegalType(FunctionType funTy) {
     for (auto ty : funTy.getInputs())
-      if (ty.isa<quake::RefType, quake::QVecType>())
+      if (ty.isa<quake::RefType, quake::VeqType>())
         return false;
     for (auto ty : funTy.getResults())
-      if (ty.isa<quake::RefType, quake::QVecType>())
+      if (ty.isa<quake::RefType, quake::VeqType>())
         return false;
     return true;
   }

--- a/lib/Optimizer/Transforms/QTXToQuake.cpp
+++ b/lib/Optimizer/Transforms/QTXToQuake.cpp
@@ -210,7 +210,7 @@ LogicalResult convertOperation(Operation &op) {
 //===----------------------------------------------------------------------===//
 
 /// Convert the types of the arguments. Add returns to the function for each
-/// quantum input. Currently this handles only Refs and not Qvecs.
+/// quantum input. Currently this handles only Refs and not Veqs.
 void fixArgumentsAndAddReturns(qtx::CircuitOp circuitOp) {
   auto context = circuitOp->getContext();
   auto refType = quake::RefType::get(context);
@@ -222,8 +222,8 @@ void fixArgumentsAndAddReturns(qtx::CircuitOp circuitOp) {
       continue;
     }
     auto type = dyn_cast<qtx::WireArrayType>(arg.getType());
-    auto qvecType = quake::QVecType::get(context, type.getSize());
-    arg.setType(qvecType);
+    auto veqType = quake::VeqType::get(context, type.getSize());
+    arg.setType(veqType);
   }
 
   auto terminator =

--- a/lib/Optimizer/Transforms/QuakeObserveAnsatz.cpp
+++ b/lib/Optimizer/Transforms/QuakeObserveAnsatz.cpp
@@ -82,8 +82,7 @@ private:
 
     // walk and find all quantum allocations
     funcOp->walk([&](quake::AllocaOp op) {
-      data.nQubits +=
-          op.getResult().getType().cast<quake::VeqType>().getSize();
+      data.nQubits += op.getResult().getType().cast<quake::VeqType>().getSize();
     });
 
     // NOTE this assumes canonicalization has run.

--- a/lib/Optimizer/Transforms/QuakeObserveAnsatz.cpp
+++ b/lib/Optimizer/Transforms/QuakeObserveAnsatz.cpp
@@ -83,7 +83,7 @@ private:
     // walk and find all quantum allocations
     funcOp->walk([&](quake::AllocaOp op) {
       data.nQubits +=
-          op.getResult().getType().cast<quake::QVecType>().getSize();
+          op.getResult().getType().cast<quake::VeqType>().getSize();
     });
 
     // NOTE this assumes canonicalization has run.

--- a/lib/Optimizer/Transforms/QuakeToQTX.cpp
+++ b/lib/Optimizer/Transforms/QuakeToQTX.cpp
@@ -85,15 +85,15 @@ public:
                                 OpAdaptor adaptor,
                                 ConvertToQTXRewriter &rewriter) const override {
     // Fail when we are try to borrow from an array that has only dead wires
-    auto arrayType = dyn_cast<qtx::WireArrayType>(adaptor.getQvec().getType());
+    auto arrayType = dyn_cast<qtx::WireArrayType>(adaptor.getVeq().getType());
     if (arrayType.getSize() == arrayType.getDead())
       return failure();
 
     auto newOp = rewriter.create<qtx::ArrayBorrowOp>(
-        op.getLoc(), adaptor.getIndex(), adaptor.getQvec());
+        op.getLoc(), adaptor.getIndex(), adaptor.getVeq());
 
     // Map (or remap) Quake values to QTX values
-    rewriter.mapOrRemap(op.getQvec(), newOp.getNewArray());
+    rewriter.mapOrRemap(op.getVeq(), newOp.getNewArray());
     rewriter.mapOrRemap(op.getResult(), newOp.getWires()[0]);
     rewriter.eraseOp(op);
     return success();

--- a/python/runtime/cudaq/builder/py_QuakeValue.cpp
+++ b/python/runtime/cudaq/builder/py_QuakeValue.cpp
@@ -59,7 +59,7 @@ void bindQuakeValue(py::module &mod) {
           R"(Return a slice of the given :class:`QuakeValue` as a new :class:`QuakeValue`. 
           
                Note:
-                 The underlying :class:`QuakeValue` must be a `list` or `qvec`.
+                 The underlying :class:`QuakeValue` must be a `list` or `veq`.
                  
                Args:
                  start (int) : The index to begin the slice from.

--- a/python/tests/compiler/adjoint.py
+++ b/python/tests/compiler/adjoint.py
@@ -83,23 +83,23 @@ def test_kernel_adjoint_qreg_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.qvec<5>) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<5>
+# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.veq<5>) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:      %[[VAL_0:.*]]: !quake.qvec<?>) {
+# CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>) {
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+# CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 # CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 # CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
 # CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.veq<?>, index) -> !quake.ref
 # CHECK:             quake.h %[[VAL_9]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {
@@ -280,15 +280,15 @@ def test_sample_adjoint_qreg():
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
-# CHECK:           %[[VAL_4:.*]] = quake.vec_size %[[VAL_3]] : (!quake.qvec<?>) -> i64
+# CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.veq<?>
+# CHECK:           %[[VAL_4:.*]] = quake.vec_size %[[VAL_3]] : (!quake.veq<?>) -> i64
 # CHECK:           %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : i64 to index
 # CHECK:           %[[VAL_6:.*]] = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_5]] : index
 # CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
-# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.veq<?>, index) -> !quake.ref
 # CHECK:             quake.x %[[VAL_10]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_9]] : index
 # CHECK:           } step {
@@ -296,15 +296,15 @@ def test_sample_adjoint_qreg():
 # CHECK:             %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_1]] : index
 # CHECK:             cc.continue %[[VAL_12]] : index
 # CHECK:           } {counted}
-# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_3]]) : (!quake.qvec<?>) -> ()
-# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_3]] : (!quake.qvec<?>) -> ()
+# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_3]]) : (!quake.veq<?>) -> ()
+# CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_3]] : (!quake.veq<?>) -> ()
 # CHECK:           %[[VAL_13:.*]] = llvm.alloca %[[VAL_4]] x i1 : (i64) -> !llvm.ptr<i1>
 # CHECK:           %[[VAL_14:.*]] = cc.loop while ((%[[VAL_15:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_16:.*]] = arith.cmpi slt, %[[VAL_15]], %[[VAL_5]] : index
 # CHECK:             cc.condition %[[VAL_16]](%[[VAL_15]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_17:.*]]: index):
-# CHECK:             %[[VAL_18:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_17]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             %[[VAL_18:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_17]]] : (!quake.veq<?>, index) -> !quake.ref
 # CHECK:             %[[VAL_19:.*]] = quake.mz %[[VAL_18]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_20:.*]] = arith.index_cast %[[VAL_17]] : index to i64
 # CHECK:             %[[VAL_21:.*]] = llvm.getelementptr %[[VAL_13]]{{\[}}%[[VAL_20]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
@@ -319,17 +319,17 @@ def test_sample_adjoint_qreg():
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.qvec<?>) {
+# CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.veq<?>) {
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+# CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 # CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 # CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
 # CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, index) -> !quake.ref
 # CHECK:             quake.x %[[VAL_9]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {

--- a/python/tests/compiler/call.py
+++ b/python/tests/compiler/call.py
@@ -83,24 +83,24 @@ def test_kernel_apply_call_qreg_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           %[[VAL_1:.*]] = quake.relax_size %[[VAL_0]] : (!quake.qvec<5>) -> !quake.qvec<?>
-# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_1]]) : (!quake.qvec<?>) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<5>
+# CHECK:           %[[VAL_1:.*]] = quake.relax_size %[[VAL_0]] : (!quake.veq<5>) -> !quake.veq<?>
+# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_1]]) : (!quake.veq<?>) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
-# CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.qvec<?>) {
+# CHECK-SAME:                                                                   %[[VAL_0:.*]]: !quake.veq<?>) {
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+# CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 # CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 # CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
 # CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
+# CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, index) -> !quake.ref
 # CHECK:             quake.h %[[VAL_9]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_8]] : index
 # CHECK:           } step {

--- a/python/tests/compiler/conditional.py
+++ b/python/tests/compiler/conditional.py
@@ -51,9 +51,9 @@ def test_kernel_conditional():
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qvec<2>
-# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.qvec<2>, i32) -> !quake.ref
-# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_3]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
+# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.veq<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_3]]] : (!quake.veq<2>, i32) -> !quake.ref
 # CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
 # CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> i1 {registerName = "measurement_"}
 # CHECK:           cc.if(%[[VAL_8]]) {
@@ -65,7 +65,7 @@ def test_kernel_conditional():
 # CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_13:.*]]: index):
-# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_13]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_13]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             quake.x %[[VAL_14]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_13]] : index
 # CHECK:           } step {

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -49,8 +49,8 @@ def test_kernel_control_no_args(qubit_count):
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]]] : (!quake.qvec<5>) -> ()
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<5>
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_0]]] : (!quake.veq<5>) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -58,13 +58,13 @@ def test_kernel_control_no_args(qubit_count):
 # CHECK:           %[[VAL_0:.*]] = arith.constant 5 : index
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<5>
+# CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<5>
 # CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_7:.*]]: index):
-# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, index) -> !quake.ref
+# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.veq<5>, index) -> !quake.ref
 # CHECK:             quake.x %[[VAL_8]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_7]] : index
 # CHECK:           } step {
@@ -112,8 +112,8 @@ def test_kernel_control_float_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: f64) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qvec<5>, f64) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<5>
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.veq<5>, f64) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -159,14 +159,14 @@ def test_kernel_control_int_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qvec<5>, i32) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<5>
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.veq<5>, i32) -> ()
 # CHECK:           return
 # CHECK:         }
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<5>
 # CHECK:           return
 # CHECK:         }
 
@@ -209,8 +209,8 @@ def test_kernel_control_list_args(qubit_count):
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.qvec<5>, !cc.stdvec<f64>) -> ()
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<5>
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.veq<5>, !cc.stdvec<f64>) -> ()
 # CHECK:           return
 # CHECK:         }
 
@@ -321,19 +321,19 @@ def test_sample_control_qreg_args():
 # CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 # CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.qvec<2>
+# CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.veq<2>, i32) -> !quake.ref
 # CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
 # CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]]] %[[VAL_6]] : (!quake.qvec<2>, !quake.ref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]]] %[[VAL_6]] : (!quake.veq<2>, !quake.ref) -> ()
 # CHECK:           %[[VAL_8:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
 # CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_12:.*]]: index):
-# CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_15:.*]] = arith.index_cast %[[VAL_12]] : index to i64
 # CHECK:             %[[VAL_16:.*]] = llvm.getelementptr %[[VAL_8]]{{\[}}%[[VAL_15]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>

--- a/python/tests/compiler/measure.py
+++ b/python/tests/compiler/measure.py
@@ -40,9 +40,9 @@ def test_kernel_measure_1q():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
-# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
 # CHECK:           %[[VAL_5:.*]] = quake.mx %[[VAL_3]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           %[[VAL_6:.*]] = quake.mx %[[VAL_4]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] : (!quake.ref) -> i1 {registerName = ""}
@@ -75,14 +75,14 @@ def test_kernel_measure_qreg():
 # CHECK:           %[[VAL_1:.*]] = arith.constant 3 : i64
 # CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.qvec<3>
+# CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<3>
 # CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
 # CHECK:           %[[VAL_6:.*]] = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
-# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_9]]] : (!quake.qvec<3>, index) -> !quake.ref
+# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_9]]] : (!quake.veq<3>, index) -> !quake.ref
 # CHECK:             %[[VAL_11:.*]] = quake.mx %[[VAL_10]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_9]] : index to i64
 # CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
@@ -99,7 +99,7 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_19]](%[[VAL_18]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_20:.*]]: index):
-# CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_20]]] : (!quake.qvec<3>, index) -> !quake.ref
+# CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_20]]] : (!quake.veq<3>, index) -> !quake.ref
 # CHECK:             %[[VAL_22:.*]] = quake.my %[[VAL_21]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_23:.*]] = arith.index_cast %[[VAL_20]] : index to i64
 # CHECK:             %[[VAL_24:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_23]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
@@ -116,7 +116,7 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_30]](%[[VAL_29]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_31:.*]]: index):
-# CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_31]]] : (!quake.qvec<3>, index) -> !quake.ref
+# CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_31]]] : (!quake.veq<3>, index) -> !quake.ref
 # CHECK:             %[[VAL_33:.*]] = quake.mz %[[VAL_32]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_34:.*]] = arith.index_cast %[[VAL_31]] : index to i64
 # CHECK:             %[[VAL_35:.*]] = llvm.getelementptr %[[VAL_27]]{{\[}}%[[VAL_34]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>

--- a/python/tests/compiler/multi_qubit.py
+++ b/python/tests/compiler/multi_qubit.py
@@ -46,9 +46,9 @@ def test_kernel_2q():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
-# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
 # CHECK:           quake.h [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.x [%[[VAL_4]]] %[[VAL_3]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.y [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
@@ -88,10 +88,10 @@ def test_kernel_3q():
 # CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i32
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
-# CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<3>
-# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<3>, i32) -> !quake.ref
-# CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<3>, i32) -> !quake.ref
-# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.qvec<3>, i32) -> !quake.ref
+# CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<3>
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.veq<3>, i32) -> !quake.ref
+# CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.veq<3>, i32) -> !quake.ref
+# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.veq<3>, i32) -> !quake.ref
 # CHECK:           quake.h [%[[VAL_4]], %[[VAL_5]]] %[[VAL_6]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
 # CHECK:           quake.x [%[[VAL_6]], %[[VAL_4]]] %[[VAL_5]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
 # CHECK:           quake.y [%[[VAL_5]], %[[VAL_6]]] %[[VAL_4]] : (!quake.ref, !quake.ref, !quake.ref) -> ()

--- a/python/tests/compiler/qalloc.py
+++ b/python/tests/compiler/qalloc.py
@@ -47,7 +47,7 @@ def test_kernel_qalloc_qreg():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<10>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<10>
 # CHECK:           return
 # CHECK:         }
 
@@ -65,7 +65,7 @@ def test_kernel_qalloc_qreg_keyword():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<10>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<10>
 # CHECK:           return
 # CHECK:         }
 
@@ -83,7 +83,7 @@ def test_kernel_qalloc_quake_val():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i32) {
-# CHECK:           %[[VAL_1:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
+# CHECK:           %[[VAL_1:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.veq<?>
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/qreg_apply.py
+++ b/python/tests/compiler/qreg_apply.py
@@ -41,13 +41,13 @@ def test_kernel_qreg():
 # CHECK:           %[[VAL_0:.*]] = arith.constant 2 : index
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
+# CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_7:.*]]: index):
-# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             quake.h %[[VAL_8]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_7]] : index
 # CHECK:           } step {
@@ -60,7 +60,7 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_13]](%[[VAL_12]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_14:.*]]: index):
-# CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_14]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_14]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             quake.x %[[VAL_15]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_14]] : index
 # CHECK:           } step {
@@ -73,7 +73,7 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_20]](%[[VAL_19]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_21:.*]]: index):
-# CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_21]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_21]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             quake.y %[[VAL_22]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_21]] : index
 # CHECK:           } step {
@@ -86,7 +86,7 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_27]](%[[VAL_26]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_28:.*]]: index):
-# CHECK:             %[[VAL_29:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_28]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_29:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_28]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             quake.z %[[VAL_29]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_28]] : index
 # CHECK:           } step {
@@ -99,7 +99,7 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_34]](%[[VAL_33]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_35:.*]]: index):
-# CHECK:             %[[VAL_36:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_35]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_36:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_35]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             quake.t %[[VAL_36]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_35]] : index
 # CHECK:           } step {
@@ -112,7 +112,7 @@ def test_kernel_qreg():
 # CHECK:             cc.condition %[[VAL_41]](%[[VAL_40]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_42:.*]]: index):
-# CHECK:             %[[VAL_43:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_42]]] : (!quake.qvec<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_43:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_42]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             quake.s %[[VAL_43]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_42]] : index
 # CHECK:           } step {

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -81,7 +81,7 @@ public:
   /// starting at the given startIdx and including the following count elements.
   QuakeValue slice(const std::size_t startIdx, const std::size_t count);
 
-  /// @brief For a QuakeValue with type StdVec or QVec, return
+  /// @brief For a QuakeValue with type StdVec or Veq, return
   /// the size QuakeValue.
   QuakeValue size();
 
@@ -96,12 +96,12 @@ public:
 
   /// @brief Return a new QuakeValue when the current value
   /// is indexed, specifically for QuakeValues of type StdVecType
-  /// and QVecType.
+  /// and VeqType.
   QuakeValue operator[](const std::size_t idx);
 
   /// @brief Return a new QuakeValue when the current value
   /// is indexed, specifically for QuakeValues of type StdVecType
-  /// and QVecType.
+  /// and VeqType.
   QuakeValue operator[](const QuakeValue &idx);
 
   /// @brief Negate this QuakeValue

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -93,9 +93,8 @@ KernelBuilderType mapArgToType(cudaq::qubit &e) {
 }
 
 KernelBuilderType mapArgToType(cudaq::qreg<> &e) {
-  return KernelBuilderType([](MLIRContext *ctx) mutable {
-    return quake::VeqType::getUnsized(ctx);
-  });
+  return KernelBuilderType(
+      [](MLIRContext *ctx) mutable { return quake::VeqType::getUnsized(ctx); });
 }
 
 MLIRContext *initializeContext() {
@@ -371,8 +370,7 @@ void handleOneQubitBroadcast(ImplicitLocOpBuilder &builder, Value veq,
 
   auto loc = builder.getLoc();
   auto indexTy = builder.getIndexType();
-  auto size =
-      builder.create<quake::VeqSizeOp>(builder.getIntegerType(64), veq);
+  auto size = builder.create<quake::VeqSizeOp>(builder.getIntegerType(64), veq);
   Value rank = builder.create<arith::IndexCastOp>(indexTy, size);
   auto bodyBuilder = [&](OpBuilder &builder, Location loc, Region &,
                          Block &block) {
@@ -396,10 +394,10 @@ void applyOneQubitOp(ImplicitLocOpBuilder &builder, auto &&params, auto &&ctrls,
     cudaq::info("kernel_builder apply {}", std::string(#NAME));                \
     auto value = target.getValue();                                            \
     auto type = value.getType();                                               \
-    if (type.isa<quake::VeqType>()) {                                         \
+    if (type.isa<quake::VeqType>()) {                                          \
       if (!ctrls.empty())                                                      \
         throw std::runtime_error(                                              \
-            "Cannot specify controls for a veq broadcast.");                  \
+            "Cannot specify controls for a veq broadcast.");                   \
       handleOneQubitBroadcast<quake::QUAKENAME>(builder, target.getValue());   \
       return;                                                                  \
     }                                                                          \

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -361,13 +361,13 @@ public:
   /// @return
   std::size_t getNumParams() { return arguments.size(); }
 
-  /// @brief Return a `QuakeValue` representing the allocated `QVec`.
+  /// @brief Return a `QuakeValue` representing the allocated `Veq`.
   QuakeValue qalloc(const std::size_t nQubits = 1) {
     return details::qalloc(*opBuilder.get(), nQubits);
   }
 
-  /// @brief Return a `QuakeValue` representing the allocated `QVec`,
-  /// size is either defined by `QuakeValue` or a `BlockArgument`.
+  /// @brief Return a `QuakeValue` representing the allocated `Veq`,
+  /// size is from a pre-allocated size `QuakeValue` or `BlockArgument`.
   QuakeValue qalloc(QuakeValue size) {
     return details::qalloc(*opBuilder.get(), size);
   }

--- a/test/AST-Quake/adjoint-1.cpp
+++ b/test/AST-Quake/adjoint-1.cpp
@@ -19,7 +19,7 @@ struct k {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__k
-// CHECK-SAME: (%[[VAL_0:.*]]: !quake.qvec<?>)
+// CHECK-SAME: (%[[VAL_0:.*]]: !quake.veq<?>)
 // CHECK:           quake.h %{{.*}}
 // CHECK:           quake.ry (%{{.*}}) %{{.*}}
 // CHECK:           quake.t %{{.*}}
@@ -34,8 +34,8 @@ struct ep {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ep()
 // CHECK:           %[[VAL_2:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<3>
-// CHECK:           %[[VAL_4:.*]] = quake.relax_size %[[VAL_3]] : (!quake.qvec<3>) -> !quake.qvec<?>
-// CHECK:           quake.apply<adj> @__nvqpp__mlirgen__k %[[VAL_4]] : (!quake.qvec<?>) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.veq<3>
+// CHECK:           %[[VAL_4:.*]] = quake.relax_size %[[VAL_3]] : (!quake.veq<3>) -> !quake.veq<?>
+// CHECK:           quake.apply<adj> @__nvqpp__mlirgen__k %[[VAL_4]] : (!quake.veq<?>) -> ()
 // CHECK:           return
 

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -48,9 +48,9 @@ struct QernelZero {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__run_circuit
 // CHECK-SAME:        (%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: f64)
 // CHECK:           %[[VAL_5:.*]] = memref.alloca() : memref<f64>
-// CHECK:           %[[VAL_10:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_10:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
 // CHECK:           %[[VAL_16:.*]] = memref.load %[[VAL_5]][] : memref<f64>
-// CHECK:           call @__nvqpp__mlirgen__statePrep_A{{.*}}(%[[VAL_10]], %[[VAL_16]]) : (!quake.qvec<?>, f64) -> ()
+// CHECK:           call @__nvqpp__mlirgen__statePrep_A{{.*}}(%[[VAL_10]], %[[VAL_16]]) : (!quake.veq<?>, f64) -> ()
 // CHECK:           cc.scope {
 // CHECK:             cc.loop while {
 // CHECK:               cc.condition %{{.*}}
@@ -58,8 +58,8 @@ struct QernelZero {
 // CHECK:               cc.scope {
 // CHECK:                 quake.z %{{.*}}
 // CHECK:                 %[[VAL_23:.*]] = memref.load %[[VAL_5]][] : memref<f64>
-// CHECK:                 quake.apply<adj> @__nvqpp__mlirgen__statePrep_A{{.*}} %[[VAL_10]], %[[VAL_23]] : (!quake.qvec<?>, f64) -> ()
-// CHECK:                 func.call @__nvqpp__mlirgen__statePrep_A{{.*}}(%[[VAL_10]], %{{.*}}) : (!quake.qvec<?>, f64) -> ()
+// CHECK:                 quake.apply<adj> @__nvqpp__mlirgen__statePrep_A{{.*}} %[[VAL_10]], %[[VAL_23]] : (!quake.veq<?>, f64) -> ()
+// CHECK:                 func.call @__nvqpp__mlirgen__statePrep_A{{.*}}(%[[VAL_10]], %{{.*}}) : (!quake.veq<?>, f64) -> ()
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
@@ -90,10 +90,10 @@ struct run_circuit {
 };
 
 // ADJOINT-LABEL:   func.func private @__nvqpp__mlirgen__statePrep_A
-// ADJOINT-SAME:        .adj(%[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: f64) {
+// ADJOINT-SAME:        .adj(%[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: f64) {
 // ADJOINT:           %[[VAL_2:.*]] = memref.alloca() : memref<f64>
 // ADJOINT:           memref.store %[[VAL_1]], %[[VAL_2]][] : memref<f64>
-// ADJOINT:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// ADJOINT:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // ADJOINT:           %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : i64 to i32
 // ADJOINT:           %[[VAL_5:.*]] = memref.alloca() : memref<i32>
 // ADJOINT:           memref.store %[[VAL_4]], %[[VAL_5]][] : memref<i32>
@@ -104,8 +104,8 @@ struct run_circuit {
 // ADJOINT:           %[[VAL_10:.*]] = arith.constant 0 : i64
 // ADJOINT:           %[[VAL_11:.*]] = arith.constant 1 : i64
 // ADJOINT:           %[[VAL_12:.*]] = arith.subi %[[VAL_9]], %[[VAL_11]] : i64
-// ADJOINT:           %[[VAL_13:.*]] = quake.subvec %[[VAL_0]], %[[VAL_10]], %[[VAL_12]] : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
-// ADJOINT:           %[[VAL_16:.*]] = quake.vec_size %[[VAL_13]] : (!quake.qvec<?>) -> i64
+// ADJOINT:           %[[VAL_13:.*]] = quake.subvec %[[VAL_0]], %[[VAL_10]], %[[VAL_12]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+// ADJOINT:           %[[VAL_16:.*]] = quake.vec_size %[[VAL_13]] : (!quake.veq<?>) -> i64
 // ADJOINT:           %[[VAL_17:.*]] = arith.index_cast %[[VAL_16]] : i64 to index
 // ADJOINT:           %[[VAL_14:.*]] = arith.constant 0 : index
 // ADJOINT:           %[[VAL_15:.*]] = arith.constant 1 : index
@@ -121,7 +121,7 @@ struct run_circuit {
 // ADJOINT:           %[[VAL_27:.*]] = arith.constant 1 : i32
 // ADJOINT:           %[[VAL_28:.*]] = arith.subi %[[VAL_26]], %[[VAL_27]] : i32
 // ADJOINT:           %[[VAL_29:.*]] = arith.extsi %[[VAL_28]] : i32 to i64
-// ADJOINT:           %[[VAL_30:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_29]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// ADJOINT:           %[[VAL_30:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_29]]] : (!quake.veq<?>, i64) -> !quake.ref
 // ADJOINT:           cc.scope {
 // ADJOINT:             %[[VAL_31:.*]] = arith.constant 1 : i32
 // ADJOINT:             %[[VAL_32:.*]] = memref.alloca() : memref<i32>
@@ -161,12 +161,12 @@ struct run_circuit {
 // ADJOINT:                 %[[VAL_62:.*]] = arith.constant 1 : i32
 // ADJOINT:                 %[[VAL_63:.*]] = arith.subi %[[VAL_61]], %[[VAL_62]] : i32
 // ADJOINT:                 %[[VAL_64:.*]] = arith.extsi %[[VAL_63]] : i32 to i64
-// ADJOINT:                 %[[VAL_65:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_64]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// ADJOINT:                 %[[VAL_65:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_64]]] : (!quake.veq<?>, i64) -> !quake.ref
 // ADJOINT:                 %[[VAL_66:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // ADJOINT:                 %[[VAL_67:.*]] = arith.constant 1 : i32
 // ADJOINT:                 %[[VAL_68:.*]] = arith.subi %[[VAL_66]], %[[VAL_67]] : i32
 // ADJOINT:                 %[[VAL_69:.*]] = arith.extsi %[[VAL_68]] : i32 to i64
-// ADJOINT:                 %[[VAL_70:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_69]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// ADJOINT:                 %[[VAL_70:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_69]]] : (!quake.veq<?>, i64) -> !quake.ref
 // ADJOINT:                 %[[VAL_71:.*]] = arith.negf %[[VAL_60]] : f64
 // ADJOINT:                 quake.ry (%[[VAL_71]]) [%[[VAL_65]]] %[[VAL_70]] : (f64, !quake.ref, !quake.ref) -> ()
 // ADJOINT:               }
@@ -197,7 +197,7 @@ struct run_circuit {
 // ADJOINT:             cc.condition %[[VAL_90]](%[[VAL_87]], %[[VAL_88]] : index, index)
 // ADJOINT:           } do {
 // ADJOINT:           ^bb0(%[[VAL_91:.*]]: index, %[[VAL_92:.*]]: index):
-// ADJOINT:             %[[VAL_93:.*]] = quake.extract_ref %[[VAL_13]][%[[VAL_91]]] : (!quake.qvec<?>, index) -> !quake.ref
+// ADJOINT:             %[[VAL_93:.*]] = quake.extract_ref %[[VAL_13]][%[[VAL_91]]] : (!quake.veq<?>, index) -> !quake.ref
 // ADJOINT:             quake.h %[[VAL_93]] : (!quake.ref) -> ()
 // ADJOINT:             cc.continue %[[VAL_91]], %[[VAL_92]] : index, index
 // ADJOINT:           } step {
@@ -214,5 +214,5 @@ struct run_circuit {
 // ADJOINT-LABEL:   func.func @__nvqpp__mlirgen__run_circuit
 // ADJOINT:               cc.scope {
 // ADJOINT:                 quake.z %{{.*}} : (!quake.ref) -> ()
-// ADJOINT:                 func.call @__nvqpp__mlirgen__statePrep_A.adj(%{{.*}}, %{{.*}}) : (!quake.qvec<?>, f64) -> ()
+// ADJOINT:                 func.call @__nvqpp__mlirgen__statePrep_A.adj(%{{.*}}, %{{.*}}) : (!quake.veq<?>, f64) -> ()
 // ADJOINT:                 func.call @__nvqpp__mlirgen__QernelZero{{.*}}(%{{[0-9]+}}) :

--- a/test/AST-Quake/auto_kernel-1.cpp
+++ b/test/AST-Quake/auto_kernel-1.cpp
@@ -23,7 +23,7 @@ struct ak1 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ak1
 // CHECK-SAME:        (%[[VAL_0:.*]]: i32) -> i1 attributes {
-// CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.qvec<?>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
 // CHECK:           %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_13]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>

--- a/test/AST-Quake/auto_kernel-2.cpp
+++ b/test/AST-Quake/auto_kernel-2.cpp
@@ -22,7 +22,7 @@ struct ak2 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ak2
 // CHECK-SAME: () -> !cc.stdvec<i1> attributes {
-// CHECK:           %[[VAL_19:.*]] = quake.mz %{{.*}} : (!quake.qvec<5>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_19:.*]] = quake.mz %{{.*}} : (!quake.veq<5>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_19]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_21:.*]] = cc.stdvec_size %[[VAL_19]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_22:.*]] = arith.constant 1 : i64

--- a/test/AST-Quake/callable-1.cpp
+++ b/test/AST-Quake/callable-1.cpp
@@ -29,27 +29,27 @@ int main() {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Z4mainE3$_0
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
-// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
-// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_5]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_5]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           %[[VAL_7:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_8:.*]] = arith.extsi %[[VAL_7]] : i32 to i64
-// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_8]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_6]]] %[[VAL_9]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_MyKernel
-// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.qvec<?>) -> ()>) attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
+// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.veq<?>) -> ()>) attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<?>
-// CHECK:           call @__nvqpp__mlirgen__Z4mainE3$_0(%[[VAL_3]]) : (!quake.qvec<?>) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.veq<?>
+// CHECK:           call @__nvqpp__mlirgen__Z4mainE3$_0(%[[VAL_3]]) : (!quake.veq<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/callable-2.cpp
+++ b/test/AST-Quake/callable-2.cpp
@@ -38,7 +38,7 @@ struct test5_caller {
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__test5_callee
 // CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:   %[[VAL_1:.*]]: !quake.qvec<?>)
+// CHECK-SAME:   %[[VAL_1:.*]]: !quake.veq<?>)
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %
@@ -59,7 +59,7 @@ struct test5_caller {
 // CHECK:           ^bb0(%[[VAL_6:.*]]: !quake.ref):
 // CHECK:             func.call @__nvqpp__mlirgen__test5_callable{{.*}}(%[[VAL_6]]) : (!quake.ref) -> ()
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__test5_callee{{.*}}(%[[VAL_5]], %{{.*}}) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           call @__nvqpp__mlirgen__test5_callee{{.*}}(%[[VAL_5]], %{{.*}}) : (!cc.lambda<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
 
 // LIFT-LABEL:   func.func @__nvqpp__mlirgen__test5_callee
 // LIFT:           %[[VAL_6:.*]] = cc.callable_func %{{.*}} : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())

--- a/test/AST-Quake/compute_action-2.cpp
+++ b/test/AST-Quake/compute_action-2.cpp
@@ -32,7 +32,7 @@ struct ctrlHeisenberg {
 };
 
 // CHECK-LABEL:   func.func private @__nvqpp__mlirgen__function_magic_func.
-// CHECK-SAME: .ctrl(%[[VAL_0:.*]]: !quake.qvec<?>, %{{.*}}: !quake.qvec<?>) {
+// CHECK-SAME: .ctrl(%[[VAL_0:.*]]: !quake.veq<?>, %{{.*}}: !quake.veq<?>) {
 // CHECK:           cc.scope {
 // CHECK:             cc.loop while {
 // CHECK:             } do {
@@ -40,7 +40,7 @@ struct ctrlHeisenberg {
 // CHECK:                 cc.scope {
 // CHECK:                   cc.loop while {
 // CHECK:                   } do {
-// CHECK:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.ref) -> ()
+// CHECK:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.veq<?>, !quake.ref) -> ()
 // CHECK:                   } step {
 // CHECK:                   }
 // CHECK:                 }
@@ -51,7 +51,7 @@ struct ctrlHeisenberg {
 // CHECK:                       quake.x [%{{.*}}] %{{.*}} : (!quake.ref, !quake.ref) -> ()
 // CHECK:                     } : !cc.lambda<() -> ()>
 // CHECK:                     %[[VAL_36:.*]] = cc.create_lambda {
-// CHECK:                       quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.ref) -> ()
+// CHECK:                       quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.veq<?>, !quake.ref) -> ()
 // CHECK:                     } : !cc.lambda<() -> ()>
 // CHECK:                     quake.compute_action %[[VAL_28]], %[[VAL_36]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
 // CHECK:                     cc.continue
@@ -72,26 +72,26 @@ struct ctrlHeisenberg {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_1]][] : memref<i32>
 // CHECK:           %[[VAL_4:.*]] = arith.extsi %[[VAL_3]] : i32 to i64
-// CHECK:           %[[VAL_5:.*]] = quake.alloca[%[[VAL_4]] : i64] !quake.qvec<?>
-// CHECK:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.ref) -> !quake.qvec<?>
-// CHECK:           call @__nvqpp__mlirgen__function_magic_func.{{.*}}.ctrl(%[[VAL_6]], %[[VAL_5]]) : (!quake.qvec<?>, !quake.qvec<?>) -> ()
+// CHECK:           %[[VAL_5:.*]] = quake.alloca[%[[VAL_4]] : i64] !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.ref) -> !quake.veq<?>
+// CHECK:           call @__nvqpp__mlirgen__function_magic_func.{{.*}}.ctrl(%[[VAL_6]], %[[VAL_5]]) : (!quake.veq<?>, !quake.veq<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 
 //===----------------------------------------------------------------------===//
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__lifted.lambda.0.adj(
-// LAMBDA-SAME:      %{{[^:]*}}: memref<i32>, %{{[^:]*}}: !quake.qvec<?>) {
+// LAMBDA-SAME:      %{{[^:]*}}: memref<i32>, %{{[^:]*}}: !quake.veq<?>) {
 // LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.ref, !quake.ref) -> ()
 // LAMBDA:           return
 
 // LAMBDA2-LABEL:   func.func private @__nvqpp__lifted.lambda.1.ctrl(
-// LAMBDA2-SAME:      %[[VAL_0:.*]]: !quake.qvec<?>, %{{.*}}: memref<i32>, %{{.*}}: !quake.qvec<?>) {
-// LAMBDA2:           quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.ref) -> ()
+// LAMBDA2-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %{{.*}}: memref<i32>, %{{.*}}: !quake.veq<?>) {
+// LAMBDA2:           quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.veq<?>, !quake.ref) -> ()
 // LAMBDA2:           return
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__mlirgen__function_magic_func.
-// LAMBDA-SAME:    .ctrl(%[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: !quake.qvec<?>) {
+// LAMBDA-SAME:    .ctrl(%[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !quake.veq<?>) {
 // LAMBDA:           cc.scope {
 // LAMBDA:             cc.loop while {
 // LAMBDA:             } do {
@@ -99,7 +99,7 @@ struct ctrlHeisenberg {
 // LAMBDA:                 cc.scope {
 // LAMBDA:                   cc.loop while {
 // LAMBDA:                   } do {
-// LAMBDA:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.qvec<?>, !quake.ref) -> ()
+// LAMBDA:                     quake.rx (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.veq<?>, !quake.ref) -> ()
 // LAMBDA:                     cc.continue
 // LAMBDA:                   } step {
 // LAMBDA:                   }
@@ -107,10 +107,10 @@ struct ctrlHeisenberg {
 // LAMBDA:                 cc.scope {
 // LAMBDA:                   cc.loop while {
 // LAMBDA:                   } do {
-// LAMBDA:                     func.call @__nvqpp__lifted.lambda.0(%{{.*}}, %[[VAL_1]]) : (memref<i32>, !quake.qvec<?>) -> ()
-// LAMBDA:                     %[[VAL_28:.*]] = quake.concat %[[VAL_0]] : (!quake.qvec<?>) -> !quake.qvec<?>
-// LAMBDA:                     func.call @__nvqpp__lifted.lambda.1.ctrl(%[[VAL_28]], %{{.*}}, %[[VAL_1]]) : (!quake.qvec<?>, memref<i32>, !quake.qvec<?>) -> ()
-// LAMBDA:                     func.call @__nvqpp__lifted.lambda.0.adj(%{{.*}}, %[[VAL_1]]) : (memref<i32>, !quake.qvec<?>) -> ()
+// LAMBDA:                     func.call @__nvqpp__lifted.lambda.0(%{{.*}}, %[[VAL_1]]) : (memref<i32>, !quake.veq<?>) -> ()
+// LAMBDA:                     %[[VAL_28:.*]] = quake.concat %[[VAL_0]] : (!quake.veq<?>) -> !quake.veq<?>
+// LAMBDA:                     func.call @__nvqpp__lifted.lambda.1.ctrl(%[[VAL_28]], %{{.*}}, %[[VAL_1]]) : (!quake.veq<?>, memref<i32>, !quake.veq<?>) -> ()
+// LAMBDA:                     func.call @__nvqpp__lifted.lambda.0.adj(%{{.*}}, %[[VAL_1]]) : (memref<i32>, !quake.veq<?>) -> ()
 // LAMBDA:                   } step {
 // LAMBDA:                   }
 // LAMBDA:                 }
@@ -124,13 +124,13 @@ struct ctrlHeisenberg {
 // LAMBDA-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenberg(
 // LAMBDA-SAME:      %{{.*}}: i32)
 // LAMBDA:           %[[VAL_2:.*]] = quake.alloca !quake.ref
-// LAMBDA:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.ref) -> !quake.qvec<?>
-// LAMBDA:           call @__nvqpp__mlirgen__function_magic_func.{{.*}}.ctrl(%[[VAL_6]], %{{.*}}) : (!quake.qvec<?>, !quake.qvec<?>) -> ()
+// LAMBDA:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.ref) -> !quake.veq<?>
+// LAMBDA:           call @__nvqpp__mlirgen__function_magic_func.{{.*}}.ctrl(%[[VAL_6]], %{{.*}}) : (!quake.veq<?>, !quake.veq<?>) -> ()
 // LAMBDA:           return
 // LAMBDA:         }
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__lifted.lambda.0(
-// LAMBDA-SAME:      %[[VAL_0:.*]]: memref<i32>, %[[VAL_1:.*]]: !quake.qvec<?>) {
+// LAMBDA-SAME:      %[[VAL_0:.*]]: memref<i32>, %[[VAL_1:.*]]: !quake.veq<?>) {
 // LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.ref, !quake.ref) -> ()
 // LAMBDA:           return
 // LAMBDA:         }

--- a/test/AST-Quake/control.cpp
+++ b/test/AST-Quake/control.cpp
@@ -38,8 +38,8 @@ struct ctrlHeisenberg {
 // CHECK-SAME:        %{{.*}}: i32) attributes
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.ref) -> !quake.qvec<2>
-// CHECK:           quake.apply @__nvqpp__mlirgen__heisenbergU[%[[VAL_8]]] %{{.*}} : (!quake.qvec<2>, !quake.qvec<?>) -> ()
+// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
+// CHECK:           quake.apply @__nvqpp__mlirgen__heisenbergU[%[[VAL_8]]] %{{.*}} : (!quake.veq<2>, !quake.veq<?>) -> ()
 // CHECK:           return
 
 struct givens {
@@ -67,8 +67,8 @@ __qpu__ void qnppx(double theta, cudaq::qubit &q, cudaq::qubit &r,
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__givens(
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qnppx
-// CHECK:           %[[VAL_7:.*]] = quake.concat %{{.*}}, %{{.*}} : (!quake.ref, !quake.ref) -> !quake.qvec<2>
-// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %{{.*}}, %{{.*}} : (!quake.qvec<2>, f64, !quake.ref, !quake.ref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.concat %{{.*}}, %{{.*}} : (!quake.ref, !quake.ref) -> !quake.veq<2>
+// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %{{.*}}, %{{.*}} : (!quake.veq<2>, f64, !quake.ref, !quake.ref) -> ()
 // CHECK:           return
 
 __qpu__ void magic_func(cudaq::qreg<> &q) {
@@ -95,7 +95,7 @@ struct ctrlHeisenbergVersion2 {
 // CHECK-SAME:      ._Z[[mangle:[^(]*]](
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenbergVersion2(
-// CHECK:           quake.apply @__nvqpp__mlirgen__function_magic_func._Z[[mangle]]{{\[}}%{{.*}}] %{{.*}} : (!quake.ref, !quake.qvec<?>) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__function_magic_func._Z[[mangle]]{{\[}}%{{.*}}] %{{.*}} : (!quake.ref, !quake.veq<?>) -> ()
 // CHECK:           return
 
 __qpu__ void qnppx2(double theta, cudaq::qubit &q, cudaq::qubit &r,
@@ -109,9 +109,9 @@ __qpu__ void qnppx2(double theta, cudaq::qubit &q, cudaq::qubit &r,
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qnppx2
 // CHECK-SAME:       %{{[^:]*}}: f64, %[[VAL_1:.*]]: !quake.ref, %[[VAL_2:.*]]: !quake.ref, %[[VAL_3:.*]]: !quake.ref, %[[VAL_4:.*]]: !quake.ref)
-// CHECK:           %[[VAL_7:.*]] = quake.concat %[[VAL_1]], %[[VAL_4]] : (!quake.ref, !quake.ref) -> !quake.qvec<2>
+// CHECK:           %[[VAL_7:.*]] = quake.concat %[[VAL_1]], %[[VAL_4]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
 // CHECK:           quake.x %[[VAL_4]]
-// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %[[VAL_2]], %[[VAL_3]] : (!quake.qvec<2>, f64, !quake.ref, !quake.ref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %[[VAL_2]], %[[VAL_3]] : (!quake.veq<2>, f64, !quake.ref, !quake.ref) -> ()
 // CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
 // CHECK:           quake.x [%[[VAL_2]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -123,7 +123,7 @@ struct F {
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_9:.*]] = memref.alloca() : memref<i32>
@@ -139,20 +139,20 @@ struct F {
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:             quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:             cf.br ^bb8
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref,
 // CHECK:             func.call @_Z2g2v() : () -> ()
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.y %[[VAL_20]] :
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb6:
@@ -162,7 +162,7 @@ struct F {
 // CHECK:               cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:             } do {
 // CHECK:             ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.veq<2>, index) -> !quake.ref
 // CHECK:               quake.z %[[VAL_25]] : (!quake.ref) -> ()
 // CHECK:               cc.continue %[[VAL_24]] : index
 // CHECK:             } step {
@@ -180,7 +180,7 @@ struct F {
 // CHECK:             cc.continue
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 
@@ -193,7 +193,7 @@ struct F {
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_9:.*]] = memref.alloca() : memref<i32>
@@ -209,20 +209,20 @@ struct F {
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] :
 // CHECK:             quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:             func.call @_Z2g2v() : () -> ()
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.y %[[VAL_20]]
 // CHECK:             cf.br ^bb8
 // CHECK:           ^bb6:
@@ -232,7 +232,7 @@ struct F {
 // CHECK:               cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:             } do {
 // CHECK:             ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.veq<2>, index) -> !quake.ref
 // CHECK:               quake.z %[[VAL_25]] : (!quake.ref) -> ()
 // CHECK:               cc.continue %[[VAL_24]] : index
 // CHECK:             } step {
@@ -250,7 +250,7 @@ struct F {
 // CHECK:             cc.continue
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 
@@ -263,7 +263,7 @@ struct F {
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           %[[VAL_9:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_7]], %[[VAL_9]][] : memref<i32>
@@ -278,20 +278,20 @@ struct F {
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
 // CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref)
 // CHECK:           quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:           cf.br ^bb8
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           call @_Z2g2v() : () -> ()
 // CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.y %[[VAL_20]]
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb6:
@@ -301,7 +301,7 @@ struct F {
 // CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.veq<2>, index) -> !quake.ref
 // CHECK:             quake.z %[[VAL_25]]
 // CHECK:             cc.continue %[[VAL_24]] : index
 // CHECK:           } step {
@@ -315,10 +315,10 @@ struct F {
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb7:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<i1>
 // CHECK:           cf.br ^bb8
 // CHECK:         ^bb8:
-// CHECK:           quake.dealloc %[[VAL_8]] : !quake.qvec<2>
+// CHECK:           quake.dealloc %[[VAL_8]] : !quake.veq<2>
 // CHECK:           return
 // CHECK:         }
 
@@ -331,7 +331,7 @@ struct F {
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           %[[VAL_9:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_7]], %[[VAL_9]][] : memref<i32>
@@ -346,20 +346,20 @@ struct F {
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
 // CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]]
 // CHECK:           quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]]
 // CHECK:           call @_Z2g2v() : () -> ()
 // CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.y %[[VAL_20]] : (!quake.ref)
 // CHECK:           cf.br ^bb9
 // CHECK:         ^bb6:
@@ -369,7 +369,7 @@ struct F {
 // CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.veq<2>, index) -> !quake.ref
 // CHECK:             quake.z %[[VAL_25]]
 // CHECK:             cc.continue %[[VAL_24]] : index
 // CHECK:           } step {
@@ -385,10 +385,10 @@ struct F {
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb8:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<i1>
 // CHECK:           cf.br ^bb9
 // CHECK:         ^bb9:
-// CHECK:           quake.dealloc %[[VAL_8]] : !quake.qvec<2>
+// CHECK:           quake.dealloc %[[VAL_8]] : !quake.veq<2>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/ctrl_vector.cpp
+++ b/test/AST-Quake/ctrl_vector.cpp
@@ -26,14 +26,14 @@ struct lower_ctrl_as_qreg {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__lower_ctrl_as_qreg
 // CHECK-SAME: () attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
 // CHECK:  %[[VAL_0:.*]] = arith.constant 4 : i32
-// CHECK:  %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:  %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
 // CHECK:  %[[VAL_3:.*]] = arith.constant 2 : i32
-// CHECK:  %[[VAL_5:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:  %[[VAL_5:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
 // CHECK:  %[[VAL_6:.*]] = arith.constant 0 : i32
-// CHECK:  %[[VAL_8:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
-// CHECK:  quake.h [%[[VAL_2]]] %[[VAL_8]] : (!quake.qvec<?>, !quake.ref) -> ()
+// CHECK:  %[[VAL_8:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:  quake.h [%[[VAL_2]]] %[[VAL_8]] : (!quake.veq<?>, !quake.ref) -> ()
 // CHECK:  %[[VAL_9:.*]] = arith.constant 1 : i32
-// CHECK:  %[[VAL_11:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:  %[[VAL_11:.*]] = quake.extract_ref %[[VAL_5]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:  quake.x [%[[VAL_2]]] %[[VAL_11]] : (
 // clang-format on
 
@@ -60,9 +60,9 @@ struct test_two_control_call {
 // CHECK:             }
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_5:.*]] = quake.alloca[%[[VAL_4]] : i64] !quake.qvec<4>
+// CHECK:           %[[VAL_5:.*]] = quake.alloca[%[[VAL_4]] : i64] !quake.veq<4>
 // CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.ref
-// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test_two_control_call{{.*}}[%[[VAL_5]]] %[[VAL_6]] : (!quake.qvec<4>, !quake.ref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test_two_control_call{{.*}}[%[[VAL_5]]] %[[VAL_6]] : (!quake.veq<4>, !quake.ref) -> ()
 // CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> i1
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/dealloc.cpp
+++ b/test/AST-Quake/dealloc.cpp
@@ -21,12 +21,12 @@ __qpu__ void magic_func(int N) {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_magic_func
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_4:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
-// CHECK:             quake.dealloc %[[VAL_4]] : !quake.qvec<?>
+// CHECK:             %[[VAL_4:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
+// CHECK:             quake.dealloc %[[VAL_4]] : !quake.veq<?>
 // CHECK:             cc.continue
 // CHECK:           }
-// CHECK:           %[[VAL_10:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
-// CHECK:           quake.dealloc %[[VAL_10]] : !quake.qvec<?>
+// CHECK:           %[[VAL_10:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
+// CHECK:           quake.dealloc %[[VAL_10]] : !quake.veq<?>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/empty_step.cpp
+++ b/test/AST-Quake/empty_step.cpp
@@ -19,10 +19,10 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test.
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:             %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:             %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:             memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -41,15 +41,15 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:                 %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:                 %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
-// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_14]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_19:.*]] = arith.subi %[[VAL_17]], %[[VAL_18]] : i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_21:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_22:.*]] = arith.extui %[[VAL_21]] : i32 to i64
-// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_22]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_22]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 func.call @__nvqpp__mlirgen__function_uma._Z3umaRN5cudaq5quditILm2EEES2_S2_(%[[VAL_15]], %[[VAL_20]], %[[VAL_23]]) : (!quake.ref, !quake.ref, !quake.ref) -> ()
 // CHECK:               }
 // CHECK:               cc.continue

--- a/test/AST-Quake/if.cpp
+++ b/test/AST-Quake/if.cpp
@@ -28,16 +28,16 @@ struct kernel {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i1>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_1]][] : memref<i1>
 // CHECK:           cc.if(%[[VAL_5]]) {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_9:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
-// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               quake.h [%[[VAL_8]]] %[[VAL_11]] :
 // CHECK:             }
 // CHECK:           }
@@ -63,26 +63,26 @@ struct kernel_else {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i1>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_1]][] : memref<i1>
 // CHECK:           cc.if(%[[VAL_5]]) {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_9:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
-// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_10]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               quake.h [%[[VAL_8]]] %[[VAL_11]] :
 // CHECK:             }
 // CHECK:           } else {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_12:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_13]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               quake.x [%[[VAL_14]]] %[[VAL_17]] :
 // CHECK:             }
 // CHECK:           }

--- a/test/AST-Quake/lambda_instance.cpp
+++ b/test/AST-Quake/lambda_instance.cpp
@@ -22,11 +22,11 @@ struct test0 {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test0
-// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
-// CHECK:           %[[VAL_12:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_12:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_2]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}test0{{.*}}[%[[VAL_12]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -47,11 +47,11 @@ struct test1 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test1
 // CHECK-SAME:        () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_3:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<2>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<2>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
-// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]][%{{.*}}] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.apply @__nvqpp__mlirgen__{{.*}}5test1{{.*}}[%[[VAL_13]]] %[[VAL_16]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -84,18 +84,18 @@ struct test2b {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test2b
-// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__instance_test2a{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           call @__nvqpp__mlirgen__instance_test2a{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
 // CHECK:           return
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test2a
 // CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2b{{.*}}(%[[VAL_4]]) : (!quake.ref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2b{{.*}}(%[[VAL_7]]) : (!quake.ref) -> ()
 // CHECK:           return
 
@@ -130,18 +130,18 @@ struct test2c {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test2c
-// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__instance_test2a_c{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           call @__nvqpp__mlirgen__instance_test2a_c{{.*}}(%{{.*}}, %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
 // CHECK:           return
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test2a_c
 // CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2c{{.*}}(%[[VAL_4]]) : (!quake.ref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2c{{.*}}(%[[VAL_7]]) : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -177,14 +177,14 @@ struct test3 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3a
 // CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_3]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_6]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_6]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -193,7 +193,7 @@ struct test3 {
 // CHECK-SAME:        () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
 // CHECK:           ^bb0(%[[VAL_4:.*]]: !quake.ref):
 // CHECK:             cc.scope {
@@ -202,7 +202,7 @@ struct test3 {
 // CHECK:               quake.h %[[VAL_4]]
 // CHECK:             }
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__test3a{{.*}}(%[[VAL_6:.*]], %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           call @__nvqpp__mlirgen__test3a{{.*}}(%[[VAL_6:.*]], %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/lambda_variable.cpp
+++ b/test/AST-Quake/lambda_variable.cpp
@@ -36,17 +36,17 @@ struct test3_caller {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_callee
 // CHECK-SAME:     (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:      %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK-SAME:      %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_7]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_caller
 // CHECK-SAME: () attributes {
-// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.ref):
 // CHECK:             cc.scope {
@@ -54,7 +54,7 @@ struct test3_caller {
 // CHECK:               quake.y %[[VAL_5]]
 // CHECK:             }
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__test3_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           call @__nvqpp__mlirgen__test3_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -84,7 +84,7 @@ struct test4_caller {
 // CHECK-SAME: () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_3:.*]] = cc.undef !llvm.struct<"test4_callee", ()>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.ref):
@@ -93,20 +93,20 @@ struct test4_caller {
 // CHECK:               quake.x %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:             }
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__instance_test4_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           call @__nvqpp__mlirgen__instance_test4_callee{{.*}}(%[[VAL_4]], %[[VAL_2]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__instance_test4_callee
 // CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:    %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:    %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           call @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(%[[VAL_4]]) : (!quake.ref) -> ()
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_6]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_6]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           call @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(%[[VAL_7]]) : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/loop_unroll.cpp
+++ b/test/AST-Quake/loop_unroll.cpp
@@ -21,12 +21,12 @@ struct C {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
+// CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
 // CHECK-DAG:       %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x i1 : (i64) -> !llvm.ptr<i1>
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.veq<2>, index) -> !quake.ref
 // CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
 // CHECK:           llvm.store %[[VAL_6]], %[[VAL_4]] : !llvm.ptr<i1>
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<2>, index) -> !quake.ref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.veq<2>, index) -> !quake.ref
 // CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
 // CHECK:           %[[VAL_9:.*]] = llvm.getelementptr %[[VAL_4]][1] : (!llvm.ptr<i1>) -> !llvm.ptr<i1>
 // CHECK:           llvm.store %[[VAL_8]], %[[VAL_9]] : !llvm.ptr<i1>

--- a/test/AST-Quake/measure_bell.cpp
+++ b/test/AST-Quake/measure_bell.cpp
@@ -34,7 +34,7 @@ int main() { bell{}(100); }
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_5]], %[[VAL_6]][] : memref<i32>
@@ -51,16 +51,16 @@ int main() { bell{}(100); }
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_12:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 quake.h %[[VAL_14]] :
 // CHECK:                 %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 quake.x [%[[VAL_17]]] %[[VAL_20]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
+// CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
 // CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
@@ -135,7 +135,7 @@ struct tinkerbell {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_5]], %[[VAL_6]][] : memref<i32>
@@ -152,16 +152,16 @@ struct tinkerbell {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_12:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 quake.h %[[VAL_14]] :
 // CHECK:                 %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 quake.x [%[[VAL_17]]] %[[VAL_20]] : (
-// CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
+// CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
 // CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
@@ -199,7 +199,7 @@ struct tinkerbell {
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_3]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_5]], %[[VAL_6]][] : memref<i32>
@@ -216,16 +216,16 @@ struct tinkerbell {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_12:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_13:.*]] = arith.extsi %[[VAL_12]] : i32 to i64
-// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_14:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_13]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 quake.h %[[VAL_14]]
 // CHECK:                 %[[VAL_15:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 quake.x {{\[}}%[[VAL_17]]] %[[VAL_20]] :
-// CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
+// CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
 // CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>

--- a/test/AST-Quake/mz.cpp
+++ b/test/AST-Quake/mz.cpp
@@ -21,8 +21,8 @@ struct S {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__S() attributes
 // CHECK:           %[[VAL_0:.*]] = arith.constant 20 : i32
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
-// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_2]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.veq<?>
+// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -41,12 +41,12 @@ struct VectorOfStaticVeq {
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_1:.*]] = arith.constant 4 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
-// CHECK:           %[[VAL_6:.*]] = quake.alloca[%[[VAL_5]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_6:.*]] = quake.alloca[%[[VAL_5]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.ref, !quake.qvec<?>, !quake.qvec<?>, !quake.ref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = cc.stdvec_size %[[VAL_8]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_11:.*]] = arith.constant 1 : i64
@@ -74,12 +74,12 @@ struct VectorOfDynamicVeq {
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_2]][] : memref<i32>
 // CHECK:           %[[VAL_6:.*]] = arith.extui %[[VAL_5]] : i32 to i64
-// CHECK:           %[[VAL_7:.*]] = quake.alloca[%[[VAL_6]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_7:.*]] = quake.alloca[%[[VAL_6]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_8:.*]] = memref.load %[[VAL_3]][] : memref<i32>
 // CHECK:           %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
-// CHECK:           %[[VAL_10:.*]] = quake.alloca[%[[VAL_9]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_10:.*]] = quake.alloca[%[[VAL_9]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.ref, !quake.qvec<?>, !quake.qvec<?>, !quake.ref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_14:.*]] = cc.stdvec_size %[[VAL_12]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_15:.*]] = arith.constant 1 : i64

--- a/test/AST-Quake/negation.cpp
+++ b/test/AST-Quake/negation.cpp
@@ -21,16 +21,16 @@ struct NegationOperatorTest {
 // CHECK-SAME: () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 3 : i32
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_4:.*]] = arith.extsi %[[VAL_3]] : i32 to i64
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_4]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_4]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_7]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_7]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           %[[VAL_9:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
-// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_10]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_10]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_5]], %[[VAL_8]] neg [true, false]] %[[VAL_11]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/passQregNToQSpan.cpp
+++ b/test/AST-Quake/passQregNToQSpan.cpp
@@ -22,15 +22,15 @@ struct entry {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_mcx._Z3mcxN5cudaq5qspan{{.*}}(
-// CHECK-SAME:                                                                                               %[[VAL_0:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:                                                                                               %[[VAL_0:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__entry() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_1:.*]] = quake.alloca[%[[VAL_0]] : i64] !quake.qvec<3>
-// CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.qvec<3>) -> !quake.qvec<?>
-// CHECK:           call @__nvqpp__mlirgen__function_mcx._Z3mcxN5cudaq5qspan{{.*}}(%[[VAL_2]]) : (!quake.qvec<?>) -> ()
+// CHECK:           %[[VAL_1:.*]] = quake.alloca[%[[VAL_0]] : i64] !quake.veq<3>
+// CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.veq<3>) -> !quake.veq<?>
+// CHECK:           call @__nvqpp__mlirgen__function_mcx._Z3mcxN5cudaq5qspan{{.*}}(%[[VAL_2]]) : (!quake.veq<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/postfix_ops.cpp
+++ b/test/AST-Quake/postfix_ops.cpp
@@ -19,10 +19,10 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test.
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>,
-// CHECK-SAME:         %[[VAL_1:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>,
+// CHECK-SAME:         %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:             %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:             %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:             memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -41,15 +41,15 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:                 %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:                 %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
-// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_14]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_19:.*]] = arith.subi %[[VAL_17]], %[[VAL_18]] : i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_21:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:                 %[[VAL_22:.*]] = arith.extui %[[VAL_21]] : i32 to i64
-// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_22]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_22]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -102,8 +102,8 @@ int main() {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_iqft
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>) attributes {"cudaq-kernel"} {
-// CHECK:           %[[VAL_1:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK:           %[[VAL_1:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_2:.*]] = arith.trunci %[[VAL_1]] : i64 to i32
 // CHECK:           %[[VAL_3:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_2]], %[[VAL_3]][] : memref<i32>
@@ -122,14 +122,14 @@ int main() {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_11:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:                 %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
-// CHECK:                 %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_12]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_12]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_14:.*]] = memref.load %[[VAL_3]][] : memref<i32>
 // CHECK:                 %[[VAL_15:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:                 %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i32
 // CHECK:                 %[[VAL_17:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_18:.*]] = arith.subi %[[VAL_16]], %[[VAL_17]] : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.extsi %[[VAL_18]] : i32 to i64
-// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 quake.swap %[[VAL_13]], %[[VAL_20]] : (
 // CHECK:               }
 // CHECK:               cc.continue
@@ -155,7 +155,7 @@ int main() {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_31:.*]] = memref.load %[[VAL_25]][] : memref<i32>
 // CHECK:                 %[[VAL_32:.*]] = arith.extsi %[[VAL_31]] : i32 to i64
-// CHECK:                 %[[VAL_33:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_32]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_33:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_32]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 quake.h %[[VAL_33]] : (!quake.ref) -> ()
 // CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_25]][] : memref<i32>
 // CHECK:                 %[[VAL_35:.*]] = arith.constant 1 : i32
@@ -187,10 +187,10 @@ int main() {
 // CHECK:                       %[[VAL_54:.*]] = memref.load %[[VAL_53]][] : memref<f64>
 // CHECK:                       %[[VAL_55:.*]] = memref.load %[[VAL_37]][] : memref<i32>
 // CHECK:                       %[[VAL_56:.*]] = arith.extsi %[[VAL_55]] : i32 to i64
-// CHECK:                       %[[VAL_57:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_56]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                       %[[VAL_57:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_56]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                       %[[VAL_58:.*]] = memref.load %[[VAL_39]][] : memref<i32>
 // CHECK:                       %[[VAL_59:.*]] = arith.extsi %[[VAL_58]] : i32 to i64
-// CHECK:                       %[[VAL_60:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_59]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:                       %[[VAL_60:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_59]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                       quake.r1 (%[[VAL_54]]) [%[[VAL_57]]] %[[VAL_60]] : (f64, !quake.ref, !quake.ref) -> ()
 // CHECK:                     }
 // CHECK:                     cc.continue
@@ -214,15 +214,15 @@ int main() {
 // CHECK:           %[[VAL_68:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_69:.*]] = arith.subi %[[VAL_67]], %[[VAL_68]] : i32
 // CHECK:           %[[VAL_70:.*]] = arith.extsi %[[VAL_69]] : i32 to i64
-// CHECK:           %[[VAL_71:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_70]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_71:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_70]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_71]]
 // CHECK:           return
 // CHECK:         }
 
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__tgate
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>) attributes
-// CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>) attributes
+// CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
@@ -231,7 +231,7 @@ int main() {
 // CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, index) -> !quake.ref
 // CHECK:             quake.t %[[VAL_9]] : (!quake.ref) -> ()
 // CHECK:             cc.continue %[[VAL_8]] : index
 // CHECK:           } step {
@@ -243,8 +243,8 @@ int main() {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Z4mainE3$_0
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>)
+// CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
@@ -253,7 +253,7 @@ int main() {
 // CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, index) -> !quake.ref
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, index) -> !quake.ref
 // CHECK:             quake.x %[[VAL_9]] :
 // CHECK:             cc.continue %[[VAL_8]] : index
 // CHECK:           } step {
@@ -266,7 +266,7 @@ int main() {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_qpe
 // CHECK-SAME:      (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32,
-// CHECK-SAME:       %[[VAL_2:.*]]: !cc.lambda<(!quake.qvec<?>) -> ()>,
+// CHECK-SAME:       %[[VAL_2:.*]]: !cc.lambda<(!quake.veq<?>) -> ()>,
 // CHECK-SAME:       %[[VAL_3:.*]]: !llvm.struct<"tgate", ()>) attributes
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_4]][] : memref<i32>
@@ -276,22 +276,22 @@ int main() {
 // CHECK:           %[[VAL_7:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           %[[VAL_9:.*]] = arith.extsi %[[VAL_8]] : i32 to i64
-// CHECK:           %[[VAL_10:.*]] = quake.alloca[%[[VAL_9]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_10:.*]] = quake.alloca[%[[VAL_9]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_11:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:           %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
 // CHECK:           %[[VAL_13:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_14:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_15:.*]] = arith.subi %[[VAL_12]], %[[VAL_14]] : i64
-// CHECK:           %[[VAL_16:.*]] = quake.subvec %[[VAL_10]], %[[VAL_13]], %[[VAL_15]] : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
+// CHECK:           %[[VAL_16:.*]] = quake.subvec %[[VAL_10]], %[[VAL_13]], %[[VAL_15]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
 // CHECK:           %[[VAL_17:.*]] = memref.load %[[VAL_5]][] : memref<i32>
 // CHECK:           %[[VAL_18:.*]] = arith.extsi %[[VAL_17]] : i32 to i64
-// CHECK:           %[[VAL_19:.*]] = quake.vec_size %[[VAL_10]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_19:.*]] = quake.vec_size %[[VAL_10]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_20:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_21:.*]] = arith.subi %[[VAL_19]], %[[VAL_20]] : i64
 // CHECK:           %[[VAL_22:.*]] = arith.subi %[[VAL_19]], %[[VAL_18]] : i64
-// CHECK:           %[[VAL_23:.*]] = quake.subvec %[[VAL_10]], %[[VAL_22]], %[[VAL_21]] : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
-// CHECK:           call @__nvqpp__mlirgen__Z4mainE3$_0(%[[VAL_23]]) : (!quake.qvec<?>) -> ()
-// CHECK:           %[[VAL_24:.*]] = quake.vec_size %[[VAL_16]] : (!quake.qvec<?>) -> i64
+// CHECK:           %[[VAL_23:.*]] = quake.subvec %[[VAL_10]], %[[VAL_22]], %[[VAL_21]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+// CHECK:           call @__nvqpp__mlirgen__Z4mainE3$_0(%[[VAL_23]]) : (!quake.veq<?>) -> ()
+// CHECK:           %[[VAL_24:.*]] = quake.vec_size %[[VAL_16]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_25:.*]] = arith.index_cast %[[VAL_24]] : i64 to index
 // CHECK:           %[[VAL_26:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_27:.*]] = arith.constant 1 : index
@@ -300,7 +300,7 @@ int main() {
 // CHECK:             cc.condition %[[VAL_30]](%[[VAL_29]] : index)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_31:.*]]: index):
-// CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_31]]] : (!quake.qvec<?>, index) -> !quake.ref
+// CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_31]]] : (!quake.veq<?>, index) -> !quake.ref
 // CHECK:             quake.h %[[VAL_32]] :
 // CHECK:             cc.continue %[[VAL_31]] : index
 // CHECK:           } step {
@@ -336,8 +336,8 @@ int main() {
 // CHECK:                     cc.scope {
 // CHECK:                       %[[VAL_49:.*]] = memref.load %[[VAL_36]][] : memref<i32>
 // CHECK:                       %[[VAL_50:.*]] = arith.extsi %[[VAL_49]] : i32 to i64
-// CHECK:                       %[[VAL_51:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_50]]] : (!quake.qvec<?>, i64) -> !quake.ref
-// CHECK:                       quake.apply @__nvqpp__mlirgen__tgate[%[[VAL_51]]] %[[VAL_23]] : (!quake.ref, !quake.qvec<?>) -> ()
+// CHECK:                       %[[VAL_51:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_50]]] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:                       quake.apply @__nvqpp__mlirgen__tgate[%[[VAL_51]]] %[[VAL_23]] : (!quake.ref, !quake.veq<?>) -> ()
 // CHECK:                     }
 // CHECK:                     cc.continue
 // CHECK:                   } step {
@@ -356,7 +356,7 @@ int main() {
 // CHECK:               memref.store %[[VAL_57]], %[[VAL_36]][] : memref<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           call @__nvqpp__mlirgen__function_iqft{{.*}}(%[[VAL_16]]) : (!quake.qvec<?>) -> ()
-// CHECK:           %[[VAL_68:.*]] = quake.mz %[[VAL_16]] : (!quake.qvec<?>) ->  !cc.stdvec<i1>
+// CHECK:           call @__nvqpp__mlirgen__function_iqft{{.*}}(%[[VAL_16]]) : (!quake.veq<?>) -> ()
+// CHECK:           %[[VAL_68:.*]] = quake.mz %[[VAL_16]] : (!quake.veq<?>) ->  !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/simple.cpp
+++ b/test/AST-Quake/simple.cpp
@@ -17,10 +17,10 @@
 // CHECK-VISIT:     memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
 // CHECK-VISIT:     %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>
 // CHECK-VISIT:     %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
-// CHECK-VISIT:     %[[VAL_4:.*]] = quake.alloca(%[[VAL_3]] : i64) : !quake.qvec<?>
+// CHECK-VISIT:     %[[VAL_4:.*]] = quake.alloca(%[[VAL_3]] : i64) : !quake.veq<?>
 // CHECK-VISIT:     %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK-VISIT:     %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK-VISIT:     %[[VAL_7:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_6]] : i64] : !quake.qvec<?> -> !quake.ref
+// CHECK-VISIT:     %[[VAL_7:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_6]] : i64] : !quake.veq<?> -> !quake.ref
 // CHECK-VISIT:     quake.h (%[[VAL_7]])
 // CHECK-VISIT:     quake.scope {
 // CHECK-VISIT:       %[[VAL_8:.*]] = arith.constant 0 : i32
@@ -37,12 +37,12 @@
 // CHECK-VISIT:         quake.scope {
 // CHECK-VISIT:           %[[VAL_15:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK-VISIT:           %[[VAL_16:.*]] = arith.extsi %[[VAL_15]] : i32 to i64
-// CHECK-VISIT:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]] : i64] : !quake.qvec<?> -> !quake.ref
+// CHECK-VISIT:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_16]] : i64] : !quake.veq<?> -> !quake.ref
 // CHECK-VISIT:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK-VISIT:           %[[VAL_19:.*]] = arith.constant 1 : i32
 // CHECK-VISIT:           %[[VAL_20:.*]] = arith.addi %[[VAL_18]], %[[VAL_19]] : i32
 // CHECK-VISIT:           %[[VAL_21:.*]] = arith.extsi %[[VAL_20]] : i32 to i64
-// CHECK-VISIT:           %[[VAL_22:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_21]] : i64] : !quake.qvec<?> -> !quake.ref
+// CHECK-VISIT:           %[[VAL_22:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_21]] : i64] : !quake.veq<?> -> !quake.ref
 // CHECK-VISIT:           quake.x [%[[VAL_17]]] (%[[VAL_22]])
 // CHECK-VISIT:         }
 // CHECK-VISIT:         quake.continue ()
@@ -53,11 +53,11 @@
 // CHECK-VISIT:         memref.store %[[VAL_25]], %[[VAL_9]][] : memref<i32>
 // CHECK-VISIT:       }
 // CHECK-VISIT:     }
-// CHECK-VISIT:     %[[VAL_26:.*]] = quake.vec_size(%[[VAL_4]] : !quake.qvec<?>) : i64
+// CHECK-VISIT:     %[[VAL_26:.*]] = quake.vec_size(%[[VAL_4]] : !quake.veq<?>) : i64
 // CHECK-VISIT:     %[[VAL_27:.*]] = arith.index_cast %[[VAL_26]] : i64 to index
 // CHECK-VISIT:     %[[VAL_28:.*]] = arith.constant 0 : index
 // CHECK-VISIT:     affine.for %[[VAL_29:.*]] = affine_map<(d0) -> (d0)>(%[[VAL_28]]) to affine_map<(d0) -> (d0)>(%[[VAL_27]]) {
-// CHECK-VISIT:       %[[VAL_30:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_29]] : index] : !quake.qvec<?> -> !quake.ref
+// CHECK-VISIT:       %[[VAL_30:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_29]] : index] : !quake.veq<?> -> !quake.ref
 // CHECK-VISIT:       %[[VAL_31:.*]] = quake.mz(%[[VAL_30]] : !quake.ref) : i1
 // CHECK-VISIT:     }
 // CHECK-VISIT:     return

--- a/test/AST-Quake/simple_qarray.cpp
+++ b/test/AST-Quake/simple_qarray.cpp
@@ -48,10 +48,10 @@ int main() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ghz
 // CHECK-SAME: ()
 // CHECK:           %[[VAL_2:.*]] = arith.constant 5 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.qvec<5>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_2]] : i64] !quake.veq<5>
 // CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, i64) -> !quake.ref
+// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.veq<5>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_8]] :
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : i32
@@ -66,12 +66,12 @@ int main() {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_14:.*]] = memref.load %[[VAL_10]][] : memref<i32>
 // CHECK:                 %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
-// CHECK:                 %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_15]]] : (!quake.qvec<5>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_15]]] : (!quake.veq<5>, i64) -> !quake.ref
 // CHECK:                 %[[VAL_17:.*]] = memref.load %[[VAL_10]][] : memref<i32>
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.addi %[[VAL_17]], %[[VAL_18]] : i32
 // CHECK:                 %[[VAL_20:.*]] = arith.extsi %[[VAL_19]] : i32 to i64
-// CHECK:                 %[[VAL_21:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_20]]] : (!quake.qvec<5>, i64) -> !quake.ref
+// CHECK:                 %[[VAL_21:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_20]]] : (!quake.veq<5>, i64) -> !quake.ref
 // CHECK:                 quake.x [%[[VAL_16]]] %[[VAL_21]] :
 // CHECK:               }
 // CHECK:               cc.continue
@@ -82,7 +82,7 @@ int main() {
 // CHECK:               memref.store %[[VAL_24]], %[[VAL_10]][] : memref<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_33:.*]] = quake.mz %[[VAL_3]] : (!quake.qvec<5>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_33:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<5>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/slice.cpp
+++ b/test/AST-Quake/slice.cpp
@@ -24,11 +24,11 @@ struct SliceTest {
 // CHECK-SAME:      (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) attributes {
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : i32
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
-// CHECK:           %[[VAL_6:.*]] = quake.alloca[%[[VAL_5]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_6:.*]] = quake.alloca[%[[VAL_5]] : i64] !quake.veq<?>
 // CHECK:           %[[VAL_11:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_12:.*]] = arith.addi %{{.*}}, %{{.*}} : i64
 // CHECK:           %[[VAL_13:.*]] = arith.subi %[[VAL_12]], %[[VAL_11]] : i64
-// CHECK:           %[[VAL_14:.*]] = quake.subvec %[[VAL_6]], %{{.*}}, %[[VAL_13]] : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
-// CHECK:           call @{{.*}}other{{.*}}(%[[VAL_14]]) : (!quake.qvec<?>) -> ()
+// CHECK:           %[[VAL_14:.*]] = quake.subvec %[[VAL_6]], %{{.*}}, %[[VAL_13]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+// CHECK:           call @{{.*}}other{{.*}}(%[[VAL_14]]) : (!quake.veq<?>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/template_lambda.cpp
+++ b/test/AST-Quake/template_lambda.cpp
@@ -34,9 +34,9 @@ int main() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test
 // CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>)
 // CHECK-NOT:       %[[VAL_0]]
-// CHECK:           %[[VAL_3:.*]] = quake.alloca[%{{.*}} : i64] !quake.qvec<?>
-// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %{{.*}} : (!quake.qvec<?>, i64) -> !quake.ref
-// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %{{.*}} : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%{{.*}} : i64] !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %{{.*}} : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %{{.*}} : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           quake.apply @__nvqpp__mlirgen__Z4mainE3$_0[%[[VAL_6]]] %[[VAL_9]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 

--- a/test/AST-Quake/vector_bool.cpp
+++ b/test/AST-Quake/vector_bool.cpp
@@ -22,7 +22,7 @@ struct t1 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__t1
 // CHECK-SAME:        (%[[VAL_0:.*]]: !cc.stdvec<f64>) -> i1 attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
-// CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.qvec<?>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
 // CHECK:           %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_13]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>

--- a/test/AST-Quake/while-1.cpp
+++ b/test/AST-Quake/while-1.cpp
@@ -43,9 +43,9 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test1
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -60,15 +60,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:               %[[VAL_10:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
-// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_13:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_14:.*]] = arith.extui %[[VAL_13]] : i32 to i64
 // CHECK:               %[[VAL_15:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
-// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_19:.*]] = arith.extui %[[VAL_18]] : i32 to i64
-// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           }
@@ -76,9 +76,9 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test2
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -91,15 +91,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i32 to i64
 // CHECK:               %[[VAL_8:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_9:.*]] = arith.subi %[[VAL_7]], %[[VAL_8]] : i64
-// CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_9]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_9]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_11:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:               %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
-// CHECK:               %[[VAL_15:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_14]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_15:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_14]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
-// CHECK:               %[[VAL_18:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_17]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_18:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_17]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           }
@@ -107,9 +107,9 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test3
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
-// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -119,15 +119,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_6:.*]] = arith.extui %[[VAL_5]] : i32 to i64
 // CHECK:               %[[VAL_7:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_8:.*]] = arith.subi %[[VAL_6]], %[[VAL_7]] : i64
-// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_11:.*]] = arith.extui %[[VAL_10]] : i32 to i64
 // CHECK:               %[[VAL_12:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_13:.*]] = arith.subi %[[VAL_11]], %[[VAL_12]] : i64
-// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_13]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_13]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_15:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_16:.*]] = arith.extui %[[VAL_15]] : i32 to i64
-// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           } while {
@@ -138,9 +138,9 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test4
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>) -> f64
-// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.qvec<?>) -> i64
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>) -> f64
+// CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
@@ -154,15 +154,15 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:               %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:               %[[VAL_10:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
-// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_13:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_14:.*]] = arith.extui %[[VAL_13]] : i32 to i64
 // CHECK:               %[[VAL_15:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
-// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_19:.*]] = arith.extui %[[VAL_18]] : i32 to i64
-// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             }
 // CHECK:             cc.continue
 // CHECK:           } while {

--- a/test/Conversion/QTXToQuake/qtx-to-quake.mlir
+++ b/test/Conversion/QTXToQuake/qtx-to-quake.mlir
@@ -68,11 +68,11 @@ module {
   // CHECK-LABEL:   func.func @qextract_and_apply_two_targets_operator() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
   // CHECK: quake.swap %[[VAL_3]], %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
-  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.veq<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @qextract_and_apply_two_targets_operator() {
@@ -90,12 +90,12 @@ module {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
   // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
-  // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<3>
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.qvec<3>, i32) -> !quake.ref
-  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<3>, i32) -> !quake.ref
-  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.qvec<3>, i32) -> !quake.ref
+  // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<3>
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.veq<3>, i32) -> !quake.ref
+  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.veq<3>, i32) -> !quake.ref
+  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.veq<3>, i32) -> !quake.ref
   // CHECK: quake.swap [%[[VAL_6]]] %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
-  // CHECK:           quake.dealloc %[[VAL_3]] : !quake.qvec<3>
+  // CHECK:           quake.dealloc %[[VAL_3]] : !quake.veq<3>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @qextract_and_apply_controlled_two_targets_operator() {
@@ -111,11 +111,11 @@ module {
   }
 
   // CHECK-LABEL:   func.func @return_array(
-  // CHECK-SAME:                            %[[VAL_0:.*]]: !quake.qvec<2>) {
+  // CHECK-SAME:                            %[[VAL_0:.*]]: !quake.veq<2>) {
   // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.veq<2>, i32) -> !quake.ref
   // CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
   // CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
   // CHECK:           return
@@ -134,12 +134,12 @@ module {
   // CHECK-LABEL:   func.func @reset_wires() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
   // CHECK:           quake.reset %[[VAL_3]] : (!quake.ref) -> ()
   // CHECK:           quake.reset %[[VAL_4]] : (!quake.ref) -> ()
-  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.veq<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @reset_wires() {
@@ -157,17 +157,17 @@ module {
   // CHECK-LABEL:   func.func @reset_array() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
   // CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
   // CHECK:           quake.x %[[VAL_4]]  : (!quake.ref) -> ()
-  // CHECK:           quake.reset %[[VAL_2]] : (!quake.qvec<2>) -> ()
-  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
-  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           quake.reset %[[VAL_2]] : (!quake.veq<2>) -> ()
+  // CHECK: %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
   // CHECK:           quake.h %[[VAL_5]] : (!quake.ref) -> ()
   // CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
-  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.veq<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @reset_array() {
@@ -190,12 +190,12 @@ module {
   // CHECK-LABEL:   func.func @mz_wires() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
   // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> i1
   // CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> i1
-  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.veq<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @mz_wires() {
@@ -213,17 +213,17 @@ module {
   // CHECK-LABEL:   func.func @mz_array() {
   // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
   // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
-  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+  // CHECK: %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
   // CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
   // CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
-  // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_2]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
-  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.qvec<2>, i32) -> !quake.ref
-  // CHECK: %[[VAL_7:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+  // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+  // CHECK: %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
+  // CHECK: %[[VAL_7:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
   // CHECK:           quake.h %[[VAL_6]] : (!quake.ref) -> ()
   // CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
-  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.qvec<2>
+  // CHECK:           quake.dealloc %[[VAL_2]] : !quake.veq<2>
   // CHECK:           return
   // CHECK:         }
   qtx.circuit @mz_array() {

--- a/test/Conversion/QuakeToQTX/quake_cc_if.qke
+++ b/test/Conversion/QuakeToQTX/quake_cc_if.qke
@@ -138,11 +138,11 @@ module {
   }
 
   // CHECK-LABEL: func.func @test06
-  func.func @test06(%qvec : !quake.qvec<2>, %c1: i1) {
+  func.func @test06(%veq : !quake.veq<2>, %c1: i1) {
     %c_0 = arith.constant 0 : i32
 
     // CHECK: %[[W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[INDEX:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
+    %q0 = quake.extract_ref %veq[%c_0] : (!quake.veq<2>, i32) -> !quake.ref
     // CHECK: %[[W0_1:.*]] = qtx.x %[[W0]]
     quake.x %q0 : (!quake.ref) -> ()
 
@@ -150,7 +150,7 @@ module {
     cc.if(%c1) {
       %c_1 = arith.constant 1 : i32
       // CHECK: %[[W1:.*]], %[[A_1:.*]] = qtx.array_borrow %{{.*}} from %[[A_0]]
-      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>, i32) -> !quake.ref
+      %q1 = quake.extract_ref %veq[%c_1] : (!quake.veq<2>, i32) -> !quake.ref
       // CHECK: %[[W1_1:.*]] = qtx.y %[[W1]]
       quake.y %q1 : (!quake.ref) -> ()
       // CHECK: %[[A_2:.*]] = qtx.array_yield %[[W1_1]] to %[[A_1]]
@@ -164,7 +164,7 @@ module {
 
     // CHECK: %[[A_4:.*]] = qtx.array_yield %[[W0_1]] to %[[A_3]]
     // CHECK: %{{.*}}, %[[A_5:.*]] = qtx.mz %[[A_4]]
-    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
 
     // We reborrow the wires after the measurement
 
@@ -175,31 +175,31 @@ module {
   }
 
   // CHECK-LABEL: func.func @test07
-  func.func @test07(%qvec : !quake.qvec<2>, %c1: i1, %c2: i1) {
+  func.func @test07(%veq : !quake.veq<2>, %c1: i1, %c2: i1) {
     %c_0 = arith.constant 0 : i32
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[INDEX_0:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
+    %q0 = quake.extract_ref %veq[%c_0] : (!quake.veq<2>, i32) -> !quake.ref
     // CHECK: %[[Q0_W1:.*]] = qtx.x %[[Q0_W0]]
     quake.x %q0 : (!quake.ref) -> ()
 
     // CHECK: %[[A_Q0:.*]]:2 = cc.if
     cc.if(%c1) {
       // CHECK: %[[Q1_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[INDEX_1:.*]] from %[[A_0]]
-      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>, i32) -> !quake.ref
+      %q1 = quake.extract_ref %veq[%c_1] : (!quake.veq<2>, i32) -> !quake.ref
 
       // CHECK: %[[A_Q0_Q1:.*]]:3 = cc.if
       cc.if(%c2) {
-        // We need to yield all wires back to the array corresponding to %qvec
+        // We need to yield all wires back to the array corresponding to %veq
 
         // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q0_W1]], %[[Q1_W0]] to %[[A_1]]
 
         // CHECK: %[[A_3:.*]] = qtx.reset %[[A_2]]
-        quake.reset %qvec : (!quake.qvec<2>) -> ()
+        quake.reset %veq : (!quake.veq<2>) -> ()
 
         // We reborrow the wires, and return a new wire that corresponds to %q0
-        // and a new array that corresponds to %qvec
+        // and a new array that corresponds to %veq
 
         // CHECK: %[[WIRES:.*]]:2, %[[A_4:.*]] = qtx.array_borrow %[[INDEX_0]], %[[INDEX_1]] from %[[A_3]]
         // CHECK: cc.continue %[[A_4]], %[[WIRES]]#0, %[[WIRES]]#1
@@ -218,7 +218,7 @@ module {
     // CHECK: %[[A_6:.*]] = qtx.array_yield %[[A_Q0]]#1 to %[[A_Q0]]#0
 
     // CHECK: %{{.*}}, %[[A_7:.*]] = qtx.mz %[[A_6]]
-    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
 
     // CHECK: %[[Q0_W2:.*]], %[[A_8:.*]] = qtx.array_borrow %[[INDEX_0:.*]] from %[[A_7]]
     // CHECK: %[[A_9:.*]] = qtx.array_yield %[[Q0_W2]] to %[[A_8]]

--- a/test/Conversion/QuakeToQTX/quake_cc_loop.qke
+++ b/test/Conversion/QuakeToQTX/quake_cc_loop.qke
@@ -53,10 +53,10 @@ module {
     %c2_i64 = arith.constant 2 : i64
 
     // CHECK: %[[A_0:.*]] = qtx.alloca
-    %qvec = quake.alloca  !quake.qvec<2>
+    %veq = quake.alloca  !quake.veq<2>
 
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2> ,i64) -> !quake.ref
+    %q0 = quake.extract_ref %veq[%c0_i64] : (!quake.veq<2> ,i64) -> !quake.ref
 
     %alloca = memref.alloca() : memref<i64>
     memref.store %c0_i64, %alloca[] : memref<i64>
@@ -71,7 +71,7 @@ module {
       // CHECK: ^bb0(%[[A_3:.*]]: !qtx.wire_array
       %3 = memref.load %alloca[] : memref<i64>
       // CHECK: %[[QX_W0:.*]], %[[A_4:.*]] = qtx.array_borrow %{{.*}} from %[[A_3]]
-      %4 = quake.extract_ref %qvec[%3] : (!quake.qvec<2> ,i64) -> !quake.ref
+      %4 = quake.extract_ref %veq[%3] : (!quake.veq<2> ,i64) -> !quake.ref
 
       // CHECK: %[[A_5:.*]] = qtx.array_yield %[[QX_W0]] to %[[A_4]]
       // CHECK: cc.continue %[[A_5]]
@@ -86,7 +86,7 @@ module {
     // CHECK: %[[A_8:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_7]]
     // CHECK: %{{.*}}, %[[A_9:.*]] = qtx.mz %[[A_8]]
     // CHECK: %{{.*}}, %{{.*}} = qtx.array_borrow %[[IDX_0]] from %[[A_9]]
-    %2 = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %2 = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
     return
   }
 

--- a/test/Conversion/QuakeToQTX/quake_cc_scope.qke
+++ b/test/Conversion/QuakeToQTX/quake_cc_scope.qke
@@ -83,17 +83,17 @@ module {
 
 
   // CHECK-LABEL: func.func @scope_local_extract_and_vec_measurement
-  func.func @scope_local_extract_and_vec_measurement(%qvec : !quake.qvec<2>) {
+  func.func @scope_local_extract_and_vec_measurement(%veq : !quake.veq<2>) {
     %c_0 = arith.constant 0 : i32
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
+    %q0 = quake.extract_ref %veq[%c_0] : (!quake.veq<2>, i32) -> !quake.ref
 
     // CHECK: %[[A_3:.*]] = cc.scope
     cc.scope {
       // CHECK: %[[Q1_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %{{.*}} from %[[A_0]]
-      %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>,i32) -> !quake.ref
+      %q1 = quake.extract_ref %veq[%c_1] : (!quake.veq<2>,i32) -> !quake.ref
 
       // CHECK:  %[[Q1_W1:.*]] = qtx.y %[[Q1_W0]]
       quake.y %q1 : (!quake.ref) -> ()
@@ -105,16 +105,16 @@ module {
     // CHECK: %[[A_4:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_3]]
     // CHECK: %{{.*}}, %[[A_5:.*]] = qtx.mz %[[A_4]]
     // CHECK: %{{.*}}, %{{.*}} = qtx.array_borrow %[[IDX_0]] from %[[A_5]]
-    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
     return
   }
 
   // CHECK-LABEL: func.func @vec_op_in_nested_scope
-  func.func @vec_op_in_nested_scope(%qvec : !quake.qvec<2>) {
+  func.func @vec_op_in_nested_scope(%veq : !quake.veq<2>) {
     %c_0 = arith.constant 0 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>,i32) -> !quake.ref
+    %q0 = quake.extract_ref %veq[%c_0] : (!quake.veq<2>,i32) -> !quake.ref
 
     // CHECK: %[[A_Q0_1:.*]]:2 = cc.scope
     cc.scope {
@@ -124,7 +124,7 @@ module {
         // CHECK: %[[A_1:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_0]]
         // CHECK: %[[A_2:.*]] = qtx.reset %[[A_1]]
         // CHECK: %[[Q0_W1:.*]], %[[A_3:.*]] = qtx.array_borrow %[[IDX_0]] from %[[A_2]]
-        quake.reset %qvec : (!quake.qvec<2>)-> ()
+        quake.reset %veq : (!quake.veq<2>)-> ()
 
         // CHECK: cc.continue %[[A_3]], %[[Q0_W1]]
       }
@@ -134,17 +134,17 @@ module {
     // CHECK: %[[A_4:.*]] = qtx.array_yield %[[A_Q0_1]]#1 to %[[A_Q0_1]]#0
     // CHECK: %{{.*}}, %[[A_5:.*]] = qtx.mz %[[A_4]]
     // CHECK: %{{.*}}, %[[A_6:.*]] = qtx.array_borrow %[[IDX_0]] from %[[A_5]]
-    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
     return
   }
 
   // CHECK-LABEL: func.func @vec_op_in_nested_scope_and_local_extraction
-  func.func @vec_op_in_nested_scope_and_local_extraction(%qvec : !quake.qvec<2>) {
+  func.func @vec_op_in_nested_scope_and_local_extraction(%veq : !quake.veq<2>) {
     %c_0 = arith.constant 0 : i32
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[Q0_W0:.*]], %[[A_0:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %{{.*}}
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>,i32) -> !quake.ref
+    %q0 = quake.extract_ref %veq[%c_0] : (!quake.veq<2>,i32) -> !quake.ref
 
     // CHECK: %[[A_Q0_1:.*]]:2 = cc.scope
     cc.scope {
@@ -152,12 +152,12 @@ module {
       // CHECK: %[[A_Q0:.*]]:2 = cc.scope
       cc.scope {
         // CHECK: %[[Q1_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_0]]
-        %q1 = quake.extract_ref %qvec[%c_1] : (!quake.qvec<2>,i32) -> !quake.ref
+        %q1 = quake.extract_ref %veq[%c_1] : (!quake.veq<2>,i32) -> !quake.ref
 
         // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q0_W0]], %[[Q1_W0]] to %[[A_1]]
         // CHECK: %[[A_3:.*]] = qtx.reset %[[A_2]]
         // CHECK: %[[Q0_Q1:.*]]:2, %[[A_4:.*]] = qtx.array_borrow %[[IDX_0]], %[[IDX_1]] from %[[A_3]]
-        quake.reset %qvec : (!quake.qvec<2>) -> ()
+        quake.reset %veq : (!quake.veq<2>) -> ()
 
         // CHECK: %[[A_5:.*]] = qtx.array_yield %[[Q0_Q1]]#1 to %[[A_4]]
         // CHECK: cc.continue %[[A_5]], %[[Q0_Q1]]#0
@@ -168,7 +168,7 @@ module {
     // CHECK: %[[A_6:.*]] = qtx.array_yield %[[A_Q0_1]]#1 to %[[A_Q0_1]]#0
     // CHECK: %{{.*}}, %[[A_7:.*]] = qtx.mz %[[A_6]]
     // CHECK: %{{.*}}, %[[A_8:.*]] = qtx.array_borrow %[[IDX_0]] from %[[A_7]]
-    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
     return
   }
 }

--- a/test/Conversion/QuakeToQTX/quake_cfg.qke
+++ b/test/Conversion/QuakeToQTX/quake_cfg.qke
@@ -91,12 +91,12 @@ module {
     %c0_i64 = arith.constant 0 : i64
 
     // CHECK: %[[A_0:.*]] = qtx.alloc
-    %qvec = quake.alloca !quake.qvec<2>
+    %veq = quake.alloca !quake.veq<2>
     cf.cond_br %c1, ^bb1, ^bb2
 
   ^bb1:
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
+    %q0 = quake.extract_ref %veq[%c0_i64] : (!quake.veq<2>, i64) -> !quake.ref
     // CHECK: %[[A_2:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_1]]
     // CHECK: cf.br ^bb3(%[[A_2]] : !qtx.wire_array<2>)
     cf.br ^bb3
@@ -108,7 +108,7 @@ module {
   // CHECK: ^bb3(%[[A_3:.*]]: !qtx.wire_array<2>):
   ^bb3:
     // CHECK: %{{.*}}, %{{.*}} = qtx.mz %[[A_3]]
-    %reg = quake.mz %qvec: (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.stdvec<i1>
     return
   }
 
@@ -118,15 +118,15 @@ module {
     %c1_i64 = arith.constant 1 : i64
 
     // CHECK: %[[A_0:.*]] = qtx.alloc
-    %qvec = quake.alloca !quake.qvec<2>
+    %veq = quake.alloca !quake.veq<2>
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
+    %q0 = quake.extract_ref %veq[%c0_i64] : (!quake.veq<2>, i64) -> !quake.ref
 
     cf.cond_br %c1, ^bb1, ^bb4
 
   ^bb1:
     // CHECK: %[[Q1_W0:.*]], %[[A_2:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_1]]
-    %q1 = quake.extract_ref %qvec[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.ref
+    %q1 = quake.extract_ref %veq[%c1_i64] : (!quake.veq<2>, i64) -> !quake.ref
     cf.cond_br %c1, ^bb2, ^bb3
 
   ^bb2:
@@ -141,7 +141,7 @@ module {
 
   ^bb4:
     // CHECK: %[[Q1_W1:.*]], %[[A_5:.*]] = qtx.array_borrow %[[IDX_1]] from %[[A_1]]
-    %q2 = quake.extract_ref %qvec[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.ref
+    %q2 = quake.extract_ref %veq[%c1_i64] : (!quake.veq<2>, i64) -> !quake.ref
     // CHECK: %[[A_6:.*]] = qtx.array_yield %[[Q1_W1]] to %[[A_5]]
     // CHECK: cf.br ^bb5(%[[A_6]] : !qtx.wire_array<2, dead = 1>)
     cf.br ^bb5
@@ -150,7 +150,7 @@ module {
   ^bb5:
     // CHECK: %[[A_8:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_7]]
     // CHECK: %{{.*}}, %{{.*}} = qtx.mz %[[A_8]]
-    %reg = quake.mz %qvec: (!quake.qvec<2>)-> !cc.stdvec<i1>
+    %reg = quake.mz %veq: (!quake.veq<2>)-> !cc.stdvec<i1>
     return
   }
 
@@ -160,15 +160,15 @@ module {
     %c1_i64 = arith.constant 1 : i64
 
     // CHECK: %[[A_0:.*]] = qtx.alloc
-    %qvec = quake.alloca !quake.qvec<2>
+    %veq = quake.alloca !quake.veq<2>
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
-    %q0 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
+    %q0 = quake.extract_ref %veq[%c0_i64] : (!quake.veq<2>, i64) -> !quake.ref
 
     cf.cond_br %c1, ^bb1, ^bb2
 
   ^bb1:
     // CHECK: %[[Q1_W0:.*]], %[[A_2:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_1]]
-    %q1 = quake.extract_ref %qvec[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
+    %q1 = quake.extract_ref %veq[%c0_i64] : (!quake.veq<2>, i64) -> !quake.ref
     // CHECK: %[[A_3:.*]] = qtx.array_yield %[[Q1_W0]] to %[[A_2]]
     // CHECK: cf.br ^bb3(%[[A_3]], %[[Q0_W0]] : !qtx.wire_array<2, dead = 1>, !qtx.wire)
     cf.br ^bb3
@@ -176,7 +176,7 @@ module {
   ^bb2:
     // CHECK: %[[A_4:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_1]]
     // CHECK: %[[A_5:.*]] = qtx.reset %[[A_4]]
-    quake.reset %qvec: (!quake.qvec<2>)->()
+    quake.reset %veq: (!quake.veq<2>)->()
     // CHECK: %[[Q0_W1:.*]], %[[A_6:.*]] = qtx.array_borrow %[[IDX_0]] from %[[A_5]]
     // CHECK: cf.br ^bb3(%[[A_6]], %[[Q0_W1]] : !qtx.wire_array<2, dead = 1>, !qtx.wire)
     cf.br ^bb3
@@ -185,7 +185,7 @@ module {
   ^bb3:
     // CHECK: %[[A_8:.*]] = qtx.array_yield %[[Q0_W2]] to %[[A_7]]
     // CHECK: %{{.*}}, %{{.*}} = qtx.mz %[[A_8]]
-    %reg = quake.mz %qvec: (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.stdvec<i1>
     return
   }
 }

--- a/test/Conversion/QuakeToQTX/straightline.qke
+++ b/test/Conversion/QuakeToQTX/straightline.qke
@@ -18,51 +18,51 @@ module {
     return
   }
 
-  // CHECK-LABEL: func.func @id_qvec(
-  // CHECK-SAME:                     %[[QVEC:.*]]: !quake.qvec<2>
-  func.func @id_qvec(%qvec: !quake.qvec<2>) {
-    // CHECK: %[[ARRAY:.*]] = builtin.unrealized_conversion_cast %[[QVEC]] : !quake.qvec<2> to !qtx.wire_array<2>
+  // CHECK-LABEL: func.func @id_veq(
+  // CHECK-SAME:                     %[[QVEC:.*]]: !quake.veq<2>
+  func.func @id_veq(%veq: !quake.veq<2>) {
+    // CHECK: %[[ARRAY:.*]] = builtin.unrealized_conversion_cast %[[QVEC]] : !quake.veq<2> to !qtx.wire_array<2>
     // CHECK: qtx.unrealized_return %[[ARRAY]] : !qtx.wire_array<2>
     return
   }
 
   // CHECK-LABEL: func.func @return_mz(
-  // CHECK-SAME:      %[[QVEC:.*]]: !quake.qvec<2>
-  func.func @return_mz(%qvec: !quake.qvec<2>) -> !cc.stdvec<i1> {
-    // CHECK: %[[ARRAY:.*]] = builtin.unrealized_conversion_cast %[[QVEC]] : !quake.qvec<2> to !qtx.wire_array<2>
+  // CHECK-SAME:      %[[QVEC:.*]]: !quake.veq<2>
+  func.func @return_mz(%veq: !quake.veq<2>) -> !cc.stdvec<i1> {
+    // CHECK: %[[ARRAY:.*]] = builtin.unrealized_conversion_cast %[[QVEC]] : !quake.veq<2> to !qtx.wire_array<2>
     // CHECK: %[[REG:.*]], %[[ARRAY_1:.*]] = qtx.mz %[[ARRAY]]
-    %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
     // CHXXXECK: qtx.unrealized_return <%[[REG]]> %[[ARRAY_1]] : <!cc.stdvec<i1>> !qtx.wire_array<2>
     %reg1 = cc.undef !cc.stdvec<i1>
     return %reg1 : !cc.stdvec<i1>
   }
 
-  // CHECK-LABEL: func.func @alloc_dealloc_ref_and_qvec
+  // CHECK-LABEL: func.func @alloc_dealloc_ref_and_veq
   // CHECK:           %[[Q0_W0:.*]] = qtx.alloca : !qtx.wire
   // CHECK:           %[[A_0:.*]] = qtx.alloca : !qtx.wire_array
   // CHECK:           qtx.dealloc %[[Q0_W0]]
   // CHECK:           qtx.dealloc %[[A_0]]
   // CHECK:           qtx.unrealized_return
-  func.func @alloc_dealloc_ref_and_qvec() {
+  func.func @alloc_dealloc_ref_and_veq() {
     %q0 = quake.alloca  !quake.ref
-    %qvec = quake.alloca  !quake.qvec<2>
+    %veq = quake.alloca  !quake.veq<2>
     quake.dealloc %q0 : !quake.ref
-    quake.dealloc %qvec : !quake.qvec<2>
+    quake.dealloc %veq : !quake.veq<2>
     return
   }
 
-  // CHECK-LABEL: func.func @alloc_dealloc_qvec_with_extracted_refs
+  // CHECK-LABEL: func.func @alloc_dealloc_veq_with_extracted_refs
   // CHECK:           %[[A_0:.*]] = qtx.alloca : !qtx.wire_array
   // CHECK:           %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %{{.*}} from %[[A_0]]
   // CHECK:           %[[A_2:.*]] = qtx.array_yield %[[Q0_W0]] to %[[A_1]]
   // CHECK:           qtx.dealloc %[[A_2]]
   // CHECK-NOT:       %{{.*}}, %{{.*}} = array_borrow
   // CHECK:           qtx.unrealized_return
-  func.func @alloc_dealloc_qvec_with_extracted_refs() {
+  func.func @alloc_dealloc_veq_with_extracted_refs() {
     %c_0 = arith.constant 0 : i32
-    %qvec = quake.alloca  !quake.qvec<2>
-    %q0 = quake.extract_ref %qvec[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
-    quake.dealloc %qvec : !quake.qvec<2>
+    %veq = quake.alloca  !quake.veq<2>
+    %q0 = quake.extract_ref %veq[%c_0] : (!quake.veq<2>, i32) -> !quake.ref
+    quake.dealloc %veq : !quake.veq<2>
     return
   }
 
@@ -118,37 +118,37 @@ module {
     %c_0 = arith.constant 0 : i32
     %c_1 = arith.constant 1 : i32
     %c_2 = arith.constant 2 : i32
-    %0 = quake.alloca !quake.qvec<3>
-    %q0 = quake.extract_ref %0 [%c_0] : (!quake.qvec<3>,i32) -> !quake.ref
-    %q1 = quake.extract_ref %0 [%c_1] : (!quake.qvec<3>,i32) -> !quake.ref
-    %q2 = quake.extract_ref %0 [%c_2] : (!quake.qvec<3>,i32) -> !quake.ref
+    %0 = quake.alloca !quake.veq<3>
+    %q0 = quake.extract_ref %0 [%c_0] : (!quake.veq<3>,i32) -> !quake.ref
+    %q1 = quake.extract_ref %0 [%c_1] : (!quake.veq<3>,i32) -> !quake.ref
+    %q2 = quake.extract_ref %0 [%c_2] : (!quake.veq<3>,i32) -> !quake.ref
     quake.swap [%q2] %q0, %q1 : (!quake.ref,!quake.ref,!quake.ref) -> ()
     return
   }
 
-  // CHECK-LABEL:   func.func @mz_and_reset_qvec_with_extracted_refs
-  func.func @mz_and_reset_qvec_with_extracted_refs() {
+  // CHECK-LABEL:   func.func @mz_and_reset_veq_with_extracted_refs
+  func.func @mz_and_reset_veq_with_extracted_refs() {
     %c_0 = arith.constant 0 : i32
     %c_1 = arith.constant 1 : i32
 
     // CHECK: %[[A_0:.*]] = qtx.alloca
-    %0 = quake.alloca !quake.qvec<2>
+    %0 = quake.alloca !quake.veq<2>
 
     // CHECK: %[[Q0_W0:.*]], %[[A_1:.*]] = qtx.array_borrow %[[IDX_0:.*]] from %[[A_0]]
     // CHECK: %[[Q1_W0:.*]], %[[A_2:.*]] = qtx.array_borrow %[[IDX_1:.*]] from %[[A_1]]
-    %q0 = quake.extract_ref %0[%c_0] : (!quake.qvec<2>, i32) -> !quake.ref
-    %q1 = quake.extract_ref %0[%c_1] : (!quake.qvec<2>, i32) -> !quake.ref
+    %q0 = quake.extract_ref %0[%c_0] : (!quake.veq<2>, i32) -> !quake.ref
+    %q1 = quake.extract_ref %0[%c_1] : (!quake.veq<2>, i32) -> !quake.ref
 
     // CHECK: %[[A_3:.*]] = qtx.array_yield %[[Q0_W0]], %[[Q1_W0]] to %[[A_2]]
     // CHECK: %{{.*}}, %[[A_4:.*]] = qtx.mz %[[A_3]]
     // CHECK: %[[Q0_Q1:.*]]:2, %[[A_5:.*]] = qtx.array_borrow %[[IDX_0]], %[[IDX_1]] from %[[A_4]]
-    %reg = quake.mz %0 : (!quake.qvec<2>) -> !cc.stdvec<i1>
+    %reg = quake.mz %0 : (!quake.veq<2>) -> !cc.stdvec<i1>
 
 
     // CHECK: %[[A_6:.*]] = qtx.array_yield %[[Q0_Q1]]#0, %[[Q0_Q1]]#1 to %[[A_5]]
     // CHECK: %[[A_7:.*]] = qtx.reset %[[A_6]]
     // CHECK: %{{.*}}:2, %[[A_8:.*]] = qtx.array_borrow %[[IDX_0]], %[[IDX_1]] from %[[A_7]]
-    quake.reset %0 : (!quake.qvec<2>) -> ()
+    quake.reset %0 : (!quake.veq<2>) -> ()
 
     // CHECK: qtx.unrealized_return
     return

--- a/test/Conversion/QuakeToQTX/unable_to_convert.qke
+++ b/test/Conversion/QuakeToQTX/unable_to_convert.qke
@@ -11,12 +11,12 @@
 
 
 // expected-warning@+1 {{couldn't convert kernel to QTX}}
-func.func @unknown_size_qvec(%qvec: !quake.qvec<?>) {
+func.func @unknown_size_veq(%veq: !quake.veq<?>) {
   return
 }
 
-// CHECK-LABEL:   func.func @unknown_size_qvec(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: !quake.qvec<?>) {
+// CHECK-LABEL:   func.func @unknown_size_veq(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: !quake.veq<?>) {
 // CHECK:           return
 // CHECK:         }
 
@@ -25,17 +25,17 @@ func.func @unknown_size_qvec(%qvec: !quake.qvec<?>) {
 // Make sure we corretly undo the in-place update of `func.return`.
 
 // expected-warning@+1 {{couldn't convert kernel to QTX}}
-func.func @return_mz(%qvec: !quake.qvec<2>, %size: i64) -> !cc.stdvec<i1> {
-  %reg = quake.mz %qvec : (!quake.qvec<2>) -> !cc.stdvec<i1>
-  %error = quake.alloca [%size : i64]  !quake.qvec<?>
+func.func @return_mz(%veq: !quake.veq<2>, %size: i64) -> !cc.stdvec<i1> {
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
+  %error = quake.alloca [%size : i64]  !quake.veq<?>
   return %reg : !cc.stdvec<i1>
 }
 
 // CHECK-LABEL:   func.func @return_mz(
-// CHECK-SAME:                         %[[VAL_0:.*]]: !quake.qvec<2>,
+// CHECK-SAME:                         %[[VAL_0:.*]]: !quake.veq<2>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: i64) -> !cc.stdvec<i1> {
-// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_0]] : (!quake.qvec<2>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_1]] : i64] !quake.veq<?>
 // CHECK:           return %[[VAL_2]] : !cc.stdvec<i1>
 // CHECK:         }
 
@@ -43,19 +43,19 @@ func.func @return_mz(%qvec: !quake.qvec<2>, %size: i64) -> !cc.stdvec<i1> {
 
 // expected-warning@+1 {{couldn't convert kernel to QTX}}
 func.func @too_many_qextracts(%a: i64, %b: i64, %c: i64) {
-  %0 = quake.alloca !quake.qvec<2>
-  %qa = quake.extract_ref %0[%a] : (!quake.qvec<2>, i64) -> !quake.ref
-  %qb = quake.extract_ref %0[%b] : (!quake.qvec<2>, i64) -> !quake.ref
-  %qc = quake.extract_ref %0[%c] : (!quake.qvec<2>, i64) -> !quake.ref
+  %0 = quake.alloca !quake.veq<2>
+  %qa = quake.extract_ref %0[%a] : (!quake.veq<2>, i64) -> !quake.ref
+  %qb = quake.extract_ref %0[%b] : (!quake.veq<2>, i64) -> !quake.ref
+  %qc = quake.extract_ref %0[%c] : (!quake.veq<2>, i64) -> !quake.ref
   return
 }
 
 // CHECK-LABEL:   func.func @too_many_qextracts(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64) {
-// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_0]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           return
 // CHECK:         }
 
@@ -67,9 +67,9 @@ func.func @for_loop_with_extracted_vector() {
   %c0_i64 = arith.constant 0 : i64
   %c1_i64 = arith.constant 1 : i64
 
-  %0 = quake.alloca  !quake.qvec<2>
-  %1 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>, i64) -> !quake.ref
-  %2 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>, i64) -> !quake.ref
+  %0 = quake.alloca  !quake.veq<2>
+  %1 = quake.extract_ref %0[%c0_i64] : (!quake.veq<2>, i64) -> !quake.ref
+  %2 = quake.extract_ref %0[%c1_i64] : (!quake.veq<2>, i64) -> !quake.ref
 
   %alloca = memref.alloca() : memref<i64>
   memref.store %c0_i64, %alloca[] : memref<i64>
@@ -79,7 +79,7 @@ func.func @for_loop_with_extracted_vector() {
     cc.condition %5
   } do {
     %4 = memref.load %alloca[] : memref<i64>
-    %5 = quake.extract_ref %0[%4] : (!quake.qvec<2>, i64) -> !quake.ref
+    %5 = quake.extract_ref %0[%4] : (!quake.veq<2>, i64) -> !quake.ref
     quake.x %5 : (!quake.ref) -> ()
     cc.continue
   } step {
@@ -94,9 +94,9 @@ func.func @for_loop_with_extracted_vector() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i64>
 // CHECK:           memref.store %[[VAL_1]], %[[VAL_6]][] : memref<i64>
 // CHECK:           cc.loop while {
@@ -105,7 +105,7 @@ func.func @for_loop_with_extracted_vector() {
 // CHECK:             cc.condition %[[VAL_8]]
 // CHECK:           } do {
 // CHECK:             %[[VAL_9:.*]] = memref.load %[[VAL_6]][] : memref<i64>
-// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_9]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.x %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:             cc.continue
 // CHECK:           } step {

--- a/test/Quake-QIR/allocaNoOperand.qke
+++ b/test/Quake-QIR/allocaNoOperand.qke
@@ -53,19 +53,19 @@ module {
 // CHECK:         %[[VAL_19:.*]] = tail call %[[VAL_16]]* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_11]])
 // CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
 // CHECK:         ret void
-    %0 = quake.alloca !quake.qvec<4>
+    %0 = quake.alloca !quake.veq<4>
     %1 = memref.alloc() : memref<4xi1>
     %c0 = arith.constant 0 : index
-    %2 = quake.extract_ref %0[%c0] : (!quake.qvec<4>, index) -> !quake.ref
+    %2 = quake.extract_ref %0[%c0] : (!quake.veq<4>, index) -> !quake.ref
     quake.x %2 : (!quake.ref) -> ()
     %c1 = arith.constant 1 : index
-    %3 = quake.extract_ref %0[%c1] : (!quake.qvec<4>, index) -> !quake.ref
+    %3 = quake.extract_ref %0[%c1] : (!quake.veq<4>, index) -> !quake.ref
     quake.x %3 : (!quake.ref) -> ()
     %c3 = arith.constant 3 : index
-    %4 = quake.extract_ref %0[%c3] : (!quake.qvec<4>, index) -> !quake.ref
+    %4 = quake.extract_ref %0[%c3] : (!quake.veq<4>, index) -> !quake.ref
     quake.h %4 : (!quake.ref) -> ()
     %c2 = arith.constant 2 : index
-    %5 = quake.extract_ref %0[%c2] : (!quake.qvec<4>, index) -> !quake.ref
+    %5 = quake.extract_ref %0[%c2] : (!quake.veq<4>, index) -> !quake.ref
     quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
     quake.t %2 : (!quake.ref) -> ()
     quake.t %3 : (!quake.ref) -> ()

--- a/test/Quake-QIR/base-profile-2.qke
+++ b/test/Quake-QIR/base-profile-2.qke
@@ -13,10 +13,10 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"}}
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
     %c2_i64 = arith.constant 2 : i64
-    %1 = quake.alloca [%c2_i64 : i64] !quake.qvec<2>
+    %1 = quake.alloca [%c2_i64 : i64] !quake.veq<2>
     %c1_i32 = arith.constant 1 : i32
     %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.qvec<2>,i64) -> !quake.ref
+    %3 = quake.extract_ref %1[%2] : (!quake.veq<2>,i64) -> !quake.ref
     %4 = quake.mz %3 : (!quake.ref) -> i1
     return
   }

--- a/test/Quake-QIR/base-profile-3.qke
+++ b/test/Quake-QIR/base-profile-3.qke
@@ -13,10 +13,10 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"}}
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
     %c2_i64 = arith.constant 2 : i64
-    %1 = quake.alloca[%c2_i64 : i64] !quake.qvec<2>
+    %1 = quake.alloca[%c2_i64 : i64] !quake.veq<2>
     %c1_i32 = arith.constant 1 : i32
     %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.qvec<2>,i64) -> !quake.ref
+    %3 = quake.extract_ref %1[%2] : (!quake.veq<2>,i64) -> !quake.ref
     %4 = quake.mz %3 : (!quake.ref) -> i1 { registerName = "Bob" }
     return
   }

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -36,9 +36,9 @@
 
 module {
      func.func @test_func(%p : i32) {
-          %qv = quake.alloca [%p : i32] !quake.qvec<?>
+          %qv = quake.alloca [%p : i32] !quake.veq<?>
           %t = arith.constant 2 : i32
-          %v = quake.alloca [%t : i32] !quake.qvec<?>
+          %v = quake.alloca [%t : i32] !quake.veq<?>
           return
      }
 
@@ -48,13 +48,13 @@ module {
       %one = arith.constant 1 : i32
       %neg = arith.constant -5 : i32
       %two = arith.constant 2 : i32
-      %0 = quake.alloca [%two : i32] !quake.qvec<?>
+      %0 = quake.alloca [%two : i32] !quake.veq<?>
      
-      %1 = quake.alloca [%two : i32] !quake.qvec<2>
-      %2 = quake.alloca [%one : i32] !quake.qvec<?>
+      %1 = quake.alloca [%two : i32] !quake.veq<2>
+      %2 = quake.alloca [%one : i32] !quake.veq<?>
       
-      %qr1 = quake.extract_ref %0[%zero] : (!quake.qvec<?>,i32) -> !quake.ref
-      %qr2 = quake.extract_ref %1[%one]  : (!quake.qvec<2>,i32) -> !quake.ref
+      %qr1 = quake.extract_ref %0[%zero] : (!quake.veq<?>,i32) -> !quake.ref
+      %qr2 = quake.extract_ref %1[%one]  : (!quake.veq<2>,i32) -> !quake.ref
 
       %fl = arith.constant 0.43 : f64
       %fl2 = arith.constant 0.33 : f64

--- a/test/Quake-QIR/ghz.qke
+++ b/test/Quake-QIR/ghz.qke
@@ -39,16 +39,16 @@ module {
     func.func @ghz(%arg0 : i32) {
         %c0 = arith.constant 0 : i32
         %one = arith.constant 1 : i32
-        %q = quake.alloca [%arg0 : i32] !quake.qvec<?>
-        %q0 = quake.extract_ref %q [%c0] : (!quake.qvec<?>,i32) -> !quake.ref
+        %q = quake.alloca [%arg0 : i32] !quake.veq<?>
+        %q0 = quake.extract_ref %q [%c0] : (!quake.veq<?>,i32) -> !quake.ref
         quake.h %q0 : (!quake.ref) -> ()
         %size_m_1 = arith.subi %arg0, %one : i32
         %upper = arith.index_cast %size_m_1 : i32 to index
         affine.for %i = 0 to %upper {
             %i_int = arith.index_cast %i : index to i32
             %ip1 = arith.addi %i_int, %one : i32
-            %qi = quake.extract_ref %q [%i] : (!quake.qvec<?>,index) -> !quake.ref
-            %qi1 = quake.extract_ref %q [%ip1] : (!quake.qvec<?>,i32) -> !quake.ref
+            %qi = quake.extract_ref %q [%i] : (!quake.veq<?>,index) -> !quake.ref
+            %qi1 = quake.extract_ref %q [%ip1] : (!quake.veq<?>,i32) -> !quake.ref
             quake.x [%qi] %qi1 : (!quake.ref,!quake.ref) -> ()
         }
         return

--- a/test/Quake-QIR/measure.qke
+++ b/test/Quake-QIR/measure.qke
@@ -13,10 +13,10 @@ module {
     %zero = arith.constant 0 : i32
     %one = arith.constant 1 : i32
     %two = arith.constant 2 : i32
-    %0 = quake.alloca [%two : i32] !quake.qvec<?>
+    %0 = quake.alloca [%two : i32] !quake.veq<?>
 
-    %qr1 = quake.extract_ref %0[%zero] : (!quake.qvec<?>,i32) -> !quake.ref
-    %qr2 = quake.extract_ref %0[%one] : (!quake.qvec<?>,i32) -> !quake.ref
+    %qr1 = quake.extract_ref %0[%zero] : (!quake.veq<?>,i32) -> !quake.ref
+    %qr2 = quake.extract_ref %0[%one] : (!quake.veq<?>,i32) -> !quake.ref
 
     quake.mx %qr1 : (!quake.ref) -> i1
     quake.my %qr1 : (!quake.ref) -> i1

--- a/test/Quake-QIR/testBaseProfile.qke
+++ b/test/Quake-QIR/testBaseProfile.qke
@@ -29,14 +29,14 @@ module {
     %c0_i32 = arith.constant 0 : i32
     %c0 = arith.constant 0 : index
     %c3_i32 = arith.constant 3 : i32
-    %0 = quake.alloca[%c3_i32 : i32] !quake.qvec<3>
-    %1 = quake.extract_ref %0[%c0_i32] : (!quake.qvec<3>,i32) -> !quake.ref
+    %0 = quake.alloca[%c3_i32 : i32] !quake.veq<3>
+    %1 = quake.extract_ref %0[%c0_i32] : (!quake.veq<3>,i32) -> !quake.ref
     quake.h %1 : (!quake.ref) -> ()
-    %2 = quake.extract_ref %0[%c0] : (!quake.qvec<3>, index) -> !quake.ref
-    %3 = quake.extract_ref %0[%c1_i32] : (!quake.qvec<3>,i32) -> !quake.ref
+    %2 = quake.extract_ref %0[%c0] : (!quake.veq<3>, index) -> !quake.ref
+    %3 = quake.extract_ref %0[%c1_i32] : (!quake.veq<3>,i32) -> !quake.ref
     quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
-    %4 = quake.extract_ref %0[%c1] : (!quake.qvec<3>,index) -> !quake.ref
-    %5 = quake.extract_ref %0[%c2_i32] : (!quake.qvec<3>,i32) -> !quake.ref
+    %4 = quake.extract_ref %0[%c1] : (!quake.veq<3>,index) -> !quake.ref
+    %5 = quake.extract_ref %0[%c2_i32] : (!quake.veq<3>,i32) -> !quake.ref
     quake.x [%4] %5 : (!quake.ref, !quake.ref) -> ()
     %6 = quake.mz %1 : (!quake.ref) -> i1
     %7 = quake.mz %3 : (!quake.ref) -> i1

--- a/test/Quake/adjoint-1.qke
+++ b/test/Quake/adjoint-1.qke
@@ -15,10 +15,10 @@ module {
     %c0_i64 = arith.constant 0 : i64
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
-    %0 = quake.alloca !quake.qvec<2>
+    %0 = quake.alloca !quake.veq<2>
     cc.if(%arg0) {
-      %3 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
-      %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+      %3 = quake.extract_ref %0[%c0_i64] : (!quake.veq<2>,i64) -> !quake.ref
+      %4 = quake.extract_ref %0[%c1_i64] : (!quake.veq<2>,i64) -> !quake.ref
       quake.h [%3] %4 : (!quake.ref, !quake.ref) -> ()
       quake.x %4 : (!quake.ref) -> ()
       quake.y [%3] %4 : (!quake.ref, !quake.ref) -> ()
@@ -28,8 +28,8 @@ module {
       cc.condition %5 (%iter : i32)
     } do {
       ^bb1(%iter : i32):
-        %3 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
-        %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+        %3 = quake.extract_ref %0[%c0_i64] : (!quake.veq<2>,i64) -> !quake.ref
+        %4 = quake.extract_ref %0[%c1_i64] : (!quake.veq<2>,i64) -> !quake.ref
         quake.x [%3] %4 : (!quake.ref, !quake.ref) -> ()
         quake.y %4 : (!quake.ref) -> ()
         quake.z [%3] %4 : (!quake.ref, !quake.ref) -> ()
@@ -45,8 +45,8 @@ module {
       cc.continue %arg1 : i1
     }
     cc.if(%b3) {
-      %3 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
-      %4 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+      %3 = quake.extract_ref %0[%c1_i64] : (!quake.veq<2>,i64) -> !quake.ref
+      %4 = quake.extract_ref %0[%c0_i64] : (!quake.veq<2>,i64) -> !quake.ref
       quake.y %4 : (!quake.ref) -> ()
       quake.z [%3] %4 : (!quake.ref, !quake.ref) -> ()
       quake.h %4 : (!quake.ref) -> ()
@@ -67,15 +67,15 @@ module {
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_8:.*]] = cc.if(%[[VAL_0]]) -> i1 {
 // CHECK:             cc.continue %[[VAL_0]] : i1
 // CHECK:           } else {
 // CHECK:             cc.continue %[[VAL_1]] : i1
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_9:.*]]) {
-// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.h %[[VAL_11]] :
 // CHECK:             quake.z [%[[VAL_10]]] %[[VAL_11]] :
 // CHECK:             quake.y %[[VAL_11]] :
@@ -88,8 +88,8 @@ module {
 // CHECK:             cc.condition %[[VAL_18]](%[[VAL_16]], %[[VAL_17]] : i32, i32)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_19:.*]]: i32, %[[VAL_20:.*]]: i32):
-// CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.z [%[[VAL_21]]] %[[VAL_22]] :
 // CHECK:             quake.y %[[VAL_22]] :
 // CHECK:             quake.x [%[[VAL_21]]] %[[VAL_22]] :
@@ -101,8 +101,8 @@ module {
 // CHECK:             cc.continue %[[VAL_25]], %[[VAL_26]] : i32, i32
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_0]]) {
-// CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_28:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_28:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.y [%[[VAL_27]]] %[[VAL_28]] :
 // CHECK:             quake.x %[[VAL_28]] :
 // CHECK:             quake.h [%[[VAL_27]]] %[[VAL_28]] :

--- a/test/Quake/apply-1.qke
+++ b/test/Quake/apply-1.qke
@@ -26,13 +26,13 @@
   }
 
 // CHECK-LABEL: func.func private @test.adj.ctrl(
-// CHECK-SAME:     %[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: !quake.ref) {
+// CHECK-SAME:     %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !quake.ref) {
 // CHECK:         %[[VAL_2:.*]] = arith.constant 1.0{{.*}} : f32
 // CHECK-DAG:     quake.x [%[[VAL_0]]] %[[VAL_1]] :
 // CHECK-DAG:     %[[VAL_3:.*]] = arith.negf %[[VAL_2]] : f32
 // CHECK:         quake.rx (%[[VAL_3]]) [%[[VAL_0]]] %[[VAL_1]] :
 // CHECK:         quake.h [%[[VAL_0]]] %[[VAL_1]] :
-// CHECK:         quake.t<adj> [%[[VAL_0]]] %[[VAL_1]] : (!quake.qvec<?>,
+// CHECK:         quake.t<adj> [%[[VAL_0]]] %[[VAL_1]] : (!quake.veq<?>,
 // CHECK:         return
 // CHECK:       }
 
@@ -40,7 +40,7 @@
 // testing it is not strictly required here.
 
 // CHECK-LABEL:   func.func private @test.ctrl(
-// CHECK-SAME:       %[[VAL_0:.*]]: !quake.qvec<?>, %[[VAL_1:.*]]: !quake.ref) {
+// CHECK-SAME:       %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !quake.ref) {
 // CHECK:           quake.t [%[[VAL_0]]] %[[VAL_1]]
 // CHECK:           quake.h [%[[VAL_0]]] %[[VAL_1]]
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1.000000e+00 : f32
@@ -61,8 +61,8 @@
 
 // CHECK-LABEL: func.func @do_apply(
 // CHECK-SAME:     %[[VAL_0:.*]]: !quake.ref, %[[VAL_1:.*]]: !quake.ref) {
-// CHECK:         %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.ref) -> !quake.qvec<?>
-// CHECK:         call @test.adj.ctrl(%[[VAL_2]], %[[VAL_0]]) : (!quake.qvec<?>, !quake.ref) -> ()
+// CHECK:         %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.ref) -> !quake.veq<?>
+// CHECK:         call @test.adj.ctrl(%[[VAL_2]], %[[VAL_0]]) : (!quake.veq<?>, !quake.ref) -> ()
 // CHECK:         return
 // CHECK:       }
 

--- a/test/Quake/basic.qke
+++ b/test/Quake/basic.qke
@@ -13,10 +13,10 @@
 func.func @alloc(%size : i32) {
   // CHECK: %[[QUBIT:.*]] = quake.alloca !quake.ref
   %qubit = quake.alloca !quake.ref
-  // CHECK: %[[QREG0:.*]] = quake.alloca[%[[SIZE]] : i32] !quake.qvec<?>
-  %qvec0 = quake.alloca [%size : i32] !quake.qvec<?>
-  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<4>
-  %qvec1 = quake.alloca !quake.qvec<4>
+  // CHECK: %[[QREG0:.*]] = quake.alloca[%[[SIZE]] : i32] !quake.veq<?>
+  %veq0 = quake.alloca [%size : i32] !quake.veq<?>
+  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.veq<4>
+  %veq1 = quake.alloca !quake.veq<4>
   return
 }
 
@@ -29,14 +29,14 @@ func.func @alloc_qubit() {
 
 // CHECK-LABEL: func @alloc_qreg
 func.func @alloc_qreg() {
-  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<2>
-  %qvec = quake.alloca !quake.qvec<2>
+  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.veq<2>
+  %veq = quake.alloca !quake.veq<2>
   return
 }
 
 // CHECK-LABEL: func @args(
-// CHECK-SAME: %{{.*}}: !quake.ref, %{{.*}}: !quake.qvec<2>)
-func.func @args(%qubit: !quake.ref, %qvec: !quake.qvec<2>) {
+// CHECK-SAME: %{{.*}}: !quake.ref, %{{.*}}: !quake.veq<2>)
+func.func @args(%qubit: !quake.ref, %veq: !quake.veq<2>) {
   return
 }
 
@@ -46,10 +46,10 @@ func.func @reset() {
   %qubit = quake.alloca !quake.ref
   // CHECK: quake.reset %[[QUBIT]] : (!quake.ref) -> ()
   quake.reset %qubit : (!quake.ref) -> ()
-  // CHECK: %[[QREG:.*]] = quake.alloca !quake.qvec<2>
-  %qreg = quake.alloca !quake.qvec<2>
-  // CHECK: quake.reset %[[QREG]] : (!quake.qvec<2>) -> ()
-  quake.reset %qreg : (!quake.qvec<2>) -> ()
+  // CHECK: %[[QREG:.*]] = quake.alloca !quake.veq<2>
+  %qreg = quake.alloca !quake.veq<2>
+  // CHECK: quake.reset %[[QREG]] : (!quake.veq<2>) -> ()
+  quake.reset %qreg : (!quake.veq<2>) -> ()
   return
 }
 
@@ -65,10 +65,10 @@ func.func @apply_x() {
 func.func @apply_cx() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<2>
-  %qvec = quake.alloca  !quake.qvec<2>
-  %q0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<2>,index) -> !quake.ref
-  %q1 = quake.extract_ref %qvec[%c1] : (!quake.qvec<2>,index) -> !quake.ref
+  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.veq<2>
+  %veq = quake.alloca  !quake.veq<2>
+  %q0 = quake.extract_ref %veq[%c0] : (!quake.veq<2>,index) -> !quake.ref
+  %q1 = quake.extract_ref %veq[%c1] : (!quake.veq<2>,index) -> !quake.ref
   quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
   return
 }
@@ -76,10 +76,10 @@ func.func @apply_cx() {
 func.func @apply_cx_v() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.qvec<2>
-  %qvec = quake.alloca  !quake.qvec<2>
-  %q0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<2>,index) -> !quake.ref
-  %q1 = quake.extract_ref %qvec[%c1] : (!quake.qvec<2>,index) -> !quake.ref
+  // CHECK: %[[QREG1:.*]] = quake.alloca !quake.veq<2>
+  %veq = quake.alloca  !quake.veq<2>
+  %q0 = quake.extract_ref %veq[%c0] : (!quake.veq<2>,index) -> !quake.ref
+  %q1 = quake.extract_ref %veq[%c1] : (!quake.veq<2>,index) -> !quake.ref
   %q2 = quake.unwrap %q0 : (!quake.ref) -> !quake.wire
   %q3 = quake.unwrap %q1 : (!quake.ref) -> !quake.wire
   // CHECK: %{{.*}} = quake.x [%{{.*}}] %{{.*}} : (!quake.wire, !quake.wire) -> !quake.wire

--- a/test/Quake/bell.qke
+++ b/test/Quake/bell.qke
@@ -11,9 +11,9 @@ module {
     // CHECK-LABEL: func @bell()
     // CHECK: %[[C0:.*]] = arith.constant 0 : i32
     // CHECK: %[[C1:.*]] = arith.constant 1 : i32
-    // CHECK: %0 = quake.alloca !quake.qvec<2>
-    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<2>, i32) -> !quake.ref
-    // CHECK: %2 = quake.extract_ref %0[%[[C1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+    // CHECK: %0 = quake.alloca !quake.veq<2>
+    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<2>, i32) -> !quake.ref
+    // CHECK: %2 = quake.extract_ref %0[%[[C1]]] : (!quake.veq<2>, i32) -> !quake.ref
     // CHECK: quake.h %1
     // CHECK: quake.x [%1] %2 :
     // CHECK: %3 = quake.mz %1 : (!quake.ref) -> i1
@@ -23,9 +23,9 @@ module {
         %0 = arith.constant 2 : i32
         %c_0 = arith.constant 0 : i32
         %c_1 = arith.constant 1 : i32
-        %qubits = quake.alloca [%0 : i32] !quake.qvec<?>
-        %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>,i32) -> !quake.ref
-        %q1 = quake.extract_ref %qubits[%c_1] : (!quake.qvec<?>,i32) -> !quake.ref
+        %qubits = quake.alloca [%0 : i32] !quake.veq<?>
+        %q0 = quake.extract_ref %qubits[%c_0] : (!quake.veq<?>,i32) -> !quake.ref
+        %q1 = quake.extract_ref %qubits[%c_1] : (!quake.veq<?>,i32) -> !quake.ref
 
         quake.h %q0 : (!quake.ref) -> ()
         quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()

--- a/test/Quake/canonical-1.qke
+++ b/test/Quake/canonical-1.qke
@@ -8,41 +8,41 @@
 
 // RUN: cudaq-opt --canonicalize %s | FileCheck %s
 
-func.func @test1(%arg0 : !quake.qvec<?>) -> i1 {
+func.func @test1(%arg0 : !quake.veq<?>) -> i1 {
   %true = arith.constant true
   return %true : i1
 }
 
 func.func @test2() {
   %0 = arith.constant 10 : i64
-  %1 = quake.alloca[%0 : i64] !quake.qvec<?>
+  %1 = quake.alloca[%0 : i64] !quake.veq<?>
   // relax_size must be inserted here
-  %2 = call @test1(%1) : (!quake.qvec<?>) -> i1
+  %2 = call @test1(%1) : (!quake.veq<?>) -> i1
   %3 = arith.constant 1 : i64
-  %4 = quake.extract_ref %1[%3] : (!quake.qvec<?>,i64) -> !quake.ref
+  %4 = quake.extract_ref %1[%3] : (!quake.veq<?>,i64) -> !quake.ref
   quake.h %4 : (!quake.ref) -> ()
   return
 }
 
 // CHECK-LABEL:   func.func @test2() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<10>
-// CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.qvec<10>) -> !quake.qvec<?>
-// CHECK:           %[[VAL_3:.*]] = call @test1(%[[VAL_2]]) : (!quake.qvec<?>) -> i1
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_0]]] : (!quake.qvec<10>, i64) -> !quake.ref
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<10>
+// CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.veq<10>) -> !quake.veq<?>
+// CHECK:           %[[VAL_3:.*]] = call @test1(%[[VAL_2]]) : (!quake.veq<?>) -> i1
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_0]]] : (!quake.veq<10>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_4]]
 // CHECK:           return
 // CHECK:         }
 
 func.func @test3() {
   %0 = arith.constant 10 : i64
-  %1 = quake.alloca [%0 : i64] !quake.qvec<?>
+  %1 = quake.alloca [%0 : i64] !quake.veq<?>
   %2 = arith.constant 4 : i64
   %3 = arith.constant 7 : i64
-  // This subvec qvec<?> can be reified to qvec<4>
-  %4 = quake.subvec %1, %2, %3 : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
+  // This subvec veq<?> can be reified to veq<4>
+  %4 = quake.subvec %1, %2, %3 : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
   %5 = arith.constant 2 : i64
-  %6 = quake.extract_ref %4[%5] : (!quake.qvec<?>,i64) -> !quake.ref
+  %6 = quake.extract_ref %4[%5] : (!quake.veq<?>,i64) -> !quake.ref
   quake.h %6 : (!quake.ref) -> ()
   return
 }
@@ -51,9 +51,9 @@ func.func @test3() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 7 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<10>
-// CHECK:           %[[VAL_4:.*]] = quake.subvec %[[VAL_3]], %[[VAL_2]], %[[VAL_1]] : (!quake.qvec<10>, i64, i64) -> !quake.qvec<4>
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_0]]] : (!quake.qvec<4>, i64) -> !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<10>
+// CHECK:           %[[VAL_4:.*]] = quake.subvec %[[VAL_3]], %[[VAL_2]], %[[VAL_1]] : (!quake.veq<10>, i64, i64) -> !quake.veq<4>
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_0]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -61,13 +61,13 @@ func.func @test3() {
 func.func @test_qextract_1() {
     %c0 = arith.constant 0 : i64
     %c2 = arith.constant 2 : i64
-    %qvec = quake.alloca [%c2 : i64] !quake.qvec<?>
-    %0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>, i64) -> !quake.ref
+    %veq = quake.alloca [%c2 : i64] !quake.veq<?>
+    %0 = quake.extract_ref %veq[%c0] : (!quake.veq<?>, i64) -> !quake.ref
     quake.h %0 : (!quake.ref) -> ()
     %c0_0 = arith.constant 0 : i64
     %c1 = arith.constant 1 : i64
-    %1 = quake.extract_ref %qvec[%c0_0] : (!quake.qvec<?>, i64) -> !quake.ref
-    %2 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>, i64) -> !quake.ref
+    %1 = quake.extract_ref %veq[%c0_0] : (!quake.veq<?>, i64) -> !quake.ref
+    %2 = quake.extract_ref %veq[%c1] : (!quake.veq<?>, i64) -> !quake.ref
     quake.x [%1] %2 : (!quake.ref, !quake.ref) -> ()
     return
 }
@@ -75,10 +75,10 @@ func.func @test_qextract_1() {
 // CHECK-LABEL:   func.func @test_qextract_1() {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -87,18 +87,18 @@ func.func @test_qextract_2(%arg0: i1) {
     %c0 = arith.constant 0 : i64
     %c2 = arith.constant 2 : i64
     %c1 = arith.constant 1 : i64
-    %qvec = quake.alloca[%c2 : i64]  !quake.qvec<?>
-    %0 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.ref
+    %veq = quake.alloca[%c2 : i64]  !quake.veq<?>
+    %0 = quake.extract_ref %veq[%c0] : (!quake.veq<?>,i64) -> !quake.ref
     quake.h %0 : (!quake.ref) -> ()
     cc.if(%arg0) {
       cc.scope {
-        %1 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.ref
-        %2 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>,i64) -> !quake.ref
+        %1 = quake.extract_ref %veq[%c0] : (!quake.veq<?>,i64) -> !quake.ref
+        %2 = quake.extract_ref %veq[%c1] : (!quake.veq<?>,i64) -> !quake.ref
         quake.x [%1] %2 : (!quake.ref,!quake.ref) -> ()
       }
     }
-    %3 = quake.extract_ref %qvec[%c0] : (!quake.qvec<?>,i64) -> !quake.ref
-    %4 = quake.extract_ref %qvec[%c1] : (!quake.qvec<?>,i64) -> !quake.ref
+    %3 = quake.extract_ref %veq[%c0] : (!quake.veq<?>,i64) -> !quake.ref
+    %4 = quake.extract_ref %veq[%c1] : (!quake.veq<?>,i64) -> !quake.ref
     quake.x [%3] %4 : (!quake.ref,!quake.ref) -> ()
     return
 }
@@ -107,15 +107,15 @@ func.func @test_qextract_2(%arg0: i1) {
 // CHECK-SAME:                               %[[VAL_0:.*]]: i1) {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_4]] :
 // CHECK:           cc.if(%[[VAL_0]]) {
-// CHECK:             %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.qvec<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_5]]] %[[VAL_6]] :
 // CHECK:           }
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.qvec<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_4]]] %[[VAL_7]] :
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/canonical-2.qke
+++ b/test/Quake/canonical-2.qke
@@ -8,34 +8,34 @@
 
 // RUN: cudaq-opt -canonicalize %s | FileCheck %s
 
-  func.func @__nvqpp__mlirgen__reflect_about_uniform(%arg0: !quake.qvec<?>) attributes {"cudaq-kernel"} {
-    %0 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
+  func.func @__nvqpp__mlirgen__reflect_about_uniform(%arg0: !quake.veq<?>) attributes {"cudaq-kernel"} {
+    %0 = quake.vec_size %arg0 : (!quake.veq<?>) -> i64
     %c1_i32 = arith.constant 1 : i32
     %1 = arith.extsi %c1_i32 : i32 to i64
     %2 = arith.subi %0, %1 : i64
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
     %3 = arith.subi %2, %c1_i64 : i64
-    %4 = quake.subvec %arg0, %c0_i64, %3 : (!quake.qvec<?>, i64, i64) -> !quake.qvec<?>
-    %5 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
+    %4 = quake.subvec %arg0, %c0_i64, %3 : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+    %5 = quake.vec_size %arg0 : (!quake.veq<?>) -> i64
     %c1_i64_0 = arith.constant 1 : i64
     %6 = arith.subi %5, %c1_i64_0 : i64
-    %7 = quake.extract_ref %arg0[%6] : (!quake.qvec<?>,i64) -> !quake.ref
+    %7 = quake.extract_ref %arg0[%6] : (!quake.veq<?>,i64) -> !quake.ref
     %8 = cc.create_lambda {
       cc.scope {
         %c0 = arith.constant 0 : index
         %c1 = arith.constant 1 : index
-        %10 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
+        %10 = quake.vec_size %arg0 : (!quake.veq<?>) -> i64
         %11 = arith.index_cast %10 : i64 to index
         scf.for %arg1 = %c0 to %11 step %c1 {
-          %12 = quake.extract_ref %arg0[%arg1] : (!quake.qvec<?>,index) -> !quake.ref
+          %12 = quake.extract_ref %arg0[%arg1] : (!quake.veq<?>,index) -> !quake.ref
           quake.h %12 : (!quake.ref) -> ()
         }
       }
     } : !cc.lambda<() -> ()>
     %9 = cc.create_lambda {
       cc.scope {
-        quake.z [%4] %7 : (!quake.qvec<?>, !quake.ref) -> ()
+        quake.z [%4] %7 : (!quake.veq<?>, !quake.ref) -> ()
       }
     } : !cc.lambda<() -> ()>
     quake.compute_action %8, %9 : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
@@ -45,7 +45,7 @@
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__reflect_about_uniform(
 // CHECK:           %[[VAL_12:.*]] = cc.create_lambda {
 // CHECK-NOT:       cc.scope
-// CHECK:             %[[VAL_13:.*]] = quake.vec_size %{{.*}} : (!quake.qvec<?>) -> i64
+// CHECK:             %[[VAL_13:.*]] = quake.vec_size %{{.*}} : (!quake.veq<?>) -> i64
 // CHECK:             %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : i64 to index
 // CHECK:             scf.for %[[VAL_15:.*]] = %{{.*}} to %[[VAL_14]] step %
 // CHECK:               %[[VAL_16:.*]] = quake.extract_ref

--- a/test/Quake/ccnot.qke
+++ b/test/Quake/ccnot.qke
@@ -18,12 +18,12 @@ module {
     
     // CHECK-LABEL: func.func @ccnot() {
     // CHECK:   %[[C1:.*]] = arith.constant 1 : i32
-    // CHECK:   %[[a0:.*]] = quake.alloca !quake.qvec<3>
+    // CHECK:   %[[a0:.*]] = quake.alloca !quake.veq<3>
     // CHECK:   affine.for %[[arg0:.*]] = 0 to 3 {
-    // CHECK:     %[[a2:.*]] = quake.extract_ref %[[a0]][%[[arg0]]] : (!quake.qvec<3>, index) -> !quake.ref
+    // CHECK:     %[[a2:.*]] = quake.extract_ref %[[a0]][%[[arg0]]] : (!quake.veq<3>, index) -> !quake.ref
     // CHECK:     quake.x %[[a2]] :
     // CHECK:   }
-    // CHECK:   %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.qvec<3>, i32) -> !quake.ref
+    // CHECK:   %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.veq<3>, i32) -> !quake.ref
     // CHECK:   quake.x %[[a1]] :
     // CHECK:   return
     // CHECK: }
@@ -38,14 +38,14 @@ module {
         %c_0 = arith.constant 0 : i32
         %c_1 = arith.constant 1 : i32
         %c_2 = arith.constant 2 : i32
-        %qubits = quake.alloca [ %c_3 : i32 ] !quake.qvec<?>
+        %qubits = quake.alloca [ %c_3 : i32 ] !quake.veq<?>
         %c_3_idx = arith.index_cast %c_3 : i32 to index
         affine.for %i = 0 to %c_3_idx {
-            %q0 = quake.extract_ref %qubits [%i] : (!quake.qvec<?>, index) -> !quake.ref
+            %q0 = quake.extract_ref %qubits [%i] : (!quake.veq<?>, index) -> !quake.ref
             quake.x %q0 : (!quake.ref) -> ()
         }
 
-        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>, i32) -> !quake.ref
+        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.veq<?>, i32) -> !quake.ref
         func.call @apply_x(%q1) : (!quake.ref) -> ()
 
         return

--- a/test/Quake/compute_action.qke
+++ b/test/Quake/compute_action.qke
@@ -9,7 +9,7 @@
 // RUN: cudaq-opt --canonicalize --lambda-lifting --lower-to-cfg --canonicalize --apply-op-specialization %s | FileCheck %s
 
 // Notes:
-//   - canonicalize is run to constant propagate through the qvec type.
+//   - canonicalize is run to constant propagate through the veq type.
 //   - lambda-lifting converts the lambda expressions to functions and converts
 //     quake.compute_action to a series of quake.apply calls.
 //   - lower-to-cfg and canonicalize then simplify the new lambdas so that we
@@ -20,16 +20,16 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
   func.func @__nvqpp__mlirgen__t() attributes {"cudaq-entrypoint"} {
     %c5_i32 = arith.constant 5 : i32
     %0 = arith.extsi %c5_i32 : i32 to i64
-    %1 = quake.alloca[%0 : i64] !quake.qvec<?>
+    %1 = quake.alloca[%0 : i64] !quake.veq<?>
     %2 = cc.create_lambda {
       cc.scope {
         %c0_i32 = arith.constant 0 : i32
         %4 = arith.extsi %c0_i32 : i32 to i64
-        %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.ref
+        %5 = quake.extract_ref %1[%4] : (!quake.veq<?>,i64) -> !quake.ref
         quake.t %5 : (!quake.ref) -> ()
         %c1_i32 = arith.constant 1 : i32
         %6 = arith.extsi %c1_i32 : i32 to i64
-        %7 = quake.extract_ref %1[%6] : (!quake.qvec<?>,i64) -> !quake.ref
+        %7 = quake.extract_ref %1[%6] : (!quake.veq<?>,i64) -> !quake.ref
         quake.x %7 : (!quake.ref) -> ()
       }
     } : !cc.lambda<() -> ()>
@@ -37,7 +37,7 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
       cc.scope {
         %c2_i32 = arith.constant 2 : i32
         %4 = arith.extsi %c2_i32 : i32 to i64
-        %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.ref
+        %5 = quake.extract_ref %1[%4] : (!quake.veq<?>,i64) -> !quake.ref
         quake.h %5 : (!quake.ref) -> ()
       }
     } : !cc.lambda<() -> ()>
@@ -47,10 +47,10 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
 }
 
 // CHECK-LABEL:   func.func private @__nvqpp__lifted.lambda.{{[01]}}.adj(
-// CHECK-SAME:            %[[VAL_0:.*]]: !quake.qvec<5>,
+// CHECK-SAME:            %[[VAL_0:.*]]: !quake.veq<5>,
 // CHECK-SAME:            %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64) {
-// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.qvec<5>, i64) -> !quake.ref
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.qvec<5>, i64) -> !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.veq<5>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.veq<5>, i64) -> !quake.ref
 // CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
 // CHECK:           quake.t<adj> %[[VAL_3]] : (!quake.ref) -> ()
 // CHECK:           return
@@ -60,10 +60,10 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.qvec<5>
-// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]], %[[VAL_2]], %[[VAL_1]]) : (!quake.qvec<5>, i64, i64) -> ()
-// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]], %[[VAL_0]]) : (!quake.qvec<5>, i64) -> ()
-// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}.adj(%[[VAL_3]], %[[VAL_2]], %[[VAL_1]]) : (!quake.qvec<5>, i64, i64) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<5>
+// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]], %[[VAL_2]], %[[VAL_1]]) : (!quake.veq<5>, i64, i64) -> ()
+// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]], %[[VAL_0]]) : (!quake.veq<5>, i64) -> ()
+// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}.adj(%[[VAL_3]], %[[VAL_2]], %[[VAL_1]]) : (!quake.veq<5>, i64, i64) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/cse.qke
+++ b/test/Quake/cse.qke
@@ -19,17 +19,17 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %c2_i64 = arith.constant 2 : i64
     %cst = arith.constant -1.000000e+00 : f64
-    %0 = quake.alloca  !quake.qvec<3>
-    %1 = quake.extract_ref %0[%c0_i64] : (!quake.qvec<3>,i64) -> !quake.ref
+    %0 = quake.alloca  !quake.veq<3>
+    %1 = quake.extract_ref %0[%c0_i64] : (!quake.veq<3>,i64) -> !quake.ref
     quake.x %1 : (!quake.ref) -> ()
     %2 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
     %3 = llvm.load %2 : !llvm.ptr<f64>
-    %4 = quake.extract_ref %0[%c1_i64] : (!quake.qvec<3>,i64) -> !quake.ref
+    %4 = quake.extract_ref %0[%c1_i64] : (!quake.veq<3>,i64) -> !quake.ref
     quake.ry (%3) %4 : (f64, !quake.ref) -> ()
     %5 = cc.stdvec_data %arg0 : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
     %6 = llvm.getelementptr %5[1] : (!llvm.ptr<f64>) -> !llvm.ptr<f64>
     %7 = llvm.load %6 : !llvm.ptr<f64>
-    %8 = quake.extract_ref %0[%c2_i64] : (!quake.qvec<3>, i64) -> !quake.ref
+    %8 = quake.extract_ref %0[%c2_i64] : (!quake.veq<3>, i64) -> !quake.ref
     quake.ry (%7) %8 : (f64, !quake.ref) -> ()
     quake.x [%8] %1 : (!quake.ref, !quake.ref) -> ()
     quake.x [%1] %4 : (!quake.ref, !quake.ref) -> ()

--- a/test/Quake/deuteron.qke
+++ b/test/Quake/deuteron.qke
@@ -12,9 +12,9 @@
 // CHECK-SAME: %[[arg0:.*]]: f64) {
 // CHECK:    %[[C0:.*]] = arith.constant 0 : i32
 // CHECK:    %[[C1:.*]] = arith.constant 1 : i32
-// CHECK:    %[[a0:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:    %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C0]]] : (!quake.qvec<2>, i32) -> !quake.ref
-// CHECK:    %[[a2:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.qvec<2>, i32) -> !quake.ref
+// CHECK:    %[[a0:.*]] = quake.alloca !quake.veq<2>
+// CHECK:    %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C0]]] : (!quake.veq<2>, i32) -> !quake.ref
+// CHECK:    %[[a2:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.veq<2>, i32) -> !quake.ref
 // CHECK:    quake.x %[[a1]]
 // CHECK:    quake.ry (%[[arg0]]) %[[a2]] : (f64, !quake.ref) -> ()
 // CHECK:    quake.x [%[[a2]]] %[[a1]] : (!quake.ref, !quake.ref) -> ()
@@ -29,9 +29,9 @@ module {
         %c_0 = arith.constant 0 : i32
         %c_1 = arith.constant 1 : i32
         %c_angle = arith.constant 0.59 : f64
-        %qubits = quake.alloca [ %0 : i32 ] !quake.qvec<?>
-        %q0 = quake.extract_ref %qubits [%c_0] : (!quake.qvec<?>,i32) -> !quake.ref
-        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>,i32) -> !quake.ref
+        %qubits = quake.alloca [ %0 : i32 ] !quake.veq<?>
+        %q0 = quake.extract_ref %qubits [%c_0] : (!quake.veq<?>,i32) -> !quake.ref
+        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.veq<?>,i32) -> !quake.ref
 
         quake.x %q0 : (!quake.ref) -> ()
         quake.ry (%theta) %q1  : (f64, !quake.ref) -> ()

--- a/test/Quake/dummy.qke
+++ b/test/Quake/dummy.qke
@@ -13,11 +13,11 @@
 // CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : i32
 // CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : i32
 // CHECK-DAG:     %[[C22:.*]] = arith.constant 22 : i64
-// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
-// CHECK:     %1 = quake.alloca[%[[C22]] : i64] !quake.qvec<?>
-// CHECK:     %2 = quake.alloca[%[[C1]] : i32] !quake.qvec<?>
-// CHECK:     %3 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
-// CHECK:     %4 = quake.extract_ref %1[%[[C1]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.veq<?>
+// CHECK:     %1 = quake.alloca[%[[C22]] : i64] !quake.veq<?>
+// CHECK:     %2 = quake.alloca[%[[C1]] : i32] !quake.veq<?>
+// CHECK:     %3 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<?>, i32) -> !quake.ref
+// CHECK:     %4 = quake.extract_ref %1[%[[C1]]] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:     quake.h %3 :
 // CHECK:     quake.x [%3] %4 :
 // CHECK:     return
@@ -27,12 +27,12 @@ func.func @bar() {
   %0 = arith.constant 2 : i32
   %one = arith.constant 1 : i32
   %1 = arith.constant 22 : i64
-  %qr2 = quake.alloca [ %0 : i32 ]  !quake.qvec<?>
-  %qr22 = quake.alloca[ %1 : i64 ]  !quake.qvec<?>
-  %q = quake.alloca [%one : i32]  !quake.qvec<?>
+  %qr2 = quake.alloca [ %0 : i32 ]  !quake.veq<?>
+  %qr22 = quake.alloca[ %1 : i64 ]  !quake.veq<?>
+  %q = quake.alloca [%one : i32]  !quake.veq<?>
 
-  %r = quake.extract_ref %qr2[%3] : (!quake.qvec<?>,i32) -> !quake.ref
-  %q1 = quake.extract_ref %qr22[%one] : (!quake.qvec<?> ,i32) -> !quake.ref
+  %r = quake.extract_ref %qr2[%3] : (!quake.veq<?>,i32) -> !quake.ref
+  %q1 = quake.extract_ref %qr22[%one] : (!quake.veq<?> ,i32) -> !quake.ref
 
   quake.h %r : (!quake.ref) -> ()
   quake.x[%r] %q1 : (!quake.ref,!quake.ref) -> ()

--- a/test/Quake/ghz.qke
+++ b/test/Quake/ghz.qke
@@ -11,16 +11,16 @@ module {
     // CHECK: func.func @ghz(%[[arg0:.*]]: i32) {
     // CHECK: %[[C0:.*]] = arith.constant 0 : i32
     // CHECK: %[[C1:.*]] = arith.constant 1 : i32
-    // CHECK: %0 = quake.alloca[%[[arg0]] : i32] !quake.qvec<?>
-    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
+    // CHECK: %0 = quake.alloca[%[[arg0]] : i32] !quake.veq<?>
+    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<?>, i32) -> !quake.ref
     // CHECK: quake.h %1 :
     // CHECK: %2 = arith.subi %arg0, %[[C1]] : i32
     // CHECK: %3 = arith.index_cast %2 : i32 to index
     // CHECK: affine.for %arg1 = 0 to %3 {
     // CHECK:   %4 = arith.index_cast %arg1 : index to i32
     // CHECK:   %5 = arith.addi %4, %[[C1]] : i32
-    // CHECK:   %6 = quake.extract_ref %0[%arg1] : (!quake.qvec<?>, index) -> !quake.ref
-    // CHECK:   %7 = quake.extract_ref %0[%5] : (!quake.qvec<?>, i32) -> !quake.ref
+    // CHECK:   %6 = quake.extract_ref %0[%arg1] : (!quake.veq<?>, index) -> !quake.ref
+    // CHECK:   %7 = quake.extract_ref %0[%5] : (!quake.veq<?>, i32) -> !quake.ref
     // CHECK:   quake.x [%6] %7 : (!quake.ref, !quake.ref) -> ()
     // CHECK: }
     // CHECK: return
@@ -29,16 +29,16 @@ module {
         // %size = arith.constant 3 : i32
         %c0 = arith.constant 0 : i32
         %one = arith.constant 1 : i32
-        %q = quake.alloca [%arg0 : i32] !quake.qvec<?>
-        %q0 = quake.extract_ref %q[%c0] : (!quake.qvec<?>, i32) -> !quake.ref
+        %q = quake.alloca [%arg0 : i32] !quake.veq<?>
+        %q0 = quake.extract_ref %q[%c0] : (!quake.veq<?>, i32) -> !quake.ref
         quake.h %q0 : (!quake.ref) -> ()
         %size_m_1 = arith.subi %arg0, %one : i32
         %upper = arith.index_cast %size_m_1 : i32 to index
         affine.for %i = 0 to %upper {
             %i_int = arith.index_cast %i : index to i32
             %ip1 = arith.addi %i_int, %one : i32
-            %qi = quake.extract_ref %q[%i] : (!quake.qvec<?>, index) -> !quake.ref
-            %qi1 = quake.extract_ref %q[%ip1] : (!quake.qvec<?>, i32) -> !quake.ref
+            %qi = quake.extract_ref %q[%i] : (!quake.veq<?>, index) -> !quake.ref
+            %qi1 = quake.extract_ref %q[%ip1] : (!quake.veq<?>, i32) -> !quake.ref
             quake.x [%qi] %qi1 : (!quake.ref, !quake.ref) -> ()
         }
         return

--- a/test/Quake/inline.qke
+++ b/test/Quake/inline.qke
@@ -31,7 +31,7 @@ func.func @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%arg0: !quake.ref
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.x %[[VAL_0]]
 // CHECK:           quake.h %[[VAL_1]]
-// CHECK:           %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.ref) -> !quake.qvec<?>
+// CHECK:           %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.ref) -> !quake.veq<?>
 // CHECK:           quake.x [%[[VAL_2]]] %[[VAL_0]] :
 // CHECK:           quake.h %[[VAL_1]] :
 // CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1 {registerName = ""}

--- a/test/Quake/iqft.qke
+++ b/test/Quake/iqft.qke
@@ -32,7 +32,7 @@
 
 // CHECK: #map = affine_map<(d0) -> (-d0)>
 // CHECK: module {
-// CHECK:   func.func @iqft(%arg0: !quake.qvec<?>) {
+// CHECK:   func.func @iqft(%arg0: !quake.veq<?>) {
 // CHECK:     %[[CF0:.*]] = arith.constant 2.000000e+00 : f64
 // CHECK:     %[[CF1:.*]] = arith.constant -3.1415926535897931 : f64
 // CHECK:     %[[CI1:.*]] = arith.constant 1 : index
@@ -40,7 +40,7 @@
 // CHECK:     %[[C1:.*]] = arith.constant 1 : i32
 // CHECK:     %[[C2:.*]] = arith.constant 2 : i32
 // CHECK:     %c-1_i32 = arith.constant -1 : i32
-// CHECK:     %0 = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
+// CHECK:     %0 = quake.vec_size %arg0 : (!quake.veq<?>) -> i64
 // CHECK:     %1 = arith.trunci %0 : i64 to i32
 // CHECK:     %2 = arith.subi %1, %[[C1]] : i32
 // CHECK:     %3 = arith.index_cast %2 : i32 to index
@@ -50,13 +50,13 @@
 // CHECK:       %7 = arith.index_cast %arg1 : index to i32
 // CHECK:       %8 = arith.subi %1, %7 : i32
 // CHECK:       %9 = arith.subi %8, %[[C1]] : i32
-// CHECK:       %10 = quake.extract_ref %arg0[%7] : (!quake.qvec<?>, i32) -> !quake.ref
-// CHECK:       %11 = quake.extract_ref %arg0[%9] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:       %10 = quake.extract_ref %arg0[%7] : (!quake.veq<?>, i32) -> !quake.ref
+// CHECK:       %11 = quake.extract_ref %arg0[%9] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:       quake.swap %10, %11 : (!quake.ref, !quake.ref) -> ()
 // CHECK:     }
 // CHECK:     affine.for %arg1 = 0 to %3 {
 // CHECK:       %7 = arith.index_cast %arg1 : index to i32
-// CHECK:       %8 = quake.extract_ref %arg0[%7] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:       %8 = quake.extract_ref %arg0[%7] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:       quake.h %8 : (!quake.ref) -> ()
 // CHECK:       %9 = arith.addi %7, %[[C1]] : i32
 // CHECK:       affine.for %arg2 = #map(%arg1) to 1 {
@@ -66,12 +66,12 @@
 // CHECK:         %13 = arith.sitofp %12 : i32 to f64
 // CHECK:         %14 = math.powf %[[CF0]], %13 : f64
 // CHECK:         %15 = arith.divf %[[CF1]], %14 : f64
-// CHECK:         %16 = quake.extract_ref %arg0[%9] : (!quake.qvec<?>, i32) -> !quake.ref
-// CHECK:         %17 = quake.extract_ref %arg0[%11] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:         %16 = quake.extract_ref %arg0[%9] : (!quake.veq<?>, i32) -> !quake.ref
+// CHECK:         %17 = quake.extract_ref %arg0[%11] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:         quake.r1 (%15) [%16] %17 : (f64, !quake.ref, !quake.ref) -> ()
 // CHECK:       }
 // CHECK:     }
-// CHECK:     %6 = quake.extract_ref %arg0[%2] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     %6 = quake.extract_ref %arg0[%2] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:     quake.h %6 : (!quake.ref) -> ()
 // CHECK:     return
 // CHECK:   }
@@ -81,12 +81,12 @@
 #lb = affine_map<(d0) -> (-1*d0)>
 
 module {
-    func.func @iqft(%arg0 : !quake.qvec<?>) {
+    func.func @iqft(%arg0 : !quake.veq<?>) {
         %c1 = arith.constant 1 : i32
         %c0 = arith.constant 0 : i32
         %c2 = arith.constant 2 : i32
         %cn1 = arith.constant -1 : i32
-        %nn = quake.vec_size %arg0 : (!quake.qvec<?>) -> i64
+        %nn = quake.vec_size %arg0 : (!quake.veq<?>) -> i64
         %n = arith.trunci %nn : i64 to i32
         %nm1 = arith.subi %n, %c1 : i32
         %nm1idx = arith.index_cast %nm1 : i32 to index
@@ -99,14 +99,14 @@ module {
             %7 = arith.index_cast %arg2 : index to i32
             %9 = arith.subi %n, %7 : i32
             %10 = arith.subi %9, %c1 : i32
-            %qi = quake.extract_ref %arg0 [%7] : (!quake.qvec<?>,i32) -> !quake.ref
-            %qi1 = quake.extract_ref %arg0 [%10] : (!quake.qvec<?>,i32) -> !quake.ref
+            %qi = quake.extract_ref %arg0 [%7] : (!quake.veq<?>,i32) -> !quake.ref
+            %qi1 = quake.extract_ref %arg0 [%10] : (!quake.veq<?>,i32) -> !quake.ref
             quake.swap %qi, %qi1 : (!quake.ref, !quake.ref) -> ()
         }
 
         affine.for %arg3 = 0 to %nm1idx {
             %11 = arith.index_cast %arg3 : index to i32
-            %qi = quake.extract_ref %arg0[%11] : (!quake.qvec<?>, i32) -> !quake.ref
+            %qi = quake.extract_ref %arg0[%11] : (!quake.veq<?>, i32) -> !quake.ref
             quake.h %qi : (!quake.ref) -> ()
             %13 = arith.addi %11, %c1 : i32
             %12 = memref.alloca() : memref<i32>
@@ -125,12 +125,12 @@ module {
                 %s2f = arith.sitofp %jmy : i32 to f64
                 %denom = math.powf %c2f, %s2f : f64
                 %24 = arith.divf %16, %denom : f64
-                %qj = quake.extract_ref %arg0[%13] : (!quake.qvec<?>, i32) -> !quake.ref
-                %qy = quake.extract_ref %arg0[%15] : (!quake.qvec<?>, i32) -> !quake.ref
+                %qj = quake.extract_ref %arg0[%13] : (!quake.veq<?>, i32) -> !quake.ref
+                %qy = quake.extract_ref %arg0[%15] : (!quake.veq<?>, i32) -> !quake.ref
                 quake.r1 (%24)[%qj] %qy : (f64,!quake.ref,!quake.ref) -> ()
             }
         }
-        %qnm1 = quake.extract_ref %arg0[%nm1] : (!quake.qvec<?>,i32) -> !quake.ref
+        %qnm1 = quake.extract_ref %arg0[%nm1] : (!quake.veq<?>,i32) -> !quake.ref
         quake.h %qnm1 : (!quake.ref) -> ()
         return
     }

--- a/test/Quake/kernel_exec.qke
+++ b/test/Quake/kernel_exec.qke
@@ -17,10 +17,10 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
     memref.store %arg0, %0[] : memref<i32>
     %1 = memref.load %0[] : memref<i32>
     %2 = arith.extsi %1 : i32 to i64
-    %3 = quake.alloca[%2 : i64] !quake.qvec<?>
+    %3 = quake.alloca[%2 : i64] !quake.veq<?>
     %c0_i32 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32 : i32 to i64
-    %5 = quake.extract_ref %3[%4] : (!quake.qvec<?>,i64) -> !quake.ref
+    %5 = quake.extract_ref %3[%4] : (!quake.veq<?>,i64) -> !quake.ref
     quake.h %5 : (!quake.ref) -> ()
     cc.scope {
       %7 = memref.alloca() : memref<i32>
@@ -38,11 +38,11 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
       } do {
       ^bb1 (%arg11 : index):
         %18 = arith.index_cast %arg11 : index to i64
-        %19 = quake.extract_ref %3[%18] : (!quake.qvec<?>,i64) -> !quake.ref
+        %19 = quake.extract_ref %3[%18] : (!quake.veq<?>,i64) -> !quake.ref
         %20 = arith.trunci %18 : i64 to i32
         %21 = arith.addi %20, %c1_i32 : i32
         %22 = arith.extsi %21 : i32 to i64
-        %23 = quake.extract_ref %3[%22] : (!quake.qvec<?>,i64) -> !quake.ref
+        %23 = quake.extract_ref %3[%22] : (!quake.veq<?>,i64) -> !quake.ref
         quake.x [%19] %23 : (!quake.ref, !quake.ref) -> ()
 	cc.continue %arg11 : index
       } step {
@@ -52,7 +52,7 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
         cc.continue %incr : index
       }
     }
-    %15 = quake.vec_size %3 : (!quake.qvec<?>) -> i64
+    %15 = quake.vec_size %3 : (!quake.veq<?>) -> i64
     %16 = arith.index_cast %15 : i64 to index
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -61,7 +61,7 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclEi"
 	cc.condition %cond (%argx1 : index)
     } do {
     ^bb1 (%arg31 : index):
-      %18 = quake.extract_ref %3[%arg31] : (!quake.qvec<?>,index) -> !quake.ref
+      %18 = quake.extract_ref %3[%arg31] : (!quake.veq<?>,index) -> !quake.ref
       %19 = quake.mz %18 : (!quake.ref) -> i1
       cc.continue %arg31 : index
     } step {

--- a/test/Quake/lambda_kernel_exec.qke
+++ b/test/Quake/lambda_kernel_exec.qke
@@ -18,14 +18,14 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
   func.func @__nvqpp__mlirgen__lambda.main.test() attributes {"cudaq-entrypoint"} {
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
-    %1 = quake.alloca[%0 : i64]  !quake.qvec<?>
+    %1 = quake.alloca[%0 : i64]  !quake.veq<?>
     %c0_i32 = arith.constant 0 : i32
     %2 = arith.extsi %c0_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.qvec<?>,i64) -> !quake.ref
+    %3 = quake.extract_ref %1[%2] : (!quake.veq<?>,i64) -> !quake.ref
     quake.h %3 : (!quake.ref) -> ()
     %c0_i32_0 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32_0 : i32 to i64
-    %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>, i64) -> !quake.ref
+    %5 = quake.extract_ref %1[%4] : (!quake.veq<?>, i64) -> !quake.ref
     %6 = quake.mz %5 : (!quake.ref)->i1 {registerName = "b"} 
     %alloca = memref.alloca() : memref<i1>
     memref.store %6, %alloca[] : memref<i1>
@@ -34,13 +34,13 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
       cc.scope {
         %c1_i32_1 = arith.constant 1 : i32
         %11 = arith.extsi %c1_i32_1 : i32 to i64
-        %12 = quake.extract_ref %1[%11] : (!quake.qvec<?>,i64) -> !quake.ref
+        %12 = quake.extract_ref %1[%11] : (!quake.veq<?>,i64) -> !quake.ref
         quake.x %12 : (!quake.ref) -> ()
       }
     }
     %c1_i32 = arith.constant 1 : i32
     %8 = arith.extsi %c1_i32 : i32 to i64
-    %9 = quake.extract_ref %1[%8] : (!quake.qvec<?>,i64) -> !quake.ref
+    %9 = quake.extract_ref %1[%8] : (!quake.veq<?>,i64) -> !quake.ref
     %10 = quake.mz %9 : (!quake.ref) -> i1
     return
   }
@@ -52,14 +52,14 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
   func.func @__nvqpp__mlirgen__lambda.main.canHaveMultiple() attributes {"cudaq-entrypoint"} {
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
-    %1 = quake.alloca[%0 : i64] !quake.qvec<?>
+    %1 = quake.alloca[%0 : i64] !quake.veq<?>
     %c0_i32 = arith.constant 0 : i32
     %2 = arith.extsi %c0_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.qvec<?>,i64) -> !quake.ref
+    %3 = quake.extract_ref %1[%2] : (!quake.veq<?>,i64) -> !quake.ref
     quake.h %3 : (!quake.ref) -> ()
     %c0_i32_0 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32_0 : i32 to i64
-    %5 = quake.extract_ref %1[%4] : (!quake.qvec<?>,i64) -> !quake.ref
+    %5 = quake.extract_ref %1[%4] : (!quake.veq<?>,i64) -> !quake.ref
     %6 = quake.mz %5 : (!quake.ref) ->i1 {registerName = "b"} 
     %alloca = memref.alloca() : memref<i1>
     memref.store %6, %alloca[] : memref<i1>
@@ -68,13 +68,13 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHave
       cc.scope {
         %c1_i32_1 = arith.constant 1 : i32
         %11 = arith.extsi %c1_i32_1 : i32 to i64
-        %12 = quake.extract_ref %1[%11] : (!quake.qvec<?>, i64) -> !quake.ref
+        %12 = quake.extract_ref %1[%11] : (!quake.veq<?>, i64) -> !quake.ref
         quake.x %12 : (!quake.ref) -> ()
       }
     }
     %c1_i32 = arith.constant 1 : i32
     %8 = arith.extsi %c1_i32 : i32 to i64
-    %9 = quake.extract_ref %1[%8] : (!quake.qvec<?>,i64) -> !quake.ref
+    %9 = quake.extract_ref %1[%8] : (!quake.veq<?>,i64) -> !quake.ref
     %10 = quake.mz %9 : (!quake.ref) -> i1
     return
   }

--- a/test/Quake/lambda_variable-1.qke
+++ b/test/Quake/lambda_variable-1.qke
@@ -13,21 +13,21 @@
 // constructing the QTX circuit.
 
 module attributes{ qtx.mangled_name_map = { __nvqpp__mlirgen__test3_callee = "_ZN12test3_calleeclEOSt8functionIFvRN4cudaq5quditILm2EEEEERNS1_4qregILm18446744073709551615ELm2EEE", __nvqpp__mlirgen__test3_caller = "_ZN12test3_callerclEv"}} {
-  func.func @__nvqpp__mlirgen__test3_callee(%arg0: !cc.lambda<(!quake.ref) -> ()>, %arg1: !quake.qvec<?>) attributes {"cudaq-kernel"} {
+  func.func @__nvqpp__mlirgen__test3_callee(%arg0: !cc.lambda<(!quake.ref) -> ()>, %arg1: !quake.veq<?>) attributes {"cudaq-kernel"} {
     %c0_i32 = arith.constant 0 : i32
     %0 = arith.extsi %c0_i32 : i32 to i64
-    %1 = quake.extract_ref %arg1[%0] : (!quake.qvec<?>,i64) -> !quake.ref
+    %1 = quake.extract_ref %arg1[%0] : (!quake.veq<?>,i64) -> !quake.ref
     cc.call_callable %arg0, %1 : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
     %c1_i32 = arith.constant 1 : i32
     %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.extract_ref %arg1[%2] : (!quake.qvec<?>,i64) -> !quake.ref
+    %3 = quake.extract_ref %arg1[%2] : (!quake.veq<?>,i64) -> !quake.ref
     cc.call_callable %arg0, %3 : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
     return
   }
   func.func @__nvqpp__mlirgen__test3_caller() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
-    %1 = quake.alloca[%0 : i64] !quake.qvec<?>
+    %1 = quake.alloca[%0 : i64] !quake.veq<?>
     %2 = cc.undef !llvm.struct<"test3_callee", ()>
     %3 = cc.create_lambda {
     ^bb0(%arg0: !quake.ref):
@@ -36,28 +36,28 @@ module attributes{ qtx.mangled_name_map = { __nvqpp__mlirgen__test3_callee = "_Z
         quake.y %arg0 : (!quake.ref) -> ()
       }
     } : !cc.lambda<(!quake.ref) -> ()>
-    call @__nvqpp__mlirgen__test3_callee(%3, %1) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
+    call @__nvqpp__mlirgen__test3_callee(%3, %1) : (!cc.lambda<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
     return
   }
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_callee(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.qvec<?>)
+// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           %[[VAL_5:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())
 // CHECK:           call_indirect %[[VAL_5]](%[[VAL_0]], %[[VAL_4]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
-// CHECK:            %[[VAL_6:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_2]]] : (!quake.qvec<?>, i64) -> !quake.ref
+// CHECK:            %[[VAL_6:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_2]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           %[[VAL_7:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())
 // CHECK:           call_indirect %[[VAL_7]](%[[VAL_0]], %[[VAL_6]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_caller()
-// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<2>
-// CHECK:           %[[VAL_1:.*]] = quake.relax_size %[[VAL_0]] : (!quake.qvec<2>) -> !quake.qvec<?>
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_1:.*]] = quake.relax_size %[[VAL_0]] : (!quake.veq<2>) -> !quake.veq<?>
 // CHECK:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0() : () -> !cc.lambda<(!quake.ref) -> ()>
-// CHECK:           call @__nvqpp__mlirgen__test3_callee(%[[VAL_2]], %[[VAL_1]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.qvec<?>) -> ()
+// CHECK:           call @__nvqpp__mlirgen__test3_callee(%[[VAL_2]], %[[VAL_1]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
 
 // CHECK-LABEL:   func.func private @__nvqpp__callable.thunk.lambda.0(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,

--- a/test/Quake/lambda_variable-2.qke
+++ b/test/Quake/lambda_variable-2.qke
@@ -15,21 +15,21 @@
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_a()
-// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.qvec<4>
-// CHECK:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0(%[[VAL_0]]) : (!quake.qvec<4>) -> !cc.lambda<() -> ()>
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_2:.*]] = cc.instantiate_callable @__nvqpp__callable.thunk.lambda.0(%[[VAL_0]]) : (!quake.veq<4>) -> !cc.lambda<() -> ()>
 // CHECK:           call @__nvqpp__mlirgen__kernel_b(%[[VAL_2]]) : (!cc.lambda<() -> ()>) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func private @__nvqpp__callable.thunk.lambda.0(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.lambda<() -> ()>) {
-// CHECK:           %[[VAL_1:.*]] = cc.callable_closure %[[VAL_0]] : (!cc.lambda<() -> ()>) -> !quake.qvec<4>
-// CHECK:           call @__nvqpp__lifted.lambda.0(%[[VAL_1]]) : (!quake.qvec<4>) -> ()
+// CHECK:           %[[VAL_1:.*]] = cc.callable_closure %[[VAL_0]] : (!cc.lambda<() -> ()>) -> !quake.veq<4>
+// CHECK:           call @__nvqpp__lifted.lambda.0(%[[VAL_1]]) : (!quake.veq<4>) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func private @__nvqpp__lifted.lambda.0(
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<4>) {
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<4>) {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.constant 4 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i32
@@ -43,7 +43,7 @@
 // CHECK:             } do {
 // CHECK:               %[[VAL_7:.*]] = memref.load %[[VAL_4]][] : memref<i32>
 // CHECK:               %[[VAL_8:.*]] = arith.extsi %[[VAL_7]] : i32 to i64
-// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.qvec<4>, i64) -> !quake.ref
+// CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:               quake.h %[[VAL_9]] :
 // CHECK:               cc.continue
 // CHECK:             } step {
@@ -76,7 +76,7 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__kernel_a = "_ZN8ker
     return
   }
   func.func @__nvqpp__mlirgen__kernel_a() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-    %1 = quake.alloca !quake.qvec<4>
+    %1 = quake.alloca !quake.veq<4>
     %5 = cc.create_lambda {
       cc.scope {
         %alloca = memref.alloca() : memref<i32>
@@ -91,7 +91,7 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__kernel_a = "_ZN8ker
           } do {
             %6 = memref.load %alloca[] : memref<i32>
             %7 = arith.extsi %6 : i32 to i64
-            %8 = quake.extract_ref %1[%7] : (!quake.qvec<4>, i64) -> !quake.ref
+            %8 = quake.extract_ref %1[%7] : (!quake.veq<4>, i64) -> !quake.ref
             quake.h %8 : (!quake.ref) -> ()
             cc.continue
           } step {

--- a/test/Quake/mz.qke
+++ b/test/Quake/mz.qke
@@ -10,38 +10,38 @@
 
 func.func @static.mz_test() {
   %0 = quake.alloca  !quake.ref
-  %1 = quake.alloca  !quake.qvec<4>
-  %2 = quake.alloca  !quake.qvec<2>
+  %1 = quake.alloca  !quake.veq<4>
+  %2 = quake.alloca  !quake.veq<2>
   %3 = quake.alloca  !quake.ref
-  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.qvec<4>, !quake.qvec<2>, !quake.ref) -> !cc.stdvec<i1>
+  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<i1>
   return
 }
 
 // CHECK-LABEL:   func.func @static.mz_test() {
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<4>
-// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.qvec<4>, !quake.qvec<2>, !quake.ref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 
 func.func @dynamic.mz_test(%arg0 : i32, %arg1 : i32) {
   %0 = quake.alloca  !quake.ref
-  %1 = quake.alloca[%arg0 : i32]  !quake.qvec<?>
-  %2 = quake.alloca [%arg1 : i32] !quake.qvec<?>
+  %1 = quake.alloca[%arg0 : i32]  !quake.veq<?>
+  %2 = quake.alloca [%arg1 : i32] !quake.veq<?>
   %3 = quake.alloca  !quake.ref
-  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.qvec<?>, !quake.qvec<?>, !quake.ref) -> !cc.stdvec<i1>
+  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
   return
 }
 
 // CHECK-LABEL:   func.func @dynamic.mz_test(
 // CHECK-SAME:        %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
-// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_1]] : i32] !quake.qvec<?>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.veq<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca[%[[VAL_1]] : i32] !quake.veq<?>
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.qvec<?>, !quake.qvec<?>, !quake.ref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/observeAnsatz.qke
+++ b/test/Quake/observeAnsatz.qke
@@ -14,14 +14,14 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ansatz = "_ZN6ansat
     %c1_i64 = arith.constant 1 : i64
     %0 = memref.alloca() : memref<f64>
     memref.store %arg0, %0[] : memref<f64>
-    %1 = quake.alloca  !quake.qvec<2>
-    %2 = quake.extract_ref %1[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+    %1 = quake.alloca  !quake.veq<2>
+    %2 = quake.extract_ref %1[%c0_i64] : (!quake.veq<2>,i64) -> !quake.ref
     quake.x %2 : (!quake.ref) -> ()
     %3 = memref.load %0[] : memref<f64>
-    %4 = quake.extract_ref %1[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+    %4 = quake.extract_ref %1[%c1_i64] : (!quake.veq<2>,i64) -> !quake.ref
     quake.ry (%3) %4 : (f64, !quake.ref) -> ()
-    %5 = quake.extract_ref %1[%c1_i64] : (!quake.qvec<2>,i64) -> !quake.ref
-    %6 = quake.extract_ref %1[%c0_i64] : (!quake.qvec<2>,i64) -> !quake.ref
+    %5 = quake.extract_ref %1[%c1_i64] : (!quake.veq<2>,i64) -> !quake.ref
+    %6 = quake.extract_ref %1[%c0_i64] : (!quake.veq<2>,i64) -> !quake.ref
     quake.x [%5] %6 : (!quake.ref,!quake.ref) -> ()
     return
   }

--- a/test/Quake/qpe.qke
+++ b/test/Quake/qpe.qke
@@ -12,10 +12,10 @@
 // CHECK:     quake.t %arg0 :
 // CHECK:     return
 // CHECK:   }
-// CHECK:   func.func @qpe_test_callable(%arg0: i32, %arg1: i32, %arg2: (!quake.qvec<?>) -> !quake.qvec<?>, %arg3: (!quake.ref) -> ()) {
+// CHECK:   func.func @qpe_test_callable(%arg0: i32, %arg1: i32, %arg2: (!quake.veq<?>) -> !quake.veq<?>, %arg3: (!quake.ref) -> ()) {
 // CHECK:     %[[C0:.*]] = arith.constant 0 : i32
-// CHECK:     %0 = quake.alloca[%arg0 : i32] !quake.qvec<?>
-// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     %0 = quake.alloca[%arg0 : i32] !quake.veq<?>
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:     call_indirect %arg3(%1) : (!quake.ref) -> ()
 // CHECK:     return
 // CHECK:   }
@@ -25,10 +25,10 @@ func.func @ctrl_t_gate(%q : !quake.ref) -> () {
   return
 }
 
-func.func @qpe_test_callable(%nq : i32, %nc : i32, %state_prep : (!quake.qvec<?>)->(!quake.qvec<?>), %oracle : (!quake.ref)->()) {
+func.func @qpe_test_callable(%nq : i32, %nc : i32, %state_prep : (!quake.veq<?>)->(!quake.veq<?>), %oracle : (!quake.ref)->()) {
   %0 = arith.constant 0 : i32
-  %qubits = quake.alloca[%nq : i32] !quake.qvec<?>
-  %q = quake.extract_ref %qubits[%0] : (!quake.qvec<?>,i32) -> !quake.ref
+  %qubits = quake.alloca[%nq : i32] !quake.veq<?>
+  %q = quake.extract_ref %qubits[%0] : (!quake.veq<?>,i32) -> !quake.ref
   func.call_indirect %oracle(%q) : (!quake.ref)->()
   return
 }

--- a/test/Quake/quake-errors.qke
+++ b/test/Quake/quake-errors.qke
@@ -330,11 +330,11 @@ func.func @test() {
 
 %neg = arith.constant -5 : i32
 // expected-error @+1 {{expected a non-negative integer size}}
-%0 = quake.alloca[%neg : i32] !quake.qvec<?>
+%0 = quake.alloca[%neg : i32] !quake.veq<?>
 
 // -----
 
 %two = arith.constant 2 : i32
-// expected-error @+1 {{expected operand size to match QVecType size}}
-%0 = quake.alloca[%two : i32] !quake.qvec<4>
+// expected-error @+1 {{expected operand size to match VeqType size}}
+%0 = quake.alloca[%two : i32] !quake.veq<4>
      

--- a/test/Quake/quake-ops.qke
+++ b/test/Quake/quake-ops.qke
@@ -10,31 +10,31 @@
 
 // RUN: cudaq-opt %s | cudaq-opt | FileCheck %s
 
-func.func private @apply_kernel(%0 : i32, %1 : !quake.qvec<?>)
+func.func private @apply_kernel(%0 : i32, %1 : !quake.veq<?>)
 
 // Test roundtripping on the various quake ops.
 func.func @quantum_ops() {
   // Allocations
   %0 = quake.alloca !quake.ref
   quake.dealloc %0 : !quake.ref
-  %v0 = quake.alloca !quake.qvec<5>
-  quake.dealloc %v0 : !quake.qvec<5>
-  %1 = quake.alloca !quake.qvec<4>
+  %v0 = quake.alloca !quake.veq<5>
+  quake.dealloc %v0 : !quake.veq<5>
+  %1 = quake.alloca !quake.veq<4>
   %2 = arith.constant 2 : i32
-  %3 = quake.alloca[%2 : i32] !quake.qvec<?>
+  %3 = quake.alloca[%2 : i32] !quake.veq<?>
   %4 = quake.alloca !quake.ref
 
   // Vectors of references
   %zero = arith.constant 0 : i32
   %i = arith.constant 3    : i64
-  %5 = quake.concat %3, %4 : (!quake.qvec<?>, !quake.ref) -> !quake.qvec<?>
-  %6 = quake.concat %4, %1 : (!quake.ref, !quake.qvec<4>) -> !quake.qvec<5>
-  %7 = quake.extract_ref %5[%zero] : (!quake.qvec<?>, i32) -> !quake.ref
-  %8 = quake.extract_ref %6[%i]    : (!quake.qvec<5>, i64) -> !quake.ref
-  %9 = quake.relax_size %6         : (!quake.qvec<5>) -> !quake.qvec<?>
+  %5 = quake.concat %3, %4 : (!quake.veq<?>, !quake.ref) -> !quake.veq<?>
+  %6 = quake.concat %4, %1 : (!quake.ref, !quake.veq<4>) -> !quake.veq<5>
+  %7 = quake.extract_ref %5[%zero] : (!quake.veq<?>, i32) -> !quake.ref
+  %8 = quake.extract_ref %6[%i]    : (!quake.veq<5>, i64) -> !quake.ref
+  %9 = quake.relax_size %6         : (!quake.veq<5>) -> !quake.veq<?>
   %z = arith.constant 0 : index
-  %10 = quake.subvec %5, %z, %i : (!quake.qvec<?>, index, i64) -> !quake.qvec<?>
-  %11 = quake.vec_size %5 : (!quake.qvec<?>) -> index
+  %10 = quake.subvec %5, %z, %i : (!quake.veq<?>, index, i64) -> !quake.veq<?>
+  %11 = quake.vec_size %5 : (!quake.veq<?>) -> index
 
   // Reference/dereference
   quake.reset %4 : (!quake.ref) -> ()
@@ -67,8 +67,8 @@ func.func @quantum_ops() {
   quake.u3 (%f, %g, %h) %7 : (f32, f32, f32, !quake.ref) -> ()
 
   %15 = quake.mx %4 : (!quake.ref) -> i1
-  %16 = quake.my %5 : (!quake.qvec<?>) -> !cc.stdvec<i1>
-  %17 = quake.mz %6 : (!quake.qvec<5>) -> !cc.stdvec<i1>
+  %16 = quake.my %5 : (!quake.veq<?>) -> !cc.stdvec<i1>
+  %17 = quake.mz %6 : (!quake.veq<5>) -> !cc.stdvec<i1>
 
   // Quantum operations, wire form
   %19 = cc.undef i32 {wires = true}
@@ -98,12 +98,12 @@ func.func @quantum_ops() {
 
   // CUDA Quantum model support
   %40 = quake.alloca !quake.ref { apply_variants = true }
-  %41 = quake.alloca !quake.qvec<2>
+  %41 = quake.alloca !quake.veq<2>
   %42 = arith.constant 0 : i32
   %43 = quake.alloca !quake.ref
   quake.apply @apply_kernel %42, %43 : (i32, !quake.ref) -> ()
-  quake.apply @apply_kernel [%40, %41] %42, %43 : (!quake.ref, !quake.qvec<2>, i32, !quake.ref) -> ()
-  quake.apply<adj> @apply_kernel [%40, %41] %42, %43 : (!quake.ref, !quake.qvec<2>, i32, !quake.ref) -> ()
+  quake.apply @apply_kernel [%40, %41] %42, %43 : (!quake.ref, !quake.veq<2>, i32, !quake.ref) -> ()
+  quake.apply<adj> @apply_kernel [%40, %41] %42, %43 : (!quake.ref, !quake.veq<2>, i32, !quake.ref) -> ()
 
   %44 = cc.undef !cc.lambda<() -> ()> { compute_action = true }
   %45 = cc.undef !cc.lambda<() -> ()>
@@ -124,22 +124,22 @@ func.func @quantum_ops() {
   quake.u3<adj> (%f, %g, %h) %7 : (f32, f32, f32, !quake.ref) -> ()
 
   // Control modifier
-  %46 = quake.alloca !quake.qvec<3> {control = true}
-  quake.x [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
-  quake.y [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
+  %46 = quake.alloca !quake.veq<3> {control = true}
+  quake.x [%46] %4 : (!quake.veq<3>, !quake.ref) -> ()
+  quake.y [%46] %4 : (!quake.veq<3>, !quake.ref) -> ()
   quake.z [%7] %4 : (!quake.ref, !quake.ref) -> ()
-  quake.h [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
-  quake.s [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
-  quake.t [%46] %4 : (!quake.qvec<3>, !quake.ref) -> ()
-  quake.swap [%46] %4, %7 : (!quake.qvec<3>, !quake.ref, !quake.ref) -> ()
+  quake.h [%46] %4 : (!quake.veq<3>, !quake.ref) -> ()
+  quake.s [%46] %4 : (!quake.veq<3>, !quake.ref) -> ()
+  quake.t [%46] %4 : (!quake.veq<3>, !quake.ref) -> ()
+  quake.swap [%46] %4, %7 : (!quake.veq<3>, !quake.ref, !quake.ref) -> ()
 
-  quake.r1 (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.ref) -> ()
-  quake.rx (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.ref) -> ()
-  quake.phased_rx (%f, %g) [%46] %7 : (f32, f32, !quake.qvec<3>, !quake.ref) -> ()
-  quake.ry (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.ref) -> ()
-  quake.rz (%f) [%46] %7 : (f32, !quake.qvec<3>, !quake.ref) -> ()
-  quake.u2 (%f, %g) [%46] %7 : (f32, f32, !quake.qvec<3>, !quake.ref) -> ()
-  quake.u3 (%f, %g, %47) [%46] %7 : (f32, f32, f64, !quake.qvec<3>, !quake.ref) -> ()
+  quake.r1 (%f) [%46] %7 : (f32, !quake.veq<3>, !quake.ref) -> ()
+  quake.rx (%f) [%46] %7 : (f32, !quake.veq<3>, !quake.ref) -> ()
+  quake.phased_rx (%f, %g) [%46] %7 : (f32, f32, !quake.veq<3>, !quake.ref) -> ()
+  quake.ry (%f) [%46] %7 : (f32, !quake.veq<3>, !quake.ref) -> ()
+  quake.rz (%f) [%46] %7 : (f32, !quake.veq<3>, !quake.ref) -> ()
+  quake.u2 (%f, %g) [%46] %7 : (f32, f32, !quake.veq<3>, !quake.ref) -> ()
+  quake.u3 (%f, %g, %47) [%46] %7 : (f32, f32, f64, !quake.veq<3>, !quake.ref) -> ()
 
   return
 }
@@ -147,22 +147,22 @@ func.func @quantum_ops() {
 // CHECK-LABEL:   func.func @quantum_ops() {
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.dealloc %[[VAL_0]] : !quake.ref
-// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.qvec<5>
-// CHECK:           quake.dealloc %[[VAL_1]] : !quake.qvec<5>
-// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.qvec<4>
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<5>
+// CHECK:           quake.dealloc %[[VAL_1]] : !quake.veq<5>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i32
-// CHECK:           %[[VAL_4:.*]] = quake.alloca{{\[}}%[[VAL_3]] : i32] !quake.qvec<?>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca{{\[}}%[[VAL_3]] : i32] !quake.veq<?>
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_4]], %[[VAL_5]] : (!quake.qvec<?>, !quake.ref) -> !quake.qvec<?>
-// CHECK:           %[[VAL_9:.*]] = quake.concat %[[VAL_5]], %[[VAL_2]] : (!quake.ref, !quake.qvec<4>) -> !quake.qvec<5>
-// CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_6]]] : (!quake.qvec<?>, i32) -> !quake.ref
-// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_7]]] : (!quake.qvec<5>, i64) -> !quake.ref
-// CHECK:           %[[VAL_12:.*]] = quake.relax_size %[[VAL_9]] : (!quake.qvec<5>) -> !quake.qvec<?>
+// CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_4]], %[[VAL_5]] : (!quake.veq<?>, !quake.ref) -> !quake.veq<?>
+// CHECK:           %[[VAL_9:.*]] = quake.concat %[[VAL_5]], %[[VAL_2]] : (!quake.ref, !quake.veq<4>) -> !quake.veq<5>
+// CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_6]]] : (!quake.veq<?>, i32) -> !quake.ref
+// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_9]]{{\[}}%[[VAL_7]]] : (!quake.veq<5>, i64) -> !quake.ref
+// CHECK:           %[[VAL_12:.*]] = quake.relax_size %[[VAL_9]] : (!quake.veq<5>) -> !quake.veq<?>
 // CHECK:           %[[VAL_13:.*]] = arith.constant 0 : index
-// CHECK:           %[[VAL_14:.*]] = quake.subvec %[[VAL_8]], %[[VAL_13]], %[[VAL_7]] : (!quake.qvec<?>, index, i64) -> !quake.qvec<?>
-// CHECK:           %[[VAL_15:.*]] = quake.vec_size %[[VAL_8]] : (!quake.qvec<?>) -> index
+// CHECK:           %[[VAL_14:.*]] = quake.subvec %[[VAL_8]], %[[VAL_13]], %[[VAL_7]] : (!quake.veq<?>, index, i64) -> !quake.veq<?>
+// CHECK:           %[[VAL_15:.*]] = quake.vec_size %[[VAL_8]] : (!quake.veq<?>) -> index
 // CHECK:           quake.reset %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_16:.*]] = quake.null_wire
 // CHECK:           %[[VAL_17:.*]] = quake.unwrap %[[VAL_5]] : (!quake.ref) -> !quake.wire
@@ -187,8 +187,8 @@ func.func @quantum_ops() {
 // CHECK:           %[[VAL_22:.*]] = arith.constant 3.400000e+01 : f32
 // CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.ref) -> ()
 // CHECK:           %[[VAL_23:.*]] = quake.mx %[[VAL_5]] : (!quake.ref) -> i1
-// CHECK:           %[[VAL_24:.*]] = quake.my %[[VAL_8]] : (!quake.qvec<?>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_25:.*]] = quake.mz %[[VAL_9]] : (!quake.qvec<5>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_24:.*]] = quake.my %[[VAL_8]] : (!quake.veq<?>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_25:.*]] = quake.mz %[[VAL_9]] : (!quake.veq<5>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_26:.*]] = cc.undef i32 {wires = true}
 // CHECK:           %[[VAL_27:.*]] = quake.null_wire
 // CHECK:           %[[VAL_28:.*]] = quake.null_wire
@@ -211,12 +211,12 @@ func.func @quantum_ops() {
 // CHECK:           %[[VAL_45:.*]] = quake.my %[[VAL_27]] : (!quake.wire) -> i1
 // CHECK:           %[[VAL_46:.*]] = quake.mz %[[VAL_43]] : (!quake.wire) -> i1
 // CHECK:           %[[VAL_47:.*]] = quake.alloca !quake.ref {apply_variants = true}
-// CHECK:           %[[VAL_48:.*]] = quake.alloca !quake.qvec<2>
+// CHECK:           %[[VAL_48:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_49:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_50:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.apply @apply_kernel %[[VAL_49]], %[[VAL_50]] : (i32, !quake.ref) -> ()
-// CHECK:           quake.apply @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.qvec<2>, i32, !quake.ref) -> ()
-// CHECK:           quake.apply<adj> @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.qvec<2>, i32, !quake.ref) -> ()
+// CHECK:           quake.apply @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.veq<2>, i32, !quake.ref) -> ()
+// CHECK:           quake.apply<adj> @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.veq<2>, i32, !quake.ref) -> ()
 // CHECK:           %[[VAL_51:.*]] = cc.undef !cc.lambda<() -> ()> {compute_action = true}
 // CHECK:           %[[VAL_52:.*]] = cc.undef !cc.lambda<() -> ()>
 // CHECK:           quake.compute_action %[[VAL_51]], %[[VAL_52]] : !cc.lambda<() -> ()>, !cc.lambda<() -> ()>
@@ -231,21 +231,21 @@ func.func @quantum_ops() {
 // CHECK:           quake.rz<adj> (%[[VAL_20]]) %[[VAL_10]] : (f32, !quake.ref) -> ()
 // CHECK:           quake.u2<adj> (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.ref) -> ()
 // CHECK:           quake.u3<adj> (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.ref) -> ()
-// CHECK:           %[[VAL_54:.*]] = quake.alloca !quake.qvec<3> {control = true}
-// CHECK:           quake.x {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.y {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           %[[VAL_54:.*]] = quake.alloca !quake.veq<3> {control = true}
+// CHECK:           quake.x {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.y {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.veq<3>, !quake.ref) -> ()
 // CHECK:           quake.z {{\[}}%[[VAL_10]]] %[[VAL_5]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           quake.h {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.s {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.t {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.swap {{\[}}%[[VAL_54]]] %[[VAL_5]], %[[VAL_10]] : (!quake.qvec<3>, !quake.ref, !quake.ref) -> ()
-// CHECK:           quake.r1 (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.rx (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.phased_rx (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.ry (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.rz (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.u2 (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.qvec<3>, !quake.ref) -> ()
-// CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_53]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, f64, !quake.qvec<3>, !quake.ref) -> ()
+// CHECK:           quake.h {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.s {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.t {{\[}}%[[VAL_54]]] %[[VAL_5]] : (!quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.swap {{\[}}%[[VAL_54]]] %[[VAL_5]], %[[VAL_10]] : (!quake.veq<3>, !quake.ref, !quake.ref) -> ()
+// CHECK:           quake.r1 (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.rx (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.phased_rx (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.ry (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.rz (%[[VAL_20]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, !quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.u2 (%[[VAL_20]], %[[VAL_21]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, !quake.veq<3>, !quake.ref) -> ()
+// CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_53]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, f64, !quake.veq<3>, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -277,14 +277,14 @@ func.func @quake_op2() -> !cc.ptr<i8> {
 }
 
 // CHECK-LABEL:   func.func @quake_op3(
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.qvec<?>,
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
 // CHECK-SAME:        %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) {
-// CHECK:           %[[VAL_3:.*]] = quake.subvec %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] : (!quake.qvec<?>, i32, i32) -> !quake.qvec<?>
+// CHECK:           %[[VAL_3:.*]] = quake.subvec %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] : (!quake.veq<?>, i32, i32) -> !quake.veq<?>
 // CHECK:           return
 // CHECK:         }
 
-func.func @quake_op3(%vec : !quake.qvec<?>, %a : i32, %b : i32) {
-  %sub = quake.subvec %vec, %a, %b : (!quake.qvec<?>, i32, i32) -> !quake.qvec<?>
+func.func @quake_op3(%vec : !quake.veq<?>, %a : i32, %b : i32) {
+  %sub = quake.subvec %vec, %a, %b : (!quake.veq<?>, i32, i32) -> !quake.veq<?>
   return
 }
 

--- a/test/Quake/test_add_dealloc.qke
+++ b/test/Quake/test_add_dealloc.qke
@@ -13,10 +13,10 @@
 func.func @ghz(%arg0 : i32) {
   %c0 = arith.constant 0 : i32
   %one = arith.constant 1 : i32
-  // CHECK: %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.qvec<?>
-  %q = quake.alloca[%arg0 : i32] !quake.qvec<?>
-  %q0 = quake.extract_ref %q[%c0] : (!quake.qvec<?>, i32) -> !quake.ref
+  // CHECK: %[[VAL_3:.*]] = quake.alloca[%[[VAL_0]] : i32] !quake.veq<?>
+  %q = quake.alloca[%arg0 : i32] !quake.veq<?>
+  %q0 = quake.extract_ref %q[%c0] : (!quake.veq<?>, i32) -> !quake.ref
   quake.h %q0 : (!quake.ref) -> () 
-  // CHECK: quake.dealloc %[[VAL_3]] : !quake.qvec<?>
+  // CHECK: quake.dealloc %[[VAL_3]] : !quake.veq<?>
   return
 }

--- a/test/Quake/test_inline_simpify.qke
+++ b/test/Quake/test_inline_simpify.qke
@@ -15,13 +15,13 @@
 // CHECK:   func.func @ccnot() {
 // CHECK:     %[[C3:.*]] = arith.constant 3 : i32
 // CHECK:     %[[C1:.*]] = arith.constant 1 : i32
-// CHECK:     %0 = quake.alloca[%[[C3]] : i32] !quake.qvec<?>
+// CHECK:     %0 = quake.alloca[%[[C3]] : i32] !quake.veq<?>
 // CHECK:     %1 = arith.index_cast %[[C3]] : i32 to index
 // CHECK:     affine.for %arg0 = 0 to %1 {
-// CHECK:       %3 = quake.extract_ref %0[%arg0] : (!quake.qvec<?>, index) -> !quake.ref
+// CHECK:       %3 = quake.extract_ref %0[%arg0] : (!quake.veq<?>, index) -> !quake.ref
 // CHECK:       quake.x %3 :
 // CHECK:     }
-// CHECK:     %2 = quake.extract_ref %0[%[[C1]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     %2 = quake.extract_ref %0[%[[C1]]] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:     call @apply_x(%2) : (!quake.ref) -> ()
 // CHECK:     return
 // CHECK:   }
@@ -38,14 +38,14 @@ module {
     func.func @ccnot() {
         %c_3 = arith.constant 3 : i32
         %c_1 = arith.constant 1 : i32
-        %qubits = quake.alloca [%c_3 : i32 ] !quake.qvec<?>
+        %qubits = quake.alloca [%c_3 : i32 ] !quake.veq<?>
         %c_3_idx = arith.index_cast %c_3 : i32 to index
         affine.for %i = 0 to %c_3_idx {
-            %q0 = quake.extract_ref %qubits [%i] :( !quake.qvec<?>,index) -> !quake.ref
+            %q0 = quake.extract_ref %qubits [%i] :( !quake.veq<?>,index) -> !quake.ref
             quake.x %q0 : (!quake.ref) -> ()
         }
 
-        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.qvec<?>, i32) -> !quake.ref
+        %q1 = quake.extract_ref %qubits [%c_1] : (!quake.veq<?>, i32) -> !quake.ref
         func.call @apply_x(%q1) : (!quake.ref) -> ()
         
         return

--- a/test/Quake/test_merge_rotation.qke
+++ b/test/Quake/test_merge_rotation.qke
@@ -11,8 +11,8 @@
 // CHECK: func.func @duplicate_rotation_check() {
 // CHECK:     %[[C2:.*]] = arith.constant 2 : i32
 // CHECK:     %[[C0:.*]] = arith.constant 0 : i32
-// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
-// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.veq<?>
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:     %[[CF:.*]] = arith.constant 5.900000e-01 : f64
 // CHECK:     quake.rx (%[[CF]]) %1 : (f64,
 // CHECK:     quake.rx (%[[CF]]) %1 : (f64,
@@ -23,8 +23,8 @@
 func.func @duplicate_rotation_check() {
   %0 = arith.constant 2 : i32
   %c_0 = arith.constant 0 : i32
-  %qubits = quake.alloca [ %0 : i32 ] !quake.qvec<?>
-  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>,i32) -> !quake.ref
+  %qubits = quake.alloca [ %0 : i32 ] !quake.veq<?>
+  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.veq<?>,i32) -> !quake.ref
   %c_angle = arith.constant 0.59 : f64
   quake.rx (%c_angle) %q0: (f64, !quake.ref) -> ()
   quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
@@ -35,8 +35,8 @@ func.func @duplicate_rotation_check() {
 // CHECK: func.func @duplicate_rotation_check2() {
 // CHECK:     %[[C2]] = arith.constant 2 : i32
 // CHECK:     %[[C0]] = arith.constant 0 : i32
-// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
-// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.veq<?>
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:     %[[CF:.*]] = arith.constant 5.900000e-01 : f64
 // CHECK:     %[[CF2:.*]] = arith.constant 2.300000e-01 : f64
 // CHECK:     quake.rx (%[[CF]]) %1 : (f64,
@@ -48,8 +48,8 @@ func.func @duplicate_rotation_check() {
 func.func @duplicate_rotation_check2() {
   %0 = arith.constant 2 : i32
   %c_0 = arith.constant 0 : i32
-  %qubits = quake.alloca [ %0 : i32] !quake.qvec<?>
-  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>, i32) -> !quake.ref
+  %qubits = quake.alloca [ %0 : i32] !quake.veq<?>
+  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.veq<?>, i32) -> !quake.ref
   %c_angle = arith.constant 0.59 : f64
   %c_angle2 = arith.constant 0.23 : f64
   quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
@@ -71,8 +71,8 @@ func.func @returns_angle(%arg0 : f64, %arg1 : f64) -> (f64) {
 // CHECK: func.func @duplicate_rotation_check3() {
 // CHECK:     %[[C2:.*]] = arith.constant 2 : i32
 // CHECK:     %[[C0:.*]] = arith.constant 0 : i32
-// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.qvec<?>
-// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.qvec<?>, i32) -> !quake.ref
+// CHECK:     %0 = quake.alloca[%[[C2]] : i32] !quake.veq<?>
+// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:     %[[CF:.*]] = arith.constant 5.900000e-01 : f64
 // CHECK:     %[[CF2:.*]] = arith.constant 2.300000e-01 : f64
 // CHECK:     %[[CF3:.*]] = arith.constant 6.400000e-01 : f64
@@ -87,8 +87,8 @@ func.func @returns_angle(%arg0 : f64, %arg1 : f64) -> (f64) {
 func.func @duplicate_rotation_check3() {
   %0 = arith.constant 2 : i32
   %c_0 = arith.constant 0 : i32
-  %qubits = quake.alloca [ %0 : i32 ] !quake.qvec<?>
-  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.qvec<?>, i32) -> !quake.ref
+  %qubits = quake.alloca [ %0 : i32 ] !quake.veq<?>
+  %q0 = quake.extract_ref %qubits[%c_0] : (!quake.veq<?>, i32) -> !quake.ref
   %c_angle = arith.constant 0.59 : f64
   %c_angle2 = arith.constant 0.23 : f64
   %c_angle3 = arith.constant 0.64 : f64

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -362,7 +362,7 @@ CUDAQ_TEST(BuilderTester, checkReset) {
     auto entryPoint = cudaq::make_kernel();
     auto q = entryPoint.qalloc(2);
     entryPoint.x(q);
-    // For now, don't allow reset on qvec.
+    // For now, don't allow reset on veq.
     entryPoint.reset(q);
     entryPoint.mz(q);
     printf("%s\n", entryPoint.to_quake().c_str());


### PR DESCRIPTION
The QVec type is already prefixed with `!quake`, so the extra `q` prefix adds little new information. As a compromise alternative, we spell the trailing `vec`, short for vector, as `veq` to make sure there is no ambiguity. In particular with the `!cc.stdvec` type, which models a C++ `std::vector<T>`.
