### PR TITLE
readable api_key instead of env var

### DIFF
--- a/docs/sphinx/using/backends/hardware/iontrap.rst
+++ b/docs/sphinx/using/backends/hardware/iontrap.rst
@@ -18,6 +18,9 @@ it as an environment variable:
 
   export IONQ_API_KEY="ionq_generated_api_key"
 
+Alternatively, pass the key with the ``api_key`` argument to
+``cudaq.set_target`` or the ``--ionq-api-key`` flag to ``nvq++``.
+
 
 Submitting
 `````````````````````````

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
@@ -104,14 +104,16 @@ void IonQServerHelper::initialize(BackendConfig config) {
   // Retrieve the noise model setting (if provided)
   if (config.find("noise") != config.end())
     backendConfig["noise_model"] = config["noise"];
-  // Retrieve the API key from the environment variables
+  // Retrieve the API key from the target arguments or the environment
   bool isTokenRequired = [&]() {
     auto it = config.find("emulate");
     if (it != config.end() && it->second == "true")
       return false;
     return true;
   }();
-  backendConfig["token"] = getEnvVar("IONQ_API_KEY", "0", isTokenRequired);
+  std::string apiKey = getValueOrDefault(config, "api_key", "");
+  backendConfig["token"] =
+      apiKey.empty() ? getEnvVar("IONQ_API_KEY", "0", isTokenRequired) : apiKey;
   // Construct the API job path
   backendConfig["job_path"] =
       backendConfig["url"] + '/' + backendConfig["version"] + "/jobs";

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.yml
@@ -35,6 +35,11 @@ target-arguments:
     type: string
     platform-arg: qpu 
     help-string: "Specify the IonQ QPU."
+  - key: api-key
+    required: false
+    type: string
+    platform-arg: api_key
+    help-string: "Specify the IonQ API key."
   - key: noise-model
     required: false
     type: string

--- a/unittests/nvqpp/backends/ionq/CMakeLists.txt
+++ b/unittests/nvqpp/backends/ionq/CMakeLists.txt
@@ -9,7 +9,7 @@
 add_backend_unittest_executable(test_ionq 
   SOURCES IonQTester.cpp
   BACKEND ionq
-  BACKEND_CONFIG "ionq emulate=false url=http://localhost:62441"
+  BACKEND_CONFIG "ionq emulate=false url=http://localhost:62441 api_key=00000000000000000000000000000000"
 )
 
 

--- a/unittests/nvqpp/backends/ionq/IonQStartServerAndTest.sh.in
+++ b/unittests/nvqpp/backends/ionq/IonQStartServerAndTest.sh.in
@@ -33,8 +33,8 @@ while ! checkServerConnection; do
     exit 99
   fi
 done
-# Set the environment before entering main
-export IONQ_API_KEY="00000000000000000000000000000000"
+# The key comes from the api_key target argument; keep the env var unset.
+unset IONQ_API_KEY
 # Run the tests
 ./test_ionq
 # Did they fail? 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Users should be able to pass an `api_key` to `set_target` instead of needing to specify an environment variable. This PR adds that `api_key` argument to the config.
