### PR TITLE
Add a loop unrolling pipeline.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -35,7 +35,12 @@ void registerAggressiveEarlyInlining();
 /// When converting to a quantum circuit, the static control program is fully
 /// expanded to eliminate control flow. This pipeline will raise an error if any
 /// loop in the module cannot be fully unrolled.
-void addUnrollingPipeline(mlir::OpPassManager &pm);
+void createUnrollingPipeline(mlir::OpPassManager &pm, unsigned threshold,
+                          bool signalFailure);
+inline void addUnrollingPipeline(mlir::OpPassManager &pm) {
+  // Set defaults used by registerUnrollingPipeline()
+  createUnrollingPipeline(pm, /*threshold=*/50, /*signalFailure=*/true);
+}
 void registerUnrollingPipeline();
 
 std::unique_ptr<mlir::Pass> createApplyOpSpecializationPass();

--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -31,6 +31,13 @@ createGenerateDeviceCodeLoader(bool genAsQuake = false);
 void addAggressiveEarlyInlining(mlir::OpPassManager &pm);
 void registerAggressiveEarlyInlining();
 
+/// Add a pass pipeline to apply the requisite passes to fully unroll loops.
+/// When converting to a quantum circuit, the static control program is fully
+/// expanded to eliminate control flow. This pipeline will raise an error if any
+/// loop in the module cannot be fully unrolled.
+void addUnrollingPipeline(mlir::OpPassManager &pm);
+void registerUnrollingPipeline();
+
 std::unique_ptr<mlir::Pass> createApplyOpSpecializationPass();
 std::unique_ptr<mlir::Pass>
 createApplyOpSpecializationPass(bool computeActionOpt);

--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -36,7 +36,7 @@ void registerAggressiveEarlyInlining();
 /// expanded to eliminate control flow. This pipeline will raise an error if any
 /// loop in the module cannot be fully unrolled.
 void createUnrollingPipeline(mlir::OpPassManager &pm, unsigned threshold,
-                          bool signalFailure);
+                             bool signalFailure);
 inline void addUnrollingPipeline(mlir::OpPassManager &pm) {
   // Set defaults used by registerUnrollingPipeline()
   createUnrollingPipeline(pm, /*threshold=*/50, /*signalFailure=*/true);

--- a/lib/Optimizer/Transforms/LoopUnroll.cpp
+++ b/lib/Optimizer/Transforms/LoopUnroll.cpp
@@ -172,13 +172,14 @@ public:
 };
 } // namespace
 
-void cudaq::opt::addUnrollingPipeline(OpPassManager &pm) {
+void cudaq::opt::createUnrollingPipeline(OpPassManager &pm, unsigned threshold,
+                                         bool signalFailure) {
   pm.addPass(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(createClassicalMemToReg());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createLoopNormalize());
   pm.addPass(createCanonicalizerPass());
-  constexpr LoopUnrollOptions luo{/*threshold=*/50, /*signalFailure=*/true};
+  LoopUnrollOptions luo{threshold, signalFailure};
   pm.addPass(createLoopUnroll(luo));
   pm.addPass(createCanonicalizerPass());
 }

--- a/lib/Optimizer/Transforms/LoopUnroll.cpp
+++ b/lib/Optimizer/Transforms/LoopUnroll.cpp
@@ -178,7 +178,7 @@ void cudaq::opt::addUnrollingPipeline(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createLoopNormalize());
   pm.addPass(createCanonicalizerPass());
-  constexpr LoopUnrollOptions luo{/*threshold=*/50, /*signalfailure=*/true};
+  constexpr LoopUnrollOptions luo{/*threshold=*/50, /*signalFailure=*/true};
   pm.addPass(createLoopUnroll(luo));
   pm.addPass(createCanonicalizerPass());
 }

--- a/lib/Optimizer/Transforms/LoopUnroll.cpp
+++ b/lib/Optimizer/Transforms/LoopUnroll.cpp
@@ -171,3 +171,21 @@ public:
   }
 };
 } // namespace
+
+void cudaq::opt::addUnrollingPipeline(OpPassManager &pm) {
+  pm.addPass(createCanonicalizerPass());
+  pm.addNestedPass<func::FuncOp>(createClassicalMemToReg());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createLoopNormalize());
+  pm.addPass(createCanonicalizerPass());
+  constexpr LoopUnrollOptions luo{/*threshold=*/50, /*signalfailure=*/true};
+  pm.addPass(createLoopUnroll(luo));
+  pm.addPass(createCanonicalizerPass());
+}
+
+void cudaq::opt::registerUnrollingPipeline() {
+  PassPipelineRegistration<>(
+      "unrolling-pipeline",
+      "Fully unroll loops that can be completely unrolled.",
+      addUnrollingPipeline);
+}

--- a/runtime/common/RuntimeMLIR.cpp
+++ b/runtime/common/RuntimeMLIR.cpp
@@ -81,37 +81,6 @@ TranslateFromMLIRRegistration::TranslateFromMLIRRegistration(
   registerTranslation(name, description, function);
 }
 
-void registerToQIRTranslation();
-void registerToOpenQASMTranslation();
-void registerToIQMJsonTranslation();
-
-std::unique_ptr<MLIRContext> initializeMLIR() {
-  if (!mlirLLVMInitialized) {
-    llvm::InitializeNativeTarget();
-    llvm::InitializeNativeTargetAsmPrinter();
-    registerAllPasses();
-    cudaq::opt::registerOptCodeGenPasses();
-    cudaq::opt::registerOptTransformsPasses();
-    registerToQIRTranslation();
-    registerToOpenQASMTranslation();
-    registerToIQMJsonTranslation();
-    cudaq::opt::registerTargetPipelines();
-    mlirLLVMInitialized = true;
-  }
-
-  // if (!llvmContext)
-  //   llvmContext = std::make_unique<llvm::LLVMContext>();
-
-  DialectRegistry registry;
-  registry.insert<arith::ArithDialect, AffineDialect, LLVM::LLVMDialect,
-                  math::MathDialect, memref::MemRefDialect, quake::QuakeDialect,
-                  cc::CCDialect, func::FuncDialect>();
-  auto context = std::make_unique<MLIRContext>(registry);
-  context->loadAllAvailableDialects();
-  registerLLVMDialectTranslation(*context);
-  return context;
-}
-
 bool setupTargetTriple(llvm::Module *llvmModule) {
   // Setup the machine properties from the current architecture.
   auto targetTriple = llvm::sys::getDefaultTargetTriple();
@@ -200,6 +169,31 @@ void registerToIQMJsonTranslation() {
       [](Operation *op, raw_ostream &output) {
         return cudaq::translateToIQMJson(op, output);
       });
+}
+
+std::unique_ptr<MLIRContext> initializeMLIR() {
+  if (!mlirLLVMInitialized) {
+    llvm::InitializeNativeTarget();
+    llvm::InitializeNativeTargetAsmPrinter();
+    registerAllPasses();
+    cudaq::opt::registerOptCodeGenPasses();
+    cudaq::opt::registerOptTransformsPasses();
+    registerToQIRTranslation();
+    registerToOpenQASMTranslation();
+    registerToIQMJsonTranslation();
+    cudaq::opt::registerUnrollingPipeline();
+    cudaq::opt::registerTargetPipelines();
+    mlirLLVMInitialized = true;
+  }
+
+  DialectRegistry registry;
+  registry.insert<arith::ArithDialect, AffineDialect, LLVM::LLVMDialect,
+                  memref::MemRefDialect, quake::QuakeDialect, cc::CCDialect,
+                  func::FuncDialect>();
+  auto context = std::make_unique<MLIRContext>(registry);
+  context->loadAllAvailableDialects();
+  registerLLVMDialectTranslation(*context);
+  return context;
 }
 
 ExecutionEngine *createQIRJITEngine(ModuleOp &moduleOp) {

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.config
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.config
@@ -16,7 +16,7 @@ GEN_TARGET_BACKEND=true
 LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline
-PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,func.func(memtoreg{quantum=0}),canonicalize,cc-loop-normalize,canonicalize,cc-loop-unroll{signal-failure-if-any-loop-cannot-be-completely-unrolled=true},canonicalize,func.func(lower-to-cfg),canonicalize,ionq-gate-set-mapping"
+PLATFORM_LOWERING_CONFIG="expand-measurements,unrolling-pipeline,func.func(lower-to-cfg),canonicalize,ionq-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 CODEGEN_EMISSION=qir

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
@@ -16,7 +16,7 @@ GEN_TARGET_BACKEND=true
 LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline, here we lower to Base QIR
-PLATFORM_LOWERING_CONFIG="expand-measurements,canonicalize,func.func(memtoreg{quantum=0}),canonicalize,cc-loop-normalize,canonicalize,cc-loop-unroll{signal-failure-if-any-loop-cannot-be-completely-unrolled=true},canonicalize,func.func(lower-to-cfg),canonicalize,func.func(quake-multicontrol-decomposition),quantinuum-gate-set-mapping"
+PLATFORM_LOWERING_CONFIG="expand-measurements,unrolling-pipeline,func.func(lower-to-cfg),canonicalize,func.func(quake-multicontrol-decomposition),quantinuum-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 CODEGEN_EMISSION=qir

--- a/tools/cudaq-opt/cudaq-opt.cpp
+++ b/tools/cudaq-opt/cudaq-opt.cpp
@@ -54,6 +54,7 @@ int main(int argc, char **argv) {
   cudaq::opt::registerOptCodeGenPasses();
   cudaq::opt::registerOptTransformsPasses();
   cudaq::opt::registerAggressiveEarlyInlining();
+  cudaq::opt::registerUnrollingPipeline();
   cudaq::opt::registerTargetPipelines();
 
   // See if we have been asked to load a pass plugin,


### PR DESCRIPTION
The sequence of steps to fully unroll loops (when possible) has become more elaborate. This introduces a named pass pipeline to consolidate and standardize this sequence of transformations.
