### PR TITLE
Increase performance of quantum allocation and deallocation in simulation

### DIFF
--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -42,7 +42,7 @@ protected:
   /// or observation
   cudaq::ExecutionContext *executionContext;
 
-  /// @brief Store qubits for delayed deletion under
+  /// @brief Store qudits for delayed deletion under
   /// certain execution contexts
   std::vector<QuditInfo> contextQuditIdsForDeletion;
 

--- a/runtime/cudaq/qis/managers/qir/QIRForwards.h
+++ b/runtime/cudaq/qis/managers/qir/QIRForwards.h
@@ -18,6 +18,7 @@ using TuplePtr = int8_t *;
 
 /// QIR QIS external declarations
 extern "C" {
+void __quantum__rt__deallocate_all(const std::size_t, const std::size_t *);
 Array *__quantum__rt__array_concatenate(Array *, Array *);
 void __quantum__rt__array_release(Array *);
 int8_t *__quantum__rt__array_get_element_ptr_1d(Array *q, uint64_t);
@@ -26,6 +27,7 @@ Array *__quantum__rt__array_create_1d(int, int64_t);
 void __quantum__qis__exp__body(Array *paulis, double angle, Array *qubits);
 void __quantum__qis__measure__body(Array *, Array *);
 Qubit *__quantum__rt__qubit_allocate();
+Array *__quantum__rt__qubit_allocate_array(uint64_t);
 void __quantum__rt__qubit_release(Qubit *);
 void __quantum__rt__setExecutionContext(cudaq::ExecutionContext *);
 void __quantum__rt__resetExecutionContext();

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -64,6 +64,9 @@ public:
   /// @brief Deallocate the qubit with give idx
   virtual void deallocate(const std::size_t qubitIdx) = 0;
 
+  /// @brief Deallocate all the provided qubits.
+  virtual void deallocateQubits(const std::vector<std::size_t> &qubits) = 0;
+
   /// @brief Reset the current execution context.
   virtual void resetExecutionContext() = 0;
 
@@ -663,6 +666,26 @@ public:
       while (!gateQueue.empty())
         gateQueue.pop();
     }
+  }
+
+  /// @brief Deallocate all requested qubits. If the number of qubits
+  /// is equal to the number of allocated qubits, then clear the entire
+  /// state at once.
+  void deallocateQubits(const std::vector<std::size_t> &qubits) override {
+    // Do nothing if there are no allocated qubits.
+    if (nQubitsAllocated == 0)
+      return;
+
+    if (qubits.size() == tracker.totalNumQubits() - tracker.numAvailable()) {
+      cudaq::info("Deallocate all qubits.");
+      deallocateState();
+      for (auto &q : qubits)
+        tracker.returnIndex(q);
+      return;
+    }
+
+    for (auto &q : qubits)
+      deallocate(q);
   }
 
   /// @brief Reset the current execution context.

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -626,6 +626,8 @@ public:
         count = qubits.back() + 1 - nQubitsAllocated;
     }
 
+    cudaq::info("Allocating {} new qubits.", count);
+
     previousStateDimension = stateDimension;
     nQubitsAllocated += count;
     stateDimension = calculateStateDim(nQubitsAllocated);

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -215,6 +215,12 @@ void __quantum__rt__qubit_release(Qubit *q) {
       end);
 }
 
+void __quantum__rt__deallocate_all(const std::size_t numQubits,
+                                   const std::size_t *qubitIdxs) {
+  std::vector<std::size_t> qubits(qubitIdxs, qubitIdxs + numQubits);
+  nvqir::getCircuitSimulatorInternal()->deallocateQubits(qubits);
+}
+
 #define ONE_QUBIT_QIS_FUNCTION(GATENAME)                                       \
   void QIS_FUNCTION_NAME(GATENAME)(Qubit * qubit) {                            \
     auto targetIdx = qubitToSizeT(qubit);                                      \

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -148,6 +148,8 @@ if (CUDAQ_ENABLE_PYTHON)
     cudaq-chemistry
     cudaq-pyscf
     gtest_main)
-  gtest_discover_tests(test_domains)
+  gtest_discover_tests(test_domains PROPERTIES 
+         ENVIRONMENT 
+         "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BINARY_DIR}/python")
 endif()
 

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -48,7 +48,13 @@ protected:
     state = qpp::kron(state, zeroState);
   }
 
-  void deallocateQudit(std::size_t q) override {}
+  void allocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {
+    for (auto &q : qudits)
+      allocateQudit(q);
+  }
+
+  void deallocateQudit(const cudaq::QuditInfo &q) override {}
+  void deallocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {}
 
   void handleExecutionContextChanged() override {}
 


### PR DESCRIPTION
For simulation (library-mode) ensure that `qreg q(N)` allocates all qubits at once. Ensure deallocations (when sampling or observing an operator) happen at once without explicit qubit reset. 