### PR TITLE
[Optimizer] Generate docs transform passes

### DIFF
--- a/include/cudaq/Optimizer/Transforms/CMakeLists.txt
+++ b/include/cudaq/Optimizer/Transforms/CMakeLists.txt
@@ -9,3 +9,5 @@
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name OptTransforms)
 add_public_tablegen_target(OptTransformsPassIncGen)
+
+add_cudaq_doc(Passes Transforms -gen-pass-doc)


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
This change enable the generation of docs for the transformation passes when building the `cudaq-doc` target.