### PR TITLE
Add the loop normalization pass to the general set of pipeline passes.

### DIFF
--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -633,6 +633,7 @@ ExecutionEngine *jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
   optPM.addPass(cudaq::opt::createClassicalMemToReg());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createExpandMeasurementsPass());
+  pm.addPass(cudaq::opt::createLoopNormalize());
   pm.addPass(cudaq::opt::createLoopUnroll());
   pm.addPass(createCanonicalizerPass());
   optPM.addPass(cudaq::opt::createQuakeAddDeallocs());

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
@@ -16,7 +16,7 @@ GEN_TARGET_BACKEND=true
 LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline, here we lower to Base QIR
-PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,cc-loop-unroll{signal-failure-if-any-loop-cannot-be-completely-unrolled=true},canonicalize,func.func(lower-to-cfg),canonicalize,func.func(quake-multicontrol-decomposition),quantinuum-gate-set-mapping"
+PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,func.func(memtoreg{quantum=0}),canonicalize,cc-loop-normalize,cc-loop-unroll{signal-failure-if-any-loop-cannot-be-completely-unrolled=true},canonicalize,func.func(lower-to-cfg),canonicalize,func.func(quake-multicontrol-decomposition),quantinuum-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 CODEGEN_EMISSION=qir

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -94,6 +94,7 @@ void addPipelineToQIR(PassManager &pm) {
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createUnwindLoweringPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createLowerToCFGPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
+  pm.addNestedPass<func::FuncOp>(cudaq::opt::createLoopNormalize());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createLoopUnroll());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -57,6 +57,7 @@ LogicalResult runQuakeSynth(std::string_view kernelName, void *rawArgs,
   pm.addPass(cudaq::opt::createExpandMeasurementsPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createClassicalMemToReg());
   pm.addPass(createCanonicalizerPass());
+  pm.addPass(cudaq::opt::createLoopNormalize());
   pm.addPass(cudaq::opt::createLoopUnroll());
   pm.addPass(createCanonicalizerPass());
   return pm.run(*module);


### PR DESCRIPTION
This pass is added before the loop unrolling pass to give unrolling an opportunity to unroll more loops.
