### PR TITLE
Throw runtime error if job fails on IonQ's server

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
@@ -227,8 +227,7 @@ bool IonQServerHelper::jobIsDone(ServerMessage &getJobResponse) {
         "account for more information.");
 
   // Return whether the job is completed
-  auto ret = jobs[0].at("status").get<std::string>() == "completed";
-  return ret;
+  return jobs[0].at("status").get<std::string>() == "completed";
 }
 
 // Process the results from a job

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
@@ -220,6 +220,12 @@ bool IonQServerHelper::jobIsDone(ServerMessage &getJobResponse) {
     throw std::runtime_error(
         "ServerMessage doesn't contain 'status' key in the first job.");
 
+  // Throw a runtime error if the job has failed
+  if (jobs[0].at("status").get<std::string>() == "failed")
+    throw std::runtime_error(
+        "The job failed upon submission. Check the job submission in your IonQ "
+        "account for more information.");
+
   // Return whether the job is completed
   auto ret = jobs[0].at("status").get<std::string>() == "completed";
   return ret;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

We weren't previously checking for a "failed" status from the IonQ jobs. This meant the terminal would hang indefinitely without informing the user of the error. 

Changes
* Throws a runtime error if the job has failed
