### PR TITLE
Fixes for running on ppc64le architectures and HPC clusters 

### DIFF
--- a/tools/cudaq-quake/cudaq-quake.cpp
+++ b/tools/cudaq-quake/cudaq-quake.cpp
@@ -12,6 +12,7 @@
 /// other MLIR dialects as well. These other dialects are convenient but not the
 /// salient part of this tool.)
 #include <filesystem>
+#include <sstream>
 
 #include "cudaq/Frontend/nvqpp/ASTBridge.h"
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
@@ -395,6 +396,17 @@ int main(int argc, char **argv) {
   if (astDump) {
     clArgs.push_back("-Xclang");
     clArgs.push_back("-ast-dump");
+  }
+
+  // Allow a user to specify extra args for clang via
+  // an environment variable.
+  if (auto extraArgs = std::getenv("CUDAQ_CLANG_EXTRA_ARGS")) {
+    std::stringstream ss;
+    ss << extraArgs;
+    std::string part;
+    std::vector<std::string> localArgs;
+    while (std::getline(ss, part, ' '))
+      clArgs.push_back(part);
   }
 
   // Set the mangled kernel names map.

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -152,7 +152,7 @@ CUDAQ_INCLUDE_PATH="${install_dir}/include"
 if [ ! -f "${install_dir}/include/cudaq.h" ]; then
 	# If the header is not there, then we are likely in
 	# the build directory for testing.
-	if [ "@CMAKE_BINARY_DIR@" == "${install_dir}" ]; then
+	if [ "@CMAKE_BINARY_DIR@" -ef "${install_dir}" ]; then
 		CUDAQ_INCLUDE_PATH="@CMAKE_SOURCE_DIR@/runtime"
 		INCLUDES="-I @CMAKE_SOURCE_DIR@/tpls/fmt/include"
 	else
@@ -171,7 +171,7 @@ if [ -d "${llvm_install_dir}/bin" -a \
 fi
 
 # Compiler and linker flags
-COMPILER_FLAGS="-std=c++20 -I${CUDAQ_INCLUDE_PATH}"
+COMPILER_FLAGS="-std=c++20 -I${CUDAQ_INCLUDE_PATH} ${CUDAQ_CLANG_EXTRA_ARGS}"
 CLANG_RESOURCE_DIR=""
 # If we are a relocatable package, we want to
 # add compiler flags that will point clang to our repackaged


### PR DESCRIPTION
On clusters we'll often encounter multiple GCC installations. Add a way for cudaq-quake to take extra input arguments via an environment variable (specifically `--gcc-toolchain=/path/to/gcc/12`). 

Fix bug in nvq++ whereby symlinks are not followed in checking path equality. 
