### PR TITLE
Reduce python wheel size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ option(CUDAQ_TEST_MOCK_SERVERS "Enable Remote QPU Tests via Mock Servers." OFF)
 option(CUDAQ_DISABLE_RUNTIME "Build without the CUDA Quantum runtime, just the compiler toolchain." OFF)
 option(CUDAQ_SKIP_MPI "Do not build with MPI, even when it is available." OFF)
 option(CUDAQ_DISABLE_CPP_FRONTEND "Build without the CUDA Quantum C++ Clang-based Frontend." OFF)
+option(CUDAQ_WHEEL_BUILD "Build CUDA Quantum as a relocatable package, using the minimal build requirements for a python wheel." OFF)
 
 # We allow to pick up certain build configurations directly from the environment,
 # since this facilitates some of the packaging (e.g. python packages built based on the pyproject.toml).
@@ -429,12 +430,18 @@ if (CUDAQ_ENABLE_PYTHON)
 endif()
 
 if (CUDAQ_BUILD_RELOCATABLE_PACKAGE) 
-  # Grab the Clang system headers / resource-dir
-  install(DIRECTORY ${LLVM_BINARY_DIR}/lib/clang/ DESTINATION lib/clang)
+  if (NOT CUDAQ_WHEEL_BUILD)
+    # Grab the Clang system headers / resource-dir
+    install(DIRECTORY ${LLVM_BINARY_DIR}/lib/clang/ DESTINATION lib/clang)
 
-  # Install the executables we need
-  install(PROGRAMS ${LLVM_BINARY_DIR}/bin/llc DESTINATION bin)
-  install(PROGRAMS ${LLVM_BINARY_DIR}/bin/clang-${CUDAQ_LLVM_VERSION} DESTINATION bin)
-  install(PROGRAMS ${LLVM_BINARY_DIR}/bin/clang DESTINATION bin)
-  install(PROGRAMS ${LLVM_BINARY_DIR}/bin/clang++ DESTINATION bin)
+    # Install the executables we need
+    install(PROGRAMS ${LLVM_BINARY_DIR}/bin/llc DESTINATION bin)
+    install(PROGRAMS ${LLVM_BINARY_DIR}/bin/clang-${CUDAQ_LLVM_VERSION} DESTINATION bin)
+    install(PROGRAMS ${LLVM_BINARY_DIR}/bin/clang DESTINATION bin)
+    install(PROGRAMS ${LLVM_BINARY_DIR}/bin/clang++ DESTINATION bin)
+  else()
+    # Only need `clang++` if this relocatable package is for the wheel.
+    install(PROGRAMS ${LLVM_BINARY_DIR}/bin/clang++ DESTINATION bin)
+  endif()
+
 endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ cmake.args = [
     "-DCUDAQ_ENABLE_PYTHON=TRUE",
     "-DCUDAQ_DISABLE_CPP_FRONTEND=TRUE",
     "-DCUDAQ_BUILD_TESTS=FALSE",
+    "-DCUDAQ_WHEEL_BUILD=TRUE",
 ]
 
 [tool.setuptools_scm]

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,8 +7,12 @@
 # ============================================================================ #
 
 add_subdirectory(cudaq-lsp-server)
-add_subdirectory(cudaq-opt)
-add_subdirectory(cudaq-translate)
+# If we're building a python wheel, don't include 
+# `cudaq-opt` or `cudaq-translate` in the build.
+if (NOT CUDAQ_WHEEL_BUILD)
+  add_subdirectory(cudaq-opt)
+  add_subdirectory(cudaq-translate)
+endif()
 
 if (NOT CUDAQ_DISABLE_CPP_FRONTEND)
   add_subdirectory(cudaq-quake)


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

To upload wheels to PyPi, they must be under 100 mb. Our initial wheels were right at this limit, so this PR removes some of the bloat and cuts the size roughly in half. This should also improve the upload/download performance of the wheel.

Changes:
* Adds a new `CUDAQ_WHEEL_BUILD` flag that will further limit what we install into the python package