### PR TITLE
Fix bug with iterator in loop normalization.

### DIFF
--- a/docs/sphinx/examples/cpp/algorithms/phase_estimation.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/phase_estimation.cpp
@@ -59,7 +59,7 @@ struct qpe {
 
     // Perform `ctrl-U^j`
     for (int i = 0; i < nCountingQubits; ++i) {
-      for (int j = 0; j < (1UL << i); ++j) {
+      for (int j = 0; j < (1 << i); ++j) {
         cudaq::control(oracle, counting_qubits[i], state_register);
       }
     }

--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -39,7 +39,7 @@ void createUnrollingPipeline(mlir::OpPassManager &pm, unsigned threshold,
                              bool signalFailure);
 inline void addUnrollingPipeline(mlir::OpPassManager &pm) {
   // Set defaults used by registerUnrollingPipeline()
-  createUnrollingPipeline(pm, /*threshold=*/50, /*signalFailure=*/true);
+  createUnrollingPipeline(pm, /*threshold=*/1028, /*signalFailure=*/true);
 }
 void registerUnrollingPipeline();
 

--- a/lib/Optimizer/Transforms/LoopNormalize.cpp
+++ b/lib/Optimizer/Transforms/LoopNormalize.cpp
@@ -139,7 +139,11 @@ public:
       rewriter.setInsertionPointToStart(entry);
       Value induct = entry->getArgument(c.induction);
       auto mul = rewriter.create<arith::MulIOp>(loc, induct, c.stepValue);
-      Value newInd = rewriter.create<arith::AddIOp>(loc, mul, c.initialValue);
+      Value newInd;
+      if (c.stepIsAnAddOp())
+        newInd = rewriter.create<arith::AddIOp>(loc, c.initialValue, mul);
+      else
+        newInd = rewriter.create<arith::SubIOp>(loc, c.initialValue, mul);
       if (c.isLinearExpr()) {
         if (c.scaleValue) {
           if (c.reciprocalScale)

--- a/lib/Optimizer/Transforms/LoopUnroll.cpp
+++ b/lib/Optimizer/Transforms/LoopUnroll.cpp
@@ -173,8 +173,9 @@ public:
         (void)applyPatternsAndFoldGreedily(op, frozen);
         if (failed(pm.run(op)))
           break;
-      } while (loopsWereUnrolled(op, numLoops, progress));
+      } while (progress);
     }
+    numLoops = countLoopOps(op);
     if (numLoops && signalFailure) {
       RewritePatternSet patterns(ctx);
       patterns.insert<UnrollCountedLoop>(ctx, threshold, signalFailure,
@@ -183,13 +184,6 @@ public:
       emitError(UnknownLoc::get(ctx), "did not unroll loops");
       signalPassFailure();
     }
-  }
-
-  static bool loopsWereUnrolled(Operation *op, unsigned &numLoops,
-                                unsigned progress) {
-    auto oldNumLoops = numLoops;
-    numLoops = numLoops >= progress ? numLoops - progress : 0;
-    return oldNumLoops > numLoops;
   }
 
   static unsigned countLoopOps(Operation *op) {

--- a/test/AST-Quake/loop_normal.cpp
+++ b/test/AST-Quake/loop_normal.cpp
@@ -103,7 +103,7 @@ __qpu__ void foo4() {
 // CHECK:             %[[VAL_8:.*]] = arith.cmpi ne, %[[VAL_7]], %[[VAL_1]] : i32
 // CHECK:           ^bb0(%[[VAL_9:.*]]: i32):
 // CHECK:             %[[VAL_10:.*]] = arith.muli %[[VAL_9]], %[[VAL_3]] : i32
-// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_0]] : i32
+// CHECK:             %[[VAL_11:.*]] = arith.subi %[[VAL_0]], %[[VAL_10]]  : i32
 // CHECK:             %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
 // CHECK:             %[[VAL_13:.*]] = quake.extract_ref %{{.*}}[%[[VAL_12]]] : (!quake.veq<10>, i64) -> !quake.ref
 // CHECK:           ^bb0(%[[VAL_14:.*]]: i32):


### PR DESCRIPTION
Simplify the fixed-point stuff, round 2.

Remove unsigned long constant from loops on int type. Not needed.

phase_estimation nirvana.