### PR TITLE
Alternative to PR #377

### DIFF
--- a/test/Quake-QIR/allocaNoOperand.qke
+++ b/test/Quake-QIR/allocaNoOperand.qke
@@ -47,10 +47,10 @@ module {
 // CHECK:         tail call void @__quantum__qis__s(%[[VAL_4]]* %[[VAL_11]])
 // CHECK: tail call void (i64, void (%Array*, %Qubit*)*, ...) @invokeWithControlQubits(i64 1, void (%Array*, %Qubit*)* nonnull @__quantum__qis__x__ctl, %Qubit* %[[VAL_11]], %Qubit* %[[VAL_5]])
 // CHECK:         tail call void @__quantum__qis__h(%[[VAL_4]]* %[[VAL_11]])
-// CHECK:         %[[VAL_15:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_5]]
-// CHECK:         %[[VAL_17:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_8]]
-// CHECK:         %[[VAL_18:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_14]]
-// CHECK:         %[[VAL_19:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_11]]
+// CHECK:         %[[VAL_15:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_5]])
+// CHECK:         %[[VAL_17:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_8]])
+// CHECK:         %[[VAL_18:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_14]])
+// CHECK:         %[[VAL_19:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_11]])
 // CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
 // CHECK:         ret void
     %0 = quake.alloca !quake.veq<4>

--- a/test/Quake-QIR/allocaNoOperand.qke
+++ b/test/Quake-QIR/allocaNoOperand.qke
@@ -47,10 +47,10 @@ module {
 // CHECK:         tail call void @__quantum__qis__s(%[[VAL_4]]* %[[VAL_11]])
 // CHECK: tail call void (i64, void (%Array*, %Qubit*)*, ...) @invokeWithControlQubits(i64 1, void (%Array*, %Qubit*)* nonnull @__quantum__qis__x__ctl, %Qubit* %[[VAL_11]], %Qubit* %[[VAL_5]])
 // CHECK:         tail call void @__quantum__qis__h(%[[VAL_4]]* %[[VAL_11]])
-// CHECK:         %[[VAL_15:.*]] = tail call %[[VAL_16:.*]]* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_5]])
-// CHECK:         %[[VAL_17:.*]] = tail call %[[VAL_16]]* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_8]])
-// CHECK:         %[[VAL_18:.*]] = tail call %[[VAL_16]]* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_14]])
-// CHECK:         %[[VAL_19:.*]] = tail call %[[VAL_16]]* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_11]])
+// CHECK:         %[[VAL_15:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_5]]
+// CHECK:         %[[VAL_17:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_8]]
+// CHECK:         %[[VAL_18:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_14]]
+// CHECK:         %[[VAL_19:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_11]]
 // CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
 // CHECK:         ret void
     %0 = quake.alloca !quake.veq<4>

--- a/test/Quake-QIR/base-profile-2.qke
+++ b/test/Quake-QIR/base-profile-2.qke
@@ -23,7 +23,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__t1()
-// CHECK: tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result*
+// CHECK: tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* null)
 // CHECK: tail call void @__quantum__rt__array_start_record_output()
 // CHECK: tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull
 // CHECK: tail call void @__quantum__rt__array_end_record_output()

--- a/test/Quake-QIR/base-profile-2.qke
+++ b/test/Quake-QIR/base-profile-2.qke
@@ -23,9 +23,9 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__t1()
-// CHECK: tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* null)
+// CHECK: tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result*
 // CHECK: tail call void @__quantum__rt__array_start_record_output()
-// CHECK: tail call void @__quantum__rt__result_record_output(%Result* null, i8* null)
+// CHECK: tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull
 // CHECK: tail call void @__quantum__rt__array_end_record_output()
 // CHECK: ret void
 

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -28,7 +28,7 @@
 // CHECK:         tail call void @__quantum__qis__h(%[[VAL_11]]* %[[VAL_12]])
 // CHECK: tail call void (i64, void (%Array*, %Qubit*)*, ...) @invokeWithControlQubits(i64 1, void (%Array*, %Qubit*)* nonnull @__quantum__qis__x__ctl, %Qubit* %[[VAL_12]], %Qubit* %[[VAL_15]])
 // CHECK:         tail call void @__quantum__qis__rx(double 4.300000e-01, %[[VAL_11]]* %[[VAL_12]])
-// CHECK:         %[[VAL_16:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_11]]* %[[VAL_12]]
+// CHECK:         %[[VAL_16:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_11]]* %[[VAL_12]])
 // CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_5]])
 // CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_7]])
 // CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_8]])

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -28,7 +28,7 @@
 // CHECK:         tail call void @__quantum__qis__h(%[[VAL_11]]* %[[VAL_12]])
 // CHECK: tail call void (i64, void (%Array*, %Qubit*)*, ...) @invokeWithControlQubits(i64 1, void (%Array*, %Qubit*)* nonnull @__quantum__qis__x__ctl, %Qubit* %[[VAL_12]], %Qubit* %[[VAL_15]])
 // CHECK:         tail call void @__quantum__qis__rx(double 4.300000e-01, %[[VAL_11]]* %[[VAL_12]])
-// CHECK:         %[[VAL_16:.*]] = tail call %[[VAL_17:.*]]* @__quantum__qis__mz(%[[VAL_11]]* %[[VAL_12]])
+// CHECK:         %[[VAL_16:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_11]]* %[[VAL_12]]
 // CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_5]])
 // CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_7]])
 // CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_8]])

--- a/test/Quake-QIR/measure.qke
+++ b/test/Quake-QIR/measure.qke
@@ -30,9 +30,9 @@ module {
 // CHECK:    %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %Qubit**
 // CHECK:    %[[VAL_5:.*]] = load %Qubit*, %Qubit** %[[VAL_3]], align 8
 // CHECK:    tail call void @__quantum__qis__h(%Qubit* %[[VAL_5]])
-// CHECK:    %[[VAL_7:.*]] = tail call %[[VAL_8:.*]]* @__quantum__qis__mz(%Qubit* %[[VAL_5]])
+// CHECK:    %[[VAL_7:.*]] = tail call %Result* @__quantum__qis__mz(%Qubit* %[[VAL_5]]
 // CHECK:    tail call void @__quantum__qis__sdg(%Qubit* %[[VAL_5]])
 // CHECK:    tail call void @__quantum__qis__h(%Qubit* %[[VAL_5]])
-// CHECK:    %[[VAL_9:.*]] = tail call %[[VAL_8]]* @__quantum__qis__mz(%Qubit* %[[VAL_5]])
+// CHECK:    %[[VAL_9:.*]] = tail call %Result* @__quantum__qis__mz(%Qubit* %[[VAL_5]], i8* nonnull
 // CHECK:    tail call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
 // CHECK:    ret void

--- a/test/Quake-QIR/measure.qke
+++ b/test/Quake-QIR/measure.qke
@@ -30,9 +30,9 @@ module {
 // CHECK:    %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %Qubit**
 // CHECK:    %[[VAL_5:.*]] = load %Qubit*, %Qubit** %[[VAL_3]], align 8
 // CHECK:    tail call void @__quantum__qis__h(%Qubit* %[[VAL_5]])
-// CHECK:    %[[VAL_7:.*]] = tail call %Result* @__quantum__qis__mz(%Qubit* %[[VAL_5]]
+// CHECK:    %[[VAL_7:.*]] = tail call %Result* @__quantum__qis__mz(%Qubit* %[[VAL_5]])
 // CHECK:    tail call void @__quantum__qis__sdg(%Qubit* %[[VAL_5]])
 // CHECK:    tail call void @__quantum__qis__h(%Qubit* %[[VAL_5]])
-// CHECK:    %[[VAL_9:.*]] = tail call %Result* @__quantum__qis__mz(%Qubit* %[[VAL_5]], i8* nonnull
+// CHECK:    %[[VAL_9:.*]] = tail call %Result* @__quantum__qis__mz(%Qubit* %[[VAL_5]])
 // CHECK:    tail call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
 // CHECK:    ret void

--- a/test/Quake-QIR/testBaseProfile.qke
+++ b/test/Quake-QIR/testBaseProfile.qke
@@ -18,9 +18,9 @@ module {
 // CHECK: tail call void @__quantum__qis__mz__body(%[[VAL_0]]* nonnull inttoptr (i64 1 to %[[VAL_0]]*), %[[VAL_1]]* nonnull inttoptr (i64 1 to %[[VAL_1]]*))
 // CHECK: tail call void @__quantum__qis__mz__body(%[[VAL_0]]* nonnull inttoptr (i64 2 to %[[VAL_0]]*), %[[VAL_1]]* nonnull inttoptr (i64 2 to %[[VAL_1]]*))
 // CHECK: tail call void @__quantum__rt__array_start_record_output()
-// CHECK: tail call void @__quantum__rt__result_record_output(%Result* null, i8* null)
-// CHECK: tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* null)
-// CHECK: tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* null)
+// CHECK: tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull
+// CHECK: tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull
+// CHECK: tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull
 // CHECK: tail call void @__quantum__rt__array_end_record_output()
 // CHECK: ret void
     %c2_i32 = arith.constant 2 : i32


### PR DESCRIPTION
This implements the same fix as PR #377, but moves the creation of the names so as to avoid any race conditions in updating the Module.

See #377 for more information.
