### PR TITLE
Fixes for slicing of std::vector.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -869,6 +869,7 @@ def cc_ComputePtrOp : CCOp<"compute_ptr", [Pure]> {
   }];
 
   let hasFolder = 1;
+  let hasCanonicalizer = 1;
 
   let builders = [
     OpBuilder<(ins "mlir::Type":$resultType, "mlir::Value":$basePtr,
@@ -928,7 +929,9 @@ def cc_GetConstantElementOp : CCOp<"get_const_element", [Pure]> {
     AnySignlessInteger:$offset
   );
   let results = (outs AnyType);
+
   let hasFolder = 1;
+  //let hasVerifier = 1; // FIXME: output type must match incoming const array
 
   let assemblyFormat = [{
     $constantArray `,` $offset `:` functional-type(operands, results) attr-dict
@@ -1018,7 +1021,10 @@ def cc_StdvecInitOp : CCOp<"stdvec_init", [Pure]> {
     ```
   }];
 
-  let arguments = (ins AnyPointerType:$buffer, AnyInteger:$length);
+  let arguments = (ins
+    AnyPointerType:$buffer,
+    AnyInteger:$length
+  );
   let results = (outs cc_StdVectorType:$stdvec);
 
   let assemblyFormat = [{
@@ -1039,6 +1045,8 @@ def cc_StdvecDataOp : CCOp<"stdvec_data", [Pure]> {
 
   let arguments = (ins cc_StdVectorType:$stdvec);
   let results = (outs AnyPointerType:$data);
+
+  let hasCanonicalizer = 1;
 
   let assemblyFormat = [{
     $stdvec `:` functional-type(operands, results) attr-dict

--- a/lib/Optimizer/CodeGen/LowerToBaseProfileQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToBaseProfileQIR.cpp
@@ -119,7 +119,7 @@ private:
                       callOp0 = callOp0->getOperand(0).getDefiningOp();
                     } else {
                       callOp0->emitError("cannot compute offset");
-		      callOp0 = nullptr;
+                      callOp0 = nullptr;
                     }
                   }
                   auto iter = callOp0 ? data.allocationOffsets.find(callOp0)

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -1333,9 +1333,8 @@ public:
     target.addLegalDialect<LLVM::LLVMDialect>();
     target.addLegalOp<ModuleOp>();
 
-    if (failed(applyFullConversion(getModule(), target, std::move(patterns)))) {
+    if (failed(applyFullConversion(getModule(), target, std::move(patterns))))
       signalPassFailure();
-    }
   }
 };
 

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -316,6 +316,79 @@ OpFoldResult cudaq::cc::ComputePtrOp::fold(ArrayRef<Attribute> params) {
   return nullptr;
 }
 
+namespace {
+// Address arithmetic for pointers to arrays is additive.
+struct FuseAddressArithmetic
+    : public OpRewritePattern<cudaq::cc::ComputePtrOp> {
+  using Base = OpRewritePattern<cudaq::cc::ComputePtrOp>;
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(cudaq::cc::ComputePtrOp ptrOp,
+                                PatternRewriter &rewriter) const override {
+    auto base = ptrOp.getBase();
+    auto checkIsPtrToArr = [&](Type ty) -> bool {
+      auto ptrTy = dyn_cast<cudaq::cc::PointerType>(ty);
+      if (!ptrTy)
+        return false;
+      return true; // isa<cudaq::cc::ArrayType>(ptrTy.getElementType());
+    };
+    if (!checkIsPtrToArr(base.getType()))
+      return success();
+    if (auto origPtr =
+            ptrOp.getBase().getDefiningOp<cudaq::cc::ComputePtrOp>()) {
+      if (!checkIsPtrToArr(origPtr.getBase().getType()))
+        return success();
+      if (ptrOp.getRawConstantIndices().size() != 1 ||
+          origPtr.getRawConstantIndices().size() != 1)
+        return success();
+      auto myOffset = ptrOp.getRawConstantIndices()[0];
+      auto inOffset = origPtr.getRawConstantIndices()[0];
+      auto extractConstant = [&](cudaq::cc::ComputePtrOp thisOp,
+                                 std::int64_t othOffset) -> Value {
+        auto v1 = thisOp.getDynamicIndices()[0];
+        auto v1Ty = v1.getType();
+        auto offAttr = IntegerAttr::get(v1Ty, othOffset);
+        auto loc = thisOp.getLoc();
+        auto newOff = rewriter.create<arith::ConstantOp>(loc, offAttr, v1Ty);
+        return rewriter.create<arith::AddIOp>(loc, newOff, v1);
+      };
+      if (myOffset == cudaq::cc::ComputePtrOp::kDynamicIndex) {
+        if (inOffset == cudaq::cc::ComputePtrOp::kDynamicIndex) {
+          Value sum = rewriter.create<arith::AddIOp>(
+              ptrOp.getLoc(), ptrOp.getDynamicIndices()[0],
+              origPtr.getDynamicIndices()[0]);
+          rewriter.replaceOpWithNewOp<cudaq::cc::ComputePtrOp>(
+              ptrOp, ptrOp.getType(), origPtr.getBase(),
+              ArrayRef<cudaq::cc::ComputePtrArg>{sum});
+          return success();
+        }
+        auto sum = extractConstant(ptrOp, inOffset);
+        rewriter.replaceOpWithNewOp<cudaq::cc::ComputePtrOp>(
+            ptrOp, ptrOp.getType(), origPtr.getBase(),
+            ArrayRef<cudaq::cc::ComputePtrArg>{sum});
+        return success();
+      }
+      if (inOffset == cudaq::cc::ComputePtrOp::kDynamicIndex) {
+        auto sum = extractConstant(origPtr, myOffset);
+        rewriter.replaceOpWithNewOp<cudaq::cc::ComputePtrOp>(
+            ptrOp, ptrOp.getType(), origPtr.getBase(),
+            ArrayRef<cudaq::cc::ComputePtrArg>{sum});
+        return success();
+      }
+      rewriter.replaceOpWithNewOp<cudaq::cc::ComputePtrOp>(
+          ptrOp, ptrOp.getType(), origPtr.getBase(),
+          ArrayRef<cudaq::cc::ComputePtrArg>{myOffset + inOffset});
+    }
+    return success();
+  }
+};
+} // namespace
+
+void cudaq::cc::ComputePtrOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<FuseAddressArithmetic>(context);
+}
+
 //===----------------------------------------------------------------------===//
 // GetConstantElementOp
 //===----------------------------------------------------------------------===//
@@ -342,6 +415,38 @@ OpFoldResult cudaq::cc::GetConstantElementOp::fold(ArrayRef<Attribute> params) {
     }
   }
   return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// StdvecDataOp
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct FuseStdvecInitData : public OpRewritePattern<cudaq::cc::StdvecDataOp> {
+  using Base = OpRewritePattern<cudaq::cc::StdvecDataOp>;
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(cudaq::cc::StdvecDataOp data,
+                                PatternRewriter &rewriter) const override {
+    // Bypass the std::vector wrappers for the creation of an abstract
+    // subvector. This is possible because copies of std::vector data aren't
+    // created but instead passed around like std::span objects. Specifically, a
+    // pointer to the data and a length. Thus the pointer wrapped by stdvec_init
+    // and unwrapped by stdvec_data is the same pointer value. This pattern will
+    // arise after inlining, for example.
+    if (auto ini = data.getStdvec().getDefiningOp<cudaq::cc::StdvecInitOp>()) {
+      Value cast = rewriter.create<cudaq::cc::CastOp>(
+          data.getLoc(), data.getType(), ini.getBuffer());
+      rewriter.replaceOp(data, cast);
+    }
+    return success();
+  }
+};
+} // namespace
+
+void cudaq::cc::StdvecDataOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<FuseStdvecInitData>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/Transforms/QuakeObserveAnsatz.cpp
+++ b/lib/Optimizer/Transforms/QuakeObserveAnsatz.cpp
@@ -163,7 +163,10 @@ struct AppendMeasurements : public OpRewritePattern<func::FuncOp> {
       // do nothing for z or identities
 
       // get the qubit value
-      auto qubitVal = iter->second.qubitValues.find(i)->second;
+      auto seek = iter->second.qubitValues.find(i);
+      if (seek == iter->second.qubitValues.end())
+        continue;
+      auto qubitVal = seek->second;
 
       // append the measurement basis change ops
       appendMeasurement(basis, builder, loc, qubitVal);
@@ -172,10 +175,10 @@ struct AppendMeasurements : public OpRewritePattern<func::FuncOp> {
         qubitsToMeasure.push_back(qubitVal);
     }
 
-    for (auto &qubitToMeasure : qubitsToMeasure)
+    for (auto &qubitToMeasure : qubitsToMeasure) {
       // add the measure
-      builder.create<quake::MzOp>(loc, builder.getIntegerType(1),
-                                  qubitToMeasure);
+      builder.create<quake::MzOp>(loc, builder.getI1Type(), qubitToMeasure);
+    }
 
     rewriter.finalizeRootUpdate(funcOp);
     return success();

--- a/runtime/common/RuntimeMLIR.cpp
+++ b/runtime/common/RuntimeMLIR.cpp
@@ -126,16 +126,16 @@ void registerToQIRTranslation() {
         PassManager pm(context);
         std::string errMsg;
         llvm::raw_string_ostream errOs(errMsg);
-        std::string qirBasePipelineConfig = "quake-to-qir,qir-to-base-qir-prep,"
-                                            "llvm.func(quake-to-base-qir-func),"
-                                            "qir-to-base-qir";
+        std::string qirBasePipelineConfig =
+            "quake-to-qir,qir-to-base-qir-prep,"
+            "llvm.func(quake-to-base-qir-func),qir-to-base-qir,"
+            "llvm.func(verify-base-profile)";
         if (failed(parsePassPipeline(qirBasePipelineConfig, pm, errOs)))
           return failure();
         if (failed(pm.run(op)))
           return failure();
 
-        std::unique_ptr<llvm::LLVMContext> llvmContext =
-            std::make_unique<llvm::LLVMContext>();
+        auto llvmContext = std::make_unique<llvm::LLVMContext>();
         llvmContext->setOpaquePointers(false);
         auto llvmModule = translateModuleToLLVMIR(op, *llvmContext);
         cudaq::optimizeLLVM(llvmModule.get());


### PR DESCRIPTION
Add verify of base profile to explicit pipeline. This should be done as a pass pipeline so it doesn't get lost again.

Teach lowering to base profile about qubit array slices.