### PR TITLE
Update unwind-lowering pass to be more general. The original pass

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -1087,6 +1087,9 @@ def cc_CreateLambdaOp : CCOp<"create_lambda",
     unsigned getNumResults() {
       return getType().getSignature().getNumResults();
     }
+
+    mlir::Region &getBody() { return getInitRegion(); }
+    llvm::StringRef getName() { return "*lambda*"; }
   }];
 }
 

--- a/lib/Optimizer/Transforms/LowerUnwind.cpp
+++ b/lib/Optimizer/Transforms/LowerUnwind.cpp
@@ -29,113 +29,237 @@ namespace {
 // with these ops. Unwind ops may require lowering to primitive cf.br ops or
 // retain some structure and conversion to cc.break or cc.continue. That
 // conversion is also tracked.
-struct ContainsUnwindGotoOf {
-  Operation *parent = nullptr;    // the original parent op
-  Block *continueBlock = nullptr; // unwind_continue landing pad
-  Block *breakBlock = nullptr;    // unwind_break landing pad
-  Block *returnBlock = nullptr;   // unwind_return landing pad
-  bool asPrimitive = false;       // convert to cf.br?
+
+struct BlockInfo {
+  Block *continueBlock = nullptr; // unwind_continue landing pads
+  Block *breakBlock = nullptr;    // unwind_break landing pads
+  Block *returnBlock = nullptr;   // unwind_return landing pads
 };
 
-using UnwindOpAnalysisInfo = llvm::DenseMap<Operation *, ContainsUnwindGotoOf>;
+struct UnwindGotoAsPrimitive {
+  Operation *parent = nullptr; // the original parent op
+  bool asPrimitive = false;    // convert to cf.br?
+};
+
+struct BlockDetails {
+  using Key = unsigned;
+  DenseMap<Operation *, Key> keyMap;
+  DenseMap<Key, SmallVector<Operation *>> allocaDomMap;
+  DenseMap<Key, BlockInfo> blockMap;
+};
+
+struct UnwindOpAnalysisInfo {
+  DenseMap<Operation *, UnwindGotoAsPrimitive> opParentMap;
+  DenseMap<Operation *, BlockDetails> blockDetails;
+
+  bool empty() const { return opParentMap.empty(); }
+};
 
 struct UnwindOpAnalysis {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(UnwindOpAnalysis)
 
-  UnwindOpAnalysis(func::FuncOp op) : func(op) {
+  UnwindOpAnalysis(func::FuncOp op, DominanceInfo &di) : func(op), dom(di) {
     performAnalysis(op.getOperation());
   }
 
   UnwindOpAnalysisInfo getAnalysisInfo() const { return infoMap; }
 
 private:
+  Operation *getParent(Operation *p) {
+    return (!p || isa<func::FuncOp, cudaq::cc::CreateLambdaOp>(p))
+               ? nullptr
+               : p->getParentOp();
+  }
+
   template <typename A>
-  void addToParents(A unwindOp) {
+  void addParents(A unwindOp) {
     bool asPrimitive = false;
+    Operation *parent = unwindOp->getParentOp();
     if constexpr (std::is_same_v<A, cudaq::cc::UnwindReturnOp>) {
       asPrimitive = true;
     } else {
+      // The unwind can be demoted to a high-level break or continue if there is
+      // no scope between the unwind and the nearest enclosing loop.
       for (Operation *parent = unwindOp->getParentOp();
            !isa<cudaq::cc::LoopOp>(parent) && !asPrimitive;
            parent = parent->getParentOp())
-        asPrimitive = isa<func::FuncOp, cudaq::cc::ScopeOp>(parent);
+        asPrimitive =
+            isa<func::FuncOp, cudaq::cc::CreateLambdaOp, cudaq::cc::ScopeOp>(
+                parent);
     }
-    Operation *parent = nullptr;
-    for (Operation *op = unwindOp.getOperation(); op; op = parent) {
-      ContainsUnwindGotoOf unwindGoto;
-      parent = op->getParentOp();
-      auto iter = infoMap.find(op);
-      auto &ref = iter == infoMap.end() ? unwindGoto : iter->second;
-      ref.asPrimitive = asPrimitive;
-      bool requiresBlock =
-          !isa<cudaq::cc::UnwindBreakOp, cudaq::cc::UnwindContinueOp,
-               cudaq::cc::UnwindReturnOp>(op);
-      if constexpr (std::is_same_v<A, cudaq::cc::UnwindBreakOp>) {
-        if (requiresBlock && !ref.breakBlock)
-          ref.breakBlock = new Block;
-        if (isa<cudaq::cc::LoopOp>(op))
-          parent = nullptr;
-      } else if constexpr (std::is_same_v<A, cudaq::cc::UnwindContinueOp>) {
-        if (requiresBlock && !ref.continueBlock)
-          ref.continueBlock = new Block;
-        if (isa<cudaq::cc::LoopOp>(op))
-          parent = nullptr;
+    auto *op = unwindOp.getOperation();
+    infoMap.opParentMap.insert({op, {parent, asPrimitive}});
+    for (auto *p = parent; p; p = parent) {
+      if constexpr (std::is_same_v<A, cudaq::cc::UnwindReturnOp>) {
+        parent = getParent(p);
       } else {
-        if (requiresBlock && !ref.returnBlock)
-          ref.returnBlock = new Block;
-        if (isa<func::FuncOp>(op)) {
-          auto *ctx = op->getContext();
-          op->setAttr("add_dealloc", UnitAttr::get(ctx));
-          parent = nullptr;
-        }
+        parent = isa<cudaq::cc::LoopOp>(p) ? nullptr : getParent(p);
       }
-      if (!ref.parent)
-        ref.parent = parent;
-      if (iter == infoMap.end()) {
-        LLVM_DEBUG(llvm::dbgs() << "analysis adding: " << op << '\n');
-        infoMap.insert(std::make_pair(op, unwindGoto));
+      if (infoMap.opParentMap.count(p)) {
+        // p is already in the op-parent map, so merge new information.
+        if (!infoMap.opParentMap[p].parent)
+          infoMap.opParentMap[p].parent = parent;
+        infoMap.opParentMap[p].asPrimitive |= asPrimitive;
+      } else {
+        // p is not in the map, so add it with the information.
+        infoMap.opParentMap.insert({p, {parent, asPrimitive}});
       }
     }
   }
 
+  template <typename A>
+  Block *createNewBlock(A unwindOp) {
+    auto *newBlock = new Block;
+    // Add blocks arguments corresponding to the jump to thread results.
+    auto argTys = unwindOp.getOperandTypes();
+    SmallVector<Location> locations(argTys.size(), unwindOp.getLoc());
+    newBlock->addArguments(argTys, locations);
+    return newBlock;
+  }
+
   void performAnalysis(Operation *func) {
+    // 1) Find all the unwind jump operations and add them and their parents to
+    // our analysis map. Record if high-level control flow must be decomposed to
+    // primitive control flow.
     func->walk([this](Operation *o) {
       if (auto brkOp = dyn_cast<cudaq::cc::UnwindBreakOp>(o))
-        addToParents(brkOp);
+        addParents(brkOp);
       else if (auto cntOp = dyn_cast<cudaq::cc::UnwindContinueOp>(o))
-        addToParents(cntOp);
+        addParents(cntOp);
       else if (auto retOp = dyn_cast<cudaq::cc::UnwindReturnOp>(o))
-        addToParents(retOp);
+        addParents(retOp);
     });
+    if (infoMap.opParentMap.empty())
+      return;
+
+    // 2) Walk all the parent ops and add an empty block details entry for each.
+    // (The unwind jumps do not have block details.)
+    for (auto &pr : infoMap.opParentMap) {
+      auto *key = pr.first;
+      if (!isa<cudaq::cc::UnwindBreakOp, cudaq::cc::UnwindContinueOp,
+               cudaq::cc::UnwindReturnOp>(key)) {
+        if (!infoMap.blockDetails.count(key)) {
+          BlockDetails details;
+          LLVM_DEBUG(llvm::dbgs() << "adding to details " << key << '\n');
+          infoMap.blockDetails.insert({key, details});
+        }
+      }
+    }
+
+    // 3) Find scopes that contain quantum allocations.
+    DenseMap<Operation *, SmallVector<Operation *>> scopeAllocMap;
+    for (auto &pr : infoMap.opParentMap) {
+      if (isa<func::FuncOp, cudaq::cc::ScopeOp, cudaq::cc::CreateLambdaOp>(
+              pr.first)) {
+        SmallVector<Operation *> allocas;
+        for (auto &region : pr.first->getRegions())
+          for (auto &block : region)
+            for (auto &o : block)
+              if (isa<quake::AllocaOp>(o))
+                allocas.push_back(&o);
+        if (!allocas.empty())
+          scopeAllocMap[pr.first] = allocas;
+      }
+    }
+
+    // 4) Walk the parent chains and record a reverse map from the unwind jump
+    // to a set of allocations that dominate the unwind jump at this parent. The
+    // set may be empty. For the set of allocations, create a block entry as
+    // needed. The block will be shared for all incident unwind jumps in the
+    // reverse map with equal allocation sets.
+    std::map<SmallVector<Operation *>, BlockDetails::Key> uniqAllocas;
+    BlockDetails::Key uniqValue = 0;
+    for (auto &pr : infoMap.opParentMap) {
+      if (isa<cudaq::cc::UnwindBreakOp, cudaq::cc::UnwindContinueOp,
+              cudaq::cc::UnwindReturnOp>(pr.first)) {
+        auto *currentOp = pr.first;
+        for (auto *p = pr.second.parent; p; p = getParent(p)) {
+          assert(infoMap.blockDetails.count(p));
+
+          // Compute the subset of allocas that dominate the current op.
+          SmallVector<Operation *> domAllocas;
+          if (scopeAllocMap.count(p)) {
+            for (auto *a : scopeAllocMap[p])
+              if (dom.dominates(a, currentOp))
+                domAllocas.push_back(a);
+          }
+
+          // Map the list of allocas to a unique key value.
+          auto ui = uniqAllocas.find(domAllocas);
+          BlockDetails::Key key;
+          if (ui == uniqAllocas.end()) {
+            key = uniqValue++;
+            uniqAllocas.insert({domAllocas, key});
+          } else {
+            key = ui->second;
+          }
+
+          // Add a relation from <parent x unwind> -> [dominating allocas]
+          auto &details = infoMap.blockDetails[p];
+          details.keyMap[currentOp] = key;
+          if (!details.allocaDomMap.count(key))
+            details.allocaDomMap[key] = domAllocas;
+
+          // Depending on the type of unwind add a relation from <parent x
+          // [dominating allocas]> -> {target blocks}
+          auto &blockInfo = details.blockMap[key];
+          if (auto unwindOp = dyn_cast<cudaq::cc::UnwindBreakOp>(pr.first)) {
+            if (!blockInfo.breakBlock)
+              blockInfo.breakBlock = createNewBlock(unwindOp);
+          } else if (auto unwindOp =
+                         dyn_cast<cudaq::cc::UnwindContinueOp>(pr.first)) {
+            if (!blockInfo.continueBlock)
+              blockInfo.continueBlock = createNewBlock(unwindOp);
+          } else if (auto unwindOp =
+                         dyn_cast<cudaq::cc::UnwindReturnOp>(pr.first)) {
+            if (!blockInfo.returnBlock)
+              blockInfo.returnBlock = createNewBlock(unwindOp);
+          }
+          if (isa<cudaq::cc::LoopOp>(p) &&
+              isa<cudaq::cc::UnwindBreakOp, cudaq::cc::UnwindContinueOp>(
+                  pr.first)) {
+            p = nullptr;
+          }
+          currentOp = p;
+        }
+      }
+    }
+    if (infoMap.blockDetails.count(func))
+      func->setAttr("add_dealloc", UnitAttr::get(func->getContext()));
   }
 
   func::FuncOp func;
   UnwindOpAnalysisInfo infoMap;
+  DominanceInfo &dom;
 };
 } // namespace
 
-static Operation *originalParent(const UnwindOpAnalysisInfo &map,
+static Operation *originalParent(const UnwindOpAnalysisInfo &infoMap,
                                  Operation *arg) {
-  auto iter = map.find(arg);
-  assert(iter != map.end());
+  auto iter = infoMap.opParentMap.find(arg);
+  assert(iter != infoMap.opParentMap.end());
   return iter->second.parent;
 }
 
-static const ContainsUnwindGotoOf &
-getLandingPad(const UnwindOpAnalysisInfo &infoMap, Operation *arg) {
-  auto *op = originalParent(infoMap, arg);
-  auto iter = infoMap.find(op);
-  if (iter != infoMap.end() &&
-      (iter->second.breakBlock || iter->second.continueBlock ||
-       iter->second.returnBlock)) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "arg " << arg << " has {" << iter->second.parent << " ["
-               << iter->second.continueBlock << ' ' << iter->second.breakBlock
-               << ' ' << iter->second.returnBlock << "] "
-               << iter->second.asPrimitive << "}\n");
-    return iter->second;
-  }
-  cudaq::emitFatalError(arg->getLoc(), "landing pad not found");
+static const BlockInfo &getLandingPad(const UnwindOpAnalysisInfo &infoMap,
+                                      Operation *arg) {
+  auto *parent = originalParent(infoMap, arg);
+  LLVM_DEBUG(llvm::dbgs() << "op " << arg << " has parent " << parent << '\n');
+  auto iter = infoMap.blockDetails.find(parent);
+  assert(iter != infoMap.blockDetails.end() && "parent not added");
+  auto &details = iter->second;
+  auto jter = details.keyMap.find(arg);
+  assert(jter != details.keyMap.end() && "no block details for enclosed op");
+  auto key = jter->second;
+  auto kter = details.blockMap.find(key);
+  assert(kter != details.blockMap.end() && "map of deallocations not added");
+  LLVM_DEBUG(llvm::dbgs() << "arg " << arg << " has {" << parent << " ["
+                          << kter->second.continueBlock << ' '
+                          << kter->second.breakBlock << ' '
+                          << kter->second.returnBlock << "] "
+                          << infoMap.opParentMap.find(arg)->second.asPrimitive
+                          << "}\n");
+  return kter->second;
 }
 
 static Block *getLandingPad(cudaq::cc::UnwindBreakOp op,
@@ -153,6 +277,38 @@ static Block *getLandingPad(cudaq::cc::UnwindReturnOp op,
   return getLandingPad(infoMap, op).returnBlock;
 }
 
+static SmallVector<Operation *> populateExitTerminators(Region &reg) {
+  SmallVector<Operation *> results;
+  for (Block &b : reg)
+    if (b.getSuccessors().empty())
+      results.push_back(b.getTerminator());
+  return results;
+}
+
+static SmallVector<quake::AllocaOp> populateQuakeAllocas(Region &reg) {
+  SmallVector<quake::AllocaOp> results;
+  for (Block &b : reg)
+    for (Operation &o : b)
+      if (auto q = dyn_cast<quake::AllocaOp>(o))
+        results.push_back(q);
+  return results;
+}
+
+static DenseMap<Operation *, SmallVector<quake::AllocaOp>>
+populateTerminatorAllocaMap(const SmallVector<Operation *> &terminators,
+                            const SmallVector<quake::AllocaOp> &qallocas,
+                            DominanceInfo &dom) {
+  DenseMap<Operation *, SmallVector<quake::AllocaOp>> results;
+  for (auto *t : terminators) {
+    SmallVector<quake::AllocaOp> domList;
+    for (auto a : qallocas)
+      if (dom.dominates(a.getOperation(), t))
+        domList.push_back(a);
+    results.insert({t, domList});
+  }
+  return results;
+}
+
 namespace {
 /// A scope op that contains an unwind op and is contained by a loop (for break
 /// or continue) or for return always, dictates that the unwind op must transfer
@@ -160,27 +316,27 @@ namespace {
 /// that scope. The exact lowering of this control transfer is determined in the
 /// analysis.
 struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
-  explicit ScopeOpPattern(MLIRContext *ctx, const UnwindOpAnalysisInfo &info)
-      : OpRewritePattern(ctx), infoMap(info) {}
+  explicit ScopeOpPattern(MLIRContext *ctx, const UnwindOpAnalysisInfo &info,
+                          DominanceInfo &di)
+      : OpRewritePattern(ctx), infoMap(info), dom(di) {}
 
   LogicalResult matchAndRewrite(cudaq::cc::ScopeOp scope,
                                 PatternRewriter &rewriter) const override {
-    auto iter = infoMap.find(scope.getOperation());
-    assert(iter != infoMap.end() && iter->second.asPrimitive);
+    auto iter = infoMap.opParentMap.find(scope.getOperation());
+    assert(iter != infoMap.opParentMap.end() && iter->second.asPrimitive);
     LLVM_DEBUG(llvm::dbgs() << "replacing scope @" << scope.getLoc() << '\n');
     auto loc = scope.getLoc();
     auto *initBlock = rewriter.getInsertionBlock();
     auto initPos = rewriter.getInsertionPoint();
     auto *nextBlock = rewriter.splitBlock(initBlock, initPos);
     auto *scopeBlock = &scope.getInitRegion().front();
-    auto *scopeEndBlock = &scope.getInitRegion().back();
-    auto *contOp = scopeEndBlock->getTerminator();
-    // Scan the scope for quake allocations.
-    SmallVector<quake::AllocaOp> qallocas;
-    for (Block &b : scope.getInitRegion())
-      for (Operation &o : b)
-        if (auto q = dyn_cast<quake::AllocaOp>(o))
-          qallocas.push_back(q);
+
+    // Find all terminators that leave the ScopeOp.
+    auto terminators = populateExitTerminators(scope.getInitRegion());
+    // Scan the scope for quantum allocations.
+    auto qallocas = populateQuakeAllocas(scope.getInitRegion());
+    auto termAllocMap = populateTerminatorAllocaMap(terminators, qallocas, dom);
+
     // Setup a block with arguments that can be forwarded.
     if (scope.getNumResults() != 0) {
       SmallVector<Location> locs(scope.getNumResults(), loc);
@@ -191,98 +347,129 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
     }
     rewriter.setInsertionPointToEnd(initBlock);
     rewriter.create<cf::BranchOp>(loc, scopeBlock, ValueRange{});
-    // Normal scope exit with deallocations.
-    rewriter.setInsertionPoint(contOp);
-    for (auto a : llvm::reverse(qallocas))
-      rewriter.create<quake::DeallocOp>(a.getLoc(), a.getResult());
-    rewriter.replaceOpWithNewOp<cf::BranchOp>(contOp, nextBlock,
-                                              contOp->getOperands());
-    // Loop continue from within scope with deallocations.
-    if (Block *blk = iter->second.continueBlock) {
-      rewriter.setInsertionPointToEnd(blk);
-      for (auto a : llvm::reverse(qallocas))
+    // Normal scope exit with inline deallocations.
+    for (auto &pr : termAllocMap) {
+      auto *contOp = pr.first;
+      rewriter.setInsertionPoint(contOp);
+      for (auto a : llvm::reverse(pr.second))
         rewriter.create<quake::DeallocOp>(a.getLoc(), a.getResult());
-      Block *landingPad = getLandingPad(infoMap, scope).continueBlock;
-      rewriter.create<cf::BranchOp>(loc, landingPad, blk->getArguments());
-      scope.getInitRegion().push_back(blk);
+      rewriter.replaceOpWithNewOp<cf::BranchOp>(contOp, nextBlock,
+                                                contOp->getOperands());
     }
-    // Loop break from within scope with deallocations.
-    if (Block *blk = iter->second.breakBlock) {
-      rewriter.setInsertionPointToEnd(blk);
-      for (auto a : llvm::reverse(qallocas))
-        rewriter.create<quake::DeallocOp>(a.getLoc(), a.getResult());
-      rewriter.create<cf::BranchOp>(
-          loc, getLandingPad(infoMap, scope).breakBlock, blk->getArguments());
-      scope.getInitRegion().push_back(blk);
-    }
-    // Function return from within scope with deallocations.
-    if (Block *blk = iter->second.returnBlock) {
-      rewriter.setInsertionPointToEnd(blk);
-      for (auto a : llvm::reverse(qallocas))
-        rewriter.create<quake::DeallocOp>(a.getLoc(), a.getResult());
-      rewriter.create<cf::BranchOp>(
-          loc, getLandingPad(infoMap, scope).returnBlock, blk->getArguments());
-      scope.getInitRegion().push_back(blk);
+    auto blockMapIter = infoMap.blockDetails.find(scope.getOperation());
+    assert(blockMapIter != infoMap.blockDetails.end());
+    auto &details = blockMapIter->second;
+    for (auto &pr : details.blockMap) {
+      auto &blockInfo = pr.second;
+      auto &qallocas = details.allocaDomMap.find(pr.first)->second;
+      // Loop continue from within scope with deallocations.
+      if (Block *blk = blockInfo.continueBlock) {
+        rewriter.setInsertionPointToEnd(blk);
+        for (auto a : llvm::reverse(qallocas))
+          rewriter.create<quake::DeallocOp>(a->getLoc(), a->getResult(0));
+        Block *landingPad = getLandingPad(infoMap, scope).continueBlock;
+        rewriter.create<cf::BranchOp>(loc, landingPad, blk->getArguments());
+        scope.getInitRegion().push_back(blk);
+      }
+      // Loop break from within scope with deallocations.
+      if (Block *blk = blockInfo.breakBlock) {
+        rewriter.setInsertionPointToEnd(blk);
+        for (auto a : llvm::reverse(qallocas))
+          rewriter.create<quake::DeallocOp>(a->getLoc(), a->getResult(0));
+        rewriter.create<cf::BranchOp>(
+            loc, getLandingPad(infoMap, scope).breakBlock, blk->getArguments());
+        scope.getInitRegion().push_back(blk);
+      }
+      // Function return from within scope with deallocations.
+      if (Block *blk = blockInfo.returnBlock) {
+        rewriter.setInsertionPointToEnd(blk);
+        for (auto a : llvm::reverse(qallocas))
+          rewriter.create<quake::DeallocOp>(a->getLoc(), a->getResult(0));
+        rewriter.create<cf::BranchOp>(loc,
+                                      getLandingPad(infoMap, scope).returnBlock,
+                                      blk->getArguments());
+        scope.getInitRegion().push_back(blk);
+      }
     }
     rewriter.inlineRegionBefore(scope.getInitRegion(), nextBlock);
-    rewriter.replaceOp(scope, contOp->getOperands());
+    rewriter.replaceOp(scope, nextBlock->getArguments());
     return success();
   }
 
   const UnwindOpAnalysisInfo &infoMap;
+  DominanceInfo &dom;
 };
 
 /// A func.func op is updated in-place to rewrite all returns to branches to a
 /// return block. The return block will deallocate all quake.alloca operations
 /// before returning from the function.
-struct FuncOpPattern : public OpRewritePattern<func::FuncOp> {
-  explicit FuncOpPattern(MLIRContext *ctx, const UnwindOpAnalysisInfo &info)
-      : OpRewritePattern(ctx), infoMap(info) {}
+template <typename OP, typename TERM>
+struct FuncLikeOpPattern : public OpRewritePattern<OP> {
+  using Base = OpRewritePattern<OP>;
 
-  LogicalResult matchAndRewrite(func::FuncOp func,
+  explicit FuncLikeOpPattern(MLIRContext *ctx, const UnwindOpAnalysisInfo &info,
+                             DominanceInfo &di)
+      : Base(ctx), infoMap(info), dom(di) {}
+
+  LogicalResult matchAndRewrite(OP func,
                                 PatternRewriter &rewriter) const override {
-    auto iter = infoMap.find(func.getOperation());
-    assert(iter != infoMap.end());
+    auto iter = infoMap.opParentMap.find(func.getOperation());
+    assert(iter != infoMap.opParentMap.end());
+    if (!func->hasAttr("add_dealloc"))
+      return success();
+    rewriter.updateRootInPlace(func,
+                               [&]() { func->removeAttr("add_dealloc"); });
     if (!iter->second.asPrimitive) {
       LLVM_DEBUG(llvm::dbgs() << "func was not marked as primitive in map\n");
       return success();
     }
-    if (!func->hasAttr("add_dealloc"))
-      return success();
     LLVM_DEBUG(llvm::dbgs() << "updating func " << func.getName() << '\n');
-    // Cannot have a break or continue block.
-    assert(!iter->second.breakBlock && !iter->second.continueBlock &&
-           iter->second.returnBlock);
-    // Scan the function for quake allocations.
-    SmallVector<quake::AllocaOp> qallocas;
-    for (Block &b : func.getBody())
-      for (Operation &o : b)
-        if (auto q = dyn_cast<quake::AllocaOp>(o))
-          qallocas.push_back(q);
-    // Add the new exit block to the end of the function with all the quake
-    // deallocations. Don't need to worry about stack allocations as they are
-    // about to be reclaimed when the function returns.
-    Block *exitBlock = iter->second.returnBlock;
-    rewriter.setInsertionPointToEnd(exitBlock);
-    for (auto a : llvm::reverse(qallocas))
-      rewriter.create<quake::DeallocOp>(a.getLoc(), a.getResult());
-    rewriter.create<func::ReturnOp>(func.getLoc(), exitBlock->getArguments());
-    rewriter.updateRootInPlace(func, [&]() {
-      for (Block &b : func.getBody())
-        for (Operation &o : b)
-          if (isa<func::ReturnOp, cudaq::cc::ReturnOp>(o)) {
-            rewriter.setInsertionPointToEnd(&b);
-            rewriter.replaceOpWithNewOp<cf::BranchOp>(&o, exitBlock,
-                                                      o.getOperands());
-          }
-      func.getBody().push_back(exitBlock);
-      func->removeAttr("add_dealloc");
-    });
+
+    // Find all terminators that leave the ScopeOp.
+    auto terminators = populateExitTerminators(func.getBody());
+    // Scan the scope for quantum allocations.
+    auto qallocas = populateQuakeAllocas(func.getBody());
+    auto termAllocMap = populateTerminatorAllocaMap(terminators, qallocas, dom);
+
+    // Normal func return with inline deallocations.
+    for (auto &pr : termAllocMap) {
+      auto *exitOp = pr.first;
+      rewriter.setInsertionPoint(exitOp);
+      for (auto a : llvm::reverse(pr.second))
+        rewriter.create<quake::DeallocOp>(a.getLoc(), a.getResult());
+    }
+
+    // Here, we handle the unwind return jumps.
+    auto blockMapIter = infoMap.blockDetails.find(func.getOperation());
+    assert(blockMapIter != infoMap.blockDetails.end());
+    auto &details = blockMapIter->second;
+    for (auto &pr : details.blockMap) {
+      auto &blockInfo = pr.second;
+      auto &qallocas = details.allocaDomMap.find(pr.first)->second;
+      assert(!blockInfo.continueBlock && !blockInfo.breakBlock &&
+             "FuncOp is not a loop");
+
+      // Add the new exit block to the end of the function with all the quake
+      // deallocations. Don't need to worry about stack allocations as they are
+      // about to be reclaimed when the function returns.
+      if (Block *exitBlock = blockInfo.returnBlock) {
+        rewriter.setInsertionPointToEnd(exitBlock);
+        for (auto a : llvm::reverse(qallocas))
+          rewriter.create<quake::DeallocOp>(a->getLoc(), a->getResult(0));
+        rewriter.create<TERM>(func.getLoc(), exitBlock->getArguments());
+        func.getBody().push_back(exitBlock);
+      }
+    }
     return success();
   }
 
   const UnwindOpAnalysisInfo &infoMap;
+  DominanceInfo &dom;
 };
+
+using FuncOpPattern = FuncLikeOpPattern<func::FuncOp, func::ReturnOp>;
+using CreateLambdaOpPattern =
+    FuncLikeOpPattern<cudaq::cc::CreateLambdaOp, cudaq::cc::ReturnOp>;
 
 /// An `if` statement that contains an unwind macro is always lowered to a
 /// primitive CFG. The presence or absence of scopes between the unwind op and
@@ -294,8 +481,8 @@ struct IfOpPattern : public OpRewritePattern<cudaq::cc::IfOp> {
 
   LogicalResult matchAndRewrite(cudaq::cc::IfOp ifOp,
                                 PatternRewriter &rewriter) const override {
-    auto iter = infoMap.find(ifOp.getOperation());
-    assert(iter != infoMap.end());
+    auto iter = infoMap.opParentMap.find(ifOp.getOperation());
+    assert(iter != infoMap.opParentMap.end());
     if (!iter->second.asPrimitive)
       return success();
     LLVM_DEBUG(llvm::dbgs() << "replacing if @" << ifOp.getLoc() << '\n');
@@ -319,23 +506,30 @@ struct IfOpPattern : public OpRewritePattern<cudaq::cc::IfOp> {
     updateBodyBranches(&ifOp.getElseRegion(), rewriter, endBlock);
     // Append blocks to tailRegion
     auto &tailRegion = hasElse ? ifOp.getElseRegion() : ifOp.getThenRegion();
-    if (auto *blk = iter->second.continueBlock) {
-      rewriter.setInsertionPointToEnd(blk);
-      auto *dest = getLandingPad(infoMap, ifOp).continueBlock;
-      rewriter.create<cf::BranchOp>(loc, dest, blk->getArguments());
-      tailRegion.push_back(blk);
-    }
-    if (auto *blk = iter->second.breakBlock) {
-      rewriter.setInsertionPointToEnd(blk);
-      auto *dest = getLandingPad(infoMap, ifOp).breakBlock;
-      rewriter.create<cf::BranchOp>(loc, dest, blk->getArguments());
-      tailRegion.push_back(blk);
-    }
-    if (auto *blk = iter->second.returnBlock) {
-      rewriter.setInsertionPointToEnd(blk);
-      auto *dest = getLandingPad(infoMap, ifOp).returnBlock;
-      rewriter.create<cf::BranchOp>(loc, dest, blk->getArguments());
-      tailRegion.push_back(blk);
+    auto blockMapIter = infoMap.blockDetails.find(ifOp.getOperation());
+    assert(blockMapIter != infoMap.blockDetails.end());
+    auto &details = blockMapIter->second;
+    for (auto &pr : details.blockMap) {
+      auto &blockInfo = pr.second;
+      assert(details.allocaDomMap.find(pr.first)->second.empty());
+      if (auto *blk = blockInfo.continueBlock) {
+        rewriter.setInsertionPointToEnd(blk);
+        auto *dest = getLandingPad(infoMap, ifOp).continueBlock;
+        rewriter.create<cf::BranchOp>(loc, dest, blk->getArguments());
+        tailRegion.push_back(blk);
+      }
+      if (auto *blk = blockInfo.breakBlock) {
+        rewriter.setInsertionPointToEnd(blk);
+        auto *dest = getLandingPad(infoMap, ifOp).breakBlock;
+        rewriter.create<cf::BranchOp>(loc, dest, blk->getArguments());
+        tailRegion.push_back(blk);
+      }
+      if (auto *blk = blockInfo.returnBlock) {
+        rewriter.setInsertionPointToEnd(blk);
+        auto *dest = getLandingPad(infoMap, ifOp).returnBlock;
+        rewriter.create<cf::BranchOp>(loc, dest, blk->getArguments());
+        tailRegion.push_back(blk);
+      }
     }
     rewriter.inlineRegionBefore(ifOp.getThenRegion(), endBlock);
     if (hasElse)
@@ -380,8 +574,8 @@ struct LoopOpPattern : public OpRewritePattern<cudaq::cc::LoopOp> {
 
   LogicalResult matchAndRewrite(cudaq::cc::LoopOp loopOp,
                                 PatternRewriter &rewriter) const override {
-    auto iter = infoMap.find(loopOp.getOperation());
-    assert(iter != infoMap.end());
+    auto iter = infoMap.opParentMap.find(loopOp.getOperation());
+    assert(iter != infoMap.opParentMap.end());
     if (!iter->second.asPrimitive)
       return success();
     LLVM_DEBUG(llvm::dbgs() << "replacing loop @" << loopOp.getLoc() << '\n');
@@ -416,22 +610,29 @@ struct LoopOpPattern : public OpRewritePattern<cudaq::cc::LoopOp> {
 
     // Append blocks to tailRegion
     auto &tailRegion = loopOp.getBodyRegion();
-    if (auto *blk = iter->second.continueBlock) {
-      rewriter.setInsertionPointToEnd(blk);
-      rewriter.create<cf::BranchOp>(loc, condBlock, blk->getArguments());
-      tailRegion.push_back(blk);
-    }
-    if (auto *blk = iter->second.breakBlock) {
-      rewriter.setInsertionPointToEnd(blk);
-      rewriter.create<cf::BranchOp>(loc, endBlock, blk->getArguments());
-      tailRegion.push_back(blk);
-    }
-    if (auto *blk = iter->second.returnBlock) {
-      rewriter.setInsertionPointToEnd(blk);
-      auto *retBlk = getLandingPad(infoMap, loopOp).returnBlock;
-      assert(retBlk);
-      rewriter.create<cf::BranchOp>(loc, retBlk, blk->getArguments());
-      tailRegion.push_back(blk);
+    auto blockMapIter = infoMap.blockDetails.find(loopOp.getOperation());
+    assert(blockMapIter != infoMap.blockDetails.end());
+    auto &details = blockMapIter->second;
+    for (auto &pr : details.blockMap) {
+      auto &blockInfo = pr.second;
+      assert(details.allocaDomMap.find(pr.first)->second.empty());
+      if (auto *blk = blockInfo.continueBlock) {
+        rewriter.setInsertionPointToEnd(blk);
+        rewriter.create<cf::BranchOp>(loc, condBlock, blk->getArguments());
+        tailRegion.push_back(blk);
+      }
+      if (auto *blk = blockInfo.breakBlock) {
+        rewriter.setInsertionPointToEnd(blk);
+        rewriter.create<cf::BranchOp>(loc, endBlock, blk->getArguments());
+        tailRegion.push_back(blk);
+      }
+      if (auto *blk = blockInfo.returnBlock) {
+        rewriter.setInsertionPointToEnd(blk);
+        auto *retBlk = getLandingPad(infoMap, loopOp).returnBlock;
+        assert(retBlk);
+        rewriter.create<cf::BranchOp>(loc, retBlk, blk->getArguments());
+        tailRegion.push_back(blk);
+      }
     }
 
     // Update the normal local branches.
@@ -511,8 +712,8 @@ struct UnwindReturnOpPattern
 
   LogicalResult matchAndRewrite(cudaq::cc::UnwindReturnOp retOp,
                                 PatternRewriter &rewriter) const override {
-    auto iter = infoMap.find(retOp.getOperation());
-    assert(iter != infoMap.end());
+    auto iter = infoMap.opParentMap.find(retOp.getOperation());
+    assert(iter != infoMap.opParentMap.end());
     auto *blk = rewriter.getInsertionBlock();
     auto pos = rewriter.getInsertionPoint();
     rewriter.splitBlock(blk, std::next(pos));
@@ -528,8 +729,8 @@ struct UnwindReturnOpPattern
 template <typename TO, typename FROM>
 LogicalResult intraLoopJump(FROM op, PatternRewriter &rewriter,
                             const UnwindOpAnalysisInfo &infoMap) {
-  auto iter = infoMap.find(op.getOperation());
-  assert(iter != infoMap.end());
+  auto iter = infoMap.opParentMap.find(op.getOperation());
+  assert(iter != infoMap.opParentMap.end());
   auto *blk = rewriter.getInsertionBlock();
   auto pos = rewriter.getInsertionPoint();
   rewriter.splitBlock(blk, std::next(pos));
@@ -541,74 +742,72 @@ LogicalResult intraLoopJump(FROM op, PatternRewriter &rewriter,
   return success();
 }
 
-/// A `break` statement is a global transfer of control that unwinds all current
-/// scope contexts up to an including the nearest loop construct. The loop
-/// terminates (or returns).
-struct UnwindBreakOpPattern
-    : public OpRewritePattern<cudaq::cc::UnwindBreakOp> {
-  explicit UnwindBreakOpPattern(MLIRContext *ctx,
-                                const UnwindOpAnalysisInfo &info)
-      : OpRewritePattern(ctx), infoMap(info) {}
+template <typename OP, typename TERM>
+struct UnwindLoopJumpOpPattern : public OpRewritePattern<OP> {
+  using Base = OpRewritePattern<OP>;
 
-  LogicalResult matchAndRewrite(cudaq::cc::UnwindBreakOp brkOp,
+  explicit UnwindLoopJumpOpPattern(MLIRContext *ctx,
+                                   const UnwindOpAnalysisInfo &info)
+      : Base(ctx), infoMap(info) {}
+
+  LogicalResult matchAndRewrite(OP brkOp,
                                 PatternRewriter &rewriter) const override {
-    return intraLoopJump<cudaq::cc::BreakOp>(brkOp, rewriter, infoMap);
+    return intraLoopJump<TERM>(brkOp, rewriter, infoMap);
   }
 
   const UnwindOpAnalysisInfo &infoMap;
 };
+
+/// A `break` statement is a global transfer of control that unwinds all current
+/// scope contexts up to an including the nearest loop construct. The loop
+/// terminates (or returns).
+using UnwindBreakOpPattern =
+    UnwindLoopJumpOpPattern<cudaq::cc::UnwindBreakOp, cudaq::cc::BreakOp>;
 
 /// A `continue` statement is a global transfer of control that unwinds all
 /// current scope contexts up to the loop's body statement. The loop iteration
 /// terminates and control transfers to the next iteration of the loop.
-struct UnwindContinueOpPattern
-    : public OpRewritePattern<cudaq::cc::UnwindContinueOp> {
-  explicit UnwindContinueOpPattern(MLIRContext *ctx,
-                                   const UnwindOpAnalysisInfo &info)
-      : OpRewritePattern(ctx), infoMap(info) {}
-
-  LogicalResult matchAndRewrite(cudaq::cc::UnwindContinueOp cntOp,
-                                PatternRewriter &rewriter) const override {
-    return intraLoopJump<cudaq::cc::ContinueOp>(cntOp, rewriter, infoMap);
-  }
-
-  const UnwindOpAnalysisInfo &infoMap;
-};
+using UnwindContinueOpPattern =
+    UnwindLoopJumpOpPattern<cudaq::cc::UnwindContinueOp, cudaq::cc::ContinueOp>;
 
 class UnwindLoweringPass
     : public cudaq::opt::UnwindLoweringBase<UnwindLoweringPass> {
 public:
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    UnwindOpAnalysis analysis(func);
+    DominanceInfo domInfo(func);
+    UnwindOpAnalysis analysis(func, domInfo);
     auto unwindInfo = analysis.getAnalysisInfo();
     // If there are no unwinding goto ops, then leave the function as-is.
     if (unwindInfo.empty()) {
       LLVM_DEBUG(llvm::dbgs() << "analysis found no unwinds\n");
       return;
     }
+
     // Otherwise lower the structured constructs to expose the CFG structure.
     auto *ctx = func.getContext();
     RewritePatternSet patterns(ctx);
     patterns.insert<UnwindBreakOpPattern, UnwindContinueOpPattern,
-                    UnwindReturnOpPattern, IfOpPattern, LoopOpPattern,
-                    FuncOpPattern, ScopeOpPattern>(ctx, unwindInfo);
+                    UnwindReturnOpPattern, IfOpPattern, LoopOpPattern>(
+        ctx, unwindInfo);
+    patterns.insert<FuncOpPattern, CreateLambdaOpPattern, ScopeOpPattern>(
+        ctx, unwindInfo, domInfo);
     ConversionTarget target(*ctx);
     target.addIllegalOp<cudaq::cc::UnwindBreakOp, cudaq::cc::UnwindContinueOp,
                         cudaq::cc::UnwindReturnOp>();
     target.addDynamicallyLegalOp<cudaq::cc::IfOp, cudaq::cc::LoopOp,
                                  cudaq::cc::ScopeOp>([&](Operation *op) {
-      auto iter = unwindInfo.find(op);
-      if (iter == unwindInfo.end())
+      auto iter = unwindInfo.opParentMap.find(op);
+      if (iter == unwindInfo.opParentMap.end())
         return true;
       return !iter->second.asPrimitive;
     });
-    target.addDynamicallyLegalOp<func::FuncOp>([&](Operation *op) {
-      auto iter = unwindInfo.find(op);
-      if (iter == unwindInfo.end())
-        return true;
-      return !op->hasAttr("add_dealloc");
-    });
+    target.addDynamicallyLegalOp<func::FuncOp, cudaq::cc::CreateLambdaOp>(
+        [&](Operation *op) {
+          if (!unwindInfo.opParentMap.count(op))
+            return true;
+          return !op->hasAttr("add_dealloc");
+        });
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
     if (failed(applyPartialConversion(func, target, std::move(patterns)))) {
       emitError(func.getLoc(), "error unwinding control flow\n");

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -42,78 +42,6 @@ struct C {
    }
 };
 
-struct D {
-   void operator()() __qpu__ {
-      cudaq::qreg r(2);
-      g1();
-      for (int i = 0; i < 10; ++i) {
-	 if (f1(i)) {
-	    cudaq::qubit q;
-	    x(q,r[0]);
-	    continue;
-	 }
-	 x(r[0],r[1]);
-	 g2();
-	 if (f2(i)) {
-	    y(r[1]);
-	    break;
-	 }
-	 g3();
-	 z(r);
-      }
-      g4();
-      mz(r);
-   }
-};
-
-struct E {
-   void operator()() __qpu__ {
-      cudaq::qreg r(2);
-      g1();
-      for (int i = 0; i < 10; ++i) {
-	 if (f1(i)) {
-	    cudaq::qubit q;
-	    x(q,r[0]);
-	    return;
-	 }
-	 x(r[0],r[1]);
-	 g2();
-	 if (f2(i)) {
-	    y(r[1]);
-	    break;
-	 }
-	 g3();
-	 z(r);
-      }
-      g4();
-      mz(r);
-   }
-};
-
-struct F {
-   void operator()() __qpu__ {
-      cudaq::qreg r(2);
-      g1();
-      for (int i = 0; i < 10; ++i) {
-	 if (f1(i)) {
-	    cudaq::qubit q;
-	    x(q,r[0]);
-	    continue;
-	 }
-	 x(r[0],r[1]);
-	 g2();
-	 if (f2(i)) {
-	    y(r[1]);
-	    return;
-	 }
-	 g3();
-	 z(r);
-      }
-      g4();
-      mz(r);
-   }
-};
-
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__C()
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
@@ -181,6 +109,30 @@ struct F {
 // CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
+
+struct D {
+   void operator()() __qpu__ {
+      cudaq::qreg r(2);
+      g1();
+      for (int i = 0; i < 10; ++i) {
+	 if (f1(i)) {
+	    cudaq::qubit q;
+	    x(q,r[0]);
+	    continue;
+	 }
+	 x(r[0],r[1]);
+	 g2();
+	 if (f2(i)) {
+	    y(r[1]);
+	    break;
+	 }
+	 g3();
+	 z(r);
+      }
+      g4();
+      mz(r);
+   }
+};
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__D()
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
@@ -250,137 +202,180 @@ struct F {
 // CHECK:           return
 // CHECK:         }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__E()
+struct E {
+   void operator()() __qpu__ {
+      cudaq::qreg r(2);
+      g1();
+      for (int i = 0; i < 10; ++i) {
+	 if (f1(i)) {
+	    cudaq::qubit q;
+	    x(q,r[0]);
+	    return;
+	 }
+	 x(r[0],r[1]);
+	 g2();
+	 if (f2(i)) {
+	    y(r[1]);
+	    break;
+	 }
+	 g3();
+	 z(r);
+      }
+      g4();
+      mz(r);
+   }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__E() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
-// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 10 : i32
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_6:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
-// CHECK:           %[[VAL_9:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_7]], %[[VAL_9]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_5]], %[[VAL_7]] : !cc.ptr<i32>
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i32
-// CHECK:           cf.cond_br %[[VAL_11]], ^bb2, ^bb7
+// CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_4]] : i32
+// CHECK:           cf.cond_br %[[VAL_9]], ^bb2, ^bb7
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_13:.*]] = call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
-// CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
+// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_11:.*]] = call @_Z2f1i(%[[VAL_10]]) : (i32) -> i1
+// CHECK:           cf.cond_br %[[VAL_11]], ^bb3, ^bb4
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref)
-// CHECK:           quake.dealloc %[[VAL_14]] : !quake.ref
-// CHECK:           cf.br ^bb8
+// CHECK:           %[[VAL_12:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_6]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_12]]] %[[VAL_13]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.dealloc %[[VAL_12]] : !quake.ref
+// CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<2>
+// CHECK:           return
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           %[[VAL_14:.*]] = quake.extract_ref %[[VAL_6]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_6]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           call @_Z2g2v() : () -> ()
-// CHECK:           %[[VAL_18:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
-// CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
+// CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_17:.*]] = call @_Z2f2i(%[[VAL_16]]) : (i32) -> i1
+// CHECK:           cf.cond_br %[[VAL_17]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           quake.y %[[VAL_20]]
+// CHECK:           %[[VAL_18:.*]] = quake.extract_ref %[[VAL_6]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           quake.y %[[VAL_18]] : (!quake.ref) -> ()
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb6:
 // CHECK:           call @_Z2g3v() : () -> ()
-// CHECK:           %[[VAL_21:.*]] = cc.loop while ((%[[VAL_22:.*]] = %[[VAL_4]]) -> (index)) {
-// CHECK:             %[[VAL_23:.*]] = arith.cmpi slt, %[[VAL_22]], %[[VAL_0]] : index
-// CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : index)
+// CHECK:           %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (index)) {
+// CHECK:             %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : index
+// CHECK:             cc.condition %[[VAL_21]](%[[VAL_20]] : index)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.veq<2>, index) -> !quake.ref
-// CHECK:             quake.z %[[VAL_25]]
-// CHECK:             cc.continue %[[VAL_24]] : index
+// CHECK:           ^bb0(%[[VAL_22:.*]]: index):
+// CHECK:             %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]][%[[VAL_22]]] : (!quake.veq<2>, index) -> !quake.ref
+// CHECK:             quake.z %[[VAL_23]] : (!quake.ref) -> ()
+// CHECK:             cc.continue %[[VAL_22]] : index
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_26:.*]]: index):
-// CHECK:             %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : index
-// CHECK:             cc.continue %[[VAL_27]] : index
+// CHECK:           ^bb0(%[[VAL_24:.*]]: index):
+// CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : index
+// CHECK:             cc.continue %[[VAL_25]] : index
 // CHECK:           } {counted}
-// CHECK:           %[[VAL_28:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_5]] : i32
-// CHECK:           cc.store %[[VAL_29]], %[[VAL_9]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : i32
+// CHECK:           cc.store %[[VAL_27]], %[[VAL_7]] : !cc.ptr<i32>
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb7:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<i1>
-// CHECK:           cf.br ^bb8
-// CHECK:         ^bb8:
-// CHECK:           quake.dealloc %[[VAL_8]] : !quake.veq<2>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<2>
 // CHECK:           return
-// CHECK:         }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__F()
+struct F {
+   void operator()() __qpu__ {
+      cudaq::qreg r(2);
+      g1();
+      for (int i = 0; i < 10; ++i) {
+	 if (f1(i)) {
+	    cudaq::qubit q;
+	    x(q,r[0]);
+	    continue;
+	 }
+	 x(r[0],r[1]);
+	 g2();
+	 if (f2(i)) {
+	    y(r[1]);
+	    return;
+	 }
+	 g3();
+	 z(r);
+      }
+      g4();
+      mz(r);
+   }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__F() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
-// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 10 : i32
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_6:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
-// CHECK:           %[[VAL_9:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_7]], %[[VAL_9]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_5]], %[[VAL_7]] : !cc.ptr<i32>
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i32
-// CHECK:           cf.cond_br %[[VAL_11]], ^bb2, ^bb8
+// CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_4]] : i32
+// CHECK:           cf.cond_br %[[VAL_9]], ^bb2, ^bb8
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_13:.*]] = call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
-// CHECK:           cf.cond_br %[[VAL_13]], ^bb3, ^bb4
+// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_11:.*]] = call @_Z2f1i(%[[VAL_10]]) : (i32) -> i1
+// CHECK:           cf.cond_br %[[VAL_11]], ^bb3, ^bb4
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]]
-// CHECK:           quake.dealloc %[[VAL_14]] : !quake.ref
+// CHECK:           %[[VAL_12:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_6]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_12]]] %[[VAL_13]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.dealloc %[[VAL_12]] : !quake.ref
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb4:
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           quake.x [%[[VAL_16]]] %[[VAL_17]]
+// CHECK:           %[[VAL_14:.*]] = quake.extract_ref %[[VAL_6]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_6]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           call @_Z2g2v() : () -> ()
-// CHECK:           %[[VAL_18:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_19:.*]] = call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
-// CHECK:           cf.cond_br %[[VAL_19]], ^bb5, ^bb6
+// CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_17:.*]] = call @_Z2f2i(%[[VAL_16]]) : (i32) -> i1
+// CHECK:           cf.cond_br %[[VAL_17]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           quake.y %[[VAL_20]] : (!quake.ref)
-// CHECK:           cf.br ^bb9
+// CHECK:           %[[VAL_18:.*]] = quake.extract_ref %[[VAL_6]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           quake.y %[[VAL_18]] : (!quake.ref) -> ()
+// CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<2>
+// CHECK:           return
 // CHECK:         ^bb6:
 // CHECK:           call @_Z2g3v() : () -> ()
-// CHECK:           %[[VAL_21:.*]] = cc.loop while ((%[[VAL_22:.*]] = %[[VAL_4]]) -> (index)) {
-// CHECK:             %[[VAL_23:.*]] = arith.cmpi slt, %[[VAL_22]], %[[VAL_0]] : index
-// CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : index)
+// CHECK:           %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (index)) {
+// CHECK:             %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : index
+// CHECK:             cc.condition %[[VAL_21]](%[[VAL_20]] : index)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.veq<2>, index) -> !quake.ref
-// CHECK:             quake.z %[[VAL_25]]
-// CHECK:             cc.continue %[[VAL_24]] : index
+// CHECK:           ^bb0(%[[VAL_22:.*]]: index):
+// CHECK:             %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]][%[[VAL_22]]] : (!quake.veq<2>, index) -> !quake.ref
+// CHECK:             quake.z %[[VAL_23]] : (!quake.ref) -> ()
+// CHECK:             cc.continue %[[VAL_22]] : index
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_26:.*]]: index):
-// CHECK:             %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : index
-// CHECK:             cc.continue %[[VAL_27]] : index
+// CHECK:           ^bb0(%[[VAL_24:.*]]: index):
+// CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : index
+// CHECK:             cc.continue %[[VAL_25]] : index
 // CHECK:           } {counted}
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb7:
-// CHECK:           %[[VAL_28:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_5]] : i32
-// CHECK:           cc.store %[[VAL_29]], %[[VAL_9]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : i32
+// CHECK:           cc.store %[[VAL_27]], %[[VAL_7]] : !cc.ptr<i32>
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb8:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<i1>
-// CHECK:           cf.br ^bb9
-// CHECK:         ^bb9:
-// CHECK:           quake.dealloc %[[VAL_8]] : !quake.veq<2>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<2>
 // CHECK:           return
-// CHECK:         }
-

--- a/test/Quake/control_flow.qke
+++ b/test/Quake/control_flow.qke
@@ -1,0 +1,261 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --unwind-lowering %s | cudaq-opt --canonicalize | FileCheck %s
+
+func.func @test1(%i : i32) -> f32 {
+  %v1 = quake.alloca !quake.veq<4>
+  %five = arith.constant 5 : i32
+  %pi = arith.constant 3.14159265 : f32
+  %b1 = arith.cmpi slt, %i, %five : i32
+  cc.if (%b1) {
+    cc.scope {
+      %v2 = quake.alloca !quake.veq<5>
+      // deallocate %v2, %v1 and return from function
+      cc.unwind_return %pi : f32
+      cc.continue
+    }
+    cc.continue
+  } else {
+    cc.scope {
+      %v3 = quake.alloca !quake.veq<6>
+      cc.continue
+    }
+    cc.continue
+  }
+  %two = arith.constant 2.0 : f32
+  cf.br ^bb3
+ ^bb3:
+  %pd2 = arith.divf %pi, %two : f32
+  return %pd2 : f32
+} 
+
+// CHECK-LABEL:   func.func @test1(
+// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> f32 {
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1.57079637 : f32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 3.14159274 : f32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_5:.*]] = arith.cmpi slt, %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           cf.cond_br %[[VAL_5]], ^bb1, ^bb2
+// CHECK:         ^bb1:
+// CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<5>
+// CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<5>
+// CHECK:           quake.dealloc %[[VAL_4]] : !quake.veq<4>
+// CHECK:           return %[[VAL_2]] : f32
+// CHECK:         ^bb2:
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_7:.*]] = quake.alloca !quake.veq<6>
+// CHECK:           }
+// CHECK:           quake.dealloc %[[VAL_4]] : !quake.veq<4>
+// CHECK:           return %[[VAL_1]] : f32
+
+func.func @test2(%i : i32) {
+  %v1 = quake.alloca !quake.veq<4>
+  %five = arith.constant 5 : i32
+  %1 = cc.loop while ((%j = %i) -> i32) {
+    %ten = arith.constant 10 : i32
+    %8 = arith.cmpi slt, %j, %ten : i32
+    cc.condition %8 (%j : i32)
+  } do {
+   ^bb0(%j : i32):
+    cc.scope {
+      %b1 = arith.cmpi slt, %j, %five : i32
+      cf.cond_br %b1, ^bb1, ^bb2
+     ^bb1:
+      %v2 = quake.alloca !quake.veq<5>
+      // deallocate %v2 and jump to ^bb8 with argument 5
+      cc.unwind_continue %five : i32
+      cc.continue
+     ^bb2:
+      %v3 = quake.alloca !quake.veq<6>
+      cc.continue
+    }
+    cc.continue %j : i32
+  } step {
+    ^bb8(%j : i32):
+      %4 = arith.constant 12 : i32
+      %6 = arith.addi %4, %j : i32
+      cc.continue %6 : i32
+  }
+  return
+} 
+
+// CHECK-LABEL:   func.func @test2(
+// CHECK-SAME:      %[[VAL_0:.*]]: i32) {
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 12 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 10 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           cf.br ^bb1(%[[VAL_0]] : i32)
+// CHECK:         ^bb1(%[[VAL_5:.*]]: i32):
+// CHECK:           %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           cf.cond_br %[[VAL_6]], ^bb2(%[[VAL_5]] : i32), ^bb6
+// CHECK:         ^bb2(%[[VAL_7:.*]]: i32):
+// CHECK:           %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_3]] : i32
+// CHECK:           cf.cond_br %[[VAL_8]], ^bb3, ^bb4
+// CHECK:         ^bb3:
+// CHECK:           %[[VAL_9:.*]] = quake.alloca !quake.veq<5>
+// CHECK:           quake.dealloc %[[VAL_9]] : !quake.veq<5>
+// CHECK:           cf.br ^bb5(%[[VAL_3]] : i32)
+// CHECK:         ^bb4:
+// CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<6>
+// CHECK:           quake.dealloc %[[VAL_10]] : !quake.veq<6>
+// CHECK:           cf.br ^bb5(%[[VAL_7]] : i32)
+// CHECK:         ^bb5(%[[VAL_11:.*]]: i32):
+// CHECK:           %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_1]] : i32
+// CHECK:           cf.br ^bb1(%[[VAL_12]] : i32)
+// CHECK:         ^bb6:
+// CHECK:           return
+
+func.func @test3(%i : i32) {
+  %v1 = quake.alloca !quake.veq<4>
+  %five = arith.constant 5 : i32
+  %1 = cc.loop while ((%j = %i) -> i32) {
+    %ten = arith.constant 10 : i32
+    %8 = arith.cmpi slt, %j, %ten : i32
+    cc.condition %8 (%j : i32)
+  } do {
+   ^bb0(%j : i32):
+    cc.scope {
+      %b1 = arith.cmpi slt, %j, %five : i32
+      cf.cond_br %b1, ^bb1, ^bb2
+     ^bb1:
+      %v3 = quake.alloca !quake.veq<6>
+      cc.continue
+     ^bb2:
+      %v2 = quake.alloca !quake.veq<5>
+      // deallocate %v2 and exit loop
+      cc.unwind_break %five : i32
+      cc.continue
+    }
+    cc.continue %j : i32
+  } step {
+    ^bb8(%j : i32):
+      %4 = arith.constant 12 : i32
+      %6 = arith.addi %4, %j : i32
+      cc.continue %6 : i32
+  }
+  cf.br ^bb3
+ ^bb3:
+  return
+} 
+
+// CHECK-LABEL:   func.func @test3(
+// CHECK-SAME:      %[[VAL_0:.*]]: i32) {
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 12 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 10 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           cf.br ^bb1(%[[VAL_0]] : i32)
+// CHECK:         ^bb1(%[[VAL_5:.*]]: i32):
+// CHECK:           %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           cf.cond_br %[[VAL_6]], ^bb2(%[[VAL_5]] : i32), ^bb5
+// CHECK:         ^bb2(%[[VAL_7:.*]]: i32):
+// CHECK:           %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_3]] : i32
+// CHECK:           cf.cond_br %[[VAL_8]], ^bb3, ^bb4
+// CHECK:         ^bb3:
+// CHECK:           %[[VAL_9:.*]] = quake.alloca !quake.veq<6>
+// CHECK:           quake.dealloc %[[VAL_9]] : !quake.veq<6>
+// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_7]], %[[VAL_1]] : i32
+// CHECK:           cf.br ^bb1(%[[VAL_10]] : i32)
+// CHECK:         ^bb4:
+// CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.veq<5>
+// CHECK:           quake.dealloc %[[VAL_11]] : !quake.veq<5>
+// CHECK:           cf.br ^bb5
+// CHECK:         ^bb5:
+// CHECK:           return
+
+func.func @test4() {
+  %veq = quake.alloca !quake.veq<5>
+  %zero = arith.constant 0 : i32
+  %2 = cc.loop while ((%i = %zero) -> i32) {
+    %ten = arith.constant 10 : i32
+    %8 = arith.cmpi slt, %i, %ten : i32
+    cc.condition %8 (%i : i32)
+  } do {
+    ^bb0(%i : i32):
+      %five = arith.constant 5 : i32
+      %18 = arith.cmpi slt, %i, %five : i32
+      cf.cond_br %18, ^bb1, ^bb2
+    ^bb1:
+      cc.break %i : i32
+    ^bb2:
+      cc.scope {
+        %92 = quake.alloca !quake.ref
+	cf.br ^bb24
+       ^bb23:
+        %93 = quake.alloca !quake.ref
+        %94 = arith.constant 26 : i32
+        %104 = arith.cmpi eq, %i, %94 : i32
+        cc.if (%104) {
+	  // dealloc %92 and %93, jump to return
+          cc.unwind_return
+        }
+        cc.continue
+       ^bb24:
+        %9 = arith.constant 25 : i32
+        %10 = arith.cmpi eq, %i, %9 : i32
+        cc.if (%10) {
+	  // dealloc %92, jump to ^bb8
+          cc.unwind_continue %i : i32
+        }
+	cf.br ^bb23
+      }
+      cc.continue %i : i32
+  } step {
+    ^bb8(%i : i32):
+      %4 = arith.constant 12 : i32
+      %6 = arith.addi %4, %i : i32
+      cc.continue %6 : i32
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @test4() {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 12 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 25 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 26 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 5 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 10 : i32
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_6:.*]] = quake.alloca !quake.veq<5>
+// CHECK:           cf.br ^bb1(%[[VAL_5]] : i32)
+// CHECK:         ^bb1(%[[VAL_7:.*]]: i32):
+// CHECK:           %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_4]] : i32
+// CHECK:           cf.cond_br %[[VAL_8]], ^bb2(%[[VAL_7]] : i32), ^bb9
+// CHECK:         ^bb2(%[[VAL_9:.*]]: i32):
+// CHECK:           %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_3]] : i32
+// CHECK:           cf.cond_br %[[VAL_10]], ^bb9, ^bb3
+// CHECK:         ^bb3:
+// CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_12:.*]] = arith.cmpi eq, %[[VAL_9]], %[[VAL_1]] : i32
+// CHECK:           cf.cond_br %[[VAL_12]], ^bb7(%[[VAL_9]] : i32), ^bb4
+// CHECK:         ^bb4:
+// CHECK:           %[[VAL_13:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_14:.*]] = arith.cmpi eq, %[[VAL_9]], %[[VAL_2]] : i32
+// CHECK:           cf.cond_br %[[VAL_14]], ^bb6, ^bb5
+// CHECK:         ^bb5:
+// CHECK:           quake.dealloc %[[VAL_13]] : !quake.ref
+// CHECK:           quake.dealloc %[[VAL_11]] : !quake.ref
+// CHECK:           cf.br ^bb8(%[[VAL_9]] : i32)
+// CHECK:         ^bb6:
+// CHECK:           quake.dealloc %[[VAL_13]] : !quake.ref
+// CHECK:           quake.dealloc %[[VAL_11]] : !quake.ref
+// CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<5>
+// CHECK:           return
+// CHECK:         ^bb7(%[[VAL_15:.*]]: i32):
+// CHECK:           quake.dealloc %[[VAL_11]] : !quake.ref
+// CHECK:           cf.br ^bb8(%[[VAL_15]] : i32)
+// CHECK:         ^bb8(%[[VAL_16:.*]]: i32):
+// CHECK:           %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_0]] : i32
+// CHECK:           cf.br ^bb1(%[[VAL_17]] : i32)
+// CHECK:         ^bb9:
+// CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<5>
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
assumed simple high-level control flow graphs. That need not be true in the general case, particularly with inlining, and will not be true when more optimization work is done. See issue #14.

These changes add support for single-entry multiple-exit control op regions. It uses dominance information to identify any subsets that need to be accounted for in deallocation when exiting scopes. In most cases, the subsets x path-types are uniqued to exploit block sharing.

These changes also fix some bugs relating to lambda expressions.

Fix tests. Exit blocks are no longer merged.

Add a new test for unwind-lowering pass that leans into dominance relations between basic blocks.

