### PR TITLE
Callable Kernel Arguments Passed QuakeSynthesizer.

### DIFF
--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -102,5 +102,10 @@ bool hasHiddenSRet(mlir::FunctionType funcTy);
 /// convert some results to `sret` pointers, etc.
 mlir::FunctionType toCpuSideFuncType(mlir::FunctionType funcTy);
 
+/// @brief Return true if the given type corresponds to a
+/// std-vector type according to our convention. The convention
+/// is a ptr<struct<ptr<T>, ptr<T>, ptr<T>>>.
+bool isStdVecArg(mlir::Type type);
+
 } // namespace opt::factory
 } // namespace cudaq

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -164,4 +164,26 @@ FunctionType factory::toCpuSideFuncType(FunctionType funcTy) {
   return FunctionType::get(ctx, inputTys, funcTy.getResults());
 }
 
+bool factory::isStdVecArg(Type type) {
+  auto ptrTy = dyn_cast<cudaq::cc::PointerType>(type);
+  if (!ptrTy)
+    return false;
+
+  auto elementTy = ptrTy.getElementType();
+  auto structTy = dyn_cast<cudaq::cc::StructType>(elementTy);
+  if (!structTy)
+    return false;
+
+  auto memberTys = structTy.getMembers();
+  if (memberTys.size() != 3)
+    return false;
+
+  for (std::size_t i = 0; i < 3; i++)
+    if (!dyn_cast<cudaq::cc::PointerType>(memberTys[i]))
+      return false;
+
+  // This is a stdvec type to us.
+  return true;
+}
+
 } // namespace cudaq::opt

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -523,6 +523,14 @@ public:
       if (inTy.isa<cudaq::cc::LambdaType, cudaq::cc::StructType>()) {
         /* do nothing */
       } else if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(inTy)) {
+
+        // This block only considers stdvec< builtin >, which have been
+        // mapped to ptr< builtin >. But now we also want callable structs
+        // represented as pointers in the new entry point. so skip this
+        // block if this is a pointer to a struct.
+        if (dyn_cast<cudaq::cc::StructType>(ptrTy.getElementType())) {
+          continue;
+        }
         // FIXME: for now assume this is a std::vector<`eleTy`>
         // FIXME: call the `size` member function. For expediency, assume this
         // is an std::vector and the size is the scaled delta between the

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -313,6 +313,31 @@ public:
     return argsCreatorFunc;
   }
 
+  /// @brief Return true if the given type corresponds to a
+  /// std-vector type according to our convention. The convention
+  /// is a ptr<struct<ptr<T>, ptr<T>, ptr<T>>>.
+  bool isStdVecArg(Type type) {
+    auto ptrTy = dyn_cast<cudaq::cc::PointerType>(type);
+    if (!ptrTy)
+      return false;
+
+    auto elementTy = ptrTy.getElementType();
+    auto structTy = dyn_cast<cudaq::cc::StructType>(elementTy);
+    if (!structTy)
+      return false;
+
+    auto memberTys = structTy.getMembers();
+    if (memberTys.size() != 3)
+      return false;
+
+    for (std::size_t i = 0; i < 3; i++)
+      if (!dyn_cast<cudaq::cc::PointerType>(memberTys[i]))
+        return false;
+
+    // This is a stdvec type to us.
+    return true;
+  }
+
   /// Generate the thunk function. This function is called by the library
   /// callback function to "unpack" the arguments and pass them to the kernel
   /// function on the QPU side. The thunk will also save any return values to
@@ -522,16 +547,8 @@ public:
       auto off = DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{idx});
       if (inTy.isa<cudaq::cc::LambdaType, cudaq::cc::StructType>()) {
         /* do nothing */
-      } else if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(inTy)) {
-
-        // This block only considers stdvec< builtin >, which have been
-        // mapped to ptr< builtin >. But now we also want callable structs
-        // represented as pointers in the new entry point. so skip this
-        // block if this is a pointer to a struct.
-        if (dyn_cast<cudaq::cc::StructType>(ptrTy.getElementType()))
-          continue;
-
-        // FIXME: for now assume this is a std::vector<`eleTy`>
+      } else if (isStdVecArg(inTy)) {
+        auto ptrTy = dyn_cast<cudaq::cc::PointerType>(inTy);
         // FIXME: call the `size` member function. For expediency, assume this
         // is an std::vector and the size is the scaled delta between the
         // first two pointers. Use the unscaled size for now.
@@ -540,6 +557,8 @@ public:
                                                          stVal, sizeBytes, off);
         extraBytes = builder.create<arith::AddIOp>(loc, extraBytes, sizeBytes);
         hasTrailingData = true;
+      } else if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(inTy)) {
+        /*do nothing*/
       } else {
         stVal = builder.create<cudaq::cc::InsertValueOp>(loc, stVal.getType(),
                                                          stVal, arg, off);

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -528,9 +528,9 @@ public:
         // mapped to ptr< builtin >. But now we also want callable structs
         // represented as pointers in the new entry point. so skip this
         // block if this is a pointer to a struct.
-        if (dyn_cast<cudaq::cc::StructType>(ptrTy.getElementType())) {
+        if (dyn_cast<cudaq::cc::StructType>(ptrTy.getElementType()))
           continue;
-        }
+
         // FIXME: for now assume this is a std::vector<`eleTy`>
         // FIXME: call the `size` member function. For expediency, assume this
         // is an std::vector and the size is the scaled delta between the

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -212,6 +212,10 @@ void QuakeSynthesizer::runOnOperation() {
         vectorSize /= sizeof(double);
         offset += sizeof(std::size_t);
         stdVecSizes.push_back(vectorSize);
+      } else if (isa<cudaq::cc::StructType>(type)) {
+        // The struct type ends up as a i64 in the thunk kernel
+        // args pointer, so just skip ahead.
+        offset += sizeof(std::size_t);
       } else {
         type.dump();
         TODO("We cannot synthesize this type of argument yet.");

--- a/test/NVQPP/test-0.cpp
+++ b/test/NVQPP/test-0.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// XFAIL: *
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/test-0.cpp
+++ b/test/NVQPP/test-0.cpp
@@ -24,10 +24,10 @@ struct baz {
 
 struct foo {
   template <typename CallableKernel>
-  __qpu__ void operator()(CallableKernel &&func) {
-    cudaq::qubit q;
-    func(q);
-    mz(q);
+  __qpu__ void operator()(CallableKernel &&func, int size) {
+    cudaq::qreg q(size);
+    func(q[0]);
+    mz(q[0]);
   }
 };
 
@@ -36,7 +36,7 @@ int main() {
   // auto result = cudaq::sample(1000, foo{}, &bar);
 
   // QuakeSynth don't support:
-  auto result = cudaq::sample(1000, foo{}, baz{});
+  auto result = cudaq::sample(1000, foo{}, baz{}, /*qreg size*/ 1);
   for (auto &&[bits, counts] : result) {
     std::cout << bits << " : " << counts << '\n';
   }


### PR DESCRIPTION
Update GenKernelExecution to output a new entry point function with any callable struct argument types emitted as pointers to the type, instead of just the type. Update QuakeSynthesizer to handle these struct types by incrementing the offset (ignoring them, since they have already been inlined). Turn the failing test on. 