### PR TITLE
Pulling `LinkedLibraryHolder` into a util lib

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,6 +5,7 @@
 # This source code and the accompanying materials are made available under     #
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
+add_subdirectory(utils)
 
 set(LIBRARY_NAME _pycudaq)
 if (NOT SKBUILD)
@@ -32,8 +33,8 @@ if (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
 endif()
 pybind11_add_module(_pycudaq 
                      cudaq/_cudaq.cpp 
-                     utils/LinkedLibraryHolder.cpp 
-                     utils/TestingUtils.cpp
+                     runtime/cudaq/target/py_runtime_target.cpp 
+                     runtime/cudaq/target/py_testing_utils.cpp
                      runtime/cudaq/builder/py_kernel_builder.cpp
                      runtime/cudaq/builder/py_QuakeValue.cpp
                      runtime/cudaq/algorithms/py_observe.cpp
@@ -57,7 +58,7 @@ target_link_libraries(_pycudaq
       cudaq-builder 
       cudaq-em-qir 
       cudaq-platform-default 
-      fmt::fmt-header-only)
+      cudaq-py-utils)
 
 if (NOT SKBUILD)
   install(DIRECTORY cudaq DESTINATION .)

--- a/python/cudaq/_cudaq.cpp
+++ b/python/cudaq/_cudaq.cpp
@@ -18,8 +18,9 @@
 #include "runtime/cudaq/kernels/py_chemistry.h"
 #include "runtime/cudaq/spin/py_matrix.h"
 #include "runtime/cudaq/spin/py_spin_op.h"
+#include "runtime/cudaq/target/py_runtime_target.h"
+#include "runtime/cudaq/target/py_testing_utils.h"
 #include "utils/LinkedLibraryHolder.h"
-#include "utils/TestingUtils.h"
 
 #include "cudaq.h"
 

--- a/python/runtime/cudaq/algorithms/py_sample.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample.cpp
@@ -17,6 +17,7 @@
 #include "cudaq/platform.h"
 
 #include "common/ExecutionContext.h"
+#include "common/Logger.h"
 #include "common/MeasureCounts.h"
 
 namespace cudaq {

--- a/python/runtime/cudaq/domains/plugins/PySCFDriver.cpp
+++ b/python/runtime/cudaq/domains/plugins/PySCFDriver.cpp
@@ -6,17 +6,12 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#include "LinkedLibraryHolder.h"
 #include "cudaq/domains/chemistry/MoleculePackageDriver.h"
-#include <iostream>
 #include <pybind11/embed.h>
+
 namespace py = pybind11;
 using namespace cudaq;
-
-/// @brief Reference to boolean flag that
-/// will turn off target modification in the Python bindings.
-namespace cudaq {
-extern bool disallowTargetModification;
-}
 
 namespace {
 
@@ -81,13 +76,13 @@ public:
     }
 
     // We don't want to modify the platform, indicate so
-    cudaq::disallowTargetModification = true;
+    cudaq::LinkedLibraryHolder::disallowTargetModification = true;
 
     // Import the cudaq python chemistry module
     auto cudaqModule = py::module_::import(ChemistryModuleName);
 
     // Reset it
-    cudaq::disallowTargetModification = false;
+    cudaq::LinkedLibraryHolder::disallowTargetModification = false;
 
     // Setup the active space if requested.
     py::object nElectrons = py::none();

--- a/python/runtime/cudaq/target/py_runtime_target.cpp
+++ b/python/runtime/cudaq/target/py_runtime_target.cpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "py_runtime_target.h"
+#include "LinkedLibraryHolder.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "common/FmtCore.h"
+#include "common/Logger.h"
+
+
+namespace cudaq
+{
+
+void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
+
+  py::class_<cudaq::RuntimeTarget>(
+      mod, "Target",
+      "The `cudaq.Target` represents the underlying infrastructure that CUDA "
+      "Quantum kernels will execute on. Instances of `cudaq.Target` describe "
+      "what simulator they may leverage, the quantum_platform required for "
+      "execution, and a description for the target.")
+      .def_readonly("name", &cudaq::RuntimeTarget::name,
+                    "The name of the `cudaq.Target`.")
+      .def_readonly("simulator", &cudaq::RuntimeTarget::simulatorName,
+                    "The name of the simulator this `cudaq.Target` leverages. "
+                    "This will be empty for physical QPUs.")
+      .def_readonly("platform", &cudaq::RuntimeTarget::simulatorName,
+                    "The name of the quantum_platform implementation this "
+                    "`cudaq.Target` leverages.")
+      .def_readonly("description", &cudaq::RuntimeTarget::simulatorName,
+                    "A string describing the features for this `cudaq.Target`.")
+      .def("num_qpus", &cudaq::RuntimeTarget::num_qpus,
+           "Return the number of QPUs available in this `cudaq.Target`.")
+      .def(
+          "__str__",
+          [](cudaq::RuntimeTarget &self) {
+            return fmt::format("Target {}\n\tsimulator={}\n\tplatform={}"
+                               "\n\tdescription={}\n",
+                               self.name, self.simulatorName, self.platformName,
+                               self.description);
+          },
+          "Persist the information in this `cudaq.Target` to a string.");
+
+  mod.def(
+      "has_target",
+      [&](const std::string &name) { return holder.hasTarget(name); },
+      "Return true if the `cudaq.Target` with the given name exists.");
+  mod.def(
+      "reset_target", [&]() { return holder.resetTarget(); },
+      "Reset the current `cudaq.Target` to the default.");
+  mod.def(
+      "get_target",
+      [&](const std::string &name) { return holder.getTarget(name); },
+      "Return the `cudaq.Target` with the given name. Will raise an exception "
+      "if the name is not valid.");
+  mod.def(
+      "get_target", [&]() { return holder.getTarget(); },
+      "Return the `cudaq.Target` with the given name. Will raise an exception "
+      "if the name is not valid.");
+  mod.def(
+      "get_targets", [&]() { return holder.getTargets(); },
+      "Return all available `cudaq.Target` instances on the current system.");
+  mod.def(
+      "set_target",
+      [&](const cudaq::RuntimeTarget &target, py::kwargs extraConfig) {
+        std::map<std::string, std::string> config;
+        for (auto &[key, value] : extraConfig) {
+          std::string strValue = "";
+          if (py::isinstance<py::bool_>(value))
+            strValue = value.cast<py::bool_>() ? "true" : "false";
+          else if (py::isinstance<py::str>(value))
+            strValue = value.cast<std::string>();
+          else
+            throw std::runtime_error(
+                "QPU kwargs config value must be cast-able to a string.");
+
+          config.emplace(key.cast<std::string>(), strValue);
+        }
+        holder.setTarget(target.name, config);
+      },
+      "Set the `cudaq.Target` to be used for CUDA Quantum kernel execution. "
+      "Can provide optional, target-specific configuration data via Python "
+      "kwargs.");
+  mod.def(
+      "set_target",
+      [&](const std::string &name, py::kwargs extraConfig) {
+        std::map<std::string, std::string> config;
+        for (auto &[key, value] : extraConfig) {
+          std::string strValue = "";
+          if (py::isinstance<py::bool_>(value))
+            strValue = value.cast<py::bool_>() ? "true" : "false";
+          else if (py::isinstance<py::str>(value))
+            strValue = value.cast<std::string>();
+          else
+            throw std::runtime_error(
+                "QPU kwargs config value must be cast-able to a string.");
+
+          config.emplace(key.cast<std::string>(), strValue);
+        }
+        holder.setTarget(name, config);
+      },
+      "Set the `cudaq.Target` with given name to be used for CUDA Quantum "
+      "kernel execution. Can provide optional, target-specific configuration "
+      "data via Python kwargs.");
+}
+
+} // namespace cudaq

--- a/python/runtime/cudaq/target/py_runtime_target.cpp
+++ b/python/runtime/cudaq/target/py_runtime_target.cpp
@@ -8,14 +8,12 @@
 
 #include "py_runtime_target.h"
 #include "LinkedLibraryHolder.h"
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include "common/FmtCore.h"
 #include "common/Logger.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
-
-namespace cudaq
-{
+namespace cudaq {
 
 void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
 

--- a/python/runtime/cudaq/target/py_runtime_target.h
+++ b/python/runtime/cudaq/target/py_runtime_target.h
@@ -1,0 +1,21 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace cudaq {
+
+class LinkedLibraryHolder;
+
+void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder);
+
+} // namespace cudaq

--- a/python/runtime/cudaq/target/py_testing_utils.cpp
+++ b/python/runtime/cudaq/target/py_testing_utils.cpp
@@ -6,15 +6,12 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "TestingUtils.h"
-#include "common/PluginUtils.h"
+#include "py_testing_utils.h"
+#include "LinkedLibraryHolder.h"
 #include "cudaq/platform.h"
 #include "nvqir/CircuitSimulator.h"
-#include <fstream>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <regex>
-#include <sstream>
 
 namespace py = pybind11;
 

--- a/python/runtime/cudaq/target/py_testing_utils.h
+++ b/python/runtime/cudaq/target/py_testing_utils.h
@@ -8,19 +8,13 @@
 
 #pragma once
 
-#include "LinkedLibraryHolder.h"
-#include "common/FmtCore.h"
-#include "common/Logger.h"
-#include <filesystem>
-#include <map>
-#include <unordered_map>
-#include <vector>
-
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 namespace cudaq {
+
+class LinkedLibraryHolder;
 
 /// @brief Bind test utilities needed for mock qpu base profile simulation
 void bindTestUtils(py::module &mod, LinkedLibraryHolder &holder);

--- a/python/utils/CMakeLists.txt
+++ b/python/utils/CMakeLists.txt
@@ -5,9 +5,10 @@
 # This source code and the accompanying materials are made available under     #
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/plugins)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 SET(CMAKE_INSTALL_RPATH "$ORIGIN:$ORIGIN/..")
 
-add_library(cudaq-pyscf SHARED PySCFDriver.cpp)
-target_link_libraries(cudaq-pyscf PRIVATE pybind11::embed cudaq-chemistry cudaq-spin cudaq cudaq-py-utils)
-install(TARGETS cudaq-pyscf DESTINATION lib/plugins)
+add_library(cudaq-py-utils SHARED LinkedLibraryHolder.cpp)
+target_link_libraries(cudaq-py-utils PRIVATE nvqir cudaq fmt::fmt-header-only)
+target_include_directories(cudaq-py-utils PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/python/utils>)
+install(TARGETS cudaq-py-utils DESTINATION lib)

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -7,16 +7,14 @@
  ******************************************************************************/
 
 #include "LinkedLibraryHolder.h"
+#include "common/FmtCore.h"
+#include "common/Logger.h"
 #include "common/PluginUtils.h"
 #include "cudaq/platform.h"
 #include "nvqir/CircuitSimulator.h"
 #include <fstream>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <regex>
 #include <sstream>
-
-namespace py = pybind11;
 
 // Our hook into configuring the NVQIR backend.
 extern "C" {
@@ -24,11 +22,6 @@ void __nvqir__setCircuitSimulator(nvqir::CircuitSimulator *);
 }
 
 namespace cudaq {
-
-/// @brief Keep an eye out for requests to ignore
-/// target modification.
-extern bool disallowTargetModification;
-
 void setQuantumPlatformInternal(quantum_platform *p);
 
 constexpr static const char PLATFORM_LIBRARY[] = "PLATFORM_LIBRARY=";
@@ -193,7 +186,7 @@ LinkedLibraryHolder::LinkedLibraryHolder() {
                   RuntimeTarget{"default", "qpp", "default",
                                 "Default OpenMP CPU-only simulated QPU."});
 
-  if (cudaq::disallowTargetModification)
+  if (disallowTargetModification)
     return;
 
   // We'll always start off with the default platform and the QPP simulator
@@ -263,7 +256,7 @@ void LinkedLibraryHolder::setTarget(
     std::map<std::string, std::string> extraConfig) {
   // Do not set the default target if the disallow
   // flag has been set.
-  if (cudaq::disallowTargetModification)
+  if (disallowTargetModification)
     return;
 
   auto iter = targets.find(targetName);
@@ -293,99 +286,6 @@ std::vector<RuntimeTarget> LinkedLibraryHolder::getTargets() const {
   for (auto &[name, target] : targets)
     ret.emplace_back(target);
   return ret;
-}
-
-void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
-
-  py::class_<cudaq::RuntimeTarget>(
-      mod, "Target",
-      "The `cudaq.Target` represents the underlying infrastructure that CUDA "
-      "Quantum kernels will execute on. Instances of `cudaq.Target` describe "
-      "what simulator they may leverage, the quantum_platform required for "
-      "execution, and a description for the target.")
-      .def_readonly("name", &cudaq::RuntimeTarget::name,
-                    "The name of the `cudaq.Target`.")
-      .def_readonly("simulator", &cudaq::RuntimeTarget::simulatorName,
-                    "The name of the simulator this `cudaq.Target` leverages. "
-                    "This will be empty for physical QPUs.")
-      .def_readonly("platform", &cudaq::RuntimeTarget::simulatorName,
-                    "The name of the quantum_platform implementation this "
-                    "`cudaq.Target` leverages.")
-      .def_readonly("description", &cudaq::RuntimeTarget::simulatorName,
-                    "A string describing the features for this `cudaq.Target`.")
-      .def("num_qpus", &cudaq::RuntimeTarget::num_qpus,
-           "Return the number of QPUs available in this `cudaq.Target`.")
-      .def(
-          "__str__",
-          [](cudaq::RuntimeTarget &self) {
-            return fmt::format("Target {}\n\tsimulator={}\n\tplatform={}"
-                               "\n\tdescription={}\n",
-                               self.name, self.simulatorName, self.platformName,
-                               self.description);
-          },
-          "Persist the information in this `cudaq.Target` to a string.");
-
-  mod.def(
-      "has_target",
-      [&](const std::string &name) { return holder.hasTarget(name); },
-      "Return true if the `cudaq.Target` with the given name exists.");
-  mod.def(
-      "reset_target", [&]() { return holder.resetTarget(); },
-      "Reset the current `cudaq.Target` to the default.");
-  mod.def(
-      "get_target",
-      [&](const std::string &name) { return holder.getTarget(name); },
-      "Return the `cudaq.Target` with the given name. Will raise an exception "
-      "if the name is not valid.");
-  mod.def(
-      "get_target", [&]() { return holder.getTarget(); },
-      "Return the `cudaq.Target` with the given name. Will raise an exception "
-      "if the name is not valid.");
-  mod.def(
-      "get_targets", [&]() { return holder.getTargets(); },
-      "Return all available `cudaq.Target` instances on the current system.");
-  mod.def(
-      "set_target",
-      [&](const cudaq::RuntimeTarget &target, py::kwargs extraConfig) {
-        std::map<std::string, std::string> config;
-        for (auto &[key, value] : extraConfig) {
-          std::string strValue = "";
-          if (py::isinstance<py::bool_>(value))
-            strValue = value.cast<py::bool_>() ? "true" : "false";
-          else if (py::isinstance<py::str>(value))
-            strValue = value.cast<std::string>();
-          else
-            throw std::runtime_error(
-                "QPU kwargs config value must be cast-able to a string.");
-
-          config.emplace(key.cast<std::string>(), strValue);
-        }
-        holder.setTarget(target.name, config);
-      },
-      "Set the `cudaq.Target` to be used for CUDA Quantum kernel execution. "
-      "Can provide optional, target-specific configuration data via Python "
-      "kwargs.");
-  mod.def(
-      "set_target",
-      [&](const std::string &name, py::kwargs extraConfig) {
-        std::map<std::string, std::string> config;
-        for (auto &[key, value] : extraConfig) {
-          std::string strValue = "";
-          if (py::isinstance<py::bool_>(value))
-            strValue = value.cast<py::bool_>() ? "true" : "false";
-          else if (py::isinstance<py::str>(value))
-            strValue = value.cast<std::string>();
-          else
-            throw std::runtime_error(
-                "QPU kwargs config value must be cast-able to a string.");
-
-          config.emplace(key.cast<std::string>(), strValue);
-        }
-        holder.setTarget(name, config);
-      },
-      "Set the `cudaq.Target` with given name to be used for CUDA Quantum "
-      "kernel execution. Can provide optional, target-specific configuration "
-      "data via Python kwargs.");
 }
 
 } // namespace cudaq

--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -8,16 +8,11 @@
 
 #pragma once
 
-#include "common/FmtCore.h"
-#include "common/Logger.h"
 #include <filesystem>
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <pybind11/pybind11.h>
-
-namespace py = pybind11;
 
 namespace nvqir {
 class CircuitSimulator;
@@ -45,6 +40,11 @@ struct RuntimeTarget {
 /// for the CUDA Quantum runtime within the Python runtime.
 class LinkedLibraryHolder {
 public:
+  /// @brief Global boolean that disables target modification.
+  /// This will turn off (bypass) target modification in the LinkedLibraryHolder
+  /// instance used by Python bindings.
+  static inline bool disallowTargetModification = false;
+
 protected:
   // Store the library suffix
   std::string libSuffix = "";
@@ -97,7 +97,4 @@ public:
   /// @brief Reset the target back to the default.
   void resetTarget();
 };
-
-void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder);
-
 } // namespace cudaq

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -194,10 +194,6 @@ bool cudaq::__internal__::isLibraryMode(const std::string &kernelname) {
 
 namespace cudaq {
 
-/// @brief Global boolean that disables
-/// target modification.
-bool disallowTargetModification = false;
-
 void set_target_backend(const char *backend) {
   std::string backendName(backend);
   auto &platform = cudaq::get_platform();


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This MR:

- Pulled `LinkedLibraryHolder` into a separate lib (`cudaq-py-utils`) to be used by both the `_pycudaq` and `cudaq-pyscf` libs.

- Made  `disallowTargetModification` a static member variable of `LinkedLibraryHolder`.

- Pulled the binding code in `utils/`  into `runtime/cudaq/target` sub-dir alongside other bindings.

Resolved https://github.com/NVIDIA/cuda-quantum/issues/416