### PR TITLE
[test] Add some target compilation tests

### DIFF
--- a/test/NVQPP/graph_coloring-1.cpp
+++ b/test/NVQPP/graph_coloring-1.cpp
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+
+#include <cudaq.h>
+#include <iostream>
+
+struct init_state {
+  __qpu__ void operator()(cudaq::qreg<> &qubits, double theta) {
+    ry(theta, qubits[0]);
+    h<cudaq::ctrl>(qubits[0], qubits[1]);
+    x(qubits[1]);
+
+    ry(theta, qubits[2]);
+    h<cudaq::ctrl>(qubits[2], qubits[3]);
+    x(qubits[3]);
+
+    ry(theta, qubits[4]);
+    h<cudaq::ctrl>(qubits[4], qubits[5]);
+    x(qubits[5]);
+
+    ry(theta, qubits[6]);
+    h<cudaq::ctrl>(qubits[6], qubits[7]);
+    x(qubits[7]);
+  }
+};
+
+__qpu__ void reflect_uniform(cudaq::qreg<> &qubits, double theta) {
+  cudaq::adjoint(init_state{}, qubits, theta);
+  x(qubits);
+  z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3], qubits[4], qubits[5], qubits[6], qubits[7]);
+  x(qubits);
+  init_state{}(qubits, theta);
+}
+
+bool oracle_classical(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3) {
+  bool c_01 = v0 != v1;
+  bool c_123 = (v1 != v2) && (v1 != v3) && (v2 != v3);
+  return c_01 && c_123;
+}
+
+__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+  x<cudaq::ctrl>(cs[0], !cs[1], cs[2], !cs[3], cs[5], target);
+  x<cudaq::ctrl>(cs[0], !cs[1], cs[2], !cs[3], cs[7], target);
+  x<cudaq::ctrl>(cs[0], !cs[1], !cs[3], cs[4], cs[7], target);
+  x<cudaq::ctrl>(cs[1], cs[2], cs[3], cs[4], target);
+  x<cudaq::ctrl>(cs[1], !cs[2], cs[3], cs[6], target);
+  x<cudaq::ctrl>(!cs[1], cs[2], cs[4], cs[7], target);
+  x<cudaq::ctrl>(cs[0], cs[1], cs[2], cs[3], cs[5], target);
+  x<cudaq::ctrl>(cs[1], !cs[2], cs[5], cs[6], target);
+  x<cudaq::ctrl>(!cs[1], cs[3], cs[4], target);
+  x<cudaq::ctrl>(cs[1], cs[4], cs[7], target);
+  x<cudaq::ctrl>(cs[0], !cs[1], !cs[3], cs[5], cs[6], target);
+  x<cudaq::ctrl>(!cs[2], cs[3], !cs[5], cs[6], target);
+  x<cudaq::ctrl>(cs[0], cs[1], cs[2], cs[3], cs[7], target);
+  x<cudaq::ctrl>(cs[0], cs[1], cs[3], cs[4], !cs[7], target);
+  x<cudaq::ctrl>(cs[2], !cs[7], target);
+  x<cudaq::ctrl>(cs[0], cs[1], cs[3], !cs[5], cs[6], target);
+  x<cudaq::ctrl>(cs[2], !cs[3], cs[6], target);
+  x<cudaq::ctrl>(cs[2], !cs[5], !cs[6], target);
+  x<cudaq::ctrl>(!cs[2], cs[3], cs[4], cs[7], target);
+}
+
+__qpu__ void grover(double theta) {
+  cudaq::qreg qubits(8);
+  cudaq::qubit ancilla;
+
+  // Initialization
+  x(ancilla);
+  h(ancilla);
+  init_state{}(qubits, theta);
+
+  // Iterations
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits, theta);
+
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits, theta);
+  mz(qubits);
+};
+
+int main() {
+  double theta = 2. * std::acos(1. / std::sqrt(3));
+  auto result = cudaq::sample(1000, grover, theta);
+  std::vector<std::string> strings;
+  for (auto &&[bits, count] : result) {
+    strings.push_back(bits);
+  }
+  std::sort(strings.begin(), strings.end(), [&](auto& a, auto& b) {
+    return result.count(a) > result.count(b);
+  });
+  for (auto i = 0; i < 12; ++i) {
+    for (auto j = 0; j < 8; j += 2)
+      std::cout << strings[i].substr(j, 2) << " ";
+    std::cout << '\n';
+  }
+  return 0;
+}
+
+// CHECK-DAG: 01 10 11 01
+// CHECK-DAG: 10 11 01 10
+// CHECK-DAG: 11 10 11 01
+// CHECK-DAG: 01 11 01 10
+// CHECK-DAG: 01 10 01 11
+// CHECK-DAG: 01 11 10 01
+// CHECK-DAG: 10 11 10 01
+// CHECK-DAG: 11 01 11 10
+// CHECK-DAG: 11 10 01 11
+// CHECK-DAG: 10 01 10 11
+// CHECK-DAG: 10 01 11 10
+// CHECK-DAG: 11 01 10 11

--- a/test/NVQPP/graph_coloring.cpp
+++ b/test/NVQPP/graph_coloring.cpp
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+
+#include <cudaq.h>
+#include <iostream>
+
+__qpu__ void init_state(cudaq::qreg<> &qubits, double theta) {
+  ry(theta, qubits[0]);
+  h<cudaq::ctrl>(qubits[0], qubits[1]);
+  x(qubits[1]);
+
+  ry(theta, qubits[2]);
+  h<cudaq::ctrl>(qubits[2], qubits[3]);
+  x(qubits[3]);
+
+  ry(theta, qubits[4]);
+  h<cudaq::ctrl>(qubits[4], qubits[5]);
+  x(qubits[5]);
+
+  ry(theta, qubits[6]);
+  h<cudaq::ctrl>(qubits[6], qubits[7]);
+  x(qubits[7]);
+}
+
+// :(
+__qpu__ void init_state_adj(cudaq::qreg<> &qubits, double theta) {
+  x(qubits[7]);
+  h<cudaq::ctrl>(qubits[6], qubits[7]);
+  ry<cudaq::adj>(theta, qubits[6]);
+
+  x(qubits[5]);
+  h<cudaq::ctrl>(qubits[4], qubits[5]);
+  ry<cudaq::adj>(theta, qubits[4]);
+
+  x(qubits[3]);
+  h<cudaq::ctrl>(qubits[2], qubits[3]);
+  ry<cudaq::adj>(theta, qubits[2]);
+
+  x(qubits[1]);
+  h<cudaq::ctrl>(qubits[0], qubits[1]);
+  ry<cudaq::adj>(theta, qubits[0]);
+}
+
+__qpu__ void reflect_uniform(cudaq::qreg<> &qubits, double theta) {
+  // Don't work:
+  // cudaq::adjoint(init_state, qubits, theta);
+  init_state_adj(qubits, theta);
+  x(qubits);
+  z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3], qubits[4], qubits[5], qubits[6], qubits[7]);
+  x(qubits);
+  init_state(qubits, theta);
+}
+
+bool oracle_classical(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3) {
+  bool c_01 = v0 != v1;
+  bool c_123 = (v1 != v2) && (v1 != v3) && (v2 != v3);
+  return c_01 && c_123;
+}
+
+__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+  x<cudaq::ctrl>(cs[0], !cs[1], cs[2], !cs[3], cs[5], target);
+  x<cudaq::ctrl>(cs[0], !cs[1], cs[2], !cs[3], cs[7], target);
+  x<cudaq::ctrl>(cs[0], !cs[1], !cs[3], cs[4], cs[7], target);
+  x<cudaq::ctrl>(cs[1], cs[2], cs[3], cs[4], target);
+  x<cudaq::ctrl>(cs[1], !cs[2], cs[3], cs[6], target);
+  x<cudaq::ctrl>(!cs[1], cs[2], cs[4], cs[7], target);
+  x<cudaq::ctrl>(cs[0], cs[1], cs[2], cs[3], cs[5], target);
+  x<cudaq::ctrl>(cs[1], !cs[2], cs[5], cs[6], target);
+  x<cudaq::ctrl>(!cs[1], cs[3], cs[4], target);
+  x<cudaq::ctrl>(cs[1], cs[4], cs[7], target);
+  x<cudaq::ctrl>(cs[0], !cs[1], !cs[3], cs[5], cs[6], target);
+  x<cudaq::ctrl>(!cs[2], cs[3], !cs[5], cs[6], target);
+  x<cudaq::ctrl>(cs[0], cs[1], cs[2], cs[3], cs[7], target);
+  x<cudaq::ctrl>(cs[0], cs[1], cs[3], cs[4], !cs[7], target);
+  x<cudaq::ctrl>(cs[2], !cs[7], target);
+  x<cudaq::ctrl>(cs[0], cs[1], cs[3], !cs[5], cs[6], target);
+  x<cudaq::ctrl>(cs[2], !cs[3], cs[6], target);
+  x<cudaq::ctrl>(cs[2], !cs[5], !cs[6], target);
+  x<cudaq::ctrl>(!cs[2], cs[3], cs[4], cs[7], target);
+}
+
+__qpu__ void grover(double theta) {
+  cudaq::qreg qubits(8);
+  cudaq::qubit ancilla;
+
+  // Initialization
+  x(ancilla);
+  h(ancilla);
+  init_state(qubits, theta);
+
+  // Iterations
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits, theta);
+
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits, theta);
+  mz(qubits);
+};
+
+int main() {
+  double theta = 2. * std::acos(1. / std::sqrt(3));
+  auto result = cudaq::sample(1000, grover, theta);
+  std::vector<std::string> strings;
+  for (auto &&[bits, count] : result) {
+    strings.push_back(bits);
+  }
+  std::sort(strings.begin(), strings.end(), [&](auto& a, auto& b) {
+    return result.count(a) > result.count(b);
+  });
+  for (auto i = 0; i < 12; ++i) {
+    for (auto j = 0; j < 8; j += 2)
+      std::cout << strings[i].substr(j, 2) << " ";
+    std::cout << '\n';
+  }
+  return 0;
+}
+
+// CHECK-DAG: 01 10 11 01
+// CHECK-DAG: 10 11 01 10
+// CHECK-DAG: 11 10 11 01
+// CHECK-DAG: 01 11 01 10
+// CHECK-DAG: 01 10 01 11
+// CHECK-DAG: 01 11 10 01
+// CHECK-DAG: 10 11 10 01
+// CHECK-DAG: 11 01 11 10
+// CHECK-DAG: 11 10 01 11
+// CHECK-DAG: 10 01 10 11
+// CHECK-DAG: 10 01 11 10
+// CHECK-DAG: 11 01 10 11

--- a/test/NVQPP/sudoku_2x2-1.cpp
+++ b/test/NVQPP/sudoku_2x2-1.cpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// XFAIL: *
+
+#include <cudaq.h>
+#include <algorithm>
+#include <iostream>
+
+__qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
+  h(qubits);
+  x(qubits);
+  z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3]);
+  x(qubits);
+  h(qubits);
+}
+
+__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+  x<cudaq::ctrl>(cs[0], !cs[1], !cs[2], cs[3], target);
+  x<cudaq::ctrl>(!cs[0], cs[1], cs[2], !cs[3], target);
+}
+
+__qpu__ void grover() {
+  cudaq::qreg qubits(4);
+  cudaq::qubit ancilla;
+
+  // Initialization
+  x(ancilla);
+  h(ancilla);
+  h(qubits); // uniform initialization
+
+  // Don't work?:
+  for (int i = 0; i < 2; ++i) {
+    oracle(qubits, ancilla);
+    reflect_uniform(qubits);
+  }
+  mz(qubits);
+};
+
+int main() {
+  auto result = cudaq::sample(1000, grover);
+  // Didn't work:
+  // std::vector<std::string> strings = result.sequential_data();
+  std::vector<std::string> strings;
+  for (auto &&[bits, count] : result) {
+    strings.push_back(bits);
+  }
+  std::sort(strings.begin(), strings.end(), [&](auto& a, auto& b) {
+    return result.count(a) > result.count(b);
+  });
+  std::cout << strings[0] << '\n';
+  std::cout << strings[1] << '\n';
+  return 0;
+}
+
+// CHECK-DAG: 1001
+// CHECK-DAG: 0110

--- a/test/NVQPP/sudoku_2x2.cpp
+++ b/test/NVQPP/sudoku_2x2.cpp
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+
+#include <cudaq.h>
+#include <algorithm>
+#include <iostream>
+
+__qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
+  h(qubits);
+  x(qubits);
+  z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3]);
+  x(qubits);
+  h(qubits);
+}
+
+__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+  x<cudaq::ctrl>(cs[0], !cs[1], !cs[2], cs[3], target);
+  x<cudaq::ctrl>(!cs[0], cs[1], cs[2], !cs[3], target);
+}
+
+__qpu__ void grover() {
+  cudaq::qreg qubits(4);
+  cudaq::qubit ancilla;
+
+  // Initialization
+  x(ancilla);
+  h(ancilla);
+  h(qubits); // uniform initialization
+
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits);
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits);
+  mz(qubits);
+};
+
+int main() {
+  auto result = cudaq::sample(1000, grover);
+  // Didn't work:
+  // std::vector<std::string> strings = result.sequential_data();
+  std::vector<std::string> strings;
+  for (auto &&[bits, count] : result) {
+    strings.push_back(bits);
+  }
+  std::sort(strings.begin(), strings.end(), [&](auto& a, auto& b) {
+    return result.count(a) > result.count(b);
+  });
+  std::cout << strings[0] << '\n';
+  std::cout << strings[1] << '\n';
+  return 0;
+}
+
+// CHECK-DAG: 1001
+// CHECK-DAG: 0110

--- a/test/NVQPP/test-0.cpp
+++ b/test/NVQPP/test-0.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// XFAIL: *
+
+#include <cudaq.h>
+#include <iostream>
+
+__qpu__ void bar(cudaq::qubit& q) {
+  x(q);
+}
+
+struct baz {
+  __qpu__ void operator()(cudaq::qubit& q) {
+    x(q);
+  }
+};
+
+struct foo {
+  template <typename CallableKernel>
+  __qpu__ void operator()(CallableKernel &&func) {
+    cudaq::qubit q;
+    func(q);
+    mz(q);
+  }
+};
+
+int main() {
+  // Not supported?:
+  // auto result = cudaq::sample(1000, foo{}, &bar);
+
+  // QuakeSynth don't support:
+  auto result = cudaq::sample(1000, foo{}, baz{});
+  for (auto &&[bits, counts] : result) {
+    std::cout << bits << " : " << counts << '\n';
+  }
+  return 0;
+}
+
+// CHECK: 1 : 1000

--- a/test/NVQPP/test-1.cpp
+++ b/test/NVQPP/test-1.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// XFAIL: *
+
+#include <cudaq.h>
+#include <iostream>
+
+__qpu__ void load_value(unsigned value) {
+  cudaq::qreg qubits(4);
+  for (std::size_t i = 0; i < 4; ++i) {
+    // Doesn't work, even with: `if (value)`
+    if (value & (1 << i))
+      x(qubits[3 - i]);
+  }
+  mz(qubits);
+}
+
+int main() {
+  for (auto i = 0; i < 16; ++i) {
+    auto result = cudaq::sample(1000, load_value, i);
+    std::cout << result.most_probable() << '\n';
+  }
+  return 0;
+}
+
+// CHECK: 0000
+// CHECK-NEXT: 0001
+// CHECK-NEXT: 0010
+// CHECK-NEXT: 0011
+// CHECK-NEXT: 0100
+// CHECK-NEXT: 0101
+// CHECK-NEXT: 0110
+// CHECK-NEXT: 0111
+// CHECK-NEXT: 1000
+// CHECK-NEXT: 1001
+// CHECK-NEXT: 1010
+// CHECK-NEXT: 1011
+// CHECK-NEXT: 1100
+// CHECK-NEXT: 1101
+// CHECK-NEXT: 1110
+// CHECK-NEXT: 1111
+
+

--- a/test/NVQPP/test-2.cpp
+++ b/test/NVQPP/test-2.cpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// XFAIL: *
+
+#include <cudaq.h>
+#include <iostream>
+
+__qpu__ void variable_qreg(std::uint8_t value) {
+  cudaq::qreg qubits(value);
+  mz(qubits);
+}
+
+int main() {
+  for (auto i = 1; i < 5; ++i) {
+    auto result = cudaq::sample(1000, variable_qreg, i);
+    std::cout << result.most_probable() << '\n';
+  }
+  return 0;
+}
+
+// CHECK: 0
+// CHECK-NEXT: 00
+// CHECK-NEXT: 000
+// CHECK-NEXT: 0000

--- a/test/NVQPP/test-3.cpp
+++ b/test/NVQPP/test-3.cpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// XFAIL: *
+
+#include <cudaq.h>
+#include <iostream>
+
+__qpu__ void init_state() {
+  double theta = 2. * std::acos(1. / std::sqrt(3));
+  cudaq::qreg qubits(2);
+  ry(theta, qubits[0]);
+  h<cudaq::ctrl>(qubits[0], qubits[1]);
+  x(qubits[1]);
+};
+
+int main() {
+  auto result = cudaq::sample(1000, init_state);
+  for (auto &&[bits, counts] : result) {
+    std::cout << bits << '\n';
+  }
+  return 0;
+}
+
+//CHECK-NOT: 00

--- a/test/NVQPP/test-4.cpp
+++ b/test/NVQPP/test-4.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// XFAIL: *
+
+#include <cudaq.h>
+#include <iostream>
+
+__qpu__ void bar(cudaq::qspan<> qubits) {
+  auto controls = qubits.front(qubits.size() - 1);
+  auto &target = qubits.back();
+  x<cudaq::ctrl>(controls, target);
+}
+
+__qpu__ void foo() {
+  cudaq::qreg qubits(4);
+  x(qubits);
+  bar(qubits);
+  mz(qubits);
+}
+
+int main() {
+  auto result = cudaq::sample(1000, foo);
+  std::cout << result.size() << '\n';
+  for (auto &&[bits, counts] : result) {
+    std::cout << bits << '\n';
+  }
+  return 0;
+}
+
+//CHECK: 1
+//CHECK-NEXT: 1110

--- a/test/NVQPP/test-5.cpp
+++ b/test/NVQPP/test-5.cpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// XFAIL: *
+
+#include <cudaq.h>
+#include <iostream>
+
+__qpu__ void variable_qreg(unsigned value) {
+  cudaq::qreg qubits(value);
+  mz(qubits);
+}
+
+int main() {
+  for (auto i = 1; i < 5; ++i) {
+    auto result = cudaq::sample(1000, variable_qreg, i);
+    std::cout << result.most_probable() << '\n';
+  }
+  return 0;
+}
+
+// CHECK: 0
+// CHECK-NEXT: 00
+// CHECK-NEXT: 000
+// CHECK-NEXT: 0000

--- a/test/NVQPP/test-6.cpp
+++ b/test/NVQPP/test-6.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// XFAIL: *
+
+#include <cudaq.h>
+#include <iostream>
+
+__qpu__ void cccx_measure_cleanup() {
+  cudaq::qreg qubits(4);
+  // Initialize
+  x(qubits[1]);
+  x(qubits[2]);
+  x(qubits[3]);
+
+  // Compute AND-operation
+  cudaq::qubit ancilla;
+  h(ancilla);
+  t(ancilla);
+  x<cudaq::ctrl>(qubits[1], ancilla);
+  t<cudaq::adj>(ancilla);
+  x<cudaq::ctrl>(qubits[0], ancilla);
+  t(ancilla);
+  x<cudaq::ctrl>(qubits[1], ancilla);
+  t<cudaq::adj>(ancilla);
+  h(ancilla);
+  s<cudaq::adj>(ancilla);
+
+  // Compute output
+  x<cudaq::ctrl>(qubits[2], ancilla, qubits[3]);
+
+  // AND's measurement based cleanup.
+  bool result = mx(ancilla);
+  if (result)
+    z<cudaq::ctrl>(qubits[0], qubits[1]);
+
+  mz(qubits);
+}
+
+int main() {
+  auto result = cudaq::sample(1000, cccx_measure_cleanup);
+  std::cout << result.most_probable() << '\n';
+  return 0;
+}
+
+// CHECK: 1111


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
This depends on #321 

For now, some tests are named `test-<number>` for my lack of imagination. I left comments on reasons why some of them are not passing as well as for things that we are supposed to support, but don't when compiling to a target.

Failed Tests (8):
  CUDAQ :: NVQPP/sudoku_2x2-1.cpp (#343)
  CUDAQ :: NVQPP/test-0.cpp (#336)
  CUDAQ :: NVQPP/test-1.cpp (#337)
  CUDAQ :: NVQPP/test-2.cpp (#344)
  CUDAQ :: NVQPP/test-3.cpp (#341)
  CUDAQ :: NVQPP/test-4.cpp (#345)
  CUDAQ :: NVQPP/test-5.cpp (#339)
  CUDAQ :: NVQPP/test-6.cpp (Not a bug. We could improve error message, tho.)
