### PR TITLE
[CircuitCheck] Handle local qubits

### DIFF
--- a/utils/CircuitCheck/UnitaryBuilder.cpp
+++ b/utils/CircuitCheck/UnitaryBuilder.cpp
@@ -20,15 +20,17 @@ LogicalResult UnitaryBuilder::build(func::FuncOp func) {
       if (allocateQubits(arg) == WalkResult::interrupt())
         return failure();
   }
+  // We need to keep track of which qubits are ancillas. Hence, we save the
+  // current number of qubits and consider any local allocations as ancillas.
+  const std::size_t numQubits = getNumQubits();
+
   SmallVector<Complex, 16> matrix;
   SmallVector<Qubit, 16> qubits;
   auto result = func.walk([&](Operation *op) {
-    if (auto allocOp = dyn_cast<quake::AllocaOp>(op)) {
+    if (auto allocOp = dyn_cast<quake::AllocaOp>(op))
       return allocateQubits(allocOp.getResult());
-    }
-    if (auto extractOp = dyn_cast<quake::ExtractRefOp>(op)) {
+    if (auto extractOp = dyn_cast<quake::ExtractRefOp>(op))
       return visitExtractOp(extractOp);
-    }
     if (auto optor = dyn_cast<quake::OperatorInterface>(op)) {
       optor.getOperatorMatrix(matrix);
       // If the operator couldn't produce a matrix, stop the walk.
@@ -52,7 +54,9 @@ LogicalResult UnitaryBuilder::build(func::FuncOp func) {
     }
     return WalkResult::advance();
   });
-  return failure(result.wasInterrupted());
+  if (result.wasInterrupted())
+    return failure();
+  return deallocateAncillas(numQubits);
 }
 
 //===----------------------------------------------------------------------===//
@@ -62,7 +66,7 @@ LogicalResult UnitaryBuilder::build(func::FuncOp func) {
 WalkResult UnitaryBuilder::visitExtractOp(quake::ExtractRefOp op) {
   Value veq = op.getVeq();
   ArrayRef<unsigned> qubits = qubitMap[veq];
-  size_t index = 0;
+  std::size_t index = 0;
   // We need to check whether the index is a "raw" index or not.
   if (op.hasConstantIndex())
     index = op.getRawIndex();
@@ -82,15 +86,15 @@ WalkResult UnitaryBuilder::allocateQubits(Value value) {
     if (!veq.hasSpecifiedSize())
       return WalkResult::interrupt();
     qubits.resize(veq.getSize());
-    std::iota(entry->second.begin(), entry->second.end(), getNextQubit());
+    std::iota(entry->second.begin(), entry->second.end(), getNumQubits());
   } else {
-    qubits.push_back(getNextQubit());
+    qubits.push_back(getNumQubits());
   }
   growMatrix(qubits.size());
   return WalkResult::advance();
 }
 
-LogicalResult UnitaryBuilder::getValueAsInt(Value value, size_t &result) {
+LogicalResult UnitaryBuilder::getValueAsInt(Value value, std::size_t &result) {
   if (auto op =
           dyn_cast_if_present<arith::ConstantIntOp>(value.getDefiningOp()))
     if (auto index = dyn_cast<IntegerAttr>(op.getValue())) {
@@ -126,6 +130,22 @@ void UnitaryBuilder::negatedControls(ArrayRef<bool> negatedControls,
   for (auto [isNegated, qubit] : llvm::zip(negatedControls, qubits))
     if (isNegated)
       applyMatrix({0, 1, 1, 0}, qubit); // Apply pauli-x to the qubit
+}
+
+LogicalResult UnitaryBuilder::deallocateAncillas(std::size_t numQubits) {
+  if (matrix.rows() == (1 << numQubits))
+    return success();
+  const std::size_t size = (1ULL << numQubits);
+  UMatrix newMatrix = matrix.block(0, 0, size, size);
+  for (std::size_t i = 0, n = getNumQubits(); i < n; ++i)
+    matrix.block((1 << i), (1 << i), size, size).setZero();
+
+  // If the resulting matrix is not zero, we have dirty ancillas.
+  if (!matrix.isZero())
+    return failure();
+
+  matrix.swap(newMatrix);
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -233,7 +253,7 @@ indicies(ArrayRef<UnitaryBuilder::Qubit> qubits,
   for (unsigned i = 0u, end = qubits.size(); i < end; ++i) {
     unsigned n = (1u << i);
     unsigned bit = (1u << qubits[i]);
-    for (size_t j = 0; j < n; j++)
+    for (std::size_t j = 0; j < n; j++)
       result.at(n + j) = result.at(j) | bit;
   }
   return result;
@@ -257,16 +277,17 @@ void UnitaryBuilder::applyMatrix(ArrayRef<Complex> u, unsigned numTargets,
   llvm::sort(qubitsSorted);
 
   auto *m = matrix.data();
-  const size_t dim = (1u << numTargets);
-  for (size_t k = 0u, end = (matrix.size() >> qubits.size()); k < end; ++k) {
+  const std::size_t dim = (1u << numTargets);
+  for (std::size_t k = 0u, end = (matrix.size() >> qubits.size()); k < end;
+       ++k) {
     auto idx = indicies(qubits, qubitsSorted, k);
     SmallVector<Complex, 8> cache(dim, 0);
-    for (size_t i = 0; i < dim; i++) {
+    for (std::size_t i = 0; i < dim; i++) {
       cache[i] = m[idx.at(i)];
       m[idx.at(i)] = 0.;
     }
-    for (size_t i = 0; i < dim; i++)
-      for (size_t j = 0; j < dim; j++)
+    for (std::size_t i = 0; i < dim; i++)
+      for (std::size_t j = 0; j < dim; j++)
         m[idx.at(i)] += u[i + dim * j] * cache[j];
   }
 }

--- a/utils/CircuitCheck/UnitaryBuilder.h
+++ b/utils/CircuitCheck/UnitaryBuilder.h
@@ -41,15 +41,17 @@ private:
   // Helpers
   //===--------------------------------------------------------------------===//
 
-  mlir::LogicalResult getValueAsInt(mlir::Value value, size_t &result);
+  mlir::LogicalResult getValueAsInt(mlir::Value value, std::size_t &result);
 
-  unsigned getNextQubit() { return std::log2(matrix.rows()); }
+  std::size_t getNumQubits() { return std::log2(matrix.rows()); }
 
   mlir::LogicalResult getQubits(mlir::ValueRange values,
                                 mlir::SmallVectorImpl<Qubit> &qubits);
 
   void negatedControls(mlir::ArrayRef<bool> negatedControls,
                        mlir::ArrayRef<Qubit> qubits);
+
+  mlir::LogicalResult deallocateAncillas(std::size_t numQubits);
 
   //===--------------------------------------------------------------------===//
   // Unitary


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
This PR allows CircuitCheck to verify decompositions that require ancillary qubits. It does this by treating local allocations as ancillas. For example:
```mlir
// It treat args as non-ancilla
func.func @cccz(%arg0: !quake.ref, %arg1: !quake.ref, %arg2: !quake.ref, %arg3: !quake.ref) {
  %0 = quake.alloca !quake.ref // It will treat it as an ancilla
  //...
}
```

The resulting unitary for the above circuit will only have 3 qubits (the arguments). CircuitCheck will also check if the ancilla(s) qubit(s) are properly cleaned up, i.e., intermediate results were uncomputed.
