### PR TITLE
[Support] Closes #532: change backtrace error message

### DIFF
--- a/include/cudaq/Support/Version.h
+++ b/include/cudaq/Support/Version.h
@@ -1,0 +1,20 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+namespace cudaq {
+
+// TODO: const char *getVersion();
+
+/// A generic bug report message.
+constexpr const char *bugReportMsg =
+    "PLEASE submit a bug report to https://github.com/NVIDIA/cuda-quantum and "
+    "include the crash backtrace.\n";
+
+} // namespace cudaq

--- a/tools/cudaq-opt/cudaq-opt.cpp
+++ b/tools/cudaq-opt/cudaq-opt.cpp
@@ -12,6 +12,7 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "cudaq/Support/Plugin.h"
+#include "cudaq/Support/Version.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
@@ -50,6 +51,10 @@ static cl::list<std::string>
                 cl::desc("Load passes from plugin library"));
 
 int main(int argc, char **argv) {
+  // Set the bug report message to indicate users should file issues on
+  // nvidia/cuda-quantum
+  llvm::setBugReportMsg(cudaq::bugReportMsg);
+
   mlir::registerAllPasses();
   cudaq::opt::registerOptCodeGenPasses();
   cudaq::opt::registerOptTransformsPasses();

--- a/tools/cudaq-quake/cudaq-quake.cpp
+++ b/tools/cudaq-quake/cudaq-quake.cpp
@@ -18,6 +18,7 @@
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/Support/Verifier.h"
+#include "cudaq/Support/Version.h"
 #include "nvqpp_config.h"
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/CodeGen/CodeGenAction.h"
@@ -261,9 +262,12 @@ std::string getExecutablePath(const char *argv0, bool canonicalPrefixes) {
 //===----------------------------------------------------------------------===//
 
 int main(int argc, char **argv) {
+  // Set the bug report message to indicate users should file issues on
+  // nvidia/cuda-quantum
+  llvm::setBugReportMsg(cudaq::bugReportMsg);
 
-  // First we need the location of this cudaq-quake executable
-  // so that we can get the install path
+  // We need the location of this cudaq-quake executable so that we can get the
+  // install path
   std::string executablePath = getExecutablePath(argv[0], true);
   std::filesystem::path cudaqQuakePath{executablePath};
   auto installBinPath = cudaqQuakePath.parent_path();

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -10,6 +10,7 @@
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
+#include "cudaq/Support/Version.h"
 #include "cudaq/Target/IQM/IQMJsonEmitter.h"
 #include "cudaq/Target/OpenQASM/OpenQASMEmitter.h"
 #include "cudaq/Todo.h"
@@ -17,6 +18,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/ToolOutputFile.h"
@@ -115,6 +117,10 @@ static void checkErrorCode(const std::error_code &ec) {
 }
 
 int main(int argc, char **argv) {
+  // Set the bug report message to indicate users should file issues on
+  // nvidia/cuda-quantum
+  llvm::setBugReportMsg(cudaq::bugReportMsg);
+
   registerAsmPrinterCLOptions();
   registerMLIRContextCLOptions();
   registerPassManagerCLOptions();


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
Closes #532.

I added this massage to a `Support/Version.h` file because I think we need to implement a way for the tools to identify the compiler version, e.g., `cudaq-opt --version`. Since both the version and this massage should be shared for all tools, makes sense to have those things in one file. The PR leave the versioning report as a TODO, focusing only on closing the current issue. (I will open a new issue for the version flag)