### PR TITLE
Use `M_PI_4` instead of `M_PI_4f32`

### DIFF
--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -183,8 +183,8 @@ CUDAQ_TEST(BuilderTester, checkSimple) {
     auto rx_builder = cudaq::make_kernel();
     auto q = rx_builder.qalloc();
     // float -> double implicit type conversion
-    rx_builder.rx<cudaq::adj>(-M_PI_4f32, q);
-    rx_builder.rx(M_PI_4f32, q);
+    rx_builder.rx<cudaq::adj>(-M_PI_4, q);
+    rx_builder.rx(M_PI_4, q);
     // long double -> double implicit type conversion
     const long double pi_4_ld = M_PI / 4.0;
     rx_builder.rx<cudaq::adj>(-pi_4_ld, q);


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
IIRC, `M_PI_4` is a POSIX standard while `M_PI_4f32` is a GNU extension not supported across the board.