### PR TITLE
Fix #286: Add canonicalization to hoist invariants cc.loop arguments.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -198,6 +198,7 @@ def cc_LoopOp : CCOp<"loop",
     AnyRegion:$stepRegion
   );
 
+  let hasCanonicalizer = 1;
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -562,6 +562,107 @@ cudaq::cc::LoopOp::getSuccessorEntryOperands(std::optional<unsigned> index) {
   return getInitialArgs();
 }
 
+namespace {
+// If an argument to a LoopOp traverses the loop unchanged then it is invariant
+// across all iterations of the loop and can be hoisted out of the loop. This
+// pattern detects invariant arguments and removes them from the LoopOp. This
+// performs the following rewrite, where the notation `⟦x := y⟧` means all uses
+// of `x` are replaced with `y`.
+//
+//    %result = cc.loop while ((%invariant = %1) -> (T)) {
+//      ...
+//      cc.condition %cond(%invariant : T)
+//    } do {
+//    ^bb1(%invariant : T):
+//      ...
+//      cc.continue %invariant : T
+//    } step {
+//    ^bb1(%invariant : T):
+//      ...
+//      cc.continue %invariant : T
+//    }
+//  ──────────────────────────────────────
+//    cc.loop while {
+//      ...⟦%invariant := %1⟧...
+//      cc.condition %cond
+//    } do {
+//    ^bb1:
+//      ...⟦%invariant := %1⟧...
+//      cc.continue
+//    } step {
+//    ^bb1:
+//      ...⟦%invariant := %1⟧...
+//      cc.continue
+//    }
+//    ...⟦%result := %1⟧...
+
+struct HoistLoopInvariantArgs : public OpRewritePattern<cudaq::cc::LoopOp> {
+  using Base = OpRewritePattern<cudaq::cc::LoopOp>;
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(cudaq::cc::LoopOp loop,
+                                PatternRewriter &rewriter) const override {
+    // 1. Find all the terminators.
+    SmallVector<Operation *> terminators;
+    for (auto *reg : loop.getRegions())
+      for (auto &block : *reg)
+        if (block.hasNoSuccessors())
+          terminators.push_back(block.getTerminator());
+
+    // 2. Determine if any arguments are invariant.
+    SmallVector<bool> invariants;
+    bool hasInvariants = false;
+    for (auto iter : llvm::enumerate(loop.getInitialArgs())) {
+      bool isInvar = true;
+      auto i = iter.index();
+      for (auto *term : terminators) {
+        Value blkArg = term->getBlock()->getParent()->front().getArgument(i);
+        if (auto cond = dyn_cast<cudaq::cc::ConditionOp>(term)) {
+          if (cond.getResults()[i] != blkArg)
+            isInvar = false;
+        } else if (auto cont = dyn_cast<cudaq::cc::ContinueOp>(term)) {
+          if (cont.getOperands()[i] != blkArg)
+            isInvar = false;
+        } else if (auto brk = dyn_cast<cudaq::cc::BreakOp>(term)) {
+          if (brk.getOperands()[i] != blkArg)
+            isInvar = false;
+        }
+        if (!isInvar)
+          break;
+      }
+      if (isInvar)
+        hasInvariants = true;
+      invariants.push_back(isInvar);
+    }
+
+    // 3. For each invariant argument replace the uses with the original
+    // invariant value throughout.
+    if (hasInvariants) {
+      for (auto iter : llvm::enumerate(invariants)) {
+        if (iter.value()) {
+          auto i = iter.index();
+          Value initialVal = loop.getInitialArgs()[i];
+          loop.getResult(i).replaceAllUsesWith(initialVal);
+          for (auto *reg : loop.getRegions()) {
+            if (reg->empty())
+              continue;
+            auto &entry = reg->front();
+            entry.getArgument(i).replaceAllUsesWith(initialVal);
+          }
+        }
+      }
+    }
+
+    return success();
+  }
+};
+} // namespace
+
+void cudaq::cc::LoopOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
+                                                    MLIRContext *context) {
+  patterns.add<HoistLoopInvariantArgs>(context);
+}
+
 //===----------------------------------------------------------------------===//
 // ScopeOp
 //===----------------------------------------------------------------------===//

--- a/test/AST-Quake/loop_unroll-2.cpp
+++ b/test/AST-Quake/loop_unroll-2.cpp
@@ -211,8 +211,6 @@ struct for_loop_3 {
 // CHECK:           return
 
 struct for_loop_4 {
-  // Not unrolled because the upper bound constant is not canonicalized but
-  // instead passed as a block argument around the loop.
   void operator()() __qpu__ {
     cudaq::qreg reg(3);
     for (size_t i = 0, n = reg.size(); i < n; ++i)
@@ -226,16 +224,16 @@ struct for_loop_4 {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__for_loop_4(
-// CHECK:           cc.loop while
-// CHECK:           } do {
+// CHECK:           quake.y %{{.*}} : (!quake.ref) -> ()
+// CHECK:           quake.y %{{.*}} : (!quake.ref) -> ()
 // CHECK:           quake.y %{{.*}} : (!quake.ref) -> ()
 // CHECK-NOT:       quake.y %{{.*}} : (!quake.ref) -> ()
-// CHECK:           cc.loop while
-// CHECK:           } do {
+// CHECK:           quake.h %{{.*}} : (!quake.ref) -> ()
+// CHECK:           quake.h %{{.*}} : (!quake.ref) -> ()
 // CHECK:           quake.h %{{.*}} : (!quake.ref) -> ()
 // CHECK-NOT:       quake.h %{{.*}} : (!quake.ref) -> ()
-// CHECK:           cc.loop while
-// CHECK:           } do {
+// CHECK:           quake.z %{{.*}} : (!quake.ref) -> ()
+// CHECK:           quake.z %{{.*}} : (!quake.ref) -> ()
 // CHECK:           quake.z %{{.*}} : (!quake.ref) -> ()
 // CHECK-NOT:       quake.z %{{.*}} : (!quake.ref) -> ()
 // CHECK:           return


### PR DESCRIPTION
Bug fix to loop unrolling to handle multiple cc.loop arguments.

Fix test case for unrolling of for loop with upper bound stored in a
variable that can be register promoted, hoisted as an invariant, and
detected as a constant for a counted loop.

Depends on #287 