### PR TITLE
Implement CUDA Quantum Kernel from State Vector.

### DIFF
--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -16,6 +16,7 @@ CUDA Quantum Python API
 Program Construction
 =============================
 
+.. autofunction:: cudaq::from_state
 .. autofunction:: cudaq::make_kernel
 .. autoclass:: cudaq::Kernel
 

--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -660,7 +660,9 @@ void bindKernel(py::module &mod) {
                                               data.data() + data.size());
         cudaq::from_state(kernel, qubits, tmp);
       },
-      py::arg("kernel"), py::arg("qubits"), py::arg("state"), "");
+      py::arg("kernel"), py::arg("qubits"), py::arg("state"),
+      "Decompose the input state vector to a set of controlled operations and "
+      "rotations.");
   mod.def(
       "from_state",
       [](py::array_t<std::complex<double>> &data) {
@@ -668,7 +670,9 @@ void bindKernel(py::module &mod) {
                                               data.data() + data.size());
         return cudaq::from_state(tmp);
       },
-      py::arg("state"), "");
+      py::arg("state"),
+      "Decompose the given state vector into a set of controlled operations "
+      "and rotations and return a valid, callable, CUDA Quantum kernel.");
 }
 
 void bindBuilder(py::module &mod) {

--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -652,14 +652,23 @@ void bindKernel(py::module &mod) {
       .def("__str__", &kernel_builder<>::to_quake,
            "Return the :class:`Kernel` as a string in its MLIR representation "
            "using the Quake dialect.\n");
-
-  mod.def("from_state", [](kernel_builder<> &kernel, QuakeValue &qubits,
-                           py::array_t<std::complex<double>> &data,
-                           std::vector<std::size_t> &wires) {
-    std::vector<std::complex<double>> tmp(data.data(),
-                                          data.data() + data.size());
-    cudaq::from_state(kernel, qubits, tmp, wires);
-  });
+  mod.def(
+      "from_state",
+      [](kernel_builder<> &kernel, QuakeValue &qubits,
+         py::array_t<std::complex<double>> &data) {
+        std::vector<std::complex<double>> tmp(data.data(),
+                                              data.data() + data.size());
+        cudaq::from_state(kernel, qubits, tmp);
+      },
+      py::arg("kernel"), py::arg("qubits"), py::arg("state"), "");
+  mod.def(
+      "from_state",
+      [](py::array_t<std::complex<double>> &data) {
+        std::vector<std::complex<double>> tmp(data.data(),
+                                              data.data() + data.size());
+        return cudaq::from_state(tmp);
+      },
+      py::arg("state"), "");
 }
 
 void bindBuilder(py::module &mod) {

--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -6,12 +6,14 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
 #include "py_kernel_builder.h"
 #include "utils/OpaqueArguments.h"
 
 #include "cudaq/builder/kernel_builder.h"
+#include "cudaq/builder/kernels.h"
 #include "cudaq/platform.h"
 
 #include "common/ExecutionContext.h"
@@ -650,6 +652,14 @@ void bindKernel(py::module &mod) {
       .def("__str__", &kernel_builder<>::to_quake,
            "Return the :class:`Kernel` as a string in its MLIR representation "
            "using the Quake dialect.\n");
+
+  mod.def("from_state", [](kernel_builder<> &kernel, QuakeValue &qubits,
+                           py::array_t<std::complex<double>> &data,
+                           std::vector<std::size_t> &wires) {
+    std::vector<std::complex<double>> tmp(data.data(),
+                                          data.data() + data.size());
+    cudaq::from_state(kernel, qubits, tmp, wires);
+  });
 }
 
 void bindBuilder(py::module &mod) {

--- a/python/tests/unittests/test_kernel_builder.py
+++ b/python/tests/unittests/test_kernel_builder.py
@@ -247,6 +247,7 @@ def test_can_progressively_build():
     assert '00' in counts 
     
 def test_from_state():
+    cudaq.reset_target()
     state = np.asarray([.70710678, 0., 0., 0.70710678])
     kernel = cudaq.make_kernel()
     qubits = kernel.qalloc(2)

--- a/python/tests/unittests/test_kernel_builder.py
+++ b/python/tests/unittests/test_kernel_builder.py
@@ -246,3 +246,29 @@ def test_can_progressively_build():
     assert '11' in counts 
     assert '00' in counts 
     
+def test_from_state():
+    state = np.asarray([.70710678, 0., 0., 0.70710678])
+    kernel = cudaq.make_kernel()
+    qubits = kernel.qalloc(2)
+
+    cudaq.from_state(kernel, qubits, state, range(2))
+
+    print(kernel)
+    counts = cudaq.sample(kernel)
+    print(counts)
+    assert '11' in counts 
+    assert '00' in counts 
+    
+    from cudaq import spin 
+    hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
+        0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)
+    state = np.asarray([0., .292786, .956178, 0.])
+    kernel = cudaq.make_kernel()
+    qubits = kernel.qalloc(2)
+    cudaq.from_state(kernel, qubits, state, range(2))
+    energy = cudaq.observe(kernel, hamiltonian).expectation_z()
+    assert np.isclose(-1.748, energy, 1e-3)
+
+    ss = cudaq.get_state(kernel)
+    for i in range(4):
+      assert np.isclose(ss[i], state[i], 1e-3)

--- a/python/tests/unittests/test_kernel_builder.py
+++ b/python/tests/unittests/test_kernel_builder.py
@@ -252,7 +252,7 @@ def test_from_state():
     kernel = cudaq.make_kernel()
     qubits = kernel.qalloc(2)
 
-    cudaq.from_state(kernel, qubits, state, range(2))
+    cudaq.from_state(kernel, qubits, state)
 
     print(kernel)
     counts = cudaq.sample(kernel)
@@ -260,13 +260,19 @@ def test_from_state():
     assert '11' in counts 
     assert '00' in counts 
     
+    kernel = cudaq.from_state(state)
+    counts = cudaq.sample(kernel)
+    print(counts)
+    assert '11' in counts 
+    assert '00' in counts 
+
     from cudaq import spin 
     hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
         0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)
     state = np.asarray([0., .292786, .956178, 0.])
     kernel = cudaq.make_kernel()
     qubits = kernel.qalloc(2)
-    cudaq.from_state(kernel, qubits, state, range(2))
+    cudaq.from_state(kernel, qubits, state)
     energy = cudaq.observe(kernel, hamiltonian).expectation_z()
     assert np.isclose(-1.748, energy, 1e-3)
 

--- a/runtime/cudaq/builder/CMakeLists.txt
+++ b/runtime/cudaq/builder/CMakeLists.txt
@@ -8,9 +8,10 @@
 
 set(LIBRARY_NAME cudaq-builder)
 
-add_library(cudaq-builder SHARED kernel_builder.cpp QuakeValue.cpp)
+add_library(cudaq-builder SHARED kernel_builder.cpp QuakeValue.cpp kernels.cpp)
 target_include_directories(cudaq-builder PUBLIC 
           $<INSTALL_INTERFACE:include> 
+          $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tpls/eigen>
           $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/runtime>)
 target_link_libraries(cudaq-builder
   PRIVATE

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -209,6 +209,13 @@ QuakeValue QuakeValue::size() {
   return QuakeValue(opBuilder, ret);
 }
 
+std::optional<std::size_t> QuakeValue::constantSize() {
+  if (auto qvecTy = dyn_cast<quake::VeqType>(getValue().getType()))
+    return qvecTy.getSize();
+
+  return std::nullopt;
+}
+
 QuakeValue QuakeValue::slice(const std::size_t startIdx,
                              const std::size_t count) {
   Value vectorValue = value->asMLIR();

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 
 namespace mlir {
 class Value;
@@ -84,6 +85,10 @@ public:
   /// @brief For a QuakeValue with type StdVec or Veq, return
   /// the size QuakeValue.
   QuakeValue size();
+
+  /// @brief Return the constant size of this QuakeValue
+  /// if it is of Veq type.
+  std::optional<std::size_t> constantSize();
 
   /// @brief Return true if this QuakeValue is of type StdVec.
   /// @return

--- a/runtime/cudaq/builder/kernels.cpp
+++ b/runtime/cudaq/builder/kernels.cpp
@@ -37,7 +37,7 @@ std::vector<std::string> grayCode(std::size_t rank) {
   return g;
 }
 
-std::vector<std::size_t> getControlIndicesFromGrayCode(std::size_t grayRank) {
+std::vector<std::size_t> getControlIndices(std::size_t grayRank) {
   auto code = grayCode(grayRank);
   std::vector<std::size_t> ctrlIds;
   for (std::size_t i = 0; i < code.size(); i++) {

--- a/runtime/cudaq/builder/kernels.cpp
+++ b/runtime/cudaq/builder/kernels.cpp
@@ -8,7 +8,6 @@
 
 #include "kernels.h"
 #include "common/EigenDense.h"
-#include <iostream>
 
 namespace cudaq::details {
 
@@ -61,7 +60,7 @@ std::size_t mEntry(std::size_t row, std::size_t col) {
   return std::pow(-1, sum_of_ones);
 }
 
-std::vector<double> computeAngle(std::vector<double> alpha) {
+std::vector<double> computeAngle(const std::vector<double> &alpha) {
   auto ln = alpha.size();
   std::size_t k = std::log2(ln);
 
@@ -71,8 +70,8 @@ std::vector<double> computeAngle(std::vector<double> alpha) {
     for (Eigen::Index j = 0; j < mTrans.cols(); j++)
       mTrans(i, j) = mEntry(i, j);
 
-  Eigen::VectorXd alphaVec =
-      Eigen::Map<Eigen::VectorXd>(alpha.data(), alpha.size());
+  Eigen::VectorXd alphaVec = Eigen::Map<Eigen::VectorXd>(
+      const_cast<double *>(alpha.data()), alpha.size());
   Eigen::VectorXd thetas = (1. / (1UL << k)) * mTrans.cast<double>() * alphaVec;
 
   std::vector<double> ret(thetas.size());

--- a/runtime/cudaq/builder/kernels.cpp
+++ b/runtime/cudaq/builder/kernels.cpp
@@ -1,3 +1,11 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
 #include "kernels.h"
 #include "common/EigenDense.h"
 #include <iostream>

--- a/runtime/cudaq/builder/kernels.cpp
+++ b/runtime/cudaq/builder/kernels.cpp
@@ -1,0 +1,125 @@
+#include "kernels.h"
+#include "common/EigenDense.h"
+
+namespace cudaq::details {
+
+std::vector<std::string> grayCode(std::size_t rank) {
+  std::function<void(std::vector<std::string> &, std::size_t)> grayCodeRecurse;
+  grayCodeRecurse = [&grayCodeRecurse](std::vector<std::string> &g,
+                                       std::size_t rank) {
+    auto k = g.size();
+    if (rank <= 0)
+      return;
+
+    for (int i = k - 1; i >= 0; --i) {
+      auto c = "1" + g[i];
+      g.push_back(c);
+    }
+    for (int i = k - 1; i >= 0; --i) {
+      g[i] = "0" + g[i];
+    }
+
+    grayCodeRecurse(g, rank - 1);
+  };
+
+  std::vector<std::string> g{"0", "1"};
+  grayCodeRecurse(g, rank - 1);
+
+  return g;
+}
+
+std::vector<std::size_t> getControlIndicesFromGrayCode(std::size_t grayRank) {
+  auto code = grayCode(grayRank);
+  std::vector<std::size_t> ctrlIds;
+  for (std::size_t i = 0; i < code.size(); i++) {
+    auto a = std::stoi(code[i], nullptr, 2);
+    auto b = std::stoi(code[(i + 1) % code.size()], nullptr, 2);
+    auto c = a ^ b % code.size();
+    ctrlIds.emplace_back(std::log2(c));
+  }
+  return ctrlIds;
+}
+
+std::size_t mEntry(std::size_t row, std::size_t col) {
+  auto b_and_g = row & ((col >> 1) ^ col);
+  std::size_t sum_of_ones = 0;
+  while (b_and_g > 0) {
+    if (b_and_g & 0b1)
+      sum_of_ones += 1;
+
+    b_and_g = b_and_g >> 1;
+  }
+  return std::pow(-1, sum_of_ones);
+}
+
+std::vector<double> computeAngle(std::vector<double> alpha) {
+  auto ln = alpha.size();
+  std::size_t k = std::log2(ln);
+
+  Eigen::MatrixXi mTrans(ln, ln);
+  mTrans.setZero();
+  for (Eigen::Index i = 0; i < mTrans.rows(); i++)
+    for (Eigen::Index j = 0; j < mTrans.cols(); j++)
+      mTrans(i, j) = mEntry(i, j);
+
+  Eigen::VectorXd alphaVec =
+      Eigen::Map<Eigen::VectorXd>(alpha.data(), alpha.size());
+  Eigen::VectorXd thetas = (1. / (1UL << k)) * mTrans.cast<double>() * alphaVec;
+
+  std::vector<double> ret(thetas.size());
+  Eigen::VectorXd::Map(&ret[0], ret.size()) = thetas;
+  return ret;
+}
+
+std::vector<double> getAlphaZ(const std::span<double> data,
+                              std::size_t numQubits, std::size_t k) {
+  return {};
+}
+std::vector<double> getAlphaY(const std::span<double> data,
+                              std::size_t numQubits, std::size_t k) {
+  std::vector<std::vector<std::size_t>> inNum, inDenom;
+  auto twoNmK = (1ULL << (numQubits - k)), twoK = (1ULL << k),
+       twoKmOne = (1ULL << (k - 1));
+  for (auto j : cudaq::range(twoNmK)) {
+    std::vector<std::size_t> local;
+    for (auto l : cudaq::range(twoKmOne))
+      local.push_back((2 * (j + 1) - 1) * twoKmOne + l);
+
+    inNum.push_back(local);
+  }
+
+  std::vector<double> numeratorSums;
+  for (auto &el : inNum) {
+    double sum = 0.0;
+    for (auto &i : el)
+      sum += std::pow(std::fabs(data[i]), 2);
+
+    numeratorSums.push_back(sum);
+  }
+
+  for (auto j : cudaq::range(twoNmK)) {
+    std::vector<std::size_t> local;
+    for (auto l : cudaq::range(twoK))
+      local.push_back(j * twoK + l);
+
+    inDenom.push_back(local);
+  }
+
+  std::vector<double> denomSums;
+  for (auto &el : inDenom) {
+    double sum = 0.0;
+    for (auto &i : el)
+      sum += std::pow(std::fabs(data[i]), 2);
+
+    denomSums.push_back(sum);
+  }
+
+  std::vector<double> res(denomSums.size());
+  for (std::size_t i = 0; i < denomSums.size(); i++) {
+    if (std::fabs(denomSums[i]) > 1e-12)
+      res[i] = 2 * std::asin(std::sqrt(numeratorSums[i] / denomSums[i]));
+  }
+
+  return res;
+}
+} // namespace cudaq::details

--- a/runtime/cudaq/builder/kernels.h
+++ b/runtime/cudaq/builder/kernels.h
@@ -1,0 +1,86 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "kernel_builder.h"
+#include <complex>
+
+namespace cudaq {
+
+namespace details {
+
+std::vector<std::string> grayCode(std::size_t rank);
+std::size_t mEntry(std::size_t row, std::size_t col);
+std::vector<double> computeAngle(std::vector<double> alpha);
+std::vector<std::size_t> getControlIndicesFromGrayCode(std::size_t grayRank);
+
+template <typename Kernel, typename RotationFunctor>
+void applyRotation(Kernel &&kernel, RotationFunctor &&rotationFunctor,
+                   QuakeValue qubits, std::vector<double> alpha,
+                   std::vector<std::size_t> controls, std::size_t target) {
+  auto thetas = computeAngle(alpha);
+  auto gcRank = controls.size();
+  if (gcRank == 0) {
+    rotationFunctor(kernel, thetas[0], qubits[target]);
+    return;
+  }
+
+  auto ctrlIds = details::getControlIndicesFromGrayCode(gcRank);
+  for (auto [i, ctrlIdx] : cudaq::enumerate(ctrlIds)) {
+    rotationFunctor(kernel, thetas[i], qubits[target]);
+    kernel.template x<cudaq::ctrl>(qubits[controls[ctrlIdx]], qubits[target]);
+  }
+}
+std::vector<double> getAlphaZ(const std::span<double> data,
+                              std::size_t numQubits, std::size_t k);
+std::vector<double> getAlphaY(const std::span<double> data,
+                              std::size_t numQubits, std::size_t k);
+} // namespace details
+
+template <typename Kernel>
+void from_state(Kernel &&kernel, QuakeValue &qubits,
+                const std::span<std::complex<double>> data,
+                const std::vector<std::size_t> &wires) {
+  bool omegaNonZero = false;
+  std::vector<double> omega, stateAbs;
+  for (auto &d : data) {
+    omega.push_back(std::arg(d));
+    stateAbs.push_back(std::fabs(d));
+    if (std::fabs(omega.back()) > 1e-6)
+      omegaNonZero = true;
+  }
+
+  for (std::size_t k = wires.size(); k > 0; k--) {
+    auto alphaYk = details::getAlphaY(stateAbs, wires.size(), k);
+    std::vector<std::size_t> controls(wires.begin() + k, wires.end());
+    auto target = wires[k - 1];
+    details::applyRotation(
+        kernel,
+        [](auto &&kernel, auto &&theta, auto &&qubit) {
+          kernel.ry(theta, qubit);
+        },
+        qubits, alphaYk, controls, target);
+  }
+
+  if (omegaNonZero) {
+    for (std::size_t k = wires.size(); k > 0; k--) {
+      auto alphaZk = details::getAlphaZ(omega, wires.size(), k);
+      std::vector<std::size_t> controls(wires.begin() + k, wires.end());
+      auto target = wires[k - 1];
+      if (!alphaZk.empty())
+        details::applyRotation(
+            kernel,
+            [](auto &&kernel, auto &&theta, auto &&qubit) {
+              kernel.rz(theta, qubit);
+            },
+            qubits, alphaZk, controls, target);
+    }
+  }
+}
+} // namespace cudaq

--- a/runtime/cudaq/builder/kernels.h
+++ b/runtime/cudaq/builder/kernels.h
@@ -47,6 +47,8 @@ template <typename Kernel>
 void from_state(Kernel &&kernel, QuakeValue &qubits,
                 const std::span<std::complex<double>> data,
                 const std::vector<std::size_t> &wires) {
+  auto mutableWires = wires;
+  std::reverse(mutableWires.begin(), mutableWires.end());
   bool omegaNonZero = false;
   std::vector<double> omega, stateAbs;
   for (auto &d : data) {
@@ -58,8 +60,9 @@ void from_state(Kernel &&kernel, QuakeValue &qubits,
 
   for (std::size_t k = wires.size(); k > 0; k--) {
     auto alphaYk = details::getAlphaY(stateAbs, wires.size(), k);
-    std::vector<std::size_t> controls(wires.begin() + k, wires.end());
-    auto target = wires[k - 1];
+    std::vector<std::size_t> controls(mutableWires.begin() + k,
+                                      mutableWires.end());
+    auto target = mutableWires[k - 1];
     details::applyRotation(
         kernel,
         [](auto &&kernel, auto &&theta, auto &&qubit) {
@@ -71,7 +74,8 @@ void from_state(Kernel &&kernel, QuakeValue &qubits,
   if (omegaNonZero) {
     for (std::size_t k = wires.size(); k > 0; k--) {
       auto alphaZk = details::getAlphaZ(omega, wires.size(), k);
-      std::vector<std::size_t> controls(wires.begin() + k, wires.end());
+      std::vector<std::size_t> controls(mutableWires.begin() + k,
+                                        mutableWires.end());
       auto target = wires[k - 1];
       if (!alphaZk.empty())
         details::applyRotation(

--- a/runtime/cudaq/builder/kernels.h
+++ b/runtime/cudaq/builder/kernels.h
@@ -17,7 +17,7 @@ namespace details {
 
 /// @brief Convert the provided angles to those rotation angles
 /// used for the gray code implementation.
-std::vector<double> computeAngle(std::vector<double> alpha);
+std::vector<double> computeAngle(const std::vector<double> &alpha);
 
 /// @brief Return the control indices dictated by the gray code implementation.
 std::vector<std::size_t> getControlIndices(std::size_t grayRank);
@@ -25,8 +25,9 @@ std::vector<std::size_t> getControlIndices(std::size_t grayRank);
 /// @brief Apply a uniformly controlled rotation on the target qubit.
 template <typename Kernel, typename RotationFunctor>
 void applyRotation(Kernel &&kernel, RotationFunctor &&rotationFunctor,
-                   QuakeValue qubits, std::vector<double> alpha,
-                   std::vector<std::size_t> controls, std::size_t target) {
+                   QuakeValue qubits, const std::vector<double> &alpha,
+                   const std::vector<std::size_t> &controls,
+                   std::size_t target) {
   auto thetas = computeAngle(alpha);
   auto gcRank = controls.size();
   if (gcRank == 0) {

--- a/runtime/cudaq/builder/kernels.h
+++ b/runtime/cudaq/builder/kernels.h
@@ -11,8 +11,6 @@
 #include "kernel_builder.h"
 #include <complex>
 
-#include <iostream>
-
 namespace cudaq {
 
 namespace details {

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(CUDAQ_RUNTIME_TEST_SOURCES
   integration/get_state_tester.cpp
   qir/NVQIRTester.cpp
   qis/QubitQISTester.cpp
+  integration/kernels_tester.cpp
   common/MeasureCountsTester.cpp
   common/NoiseModelTester.cpp
   integration/tracer_tester.cpp

--- a/unittests/integration/kernels_tester.cpp
+++ b/unittests/integration/kernels_tester.cpp
@@ -11,6 +11,12 @@
 #include "cudaq/builder/kernels.h"
 #include <iostream>
 
+namespace cudaq {
+namespace details {
+std::vector<std::string> grayCode(std::size_t);
+}
+} // namespace cudaq
+
 CUDAQ_TEST(KernelsTester, checkGrayCode) {
   {
     auto test = cudaq::details::grayCode(2);
@@ -39,7 +45,7 @@ CUDAQ_TEST(KernelsTester, checkGrayCode) {
 
 CUDAQ_TEST(KernelsTester, checkGenCtrlIndices) {
   {
-    auto test = cudaq::details::getControlIndicesFromGrayCode(2);
+    auto test = cudaq::details::getControlIndices(2);
     std::vector<std::size_t> expected{0, 1, 0, 1};
     EXPECT_EQ(test.size(), expected.size());
     EXPECT_EQ(test, expected);
@@ -49,7 +55,7 @@ CUDAQ_TEST(KernelsTester, checkGenCtrlIndices) {
                                       2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1,
                                       0, 3, 0, 1, 0, 2, 0, 1, 0, 4};
 
-    auto test = cudaq::details::getControlIndicesFromGrayCode(5);
+    auto test = cudaq::details::getControlIndices(5);
     EXPECT_EQ(test.size(), expected.size());
     EXPECT_EQ(test, expected);
   }

--- a/unittests/integration/kernels_tester.cpp
+++ b/unittests/integration/kernels_tester.cpp
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "CUDAQTestUtils.h"
+#include "cudaq/builder/kernels.h"
+#include <iostream>
+
+CUDAQ_TEST(KernelsTester, checkGrayCode) {
+  {
+    auto test = cudaq::details::grayCode(2);
+    std::vector<std::string> expected{"00", "01", "11", "10"};
+    EXPECT_EQ(test.size(), expected.size());
+    for (auto &t : test) {
+      EXPECT_TRUE(std::find(expected.begin(), expected.end(), t) !=
+                  expected.end());
+    }
+  }
+  {
+    std::vector<std::string> expected{
+        "00000", "00001", "00011", "00010", "00110", "00111", "00101", "00100",
+        "01100", "01101", "01111", "01110", "01010", "01011", "01001", "01000",
+        "11000", "11001", "11011", "11010", "11110", "11111", "11101", "11100",
+        "10100", "10101", "10111", "10110", "10010", "10011", "10001", "10000"};
+
+    auto test = cudaq::details::grayCode(5);
+    EXPECT_EQ(test.size(), expected.size());
+    for (auto &t : test) {
+      EXPECT_TRUE(std::find(expected.begin(), expected.end(), t) !=
+                  expected.end());
+    }
+  }
+}
+
+CUDAQ_TEST(KernelsTester, checkGenCtrlIndices) {
+  {
+    auto test = cudaq::details::getControlIndicesFromGrayCode(2);
+    std::vector<std::size_t> expected{0, 1, 0, 1};
+    EXPECT_EQ(test.size(), expected.size());
+    EXPECT_EQ(test, expected);
+  }
+  {
+    std::vector<std::size_t> expected{0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0,
+                                      2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1,
+                                      0, 3, 0, 1, 0, 2, 0, 1, 0, 4};
+
+    auto test = cudaq::details::getControlIndicesFromGrayCode(5);
+    EXPECT_EQ(test.size(), expected.size());
+    EXPECT_EQ(test, expected);
+  }
+}
+
+CUDAQ_TEST(KernelsTester, checkGetAlphaY) {
+  {
+    std::vector<double> state{.70710678, 0., 0., 0.70710678};
+    auto thetas = cudaq::details::getAlphaY(state, 2, 2);
+    std::vector<double> expected{1.57079633};
+    for (std::size_t i = 0; auto t : thetas) {
+      EXPECT_NEAR(t, expected[i++], 1e-3);
+      std::cout << t << "\n";
+    }
+  }
+
+  {
+    std::vector<double> state{.70710678, 0., 0., 0.70710678};
+    auto thetas = cudaq::details::getAlphaY(state, 2, 1);
+    std::vector<double> expected{0.0, 3.14159265};
+    for (std::size_t i = 0; auto t : thetas) {
+      EXPECT_NEAR(t, expected[i++], 1e-3);
+      std::cout << t << "\n";
+    }
+  }
+}
+
+CUDAQ_TEST(KernelsTester, checkFromState) {
+  {
+    std::vector<std::complex<double>> state{.70710678, 0., 0., 0.70710678};
+    auto kernel = cudaq::make_kernel();
+    auto qubits = kernel.qalloc(2);
+
+    cudaq::from_state(kernel, qubits, state, cudaq::range(2));
+
+    std::cout << kernel << "\n";
+    auto counts = cudaq::sample(kernel);
+    counts.dump();
+  }
+}

--- a/unittests/integration/kernels_tester.cpp
+++ b/unittests/integration/kernels_tester.cpp
@@ -103,6 +103,8 @@ CUDAQ_TEST(KernelsTester, checkGetAlphaZ) {
   }
 }
 
+#ifndef CUDAQ_BACKEND_DM
+
 CUDAQ_TEST(KernelsTester, checkFromState) {
   {
     std::vector<std::complex<double>> state{.70710678, 0., 0., 0.70710678};
@@ -133,3 +135,5 @@ CUDAQ_TEST(KernelsTester, checkFromState) {
       EXPECT_NEAR(ss[i].real(), state[i].real(), 1e-3);
   }
 }
+
+#endif

--- a/unittests/integration/kernels_tester.cpp
+++ b/unittests/integration/kernels_tester.cpp
@@ -117,7 +117,7 @@ CUDAQ_TEST(KernelsTester, checkFromState) {
     auto kernel = cudaq::make_kernel();
     auto qubits = kernel.qalloc(2);
 
-    cudaq::from_state(kernel, qubits, state, cudaq::range(2));
+    cudaq::from_state(kernel, qubits, state);
 
     std::cout << kernel << "\n";
     auto counts = cudaq::sample(kernel);
@@ -128,7 +128,7 @@ CUDAQ_TEST(KernelsTester, checkFromState) {
     std::vector<std::complex<double>> state{0., .292786, .956178, 0.};
     auto kernel = cudaq::make_kernel();
     auto qubits = kernel.qalloc(2);
-    cudaq::from_state(kernel, qubits, state, cudaq::range(2));
+    cudaq::from_state(kernel, qubits, state);
     std::cout << kernel << "\n";
     using namespace cudaq::spin;
     auto H = 5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) +
@@ -139,6 +139,17 @@ CUDAQ_TEST(KernelsTester, checkFromState) {
     auto ss = cudaq::get_state(kernel);
     for (std::size_t i = 0; i < 4; i++)
       EXPECT_NEAR(ss[i].real(), state[i].real(), 1e-3);
+  }
+
+  {
+    std::vector<std::complex<double>> state{.70710678, 0., 0., 0.70710678};
+
+    // Return a kernel from the given state, this
+    // comes back as a unique_ptr.
+    auto kernel = cudaq::from_state(state);
+    std::cout << *kernel << "\n";
+    auto counts = cudaq::sample(*kernel);
+    counts.dump();
   }
 }
 


### PR DESCRIPTION
Enable kernel creation from a state vector. 
```python 
state = np.asarray([.70710678, 0., 0., 0.70710678])
kernel = cudaq.from_state(state)
counts = cudaq.sample(kernel)
```
```cpp
std::vector<std::complex<double>> state{.70710678, 0., 0., 0.70710678};
auto kernel = cudaq::from_state(state);
auto counts = cudaq::sample(*kernel);
```