### PR TITLE
Fix #428, duplicate register names clashing in base profile

### DIFF
--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -716,7 +716,7 @@ public:
     std::vector<Value> args{adaptor.getOperands().front()};
 
     bool appendName;
-    if (regName) {
+    if (regName && !regName.cast<StringAttr>().getValue().empty()) {
       // Change the function name
       qFunctionName += "__to__register";
       // Append a string type argument


### PR DESCRIPTION
Fix issue with multiple mz creating a register name targeting the same global string. 
```python
import cudaq
cudaq.set_target('quantinuum')
kernel = cudaq.make_kernel()
qubits = kernel.qalloc(2)
kernel.h(qubits[0])
kernel.cx(qubits[0], qubits[1])
kernel.mz(qubits[0])
kernel.mz(qubits[1])
print(kernel)
counts = cudaq.sample(kernel)
```