### PR TITLE
Fix #475: bug with measurement operations in value semantics

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
@@ -34,6 +34,16 @@ mlir::Value createSizedSubVecOp(mlir::PatternRewriter &builder,
                                 mlir::Value inVec, mlir::Value lo,
                                 mlir::Value hi);
 
+void getResetEffectsImpl(
+    mlir::SmallVectorImpl<
+        mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>
+        &effects,
+    mlir::ValueRange targets);
+void getMeasurementEffectsImpl(
+    mlir::SmallVectorImpl<
+        mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>
+        &effects,
+    mlir::ValueRange targets);
 void getOperatorEffectsImpl(
     mlir::SmallVectorImpl<
         mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -505,7 +505,7 @@ def quake_ResetOp : QuakeOp<"reset", [QuantumGate,
   let extraClassDeclaration = [{
     void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::
         EffectInstance<mlir::MemoryEffects::Effect>> &effects) {
-      quake::getOperatorEffectsImpl(effects, {}, getTargets());
+      quake::getResetEffectsImpl(effects, getTargets());
     }
   }];
 }
@@ -529,7 +529,7 @@ class Measurement<string mnemonic> : QuakeOp<mnemonic,
   code OpBaseDeclaration = [{
     void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::EffectInstance<
       mlir::MemoryEffects::Effect>> &effects) {
-      quake::getOperatorEffectsImpl(effects, {}, getTargets());
+      quake::getMeasurementEffectsImpl(effects, getTargets());
     }
   }];
 

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -536,10 +536,36 @@ bool cudaq::EnableInlinerInterface::isLegalToInline(Operation *call,
   return !(callable->hasAttr(cudaq::entryPointAttrName));
 }
 
-void quake::getOperatorEffectsImpl(
-    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
-        &effects,
-    ValueRange controls, ValueRange targets) {
+using EffectsVectorImpl =
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>;
+
+/// For an operation with modeless effects, the operation always has effects on
+/// the control and target quantum operands, whether those operands are in
+/// reference or value form. A operation with modeless effects is not removed
+/// when its result(s) is (are) unused.
+inline static void getModelessEffectsImpl(EffectsVectorImpl &effects,
+                                          ValueRange controls,
+                                          ValueRange targets) {
+  for (auto v : controls)
+    effects.emplace_back(MemoryEffects::Read::get(), v,
+                         SideEffects::DefaultResource::get());
+  for (auto v : targets) {
+    effects.emplace_back(MemoryEffects::Read::get(), v,
+                         SideEffects::DefaultResource::get());
+    effects.emplace_back(MemoryEffects::Write::get(), v,
+                         SideEffects::DefaultResource::get());
+  }
+}
+
+/// For an operation with moded effects, the operation conditionally has effects
+/// on the control and target quantum operands. If those operands are in
+/// reference form, then the operation does have effects on those references.
+/// Control operands have a read effect, while target operands have both a read
+/// and write effect. If the operand is in value form, the operation introduces
+/// no effects on that operand.
+inline static void getModedEffectsImpl(EffectsVectorImpl &effects,
+                                       ValueRange controls,
+                                       ValueRange targets) {
   for (auto v : controls)
     if (isa<quake::RefType, quake::VeqType>(v.getType()))
       effects.emplace_back(MemoryEffects::Read::get(), v,
@@ -551,6 +577,24 @@ void quake::getOperatorEffectsImpl(
       effects.emplace_back(MemoryEffects::Write::get(), v,
                            SideEffects::DefaultResource::get());
     }
+}
+
+/// Quake reset has modeless effects.
+void quake::getResetEffectsImpl(EffectsVectorImpl &effects,
+                                ValueRange targets) {
+  getModelessEffectsImpl(effects, {}, targets);
+}
+
+/// Quake measurement operations have modeless effects.
+void quake::getMeasurementEffectsImpl(EffectsVectorImpl &effects,
+                                      ValueRange targets) {
+  getModelessEffectsImpl(effects, {}, targets);
+}
+
+/// Quake quantum operators have moded effects.
+void quake::getOperatorEffectsImpl(EffectsVectorImpl &effects,
+                                   ValueRange controls, ValueRange targets) {
+  getModedEffectsImpl(effects, controls, targets);
 }
 
 // This is a workaround for ODS generating these member function declarations

--- a/test/Quake/modeless_effects.qke
+++ b/test/Quake/modeless_effects.qke
@@ -1,0 +1,40 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt %s  --canonicalize | FileCheck %s
+
+func.func @measures(%a0: !quake.wire, %a1: !quake.wire, %a2: !quake.wire,
+                    %a4: !quake.wire) {
+  %0 = quake.x %a4 : (!quake.wire) -> !quake.wire		    
+  %1 = quake.mx %a0 : (!quake.wire) -> i1
+  %2 = quake.my %a1 : (!quake.wire) -> i1
+  %3 = quake.mz %a2 : (!quake.wire) -> i1
+  return
+}
+
+// CHECK-LABEL:   func.func @measures(
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.wire, %[[VAL_1:.*]]: !quake.wire, %[[VAL_2:.*]]: !quake.wire, %[[VAL_3:.*]]: !quake.wire) {
+// CHECK:           %[[VAL_4:.*]] = quake.mx %[[VAL_0]] : (!quake.wire) -> i1
+// CHECK:           %[[VAL_5:.*]] = quake.my %[[VAL_1]] : (!quake.wire) -> i1
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]] : (!quake.wire) -> i1
+// CHECK:           return
+// CHECK:         }
+
+func.func @red_button(%arg0: !quake.wire, %arg1: !quake.wire) {
+  %0 = quake.h %arg0 : (!quake.wire) -> !quake.wire
+  %1 = quake.reset %0 : (!quake.wire) -> !quake.wire
+  %2 = quake.h %arg1 : (!quake.wire) -> !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @red_button(
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.wire, %[[VAL_1:.*]]: !quake.wire) {
+// CHECK:           %[[VAL_2:.*]] = quake.h %[[VAL_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_3:.*]] = quake.reset %[[VAL_2]] : (!quake.wire) -> !quake.wire
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
Do not eliminate measurements and resets if their results are unused. These operations should be considered pinned in the IR.
