### PR TITLE
Fix bug 8 for release.

### DIFF
--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -75,10 +75,8 @@ static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
   // there is one stdvecDataOp.
   auto stdvecDataOp =
       cast<cudaq::cc::StdvecDataOp>(*argument.getUsers().begin());
-  stdvecDataOp.dump();
   SmallVector<Operation *> cleanUps;
   for (auto *user : stdvecDataOp->getUsers()) {
-    user->dump();
     // could be a load, or a getelementptr.
     // if load, the index is 0
     // if getelementptr, then we get the index there to use


### PR DESCRIPTION
The primary issue here is that not all uses of the compute_ptr op were being updated, so removing it wasn't working. A second issue was deleting the IR while looking at it. This left pointers in bad states and we segfaulted by dereferencing into garbage.