### PR TITLE
Fixing segfault crashes when using measure/reset ops.

### DIFF
--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -82,7 +82,8 @@ public:
                      const std::vector<QuditInfo> &targets,
                      bool isAdjoint = false) = 0;
 
-  virtual void resetQudit(const QuditInfo &id) = 0;
+  /// Reset the qubit to the |0> state
+  virtual void reset(const QuditInfo &target) = 0;
 
   /// Begin an region of code where all operations will be adjoint-ed
   virtual void startAdjointRegion() = 0;

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -96,6 +96,9 @@ protected:
   /// @brief Measure the state in the basis described by the given `spin_op`.
   virtual void measureSpinOp(const cudaq::spin_op &op) = 0;
 
+  /// @brief Subtype-specific method for performing qudit reset.
+  /// @param q Qudit to reset
+  virtual void resetQudit(const QuditInfo &q) = 0;
 public:
   BasicExecutionManager() = default;
   virtual ~BasicExecutionManager() = default;
@@ -277,6 +280,11 @@ public:
     measureSpinOp(op);
     return std::make_pair(executionContext->expectationValue.value(),
                           executionContext->result);
+  }
+
+  void reset(const QuditInfo &target) override {
+    synchronize();
+    resetQudit(target);
   }
 };
 

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -99,6 +99,7 @@ protected:
   /// @brief Subtype-specific method for performing qudit reset.
   /// @param q Qudit to reset
   virtual void resetQudit(const QuditInfo &q) = 0;
+
 public:
   BasicExecutionManager() = default;
   virtual ~BasicExecutionManager() = default;
@@ -283,6 +284,7 @@ public:
   }
 
   void reset(const QuditInfo &target) override {
+    // We hit a reset, need to exec / clear instruction queue
     synchronize();
     resetQudit(target);
   }

--- a/runtime/cudaq/qis/managers/qir/QubitQIRExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/qir/QubitQIRExecutionManager.cpp
@@ -214,12 +214,14 @@ protected:
   }
 
   int measureQudit(const cudaq::QuditInfo &q) override {
+    flushRequestedAllocations();
     auto res_ptr = __quantum__qis__mz(qubits[q.id]);
     auto res = *reinterpret_cast<bool *>(res_ptr);
     return res ? 1 : 0;
   }
 
   void measureSpinOp(const cudaq::spin_op &op) override {
+    flushRequestedAllocations();
     Array *term_arr = spinToArray(op);
     __quantum__qis__measure__body(term_arr, nullptr);
   }
@@ -229,6 +231,7 @@ public:
   virtual ~QIRExecutionManager() {}
 
   void resetQudit(const cudaq::QuditInfo &id) override {
+    flushRequestedAllocations();
     __quantum__qis__reset(qubits[id.id]);
   }
 };

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -295,7 +295,7 @@ inline bool my(qubit &q) {
 }
 
 inline void reset(qubit &q) {
-  getExecutionManager()->resetQudit({q.n_levels(), q.id()});
+  getExecutionManager()->reset({q.n_levels(), q.id()});
 }
 
 // Measure all qubits in the range, return vector of 0,1

--- a/unittests/qis/QubitQISTester.cpp
+++ b/unittests/qis/QubitQISTester.cpp
@@ -341,7 +341,7 @@ CUDAQ_TEST(QubitQISTester, checkMeasureResetFence) {
       auto operator()() __qpu__ {
         // Allocate then measure, no gates.
         // Check that allocation requests are flushed.
-        cudaq::qreg q(2);
+        cudaq::qvector q(2);
         mz(q);
       }
     };
@@ -353,7 +353,7 @@ CUDAQ_TEST(QubitQISTester, checkMeasureResetFence) {
   {
     struct reset_circ {
       auto operator()() __qpu__ {
-        cudaq::qreg q(2);
+        cudaq::qvector q(2);
         x(q);
         reset(q[0]);
         mz(q);


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This is probably a regression since https://github.com/NVIDIA/cuda-quantum/pull/167 

Specifically, `flushRequestedAllocations()` is not called when handling measurement at the concrete `ExecutionManager` implementation (i.e., `QIRExecutionManager`) with the assumption that it has been called during `executeInstruction()`.
This will lead to a Segfault in this case (no gates)
```
{
        cudaq::qvector q(2);
        mz(q);
 }
```

For `reset` gate, there is a subtle issue w.r.t. gate ordering (leading to segfault eventually):
`ExecutionManager::resetQudit` is skipped by the middle `BasicExecutionManager` (where instruction batching occurs) and only implemented by the concrete subclass `QIRExecutionManager` -> `reset` op could be dispatched out of order due to no `synchronize()` call (-> segfault due to no `flushRequestedAllocations` call).

###  Changes
- Rename `ExecutionManager::resetQudit` -> `ExecutionManager::reset` and use `BasicExecutionManager::resetQudit` as the pure virtual method for sub-class implementation. This is to make it consistent with how `measure` is handled. 

- Add `flushRequestedAllocations()` call to `measureQudit`/`measureSpinOp`/`resetQudit` implementations.

- Add unit test cases.
