### PR TITLE
Add promote single qubit pass

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -41,6 +41,7 @@ std::unique_ptr<mlir::Pass> createConvertToQIRFuncPass();
 void registerTargetPipelines();
 
 // declarative passes
+#define GEN_PASS_DECL
 #define GEN_PASS_REGISTRATION
 #include "cudaq/Optimizer/CodeGen/Passes.h.inc"
 

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -11,6 +11,15 @@
 
 include "mlir/Pass/PassBase.td"
 
+def PromoteRefToVeqAlloc : Pass<"promote-qubit-allocation"> {
+  let summary = "Promote single qubit allocations.";
+  let description = [{
+    This pass converts all single qubit allocations in the quake dialect to
+    allocations of vectors of qubits of length one. This conversion makes all
+    allocations uniform for the conversion to QIR.
+  }];
+}
+
 def QuakeToQIR : Pass<"quake-to-qir", "mlir::ModuleOp"> {
   let summary = "Lower Quake to QIR.";
   let description = [{

--- a/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -14,6 +14,7 @@ add_cudaq_library(OptCodeGen
   LowerToBaseProfileQIR.cpp
   LowerToQIR.cpp
   Passes.cpp
+  RefToVeqAlloc.cpp
 
   DEPENDS
     CCDialect

--- a/lib/Optimizer/CodeGen/RefToVeqAlloc.cpp
+++ b/lib/Optimizer/CodeGen/RefToVeqAlloc.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/CodeGen/Passes.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_PROMOTEREFTOVEQALLOC
+#include "cudaq/Optimizer/CodeGen/Passes.h.inc"
+} // namespace cudaq::opt
+
+using namespace mlir;
+
+namespace {
+struct AllocaPat : public OpRewritePattern<quake::AllocaOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  // Replace:
+  //   %1 = quake.alloca !quake.ref
+  // with:
+  //   %0 = quake.alloca !quake.veq<1>
+  //   %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
+  LogicalResult matchAndRewrite(quake::AllocaOp alloc,
+                                PatternRewriter &rewriter) const override {
+    if (isa<quake::VeqType>(alloc.getType()))
+      return failure();
+    Value newAlloc = rewriter.create<quake::AllocaOp>(alloc.getLoc(), 1u);
+    rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(alloc, newAlloc, 0u);
+    return success();
+  }
+};
+
+class PromoteRefToVeqAllocPass
+    : public cudaq::opt::impl::PromoteRefToVeqAllocBase<
+          PromoteRefToVeqAllocPass> {
+public:
+  using PromoteRefToVeqAllocBase::PromoteRefToVeqAllocBase;
+
+  void runOnOperation() override {
+    auto *op = getOperation();
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<AllocaPat>(ctx);
+    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+      op->emitOpError("could not promote allocations");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace

--- a/runtime/common/RuntimeMLIR.cpp
+++ b/runtime/common/RuntimeMLIR.cpp
@@ -126,7 +126,8 @@ void registerToQIRTranslation() {
         PassManager pm(context);
         std::string errMsg;
         llvm::raw_string_ostream errOs(errMsg);
-        auto qirBasePipelineConfig = "quake-to-qir,base-profile-pipeline";
+        auto qirBasePipelineConfig =
+            "promote-qubit-allocation,quake-to-qir,base-profile-pipeline";
         if (failed(parsePassPipeline(qirBasePipelineConfig, pm, errOs)))
           return failure();
         if (failed(pm.run(op)))
@@ -209,6 +210,7 @@ ExecutionEngine *createQIRJITEngine(ModuleOp &moduleOp) {
     llvm::raw_string_ostream errOs(errMsg);
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
     pm.addPass(createCanonicalizerPass());
+    pm.addPass(cudaq::opt::createPromoteRefToVeqAlloc());
     pm.addPass(cudaq::opt::createConvertToQIRPass());
     if (failed(pm.run(module)))
       throw std::runtime_error(

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -750,6 +750,7 @@ ExecutionEngine *jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
   pm.addPass(cudaq::opt::createGenerateDeviceCodeLoader(/*genAsQuake=*/true));
   pm.addPass(cudaq::opt::createGenerateKernelExecution());
   optPM.addPass(cudaq::opt::createLowerToCFGPass());
+  pm.addPass(cudaq::opt::createPromoteRefToVeqAlloc());
   pm.addPass(cudaq::opt::createConvertToQIRPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/test/NVQPP/bug_qubit.cpp
+++ b/test/NVQPP/bug_qubit.cpp
@@ -9,6 +9,7 @@
 // This code is from Issue 251.
 
 // RUN: nvq++ --enable-mlir -v %s --target quantinuum --emulate -o %t.x && %t.x | FileCheck %s
+// RUN: cudaq-quake %s | cudaq-opt --promote-qubit-allocation | FileCheck --check-prefixes=MLIR %s
 
 // CHECK: Test: { 0:{{[0-9]+}} 1:{{[0-9]+}} }
 
@@ -22,6 +23,11 @@ struct ak2 {
     mz(q);
   }
 };
+
+// MLIR-LABEL:   func.func @__nvqpp__mlirgen__ak2()
+// MLIR-NOT:       quake.alloca !quake.ref
+// MLIR:           %[[VAL_0:.*]] = quake.alloca !quake.veq<1>
+// MLIR-NEXT:      %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<1>) -> !quake.ref
 
 int main() {
   auto counts = cudaq::sample(ak2{});

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -98,6 +98,7 @@ void addPipelineToQIR(PassManager &pm) {
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createLoopUnroll());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
+  pm.addPass(cudaq::opt::createPromoteRefToVeqAlloc());
   pm.addPass(cudaq::opt::createConvertToQIRPass());
   pm.addPass(createCanonicalizerPass());
   if constexpr (BaseProfile) {

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -76,6 +76,7 @@ LogicalResult lowerToLLVMDialect(ModuleOp module) {
   optPM.addPass(cudaq::opt::createQuakeAddDeallocs());
   optPM.addPass(cudaq::opt::createQuakeAddMetadata());
   optPM.addPass(cudaq::opt::createLowerToCFGPass());
+  pm.addPass(cudaq::opt::createPromoteRefToVeqAlloc());
   pm.addPass(cudaq::opt::createConvertToQIRPass());
   return pm.run(module);
 }


### PR DESCRIPTION
Add a pass to convert quake allocations of qubit references to
allocations of vectors of size 1. This presents the conversion to QIR in
code gen with a uniform set of allocations.

