### PR TITLE
Improve synthesis.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -902,7 +902,7 @@ def cc_ConstantArrayOp : CCOp<"const_array", [Pure]> {
   );
   let results = (outs cc_ArrayType:$arrayType);
   let assemblyFormat = [{
-    $constantValues `:` type($arrayType) attr-dict
+    $constantValues `:` qualified(type($arrayType)) attr-dict
   }];
 }
 

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -884,6 +884,57 @@ def cc_ComputePtrOp : CCOp<"compute_ptr", [Pure]> {
   }];
 }
 
+def cc_ConstantArrayOp : CCOp<"const_array", [Pure]> {
+  let summary = "A one dimensional array of constant values.";
+  let description = [{
+    A ConstantArrayOp is used to create a constant value that is an aggregate of
+    type !cc.array<T,n> and is composed of constant values. The aggregate has a
+    constant length.
+
+    Example:
+
+    ```mlir
+      %arrCon = cc.const_array [1.0, 2.0] : !cc.array<f64, 2>
+    ```
+  }];
+  let arguments = (ins
+    ArrayAttr:$constantValues
+  );
+  let results = (outs cc_ArrayType:$arrayType);
+  let assemblyFormat = [{
+    $constantValues `:` type($arrayType) attr-dict
+  }];
+}
+
+def cc_GetConstantElementOp : CCOp<"get_const_element", [Pure]> {
+  let summary = "Get a constant value from a constant array.";
+  let description = [{
+    A GetConstantElementOp is used to extract a constant value from an aggregate
+    of type !cc.array<T,n>. The aggregate must be built by a `cc.const_array`
+    operation. The offset of the element must be between 0 and the length of the
+    array minus 1 (inclusive). Any other value has undefined behavior. If the
+    offset is a constant, this operation can be folded into a scalar constant
+    (or a cc.undef operation).
+
+    Example:
+
+    ```mlir
+      %arrCon = cc.get_const_element %4[%5] : (!cc.array<f64, 2>, i32) -> f64
+    ```
+  }];
+
+  let arguments = (ins
+    cc_ArrayType:$constantArray,
+    AnySignlessInteger:$offset
+  );
+  let results = (outs AnyType);
+  let hasFolder = 1;
+
+  let assemblyFormat = [{
+    $constantArray `,` $offset `:` functional-type(operands, results) attr-dict
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Cast operation.
 //===----------------------------------------------------------------------===//

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -894,7 +894,7 @@ def cc_ConstantArrayOp : CCOp<"const_array", [Pure]> {
     Example:
 
     ```mlir
-      %arrCon = cc.const_array [1.0, 2.0] : !cc.array<f64, 2>
+      %arrCon = cc.const_array [1.0, 2.0] : !cc.array<f64 x 2>
     ```
   }];
   let arguments = (ins
@@ -919,7 +919,7 @@ def cc_GetConstantElementOp : CCOp<"get_const_element", [Pure]> {
     Example:
 
     ```mlir
-      %arrCon = cc.get_const_element %4[%5] : (!cc.array<f64, 2>, i32) -> f64
+      %arrCon = cc.get_const_element %4[%5] : (!cc.array<f64 x 2>, i32) -> f64
     ```
   }];
 

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -244,8 +244,6 @@ public:
 
       // For any `std::vector` arguments, we now know the sizes so let's replace
       // the block arg with the actual vector element data.
-      // For any std vec arguments, we now know the sizes
-      // let's replace the block arg with the actual vector element data.
       double *ptr = (double *)(((char *)args) + offset);
       for (std::size_t idx = 0; auto &stdVecSize : stdVecSizes) {
         // FIXME: this only works with std::vector<double> for now.

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -659,6 +659,8 @@ func.func @cc_struct() {
 // CHECK:           cc.store %[[VAL_6]], %[[VAL_7]] : !cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>
 // CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_7]][1, 4, 3] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_7]][1, %[[VAL_4]], 1] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>, i32) -> !cc.ptr<i16>
+// CHECK:           %[[VAL_10:.*]] = cc.const_array [1.000000e+00, 2.000000e+00] : <f32 x 2>
+// CHECK:           %[[VAL_11:.*]] = cc.get_const_element %[[VAL_10]], %[[VAL_4]] : (!cc.array<f32 x 2>, i32) -> f32
 // CHECK:           return
 // CHECK:         }
 
@@ -673,5 +675,7 @@ func.func @cc_indexing(%arg0 : !cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f
   cc.store %3, %ss : !cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>
   %p = cc.compute_ptr %ss[1, 4, 3] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>) -> !cc.ptr<i64>
   %q = cc.compute_ptr %ss[1, %one, 1] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>, i32) -> !cc.ptr<i16>
+  %arr = cc.const_array [1.0, 2.0] : !cc.array<f32 x 2>
+  %ele = cc.get_const_element %arr, %one : (!cc.array<f32 x 2>, i32) -> f32
   return
 }

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -659,7 +659,7 @@ func.func @cc_struct() {
 // CHECK:           cc.store %[[VAL_6]], %[[VAL_7]] : !cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>
 // CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_7]][1, 4, 3] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_7]][1, %[[VAL_4]], 1] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>, i32) -> !cc.ptr<i16>
-// CHECK:           %[[VAL_10:.*]] = cc.const_array [1.000000e+00, 2.000000e+00] : <f32 x 2>
+// CHECK:           %[[VAL_10:.*]] = cc.const_array [1.000000e+00, 2.000000e+00] : !cc.array<f32 x 2>
 // CHECK:           %[[VAL_11:.*]] = cc.get_const_element %[[VAL_10]], %[[VAL_4]] : (!cc.array<f32 x 2>, i32) -> f32
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
This patch allows synthesis to create inline IR for a std::vector<double> of constants. After the loop unrolling pipeline has run (which is after synthesis), the abstract constant vector of doubles can be rewritten as simple scalars, which can be lowered to QIR and LLVM. The constant vector abstraction lets us escape the phase ordering issues of synthesis and loop unrolling.
