### PR TITLE
[cc] Add a folder to compute_ptr op.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -866,6 +866,8 @@ def cc_ComputePtrOp : CCOp<"compute_ptr", [Pure]> {
       `]` `:` functional-type(operands, results) attr-dict
   }];
 
+  let hasFolder = 1;
+
   let builders = [
     OpBuilder<(ins "mlir::Type":$resultType, "mlir::Value":$basePtr,
                "mlir::ValueRange":$indices,

--- a/test/AST-Quake/loop_unroll.cpp
+++ b/test/AST-Quake/loop_unroll.cpp
@@ -27,7 +27,7 @@ struct C {
 // CHECK:           cc.store %[[VAL_6]], %{{.*}} : !cc.ptr<i1>
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_1]]] : (!quake.veq<2>, index) -> !quake.ref
 // CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][%{{.*}}] : (!cc.ptr<!cc.array<i1 x 2>>, i64) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<i1 x 2>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<i1>
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/compute_ptr.qke
+++ b/test/Quake/compute_ptr.qke
@@ -1,0 +1,43 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --canonicalize %s | FileCheck %s
+
+func.func @e() -> !cc.ptr<f64> {
+  %0 = arith.constant 1 : i32
+  %z = arith.constant 0 : i32
+  %1 = arith.addi %z, %0 : i32
+  %2 = arith.addi %1, %0 : i32
+  %3 = cc.alloca !cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>
+  %4 = cc.compute_ptr %3[%1, %2] : (!cc.ptr<!cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>>, i32, i32) -> !cc.ptr<f64>
+  return %4 : !cc.ptr<f64>
+}
+
+func.func @r(%arg0: i64) -> !cc.ptr<f64> {
+  %0 = arith.constant 1 : i32
+  %z = arith.constant 0 : i32
+  %1 = arith.addi %z, %0 : i32
+  %2 = arith.addi %1, %0 : i32
+  %3 = cc.alloca !cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>
+  %4 = cc.compute_ptr %3[%1, %arg0] : (!cc.ptr<!cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>>, i32, i64) -> !cc.ptr<f64>
+  return %4 : !cc.ptr<f64>
+}
+
+// CHECK-LABEL:   func.func @e() -> !cc.ptr<f64> {
+// CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>
+// CHECK:           %[[VAL_1:.*]] = cc.compute_ptr %[[VAL_0]][1, 2] : (!cc.ptr<!cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>>) -> !cc.ptr<f64>
+// CHECK:           return %[[VAL_1]] : !cc.ptr<f64>
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @r(
+// CHECK-SAME:                 %[[VAL_0:.*]]: i64) -> !cc.ptr<f64> {
+// CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>
+// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][1, %[[VAL_0]]] : (!cc.ptr<!cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>>, i64) -> !cc.ptr<f64>
+// CHECK:           return %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:         }
+


### PR DESCRIPTION
The compute_ptr op can have (and prefers) constant operands. Make sure constants get folded into the op whenever possible.

