### PR TITLE
[pass] Add a loop normalization pass.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -147,16 +147,27 @@ def LambdaLifting : Pass<"lambda-lifting", "mlir::ModuleOp"> {
   let constructor = "cudaq::opt::createLambdaLiftingPass()";
 }
 
+def LoopNormalize : Pass<"cc-loop-normalize"> {
+  let summary = "Normalize classical compute (C++) loops.";
+  let description = [{
+    Transform a monotonic loop with constant step (slope) into an invariant loop
+    or, if the bounds are constant, a simple counted loop.
+  }];
+
+  let dependentDialects = ["mlir::arith::ArithDialect"];
+}
+
 def LoopUnroll : Pass<"cc-loop-unroll"> {
   let summary = "Unroll classical compute (C++) loops.";
   let description = [{
     If a cc.loop op is a simple, constant counted loop, it can be fully
     unrolled into <i>n</i> copies of the body of the loop.
 
-    The full-unroll option controls whether not being able to unroll all loops
-    is a pass failure. This is necessary when synthesizing/compiling kernels
-    that will be converted to QIR base profile: we need to guarantee that all
-    loops have been unrolled.
+    The signal-failure option controls whether not being able to unroll all
+    loops should be handled as a pass failure. This is necessary when
+    synthesizing quantum circuits from CUDA Quantum kernels, such as when
+    generating a QIR base profile. A quantum circuit requires all loops be
+    completely unrolled.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect",
@@ -165,8 +176,8 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
   let options = [
     Option<"threshold", "maximum-iterations", "std::size_t",
       /*default=*/"50", "Maximum iterations to unroll.">,
-    Option<"full_unroll", "full-unroll", "bool", /*default=*/"false",
-           "Pass will fail if it can't unroll all loops.">
+    Option<"signalFailure", "signal-failure", "bool", /*default=*/"false",
+           "Signal failure if pass can't unroll all loops.">
   ];
 }
 

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -163,10 +163,11 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
     If a cc.loop op is a simple, constant counted loop, it can be fully
     unrolled into <i>n</i> copies of the body of the loop.
 
-    The signal-failure option controls whether to signal a failure if all loops
-    cannot be fully unrolled. This is necessary when synthesizing quantum
-    circuits from CUDA Quantum kernels, such as when generating a QIR base
-    profile. A quantum circuit requires all loops be completely unrolled.
+    The signal-failure-if-any-loop-cannot-be-completely-unrolled option controls
+    whether to signal a failure if all loops cannot be fully unrolled. This is
+    necessary when synthesizing quantum circuits from CUDA Quantum kernels, such
+    as when generating a QIR base profile. A quantum circuit requires all loops
+    be completely unrolled.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect",
@@ -175,8 +176,9 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
   let options = [
     Option<"threshold", "maximum-iterations", "std::size_t",
       /*default=*/"50", "Maximum iterations to unroll.">,
-    Option<"signalFailure", "signal-failure", "bool", /*default=*/"false",
-           "Signal failure if pass can't unroll all loops.">
+    Option<"signalFailure",
+      "signal-failure-if-any-loop-cannot-be-completely-unrolled", "bool",
+      /*default=*/"false", "Signal failure if pass can't unroll all loops.">
   ];
 }
 

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -163,11 +163,10 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
     If a cc.loop op is a simple, constant counted loop, it can be fully
     unrolled into <i>n</i> copies of the body of the loop.
 
-    The signal-failure option controls whether not being able to unroll all
-    loops should be handled as a pass failure. This is necessary when
-    synthesizing quantum circuits from CUDA Quantum kernels, such as when
-    generating a QIR base profile. A quantum circuit requires all loops be
-    completely unrolled.
+    The signal-failure option controls whether to signal a failure if all loops
+    cannot be fully unrolled. This is necessary when synthesizing quantum
+    circuits from CUDA Quantum kernels, such as when generating a QIR base
+    profile. A quantum circuit requires all loops be completely unrolled.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect",

--- a/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -444,10 +444,7 @@ public:
       iters = builder.create<arith::AddIOp>(loc, iters, adj);
     }
     iters = builder.create<arith::AddIOp>(loc, iters, newStepVal);
-    if (cudaq::opt::isUnsignedPredicate(pred))
-      iters = builder.create<arith::DivUIOp>(loc, iters, newStepVal);
-    else
-      iters = builder.create<arith::DivSIOp>(loc, iters, newStepVal);
+    iters = builder.create<arith::DivSIOp>(loc, iters, newStepVal);
     Value noLoopCond = builder.create<arith::CmpIOp>(
         loc, arith::CmpIPredicate::sgt, iters, zero);
     iters = builder.create<arith::SelectOp>(loc, iters.getType(), noLoopCond,

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ add_cudaq_library(OptTransforms
   GenDeviceCodeLoader.cpp
   LambdaLifting.cpp
   LoopAnalysis.cpp
+  LoopNormalize.cpp
   LoopUnroll.cpp
   LowerToCFG.cpp
   LowerUnwind.cpp

--- a/lib/Optimizer/Transforms/LoopAnalysis.cpp
+++ b/lib/Optimizer/Transforms/LoopAnalysis.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "LoopAnalysis.h"
+#include "mlir/IR/Dominance.h"
 
 using namespace mlir;
 
@@ -68,7 +69,46 @@ static bool validCountedLoopIntervalForm(arith::CmpIOp cmp,
          (allowClosedInterval && isClosedIntervalForm(p));
 }
 
+// If the value, v, dominates the loop then it is invariant by definition. Block
+// arguments that are, in fact, a threaded invariant value should have been
+// converted to their dominating definition by the canonicalization pass.
+static bool isLoopInvariant(ArrayRef<Value> vs, cudaq::cc::LoopOp loop) {
+  DominanceInfo dom(loop->getParentOfType<func::FuncOp>());
+  for (auto v : vs)
+    if (!dom.dominates(v, loop.getOperation()))
+      return false;
+  return true;
+}
+
+/// Returns a pair `(true, stepValue)` if and only if the operation, \p op, is
+/// an induction computation (integer add or subtract). Otherwise returns
+/// `(false, null)`.
+static std::pair<bool, Value> isInductionOn(unsigned offset, Operation *op,
+                                            ArrayRef<BlockArgument> args) {
+  if (auto addOp = dyn_cast_or_null<arith::AddIOp>(op)) {
+    if (addOp.getLhs() == args[offset])
+      return {true, addOp.getRhs()};
+    if (addOp.getRhs() == args[offset])
+      return {true, addOp.getLhs()};
+  } else if (auto subOp = dyn_cast_or_null<arith::SubIOp>(op)) {
+    if (subOp.getLhs() == args[offset])
+      return {true, subOp.getRhs()};
+  }
+  return {false, Value{}};
+}
+
 namespace cudaq {
+
+bool opt::isSemiOpenPredicate(arith::CmpIPredicate p) {
+  return p == arith::CmpIPredicate::ult || p == arith::CmpIPredicate::slt ||
+         p == arith::CmpIPredicate::ugt || p == arith::CmpIPredicate::sgt ||
+         p == arith::CmpIPredicate::ne;
+}
+
+bool opt::isUnsignedPredicate(arith::CmpIPredicate p) {
+  return p == arith::CmpIPredicate::ult || p == arith::CmpIPredicate::ule ||
+         p == arith::CmpIPredicate::ugt || p == arith::CmpIPredicate::uge;
+}
 
 // We expect the loop control value to have the following form.
 //
@@ -91,36 +131,18 @@ namespace cudaq {
 // the value of `%bound` or `%step`. Those values are invariant if there are
 // no side-effects in the loop Op (no store or call operations) and these values
 // do not depend on a block argument.
-// FIXME: assumes only the LCV is passed as a Value.
-bool opt::hasMonotonicControlInduction(cc::LoopOp loop) {
+bool opt::hasMonotonicControlInduction(cc::LoopOp loop, LoopComponents *lcp) {
   if (loop.getInitialArgs().empty() || loop.getResults().empty())
     return false;
-  auto &whileBlock = loop.getWhileRegion().back();
-  auto condition = dyn_cast<cc::ConditionOp>(whileBlock.back());
-  if (!condition || whileBlock.getArguments()[0] != condition.getResults()[0])
-    return false;
-  auto *cmpOp = condition.getCondition().getDefiningOp();
-  if (std::find(cmpOp->getOperands().begin(), cmpOp->getOperands().end(),
-                whileBlock.getArguments()[0]) == cmpOp->getOperands().end())
-    return false;
-  auto &bodyBlock = loop.getBodyRegion().back();
-  auto bodyTermOp = dyn_cast<cc::ContinueOp>(bodyBlock.back());
-  if (!bodyTermOp || (bodyBlock.getArguments()[0] != bodyTermOp.getOperand(0)))
-    return false;
-  auto &stepBlock = loop.getStepRegion().back();
-  auto backedgeOp = dyn_cast<cc::ContinueOp>(stepBlock.back());
-  if (!backedgeOp)
-    return false;
-  auto *mutateOp = backedgeOp.getOperand(0).getDefiningOp();
-  if (!isa<arith::AddIOp, arith::SubIOp>(mutateOp) ||
-      std::find(mutateOp->getOperands().begin(), mutateOp->getOperands().end(),
-                stepBlock.getArguments()[0]) == mutateOp->getOperands().end())
-    return false;
-  // FIXME: should verify %bound, %step are loop invariant.
-  return true;
+  if (auto c = getLoopComponents(loop)) {
+    if (lcp)
+      *lcp = *c;
+    return isLoopInvariant({c->compareValue, c->stepValue}, loop);
+  }
+  return false;
 }
 
-bool opt::isaMonotonicLoop(Operation *op) {
+bool opt::isaMonotonicLoop(Operation *op, LoopComponents *lcp) {
   if (auto loopOp = dyn_cast_or_null<cc::LoopOp>(op)) {
     // Cannot be a `while` or `do while` loop.
     if (loopOp.isPostConditional() || !loopOp.hasStep())
@@ -131,23 +153,35 @@ bool opt::isaMonotonicLoop(Operation *op) {
     // This is in keeping with our definition of structured control flow.
     return !reg.empty() && reg.hasOneBlock() &&
            isa<cc::ContinueOp>(reg.front().getTerminator()) &&
-           hasMonotonicControlInduction(loopOp);
+           hasMonotonicControlInduction(loopOp, lcp);
+  }
+  return false;
+}
+
+bool opt::isaInvariantLoop(const LoopComponents &c, bool allowClosedInterval) {
+  if (isaConstantOf(c.initialValue, 0) && isaConstantOf(c.stepValue, 1) &&
+      isa<arith::AddIOp>(c.stepOp)) {
+    auto cmp = cast<arith::CmpIOp>(c.compareOp);
+    return validCountedLoopIntervalForm(cmp, allowClosedInterval);
+  }
+  return false;
+}
+
+bool opt::isaInvariantLoop(cc::LoopOp loop, bool allowClosedInterval,
+                           LoopComponents *lcp) {
+  LoopComponents c;
+  if (isaMonotonicLoop(loop.getOperation(), &c)) {
+    if (lcp)
+      *lcp = c;
+    return isaInvariantLoop(c, allowClosedInterval);
   }
   return false;
 }
 
 bool opt::isaCountedLoop(cc::LoopOp loop, bool allowClosedInterval) {
-  if (isaMonotonicLoop(loop.getOperation())) {
-    if (auto components = getLoopComponents(loop)) {
-      auto &c = *components;
-      if (isaConstantOf(c.initialValue, 0) && isaConstant(c.compareValue) &&
-          isaConstantOf(c.stepValue, 1) && isa<arith::AddIOp>(c.stepOp)) {
-        auto cmp = cast<arith::CmpIOp>(c.compareOp);
-        return validCountedLoopIntervalForm(cmp, allowClosedInterval);
-      }
-    }
-  }
-  return false;
+  LoopComponents c;
+  return isaInvariantLoop(loop, allowClosedInterval, &c) &&
+         isaConstant(c.compareValue);
 }
 
 bool opt::LoopComponents::stepIsAnAddOp() { return isa<arith::AddIOp>(stepOp); }
@@ -162,20 +196,6 @@ bool opt::LoopComponents::shouldCommuteStepOp() {
 bool opt::LoopComponents::isClosedIntervalForm() {
   auto cmp = cast<arith::CmpIOp>(compareOp);
   return ::isClosedIntervalForm(cmp.getPredicate());
-}
-
-static std::pair<bool, Value> isInductionOn(unsigned offset, Operation *op,
-                                            ArrayRef<BlockArgument> args) {
-  if (auto addOp = dyn_cast_or_null<arith::AddIOp>(op)) {
-    if (addOp.getLhs() == args[offset])
-      return {true, addOp.getRhs()};
-    if (addOp.getRhs() == args[offset])
-      return {true, addOp.getLhs()};
-  } else if (auto subOp = dyn_cast_or_null<arith::SubIOp>(op)) {
-    if (subOp.getLhs() == args[offset])
-      return {true, subOp.getRhs()};
-  }
-  return {false, Value{}};
 }
 
 std::optional<opt::LoopComponents> opt::getLoopComponents(cc::LoopOp loop) {
@@ -232,6 +252,17 @@ std::optional<opt::LoopComponents> opt::getLoopComponents(cc::LoopOp loop) {
     return {};
 
   result.initialValue = loop.getInitialArgs()[result.induction];
+
+  // TODO: The comparison operation requires that the induction value appear
+  // explicitly on one side of the comparison. That is, it is required that the
+  // comparison look like `i < exp` where `i` is the induction value. This could
+  // be relaxed to allow invariant expressions on each side, such as, `i + 1 <
+  // exp`. This relaxation to invariant expressions would require some
+  // transformations to normalize the comparison operation. Taking the example,
+  // this would transform to `i < exp - 1`.
+  // A second possible extension is to detect \em{conditionally iterated} loops
+  // and open those up to further analysis and transformations such as loop
+  // unrolling.
   if (cmpOp.getLhs() ==
       loop.getWhileRegion().front().getArgument(result.induction))
     result.compareValue = cmpOp.getRhs();

--- a/lib/Optimizer/Transforms/LoopNormalize.cpp
+++ b/lib/Optimizer/Transforms/LoopNormalize.cpp
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "LoopAnalysis.h"
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_LOOPNORMALIZE
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "cc-loop-normalize"
+
+using namespace mlir;
+
+namespace {
+class LoopPat : public OpRewritePattern<cudaq::cc::LoopOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::cc::LoopOp loop,
+                                PatternRewriter &rewriter) const override {
+    // loop is monotonic but not invariant.
+    LLVM_DEBUG(llvm::dbgs() << "loop before normalization: " << loop << '\n');
+    auto componentsOpt = cudaq::opt::getLoopComponents(loop);
+    assert(componentsOpt && "loop must have components");
+    auto c = *componentsOpt;
+    auto loc = loop.getLoc();
+
+    // 1) Set initial value to 0.
+    auto ty = c.initialValue.getType();
+    rewriter.startRootUpdate(loop);
+    auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, ty);
+    loop->setOperand(c.induction, zero);
+
+    // 2) Compute the number of iterations as an invariant. `iterations = max(0,
+    // (upper - lower + step) / step)`.
+    Value upper = c.compareValue;
+    auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, ty);
+    Value step = c.stepValue;
+    if (!c.stepIsAnAddOp())
+      step = rewriter.create<arith::SubIOp>(loc, zero, step);
+    if (!c.isClosedIntervalForm()) {
+      // Note: treating the step as a signed value to process countdown loops as
+      // well as countup loops.
+      Value negStepCond = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::slt, step, zero);
+      auto negOne = rewriter.create<arith::ConstantIntOp>(loc, -1, ty);
+      Value adj =
+          rewriter.create<arith::SelectOp>(loc, ty, negStepCond, negOne, one);
+      upper = rewriter.create<arith::SubIOp>(loc, upper, adj);
+    }
+    Value diff = rewriter.create<arith::SubIOp>(loc, upper, c.initialValue);
+    Value disp = rewriter.create<arith::AddIOp>(loc, diff, step);
+    auto cmpOp = cast<arith::CmpIOp>(c.compareOp);
+    auto isUnsignedPred = cudaq::opt::isUnsignedPredicate(cmpOp.getPredicate());
+    auto up1 = [&]() -> Value {
+      if (isUnsignedPred)
+        return rewriter.create<arith::DivUIOp>(loc, disp, step);
+      return rewriter.create<arith::DivSIOp>(loc, disp, step);
+    }();
+    Value noLoopCond = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::sgt, up1, zero);
+    Value newUpper =
+        rewriter.create<arith::SelectOp>(loc, ty, noLoopCond, up1, zero);
+
+    // 3) Rewrite the comparison (!=) and step operations (+1).
+    Value v1 =
+        cmpOp.getLhs() == c.compareValue ? cmpOp.getRhs() : cmpOp.getLhs();
+    rewriter.setInsertionPoint(cmpOp);
+    Value newCmp = rewriter.create<arith::CmpIOp>(
+        cmpOp.getLoc(), arith::CmpIPredicate::ne, v1, newUpper);
+    cmpOp->replaceAllUsesWith(ValueRange{newCmp});
+    auto v2 = c.stepOp->getOperand(
+        c.stepIsAnAddOp() && c.shouldCommuteStepOp() ? 1 : 0);
+    rewriter.setInsertionPoint(c.stepOp);
+    Value newStep = rewriter.create<arith::AddIOp>(c.stepOp->getLoc(), v2, one);
+    c.stepOp->replaceAllUsesWith(ValueRange{newStep});
+
+    // 4) Compute original induction value as a loop variant and replace the
+    // uses. `lower + step * i`. Careful to not replace the new induction.
+    if (!loop.getBodyRegion().empty()) {
+      Block *entry = &loop.getBodyRegion().front();
+      rewriter.setInsertionPointToStart(entry);
+      Value induct = entry->getArgument(c.induction);
+      auto mul = rewriter.create<arith::MulIOp>(loc, induct, c.stepValue);
+      Value newInd = rewriter.create<arith::AddIOp>(loc, mul, c.initialValue);
+      induct.replaceUsesWithIf(newInd, [&](OpOperand &opnd) {
+        auto *op = opnd.getOwner();
+        return op != mul && !isa<cudaq::cc::ContinueOp>(op);
+      });
+    }
+
+    rewriter.finalizeRootUpdate(loop);
+    LLVM_DEBUG(llvm::dbgs() << "loop after normalization: " << loop << '\n');
+    return success();
+  }
+};
+
+class LoopNormalizePass
+    : public cudaq::opt::impl::LoopNormalizeBase<LoopNormalizePass> {
+public:
+  using LoopNormalizeBase::LoopNormalizeBase;
+
+  void runOnOperation() override {
+    auto *op = getOperation();
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<LoopPat>(ctx);
+    ConversionTarget target(*ctx);
+    target.addDynamicallyLegalOp<cudaq::cc::LoopOp>(
+        [&](cudaq::cc::LoopOp loop) {
+          cudaq::opt::LoopComponents c;
+          return !cudaq::opt::isaMonotonicLoop(loop, &c) ||
+                 cudaq::opt::isaInvariantLoop(c, /*allowClosedInterval=*/true);
+        });
+    target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+    if (failed(applyPartialConversion(op, target, std::move(patterns)))) {
+      op->emitOpError("could not normalize loop");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace

--- a/lib/Optimizer/Transforms/LoopNormalize.cpp
+++ b/lib/Optimizer/Transforms/LoopNormalize.cpp
@@ -63,12 +63,7 @@ public:
     Value diff = rewriter.create<arith::SubIOp>(loc, upper, c.initialValue);
     Value disp = rewriter.create<arith::AddIOp>(loc, diff, step);
     auto cmpOp = cast<arith::CmpIOp>(c.compareOp);
-    auto isUnsignedPred = cudaq::opt::isUnsignedPredicate(cmpOp.getPredicate());
-    auto up1 = [&]() -> Value {
-      if (isUnsignedPred)
-        return rewriter.create<arith::DivUIOp>(loc, disp, step);
-      return rewriter.create<arith::DivSIOp>(loc, disp, step);
-    }();
+    Value up1 = rewriter.create<arith::DivSIOp>(loc, disp, step);
     Value noLoopCond = rewriter.create<arith::CmpIOp>(
         loc, arith::CmpIPredicate::sgt, up1, zero);
     Value newUpper =

--- a/lib/Optimizer/Transforms/LoopUnroll.cpp
+++ b/lib/Optimizer/Transforms/LoopUnroll.cpp
@@ -67,6 +67,10 @@ struct UnrollCountedLoop : public OpRewritePattern<cudaq::cc::LoopOp> {
 
   LogicalResult matchAndRewrite(cudaq::cc::LoopOp loop,
                                 PatternRewriter &rewriter) const override {
+    // When the signalFailure flag is set, all loops are matched since that flag
+    // requires that all LoopOp operations be rewritten. Despite the setting of
+    // this flag, it may not be possible to fully unroll every LoopOp anyway.
+    // Check for cases that are clearly not going to be unrolled.
     if (!cudaq::opt::isaCountedLoop(loop))
       return loop.emitOpError("not a simple counted loop");
     if (exceedsThresholdValue(loop, threshold))

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
@@ -16,7 +16,7 @@ GEN_TARGET_BACKEND=true
 LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline, here we lower to Base QIR
-PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,cc-loop-unroll{full-unroll=true},canonicalize,func.func(lower-to-cfg),canonicalize,quantinuum-gate-set-mapping"
+PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,cc-loop-unroll{signal-failure=true},canonicalize,func.func(lower-to-cfg),canonicalize,quantinuum-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 CODEGEN_EMISSION=qir

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
@@ -16,7 +16,7 @@ GEN_TARGET_BACKEND=true
 LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline, here we lower to Base QIR
-PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,cc-loop-unroll{signal-failure=true},canonicalize,func.func(lower-to-cfg),canonicalize,quantinuum-gate-set-mapping"
+PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,cc-loop-unroll{signal-failure-if-any-loop-cannot-be-completely-unrolled=true},canonicalize,func.func(lower-to-cfg),canonicalize,quantinuum-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 CODEGEN_EMISSION=qir

--- a/test/AST-Quake/adjoint-2.cpp
+++ b/test/AST-Quake/adjoint-2.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: cudaq-quake %s | cudaq-opt --memtoreg=quantum=0 --apply-op-specialization --canonicalize | FileCheck %s
+// RUN: cudaq-quake %s | cudaq-opt --memtoreg=quantum=0 --canonicalize --apply-op-specialization --canonicalize | FileCheck %s
 
 #include <cudaq.h>
 

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // RUN: cudaq-quake %s | FileCheck %s
-// RUN: cudaq-quake %s | cudaq-opt --memtoreg=quantum=0 --apply-op-specialization | FileCheck --check-prefixes=ADJOINT %s
+// RUN: cudaq-quake %s | cudaq-opt --memtoreg=quantum=0 --canonicalize --apply-op-specialization | FileCheck --check-prefixes=ADJOINT %s
 
 #include <cudaq.h>
 
@@ -89,121 +89,109 @@ struct run_circuit {
   }
 };
 
-// ADJOINT-LABEL:   func.func private @__nvqpp__mlirgen__statePrep_A
-// ADJOINT-SAME:        .adj(%[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: f64) {
-// ADJOINT:           %[[VAL_3:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
-// ADJOINT:           %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : i64 to i32
-// ADJOINT:           %[[VAL_6:.*]] = arith.constant 1 : i32
-// ADJOINT:           %[[VAL_7:.*]] = arith.subi %[[VAL_4]], %[[VAL_6]] : i32
-// ADJOINT:           %[[VAL_8:.*]] = arith.extsi %[[VAL_7]] : i32 to i64
-// ADJOINT:           %[[VAL_9:.*]] = arith.constant 0 : i64
-// ADJOINT:           %[[VAL_10:.*]] = arith.constant 1 : i64
-// ADJOINT:           %[[VAL_11:.*]] = arith.subi %[[VAL_8]], %[[VAL_10]] : i64
-// ADJOINT:           %[[VAL_12:.*]] = quake.subvec %[[VAL_0]], %[[VAL_9]], %[[VAL_11]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
-// ADJOINT:           %[[VAL_13:.*]] = quake.vec_size %[[VAL_12]] : (!quake.veq<?>) -> i64
-// ADJOINT:           %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : i64 to index
-// ADJOINT:           %[[VAL_15:.*]] = arith.constant 0 : index
-// ADJOINT:           %[[VAL_16:.*]] = arith.constant 1 : index
-// ADJOINT:           %[[VAL_17:.*]] = arith.constant 2.000000e+00 : f64
-// ADJOINT:           %[[VAL_18:.*]] = arith.constant 1 : i32
-// ADJOINT:           %[[VAL_19:.*]] = arith.subi %[[VAL_4]], %[[VAL_18]] : i32
-// ADJOINT:           %[[VAL_20:.*]] = arith.sitofp %[[VAL_19]] : i32 to f64
-// ADJOINT:           %[[VAL_21:.*]] = math.powf %[[VAL_17]], %[[VAL_20]] : f64
-// ADJOINT:           %[[VAL_22:.*]] = arith.divf %[[VAL_1]], %[[VAL_21]] : f64
-// ADJOINT:           %[[VAL_23:.*]] = arith.constant 1 : i32
-// ADJOINT:           %[[VAL_24:.*]] = arith.subi %[[VAL_4]], %[[VAL_23]] : i32
-// ADJOINT:           %[[VAL_25:.*]] = arith.extsi %[[VAL_24]] : i32 to i64
-// ADJOINT:           %[[VAL_26:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_25]]] : (!quake.veq<?>, i64) -> !quake.ref
-// ADJOINT:           %[[VAL_27:.*]]:2 = cc.scope -> (i32, f64) {
-// ADJOINT:             %[[VAL_28:.*]] = arith.constant 1 : i32
-// ADJOINT:             %[[VAL_29:.*]] = cc.undef i32
-// ADJOINT:             %[[VAL_30:.*]] = arith.constant 1 : i32
-// ADJOINT:             %[[VAL_31:.*]] = arith.constant 0 : i32
-// ADJOINT:             %[[VAL_32:.*]] = arith.subi %[[VAL_4]], %[[VAL_28]] : i32
-// ADJOINT:             %[[VAL_33:.*]] = arith.constant 1 : i32
-// ADJOINT:             %[[VAL_34:.*]] = arith.cmpi slt, %[[VAL_30]], %[[VAL_31]] : i32
-// ADJOINT:             %[[VAL_35:.*]] = arith.constant -1 : i32
-// ADJOINT:             %[[VAL_36:.*]] = arith.select %[[VAL_34]], %[[VAL_33]], %[[VAL_35]] : i32
-// ADJOINT:             %[[VAL_37:.*]] = arith.addi %[[VAL_32]], %[[VAL_36]] : i32
-// ADJOINT:             %[[VAL_38:.*]] = arith.addi %[[VAL_37]], %[[VAL_30]] : i32
-// ADJOINT:             %[[VAL_39:.*]] = arith.cmpi sgt, %[[VAL_38]], %[[VAL_31]] : i32
-// ADJOINT:             %[[VAL_40:.*]] = arith.select %[[VAL_39]], %[[VAL_38]], %[[VAL_31]] : i32
-// ADJOINT:             %[[VAL_41:.*]] = arith.subi %[[VAL_40]], %[[VAL_33]] : i32
-// ADJOINT:             %[[VAL_42:.*]] = arith.addi %[[VAL_28]], %[[VAL_41]] : i32
-// ADJOINT:             %[[VAL_43:.*]] = arith.constant 0 : i32
-// ADJOINT:             %[[VAL_44:.*]]:4 = cc.loop while ((%[[VAL_45:.*]] = %[[VAL_42]], %[[VAL_46:.*]] = %[[VAL_4]], %[[VAL_47:.*]] = %[[VAL_1]], %[[VAL_48:.*]] = %[[VAL_40]]) -> (i32, i32, f64, i32)) {
-// ADJOINT:               %[[VAL_49:.*]] = arith.cmpi slt, %[[VAL_45]], %[[VAL_46]] : i32
-// ADJOINT:               %[[VAL_50:.*]] = arith.cmpi sgt, %[[VAL_48]], %[[VAL_43]] : i32
-// ADJOINT:               cc.condition %[[VAL_50]](%[[VAL_45]], %[[VAL_46]], %[[VAL_47]], %[[VAL_48]] : i32, i32, f64, i32)
-// ADJOINT:             } do {
-// ADJOINT:             ^bb0(%[[VAL_51:.*]]: i32, %[[VAL_52:.*]]: i32, %[[VAL_53:.*]]: f64, %[[VAL_54:.*]]: i32):
-// ADJOINT:               cc.scope {
-// ADJOINT:                 %[[VAL_55:.*]] = arith.constant 2.000000e+00 : f64
-// ADJOINT:                 %[[VAL_56:.*]] = arith.subi %[[VAL_52]], %[[VAL_51]] : i32
-// ADJOINT:                 %[[VAL_57:.*]] = arith.constant 1 : i32
-// ADJOINT:                 %[[VAL_58:.*]] = arith.subi %[[VAL_56]], %[[VAL_57]] : i32
-// ADJOINT:                 %[[VAL_59:.*]] = arith.sitofp %[[VAL_58]] : i32 to f64
-// ADJOINT:                 %[[VAL_60:.*]] = math.powf %[[VAL_55]], %[[VAL_59]] : f64
-// ADJOINT:                 %[[VAL_61:.*]] = arith.divf %[[VAL_53]], %[[VAL_60]] : f64
-// ADJOINT:                 %[[VAL_62:.*]] = arith.constant 1 : i32
-// ADJOINT:                 %[[VAL_63:.*]] = arith.subi %[[VAL_51]], %[[VAL_62]] : i32
-// ADJOINT:                 %[[VAL_64:.*]] = arith.extsi %[[VAL_63]] : i32 to i64
-// ADJOINT:                 %[[VAL_65:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_64]]] : (!quake.veq<?>, i64) -> !quake.ref
-// ADJOINT:                 %[[VAL_66:.*]] = arith.constant 1 : i32
-// ADJOINT:                 %[[VAL_67:.*]] = arith.subi %[[VAL_52]], %[[VAL_66]] : i32
-// ADJOINT:                 %[[VAL_68:.*]] = arith.extsi %[[VAL_67]] : i32 to i64
-// ADJOINT:                 %[[VAL_69:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_68]]] : (!quake.veq<?>, i64) -> !quake.ref
-// ADJOINT:                 %[[VAL_70:.*]] = arith.negf %[[VAL_61]] : f64
-// ADJOINT:                 quake.ry (%[[VAL_70]]) {{\[}}%[[VAL_65]]] %[[VAL_69]] : (f64, !quake.ref, !quake.ref) -> ()
-// ADJOINT:               }
-// ADJOINT:               cc.continue %[[VAL_51]], %[[VAL_52]], %[[VAL_53]], %[[VAL_54]] : i32, i32, f64, i32
-// ADJOINT:             } step {
-// ADJOINT:             ^bb0(%[[VAL_71:.*]]: i32, %[[VAL_72:.*]]: i32, %[[VAL_73:.*]]: f64, %[[VAL_74:.*]]: i32):
-// ADJOINT:               %[[VAL_75:.*]] = arith.constant 1 : i32
-// ADJOINT:               %[[VAL_76:.*]] = arith.addi %[[VAL_71]], %[[VAL_75]] : i32
-// ADJOINT:               %[[VAL_77:.*]] = arith.subi %[[VAL_71]], %[[VAL_75]] : i32
-// ADJOINT:               %[[VAL_78:.*]] = arith.constant 1 : i32
-// ADJOINT:               %[[VAL_79:.*]] = arith.subi %[[VAL_74]], %[[VAL_78]] : i32
-// ADJOINT:               cc.continue %[[VAL_77]], %[[VAL_72]], %[[VAL_73]], %[[VAL_79]] : i32, i32, f64, i32
-// ADJOINT:             }
-// ADJOINT:             cc.continue %[[VAL_80:.*]]#1, %[[VAL_80]]#2 : i32, f64
-// ADJOINT:           }
-// ADJOINT:           %[[VAL_81:.*]] = arith.negf %[[VAL_22]] : f64
-// ADJOINT:           quake.ry (%[[VAL_81]]) %[[VAL_26]] : (f64, !quake.ref) -> ()
-// ADJOINT:           %[[VAL_82:.*]] = arith.constant 0 : index
-// ADJOINT:           %[[VAL_83:.*]] = arith.constant 1 : index
-// ADJOINT:           %[[VAL_84:.*]] = arith.cmpi slt, %[[VAL_16]], %[[VAL_82]] : index
-// ADJOINT:           %[[VAL_85:.*]] = arith.constant -1 : index
-// ADJOINT:           %[[VAL_86:.*]] = arith.select %[[VAL_84]], %[[VAL_83]], %[[VAL_85]] : index
-// ADJOINT:           %[[VAL_87:.*]] = arith.addi %[[VAL_14]], %[[VAL_86]] : index
-// ADJOINT:           %[[VAL_88:.*]] = arith.addi %[[VAL_87]], %[[VAL_16]] : index
-// ADJOINT:           %[[VAL_89:.*]] = arith.cmpi sgt, %[[VAL_88]], %[[VAL_82]] : index
-// ADJOINT:           %[[VAL_90:.*]] = arith.select %[[VAL_89]], %[[VAL_88]], %[[VAL_82]] : index
-// ADJOINT:           %[[VAL_91:.*]] = arith.subi %[[VAL_90]], %[[VAL_83]] : index
-// ADJOINT:           %[[VAL_92:.*]] = arith.addi %[[VAL_15]], %[[VAL_91]] : index
-// ADJOINT:           %[[VAL_93:.*]] = arith.constant 0 : index
-// ADJOINT:           %[[VAL_94:.*]]:2 = cc.loop while ((%[[VAL_95:.*]] = %[[VAL_92]], %[[VAL_96:.*]] = %[[VAL_90]]) -> (index, index)) {
-// ADJOINT:             %[[VAL_97:.*]] = arith.cmpi slt, %[[VAL_95]], %[[VAL_14]] : index
-// ADJOINT:             %[[VAL_98:.*]] = arith.cmpi sgt, %[[VAL_96]], %[[VAL_93]] : index
-// ADJOINT:             cc.condition %[[VAL_98]](%[[VAL_95]], %[[VAL_96]] : index, index)
+// ADJOINT-LABEL:   func.func private @__nvqpp__mlirgen__statePrep_A.adj(
+// ADJOINT-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: f64) {
+// ADJOINT-DAG:       %[[VAL_2:.*]] = arith.constant 2.000000e+00 : f64
+// ADJOINT-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// ADJOINT-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
+// ADJOINT-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i64
+// ADJOINT-DAG:       %[[VAL_6:.*]] = arith.constant 0 : i64
+// ADJOINT-DAG:       %[[VAL_7:.*]] = arith.constant 1 : i32
+// ADJOINT:           %[[VAL_8:.*]] = quake.vec_size %[[VAL_0]] : (!quake.veq<?>) -> i64
+// ADJOINT:           %[[VAL_9:.*]] = arith.trunci %[[VAL_8]] : i64 to i32
+// ADJOINT:           %[[VAL_10:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
+// ADJOINT:           %[[VAL_11:.*]] = arith.extsi %[[VAL_10]] : i32 to i64
+// ADJOINT:           %[[VAL_12:.*]] = arith.subi %[[VAL_11]], %[[VAL_5]] : i64
+// ADJOINT:           %[[VAL_13:.*]] = quake.subvec %[[VAL_0]], %[[VAL_6]], %[[VAL_12]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+// ADJOINT:           %[[VAL_14:.*]] = quake.vec_size %[[VAL_13]] : (!quake.veq<?>) -> i64
+// ADJOINT:           %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i64 to index
+// ADJOINT:           %[[VAL_16:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
+// ADJOINT:           %[[VAL_17:.*]] = arith.sitofp %[[VAL_16]] : i32 to f64
+// ADJOINT:           %[[VAL_18:.*]] = math.powf %[[VAL_2]], %[[VAL_17]] : f64
+// ADJOINT:           %[[VAL_19:.*]] = arith.divf %[[VAL_1]], %[[VAL_18]] : f64
+// ADJOINT:           %[[VAL_20:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
+// ADJOINT:           %[[VAL_21:.*]] = arith.extsi %[[VAL_20]] : i32 to i64
+// ADJOINT:           %[[VAL_22:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_21]]] : (!quake.veq<?>, i64) -> !quake.ref
+// ADJOINT:           %[[VAL_23:.*]] = arith.constant 0 : i32
+// ADJOINT:           %[[VAL_24:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
+// ADJOINT:           %[[VAL_25:.*]] = arith.constant 1 : i32
+// ADJOINT:           %[[VAL_26:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_23]] : i32
+// ADJOINT:           %[[VAL_27:.*]] = arith.constant -1 : i32
+// ADJOINT:           %[[VAL_28:.*]] = arith.select %[[VAL_26]], %[[VAL_25]], %[[VAL_27]] : i32
+// ADJOINT:           %[[VAL_29:.*]] = arith.addi %[[VAL_24]], %[[VAL_28]] : i32
+// ADJOINT:           %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_7]] : i32
+// ADJOINT:           %[[VAL_31:.*]] = arith.cmpi sgt, %[[VAL_30]], %[[VAL_23]] : i32
+// ADJOINT:           %[[VAL_32:.*]] = arith.select %[[VAL_31]], %[[VAL_30]], %[[VAL_23]] : i32
+// ADJOINT:           %[[VAL_33:.*]] = arith.subi %[[VAL_32]], %[[VAL_25]] : i32
+// ADJOINT:           %[[VAL_34:.*]] = arith.addi %[[VAL_7]], %[[VAL_33]] : i32
+// ADJOINT:           %[[VAL_35:.*]] = arith.constant 0 : i32
+// ADJOINT:           %[[VAL_36:.*]]:4 = cc.loop while ((%[[VAL_37:.*]] = %[[VAL_34]], %[[VAL_38:.*]] = %[[VAL_9]], %[[VAL_39:.*]] = %[[VAL_1]], %[[VAL_40:.*]] = %[[VAL_32]]) -> (i32, i32, f64, i32)) {
+// ADJOINT:             %[[VAL_41:.*]] = arith.cmpi slt, %[[VAL_37]], %[[VAL_9]] : i32
+// ADJOINT:             %[[VAL_42:.*]] = arith.cmpi sgt, %[[VAL_40]], %[[VAL_35]] : i32
+// ADJOINT:             cc.condition %[[VAL_42]](%[[VAL_37]], %[[VAL_9]], %[[VAL_1]], %[[VAL_40]] : i32, i32, f64, i32)
 // ADJOINT:           } do {
-// ADJOINT:           ^bb0(%[[VAL_99:.*]]: index, %[[VAL_100:.*]]: index):
-// ADJOINT:             %[[VAL_101:.*]] = quake.extract_ref %[[VAL_12]]{{\[}}%[[VAL_99]]] : (!quake.veq<?>, index) -> !quake.ref
-// ADJOINT:             quake.h %[[VAL_101]] : (!quake.ref) -> ()
-// ADJOINT:             cc.continue %[[VAL_99]], %[[VAL_100]] : index, index
+// ADJOINT:           ^bb0(%[[VAL_43:.*]]: i32, %[[VAL_44:.*]]: i32, %[[VAL_45:.*]]: f64, %[[VAL_46:.*]]: i32):
+// ADJOINT:             %[[VAL_47:.*]] = arith.subi %[[VAL_9]], %[[VAL_43]] : i32
+// ADJOINT:             %[[VAL_48:.*]] = arith.subi %[[VAL_47]], %[[VAL_7]] : i32
+// ADJOINT:             %[[VAL_49:.*]] = arith.sitofp %[[VAL_48]] : i32 to f64
+// ADJOINT:             %[[VAL_50:.*]] = math.powf %[[VAL_2]], %[[VAL_49]] : f64
+// ADJOINT:             %[[VAL_51:.*]] = arith.divf %[[VAL_1]], %[[VAL_50]] : f64
+// ADJOINT:             %[[VAL_52:.*]] = arith.subi %[[VAL_43]], %[[VAL_7]] : i32
+// ADJOINT:             %[[VAL_53:.*]] = arith.extsi %[[VAL_52]] : i32 to i64
+// ADJOINT:             %[[VAL_54:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_53]]] : (!quake.veq<?>, i64) -> !quake.ref
+// ADJOINT:             %[[VAL_55:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
+// ADJOINT:             %[[VAL_56:.*]] = arith.extsi %[[VAL_55]] : i32 to i64
+// ADJOINT:             %[[VAL_57:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_56]]] : (!quake.veq<?>, i64) -> !quake.ref
+// ADJOINT:             %[[VAL_58:.*]] = arith.negf %[[VAL_51]] : f64
+// ADJOINT:             quake.ry (%[[VAL_58]]) {{\[}}%[[VAL_54]]] %[[VAL_57]] : (f64, !quake.ref, !quake.ref) -> ()
+// ADJOINT:             cc.continue %[[VAL_43]], %[[VAL_44]], %[[VAL_45]], %[[VAL_46]] : i32, i32, f64, i32
 // ADJOINT:           } step {
-// ADJOINT:           ^bb0(%[[VAL_102:.*]]: index, %[[VAL_103:.*]]: index):
-// ADJOINT:             %[[VAL_104:.*]] = arith.addi %[[VAL_102]], %[[VAL_16]] : index
-// ADJOINT:             %[[VAL_105:.*]] = arith.subi %[[VAL_102]], %[[VAL_16]] : index
-// ADJOINT:             %[[VAL_106:.*]] = arith.constant 1 : index
-// ADJOINT:             %[[VAL_107:.*]] = arith.subi %[[VAL_103]], %[[VAL_106]] : index
-// ADJOINT:             cc.continue %[[VAL_105]], %[[VAL_107]] : index, index
+// ADJOINT:           ^bb0(%[[VAL_59:.*]]: i32, %[[VAL_60:.*]]: i32, %[[VAL_61:.*]]: f64, %[[VAL_62:.*]]: i32):
+// ADJOINT:             %[[VAL_63:.*]] = arith.addi %[[VAL_59]], %[[VAL_7]] : i32
+// ADJOINT:             %[[VAL_64:.*]] = arith.subi %[[VAL_59]], %[[VAL_7]] : i32
+// ADJOINT:             %[[VAL_65:.*]] = arith.constant 1 : i32
+// ADJOINT:             %[[VAL_66:.*]] = arith.subi %[[VAL_62]], %[[VAL_65]] : i32
+// ADJOINT:             cc.continue %[[VAL_64]], %[[VAL_9]], %[[VAL_1]], %[[VAL_66]] : i32, i32, f64, i32
+// ADJOINT:           }
+// ADJOINT:           %[[VAL_67:.*]] = arith.negf %[[VAL_19]] : f64
+// ADJOINT:           quake.ry (%[[VAL_67]]) %[[VAL_22]] : (f64, !quake.ref) -> ()
+// ADJOINT:           %[[VAL_68:.*]] = arith.constant 0 : index
+// ADJOINT:           %[[VAL_69:.*]] = arith.constant 1 : index
+// ADJOINT:           %[[VAL_70:.*]] = arith.cmpi slt, %[[VAL_3]], %[[VAL_68]] : index
+// ADJOINT:           %[[VAL_71:.*]] = arith.constant -1 : index
+// ADJOINT:           %[[VAL_72:.*]] = arith.select %[[VAL_70]], %[[VAL_69]], %[[VAL_71]] : index
+// ADJOINT:           %[[VAL_73:.*]] = arith.addi %[[VAL_15]], %[[VAL_72]] : index
+// ADJOINT:           %[[VAL_74:.*]] = arith.addi %[[VAL_73]], %[[VAL_3]] : index
+// ADJOINT:           %[[VAL_75:.*]] = arith.cmpi sgt, %[[VAL_74]], %[[VAL_68]] : index
+// ADJOINT:           %[[VAL_76:.*]] = arith.select %[[VAL_75]], %[[VAL_74]], %[[VAL_68]] : index
+// ADJOINT:           %[[VAL_77:.*]] = arith.subi %[[VAL_76]], %[[VAL_69]] : index
+// ADJOINT:           %[[VAL_78:.*]] = arith.addi %[[VAL_4]], %[[VAL_77]] : index
+// ADJOINT:           %[[VAL_79:.*]] = arith.constant 0 : index
+// ADJOINT:           %[[VAL_80:.*]]:2 = cc.loop while ((%[[VAL_81:.*]] = %[[VAL_78]], %[[VAL_82:.*]] = %[[VAL_76]]) -> (index, index)) {
+// ADJOINT:             %[[VAL_83:.*]] = arith.cmpi slt, %[[VAL_81]], %[[VAL_15]] : index
+// ADJOINT:             %[[VAL_84:.*]] = arith.cmpi sgt, %[[VAL_82]], %[[VAL_79]] : index
+// ADJOINT:             cc.condition %[[VAL_84]](%[[VAL_81]], %[[VAL_82]] : index, index)
+// ADJOINT:           } do {
+// ADJOINT:           ^bb0(%[[VAL_85:.*]]: index, %[[VAL_86:.*]]: index):
+// ADJOINT:             %[[VAL_87:.*]] = quake.extract_ref %[[VAL_13]]{{\[}}%[[VAL_85]]] : (!quake.veq<?>, index) -> !quake.ref
+// ADJOINT:             quake.h %[[VAL_87]] : (!quake.ref) -> ()
+// ADJOINT:             cc.continue %[[VAL_85]], %[[VAL_86]] : index, index
+// ADJOINT:           } step {
+// ADJOINT:           ^bb0(%[[VAL_88:.*]]: index, %[[VAL_89:.*]]: index):
+// ADJOINT:             %[[VAL_90:.*]] = arith.addi %[[VAL_88]], %[[VAL_3]] : index
+// ADJOINT:             %[[VAL_91:.*]] = arith.subi %[[VAL_88]], %[[VAL_3]] : index
+// ADJOINT:             %[[VAL_92:.*]] = arith.constant 1 : index
+// ADJOINT:             %[[VAL_93:.*]] = arith.subi %[[VAL_89]], %[[VAL_92]] : index
+// ADJOINT:             cc.continue %[[VAL_91]], %[[VAL_93]] : index, index
 // ADJOINT:           }
 // ADJOINT:           return
 // ADJOINT:         }
 
-// ADJOINT-LABEL:   func.func @__nvqpp__mlirgen__run_circuit
-// ADJOINT:               cc.scope {
-// ADJOINT:                 quake.z %{{.*}} : (!quake.ref) -> ()
-// ADJOINT:                 func.call @__nvqpp__mlirgen__statePrep_A.adj(%{{.*}}, %{{.*}}) : (!quake.veq<?>, f64) -> ()
-// ADJOINT:                 func.call @__nvqpp__mlirgen__QernelZero{{.*}}(%{{[0-9]+}}) :
+// ADJOINT-LABEL:   func.func @__nvqpp__mlirgen__QernelZero(
+
+// ADJOINT-LABEL:   func.func @__nvqpp__mlirgen__run_circuit(
+// ADJOINT:           ^bb0(
+// ADJOINT:             quake.z %
+// ADJOINT:             func.call @__nvqpp__mlirgen__statePrep_A.adj(%
+// ADJOINT:             func.call @__nvqpp__mlirgen__QernelZero(%
+// ADJOINT:             func.call @__nvqpp__mlirgen__statePrep_A(%

--- a/test/AST-Quake/loop_normal.cpp
+++ b/test/AST-Quake/loop_normal.cpp
@@ -109,3 +109,90 @@ __qpu__ void foo4() {
 // CHECK:           ^bb0(%[[VAL_14:.*]]: i32):
 // CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_2]] : i32
 
+__qpu__ void foo5() {
+  cudaq::qubit q;
+  for (int i = 0; i < 9; i += 2)
+    x(q);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_foo5
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (i32)) {
+// CHECK:             %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_0]] : i32
+// CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : i32)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32):
+// CHECK:             quake.x %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:             cc.continue %[[VAL_7]] : i32
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i32):
+// CHECK:             %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_1]] : i32
+// CHECK:             cc.continue %[[VAL_9]] : i32
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+__qpu__ void foo6() {
+  cudaq::qubit q;
+  for (int i = -2; i < 16; i += 4)
+    x(q);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_foo6
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (i32)) {
+// CHECK:             %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_0]] : i32
+// CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : i32)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32):
+// CHECK:             quake.x %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:             cc.continue %[[VAL_7]] : i32
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i32):
+// CHECK:             %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_1]] : i32
+// CHECK:             cc.continue %[[VAL_9]] : i32
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+__qpu__ void negative1() {
+  cudaq::qubit q;
+  for (int i = 5; i < 5; i += 4)
+    x(q);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_negative1
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_3:.*]] = cc.loop while ((%[[VAL_4:.*]] = %[[VAL_0]]) -> (i32)) {
+// CHECK:             %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_4]], %[[VAL_0]] : i32
+// CHECK:             cc.condition %[[VAL_5]](%[[VAL_4]] : i32)
+
+__qpu__ void negative2() {
+  cudaq::qubit q;
+  for (int i = 5; i <= 4; i += 32)
+    x(q);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_negative2
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_3:.*]] = cc.loop while ((%[[VAL_4:.*]] = %[[VAL_0]]) -> (i32)) {
+// CHECK:             %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_4]], %[[VAL_0]] : i32
+// CHECK:             cc.condition %[[VAL_5]](%[[VAL_4]] : i32)
+
+__qpu__ void negative3() {
+  cudaq::qubit q;
+  for (int i = -10; i < -1; i += -2)
+    x(q);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_negative3
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_3:.*]] = cc.loop while ((%[[VAL_4:.*]] = %[[VAL_0]]) -> (i32)) {
+// CHECK:             %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_4]], %[[VAL_0]] : i32
+// CHECK:             cc.condition %[[VAL_5]](%[[VAL_4]] : i32)

--- a/test/AST-Quake/loop_normal.cpp
+++ b/test/AST-Quake/loop_normal.cpp
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | cudaq-opt --memtoreg=quantum=0 --canonicalize --cc-loop-normalize --canonicalize | FileCheck %s
+
+#include <cudaq.h>
+
+__qpu__ void foo1() {
+  cudaq::qubit q;
+  for (int i = 0; i < 10; i += 2)
+    x(q);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_foo1
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (i32)) {
+// CHECK:             %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_0]] : i32
+// CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : i32)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32):
+// CHECK:             quake.x %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:             cc.continue %[[VAL_7]] : i32
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i32):
+// CHECK:             %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_1]] : i32
+// CHECK:             cc.continue %[[VAL_9]] : i32
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+__qpu__ void foo2() {
+  cudaq::qubit q;
+  for (int i = 15; i > 0; i -= 3)
+    x(q);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_foo2
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (i32)) {
+// CHECK:             %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_0]] : i32
+// CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : i32)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i32):
+// CHECK:             quake.x %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:             cc.continue %[[VAL_7]] : i32
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i32):
+// CHECK:             %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_1]] : i32
+// CHECK:             cc.continue %[[VAL_9]] : i32
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+__qpu__ void foo3() {
+  cudaq::qreg q(10);
+  for (int i = 0; i < 10; i += 2)
+    x(q[i]);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_foo3
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 2 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_3]]) -> (i32)) {
+// CHECK:             %[[VAL_7:.*]] = arith.cmpi ne, %[[VAL_6]], %[[VAL_0]] : i32
+// CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : i32)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i32):
+// CHECK:             %[[VAL_9:.*]] = arith.muli %[[VAL_8]], %[[VAL_2]] : i32
+// CHECK:             %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
+// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %{{.*}}[%[[VAL_10]]] : (!quake.veq<10>, i64) -> !quake.ref
+// CHECK:             cc.continue %[[VAL_8]] : i32
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_12:.*]]: i32):
+// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : i32
+// CHECK:             cc.continue %[[VAL_13]] : i32
+
+__qpu__ void foo4() {
+  cudaq::qreg q(10);
+  for (int i = 10; i > 0; i -= 2)
+    x(q[i-1]);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_foo4
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 9 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_6:.*]] = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_4]]) -> (i32)) {
+// CHECK:             %[[VAL_8:.*]] = arith.cmpi ne, %[[VAL_7]], %[[VAL_1]] : i32
+// CHECK:           ^bb0(%[[VAL_9:.*]]: i32):
+// CHECK:             %[[VAL_10:.*]] = arith.muli %[[VAL_9]], %[[VAL_3]] : i32
+// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_0]] : i32
+// CHECK:             %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
+// CHECK:             %[[VAL_13:.*]] = quake.extract_ref %{{.*}}[%[[VAL_12]]] : (!quake.veq<10>, i64) -> !quake.ref
+// CHECK:           ^bb0(%[[VAL_14:.*]]: i32):
+// CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_2]] : i32
+


### PR DESCRIPTION
Implement enhancement #288.

This pass converts monotonic loops with constant step into invariant loops or counted loops depending on whether the total number of iterations is constant. This pass has some limitations which can be addressed in future work. For now it will convert some interesting loops such as countdown loops, loops with steps != 1, etc.

Normalizing loops is an important transformation in that it will allow the loop unrolling pass to find more counted loops to unroll.

