### PR TITLE
Convert IonQ outputs to bit strings and correct order

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
@@ -265,20 +265,17 @@ IonQServerHelper::processResults(ServerMessage &postJobResponse) {
   cudaq::CountsDictionary counts;
 
   // Process the results
+  assert(nQubits <= 64);
   for (const auto &element : results.items()) {
-    std::string key = element.key();
-
     // Convert base-10 ASCII key to bitstring and perform endian swap
-    uint64_t s = std::stoull(key);
-    assert(nQubits <= 64);
+    uint64_t s = std::stoull(element.key());
     std::string newkey = std::bitset<64>(s).to_string();
-    newkey.erase(0, 64 - nQubits);
     std::reverse(newkey.begin(), newkey.end()); // perform endian swap
-    key = newkey;
+    newkey.resize(nQubits);
 
     double value = element.value().get<double>();
     std::size_t count = static_cast<std::size_t>(value * shots);
-    counts[key] = count;
+    counts[newkey] = count;
   }
 
   // Create an execution result

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
@@ -9,6 +9,7 @@
 #include "common/RestClient.h"
 #include "common/ServerHelper.h"
 #include "cudaq/utils/cudaq_utils.h"
+#include <bitset>
 #include <fstream>
 #include <thread>
 
@@ -248,11 +249,33 @@ IonQServerHelper::processResults(ServerMessage &postJobResponse) {
   auto resultsGetPath = constructGetResultsPath(postJobResponse);
   // Get the results
   auto results = getResults(resultsGetPath);
+
+  // Get the number of qubits. This assumes the all qubits are measured, which
+  // is a safe assumption for now but may change in the future.
+  cudaq::debug("postJobResponse message: {}", postJobResponse.dump());
+  auto &jobs = postJobResponse.at("jobs");
+  if (!jobs[0].contains("qubits"))
+    throw std::runtime_error(
+        "ServerMessage doesn't tell us how many qubits there were");
+
+  auto nQubits = jobs[0].at("qubits").get<int>();
+  cudaq::debug("nQubits is : {}", nQubits);
+  cudaq::debug("Results message: {}", results.dump());
+
   cudaq::CountsDictionary counts;
 
   // Process the results
   for (const auto &element : results.items()) {
     std::string key = element.key();
+
+    // Convert base-10 ASCII key to bitstring and perform endian swap
+    uint64_t s = std::stoull(key);
+    assert(nQubits <= 64);
+    std::string newkey = std::bitset<64>(s).to_string();
+    newkey.erase(0, 64 - nQubits);
+    std::reverse(newkey.begin(), newkey.end()); // perform endian swap
+    key = newkey;
+
     double value = element.value().get<double>();
     std::size_t count = static_cast<std::size_t>(value * shots);
     counts[key] = count;

--- a/utils/mock_qpu/ionq/__init__.py
+++ b/utils/mock_qpu/ionq/__init__.py
@@ -36,6 +36,9 @@ createdJobs = {}
 # Could how many times the client has requested the Job
 countJobGetRequests = 0
 
+# Save how many qubits were needed for each test (emulates real backend)
+numQubitsRequired = 0
+
 llvm.initialize()
 llvm.initialize_native_target()
 llvm.initialize_native_asmprinter()
@@ -76,7 +79,7 @@ async def login(token: Union[str, None] = Header(alias="Authorization",
 async def postJob(job: Job,
                   token: Union[str, None] = Header(alias="Authorization",
                                                    default=None)):
-    global createdJobs, shots
+    global createdJobs, shots, numQubitsRequired
 
     if token == None:
         raise HTTPException(status_code(401), detail="Credentials not provided")
@@ -125,7 +128,7 @@ async def postJob(job: Job,
 # until we return the job results
 @app.get("/v0.3/jobs")
 async def getJob(id: str):
-    global countJobGetRequests, createdJobs
+    global countJobGetRequests, createdJobs, numQubitsRequired
 
     # Simulate asynchronous execution
     if countJobGetRequests < 3:
@@ -136,6 +139,7 @@ async def getJob(id: str):
     res = {
         "jobs": [{
             "status": "completed",
+            "qubits": numQubitsRequired,
             "results_url": "/v0.3/jobs/{}/results".format(id)
         }]
     }


### PR DESCRIPTION
This will enable more nightly integration tests to be enabled and pass.