### PR TITLE
Updating docs (#519)

### DIFF
--- a/.github/workflows/config/spelling_allowlist.txt
+++ b/.github/workflows/config/spelling_allowlist.txt
@@ -35,6 +35,7 @@ OpenMPI
 OpenQASM
 Pauli
 Paulis
+PyPI
 QAOA
 QIR
 QIS

--- a/docs/sphinx/examples/cpp/basics/cuquantum_backends.cpp
+++ b/docs/sphinx/examples/cpp/basics/cuquantum_backends.cpp
@@ -1,13 +1,13 @@
 // Compile and run with:
 // ```
-// nvq++ cuquantum_backends.cpp -o dyn.x -qpu cuquantum && ./dyn.x
+// nvq++ cuquantum_backends.cpp -o dyn.x --target nvidia && ./dyn.x
 // ```
 
 // This example is meant to demonstrate the cuQuantum
-// target and its ability to easily handle a larger number
-// of qubits compared the CPU-only backend.
+// GPU-accelerated backends and their ability to easily handle
+// a larger number of qubits compared the CPU-only backend.
 
-// Without the `-qpu cuquantum` flag, this seems to hang, i.e.
+// Without the `--target nvidia` flag, this seems to hang, i.e.
 // it takes a long time for the CPU-only backend to handle
 // this number of qubits.
 

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -103,6 +103,25 @@ or run the Python examples using the Python interpreter.
     may not be automatically active in the container environment. You may need to install your preferred 
     extension in the container environment for all of your development tools to be available.
 
+Python wheels
+--------------------
+
+CUDA Quantum Python wheels are available on [PyPI.org](https://pypi.org/project/cuda-quantum). 
+The CUDA Quantum Python wheels contain the Python API and core components of
+CUDA Quantum. For more information about available packages and documentation,
+see :doc:`versions`.
+
+To install the latest release using `pip <https://pypi.org/project/pip/>`__, run
+
+.. code-block:: console
+
+    python3 -m pip install cuda-quantum
+
+There are currently no source distributions available on PyPI, but you can download the source code 
+for all releases `here <https://github.com/NVIDIA/cuda-quantum/releases>`__. 
+For more information about building a CUDA Quantum Python wheel from source, see the 
+`README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
+
 
 Build CUDA Quantum from Source
 ------------------------------

--- a/docs/sphinx/releases.rst
+++ b/docs/sphinx/releases.rst
@@ -8,11 +8,23 @@ The latest version of CUDA Quantum is on the main branch of our `GitHub reposito
 
 - `Documentation <https://nvidia.github.io/cuda-quantum/latest>`__
 
+**0.4.0**
+
+CUDA Quantum is now available on PyPI!
+The 0.4.0 release adds support for quantum kernel execution on Quantinuum and IonQ backends. For more information, see :doc:`using/hardware`.
+
+The 0.4.0 PyPI release does not yet include all of the GPU-based backends.
+The fully featured version is available as a Docker image for `linux/amd64` platforms.
+
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum>`__
+- `Python wheel <https://pypi.org/project/cuda-quantum/>`__
+- `Documentation <https://nvidia.github.io/cuda-quantum/0.4.0>`__
+
+The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/releases>`__.
+
 **0.3.0**
 
 The 0.3.0 release of CUDA Quantum is available as a Docker image for `linux/amd64` platforms.
 
-- `Download <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.3.0>`__
-
-.. TODO: add release notes for official releases.

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -31,22 +31,22 @@ switch to :code:`FP64`, specify the :code:`nvidia-fp64` target instead.
 cuQuantum multi-node multi-GPU
 ++++++++++++++++++++++++++++++++++
 
-The :code:`nvidia_mgpu` target provides a state vector simulator accelerated with 
+The :code:`nvidia-mgpu` target provides a state vector simulator accelerated with 
 the :code:`cuStateVec` library but with support for Multi-Node, Multi-GPU distribution of the 
 state vector. 
 
-To specify the use of the :code:`nvidia_mgpu` target, pass the following command line 
+To specify the use of the :code:`nvidia-mgpu` target, pass the following command line 
 options to :code:`nvq++`
 
 .. code:: bash 
 
-    nvq++ --target nvidia_mgpu src.cpp ...
+    nvq++ --target nvidia-mgpu src.cpp ...
 
 In python, this can be specified with 
 
 .. code:: python 
 
-    cudaq.set_target('nvidia_mgpu')
+    cudaq.set_target('nvidia-mgpu')
 
 OpenMP CPU-only
 ++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Cherry-picking #519 into main.

Fixes the nvidia-mgpu target name and an example, adds a 0.4.0 section in versions, and adds a section on Python wheels to the install instructions.
