### PR TITLE
 Added kernel_builder functions for the hardware efficient ansatz #361

### DIFF
--- a/python/runtime/cudaq/kernels/py_chemistry.cpp
+++ b/python/runtime/cudaq/kernels/py_chemistry.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/stl.h>
 
 #include "cudaq/domains/chemistry/uccsd.h"
+#include "cudaq/domains/chemistry/hwe.h"
 #include "py_chemistry.h"
 
 namespace cudaq {
@@ -21,6 +22,27 @@ void bindChemistry(py::module &mod) {
           "kernel. This function takes as input the existing `cudaq.Kernel` to "
           "append to, pre-allocated qubits, list of parameters, number of "
           "electrons, and number of qubits as input, in that order.");
+  
+  mod.def("num_hwe_parameters", &cudaq::num_hwe_parameters,
+          "For the given number of qubits and layers, return the required "
+          "number of hwe parameters."); 
+// use explicit overload as we have two overloaded signatures, i.e. with and without CNOT couplers
+//   mod.def("hwe_cnot", &cudaq::hwe_cnot<kernel_builder<>>,
+  mod.def("hwe", [](kernel_builder<> &kernel, QuakeValue &qubits, std::size_t numQubits, std::size_t numLayers, 
+                        QuakeValue &parameters, const std::vector<cnot_coupling> &cnotCoupling)
+          { return cudaq::hwe(kernel, qubits, numQubits, numLayers, parameters, cnotCoupling); },
+          "Generate the hardware-efficient CUDA Quantum Kernel. This function "
+          "takes as input the existing `cudaq.Kernel` to append to, "
+          "pre-allocated qubits, number of qubits, number of layers, the list "
+          "of parameters, and the CNOT couplers as input, in that order.");
+  
+  mod.def("hwe", [](kernel_builder<> &kernel, QuakeValue &qubits, std::size_t numQubits, std::size_t numLayers, 
+                        QuakeValue &parameters)
+          { return cudaq::hwe(kernel, qubits, numQubits, numLayers, parameters); },
+          "Generate the hardware-efficient CUDA Quantum Kernel. This function "
+          "takes as input the existing `cudaq.Kernel` to append to, "
+          "pre-allocated qubits, number of qubits, number of layers, and the list "
+          "of parameters as input, in that order. Using default CNOT couplers.");
 }
 
 } // namespace cudaq

--- a/python/runtime/cudaq/kernels/py_chemistry.cpp
+++ b/python/runtime/cudaq/kernels/py_chemistry.cpp
@@ -28,7 +28,6 @@ void bindChemistry(py::module &mod) {
           "number of hwe parameters.");
   // use explicit overload as we have two overloaded signatures, i.e. with and
   // without CNOT couplers
-  //   mod.def("hwe_cnot", &cudaq::hwe_cnot<kernel_builder<>>,
   mod.def(
       "hwe",
       [](kernel_builder<> &kernel, QuakeValue &qubits, std::size_t numQubits,

--- a/python/runtime/cudaq/kernels/py_chemistry.cpp
+++ b/python/runtime/cudaq/kernels/py_chemistry.cpp
@@ -7,8 +7,8 @@
  ******************************************************************************/
 #include <pybind11/stl.h>
 
-#include "cudaq/domains/chemistry/uccsd.h"
 #include "cudaq/domains/chemistry/hwe.h"
+#include "cudaq/domains/chemistry/uccsd.h"
 #include "py_chemistry.h"
 
 namespace cudaq {
@@ -22,27 +22,36 @@ void bindChemistry(py::module &mod) {
           "kernel. This function takes as input the existing `cudaq.Kernel` to "
           "append to, pre-allocated qubits, list of parameters, number of "
           "electrons, and number of qubits as input, in that order.");
-  
+
   mod.def("num_hwe_parameters", &cudaq::num_hwe_parameters,
           "For the given number of qubits and layers, return the required "
-          "number of hwe parameters."); 
-// use explicit overload as we have two overloaded signatures, i.e. with and without CNOT couplers
-//   mod.def("hwe_cnot", &cudaq::hwe_cnot<kernel_builder<>>,
-  mod.def("hwe", [](kernel_builder<> &kernel, QuakeValue &qubits, std::size_t numQubits, std::size_t numLayers, 
-                        QuakeValue &parameters, const std::vector<cnot_coupling> &cnotCoupling)
-          { return cudaq::hwe(kernel, qubits, numQubits, numLayers, parameters, cnotCoupling); },
-          "Generate the hardware-efficient CUDA Quantum Kernel. This function "
-          "takes as input the existing `cudaq.Kernel` to append to, "
-          "pre-allocated qubits, number of qubits, number of layers, the list "
-          "of parameters, and the CNOT couplers as input, in that order.");
-  
-  mod.def("hwe", [](kernel_builder<> &kernel, QuakeValue &qubits, std::size_t numQubits, std::size_t numLayers, 
-                        QuakeValue &parameters)
-          { return cudaq::hwe(kernel, qubits, numQubits, numLayers, parameters); },
-          "Generate the hardware-efficient CUDA Quantum Kernel. This function "
-          "takes as input the existing `cudaq.Kernel` to append to, "
-          "pre-allocated qubits, number of qubits, number of layers, and the list "
-          "of parameters as input, in that order. Using default CNOT couplers.");
+          "number of hwe parameters.");
+  // use explicit overload as we have two overloaded signatures, i.e. with and
+  // without CNOT couplers
+  //   mod.def("hwe_cnot", &cudaq::hwe_cnot<kernel_builder<>>,
+  mod.def(
+      "hwe",
+      [](kernel_builder<> &kernel, QuakeValue &qubits, std::size_t numQubits,
+         std::size_t numLayers, QuakeValue &parameters,
+         const std::vector<cnot_coupling> &cnotCoupling) {
+        return cudaq::hwe(kernel, qubits, numQubits, numLayers, parameters,
+                          cnotCoupling);
+      },
+      "Generate the hardware-efficient CUDA Quantum Kernel. This function "
+      "takes as input the existing `cudaq.Kernel` to append to, "
+      "pre-allocated qubits, number of qubits, number of layers, the list "
+      "of parameters, and the CNOT couplers as input, in that order.");
+
+  mod.def(
+      "hwe",
+      [](kernel_builder<> &kernel, QuakeValue &qubits, std::size_t numQubits,
+         std::size_t numLayers, QuakeValue &parameters) {
+        return cudaq::hwe(kernel, qubits, numQubits, numLayers, parameters);
+      },
+      "Generate the hardware-efficient CUDA Quantum Kernel. This function "
+      "takes as input the existing `cudaq.Kernel` to append to, "
+      "pre-allocated qubits, number of qubits, number of layers, and the list "
+      "of parameters as input, in that order. Using default CNOT couplers.");
 }
 
 } // namespace cudaq

--- a/runtime/cudaq/domains/chemistry/hwe.h
+++ b/runtime/cudaq/domains/chemistry/hwe.h
@@ -28,12 +28,12 @@ struct cnot_coupling {
 };
 
 /// @brief Utility function generation default coupling for the HWE ansatz.
-inline std::vector<cnot_coupling> default_cnotCoupling(std::size_t numQubits) {
+inline std::vector<cnot_coupling> default_cnot_coupling(std::size_t numQubits) {
   std::vector<cnot_coupling> cnotCoupling;
-  cnotCoupling.reserve(numQubits-1);  
-  for (std::size_t q = 0; q < numQubits - 1; q++) {
-      cnotCoupling.push_back( {q, q + 1} );
-  }
+  cnotCoupling.reserve(numQubits - 1);
+  for (std::size_t q = 0; q < numQubits - 1; q++)
+    cnotCoupling.push_back({q, q + 1});
+
   return cnotCoupling;
 }
 
@@ -42,7 +42,8 @@ inline std::vector<cnot_coupling> default_cnotCoupling(std::size_t numQubits) {
 /// qubits the state is on, the number of layers, the vector of variational
 /// parameters and the CNOT couplers.
 __qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers,
-                 std::vector<double> parameters, const std::vector<cnot_coupling> &cnotCoupling) {
+                 std::vector<double> parameters,
+                 const std::vector<cnot_coupling> &cnotCoupling) {
   std::size_t numQubits = qubits.size();
 
   for (std::size_t thetaCounter = 0, i = 0; i < numQubits; i++) {
@@ -51,7 +52,8 @@ __qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers,
     thetaCounter += 2;
   }
 
-  for (std::size_t thetaCounter = numQubits * 2, layer = 0; layer < numLayers; layer++) {
+  for (std::size_t thetaCounter = numQubits * 2, layer = 0; layer < numLayers;
+       layer++) {
     for (auto &cnot : cnotCoupling)
       x<cudaq::ctrl>(qubits[cnot.source], qubits[cnot.target]);
 
@@ -63,27 +65,28 @@ __qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers,
   }
 }
 
-
 /// @brief This CUDA Quantum kernel implements the hardware-efficient ansatz
 /// from Kandala et. al [https://arxiv.org/abs/1704.05018]. It takes the
 /// qubits the state is on, the number of layers, and the vector of
 /// variational parameters. Uses default CNOT couplers.
-__qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers, std::vector<double> parameters) {
+__qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers,
+                 std::vector<double> parameters) {
   std::size_t numQubits = qubits.size();
 
   // generate default cnotCoupling and forward the call
-  std::vector<cnot_coupling> cnotCoupling = default_cnotCoupling(numQubits);
+  std::vector<cnot_coupling> cnotCoupling = default_cnot_coupling(numQubits);
   hwe(qubits, numLayers, parameters, cnotCoupling);
 }
 
-
-/// @brief This function creates the hardware-efficient ansatz from Kandala et. al 
-/// [https://arxiv.org/abs/1704.05018] on an existing kernel_builder instance. 
-/// It takes the qubits the state is on, the number of qubits and layers, the 
-/// vector of variational parameters and the CNOT couplers as input as a QuakeValue.
+/// @brief This function creates the hardware-efficient ansatz from Kandala et.
+/// al [https://arxiv.org/abs/1704.05018] on an existing kernel_builder
+/// instance. It takes the qubits the state is on, the number of qubits and
+/// layers, the vector of variational parameters and the CNOT couplers as input
+/// as a QuakeValue.
 template <typename KernelBuilder>
-void hwe(KernelBuilder &kernel, QuakeValue &qubits, std::size_t numQubits, std::size_t numLayers, 
-         QuakeValue &parameters, const std::vector<cnot_coupling> &cnotCoupling) {
+void hwe(KernelBuilder &kernel, QuakeValue &qubits, std::size_t numQubits,
+         std::size_t numLayers, QuakeValue &parameters,
+         const std::vector<cnot_coupling> &cnotCoupling) {
 
   for (std::size_t thetaCounter = 0, i = 0; i < numQubits; i++) {
     kernel.ry(parameters[thetaCounter], qubits[i]);
@@ -91,10 +94,11 @@ void hwe(KernelBuilder &kernel, QuakeValue &qubits, std::size_t numQubits, std::
     thetaCounter += 2;
   }
 
-  for (std::size_t thetaCounter = numQubits * 2, layer = 0; layer < numLayers; layer++) {
-    for (auto &cnot : cnotCoupling){
+  for (std::size_t thetaCounter = numQubits * 2, layer = 0; layer < numLayers;
+       layer++) {
+    for (auto &cnot : cnotCoupling)
       kernel.template x<cudaq::ctrl>(qubits[cnot.source], qubits[cnot.target]);
-    }
+
     for (std::size_t q = 0; q < numQubits; q++) {
       kernel.ry(parameters[thetaCounter], qubits[q]);
       kernel.rz(parameters[thetaCounter + 1], qubits[q]);
@@ -103,17 +107,16 @@ void hwe(KernelBuilder &kernel, QuakeValue &qubits, std::size_t numQubits, std::
   }
 }
 
-
-/// @brief This function creates the hardware-efficient ansatz from Kandala et. al 
-/// [https://arxiv.org/abs/1704.05018] on an existing kernel_builder instance. 
-/// It takes the qubits the state is on, the number of layers, 
-/// and the vector of variational parameters as input as a QuakeValue.
+/// @brief This function creates the hardware-efficient ansatz from Kandala et.
+/// al [https://arxiv.org/abs/1704.05018] on an existing kernel_builder
+/// instance. It takes the qubits the state is on, the number of layers, and the
+/// vector of variational parameters as input as a QuakeValue.
 template <typename KernelBuilder>
-void hwe(KernelBuilder &kernel, QuakeValue &qubits, std::size_t numQubits, 
+void hwe(KernelBuilder &kernel, QuakeValue &qubits, std::size_t numQubits,
          std::size_t numLayers, QuakeValue &parameters) {
 
   // generate default cnotCoupling and forward the call
-  std::vector<cnot_coupling> cnotCoupling = default_cnotCoupling(numQubits);
+  std::vector<cnot_coupling> cnotCoupling = default_cnot_coupling(numQubits);
   hwe(kernel, qubits, numQubits, numLayers, parameters, cnotCoupling);
 }
 

--- a/runtime/cudaq/domains/chemistry/hwe.h
+++ b/runtime/cudaq/domains/chemistry/hwe.h
@@ -14,31 +14,10 @@
 
 namespace cudaq {
 
-/// @brief This CUDA Quantum kernel implements the hardware-efficient ansatz
-/// from Kandala et. al [https://arxiv.org/abs/1704.05018]. It takes the
-/// qubits the state is on, the number of layers, and the vector of
-/// variational parameters.
-__qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers,
-                 std::vector<double> parameters) {
-  auto numQubits = qubits.size();
-
-  for (std::size_t thetaCounter = 0, i = 0; i < numQubits; i++) {
-    ry(parameters[thetaCounter], qubits[i]);
-    rz(parameters[thetaCounter + 1], qubits[i]);
-    thetaCounter += 2;
-  }
-
-  for (std::size_t thetaCounter = numQubits * 2, layer = 0; layer < numLayers;
-       layer++) {
-    for (std::size_t q = 0; q < numQubits - 1; q++)
-      x<cudaq::ctrl>(qubits[q], qubits[q + 1]);
-
-    for (std::size_t q = 0; q < numQubits; q++) {
-      ry(parameters[thetaCounter], qubits[q]);
-      rz(parameters[thetaCounter + 1], qubits[q]);
-      thetaCounter += 2;
-    }
-  }
+/// @brief Given the number of qubits and number of layers,
+/// return the number of variational parameters for the HWE ansatz.
+std::size_t num_hwe_parameters(std::size_t numQubits, std::size_t numLayers) {
+  return 2 * numQubits * (1 + numLayers);
 }
 
 /// @brief Utility type describing a CNOT coupler for the HWE ansatz.
@@ -48,14 +27,23 @@ struct cnot_coupling {
   cnot_coupling(std::size_t s, std::size_t t) : source(s), target(t) {}
 };
 
+/// @brief Utility function generation default coupling for the HWE ansatz.
+inline std::vector<cnot_coupling> default_cnotCoupling(std::size_t numQubits) {
+  std::vector<cnot_coupling> cnotCoupling;
+  cnotCoupling.reserve(numQubits-1);  
+  for (std::size_t q = 0; q < numQubits - 1; q++) {
+      cnotCoupling.push_back( {q, q + 1} );
+  }
+  return cnotCoupling;
+}
+
 /// @brief This CUDA Quantum kernel implements the hardware-efficient ansatz
 /// from Kandala et. al [https://arxiv.org/abs/1704.05018]. It takes the
-/// qubits the state is on, the number of layers, the CNOT couplers,
-/// and the vector of variational parameters.
+/// qubits the state is on, the number of layers, the vector of variational
+/// parameters and the CNOT couplers.
 __qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers,
-                 const std::vector<cnot_coupling> &cnotCoupling,
-                 std::vector<double> parameters) {
-  auto numQubits = qubits.size();
+                 std::vector<double> parameters, const std::vector<cnot_coupling> &cnotCoupling) {
+  std::size_t numQubits = qubits.size();
 
   for (std::size_t thetaCounter = 0, i = 0; i < numQubits; i++) {
     ry(parameters[thetaCounter], qubits[i]);
@@ -63,8 +51,7 @@ __qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers,
     thetaCounter += 2;
   }
 
-  for (std::size_t thetaCounter = numQubits * 2, layer = 0; layer < numLayers;
-       layer++) {
+  for (std::size_t thetaCounter = numQubits * 2, layer = 0; layer < numLayers; layer++) {
     for (auto &cnot : cnotCoupling)
       x<cudaq::ctrl>(qubits[cnot.source], qubits[cnot.target]);
 
@@ -76,10 +63,58 @@ __qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers,
   }
 }
 
-/// @brief Given the number of qubits and number of layers,
-/// return the number of variational parameters for the HWE ansatz.
-std::size_t num_hwe_parameters(std::size_t numQubits, std::size_t numLayers) {
-  return 2 * numQubits * (1 + numLayers);
+
+/// @brief This CUDA Quantum kernel implements the hardware-efficient ansatz
+/// from Kandala et. al [https://arxiv.org/abs/1704.05018]. It takes the
+/// qubits the state is on, the number of layers, and the vector of
+/// variational parameters. Uses default CNOT couplers.
+__qpu__ void hwe(cudaq::qview<> qubits, std::size_t numLayers, std::vector<double> parameters) {
+  std::size_t numQubits = qubits.size();
+
+  // generate default cnotCoupling and forward the call
+  std::vector<cnot_coupling> cnotCoupling = default_cnotCoupling(numQubits);
+  hwe(qubits, numLayers, parameters, cnotCoupling);
+}
+
+
+/// @brief This function creates the hardware-efficient ansatz from Kandala et. al 
+/// [https://arxiv.org/abs/1704.05018] on an existing kernel_builder instance. 
+/// It takes the qubits the state is on, the number of qubits and layers, the 
+/// vector of variational parameters and the CNOT couplers as input as a QuakeValue.
+template <typename KernelBuilder>
+void hwe(KernelBuilder &kernel, QuakeValue &qubits, std::size_t numQubits, std::size_t numLayers, 
+         QuakeValue &parameters, const std::vector<cnot_coupling> &cnotCoupling) {
+
+  for (std::size_t thetaCounter = 0, i = 0; i < numQubits; i++) {
+    kernel.ry(parameters[thetaCounter], qubits[i]);
+    kernel.rz(parameters[thetaCounter + 1], qubits[i]);
+    thetaCounter += 2;
+  }
+
+  for (std::size_t thetaCounter = numQubits * 2, layer = 0; layer < numLayers; layer++) {
+    for (auto &cnot : cnotCoupling){
+      kernel.template x<cudaq::ctrl>(qubits[cnot.source], qubits[cnot.target]);
+    }
+    for (std::size_t q = 0; q < numQubits; q++) {
+      kernel.ry(parameters[thetaCounter], qubits[q]);
+      kernel.rz(parameters[thetaCounter + 1], qubits[q]);
+      thetaCounter += 2;
+    }
+  }
+}
+
+
+/// @brief This function creates the hardware-efficient ansatz from Kandala et. al 
+/// [https://arxiv.org/abs/1704.05018] on an existing kernel_builder instance. 
+/// It takes the qubits the state is on, the number of layers, 
+/// and the vector of variational parameters as input as a QuakeValue.
+template <typename KernelBuilder>
+void hwe(KernelBuilder &kernel, QuakeValue &qubits, std::size_t numQubits, 
+         std::size_t numLayers, QuakeValue &parameters) {
+
+  // generate default cnotCoupling and forward the call
+  std::vector<cnot_coupling> cnotCoupling = default_cnotCoupling(numQubits);
+  hwe(kernel, qubits, numQubits, numLayers, parameters, cnotCoupling);
 }
 
 } // namespace cudaq

--- a/unittests/domains/ChemistryTester.cpp
+++ b/unittests/domains/ChemistryTester.cpp
@@ -160,7 +160,7 @@ CUDAQ_TEST(H2MoleculeTester, checkHWE) {
       cudaq::qvector q(numQubits);
       x(q[0]);
       x(q[1]);
-      cudaq::hwe(q, numLayers, {{0, 1}, {1, 2}, {2, 3}}, thetas);
+      cudaq::hwe(q, numLayers, thetas, {{0, 1}, {1, 2}, {2, 3}});
     };
 
     double res = cudaq::observe(ansatz, H, optParams);


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
The hardware efficient ansatz was extended to allow kernel builder calling.
Additionally the hwe.h was refactored a bit to reduce code duplication via free function for defaults and forwarding.
Tests in python were added.