### PR TITLE
Fix #343: Allow unrolling to work on more loops.

### DIFF
--- a/test/NVQPP/sudoku_2x2-1.cpp
+++ b/test/NVQPP/sudoku_2x2-1.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// XFAIL: *
 
 #include <cudaq.h>
 #include <algorithm>


### PR DESCRIPTION
Especially with inlining, a loop's body may contain a non-trivial CFG. Allow that. Make unrolling greedy so that loops that contain loops will have the entire loop nest tree unrolled, if possible. Mark existing test as passing.
