### PR TITLE
Fix sporadic python test error #191

### DIFF
--- a/python/tests/unittests/test_sample.py
+++ b/python/tests/unittests/test_sample.py
@@ -358,8 +358,10 @@ def test_sample_result_observe(shots_count):
             sub_register_counts = sample_result.get_register_counts(got_name)
             # Sub-term should have the an expectation proportional to the entire
             # system.
-            assert sub_term_counts.expectation_z() == want_expectation / qubit_count
-            assert sub_register_counts.expectation_z() == want_expectation / qubit_count
+            assert sub_term_counts.expectation_z(
+            ) == want_expectation / qubit_count
+            assert sub_register_counts.expectation_z(
+            ) == want_expectation / qubit_count
             # Should have `shots_count` results for each.
             assert sum(sub_term_counts.values()) == shots_count
             assert sum(sub_register_counts.values()) == shots_count
@@ -474,6 +476,7 @@ def test_sample_marginalize():
     marginal_result = sample_result.get_marginal_counts([1, 2, 3])
     assert marginal_result.most_probable() == "101"
 
+
 def test_qubit_reset():
     """
     Basic test that we can apply a qubit reset.
@@ -486,7 +489,8 @@ def test_qubit_reset():
 
     counts = cudaq.sample(kernel)
     assert (len(counts) == 1)
-    assert('0' in counts)
+    assert ('0' in counts)
+
 
 def test_qreg_reset():
     """
@@ -500,8 +504,9 @@ def test_qreg_reset():
 
     counts = cudaq.sample(kernel)
     assert (len(counts) == 1)
-    assert('00' in counts)
-    
+    assert ('00' in counts)
+
+
 def test_for_loop():
     """
     Test that we can build a kernel expression with a for loop.
@@ -510,14 +515,16 @@ def test_for_loop():
     qubits = circuit.qalloc(inSize)
     circuit.h(qubits[0])
     # can pass concrete integers for both
-    circuit.for_loop(0, inSize-1, lambda index : circuit.cx(qubits[index], qubits[index+1]))
+    circuit.for_loop(0, inSize - 1,
+                     lambda index: circuit.cx(qubits[index], qubits[index + 1]))
     print(circuit)
     counts = cudaq.sample(circuit, 5)
     assert len(counts) == 2
-    assert '0'*5 in counts
-    assert '1'*5 in counts 
+    assert '0' * 5 in counts
+    assert '1' * 5 in counts
 
     counts.dump()
+
 
 def test_sample_n():
     """
@@ -527,11 +534,12 @@ def test_sample_n():
     qubits = circuit.qalloc(inSize)
     circuit.h(qubits[0])
     # can pass concrete integers for both
-    circuit.for_loop(0, inSize-1, lambda index : circuit.cx(qubits[index], qubits[index+1]))
+    circuit.for_loop(0, inSize - 1,
+                     lambda index: circuit.cx(qubits[index], qubits[index + 1]))
     # circuit.mz(qubits)
     print(circuit)
 
-    allCounts = cudaq.sample_n(circuit, [3,4,5,6,7])
+    allCounts = cudaq.sample_n(circuit, [3, 4, 5, 6, 7])
     first0 = '000'
     first1 = '111'
     for c in allCounts:
@@ -545,20 +553,21 @@ def test_sample_n():
     allCounts = cudaq.sample_n(circuit, testNpArray)
     for i, c in enumerate(allCounts):
         print(c)
-        assert '0'*testNpArray[i] in c and '1'*testNpArray[i] in c 
+        assert '0' * testNpArray[i] in c and '1' * testNpArray[i] in c
 
-    circuit, angles = cudaq.make_kernel(list) 
+    circuit, angles = cudaq.make_kernel(list)
     q = circuit.qalloc(2)
     circuit.rx(angles[0], q[0])
     circuit.ry(angles[1], q[0])
     circuit.cx(q[0], q[1])
 
-    runtimeAngles = np.random.uniform(low=1.0, high=np.pi, size=(10,2))
+    runtimeAngles = np.random.uniform(low=1.0, high=np.pi, size=(10, 2))
     print(runtimeAngles)
     allCounts = cudaq.sample_n(circuit, runtimeAngles)
     for i, c in enumerate(allCounts):
         print(runtimeAngles[i, :], c)
         assert len(c) == 2
+
 
 # leave for gdb debugging
 if __name__ == "__main__":

--- a/python/tests/unittests/test_sample.py
+++ b/python/tests/unittests/test_sample.py
@@ -553,11 +553,11 @@ def test_sample_n():
     circuit.ry(angles[1], q[0])
     circuit.cx(q[0], q[1])
 
-    runtimeAngles = np.random.uniform(low=-np.pi, high=np.pi, size=(10,2))
+    runtimeAngles = np.random.uniform(low=1.0, high=np.pi, size=(10,2))
     print(runtimeAngles)
     allCounts = cudaq.sample_n(circuit, runtimeAngles)
     for i, c in enumerate(allCounts):
-        print(c)
+        print(runtimeAngles[i, :], c)
         assert len(c) == 2
 
 # leave for gdb debugging


### PR DESCRIPTION
Failure was due to random angles being too close to `0.0`, therefore not adequately rotating the state.  