### PR TITLE
[opt] Flag to raise an error if cannot unroll a loop

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -152,6 +152,11 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
   let description = [{
     If a cc.loop op is a simple, constant counted loop, it can be fully
     unrolled into <i>n</i> copies of the body of the loop.
+
+    The full-unroll option controls whether not being able to unroll all loops
+    is a pass failure. This is necessary when synthesizing/compiling kernels
+    that will be converted to QIR base profile: we need to guarantee that all
+    loops have been unrolled.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect",
@@ -160,6 +165,8 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
   let options = [
     Option<"threshold", "maximum-iterations", "std::size_t",
       /*default=*/"50", "Maximum iterations to unroll.">,
+    Option<"full_unroll", "full-unroll", "bool", /*default=*/"false",
+           "Pass will fail if it can't unroll all loops.">
   ];
 }
 

--- a/lib/Optimizer/Transforms/LoopUnroll.cpp
+++ b/lib/Optimizer/Transforms/LoopUnroll.cpp
@@ -153,6 +153,23 @@ public:
       emitError(op->getLoc(), "could not unroll cc.loop\n");
       signalPassFailure();
     }
+    if (full_unroll) {
+      bool fail = false;
+      op->walk([&](cudaq::cc::LoopOp loop) {
+        fail = true;
+        if (!cudaq::opt::isaCountedLoop(loop))
+          loop.emitError("cannot unroll non-counted loop.");
+        else if (exceedsThresholdValue(loop))
+          loop.emitError(
+              "cannot unroll loop that exceeds iteration threshold.");
+        else
+          loop.emitError("cannot unroll loop.");
+      });
+      if (fail) {
+        emitError(op->getLoc(), "could not unroll all loops.\n");
+        signalPassFailure();
+      }
+    }
   }
 
   bool exceedsThresholdValue(cudaq::cc::LoopOp loop) {

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
@@ -16,7 +16,7 @@ GEN_TARGET_BACKEND=true
 LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline, here we lower to Base QIR
-PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,cc-loop-unroll,canonicalize,func.func(lower-to-cfg),canonicalize,quantinuum-gate-set-mapping"
+PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,cc-loop-unroll{full-unroll=true},canonicalize,func.func(lower-to-cfg),canonicalize,quantinuum-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 CODEGEN_EMISSION=qir


### PR DESCRIPTION
This adds an option to the loop unrolling pass that will signal a pass failure if it cannot unroll all loops.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
Closes #277. 
