### PR TITLE
Fixed shutdown SEGFAULT in ARM build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
     needs: config
     strategy:
       matrix:
-        platform: [amd64] # ARM: [amd64, arm64]
+        platform: [amd64, arm64]
         python_version: ['3.9', '3.11']
       fail-fast: false
     uses: ./.github/workflows/python_wheels.yml

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -305,7 +305,7 @@ jobs:
     needs: [metadata, config]
     strategy:
       matrix:
-        platform: [amd64] # ARM: ${{ fromJson(needs.metadata.outputs.platforms).ids }}
+        platform: ${{ fromJson(needs.metadata.outputs.platforms).ids }}
         python_version: ['3.8', '3.9', '3.10', '3.11']
       fail-fast: false
     uses: ./.github/workflows/python_wheels.yml


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

**Root cause**: calling `dlclose`, during `LinkedLibraryHolder` destructor (shutdown), with `NULL` due to a previous failure of `dlopen`.

In this particular case, `libnvqir-custatevec-fp32.so`, though present in the wheel, cannot be loaded due to no `libcublas.so.11` in the ARM environment.

This is not ARM-specific but related generally to error-handling in `LinkedLibraryHolder`. e.g., those NVIDIA libs may also be corrupted due to users' actions (uninstall them...)

**Fixes:**

- Don't add the simulator backend if cannot load the corresponding .so lib.

- Add an additional `NULL` safeguard when using `dlclose`.

Tested locally by installing the wheel on a vanilla Ubuntu22.04 ARM VM and running CUDAQ python tests.

https://github.com/NVIDIA/cuda-quantum/issues/554
