### PR TITLE
Fix #338: Work on implementation of cudaq::adjoint.

### DIFF
--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1405,15 +1405,16 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
                                        kernelArgs);
         return inlinedFinishControlNegations();
       }
-      ValueRange argRange = args;
       if (auto func =
               dyn_cast_or_null<func::ConstantOp>(calleeValue.getDefiningOp())) {
         auto funcTy = cast<FunctionType>(func.getType());
         auto callableSym = func.getValueAttr();
         inlinedStartControlNegations();
+        auto kernelArgs =
+            convertKernelArgs(builder, loc, 2, args, funcTy.getInputs());
         builder.create<quake::ApplyOp>(loc, funcTy.getResults(), callableSym,
                                        /*isAdjoint=*/false, ctrlValues,
-                                       argRange.drop_front(2));
+                                       kernelArgs);
         return inlinedFinishControlNegations();
       }
       if (auto ty = dyn_cast<cc::LambdaType>(calleeValue.getType())) {
@@ -1445,9 +1446,11 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           calleeSymbol = SymbolRefAttr::get(ctx, mangledName);
           auto funcTy = ty.getSignature();
           inlinedStartControlNegations();
+          auto kernelArgs =
+              convertKernelArgs(builder, loc, 2, args, funcTy.getInputs());
           builder.create<quake::ApplyOp>(loc, funcTy.getResults(), calleeSymbol,
                                          /*isAdjoint=*/false, ctrlValues,
-                                         argRange.drop_front(2));
+                                         kernelArgs);
           return inlinedFinishControlNegations();
         }
         TODO_loc(loc, "value has !cc.lambda type but decl isn't a lambda");
@@ -1499,6 +1502,53 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         return builder.create<quake::ApplyOp>(loc, TypeRange{}, calleeSymbol,
                                               /*isAdjoint=*/true, ValueRange{},
                                               kernelArgs);
+      }
+      if (auto func =
+              dyn_cast_or_null<func::ConstantOp>(calleeValue.getDefiningOp())) {
+        auto calleeSym = func.getValueAttr();
+        auto funcTy = cast<FunctionType>(func.getType());
+        auto kernelArgs =
+            convertKernelArgs(builder, loc, 1, args, funcTy.getInputs());
+        return builder.create<quake::ApplyOp>(
+            loc, funcTy.getResults(), calleeSym,
+            /*isAdjoint=*/true, ValueRange{}, kernelArgs);
+      }
+      if (auto ty = dyn_cast<cc::LambdaType>(calleeValue.getType())) {
+        // In order to autogenerate the control form of the called kernel, we
+        // have to be able to determine precisely which kernel is being called
+        // at this point. If this is a local lambda expression, it is handled
+        // elsewhere. If this is a lambda expression argument, then we have to
+        // recover it or give a compilation error.
+        auto *tyPtr = x->getArg(0)->getType().getTypePtr();
+        auto *recTy = dyn_cast<clang::RecordType>(tyPtr);
+        if (!recTy && isa<clang::AutoType>(tyPtr)) {
+          recTy = dyn_cast_or_null<clang::RecordType>(
+              cast<clang::AutoType>(tyPtr)->desugar().getTypePtr());
+        }
+        if (!recTy && isa<clang::SubstTemplateTypeParmType>(tyPtr)) {
+          auto *ty = cast<clang::SubstTemplateTypeParmType>(tyPtr);
+          recTy = dyn_cast_or_null<clang::RecordType>(
+              ty->getReplacementType().getTypePtr());
+        }
+        if (!recTy) {
+          TODO_loc(loc,
+                   "adjoint does not appear to be on a user-defined kernel");
+        }
+        auto *decl = recTy->getDecl();
+        if (decl->isLambda()) {
+          auto *lambdaClass = cast<clang::CXXRecordDecl>(decl);
+          auto mangledName =
+              generateCudaqKernelName(findCallOperator(lambdaClass));
+          auto calleeSymbol =
+              SymbolRefAttr::get(builder.getContext(), mangledName);
+          auto funcTy = ty.getSignature();
+          auto kernelArgs =
+              convertKernelArgs(builder, loc, 1, args, funcTy.getInputs());
+          return builder.create<quake::ApplyOp>(
+              loc, funcTy.getResults(), calleeSymbol,
+              /*isAdjoint=*/true, ValueRange{}, kernelArgs);
+        }
+        TODO_loc(loc, "value has !cc.lambda type but decl isn't a lambda");
       }
       TODO_loc(loc, "adjoint does not appear to be on a user-defined kernel");
     }

--- a/test/AST-Quake/adjoint-4.cpp
+++ b/test/AST-Quake/adjoint-4.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
+
+#include <cudaq.h>
+
+__qpu__ void init_state(cudaq::qreg<> &qubits, double theta) {}
+
+__qpu__ void reflect_uni(cudaq::qreg<> &ctrls, cudaq::qreg<> &qubits,
+                         double theta) {
+  cudaq::adjoint(init_state, qubits, theta);
+}
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_init_state.
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: f64)
+// CHECK:           return
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_reflect_uni.
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !quake.veq<?>, %[[VAL_2:.*]]: f64)
+// CHECK:           %[[VAL_3:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_3]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_4:.*]] = constant @__nvqpp__mlirgen__function_init_state.[[MANGLE:.*]] : (!quake.veq<?>, f64) -> ()
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_3]] : !cc.ptr<f64>
+// CHECK:           quake.apply<adj> @__nvqpp__mlirgen__function_init_state.[[MANGLE]] %[[VAL_1]], %[[VAL_5]] : (!quake.veq<?>, f64) -> ()
+// CHECK:           return
+// CHECK:         }
+


### PR DESCRIPTION
Fix #338 
These patches bring cudaq::control and cudaq::adjoint to parity. Add test.
