### PR TITLE
Add option to set the noise model when using the IonQ-hosted simulator

### DIFF
--- a/docs/sphinx/examples/cpp/providers/ionq.cpp
+++ b/docs/sphinx/examples/cpp/providers/ionq.cpp
@@ -4,7 +4,7 @@
 // ```
 // This will submit the job to the IonQ ideal simulator target (default).
 // Alternatively, we can enable hardware noise model simulation by specifying
-// the --ionq-noise-model, e.g.,
+// the `--ionq-noise-model`, e.g.,
 // ```
 // nvq++ --target ionq --ionq-machine simulator --ionq-noise-model aria-1
 // ionq.cpp -o out.x && ./out.x

--- a/docs/sphinx/examples/cpp/providers/ionq.cpp
+++ b/docs/sphinx/examples/cpp/providers/ionq.cpp
@@ -2,7 +2,19 @@
 // ```
 // nvq++ --target ionq ionq.cpp -o out.x && ./out.x
 // ```
-// Assumes a valid set of credentials have been stored.
+// This will submit the job to the IonQ ideal simulator target (default).
+// Alternatively, we can enable hardware noise model simulation by specifying
+// the --ionq-noise-model, e.g.,
+// ```
+// nvq++ --target ionq --ionq-machine simulator --ionq-noise-model aria-1
+// ionq.cpp -o out.x && ./out.x
+// ```
+// where we set the noise model to mimic the 'aria-1' hardware device.
+// Please refer to your IonQ Cloud dashboard for the list of simulator noise
+// models.
+// Note: `--ionq-machine simulator` is  optional since 'simulator' is the
+// default configuration if not provided. Assumes a valid set of credentials
+// have been stored.
 
 #include <cudaq.h>
 #include <fstream>

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
@@ -126,16 +126,12 @@ IonQServerHelper::createJob(std::vector<KernelExecution> &circuitCodes) {
     // Construct the job message
     ServerMessage job;
     job["target"] = backendConfig.at("target");
-    // Add noise model config to the JSON job request
-    if (keyExists("noise_model")) {
-      if (backendConfig.at("target") == "simulator") {
-        nlohmann::json noiseModel;
-        noiseModel["model"] = backendConfig.at("noise_model");
-        job["noise"] = noiseModel;
-      } else {
-        printf("IonQ noise model setting is only valid for the 'simulator' "
-               "ionq-machine target. This will be ignored.\n");
-      }
+    // Add noise model config to the JSON job request if a noise model was set
+    // and the IonQ 'simulator' target was selected.
+    if (keyExists("noise_model") && backendConfig.at("target") == "simulator") {
+      nlohmann::json noiseModel;
+      noiseModel["model"] = backendConfig.at("noise_model");
+      job["noise"] = noiseModel;
     }
 
     job["qubits"] = backendConfig.at("qubits");

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.config
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.config
@@ -33,6 +33,10 @@ while [ $# -ne 0 ]; do
 		PLATFORM_EXTRA_ARGS="$PLATFORM_EXTRA_ARGS;qpu;$2"
 		shift
 		;;
+	--ionq-noise-model)
+		PLATFORM_EXTRA_ARGS="$PLATFORM_EXTRA_ARGS;noise;$2"
+		shift
+		;;
 	esac
 	shift
 done

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.config
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.config
@@ -25,18 +25,33 @@ CODEGEN_EMISSION=qir
 # and it is the default, physical backends must 
 # turn this off
 LIBRARY_MODE=false
+# Variables for validation
+# Default ionq-machine target if not specified.
+IONQ_MACHINE="simulator"
+IONQ_NOISE_MODEL=""
 
 PLATFORM_EXTRA_ARGS=""
 while [ $# -ne 0 ]; do
 	case "$1" in
 	--ionq-machine)
 		PLATFORM_EXTRA_ARGS="$PLATFORM_EXTRA_ARGS;qpu;$2"
+		IONQ_MACHINE="$2"
 		shift
 		;;
 	--ionq-noise-model)
 		PLATFORM_EXTRA_ARGS="$PLATFORM_EXTRA_ARGS;noise;$2"
+		IONQ_NOISE_MODEL="$2"
 		shift
 		;;
 	esac
 	shift
 done
+
+# Validate the settings
+MAGENTA=$(tput setaf 5)
+BOLD=$(tput bold)
+NORMAL=$(tput sgr0)
+if [ ! -z "$IONQ_NOISE_MODEL" ] && [ "$IONQ_MACHINE" != "simulator"  ]
+then
+	echo "${MAGENTA}${BOLD}warning:${NORMAL} IonQ noise model setting (--ionq-noise-model) is only valid for the 'simulator' ionq-machine target. This noise model setting will be ignored."
+fi


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Trying the IonQ simulator target, I saw that we didn't have an option to use the free hardware noise model simulation hence adding it in this PR.

- Add a CLI option (`--ionq-noise-model`) for users to set the noise model (ideal/aria-1/harmony).

- Send on to the job request JSON according to https://ionq.com/docs/get-started-with-hardware-noise-model-simulation

- Update the example to include instructions on how to use noise model simulation.

