### PR TITLE
[pass] Fix #291: don't erase non-controlled ops

### DIFF
--- a/lib/Optimizer/Transforms/MultiControlDecomposition.cpp
+++ b/lib/Optimizer/Transforms/MultiControlDecomposition.cpp
@@ -113,11 +113,11 @@ LogicalResult Decomposer::v_decomposition(quake::OperatorInterface op) {
 
   // We only decompose operations with multiple controls.
   if (controls.size() <= 1)
-    return success();
+    return failure();
 
   // We don't decompose CCX and CCZ as they are handle by another pass.
   if (controls.size() == 2 && isa<quake::XOp, quake::ZOp>(op))
-    return success();
+    return failure();
 
   // Operator info
   Location loc = op->getLoc();

--- a/test/Transforms/multicontrol_decomposition.qke
+++ b/test/Transforms/multicontrol_decomposition.qke
@@ -63,7 +63,7 @@ func.func @cccz(%c0: !quake.ref,  %c1: !quake.ref, %c2: !quake.ref, %t: !quake.r
   return
 }
 
-// Make sure that non-controlled ops will be left allone.
+// Make sure that non-controlled ops will be left alone.
 // CHECK-LABEL: func.func @bug_291
 func.func @bug_291(%c: !quake.veq<3>, %t: !quake.ref) {
   // CHECK: quake.alloca !quake.ref

--- a/test/Transforms/multicontrol_decomposition.qke
+++ b/test/Transforms/multicontrol_decomposition.qke
@@ -62,3 +62,16 @@ func.func @cccz(%c0: !quake.ref,  %c1: !quake.ref, %c2: !quake.ref, %t: !quake.r
   quake.z [%c0, %c1, %c2] %t : (!quake.ref, !quake.ref, !quake.ref, !quake.ref) -> ()
   return
 }
+
+// Make sure that non-controlled ops will be left allone.
+// CHECK-LABEL: func.func @bug_291
+func.func @bug_291(%c: !quake.veq<3>, %t: !quake.ref) {
+  // CHECK: quake.alloca !quake.ref
+  // CHECK-NOT: quake.alloca !quake.ref
+  // CHECK: quake.h
+  quake.h %t : (!quake.ref) -> ()
+  // CHECK: quake.extract_ref
+  quake.x [%c] %t : (!quake.veq<3>, !quake.ref) -> ()
+  quake.x [%c] %t : (!quake.veq<3>, !quake.ref) -> ()
+  return
+}


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
This PR fixes #291. The decomposition function was wrongly returning `success()` when it was not transforming the IR.
