### PR TITLE
Fix #251: Base profile should handle single qubit allocations.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -4,7 +4,7 @@
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
- *******************************************************************************/
+ ******************************************************************************/
 
 #ifndef CUDAQ_OPT_OPTIMIZER_TRANSFORMS_PASSES
 #define CUDAQ_OPT_OPTIMIZER_TRANSFORMS_PASSES
@@ -33,6 +33,25 @@ def ApplySpecialization : Pass<"apply-op-specialization", "mlir::ModuleOp"> {
     Option<"computeActionOptimization", "compute-action-opt", "bool",
       /*default=*/"true", "Enable the compute-action control optimization.">
   ];
+}
+
+def CombineQuantumAllocations :
+    Pass<"combine-quantum-alloc", "mlir::func::FuncOp"> {
+  let summary = "Combines quake alloca operations.";
+  let description = [{
+    Quake code may contain several distinct `quake.alloca` operations prior to
+    final code gen. This pass will combine them into a single allocation of
+    type `!quake.veq` with appropriate `quake.extract_ref` operations. The
+    combined allocation will be placed in the entry block and thus dominate all
+    potential uses.
+
+    This pass will only process `quake.alloca` operations at the top-level of
+    a function. It assumes all calls have been inlined, loops unrolled, etc.
+
+    If the function contains deallocations, these are combined as well. The
+    combined deallocation will be added to each exit block.
+  }];
+  let dependentDialects = ["cudaq::cc::CCDialect", "quake::QuakeDialect"];
 }
 
 def ConvertToDirectCalls :

--- a/lib/Optimizer/CodeGen/LowerToBaseProfileQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToBaseProfileQIR.cpp
@@ -46,6 +46,7 @@ struct FunctionAnalysisData {
   std::size_t nResults = 0;
   // Use std::map to keep these sorted in ascending order.
   std::map<std::size_t, std::pair<std::size_t, StringAttr>> resultPtrValues;
+  DenseMap<Operation *, std::size_t> allocationOffsets;
 };
 
 using FunctionAnalysisInfo = DenseMap<Operation *, FunctionAnalysisData>;
@@ -68,29 +69,59 @@ private:
     funcOp->walk([&](Operation *op) {
       if (auto callOp = dyn_cast<LLVM::CallOp>(op)) {
         StringRef funcName = callOp.getCalleeAttr().getValue();
+        auto addAllocation = [&](auto incrementBy) {
+          // Maybe add an allocation, setting its offset, and the total number
+          // of qubits.
+          if (data.allocationOffsets.find(callOp) ==
+              data.allocationOffsets.end()) {
+            data.allocationOffsets[callOp] = data.nQubits;
+            data.nQubits += incrementBy();
+          }
+        };
+
         if (funcName.equals(cudaq::opt::QIRMeasure) ||
             // FIXME Store the register names for the record_output functions
             funcName.equals(cudaq::opt::QIRMeasureToRegister)) {
-          auto load = dyn_cast_or_null<LLVM::LoadOp>(
-              callOp.getOperand(0).getDefiningOp());
-          auto bitcast = dyn_cast_or_null<LLVM::BitcastOp>(
-              load ? load.getOperand().getDefiningOp() : nullptr);
-          Value constVal;
-          if (auto call = dyn_cast_or_null<LLVM::CallOp>(
-                  bitcast ? bitcast.getOperand().getDefiningOp() : nullptr)) {
-            if (auto c = dyn_cast_or_null<LLVM::ConstantOp>(
-                    call.getOperand(1).getDefiningOp())) {
-              constVal = c;
-            } else {
-              // Skip over any intermediate cast.
-              auto defOp = call.getOperand(1).getDefiningOp();
-              constVal = defOp->getOperand(0);
+          std::optional<std::size_t> optQb;
+          if (auto allocCall =
+                  callOp.getOperand(0).getDefiningOp<LLVM::CallOp>()) {
+            auto iter = data.allocationOffsets.find(allocCall.getOperation());
+            if (iter != data.allocationOffsets.end())
+              optQb = iter->second;
+          } else {
+            if (auto load =
+                    callOp.getOperand(0).getDefiningOp<LLVM::LoadOp>()) {
+              if (auto bitcast =
+                      load.getOperand().getDefiningOp<LLVM::BitcastOp>()) {
+                std::optional<Value> constVal;
+                std::size_t allocOffset;
+                if (auto call =
+                        bitcast.getOperand().getDefiningOp<LLVM::CallOp>()) {
+                  auto iter = data.allocationOffsets.find(
+                      call.getOperand(0).getDefiningOp());
+                  if (iter != data.allocationOffsets.end()) {
+                    allocOffset = iter->second;
+                    if (auto c = call.getOperand(1)
+                                     .getDefiningOp<LLVM::ConstantOp>()) {
+                      constVal = c;
+                    } else {
+                      // Skip over any potential intermediate cast.
+                      auto *defOp = call.getOperand(1).getDefiningOp();
+                      if (isa<LLVM::ZExtOp, LLVM::SExtOp, LLVM::PtrToIntOp,
+                              LLVM::BitcastOp, LLVM::TruncOp>(defOp))
+                        constVal = defOp->getOperand(0);
+                    }
+                  }
+                }
+                if (constVal)
+                  if (auto incr = constVal->getDefiningOp<LLVM::ConstantOp>())
+                    optQb = allocOffset +
+                            incr.getValue().cast<IntegerAttr>().getInt();
+              }
             }
           }
-          auto offset = dyn_cast_or_null<LLVM::ConstantOp>(
-              constVal ? constVal.getDefiningOp() : nullptr);
-          if (offset) {
-            auto qb = offset.getValue().cast<IntegerAttr>().getInt();
+          if (optQb) {
+            auto qb = *optQb;
             auto iter = data.resultPtrValues.find(qb);
             auto *ctx = callOp.getContext();
             auto intTy = IntegerType::get(ctx, 64);
@@ -113,7 +144,9 @@ private:
             callOp.emitError("could not trace offset value");
           }
         } else if (funcName.equals(cudaq::opt::QIRArrayQubitAllocateArray)) {
-          data.nQubits += getNumQubits(callOp);
+          addAllocation([&]() { return getNumQubits(callOp); });
+        } else if (funcName.equals(cudaq::opt::QIRQubitAllocate)) {
+          addAllocation([]() { return 1; });
         }
       }
     });

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ add_cudaq_library(OptTransforms
   AggressiveEarlyInlining.cpp
   ApplyOpSpecialization.cpp
   BasisConversion.cpp
+  CombineQuantumAlloc.cpp
   Decomposition.cpp
   DecompositionPatterns.cpp
   ExpandMeasurements.cpp

--- a/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -1,0 +1,221 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "cudaq/Todo.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_COMBINEQUANTUMALLOCATIONS
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "combine-quantum-alloc"
+
+using namespace mlir;
+
+namespace {
+struct Analysis {
+  Analysis() = default;
+  Analysis(const Analysis &) = delete;
+  Analysis(Analysis &&) = delete;
+  Analysis &operator=(const Analysis &) = delete;
+
+  SmallVector<quake::AllocaOp> allocations;
+  SmallVector<std::pair<std::size_t, std::size_t>> offsetSizes;
+  SmallVector<quake::DeallocOp> deallocs;
+  quake::AllocaOp newAlloc;
+
+  bool empty() const { return allocations.empty(); }
+};
+
+class AllocaPat : public OpRewritePattern<quake::AllocaOp> {
+public:
+  explicit AllocaPat(MLIRContext *ctx, Analysis &a)
+      : OpRewritePattern(ctx), analysis(a) {}
+
+  LogicalResult matchAndRewrite(quake::AllocaOp alloc,
+                                PatternRewriter &rewriter) const override {
+    for (auto p : llvm::enumerate(analysis.allocations)) {
+      if (alloc == p.value()) {
+        auto i = p.index();
+        auto &os = analysis.offsetSizes[i];
+        if (os.second == 1) {
+          [[maybe_unused]] Value ext =
+              rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(
+                  alloc, analysis.newAlloc, os.first);
+          LLVM_DEBUG(llvm::dbgs()
+                     << "replace " << alloc << " with " << ext << '\n');
+          return success();
+        }
+        Value lo = rewriter.create<arith::ConstantIntOp>(
+            alloc.getLoc(), os.first, rewriter.getI64Type());
+        Value hi = rewriter.create<arith::ConstantIntOp>(
+            alloc.getLoc(), os.first + os.second - 1, rewriter.getI64Type());
+        [[maybe_unused]] Value subvec =
+            rewriter.replaceOpWithNewOp<quake::SubVecOp>(
+                alloc, alloc.getType(), analysis.newAlloc, lo, hi);
+        LLVM_DEBUG(llvm::dbgs()
+                   << "replace " << alloc << " with " << subvec << '\n');
+        return success();
+      }
+    }
+    return failure();
+  }
+
+  Analysis &analysis;
+};
+
+class ExtractPat : public OpRewritePattern<quake::ExtractRefOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  // Replace a pattern such as:
+  // ```
+  //   %1 = ... : !quake.veq<4>
+  //   %2 = quake.subvec %1, %c2, %c3 : (!quake.veq<4>, i32, i32) ->
+  //        !quake.veq<2>
+  //   %3 = quake.extract_ref %2[0] : (!quake.veq<2>) -> !quake.ref
+  // ```
+  // with:
+  // ```
+  //   %1 = ... : !quake.veq<4>
+  //   %3 = quake.extract_ref %1[2] : (!uwake.veq<4>) -> !quake.ref
+  // ```
+  LogicalResult matchAndRewrite(quake::ExtractRefOp extract,
+                                PatternRewriter &rewriter) const override {
+    if (auto subvec = extract.getVeq().getDefiningOp<quake::SubVecOp>()) {
+      Value offset;
+      auto loc = extract.getLoc();
+      Value low = subvec.getLow();
+      if (extract.hasConstantIndex()) {
+        Value cv = rewriter.create<arith::ConstantIntOp>(
+            loc, extract.getConstantIndex(), low.getType());
+        offset = rewriter.create<arith::AddIOp>(loc, cv, low);
+      } else {
+        Value cast = rewriter.create<cudaq::cc::CastOp>(loc, low.getType(),
+                                                        extract.getIndex());
+        offset = rewriter.create<arith::AddIOp>(loc, cast, low);
+      }
+      rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(extract, subvec.getVeq(),
+                                                       offset);
+    }
+    return success();
+  }
+};
+
+class CombineQuantumAllocationsPass
+    : public cudaq::opt::impl::CombineQuantumAllocationsBase<
+          CombineQuantumAllocationsPass> {
+public:
+  using CombineQuantumAllocationsBase::CombineQuantumAllocationsBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    LLVM_DEBUG(llvm::dbgs() << "Function before combining quake alloca:\n"
+                            << func << "\n\n");
+
+    // 1. Scan the top-level of the function for all alloca operations. Exit if
+    // any of them are parametric.
+    Analysis analysis;
+    std::size_t currentOffset = 0;
+    for (auto &block : func.getRegion())
+      for (auto &op : block) {
+        if (auto alloc = dyn_cast_or_null<quake::AllocaOp>(&op)) {
+          if (alloc.getSize())
+            return;
+          analysis.allocations.push_back(alloc);
+          auto size = allocationSize(alloc);
+          analysis.offsetSizes.emplace_back(currentOffset, size);
+          currentOffset += size;
+        } else if (auto dealloc = dyn_cast_or_null<quake::DeallocOp>(&op)) {
+          analysis.deallocs.push_back(dealloc);
+        }
+      }
+    if (analysis.empty())
+      return;
+
+    // 2. Combine all the allocas into a single alloca at the top of the
+    // function.
+    auto *entryBlock = &func.getRegion().front();
+    auto *ctx = &getContext();
+    auto loc = analysis.allocations.front().getLoc();
+    OpBuilder rewriter(ctx);
+    rewriter.setInsertionPointToStart(entryBlock);
+    auto veqTy = quake::VeqType::get(ctx, currentOffset);
+    analysis.newAlloc = rewriter.create<quake::AllocaOp>(loc, veqTy);
+
+    // 3. Replace the uses of the original alloca ops with uses of partitions of
+    // the new alloca op.
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.insert<AllocaPat>(ctx, analysis);
+      ConversionTarget target(*ctx);
+      target.addLegalDialect<quake::QuakeDialect, arith::ArithDialect>();
+      target.addDynamicallyLegalOp<quake::AllocaOp>([&](quake::AllocaOp alloc) {
+        return std::find(analysis.allocations.begin(),
+                         analysis.allocations.end(),
+                         alloc) == analysis.allocations.end();
+      });
+      if (failed(applyPartialConversion(func.getOperation(), target,
+                                        std::move(patterns)))) {
+        func.emitOpError("rewriting alloca ops failed");
+        signalPassFailure();
+      }
+    }
+
+    // 4. Replace extract from subvec with extract from original veq.
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.insert<ExtractPat>(ctx);
+      ConversionTarget target(*ctx);
+      target.addLegalDialect<quake::QuakeDialect, cudaq::cc::CCDialect,
+                             arith::ArithDialect>();
+      target.addDynamicallyLegalOp<quake::ExtractRefOp>(
+          [&](quake::ExtractRefOp ext) {
+            return !ext.getVeq().getDefiningOp<quake::SubVecOp>();
+          });
+      if (failed(applyPartialConversion(func.getOperation(), target,
+                                        std::move(patterns)))) {
+        func.emitOpError("combining subvec and extract ops failed");
+        signalPassFailure();
+      }
+    }
+
+    // 5. Remove the deallocations, if any. Add new dealloc to exits.
+    if (!analysis.deallocs.empty()) {
+      for (auto d : analysis.deallocs)
+        d.erase();
+      for (auto &block : func.getRegion()) {
+        if (block.hasNoSuccessors()) {
+          rewriter.setInsertionPoint(block.getTerminator());
+          rewriter.create<quake::DeallocOp>(analysis.newAlloc.getLoc(),
+                                            analysis.newAlloc);
+        }
+      }
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "Function after combining quake alloca:\n"
+                            << func << "\n\n");
+  }
+
+  // TODO: move this to a place where it can be shared.
+  static std::size_t allocationSize(quake::AllocaOp alloc) {
+    if (isa<quake::RefType>(alloc.getType()))
+      return 1;
+    auto veq = cast<quake::VeqType>(alloc.getType());
+    assert(veq.hasSpecifiedSize() && "veq type must have constant size");
+    return veq.getSize();
+  }
+};
+} // namespace

--- a/lib/Optimizer/Transforms/ExpandMeasurements.cpp
+++ b/lib/Optimizer/Transforms/ExpandMeasurements.cpp
@@ -126,7 +126,7 @@ public:
     target.addDynamicallyLegalOp<quake::MzOp>(
         [](quake::MzOp x) { return usesIndividualQubit(x); });
     if (failed(applyPartialConversion(op, target, std::move(patterns)))) {
-      emitError(op->getLoc(), "error expanding measurements\n");
+      op->emitOpError("could not expand measurements");
       signalPassFailure();
     }
   }

--- a/test/NVQPP/bug_qubit.cpp
+++ b/test/NVQPP/bug_qubit.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// This code is from Issue 251.
+
+// RUN: nvq++ --enable-mlir -v %s --target quantinuum --quantinuum-url http://localhost:6245 && ( ./a.out > %t 2>&1 || ( cat %t | FileCheck %s ) )
+
+// CHECK-NOT: could not trace offset value
+// CHECK: terminate called
+
+#include <cudaq.h>
+#include <iostream>
+
+struct ak2 {
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    h(q);
+    mz(q);
+  }
+};
+
+int main() {
+  auto counts = cudaq::sample(ak2{});
+  std::cout << "Test: ";
+  counts.dump();
+  return 0;
+}

--- a/test/NVQPP/bug_qubit.cpp
+++ b/test/NVQPP/bug_qubit.cpp
@@ -8,10 +8,9 @@
 
 // This code is from Issue 251.
 
-// RUN: nvq++ --enable-mlir -v %s --target quantinuum --quantinuum-url http://localhost:6245 && ( ./a.out > %t 2>&1 || ( cat %t | FileCheck %s ) )
+// RUN: nvq++ --enable-mlir -v %s --target quantinuum --emulate && ./a.out | FileCheck %s
 
-// CHECK-NOT: could not trace offset value
-// CHECK: terminate called
+// CHECK: Test: { 0:{{[0-9]+}} 1:{{[0-9]+}} }
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/Quake/combine.qke
+++ b/test/Quake/combine.qke
@@ -1,0 +1,72 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --combine-quantum-alloc --canonicalize %s | FileCheck %s
+
+func.func @a() {
+  %0 = quake.alloca !quake.ref
+  quake.x %0 : (!quake.ref) -> ()
+  %1 = quake.alloca !quake.veq<4>
+  %a1 = quake.extract_ref %1 [0] : (!quake.veq<4>) -> !quake.ref
+  quake.x %a1 : (!quake.ref) -> ()
+  %b1 = quake.extract_ref %1 [1] : (!quake.veq<4>) -> !quake.ref
+  quake.x %b1 : (!quake.ref) -> ()
+  %2 = quake.alloca !quake.ref
+  quake.x %2 : (!quake.ref) -> ()
+  %3 = quake.alloca !quake.veq<7>
+  %a3 = quake.extract_ref %3 [0] : (!quake.veq<7>) -> !quake.ref
+  quake.x %a3 : (!quake.ref) -> ()
+  %b3 = quake.extract_ref %3 [1] : (!quake.veq<7>) -> !quake.ref
+  quake.x %b3 : (!quake.ref) -> ()
+  %c3 = quake.extract_ref %3 [2] : (!quake.veq<7>) -> !quake.ref
+  quake.x %c3 : (!quake.ref) -> ()
+  %c1 = quake.extract_ref %1 [2] : (!quake.veq<4>) -> !quake.ref
+  quake.x %c1 : (!quake.ref) -> ()
+  %d1 = quake.extract_ref %1 [3] : (!quake.veq<4>) -> !quake.ref
+  quake.x %d1 : (!quake.ref) -> ()
+  %d3 = quake.extract_ref %3 [3] : (!quake.veq<7>) -> !quake.ref
+  quake.x %d3 : (!quake.ref) -> ()
+  %e3 = quake.extract_ref %3 [4] : (!quake.veq<7>) -> !quake.ref
+  quake.x %e3 : (!quake.ref) -> ()
+  %f3 = quake.extract_ref %3 [5] : (!quake.veq<7>) -> !quake.ref
+  quake.x %f3 : (!quake.ref) -> ()
+  %g3 = quake.extract_ref %3 [6] : (!quake.veq<7>) -> !quake.ref
+  quake.x %g3 : (!quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @a() {
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<13>
+// CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_2]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][2] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][5] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_0]][6] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_5]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_0]][7] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_0]][8] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_0]][3] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_8]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][4] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_9]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_0]][9] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_10]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_0]][10] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_11]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]][11] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_12]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]][12] : (!quake.veq<13>) -> !quake.ref
+// CHECK:           quake.x %[[VAL_13]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
This is a direct fix to handle both array and single qubit allocations in the base profile pass.

Add a pass to combine quantum allocations.
