### PR TITLE
[bridge, runtime] Replace use of LLVM-IR dialect in the bridge and python interface with CC dialect operations.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.h
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.h
@@ -20,6 +20,25 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 
+namespace cudaq::cc {
+constexpr int kComputePtrConstantBitWidth = 29;
+using ComputePtrConstantIndex =
+    llvm::PointerEmbeddedInt<std::int32_t, kComputePtrConstantBitWidth>;
+
+// Allow a mix of values and constants to be passed as arguments to
+// ComputePtrOp's builder.
+class ComputePtrArg
+    : public llvm::PointerUnion<mlir::Value, ComputePtrConstantIndex> {
+  using BaseT = llvm::PointerUnion<mlir::Value, ComputePtrConstantIndex>;
+
+public:
+  ComputePtrArg(std::int32_t integer) : BaseT(integer) {}
+  ComputePtrArg(mlir::Value value) : BaseT(value) {}
+
+  using BaseT::operator=;
+};
+} // namespace cudaq::cc
+
 //===----------------------------------------------------------------------===//
 // Generated logic
 //===----------------------------------------------------------------------===//

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -865,6 +865,19 @@ def cc_ComputePtrOp : CCOp<"compute_ptr", [Pure]> {
     $base `[` custom<ComputePtrIndices>($dynamicIndices, $rawConstantIndices)
       `]` `:` functional-type(operands, results) attr-dict
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$resultType, "mlir::Value":$basePtr,
+               "mlir::ValueRange":$indices,
+               CArg<"mlir::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes)>,
+    OpBuilder<(ins "mlir::Type":$resultType, "mlir::Value":$basePtr,
+               "mlir::ArrayRef<cudaq::cc::ComputePtrArg>":$indices,
+               CArg<"mlir::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes)> 
+  ];
+  let extraClassDeclaration = [{
+    static constexpr std::int32_t kDynamicIndex =
+      std::numeric_limits<std::int32_t>::min();
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -46,6 +46,9 @@ def cc_PointerType : CCType<"Pointer", "ptr"> {
     TypeBuilderWithInferredContext<(ins "mlir::Type":$elementType), [{
       return Base::get(elementType.getContext(), elementType);
     }]>,
+    TypeBuilder<(ins), [{
+      return $_get($_ctxt, mlir::NoneType::get($_ctxt));
+    }]>
   ];
 }
 
@@ -55,7 +58,6 @@ def cc_PointerType : CCType<"Pointer", "ptr"> {
 
 def cc_StructType : CCType<"Struct", "struct",
     [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
-
   let summary = "Primitive aggregate C/C++ type.";
   let description = [{
     A struct is first-class type for an aggregate tuple value composed of
@@ -74,6 +76,25 @@ def cc_StructType : CCType<"Struct", "struct",
   );
 
   let hasCustomAssemblyFormat = 1;
+
+  let builders = [
+    TypeBuilder<(ins CArg<"llvm::StringRef">:$name,
+                 CArg<"bool", "true">:$isOpaque), [{
+      return $_get($_ctxt, mlir::StringAttr::get($_ctxt, name),
+                   llvm::ArrayRef<mlir::Type>{}, isOpaque, /*isPacked=*/false);
+    }]>,
+    TypeBuilder<(ins CArg<"llvm::StringRef">:$name,
+                 CArg<"llvm::ArrayRef<mlir::Type>">:$members,
+                 CArg<"bool", "false">:$isPacked), [{
+      return $_get($_ctxt, mlir::StringAttr::get($_ctxt, name), members,
+                   /*isOpaque=*/false, isPacked);
+    }]>,
+    TypeBuilder<(ins CArg<"llvm::ArrayRef<mlir::Type>">:$members,
+                 CArg<"bool", "false">:$isPacked), [{
+      return $_get($_ctxt, mlir::StringAttr{}, members, /*isOpaque=*/false,
+                   isPacked);
+    }]>
+  ];
 }
 
 //===----------------------------------------------------------------------===//
@@ -112,7 +133,7 @@ def cc_ArrayType : CCType<"Array", "array"> {
   let builders = [
     TypeBuilderWithInferredContext<(ins "mlir::Type":$elementType), [{
       return Base::get(elementType.getContext(), elementType, unknownSize);
-    }]>,
+    }]>
   ];
 }
 
@@ -137,7 +158,7 @@ def cc_LambdaType : CCType<"Lambda", "lambda"> {
   let builders = [
     TypeBuilderWithInferredContext<(ins "mlir::FunctionType":$signature), [{
       return Base::get(signature.getContext(), signature);
-    }]>,
+    }]>
   ];
 
   let extraClassDeclaration = [{
@@ -174,7 +195,7 @@ def cc_StdVectorType : CCType<"Stdvec", "stdvec"> {
   let builders = [
     TypeBuilderWithInferredContext<(ins "mlir::Type":$elementType), [{
       return Base::get(elementType.getContext(), elementType);
-    }]>,
+    }]>
   ];
 }
 

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -258,12 +258,12 @@ static Value toIntegerImpl(OpBuilder &builder, Location loc, Value bitVec) {
         // bits[k]
         auto eleTy =
             bitVec.getType().cast<cudaq::cc::StdvecType>().getElementType();
-        auto elePtrTy = cudaq::opt::factory::getPointerType(eleTy);
+        auto elePtrTy = cudaq::cc::PointerType::get(eleTy);
         auto vecPtr =
             builder.create<cudaq::cc::StdvecDataOp>(loc, elePtrTy, bitVec);
-        auto eleAddr = builder.create<LLVM::GEPOp>(loc, elePtrTy, vecPtr,
-                                                   ValueRange{kIter});
-        Value bitElement = builder.create<LLVM::LoadOp>(loc, eleAddr);
+        auto eleAddr = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, elePtrTy, vecPtr, ValueRange{kIter});
+        Value bitElement = builder.create<cudaq::cc::LoadOp>(loc, eleAddr);
 
         // -bits[k]
         bitElement = builder.create<arith::ExtUIOp>(loc, builder.getI32Type(),
@@ -640,7 +640,7 @@ bool QuakeBridgeVisitor::VisitImplicitCastExpr(clang::ImplicitCastExpr *x) {
       // Enable implicit conversion of callable -> std::function.
       if (auto cxxExpr = dyn_cast<clang::CXXConstructExpr>(subExpr);
           cxxExpr->getNumArgs() == 1 &&
-          genType(cxxExpr->getArg(0)->getType()).isa<LLVM::LLVMStructType>()) {
+          genType(cxxExpr->getArg(0)->getType()).isa<cc::StructType>()) {
         return true;
       }
     }
@@ -1005,8 +1005,8 @@ bool QuakeBridgeVisitor::VisitMaterializeTemporaryExpr(
     assert(isa<quake::VeqType>(peekValue().getType()));
     return true;
   }
-  if (auto structTy = dyn_cast<LLVM::LLVMStructType>(ty);
-      structTy && structTy.getName().equals("reference_wrapper")) {
+  if (auto structTy = dyn_cast<cc::StructType>(ty);
+      structTy && structTy.getName().getValue().equals("reference_wrapper")) {
     assert(isa<quake::RefType>(peekValue().getType()) ||
            isa<quake::VeqType>(peekValue().getType()));
     return true;
@@ -1373,7 +1373,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         return true;
       };
 
-      if (auto ty = dyn_cast<LLVM::LLVMStructType>(calleeValue.getType())) {
+      if (auto ty = dyn_cast<cc::StructType>(calleeValue.getType())) {
         auto *classDecl = classDeclFromTemplateArgument(*func, 0, *astContext);
         if (!classDecl) {
           // This shouldn't happen if the cudaq headers are used, but add a
@@ -1469,7 +1469,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       // to be called.
       auto calleeValue = args[0];
       SymbolRefAttr calleeSymbol;
-      if (auto ty = dyn_cast<LLVM::LLVMStructType>(calleeValue.getType())) {
+      if (auto ty = dyn_cast<cc::StructType>(calleeValue.getType())) {
         auto *ctx = builder.getContext();
         auto *classDecl = classDeclFromTemplateArgument(*func, 0, *astContext);
         if (!classDecl) {
@@ -1522,15 +1522,15 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
     if (funcName.equals("slice_vector")) {
       auto svecTy = dyn_cast<cc::StdvecType>(args[0].getType());
       assert(svecTy && "first argument must be std::vector");
-      auto ptrTy = opt::factory::getPointerType(builder.getContext());
+      auto ptrTy = cc::PointerType::get(builder.getContext());
       auto vecPtr = builder.create<cc::StdvecDataOp>(loc, ptrTy, args[0]);
       auto bits = svecTy.getElementType().getIntOrFloatBitWidth();
       assert(bits > 0);
       auto scale = builder.create<arith::ConstantIntOp>(loc, (bits + 7) / 8,
                                                         args[1].getType());
       auto offset = builder.create<arith::MulIOp>(loc, scale, args[1]);
-      auto ptr = builder.create<LLVM::GEPOp>(loc, ptrTy, vecPtr,
-                                             ArrayRef<Value>{offset});
+      auto ptr = builder.create<cc::ComputePtrOp>(loc, ptrTy, vecPtr,
+                                                  ArrayRef<Value>{offset});
       return pushValue(builder.create<cc::StdvecInitOp>(loc, args[0].getType(),
                                                         ptr, args[2]));
     }
@@ -1620,11 +1620,11 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
       auto svec = popValue();
       assert(svec.getType().isa<cc::StdvecType>());
       auto eleTy = svec.getType().cast<cc::StdvecType>().getElementType();
-      auto elePtrTy = opt::factory::getPointerType(eleTy);
+      auto elePtrTy = cc::PointerType::get(eleTy);
       auto vecPtr = builder.create<cc::StdvecDataOp>(loc, elePtrTy, svec);
-      auto eleAddr = builder.create<LLVM::GEPOp>(loc, elePtrTy, vecPtr,
-                                                 ValueRange{indexVar});
-      return pushValue(builder.create<LLVM::LoadOp>(loc, eleAddr));
+      auto eleAddr = builder.create<cc::ComputePtrOp>(loc, elePtrTy, vecPtr,
+                                                      ValueRange{indexVar});
+      return pushValue(builder.create<cc::LoadOp>(loc, eleAddr));
     }
     TODO_loc(loc, "unhandled operator call for quake conversion");
   }
@@ -1746,8 +1746,8 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
           // Skip this constructor (for now).
           return true;
         }
-        if (auto stTy = backTy.dyn_cast_or_null<LLVM::LLVMStructType>()) {
-          if (!stTy.getBody().empty()) {
+        if (auto stTy = backTy.dyn_cast_or_null<cc::StructType>()) {
+          if (!stTy.getMembers().empty()) {
             // TODO: We don't support a callable class with data members yet.
             TODO_loc(loc, "callable class with data members");
           }
@@ -1802,13 +1802,13 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
     // FIXME: As this is now, the stack space isn't correctly sized. The
     // next line should be something like:
     //   auto ty = genType(x->getType());
-    auto ty = LLVM::LLVMStructType::getLiteral(
-        builder.getContext(), ArrayRef<Type>{builder.getIntegerType(8)});
+    auto ty = cc::StructType::get(builder.getContext(),
+                                  ArrayRef<Type>{builder.getIntegerType(8)});
     auto ptrTy = opt::factory::getPointerType(ty);
     auto oneAttr = builder.getI64IntegerAttr(1);
     auto i64Ty = builder.getIntegerType(64);
-    auto one = builder.create<LLVM::ConstantOp>(loc, i64Ty, oneAttr);
-    auto mem = builder.create<LLVM::AllocaOp>(loc, ptrTy, ValueRange{one});
+    auto one = builder.create<arith::ConstantOp>(loc, i64Ty, oneAttr);
+    auto mem = builder.create<cc::AllocaOp>(loc, ptrTy, ValueRange{one});
     // FIXME: Using Ctor_Complete for mangled name generation blindly here.
     // Is there a programmatic way of determining which enum to use from the
     // AST?

--- a/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -190,19 +190,18 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *stmt) {
         module.emitError("failed to load intrinsic");
       auto eleTy = vecTy.getElementType();
       Value resBuff = builder.create<cc::StdvecDataOp>(
-          loc, cudaq::opt::factory::getPointerType(mlirContext), result);
+          loc, cudaq::cc::PointerType::get(mlirContext), result);
       std::size_t byteWidth = (eleTy.getIntOrFloatBitWidth() + 7) / 8;
       Value dynSize =
           builder.create<cc::StdvecSizeOp>(loc, builder.getI64Type(), result);
       auto eleSize = builder.create<arith::ConstantOp>(
           loc, builder.getI64Type(), builder.getI64IntegerAttr(byteWidth));
-      Value heapCopy =
-          builder
-              .create<func::CallOp>(
-                  loc, cudaq::opt::factory::getPointerType(mlirContext),
-                  "__nvqpp_vectorCopyCtor",
-                  ValueRange{resBuff, dynSize, eleSize})
-              .getResult(0);
+      Value heapCopy = builder
+                           .create<func::CallOp>(
+                               loc, cudaq::cc::PointerType::get(mlirContext),
+                               "__nvqpp_vectorCopyCtor",
+                               ValueRange{resBuff, dynSize, eleSize})
+                           .getResult(0);
       result = builder.create<cc::StdvecInitOp>(loc, resTy,
                                                 ValueRange{heapCopy, dynSize});
     }

--- a/lib/Frontend/nvqpp/ConvertType.cpp
+++ b/lib/Frontend/nvqpp/ConvertType.cpp
@@ -107,6 +107,8 @@ static bool isQuantumType(Type t) {
 static bool isArithmeticSequenceType(Type t) {
   if (auto vec = dyn_cast<cudaq::cc::StdvecType>(t))
     return isArithmeticType(vec.getElementType());
+  if (auto vec = dyn_cast<cudaq::cc::ArrayType>(t))
+    return isArithmeticType(vec.getElementType());
   return false;
 }
 
@@ -128,7 +130,7 @@ static bool isKernelSignatureType(FunctionType t) {
   for (auto t : t.getInputs()) {
     if (isArithmeticType(t) || isArithmeticSequenceType(t) ||
         isQuantumType(t) || isKernelCallable(t) || isFunctionCallable(t) ||
-        isa<LLVM::LLVMStructType>(t)) {
+        isa<cudaq::cc::StructType>(t)) {
       // Assume a class (LLVMStructType) is callable.
       continue;
     }
@@ -145,7 +147,7 @@ static bool isKernelSignatureType(FunctionType t) {
 static bool isReferenceToCallableRecord(Type t, clang::ParmVarDecl *arg) {
   // TODO: add check that the Decl is, in fact, a callable with a legal kernel
   // signature.
-  return isa<LLVM::LLVMStructType>(t);
+  return isa<cudaq::cc::StructType>(t);
 }
 
 namespace cudaq::details {
@@ -253,12 +255,8 @@ bool QuakeBridgeVisitor::VisitRecordDecl(clang::RecordDecl *x) {
   }
   SmallVector<Type> fieldTys = lastTypes(fieldCount());
   if (name.empty())
-    return pushType(LLVM::LLVMStructType::getLiteral(ctx, fieldTys));
-  auto structTy = LLVM::LLVMStructType::getIdentified(ctx, name);
-  if (!structTy.isInitialized())
-    if (failed(structTy.setBody(fieldTys, /*isPacked=*/false)))
-      return false;
-  return pushType(structTy);
+    return pushType(cc::StructType::get(ctx, fieldTys));
+  return pushType(cc::StructType::get(ctx, name, fieldTys));
 }
 
 bool QuakeBridgeVisitor::VisitFunctionProtoType(clang::FunctionProtoType *x) {
@@ -375,7 +373,7 @@ Type QuakeBridgeVisitor::builtinTypeToType(const clang::BuiltinType *t) {
   case BuiltinType::Ibm128: /* double double format -> {double, double} */
     return builder.getF128Type();
   case BuiltinType::NullPtr:
-    return cudaq::opt::factory::getPointerType(builder.getI8Type());
+    return cc::PointerType::get(builder.getContext());
   case BuiltinType::UInt128:
   case BuiltinType::Int128:
     return builder.getIntegerType(128);
@@ -406,8 +404,8 @@ bool QuakeBridgeVisitor::VisitRValueReferenceType(
     clang::RValueReferenceType *t) {
   auto eleTy = popType();
   // FIXME: LLVMStructType is promoted as a temporary workaround.
-  if (isa<cc::LambdaType, cc::StdvecType, quake::VeqType, quake::RefType,
-          LLVM::LLVMStructType>(eleTy))
+  if (isa<cc::LambdaType, cc::StdvecType, cc::ArrayType, cc::StructType,
+          quake::VeqType, quake::RefType, LLVM::LLVMStructType>(eleTy))
     return pushType(eleTy);
   return pushType(cc::PointerType::get(eleTy));
 }

--- a/lib/Optimizer/Builder/CUDAQBuilder.cpp
+++ b/lib/Optimizer/Builder/CUDAQBuilder.cpp
@@ -73,12 +73,14 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   llvm.func @__nvqpp_initializer_list_to_vector_bool(!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> ())#"},
 
     {"__nvqpp_vectorCopyCtor", {llvmMemCopyIntrinsic, "malloc"}, R"#(
-  func.func private @__nvqpp_vectorCopyCtor(%arg0: !llvm.ptr<i8>, %arg1: i64, %arg2: i64) -> !llvm.ptr<i8> {
+  func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<none>, %arg1: i64, %arg2: i64) -> !cc.ptr<none> {
+    %a0 = cc.cast %arg0 : (!cc.ptr<none>) -> !llvm.ptr<i8>
     %size = arith.muli %arg1, %arg2 : i64
     %0 = call @malloc(%size) : (i64) -> !llvm.ptr<i8>
     %false = arith.constant false
-    call @llvm.memcpy.p0i8.p0i8.i64(%0, %arg0, %arg1, %false) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
-    return %0 : !llvm.ptr<i8>
+    call @llvm.memcpy.p0i8.p0i8.i64(%0, %0, %arg1, %false) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
+    %r = cc.cast %0 : (!llvm.ptr<i8>) -> !cc.ptr<none>
+    return %r : !cc.ptr<none>
   })#"},
 
     {"__nvqpp_zeroDynamicResult", {}, R"#(

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -83,19 +83,20 @@ LogicalResult synthesizeVectorArgument(OpBuilder &builder,
     // could be a load, or a getelementptr.
     // if load, the index is 0
     // if getelementptr, then we get the index there to use
-    if (auto loadOp = dyn_cast_or_null<LLVM::LoadOp>(user)) {
+    if (auto loadOp = dyn_cast_or_null<cudaq::cc::LoadOp>(user)) {
       llvm::APFloat f(vec[0]);
       Value runtimeParam = builder.create<arith::ConstantFloatOp>(
           builder.getUnknownLoc(), f, builder.getF64Type());
       // Replace with the constant value, remove the load
       loadOp.replaceAllUsesWith(runtimeParam);
       loadOp.erase();
-    } else if (auto gepOp = dyn_cast_or_null<LLVM::GEPOp>(user)) {
+    } else if (auto gepOp = dyn_cast_or_null<cudaq::cc::ComputePtrOp>(user)) {
       auto index = gepOp.getRawConstantIndices()[0];
       llvm::APFloat f(vec[index]);
       Value runtimeParam = builder.create<arith::ConstantFloatOp>(
           builder.getUnknownLoc(), f, builder.getF64Type());
-      auto loadOp = dyn_cast_or_null<LLVM::LoadOp>(*gepOp->getUsers().begin());
+      auto loadOp =
+          dyn_cast_or_null<cudaq::cc::LoadOp>(*gepOp->getUsers().begin());
       if (!loadOp)
         return loadOp.emitError(
             "Unknown gep/load configuration for quake-synth.");

--- a/python/tests/compiler/adjoint.py
+++ b/python/tests/compiler/adjoint.py
@@ -198,8 +198,9 @@ def test_kernel_adjoint_list_args():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
-# CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
+# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
+# CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
@@ -298,7 +299,7 @@ def test_sample_adjoint_qreg():
 # CHECK:           } {counted}
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_3]]) : (!quake.veq<?>) -> ()
 # CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_3]] : (!quake.veq<?>) -> ()
-# CHECK:           %[[VAL_13:.*]] = llvm.alloca %[[VAL_4]] x i1 : (i64) -> !llvm.ptr<i1>
+# CHECK:           %[[VAL_13:.*]] = cc.alloca i1[%[[VAL_4]] : i64]
 # CHECK:           %[[VAL_14:.*]] = cc.loop while ((%[[VAL_15:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_16:.*]] = arith.cmpi slt, %[[VAL_15]], %[[VAL_5]] : index
 # CHECK:             cc.condition %[[VAL_16]](%[[VAL_15]] : index)
@@ -307,8 +308,8 @@ def test_sample_adjoint_qreg():
 # CHECK:             %[[VAL_18:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_17]]] : (!quake.veq<?>, index) -> !quake.ref
 # CHECK:             %[[VAL_19:.*]] = quake.mz %[[VAL_18]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_20:.*]] = arith.index_cast %[[VAL_17]] : index to i64
-# CHECK:             %[[VAL_21:.*]] = llvm.getelementptr %[[VAL_13]]{{\[}}%[[VAL_20]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-# CHECK:             llvm.store %[[VAL_19]], %[[VAL_21]] : !llvm.ptr<i1>
+# CHECK:             %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_13]][%[[VAL_20]]] : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.ptr<i1>
+# CHECK:             cc.store %[[VAL_19]], %[[VAL_21]] : !cc.ptr<i1>
 # CHECK:             cc.continue %[[VAL_17]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_22:.*]]: index):

--- a/python/tests/compiler/call.py
+++ b/python/tests/compiler/call.py
@@ -192,8 +192,9 @@ def test_kernel_apply_call_list_args():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
-# CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
+# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
+# CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64,
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -215,8 +215,9 @@ def test_kernel_control_list_args(qubit_count):
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
-# CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
+# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
+# CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
@@ -231,8 +232,9 @@ def test_kernel_control_list_args(qubit_count):
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !llvm.ptr<f64>
-# CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f64>
+# CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64> 
+# CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
@@ -331,7 +333,6 @@ def test_sample_control_qreg_args():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = arith.constant 2 : index
-# CHECK:           %[[VAL_1:.*]] = arith.constant 2 : i64
 # CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 # CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
@@ -340,7 +341,7 @@ def test_sample_control_qreg_args():
 # CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
 # CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]]] %[[VAL_6]] : (!quake.veq<2>, !quake.ref) -> ()
-# CHECK:           %[[VAL_8:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
+# CHECK:           %[[VAL_8:.*]] = cc.alloca !cc.array<i1 x 2>
 # CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : index)
@@ -349,8 +350,8 @@ def test_sample_control_qreg_args():
 # CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_5]][%[[VAL_12]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_15:.*]] = arith.index_cast %[[VAL_12]] : index to i64
-# CHECK:             %[[VAL_16:.*]] = llvm.getelementptr %[[VAL_8]]{{\[}}%[[VAL_15]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-# CHECK:             llvm.store %[[VAL_14]], %[[VAL_16]] : !llvm.ptr<i1>
+# CHECK:             %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_8]][%[[VAL_15]]] : (!cc.ptr<!cc.array<i1 x 2>>, i64) -> !cc.ptr<i1>
+# CHECK:             cc.store %[[VAL_14]], %[[VAL_16]] : !cc.ptr<i1>
 # CHECK:             cc.continue %[[VAL_12]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_17:.*]]: index):

--- a/python/tests/compiler/measure.py
+++ b/python/tests/compiler/measure.py
@@ -70,11 +70,10 @@ def test_kernel_measure_qreg():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = arith.constant 3 : index
-# CHECK:           %[[VAL_1:.*]] = arith.constant 3 : i64
 # CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 # CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<3>
-# CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
+# CHECK:           %[[VAL_5:.*]] = cc.alloca !cc.array<i1 x 3>
 # CHECK:           %[[VAL_6:.*]] = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : index)
@@ -83,15 +82,15 @@ def test_kernel_measure_qreg():
 # CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_9]]] : (!quake.veq<3>, index) -> !quake.ref
 # CHECK:             %[[VAL_11:.*]] = quake.mx %[[VAL_10]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_9]] : index to i64
-# CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_12]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-# CHECK:             llvm.store %[[VAL_11]], %[[VAL_13]] : !llvm.ptr<i1>
+# CHECK:             %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_5]][%[[VAL_12]]] : (!cc.ptr<!cc.array<i1 x 3>>, i64) -> !cc.ptr<i1>
+# CHECK:             cc.store %[[VAL_11]], %[[VAL_13]] : !cc.ptr<i1>
 # CHECK:             cc.continue %[[VAL_9]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_14:.*]]: index):
 # CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_2]] : index
 # CHECK:             cc.continue %[[VAL_15]] : index
 # CHECK:           } {counted}
-# CHECK:           %[[VAL_16:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
+# CHECK:           %[[VAL_16:.*]] = cc.alloca !cc.array<i1 x 3>
 # CHECK:           %[[VAL_17:.*]] = cc.loop while ((%[[VAL_18:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_19:.*]] = arith.cmpi slt, %[[VAL_18]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_19]](%[[VAL_18]] : index)
@@ -100,15 +99,15 @@ def test_kernel_measure_qreg():
 # CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_20]]] : (!quake.veq<3>, index) -> !quake.ref
 # CHECK:             %[[VAL_22:.*]] = quake.my %[[VAL_21]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_23:.*]] = arith.index_cast %[[VAL_20]] : index to i64
-# CHECK:             %[[VAL_24:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_23]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-# CHECK:             llvm.store %[[VAL_22]], %[[VAL_24]] : !llvm.ptr<i1>
+# CHECK:             %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_16]][%[[VAL_23]]] : (!cc.ptr<!cc.array<i1 x 3>>, i64) -> !cc.ptr<i1>
+# CHECK:             cc.store %[[VAL_22]], %[[VAL_24]] : !cc.ptr<i1>
 # CHECK:             cc.continue %[[VAL_20]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_25:.*]]: index):
 # CHECK:             %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_2]] : index
 # CHECK:             cc.continue %[[VAL_26]] : index
 # CHECK:           } {counted}
-# CHECK:           %[[VAL_27:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
+# CHECK:           %[[VAL_27:.*]] = cc.alloca !cc.array<i1 x 3>
 # CHECK:           %[[VAL_28:.*]] = cc.loop while ((%[[VAL_29:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_30:.*]] = arith.cmpi slt, %[[VAL_29]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_30]](%[[VAL_29]] : index)
@@ -117,8 +116,8 @@ def test_kernel_measure_qreg():
 # CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_31]]] : (!quake.veq<3>, index) -> !quake.ref
 # CHECK:             %[[VAL_33:.*]] = quake.mz %[[VAL_32]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_34:.*]] = arith.index_cast %[[VAL_31]] : index to i64
-# CHECK:             %[[VAL_35:.*]] = llvm.getelementptr %[[VAL_27]]{{\[}}%[[VAL_34]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-# CHECK:             llvm.store %[[VAL_33]], %[[VAL_35]] : !llvm.ptr<i1>
+# CHECK:             %[[VAL_35:.*]] = cc.compute_ptr %[[VAL_27]][%[[VAL_34]]] : (!cc.ptr<!cc.array<i1 x 3>>, i64) -> !cc.ptr<i1>
+# CHECK:             cc.store %[[VAL_33]], %[[VAL_35]] : !cc.ptr<i1>
 # CHECK:             cc.continue %[[VAL_31]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_36:.*]]: index):

--- a/python/tests/compiler/swap.py
+++ b/python/tests/compiler/swap.py
@@ -34,7 +34,6 @@ def test_swap_2q():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() {
 # CHECK:           %[[VAL_0:.*]] = arith.constant 2 : index
-# CHECK:           %[[VAL_1:.*]] = arith.constant 2 : i64
 # CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 # CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 # CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<2>
@@ -42,7 +41,7 @@ def test_swap_2q():
 # CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_5]] : (!quake.ref) -> ()
 # CHECK:           quake.swap %[[VAL_5]], %[[VAL_6]] : (!quake.ref, !quake.ref) -> ()
-# CHECK:           %[[VAL_7:.*]] = llvm.alloca %[[VAL_1]] x i1 : (i64) -> !llvm.ptr<i1>
+# CHECK:           %[[VAL_7:.*]] = cc.alloca !cc.array<i1 x 2>
 # CHECK:           %[[VAL_8:.*]] = cc.loop while ((%[[VAL_9:.*]] = %[[VAL_3]]) -> (index)) {
 # CHECK:             %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_0]] : index
 # CHECK:             cc.condition %[[VAL_10]](%[[VAL_9]] : index)
@@ -51,8 +50,8 @@ def test_swap_2q():
 # CHECK:             %[[VAL_12:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_11]]] : (!quake.veq<2>, index) -> !quake.ref
 # CHECK:             %[[VAL_13:.*]] = quake.mz %[[VAL_12]] : (!quake.ref) -> i1
 # CHECK:             %[[VAL_14:.*]] = arith.index_cast %[[VAL_11]] : index to i64
-# CHECK:             %[[VAL_15:.*]] = llvm.getelementptr %[[VAL_7]]{{\[}}%[[VAL_14]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-# CHECK:             llvm.store %[[VAL_13]], %[[VAL_15]] : !llvm.ptr<i1>
+# CHECK:             %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_7]][%[[VAL_14]]] : (!cc.ptr<!cc.array<i1 x 2>>, i64) -> !cc.ptr<i1>
+# CHECK:             cc.store %[[VAL_13]], %[[VAL_15]] : !cc.ptr<i1>
 # CHECK:             cc.continue %[[VAL_11]] : index
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_16:.*]]: index):

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -135,8 +135,9 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
   auto arrPtrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
   Value vecPtr = opBuilder.create<cc::StdvecDataOp>(arrPtrTy, vectorValue);
   Type elePtrTy = cc::PointerType::get(eleTy);
+  std::int32_t idx32 = static_cast<std::int32_t>(idx);
   Value eleAddr = opBuilder.create<cc::ComputePtrOp>(
-      elePtrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{idx});
+      elePtrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{idx32});
   Value loaded = opBuilder.create<cc::LoadOp>(eleAddr);
   auto ret = extractedFromIndex.emplace(
       std::make_pair(idx, QuakeValue(opBuilder, loaded)));

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -132,11 +132,12 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
 
   Type eleTy = vectorValue.getType().cast<cc::StdvecType>().getElementType();
 
-  Type elePtrTy = LLVM::LLVMPointerType::get(eleTy);
-  Value vecPtr = opBuilder.create<cc::StdvecDataOp>(elePtrTy, vectorValue);
-  Value eleAddr =
-      opBuilder.create<LLVM::GEPOp>(elePtrTy, vecPtr, ValueRange{indexVar});
-  Value loaded = opBuilder.create<LLVM::LoadOp>(eleAddr);
+  auto arrPtrTy = cc::PointerType::get(cc::ArrayType::get(eleTy));
+  Value vecPtr = opBuilder.create<cc::StdvecDataOp>(arrPtrTy, vectorValue);
+  Type elePtrTy = cc::PointerType::get(eleTy);
+  Value eleAddr = opBuilder.create<cc::ComputePtrOp>(
+      elePtrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{idx});
+  Value loaded = opBuilder.create<cc::LoadOp>(eleAddr);
   auto ret = extractedFromIndex.emplace(
       std::make_pair(idx, QuakeValue(opBuilder, loaded)));
   return ret.first->second;
@@ -181,11 +182,11 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
 
   Type eleTy = vectorValue.getType().cast<cc::StdvecType>().getElementType();
 
-  Type elePtrTy = LLVM::LLVMPointerType::get(eleTy);
+  Type elePtrTy = cc::PointerType::get(eleTy);
   Value vecPtr = opBuilder.create<cc::StdvecDataOp>(elePtrTy, vectorValue);
-  Value eleAddr =
-      opBuilder.create<LLVM::GEPOp>(elePtrTy, vecPtr, ValueRange{indexVar});
-  Value loaded = opBuilder.create<LLVM::LoadOp>(eleAddr);
+  Value eleAddr = opBuilder.create<cc::ComputePtrOp>(
+      elePtrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{indexVar});
+  Value loaded = opBuilder.create<cc::LoadOp>(eleAddr);
   auto ret = extractedFromValue.emplace(
       std::make_pair(opaquePtr, QuakeValue(opBuilder, loaded)));
   return ret.first->second;
@@ -237,15 +238,15 @@ QuakeValue QuakeValue::slice(const std::size_t startIdx,
 
   // must be a stdvec type
   auto svecTy = dyn_cast<cc::StdvecType>(vectorValue.getType());
-  auto ptrTy = opt::factory::getPointerType(opBuilder.getContext());
+  auto ptrTy = cc::PointerType::get(opBuilder.getI8Type());
   auto vecPtr = opBuilder.create<cc::StdvecDataOp>(ptrTy, vectorValue);
   auto bits = svecTy.getElementType().getIntOrFloatBitWidth();
   assert(bits > 0);
   auto scale = opBuilder.create<arith::ConstantIntOp>((bits + 7) / 8,
                                                       startIdxValue.getType());
-  auto offset = opBuilder.create<arith::MulIOp>(scale, startIdxValue);
-  auto ptr =
-      opBuilder.create<LLVM::GEPOp>(ptrTy, vecPtr, ArrayRef<Value>{offset});
+  Value offset = opBuilder.create<arith::MulIOp>(scale, startIdxValue);
+  auto ptr = opBuilder.create<cc::ComputePtrOp>(
+      ptrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{offset});
   Value subVecInit = opBuilder.create<cc::StdvecInitOp>(vectorValue.getType(),
                                                         ptr, countValue);
 

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -460,8 +460,7 @@ QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,
       builder.getIntegerType(64), value);
   Value size = builder.template create<arith::IndexCastOp>(
       builder.getIndexType(), vecSize);
-  auto i1PtrTy = cudaq::opt::factory::getPointerType(i1Ty);
-  auto buff = builder.template create<LLVM::AllocaOp>(i1PtrTy, vecSize);
+  auto buff = builder.template create<cc::AllocaOp>(i1Ty, vecSize);
   cudaq::opt::factory::createCountedLoop(
       builder, builder.getLoc(), size,
       [&](OpBuilder &nestedBuilder, Location nestedLoc, Region &,
@@ -475,9 +474,10 @@ QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,
         auto i64Ty = nestedBuilder.getIntegerType(64);
         auto intIv =
             nestedBuilder.create<arith::IndexCastOp>(nestedLoc, i64Ty, iv);
-        auto addr = nestedBuilder.create<LLVM::GEPOp>(nestedLoc, i1PtrTy, buff,
-                                                      ValueRange{intIv});
-        nestedBuilder.create<LLVM::StoreOp>(nestedLoc, bit, addr);
+        auto i1PtrTy = cudaq::cc::PointerType::get(i1Ty);
+        auto addr = nestedBuilder.create<cc::ComputePtrOp>(
+            nestedLoc, i1PtrTy, buff, ValueRange{intIv});
+        nestedBuilder.create<cc::StoreOp>(nestedLoc, bit, addr);
       });
   Value ret = builder.template create<cc::StdvecInitOp>(
       cc::StdvecType::get(builder.getContext(), i1Ty), buff, vecSize);

--- a/test/AST-Quake/auto_kernel-1.cpp
+++ b/test/AST-Quake/auto_kernel-1.cpp
@@ -26,9 +26,9 @@ struct ak1 {
 // CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
-// CHECK:           %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_13]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
-// CHECK:           %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_16]][%[[VAL_15]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-// CHECK:           %[[VAL_18:.*]] = llvm.load %[[VAL_17]] : !llvm.ptr<i1>
+// CHECK:           %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_13]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_17:.*]] = cc.compute_ptr %[[VAL_16]][%[[VAL_15]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_18:.*]] = cc.load %[[VAL_17]] : !cc.ptr<i1>
 // CHECK:           return %[[VAL_18]] : i1
 // CHECK:         }
 // CHECK-NOT:     func.func private @_ZNKSt14_Bit_referencecvbEv() -> i1

--- a/test/AST-Quake/auto_kernel-2.cpp
+++ b/test/AST-Quake/auto_kernel-2.cpp
@@ -23,11 +23,11 @@ struct ak2 {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ak2
 // CHECK-SAME: () -> !cc.stdvec<i1> attributes {
 // CHECK:           %[[VAL_19:.*]] = quake.mz %{{.*}} : (!quake.veq<5>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_19]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_19]] : (!cc.stdvec<i1>) -> !cc.ptr<none>
 // CHECK:           %[[VAL_21:.*]] = cc.stdvec_size %[[VAL_19]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_22:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_23:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) : (!llvm.ptr<i8>, i64, i64) -> !llvm.ptr<i8>
-// CHECK:           %[[VAL_24:.*]] = cc.stdvec_init %[[VAL_23]], %[[VAL_21]] : (!llvm.ptr<i8>, i64) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_23:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) : (!cc.ptr<none>, i64, i64) -> !cc.ptr<none>
+// CHECK:           %[[VAL_24:.*]] = cc.stdvec_init %[[VAL_23]], %[[VAL_21]] : (!cc.ptr<none>, i64) -> !cc.stdvec<i1>
 // CHECK:           return %[[VAL_24]] : !cc.stdvec<i1>
 // CHECK:         }
 // CHECK-NOT:   func.func {{.*}} @_ZNKSt14_Bit_referencecvbEv() -> i1

--- a/test/AST-Quake/lambda_variable.cpp
+++ b/test/AST-Quake/lambda_variable.cpp
@@ -85,7 +85,7 @@ struct test4_caller {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<?>[%[[VAL_1]] : i64]
-// CHECK:           %[[VAL_3:.*]] = cc.undef !llvm.struct<"test4_callee", ()>
+// CHECK:           %[[VAL_3:.*]] = cc.undef !cc.struct<"test4_callee" {}>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.ref):
 // CHECK:             cc.scope {

--- a/test/AST-Quake/loop_unroll.cpp
+++ b/test/AST-Quake/loop_unroll.cpp
@@ -18,18 +18,17 @@ struct C {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__C()
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
-// CHECK-DAG:       %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x i1 : (i64) -> !llvm.ptr<i1>
+// CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.array<i1 x 2>
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_2]]] : (!quake.veq<2>, index) -> !quake.ref
 // CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
-// CHECK:           llvm.store %[[VAL_6]], %[[VAL_4]] : !llvm.ptr<i1>
+// CHECK:           cc.store %[[VAL_6]], %{{.*}} : !cc.ptr<i1>
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.veq<2>, index) -> !quake.ref
 // CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
-// CHECK:           %[[VAL_9:.*]] = llvm.getelementptr %[[VAL_4]][1] : (!llvm.ptr<i1>) -> !llvm.ptr<i1>
-// CHECK:           llvm.store %[[VAL_8]], %[[VAL_9]] : !llvm.ptr<i1>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][%{{.*}}] : (!cc.ptr<!cc.array<i1 x 2>>, i64) -> !cc.ptr<i1>
+// CHECK:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<i1>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/measure_bell.cpp
+++ b/test/AST-Quake/measure_bell.cpp
@@ -63,18 +63,18 @@ int main() { bell{}(100); }
 // CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
-// CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_25:.*]] = llvm.getelementptr %[[VAL_24]]{{\[}}%[[VAL_23]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_26:.*]] = llvm.load %[[VAL_25]] : !llvm.ptr<i1>
+// CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_24]]{{\[}}%[[VAL_23]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i1>
 // CHECK:                 %[[VAL_27:.*]] = memref.alloca() : memref<i1>
 // CHECK:                 memref.store %[[VAL_26]], %[[VAL_27]][] : memref<i1>
 // CHECK:                 %[[VAL_28:.*]] = memref.load %[[VAL_27]][] : memref<i1>
 // CHECK:                 %[[VAL_29:.*]] = arith.extui %[[VAL_28]] : i1 to i32
 // CHECK:                 %[[VAL_30:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_31:.*]] = arith.extsi %[[VAL_30]] : i32 to i64
-// CHECK:                 %[[VAL_32:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_33:.*]] = llvm.getelementptr %[[VAL_32]]{{\[}}%[[VAL_31]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_34:.*]] = llvm.load %[[VAL_33]] : !llvm.ptr<i1>
+// CHECK:                 %[[VAL_32:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_33:.*]] = cc.compute_ptr %[[VAL_32]]{{\[}}%[[VAL_31]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_34:.*]] = cc.load %[[VAL_33]] : !cc.ptr<i1>
 // CHECK:                 %[[VAL_35:.*]] = arith.extui %[[VAL_34]] : i1 to i32
 // CHECK:                 %[[VAL_36:.*]] = arith.cmpi eq, %[[VAL_29]], %[[VAL_35]] : i32
 // CHECK:                 cc.if(%[[VAL_36]]) {
@@ -164,14 +164,14 @@ struct tinkerbell {
 // CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
-// CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_25:.*]] = llvm.getelementptr %[[VAL_24]]{{\[}}%[[VAL_23]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_26:.*]] = llvm.load %[[VAL_25]] : !llvm.ptr<i1>
+// CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_24]][%[[VAL_23]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i1>
 // CHECK:                 %[[VAL_27:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_28:.*]] = arith.extsi %[[VAL_27]] : i32 to i64
-// CHECK:                 %[[VAL_29:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_30:.*]] = llvm.getelementptr %[[VAL_29]]{{\[}}%[[VAL_28]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_31:.*]] = llvm.load %[[VAL_30]] : !llvm.ptr<i1>
+// CHECK:                 %[[VAL_29:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_30:.*]] = cc.compute_ptr %[[VAL_29]][%[[VAL_28]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_31:.*]] = cc.load %[[VAL_30]] : !cc.ptr<i1>
 // CHECK:                 %[[VAL_32:.*]] = arith.cmpi eq, %[[VAL_31]], %[[VAL_26]] : i1
 // CHECK:                 cc.if(%[[VAL_32]]) {
 // CHECK:                   cc.scope {
@@ -228,16 +228,16 @@ struct tinkerbell {
 // CHECK:                 %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:                 %[[VAL_22:.*]] = arith.constant 0 : i32
 // CHECK:                 %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i32 to i64
-// CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_25:.*]] = llvm.getelementptr %[[VAL_24]]{{\[}}%[[VAL_23]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_26:.*]] = llvm.load %[[VAL_25]] : !llvm.ptr<i1>
+// CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_24]][%[[VAL_23]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i1>
 // CHECK:                 %[[VAL_27:.*]] = memref.alloca() : memref<i1>
 // CHECK:                 memref.store %[[VAL_26]], %[[VAL_27]][] : memref<i1>
 // CHECK:                 %[[VAL_28:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_29:.*]] = arith.extsi %[[VAL_28]] : i32 to i64
-// CHECK:                 %[[VAL_30:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_31:.*]] = llvm.getelementptr %[[VAL_30]]{{\[}}%[[VAL_29]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-// CHECK:                 %[[VAL_32:.*]] = llvm.load %[[VAL_31]] : !llvm.ptr<i1>
+// CHECK:                 %[[VAL_30:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_31:.*]] = cc.compute_ptr %[[VAL_30]][%[[VAL_29]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
+// CHECK:                 %[[VAL_32:.*]] = cc.load %[[VAL_31]] : !cc.ptr<i1>
 // CHECK:                 %[[VAL_33:.*]] = memref.alloca() : memref<i1>
 // CHECK:                 memref.store %[[VAL_32]], %[[VAL_33]][] : memref<i1>
 // CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_33]][] : memref<i1>

--- a/test/AST-Quake/mz.cpp
+++ b/test/AST-Quake/mz.cpp
@@ -47,11 +47,11 @@ struct VectorOfStaticVeq {
 // CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<?>[%[[VAL_5]] : i64]
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i1>) -> !cc.ptr<none>
 // CHECK:           %[[VAL_10:.*]] = cc.stdvec_size %[[VAL_8]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_11:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_12:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_9]], %[[VAL_10]], %[[VAL_11]]) : (!llvm.ptr<i8>, i64, i64) -> !llvm.ptr<i8>
-// CHECK:           %[[VAL_13:.*]] = cc.stdvec_init %[[VAL_12]], %[[VAL_10]] : (!llvm.ptr<i8>, i64) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_12:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_9]], %[[VAL_10]], %[[VAL_11]]) : (!cc.ptr<none>, i64, i64) -> !cc.ptr<none>
+// CHECK:           %[[VAL_13:.*]] = cc.stdvec_init %[[VAL_12]], %[[VAL_10]] : (!cc.ptr<none>, i64) -> !cc.stdvec<i1>
 // CHECK:           return %[[VAL_13]] : !cc.stdvec<i1>
 // CHECK:         }
 
@@ -80,11 +80,11 @@ struct VectorOfDynamicVeq {
 // CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<?>[%[[VAL_9]] : i64]
 // CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<none>
 // CHECK:           %[[VAL_14:.*]] = cc.stdvec_size %[[VAL_12]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_15:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_16:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]]) : (!llvm.ptr<i8>, i64, i64) -> !llvm.ptr<i8>
-// CHECK:           %[[VAL_17:.*]] = cc.stdvec_init %[[VAL_16]], %[[VAL_14]] : (!llvm.ptr<i8>, i64) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_16:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]]) : (!cc.ptr<none>, i64, i64) -> !cc.ptr<none>
+// CHECK:           %[[VAL_17:.*]] = cc.stdvec_init %[[VAL_16]], %[[VAL_14]] : (!cc.ptr<none>, i64) -> !cc.stdvec<i1>
 // CHECK:           return %[[VAL_17]] : !cc.stdvec<i1>
 // CHECK:         }
 

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -267,7 +267,7 @@ int main() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_qpe
 // CHECK-SAME:      (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32,
 // CHECK-SAME:       %[[VAL_2:.*]]: !cc.lambda<(!quake.veq<?>) -> ()>,
-// CHECK-SAME:       %[[VAL_3:.*]]: !llvm.struct<"tgate", ()>) attributes
+// CHECK-SAME:       %[[VAL_3:.*]]: !cc.struct<"tgate" {}>) attributes
 // CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
 // CHECK:           memref.store %[[VAL_0]], %[[VAL_4]][] : memref<i32>
 // CHECK:           %[[VAL_5:.*]] = memref.alloca() : memref<i32>

--- a/test/AST-Quake/vector_bool.cpp
+++ b/test/AST-Quake/vector_bool.cpp
@@ -25,9 +25,9 @@ struct t1 {
 // CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
-// CHECK:           %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_13]] : (!cc.stdvec<i1>) -> !llvm.ptr<i1>
-// CHECK:           %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_16]][%[[VAL_15]]] : (!llvm.ptr<i1>, i64) -> !llvm.ptr<i1>
-// CHECK:           %[[VAL_18:.*]] = llvm.load %[[VAL_17]] : !llvm.ptr<i1>
+// CHECK:           %[[VAL_16:.*]] = cc.stdvec_data %[[VAL_13]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_17:.*]] = cc.compute_ptr %[[VAL_16]][%[[VAL_15]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_18:.*]] = cc.load %[[VAL_17]] : !cc.ptr<i1>
 // CHECK:           return %[[VAL_18]] : i1
 // CHECK:         }
 // CHECK-NOT:     func.func private @_ZNKSt14_Bit_referencecvbEv() -> i1


### PR DESCRIPTION
Fix tests. Add new CC ops to codegen for end-to-end compilation.
