### PR TITLE
Better exception messages for cudaq::future

### DIFF
--- a/runtime/common/Future.cpp
+++ b/runtime/common/Future.cpp
@@ -89,7 +89,7 @@ std::istream &operator>>(std::istream &is, future &f) {
   try {
     is >> j;
   } catch (std::exception &ex) {
-    throw std::runtime_error("Failed to read job json into a cudaq::future.");
+    throw std::runtime_error("Formatting error; could not parse input as json.");
   }
   f.jobs = j["jobs"].get<std::vector<future::Job>>();
   f.qpuName = j["qpu"].get<std::string>();

--- a/runtime/common/Future.cpp
+++ b/runtime/common/Future.cpp
@@ -89,7 +89,8 @@ std::istream &operator>>(std::istream &is, future &f) {
   try {
     is >> j;
   } catch (std::exception &ex) {
-    throw std::runtime_error("Formatting error; could not parse input as json.");
+    throw std::runtime_error(
+        "Formatting error; could not parse input as json.");
   }
   f.jobs = j["jobs"].get<std::vector<future::Job>>();
   f.qpuName = j["qpu"].get<std::string>();

--- a/runtime/common/Future.cpp
+++ b/runtime/common/Future.cpp
@@ -74,7 +74,7 @@ future &future::operator=(future &&other) {
 std::ostream &operator<<(std::ostream &os, future &f) {
   if (f.wrapsFutureSampling)
     throw std::runtime_error(
-        "Cannot persist a cudaq::future that wraps a std::future.");
+        "Cannot persist a cudaq::future for a local kernel execution.");
 
   nlohmann::json j;
   j["jobs"] = f.jobs;
@@ -86,7 +86,11 @@ std::ostream &operator<<(std::ostream &os, future &f) {
 
 std::istream &operator>>(std::istream &is, future &f) {
   nlohmann::json j;
-  is >> j;
+  try {
+    is >> j;
+  } catch (std::exception &ex) {
+    throw std::runtime_error("Failed to read job json into a cudaq::future.");
+  }
   f.jobs = j["jobs"].get<std::vector<future::Job>>();
   f.qpuName = j["qpu"].get<std::string>();
   f.serverConfig = j["config"].get<std::map<std::string, std::string>>();

--- a/test/NVQPP/test-6.cpp
+++ b/test/NVQPP/test-6.cpp
@@ -15,9 +15,9 @@
 __qpu__ void cccx_measure_cleanup() {
   cudaq::qreg qubits(4);
   // Initialize
+  x(qubits[0]);
   x(qubits[1]);
   x(qubits[2]);
-  x(qubits[3]);
 
   // Compute AND-operation
   cudaq::qubit ancilla;
@@ -44,8 +44,9 @@ __qpu__ void cccx_measure_cleanup() {
 }
 
 int main() {
-  auto result = cudaq::sample(1000, cccx_measure_cleanup);
+  auto result = cudaq::sample(10, cccx_measure_cleanup);
   std::cout << result.most_probable() << '\n';
+  result.dump();
   return 0;
 }
 


### PR DESCRIPTION
also fix the `test-6.cpp` x operations on the right qubits to produce 1111, even though its currently marked XFAIL (and should be)