### PR TITLE
Fold constant into extract_ref op

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,8 +68,8 @@ Additional links that may be helpful that are not listed above:
   objects](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing)
 - [Sphinx configuration
   options](https://www.sphinx-doc.org/en/master/usage/configuration.html)
-- [Common Sphinx warnings and
-  fixes](https://developer.mantidproject.org/Standards/DocumentationGuideForDevs.html#common-warnings-and-fixes)
+- <!-- markdown-link-check-disable> [Common Sphinx warnings and
+  fixes](https://developer.mantidproject.org/Standards/DocumentationGuideForDevs.html#common-warnings-and-fixes) <!-- markdown-link-check-enable>
 - [Syntax highlighting in inline
   code](https://sphinxawesome.xyz/demo/inline-code/#syntax-highlighting-in-inline-code)
 - [Test examples in Python

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,8 @@ Additional links that may be helpful that are not listed above:
 - [Sphinx configuration
   options](https://www.sphinx-doc.org/en/master/usage/configuration.html)
 - <!-- markdown-link-check-disable> [Common Sphinx warnings and
-  fixes](https://developer.mantidproject.org/Standards/DocumentationGuideForDevs.html#common-warnings-and-fixes) <!-- markdown-link-check-enable>
+  fixes](https://developer.mantidproject.org/Standards/DocumentationGuideForDevs.html#common-warnings-and-fixes)
+  <!-- markdown-link-check-enable>
 - [Syntax highlighting in inline
   code](https://sphinxawesome.xyz/demo/inline-code/#syntax-highlighting-in-inline-code)
 - [Test examples in Python

--- a/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
@@ -36,18 +36,32 @@ def ForwardConstantVeqSizePattern : Pat<
 
 def SizeIsPresentPred : Constraint<CPred<
       "$0.size() == 1 &&"
-      " dyn_cast_or_null<mlir::arith::ConstantOp>($0[0].getDefiningOp())">>;
+      " dyn_cast_or_null<mlir::arith::ConstantIntOp>($0[0].getDefiningOp())">>;
 
 def createAllocaOp : NativeCodeCall<
       "quake::createConstantAlloca($_builder, $_loc, $0, $1)">;
 
 // %2 = constant 10 : i32
-// %3 = quake.alloca (%2 : i32) : !quake.ref<?>
+// %3 = quake.alloca [%2 : i32] !quake.veq<?>
 // ───────────────────────────────────────────
-// %3 = quake.alloca : !quake.ref<10>
+// %3 = quake.alloca !quake.veq<10>
 def FuseConstantToAllocaPattern : Pat<
       (quake_AllocaOp:$alloca $optSize), (createAllocaOp $alloca, $optSize),
       [(SizeIsPresentPred $optSize)]>;
+
+def createExtractRefOp : NativeCodeCall<
+      "$_builder.create<quake::ExtractRefOp>($_loc, $0,"
+      " cast<mlir::arith::ConstantIntOp>($1[0].getDefiningOp()).getValue()."
+      " cast<mlir::IntegerAttr>().getInt())">;
+
+// %2 = constant 10 : i32
+// %3 = quake.extract_ref %1[%2] : (!quake.veq<?>, i32) -> !quake.ref
+// ───────────────────────────────────────────
+// %3 = quake.extract_ref %1[10] : (!quake.veq<?>) -> !quake.ref
+def FuseConstantToExtractRefPattern : Pat<
+      (quake_ExtractRefOp $veq, $index, $rawIndex),
+      (createExtractRefOp $veq, $index),
+      [(SizeIsPresentPred $index)]>;
 
 def createSizedSubVecOp : NativeCodeCall<
       "quake::createSizedSubVecOp($_builder, $_loc, $0, $1, $2, $3)">;

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -223,21 +223,44 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
 
   let arguments = (ins
     VeqType:$veq,
-    AnySignlessIntegerOrIndex:$index
+    Optional<AnySignlessIntegerOrIndex>:$index,
+    I64Attr:$rawIndex
   );
   let results = (outs RefType:$ref);
 
-  let assemblyFormat = [{
-    $veq `[` $index `]` `:`  functional-type(operands, results) attr-dict
-  }];
-
   let builders = [
+    OpBuilder<(ins "mlir::Value":$veq, "mlir::Value":$index,
+                   "mlir::IntegerAttr":$rawIndex), [{
+      return build($_builder, $_state, $_builder.getType<RefType>(), veq,
+                   index, rawIndex);
+    }]>,
     OpBuilder<(ins "mlir::Value":$veq, "mlir::Value":$index), [{
       return build($_builder, $_state, $_builder.getType<RefType>(), veq,
-                   index);
+                   index, ExtractRefOp::kDynamicIndex);
     }]>,
+    OpBuilder<(ins "mlir::Value":$veq, "std::size_t":$rawIndex), [{
+      auto i64Ty = $_builder.getI64Type();
+      return build($_builder, $_state, $_builder.getType<RefType>(), veq,
+                   mlir::Value{}, mlir::IntegerAttr::get(i64Ty, rawIndex));
+    }]>
   ];
-  let hasFolder = 1;
+
+  let assemblyFormat = [{
+    $veq `[` custom<RawIndex>($index, $rawIndex) `]` `:`
+      functional-type(operands, results) attr-dict
+  }];
+
+  //let hasFolder = 1;
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    static constexpr std::size_t kDynamicIndex =
+      std::numeric_limits<std::size_t>::max();
+
+    bool hasConstantIndex() { return !getIndex(); }
+    std::size_t getConstantIndex() { return getRawIndex(); }
+  }];
 }
 
 def quake_RelaxSizeOp : QuakeOp<"relax_size", [Pure]> {

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -250,7 +250,6 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
       functional-type(operands, results) attr-dict
   }];
 
-  //let hasFolder = 1;
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
 

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -114,38 +114,6 @@ static void printRawIndex(OpAsmPrinter &printer, quake::ExtractRefOp refOp,
     printer << rawIndex.getValue();
 }
 
-#if 0
-OpFoldResult quake::ExtractRefOp::fold(FoldAdaptor adaptor) {
-  auto veq = getVeq();
-  auto op = getOperation();
-  for (auto user : veq.getUsers()) {
-    if (user == op || op->getBlock() != user->getBlock() ||
-        op->isBeforeInBlock(user))
-      continue;
-    if (auto extractRefOp = dyn_cast<quake::ExtractRefOp>(user)) {
-      // Compare any constant extract_ref index values.
-      auto getOffset =
-          [&](quake::ExtractRefOp extract) -> std::optional<std::size_t> {
-        if (static_cast<std::size_t>(extract.getRawIndex()) == kDynamicIndex) {
-          if (auto val = extract.getIndex())
-            if (auto defv = cast<arith::ConstantOp>(val.getDefiningOp()))
-              if (auto intv = dyn_cast_or_null<IntegerAttr>(defv.getValue()))
-                return intv.getValue().getLimitedValue();
-          return {};
-        }
-        return extract.getRawIndex();
-      };
-      auto firstIdx = getOffset(extractRefOp);
-      auto secondIdx = getOffset(*this);
-      // Merge the two extract_ref ops if the indices are the same.
-      if (firstIdx && secondIdx && firstIdx == secondIdx)
-        return extractRefOp.getResult();
-    }
-  }
-  return {};
-}
-#endif
-
 void quake::ExtractRefOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<FuseConstantToExtractRefPattern>(context);

--- a/lib/Optimizer/Transforms/QuakeObserveAnsatz.cpp
+++ b/lib/Optimizer/Transforms/QuakeObserveAnsatz.cpp
@@ -85,13 +85,10 @@ private:
       data.nQubits += op.getResult().getType().cast<quake::VeqType>().getSize();
     });
 
-    // NOTE this assumes canonicalization has run.
+    // NOTE: assumes canonicalization and cse have run.
     funcOp->walk([&](quake::ExtractRefOp op) {
-      auto idxVal = op.getIndex();
-      if (auto defOp = idxVal.getDefiningOp<arith::ConstantIntOp>()) {
-        auto constant = defOp.value();
-        data.qubitValues.insert({constant, op.getResult()});
-      }
+      if (op.hasConstantIndex())
+        data.qubitValues.insert({op.getConstantIndex(), op.getResult()});
     });
 
     // Count all measures

--- a/python/tests/compiler/conditional.py
+++ b/python/tests/compiler/conditional.py
@@ -49,11 +49,9 @@ def test_kernel_conditional():
 # CHECK:           %[[VAL_0:.*]] = arith.constant 2 : index
 # CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i32
-# CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
-# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.veq<2>, i32) -> !quake.ref
-# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_3]]] : (!quake.veq<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]][0] : (!quake.veq<2>) -> !quake.ref
+# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
 # CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> i1 {registerName = "measurement_"}
 # CHECK:           cc.if(%[[VAL_8]]) {
@@ -65,7 +63,7 @@ def test_kernel_conditional():
 # CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_13:.*]]: index):
-# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_13]]] : (!quake.veq<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_5]][%[[VAL_13]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             quake.x %[[VAL_14]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_13]] : index
 # CHECK:           } step {

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -64,7 +64,7 @@ def test_kernel_control_no_args(qubit_count):
 # CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_7:.*]]: index):
-# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!quake.veq<5>, index) -> !quake.ref
+# CHECK:             %[[VAL_8:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_7]]] : (!quake.veq<5>, index) -> !quake.ref
 # CHECK:             quake.x %[[VAL_8]] : (!quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_7]] : index
 # CHECK:           } step {
@@ -320,10 +320,9 @@ def test_sample_control_qreg_args():
 # CHECK:           %[[VAL_1:.*]] = arith.constant 2 : i64
 # CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!quake.veq<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
 # CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]]] %[[VAL_6]] : (!quake.veq<2>, !quake.ref) -> ()
@@ -333,7 +332,7 @@ def test_sample_control_qreg_args():
 # CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_12:.*]]: index):
-# CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!quake.veq<2>, index) -> !quake.ref
+# CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_5]][%[[VAL_12]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_15:.*]] = arith.index_cast %[[VAL_12]] : index to i64
 # CHECK:             %[[VAL_16:.*]] = llvm.getelementptr %[[VAL_8]]{{\[}}%[[VAL_15]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>

--- a/python/tests/compiler/measure.py
+++ b/python/tests/compiler/measure.py
@@ -38,11 +38,9 @@ def test_kernel_measure_1q():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
-# CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
-# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
-# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<2>) -> !quake.ref
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           %[[VAL_5:.*]] = quake.mx %[[VAL_3]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           %[[VAL_6:.*]] = quake.mx %[[VAL_4]] : (!quake.ref) -> i1 {registerName = ""}
 # CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] : (!quake.ref) -> i1 {registerName = ""}
@@ -82,7 +80,7 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
-# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_9]]] : (!quake.veq<3>, index) -> !quake.ref
+# CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_9]]] : (!quake.veq<3>, index) -> !quake.ref
 # CHECK:             %[[VAL_11:.*]] = quake.mx %[[VAL_10]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_9]] : index to i64
 # CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
@@ -99,7 +97,7 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_19]](%[[VAL_18]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_20:.*]]: index):
-# CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_20]]] : (!quake.veq<3>, index) -> !quake.ref
+# CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_20]]] : (!quake.veq<3>, index) -> !quake.ref
 # CHECK:             %[[VAL_22:.*]] = quake.my %[[VAL_21]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_23:.*]] = arith.index_cast %[[VAL_20]] : index to i64
 # CHECK:             %[[VAL_24:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_23]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
@@ -116,7 +114,7 @@ def test_kernel_measure_qreg():
 # CHECK:             cc.condition %[[VAL_30]](%[[VAL_29]] : index)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_31:.*]]: index):
-# CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_31]]] : (!quake.veq<3>, index) -> !quake.ref
+# CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_31]]] : (!quake.veq<3>, index) -> !quake.ref
 # CHECK:             %[[VAL_33:.*]] = quake.mz %[[VAL_32]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_34:.*]] = arith.index_cast %[[VAL_31]] : index to i64
 # CHECK:             %[[VAL_35:.*]] = llvm.getelementptr %[[VAL_27]]{{\[}}%[[VAL_34]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>

--- a/python/tests/compiler/multi_qubit.py
+++ b/python/tests/compiler/multi_qubit.py
@@ -44,11 +44,9 @@ def test_kernel_2q():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
-# CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
-# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
-# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_0]]] : (!quake.veq<2>, i32) -> !quake.ref
+# CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<2>) -> !quake.ref
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.h [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.x [%[[VAL_4]]] %[[VAL_3]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.y [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
@@ -85,13 +83,10 @@ def test_kernel_3q():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
-# CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i32
-# CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-# CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 # CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<3>
-# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.veq<3>, i32) -> !quake.ref
-# CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.veq<3>, i32) -> !quake.ref
-# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_0]]] : (!quake.veq<3>, i32) -> !quake.ref
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<3>) -> !quake.ref
+# CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<3>) -> !quake.ref
+# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][2] : (!quake.veq<3>) -> !quake.ref
 # CHECK:           quake.h [%[[VAL_4]], %[[VAL_5]]] %[[VAL_6]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
 # CHECK:           quake.x [%[[VAL_6]], %[[VAL_4]]] %[[VAL_5]] : (!quake.ref, !quake.ref, !quake.ref) -> ()
 # CHECK:           quake.y [%[[VAL_5]], %[[VAL_6]]] %[[VAL_4]] : (!quake.ref, !quake.ref, !quake.ref) -> ()

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -116,8 +116,6 @@ struct F {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__C()
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
@@ -139,20 +137,20 @@ struct F {
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:             quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:             cf.br ^bb8
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref,
 // CHECK:             func.call @_Z2g2v() : () -> ()
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.y %[[VAL_20]] :
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb6:
@@ -186,8 +184,6 @@ struct F {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__D()
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
@@ -209,20 +205,20 @@ struct F {
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] :
 // CHECK:             quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:             func.call @_Z2g2v() : () -> ()
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.y %[[VAL_20]]
 // CHECK:             cf.br ^bb8
 // CHECK:           ^bb6:
@@ -256,8 +252,6 @@ struct F {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__E()
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
@@ -278,20 +272,20 @@ struct F {
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
 // CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref)
 // CHECK:           quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:           cf.br ^bb8
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           call @_Z2g2v() : () -> ()
 // CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.y %[[VAL_20]]
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb6:
@@ -324,8 +318,6 @@ struct F {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__F()
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
@@ -346,20 +338,20 @@ struct F {
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
 // CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]]
 // CHECK:           quake.dealloc %[[VAL_14]] : !quake.ref
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]]
 // CHECK:           call @_Z2g2v() : () -> ()
 // CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.y %[[VAL_20]] : (!quake.ref)
 // CHECK:           cf.br ^bb9
 // CHECK:         ^bb6:

--- a/test/Quake-QIR/negated_control.cpp
+++ b/test/Quake-QIR/negated_control.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  *******************************************************************************/
 
-// RUN: cudaq-quake %s | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-quake %s | cudaq-opt --canonicalize --cse | cudaq-translate --convert-to=qir | FileCheck %s
 
 #include <cudaq.h>
 

--- a/test/Quake/adjoint-1.qke
+++ b/test/Quake/adjoint-1.qke
@@ -63,8 +63,6 @@ module {
 
 // CHECK-LABEL:   func.func private @__nvqpp__mlirgen__MyKernel.adj(
 // CHECK-SAME:        %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i32) {
-// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<2>
@@ -74,8 +72,8 @@ module {
 // CHECK:             cc.continue %[[VAL_1]] : i1
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_9:.*]]) {
-// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_7]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %[[VAL_7]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.h %[[VAL_11]] :
 // CHECK:             quake.z [%[[VAL_10]]] %[[VAL_11]] :
 // CHECK:             quake.y %[[VAL_11]] :
@@ -88,8 +86,8 @@ module {
 // CHECK:             cc.condition %[[VAL_18]](%[[VAL_16]], %[[VAL_17]] : i32, i32)
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_19:.*]]: i32, %[[VAL_20:.*]]: i32):
-// CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_7]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:             %[[VAL_22:.*]] = quake.extract_ref %[[VAL_7]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.z [%[[VAL_21]]] %[[VAL_22]] :
 // CHECK:             quake.y %[[VAL_22]] :
 // CHECK:             quake.x [%[[VAL_21]]] %[[VAL_22]] :
@@ -101,8 +99,8 @@ module {
 // CHECK:             cc.continue %[[VAL_25]], %[[VAL_26]] : i32, i32
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_0]]) {
-// CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_4]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_28:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_3]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:             %[[VAL_27:.*]] = quake.extract_ref %[[VAL_7]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:             %[[VAL_28:.*]] = quake.extract_ref %[[VAL_7]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.y [%[[VAL_27]]] %[[VAL_28]] :
 // CHECK:             quake.x %[[VAL_28]] :
 // CHECK:             quake.h [%[[VAL_27]]] %[[VAL_28]] :

--- a/test/Quake/bell.qke
+++ b/test/Quake/bell.qke
@@ -9,11 +9,9 @@
 // RUN: cudaq-opt %s  --canonicalize | FileCheck %s
 module {
     // CHECK-LABEL: func @bell()
-    // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-    // CHECK: %[[C1:.*]] = arith.constant 1 : i32
     // CHECK: %0 = quake.alloca !quake.veq<2>
-    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<2>, i32) -> !quake.ref
-    // CHECK: %2 = quake.extract_ref %0[%[[C1]]] : (!quake.veq<2>, i32) -> !quake.ref
+    // CHECK: %1 = quake.extract_ref %0[0] : (!quake.veq<2>) -> !quake.ref
+    // CHECK: %2 = quake.extract_ref %0[1] : (!quake.veq<2>) -> !quake.ref
     // CHECK: quake.h %1
     // CHECK: quake.x [%1] %2 :
     // CHECK: %3 = quake.mz %1 : (!quake.ref) -> i1

--- a/test/Quake/canonical-1.qke
+++ b/test/Quake/canonical-1.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --canonicalize %s | FileCheck %s
+// RUN: cudaq-opt --canonicalize --cse %s | FileCheck %s
 
 func.func @test1(%arg0 : !quake.veq<?>) -> i1 {
   %true = arith.constant true
@@ -25,11 +25,10 @@ func.func @test2() {
 }
 
 // CHECK-LABEL:   func.func @test2() {
-// CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<10>
 // CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.veq<10>) -> !quake.veq<?>
 // CHECK:           %[[VAL_3:.*]] = call @test1(%[[VAL_2]]) : (!quake.veq<?>) -> i1
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_0]]] : (!quake.veq<10>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<10>) -> !quake.ref
 // CHECK:           quake.h %[[VAL_4]]
 // CHECK:           return
 // CHECK:         }
@@ -48,12 +47,11 @@ func.func @test3() {
 }
 
 // CHECK-LABEL:   func.func @test3() {
-// CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 7 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 4 : i64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<10>
 // CHECK:           %[[VAL_4:.*]] = quake.subvec %[[VAL_3]], %[[VAL_2]], %[[VAL_1]] : (!quake.veq<10>, i64, i64) -> !quake.veq<4>
-// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_0]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_4]][2] : (!quake.veq<4>) -> !quake.ref
 // CHECK:           quake.h %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -73,12 +71,10 @@ func.func @test_qextract_1() {
 }
 
 // CHECK-LABEL:   func.func @test_qextract_1() {
-// CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -105,17 +101,14 @@ func.func @test_qextract_2(%arg0: i1) {
 
 // CHECK-LABEL:   func.func @test_qextract_2(
 // CHECK-SAME:                               %[[VAL_0:.*]]: i1) {
-// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.h %[[VAL_4]] :
 // CHECK:           cc.if(%[[VAL_0]]) {
-// CHECK:             %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:             %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:             quake.x [%[[VAL_5]]] %[[VAL_6]] :
+// CHECK:             %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:             quake.x [%[[VAL_4]]] %[[VAL_6]] :
 // CHECK:           }
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_4]]] %[[VAL_7]] :
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/ccnot.qke
+++ b/test/Quake/ccnot.qke
@@ -17,13 +17,12 @@ module {
     // CHECK: }
     
     // CHECK-LABEL: func.func @ccnot() {
-    // CHECK:   %[[C1:.*]] = arith.constant 1 : i32
     // CHECK:   %[[a0:.*]] = quake.alloca !quake.veq<3>
     // CHECK:   affine.for %[[arg0:.*]] = 0 to 3 {
     // CHECK:     %[[a2:.*]] = quake.extract_ref %[[a0]][%[[arg0]]] : (!quake.veq<3>, index) -> !quake.ref
     // CHECK:     quake.x %[[a2]] :
     // CHECK:   }
-    // CHECK:   %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.veq<3>, i32) -> !quake.ref
+    // CHECK:   %[[a1:.*]] = quake.extract_ref %[[a0]][1] : (!quake.veq<3>) -> !quake.ref
     // CHECK:   quake.x %[[a1]] :
     // CHECK:   return
     // CHECK: }

--- a/test/Quake/compute_action.qke
+++ b/test/Quake/compute_action.qke
@@ -47,23 +47,19 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
 }
 
 // CHECK-LABEL:   func.func private @__nvqpp__lifted.lambda.{{[01]}}.adj(
-// CHECK-SAME:            %[[VAL_0:.*]]: !quake.veq<5>,
-// CHECK-SAME:            %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64) {
-// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_1]]] : (!quake.veq<5>, i64) -> !quake.ref
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.veq<5>, i64) -> !quake.ref
+// CHECK-SAME:            %[[VAL_0:.*]]: !quake.veq<5>) {
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<5>) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<5>) -> !quake.ref
 // CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
 // CHECK:           quake.t<adj> %[[VAL_3]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__t() attributes {"cudaq-entrypoint"} {
-// CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i64
-// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<5>
-// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]], %[[VAL_2]], %[[VAL_1]]) : (!quake.veq<5>, i64, i64) -> ()
-// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]], %[[VAL_0]]) : (!quake.veq<5>, i64) -> ()
-// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}.adj(%[[VAL_3]], %[[VAL_2]], %[[VAL_1]]) : (!quake.veq<5>, i64, i64) -> ()
+// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]]) : (!quake.veq<5>) -> ()
+// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}(%[[VAL_3]]) : (!quake.veq<5>) -> ()
+// CHECK:           call @__nvqpp__lifted.lambda.{{[01]}}.adj(%[[VAL_3]]) : (!quake.veq<5>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/deuteron.qke
+++ b/test/Quake/deuteron.qke
@@ -10,11 +10,9 @@
 
 // CHECK-LABEL:  func.func @ansatz(
 // CHECK-SAME: %[[arg0:.*]]: f64) {
-// CHECK:    %[[C0:.*]] = arith.constant 0 : i32
-// CHECK:    %[[C1:.*]] = arith.constant 1 : i32
 // CHECK:    %[[a0:.*]] = quake.alloca !quake.veq<2>
-// CHECK:    %[[a1:.*]] = quake.extract_ref %[[a0]][%[[C0]]] : (!quake.veq<2>, i32) -> !quake.ref
-// CHECK:    %[[a2:.*]] = quake.extract_ref %[[a0]][%[[C1]]] : (!quake.veq<2>, i32) -> !quake.ref
+// CHECK:    %[[a1:.*]] = quake.extract_ref %[[a0]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:    %[[a2:.*]] = quake.extract_ref %[[a0]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:    quake.x %[[a1]]
 // CHECK:    quake.ry (%[[arg0]]) %[[a2]] : (f64, !quake.ref) -> ()
 // CHECK:    quake.x [%[[a2]]] %[[a1]] : (!quake.ref, !quake.ref) -> ()

--- a/test/Quake/ghz.qke
+++ b/test/Quake/ghz.qke
@@ -9,10 +9,9 @@
 // RUN: cudaq-opt %s --canonicalize | FileCheck %s
 module {
     // CHECK: func.func @ghz(%[[arg0:.*]]: i32) {
-    // CHECK: %[[C0:.*]] = arith.constant 0 : i32
     // CHECK: %[[C1:.*]] = arith.constant 1 : i32
     // CHECK: %0 = quake.alloca[%[[arg0]] : i32] !quake.veq<?>
-    // CHECK: %1 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<?>, i32) -> !quake.ref
+    // CHECK: %1 = quake.extract_ref %0[0] : (!quake.veq<?>) -> !quake.ref
     // CHECK: quake.h %1 :
     // CHECK: %2 = arith.subi %arg0, %[[C1]] : i32
     // CHECK: %3 = arith.index_cast %2 : i32 to index

--- a/test/Quake/lambda_variable-1.qke
+++ b/test/Quake/lambda_variable-1.qke
@@ -44,12 +44,10 @@ module attributes{ qtx.mangled_name_map = { __nvqpp__mlirgen__test3_callee = "_Z
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_callee(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][0] : (!quake.veq<?>) -> !quake.ref
 // CHECK:           %[[VAL_5:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())
 // CHECK:           call_indirect %[[VAL_5]](%[[VAL_0]], %[[VAL_4]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
-// CHECK:            %[[VAL_6:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_2]]] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:            %[[VAL_6:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<?>) -> !quake.ref
 // CHECK:           %[[VAL_7:.*]] = cc.callable_func %[[VAL_0]] : (!cc.lambda<(!quake.ref) -> ()>) -> ((!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ())
 // CHECK:           call_indirect %[[VAL_7]](%[[VAL_0]], %[[VAL_6]]) : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 

--- a/test/Quake/observeAnsatz.qke
+++ b/test/Quake/observeAnsatz.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(canonicalize,quake-observe-ansatz{term-bsf=1,1,0,0}),canonicalize)' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(canonicalize,cse,quake-observe-ansatz{term-bsf=1,1,0,0}),canonicalize)' %s | FileCheck %s
 
 module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ansatz = "_ZN6ansatzclEd"}} {
   func.func @__nvqpp__mlirgen__ansatz(%arg0: f64) {
@@ -27,7 +27,7 @@ module attributes {qtx.mangled_name_map = {__nvqpp__mlirgen__ansatz = "_ZN6ansat
   }
 }
 
-// CHECK: quake.h %[[VAL_4:.*]]
-// CHECK: quake.h %[[VAL_5:.*]]
-// CHECK: %[[VAL_0:.*]] = quake.mz %[[VAL_1:.*]] : (!quake.ref) -> i1
-// CHECK: %[[VAL_2:.*]] = quake.mz %[[VAL_3:.*]] : (!quake.ref) -> i1
+// CHECK: quake.h %
+// CHECK: quake.h %
+// CHECK: %{{.*}} = quake.mz %{{.*}} : (!quake.ref) -> i1
+// CHECK: %{{.*}} = quake.mz %{{.*}} : (!quake.ref) -> i1

--- a/test/Quake/qpe.qke
+++ b/test/Quake/qpe.qke
@@ -13,9 +13,8 @@
 // CHECK:     return
 // CHECK:   }
 // CHECK:   func.func @qpe_test_callable(%arg0: i32, %arg1: i32, %arg2: (!quake.veq<?>) -> !quake.veq<?>, %arg3: (!quake.ref) -> ()) {
-// CHECK:     %[[C0:.*]] = arith.constant 0 : i32
 // CHECK:     %0 = quake.alloca[%arg0 : i32] !quake.veq<?>
-// CHECK:     %1 = quake.extract_ref %0[%[[C0]]] : (!quake.veq<?>, i32) -> !quake.ref
+// CHECK:     %1 = quake.extract_ref %0[0] : (!quake.veq<?>) -> !quake.ref
 // CHECK:     call_indirect %arg3(%1) : (!quake.ref) -> ()
 // CHECK:     return
 // CHECK:   }


### PR DESCRIPTION
Typically the index into the veq is a constant. These changes allow the op to hold the constant itself instead of relying on a ConstantOp. This will avoid issues with bad code sharing, allow the use of CSE, etc.