### PR TITLE
Fix #324: Update the old aggressive early inlining pass.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -29,9 +29,6 @@ createGenerateDeviceCodeLoader(bool genAsQuake = false);
 /// quantum calls to direct quantum calls.
 std::unique_ptr<mlir::Pass> createAggressiveEarlyInlining();
 
-/// Create the pass to convert indirect calls to direct calls.
-std::unique_ptr<mlir::Pass> createConvertToDirectCalls();
-
 std::unique_ptr<mlir::Pass> createApplyOpSpecializationPass();
 std::unique_ptr<mlir::Pass>
 createApplyOpSpecializationPass(bool computeActionOpt);

--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -25,9 +25,11 @@ std::unique_ptr<mlir::Pass> createGenerateKernelExecution();
 std::unique_ptr<mlir::Pass>
 createGenerateDeviceCodeLoader(bool genAsQuake = false);
 
-/// Create an inlining pass with a nested pipeline that transforms any indirect
-/// quantum calls to direct quantum calls.
-std::unique_ptr<mlir::Pass> createAggressiveEarlyInlining();
+/// Add a pass pipeline to transform call between kernels to direct calls that
+/// do not go through the runtime layers, inline all calls, and detect if calls
+/// to kernels remain in the fully inlined into entry point kernel.
+void addAggressiveEarlyInlining(mlir::OpPassManager &pm);
+void registerAggressiveEarlyInlining();
 
 std::unique_ptr<mlir::Pass> createApplyOpSpecializationPass();
 std::unique_ptr<mlir::Pass>

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -35,6 +35,16 @@ def ApplySpecialization : Pass<"apply-op-specialization", "mlir::ModuleOp"> {
   ];
 }
 
+def CheckKernelCalls : Pass<"check-kernel-calls", "mlir::func::FuncOp"> {
+  let summary = "Check calls between quantum kernels have been inlined.";
+  let description = [{
+    The aggressive inlining pass should fully inline any calls between quantum
+    kernels. Any residual calls will be because the call graph contains cycles.
+    This pass checks that there are no residual calls and print a diagnostic if
+    any are found.
+  }];
+}
+
 def CombineQuantumAllocations :
     Pass<"combine-quantum-alloc", "mlir::func::FuncOp"> {
   let summary = "Combines quake alloca operations.";
@@ -63,8 +73,6 @@ def ConvertToDirectCalls :
     quantum code will call other quantum code directly and without going
     indirectly through the launch kernel runtime.
   }];
-
-  let constructor = "cudaq::opt::createConvertToDirectCalls()";
 }
 
 def ExpandMeasurements : Pass<"expand-measurements"> {

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -116,16 +116,16 @@ void QuakeBridgeVisitor::addArgumentSymbols(
     auto index = arg.index();
     auto *argVal = arg.value();
     auto name = argVal->getName();
-    if (entryBlock->getArgument(index).getType().isa<OpaqueType>()) {
+    if (isa<OpaqueType>(entryBlock->getArgument(index).getType())) {
       // This is a reference type, we want to forward the value.
       symbolTable.insert(name, entryBlock->getArgument(index));
     } else {
       // Transform pass-by-value arguments to stack slots.
       auto loc = toLocation(argVal);
       auto parmTy = entryBlock->getArgument(index).getType();
-      if (parmTy.isa<cc::LambdaType, cc::StdvecType, cc::ArrayType,
-                     cc::StructType, LLVM::LLVMStructType, FunctionType,
-                     quake::RefType, quake::VeqType>()) {
+      if (isa<cc::LambdaType, cc::StdvecType, cc::ArrayType, cc::StructType,
+              LLVM::LLVMStructType, FunctionType, quake::RefType,
+              quake::VeqType>(parmTy)) {
         symbolTable.insert(name, entryBlock->getArgument(index));
       } else {
         auto stackSlot = builder.create<cc::AllocaOp>(loc, parmTy);
@@ -361,7 +361,7 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     mz->setAttr("registerName", builder.getStringAttr(x->getName()));
 
   assert(initValue && "initializer value must be lowered");
-  if (initValue.getType().isa<IntegerType>() && type.isa<IntegerType>()) {
+  if (isa<IntegerType>(initValue.getType()) && isa<IntegerType>(type)) {
     if (initValue.getType().getIntOrFloatBitWidth() <
         type.getIntOrFloatBitWidth()) {
       // FIXME: Use zero-extend if this is unsigned!
@@ -370,7 +370,7 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
                type.getIntOrFloatBitWidth()) {
       initValue = builder.create<arith::TruncIOp>(loc, type, initValue);
     }
-  } else if (initValue.getType().isa<IntegerType>() && type.isa<FloatType>()) {
+  } else if (isa<IntegerType>(initValue.getType()) && isa<FloatType>(type)) {
     // FIXME: Use UIToFP if this is unsigned!
     initValue = builder.create<arith::SIToFPOp>(loc, type, initValue);
   }

--- a/lib/Optimizer/Transforms/AggressiveEarlyInlining.cpp
+++ b/lib/Optimizer/Transforms/AggressiveEarlyInlining.cpp
@@ -101,7 +101,7 @@ public:
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.empty() || !func->hasAttr("cudaq-kernel"))
+    if (func.empty() || !func->hasAttr(cudaq::kernelAttrName))
       return;
 
     auto module = func->template getParentOfType<ModuleOp>();
@@ -109,7 +109,7 @@ public:
     func.walk([&](func::CallOp call) {
       auto callee = call.getCallee();
       if (auto *decl = module.lookupSymbol(callee))
-        if (decl->hasAttr("cudaq-kernel")) {
+        if (decl->hasAttr(cudaq::kernelAttrName)) {
           call.emitOpError("kernel call was not inlined, "
                            "possible recursion in call tree");
           passFailed = true;

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -625,9 +625,7 @@ ExecutionEngine *jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
 
   PassManager pm(context);
   OpPassManager &optPM = pm.nest<func::FuncOp>();
-  optPM.addPass(cudaq::opt::createConvertToDirectCalls());
-  pm.addPass(cudaq::opt::createAggressiveEarlyInlining());
-  optPM.addPass(cudaq::opt::createCheckKernelCalls());
+  cudaq::opt::addAggressiveEarlyInlining(pm);
   pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createApplyOpSpecializationPass());
   optPM.addPass(cudaq::opt::createClassicalMemToReg());

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -625,9 +625,10 @@ ExecutionEngine *jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
   });
 
   PassManager pm(context);
-  pm.addPass(createInlinerPass());
-  pm.addPass(createCanonicalizerPass());
   OpPassManager &optPM = pm.nest<func::FuncOp>();
+  optPM.addPass(cudaq::opt::createConvertToDirectCalls());
+  pm.addPass(cudaq::opt::createAggressiveEarlyInlining());
+  optPM.addPass(cudaq::opt::createCheckKernelCalls());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createApplyOpSpecializationPass());
   optPM.addPass(cudaq::opt::createClassicalMemToReg());

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -348,9 +348,8 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder, const std::size_t nQubits) {
   cudaq::info("kernel_builder allocating {} qubits", nQubits);
 
   auto context = builder.getContext();
-  Value qubits = builder.create<quake::AllocaOp>(
-      quake::VeqType::get(context, nQubits),
-      builder.create<arith::ConstantIntOp>(nQubits, 32));
+  Value qubits =
+      builder.create<quake::AllocaOp>(quake::VeqType::get(context, nQubits));
 
   return QuakeValue(builder, qubits);
 }

--- a/tools/cudaq-opt/cudaq-opt.cpp
+++ b/tools/cudaq-opt/cudaq-opt.cpp
@@ -53,6 +53,7 @@ int main(int argc, char **argv) {
   mlir::registerAllPasses();
   cudaq::opt::registerOptCodeGenPasses();
   cudaq::opt::registerOptTransformsPasses();
+  cudaq::opt::registerAggressiveEarlyInlining();
   cudaq::opt::registerTargetPipelines();
 
   // See if we have been asked to load a pass plugin,

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -85,9 +85,7 @@ using namespace mlir;
 // Pipeline builder to convert Quake to QIR.
 template <bool BaseProfile = false>
 void addPipelineToQIR(PassManager &pm) {
-  pm.addNestedPass<func::FuncOp>(cudaq::opt::createConvertToDirectCalls());
-  pm.addPass(cudaq::opt::createAggressiveEarlyInlining());
-  pm.addNestedPass<func::FuncOp>(cudaq::opt::createCheckKernelCalls());
+  cudaq::opt::addAggressiveEarlyInlining(pm);
   pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createExpandMeasurementsPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createClassicalMemToReg());

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -85,7 +85,9 @@ using namespace mlir;
 // Pipeline builder to convert Quake to QIR.
 template <bool BaseProfile = false>
 void addPipelineToQIR(PassManager &pm) {
-  pm.addPass(createInlinerPass());
+  pm.addNestedPass<func::FuncOp>(cudaq::opt::createConvertToDirectCalls());
+  pm.addPass(cudaq::opt::createAggressiveEarlyInlining());
+  pm.addNestedPass<func::FuncOp>(cudaq::opt::createCheckKernelCalls());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createExpandMeasurementsPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createClassicalMemToReg());

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -459,9 +459,10 @@ if ${ENABLE_KERNEL_EXECUTION}; then
 fi
 if ${ENABLE_AGGRESSIVE_EARLY_INLINE}; then
 	RUN_OPT=true
-	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(indirect-to-direct-calls),inline")
 	if ${DO_LINK}; then
-		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(check-kernel-calls)")
+		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "aggressive-early-inlining")
+	else
+		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(indirect-to-direct-calls),inline")
 	fi
 fi
 if ${ENABLE_DEVICE_CODE_LOADERS}; then

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -459,7 +459,10 @@ if ${ENABLE_KERNEL_EXECUTION}; then
 fi
 if ${ENABLE_AGGRESSIVE_EARLY_INLINE}; then
 	RUN_OPT=true
-	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "inline{default-pipeline=func.func(indirect-to-direct-calls)}")
+	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(indirect-to-direct-calls),inline")
+	if ${DO_LINK}; then
+		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(check-kernel-calls)")
+	fi
 fi
 if ${ENABLE_DEVICE_CODE_LOADERS}; then
 	RUN_OPT=true


### PR DESCRIPTION
Add it to the pass pipeline. Move the indirect to direct call conversion to a distinct and greedy pass. Add a check inlining kernel pass to verify that calls to kernels are, in fact, inlined.

(Includes PR #326 as well.)

