### PR TITLE
Remove the use of the MLIR Memref dialect.

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -10,6 +10,7 @@
 
 #include "cudaq/Frontend/nvqpp/AttributeNames.h"
 #include "cudaq/Optimizer/Builder/Runtime.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Todo.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/GlobalDecl.h"
@@ -22,7 +23,6 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
@@ -308,8 +308,8 @@ public:
   /// type. Otherwise, just returns \p val.
   mlir::Value loadLValue(mlir::Value val) {
     auto valTy = val.getType();
-    if (valTy.isa<mlir::MemRefType>())
-      return builder.create<mlir::memref::LoadOp>(val.getLoc(), val);
+    if (valTy.isa<cudaq::cc::PointerType>())
+      return builder.create<cudaq::cc::LoadOp>(val.getLoc(), val);
     if (valTy.isa<mlir::LLVM::LLVMPointerType>())
       return builder.create<mlir::LLVM::LoadOp>(val.getLoc(), val);
     return val;
@@ -502,7 +502,7 @@ private:
 /// The ASTBridgeAction enables the insertion of a custom ASTConsumer to the
 /// Clang AST analysis / processing workflow. The nested ASTBridgeConsumer
 /// drives the process of walking the Clang AST and translate pertinent nodes to
-/// an MLIR Op tree containing Quantum, Standard, Memref, and LLVM operations.
+/// an MLIR Op tree containing Quake, CC, and other MLIR dialect operations.
 /// This Action will generate this MLIR Module and rewrite the input source code
 /// (using the Clang Rewriter system) to define quantum kernels as extern.
 class ASTBridgeAction : public clang::ASTFrontendAction {

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -45,14 +45,6 @@ inline mlir::Type getStringType(mlir::MLIRContext *ctx, std::size_t length) {
   return mlir::LLVM::LLVMArrayType::get(mlir::IntegerType::get(ctx, 8), length);
 }
 
-/// Return a 1D MemRefType with a non-constant size.
-inline mlir::MemRefType getDynamicSize1DMemRef(mlir::Type elementType) {
-  // -1 is used to indicate that the size is dynamic.
-  constexpr int DYNAMIC = -1;
-  mlir::ArrayRef<int64_t> shape = {DYNAMIC};
-  return mlir::MemRefType::get(shape, elementType);
-}
-
 /// Return the QPU-side version of a `std::vector<T>` when lowered to a plain
 /// old C `struct`. Currently, the QPU-side struct is `{ T*, i64 }` where the
 /// fields are the buffer pointer and a length (in number of elements). The size

--- a/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -15,7 +15,6 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/IRMapping.h"
 #include <cxxabi.h>
 #include <fstream>

--- a/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -103,7 +103,7 @@ bool QuakeBridgeVisitor::VisitCompoundAssignOperator(
     TODO_loc(loc, "assignment operator");
   }();
 
-  builder.create<mlir::memref::StoreOp>(loc, result, lhsPtr);
+  builder.create<cudaq::cc::StoreOp>(loc, result, lhsPtr);
   return pushValue(lhsPtr);
 }
 

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -22,7 +22,6 @@
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
-#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -1300,7 +1299,6 @@ public:
     populateAffineToStdConversionPatterns(patterns);
     arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
     populateMathToLLVMConversionPatterns(typeConverter, patterns);
-    populateMemRefToLLVMConversionPatterns(typeConverter, patterns);
 
     populateSCFToControlFlowConversionPatterns(patterns);
     cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);

--- a/lib/Optimizer/Transforms/QuakeAddMetadata.cpp
+++ b/lib/Optimizer/Transforms/QuakeAddMetadata.cpp
@@ -15,7 +15,6 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
@@ -75,34 +74,37 @@ private:
         }
 
         // See if it is a store op, storing the bit to memory
-        auto storeOp = dyn_cast_or_null<memref::StoreOp>(user);
+        auto storeOp = dyn_cast_or_null<cudaq::cc::StoreOp>(user);
         if (!storeOp)
           return WalkResult::skip();
 
         // Get the alloca op that this store op operates on
         auto allocValue = storeOp.getOperand(1);
-        auto allocaOp = allocValue.getDefiningOp<memref::AllocaOp>();
+        if (auto cp = allocValue.getDefiningOp<cudaq::cc::ComputePtrOp>())
+          allocValue = cp.getBase();
 
-        // Get the alloca users
-        for (auto allocUser : allocaOp->getUsers()) {
+        if (auto allocaOp = allocValue.getDefiningOp<cudaq::cc::AllocaOp>()) {
+          // Get the alloca users
+          for (auto allocUser : allocaOp->getUsers()) {
 
-          // Look for any future loads, and if that load is
-          // used by a conditional statement
-          if (auto load = dyn_cast<memref::LoadOp>(allocUser)) {
-            auto loadUser = *load->getUsers().begin();
+            // Look for any future loads, and if that load is
+            // used by a conditional statement
+            if (auto load = dyn_cast<cudaq::cc::LoadOp>(allocUser)) {
+              auto loadUser = *load->getUsers().begin();
 
-            // Loaded Val could be used directly or by an Arith boolean
-            // operation
-            while (loadUser->getDialect()->getNamespace() == "arith") {
-              auto res = loadUser->getResult(0);
-              loadUser = *res.getUsers().begin();
-            }
+              // Loaded Val could be used directly or by an Arith boolean
+              // operation
+              while (loadUser->getDialect()->getNamespace() == "arith") {
+                auto res = loadUser->getResult(0);
+                loadUser = *res.getUsers().begin();
+              }
 
-            // At this point we should be able to check if we are
-            // being used by a conditional
-            if (isa<cudaq::cc::IfOp, cf::CondBranchOp>(loadUser)) {
-              data.hasConditionalsOnMeasure = true;
-              return WalkResult::interrupt();
+              // At this point we should be able to check if we are
+              // being used by a conditional
+              if (isa<cudaq::cc::IfOp, cf::CondBranchOp>(loadUser)) {
+                data.hasConditionalsOnMeasure = true;
+                return WalkResult::interrupt();
+              }
             }
           }
         }

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -15,7 +15,6 @@
 #include "cudaq/Todo.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -61,13 +60,11 @@ void synthesizeRuntimeArgument(
   // and replace with the concrete op.
   if (!argument.getUsers().empty()) {
     auto firstUse = *argument.user_begin();
-    if (dyn_cast<memref::StoreOp>(firstUse)) {
+    if (dyn_cast<cudaq::cc::StoreOp>(firstUse)) {
       auto memrefValue = firstUse->getOperand(1);
-      for (auto user : memrefValue.getUsers()) {
-        if (auto load = dyn_cast<memref::LoadOp>(user)) {
+      for (auto user : memrefValue.getUsers())
+        if (auto load = dyn_cast<cudaq::cc::LoadOp>(user))
           load.getResult().replaceAllUsesWith(runtimeArg);
-        }
-      }
     }
   }
   argument.replaceAllUsesWith(runtimeArg);

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -39,7 +39,6 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"

--- a/test/AST-Quake/adjoint-2.cpp
+++ b/test/AST-Quake/adjoint-2.cpp
@@ -50,9 +50,9 @@ struct kernel_delta {
 // CHECK-SAME:        .adj(%[[VAL_0:.*]]: !quake.ref) {
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_1:.*]] = arith.constant 6 : i32
-// CHECK:             %[[VAL_2:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_1]], %[[VAL_2]][] : memref<i32>
-// CHECK:             %[[VAL_3:.*]] = memref.load %[[VAL_2]][] : memref<i32>
+// CHECK:             %[[VAL_2:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<i32>
+// CHECK:             %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_4:.*]] = arith.constant 0 : i32
 // CHECK:             %[[VAL_5:.*]] = arith.constant 2 : i32
 // CHECK:             %[[VAL_6:.*]] = arith.constant 0 : i32
@@ -66,10 +66,10 @@ struct kernel_delta {
 // CHECK:             %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i32
 // CHECK:             %[[VAL_15:.*]] = arith.muli %[[VAL_14]], %[[VAL_7]] : i32
 // CHECK:             %[[VAL_16:.*]] = arith.addi %[[VAL_3]], %[[VAL_15]] : i32
-// CHECK:             memref.store %[[VAL_16]], %[[VAL_2]][] : memref<i32>
+// CHECK:             cc.store %[[VAL_16]], %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_17:.*]] = arith.constant 0 : i32
 // CHECK:             %[[VAL_18:.*]] = cc.loop while ((%[[VAL_19:.*]] = %[[VAL_12]]) -> (i32)) {
-// CHECK:               %[[VAL_20:.*]] = memref.load %[[VAL_2]][] : memref<i32>
+// CHECK:               %[[VAL_20:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_21:.*]] = arith.constant 0 : i32
 // CHECK:               %[[VAL_22:.*]] = arith.cmpi sge, %[[VAL_20]], %[[VAL_21]] : i32
 // CHECK:               %[[VAL_23:.*]] = arith.cmpi sgt, %[[VAL_19]], %[[VAL_17]] : i32
@@ -85,9 +85,9 @@ struct kernel_delta {
 // CHECK:             } step {
 // CHECK:             ^bb0(%[[VAL_25:.*]]: i32):
 // CHECK:               %[[VAL_26:.*]] = arith.constant 2 : i32
-// CHECK:               %[[VAL_27:.*]] = memref.load %[[VAL_2]][] : memref<i32>
+// CHECK:               %[[VAL_27:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_28:.*]] = arith.addi %[[VAL_27]], %[[VAL_26]] : i32
-// CHECK:               memref.store %[[VAL_28]], %[[VAL_2]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_28]], %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_29:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_30:.*]] = arith.subi %[[VAL_25]], %[[VAL_29]] : i32
 // CHECK:               cc.continue %[[VAL_30]] : i32
@@ -100,9 +100,9 @@ struct kernel_delta {
 // CHECK-SAME:        .adj(%[[VAL_0:.*]]: !quake.ref) {
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_1:.*]] = arith.constant 0 : i32
-// CHECK:             %[[VAL_2:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_1]], %[[VAL_2]][] : memref<i32>
-// CHECK:             %[[VAL_3:.*]] = memref.load %[[VAL_2]][] : memref<i32>
+// CHECK:             %[[VAL_2:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<i32>
+// CHECK:             %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_4:.*]] = arith.constant 4 : i32
 // CHECK:             %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:             %[[VAL_6:.*]] = arith.constant 0 : i32
@@ -112,10 +112,10 @@ struct kernel_delta {
 // CHECK:             %[[VAL_10:.*]] = arith.constant 1 : i32
 // CHECK:             %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i32
 // CHECK:             %[[VAL_12:.*]] = arith.addi %[[VAL_3]], %[[VAL_11]] : i32
-// CHECK:             memref.store %[[VAL_12]], %[[VAL_2]][] : memref<i32>
+// CHECK:             cc.store %[[VAL_12]], %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_13:.*]] = arith.constant 0 : i32
 // CHECK:             %[[VAL_14:.*]] = cc.loop while ((%[[VAL_15:.*]] = %[[VAL_9]]) -> (i32)) {
-// CHECK:               %[[VAL_16:.*]] = memref.load %[[VAL_2]][] : memref<i32>
+// CHECK:               %[[VAL_16:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_17:.*]] = arith.constant 4 : i32
 // CHECK:               %[[VAL_18:.*]] = arith.cmpi slt, %[[VAL_16]], %[[VAL_17]] : i32
 // CHECK:               %[[VAL_19:.*]] = arith.cmpi sgt, %[[VAL_15]], %[[VAL_13]] : i32
@@ -130,10 +130,10 @@ struct kernel_delta {
 // CHECK:               cc.continue %[[VAL_20]] : i32
 // CHECK:             } step {
 // CHECK:             ^bb0(%[[VAL_21:.*]]: i32):
-// CHECK:               %[[VAL_22:.*]] = memref.load %[[VAL_2]][] : memref<i32>
+// CHECK:               %[[VAL_22:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_23:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_24:.*]] = arith.subi %[[VAL_22]], %[[VAL_23]] : i32
-// CHECK:               memref.store %[[VAL_24]], %[[VAL_2]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_24]], %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_25:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_26:.*]] = arith.subi %[[VAL_21]], %[[VAL_25]] : i32
 // CHECK:               cc.continue %[[VAL_26]] : i32

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -47,9 +47,9 @@ struct QernelZero {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__run_circuit
 // CHECK-SAME:        (%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: f64)
-// CHECK:           %[[VAL_5:.*]] = memref.alloca() : memref<f64>
+// CHECK:           %[[VAL_5:.*]] = cc.alloca f64
 // CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<?>[%{{.*}} : i64]
-// CHECK:           %[[VAL_16:.*]] = memref.load %[[VAL_5]][] : memref<f64>
+// CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           call @__nvqpp__mlirgen__statePrep_A{{.*}}(%[[VAL_10]], %[[VAL_16]]) : (!quake.veq<?>, f64) -> ()
 // CHECK:           cc.scope {
 // CHECK:             cc.loop while {
@@ -57,7 +57,7 @@ struct QernelZero {
 // CHECK:             } do {
 // CHECK:               cc.scope {
 // CHECK:                 quake.z %{{.*}}
-// CHECK:                 %[[VAL_23:.*]] = memref.load %[[VAL_5]][] : memref<f64>
+// CHECK:                 %[[VAL_23:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:                 quake.apply<adj> @__nvqpp__mlirgen__statePrep_A{{.*}} %[[VAL_10]], %[[VAL_23]] : (!quake.veq<?>, f64) -> ()
 // CHECK:                 func.call @__nvqpp__mlirgen__statePrep_A{{.*}}(%[[VAL_10]], %{{.*}}) : (!quake.veq<?>, f64) -> ()
 // CHECK:               }
@@ -91,13 +91,13 @@ struct run_circuit {
 
 // ADJOINT-LABEL:   func.func private @__nvqpp__mlirgen__statePrep_A
 // ADJOINT-SAME:        .adj(%[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: f64) {
-// ADJOINT:           %[[VAL_2:.*]] = memref.alloca() : memref<f64>
-// ADJOINT:           memref.store %[[VAL_1]], %[[VAL_2]][] : memref<f64>
+// ADJOINT:           %[[VAL_2:.*]] = cc.alloca f64
+// ADJOINT:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<f64>
 // ADJOINT:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // ADJOINT:           %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : i64 to i32
-// ADJOINT:           %[[VAL_5:.*]] = memref.alloca() : memref<i32>
-// ADJOINT:           memref.store %[[VAL_4]], %[[VAL_5]][] : memref<i32>
-// ADJOINT:           %[[VAL_6:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// ADJOINT:           %[[VAL_5:.*]] = cc.alloca i32
+// ADJOINT:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<i32>
+// ADJOINT:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // ADJOINT:           %[[VAL_7:.*]] = arith.constant 1 : i32
 // ADJOINT:           %[[VAL_8:.*]] = arith.subi %[[VAL_6]], %[[VAL_7]] : i32
 // ADJOINT:           %[[VAL_9:.*]] = arith.extsi %[[VAL_8]] : i32 to i64
@@ -109,25 +109,25 @@ struct run_circuit {
 // ADJOINT:           %[[VAL_17:.*]] = arith.index_cast %[[VAL_16]] : i64 to index
 // ADJOINT:           %[[VAL_14:.*]] = arith.constant 0 : index
 // ADJOINT:           %[[VAL_15:.*]] = arith.constant 1 : index
-// ADJOINT:           %[[VAL_18:.*]] = memref.load %[[VAL_2]][] : memref<f64>
+// ADJOINT:           %[[VAL_18:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
 // ADJOINT:           %[[VAL_19:.*]] = arith.constant 2.0{{.*}} : f64
-// ADJOINT:           %[[VAL_20:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// ADJOINT:           %[[VAL_20:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // ADJOINT:           %[[VAL_21:.*]] = arith.constant 1 : i32
 // ADJOINT:           %[[VAL_22:.*]] = arith.subi %[[VAL_20]], %[[VAL_21]] : i32
 // ADJOINT:           %[[VAL_23:.*]] = arith.sitofp %[[VAL_22]] : i32 to f64
 // ADJOINT:           %[[VAL_24:.*]] = math.powf %[[VAL_19]], %[[VAL_23]] : f64
 // ADJOINT:           %[[VAL_25:.*]] = arith.divf %[[VAL_18]], %[[VAL_24]] : f64
-// ADJOINT:           %[[VAL_26:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// ADJOINT:           %[[VAL_26:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // ADJOINT:           %[[VAL_27:.*]] = arith.constant 1 : i32
 // ADJOINT:           %[[VAL_28:.*]] = arith.subi %[[VAL_26]], %[[VAL_27]] : i32
 // ADJOINT:           %[[VAL_29:.*]] = arith.extsi %[[VAL_28]] : i32 to i64
 // ADJOINT:           %[[VAL_30:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_29]]] : (!quake.veq<?>, i64) -> !quake.ref
 // ADJOINT:           cc.scope {
 // ADJOINT:             %[[VAL_31:.*]] = arith.constant 1 : i32
-// ADJOINT:             %[[VAL_32:.*]] = memref.alloca() : memref<i32>
-// ADJOINT:             memref.store %[[VAL_31]], %[[VAL_32]][] : memref<i32>
-// ADJOINT:             %[[VAL_33:.*]] = memref.load %[[VAL_32]][] : memref<i32>
-// ADJOINT:             %[[VAL_34:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// ADJOINT:             %[[VAL_32:.*]] = cc.alloca i32
+// ADJOINT:             cc.store %[[VAL_31]], %[[VAL_32]] : !cc.ptr<i32>
+// ADJOINT:             %[[VAL_33:.*]] = cc.load %[[VAL_32]] : !cc.ptr<i32>
+// ADJOINT:             %[[VAL_34:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // ADJOINT:             %[[VAL_35:.*]] = arith.constant 1 : i32
 // ADJOINT:             %[[VAL_36:.*]] = arith.constant 0 : i32
 // ADJOINT:             %[[VAL_37:.*]] = arith.subi %[[VAL_34]], %[[VAL_33]] : i32
@@ -136,33 +136,33 @@ struct run_circuit {
 // ADJOINT:             %[[VAL_40:.*]] = arith.constant 1 : i32
 // ADJOINT:             %[[VAL_41:.*]] = arith.subi %[[VAL_39]], %[[VAL_40]] : i32
 // ADJOINT:             %[[VAL_42:.*]] = arith.addi %[[VAL_33]], %[[VAL_41]] : i32
-// ADJOINT:             memref.store %[[VAL_42]], %[[VAL_32]][] : memref<i32>
+// ADJOINT:             cc.store %[[VAL_42]], %[[VAL_32]] : !cc.ptr<i32>
 // ADJOINT:             %[[VAL_43:.*]] = arith.constant 0 : i32
 // ADJOINT:             %[[VAL_44:.*]] = cc.loop while ((%[[VAL_45:.*]] = %[[VAL_39]]) -> (i32)) {
-// ADJOINT:               %[[VAL_46:.*]] = memref.load %[[VAL_32]][] : memref<i32>
-// ADJOINT:               %[[VAL_47:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// ADJOINT:               %[[VAL_46:.*]] = cc.load %[[VAL_32]] : !cc.ptr<i32>
+// ADJOINT:               %[[VAL_47:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // ADJOINT:               %[[VAL_48:.*]] = arith.cmpi slt, %[[VAL_46]], %[[VAL_47]] : i32
 // ADJOINT:               %[[VAL_49:.*]] = arith.cmpi sgt, %[[VAL_45]], %[[VAL_43]] : i32
 // ADJOINT:               cc.condition %[[VAL_49]](%[[VAL_45]] : i32)
 // ADJOINT:             } do {
 // ADJOINT:             ^bb0(%[[VAL_50:.*]]: i32):
 // ADJOINT:               cc.scope {
-// ADJOINT:                 %[[VAL_51:.*]] = memref.load %[[VAL_2]][] : memref<f64>
+// ADJOINT:                 %[[VAL_51:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
 // ADJOINT:                 %[[VAL_52:.*]] = arith.constant 2.0{{.*}} : f64
-// ADJOINT:                 %[[VAL_53:.*]] = memref.load %[[VAL_5]][] : memref<i32>
-// ADJOINT:                 %[[VAL_54:.*]] = memref.load %[[VAL_32]][] : memref<i32>
+// ADJOINT:                 %[[VAL_53:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
+// ADJOINT:                 %[[VAL_54:.*]] = cc.load %[[VAL_32]] : !cc.ptr<i32>
 // ADJOINT:                 %[[VAL_55:.*]] = arith.subi %[[VAL_53]], %[[VAL_54]] : i32
 // ADJOINT:                 %[[VAL_56:.*]] = arith.constant 1 : i32
 // ADJOINT:                 %[[VAL_57:.*]] = arith.subi %[[VAL_55]], %[[VAL_56]] : i32
 // ADJOINT:                 %[[VAL_58:.*]] = arith.sitofp %[[VAL_57]] : i32 to f64
 // ADJOINT:                 %[[VAL_59:.*]] = math.powf %[[VAL_52]], %[[VAL_58]] : f64
 // ADJOINT:                 %[[VAL_60:.*]] = arith.divf %[[VAL_51]], %[[VAL_59]] : f64
-// ADJOINT:                 %[[VAL_61:.*]] = memref.load %[[VAL_32]][] : memref<i32>
+// ADJOINT:                 %[[VAL_61:.*]] = cc.load %[[VAL_32]] : !cc.ptr<i32>
 // ADJOINT:                 %[[VAL_62:.*]] = arith.constant 1 : i32
 // ADJOINT:                 %[[VAL_63:.*]] = arith.subi %[[VAL_61]], %[[VAL_62]] : i32
 // ADJOINT:                 %[[VAL_64:.*]] = arith.extsi %[[VAL_63]] : i32 to i64
 // ADJOINT:                 %[[VAL_65:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_64]]] : (!quake.veq<?>, i64) -> !quake.ref
-// ADJOINT:                 %[[VAL_66:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// ADJOINT:                 %[[VAL_66:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // ADJOINT:                 %[[VAL_67:.*]] = arith.constant 1 : i32
 // ADJOINT:                 %[[VAL_68:.*]] = arith.subi %[[VAL_66]], %[[VAL_67]] : i32
 // ADJOINT:                 %[[VAL_69:.*]] = arith.extsi %[[VAL_68]] : i32 to i64
@@ -173,10 +173,10 @@ struct run_circuit {
 // ADJOINT:               cc.continue %[[VAL_50]] : i32
 // ADJOINT:             } step {
 // ADJOINT:             ^bb0(%[[VAL_72:.*]]: i32):
-// ADJOINT:               %[[VAL_73:.*]] = memref.load %[[VAL_32]][] : memref<i32>
+// ADJOINT:               %[[VAL_73:.*]] = cc.load %[[VAL_32]] : !cc.ptr<i32>
 // ADJOINT:               %[[VAL_74:.*]] = arith.constant 1 : i32
 // ADJOINT:               %[[VAL_75:.*]] = arith.subi %[[VAL_73]], %[[VAL_74]] : i32
-// ADJOINT:               memref.store %[[VAL_75]], %[[VAL_32]][] : memref<i32>
+// ADJOINT:               cc.store %[[VAL_75]], %[[VAL_32]] : !cc.ptr<i32>
 // ADJOINT:               %[[VAL_76:.*]] = arith.constant 1 : i32
 // ADJOINT:               %[[VAL_77:.*]] = arith.subi %[[VAL_72]], %[[VAL_76]] : i32
 // ADJOINT:               cc.continue %[[VAL_77]] : i32

--- a/test/AST-Quake/bool_literal.cpp
+++ b/test/AST-Quake/bool_literal.cpp
@@ -13,8 +13,8 @@
 
 // CHECK: quake.h %[[VAL_0:.*]] : (!quake.ref) -> ()
 // CHECK: %false = arith.constant false
-// CHECK: %[[VAL_1:.*]] = memref.alloca() : memref<i1>
-// CHECK: memref.store %false, %[[VAL_1]][] : memref<i1>
+// CHECK: %[[VAL_1:.*]] = cc.alloca i1
+// CHECK: cc.store %false, %[[VAL_1]] : !cc.ptr<i1>
 
 struct testBoolLiteral {
   bool operator()() __qpu__ {

--- a/test/AST-Quake/compute_action-2.cpp
+++ b/test/AST-Quake/compute_action-2.cpp
@@ -67,10 +67,10 @@ struct ctrlHeisenberg {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenberg(
 // CHECK-SAME:        %[[VAL_0:.*]]: i32)
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_3:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_4:.*]] = arith.extsi %[[VAL_3]] : i32 to i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_4]] : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.concat %[[VAL_2]] : (!quake.ref) -> !quake.veq<?>
@@ -81,12 +81,12 @@ struct ctrlHeisenberg {
 //===----------------------------------------------------------------------===//
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__lifted.lambda.0.adj(
-// LAMBDA-SAME:      %{{[^:]*}}: memref<i32>, %{{[^:]*}}: !quake.veq<?>) {
+// LAMBDA-SAME:      %{{[^:]*}}: !cc.ptr<i32>, %{{[^:]*}}: !quake.veq<?>) {
 // LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.ref, !quake.ref) -> ()
 // LAMBDA:           return
 
 // LAMBDA2-LABEL:   func.func private @__nvqpp__lifted.lambda.1.ctrl(
-// LAMBDA2-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %{{.*}}: memref<i32>, %{{.*}}: !quake.veq<?>) {
+// LAMBDA2-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %{{.*}}: !cc.ptr<i32>, %{{.*}}: !quake.veq<?>) {
 // LAMBDA2:           quake.rz (%{{.*}}) [%[[VAL_0]]] %{{.*}} : (f64, !quake.veq<?>, !quake.ref) -> ()
 // LAMBDA2:           return
 
@@ -107,10 +107,10 @@ struct ctrlHeisenberg {
 // LAMBDA:                 cc.scope {
 // LAMBDA:                   cc.loop while {
 // LAMBDA:                   } do {
-// LAMBDA:                     func.call @__nvqpp__lifted.lambda.0(%{{.*}}, %[[VAL_1]]) : (memref<i32>, !quake.veq<?>) -> ()
+// LAMBDA:                     func.call @__nvqpp__lifted.lambda.0(%{{.*}}, %[[VAL_1]]) : (!cc.ptr<i32>, !quake.veq<?>) -> ()
 // LAMBDA:                     %[[VAL_28:.*]] = quake.concat %[[VAL_0]] : (!quake.veq<?>) -> !quake.veq<?>
-// LAMBDA:                     func.call @__nvqpp__lifted.lambda.1.ctrl(%[[VAL_28]], %{{.*}}, %[[VAL_1]]) : (!quake.veq<?>, memref<i32>, !quake.veq<?>) -> ()
-// LAMBDA:                     func.call @__nvqpp__lifted.lambda.0.adj(%{{.*}}, %[[VAL_1]]) : (memref<i32>, !quake.veq<?>) -> ()
+// LAMBDA:                     func.call @__nvqpp__lifted.lambda.1.ctrl(%[[VAL_28]], %{{.*}}, %[[VAL_1]]) : (!quake.veq<?>, !cc.ptr<i32>, !quake.veq<?>) -> ()
+// LAMBDA:                     func.call @__nvqpp__lifted.lambda.0.adj(%{{.*}}, %[[VAL_1]]) : (!cc.ptr<i32>, !quake.veq<?>) -> ()
 // LAMBDA:                   } step {
 // LAMBDA:                   }
 // LAMBDA:                 }
@@ -130,7 +130,7 @@ struct ctrlHeisenberg {
 // LAMBDA:         }
 
 // LAMBDA-LABEL:   func.func private @__nvqpp__lifted.lambda.0(
-// LAMBDA-SAME:      %[[VAL_0:.*]]: memref<i32>, %[[VAL_1:.*]]: !quake.veq<?>) {
+// LAMBDA-SAME:      %[[VAL_0:.*]]: !cc.ptr<i32>, %[[VAL_1:.*]]: !quake.veq<?>) {
 // LAMBDA:           quake.x [%{{.*}}] %{{.*}} : (!quake.ref, !quake.ref) -> ()
 // LAMBDA:           return
 // LAMBDA:         }

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -124,15 +124,15 @@ struct F {
 // CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_9:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_7]], %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_9:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_7]], %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             cf.br ^bb1
 // CHECK:           ^bb1:
-// CHECK:             %[[VAL_10:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i32
 // CHECK:             cf.cond_br %[[VAL_11]], ^bb2, ^bb8
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_12:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_12:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_13:.*]] = func.call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
@@ -146,7 +146,7 @@ struct F {
 // CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref,
 // CHECK:             func.call @_Z2g2v() : () -> ()
-// CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_18:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
@@ -170,9 +170,9 @@ struct F {
 // CHECK:             } {counted}
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb7:
-// CHECK:             %[[VAL_28:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_28:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_5]] : i32
-// CHECK:             memref.store %[[VAL_29]], %[[VAL_9]][] : memref<i32>
+// CHECK:             cc.store %[[VAL_29]], %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             cf.br ^bb1
 // CHECK:           ^bb8:
 // CHECK:             cc.continue
@@ -192,15 +192,15 @@ struct F {
 // CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_9:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_7]], %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_9:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_7]], %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             cf.br ^bb1
 // CHECK:           ^bb1:
-// CHECK:             %[[VAL_10:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i32
 // CHECK:             cf.cond_br %[[VAL_11]], ^bb2, ^bb8
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_12:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_12:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_13:.*]] = func.call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:           ^bb3:
@@ -214,7 +214,7 @@ struct F {
 // CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:             func.call @_Z2g2v() : () -> ()
-// CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_18:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:           ^bb5:
@@ -238,9 +238,9 @@ struct F {
 // CHECK:             } {counted}
 // CHECK:             cf.br ^bb7
 // CHECK:           ^bb7:
-// CHECK:             %[[VAL_28:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:             %[[VAL_28:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_5]] : i32
-// CHECK:             memref.store %[[VAL_29]], %[[VAL_9]][] : memref<i32>
+// CHECK:             cc.store %[[VAL_29]], %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:             cf.br ^bb1
 // CHECK:           ^bb8:
 // CHECK:             cc.continue
@@ -259,15 +259,15 @@ struct F {
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
-// CHECK:           %[[VAL_9:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_7]], %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_9:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_7]], %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i32
 // CHECK:           cf.cond_br %[[VAL_11]], ^bb2, ^bb7
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_13:.*]] = call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
@@ -281,7 +281,7 @@ struct F {
 // CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           call @_Z2g2v() : () -> ()
-// CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_18:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
@@ -303,9 +303,9 @@ struct F {
 // CHECK:             %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : index
 // CHECK:             cc.continue %[[VAL_27]] : index
 // CHECK:           } {counted}
-// CHECK:           %[[VAL_28:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_28:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_5]] : i32
-// CHECK:           memref.store %[[VAL_29]], %[[VAL_9]][] : memref<i32>
+// CHECK:           cc.store %[[VAL_29]], %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb7:
 // CHECK:           call @_Z2g4v() : () -> ()
@@ -325,15 +325,15 @@ struct F {
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
-// CHECK:           %[[VAL_9:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_7]], %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_9:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_7]], %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i32
 // CHECK:           cf.cond_br %[[VAL_11]], ^bb2, ^bb8
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_13:.*]] = call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
 // CHECK:         ^bb3:
@@ -347,7 +347,7 @@ struct F {
 // CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]]
 // CHECK:           call @_Z2g2v() : () -> ()
-// CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_18:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
 // CHECK:         ^bb5:
@@ -371,9 +371,9 @@ struct F {
 // CHECK:           } {counted}
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb7:
-// CHECK:           %[[VAL_28:.*]] = memref.load %[[VAL_9]][] : memref<i32>
+// CHECK:           %[[VAL_28:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_5]] : i32
-// CHECK:           memref.store %[[VAL_29]], %[[VAL_9]][] : memref<i32>
+// CHECK:           cc.store %[[VAL_29]], %[[VAL_9]] : !cc.ptr<i32>
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb8:
 // CHECK:           call @_Z2g4v() : () -> ()

--- a/test/AST-Quake/empty_step.cpp
+++ b/test/AST-Quake/empty_step.cpp
@@ -24,30 +24,30 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:             %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
-// CHECK:             %[[VAL_4:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
+// CHECK:             %[[VAL_4:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_5:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_7:.*]] = arith.subi %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:               memref.store %[[VAL_7]], %[[VAL_4]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_7]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_8:.*]] = arith.extui %[[VAL_5]] : i32 to i64
 // CHECK:               %[[VAL_9:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_10:.*]] = arith.cmpi ugt, %[[VAL_8]], %[[VAL_9]] : i64
 // CHECK:               cc.condition %[[VAL_10]]
 // CHECK:             } do {
 // CHECK:               cc.scope {
-// CHECK:                 %[[VAL_11:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:                 %[[VAL_11:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:                 %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
 // CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_14]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:                 %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:                 %[[VAL_16:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_19:.*]] = arith.subi %[[VAL_17]], %[[VAL_18]] : i64
 // CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:                 %[[VAL_21:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:                 %[[VAL_21:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_22:.*]] = arith.extui %[[VAL_21]] : i32 to i64
 // CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_22]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 func.call @__nvqpp__mlirgen__function_uma._Z3umaRN5cudaq5quditILm2EEES2_S2_(%[[VAL_15]], %[[VAL_20]], %[[VAL_23]]) : (!quake.ref, !quake.ref, !quake.ref) -> ()

--- a/test/AST-Quake/if.cpp
+++ b/test/AST-Quake/if.cpp
@@ -24,12 +24,12 @@ struct kernel {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel
 // CHECK-SAME: (%[[VAL_0:.*]]: i1) -> i32
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i1>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i1>
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i1
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_1]][] : memref<i1>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_1]] : !cc.ptr<i1>
 // CHECK:           cc.if(%[[VAL_5]]) {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_6:.*]] = arith.constant 0 : i32
@@ -59,12 +59,12 @@ struct kernel_else {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_else
 // CHECK-SAME:        (%[[VAL_0:.*]]: i1) -> i32
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i1>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i1>
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i1
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_1]][] : memref<i1>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_1]] : !cc.ptr<i1>
 // CHECK:           cc.if(%[[VAL_5]]) {
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_6:.*]] = arith.constant 0 : i32

--- a/test/AST-Quake/measure_bell.cpp
+++ b/test/AST-Quake/measure_bell.cpp
@@ -30,21 +30,21 @@ int main() { bell{}(100); }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__bell(
 // CHECK-SAME:      %[[VAL_0:.*]]: i32)
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_5]], %[[VAL_6]][] : memref<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:             %[[VAL_8:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_7]], %[[VAL_8]][] : memref<i32>
+// CHECK:             %[[VAL_8:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_7]], %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_9:.*]] = memref.load %[[VAL_8]][] : memref<i32>
-// CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:               %[[VAL_9:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_10:.*]] = cc.load %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_10]] : i32
 // CHECK:               cc.condition %[[VAL_11]]
 // CHECK:             } do {
@@ -66,9 +66,9 @@ int main() { bell{}(100); }
 // CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
 // CHECK:                 %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_24]]{{\[}}%[[VAL_23]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
 // CHECK:                 %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i1>
-// CHECK:                 %[[VAL_27:.*]] = memref.alloca() : memref<i1>
-// CHECK:                 memref.store %[[VAL_26]], %[[VAL_27]][] : memref<i1>
-// CHECK:                 %[[VAL_28:.*]] = memref.load %[[VAL_27]][] : memref<i1>
+// CHECK:                 %[[VAL_27:.*]] = cc.alloca i1
+// CHECK:                 cc.store %[[VAL_26]], %[[VAL_27]] : !cc.ptr<i1>
+// CHECK:                 %[[VAL_28:.*]] = cc.load %[[VAL_27]] : !cc.ptr<i1>
 // CHECK:                 %[[VAL_29:.*]] = arith.extui %[[VAL_28]] : i1 to i32
 // CHECK:                 %[[VAL_30:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_31:.*]] = arith.extsi %[[VAL_30]] : i32 to i64
@@ -79,19 +79,19 @@ int main() { bell{}(100); }
 // CHECK:                 %[[VAL_36:.*]] = arith.cmpi eq, %[[VAL_29]], %[[VAL_35]] : i32
 // CHECK:                 cc.if(%[[VAL_36]]) {
 // CHECK:                   cc.scope {
-// CHECK:                     %[[VAL_37:.*]] = memref.load %[[VAL_6]][] : memref<i32>
+// CHECK:                     %[[VAL_37:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_38:.*]] = arith.constant 1 : i32
 // CHECK:                     %[[VAL_39:.*]] = arith.addi %[[VAL_37]], %[[VAL_38]] : i32
-// CHECK:                     memref.store %[[VAL_39]], %[[VAL_6]][] : memref<i32>
+// CHECK:                     cc.store %[[VAL_39]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:                   }
 // CHECK:                 }
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_40:.*]] = memref.load %[[VAL_8]][] : memref<i32>
+// CHECK:               %[[VAL_40:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_41:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_42:.*]] = arith.addi %[[VAL_40]], %[[VAL_41]] : i32
-// CHECK:               memref.store %[[VAL_42]], %[[VAL_8]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_42]], %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return
@@ -131,21 +131,21 @@ struct tinkerbell {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__libertybell(
 // CHECK-SAME:        %[[VAL_0:.*]]: i32)
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_5]], %[[VAL_6]][] : memref<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:             %[[VAL_8:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_7]], %[[VAL_8]][] : memref<i32>
+// CHECK:             %[[VAL_8:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_7]], %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_9:.*]] = memref.load %[[VAL_8]][] : memref<i32>
-// CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:               %[[VAL_9:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_10:.*]] = cc.load %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_10]] : i32
 // CHECK:               cc.condition %[[VAL_11]]
 // CHECK:             } do {
@@ -175,19 +175,19 @@ struct tinkerbell {
 // CHECK:                 %[[VAL_32:.*]] = arith.cmpi eq, %[[VAL_31]], %[[VAL_26]] : i1
 // CHECK:                 cc.if(%[[VAL_32]]) {
 // CHECK:                   cc.scope {
-// CHECK:                     %[[VAL_33:.*]] = memref.load %[[VAL_6]][] : memref<i32>
+// CHECK:                     %[[VAL_33:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_34:.*]] = arith.constant 1 : i32
 // CHECK:                     %[[VAL_35:.*]] = arith.addi %[[VAL_33]], %[[VAL_34]] : i32
-// CHECK:                     memref.store %[[VAL_35]], %[[VAL_6]][] : memref<i32>
+// CHECK:                     cc.store %[[VAL_35]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:                   }
 // CHECK:                 }
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_36:.*]] = memref.load %[[VAL_8]][] : memref<i32>
+// CHECK:               %[[VAL_36:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_37:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_38:.*]] = arith.addi %[[VAL_36]], %[[VAL_37]] : i32
-// CHECK:               memref.store %[[VAL_38]], %[[VAL_8]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_38]], %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return
@@ -195,21 +195,21 @@ struct tinkerbell {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__tinkerbell(
 // CHECK-SAME:        %[[VAL_0:.*]]: i32) attributes
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_6:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_5]], %[[VAL_6]][] : memref<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:             %[[VAL_8:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_7]], %[[VAL_8]][] : memref<i32>
+// CHECK:             %[[VAL_8:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_7]], %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_9:.*]] = memref.load %[[VAL_8]][] : memref<i32>
-// CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:               %[[VAL_9:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_10:.*]] = cc.load %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_10]] : i32
 // CHECK:               cc.condition %[[VAL_11]]
 // CHECK:             } do {
@@ -231,33 +231,33 @@ struct tinkerbell {
 // CHECK:                 %[[VAL_24:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
 // CHECK:                 %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_24]][%[[VAL_23]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
 // CHECK:                 %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i1>
-// CHECK:                 %[[VAL_27:.*]] = memref.alloca() : memref<i1>
-// CHECK:                 memref.store %[[VAL_26]], %[[VAL_27]][] : memref<i1>
+// CHECK:                 %[[VAL_27:.*]] = cc.alloca i1
+// CHECK:                 cc.store %[[VAL_26]], %[[VAL_27]] : !cc.ptr<i1>
 // CHECK:                 %[[VAL_28:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_29:.*]] = arith.extsi %[[VAL_28]] : i32 to i64
 // CHECK:                 %[[VAL_30:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
 // CHECK:                 %[[VAL_31:.*]] = cc.compute_ptr %[[VAL_30]][%[[VAL_29]]] : (!cc.ptr<i1>, i64) -> !cc.ptr<i1>
 // CHECK:                 %[[VAL_32:.*]] = cc.load %[[VAL_31]] : !cc.ptr<i1>
-// CHECK:                 %[[VAL_33:.*]] = memref.alloca() : memref<i1>
-// CHECK:                 memref.store %[[VAL_32]], %[[VAL_33]][] : memref<i1>
-// CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_33]][] : memref<i1>
-// CHECK:                 %[[VAL_35:.*]] = memref.load %[[VAL_27]][] : memref<i1>
+// CHECK:                 %[[VAL_33:.*]] = cc.alloca i1
+// CHECK:                 cc.store %[[VAL_32]], %[[VAL_33]] : !cc.ptr<i1>
+// CHECK:                 %[[VAL_34:.*]] = cc.load %[[VAL_33]] : !cc.ptr<i1>
+// CHECK:                 %[[VAL_35:.*]] = cc.load %[[VAL_27]] : !cc.ptr<i1>
 // CHECK:                 %[[VAL_36:.*]] = arith.cmpi eq, %[[VAL_34]], %[[VAL_35]] : i1
 // CHECK:                 cc.if(%[[VAL_36]]) {
 // CHECK:                   cc.scope {
-// CHECK:                     %[[VAL_37:.*]] = memref.load %[[VAL_6]][] : memref<i32>
+// CHECK:                     %[[VAL_37:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_38:.*]] = arith.constant 1 : i32
 // CHECK:                     %[[VAL_39:.*]] = arith.addi %[[VAL_37]], %[[VAL_38]] : i32
-// CHECK:                     memref.store %[[VAL_39]], %[[VAL_6]][] : memref<i32>
+// CHECK:                     cc.store %[[VAL_39]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:                   }
 // CHECK:                 }
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_40:.*]] = memref.load %[[VAL_8]][] : memref<i32>
+// CHECK:               %[[VAL_40:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_41:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_42:.*]] = arith.addi %[[VAL_40]], %[[VAL_41]] : i32
-// CHECK:               memref.store %[[VAL_42]], %[[VAL_8]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_42]], %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return

--- a/test/AST-Quake/mz.cpp
+++ b/test/AST-Quake/mz.cpp
@@ -67,15 +67,15 @@ struct VectorOfDynamicVeq {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorOfDynamicVeq(
 // CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) -> !cc.stdvec<i1> attributes {
-// CHECK:           %[[VAL_2:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_2]][] : memref<i32>
-// CHECK:           %[[VAL_3:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_1]], %[[VAL_3]][] : memref<i32>
+// CHECK:           %[[VAL_2:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_2]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_3:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_3]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_2]][] : memref<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = arith.extui %[[VAL_5]] : i32 to i64
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<?>[%[[VAL_6]] : i64]
-// CHECK:           %[[VAL_8:.*]] = memref.load %[[VAL_3]][] : memref<i32>
+// CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<?>[%[[VAL_9]] : i64]
 // CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.ref

--- a/test/AST-Quake/nested_scope.cpp
+++ b/test/AST-Quake/nested_scope.cpp
@@ -52,65 +52,65 @@ struct test3 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test1
 // CHECK-SAME: ()
-// CHECK:           %[[VAL_0:.*]] = memref.alloca() : memref<i32>
+// CHECK:           %[[VAL_0:.*]] = cc.alloca i32
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
-// CHECK:           memref.store %[[VAL_1]], %[[VAL_0]][] : memref<i32>
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_0]] : !cc.ptr<i32>
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_2:.*]] = memref.alloca() : memref<f64>
+// CHECK:             %[[VAL_2:.*]] = cc.alloca f64
 // CHECK:             %[[VAL_3:.*]] = arith.constant 3.14
-// CHECK:             memref.store %[[VAL_3]], %[[VAL_2]][] : memref<f64>
-// CHECK:             %[[VAL_4:.*]] = memref.load %[[VAL_2]][] : memref<f64>
+// CHECK:             cc.store %[[VAL_3]], %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:             %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
 // CHECK:             func.call @_Z3foo(%[[VAL_4]]) : (f64) -> ()
 // CHECK:           }
-// CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_0]][] : memref<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_0]] : !cc.ptr<i32>
 // CHECK:           call @_Z3bar(%[[VAL_5]]) : (i32) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test2
 // CHECK-SAME:         (%[[VAL_0:.*]]: i32)
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK:           memref.store %[[VAL_2]], %[[VAL_1]][] : memref<i32>
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_3:.*]] = memref.alloca() : memref<f64>
+// CHECK:             %[[VAL_3:.*]] = cc.alloca f64
 // CHECK:             %[[VAL_4:.*]] = arith.constant 3.14
-// CHECK:             memref.store %[[VAL_4]], %[[VAL_3]][] : memref<f64>
-// CHECK:             %[[VAL_5:.*]] = memref.load %[[VAL_3]][] : memref<f64>
+// CHECK:             cc.store %[[VAL_4]], %[[VAL_3]] : !cc.ptr<f64>
+// CHECK:             %[[VAL_5:.*]] = cc.load %[[VAL_3]] : !cc.ptr<f64>
 // CHECK:             func.call @_Z3foo(%[[VAL_5]]) : (f64) -> ()
 // CHECK:           }
-// CHECK:           %[[VAL_6:.*]] = memref.load %[[VAL_1]][] : memref<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           call @_Z3bar(%[[VAL_6]]) : (i32) -> ()
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3
 // CHECK-SAME:         (%[[VAL_0:.*]]: f64)
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<f64>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_1:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 3.14
-// CHECK:           memref.store %[[VAL_2]], %[[VAL_1]][] : memref<f64>
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_1]] : !cc.ptr<f64>
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_3:.*]] = arith.constant 0 : i32
-// CHECK:             %[[VAL_4:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
+// CHECK:             %[[VAL_4:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_5:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_6:.*]] = arith.constant 20 : i32
 // CHECK:               %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_6]] : i32
 // CHECK:               cc.condition %[[VAL_7]]
 // CHECK:             } do {
-// CHECK:                 %[[VAL_8:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:                 %[[VAL_8:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:                 func.call @_Z3bar(%[[VAL_8]]) : (i32) -> ()
 // CHECK:             } step {
-// CHECK:               %[[VAL_9:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_9:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_10:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_11:.*]] = arith.addi %[[VAL_9]], %[[VAL_10]] : i32
-// CHECK:               memref.store %[[VAL_11]], %[[VAL_4]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_11]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_1]][] : memref<f64>
+// CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_1]] : !cc.ptr<f64>
 // CHECK:           call @_Z3foo(%[[VAL_12]]) : (f64) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/operators.cpp
+++ b/test/AST-Quake/operators.cpp
@@ -34,28 +34,28 @@ struct integer_test {
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %{{.*}} : i16 to i32
 // CHECK:           %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_7:.*]] = arith.shrsi %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           %[[VAL_10:.*]] = arith.extui %{{.*}} : i16 to i32
 // CHECK:           %[[VAL_11:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_12:.*]] = arith.shrsi %[[VAL_10]], %[[VAL_11]] : i32
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           %[[VAL_15:.*]] = arith.extsi %{{.*}} : i16 to i32
 // CHECK:           %[[VAL_16:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_17:.*]] = arith.shli %[[VAL_15]], %[[VAL_16]] : i32
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           %[[VAL_20:.*]] = arith.extui %{{.*}} : i16 to i32
 // CHECK:           %[[VAL_21:.*]] = arith.constant 3 : i32
 // CHECK:           %[[VAL_22:.*]] = arith.shli %[[VAL_20]], %[[VAL_21]] : i32
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           %[[VAL_26:.*]] = arith.andi %{{.*}}, %{{.*}} : i32
 // CHECK:           %[[VAL_29:.*]] = arith.xori %{{.*}}, %{{.*}} : i32
 // CHECK:           %[[VAL_30:.*]] = arith.ori %[[VAL_26]], %[[VAL_29]] : i32
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           %[[VAL_35:.*]] = arith.muli %{{.*}}, %{{.*}} : i32
 // CHECK:           %[[VAL_36:.*]] = arith.addi %{{.*}}, %[[VAL_35]] : i32
 // CHECK:           %[[VAL_39:.*]] = arith.divsi %{{.*}}, %{{.*}} : i32
 // CHECK:           %[[VAL_40:.*]] = arith.subi %[[VAL_36]], %[[VAL_39]] : i32
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           call @_Z3fooii(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
 // CHECK:           return
 
@@ -75,14 +75,14 @@ struct fp_test {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__fp_test
 // CHECK:           %[[VAL_6:.*]] = arith.addf %{{.*}}, %{{.*}} : f32
 // CHECK:           %[[VAL_7:.*]] = arith.extf %[[VAL_6]] : f32 to f64
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           %[[VAL_11:.*]] = arith.mulf %{{.*}}, %{{.*}} : f32
 // CHECK:           %[[VAL_12:.*]] = arith.extf %[[VAL_11]] : f32 to f64
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           %[[VAL_15:.*]] = arith.extf %{{.*}} : f32 to f64
 // CHECK:           %[[VAL_17:.*]] = arith.subf %[[VAL_15]], %{{.*}} : f64
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           %[[VAL_21:.*]] = arith.divf %{{.*}}, %{{.*}} : f64
-// CHECK:           memref.store
+// CHECK:           cc.store
 // CHECK:           call @_Z3bard(%{{.*}}) : (f64) -> ()
 // CHECK:           return

--- a/test/AST-Quake/postfix_ops.cpp
+++ b/test/AST-Quake/postfix_ops.cpp
@@ -24,30 +24,30 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:             %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
-// CHECK:             %[[VAL_4:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
+// CHECK:             %[[VAL_4:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_5:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_7:.*]] = arith.subi %[[VAL_5]], %[[VAL_6]] : i32
-// CHECK:               memref.store %[[VAL_7]], %[[VAL_4]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_7]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_8:.*]] = arith.extui %[[VAL_5]] : i32 to i64
 // CHECK:               %[[VAL_9:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_10:.*]] = arith.cmpi ugt, %[[VAL_8]], %[[VAL_9]] : i64
 // CHECK:               cc.condition %[[VAL_10]]
 // CHECK:             } do {
 // CHECK:               cc.scope {
-// CHECK:                 %[[VAL_11:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:                 %[[VAL_11:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:                 %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
 // CHECK:                 %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_14]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:                 %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:                 %[[VAL_16:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i64
 // CHECK:                 %[[VAL_19:.*]] = arith.subi %[[VAL_17]], %[[VAL_18]] : i64
 // CHECK:                 %[[VAL_20:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:                 %[[VAL_21:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:                 %[[VAL_21:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_22:.*]] = arith.extui %[[VAL_21]] : i32 to i64
 // CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_22]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               }

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -105,26 +105,26 @@ int main() {
 // CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_1:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_2:.*]] = arith.trunci %[[VAL_1]] : i64 to i32
-// CHECK:           %[[VAL_3:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_2]], %[[VAL_3]][] : memref<i32>
+// CHECK:           %[[VAL_3:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_3]] : !cc.ptr<i32>
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_4:.*]] = arith.constant 0 : i32
-// CHECK:             %[[VAL_5:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_4]], %[[VAL_5]][] : memref<i32>
+// CHECK:             %[[VAL_5:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_6:.*]] = memref.load %[[VAL_5]][] : memref<i32>
-// CHECK:               %[[VAL_7:.*]] = memref.load %[[VAL_3]][] : memref<i32>
+// CHECK:               %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_7:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_8:.*]] = arith.constant 2 : i32
 // CHECK:               %[[VAL_9:.*]] = arith.divsi %[[VAL_7]], %[[VAL_8]] : i32
 // CHECK:               %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_9]] : i32
 // CHECK:               cc.condition %[[VAL_10]]
 // CHECK:             } do {
 // CHECK:               cc.scope {
-// CHECK:                 %[[VAL_11:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// CHECK:                 %[[VAL_11:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
 // CHECK:                 %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_12]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:                 %[[VAL_14:.*]] = memref.load %[[VAL_3]][] : memref<i32>
-// CHECK:                 %[[VAL_15:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// CHECK:                 %[[VAL_14:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
+// CHECK:                 %[[VAL_15:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i32
 // CHECK:                 %[[VAL_17:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_18:.*]] = arith.subi %[[VAL_16]], %[[VAL_17]] : i32
@@ -134,40 +134,40 @@ int main() {
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_21:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// CHECK:               %[[VAL_21:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_22:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_23:.*]] = arith.addi %[[VAL_21]], %[[VAL_22]] : i32
-// CHECK:               memref.store %[[VAL_23]], %[[VAL_5]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_23]], %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_24:.*]] = arith.constant 0 : i32
-// CHECK:             %[[VAL_25:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_24]], %[[VAL_25]][] : memref<i32>
+// CHECK:             %[[VAL_25:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_24]], %[[VAL_25]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_26:.*]] = memref.load %[[VAL_25]][] : memref<i32>
-// CHECK:               %[[VAL_27:.*]] = memref.load %[[VAL_3]][] : memref<i32>
+// CHECK:               %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_27:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_28:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_29:.*]] = arith.subi %[[VAL_27]], %[[VAL_28]] : i32
 // CHECK:               %[[VAL_30:.*]] = arith.cmpi slt, %[[VAL_26]], %[[VAL_29]] : i32
 // CHECK:               cc.condition %[[VAL_30]]
 // CHECK:             } do {
 // CHECK:               cc.scope {
-// CHECK:                 %[[VAL_31:.*]] = memref.load %[[VAL_25]][] : memref<i32>
+// CHECK:                 %[[VAL_31:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_32:.*]] = arith.extsi %[[VAL_31]] : i32 to i64
 // CHECK:                 %[[VAL_33:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_32]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                 quake.h %[[VAL_33]] : (!quake.ref) -> ()
-// CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_25]][] : memref<i32>
+// CHECK:                 %[[VAL_34:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_35:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_36:.*]] = arith.addi %[[VAL_34]], %[[VAL_35]] : i32
-// CHECK:                 %[[VAL_37:.*]] = memref.alloca() : memref<i32>
-// CHECK:                 memref.store %[[VAL_36]], %[[VAL_37]][] : memref<i32>
+// CHECK:                 %[[VAL_37:.*]] = cc.alloca i32
+// CHECK:                 cc.store %[[VAL_36]], %[[VAL_37]] : !cc.ptr<i32>
 // CHECK:                 cc.scope {
-// CHECK:                   %[[VAL_38:.*]] = memref.load %[[VAL_25]][] : memref<i32>
-// CHECK:                   %[[VAL_39:.*]] = memref.alloca() : memref<i32>
-// CHECK:                   memref.store %[[VAL_38]], %[[VAL_39]][] : memref<i32>
+// CHECK:                   %[[VAL_38:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i32>
+// CHECK:                   %[[VAL_39:.*]] = cc.alloca i32
+// CHECK:                   cc.store %[[VAL_38]], %[[VAL_39]] : !cc.ptr<i32>
 // CHECK:                   cc.loop while {
-// CHECK:                     %[[VAL_40:.*]] = memref.load %[[VAL_39]][] : memref<i32>
+// CHECK:                     %[[VAL_40:.*]] = cc.load %[[VAL_39]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_41:.*]] = arith.constant 0 : i32
 // CHECK:                     %[[VAL_42:.*]] = arith.cmpi sge, %[[VAL_40]], %[[VAL_41]] : i32
 // CHECK:                     cc.condition %[[VAL_42]]
@@ -177,40 +177,40 @@ int main() {
 // CHECK:                       %[[VAL_44:.*]] = arith.constant -1.000000e+00 : f64
 // CHECK:                       %[[VAL_45:.*]] = arith.mulf %[[VAL_43]], %[[VAL_44]] : f64
 // CHECK:                       %[[VAL_46:.*]] = arith.constant 2.000000e+00 : f64
-// CHECK:                       %[[VAL_47:.*]] = memref.load %[[VAL_37]][] : memref<i32>
-// CHECK:                       %[[VAL_48:.*]] = memref.load %[[VAL_39]][] : memref<i32>
+// CHECK:                       %[[VAL_47:.*]] = cc.load %[[VAL_37]] : !cc.ptr<i32>
+// CHECK:                       %[[VAL_48:.*]] = cc.load %[[VAL_39]] : !cc.ptr<i32>
 // CHECK:                       %[[VAL_49:.*]] = arith.subi %[[VAL_47]], %[[VAL_48]] : i32
 // CHECK:                       %[[VAL_51:.*]] = math.fpowi %[[VAL_46]], %[[VAL_49]] : f64, i32
 // CHECK:                       %[[VAL_52:.*]] = arith.divf %[[VAL_45]], %[[VAL_51]] : f64
-// CHECK:                       %[[VAL_53:.*]] = memref.alloca() : memref<f64>
-// CHECK:                       memref.store %[[VAL_52]], %[[VAL_53]][] : memref<f64>
-// CHECK:                       %[[VAL_54:.*]] = memref.load %[[VAL_53]][] : memref<f64>
-// CHECK:                       %[[VAL_55:.*]] = memref.load %[[VAL_37]][] : memref<i32>
+// CHECK:                       %[[VAL_53:.*]] = cc.alloca f64
+// CHECK:                       cc.store %[[VAL_52]], %[[VAL_53]] : !cc.ptr<f64>
+// CHECK:                       %[[VAL_54:.*]] = cc.load %[[VAL_53]] : !cc.ptr<f64>
+// CHECK:                       %[[VAL_55:.*]] = cc.load %[[VAL_37]] : !cc.ptr<i32>
 // CHECK:                       %[[VAL_56:.*]] = arith.extsi %[[VAL_55]] : i32 to i64
 // CHECK:                       %[[VAL_57:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_56]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:                       %[[VAL_58:.*]] = memref.load %[[VAL_39]][] : memref<i32>
+// CHECK:                       %[[VAL_58:.*]] = cc.load %[[VAL_39]] : !cc.ptr<i32>
 // CHECK:                       %[[VAL_59:.*]] = arith.extsi %[[VAL_58]] : i32 to i64
 // CHECK:                       %[[VAL_60:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_59]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                       quake.r1 (%[[VAL_54]]) [%[[VAL_57]]] %[[VAL_60]] : (f64, !quake.ref, !quake.ref) -> ()
 // CHECK:                     }
 // CHECK:                     cc.continue
 // CHECK:                   } step {
-// CHECK:                     %[[VAL_61:.*]] = memref.load %[[VAL_39]][] : memref<i32>
+// CHECK:                     %[[VAL_61:.*]] = cc.load %[[VAL_39]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_62:.*]] = arith.constant 1 : i32
 // CHECK:                     %[[VAL_63:.*]] = arith.subi %[[VAL_61]], %[[VAL_62]] : i32
-// CHECK:                     memref.store %[[VAL_63]], %[[VAL_39]][] : memref<i32>
+// CHECK:                     cc.store %[[VAL_63]], %[[VAL_39]] : !cc.ptr<i32>
 // CHECK:                   }
 // CHECK:                 }
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_64:.*]] = memref.load %[[VAL_25]][] : memref<i32>
+// CHECK:               %[[VAL_64:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_65:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_66:.*]] = arith.addi %[[VAL_64]], %[[VAL_65]] : i32
-// CHECK:               memref.store %[[VAL_66]], %[[VAL_25]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_66]], %[[VAL_25]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_67:.*]] = memref.load %[[VAL_3]][] : memref<i32>
+// CHECK:           %[[VAL_67:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_68:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_69:.*]] = arith.subi %[[VAL_67]], %[[VAL_68]] : i32
 // CHECK:           %[[VAL_70:.*]] = arith.extsi %[[VAL_69]] : i32 to i64
@@ -268,22 +268,22 @@ int main() {
 // CHECK-SAME:      (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32,
 // CHECK-SAME:       %[[VAL_2:.*]]: !cc.lambda<(!quake.veq<?>) -> ()>,
 // CHECK-SAME:       %[[VAL_3:.*]]: !cc.struct<"tgate" {}>) attributes
-// CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_0]], %[[VAL_4]][] : memref<i32>
-// CHECK:           %[[VAL_5:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_1]], %[[VAL_5]][] : memref<i32>
-// CHECK:           %[[VAL_6:.*]] = memref.load %[[VAL_4]][] : memref<i32>
-// CHECK:           %[[VAL_7:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           %[[VAL_9:.*]] = arith.extsi %[[VAL_8]] : i32 to i64
 // CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<?>[%[[VAL_9]] : i64]
-// CHECK:           %[[VAL_11:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
 // CHECK:           %[[VAL_13:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_14:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_15:.*]] = arith.subi %[[VAL_12]], %[[VAL_14]] : i64
 // CHECK:           %[[VAL_16:.*]] = quake.subvec %[[VAL_10]], %[[VAL_13]], %[[VAL_15]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
-// CHECK:           %[[VAL_17:.*]] = memref.load %[[VAL_5]][] : memref<i32>
+// CHECK:           %[[VAL_17:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_18:.*]] = arith.extsi %[[VAL_17]] : i32 to i64
 // CHECK:           %[[VAL_19:.*]] = quake.vec_size %[[VAL_10]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_20:.*]] = arith.constant 1 : i64
@@ -310,50 +310,50 @@ int main() {
 // CHECK:           }
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_35:.*]] = arith.constant 0 : i32
-// CHECK:             %[[VAL_36:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_35]], %[[VAL_36]][] : memref<i32>
+// CHECK:             %[[VAL_36:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_35]], %[[VAL_36]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_37:.*]] = memref.load %[[VAL_36]][] : memref<i32>
-// CHECK:               %[[VAL_38:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_37:.*]] = cc.load %[[VAL_36]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_38:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_39:.*]] = arith.cmpi slt, %[[VAL_37]], %[[VAL_38]] : i32
 // CHECK:               cc.condition %[[VAL_39]]
 // CHECK:             } do {
 // CHECK:               cc.scope {
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_40:.*]] = arith.constant 0 : i32
-// CHECK:                   %[[VAL_41:.*]] = memref.alloca() : memref<i32>
-// CHECK:                   memref.store %[[VAL_40]], %[[VAL_41]][] : memref<i32>
+// CHECK:                   %[[VAL_41:.*]] = cc.alloca i32
+// CHECK:                   cc.store %[[VAL_40]], %[[VAL_41]] : !cc.ptr<i32>
 // CHECK:                   cc.loop while {
-// CHECK:                     %[[VAL_42:.*]] = memref.load %[[VAL_41]][] : memref<i32>
+// CHECK:                     %[[VAL_42:.*]] = cc.load %[[VAL_41]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_43:.*]] = arith.extsi %[[VAL_42]] : i32 to i64
 // CHECK:                     %[[VAL_44:.*]] = arith.constant 1 : i64
-// CHECK:                     %[[VAL_45:.*]] = memref.load %[[VAL_36]][] : memref<i32>
+// CHECK:                     %[[VAL_45:.*]] = cc.load %[[VAL_36]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_46:.*]] = arith.extsi %[[VAL_45]] : i32 to i64
 // CHECK:                     %[[VAL_47:.*]] = arith.shli %[[VAL_44]], %[[VAL_46]] : i64
 // CHECK:                     %[[VAL_48:.*]] = arith.cmpi ult, %[[VAL_43]], %[[VAL_47]] : i64
 // CHECK:                     cc.condition %[[VAL_48]]
 // CHECK:                   } do {
 // CHECK:                     cc.scope {
-// CHECK:                       %[[VAL_49:.*]] = memref.load %[[VAL_36]][] : memref<i32>
+// CHECK:                       %[[VAL_49:.*]] = cc.load %[[VAL_36]] : !cc.ptr<i32>
 // CHECK:                       %[[VAL_50:.*]] = arith.extsi %[[VAL_49]] : i32 to i64
 // CHECK:                       %[[VAL_51:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_50]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:                       quake.apply @__nvqpp__mlirgen__tgate[%[[VAL_51]]] %[[VAL_23]] : (!quake.ref, !quake.veq<?>) -> ()
 // CHECK:                     }
 // CHECK:                     cc.continue
 // CHECK:                   } step {
-// CHECK:                     %[[VAL_52:.*]] = memref.load %[[VAL_41]][] : memref<i32>
+// CHECK:                     %[[VAL_52:.*]] = cc.load %[[VAL_41]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_53:.*]] = arith.constant 1 : i32
 // CHECK:                     %[[VAL_54:.*]] = arith.addi %[[VAL_52]], %[[VAL_53]] : i32
-// CHECK:                     memref.store %[[VAL_54]], %[[VAL_41]][] : memref<i32>
+// CHECK:                     cc.store %[[VAL_54]], %[[VAL_41]] : !cc.ptr<i32>
 // CHECK:                   }
 // CHECK:                 }
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_55:.*]] = memref.load %[[VAL_36]][] : memref<i32>
+// CHECK:               %[[VAL_55:.*]] = cc.load %[[VAL_36]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_56:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_57:.*]] = arith.addi %[[VAL_55]], %[[VAL_56]] : i32
-// CHECK:               memref.store %[[VAL_57]], %[[VAL_36]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_57]], %[[VAL_36]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           call @__nvqpp__mlirgen__function_iqft{{.*}}(%[[VAL_16]]) : (!quake.veq<?>) -> ()

--- a/test/AST-Quake/simple_qarray.cpp
+++ b/test/AST-Quake/simple_qarray.cpp
@@ -54,19 +54,19 @@ int main() {
 // CHECK:           quake.h %[[VAL_8]] :
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : i32
-// CHECK:             %[[VAL_10:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_9]], %[[VAL_10]][] : memref<i32>
+// CHECK:             %[[VAL_10:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_9]], %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_11:.*]] = memref.load %[[VAL_10]][] : memref<i32>
+// CHECK:               %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_12:.*]] = arith.constant 4 : i32
 // CHECK:               %[[VAL_13:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_12]] : i32
 // CHECK:               cc.condition %[[VAL_13]]
 // CHECK:             } do {
 // CHECK:               cc.scope {
-// CHECK:                 %[[VAL_14:.*]] = memref.load %[[VAL_10]][] : memref<i32>
+// CHECK:                 %[[VAL_14:.*]] = cc.load %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64
 // CHECK:                 %[[VAL_16:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_15]]] : (!quake.veq<5>, i64) -> !quake.ref
-// CHECK:                 %[[VAL_17:.*]] = memref.load %[[VAL_10]][] : memref<i32>
+// CHECK:                 %[[VAL_17:.*]] = cc.load %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:                 %[[VAL_18:.*]] = arith.constant 1 : i32
 // CHECK:                 %[[VAL_19:.*]] = arith.addi %[[VAL_17]], %[[VAL_18]] : i32
 // CHECK:                 %[[VAL_20:.*]] = arith.extsi %[[VAL_19]] : i32 to i64
@@ -75,10 +75,10 @@ int main() {
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_22:.*]] = memref.load %[[VAL_10]][] : memref<i32>
+// CHECK:               %[[VAL_22:.*]] = cc.load %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_23:.*]] = arith.constant 1 : i32
 // CHECK:               %[[VAL_24:.*]] = arith.addi %[[VAL_22]], %[[VAL_23]] : i32
-// CHECK:               memref.store %[[VAL_24]], %[[VAL_10]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_24]], %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[VAL_33:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<5>) -> !cc.stdvec<i1>

--- a/test/AST-Quake/single_qubit_ctor.cpp
+++ b/test/AST-Quake/single_qubit_ctor.cpp
@@ -13,12 +13,12 @@
 // CHECK: module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__super{{.*}} = "_ZN5superclEd"}} {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__super
 // CHECK-SAME: (%[[arg0:.*]]: f64) -> i1
-// CHECK:     %[[V0:.*]] = memref.alloca() : memref<f64>
-// CHECK:     memref.store %[[arg0]], %[[V0]][] : memref<f64>
+// CHECK:     %[[V0:.*]] = cc.alloca f64
+// CHECK:     cc.store %[[arg0]], %[[V0]] : !cc.ptr<f64>
 // CHECK:     %[[V1:.*]] = quake.alloca !quake.ref
-// CHECK:     %[[V2:.*]] = memref.load %[[V0]][] : memref<f64>
+// CHECK:     %[[V2:.*]] = cc.load %[[V0]] : !cc.ptr<f64>
 // CHECK:     quake.rx (%[[V2]]) %[[V1]] : (f64,
-// CHECK:     %[[V3:.*]] = memref.load %[[V0]][] : memref<f64>
+// CHECK:     %[[V3:.*]] = cc.load %[[V0]] : !cc.ptr<f64>
 // CHECK:     %[[cst:.*]] = arith.constant 2.0{{.*}} : f64
 // CHECK:     %[[V4:.*]] = arith.divf %[[V3]], %[[cst]] : f64
 // CHECK:     quake.ry (%[[V4]]) %[[V1]] : (f64,

--- a/test/AST-Quake/while-1.cpp
+++ b/test/AST-Quake/while-1.cpp
@@ -47,8 +47,8 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
 // CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
-// CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           cc.loop while {
 // CHECK:             %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:             %[[VAL_6:.*]] = arith.constant 0 : i32
@@ -56,17 +56,17 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:             cc.condition %[[VAL_7]]
 // CHECK:           } do {
 // CHECK:             cc.scope {
-// CHECK:               %[[VAL_8:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_8:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:               %[[VAL_10:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
 // CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_13:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_13:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_14:.*]] = arith.extui %[[VAL_13]] : i32 to i64
 // CHECK:               %[[VAL_15:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
 // CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_18:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_19:.*]] = arith.extui %[[VAL_18]] : i32 to i64
 // CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             }
@@ -80,24 +80,24 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
 // CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
-// CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           cc.loop while {
 // CHECK:             %[[VAL_5:.*]] = arith.constant true
 // CHECK:             cc.condition %[[VAL_5]]
 // CHECK:           } do {
 // CHECK:             cc.scope {
-// CHECK:               %[[VAL_6:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_6:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i32 to i64
 // CHECK:               %[[VAL_8:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_9:.*]] = arith.subi %[[VAL_7]], %[[VAL_8]] : i64
 // CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_9]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_11:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_11:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_12:.*]] = arith.extui %[[VAL_11]] : i32 to i64
 // CHECK:               %[[VAL_13:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_14:.*]] = arith.subi %[[VAL_12]], %[[VAL_13]] : i64
 // CHECK:               %[[VAL_15:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_14]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_16:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_16:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_17:.*]] = arith.extui %[[VAL_16]] : i32 to i64
 // CHECK:               %[[VAL_18:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_17]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             }
@@ -111,21 +111,21 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
 // CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
-// CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           cc.loop do {
 // CHECK:             cc.scope {
-// CHECK:               %[[VAL_5:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_6:.*]] = arith.extui %[[VAL_5]] : i32 to i64
 // CHECK:               %[[VAL_7:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_8:.*]] = arith.subi %[[VAL_6]], %[[VAL_7]] : i64
 // CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_10:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_11:.*]] = arith.extui %[[VAL_10]] : i32 to i64
 // CHECK:               %[[VAL_12:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_13:.*]] = arith.subi %[[VAL_11]], %[[VAL_12]] : i64
 // CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_13]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_15:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_16:.*]] = arith.extui %[[VAL_15]] : i32 to i64
 // CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             }
@@ -142,25 +142,25 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>) -> f64
 // CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
-// CHECK:           %[[VAL_4:.*]] = memref.alloca() : memref<i32>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
-// CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = arith.uitofp %[[VAL_5]] : i32 to f64
-// CHECK:           %[[VAL_7:.*]] = memref.alloca() : memref<f64>
-// CHECK:           memref.store %[[VAL_6]], %[[VAL_7]][] : memref<f64>
+// CHECK:           %[[VAL_7:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_6]], %[[VAL_7]] : !cc.ptr<f64>
 // CHECK:           cc.loop do {
 // CHECK:             cc.scope {
-// CHECK:               %[[VAL_8:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_8:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:               %[[VAL_10:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
 // CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_13:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_13:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_14:.*]] = arith.extui %[[VAL_13]] : i32 to i64
 // CHECK:               %[[VAL_15:.*]] = arith.constant 1 : i64
 // CHECK:               %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
 // CHECK:               %[[VAL_17:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_18:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_19:.*]] = arith.extui %[[VAL_18]] : i32 to i64
 // CHECK:               %[[VAL_20:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_19]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             }
@@ -171,7 +171,7 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:             %[[VAL_23:.*]] = arith.cmpi ne, %[[VAL_21]], %[[VAL_22]] : i32
 // CHECK:             cc.condition %[[VAL_23]]
 // CHECK:           }
-// CHECK:           %[[VAL_24:.*]] = memref.load %[[VAL_7]][] : memref<f64>
+// CHECK:           %[[VAL_24:.*]] = cc.load %[[VAL_7]] : !cc.ptr<f64>
 // CHECK:           cc.return %[[VAL_24]] : f64
 // CHECK:         }
 

--- a/test/Quake/lambda_variable-2.qke
+++ b/test/Quake/lambda_variable-2.qke
@@ -34,22 +34,22 @@
 // CHECK:           %[[VAL_2:.*]] = arith.constant 4 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_4:.*]] = memref.alloca() : memref<i32>
-// CHECK:             memref.store %[[VAL_3]], %[[VAL_4]][] : memref<i32>
+// CHECK:             %[[VAL_4:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_5:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_2]] : i32
 // CHECK:               cc.condition %[[VAL_6]]
 // CHECK:             } do {
-// CHECK:               %[[VAL_7:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_7:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_8:.*]] = arith.extsi %[[VAL_7]] : i32 to i64
 // CHECK:               %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:               quake.h %[[VAL_9]] :
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_4]][] : memref<i32>
+// CHECK:               %[[VAL_10:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:               %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_1]] : i32
-// CHECK:               memref.store %[[VAL_11]], %[[VAL_4]][] : memref<i32>
+// CHECK:               cc.store %[[VAL_11]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return
@@ -79,26 +79,26 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel_a = "_ZN8k
     %1 = quake.alloca !quake.veq<4>
     %5 = cc.create_lambda {
       cc.scope {
-        %alloca = memref.alloca() : memref<i32>
+        %alloca = cc.alloca i32
         cc.scope {
           %c0_i32 = arith.constant 0 : i32
-          memref.store %c0_i32, %alloca[] : memref<i32>
+          cc.store %c0_i32, %alloca : !cc.ptr<i32>
           cc.loop while {
-            %6 = memref.load %alloca[] : memref<i32>
+            %6 = cc.load %alloca : !cc.ptr<i32>
             %c4_i32_0 = arith.constant 4 : i32
             %7 = arith.cmpi slt, %6, %c4_i32_0 : i32
             cc.condition %7
           } do {
-            %6 = memref.load %alloca[] : memref<i32>
+            %6 = cc.load %alloca : !cc.ptr<i32>
             %7 = arith.extsi %6 : i32 to i64
             %8 = quake.extract_ref %1[%7] : (!quake.veq<4>, i64) -> !quake.ref
             quake.h %8 : (!quake.ref) -> ()
             cc.continue
           } step {
-            %6 = memref.load %alloca[] : memref<i32>
+            %6 = cc.load %alloca : !cc.ptr<i32>
             %c1_i32 = arith.constant 1 : i32
             %7 = arith.addi %6, %c1_i32 : i32
-            memref.store %7, %alloca[] : memref<i32>
+            cc.store %7, %alloca : !cc.ptr<i32>
           }
         }
       }

--- a/utils/CircuitCheck/CMakeLists.txt
+++ b/utils/CircuitCheck/CMakeLists.txt
@@ -19,7 +19,6 @@ target_include_directories(CircuitCheck
 target_link_libraries(CircuitCheck
   PRIVATE
   MLIRArithDialect
-  MLIRMemRefDialect
   MLIRParser
   MLIRPass
   MLIRTransforms

--- a/utils/CircuitCheck/CircuitCheck.cpp
+++ b/utils/CircuitCheck/CircuitCheck.cpp
@@ -12,7 +12,6 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/SourceMgr.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -53,7 +52,7 @@ int main(int argc, char **argv) {
 
   MLIRContext context;
   context.loadDialect<cudaq::cc::CCDialect, quake::QuakeDialect,
-                      func::FuncDialect, memref::MemRefDialect>();
+                      func::FuncDialect>();
 
   ParserConfig config(&context);
   auto checkMod = parseSourceFile<mlir::ModuleOp>(checkFilename, config);


### PR DESCRIPTION
MLIR's Memref dialect offers full support for dynamic, multidimensional arrays. Since these are not part of C and not supported on the QPU, they are not needed. Rather than trying to constrain MLIR itself, we use the CC dialect to have direct control over the transformations applied to QPU code.