### PR TITLE
Allow more descriptive output names

### DIFF
--- a/.github/workflows/config/spelling_allowlist.txt
+++ b/.github/workflows/config/spelling_allowlist.txt
@@ -73,6 +73,7 @@ coprocessor
 coprocessors
 copyable
 cortex-cli
+cudaq
 cuQuantum
 deallocate
 deallocated
@@ -92,7 +93,9 @@ eigenvalue
 eigenvalues
 eigenvector
 eigenvectors
+enqueue
 enqueues
+enqueuing
 entangler
 entanglers
 enum
@@ -110,6 +113,8 @@ parallelization
 precompute
 precomputed
 prepend
+qplt
+qpu
 quantize
 quantized
 qubit
@@ -128,6 +133,7 @@ subfolder
 submodule
 subscriptable
 subtype
+subtyped
 subtypes
 subtyping
 symplectic

--- a/.github/workflows/config/spelling_allowlist.txt
+++ b/.github/workflows/config/spelling_allowlist.txt
@@ -73,8 +73,8 @@ coprocessor
 coprocessors
 copyable
 cortex-cli
-cudaq
 cuQuantum
+cudaq
 deallocate
 deallocated
 deallocates

--- a/docs/sphinx/examples/cpp/providers/quantinuum.cpp
+++ b/docs/sphinx/examples/cpp/providers/quantinuum.cpp
@@ -19,7 +19,7 @@ struct ghz {
     for (int i = 0; i < 4; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);
     }
-    mz(q);
+    auto myResultName = mz(q);
   }
 };
 

--- a/docs/sphinx/examples/cpp/providers/quantinuum.cpp
+++ b/docs/sphinx/examples/cpp/providers/quantinuum.cpp
@@ -19,7 +19,7 @@ struct ghz {
     for (int i = 0; i < 4; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);
     }
-    auto myResultName = mz(q);
+    mz(q);
   }
 };
 

--- a/docs/sphinx/specification/cudaq/platform.rst
+++ b/docs/sphinx/specification/cudaq/platform.rst
@@ -32,8 +32,9 @@ The :code:`cudaq::quantum_platform` should take the following structure
       std::size_t num_qpus() const;
       std::size_t get_num_qubits(std::size_t qpu_id = 0) const;
  
-      bool is_simulator(std::size_t qpu_id = 0) const; 
+      bool is_simulator(std::size_t qpu_id = 0) const;
       bool is_remote(std::size_t qpuId = 0);
+      bool is_emulated(std::size_t qpuId = 0) const;
       std::string name() const;
  
       std::size_t get_current_qpu() const ;

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -190,6 +190,15 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
   ];
 }
 
+def UpdateRegisterNames : Pass<"update-register-names"> {
+  let summary = "Update register names";
+  let description = [{
+    After loop unrolling, there may be duplicate registerName attributes. Run
+    this pass to give them unique attribute values.
+  }];
+}
+
+
 def LowerToCFG : Pass<"lower-to-cfg", "mlir::func::FuncOp"> {
   let summary = "Erase CLoop, CIf, etc. ops, replacing them with a CFG.";
   let description = [{

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -191,7 +191,7 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
 }
 
 def UpdateRegisterNames : Pass<"update-register-names"> {
-  let summary = "Update register names";
+  let summary = "Update classical register names";
   let description = [{
     After loop unrolling, there may be duplicate registerName attributes. Run
     this pass to give them unique attribute values.

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -198,7 +198,6 @@ def UpdateRegisterNames : Pass<"update-register-names"> {
   }];
 }
 
-
 def LowerToCFG : Pass<"lower-to-cfg", "mlir::func::FuncOp"> {
   let summary = "Erase CLoop, CIf, etc. ops, replacing them with a CFG.";
   let description = [{

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -299,6 +299,12 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
 
       // Did this come from a stdvec init op? If not drop out
       auto stdVecInit = initVec.getDefiningOp<cc::StdvecInitOp>();
+      if (auto mx = initVec.getDefiningOp<quake::MxOp>())
+        mx->setAttr("registerName", builder.getStringAttr(x->getName()));
+      if (auto my = initVec.getDefiningOp<quake::MyOp>())
+        my->setAttr("registerName", builder.getStringAttr(x->getName()));
+      if (auto mz = initVec.getDefiningOp<quake::MzOp>())
+        mz->setAttr("registerName", builder.getStringAttr(x->getName()));
       if (!stdVecInit)
         return true;
 

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -297,14 +297,16 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
           elementType.getIntOrFloatBitWidth() != 1)
         return true;
 
-      // Did this come from a stdvec init op? If not drop out
-      auto stdVecInit = initVec.getDefiningOp<cc::StdvecInitOp>();
+      // Assign registerName
       if (auto mx = initVec.getDefiningOp<quake::MxOp>())
         mx->setAttr("registerName", builder.getStringAttr(x->getName()));
       if (auto my = initVec.getDefiningOp<quake::MyOp>())
         my->setAttr("registerName", builder.getStringAttr(x->getName()));
       if (auto mz = initVec.getDefiningOp<quake::MzOp>())
         mz->setAttr("registerName", builder.getStringAttr(x->getName()));
+
+      // Did this come from a stdvec init op? If not drop out
+      auto stdVecInit = initVec.getDefiningOp<cc::StdvecInitOp>();
       if (!stdVecInit)
         return true;
 

--- a/lib/Optimizer/Transforms/ExpandMeasurements.cpp
+++ b/lib/Optimizer/Transforms/ExpandMeasurements.cpp
@@ -82,6 +82,8 @@ public:
               Value qv =
                   builder.template create<quake::ExtractRefOp>(loc, v, iv);
               auto bit = builder.template create<A>(loc, i1Ty, qv);
+              if (auto registerName = measureOp->getAttr("registerName"))
+                bit->setAttr("registerName", registerName);
               auto offset =
                   builder.template create<arith::AddIOp>(loc, iv, buffOff);
               Value offCast = builder.template create<arith::IndexCastOp>(

--- a/lib/Optimizer/Transforms/LoopUnroll.cpp
+++ b/lib/Optimizer/Transforms/LoopUnroll.cpp
@@ -186,22 +186,23 @@ public:
     }
 
     // First get a count of the number of times a variable is used.
-    std::unordered_map<std::string, int> myCounts;
+    std::unordered_map<std::string, int> varNameCounts;
     op->walk([&](mlir::Operation *walkOp) {
       if (auto prevAttr = walkOp->getAttr("registerName")) {
         auto varName = prevAttr.cast<StringAttr>().getValue().str();
-        myCounts[varName]++;
+        varNameCounts[varName]++;
       }
+      return WalkResult::advance();
     });
 
     // Now apply new labels, appending a counter if necessary
-    std::unordered_map<std::string, int> myMap;
+    std::unordered_map<std::string, int> varCounter;
     op->walk([&](mlir::Operation *walkOp) {
       if (auto prevAttr = walkOp->getAttr("registerName")) {
         auto varName = prevAttr.cast<StringAttr>().getValue().str();
-        if (myCounts[varName] > 1) {
-          auto strLen = std::to_string(myCounts[varName] - 1).size();
-          auto suffix = std::to_string(myMap[varName]++);
+        if (varNameCounts[varName] > 1) {
+          auto strLen = std::to_string(varNameCounts[varName] - 1).size();
+          auto suffix = std::to_string(varCounter[varName]++);
           if (suffix.size() < strLen)
             suffix = std::string(strLen - suffix.size(), '0') + suffix;
           // Note Quantinuum can't support a ":" delimiter, so use '%'
@@ -210,6 +211,7 @@ public:
           walkOp->setAttr("registerName", newAttr);
         }
       }
+      return WalkResult::advance();
     });
   }
 

--- a/python/tests/unittests/test_sample.py
+++ b/python/tests/unittests/test_sample.py
@@ -77,7 +77,7 @@ def test_sample_result_single_register(qubit_count, shots_count):
             assert marginal_counts.most_probable() == "1"
     # `get_sequential_data`
     # In this case, should just contain the single bitstring in a list.
-    assert sample_result.get_sequential_data() == [want_bitstring]
+    assert sample_result.get_sequential_data() == [want_bitstring] * shots_count
 
     # `::items()`
     for key, value in sample_result.items():
@@ -165,7 +165,7 @@ def test_sample_result_single_register_float_param(qubit_count, shots_count):
             assert marginal_counts.most_probable() == "1"
     # `get_sequential_data`
     # In this case, should just contain the single bitstring in a list.
-    assert sample_result.get_sequential_data() == [want_bitstring]
+    assert sample_result.get_sequential_data() == [want_bitstring] * shots_count
 
     # `::items()`
     for key, value in sample_result.items():
@@ -253,7 +253,7 @@ def test_sample_result_single_register_list_param(qubit_count, shots_count):
             assert marginal_counts.most_probable() == "1"
     # `get_sequential_data`
     # In this case, should just contain the single bitstring in a list.
-    assert sample_result.get_sequential_data() == [want_bitstring]
+    assert sample_result.get_sequential_data() == [want_bitstring] * shots_count
 
     # `::items()`
     for key, value in sample_result.items():

--- a/runtime/common/MeasureCounts.cpp
+++ b/runtime/common/MeasureCounts.cpp
@@ -58,7 +58,7 @@ void ExecutionResult::appendResult(std::string bitString, std::size_t count) {
   else
     iter->second += count;
 
-  sequentialData.push_back(bitString);
+  sequentialData.insert(sequentialData.end(), count, bitString);
 }
 
 bool ExecutionResult::operator==(const ExecutionResult &result) const {

--- a/runtime/common/MeasureCounts.h
+++ b/runtime/common/MeasureCounts.h
@@ -229,7 +229,7 @@ public:
   sample_result
   get_marginal(const std::vector<std::size_t> &&marginalIndices,
                const std::string_view registerName = GlobalRegisterName) {
-    return get_marginal(marginalIndices);
+    return get_marginal(marginalIndices, registerName);
   }
 
   /// @brief Extract marginal counts, that is those counts for a subset

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -236,7 +236,7 @@ public:
     std::regex pipeline("^PLATFORM_LOWERING_CONFIG\\s*=\\s*\"(\\S+)\"");
     std::regex emissionType("^CODEGEN_EMISSION\\s*=\\s*(\\S+)");
     std::smatch match;
-    for (std::string &line : lines) {
+    for (const std::string &line : lines) {
       if (std::regex_search(line, match, pipeline)) {
         cudaq::info("Appending lowering pipeline: {}", match[1].str());
         passPipelineConfig += "," + match[1].str();

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -230,14 +230,10 @@ public:
 
     // Loop through the file, extract the pass pipeline and CODEGEN Type
     auto lines = cudaq::split(configContents, '\n');
-    std::regex pipeline("PLATFORM_LOWERING_CONFIG\\s*=\\s*\"(\\S+)\"");
-    std::regex emissionType("CODEGEN_EMISSION\\s*=\\s*(\\S+)");
+    std::regex pipeline("^PLATFORM_LOWERING_CONFIG\\s*=\\s*\"(\\S+)\"");
+    std::regex emissionType("^CODEGEN_EMISSION\\s*=\\s*(\\S+)");
     std::smatch match;
     for (std::string &line : lines) {
-      // Remove comments from the line
-      size_t pos = line.find('#');
-      if (pos != std::string::npos)
-        line = line.substr(0, pos);
       if (std::regex_search(line, match, pipeline)) {
         cudaq::info("Appending lowering pipeline: {}", match[1].str());
         passPipelineConfig += "," + match[1].str();

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -154,6 +154,9 @@ public:
   void clearShots() override { nShots = std::nullopt; }
   virtual bool isRemote() override { return !emulate; }
 
+  /// @brief Return true if locally emulating a remote QPU
+  virtual bool isEmulated() override { return emulate; }
+
   /// @brief Set the noise model, only allow this for
   /// emulation.
   void setNoiseModel(cudaq::noise_model *model) override {

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
@@ -264,6 +264,8 @@ IonQServerHelper::processResults(ServerMessage &postJobResponse) {
 
   cudaq::CountsDictionary counts;
 
+  cudaq::info("Results message: {}", results.dump());
+
   // Process the results
   assert(nQubits <= 64);
   for (const auto &element : results.items()) {

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
@@ -162,6 +162,8 @@ QuantinuumServerHelper::processResults(ServerMessage &postJobResponse) {
   //                      "r1" : ["1", "0", ...]  } }
   auto results = postJobResponse["results"];
 
+  cudaq::info("Results message: {}", results.dump());
+
   // For each shot, we concatenate the measurements results of all qubits.
   auto begin = results.begin();
   std::vector<std::string> bitstrings =

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
@@ -164,6 +164,18 @@ QuantinuumServerHelper::processResults(ServerMessage &postJobResponse) {
 
   cudaq::info("Results message: {}", results.dump());
 
+  std::vector<ExecutionResult> srs;
+
+  // Populate individual registers' results into srs
+  for (auto &[registerName, result] : results.items()) {
+    auto bitResults = result.get<std::vector<std::string>>();
+    CountsDictionary thisRegCounts;
+    for (auto &b : bitResults)
+      thisRegCounts[b]++;
+    srs.emplace_back(thisRegCounts, registerName);
+    srs.back().sequentialData = bitResults;
+  }
+
   // For each shot, we concatenate the measurements results of all qubits.
   auto begin = results.begin();
   std::vector<std::string> bitstrings =
@@ -175,15 +187,12 @@ QuantinuumServerHelper::processResults(ServerMessage &postJobResponse) {
   }
 
   cudaq::CountsDictionary counts;
-  for (auto &b : bitstrings) {
-    if (counts.count(b))
-      counts[b]++;
-    else
-      counts.insert({b, 1});
-  }
+  for (auto &b : bitstrings)
+    counts[b]++;
 
-  std::vector<ExecutionResult> srs;
-  srs.emplace_back(counts);
+  // Store the combined results into the global register
+  srs.emplace_back(counts, GlobalRegisterName);
+  srs.back().sequentialData = bitstrings;
   return sample_result(srs);
 }
 

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -119,6 +119,9 @@ public:
 
   virtual bool isRemote() { return false; }
 
+  /// Is this a local emulator of a remote QPU?
+  virtual bool isEmulated() { return false; }
+
   /// Enqueue a quantum task on the asynchronous execution queue.
   virtual void
   enqueue(QuantumTask &task) = 0; //{ execution_queue->enqueue(task); }

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -115,6 +115,10 @@ bool quantum_platform::is_remote(const std::size_t qpu_id) {
   return platformQPUs[qpu_id]->isRemote();
 }
 
+bool quantum_platform::is_emulated(const std::size_t qpu_id) const {
+  return platformQPUs[qpu_id]->isEmulated();
+}
+
 bool quantum_platform::supports_conditional_feedback(
     const std::size_t qpu_id) const {
   return platformQPUs[qpu_id]->supportsConditionalFeedback();

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -101,6 +101,9 @@ public:
   /// @brief Return true if the QPU is remote.
   bool is_remote(const std::size_t qpuId = 0);
 
+  /// @brief Return true if QPU is locally emulating a remote QPU
+  bool is_emulated(const std::size_t qpuId = 0) const;
+
   /// @brief Set the noise model for future invocations of
   /// quantum kernels.
   void set_noise(noise_model *model);

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -498,7 +498,12 @@ protected:
       executionContext->result.append(execResult);
     } else {
 
+      bool hasGlobal = false;
+
       for (auto &[regName, qubits] : registerNameToMeasuredQubit) {
+        if (regName == cudaq::GlobalRegisterName)
+          hasGlobal = true;
+
         // Find the position of the qubits we have in the result bit string
         // Create a map of qubit to bit string location
         std::unordered_map<std::size_t, std::size_t> qubitLocMap;
@@ -518,6 +523,33 @@ protected:
         }
 
         executionContext->result.append(tmp);
+      }
+
+      // Form the global register from a combination of the sorted register
+      // names. In the future, we may want to let the user customize
+      if (!hasGlobal) {
+        cudaq::ExecutionResult globalResult(cudaq::GlobalRegisterName);
+        std::vector<std::string> sortedRegNames =
+            executionContext->result.register_names();
+        std::sort(sortedRegNames.begin(), sortedRegNames.end());
+        for (size_t shot = 0; shot < executionContext->shots; shot++) {
+          std::string myResult;
+          for (auto regName : sortedRegNames) {
+            auto dataByShot = executionContext->result.sequential_data(regName);
+            if (shot < dataByShot.size())
+              myResult += dataByShot[shot];
+          }
+          globalResult.sequentialData.push_back(myResult);
+        }
+        // Count how often each occurrence happened (in the new sorted order)
+        cudaq::CountsDictionary myGlobalCountDict;
+        for (size_t shot = 0; shot < executionContext->shots; shot++)
+          myGlobalCountDict[globalResult.sequentialData[shot]]++;
+        for (auto &[bits, count] : myGlobalCountDict)
+          globalResult.appendResult(bits, count);
+
+        // Append the newly calculated globalResult into the result list
+        executionContext->result.append(globalResult);
       }
     }
 

--- a/test/AST-Quake/loop_unroll-1.cpp
+++ b/test/AST-Quake/loop_unroll-1.cpp
@@ -13,18 +13,22 @@
 struct C {
    void operator()() __qpu__ {
       cudaq::qreg r(2);
-      mz(r);
+      cudaq::qubit w;
+      auto singleQubit = mz(w);
+      auto myRegister = mz(r);
    }
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__C()
 // CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
+// CHECK-DAG:       %[[VAL_10:.*]] = quake.alloca !quake.ref
+// CHECK-DAG:       %[[VAL_11:.*]] = quake.mz %[[VAL_10]] : (!quake.ref) -> i1 {registerName = "singleQubit"}
 // CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.array<i1 x 2>
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1 {registerName = "myRegister%0"}
 // CHECK:           cc.store %[[VAL_6]], %{{.*}} : !cc.ptr<i1>
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1 {registerName = "myRegister%1"}
 // CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<i1 x 2>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<i1>
 // CHECK:           return

--- a/test/AST-Quake/loop_unroll-1.cpp
+++ b/test/AST-Quake/loop_unroll-1.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: cudaq-quake %s | cudaq-opt --pass-pipeline='builtin.module(expand-measurements,canonicalize,cc-loop-unroll,update-register-names,canonicalize)' | FileCheck %s
+// RUN: cudaq-quake %s | cudaq-opt --pass-pipeline='builtin.module(expand-measurements,unrolling-pipeline)' | FileCheck %s
 
 #include <cudaq.h>
 

--- a/test/AST-Quake/loop_unroll-1.cpp
+++ b/test/AST-Quake/loop_unroll-1.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: cudaq-quake %s | cudaq-opt --pass-pipeline='builtin.module(expand-measurements,canonicalize,cc-loop-unroll,canonicalize)' | FileCheck %s
+// RUN: cudaq-quake %s | cudaq-opt --pass-pipeline='builtin.module(expand-measurements,canonicalize,cc-loop-unroll,update-register-names,canonicalize)' | FileCheck %s
 
 #include <cudaq.h>
 

--- a/test/NVQPP/integration/sudoku_2x2-bit_names.cpp
+++ b/test/NVQPP/integration/sudoku_2x2-bit_names.cpp
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+
+#include <cudaq.h>
+#include <algorithm>
+#include <iostream>
+#include <unordered_set>
+
+__qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
+  h(qubits);
+  x(qubits);
+  z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3]);
+  x(qubits);
+  h(qubits);
+}
+
+__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+  x<cudaq::ctrl>(cs[0], !cs[1], !cs[2], cs[3], target);
+  x<cudaq::ctrl>(!cs[0], cs[1], cs[2], !cs[3], target);
+}
+
+__qpu__ void grover() {
+  cudaq::qreg qubits(4);
+  cudaq::qubit ancilla;
+
+  // Initialization
+  x(ancilla);
+  h(ancilla);
+  h(qubits); // uniform initialization
+
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits);
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits);
+
+// TODO: Extend measurement support for submissions to IonQ,
+// see https://github.com/NVIDIA/cuda-quantum/issues/512.
+#ifndef IONQ_TARGET
+  auto groverQubits0 = mz(qubits[0]);
+  auto groverQubits1 = mz(qubits[1]);
+  auto groverQubits2 = mz(qubits[2]);
+  auto groverQubits3 = mz(qubits[3]);
+#endif
+};
+
+int main() {
+  auto result = cudaq::sample(1000, grover);
+  result.dump();
+
+#ifndef SYNTAX_CHECK
+  std::vector<std::string> strings;
+  for (auto &&[bits, count] : result) {
+    strings.push_back(bits);
+  }
+  std::sort(strings.begin(), strings.end(), [&](auto& a, auto& b) {
+    return result.count(a) > result.count(b);
+  });
+  std::cout << strings[0] << '\n';
+  std::cout << strings[1] << '\n';
+
+  std::unordered_set<std::string> most_probable{strings[0], strings[1]};
+  assert(most_probable.count("1001") == 1);
+  assert(most_probable.count("0110") == 1);
+#endif
+
+  return 0;
+}
+
+// CHECK-DAG: 1001
+// CHECK-DAG: 0110

--- a/test/NVQPP/integration/sudoku_2x2-bit_names.cpp
+++ b/test/NVQPP/integration/sudoku_2x2-bit_names.cpp
@@ -54,6 +54,24 @@ int main() {
   auto result = cudaq::sample(1000, grover);
   result.dump();
 
+  // Make sure that the get_marginal() results for the individual register names
+  // match the subset of the bits from the global register.
+  // Note that this will fail if you only compile this in library mode.
+  auto numBits = result.begin()->first.size();
+  std::cout << "Checking " << numBits << " bits against global register\n";
+  for (size_t b = 0;  b < numBits; b++) {
+    auto regName = "groverQubits" + std::to_string(b);
+    auto valFromRegName = result.get_marginal({0}, regName);
+    auto valFromGlobal = result.get_marginal({b});
+    if (valFromRegName.to_map() != valFromGlobal.to_map()) {
+      std::cout << "--- MISMATCH DETECTED in bit " << b << " ---\n";
+      valFromRegName.dump();
+      valFromGlobal.dump();
+      // Mark test failure
+      assert(valFromRegName.to_map() == valFromGlobal.to_map());
+    }
+  }
+
 #ifndef SYNTAX_CHECK
   std::vector<std::string> strings;
   for (auto &&[bits, count] : result) {

--- a/test/NVQPP/integration/sudoku_2x2-bit_names.cpp
+++ b/test/NVQPP/integration/sudoku_2x2-bit_names.cpp
@@ -54,21 +54,24 @@ int main() {
   auto result = cudaq::sample(1000, grover);
   result.dump();
 
-  // Make sure that the get_marginal() results for the individual register names
-  // match the subset of the bits from the global register.
-  // Note that this will fail if you only compile this in library mode.
-  auto numBits = result.begin()->first.size();
-  std::cout << "Checking " << numBits << " bits against global register\n";
-  for (size_t b = 0;  b < numBits; b++) {
-    auto regName = "groverQubits" + std::to_string(b);
-    auto valFromRegName = result.get_marginal({0}, regName);
-    auto valFromGlobal = result.get_marginal({b});
-    if (valFromRegName.to_map() != valFromGlobal.to_map()) {
-      std::cout << "--- MISMATCH DETECTED in bit " << b << " ---\n";
-      valFromRegName.dump();
-      valFromGlobal.dump();
-      // Mark test failure
-      assert(valFromRegName.to_map() == valFromGlobal.to_map());
+  auto& platform = cudaq::get_platform();
+  if (platform.is_remote() || platform.is_emulated()) {
+    // Make sure that the get_marginal() results for the individual register names
+    // match the subset of the bits from the global register.
+    // Note that this will fail if you only compile this in library mode.
+    auto numBits = result.begin()->first.size();
+    std::cout << "Checking " << numBits << " bits against global register\n";
+    for (size_t b = 0;  b < numBits; b++) {
+      auto regName = "groverQubits" + std::to_string(b);
+      auto valFromRegName = result.get_marginal({0}, regName);
+      auto valFromGlobal = result.get_marginal({b});
+      if (valFromRegName.to_map() != valFromGlobal.to_map()) {
+        std::cout << "--- MISMATCH DETECTED in bit " << b << " ---\n";
+        valFromRegName.dump();
+        valFromGlobal.dump();
+        // Mark test failure
+        assert(valFromRegName.to_map() == valFromGlobal.to_map());
+      }
     }
   }
 

--- a/test/NVQPP/integration/sudoku_2x2-reg_name.cpp
+++ b/test/NVQPP/integration/sudoku_2x2-reg_name.cpp
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+
+#include <cudaq.h>
+#include <algorithm>
+#include <iostream>
+#include <unordered_set>
+
+__qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
+  h(qubits);
+  x(qubits);
+  z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3]);
+  x(qubits);
+  h(qubits);
+}
+
+__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+  x<cudaq::ctrl>(cs[0], !cs[1], !cs[2], cs[3], target);
+  x<cudaq::ctrl>(!cs[0], cs[1], cs[2], !cs[3], target);
+}
+
+__qpu__ void grover() {
+  cudaq::qreg qubits(4);
+  cudaq::qubit ancilla;
+
+  // Initialization
+  x(ancilla);
+  h(ancilla);
+  h(qubits); // uniform initialization
+
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits);
+  oracle(qubits, ancilla);
+  reflect_uniform(qubits);
+
+// TODO: Extend measurement support for submissions to IonQ,
+// see https://github.com/NVIDIA/cuda-quantum/issues/512.
+#ifndef IONQ_TARGET
+  auto groverQubits = mz(qubits);
+#endif
+};
+
+int main() {
+  auto result = cudaq::sample(1000, grover);
+  result.dump();
+
+#ifndef SYNTAX_CHECK
+  std::vector<std::string> strings;
+  for (auto &&[bits, count] : result) {
+    strings.push_back(bits);
+  }
+  std::sort(strings.begin(), strings.end(), [&](auto& a, auto& b) {
+    return result.count(a) > result.count(b);
+  });
+  std::cout << strings[0] << '\n';
+  std::cout << strings[1] << '\n';
+
+  std::unordered_set<std::string> most_probable{strings[0], strings[1]};
+  assert(most_probable.count("1001") == 1);
+  assert(most_probable.count("0110") == 1);
+#endif
+
+  return 0;
+}
+
+// CHECK-DAG: 1001
+// CHECK-DAG: 0110

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -573,8 +573,9 @@ CUDAQ_TEST(BuilderTester, checkMidCircuitMeasure) {
 
     auto counts = cudaq::sample(entryPoint);
     counts.dump();
-    EXPECT_EQ(counts.register_names().size(), 1);
-    EXPECT_EQ(counts.register_names()[0], "c0");
+    EXPECT_EQ(counts.register_names().size(), 2); // includes synthetic global
+    EXPECT_EQ(counts.register_names()[0], "__global__");
+    EXPECT_EQ(counts.register_names()[1], "c0");
   }
 
   {
@@ -589,7 +590,7 @@ CUDAQ_TEST(BuilderTester, checkMidCircuitMeasure) {
 
     auto counts = cudaq::sample(entryPoint);
     counts.dump();
-    EXPECT_EQ(counts.register_names().size(), 2);
+    EXPECT_EQ(counts.register_names().size(), 3); // includes synthetic global
     auto regNames = counts.register_names();
     EXPECT_TRUE(std::find(regNames.begin(), regNames.end(), "c0") !=
                 regNames.end());


### PR DESCRIPTION
This will resolve #579.

### Description
* Pass user-generated variable names into registerName attribute and count bits with a counter
* Form synthetic global register if one doesn't exist
* Change result handling in launchKernel output handling
* Log results messages in server helpers for debug
* Remove comments while parsing .config file

The main improvements are that it allows custom output names as demonstrated in sudoku_2x2-*.cpp. It also includes a synthetic global register if you want to get it the old way, but the synthetic global register is formed based off the alphabetical register names.

For example, 2 new tests were added to demonstrate the fix. when you compile and run the new test programs test/NVQPP/integration/sudoku_2x2-*.cpp, you will see the following results (as part of `results.dump()`):

```bash
root@docker-desktop:/workspaces/cuda-quantum# nvq++ test/NVQPP/integration/sudoku_2x2-bit_names.cpp --target quantinuum --emulate
root@docker-desktop:/workspaces/cuda-quantum# ./a.out 
{ 
  __global__ : { 0111:2 0101:2 1111:3 1010:4 1001:466 1110:3 1101:3 0000:2 1000:3 0011:4 0001:2 0010:4 0100:4 1011:1 0110:495 1100:2 }
   groverQubits0 : { 0:515 1:485 }
   groverQubits1 : { 0:486 1:514 }
   groverQubits2 : { 0:484 1:516 }
   groverQubits3 : { 1:483 0:517 }
}
0110
1001
root@docker-desktop:/workspaces/cuda-quantum# nvq++ test/NVQPP/integration/sudoku_2x2-reg_name.cpp --target quantinuum --emulate
root@docker-desktop:/workspaces/cuda-quantum# ./a.out 
{ 
  __global__ : { 1101:5 1010:6 1001:457 1111:3 0110:471 1100:3 1110:4 0000:3 1000:1 0011:9 0001:13 0010:8 0100:5 1011:7 0111:5 }
   groverQubits%0 : { 0:514 1:486 }
   groverQubits%2 : { 0:487 1:513 }
   groverQubits%1 : { 0:504 1:496 }
   groverQubits%3 : { 0:501 1:499 }
}
0110
1001
```