### PR TITLE
Fixes bug with null_wire.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -466,7 +466,7 @@ def quake_WrapOp : QuakeOp<"wrap"> {
   let hasCanonicalizer = 1;
 }
 
-def quake_NullWireOp : QuakeOp<"null_wire", [Pure]> {
+def quake_NullWireOp : QuakeOp<"null_wire", []> {
   let summary = "Initial state of a wire.";
   let description = [{
     |0> - the initial state of a wire when first constructed. A wire is assumed

--- a/test/Quake/nullwire.qke
+++ b/test/Quake/nullwire.qke
@@ -1,0 +1,34 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --cse %s | FileCheck %s
+
+func.func @do_not_merge() {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2 = quake.null_wire
+  %3 = quake.h %0 : (!quake.wire) -> !quake.wire
+  %4 = quake.x [%3] %1 : (!quake.wire, !quake.wire) -> !quake.wire
+  %5 = quake.h %2 : (!quake.wire) -> !quake.wire
+  %6 = quake.x [%5] %4 : (!quake.wire, !quake.wire) -> !quake.wire
+  %7 = quake.mz %6 : (!quake.wire) -> i1
+  return
+}
+
+// CHECK-LABEL:   func.func @do_not_merge() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK:           %[[VAL_1:.*]] = quake.null_wire
+// CHECK:           %[[VAL_2:.*]] = quake.null_wire
+// CHECK:           %[[VAL_3:.*]] = quake.h %[[VAL_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_4:.*]] = quake.x [%[[VAL_3]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_5:.*]] = quake.h %[[VAL_2]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_6:.*]] = quake.x [%[[VAL_5]]] %[[VAL_4]] : (!quake.wire, !quake.wire) -> !quake.wire
+// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_6]] : (!quake.wire) -> i1
+// CHECK:           return
+// CHECK:         }
+


### PR DESCRIPTION
The null_wire op differs from the classical value undef (or 0) in that it is not an SSA-value and not pure.
