### PR TITLE
Fix QIR translation bug.

### DIFF
--- a/lib/Optimizer/CodeGen/LowerToBaseProfileQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToBaseProfileQIR.cpp
@@ -411,18 +411,42 @@ struct VerifyBaseProfilePass
     bool passFailed = false;
     if (!func->hasAttr(cudaq::entryPointAttrName))
       return;
+    auto *ctx = &getContext();
     func.walk([&](Operation *op) {
       if (auto call = dyn_cast<LLVM::CallOp>(op)) {
         auto funcName = call.getCalleeAttr().getValue();
         if (!funcName.startswith("__quantum_")) {
           call.emitOpError("unexpected call in QIR base profile");
           passFailed = true;
+          return WalkResult::advance();
         }
-      } else if (isa<LLVM::BrOp, LLVM::CondBrOp, LLVM::ResumeOp,
-                     LLVM::UnreachableOp, LLVM::SwitchOp>(op)) {
+
+        // Check that qubits are unique values.
+        const std::size_t numOpnds = call.getNumOperands();
+        auto qubitTy = cudaq::opt::getQubitType(ctx);
+        if (numOpnds > 0)
+          for (std::size_t i = 0; i < numOpnds - 1; ++i)
+            if (call.getOperand(i).getType() == qubitTy)
+              for (std::size_t j = i + 1; j < numOpnds; ++j)
+                if (call.getOperand(j).getType() == qubitTy) {
+                  auto i1 =
+                      call.getOperand(i).getDefiningOp<LLVM::IntToPtrOp>();
+                  auto j1 =
+                      call.getOperand(j).getDefiningOp<LLVM::IntToPtrOp>();
+                  if (i1 && j1 && i1.getOperand() == j1.getOperand()) {
+                    call.emitOpError("uses same qubit as multiple operands");
+                    passFailed = true;
+                    return WalkResult::interrupt();
+                  }
+                }
+        return WalkResult::advance();
+      }
+      if (isa<LLVM::BrOp, LLVM::CondBrOp, LLVM::ResumeOp, LLVM::UnreachableOp,
+              LLVM::SwitchOp>(op)) {
         op->emitOpError("QIR base profile does not support control-flow");
         passFailed = true;
       }
+      return WalkResult::advance();
     });
     if (passFailed) {
       emitError(func.getLoc(),

--- a/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -53,11 +53,12 @@ public:
 
   LogicalResult matchAndRewrite(quake::AllocaOp alloc,
                                 PatternRewriter &rewriter) const override {
+    Type refTy = quake::RefType::get(rewriter.getContext());
     for (auto p : llvm::enumerate(analysis.allocations)) {
       if (alloc == p.value()) {
         auto i = p.index();
         auto &os = analysis.offsetSizes[i];
-        if (os.second == 1) {
+        if (alloc.getType() == refTy) {
           [[maybe_unused]] Value ext =
               rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(
                   alloc, analysis.newAlloc, os.first);

--- a/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -23,6 +23,14 @@ namespace cudaq::opt {
 
 using namespace mlir;
 
+static Value createCast(PatternRewriter &rewriter, Location loc, Value inVal) {
+  auto i64Ty = rewriter.getI64Type();
+  if (inVal.getType() == rewriter.getIndexType())
+    return rewriter.create<arith::IndexCastOp>(loc, i64Ty, inVal);
+  return rewriter.create<cudaq::cc::CastOp>(loc, i64Ty, inVal,
+                                            cudaq::cc::CastOpMode::Unsigned);
+}
+
 namespace {
 struct Analysis {
   Analysis() = default;
@@ -105,11 +113,8 @@ public:
           loc, extract.getConstantIndex(), low.getType());
       offset = rewriter.create<arith::AddIOp>(loc, cv, low);
     } else {
-      Value cast1 = rewriter.create<cudaq::cc::CastOp>(
-          loc, rewriter.getI64Type(), extract.getIndex(),
-          cudaq::cc::CastOpMode::Unsigned);
-      Value cast2 = rewriter.create<cudaq::cc::CastOp>(
-          loc, rewriter.getI64Type(), low, cudaq::cc::CastOpMode::Unsigned);
+      Value cast1 = createCast(rewriter, loc, extract.getIndex());
+      Value cast2 = createCast(rewriter, loc, low);
       offset = rewriter.create<arith::AddIOp>(loc, cast1, cast2);
     }
     rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(extract, subvec.getVeq(),
@@ -129,15 +134,9 @@ public:
       return failure();
 
     auto loc = subvec.getLoc();
-    Value cast1 = rewriter.create<cudaq::cc::CastOp>(
-        loc, rewriter.getI64Type(), prior.getLow(),
-        cudaq::cc::CastOpMode::Unsigned);
-    Value cast2 = rewriter.create<cudaq::cc::CastOp>(
-        loc, rewriter.getI64Type(), subvec.getLow(),
-        cudaq::cc::CastOpMode::Unsigned);
-    Value cast3 = rewriter.create<cudaq::cc::CastOp>(
-        loc, rewriter.getI64Type(), subvec.getHigh(),
-        cudaq::cc::CastOpMode::Unsigned);
+    Value cast1 = createCast(rewriter, loc, prior.getLow());
+    Value cast2 = createCast(rewriter, loc, subvec.getLow());
+    Value cast3 = createCast(rewriter, loc, subvec.getHigh());
     Value sum1 = rewriter.create<arith::AddIOp>(loc, cast1, cast2);
     Value sum2 = rewriter.create<arith::AddIOp>(loc, cast1, cast3);
     auto veqTy = subvec.getType();

--- a/runtime/common/CMakeLists.txt
+++ b/runtime/common/CMakeLists.txt
@@ -65,7 +65,7 @@ if(OPENSSL_FOUND)
   FetchContent_GetProperties(cpr)
   if(NOT cpr_POPULATED)
     FetchContent_Populate(cpr)
-    add_subdirectory(${cpr_SOURCE_DIR} ${cpr_BINARY_DIR} EXCLUDE_FROM_ALL SYSTEM)
+    add_subdirectory(${cpr_SOURCE_DIR} ${cpr_BINARY_DIR} EXCLUDE_FROM_ALL)
     target_compile_options(cpr PRIVATE "-w")
   endif()
 

--- a/runtime/common/RuntimeMLIR.cpp
+++ b/runtime/common/RuntimeMLIR.cpp
@@ -127,7 +127,8 @@ void registerToQIRTranslation() {
         std::string errMsg;
         llvm::raw_string_ostream errOs(errMsg);
         auto qirBasePipelineConfig =
-            "promote-qubit-allocation,quake-to-qir,base-profile-pipeline";
+            "func.func(combine-quantum-alloc),canonicalize,cse,quake-to-qir,"
+            "base-profile-pipeline";
         if (failed(parsePassPipeline(qirBasePipelineConfig, pm, errOs)))
           return failure();
         if (failed(pm.run(op)))
@@ -218,8 +219,10 @@ ExecutionEngine *createQIRJITEngine(ModuleOp &moduleOp) {
     std::string errMsg;
     llvm::raw_string_ostream errOs(errMsg);
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
+    pm.addNestedPass<func::FuncOp>(
+        cudaq::opt::createCombineQuantumAllocations());
     pm.addPass(createCanonicalizerPass());
-    pm.addPass(cudaq::opt::createPromoteRefToVeqAlloc());
+    pm.addPass(createCSEPass());
     pm.addPass(cudaq::opt::createConvertToQIRPass());
     if (failed(pm.run(module)))
       throw std::runtime_error(

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -750,10 +750,10 @@ ExecutionEngine *jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
   pm.addPass(cudaq::opt::createGenerateDeviceCodeLoader(/*genAsQuake=*/true));
   pm.addPass(cudaq::opt::createGenerateKernelExecution());
   optPM.addPass(cudaq::opt::createLowerToCFGPass());
-  pm.addPass(cudaq::opt::createPromoteRefToVeqAlloc());
-  pm.addPass(cudaq::opt::createConvertToQIRPass());
+  optPM.addPass(cudaq::opt::createCombineQuantumAllocations());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
+  pm.addPass(cudaq::opt::createConvertToQIRPass());
 
   if (failed(pm.run(module)))
     throw std::runtime_error(

--- a/test/NVQPP/test-int8_t_free_func.cpp
+++ b/test/NVQPP/test-int8_t_free_func.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -8,32 +8,6 @@
 
 // RUN: cudaq-opt %s --quake-add-deallocs | cudaq-translate --convert-to=qir | FileCheck %s
 
-// CHECK:         %[[VAL_0:.*]] = zext i32
-// CHECK:         %[[VAL_1:.*]] to i64
-// CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_0]])
-// CHECK:         %[[VAL_4:.*]] = tail call %[[VAL_3]]* @__quantum__rt__qubit_allocate_array(i64 2)
-// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
-// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_4]])
-// CHECK:         ret void
-
-// CHECK:         %[[VAL_5:.*]] = tail call %[[VAL_6:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
-// CHECK:         %[[VAL_7:.*]] = tail call %[[VAL_6]]* @__quantum__rt__qubit_allocate_array(i64 2)
-// CHECK:         %[[VAL_8:.*]] = tail call %[[VAL_6]]* @__quantum__rt__qubit_allocate_array(i64 1)
-// CHECK:         %[[VAL_9:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_5]], i64 0)
-// CHECK:         %[[VAL_10:.*]] = bitcast i8* %[[VAL_9]] to %[[VAL_11:.*]]**
-// CHECK:         %[[VAL_12:.*]] = load %[[VAL_11]]*, %[[VAL_11]]** %[[VAL_10]], align 8
-// CHECK:         %[[VAL_13:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_7]], i64 1)
-// CHECK:         %[[VAL_14:.*]] = bitcast i8* %[[VAL_13]] to %[[VAL_11]]**
-// CHECK:         %[[VAL_15:.*]] = load %[[VAL_11]]*, %[[VAL_11]]** %[[VAL_14]], align 8
-// CHECK:         tail call void @__quantum__qis__h(%[[VAL_11]]* %[[VAL_12]])
-// CHECK: tail call void (i64, void (%Array*, %Qubit*)*, ...) @invokeWithControlQubits(i64 1, void (%Array*, %Qubit*)* nonnull @__quantum__qis__x__ctl, %Qubit* %[[VAL_12]], %Qubit* %[[VAL_15]])
-// CHECK:         tail call void @__quantum__qis__rx(double 4.300000e-01, %[[VAL_11]]* %[[VAL_12]])
-// CHECK:         %[[VAL_16:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_11]]* %[[VAL_12]])
-// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_5]])
-// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_7]])
-// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_8]])
-// CHECK:         ret void
-
 module {
      func.func @test_func(%p : i32) {
           %qv = quake.alloca !quake.veq<?>[%p : i32]
@@ -42,7 +16,17 @@ module {
           return
      }
 
-    func.func @test_func2(){
+// CHECK-LABEL: define void @test_func(i32 
+// CHECK-SAME:                             %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_1:.*]] = zext i32 %[[VAL_0]] to i64
+// CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_1]])
+// CHECK:         %[[VAL_4:.*]] = tail call %[[VAL_3]]* @__quantum__rt__qubit_allocate_array(i64 2)
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_4]])
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
+// CHECK:         ret void
+// CHECK:       }
+
+   func.func @test_func2(){
 
       %zero = arith.constant 0 : i32
       %one = arith.constant 1 : i32
@@ -67,4 +51,20 @@ module {
       return 
     }
 }
+
+// CHECK-LABEL: define void @test_func2() local_unnamed_addr {
+// CHECK:         %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 5)
+// CHECK:         %[[VAL_2:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
+// CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %[[VAL_4:.*]]**
+// CHECK:         %[[VAL_5:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_3]], align 8
+// CHECK:         %[[VAL_6:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 3)
+// CHECK:         %[[VAL_7:.*]] = bitcast i8* %[[VAL_6]] to %[[VAL_4]]**
+// CHECK:         %[[VAL_8:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_7]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_4]]* %[[VAL_5]])
+// CHECK:         tail call void (i64, void (%[[VAL_1]]*, %[[VAL_4]]*)*, ...) @invokeWithControlQubits(i64 1, void (%[[VAL_1]]*, %[[VAL_4]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_4]]* %[[VAL_5]], %[[VAL_4]]* %[[VAL_8]])
+// CHECK:         tail call void @__quantum__qis__rx(double 4.300000e-01, %[[VAL_4]]* %[[VAL_5]])
+// CHECK:         %[[VAL_9:.*]] = tail call %[[VAL_10:.*]]* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_5]])
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
+// CHECK:         ret void
+// CHECK:       }
 

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -21,8 +21,8 @@ module {
 // CHECK:         %[[VAL_1:.*]] = zext i32 %[[VAL_0]] to i64
 // CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_1]])
 // CHECK:         %[[VAL_4:.*]] = tail call %[[VAL_3]]* @__quantum__rt__qubit_allocate_array(i64 2)
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_4]])
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
+// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_4]])
+// CHECK-DAG:     tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
 // CHECK:         ret void
 // CHECK:       }
 

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -98,9 +98,10 @@ void addPipelineToQIR(PassManager &pm) {
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createLoopUnroll());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
-  pm.addPass(cudaq::opt::createPromoteRefToVeqAlloc());
-  pm.addPass(cudaq::opt::createConvertToQIRPass());
+  pm.addNestedPass<func::FuncOp>(cudaq::opt::createCombineQuantumAllocations());
   pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(cudaq::opt::createConvertToQIRPass());
   if constexpr (BaseProfile) {
     cudaq::opt::addBaseProfilePipeline(pm);
   }

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -76,7 +76,9 @@ LogicalResult lowerToLLVMDialect(ModuleOp module) {
   optPM.addPass(cudaq::opt::createQuakeAddDeallocs());
   optPM.addPass(cudaq::opt::createQuakeAddMetadata());
   optPM.addPass(cudaq::opt::createLowerToCFGPass());
-  pm.addPass(cudaq::opt::createPromoteRefToVeqAlloc());
+  optPM.addPass(cudaq::opt::createCombineQuantumAllocations());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
   pm.addPass(cudaq::opt::createConvertToQIRPass());
   return pm.run(module);
 }


### PR DESCRIPTION
QIR translation is buggy when there are multiple qubit allocations. Change the pipelines to use the qubit combine pass to move all allocations into a single vector allocation.

Also adds another checker to the base profile verifier to make sure that qubits are not misused in the base profile.
