### PR TITLE
Improve unique qudit index allocation and deallocation.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ if (CUSTATEVEC_ROOT AND CUDA_FOUND)
     NAME
       nvqpp_cuquantum
     COMMAND
-      bash -c "${CMAKE_BINARY_DIR}/bin/nvq++ -qpu cuquantum ${CMAKE_CURRENT_SOURCE_DIR}/sphinx/examples/cpp/basics/cuquantum_backends.cpp -o CuQuantumBackend ;\
+      bash -c "${CMAKE_BINARY_DIR}/bin/nvq++ --target nvidia ${CMAKE_CURRENT_SOURCE_DIR}/sphinx/examples/cpp/basics/cuquantum_backends.cpp -o CuQuantumBackend ;\
                 ${CMAKE_CURRENT_BINARY_DIR}/CuQuantumBackend"
     )
 endif()

--- a/runtime/common/QuditIdTracker.h
+++ b/runtime/common/QuditIdTracker.h
@@ -25,6 +25,9 @@ private:
   std::vector<std::size_t> recycledQudits;
 
 public:
+  QuditIdTracker() = default;
+  QuditIdTracker(const QuditIdTracker &) = delete;
+
   /// @brief Return the next available index,
   /// take from the recycled qudit indentifiers
   /// if possible.
@@ -35,8 +38,8 @@ public:
       return ret;
     }
 
-    auto next = recycledQudits.front();
-    recycledQudits.erase(recycledQudits.begin());
+    auto next = recycledQudits.back();
+    recycledQudits.pop_back();
     return next;
   }
 
@@ -45,7 +48,8 @@ public:
   /// tracker.
   void returnIndex(std::size_t idx) {
     recycledQudits.push_back(idx);
-    std::sort(recycledQudits.begin(), recycledQudits.end());
+    std::sort(recycledQudits.begin(), recycledQudits.end(),
+              std::greater<std::size_t>());
     if (recycledQudits.size() == currentId) {
       currentId = 0;
       recycledQudits.clear();
@@ -55,7 +59,7 @@ public:
   /// @brief Return true if all qudits have been deallocated.
   bool allDeallocated() {
     // Either current id is 0 and we don't have recycled bits,
-    return (currentId == 0 && recycledQudits.empty());
+    return currentId == 0 && recycledQudits.empty();
   }
 
   /// @brief Return the number of qudits allocated.

--- a/runtime/common/QuditIdTracker.h
+++ b/runtime/common/QuditIdTracker.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <algorithm>
-#include <deque>
+#include <vector>
 
 namespace cudaq {
 

--- a/runtime/common/QuditIdTracker.h
+++ b/runtime/common/QuditIdTracker.h
@@ -1,0 +1,67 @@
+/*************************************************************** -*- C++ -*- ***
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ *******************************************************************************/
+
+#pragma once
+
+#include <deque>
+#include <algorithm>
+
+namespace cudaq {
+
+/// @brief The QuditIdTracker tracks unique integer 
+/// indices for allocated qudits. It will recycle indices 
+/// when the qudit is deallocated, so that it can be reused. 
+class QuditIdTracker {
+private:
+
+  /// @brief The current identifier.
+  std::size_t currentId = 0;
+
+  /// @brief The queue of recycled qubits. 
+  std::deque<std::size_t> recycledQudits;
+
+public:
+
+  /// @brief Return the next available index, 
+  /// take from the recycled qudit indentifiers 
+  /// if possible. 
+  std::size_t getNextIndex() {
+    if (recycledQudits.empty()) {
+      std::size_t ret = currentId;
+      currentId++;
+      return ret;
+    }
+
+    auto next = recycledQudits.front();
+    recycledQudits.pop_front();
+    return next;
+  }
+
+  /// @brief Return indices due to qudit deallocation.
+  /// If all qudits have been deallocated, reset the 
+  /// tracker. 
+  void returnIndex(std::size_t idx) {
+    recycledQudits.push_front(idx);
+    std::sort(recycledQudits.begin(), recycledQudits.end());
+    if (recycledQudits.size() == currentId) {
+      currentId = 0;
+      recycledQudits.clear();
+    }
+  }
+
+  /// @brief Return true if all qudits have been deallocated.
+  bool allDeallocated() {
+    // Either current id is 0 and we don't have recycled bits,
+    return (currentId == 0 && recycledQudits.empty());
+  }
+
+  /// @brief Return the number of qudits allocated.
+  std::size_t numAllocated() { return currentId - recycledQudits.size(); }
+};
+
+} // namespace cudaq

--- a/runtime/common/QuditIdTracker.h
+++ b/runtime/common/QuditIdTracker.h
@@ -8,28 +8,26 @@
 
 #pragma once
 
-#include <deque>
 #include <algorithm>
+#include <deque>
 
 namespace cudaq {
 
-/// @brief The QuditIdTracker tracks unique integer 
-/// indices for allocated qudits. It will recycle indices 
-/// when the qudit is deallocated, so that it can be reused. 
+/// @brief The QuditIdTracker tracks unique integer
+/// indices for allocated qudits. It will recycle indices
+/// when the qudit is deallocated, so that it can be reused.
 class QuditIdTracker {
 private:
-
   /// @brief The current identifier.
   std::size_t currentId = 0;
 
-  /// @brief The queue of recycled qubits. 
+  /// @brief The queue of recycled qubits.
   std::deque<std::size_t> recycledQudits;
 
 public:
-
-  /// @brief Return the next available index, 
-  /// take from the recycled qudit indentifiers 
-  /// if possible. 
+  /// @brief Return the next available index,
+  /// take from the recycled qudit indentifiers
+  /// if possible.
   std::size_t getNextIndex() {
     if (recycledQudits.empty()) {
       std::size_t ret = currentId;
@@ -43,8 +41,8 @@ public:
   }
 
   /// @brief Return indices due to qudit deallocation.
-  /// If all qudits have been deallocated, reset the 
-  /// tracker. 
+  /// If all qudits have been deallocated, reset the
+  /// tracker.
   void returnIndex(std::size_t idx) {
     recycledQudits.push_front(idx);
     std::sort(recycledQudits.begin(), recycledQudits.end());

--- a/runtime/common/QuditIdTracker.h
+++ b/runtime/common/QuditIdTracker.h
@@ -22,7 +22,7 @@ private:
   std::size_t currentId = 0;
 
   /// @brief The queue of recycled qubits.
-  std::deque<std::size_t> recycledQudits;
+  std::vector<std::size_t> recycledQudits;
 
 public:
   /// @brief Return the next available index,
@@ -36,7 +36,7 @@ public:
     }
 
     auto next = recycledQudits.front();
-    recycledQudits.pop_front();
+    recycledQudits.erase(recycledQudits.begin());
     return next;
   }
 
@@ -44,7 +44,7 @@ public:
   /// If all qudits have been deallocated, reset the
   /// tracker.
   void returnIndex(std::size_t idx) {
-    recycledQudits.push_front(idx);
+    recycledQudits.push_back(idx);
     std::sort(recycledQudits.begin(), recycledQudits.end());
     if (recycledQudits.size() == currentId) {
       currentId = 0;

--- a/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
+++ b/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
@@ -116,7 +116,7 @@ public:
   /// specified by that variable.
   void setTargetBackend(const std::string &backend) override {
     std::filesystem::path cudaqLibPath{cudaq::getCUDAQLibraryPath()};
-    auto platformPath = cudaqLibPath.parent_path().parent_path() / "platforms";
+    auto platformPath = cudaqLibPath.parent_path().parent_path() / "targets";
 
     auto mutableBackend = backend;
     if (mutableBackend.find(";") != std::string::npos) {

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -151,12 +151,12 @@ public:
 
     deallocateQudit(qid);
     returnIndex(qid.id);
-    if (numAvailable() == totalNumQudits()) {
-      if (executionContext && ctx_name == "observe") {
-        while (!instructionQueue.empty())
-          instructionQueue.pop();
-      }
-    }
+    // if (numAvailable() == totalNumQudits()) {
+    //   if (executionContext && ctx_name == "observe") {
+    //     while (!instructionQueue.empty())
+    //       instructionQueue.pop();
+    //   }
+    // }
   }
 
   void startAdjointRegion() override { adjointQueueStack.emplace(); }

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -151,12 +151,6 @@ public:
 
     deallocateQudit(qid);
     returnIndex(qid.id);
-    // if (numAvailable() == totalNumQudits()) {
-    //   if (executionContext && ctx_name == "observe") {
-    //     while (!instructionQueue.empty())
-    //       instructionQueue.pop();
-    //   }
-    // }
   }
 
   void startAdjointRegion() override { adjointQueueStack.emplace(); }

--- a/runtime/cudaq/qis/managers/qir/QubitQIRExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/qir/QubitQIRExecutionManager.cpp
@@ -184,6 +184,7 @@ protected:
   }
 
   void handleExecutionContextChanged() override {
+    requestedAllocations.clear();
     __quantum__rt__setExecutionContext(executionContext);
   }
 

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -206,7 +206,7 @@ protected:
   cudaq::ExecutionContext *executionContext = nullptr;
 
   /// @brief A tracker for allocating and deallocating qubit ids
-  nvqir::QubitIdTracker tracker;
+  cudaq::QuditIdTracker tracker;
 
   /// @brief The number of qubits that have been allocated
   std::size_t nQubitsAllocated = 0;
@@ -661,7 +661,7 @@ public:
     --nQubitsAllocated;
 
     // Reset the state if we've deallocated all qubits.
-    if (tracker.numAvailable() == tracker.totalNumQubits()) {
+    if (tracker.allDeallocated()) {
       cudaq::info("Deallocated all qubits, reseting state vector.");
       // all qubits deallocated,
       deallocateState();
@@ -678,7 +678,7 @@ public:
     if (nQubitsAllocated == 0)
       return;
 
-    if (qubits.size() == tracker.totalNumQubits() - tracker.numAvailable()) {
+    if (qubits.size() == tracker.numAllocated()) {
       cudaq::info("Deallocate all qubits.");
       deallocateState();
       for (auto &q : qubits)
@@ -763,7 +763,7 @@ public:
     executionContext = nullptr;
 
     // Reset the state if we've deallocated all qubits.
-    if (tracker.numAvailable() == tracker.totalNumQubits()) {
+    if (tracker.allDeallocated()) {
       if (shouldSetToZero) {
         cudaq::info("In batch mode currently, reset state to |0>");
         // Do not deallocate the state, but reset it to |0>

--- a/runtime/nvqir/QIRTypes.h
+++ b/runtime/nvqir/QIRTypes.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "common/ExecutionContext.h"
+#include "common/QuditIdTracker.h"
+
 #include <algorithm>
 #include <atomic>
 #include <cassert>
@@ -17,13 +19,10 @@
 #include <memory>
 #include <numeric>
 #include <vector>
-///
+
 /// This file defines the various types that we will use
 /// throughout the NVQIR library. Specifically, we will define
 /// the QIR specification types here (Qubit, Array, TuplePtr, Result, etc.)
-/// as well as C++ types that our library will leverage (ExecutionResult,
-/// QubitIdTracker)
-///
 
 // The TuplePtr is just a i8 pointer.
 using TuplePtr = int8_t *;
@@ -100,49 +99,3 @@ enum Pauli : int8_t {
   Pauli_Z,
   Pauli_Y,
 };
-
-namespace nvqir {
-
-/// The QubitIdTracker is a utility class that keeps
-/// track of available qubit ids and provides and API to
-/// get new qubit ids from the available set and return them
-/// for future use.
-class QubitIdTracker {
-
-  /// Available qubit indices
-  std::deque<std::size_t> availableIndices;
-
-  /// Total qubits available
-  std::size_t totalQubits;
-
-public:
-  /// The Constructor
-  QubitIdTracker() {
-    // FIXME calculate the memory available
-    totalQubits = 30;
-    for (std::size_t i = 0; i < totalQubits; i++) {
-      availableIndices.push_back(i);
-    }
-  }
-
-  /// Get the next available qubit index
-  std::size_t getNextIndex() {
-    assert(!availableIndices.empty() && "No more qubits available.");
-    auto next = availableIndices.front();
-    availableIndices.pop_front();
-    return next;
-  }
-
-  /// At qubit deallocation, return the qubit index
-  void returnIndex(std::size_t idx) {
-    availableIndices.push_front(idx);
-    std::sort(availableIndices.begin(), availableIndices.end());
-  }
-
-  /// Get the number of remaining available qubit ids
-  std::size_t numAvailable() { return availableIndices.size(); }
-
-  /// Get the total number of qubit ids available
-  std::size_t totalNumQubits() { return totalQubits; }
-};
-} // namespace nvqir


### PR DESCRIPTION
The current methodology used by the ExecutionManager and the CircuitSimulator for creating unique qudit integer identifiers is not future proof. It currently keeps track of a discrete set of available qudit ids and caps the maximum number of qudits in a platform-specific manner. As we start to consider Clifford simulator plugins, this will become a problem, as we don't want to allocate and keep track of an enormous number of available qudit indices. 

This PR leaves the API exactly the same, but cleans up how qudit indices are handled internally. 