### PR TITLE
Updating links on GitHub to point to the new docs location

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -5,7 +5,7 @@ Quantum Documentation][cuda_quantum_docs]. The page also contains [installation
 instructions][official_install] for released packages.
 
 [cuda_quantum_docs]: https://nvidia.github.io/cuda-quantum/
-[official_install]: https://nvidia.github.io/cuda-quantum/install.html
+[official_install]: https://nvidia.github.io/cuda-quantum/latest/install.html
 
 This document contains instructions for how to build CUDA Quantum from source.
 This is only needed if you would like to try out the latest (unreleased) version

--- a/Developing.md
+++ b/Developing.md
@@ -7,7 +7,7 @@ you would like to contribute applications and examples that use the CUDA Quantum
 platform, please follow the instructions for [installing CUDA
 Quantum][official_install] instead.
 
-[official_install]: https://nvidia.github.io/cuda-quantum/install.html
+[official_install]: https://nvidia.github.io/cuda-quantum/latest/install.html
 
 ## Quick start guide
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repository and/or add your own modifications, please build CUDA Quantum from
 source following [these instructions](./Building.md).
 
 [cuda_quantum_docs]: https://nvidia.github.io/cuda-quantum/
-[official_install]: https://nvidia.github.io/cuda-quantum/install.html
+[official_install]: https://nvidia.github.io/cuda-quantum/latest/install.html
 
 ## Contributing
 

--- a/docs/sphinx/specification/cudaq/synthesis.rst
+++ b/docs/sphinx/specification/cudaq/synthesis.rst
@@ -56,7 +56,7 @@ or :code:`cudaq::qspan`), and the remaining arguments for the kernel itself.
 Compiler implementations are free to synthesize multi-controlled operations
 using any pertinent synthesis strategy available. Qubits may be aggregated into
 a range of control qubits with or without the use of the :code:`operator!`
-`negated polarity operator <https://nvidia.github.io/cuda-quantum/specification/cudaq/operations.html>`_.
+:doc:`negated polarity operator <operations>`.
 
 .. code-block:: cpp
 


### PR DESCRIPTION
In prep for publishing versioned docs, I moved the docs under the `latest` folder. While I redirected the primary landing page, I did not set up redirects for all subpages, hence these links need to be updated.

