### PR TITLE
Preserve the line information in the source code for JIT compilation.

### DIFF
--- a/lib/Optimizer/Transforms/GenDeviceCodeLoader.cpp
+++ b/lib/Optimizer/Transforms/GenDeviceCodeLoader.cpp
@@ -80,7 +80,12 @@ public:
         std::string thunkName = className.str() + ".thunk";
         std::string funcCode;
         llvm::raw_string_ostream strOut(funcCode);
-        strOut << "module { " << funcOp << '\n';
+        OpPrintingFlags opf;
+        opf.enableDebugInfo(/*enable=*/true,
+                            /*pretty=*/false);
+        strOut << "module { ";
+        funcOp.print(strOut, opf);
+        strOut << '\n';
 
         // We'll also need any non-inlined functions that are
         // called by our cudaq kernel
@@ -89,7 +94,8 @@ public:
                   module.lookupSymbol<func::FuncOp>(callOp.getCallee())) {
             if (neededFunc.empty())
               return WalkResult::skip();
-            strOut << neededFunc << '\n';
+            neededFunc.print(strOut, opf);
+            strOut << '\n';
             return WalkResult::advance();
           }
           return WalkResult::advance();

--- a/test/AST-Quake/adjoint-1.cpp
+++ b/test/AST-Quake/adjoint-1.cpp
@@ -19,7 +19,7 @@ struct k {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__k
-// CHECK-SAME: (%[[VAL_0:.*]]: !quake.veq<?>)
+// CHECK-SAME: (%[[VAL_0:.*]]: !quake.veq<?>{{.*}})
 // CHECK:           quake.h %{{.*}}
 // CHECK:           quake.ry (%{{.*}}) %{{.*}}
 // CHECK:           quake.t %{{.*}}

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -46,7 +46,7 @@ struct QernelZero {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__QernelZero
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__run_circuit
-// CHECK-SAME:        (%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: f64)
+// CHECK-SAME:        (%{{.*}}: i32{{.*}}, %{{.*}}: i32{{.*}}, %{{.*}}: f64{{.*}})
 // CHECK:           %[[VAL_5:.*]] = cc.alloca f64
 // CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<?>[%{{.*}} : i64]
 // CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>

--- a/test/AST-Quake/auto_kernel-1.cpp
+++ b/test/AST-Quake/auto_kernel-1.cpp
@@ -22,7 +22,7 @@ struct ak1 {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ak1
-// CHECK-SAME:        (%[[VAL_0:.*]]: i32) -> i1 attributes {
+// CHECK-SAME:        (%[[VAL_0:.*]]: i32{{.*}}) -> i1 attributes {
 // CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64

--- a/test/AST-Quake/callable-1.cpp
+++ b/test/AST-Quake/callable-1.cpp
@@ -29,7 +29,7 @@ int main() {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Z4mainE3$_0
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>{{.*}}) attributes
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.veq<?>, i64) -> !quake.ref
@@ -45,7 +45,7 @@ int main() {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_MyKernel
-// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.veq<?>) -> ()>) attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
+// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.veq<?>) -> ()>{{.*}}) attributes
 // CHECK:           %[[VAL_1:.*]] = arith.constant 2 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : i32 to i64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<?>[%[[VAL_2]] : i64]

--- a/test/AST-Quake/callable-2.cpp
+++ b/test/AST-Quake/callable-2.cpp
@@ -37,8 +37,7 @@ struct test5_caller {
 };
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__test5_callee
-// CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:   %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}})
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %
@@ -48,7 +47,7 @@ struct test5_caller {
 // CHECK:           return
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__test5_callable
-// CHECK-SAME:   (%[[VAL_0:.*]]: !quake.ref)
+// CHECK-SAME:   (%[[VAL_0:.*]]: !quake.ref{{.*}})
 // CHECK:           quake.h %[[VAL_0]]
 // CHECK:           quake.x %[[VAL_0]]
 // CHECK:           quake.z %[[VAL_0]]
@@ -56,7 +55,7 @@ struct test5_caller {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test5_caller
 // CHECK-SAME: () attributes
 // CHECK:           %[[VAL_5:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_6:.*]]: !quake.ref):
+// CHECK:           ^bb0(%[[VAL_6:.*]]: !quake.ref
 // CHECK:             func.call @__nvqpp__mlirgen__test5_callable{{.*}}(%[[VAL_6]]) : (!quake.ref) -> ()
 // CHECK:           } : !cc.lambda<(!quake.ref) -> ()>
 // CHECK:           call @__nvqpp__mlirgen__test5_callee{{.*}}(%[[VAL_5]], %{{.*}}) : (!cc.lambda<(!quake.ref) -> ()>, !quake.veq<?>) -> ()

--- a/test/AST-Quake/control.cpp
+++ b/test/AST-Quake/control.cpp
@@ -35,7 +35,7 @@ struct ctrlHeisenberg {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__heisenbergU(
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenberg(
-// CHECK-SAME:        %{{.*}}: i32) attributes
+// CHECK-SAME:        %{{.*}}: i32{{.*}}) attributes
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
@@ -108,7 +108,7 @@ __qpu__ void qnppx2(double theta, cudaq::qubit &q, cudaq::qubit &r,
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qnppx2
-// CHECK-SAME:       %{{[^:]*}}: f64, %[[VAL_1:.*]]: !quake.ref, %[[VAL_2:.*]]: !quake.ref, %[[VAL_3:.*]]: !quake.ref, %[[VAL_4:.*]]: !quake.ref)
+// CHECK-SAME:       %{{[^:]*}}: f64{{.*}}, %[[VAL_1:.*]]: !quake.ref{{.*}}, %[[VAL_2:.*]]: !quake.ref{{.*}}, %[[VAL_3:.*]]: !quake.ref{{.*}}, %[[VAL_4:.*]]: !quake.ref{{.*}})
 // CHECK:           %[[VAL_7:.*]] = quake.concat %[[VAL_1]], %[[VAL_4]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
 // CHECK:           quake.x %[[VAL_4]]
 // CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %[[VAL_2]], %[[VAL_3]] : (!quake.veq<2>, f64, !quake.ref, !quake.ref) -> ()

--- a/test/AST-Quake/ctor.cpp
+++ b/test/AST-Quake/ctor.cpp
@@ -14,7 +14,7 @@
 using namespace cudaq;
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Teste
-// CHECK-SAME: (%[[VAL_0:.*]]: !quake.ref)
+// CHECK-SAME: (%[[VAL_0:.*]]: !quake.ref{{.*}})
 // CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1
 // CHECK:           return

--- a/test/AST-Quake/ctrl_vector.cpp
+++ b/test/AST-Quake/ctrl_vector.cpp
@@ -53,7 +53,7 @@ struct test_two_control_call {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test_two
 // CHECK-SAME: () attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_1:.*]]: !quake.ref):
+// CHECK:           ^bb0(%[[VAL_1:.*]]: !quake.ref loc{{.*}}):
 // CHECK:             cc.scope {
 // CHECK:               quake.h %[[VAL_1]]
 // CHECK:               quake.x %[[VAL_1]]

--- a/test/AST-Quake/empty_step.cpp
+++ b/test/AST-Quake/empty_step.cpp
@@ -19,8 +19,7 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test.
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}}) attributes
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:             %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32

--- a/test/AST-Quake/lambda_instance.cpp
+++ b/test/AST-Quake/lambda_instance.cpp
@@ -33,7 +33,7 @@ struct test0 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        5test0
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref{{.*}})
 // CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return
 // CHECK:         }
@@ -56,7 +56,7 @@ struct test1 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        5test1
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref{{.*}})
 // CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return
 // CHECK:         }
@@ -89,8 +89,7 @@ struct test2b {
 // CHECK:           return
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test2a
-// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}})
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2b{{.*}}(%[[VAL_4]]) : (!quake.ref) -> ()
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
@@ -99,7 +98,7 @@ struct test2b {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        6test2b
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref{{.*}})
 // CHECK:           quake.h %[[VAL_0]] :
 // CHECK:           quake.y %[[VAL_0]] : (!quake.ref) -> ()
 // CHECK:           return
@@ -135,8 +134,7 @@ struct test2c {
 // CHECK:           return
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test2a_c
-// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}})
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           call @__nvqpp__mlirgen__{{.*}}test2c{{.*}}(%[[VAL_4]]) : (!quake.ref) -> ()
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
@@ -146,7 +144,7 @@ struct test2c {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__
 // CHECK-SAME:        6test2c
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref{{.*}})
 // CHECK:           quake.h %[[VAL_0]]
 // CHECK:           quake.z %[[VAL_0]]
 // CHECK:           quake.h %[[VAL_0]]
@@ -174,8 +172,7 @@ struct test3 {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3a
-// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:       (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}}) attributes
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]]{{\[}}%[[VAL_3]]] : (!quake.veq<?>, i64) -> !quake.ref
@@ -193,7 +190,7 @@ struct test3 {
 // CHECK:           %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<?>[%[[VAL_1]] : i64]
 // CHECK:           %[[VAL_3:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_4:.*]]: !quake.ref):
+// CHECK:           ^bb0(%[[VAL_4:.*]]: !quake.ref
 // CHECK:             cc.scope {
 // CHECK:               quake.h %[[VAL_4]]
 // CHECK:               quake.z %[[VAL_4]]

--- a/test/AST-Quake/lambda_variable.cpp
+++ b/test/AST-Quake/lambda_variable.cpp
@@ -35,8 +35,7 @@ struct test3_caller {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_callee
-// CHECK-SAME:     (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:      %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:     (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}}) attributes {
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:           cc.call_callable %[[VAL_0]], %[[VAL_4]] : (!cc.lambda<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %{{.*}}[%{{.*}}] : (!quake.veq<?>, i64) -> !quake.ref
@@ -48,7 +47,7 @@ struct test3_caller {
 // CHECK-SAME: () attributes {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<?>[%{{.*}} : i64]
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.ref):
+// CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.ref
 // CHECK:             cc.scope {
 // CHECK:               quake.h %[[VAL_5]]
 // CHECK:               quake.y %[[VAL_5]]
@@ -87,7 +86,7 @@ struct test4_caller {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<?>[%[[VAL_1]] : i64]
 // CHECK:           %[[VAL_3:.*]] = cc.undef !cc.struct<"test4_callee" {}>
 // CHECK:           %[[VAL_4:.*]] = cc.create_lambda {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.ref):
+// CHECK:           ^bb0(%[[VAL_5:.*]]: !quake.ref
 // CHECK:             cc.scope {
 // CHECK:               quake.h %[[VAL_5]] :
 // CHECK:               quake.x %[[VAL_5]] : (!quake.ref) -> ()
@@ -98,8 +97,7 @@ struct test4_caller {
 // CHECK:         }
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__instance_test4_callee
-// CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>,
-// CHECK-SAME:    %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:   (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}}) attributes {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_2]] : i32 to i64
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_3]]] : (!quake.veq<?>, i64) -> !quake.ref
@@ -112,7 +110,7 @@ struct test4_caller {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ZN12test4_callerclEvEUlRN5cudaq5quditILm2EEEE_(
-// CHECK-SAME:                                                                                          %[[VAL_0:.*]]: !quake.ref) attributes {"cudaq-kernel"} {
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.ref{{.*}}) attributes {
 // CHECK:           quake.h %[[VAL_0]] :
 // CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return

--- a/test/AST-Quake/measure_bell.cpp
+++ b/test/AST-Quake/measure_bell.cpp
@@ -29,7 +29,7 @@ struct bell {
 int main() { bell{}(100); }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__bell(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32)
+// CHECK-SAME:      %[[VAL_0:.*]]: i32{{.*}})
 // CHECK:           %[[VAL_1:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
@@ -130,7 +130,7 @@ struct tinkerbell {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__libertybell(
-// CHECK-SAME:        %[[VAL_0:.*]]: i32)
+// CHECK-SAME:        %[[VAL_0:.*]]: i32{{.*}})
 // CHECK:           %[[VAL_1:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32
@@ -194,7 +194,7 @@ struct tinkerbell {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__tinkerbell(
-// CHECK-SAME:        %[[VAL_0:.*]]: i32) attributes
+// CHECK-SAME:        %[[VAL_0:.*]]: i32{{.*}}) attributes
 // CHECK:           %[[VAL_1:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : i32

--- a/test/AST-Quake/mz.cpp
+++ b/test/AST-Quake/mz.cpp
@@ -66,7 +66,7 @@ struct VectorOfDynamicVeq {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorOfDynamicVeq(
-// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) -> !cc.stdvec<i1> attributes {
+// CHECK-SAME:           %[[VAL_0:.*]]: i32{{.*}}, %[[VAL_1:.*]]: i32{{.*}}) -> !cc.stdvec<i1> attributes {
 // CHECK:           %[[VAL_2:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_3:.*]] = cc.alloca i32

--- a/test/AST-Quake/nested_scope.cpp
+++ b/test/AST-Quake/nested_scope.cpp
@@ -68,7 +68,7 @@ struct test3 {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test2
-// CHECK-SAME:         (%[[VAL_0:.*]]: i32)
+// CHECK-SAME:         (%[[VAL_0:.*]]: i32{{.*}})
 // CHECK:           %[[VAL_1:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
@@ -86,7 +86,7 @@ struct test3 {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3
-// CHECK-SAME:         (%[[VAL_0:.*]]: f64)
+// CHECK-SAME:         (%[[VAL_0:.*]]: f64{{.*}})
 // CHECK:           %[[VAL_1:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 3.14

--- a/test/AST-Quake/passQregNToQSpan.cpp
+++ b/test/AST-Quake/passQregNToQSpan.cpp
@@ -21,12 +21,12 @@ struct entry {
  }
 };
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_mcx._Z3mcxN5cudaq5qspan{{.*}}(
-// CHECK-SAME:                                                                                               %[[VAL_0:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_mcx.
+// CHECK-SAME:      (%[[VAL_0:.*]]: !quake.veq<?>{{.*}}) attributes {
 // CHECK:           return
 // CHECK:         }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__entry() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__entry() attributes {
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<3>
 // CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.veq<3>) -> !quake.veq<?>
 // CHECK:           call @__nvqpp__mlirgen__function_mcx._Z3mcxN5cudaq5qspan{{.*}}(%[[VAL_2]]) : (!quake.veq<?>) -> ()

--- a/test/AST-Quake/postfix_ops.cpp
+++ b/test/AST-Quake/postfix_ops.cpp
@@ -19,8 +19,7 @@ __qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test.
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>,
-// CHECK-SAME:         %[[VAL_1:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}}) attributes
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:             %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32

--- a/test/AST-Quake/qbit_arg.cpp
+++ b/test/AST-Quake/qbit_arg.cpp
@@ -9,7 +9,7 @@
 // RUN: cudaq-quake --emit-llvm-file %s | FileCheck %s
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__function_testFunc
-// CHECK-SAME:    (%[[VAL_0:.*]]: !quake.ref)
+// CHECK-SAME:    (%[[VAL_0:.*]]: !quake.ref{{.*}})
 // CHECK: quake.h %[[VAL_0]] :
 // CHECK: %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1
 // CHECK: return

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -102,7 +102,7 @@ int main() {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_iqft
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>{{.*}}) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_1:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_2:.*]] = arith.trunci %[[VAL_1]] : i64 to i32
 // CHECK:           %[[VAL_3:.*]] = cc.alloca i32
@@ -221,7 +221,7 @@ int main() {
 
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__tgate
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>) attributes
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>{{.*}}) attributes
 // CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
@@ -230,12 +230,12 @@ int main() {
 // CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
 // CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_8:.*]]: index):
+// CHECK:           ^bb0(%[[VAL_8:.*]]: index
 // CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, index) -> !quake.ref
 // CHECK:             quake.t %[[VAL_9]] : (!quake.ref) -> ()
 // CHECK:             cc.continue %[[VAL_8]] : index
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_10:.*]]: index):
+// CHECK:           ^bb0(%[[VAL_10:.*]]: index
 // CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_2]] : index
 // CHECK:             cc.continue %[[VAL_11]] : index
 // CHECK:           }
@@ -243,7 +243,7 @@ int main() {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Z4mainE3$_0
-// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>)
+// CHECK-SAME:        (%[[VAL_0:.*]]: !quake.veq<?>
 // CHECK:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
@@ -252,12 +252,12 @@ int main() {
 // CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
 // CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_8:.*]]: index):
+// CHECK:           ^bb0(%[[VAL_8:.*]]: index
 // CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, index) -> !quake.ref
 // CHECK:             quake.x %[[VAL_9]] :
 // CHECK:             cc.continue %[[VAL_8]] : index
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_10:.*]]: index):
+// CHECK:           ^bb0(%[[VAL_10:.*]]: index
 // CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_2]] : index
 // CHECK:             cc.continue %[[VAL_11]] : index
 // CHECK:           }
@@ -265,9 +265,7 @@ int main() {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_qpe
-// CHECK-SAME:      (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32,
-// CHECK-SAME:       %[[VAL_2:.*]]: !cc.lambda<(!quake.veq<?>) -> ()>,
-// CHECK-SAME:       %[[VAL_3:.*]]: !cc.struct<"tgate" {}>) attributes
+// CHECK-SAME:      (%[[VAL_0:.*]]: i32{{.*}}, %[[VAL_1:.*]]: i32{{.*}}, %[[VAL_2:.*]]: !cc.lambda<(!quake.veq<?>) -> ()>{{.*}}, %[[VAL_3:.*]]: !cc.struct<"tgate" {}>{{.*}}) attributes
 // CHECK:           %[[VAL_4:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.alloca i32
@@ -299,12 +297,12 @@ int main() {
 // CHECK:             %[[VAL_30:.*]] = arith.cmpi slt, %[[VAL_29]], %[[VAL_25]] : index
 // CHECK:             cc.condition %[[VAL_30]](%[[VAL_29]] : index)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_31:.*]]: index):
+// CHECK:           ^bb0(%[[VAL_31:.*]]: index
 // CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_16]]{{\[}}%[[VAL_31]]] : (!quake.veq<?>, index) -> !quake.ref
 // CHECK:             quake.h %[[VAL_32]] :
 // CHECK:             cc.continue %[[VAL_31]] : index
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_33:.*]]: index):
+// CHECK:           ^bb0(%[[VAL_33:.*]]: index
 // CHECK:             %[[VAL_34:.*]] = arith.addi %[[VAL_33]], %[[VAL_27]] : index
 // CHECK:             cc.continue %[[VAL_34]] : index
 // CHECK:           }

--- a/test/AST-Quake/simple.cpp
+++ b/test/AST-Quake/simple.cpp
@@ -12,7 +12,7 @@
 // RUN: FileCheck --check-prefixes=CHECK-LLVM %s < simple.ll
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ghz
-// CHECK-SAME:        (%[[VAL_0:.*]]: i32)
+// CHECK-SAME:        (%[[VAL_0:.*]]: i32{{.*}})
 // CHECK-VISIT:     %[[VAL_1:.*]] = memref.alloca() : memref<i32>
 // CHECK-VISIT:     memref.store %[[VAL_0]], %[[VAL_1]][] : memref<i32>
 // CHECK-VISIT:     %[[VAL_2:.*]] = memref.load %[[VAL_1]][] : memref<i32>

--- a/test/AST-Quake/single_qubit_ctor.cpp
+++ b/test/AST-Quake/single_qubit_ctor.cpp
@@ -12,7 +12,7 @@
 
 // CHECK: module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__super{{.*}} = "_ZN5superclEd"}} {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__super
-// CHECK-SAME: (%[[arg0:.*]]: f64) -> i1
+// CHECK-SAME: (%[[arg0:.*]]: f64{{.*}}) -> i1
 // CHECK:     %[[V0:.*]] = cc.alloca f64
 // CHECK:     cc.store %[[arg0]], %[[V0]] : !cc.ptr<f64>
 // CHECK:     %[[V1:.*]] = quake.alloca !quake.ref

--- a/test/AST-Quake/slice.cpp
+++ b/test/AST-Quake/slice.cpp
@@ -21,7 +21,7 @@ struct SliceTest {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__SliceTest
-// CHECK-SAME:      (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) attributes {
+// CHECK-SAME:      (%[[VAL_0:.*]]: i32{{.*}}, %[[VAL_1:.*]]: i32{{.*}}) attributes {
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : i32
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
 // CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<?>[%[[VAL_5]] : i64]

--- a/test/AST-Quake/template_lambda.cpp
+++ b/test/AST-Quake/template_lambda.cpp
@@ -32,7 +32,7 @@ int main() {
 // CHECK:           quake.x %{{.*}} :
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__instance_test
-// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>)
+// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.lambda<(!quake.ref) -> ()>
 // CHECK-NOT:       %[[VAL_0]]
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<?>[%{{.*}} : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.extract_ref %{{.*}} : (!quake.veq<?>, i64) -> !quake.ref

--- a/test/AST-Quake/typename.cpp
+++ b/test/AST-Quake/typename.cpp
@@ -19,7 +19,7 @@ struct test {
 } // namespace ns
 
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__name1
-// CHECK-SAME: (%{{.*}}: !cc.stdvec<f64>) attributes {
+// CHECK-SAME: (%{{.*}}: !cc.stdvec<f64>{{.*}}) attributes {
 struct name1 {
   void operator()(std::vector<ns::test<double>::Type> variable) __qpu__ {}
 };

--- a/test/AST-Quake/vector.cpp
+++ b/test/AST-Quake/vector.cpp
@@ -16,7 +16,7 @@
 // Define a quantum kernel
 struct simple_double_rotation {
   // CHECK-LABEL: func.func @__nvqpp__mlirgen__simple_double_rotation
-  // CHECK-SAME: ([[arg:.*]]: !cc.stdvec<f64>) attributes
+  // CHECK-SAME: ([[arg:.*]]: !cc.stdvec<f64>{{.*}}) attributes
   auto operator()(std::vector<double> theta) __qpu__ {
     auto size = theta.size();
     bool empty = theta.empty();
@@ -29,7 +29,7 @@ struct simple_double_rotation {
 
 struct simple_float_rotation {
   // CHECK-LABEL: func.func @__nvqpp__mlirgen__simple_float_rotation
-  // CHECK-SAME: ([[arg:.*]]: !cc.stdvec<f32>) attributes
+  // CHECK-SAME: ([[arg:.*]]: !cc.stdvec<f32>{{.*}}) attributes
   auto operator()(std::vector<float> theta) __qpu__ {
     int size = theta.size();
     bool empty = theta.empty();

--- a/test/AST-Quake/vector_bool.cpp
+++ b/test/AST-Quake/vector_bool.cpp
@@ -21,7 +21,7 @@ struct t1 {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__t1
-// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.stdvec<f64>) -> i1 attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
+// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.stdvec<f64>{{.*}}) -> i1 attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
 // CHECK:           %[[VAL_13:.*]] = quake.mz %{{.*}} : (!quake.veq<?>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_15:.*]] = arith.extsi %[[VAL_14]] : i32 to i64

--- a/test/AST-Quake/while-1.cpp
+++ b/test/AST-Quake/while-1.cpp
@@ -43,8 +43,7 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test1
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}})
 // CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = cc.alloca i32
@@ -76,8 +75,7 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test2
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}})
 // CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = cc.alloca i32
@@ -107,8 +105,7 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test3
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}})
 // CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = cc.alloca i32
@@ -138,8 +135,7 @@ __qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test4
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>) -> f64
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}}) -> f64
 // CHECK:           %[[VAL_2:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 // CHECK:           %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i64 to i32
 // CHECK:           %[[VAL_4:.*]] = cc.alloca i32

--- a/test/NVQPP/testDeviceCodeLoaded.cpp
+++ b/test/NVQPP/testDeviceCodeLoaded.cpp
@@ -11,7 +11,7 @@
 #include <cudaq.h>
 
 // CHECK: { [[B0:.*]]:[[C0:.*]] [[B1:.*]]:[[C1:.*]] }
-// CHECK-NEXT: module { func.func @__nvqpp__mlirgen__ghz{{.*}}(%arg0: i32) attributes {
+// CHECK-NEXT: module { func.func @__nvqpp__mlirgen__ghz{{.*}}(%arg0: i32{{.*}}) attributes {
 
 // Define a quantum kernel
 struct ghz {

--- a/tools/cudaq-quake/cudaq-quake.cpp
+++ b/tools/cudaq-quake/cudaq-quake.cpp
@@ -431,17 +431,18 @@ int main(int argc, char **argv) {
       moduleOp->setAttr(mangledKernelNameMapAttrName, mapAttr);
     }
 
-    // Running a basic pass so that the verifiers will run, and it will be
-    // easier to track down errors. Previously the only hint that something was
-    // awry was ugly MLIR being emitted. Probably a way to just run the
-    // verifiers, but seems like there is no harm in running CSE.
+    // Running the verifier to make it easier to track down errors.
     mlir::PassManager pm(&context);
     pm.addPass(std::make_unique<cudaq::VerifierPass>());
     if (failed(pm.run(moduleOp))) {
       moduleOp->dump();
       llvm::errs() << "Passes failed!\n";
     } else {
-      out.os() << moduleOp << "\n";
+      mlir::OpPrintingFlags opf;
+      opf.enableDebugInfo(/*enable=*/true,
+                          /*pretty=*/false);
+      moduleOp.print(out.os(), opf);
+      out.os() << '\n';
       out.keep();
     }
   }


### PR DESCRIPTION
Enable line info in cudaq-quake. Allows the original C++ source lines to be passed to later stages.  Do not use pretty format, causes roundtrip issues.
