### PR TITLE
Load available simulators and platforms lazily in Python

### DIFF
--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -46,6 +46,12 @@ struct RuntimeTarget {
 class LinkedLibraryHolder {
 public:
 protected:
+  /// @brief Lazy-loader functor for CircuitSimulators
+  using SimulatorCreator = std::function<nvqir::CircuitSimulator *()>;
+
+  /// @brief Lazy-loader functor for Quantum Platforms
+  using PlatformCreator = std::function<quantum_platform *()>;
+
   // Store the library suffix
   std::string libSuffix = "";
 
@@ -56,10 +62,10 @@ protected:
   std::unordered_map<std::string, void *> libHandles;
 
   /// @brief Map of available simulators
-  std::unordered_map<std::string, nvqir::CircuitSimulator *> simulators;
+  std::unordered_map<std::string, SimulatorCreator> simulators;
 
   /// @brief Map of available platforms
-  std::unordered_map<std::string, quantum_platform *> platforms;
+  std::unordered_map<std::string, PlatformCreator> platforms;
 
   /// @brief Map of available targets.
   std::unordered_map<std::string, RuntimeTarget> targets;

--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -46,12 +46,6 @@ struct RuntimeTarget {
 class LinkedLibraryHolder {
 public:
 protected:
-  /// @brief Lazy-loader functor for CircuitSimulators
-  using SimulatorCreator = std::function<nvqir::CircuitSimulator *()>;
-
-  /// @brief Lazy-loader functor for Quantum Platforms
-  using PlatformCreator = std::function<quantum_platform *()>;
-
   // Store the library suffix
   std::string libSuffix = "";
 
@@ -61,17 +55,23 @@ protected:
   /// @brief Map of path strings to loaded library handles.
   std::unordered_map<std::string, void *> libHandles;
 
-  /// @brief Map of available simulators
-  std::unordered_map<std::string, SimulatorCreator> simulators;
+  /// @brief Vector of available simulators
+  std::vector<std::string> availableSimulators;
 
-  /// @brief Map of available platforms
-  std::unordered_map<std::string, PlatformCreator> platforms;
+  /// @brief Vector of available platforms
+  std::vector<std::string> availablePlatforms;
 
   /// @brief Map of available targets.
   std::unordered_map<std::string, RuntimeTarget> targets;
 
   /// @brief Store the name of the current target
   std::string currentTarget = "default";
+
+  /// @brief Return the registered simulator with the given name.
+  nvqir::CircuitSimulator *getSimulator(const std::string &name);
+
+  /// @brief Return the registered quantum_platform with the given name.
+  quantum_platform *getPlatform(const std::string &name);
 
 public:
   LinkedLibraryHolder();


### PR DESCRIPTION
Currently we create all available CircuitSimulators and quantum_platforms at Python startup. This is not very efficient since we'll likely only use one of each in a given Python execution. 

Update to load these pointers lazily via storage of a creation functor for each. 