### PR TITLE
[Don't merge, RFC] Idea for cross-platform build of external artifacts

### DIFF
--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -81,14 +81,14 @@ Tensornet Simulator:
   interruptible: false
   artifacts:
     paths:
-      - artifacts/tensornet/
+      - artifacts/**/tensornet/
     expire_in: 1 day
   script:
     - echo "Checking out commit $CUDAQ_TENSORNET_COMMIT on $CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO."
     - mkdir cudaq_tensornet && cd cudaq_tensornet && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO $CUDAQ_TENSORNET_COMMIT && git checkout FETCH_HEAD
     - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
-    - mkdir -p ../artifacts/tensornet/$(uname -m) && mv artifacts/* ../artifacts/tensornet/$(uname -m)
+    - mkdir -p ../artifacts/$(uname -m)/tensornet && mv artifacts/* ../artifacts/$(uname -m)/tensornet
     - cd .. && rm -rf cudaq_tensornet
     - if $built; then `exit 0`; else `exit 1`; fi
 

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -1,10 +1,6 @@
 workflow:
   name: 'Staging'
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^bot/ && $CI_COMMIT_BRANCH =~ /arm64/ && $CI_COMMIT_TITLE =~ /^ghcr\.io\/nvidia\/cuda-quantum-dev@sha256:\S+$/'
-      variables:
-        runner: os/linux-arm
-        staged: "cuda-quantum-dev"
     - if: '$CI_COMMIT_BRANCH =~ /^bot/ && $CI_COMMIT_TITLE =~ /^ghcr\.io\/nvidia\/cuda-quantum-dev@sha256:\S+$/'
       variables:
         runner: hostname/xpl-dvt-55
@@ -77,8 +73,11 @@ Tensornet Simulator:
   stage: build
   dependencies: []
   image: $CI_COMMIT_TITLE
+  parallel:
+    matrix:
+      - runner_tag: [hostname/xpl-dvt-55, os/linux-arm]
   tags:
-    - $runner
+    - $runner_tag
   interruptible: false
   artifacts:
     paths:
@@ -89,7 +88,7 @@ Tensornet Simulator:
     - mkdir cudaq_tensornet && cd cudaq_tensornet && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO $CUDAQ_TENSORNET_COMMIT && git checkout FETCH_HEAD
     - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
-    - mkdir -p ../artifacts/tensornet && mv artifacts/* ../artifacts/tensornet
+    - mkdir -p ../artifacts/tensornet/$(uname -m) && mv artifacts/* ../artifacts/tensornet/$(uname -m)
     - cd .. && rm -rf cudaq_tensornet
     - if $built; then `exit 0`; else `exit 1`; fi
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->


Use GitLab matrix CI to build x86 and ARM artifacts: the runner will pick up the correct flavor of the docker image based on its CPU architecture.

When uploading the artifacts, use `$(uname -m)` to distinguish the artifacts for each processor architecture.
For example, the `artifacts` directory at the `Push to GitHub` step would look like:
```
artifacts/
   - x86_64/
       - tensornet/
       - mgmn_svsim
   - aarch64/
      - tensornet/
      - mgmn_svsim
 ```           

When doing the `migrate_assets`, we can migrate either `artifacts/x86_64` or `artifacts/aarch64` depending on the CPU architecture of the Docker image being built.