### PR TITLE
Various minor workflow fixes

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -10,6 +10,10 @@ on:
         description: Create or update the build caches on the container registry.
         required: false
         default: false
+      cache_base:
+        required: false
+        type: string
+        description: 'The name of the branch to use as cache base.'
       platforms:
         type: string
         description: The platforms to build the Docker images for.
@@ -49,6 +53,7 @@ jobs:
       platforms: ${{ inputs.platforms }}
       toolchain: ${{ matrix.toolchain }}
       matrix_key: ${{ matrix.toolchain }}
+      registry_cache_from: ${{ inputs.cache_base }}
       registry_cache_update: ${{ github.event_name == 'workflow_dispatch' && inputs.update_registry_cache }}
       registry_cache_update_only: ${{ github.event.pull_request.merged == true }}
       environment: ${{ (github.event.pull_request.merged != true && 'ghcr-deployment') || '' }}
@@ -100,6 +105,7 @@ jobs:
     with:
       dockerfile: build/devdeps.ompi.Dockerfile
       platforms: ${{ inputs.platforms }}
+      registry_cache_from: ${{ inputs.cache_base || github.ref_name }}
       registry_cache_update: true
       environment: ghcr-deployment
 
@@ -114,6 +120,7 @@ jobs:
       build_args: |
         base_image=${{ needs.config.outputs.base_image }}
         ompidev_image=${{ needs.openmpi.outputs.image_hash }}
+      registry_cache_from: ${{ inputs.cache_base || github.ref_name }}
       registry_cache_update: true
       environment: ghcr-deployment
 

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -32,6 +32,12 @@ on:
     branches:
       - 'main'
       - 'releases/*'
+  # Whenever we create a release branch, we want to populate the caches.
+  # Unfortunately, it is not currently possible to filter by branch,
+  # see also: https://github.com/orgs/community/discussions/26286
+  push:
+    branches:
+      - 'releases/*'
 
 name: Deployments # do not change name without updating workflow_run triggers
 
@@ -41,7 +47,7 @@ concurrency:
 
 jobs:
   devdeps:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.event.created) || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
     name: Build dev dependencies
     strategy:
       matrix:
@@ -53,7 +59,7 @@ jobs:
       platforms: ${{ inputs.platforms }}
       toolchain: ${{ matrix.toolchain }}
       matrix_key: ${{ matrix.toolchain }}
-      registry_cache_from: ${{ inputs.cache_base }}
+      registry_cache_from: ${{ (github.event_name == 'push' && 'main') || inputs.cache_base }}
       registry_cache_update: ${{ github.event_name == 'workflow_dispatch' && inputs.update_registry_cache }}
       registry_cache_update_only: ${{ github.event.pull_request.merged == true }}
       environment: ${{ (github.event.pull_request.merged != true && 'ghcr-deployment') || '' }}
@@ -99,13 +105,13 @@ jobs:
           matrix-step-name: dev_environment
 
   openmpi:
-    if: github.event_name != 'pull_request_target'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.event.created)
     name: Build Open MPI
     uses: ./.github/workflows/dev_environment.yml
     with:
       dockerfile: build/devdeps.ompi.Dockerfile
       platforms: ${{ inputs.platforms }}
-      registry_cache_from: ${{ inputs.cache_base || github.ref_name }}
+      registry_cache_from: ${{ (github.event_name == 'push' && 'main') || inputs.cache_base || github.ref_name }}
       registry_cache_update: true
       environment: ghcr-deployment
 
@@ -120,7 +126,7 @@ jobs:
       build_args: |
         base_image=${{ needs.config.outputs.base_image }}
         ompidev_image=${{ needs.openmpi.outputs.image_hash }}
-      registry_cache_from: ${{ inputs.cache_base || github.ref_name }}
+      registry_cache_from: ${{ (github.event_name == 'push' && 'main') || inputs.cache_base || github.ref_name }}
       registry_cache_update: true
       environment: ghcr-deployment
 

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -182,10 +182,12 @@ jobs:
         id: cache
         run: |
           toolchain=${{ inputs.toolchain }}
+          platform_id=`echo "${{ inputs.platforms }}" | tr -d ' ' | tr / - | tr ',' -`
+          if [ "$platform_id" == "linux-amd64" ]; then unset platform_id; fi
           registry_cache=ghcr.io/${{ needs.metadata.outputs.owner }}/buildcache-cuda-quantum
           nvidia_registry_cache=ghcr.io/nvidia/buildcache-cuda-quantum
           registry_cache_base=$(echo ${{ inputs.registry_cache_from || github.event.pull_request.base.ref || 'main' }} | tr / -)
-          cache_id=$(echo ${{ needs.metadata.outputs.image_id }}${toolchain:+-$toolchain} | tr . -)
+          cache_id=$(echo ${{ needs.metadata.outputs.image_id }}${toolchain:+-$toolchain}${platform_id:+-$platform_id} | tr . -)
 
           local_buildcache_path="/tmp/.buildcache-${cache_id}"
           local_buildcache_key_suffix="-$(git rev-parse HEAD)"

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -16,7 +16,7 @@ name: Packages
 jobs:
   cudaq_hpc:
     name: CUDA Quantum Docker image
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.actor.name == 'cuda-quantum-bot')
     runs-on: ubuntu-latest
     timeout-minutes: 100
     permissions:

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -83,7 +83,7 @@ jobs:
           cudaqdevdeps_image=`cat build_info* | grep -o 'cuda-quantum-devdeps-image: \S*' | cut -d ' ' -f 2`
           data_commit=`cat build_info* | grep -o 'data-commit: \S*' | cut -d ' ' -f 2`
           release_title=`cat build_info* | grep -o 'publish: \S*' | cut -d ' ' -f 2`
-          unzip mgmn_svsim.zip && rm mgmn_svsim.zip && cd -
+          for file in `ls *zip`; do unzip "$file" && rm "$file"; done && cd -
 
           docker pull $cudaq_image
           repo_owner=${{ github.repository_owner }}

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -57,9 +57,6 @@ jobs:
         id: assets
         run: |
           release_id=${{ inputs.release_id || steps.artifacts.outputs.release_id }}
-          while [ -z "$(gh release list -R ${{ github.repository }} | grep -s $release_id)" ];
-          do echo "waiting for assets..." && sleep 300; 
-          done && sleep 300 # upload may take a while...
           github_commit=`gh release view $release_id -R ${{ github.repository }} --json targetCommitish --jq .targetCommitish`
 
           echo "release_id=$release_id" >> $GITHUB_OUTPUT
@@ -76,7 +73,12 @@ jobs:
         id: release_info
         run: |
           assets_folder=assets && release_id=${{ steps.assets.outputs.release_id }}
-          gh release download $release_id --dir "$assets_folder" -R ${{ github.repository }} && cd "$assets_folder"
+          mkdir "$assets_folder" && cd "$assets_folder"
+          while [ -z `ls | egrep '^build_info'` ]; do
+            gh release download $release_id -R ${{ github.repository }}
+            sleep 30 # waiting for assets to be created...
+          done
+
           platforms=`cat build_info* | grep -o 'platforms: \S*' | cut -d ' ' -f 2`
           cudaq_image=`cat build_info* | grep -o 'cuda-quantum-image: \S*' | cut -d ' ' -f 2`
           cudaqdev_image=`cat build_info* | grep -o 'cuda-quantum-dev-image: \S*' | cut -d ' ' -f 2`


### PR DESCRIPTION
This PR
- makes sure that build caches get populated based on the main cache when release branches are created
- makes sure a set of packages is deployed to GHCR when release branches are created
- allows to specify the cache base when manually triggering deployment
- adds the platform id to the cache id to ensure caches are not overwritten when building for a different platform
- makes sure the publishing is only triggered (manually or) by workflows that are run by the cuda-quantum bot
- ensures that all release assets are picked up for the final packaging