### PR TITLE
Fix #379, cu1 -> u1 (bad copy-paste)

### DIFF
--- a/lib/Target/OpenQASM/TranslateToOpenQASM.cpp
+++ b/lib/Target/OpenQASM/TranslateToOpenQASM.cpp
@@ -26,7 +26,7 @@ static LogicalResult translateOperatorName(quake::OperatorInterface optor,
                                            StringRef &name) {
   StringRef qkeName = optor->getName().stripDialect();
   if (optor.getControls().size() == 0) {
-    name = StringSwitch<StringRef>(qkeName).Case("r1", "cu1").Default(qkeName);
+    name = StringSwitch<StringRef>(qkeName).Case("r1", "u1").Default(qkeName);
   } else if (optor.getControls().size() == 1) {
     name = StringSwitch<StringRef>(qkeName)
                .Case("h", "ch")

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -310,6 +310,14 @@ public:
   virtual std::string to_quake() const = 0;
   virtual void jitCode(std::vector<std::string> extraLibPaths = {}) = 0;
   virtual ~kernel_builder_base() = default;
+
+  /// @brief Write the kernel_builder to the given output stream.
+  /// This outputs the Quake representation.
+  friend std::ostream &operator<<(std::ostream &stream,
+                                  const kernel_builder_base &builder) {
+    stream << builder.to_quake();
+    return stream;
+  }
 };
 
 } // namespace details


### PR DESCRIPTION
Also implement 
```cpp
std::ostream &operator<<(std::ostream &stream,
                                  const kernel_builder_base &builder);
```
so users can write kernel_builders to ostream 
```cpp
std::cout << kernel << "\n";
```