### PR TITLE
[cg] Move GenKernelExecution to CC dialect.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -819,8 +819,9 @@ def cc_InsertValueOp : CCOp<"insert_value", [Pure]> {
     Example:
 
     ```mlir
-      %s = cc.insert_value %r, %i [1, 0] : (!cc.struct<{i32, !cc.struct<{i16,
-           f32, i64}>}>, i16) -> !cc.struct<{i32, !cc.struct<{i16, f32, i64}>}>
+      %s = cc.insert_value %i16, %r[1, 0] :
+           (!cc.struct<{i32, !cc.struct<{i16, f32}>}>, i16) ->
+           !cc.struct<{i32, !cc.struct<{i16, f32}>}>
     ```
   }];
 
@@ -925,6 +926,12 @@ def cc_CastOp : CCOp<"cast", [Pure]> {
     ( `signed` $sint^ ):( ( `unsigned` $zint^ )? )? $value `:`
       functional-type(operands, results) attr-dict
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$resTy, "mlir::Value":$value), [{
+      return build($_builder, $_state, resTy, value, {}, {});
+    }]>
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/Builder/CUDAQBuilder.cpp
+++ b/lib/Optimizer/Builder/CUDAQBuilder.cpp
@@ -50,60 +50,58 @@ static constexpr IntrinsicCode intrinsicTable[] = {
     {"__nvqpp_createDynamicResult",
      {llvmMemCopyIntrinsic, "malloc"},
      R"#(
-  func.func private @__nvqpp_createDynamicResult(%arg0: !llvm.ptr<i8>, %arg1: i64, %arg2: !llvm.ptr<struct<(ptr<i8>, i64)>>) -> !llvm.struct<(ptr<i8>, i64)> {
-    %0 = llvm.getelementptr %arg2[0, 1] : (!llvm.ptr<struct<(ptr<i8>, i64)>>) -> !llvm.ptr<i64>
-    %1 = llvm.load %0 : !llvm.ptr<i64>
+  func.func private @__nvqpp_createDynamicResult(%arg0: !cc.ptr<i8>, %arg1: i64, %arg2: !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+    %0 = cc.compute_ptr %arg2[0, 1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+    %1 = cc.load %0 : !cc.ptr<i64>
     %2 = arith.addi %arg1, %1 : i64
-    %3 = call @malloc(%2) : (i64) -> !llvm.ptr<i8>
+    %3 = call @malloc(%2) : (i64) -> !cc.ptr<i8>
     %false = arith.constant false
-    call @llvm.memcpy.p0i8.p0i8.i64(%3, %arg0, %arg1, %false) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
-    %4 = llvm.getelementptr %arg2[0, 0] : (!llvm.ptr<struct<(ptr<i8>, i64)>>) -> !llvm.ptr<ptr<i8>>
-    %5 = llvm.load %4 : !llvm.ptr<ptr<i8>>
-    %6 = llvm.getelementptr %arg0[%arg1] : (!llvm.ptr<i8>, i64) -> !llvm.ptr<i8>
-    call @llvm.memcpy.p0i8.p0i8.i64(%6, %5, %1, %false) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
-    %7 = llvm.mlir.undef : !llvm.struct<(ptr<i8>, i64)>
-    %8 = llvm.insertvalue %3, %7[0] : !llvm.struct<(ptr<i8>, i64)> 
-    %9 = llvm.insertvalue %2, %8[1] : !llvm.struct<(ptr<i8>, i64)> 
-    return %9 : !llvm.struct<(ptr<i8>, i64)>
+    call @llvm.memcpy.p0i8.p0i8.i64(%3, %arg0, %arg1, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+    %4 = cc.compute_ptr %arg2[0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+    %5 = cc.load %4 : !cc.ptr<!cc.ptr<i8>>
+    %6 = cc.compute_ptr %arg0[%arg1] : (!cc.ptr<i8>, i64) -> !cc.ptr<i8>
+    call @llvm.memcpy.p0i8.p0i8.i64(%6, %5, %1, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+    %7 = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+    %8 = cc.insert_value %3, %7[0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+    %9 = cc.insert_value %2, %8[1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+    return %9 : !cc.struct<{!cc.ptr<i8>, i64}>
   })#"},
 
     {stdvecBoolCtorFromInitList, // __nvqpp_initializer_list_to_vector_bool
      {},
      R"#(
-  llvm.func @__nvqpp_initializer_list_to_vector_bool(!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> ())#"},
+  func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64) -> ())#"},
 
     {"__nvqpp_vectorCopyCtor", {llvmMemCopyIntrinsic, "malloc"}, R"#(
-  func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<none>, %arg1: i64, %arg2: i64) -> !cc.ptr<none> {
-    %a0 = cc.cast %arg0 : (!cc.ptr<none>) -> !llvm.ptr<i8>
+  func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<i8>, %arg1: i64, %arg2: i64) -> !cc.ptr<i8> {
     %size = arith.muli %arg1, %arg2 : i64
-    %0 = call @malloc(%size) : (i64) -> !llvm.ptr<i8>
+    %0 = call @malloc(%size) : (i64) -> !cc.ptr<i8>
     %false = arith.constant false
-    call @llvm.memcpy.p0i8.p0i8.i64(%0, %0, %arg1, %false) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
-    %r = cc.cast %0 : (!llvm.ptr<i8>) -> !cc.ptr<none>
-    return %r : !cc.ptr<none>
+    call @llvm.memcpy.p0i8.p0i8.i64(%0, %arg0, %arg1, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+    return %0 : !cc.ptr<i8>
   })#"},
 
     {"__nvqpp_zeroDynamicResult", {}, R"#(
-  func.func private @__nvqpp_zeroDynamicResult() -> !llvm.struct<(ptr<i8>, i64)> {
+  func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {
     %c0_i64 = arith.constant 0 : i64
-    %0 = llvm.inttoptr %c0_i64 : i64 to !llvm.ptr<i8>
-    %1 = llvm.mlir.undef : !llvm.struct<(ptr<i8>, i64)>
-    %2 = llvm.insertvalue %0, %1[0] : !llvm.struct<(ptr<i8>, i64)> 
-    %3 = llvm.insertvalue %c0_i64, %2[1] : !llvm.struct<(ptr<i8>, i64)> 
-    return %3 : !llvm.struct<(ptr<i8>, i64)>
+    %0 = cc.cast %c0_i64 : (i64) -> !cc.ptr<i8>
+    %1 = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+    %2 = cc.insert_value %0, %1[0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+    %3 = cc.insert_value %c0_i64, %2[1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+    return %3 : !cc.struct<{!cc.ptr<i8>, i64}>
   })#"},
 
     {cudaq::runtime::launchKernelFuncName, // altLaunchKernel
      {},
      R"#(
-  func.func private @altLaunchKernel(!llvm.ptr<i8>, !llvm.ptr<i8>, !llvm.ptr<i8>, i64, i64) -> ())#"},
+  func.func private @altLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> ())#"},
 
     {llvmMemCopyIntrinsic, // llvm.memcpy.p0i8.p0i8.i64
      {},
      R"#(
-  func.func private @llvm.memcpy.p0i8.p0i8.i64(!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ())#"},
+  func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ())#"},
 
-    {"malloc", {}, "func.func private @malloc(i64) -> !llvm.ptr<i8>"}};
+    {"malloc", {}, "func.func private @malloc(i64) -> !cc.ptr<i8>"}};
 
 static constexpr std::size_t intrinsicTableSize =
     sizeof(intrinsicTable) / sizeof(IntrinsicCode);

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -980,6 +980,22 @@ public:
   }
 };
 
+class ExtractValueOpPattern
+    : public ConvertOpToLLVMPattern<cudaq::cc::ExtractValueOp> {
+public:
+  using Base = ConvertOpToLLVMPattern<cudaq::cc::ExtractValueOp>;
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(cudaq::cc::ExtractValueOp extract, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto toTy = getTypeConverter()->convertType(extract.getType());
+    rewriter.replaceOpWithNewOp<LLVM::ExtractValueOp>(
+        extract, toTy, adaptor.getContainer(), adaptor.getPosition());
+    return success();
+  }
+};
+
 class FuncToPtrOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::FuncToPtrOp> {
 public:
@@ -991,8 +1007,25 @@ public:
   matchAndRewrite(cudaq::cc::FuncToPtrOp ftp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto operands = adaptor.getOperands();
-    auto toTy = ftp.getType();
+    auto toTy = getTypeConverter()->convertType(ftp.getType());
     rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(ftp, toTy, operands);
+    return success();
+  }
+};
+
+class InsertValueOpPattern
+    : public ConvertOpToLLVMPattern<cudaq::cc::InsertValueOp> {
+public:
+  using Base = ConvertOpToLLVMPattern<cudaq::cc::InsertValueOp>;
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(cudaq::cc::InsertValueOp insert, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto toTy = getTypeConverter()->convertType(insert.getType());
+    rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(
+        insert, toTy, adaptor.getContainer(), adaptor.getValue(),
+        adaptor.getPosition());
     return success();
   }
 };
@@ -1256,6 +1289,12 @@ public:
         return type;
       return LLVM::LLVMArrayType::get(eleTy, type.getSize());
     });
+    typeConverter.addConversion([&](cudaq::cc::StructType type) -> Type {
+      SmallVector<Type> members;
+      for (auto t : type.getMembers())
+        members.push_back(typeConverter.convertType(t));
+      return LLVM::LLVMStructType::getLiteral(context, members);
+    });
     RewritePatternSet patterns(context);
 
     populateAffineToStdConversionPatterns(patterns);
@@ -1273,7 +1312,8 @@ public:
         AllocaOpRewrite, AllocaOpPattern, CallableClosureOpPattern,
         CallableFuncOpPattern, CastOpPattern, ComputePtrOpPattern,
         ConcatOpRewrite, DeallocOpRewrite, ExtractQubitOpRewrite,
-        FuncToPtrOpPattern, InstantiateCallableOpPattern, LoadOpPattern,
+        ExtractValueOpPattern, FuncToPtrOpPattern, InsertValueOpPattern,
+        InstantiateCallableOpPattern, LoadOpPattern,
         MeasureRewrite<quake::MzOp>, OneTargetRewrite<quake::HOp>,
         OneTargetRewrite<quake::XOp>, OneTargetRewrite<quake::YOp>,
         OneTargetRewrite<quake::ZOp>, OneTargetRewrite<quake::SOp>,

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -58,13 +58,13 @@ public:
   /// ```
   /// where the values of the vector argument are pass-by-value and appended to
   /// the end of the struct as a sequence of \i n double values.
-  LLVM::LLVMStructType buildStructType(const std::string &name,
-                                       FunctionType funcTy) {
+  cudaq::cc::StructType buildStructType(const std::string &name,
+                                        FunctionType funcTy) {
     auto *ctx = funcTy.getContext();
     SmallVector<Type> eleTys;
     // Add all argument types, translating std::vector to a length.
     for (auto inTy : funcTy.getInputs()) {
-      if (inTy.isa<cudaq::cc::LambdaType, LLVM::LLVMStructType>())
+      if (inTy.isa<cudaq::cc::LambdaType, cudaq::cc::StructType>())
         eleTys.push_back(IntegerType::get(ctx, 64));
       else if (inTy.isa<cudaq::cc::StdvecType, quake::VeqType>())
         eleTys.push_back(IntegerType::get(ctx, 64));
@@ -73,26 +73,25 @@ public:
     }
     // Add all result types, translating std::vector to a length.
     for (auto outTy : funcTy.getResults()) {
-      if (outTy.isa<cudaq::cc::LambdaType, LLVM::LLVMStructType>()) {
+      if (outTy.isa<cudaq::cc::LambdaType, cudaq::cc::StructType>()) {
         eleTys.push_back(IntegerType::get(ctx, 64));
       } else if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(outTy)) {
-        eleTys.push_back(
-            cudaq::opt::factory::getPointerType(vecTy.getElementType()));
+        eleTys.push_back(cudaq::cc::PointerType::get(vecTy.getElementType()));
         eleTys.push_back(IntegerType::get(ctx, 64));
       } else {
         eleTys.push_back(outTy);
       }
     }
-    return LLVM::LLVMStructType::getLiteral(ctx, eleTys);
+    return cudaq::cc::StructType::get(ctx, eleTys);
   }
 
   // FIXME: We should get the underlying structure of a std::vector from the
   // AST. For expediency, we just construct the expected type directly here.
-  LLVM::LLVMStructType stlVectorType(Type eleTy) {
+  cudaq::cc::StructType stlVectorType(Type eleTy) {
     MLIRContext *ctx = eleTy.getContext();
-    auto elePtrTy = cudaq::opt::factory::getPointerType(eleTy);
+    auto elePtrTy = cudaq::cc::PointerType::get(eleTy);
     SmallVector<Type> eleTys = {elePtrTy, elePtrTy, elePtrTy};
-    return LLVM::LLVMStructType::getLiteral(ctx, eleTys);
+    return cudaq::cc::StructType::get(ctx, eleTys);
   }
 
   bool hasHiddenSRet(FunctionType funcTy) {
@@ -106,7 +105,7 @@ public:
     // kernel entry function. The CUDA Quantum language spec doesn't allow the
     // kernel object to contain data members (yet), so we can ignore this
     // pointer.
-    auto ptrTy = cudaq::opt::factory::getPointerType(ctx);
+    auto ptrTy = cudaq::cc::PointerType::get(IntegerType::get(ctx, 8));
     SmallVector<Type> inputTys = {ptrTy};
     bool hasSRet = false;
     if (hasHiddenSRet(funcTy)) {
@@ -121,10 +120,10 @@ public:
     // Add all the explicit (not hidden) arguments after the hidden ones.
     for (auto inTy : funcTy.getInputs()) {
       if (auto memrefTy = dyn_cast<cudaq::cc::StdvecType>(inTy))
-        inputTys.push_back(cudaq::opt::factory::getPointerType(
+        inputTys.push_back(cudaq::cc::PointerType::get(
             stlVectorType(memrefTy.getElementType())));
       else if (auto memrefTy = dyn_cast<quake::VeqType>(inTy))
-        inputTys.push_back(cudaq::opt::factory::getPointerType(stlVectorType(
+        inputTys.push_back(cudaq::cc::PointerType::get(stlVectorType(
             IntegerType::get(ctx, /*FIXME sizeof a pointer?*/ 64))));
       else
         inputTys.push_back(inTy);
@@ -139,10 +138,10 @@ public:
   }
 
   FunctionType getThunkType(MLIRContext *ctx) {
-    auto ptrTy = cudaq::opt::factory::getPointerType(ctx);
+    auto ptrTy = cudaq::cc::PointerType::get(IntegerType::get(ctx, 8));
     return FunctionType::get(
         ctx, {ptrTy, IntegerType::get(ctx, 1)},
-        {LLVM::LLVMStructType::getLiteral(
+        {cudaq::cc::StructType::get(
             ctx, ArrayRef<Type>{ptrTy, IntegerType::get(ctx, 64)})});
   }
 
@@ -163,63 +162,60 @@ public:
   /// `sizeof(data[N])` by the `sizeof(T)`. The result is the total required
   /// memory size for the vector data itself in \e bytes.
   Value getVectorSize(OpBuilder &builder, Location loc,
-                      LLVM::LLVMPointerType ptrTy, Value arg) {
+                      cudaq::cc::PointerType ptrTy, Value arg) {
     // Create the i64 type
     Type i64Ty = builder.getI64Type();
 
     // We're given ptr<struct<...>>, get that struct type (struct<T*,T*,T*>)
-    auto inpStructTy = ptrTy.getElementType().cast<LLVM::LLVMStructType>();
+    auto inpStructTy = ptrTy.getElementType().cast<cudaq::cc::StructType>();
 
     // For the following GEP calls, we'll expect them to return T**
-    auto ptrTtype =
-        cudaq::opt::factory::getPointerType(inpStructTy.getBody()[0]);
+    auto ptrTtype = cudaq::cc::PointerType::get(inpStructTy.getMembers()[0]);
 
     // Get the pointer to the pointer of the end of the array
-    Value endPtr = builder.create<LLVM::GEPOp>(loc, ptrTtype, arg,
-                                               SmallVector<LLVM::GEPArg>{0, 1});
+    Value endPtr = builder.create<cudaq::cc::ComputePtrOp>(
+        loc, ptrTtype, arg, SmallVector<cudaq::cc::ComputePtrArg>{0, 1});
 
     // Get the pointer to the pointer of the beginning of the array
-    Value beginPtr = builder.create<LLVM::GEPOp>(
-        loc, ptrTtype, arg, SmallVector<LLVM::GEPArg>{0, 0});
+    Value beginPtr = builder.create<cudaq::cc::ComputePtrOp>(
+        loc, ptrTtype, arg, SmallVector<cudaq::cc::ComputePtrArg>{0, 0});
 
     // Load to a T*
-    endPtr =
-        builder.create<LLVM::LoadOp>(loc, inpStructTy.getBody()[1], endPtr, 8);
-    beginPtr = builder.create<LLVM::LoadOp>(loc, inpStructTy.getBody()[0],
-                                            beginPtr, 8);
+    endPtr = builder.create<cudaq::cc::LoadOp>(loc, endPtr);
+    beginPtr = builder.create<cudaq::cc::LoadOp>(loc, beginPtr);
 
     // Map those pointers to integers
-    Value endInt = builder.create<LLVM::PtrToIntOp>(loc, i64Ty, endPtr);
-    Value beginInt = builder.create<LLVM::PtrToIntOp>(loc, i64Ty, beginPtr);
+    Value endInt = builder.create<cudaq::cc::CastOp>(loc, i64Ty, endPtr);
+    Value beginInt = builder.create<cudaq::cc::CastOp>(loc, i64Ty, beginPtr);
 
     // Subtracting these will give us the size in bytes.
-    return builder.create<LLVM::SubOp>(loc, endInt, beginInt);
+    return builder.create<arith::SubIOp>(loc, endInt, beginInt);
   }
 
   Value copyVectorData(OpBuilder &builder, Location loc, Value stVal, Value arg,
                        Value vecToBuffer, DenseI64ArrayAttr off) {
-    auto ctx = builder.getContext();
-    auto falseAttr = IntegerAttr::get(IntegerType::get(ctx, 1), 0);
-    auto notVolatile = builder.create<LLVM::ConstantOp>(
-        loc, IntegerType::get(ctx, 1), falseAttr);
+    auto falseAttr = IntegerAttr::get(builder.getI1Type(), 0);
+    auto notVolatile =
+        builder.create<arith::ConstantOp>(loc, builder.getI1Type(), falseAttr);
     // memcpy from arg->begin to vecToBuffer, size bytes.
-    auto bytes = builder.create<LLVM::ExtractValueOp>(loc, stVal, off);
+    auto bytes = builder.create<cudaq::cc::ExtractValueOp>(
+        loc, builder.getI64Type(), stVal, off);
     auto inStructTy = arg.getType()
-                          .cast<LLVM::LLVMPointerType>()
+                          .cast<cudaq::cc::PointerType>()
                           .getElementType()
-                          .cast<LLVM::LLVMStructType>();
-    auto beginPtr = builder.create<LLVM::GEPOp>(
-        loc, cudaq::opt::factory::getPointerType(inStructTy.getBody()[0]), arg,
-        SmallVector<LLVM::GEPArg>{0, 0});
-    auto fromBuff = builder.create<LLVM::LoadOp>(loc, beginPtr);
-    auto vecFromBuff = builder.create<LLVM::BitcastOp>(
-        loc, cudaq::opt::factory::getPointerType(ctx), fromBuff);
+                          .cast<cudaq::cc::StructType>();
+    auto beginPtr = builder.create<cudaq::cc::ComputePtrOp>(
+        loc, cudaq::cc::PointerType::get(inStructTy.getMembers()[0]), arg,
+        SmallVector<cudaq::cc::ComputePtrArg>{0, 0});
+    auto fromBuff = builder.create<cudaq::cc::LoadOp>(loc, beginPtr);
+    auto vecFromBuff = builder.create<cudaq::cc::CastOp>(
+        loc, cudaq::cc::PointerType::get(builder.getI8Type()), fromBuff);
     builder.create<func::CallOp>(
         loc, std::nullopt, llvmMemCopyIntrinsic,
         SmallVector<Value>{vecToBuffer, vecFromBuff, bytes, notVolatile});
     // Increment vecToBuffer by size bytes.
-    return builder.create<LLVM::GEPOp>(loc, vecToBuffer.getType(), vecToBuffer,
-                                       SmallVector<Value>{bytes});
+    return builder.create<cudaq::cc::ComputePtrOp>(
+        loc, vecToBuffer.getType(), vecToBuffer, SmallVector<Value>{bytes});
   }
 
   // Create a function that takes void**, void* and returns void
@@ -229,10 +225,9 @@ public:
                                             FunctionType funcTy) {
     // Local types and values we'll need
     auto *ctx = builder.getContext();
-    auto ptrType = cudaq::opt::factory::getPointerType(ctx);
-    auto ptrPtrType = LLVM::LLVMPointerType::get(ptrType);
-    Type i8PtrTy =
-        cudaq::opt::factory::getPointerType(builder.getIntegerType(8));
+    auto ptrType = cudaq::cc::PointerType::get(builder.getI8Type());
+    auto ptrPtrType = cudaq::cc::PointerType::get(ptrType);
+    Type i8PtrTy = cudaq::cc::PointerType::get(builder.getI8Type());
     Type i64Ty = builder.getI64Type();
     Attribute zeroAttr = builder.getI64IntegerAttr(0);
 
@@ -245,14 +240,14 @@ public:
     builder.setInsertionPointToStart(entry);
 
     // Get the struct type
-    auto structType = structPtrTy.cast<LLVM::LLVMPointerType>()
+    auto structType = structPtrTy.cast<cudaq::cc::PointerType>()
                           .getElementType()
-                          .cast<LLVM::LLVMStructType>();
+                          .cast<cudaq::cc::StructType>();
     // Get the original function args
     auto kernelArgTypes = funcTy.getInputs();
 
     // Init the struct
-    Value stVal = builder.create<LLVM::UndefOp>(loc, structType);
+    Value stVal = builder.create<cudaq::cc::UndefOp>(loc, structType);
 
     // Get the variadic void* args
     auto variadicArgs = entry->getArgument(0);
@@ -261,11 +256,12 @@ public:
     SmallVector<std::pair<std::int64_t, Value>> vectorArgIndices;
 
     // Initialize the counter for extra size.
-    Value zero = builder.create<LLVM::ConstantOp>(loc, i64Ty, zeroAttr);
+    Value zero = builder.create<arith::ConstantOp>(loc, i64Ty, zeroAttr);
     Value extraBytes = zero;
 
     // Loop over the struct elements
-    for (auto structElementTypeIter : llvm::enumerate(structType.getBody())) {
+    for (auto structElementTypeIter :
+         llvm::enumerate(structType.getMembers())) {
       std::size_t idx = structElementTypeIter.index();
 
       // Don't do anything with return args.
@@ -283,10 +279,10 @@ public:
       auto type = structElementTypeIter.value();
 
       // Get the pointer out of the void** variadic args - > void* -> TYPE*
-      Value argPtrPtr =
-          builder.create<LLVM::GEPOp>(loc, ptrPtrType, variadicArgs,
-                                      SmallVector<LLVM::GEPArg>{(int32_t)idx});
-      Value argPtr = builder.create<LLVM::LoadOp>(loc, ptrType, argPtrPtr);
+      Value argPtrPtr = builder.create<cudaq::cc::ComputePtrOp>(
+          loc, ptrPtrType, variadicArgs,
+          SmallVector<cudaq::cc::ComputePtrArg>{static_cast<int32_t>(idx)});
+      Value argPtr = builder.create<cudaq::cc::LoadOp>(loc, ptrType, argPtrPtr);
 
       // Is this a vecType, storing it to a bool so we can check
       // in multiple parts of the following code
@@ -296,17 +292,17 @@ public:
       Value loadedVal;
       if (isVecType) {
         auto vecEleTy = vecType.getElementType();
-        auto vecElePtrTy = cudaq::opt::factory::getPointerType(vecEleTy);
+        auto vecElePtrTy = cudaq::cc::PointerType::get(vecEleTy);
         SmallVector<Type> vecStructEleTys = {vecElePtrTy, vecElePtrTy,
                                              vecElePtrTy};
-        type = cudaq::opt::factory::getPointerType(
-            LLVM::LLVMStructType::getLiteral(ctx, vecStructEleTys));
-        loadedVal = builder.create<LLVM::BitcastOp>(loc, type, argPtr);
+        type = cudaq::cc::PointerType::get(
+            cudaq::cc::StructType::get(ctx, vecStructEleTys));
+        loadedVal = builder.create<cudaq::cc::CastOp>(loc, type, argPtr);
       } else {
-        argPtr = builder.create<LLVM::BitcastOp>(
-            loc, LLVM::LLVMPointerType::get(type), argPtr);
+        argPtr = builder.create<cudaq::cc::CastOp>(
+            loc, cudaq::cc::PointerType::get(type), argPtr);
         // cast to the struct element type, void* -> TYPE *
-        loadedVal = builder.create<LLVM::LoadOp>(loc, type, argPtr);
+        loadedVal = builder.create<cudaq::cc::LoadOp>(loc, type, argPtr);
       }
 
       if (isVecType) {
@@ -314,19 +310,20 @@ public:
         vectorArgIndices.push_back(std::make_pair(idx, loadedVal));
         // compute the extra size needed for the vector data
         loadedVal = getVectorSize(
-            builder, loc, type.cast<LLVM::LLVMPointerType>(), loadedVal);
-        extraBytes = builder.create<LLVM::AddOp>(loc, extraBytes, loadedVal);
+            builder, loc, type.cast<cudaq::cc::PointerType>(), loadedVal);
+        extraBytes = builder.create<arith::AddIOp>(loc, extraBytes, loadedVal);
       }
 
-      stVal = builder.create<LLVM::InsertValueOp>(loc, stVal, loadedVal, off);
+      stVal = builder.create<cudaq::cc::InsertValueOp>(loc, stVal.getType(),
+                                                       stVal, loadedVal, off);
     }
 
     // Compute the struct size
-    auto nullSt = builder.create<LLVM::IntToPtrOp>(loc, structPtrTy, zero);
-    auto computedOffset = builder.create<LLVM::GEPOp>(
-        loc, structPtrTy, nullSt, SmallVector<LLVM::GEPArg>{1});
+    auto nullSt = builder.create<cudaq::cc::CastOp>(loc, structPtrTy, zero);
+    auto computedOffset = builder.create<cudaq::cc::ComputePtrOp>(
+        loc, structPtrTy, nullSt, SmallVector<cudaq::cc::ComputePtrArg>{1});
     Value structSize =
-        builder.create<LLVM::PtrToIntOp>(loc, i64Ty, computedOffset);
+        builder.create<cudaq::cc::CastOp>(loc, i64Ty, computedOffset);
 
     // If no vector args, handle this simple case and drop out
     if (vectorArgIndices.empty()) {
@@ -335,9 +332,9 @@ public:
                                              ValueRange(structSize))
                        .getResult(0);
 
-      Value casted = builder.create<LLVM::BitcastOp>(loc, structPtrTy, buff);
-      builder.create<LLVM::StoreOp>(loc, stVal, casted);
-      builder.create<LLVM::StoreOp>(loc, buff, entry->getArgument(1));
+      Value casted = builder.create<cudaq::cc::CastOp>(loc, structPtrTy, buff);
+      builder.create<cudaq::cc::StoreOp>(loc, stVal, casted);
+      builder.create<cudaq::cc::StoreOp>(loc, buff, entry->getArgument(1));
       builder.create<func::ReturnOp>(loc, ValueRange{structSize});
       builder.restoreInsertionPoint(insPt);
       return argsCreatorFunc;
@@ -345,15 +342,15 @@ public:
 
     // Here we do have vector args
     Value extendedStructSize =
-        builder.create<LLVM::AddOp>(loc, structSize, extraBytes);
+        builder.create<arith::AddIOp>(loc, structSize, extraBytes);
     Value buff = builder
                      .create<func::CallOp>(loc, i8PtrTy, "malloc",
                                            ValueRange(extendedStructSize))
                      .getResult(0);
 
-    auto casted = builder.create<LLVM::BitcastOp>(loc, structPtrTy, buff);
-    builder.create<LLVM::StoreOp>(loc, stVal, casted);
-    Value vecToBuffer = builder.create<LLVM::GEPOp>(
+    auto casted = builder.create<cudaq::cc::CastOp>(loc, structPtrTy, buff);
+    builder.create<cudaq::cc::StoreOp>(loc, stVal, casted);
+    Value vecToBuffer = builder.create<cudaq::cc::ComputePtrOp>(
         loc, i8PtrTy, buff, SmallVector<Value>{structSize});
 
     for (auto [idx, vecVal] : vectorArgIndices) {
@@ -362,7 +359,7 @@ public:
           copyVectorData(builder, loc, stVal, vecVal, vecToBuffer, off);
     }
 
-    builder.create<LLVM::StoreOp>(loc, buff, entry->getArgument(1));
+    builder.create<cudaq::cc::StoreOp>(loc, buff, entry->getArgument(1));
     builder.create<func::ReturnOp>(loc, ValueRange{extendedStructSize});
     builder.restoreInsertionPoint(insPt);
     return argsCreatorFunc;
@@ -385,25 +382,24 @@ public:
     auto insPt = builder.saveInsertionPoint();
     auto *thunkEntry = thunk.addEntryBlock();
     builder.setInsertionPointToStart(thunkEntry);
-    auto cast = builder.create<LLVM::BitcastOp>(loc, structPtrTy,
-                                                thunkEntry->getArgument(0));
+    auto cast = builder.create<cudaq::cc::CastOp>(loc, structPtrTy,
+                                                  thunkEntry->getArgument(0));
     auto isClientServer = thunkEntry->getArgument(1);
-    Value val = builder.create<LLVM::LoadOp>(loc, cast);
+    Value val = builder.create<cudaq::cc::LoadOp>(loc, cast);
     auto i64Ty = builder.getIntegerType(64);
 
     // Compute the struct size without the trailing bytes, structSize.
     auto zeroAttr = builder.getI64IntegerAttr(0);
-    auto zero = builder.create<LLVM::ConstantOp>(loc, i64Ty, zeroAttr);
-    auto nullSt = builder.create<LLVM::IntToPtrOp>(loc, structPtrTy, zero);
-    auto computedOffset = builder.create<LLVM::GEPOp>(
-        loc, structPtrTy, nullSt, SmallVector<LLVM::GEPArg>{1});
+    auto zero = builder.create<arith::ConstantOp>(loc, i64Ty, zeroAttr);
+    auto nullSt = builder.create<cudaq::cc::CastOp>(loc, structPtrTy, zero);
+    auto computedOffset = builder.create<cudaq::cc::ComputePtrOp>(
+        loc, structPtrTy, nullSt, SmallVector<cudaq::cc::ComputePtrArg>{1});
     Value structSize =
-        builder.create<LLVM::PtrToIntOp>(loc, i64Ty, computedOffset);
+        builder.create<cudaq::cc::CastOp>(loc, i64Ty, computedOffset);
 
     // Compute location of trailing bytes.
-    auto i8PtrTy =
-        cudaq::opt::factory::getPointerType(builder.getIntegerType(8));
-    Value trailingData = builder.create<LLVM::GEPOp>(
+    auto i8PtrTy = cudaq::cc::PointerType::get(builder.getI8Type());
+    Value trailingData = builder.create<cudaq::cc::ComputePtrOp>(
         loc, i8PtrTy, thunkEntry->getArgument(0), structSize);
 
     // Unpack the arguments in the struct and build the argument list for
@@ -413,7 +409,7 @@ public:
       Type inTy = inp.value();
       std::int64_t idx = inp.index();
       auto off = DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{idx});
-      if (inTy.isa<cudaq::cc::LambdaType, LLVM::LLVMStructType>()) {
+      if (inTy.isa<cudaq::cc::LambdaType, cudaq::cc::StructType>()) {
         auto undef = builder.create<cudaq::cc::UndefOp>(loc, inTy);
         args.push_back(undef);
       } else if (inTy.isa<cudaq::cc::StdvecType, quake::VeqType>()) {
@@ -424,21 +420,22 @@ public:
         // Must divide by byte, 8 bits.
         auto eleSize = eleTy.getIntOrFloatBitWidth() / 8;
         Value vecSize =
-            builder.create<LLVM::ExtractValueOp>(loc, i64Ty, val, off);
+            builder.create<cudaq::cc::ExtractValueOp>(loc, i64Ty, val, off);
         auto eleSizeAttr = builder.getI64IntegerAttr(eleSize);
         auto eleSizeVal =
-            builder.create<LLVM::ConstantOp>(loc, i64Ty, eleSizeAttr);
-        auto vecLength = builder.create<LLVM::SDivOp>(loc, vecSize, eleSizeVal);
+            builder.create<arith::ConstantOp>(loc, i64Ty, eleSizeAttr);
+        auto vecLength =
+            builder.create<arith::DivSIOp>(loc, vecSize, eleSizeVal);
         // The data is at trailingData and is valid for vecLength of eleTy.
-        auto castData = builder.create<LLVM::BitcastOp>(
-            loc, cudaq::opt::factory::getPointerType(eleTy), trailingData);
+        auto castData = builder.create<cudaq::cc::CastOp>(
+            loc, cudaq::cc::PointerType::get(eleTy), trailingData);
         args.push_back(builder.create<cudaq::cc::StdvecInitOp>(
             loc, stdvecTy, castData, vecLength));
-        trailingData =
-            builder.create<LLVM::GEPOp>(loc, i8PtrTy, trailingData, vecSize);
+        trailingData = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, i8PtrTy, trailingData, vecSize);
       } else {
         args.push_back(
-            builder.create<LLVM::ExtractValueOp>(loc, inTy, val, off));
+            builder.create<cudaq::cc::ExtractValueOp>(loc, inTy, val, off));
       }
     }
     auto call = builder.create<func::CallOp>(loc, funcTy.getResults(),
@@ -452,28 +449,28 @@ public:
       int off = res.index() + offset;
       if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(res.value())) {
         auto callResult = call.getResult(res.index());
-        auto ptrTy =
-            cudaq::opt::factory::getPointerType(vecTy.getElementType());
-        auto gep0 = builder.create<LLVM::GEPOp>(
-            loc, cudaq::opt::factory::getPointerType(ptrTy), cast,
-            SmallVector<LLVM::GEPArg>{0, off});
+        auto ptrTy = cudaq::cc::PointerType::get(vecTy.getElementType());
+        auto gep0 = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, cudaq::cc::PointerType::get(ptrTy), cast,
+            SmallVector<cudaq::cc::ComputePtrArg>{0, off});
         auto pointer =
             builder.create<cudaq::cc::StdvecDataOp>(loc, ptrTy, callResult);
-        builder.create<LLVM::StoreOp>(loc, pointer, gep0);
+        builder.create<cudaq::cc::StoreOp>(loc, pointer, gep0);
         auto lenTy = builder.getI64Type();
-        auto gep1 = builder.create<LLVM::GEPOp>(
-            loc, cudaq::opt::factory::getPointerType(lenTy), cast,
-            SmallVector<LLVM::GEPArg>{0, off + 1});
+        auto gep1 = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, cudaq::cc::PointerType::get(lenTy), cast,
+            SmallVector<cudaq::cc::ComputePtrArg>{0, off + 1});
         auto length =
             builder.create<cudaq::cc::StdvecSizeOp>(loc, lenTy, callResult);
-        builder.create<LLVM::StoreOp>(loc, length, gep1);
+        builder.create<cudaq::cc::StoreOp>(loc, length, gep1);
         offset++;
         hasVectorResult = true;
       } else {
-        auto gep = builder.create<LLVM::GEPOp>(
-            loc, cudaq::opt::factory::getPointerType(res.value()), cast,
-            SmallVector<LLVM::GEPArg>{0, off});
-        builder.create<LLVM::StoreOp>(loc, call.getResult(res.index()), gep);
+        auto gep = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, cudaq::cc::PointerType::get(res.value()), cast,
+            SmallVector<cudaq::cc::ComputePtrArg>{0, off});
+        builder.create<cudaq::cc::StoreOp>(loc, call.getResult(res.index()),
+                                           gep);
       }
     }
     if (hasVectorResult) {
@@ -486,15 +483,14 @@ public:
                                        elseBlock);
       builder.setInsertionPointToEnd(thenBlock);
       int offset = funcTy.getNumInputs();
-      auto structTy = structPtrTy.cast<LLVM::LLVMPointerType>()
+      auto structTy = structPtrTy.cast<cudaq::cc::PointerType>()
                           .getElementType()
-                          .cast<LLVM::LLVMStructType>();
-      auto gepRes = builder.create<LLVM::GEPOp>(
-          loc, cudaq::opt::factory::getPointerType(structTy.getBody()[offset]),
-          cast, SmallVector<LLVM::GEPArg>{0, offset});
-      auto gepRes2 = builder.create<LLVM::BitcastOp>(
-          loc, cudaq::opt::factory::getPointerType(thunkTy.getResults()[0]),
-          gepRes);
+                          .cast<cudaq::cc::StructType>();
+      auto gepRes = builder.create<cudaq::cc::ComputePtrOp>(
+          loc, cudaq::cc::PointerType::get(structTy.getMembers()[offset]), cast,
+          SmallVector<cudaq::cc::ComputePtrArg>{0, offset});
+      auto gepRes2 = builder.create<cudaq::cc::CastOp>(
+          loc, cudaq::cc::PointerType::get(thunkTy.getResults()[0]), gepRes);
       auto res = builder.create<func::CallOp>(
           loc, thunkTy.getResults()[0], "__nvqpp_createDynamicResult",
           ValueRange{thunkEntry->getArgument(0), structSize, gepRes2});
@@ -511,13 +507,14 @@ public:
 
   /// Generate code to initialize the std::vector<T>, \p sret, from an
   /// initializer list with data at \p data and length \p size. Use the library
-  /// helper routine.
+  /// helper routine. This function takes two !llvm.ptr arguments.
   void genStdvecBoolFromInitList(Location loc, OpBuilder &builder, Value sret,
                                  Value data, Value size) {
-    auto ptrTy = cudaq::opt::factory::getPointerType(builder.getContext());
-    auto castData = builder.create<LLVM::BitcastOp>(loc, ptrTy, data);
-    builder.create<LLVM::CallOp>(loc, std::nullopt, stdvecBoolCtorFromInitList,
-                                 ArrayRef<Value>{sret, castData, size});
+    auto ptrTy = cudaq::cc::PointerType::get(builder.getContext());
+    auto castData = builder.create<cudaq::cc::CastOp>(loc, ptrTy, data);
+    auto castSret = builder.create<cudaq::cc::CastOp>(loc, ptrTy, sret);
+    builder.create<func::CallOp>(loc, std::nullopt, stdvecBoolCtorFromInitList,
+                                 ArrayRef<Value>{castSret, castData, size});
   }
 
   /// Generate an all new entry point body, calling launchKernel in the runtime
@@ -533,17 +530,17 @@ public:
     auto zeroAttr = builder.getI64IntegerAttr(0);
     auto offset = funcTy.getNumInputs();
     auto thunkTy = getThunkType(ctx);
-    auto structPtrTy = cudaq::opt::factory::getPointerType(structTy);
+    auto structPtrTy = cudaq::cc::PointerType::get(structTy);
     auto rewriteEntry = builder.create<func::FuncOp>(
         loc, mangledAttr.getValue(), toLLVMFuncType(funcTy));
     auto insPt = builder.saveInsertionPoint();
     auto *rewriteEntryBlock = rewriteEntry.addEntryBlock();
     builder.setInsertionPointToStart(rewriteEntryBlock);
-    Value stVal = builder.create<LLVM::UndefOp>(loc, structTy);
+    Value stVal = builder.create<cudaq::cc::UndefOp>(loc, structTy);
 
     // Process all the arguments for the original call, ignoring the `this`
     // pointer.
-    auto zero = builder.create<LLVM::ConstantOp>(loc, i64Ty, zeroAttr);
+    auto zero = builder.create<arith::ConstantOp>(loc, i64Ty, zeroAttr);
     Value extraBytes = zero;
     bool hasTrailingData = false;
     for (auto inp :
@@ -553,45 +550,48 @@ public:
       Type inTy = arg.getType();
       std::int64_t idx = inp.index();
       auto off = DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{idx});
-      if (inTy.isa<cudaq::cc::LambdaType, LLVM::LLVMStructType>()) {
+      if (inTy.isa<cudaq::cc::LambdaType, cudaq::cc::StructType>()) {
         /* do nothing */
-      } else if (auto ptrTy = dyn_cast<LLVM::LLVMPointerType>(inTy)) {
+      } else if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(inTy)) {
         // FIXME: for now assume this is a std::vector<`eleTy`>
         // FIXME: call the `size` member function. For expediency, assume this
         // is an std::vector and the size is the scaled delta between the
         // first two pointers. Use the unscaled size for now.
         auto sizeBytes = getVectorSize(builder, loc, ptrTy, arg);
-        stVal = builder.create<LLVM::InsertValueOp>(loc, stVal, sizeBytes, off);
-        extraBytes = builder.create<LLVM::AddOp>(loc, extraBytes, sizeBytes);
+        stVal = builder.create<cudaq::cc::InsertValueOp>(loc, stVal.getType(),
+                                                         stVal, sizeBytes, off);
+        extraBytes = builder.create<arith::AddIOp>(loc, extraBytes, sizeBytes);
         hasTrailingData = true;
       } else {
-        stVal = builder.create<LLVM::InsertValueOp>(loc, stVal, arg, off);
+        stVal = builder.create<cudaq::cc::InsertValueOp>(loc, stVal.getType(),
+                                                         stVal, arg, off);
       }
     }
 
     // Compute the struct size without the trailing bytes, structSize, and with
     // the trailing bytes, extendedStructSize.
-    auto nullSt = builder.create<LLVM::IntToPtrOp>(loc, structPtrTy, zero);
-    auto computedOffset = builder.create<LLVM::GEPOp>(
-        loc, structPtrTy, nullSt, SmallVector<LLVM::GEPArg>{1});
+    auto nullSt = builder.create<cudaq::cc::CastOp>(loc, structPtrTy, zero);
+    auto computedOffset = builder.create<cudaq::cc::ComputePtrOp>(
+        loc, structPtrTy, nullSt, SmallVector<cudaq::cc::ComputePtrArg>{1});
     Value structSize =
-        builder.create<LLVM::PtrToIntOp>(loc, i64Ty, computedOffset);
+        builder.create<cudaq::cc::CastOp>(loc, i64Ty, computedOffset);
     Value extendedStructSize =
-        builder.create<LLVM::AddOp>(loc, structSize, extraBytes);
+        builder.create<arith::AddIOp>(loc, structSize, extraBytes);
 
     // Allocate our struct to save the argument to.
-    auto i8PtrTy = cudaq::opt::factory::getPointerType(builder.getI8Type());
+    auto i8Ty = builder.getI8Type();
+    auto i8PtrTy = cudaq::cc::PointerType::get(i8Ty);
     auto buff =
-        builder.create<LLVM::AllocaOp>(loc, i8PtrTy, extendedStructSize);
+        builder.create<cudaq::cc::AllocaOp>(loc, i8Ty, extendedStructSize);
 
-    auto temp = builder.create<LLVM::BitcastOp>(loc, structPtrTy, buff);
+    auto temp = builder.create<cudaq::cc::CastOp>(loc, structPtrTy, buff);
 
     // Store the arguments to the argument section.
-    builder.create<LLVM::StoreOp>(loc, stVal, temp);
+    builder.create<cudaq::cc::StoreOp>(loc, stVal, temp);
 
     // Append the vector data to the end of the struct.
     if (hasTrailingData) {
-      Value vecToBuffer = builder.create<LLVM::GEPOp>(
+      Value vecToBuffer = builder.create<cudaq::cc::ComputePtrOp>(
           loc, i8PtrTy, buff, SmallVector<Value>{structSize});
       for (auto inp :
            llvm::enumerate(rewriteEntryBlock->getArguments().drop_front(1))) {
@@ -599,7 +599,7 @@ public:
         Type inTy = arg.getType();
         std::int64_t idx = inp.index();
         auto off = DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{idx});
-        if (auto ptrTy = dyn_cast<LLVM::LLVMPointerType>(inTy)) {
+        if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(inTy)) {
           // memcpy from arg->begin to vecToBuffer, size bytes.
           vecToBuffer =
               copyVectorData(builder, loc, stVal, arg, vecToBuffer, off);
@@ -613,22 +613,23 @@ public:
         kernName.getSymName());
     Value loadThunk =
         builder.create<func::ConstantOp>(loc, thunkTy, thunk.getName());
-    auto castLoadKernName = builder.create<LLVM::BitcastOp>(
-        loc, cudaq::opt::factory::getPointerType(ctx), loadKernName);
+    auto castLoadKernName = builder.create<cudaq::cc::CastOp>(
+        loc, cudaq::cc::PointerType::get(builder.getI8Type()), loadKernName);
     auto castLoadThunk = builder.create<cudaq::cc::FuncToPtrOp>(
-        loc, cudaq::opt::factory::getPointerType(ctx), loadThunk);
-    auto castTemp = builder.create<LLVM::BitcastOp>(
-        loc, cudaq::opt::factory::getPointerType(ctx), temp);
+        loc, cudaq::cc::PointerType::get(builder.getI8Type()), loadThunk);
+    auto castTemp = builder.create<cudaq::cc::CastOp>(
+        loc, cudaq::cc::PointerType::get(builder.getI8Type()), temp);
 
     auto resultOffset = [&]() -> Value {
       if (funcTy.getNumResults() == 0) {
         auto notZeroAttr = builder.getI64IntegerAttr(NoResultOffset);
-        return builder.create<LLVM::ConstantOp>(loc, i64Ty, notZeroAttr);
+        return builder.create<arith::ConstantOp>(loc, i64Ty, notZeroAttr);
       }
       int offset = funcTy.getNumInputs();
-      auto gep = builder.create<LLVM::GEPOp>(
-          loc, structPtrTy, nullSt, SmallVector<LLVM::GEPArg>{0, offset});
-      return builder.create<LLVM::PtrToIntOp>(loc, i64Ty, gep);
+      auto gep = builder.create<cudaq::cc::ComputePtrOp>(
+          loc, structPtrTy, nullSt,
+          SmallVector<cudaq::cc::ComputePtrArg>{0, offset});
+      return builder.create<cudaq::cc::CastOp>(loc, i64Ty, gep);
     }();
 
     // Generate the call to `launchKernel`.
@@ -644,17 +645,16 @@ public:
     for (auto res : llvm::enumerate(funcTy.getResults())) {
       int off = res.index() + offset;
       if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(res.value())) {
-        auto ptrTy =
-            cudaq::opt::factory::getPointerType(vecTy.getElementType());
-        auto gep0 = builder.create<LLVM::GEPOp>(
-            loc, cudaq::opt::factory::getPointerType(ptrTy), temp,
-            SmallVector<LLVM::GEPArg>{0, off});
-        auto dataPtr = builder.create<LLVM::LoadOp>(loc, gep0);
-        auto lenPtrTy =
-            cudaq::opt::factory::getPointerType(builder.getI64Type());
-        auto gep1 = builder.create<LLVM::GEPOp>(
-            loc, lenPtrTy, temp, SmallVector<LLVM::GEPArg>{0, off + 1});
-        auto vecLen = builder.create<LLVM::LoadOp>(loc, gep1);
+        auto ptrTy = cudaq::cc::PointerType::get(vecTy.getElementType());
+        auto gep0 = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, cudaq::cc::PointerType::get(ptrTy), temp,
+            SmallVector<cudaq::cc::ComputePtrArg>{0, off});
+        auto dataPtr = builder.create<cudaq::cc::LoadOp>(loc, gep0);
+        auto lenPtrTy = cudaq::cc::PointerType::get(builder.getI64Type());
+        auto gep1 = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, lenPtrTy, temp,
+            SmallVector<cudaq::cc::ComputePtrArg>{0, off + 1});
+        auto vecLen = builder.create<cudaq::cc::LoadOp>(loc, gep1);
         if (vecTy.getElementType() == builder.getI1Type())
           genStdvecBoolFromInitList(loc, builder,
                                     rewriteEntryBlock->getArguments().front(),
@@ -663,10 +663,10 @@ public:
           TODO_loc(loc, "return is std::vector<T> where T != bool");
         offset++;
       } else {
-        auto gep = builder.create<LLVM::GEPOp>(
-            loc, cudaq::opt::factory::getPointerType(res.value()), temp,
-            SmallVector<LLVM::GEPArg>{0, off});
-        results.push_back(builder.create<LLVM::LoadOp>(loc, gep));
+        auto gep = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, cudaq::cc::PointerType::get(res.value()), temp,
+            SmallVector<cudaq::cc::ComputePtrArg>{0, off});
+        results.push_back(builder.create<cudaq::cc::LoadOp>(loc, gep));
       }
     }
     builder.create<func::ReturnOp>(loc, results);
@@ -706,17 +706,14 @@ public:
     }
 
     auto loc = module.getLoc();
-    builder.create<LLVM::LLVMFuncOp>(
-        loc, cudaqRegisterKernelName,
-        LLVM::LLVMFunctionType::get(
-            cudaq::opt::factory::getVoidType(ctx),
-            {cudaq::opt::factory::getPointerType(ctx)}));
-    builder.create<LLVM::LLVMFuncOp>(
+    auto ptrType = cudaq::cc::PointerType::get(builder.getI8Type());
+    auto regKern = builder.create<func::FuncOp>(
+        loc, cudaqRegisterKernelName, FunctionType::get(ctx, {ptrType}, {}));
+    regKern.setPrivate();
+    auto regArgs = builder.create<func::FuncOp>(
         loc, cudaqRegisterArgsCreator,
-        LLVM::LLVMFunctionType::get(
-            cudaq::opt::factory::getVoidType(ctx),
-            {cudaq::opt::factory::getPointerType(ctx),
-             cudaq::opt::factory::getPointerType(ctx)}));
+        FunctionType::get(ctx, {ptrType, ptrType}, {}));
+    regArgs.setPrivate();
 
     if (failed(irBuilder.loadIntrinsic(module, "malloc"))) {
       module.emitError("could not load malloc");
@@ -768,7 +765,7 @@ public:
       // Create a new struct type to pass arguments and results.
       auto funcTy = funcOp.getFunctionType();
       auto structTy = buildStructType(classNameStr, funcTy);
-      auto structPtrTy = cudaq::opt::factory::getPointerType(structTy);
+      auto structPtrTy = cudaq::cc::PointerType::get(structTy);
 
       // Generate thunk, `<kernel>.thunk`, to call back to the MLIR code.
       auto thunk = genThunkFunction(loc, builder, classNameStr, structPtrTy,
@@ -798,25 +795,23 @@ public:
       auto kernRef = builder.create<LLVM::AddressOfOp>(
           loc, cudaq::opt::factory::getPointerType(kernName.getType()),
           kernName.getSymName());
-      auto castKernRef = builder.create<LLVM::BitcastOp>(
-          loc, cudaq::opt::factory::getPointerType(ctx), kernRef);
-      builder.create<LLVM::CallOp>(loc, std::nullopt, cudaqRegisterKernelName,
+      auto castKernRef = builder.create<cudaq::cc::CastOp>(
+          loc, cudaq::cc::PointerType::get(builder.getI8Type()), kernRef);
+      builder.create<func::CallOp>(loc, std::nullopt, cudaqRegisterKernelName,
                                    ValueRange{castKernRef});
 
       // Register the argsCreator too
-      auto ptrType = cudaq::opt::factory::getPointerType(ctx);
-      auto ptrPtrType = LLVM::LLVMPointerType::get(ptrType);
+      auto ptrPtrType = cudaq::cc::PointerType::get(ptrType);
       auto argsCreatorFuncType = FunctionType::get(
           ctx, {ptrPtrType, ptrPtrType}, {builder.getI64Type()});
       Value loadArgsCreator = builder.create<func::ConstantOp>(
           loc, argsCreatorFuncType, argsCreatorFunc.getName());
-      auto castLoadArgsCreator = builder.create<cudaq::cc::FuncToPtrOp>(
-          loc, cudaq::opt::factory::getPointerType(ctx), loadArgsCreator);
-      builder.create<LLVM::CallOp>(
+      auto castLoadArgsCreator =
+          builder.create<cudaq::cc::FuncToPtrOp>(loc, ptrType, loadArgsCreator);
+      builder.create<func::CallOp>(
           loc, std::nullopt, cudaqRegisterArgsCreator,
           ValueRange{castKernRef, castLoadArgsCreator});
 
-      // -------------
       // Check if this is a lambda mangled name
       auto demangledPtr = abi::__cxa_demangle(
           mangledAttr.getValue().str().c_str(), nullptr, nullptr, nullptr);
@@ -851,14 +846,15 @@ public:
               loc, cudaq::opt::factory::getPointerType(lambdaName.getType()),
               lambdaName.getSymName());
 
-          auto castlambdaRef = builder.create<LLVM::BitcastOp>(
+          auto castLambdaRef = builder.create<cudaq::cc::CastOp>(
               loc, cudaq::opt::factory::getPointerType(ctx), lambdaRef);
-          builder.create<LLVM::CallOp>(loc, std::nullopt,
-                                       cudaqRegisterLambdaName,
-                                       ValueRange{castlambdaRef, castKernRef});
+          auto castKernelRef = builder.create<cudaq::cc::CastOp>(
+              loc, cudaq::opt::factory::getPointerType(ctx), castKernRef);
+          builder.create<LLVM::CallOp>(
+              loc, std::nullopt, cudaqRegisterLambdaName,
+              ValueRange{castLambdaRef, castKernelRef});
         }
       }
-      // -------------
 
       builder.create<LLVM::ReturnOp>(loc, ValueRange{});
       builder.restoreInsertionPoint(insPt);

--- a/test/AST-Quake/auto_kernel-2.cpp
+++ b/test/AST-Quake/auto_kernel-2.cpp
@@ -23,11 +23,11 @@ struct ak2 {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ak2
 // CHECK-SAME: () -> !cc.stdvec<i1> attributes {
 // CHECK:           %[[VAL_19:.*]] = quake.mz %{{.*}} : (!quake.veq<5>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_19]] : (!cc.stdvec<i1>) -> !cc.ptr<none>
+// CHECK:           %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_19]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_21:.*]] = cc.stdvec_size %[[VAL_19]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_22:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_23:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) : (!cc.ptr<none>, i64, i64) -> !cc.ptr<none>
-// CHECK:           %[[VAL_24:.*]] = cc.stdvec_init %[[VAL_23]], %[[VAL_21]] : (!cc.ptr<none>, i64) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_23:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_24:.*]] = cc.stdvec_init %[[VAL_23]], %[[VAL_21]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
 // CHECK:           return %[[VAL_24]] : !cc.stdvec<i1>
 // CHECK:         }
 // CHECK-NOT:   func.func {{.*}} @_ZNKSt14_Bit_referencecvbEv() -> i1

--- a/test/AST-Quake/mz.cpp
+++ b/test/AST-Quake/mz.cpp
@@ -47,11 +47,11 @@ struct VectorOfStaticVeq {
 // CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<?>[%[[VAL_5]] : i64]
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i1>) -> !cc.ptr<none>
+// CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = cc.stdvec_size %[[VAL_8]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_11:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_12:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_9]], %[[VAL_10]], %[[VAL_11]]) : (!cc.ptr<none>, i64, i64) -> !cc.ptr<none>
-// CHECK:           %[[VAL_13:.*]] = cc.stdvec_init %[[VAL_12]], %[[VAL_10]] : (!cc.ptr<none>, i64) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_12:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_9]], %[[VAL_10]], %[[VAL_11]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_13:.*]] = cc.stdvec_init %[[VAL_12]], %[[VAL_10]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
 // CHECK:           return %[[VAL_13]] : !cc.stdvec<i1>
 // CHECK:         }
 
@@ -80,11 +80,11 @@ struct VectorOfDynamicVeq {
 // CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<?>[%[[VAL_9]] : i64]
 // CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<none>
+// CHECK:           %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_14:.*]] = cc.stdvec_size %[[VAL_12]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_15:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_16:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]]) : (!cc.ptr<none>, i64, i64) -> !cc.ptr<none>
-// CHECK:           %[[VAL_17:.*]] = cc.stdvec_init %[[VAL_16]], %[[VAL_14]] : (!cc.ptr<none>, i64) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_16:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_17:.*]] = cc.stdvec_init %[[VAL_16]], %[[VAL_14]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
 // CHECK:           return %[[VAL_17]] : !cc.stdvec<i1>
 // CHECK:         }
 

--- a/test/Quake/kernel_exec.qke
+++ b/test/Quake/kernel_exec.qke
@@ -77,79 +77,83 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclE
 
 // Check the generated code.
 
-// CHECK:         func.func private @altLaunchKernel(!llvm.ptr<i8>, !llvm.ptr<i8>, !llvm.ptr<i8>, i64, i64)
-// CHECK:         llvm.func @cudaqRegisterKernelName(!llvm.ptr<i8>)
-// CHECK:         llvm.mlir.global external constant @ghz.kernelName(
+// CHECK:         func.func private @altLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64)
+// CHECK:         func.func private @cudaqRegisterKernelName(!cc.ptr<i8>)
+
+// CHECK:         llvm.mlir.global external constant @ghz.kernelName("ghz\00") {addr_space = 0 : i32}
 
 // CHECK-LABEL:   func.func @ghz.thunk(
-// CHECK-SAME:                         %[[VAL_0:.*]]: !llvm.ptr<i8>,
-// CHECK-SAME:                         %[[VAL_1:.*]]: i1) -> !llvm.struct<(ptr<i8>, i64)> {
-// CHECK:           %[[VAL_2:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<i8> to !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:           %[[VAL_5:.*]] = llvm.inttoptr %[[VAL_4]] : i64 to !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_5]][1] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           %[[VAL_7:.*]] = llvm.ptrtoint %[[VAL_6]] : !llvm.ptr<struct<(i32, f64)>> to i64
-// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<i8>, i64) -> !llvm.ptr<i8>
-// CHECK:           %[[VAL_9:.*]] = llvm.extractvalue %[[VAL_3]][0] : !llvm.struct<(i32, f64)>
+// CHECK-SAME:                         %[[VAL_0:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (i64) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> i64
+// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_0]]{{\[}}%[[VAL_7]]] : (!cc.ptr<i8>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i32, f64}>) -> i32
 // CHECK:           %[[VAL_10:.*]] = call @__nvqpp__mlirgen__ghz(%[[VAL_9]]) : (i32) -> f64
-// CHECK:           %[[VAL_11:.*]] = llvm.getelementptr %[[VAL_2]][0, 1] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<f64>
-// CHECK:           llvm.store %[[VAL_10]], %[[VAL_11]] : !llvm.ptr<f64>
-// CHECK:           %[[VAL_12:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !llvm.struct<(ptr<i8>, i64)>
-// CHECK:           return %[[VAL_12]] : !llvm.struct<(ptr<i8>, i64)>
+// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_2]][0, 1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// CHECK:           cc.store %[[VAL_10]], %[[VAL_11]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_12:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           return %[[VAL_12]] : !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @ghz.argsCreator(
-// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm.ptr<ptr<i8>>,
-// CHECK-SAME:                               %[[VAL_1:.*]]: !llvm.ptr<ptr<i8>>) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.struct<(i32, f64)>
-// CHECK:           %[[VAL_3:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:           %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_0]][0] : (!llvm.ptr<ptr<i8>>) -> !llvm.ptr<ptr<i8>>
-// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<ptr<i8>>
-// CHECK:           %[[VAL_6:.*]] = llvm.bitcast %[[VAL_5]] : !llvm.ptr<i8> to !llvm.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i32>
-// CHECK:           %[[VAL_8:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_2]][0] : !llvm.struct<(i32, f64)>
-// CHECK:           %[[VAL_9:.*]] = llvm.inttoptr %[[VAL_3]] : i64 to !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           %[[VAL_10:.*]] = llvm.getelementptr %[[VAL_9]][1] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           %[[VAL_11:.*]] = llvm.ptrtoint %[[VAL_10]] : !llvm.ptr<struct<(i32, f64)>> to i64
-// CHECK:           %[[VAL_12:.*]] = call @malloc(%[[VAL_11]]) : (i64) -> !llvm.ptr<i8>
-// CHECK:           %[[VAL_13:.*]] = llvm.bitcast %[[VAL_12]] : !llvm.ptr<i8> to !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           llvm.store %[[VAL_8]], %[[VAL_13]] : !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           llvm.store %[[VAL_12]], %[[VAL_1]] : !llvm.ptr<ptr<i8>>
+// CHECK-SAME:                               %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
+// CHECK-SAME:                               %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
+// CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{i32, f64}>
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_8:.*]] = cc.insert_value %[[VAL_7]], %[[VAL_2]][0] : (!cc.struct<{i32, f64}>, i32) -> !cc.struct<{i32, f64}>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_3]] : (i64) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_9]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> i64
+// CHECK:           %[[VAL_12:.*]] = call @malloc(%[[VAL_11]]) : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_12]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           cc.store %[[VAL_8]], %[[VAL_13]] : !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           cc.store %[[VAL_12]], %[[VAL_1]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           return %[[VAL_11]] : i64
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @_ZN3ghzclEi(
-// CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr<i8>,
+// CHECK-SAME:                           %[[VAL_0:.*]]: !cc.ptr<i8>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: i32) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.struct<(i32, f64)>
-// CHECK:           %[[VAL_3:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:           %[[VAL_4:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_2]][0] : !llvm.struct<(i32, f64)>
-// CHECK:           %[[VAL_5:.*]] = llvm.inttoptr %[[VAL_3]] : i64 to !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_5]][1] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           %[[VAL_7:.*]] = llvm.ptrtoint %[[VAL_6]] : !llvm.ptr<struct<(i32, f64)>> to i64
-// CHECK:           %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_3]]  : i64
-// CHECK:           %[[VAL_9:.*]] = llvm.alloca %[[VAL_8]] x i8 : (i64) -> !llvm.ptr<i8>
-// CHECK:           %[[VAL_10:.*]] = llvm.bitcast %[[VAL_9]] : !llvm.ptr<i8> to !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           llvm.store %[[VAL_4]], %[[VAL_10]] : !llvm.ptr<struct<(i32, f64)>>
+// CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{i32, f64}>
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_1]], %[[VAL_2]][0] : (!cc.struct<{i32, f64}>, i32) -> !cc.struct<{i32, f64}>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_3]] : (i64) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> i64
+// CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_7]], %[[VAL_3]] : i64
+// CHECK:           %[[VAL_9:.*]] = cc.alloca i8{{\[}}%[[VAL_8]] : i64]
+// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           cc.store %[[VAL_4]], %[[VAL_10]] : !cc.ptr<!cc.struct<{i32, f64}>>
 // CHECK:           %[[VAL_11:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
-// CHECK:           %[[VAL_12:.*]] = constant @ghz.thunk : (!llvm.ptr<i8>, i1) -> !llvm.struct<(ptr<i8>, i64)>
-// CHECK:           %[[VAL_13:.*]] = llvm.bitcast %[[VAL_11]] : !llvm.ptr<array<4 x i8>> to !llvm.ptr<i8>
-// CHECK:           %[[VAL_14:.*]] = cc.func_ptr %[[VAL_12]] : ((!llvm.ptr<i8>, i1) -> !llvm.struct<(ptr<i8>, i64)>) -> !llvm.ptr<i8>
-// CHECK:           %[[VAL_15:.*]] = llvm.bitcast %[[VAL_10]] : !llvm.ptr<struct<(i32, f64)>> to !llvm.ptr<i8>
-// CHECK:           %[[VAL_16:.*]] = llvm.getelementptr %[[VAL_5]][0, 1] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK:           %[[VAL_17:.*]] = llvm.ptrtoint %[[VAL_16]] : !llvm.ptr<struct<(i32, f64)>> to i64
-// CHECK:           call @altLaunchKernel(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_8]], %[[VAL_17]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, !llvm.ptr<i8>, i64, i64) -> ()
-// CHECK:           %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_10]][0, 1] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<f64>
-// CHECK:           %[[VAL_19:.*]] = llvm.load %[[VAL_18]] : !llvm.ptr<f64>
+// CHECK:           %[[VAL_12:.*]] = constant @ghz.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_11]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = cc.func_ptr %[[VAL_12]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_5]][0, 1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> i64
+// CHECK:           call @altLaunchKernel(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_8]], %[[VAL_17]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> ()
+// CHECK:           %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_10]][0, 1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_19:.*]] = cc.load %[[VAL_18]] : !cc.ptr<f64>
 // CHECK:           return %[[VAL_19]] : f64
 // CHECK:         }
 
 // CHECK-LABEL:   llvm.func @ghz.kernelRegFunc() {
 // CHECK:           %[[VAL_0:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
-// CHECK:           %[[VAL_1:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<array<4 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.call @cudaqRegisterKernelName(%[[VAL_1]]) : (!llvm.ptr<i8>) -> ()
+// CHECK:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
+// CHECK:           func.call @cudaqRegisterKernelName(%[[VAL_1]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           %[[VAL_2:.*]] = func.constant @ghz.argsCreator : (!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64
+// CHECK:           %[[VAL_3:.*]] = cc.func_ptr %[[VAL_2]] : ((!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64) -> !cc.ptr<i8>
+// CHECK:           func.call @cudaqRegisterArgsCreator(%[[VAL_1]], %[[VAL_3]]) : (!cc.ptr<i8>, !cc.ptr<i8>) -> ()
 // CHECK:           llvm.return
 // CHECK:         }
-// CHECK:         llvm.mlir.global_ctors {ctors = [@ghz.kernelRegFunc], priorities = [17 : i32]}
 
+// CHECK:         llvm.mlir.global_ctors {ctors = [@ghz.kernelRegFunc], priorities = [17 : i32]}

--- a/test/Quake/lambda_kernel_exec.qke
+++ b/test/Quake/lambda_kernel_exec.qke
@@ -11,8 +11,8 @@
 // CHECK:   llvm.mlir.global external constant @lambda.main.canHaveMultiple.lambdaName("main::$_1\00") {addr_space = 0 : i32}
 // CHECK:   llvm.mlir.global external constant @lambda.main.test.lambdaName("main::$_0\00") {addr_space = 0 : i32}
 // CHECK: %[[VAL_0:.*]] = llvm.mlir.addressof @lambda.main.test.lambdaName : !llvm.ptr<array<10 x i8>>
-// CHECK-NEXT: %[[VAL_1:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<array<10 x i8>> to !llvm.ptr<i8>
-// CHECK-NEXT: llvm.call @cudaqRegisterLambdaName(%[[VAL_1]], %[[VAL_2:.*]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>) -> ()
+// CHECK-NEXT: %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!llvm.ptr<array<10 x i8>>) -> !llvm.ptr<i8>
+// CHECK: llvm.call @cudaqRegisterLambdaName(%[[VAL_1]], %{{.*}}) : (!llvm.ptr<i8>, !llvm.ptr<i8>) -> ()
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHaveMultiple = "_ZZ4mainENK3$_1clEv", __nvqpp__mlirgen__lambda.main.test = "_ZZ4mainENK3$_0clEv"}} {
   func.func @__nvqpp__mlirgen__lambda.main.test() attributes {"cudaq-entrypoint"} {
@@ -46,8 +46,8 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHa
   }
 
 // CHECK: %[[VAL_3:.*]] = llvm.mlir.addressof @lambda.main.canHaveMultiple.lambdaName : !llvm.ptr<array<10 x i8>>
-// CHECK-NEXT: %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm.ptr<array<10 x i8>> to !llvm.ptr<i8>
-// CHECK-NEXT: llvm.call @cudaqRegisterLambdaName(%[[VAL_4]], %[[VAL_5:.*]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>) -> ()
+// CHECK-NEXT: %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!llvm.ptr<array<10 x i8>>) -> !llvm.ptr<i8>
+// CHECK: llvm.call @cudaqRegisterLambdaName(%[[VAL_4]], %{{.*}}) : (!llvm.ptr<i8>, !llvm.ptr<i8>) -> ()
 
   func.func @__nvqpp__mlirgen__lambda.main.canHaveMultiple() attributes {"cudaq-entrypoint"} {
     %c2_i32 = arith.constant 2 : i32


### PR DESCRIPTION
Continue to eliminate the use of the LLVM-IR dialect from the compiler. These patches replace the uses of LLVM-IR in the kernel-execution pass with uses of our CC dialect.

