### PR TITLE
Add some canonicalizations for ConcatOp and ExtractRefOp

### DIFF
--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -109,6 +109,12 @@ struct ConcatNoOpPattern : public OpRewritePattern<quake::ConcatOp> {
     if (qubitsToConcat.size() > 1)
       return failure();
 
+    // We only want to handle veq -> veq here.
+    if (isa<quake::RefType>(qubitsToConcat.front().getType())) {
+      return failure();
+    }
+
+    // Do not handle anything where we don't know the sizes.
     auto retTy = concat.getResult().getType();
     if (auto veqTy = dyn_cast<quake::VeqType>(retTy))
       if (!veqTy.hasSpecifiedSize())

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -115,8 +115,7 @@ struct ConcatNoOpPattern : public OpRewritePattern<quake::ConcatOp> {
         // This could be a folded quake.relax_size op.
         return failure();
 
-    rewriter.replaceAllUsesWith(concat.getResult(), qubitsToConcat.front());
-    rewriter.eraseOp(concat);
+    rewriter.replaceOp(concat, qubitsToConcat);
     return success();
   }
 };
@@ -219,10 +218,8 @@ struct ForwardConcatExtractPattern
       auto index = extract.getConstantIndex();
       if (index < concatQubits.size()) {
         auto qOpValue = concatQubits[index];
-        if (isa<quake::RefType>(qOpValue.getType())) {
-          rewriter.replaceAllUsesWith(extract.getResult(), qOpValue);
-          rewriter.eraseOp(extract);
-        }
+        if (isa<quake::RefType>(qOpValue.getType()))
+          rewriter.replaceOp(extract, {qOpValue});
       }
     }
     return success();

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -94,6 +94,27 @@ void quake::AllocaOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 //===----------------------------------------------------------------------===//
 
 namespace {
+// %7 = quake.concat %4 : (!quake.veq<2>) -> !quake.veq<2>
+// ───────────────────────────────────────────
+// removed
+struct ConcatNoOpPattern : public OpRewritePattern<quake::ConcatOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(quake::ConcatOp concat,
+                                PatternRewriter &rewriter) const override {
+    // Remove concat veq<N> -> veq<N>
+    auto qubitsToConcat = concat.getQbits();
+    if (qubitsToConcat.size() == 1 &&
+        qubitsToConcat.front().getType() == concat.getResult().getType() &&
+        concat->hasOneUse()) {
+
+      rewriter.replaceAllUsesWith(concat.getResult(), qubitsToConcat.front());
+      rewriter.eraseOp(concat);
+    }
+    return success();
+  }
+};
+
 struct ConcatSizePattern : public OpRewritePattern<quake::ConcatOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -130,7 +151,7 @@ struct ConcatSizePattern : public OpRewritePattern<quake::ConcatOp> {
 
 void quake::ConcatOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                                   MLIRContext *context) {
-  patterns.add<ConcatSizePattern>(context);
+  patterns.add<ConcatSizePattern, ConcatNoOpPattern>(context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -168,6 +189,33 @@ static void printRawIndex(OpAsmPrinter &printer, quake::ExtractRefOp refOp,
 }
 
 namespace {
+// %4 = quake.concat %2, %3 : (!quake.ref, !quake.ref) -> !quake.veq<2>
+// %7 = quake.extract_ref %4[0] : (!quake.veq<2>) -> !quake.ref
+// ───────────────────────────────────────────
+// replace all use with %2
+struct BackwardConcatExtractPattern
+    : public OpRewritePattern<quake::ExtractRefOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(quake::ExtractRefOp extract,
+                                PatternRewriter &rewriter) const override {
+    auto veq = extract.getVeq();
+    auto concatOp = veq.getDefiningOp<quake::ConcatOp>();
+    if (concatOp && extract.hasConstantIndex()) {
+      auto index = extract.getConstantIndex();
+      auto concatQubits = concatOp.getQbits();
+      if (index < concatQubits.size()) {
+        auto qOpValue = concatQubits[index];
+        if (isa<quake::RefType>(qOpValue.getType())) {
+          rewriter.replaceAllUsesWith(extract.getResult(), qOpValue);
+          rewriter.eraseOp(extract);
+        }
+      }
+    }
+    return success();
+  }
+};
+
 // %2 = quake.concat %1 : (!quake.ref) -> !quake.veq<1>
 // %3 = quake.extract_ref %2[0] : (!quake.veq<1>) -> !quake.ref
 // quake.* %3 ...
@@ -198,8 +246,8 @@ struct ForwardConcatExtractSingleton
 
 void quake::ExtractRefOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<FuseConstantToExtractRefPattern, ForwardConcatExtractSingleton>(
-      context);
+  patterns.add<FuseConstantToExtractRefPattern, ForwardConcatExtractSingleton,
+               BackwardConcatExtractPattern>(context);
 }
 
 LogicalResult quake::ExtractRefOp::verify() {

--- a/lib/Target/OpenQASM/TranslateToOpenQASM.cpp
+++ b/lib/Target/OpenQASM/TranslateToOpenQASM.cpp
@@ -23,12 +23,12 @@ using namespace cudaq;
 
 /// Translates operation names into OpenQASM gate names
 static LogicalResult translateOperatorName(quake::OperatorInterface optor,
-                                           StringRef &name) {
-  StringRef qkeName = optor->getName().stripDialect();
+                                           std::string &name) {
+  std::string qkeName = optor->getName().stripDialect().str();
   if (optor.getControls().size() == 0) {
-    name = StringSwitch<StringRef>(qkeName).Case("r1", "u1").Default(qkeName);
+    name = StringSwitch<std::string>(qkeName).Case("r1", "u1").Default(qkeName);
   } else if (optor.getControls().size() == 1) {
-    name = StringSwitch<StringRef>(qkeName)
+    name = StringSwitch<std::string>(qkeName)
                .Case("h", "ch")
                .Case("x", "cx")
                .Case("y", "cy")
@@ -39,7 +39,7 @@ static LogicalResult translateOperatorName(quake::OperatorInterface optor,
                .Case("rz", "crz")
                .Default("");
   } else if (optor.getControls().size() == 2) {
-    name = StringSwitch<StringRef>(qkeName).Case("x", "ccx").Default("");
+    name = StringSwitch<std::string>(qkeName).Case("x", "ccx").Default("");
   }
   if (name.empty())
     return failure();
@@ -235,13 +235,15 @@ static LogicalResult emitOperation(Emitter &emitter, func::CallOp callOp) {
 
 static LogicalResult emitOperation(Emitter &emitter,
                                    quake::OperatorInterface optor) {
-  // TODO: Handle adjoint for T and S
-  if (optor.isAdj())
-    return optor.emitError("cannot convert adjoint operations to OpenQASM 2.0");
-
-  StringRef name;
+  // Handle adjoint for T and S
+  std::string name = "";
   if (failed(translateOperatorName(optor, name)))
-    return optor.emitError("cannot convert operation to OpenQASM 2.0");
+    return optor.emitError(
+        "cannot convert operation to CUDA Quantum Python API");
+
+  if (optor.isAdj())
+    name = name + "dg";
+
   emitter.os << name;
 
   if (failed(printParameters(emitter, optor.getParameters())))

--- a/lib/Target/OpenQASM/TranslateToOpenQASM.cpp
+++ b/lib/Target/OpenQASM/TranslateToOpenQASM.cpp
@@ -238,12 +238,15 @@ static LogicalResult emitOperation(Emitter &emitter,
   // Handle adjoint for T and S
   StringRef name = "";
   if (failed(translateOperatorName(optor, name)))
-    return optor.emitError(
-        "cannot convert operation to CUDA Quantum Python API");
+    return optor.emitError("cannot convert operation to OpenQASM 2.0.");
 
-  if (optor.isAdj())
+  if (optor.isAdj()) {
+    std::vector<std::string> validAdjointOps{"s", "t"};
+    if (std::find(validAdjointOps.begin(), validAdjointOps.end(), name.str()) ==
+        validAdjointOps.end())
+      return optor.emitError("cannot create adjoint for this operation.");
     emitter.os << name << "dg";
-  else
+  } else
     emitter.os << name;
 
   if (failed(printParameters(emitter, optor.getParameters())))


### PR DESCRIPTION
@schweitzpgi please double check me on these. This is an attempted fix of #573. 

Also @boschmitt I'm attempting to enable adjoint operation lowering to OpenQASM here. 

This PR supports a demo the following demo I'd like to give:
```cpp
#include "cudaq.h"

// Demo Steps: 

// Show code: cudaq-quake demo/multicontrol_decomp.cpp | cudaq-opt --canonicalize 
// Synthesize ctrl kernels;   --apply-op-specialization 
// inline the functions:      --inline 
// Decompose multi-ctrl ops:  --quake-multicontrol-decomposition 
// Target a native gate set:  --quantinuum-gate-set-mapping --canonicalize 
// Canonicalize:              --canonicalize --factor-quantum-alloc

// See the code, the structure of the circuit

// Run the code, show how NVQ++ automates these things
//
// nvq++ --emulate --target quantinuum demo/multicontrol_decomp.cpp 
// CUDAQ_LOG_LEVEL=info ./a.out 
// 
// the output shows the code

// We can also take that code out to other representations
//
// | cudaq-translate --convert-to=qir-base 
// 
// | cudaq-translate --convert-to=openqasm 
//

__qpu__ void cnotKernel(cudaq::qubit &q, cudaq::qubit &r) {
  x<cudaq::ctrl>(q, r);
}

__qpu__ void multiCtrlTest() {
  cudaq::qreg q(4);
  cudaq::control(cnotKernel, {q[0], q[1]}, q[2], q[3]);
  // This is overly complicated for demo purposes
  // could have just done 
  // x<cudaq::ctrl>(q[0], q[1], q[2], q[3]);
}

int main() { cudaq::sample(multiCtrlTest); }
```
