### PR TITLE
Reset and and parametric gates in `kernel_builder`

### DIFF
--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -262,7 +262,7 @@ QuakeValue QuakeValue::slice(const std::size_t startIdx,
 
 mlir::Value QuakeValue::getValue() const { return value->asMLIR(); }
 
-QuakeValue QuakeValue::operator-() {
+QuakeValue QuakeValue::operator-() const {
   auto v = value->asMLIR();
   if (!v.getType().isIntOrFloat())
     throw std::runtime_error("Can only negate double/float QuakeValues.");

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -104,8 +104,8 @@ public:
   /// and VeqType.
   QuakeValue operator[](const QuakeValue &idx);
 
-  /// @brief Negate this QuakeValue
-  QuakeValue operator-();
+  /// @brief Return the negation of this QuakeValue
+  QuakeValue operator-() const;
 
   /// @brief Multiply this QuakeValue by the given double.
   QuakeValue operator*(const double);

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -499,7 +499,7 @@ QuakeValue mz(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQvec,
   return applyMeasure<quake::MzOp>(builder, qubitOrQvec.getValue(), regName);
 }
 
-void reset(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQvec) {
+void reset(ImplicitLocOpBuilder &builder, const QuakeValue &qubitOrQvec) {
   auto value = qubitOrQvec.getValue();
   if (isa<quake::RefType>(value.getType())) {
     builder.create<quake::ResetOp>(TypeRange{}, value);

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -457,7 +457,7 @@ public:
             typename =                                                         \
                 typename std::enable_if_t<std::is_same_v<mod, cudaq::adj>>>    \
   void NAME(const ParamT &parameter, QuakeValue qubit) {                       \
-    if constexpr (NumericType<ParamT>)                                         \
+    if constexpr (std::is_floating_point_v<ParamT>)                            \
       NAME(QuakeValue(*opBuilder, -parameter), qubit);                         \
     else                                                                       \
       NAME(-parameter, qubit);                                                 \
@@ -470,7 +470,7 @@ public:
     if constexpr (std::is_same_v<mod, cudaq::ctrl>) {                          \
       std::vector<QuakeValue> ctrls(values.begin(), values.end() - 1);         \
       auto &target = values.back();                                            \
-      if constexpr (NumericType<ParamT>)                                       \
+      if constexpr (std::is_floating_point_v<ParamT>)                          \
         NAME(QuakeValue(*opBuilder, parameter), ctrls, target);                \
       else                                                                     \
         NAME(parameter, ctrls, target);                                        \

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -453,24 +453,24 @@ public:
     QuakeValue v(*opBuilder, param);                                           \
     details::NAME(*opBuilder, v, empty, qubit);                                \
   }                                                                            \
-  template <typename mod, QuakeValueOrNumericType paramT,                      \
+  template <typename mod, QuakeValueOrNumericType ParamT,                      \
             typename =                                                         \
                 typename std::enable_if_t<std::is_same_v<mod, cudaq::adj>>>    \
-  void NAME(paramT &&parameter, QuakeValue qubit) {                            \
-    if constexpr (NumericType<paramT>)                                         \
+  void NAME(const ParamT &parameter, QuakeValue qubit) {                       \
+    if constexpr (NumericType<ParamT>)                                         \
       NAME(QuakeValue(*opBuilder, -parameter), qubit);                         \
     else                                                                       \
       NAME(-parameter, qubit);                                                 \
   }                                                                            \
-  template <typename mod, QuakeValueOrNumericType paramT,                      \
+  template <typename mod, QuakeValueOrNumericType ParamT,                      \
             typename... QubitValues,                                           \
             typename = typename std::enable_if_t<sizeof...(QubitValues) >= 2>> \
-  void NAME(paramT &&parameter, QubitValues... args) {                         \
+  void NAME(const ParamT &parameter, QubitValues... args) {                    \
     std::vector<QuakeValue> values{args...};                                   \
     if constexpr (std::is_same_v<mod, cudaq::ctrl>) {                          \
       std::vector<QuakeValue> ctrls(values.begin(), values.end() - 1);         \
       auto &target = values.back();                                            \
-      if constexpr (NumericType<paramT>)                                       \
+      if constexpr (NumericType<ParamT>)                                       \
         NAME(QuakeValue(*opBuilder, parameter), ctrls, target);                \
       else                                                                     \
         NAME(parameter, ctrls, target);                                        \

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -147,6 +147,21 @@ CUDAQ_TEST(BuilderTester, checkSimple) {
   }
 
   {
+    // Check controlled parametric gates (QuakeValue angle)
+    auto [cnot_builder, theta] = cudaq::make_kernel<double>();
+    auto q = cnot_builder.qalloc(2);
+    cnot_builder.x(q);
+    // controlled-Rx(theta)
+    cnot_builder.rx<cudaq::ctrl>(theta, q[0], q[1]);
+    cnot_builder.mz(q);
+    // assign theta = pi; controlled-Rx(pi) == CNOT
+    auto counts = cudaq::sample(cnot_builder, M_PI);
+    counts.dump();
+    EXPECT_EQ(counts.size(), 1);
+    EXPECT_TRUE(counts.begin()->first == "10");
+  }
+
+  {
     // Check adjoint parametric gates (constant angles)
     auto rx_builder = cudaq::make_kernel();
     auto q = rx_builder.qalloc();
@@ -176,6 +191,20 @@ CUDAQ_TEST(BuilderTester, checkSimple) {
     rx_builder.mz(q);
     // Rx(pi) == X (four pi/4 rotations)
     auto counts = cudaq::sample(rx_builder);
+    counts.dump();
+    EXPECT_EQ(counts.size(), 1);
+    EXPECT_TRUE(counts.begin()->first == "1");
+  }
+
+  {
+    // Check adjoint parametric gates (QuakeValue angle)
+    auto [rx_builder, angle] = cudaq::make_kernel<double>();
+    auto q = rx_builder.qalloc();
+    rx_builder.rx<cudaq::adj>(-angle, q);
+    rx_builder.rx(angle, q);
+    rx_builder.mz(q);
+    // angle = pi/2 => equivalent to Rx(pi) == X
+    auto counts = cudaq::sample(rx_builder, M_PI_2);
     counts.dump();
     EXPECT_EQ(counts.size(), 1);
     EXPECT_TRUE(counts.begin()->first == "1");


### PR DESCRIPTION
### Description

- Use `const QuakeValue &` for `reset` rather than `QuakeValue &` to handle the `reset(q_reg[idx])` use case since `QuakeValue::operator[]` returns a `QuakeValue` rval.

- `CUDAQ_BUILDER_ADD_ONE_QUBIT_PARAM` to handle floating-point params in adjoint and control code paths (in addition to the base one) by converting the floating point number to a `QuakeValue` if necessary.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

<!-- Include relevant issues here, describe what changed and why -->
