### PR TITLE
Minimal verification of QIR base profile.

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -32,6 +32,7 @@ void addBaseProfilePipeline(mlir::PassManager &pm);
 
 // Use the addBaseProfilePipeline() for the following passes.
 std::unique_ptr<mlir::Pass> createQIRToBaseProfilePass();
+std::unique_ptr<mlir::Pass> verifyBaseProfilePass();
 std::unique_ptr<mlir::Pass> createBaseProfilePreparationPass();
 std::unique_ptr<mlir::Pass> createConvertToQIRFuncPass();
 

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -38,6 +38,16 @@ def QIRToBaseQIRPrep : Pass<"qir-to-base-qir-prep", "mlir::ModuleOp"> {
   let constructor = "cudaq::opt::createBaseProfilePreparationPass()";
 }
 
+def VerifyBaseProfile : Pass<"verify-base-profile", "mlir::LLVM::LLVMFuncOp"> {
+  let summary = "Verify that the output conforms to the base profile";
+  let description = [{
+    This pass scans over functions in the LLVM-IR dialect to make sure they
+    conform to the QIR base profile.
+  }];
+
+  let constructor = "cudaq::opt::verifyBaseProfilePass()";
+}
+
 def QIRToBaseQIRFunc : Pass<"quake-to-base-qir-func",
                             "mlir::LLVM::LLVMFuncOp"> {
   let summary = "Analyze kernels and add attributes and record calls.";

--- a/lib/Optimizer/CodeGen/LowerToBaseProfileQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToBaseProfileQIR.cpp
@@ -21,10 +21,9 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
-/// This file maps full QIR to the Base Profile QIR.
-/// It is generally assumed that the input QIR here will be
-/// generated after the quake-synth pass, thereby greatly simplifying
-/// the transformations required here.
+/// This file maps full QIR to the Base Profile QIR. It is generally assumed
+/// that the input QIR here will be generated after the quake-synth pass,
+/// thereby greatly simplifying the transformations required here.
 
 using namespace mlir;
 
@@ -298,7 +297,8 @@ struct QIRToBaseProfileQIRPass
     config.useTopDownTraversal = topDownProcessingEnabled;
     config.enableRegionSimplification = enableRegionSimplification;
     config.maxIterations = maxIterations;
-    (void)applyPatternsAndFoldGreedily(getOperation(), patterns, config);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), patterns, config)))
+      signalPassFailure();
   }
 
 private:
@@ -329,7 +329,7 @@ struct BaseProfilePreparationPass
     ModuleOp module = getOperation();
     auto *ctx = module.getContext();
 
-    // Add cnot declaration as it made be referenced after peepholes run.
+    // Add cnot declaration as it may be referenced after peepholes run.
     cudaq::opt::factory::createLLVMFunctionSymbol(
         cudaq::opt::QIRCnot, LLVM::LLVMVoidType::get(ctx),
         {cudaq::opt::getQubitType(ctx), cudaq::opt::getQubitType(ctx)}, module);
@@ -355,8 +355,8 @@ struct BaseProfilePreparationPass
         {cudaq::opt::getResultType(ctx), cudaq::opt::getCharPointerType(ctx)},
         module);
 
-    // Add functions `__quantum__qis__*__body` for all `__quantum__qis__*`
-    // found.
+    // Add functions `__quantum__qis__*__body` for all functions matching
+    // `__quantum__qis__*` that are found.
     for (auto &global : module)
       if (auto func = dyn_cast<LLVM::LLVMFuncOp>(global))
         if (needsToBeRenamed(func.getName()))
@@ -372,9 +372,44 @@ std::unique_ptr<Pass> cudaq::opt::createBaseProfilePreparationPass() {
   return std::make_unique<BaseProfilePreparationPass>();
 }
 
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Verify that the base profile QIR code is sane. For now, this simply checks
+/// that the QIR base profile doesn't have any "bonus" calls to arbitrary code
+/// that is not possibly defined in the QIR standard.
+struct VerifyBaseProfilePass
+    : public cudaq::opt::VerifyBaseProfileBase<VerifyBaseProfilePass> {
+
+  void runOnOperation() override {
+    auto func = getOperation();
+    bool passFailed = false;
+    if (!func->hasAttr(cudaq::entryPointAttrName))
+      return;
+    func.walk([&](LLVM::CallOp call) {
+      auto funcName = call.getCalleeAttr().getValue();
+      if (!funcName.startswith("__quantum_")) {
+        call.emitOpError("unexpected call in QIR base profile");
+        passFailed = true;
+      }
+    });
+    if (passFailed) {
+      emitError(func.getLoc(),
+                "function " + func.getName() + " not in base profile QIR");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<Pass> cudaq::opt::verifyBaseProfilePass() {
+  return std::make_unique<VerifyBaseProfilePass>();
+}
+
 // The various passes defined here should be added as a pipeline.
 void cudaq::opt::addBaseProfilePipeline(PassManager &pm) {
   pm.addPass(createBaseProfilePreparationPass());
   pm.addNestedPass<LLVM::LLVMFuncOp>(createConvertToQIRFuncPass());
   pm.addPass(createQIRToBaseProfilePass());
+  pm.addNestedPass<LLVM::LLVMFuncOp>(verifyBaseProfilePass());
 }

--- a/test/Quake-QIR/base_profile_verify.qke
+++ b/test/Quake-QIR/base_profile_verify.qke
@@ -1,0 +1,31 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: (cudaq-translate --convert-to=qir-base %s 2>&1 || true) | FileCheck %s
+
+func.func @__nvqpp__mlirgen__function_init_state._Z10init_statev() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %cst = arith.constant 2.000000e+00 : f64
+  %cst_0 = arith.constant 1.000000e+00 : f64
+  %c3_i32 = arith.constant 3 : i32
+  %0 = call @_ZSt4sqrtIiEN9__gnu_cxx11__enable_ifIXsr12__is_integerIT_EE7__valueEdE6__typeES2_(%c3_i32) : (i32) -> f64
+  %1 = arith.divf %cst_0, %0 : f64
+  %2 = call @acos(%1) : (f64) -> f64
+  %3 = arith.mulf %2, %cst : f64
+  %4 = quake.alloca !quake.veq<2>
+  %5 = quake.extract_ref %4[0] : (!quake.veq<2>) -> !quake.ref
+  quake.ry (%3) %5 : (f64, !quake.ref) -> ()
+  %6 = quake.extract_ref %4[1] : (!quake.veq<2>) -> !quake.ref
+  quake.h [%5] %6 : (!quake.ref, !quake.ref) -> ()
+  quake.x %6 : (!quake.ref) -> ()
+  return
+}
+func.func private @_ZSt4sqrtIiEN9__gnu_cxx11__enable_ifIXsr12__is_integerIT_EE7__valueEdE6__typeES2_(i32) -> f64
+func.func private @acos(f64) -> f64
+
+// CHECK: unexpected call in QIR base profile
+// CHECK: unexpected call in QIR base profile

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -263,8 +263,7 @@ while [ $# -ne 0 ]; do
 		shift
 		;;
 	--emit-qir | -emit-qir)
-		EMIT_QIR="$2"
-		shift
+		EMIT_QIR=true
 		;;
 	--emulate | -emulate)
 		CUDAQ_EMULATE_REMOTE=true


### PR DESCRIPTION
This patch introduces a minimal base profile verification. It will catch cases where the JIT produces QIR base profile code that calls non-QIR functions.

See https://github.com/NVIDIA/cuda-quantum/issues#issuecomment-1621658944
