### PR TITLE
Add mx/my checks to QuakeAddMetadata

### DIFF
--- a/python/tests/compiler/conditional.py
+++ b/python/tests/compiler/conditional.py
@@ -114,7 +114,7 @@ def test_kernel_conditional_with_sample():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1 {registerName = ""}
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1 {registerName = "auto_register_0"}
 # CHECK:           cc.if(%[[VAL_1]]) {
 # CHECK:             quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           }

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -511,6 +511,8 @@ CUDAQ_ONE_QUBIT_PARAM_IMPL(ry, RyOp)
 CUDAQ_ONE_QUBIT_PARAM_IMPL(rz, RzOp)
 CUDAQ_ONE_QUBIT_PARAM_IMPL(r1, R1Op)
 
+static std::size_t regCounter = 0;
+
 template <typename QuakeMeasureOp>
 QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,
                         std::string regName) {
@@ -519,6 +521,9 @@ QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,
     throw std::runtime_error("Invalid parameter passed to mz.");
 
   cudaq::info("kernel_builder apply measurement");
+
+  if (regName.empty())
+    regName = "auto_register_" + std::to_string(regCounter++);
 
   auto i1Ty = builder.getI1Type();
   if (type.isa<quake::RefType>()) {

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -42,6 +42,9 @@ void altLaunchKernel(const char *kernelName, void (*kernelFunc)(void *),
 
 namespace cudaq::details {
 
+/// @brief Track unique measurement register names.
+static std::size_t regCounter = 0;
+
 KernelBuilderType mapArgToType(double &e) {
   return KernelBuilderType(
       [](MLIRContext *ctx) { return Float64Type::get(ctx); });
@@ -510,8 +513,6 @@ CUDAQ_ONE_QUBIT_PARAM_IMPL(rx, RxOp)
 CUDAQ_ONE_QUBIT_PARAM_IMPL(ry, RyOp)
 CUDAQ_ONE_QUBIT_PARAM_IMPL(rz, RzOp)
 CUDAQ_ONE_QUBIT_PARAM_IMPL(r1, R1Op)
-
-static std::size_t regCounter = 0;
 
 template <typename QuakeMeasureOp>
 QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -523,9 +523,6 @@ QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,
 
   cudaq::info("kernel_builder apply measurement");
 
-  // if (regName.empty())
-  //   regName = "auto_register_" + std::to_string(regCounter++);
-
   auto i1Ty = builder.getI1Type();
   if (type.isa<quake::RefType>()) {
     Value measureResult = builder.template create<QuakeMeasureOp>(


### PR DESCRIPTION
Take Quake code with `qubitMeasurementFeedback` when `if(mx(q))` or `if(my(q))` are encountered. Current implementation only considers `mz`.