### PR TITLE
try calling set_shots and setShots

### DIFF
--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -234,8 +234,14 @@ bool kernelHasConditionalFeedback(const std::string &kernelName) {
 
 void set_shots(const std::size_t nShots) {
   auto &platform = cudaq::get_platform();
-  platform.set_shots(nShots);
+  try {
+    platform.set_shots(nShots);
+  } catch (const std::exception &e) {
+    // Assuming platform has setShots method
+    platform.setShots(nShots);
+  }
 }
+
 void clear_shots(const std::size_t nShots) {
   auto &platform = cudaq::get_platform();
   platform.clear_shots();


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

There's a bug in setting the `shots_count` from python - my guess is it has something to do with the `set_shots` function not calling `setShots` in the ServerHelper.

![image](https://github.com/NVIDIA/cuda-quantum/assets/25377399/fb22a721-d2ee-4108-8e4b-56fd2734b517)

This PR just calls both `set_shots` and `setShots` if that fails. However, since no exception is raised, I don't think it's failing.