### PR TITLE
Fixes the handling of the this pointer.

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -553,6 +553,11 @@ public:
     mlir::Value getConstantInt(mlir::Location loc, const uint64_t value,
                                const int bitwidth = 64);
 
+    /// Add a declaration to the module for the function, \p funcDecl.
+    void addFunctionDecl(const clang::FunctionDecl *funcDecl,
+                         details::QuakeBridgeVisitor &visitor,
+                         mlir::FunctionType funcTy);
+
   public:
     ASTBridgeConsumer(clang::CompilerInstance &compiler,
                       mlir::OwningOpRef<mlir::ModuleOp> &_module,

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -95,5 +95,12 @@ createCountedLoop(mlir::OpBuilder &builder, mlir::Location loc,
                                           mlir::Region &, mlir::Block &)>
                       bodyBuilder);
 
+bool hasHiddenSRet(mlir::FunctionType funcTy);
+
+/// Convert the function type \p funcTy to a signature compatible with the code
+/// on the CPU side. This will add hidden arguments, such as the `this` pointer,
+/// convert some results to `sret` pointers, etc.
+mlir::FunctionType toCpuSideFuncType(mlir::FunctionType funcTy);
+
 } // namespace opt::factory
 } // namespace cudaq

--- a/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -354,7 +354,7 @@ void ASTBridgeAction::ASTBridgeConsumer::addFunctionDecl(
   OpBuilder::InsertionGuard guard(build);
   build.setInsertionPointToEnd(module->getBody());
   if (isa<clang::CXXMethodDecl>(funcDecl))
-     funcTy = cudaq::opt::factory::toCpuSideFuncType(funcTy);
+    funcTy = cudaq::opt::factory::toCpuSideFuncType(funcTy);
   auto func = build.create<func::FuncOp>(loc, funcName, funcTy,
                                          ArrayRef<NamedAttribute>{});
   func.setPrivate();

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -145,6 +145,10 @@ FunctionType factory::toCpuSideFuncType(FunctionType funcTy) {
     if (auto memrefTy = dyn_cast<cudaq::cc::StdvecType>(inTy))
       inputTys.push_back(cudaq::cc::PointerType::get(
           stlVectorType(memrefTy.getElementType())));
+      else if (auto structTy = dyn_cast<cudaq::cc::StructType>(inTy))
+        // cc.struct args are callable (at this point), need them as pointers
+        // for the new entry point
+        inputTys.push_back(cudaq::cc::PointerType::get(structTy));
     else if (auto memrefTy = dyn_cast<quake::VeqType>(inTy))
       inputTys.push_back(cudaq::cc::PointerType::get(stlVectorType(
           IntegerType::get(ctx, /*FIXME sizeof a pointer?*/ 64))));

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -145,10 +145,10 @@ FunctionType factory::toCpuSideFuncType(FunctionType funcTy) {
     if (auto memrefTy = dyn_cast<cudaq::cc::StdvecType>(inTy))
       inputTys.push_back(cudaq::cc::PointerType::get(
           stlVectorType(memrefTy.getElementType())));
-      else if (auto structTy = dyn_cast<cudaq::cc::StructType>(inTy))
-        // cc.struct args are callable (at this point), need them as pointers
-        // for the new entry point
-        inputTys.push_back(cudaq::cc::PointerType::get(structTy));
+    else if (auto structTy = dyn_cast<cudaq::cc::StructType>(inTy))
+      // cc.struct args are callable (at this point), need them as pointers
+      // for the new entry point
+      inputTys.push_back(cudaq::cc::PointerType::get(structTy));
     else if (auto memrefTy = dyn_cast<quake::VeqType>(inTy))
       inputTys.push_back(cudaq::cc::PointerType::get(stlVectorType(
           IntegerType::get(ctx, /*FIXME sizeof a pointer?*/ 64))));

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -108,4 +108,56 @@ cudaq::cc::LoopOp factory::createCountedLoop(
   return loop;
 }
 
+bool factory::hasHiddenSRet(FunctionType funcTy) {
+  return funcTy.getNumResults() == 1 &&
+         funcTy.getResult(0).isa<cudaq::cc::StdvecType>();
+}
+
+// FIXME: We should get the underlying structure of a std::vector from the
+// AST. For expediency, we just construct the expected type directly here.
+static cudaq::cc::StructType stlVectorType(Type eleTy) {
+  MLIRContext *ctx = eleTy.getContext();
+  auto elePtrTy = cudaq::cc::PointerType::get(eleTy);
+  SmallVector<Type> eleTys = {elePtrTy, elePtrTy, elePtrTy};
+  return cudaq::cc::StructType::get(ctx, eleTys);
+}
+
+FunctionType factory::toCpuSideFuncType(FunctionType funcTy) {
+  auto *ctx = funcTy.getContext();
+  // When the kernel comes from a class, there is always a default "this"
+  // argument to the kernel entry function. The CUDA Quantum language spec
+  // doesn't allow the kernel object to contain data members (yet), so we can
+  // ignore the `this` pointer.
+  auto ptrTy = cudaq::cc::PointerType::get(IntegerType::get(ctx, 8));
+  SmallVector<Type> inputTys = {ptrTy};
+  bool hasSRet = false;
+  if (factory::hasHiddenSRet(funcTy)) {
+    // When the kernel is returning a std::vector<T> result, the result is
+    // returned via a sret argument in the first position. When this argument
+    // is added, the this pointer becomes the second argument. Both are opaque
+    // pointers at this point.
+    inputTys.push_back(ptrTy);
+    hasSRet = true;
+  }
+
+  // Add all the explicit (not hidden) arguments after the hidden ones.
+  for (auto inTy : funcTy.getInputs()) {
+    if (auto memrefTy = dyn_cast<cudaq::cc::StdvecType>(inTy))
+      inputTys.push_back(cudaq::cc::PointerType::get(
+          stlVectorType(memrefTy.getElementType())));
+    else if (auto memrefTy = dyn_cast<quake::VeqType>(inTy))
+      inputTys.push_back(cudaq::cc::PointerType::get(stlVectorType(
+          IntegerType::get(ctx, /*FIXME sizeof a pointer?*/ 64))));
+    else
+      inputTys.push_back(inTy);
+  }
+
+  // Handle the result type. We only add a result type when there is a result
+  // and it hasn't been converted to a hidden sret argument.
+  if (funcTy.getNumResults() == 0 || hasSRet)
+    return FunctionType::get(ctx, inputTys, {});
+  assert(funcTy.getNumResults() == 1);
+  return FunctionType::get(ctx, inputTys, funcTy.getResults());
+}
+
 } // namespace cudaq::opt

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -523,6 +523,13 @@ public:
       if (inTy.isa<cudaq::cc::LambdaType, cudaq::cc::StructType>()) {
         /* do nothing */
       } else if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(inTy)) {
+        // This block only considers stdvec< builtin >, which have been
+        // mapped to ptr< builtin >. But now we also want callable structs
+        // represented as pointers in the new entry point. So skip this
+        // block if this is a pointer to a struct.
+        if (dyn_cast<cudaq::cc::StructType>(ptrTy.getElementType()))
+          continue;
+
         // FIXME: for now assume this is a std::vector<`eleTy`>
         // FIXME: call the `size` member function. For expediency, assume this
         // is an std::vector and the size is the scaled delta between the

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -523,13 +523,6 @@ public:
       if (inTy.isa<cudaq::cc::LambdaType, cudaq::cc::StructType>()) {
         /* do nothing */
       } else if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(inTy)) {
-        // This block only considers stdvec< builtin >, which have been
-        // mapped to ptr< builtin >. But now we also want callable structs
-        // represented as pointers in the new entry point. So skip this
-        // block if this is a pointer to a struct.
-        if (dyn_cast<cudaq::cc::StructType>(ptrTy.getElementType()))
-          continue;
-
         // FIXME: for now assume this is a std::vector<`eleTy`>
         // FIXME: call the `size` member function. For expediency, assume this
         // is an std::vector and the size is the scaled delta between the

--- a/test/NVQPP/if_jit.cpp
+++ b/test/NVQPP/if_jit.cpp
@@ -10,7 +10,7 @@
 
 // RUN: nvq++ %s --target quantinuum --emulate -o %t.x && %t.x | FileCheck %s
 
-// CHECK: { {{[1-9][0-9]*}}:{{[1-9][0-9]*}} }
+// CHECK: { 1:100 }
 
 #include <cudaq.h>
 

--- a/test/NVQPP/if_jit.cpp
+++ b/test/NVQPP/if_jit.cpp
@@ -10,7 +10,7 @@
 
 // RUN: nvq++ %s --target quantinuum --emulate -o %t.x && %t.x | FileCheck %s
 
-// CHECK: { 0:{{[0-9]+}} }
+// CHECK: { {{[1-9][0-9]*}}:{{[1-9][0-9]*}} }
 
 #include <cudaq.h>
 

--- a/test/NVQPP/test-1.cpp
+++ b/test/NVQPP/test-1.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// XFAIL: *
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/test-5.cpp
+++ b/test/NVQPP/test-5.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// XFAIL: *
 
 #include <cudaq.h>
 #include <iostream>


### PR DESCRIPTION
As we now allow plain old functions to be quantum kernels, we can no longer assume that an entry point kernel will have a this pointer. These changes will generate signatures for kernel entry points that do not assume that a this pointer must always be added.

This fixes (part of) #337 as well as other issues. #339 
