### PR TITLE
Catch NLOpt errors and rethrow with a verbose message

### DIFF
--- a/runtime/cudaq/algorithms/optimizers/nlopt/nlopt.cpp
+++ b/runtime/cudaq/algorithms/optimizers/nlopt/nlopt.cpp
@@ -64,8 +64,29 @@ double nlopt_wrapper_call(const std::vector<double> &x,
     double optF;                                                               \
     try {                                                                      \
       _opt.optimize(x, optF);                                                  \
+    } catch (const ::nlopt::roundoff_limited &e) {                             \
+      throw std::runtime_error(                                                \
+          "NLOpt error: round-off errors limited progress (" +                 \
+          std::string(e.what()) +                                              \
+          "). \nConsider changing the stopping criteria (e.g., reducing "      \
+          "max_eval or increasing f_tol) and/or increase the number of "       \
+          "measurement shots.");                                               \
+    } catch (::nlopt::forced_stop & e) {                                       \
+      throw std::runtime_error("NLOpt forced termination: " +                  \
+                               std::string(e.what()));                         \
+    } catch (std::invalid_argument & e) {                                      \
+      throw std::invalid_argument(                                             \
+          "Invalid NLOpt arguments (e.g. lower bounds "                        \
+          "are bigger than upper bounds): " +                                  \
+          std::string(e.what()));                                              \
+    } catch (std::bad_alloc & e) {                                             \
+      throw std::runtime_error("NLOpt ran out of memory.");                    \
+    } catch (std::runtime_error & e) {                                         \
+      throw std::runtime_error("NLOpt runtime error: " +                       \
+                               std::string(e.what()));                         \
     } catch (std::exception & e) {                                             \
-      throw e;                                                                 \
+      throw std::runtime_error("Unknown NLOpt error: " +                       \
+                               std::string(e.what()));                         \
     }                                                                          \
     return std::make_tuple(optF, x);                                           \
   }

--- a/runtime/cudaq/algorithms/optimizers/nlopt/nlopt.cpp
+++ b/runtime/cudaq/algorithms/optimizers/nlopt/nlopt.cpp
@@ -71,20 +71,20 @@ double nlopt_wrapper_call(const std::vector<double> &x,
           "). \nConsider changing the stopping criteria (e.g., reducing "      \
           "max_eval or increasing f_tol) and/or increase the number of "       \
           "measurement shots.");                                               \
-    } catch (::nlopt::forced_stop & e) {                                       \
+    } catch (const ::nlopt::forced_stop &e) {                                  \
       throw std::runtime_error("NLOpt forced termination: " +                  \
                                std::string(e.what()));                         \
-    } catch (std::invalid_argument & e) {                                      \
+    } catch (const std::invalid_argument &e) {                                 \
       throw std::invalid_argument(                                             \
           "Invalid NLOpt arguments (e.g. lower bounds "                        \
           "are bigger than upper bounds): " +                                  \
           std::string(e.what()));                                              \
-    } catch (std::bad_alloc & e) {                                             \
+    } catch (const std::bad_alloc &e) {                                        \
       throw std::runtime_error("NLOpt ran out of memory.");                    \
-    } catch (std::runtime_error & e) {                                         \
+    } catch (const std::runtime_error &e) {                                    \
       throw std::runtime_error("NLOpt runtime error: " +                       \
                                std::string(e.what()));                         \
-    } catch (std::exception & e) {                                             \
+    } catch (const std::exception &e) {                                        \
       throw std::runtime_error("Unknown NLOpt error: " +                       \
                                std::string(e.what()));                         \
     }                                                                          \


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
Catching exceptions from NLOpt and re-throw them with a more verbose message.

I think the most common one is the `roundoff_limited` error. It will occur when running in 'shots' mode, e.g., 
```
 cudaq::observe(1000, deuteron_n3_ansatz{}, ...
```
in `docs/sphinx/examples/cpp/other/gradients.cpp`.

Might be related to https://github.com/NVIDIA/cuda-quantum/issues/399 (not fixing it, but could make the error message more helpful).