### PR TITLE
Fixed `QppCircuitSimulator` shots `ExecutionResult.expectationValue` 

### DIFF
--- a/python/tests/unittests/test_vqe.py
+++ b/python/tests/unittests/test_vqe.py
@@ -123,7 +123,7 @@ def test_vqe_two_qubit_float(optimizer, kernel_two_qubit_vqe_float,
         optimizer,
         parameter_count=1,
         argument_mapper=lambda parameter_vector: parameter_vector[0],
-        shots=100)
+        shots=-1)
 
     # Known minimal expectation value for this system:
     want_expectation_value = -1.7487948611472093
@@ -149,7 +149,7 @@ def test_vqe_two_qubit_list(optimizer, kernel_two_qubit_vqe_list,
                                                hamiltonian_2q,
                                                optimizer,
                                                parameter_count=1,
-                                               shots=100)
+                                               shots=-1)
 
     # Known minimal expectation value for this system:
     want_expectation_value = -1.7487948611472093
@@ -197,7 +197,7 @@ def test_vqe_two_qubit_float_gradients(optimizer, gradient,
         optimizer=optimizer,
         parameter_count=1,
         argument_mapper=argument_map,
-        shots=100)
+        shots=-1)
 
     # Known minimal expectation value for this system:
     want_expectation_value = -1.7487948611472093
@@ -237,7 +237,7 @@ def test_vqe_two_qubit_list_gradients(optimizer, gradient,
                                                spin_operator=hamiltonian_2q,
                                                optimizer=optimizer,
                                                parameter_count=1,
-                                               shots=100)
+                                               shots=-1)
 
     # Known minimal expectation value for this system:
     want_expectation_value = -1.7487948611472093

--- a/runtime/common/MeasureCounts.cpp
+++ b/runtime/common/MeasureCounts.cpp
@@ -344,11 +344,6 @@ bool sample_result::has_expectation(const std::string_view registerName) {
 
 double sample_result::exp_val_z(const std::string_view registerName) {
   double aver = 0.0;
-  auto has_even_parity = [](const std::string &x) -> bool {
-    int c = std::count(x.begin(), x.end(), '1');
-    return c % 2 == 0;
-  };
-
   auto iter = sampleResults.find(registerName.data());
   if (iter == sampleResults.end())
     return 0.0;
@@ -460,4 +455,8 @@ void sample_result::dump(std::ostream &os) {
 
 void sample_result::dump() { dump(std::cout); }
 
+bool sample_result::has_even_parity(std::string_view bitString) {
+  int c = std::count(bitString.begin(), bitString.end(), '1');
+  return c % 2 == 0;
+}
 } // namespace cudaq

--- a/runtime/common/MeasureCounts.h
+++ b/runtime/common/MeasureCounts.h
@@ -265,6 +265,11 @@ public:
   /// @brief Range-based constant iterator end function
   /// @return
   CountsDictionary::const_iterator end() const { return cend(); }
+
+  /// @brief Return true if the bit string has even parity
+  /// @param bitString 
+  /// @return 
+  static bool has_even_parity(std::string_view bitString);
 };
 
 } // namespace cudaq

--- a/runtime/common/MeasureCounts.h
+++ b/runtime/common/MeasureCounts.h
@@ -267,8 +267,8 @@ public:
   CountsDictionary::const_iterator end() const { return cend(); }
 
   /// @brief Return true if the bit string has even parity
-  /// @param bitString 
-  /// @return 
+  /// @param bitString
+  /// @return
   static bool has_even_parity(std::string_view bitString);
 };
 

--- a/runtime/cudaq/domains/chemistry/molecule.h
+++ b/runtime/cudaq/domains/chemistry/molecule.h
@@ -29,6 +29,7 @@ private:
 public:
   molecular_geometry(std::initializer_list<atom> &&args)
       : atoms(args.begin(), args.end()) {}
+  molecular_geometry(const std::vector<atom> &args) : atoms(args) {}
   std::size_t size() const { return atoms.size(); }
   auto begin() { return atoms.begin(); }
   auto end() { return atoms.end(); }

--- a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
+++ b/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
@@ -137,14 +137,6 @@ protected:
   custatevecComputeType_t cuStateVecComputeType = CUSTATEVEC_COMPUTE_64F;
   cudaDataType_t cuStateVecCudaDataType = CUDA_C_64F;
 
-  /// @brief Return true if the bit string has even parity
-  /// @param x
-  /// @return
-  bool hasEvenParity(const std::string &x) {
-    int c = std::count(x.begin(), x.end(), '1');
-    return c % 2 == 0;
-  }
-
   /// @brief Convert the pauli rotation gate name to a CUSTATEVEC_PAULI Type
   /// @param type
   /// @return
@@ -514,7 +506,7 @@ public:
 
     // Compute the expectation value from the counts
     for (auto &kv : counts.counts) {
-      auto par = hasEvenParity(kv.first);
+      auto par = sample_result::has_even_parity(kv.first);
       auto p = kv.second / (double)shots;
       if (!par) {
         p = -p;

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -92,7 +92,7 @@ cudaq::sample_result sampleJitCode(ExecutionEngine *jit,
       .value();
 }
 
-/// @brief Run sampling on the JIT compiled kernel function
+/// @brief Run observation on the JIT compiled kernel function
 cudaq::observe_result observeJitCode(ExecutionEngine *jit, cudaq::spin_op &h,
                                      const std::string &kernelName) {
   auto &p = cudaq::get_platform();
@@ -102,7 +102,7 @@ cudaq::observe_result observeJitCode(ExecutionEngine *jit, cudaq::spin_op &h,
                                             kernelName);
                ASSERT_TRUE(!err);
              },
-             h, p, 1000, "")
+             h, p, /*shots=*/-1, "")
       .value();
 }
 

--- a/unittests/domains/ChemistryTester.cpp
+++ b/unittests/domains/ChemistryTester.cpp
@@ -6,8 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include <random>
 #include "CUDAQTestUtils.h"
+#include <random>
 
 #include "cudaq/algorithm.h"
 #include "cudaq/domains/chemistry.h"

--- a/unittests/domains/ChemistryTester.cpp
+++ b/unittests/domains/ChemistryTester.cpp
@@ -6,6 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#include <random>
 #include "CUDAQTestUtils.h"
 
 #include "cudaq/algorithm.h"
@@ -84,5 +85,38 @@ CUDAQ_TEST(H2MoleculeTester, checkUCCSD) {
 
     // Make sure our UCCSD state at the optimal parameters is the ground state
     EXPECT_NEAR(1.0, groundState.overlap(expectedState), 1e-6);
+  }
+
+  {
+    // Test dynamic molecular_geometry generation
+    const auto gen_random_h2_geometry = []() -> std::vector<cudaq::atom> {
+      std::vector<cudaq::atom> geom;
+      geom.emplace_back(cudaq::atom{"H", {0.0, 0.0, 0.0}});
+      static std::random_device rd;
+      static std::uniform_real_distribution<> dist(0.1, 1); // range [0.1, 1)
+      geom.emplace_back(cudaq::atom{"H", {0.0, 0.0, dist(rd)}});
+      return geom;
+    };
+
+    cudaq::molecular_geometry geometry(gen_random_h2_geometry());
+    auto molecule = cudaq::create_molecule(geometry, "sto-3g", 1, 0);
+    auto ansatz = [&](const std::vector<double> &thetas) __qpu__ {
+      cudaq::qreg q(2 * molecule.n_orbitals);
+      for (std::size_t qId = 0; qId < molecule.n_orbitals; ++qId) {
+        x(q[qId]);
+      }
+      cudaq::uccsd(q, thetas, molecule.n_electrons);
+    };
+
+    cudaq::optimizers::cobyla optimizer;
+    auto res = cudaq::vqe(ansatz, molecule.hamiltonian, optimizer,
+                          cudaq::uccsd_num_parameters(molecule.n_electrons,
+                                                      2 * molecule.n_orbitals));
+
+    // Get the true ground state eigenvalue
+    auto matrix = molecule.hamiltonian.to_matrix();
+    const auto min_eigenvalue = matrix.minimal_eigenvalue();
+    EXPECT_NEAR(min_eigenvalue.real(), std::get<0>(res), 1e-3);
+    EXPECT_NEAR(min_eigenvalue.imag(), 0.0, 1e-9);
   }
 }


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
There is a discrepancy b/w `QppCircuitSimulator::sample()` and `CuStateVecCircuitSimulator::sample()` when computing `expectationValue` for the `shots > 0` case. `QppCircuitSimulator` always sets `expectationValue` to the true value, not from the shots distribution like `CuStateVecCircuitSimulator`.

This MR is to make `QppCircuitSimulator::sample()` consistent with  `CuStateVecCircuitSimulator::sample()`. 

Changes:

- Refactor the even parity checker into a static helper of `sample_result` (I think it is a logical place) to reduce code duplication.

- Move `QppCircuitSimulator::calculateExpectationValue` (compute the true expectation value) to within the `if` block (no need to do it when we don't need to).

- Compute and set the  `expectationValue` in `QppCircuitSimulator::sample()` from shots.

- Fix a unit test `QuakeSynthTests` which relied on the old behavior (get the true expectation even when the `shots` value was set, hence the check tolerance was tight).

- [unrelated] Add a constructor to `molecular_geometry` and a test for that (per conversation with @amccaskey) 