### PR TITLE
Implement MPI support in CUDA Quantum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,12 @@ endif()
 find_package(CURL COMPONENTS HTTP HTTPS QUIET) 
 find_package(OpenSSL QUIET)
 
+# Optionally build with MPI
+find_package(MPI COMPONENTS CXX)
+if (MPI_FOUND) 
+  message(STATUS "MPI CXX Found: ${MPIEXEC}")
+endif()
+
 # Directory setup
 # ==============================================================================
 if (CUDAQ_ENABLE_PYTHON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ option(CUDAQ_ENABLE_RPC_LOGGING "Enable verbose printout for client/server qpud 
 option(CUDAQ_BUILD_RELOCATABLE_PACKAGE "Make CUDA Quantum install tree relocatable, system headers included." OFF)
 option(CUDAQ_TEST_MOCK_SERVERS "Enable Remote QPU Tests via Mock Servers." OFF)
 option(CUDAQ_DISABLE_RUNTIME "Build without the CUDA Quantum runtime, just the compiler toolchain." OFF)
+option(CUDAQ_SKIP_MPI "Do not build with MPI, even when it is available." OFF)
 
 if (CUDAQ_BUILD_RELOCATABLE_PACKAGE) 
   if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -341,9 +342,11 @@ find_package(CURL COMPONENTS HTTP HTTPS QUIET)
 find_package(OpenSSL QUIET)
 
 # Optionally build with MPI
-find_package(MPI COMPONENTS CXX)
-if (MPI_FOUND) 
-  message(STATUS "MPI CXX Found: ${MPIEXEC}")
+if (NOT CUDAQ_SKIP_MPI)
+  find_package(MPI COMPONENTS CXX)
+  if (MPI_FOUND) 
+    message(STATUS "MPI CXX Found: ${MPIEXEC}")
+  endif()
 endif()
 
 # Directory setup

--- a/python/_cudaq.cpp
+++ b/python/_cudaq.cpp
@@ -50,7 +50,7 @@ PYBIND11_MODULE(_pycudaq, mod) {
       "initialize", []() { cudaq::mpi::initialize(); },
       "Initialize MPI if available.");
   mpiSubmodule.def(
-      "is_initialized", []() { cudaq::mpi::is_initialized(); },
+      "is_initialized", []() { return cudaq::mpi::is_initialized(); },
       "Return true if MPI has already been initialized.");
   mpiSubmodule.def(
       "finalize", []() { cudaq::mpi::finalize(); }, "Finalize MPI.");

--- a/python/_cudaq.cpp
+++ b/python/_cudaq.cpp
@@ -21,6 +21,8 @@
 #include "utils/LinkedLibraryHolder.h"
 #include "utils/TestingUtils.h"
 
+#include "cudaq.h"
+
 PYBIND11_MODULE(_pycudaq, mod) {
   static cudaq::LinkedLibraryHolder holder;
 
@@ -42,6 +44,12 @@ PYBIND11_MODULE(_pycudaq, mod) {
         }
       },
       "");
+
+  mod.def(
+      "mpi_initialize", []() { cudaq::mpi_initialize(); },
+      "Initialize MPI if available.");
+  mod.def(
+      "mpi_finalize", []() { cudaq::mpi_finalize(); }, "Finalize MPI.");
 
   cudaq::bindRuntimeTarget(mod, holder);
   cudaq::bindBuilder(mod);

--- a/python/_cudaq.cpp
+++ b/python/_cudaq.cpp
@@ -45,11 +45,15 @@ PYBIND11_MODULE(_pycudaq, mod) {
       },
       "");
 
-  mod.def(
-      "mpi_initialize", []() { cudaq::mpi_initialize(); },
+  auto mpiSubmodule = mod.def_submodule("mpi");
+  mpiSubmodule.def(
+      "initialize", []() { cudaq::mpi::initialize(); },
       "Initialize MPI if available.");
-  mod.def(
-      "mpi_finalize", []() { cudaq::mpi_finalize(); }, "Finalize MPI.");
+  mpiSubmodule.def(
+      "is_initialized", []() { cudaq::mpi::is_initialized(); },
+      "Return true if MPI has already been initialized.");
+  mpiSubmodule.def(
+      "finalize", []() { cudaq::mpi::finalize(); }, "Finalize MPI.");
 
   cudaq::bindRuntimeTarget(mod, holder);
   cudaq::bindBuilder(mod);

--- a/python/runtime/cudaq/algorithms/py_observe.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe.cpp
@@ -112,7 +112,7 @@ observe_result pyObservePar(const PyParType &type, kernel_builder<> &kernel,
 
   // combine all the data via an all_reduce
   auto exp_val = localRankResult.exp_val_z();
-  auto globalExpVal = mpi::allreduce_double_add(exp_val);
+  auto globalExpVal = mpi::all_reduce(exp_val, std::plus<double>());
   return observe_result(globalExpVal, spin_operator);
 }
 

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -10,6 +10,7 @@
 add_subdirectory(compiler)
 # Unit tests that are run exclusively through pytest.
 add_subdirectory(unittests)     
+add_subdirectory(parallel)
 
 if (NOT CUDAQ_TEST_MOCK_SERVERS)
   message(STATUS "CUDAQ_TEST_MOCK_SERVERS=FALSE, skipping Python remote QPU tests.")

--- a/python/tests/parallel/CMakeLists.txt
+++ b/python/tests/parallel/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+if (NOT MPI_CXX_FOUND)
+  return()
+endif()
+
+if (NOT CUSTATEVEC_ROOT)
+  return()
+endif()
+
+if (NOT CUDA_FOUND)
+  return()
+endif()
+
+message(STATUS "MPI and CUDA Found, Adding PyMPITester")
+configure_file("run_mpi_py.sh.in"
+                    "${CMAKE_BINARY_DIR}/python/tests/parallel/run_mpi_py.sh" @ONLY)
+add_test(NAME PyMPITest COMMAND ${MPIEXEC} --allow-run-as-root -np 2 ${CMAKE_BINARY_DIR}/python/tests/parallel/run_mpi_py.sh)
+set_tests_properties(PyMPITest PROPERTIES 
+                    ENVIRONMENT 
+                    "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_BINARY_DIR}/python")  
+add_test(NAME PyMQPUTest 
+    COMMAND ${Python_EXECUTABLE} -m pytest -rP test_mqpu.py
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/python/tests/parallel/run_mpi_py.sh.in
+++ b/python/tests/parallel/run_mpi_py.sh.in
@@ -1,4 +1,12 @@
 #!/bin/bash
 
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
 # FIXME What is this for MPICH
 CUDA_VISIBLE_DEVICES=$OMPI_COMM_WORLD_LOCAL_RANK @Python_EXECUTABLE@ -m pytest -rP @CMAKE_SOURCE_DIR@/python/tests/parallel/test_mpi_mqpu.py

--- a/python/tests/parallel/run_mpi_py.sh.in
+++ b/python/tests/parallel/run_mpi_py.sh.in
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# FIXME What is this for MPICH
+CUDA_VISIBLE_DEVICES=$OMPI_COMM_WORLD_LOCAL_RANK @Python_EXECUTABLE@ -m pytest -rP @CMAKE_SOURCE_DIR@/python/tests/parallel/test_mpi_mqpu.py

--- a/python/tests/parallel/test_mpi_mqpu.py
+++ b/python/tests/parallel/test_mpi_mqpu.py
@@ -1,0 +1,52 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import cudaq, os, pytest, random, timeit
+from cudaq import spin
+import numpy as np
+
+def testMPI():
+    cudaq.mpi.initialize()
+
+    # If this test harness does not have MPI support
+    # we'll drop out
+    if not cudaq.mpi.is_initialized():
+        return
+
+    if not cudaq.has_target('nvidia'):
+        return
+    
+    cudaq.set_target('nvidia-mqpu')
+
+    target = cudaq.get_target()
+    numQpus = target.num_qpus()
+
+    kernel, theta = cudaq.make_kernel(float)
+    qreg = kernel.qalloc(2)
+    kernel.x(qreg[0])
+    kernel.ry(theta, qreg[1])
+    kernel.cx(qreg[1], qreg[0])
+    # Define its spin Hamiltonian.
+    hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
+        0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)
+    # Confirmed expectation value for this system when `theta=0.59`.
+    want_expectation_value = -1.7487948611472093
+
+    # Get the `cudaq.ObserveResult` back from `cudaq.observe()`.
+    # No shots provided.
+    result_no_shots = cudaq.observe(kernel, hamiltonian, 0.59, execution=cudaq.par.mpi)
+    expectation_value_no_shots = result_no_shots.expectation_z()
+    assert np.isclose(want_expectation_value, expectation_value_no_shots)
+
+    cudaq.reset_target()
+    cudaq.mpi.finalize()
+
+# leave for gdb debugging
+if __name__ == "__main__":
+    loc = os.path.abspath(__file__)
+    pytest.main([loc, "-s"])

--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -190,20 +190,25 @@ void unset_noise();
 /// @brief Utility function for clearing the shots
 void clear_shots(const std::size_t nShots);
 
+namespace mpi {
 /// @brief Initialize MPI if available. This function
 /// is a no-op if there CUDA Quantum has not been built
 /// against MPI.
-void mpi_initialize();
+void initialize();
 
 /// @brief Initialize MPI if available. This function
 /// is a no-op if there CUDA Quantum has not been built
 /// against MPI. Takes program arguments as input.
-void mpi_initialize(int argc, char **argv);
+void initialize(int argc, char **argv);
+
+bool is_initialized();
 
 /// @brief Finalize MPI. This function
 /// is a no-op if there CUDA Quantum has not been built
 /// against MPI.
-void mpi_finalize();
+void finalize();
+
+} // namespace mpi
 
 } // namespace cudaq
 

--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -191,6 +191,7 @@ void unset_noise();
 void clear_shots(const std::size_t nShots);
 
 namespace mpi {
+
 /// @brief Initialize MPI if available. This function
 /// is a no-op if there CUDA Quantum has not been built
 /// against MPI.

--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -190,7 +190,24 @@ void unset_noise();
 /// @brief Utility function for clearing the shots
 void clear_shots(const std::size_t nShots);
 
+/// @brief Initialize MPI if available. This function
+/// is a no-op if there CUDA Quantum has not been built
+/// against MPI.
+void mpi_initialize();
+
+/// @brief Initialize MPI if available. This function
+/// is a no-op if there CUDA Quantum has not been built
+/// against MPI. Takes program arguments as input.
+void mpi_initialize(int argc, char **argv);
+
+/// @brief Finalize MPI. This function
+/// is a no-op if there CUDA Quantum has not been built
+/// against MPI.
+void mpi_finalize();
+
 } // namespace cudaq
 
 // Users should get sample by default
 #include "cudaq/algorithms/sample.h"
+// Users should get observe by default
+#include "cudaq/algorithms/observe.h"

--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -201,7 +201,16 @@ void initialize();
 /// against MPI. Takes program arguments as input.
 void initialize(int argc, char **argv);
 
+/// @brief Return the rank of the calling process.
+int rank();
+
+/// @brief Return the number of MPI ranks.
+int num_ranks();
+
+/// @brief Return true if MPI is already initialized, false otherwise.
 bool is_initialized();
+
+double allreduce_double_add(double localValue);
 
 /// @brief Finalize MPI. This function
 /// is a no-op if there CUDA Quantum has not been built

--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -212,6 +212,24 @@ bool is_initialized();
 
 double allreduce_double_add(double localValue);
 
+namespace details {
+#define CUDAQ_ALL_REDUCE_DEF(TYPE, BINARY)                                     \
+  TYPE allReduce(const TYPE &, const BINARY<TYPE> &);
+
+CUDAQ_ALL_REDUCE_DEF(float, std::plus)
+CUDAQ_ALL_REDUCE_DEF(float, std::multiplies)
+
+CUDAQ_ALL_REDUCE_DEF(double, std::plus)
+CUDAQ_ALL_REDUCE_DEF(double, std::multiplies)
+
+} // namespace details
+
+/// @brief Reduce all values across ranks with the specified binary function.
+template <typename T, typename BinaryFunction>
+T all_reduce(const T &localValue, const BinaryFunction &function) {
+  return details::allReduce(localValue, function);
+}
+
 /// @brief Finalize MPI. This function
 /// is a no-op if there CUDA Quantum has not been built
 /// against MPI.

--- a/runtime/cudaq/CMakeLists.txt
+++ b/runtime/cudaq/CMakeLists.txt
@@ -29,6 +29,11 @@ target_link_libraries(${LIBRARY_NAME}
   PUBLIC dl cudaq-spin cudaq-common cudaq-nlopt cudaq-ensmallen
   PRIVATE fmt::fmt-header-only)
 
+if (MPI_CXX_FOUND)
+  target_compile_definitions(${LIBRARY_NAME} PRIVATE CUDAQ_HAS_MPI)
+  target_link_libraries(${LIBRARY_NAME} PRIVATE MPI::MPI_CXX)
+endif()
+
 cudaq_library_set_rpath(${LIBRARY_NAME})
 
 add_subdirectory(qis/managers)

--- a/runtime/cudaq/algorithms/observe.h
+++ b/runtime/cudaq/algorithms/observe.h
@@ -21,8 +21,27 @@
 
 namespace cudaq {
 
+namespace mpi {
+int rank();
+int num_ranks();
+bool is_initialized();
+double allreduce_double_add(double localValue);
+} // namespace mpi
+
 /// @brief Return type for asynchronous observation.
 using async_observe_result = async_result<observe_result>;
+
+/// @brief Multi-GPU Multi-Node (MPI)
+/// Distribution Type for observe
+struct mgmn {};
+
+/// @brief Multi-GPU Single-Node
+/// Distribution Type for observe
+struct mgsn {};
+
+/// @brief Multi-Node, no GPU,
+/// Distribution Type for observe
+struct mn {};
 
 /// @brief Define a combined sample function validation concept.
 /// These concepts provide much better error messages than old-school SFINAE
@@ -176,18 +195,6 @@ observe_result observe(QuantumKernel &&kernel, spin_op H, Args &&...args) {
   // Run this SHOTS times
   auto &platform = cudaq::get_platform();
   auto shots = platform.get_shots().value_or(-1);
-
-  // Does this platform expose more than 1 QPU
-  // If so, let's distribute the work among the QPUs
-  if (auto nQpus = platform.num_qpus(); nQpus > 1)
-    return details::distributeComputations(
-        [&kernel, ... args = std::forward<Args>(args)](std::size_t i,
-                                                       spin_op &op) mutable {
-          return observe_async(i, std::forward<QuantumKernel>(kernel), op,
-                               std::forward<Args>(args)...);
-        },
-        H, nQpus);
-
   auto kernelName = cudaq::getKernelName(kernel);
   return details::runObservation(
              [&kernel, ... args = std::forward<Args>(args)]() mutable {
@@ -195,6 +202,80 @@ observe_result observe(QuantumKernel &&kernel, spin_op H, Args &&...args) {
              },
              H, platform, shots, kernelName)
       .value();
+}
+
+/// @brief Compute the expected value of `H` with respect to `kernel(Args...)`.
+/// Distribute the work amongst available QPUs on the platform in parallel. This
+/// distribution can occur on multi-gpu multi-node platforms, multi-gpu
+/// single-node platforms, or multi-node no-gpu platforms. Programmers must
+/// indicate the distribution type via the corresponding template types
+/// (cudaq::mgmn, cudaq::mgsn, cudaq::mn).
+template <typename DistributionType, typename QuantumKernel, typename... Args>
+  requires ObserveCallValid<QuantumKernel, Args...>
+observe_result observe(std::size_t shots, QuantumKernel &&kernel, spin_op H,
+                       Args &&...args) {
+  // Run this SHOTS times
+  auto &platform = cudaq::get_platform();
+  auto nQpus = platform.num_qpus();
+  if constexpr (std::is_same_v<DistributionType, mgsn>) {
+    if (nQpus == 1)
+      printf(
+          "[cudaq::observe warning] distributed observe requested but only 1 "
+          "QPU available. no speedup expected.\n");
+    // Let's distribute the work among the QPUs on this node
+    return details::distributeComputations(
+        [&kernel, ... args = std::forward<Args>(args)](std::size_t i,
+                                                       spin_op &op) mutable {
+          return observe_async(i, std::forward<QuantumKernel>(kernel), op,
+                               std::forward<Args>(args)...);
+        },
+        H, nQpus);
+  } else if (std::is_same_v<DistributionType, mgmn>) {
+
+    // This is an MPI distribution, where each node has N GPUs.
+    if (!mpi::is_initialized())
+      throw std::runtime_error(
+          "Cannot use mgmn or mn multi-node observe() without MPI.");
+
+    // Note - For MGMN, we assume that nQpus == num visible GPUs for this local
+    // rank.
+
+    // Get the rank and the number of ranks
+    auto rank = mpi::rank();
+    auto nRanks = mpi::num_ranks();
+
+    // Each rank gets a subset of the spin terms
+    auto spins = H.distribute_terms(nRanks);
+
+    // Get this rank's set of spins to compute
+    auto localH = spins[rank];
+
+    // Distribute locally, i.e. to the local nodes QPUs
+    auto localRankResult = details::distributeComputations(
+        [&kernel, ... args = std::forward<Args>(args)](std::size_t i,
+                                                       spin_op &op) mutable {
+          return observe_async(i, std::forward<QuantumKernel>(kernel), op,
+                               std::forward<Args>(args)...);
+        },
+        localH, nQpus);
+
+    // combine all the data via an all_reduce
+    auto exp_val = localRankResult.exp_val_z();
+    auto globalExpVal = mpi::allreduce_double_add(exp_val);
+    return observe_result(globalExpVal, H);
+
+  } else {
+    throw std::runtime_error("Not implemented.");
+  }
+}
+
+template <typename DistributionType, typename QuantumKernel, typename... Args>
+  requires ObserveCallValid<QuantumKernel, Args...>
+observe_result observe(QuantumKernel &&kernel, spin_op H, Args &&...args) {
+  auto &platform = cudaq::get_platform();
+  auto shots = platform.get_shots().value_or(-1);
+  return observe<DistributionType>(shots, std::forward<QuantumKernel>(kernel),
+                                   H, std::forward<Args>(args)...);
 }
 
 /// \brief Compute the expected value of `H` with respect to `kernel(Args...)`.

--- a/runtime/cudaq/algorithms/observe.h
+++ b/runtime/cudaq/algorithms/observe.h
@@ -25,7 +25,8 @@ namespace mpi {
 int rank();
 int num_ranks();
 bool is_initialized();
-double allreduce_double_add(double localValue);
+template <typename T, typename Func>
+T all_reduce(const T &, const Func &);
 } // namespace mpi
 
 /// @brief Return type for asynchronous observation.
@@ -36,6 +37,7 @@ namespace par {
 /// Distribution Type for observe
 struct mpi {};
 
+/// @brief Single node, multi-GPU
 struct thread {};
 
 } // namespace par
@@ -267,7 +269,7 @@ observe_result observe(std::size_t shots, QuantumKernel &&kernel, spin_op H,
 
     // combine all the data via an all_reduce
     auto exp_val = localRankResult.exp_val_z();
-    auto globalExpVal = mpi::allreduce_double_add(exp_val);
+    auto globalExpVal = mpi::all_reduce(exp_val, std::plus<double>());
     return observe_result(globalExpVal, H);
 
   } else

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -20,13 +20,13 @@
 
 #ifdef CUDAQ_HAS_MPI
 #include <mpi.h>
-namespace cudaq {
-void mpi_initialize() {
+namespace cudaq::mpi {
+void initialize() {
   int argc{0};
   char **argv = nullptr;
-  mpi_initialize(argc, argv);
+  initialize(argc, argv);
 }
-void mpi_initialize(int argc, char **argv) {
+void initialize(int argc, char **argv) {
   int pid, np, thread_provided;
   int mpi_error =
       MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &thread_provided);
@@ -37,16 +37,23 @@ void mpi_initialize(int argc, char **argv) {
   if (pid == 0)
     cudaq::info("MPI Enabled, nRanks = {}", np);
 }
-void mpi_finalize() {
+bool is_initialized() {
+  int i;
+  MPI_Initialized(&i);
+  return i == 1;
+}
+
+void finalize() {
   int mpi_error = MPI_Finalize();
   assert(mpi_error == MPI_SUCCESS);
 }
-} // namespace cudaq
+} // namespace cudaq::mpi
 #else
 namespace cudaq {
-void mpi_initialize() {}
-void mpi_initialize(int argc, char **argv) {}
-void mpi_finalize() {}
+void initialize() {}
+void initialize(int argc, char **argv) {}
+bool is_initialized() { return false; }
+void finalize() {}
 } // namespace cudaq
 #endif
 

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -44,6 +44,7 @@ void mpi_finalize() {
 } // namespace cudaq
 #else
 namespace cudaq {
+void mpi_initialize() {}
 void mpi_initialize(int argc, char **argv) {}
 void mpi_finalize() {}
 } // namespace cudaq

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -21,11 +21,13 @@
 #ifdef CUDAQ_HAS_MPI
 #include <mpi.h>
 namespace cudaq::mpi {
+
 void initialize() {
   int argc{0};
   char **argv = nullptr;
   initialize(argc, argv);
 }
+
 void initialize(int argc, char **argv) {
   int pid, np, thread_provided;
   int mpi_error =
@@ -37,16 +39,19 @@ void initialize(int argc, char **argv) {
   if (pid == 0)
     cudaq::info("MPI Initialized, nRanks = {}", np);
 }
+
 int rank() {
   int pid;
   MPI_Comm_rank(MPI_COMM_WORLD, &pid);
   return pid;
 }
+
 int num_ranks() {
   int np;
   MPI_Comm_size(MPI_COMM_WORLD, &np);
   return np;
 }
+
 bool is_initialized() {
   int i;
   auto err = MPI_Initialized(&i);
@@ -55,6 +60,7 @@ bool is_initialized() {
 }
 
 namespace details {
+
 #define CUDAQ_ALL_REDUCE_IMPL(TYPE, MPI_TYPE, BINARY, MPI_OP)                  \
   TYPE allReduce(const TYPE &local, const BINARY<TYPE> &) {                    \
     TYPE result;                                                               \
@@ -67,6 +73,7 @@ CUDAQ_ALL_REDUCE_IMPL(float, MPI_FLOAT, std::multiplies, MPI_PROD)
 
 CUDAQ_ALL_REDUCE_IMPL(double, MPI_DOUBLE, std::plus, MPI_SUM)
 CUDAQ_ALL_REDUCE_IMPL(double, MPI_DOUBLE, std::multiplies, MPI_PROD)
+
 } // namespace details
 
 void finalize() {
@@ -75,16 +82,23 @@ void finalize() {
   int mpi_error = MPI_Finalize();
   assert(mpi_error == MPI_SUCCESS && "MPI_Finalize failed.");
 }
+
 } // namespace cudaq::mpi
 #else
 namespace cudaq::mpi {
+
 void initialize() {}
+
 void initialize(int argc, char **argv) {}
+
 bool is_initialized() { return false; }
+
 int rank() { return 0; }
+
 int num_ranks() { return 1; }
 
 namespace details {
+
 #define CUDAQ_ALL_REDUCE_IMPL(TYPE, BINARY)                                    \
   TYPE allReduce(const TYPE &local, const BINARY<TYPE> &) { return TYPE(); }
 
@@ -93,9 +107,11 @@ CUDAQ_ALL_REDUCE_IMPL(float, std::multiplies)
 
 CUDAQ_ALL_REDUCE_IMPL(double, std::plus)
 CUDAQ_ALL_REDUCE_IMPL(double, std::multiplies)
+
 } // namespace details
 
 void finalize() {}
+
 } // namespace cudaq::mpi
 #endif
 

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -37,10 +37,26 @@ void initialize(int argc, char **argv) {
   if (pid == 0)
     cudaq::info("MPI Enabled, nRanks = {}", np);
 }
+int rank() {
+  int pid;
+  MPI_Comm_rank(MPI_COMM_WORLD, &pid);
+  return pid;
+}
+int num_ranks() {
+  int np;
+  MPI_Comm_size(MPI_COMM_WORLD, &np);
+  return np;
+}
 bool is_initialized() {
   int i;
   MPI_Initialized(&i);
   return i == 1;
+}
+
+double allreduce_double_add(double localValue) {
+  double result;
+  MPI_Allreduce(&localValue, &result, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+  return result;
 }
 
 void finalize() {
@@ -53,6 +69,9 @@ namespace cudaq::mpi {
 void initialize() {}
 void initialize(int argc, char **argv) {}
 bool is_initialized() { return false; }
+int rank() { return 0; }
+int num_ranks() { return 1; }
+double allreduce_double_add(double value) { return 0.0; }
 void finalize() {}
 } // namespace cudaq::mpi
 #endif

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -49,7 +49,7 @@ void finalize() {
 }
 } // namespace cudaq::mpi
 #else
-namespace cudaq {
+namespace cudaq::mpi {
 void initialize() {}
 void initialize(int argc, char **argv) {}
 bool is_initialized() { return false; }

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -30,12 +30,12 @@ void initialize(int argc, char **argv) {
   int pid, np, thread_provided;
   int mpi_error =
       MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &thread_provided);
-  assert(mpi_error == MPI_SUCCESS);
+  assert(mpi_error == MPI_SUCCESS && "MPI_Init_thread failed");
   assert(thread_provided == MPI_THREAD_MULTIPLE);
   MPI_Comm_rank(MPI_COMM_WORLD, &pid);
   MPI_Comm_size(MPI_COMM_WORLD, &np);
   if (pid == 0)
-    cudaq::info("MPI Enabled, nRanks = {}", np);
+    cudaq::info("MPI Initialized, nRanks = {}", np);
 }
 int rank() {
   int pid;
@@ -49,7 +49,8 @@ int num_ranks() {
 }
 bool is_initialized() {
   int i;
-  MPI_Initialized(&i);
+  auto err = MPI_Initialized(&i);
+  assert(err == MPI_SUCCESS && "MPI_Initialized failed.");
   return i == 1;
 }
 
@@ -60,8 +61,10 @@ double allreduce_double_add(double localValue) {
 }
 
 void finalize() {
+  if (rank() == 0)
+    cudaq::info("Finalizing MPI.");
   int mpi_error = MPI_Finalize();
-  assert(mpi_error == MPI_SUCCESS);
+  assert(mpi_error == MPI_SUCCESS && "MPI_Finalize failed.");
 }
 } // namespace cudaq::mpi
 #else

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -54,7 +54,7 @@ void initialize() {}
 void initialize(int argc, char **argv) {}
 bool is_initialized() { return false; }
 void finalize() {}
-} // namespace cudaq
+} // namespace cudaq::mpi
 #endif
 
 namespace cudaq::__internal__ {

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -86,10 +86,7 @@ int num_ranks() { return 1; }
 
 namespace details {
 #define CUDAQ_ALL_REDUCE_IMPL(TYPE, BINARY)                                    \
-  TYPE allReduce(const TYPE &local, const BINARY<TYPE> &) {                    \
-    TYPE result;                                                               \
-    return result;                                                             \
-  }
+  TYPE allReduce(const TYPE &local, const BINARY<TYPE> &) { return TYPE(); }
 
 CUDAQ_ALL_REDUCE_IMPL(float, std::plus)
 CUDAQ_ALL_REDUCE_IMPL(float, std::multiplies)

--- a/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
+++ b/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
@@ -132,6 +132,8 @@ public:
     platformNumQPUs = platformQPUs.size();
     platformCurrentQPU = 0;
   }
+
+  bool supports_task_distribution() const override { return true; }
 };
 } // namespace
 

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -54,6 +54,10 @@ public:
   /// Get the number of qubits for the current QPU
   std::size_t get_num_qubits();
 
+  /// @brief Return true if this platform exposes multiple QPUs and
+  /// supports parallel distribution of quantum tasks.
+  virtual bool supports_task_distribution() const { return false; }
+
   /// Get the number of qubits for the QPU with ID qpu_id
   std::size_t get_num_qubits(std::size_t qpu_id);
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -90,6 +90,27 @@ if (CUSTATEVEC_ROOT AND CUDA_FOUND)
     nvqir-custatevec-fp64
     gtest_main)
     gtest_discover_tests(test_mqpu)
+
+    if (MPI_CXX_FOUND)
+      # Count the number of GPUs
+      execute_process(COMMAND bash -c "nvidia-smi --list-gpus | wc -l" OUTPUT_VARIABLE NGPUS)
+      # Only build this test if we have more than 1 GPU
+      if (${NGPUS} GREATER_EQUAL 2)
+        add_executable(test_mpi main.cpp mqpu/mpi_mqpu_tester.cpp)
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
+          target_link_options(test_mpi PRIVATE -Wl,--no-as-needed)
+        endif()
+        target_link_libraries(test_mpi
+            PRIVATE 
+            cudaq
+            cudaq-platform-mqpu
+            nvqir-custatevec-fp32
+            gtest_main)
+          configure_file("mqpu/run_mpi.sh.in"
+                    "${CMAKE_BINARY_DIR}/unittests/run_mpi.sh" @ONLY)
+        add_test(NAME MPITest COMMAND ${MPIEXEC} --allow-run-as-root -np 2 ${CMAKE_BINARY_DIR}/unittests/run_mpi.sh)
+      endif()
+    endif() 
 endif() 
 
 # Create an executable for SpinOp UnitTests

--- a/unittests/mqpu/mpi_mqpu_tester.cpp
+++ b/unittests/mqpu/mpi_mqpu_tester.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#include <cudaq.h>
+#include <cudaq/algorithm.h>
+#include <gtest/gtest.h>
+#include <random>
+
+class TestEnvironment : public ::testing::Environment {
+protected:
+  void SetUp() override { cudaq::mpi::initialize(); }
+  void TearDown() override { cudaq::mpi::finalize(); }
+};
+
+::testing::Environment *const foo_env =
+    AddGlobalTestEnvironment(new TestEnvironment);
+
+TEST(MPIObserveTester, checkSimple) {
+  using namespace cudaq::spin;
+  cudaq::spin_op h = 5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) +
+                     .21829 * z(0) - 6.125 * z(1);
+
+  auto ansatz = [](double theta) __qpu__ {
+    cudaq::qubit q, r;
+    x(q);
+    ry(theta, r);
+    x<cudaq::ctrl>(r, q);
+  };
+
+  double result = cudaq::observe<cudaq::par::mpi>(ansatz, h, 0.59);
+  if (cudaq::mpi::rank() == 0) {
+    EXPECT_NEAR(result, -1.7487, 1e-3);
+    printf("Get energy directly as double %lf\n", result);
+  }
+}

--- a/unittests/mqpu/mqpu_tester.cpp
+++ b/unittests/mqpu/mqpu_tester.cpp
@@ -22,7 +22,7 @@ TEST(MQPUTester, checkSimple) {
     x<cudaq::ctrl>(r, q);
   };
 
-  double result = cudaq::observe(ansatz, h, 0.59);
+  double result = cudaq::observe<cudaq::par::thread>(ansatz, h, 0.59);
   EXPECT_NEAR(result, -1.7487, 1e-3);
   printf("Get energy directly as double %lf\n", result);
 }
@@ -84,7 +84,8 @@ TEST(MQPUTester, checkLarge) {
   std::shuffle(cnot_pairs.begin(), cnot_pairs.end(), g);
 
   auto t1 = std::chrono::high_resolution_clock::now();
-  cudaq::observe(kernel, H, nQubits, nLayers, cnot_pairs, execParams);
+  cudaq::observe<cudaq::par::thread>(kernel, H, nQubits, nLayers, cnot_pairs,
+                                     execParams);
   auto t2 = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double, std::milli> ms_double = t2 - t1;
   printf("Time %lf s\n", ms_double.count() * 1e-3);

--- a/unittests/mqpu/run_mpi.sh.in
+++ b/unittests/mqpu/run_mpi.sh.in
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# FIXME What is this for MPICH
+CUDA_VISIBLE_DEVICES=$OMPI_COMM_WORLD_LOCAL_RANK @CMAKE_BINARY_DIR@/unittests/test_mpi

--- a/unittests/mqpu/run_mpi.sh.in
+++ b/unittests/mqpu/run_mpi.sh.in
@@ -1,4 +1,12 @@
 #!/bin/bash
 
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
 # FIXME What is this for MPICH
 CUDA_VISIBLE_DEVICES=$OMPI_COMM_WORLD_LOCAL_RANK @CMAKE_BINARY_DIR@/unittests/test_mpi


### PR DESCRIPTION
Add optional MPI support to CUDA Quantum. 

Implement `observe()` functions that distribute expectation value computations across available GPUs on a multi-node, multi-gpu system. 

User surface: 
```python
# User must initialize MPI (if using MPI)
cudaq.mpi.initialize()
...
ansatz, parameters = cudaq.make_kernel(list)
... 
hamiltonian = ...
# MPI distribution
energy = cudaq.observe(ansatz, hamiltonian, args, execution=cudaq.par.mpi)
# Single-node, multi-GPU distribution
energy = cudaq.observe(ansatz, hamiltonian, args, execution=cudaq.par.thread)
# No Parallelism
energy = cudaq.observe(ansatz, hamiltonian, args)

# If initialized, must finalize
cudaq.mpi.finalize()
```
```cpp
// Must initialize if using MPI
cudaq::mpi::initialize();
...
auto ansatz = [](std::vector<double> parameters) __qpu__ {
  ...
};
auto H = ... ;
// MPI Distribution
auto result = cudaq::observe<cudaq::par::mpi>(ansatz, H, args...);
// Single-node, multi-GPU Distribution
auto result = cudaq::observe<cudaq::par::thread>(ansatz, H, args...);
// No Parallelism
auto result = cudaq::observe(ansatz, H, args...);
...
// Must finalize MPI
cudaq::mpi::finalize();
```

We also introduce user API for initializing and finalizing MPI, getting the number of ranks, and getting the current rank.
