### PR TITLE
[custatevec] `getStateData` to return data consistent with qpp and `cudaq::from_state`

### DIFF
--- a/runtime/cudaq/builder/kernels.cpp
+++ b/runtime/cudaq/builder/kernels.cpp
@@ -48,7 +48,7 @@ std::vector<std::size_t> getControlIndices(std::size_t grayRank) {
   return ctrlIds;
 }
 
-std::size_t mEntry(std::size_t row, std::size_t col) {
+int mEntry(std::size_t row, std::size_t col) {
   auto b_and_g = row & ((col >> 1) ^ col);
   std::size_t sum_of_ones = 0;
   while (b_and_g > 0) {

--- a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
+++ b/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
@@ -521,8 +521,40 @@ public:
 
   cudaq::State getStateData() override {
     std::vector<std::complex<ScalarType>> tmp(stateDimension);
-    cudaMemcpy(tmp.data(), deviceStateVector,
-               stateDimension * sizeof(CudaDataType), cudaMemcpyDeviceToHost);
+    // Use custatevec accessor to retrieve the view
+    custatevecAccessorDescriptor_t accessor;
+    const uint32_t nIndexBits = std::log2(stateDimension);
+    // Note: we use MSB bit ordering when reporting the state vector
+    // hence, bit ordering vector = [N-1, N-2, ..., 0]
+    std::vector<int32_t> bitOrdering(nIndexBits);
+    std::iota(std::rbegin(bitOrdering), std::rend(bitOrdering), 0);
+    std::size_t extraWorkspaceSizeInBytes = 0;
+    // create accessor view
+    HANDLE_ERROR(custatevecAccessorCreateView(
+        handle, deviceStateVector, cuStateVecCudaDataType, nIndexBits,
+        &accessor, bitOrdering.data(), bitOrdering.size(),
+        /*maskBitString*/ nullptr, /*maskOrdering*/ nullptr,
+        /*maskLen*/ 0, &extraWorkspaceSizeInBytes));
+    // allocate external workspace if necessary
+    void *extraWorkspace = nullptr;
+    if (extraWorkspaceSizeInBytes > 0)
+      HANDLE_CUDA_ERROR(cudaMalloc(&extraWorkspace, extraWorkspaceSizeInBytes));
+
+    // set external workspace
+    HANDLE_ERROR(custatevecAccessorSetExtraWorkspace(
+        handle, accessor, extraWorkspace, extraWorkspaceSizeInBytes));
+
+    // get all state vector components: [0, stateDimension)
+    HANDLE_ERROR(custatevecAccessorGet(handle, accessor, tmp.data(),
+                                       /*begin*/ 0,
+                                       /*end*/
+                                       stateDimension));
+    // destroy descriptor
+    HANDLE_ERROR(custatevecAccessorDestroy(accessor));
+    // free extra workspace if allocated
+    if (extraWorkspaceSizeInBytes > 0)
+      HANDLE_CUDA_ERROR(cudaFree(extraWorkspace));
+
     if constexpr (std::is_same_v<ScalarType, float>) {
       std::vector<std::complex<double>> data;
       std::transform(tmp.begin(), tmp.end(), std::back_inserter(data),

--- a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
+++ b/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
@@ -520,6 +520,10 @@ public:
   }
 
   cudaq::State getStateData() override {
+    // Handle empty state (e.g., no qubit allocation)
+    if (stateDimension == 0)
+      return cudaq::State{{stateDimension}, {}};
+
     std::vector<std::complex<ScalarType>> tmp(stateDimension);
     // Use custatevec accessor to retrieve the view
     custatevecAccessorDescriptor_t accessor;


### PR DESCRIPTION



<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
Since we now have `cudaq::from_state`, which assumes MSB bit-ordering for its input, this PR makes `CuStateVecCircuitSimulator::getStateData` to return the state data in that bit ordering.

This will make it consistent with qpp as well as the `cudaq::from_state` convention.

Tested by:   running `test_runtime_custatevec-fp32`: `KernelsTester.checkFromState` test passed.
