### PR TITLE
Fixed a subtle bug in `QppCircuitSimulator::observe`

### DIFF
--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -189,7 +189,8 @@ public:
     });
 
     std::sort(targets.begin(), targets.end());
-    std::unique(targets.begin(), targets.end());
+    const auto last_iter = std::unique(targets.begin(), targets.end());
+    targets.erase(last_iter, targets.end());
 
     // Get the matrix as an Eigen matrix
     auto matrix = op.to_matrix();

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -149,8 +149,17 @@ if (CUDAQ_ENABLE_PYTHON)
     cudaq-chemistry
     cudaq-pyscf
     gtest_main)
-  gtest_discover_tests(test_domains PROPERTIES 
-         ENVIRONMENT 
-         "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BINARY_DIR}/python")
+  gtest_discover_tests(test_domains
+    TEST_SUFFIX _Sampling
+    PROPERTIES
+      ENVIRONMENT
+        "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BINARY_DIR}/python")
+  gtest_discover_tests(test_domains
+    TEST_SUFFIX _Observe
+    PROPERTIES
+      ENVIRONMENT
+        "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BINARY_DIR}/python"
+      ENVIRONMENT
+        "CUDAQ_OBSERVE_FROM_SAMPLING=false")
 endif()
 


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

It looks like we missed a call to `std::vector`'s `erase` after using `std::unique`.

This will cause the underlying qpp lib to throw (dimension mismatches).

### Steps to reproduce the bug

Run `test_domains` with `CUDAQ_OBSERVE_FROM_SAMPLING` environment variable set to false.

Hence, also added a variant of `test_domains`  unit test to check for this case.
