### PR TITLE
Add new ops to quake dialect.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -146,22 +146,19 @@ def quake_ComputeActionOp : QuakeOp<"compute_action"> {
   }];
 }
 
-def quake_ConvertControlOp : QuakeOp<"convert_ctrl"> {
+def quake_ToControlOp : QuakeOp<"to_ctrl"> {
   let summary = "Convert a wire value to a control value.";
   let description = [{
-    This operation should be considered experimental. It is currently not used.
-
     This operation makes the conversion of a wire value to a control value
     explicit in the quake IR. These values have different semantics in the IR.
-    Ensuring these semantics via the type system may (or may not) prove to be
-    advantageous.
+    This op ensures these semantics via the type system.
 
     A value of type control is (nearly) an SSA-value. Once defined, via the
-    `convert_ctrl` operation, it can be used as an argument to other operations.
+    `to_ctrl` operation, it can be used as an argument to other operations.
     These uses are qualified. They must be in control argument positions and
-    these operations must dominate any second use of the `qubit` argument to
-    the `convert_ctrl`. The operand value and result value of a `convert_ctrl`
-    may not be used as arguments to the exact same subsequent operation.
+    these operations must dominate a `from_ctrl` operation that returns the
+    control qubit back to a wire. The operand value and result value of a
+    `to_ctrl` may NOT be used as arguments to the same operation.
   }];
 
   let arguments = (ins WireType:$qubit);
@@ -169,6 +166,22 @@ def quake_ConvertControlOp : QuakeOp<"convert_ctrl"> {
 
   let assemblyFormat = [{
     $qubit `:` functional-type(operands, results) attr-dict
+  }];
+}
+
+def quake_FromControlOp : QuakeOp<"from_ctrl"> {
+  let summary = "Convert a control value to a wire value.";
+  let description = [{
+    This operation makes the conversion of a control value to a wire value
+    explicit in the quake IR. These values have different semantics in the IR.
+    This op ensures these semantics via the type system.
+  }];
+
+  let arguments = (ins ControlType:$ctrlbit);
+  let results = (outs WireType);
+
+  let assemblyFormat = [{
+    $ctrlbit `:` functional-type(operands, results) attr-dict
   }];
 }
 
@@ -507,6 +520,34 @@ def quake_ResetOp : QuakeOp<"reset", [QuantumGate,
         EffectInstance<mlir::MemoryEffects::Effect>> &effects) {
       quake::getResetEffectsImpl(effects, getTargets());
     }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Sink
+//===----------------------------------------------------------------------===//
+
+def quake_SinkOp : QuakeOp<"sink", [QuantumGate]> {
+  let summary = "Sink for a qubit that is used but not measured.";
+  let description = [{
+    The `quake.sink` operation is used to mark a particular wire in the value
+    semantics as used at the end of a circuit. Typically a wire is measured, but
+    in some cases the wire needs to be marked as if it were measured even though
+    a measurement is not desired.
+
+    This op is similar to the dealloc op in the reference semantics.
+
+    Example:
+    ```mlir
+      quake.sink %0 : !quake.wire
+    ```
+  }];
+
+  let arguments = (ins 
+    Arg<WireType,"wire to sink",[MemRead, MemWrite]>:$target
+  );
+  let assemblyFormat = [{
+     $target `:` qualified(type(operands)) attr-dict
   }];
 }
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -479,7 +479,7 @@ def quake_WrapOp : QuakeOp<"wrap"> {
   let hasCanonicalizer = 1;
 }
 
-def quake_NullWireOp : QuakeOp<"null_wire", []> {
+def quake_NullWireOp : QuakeOp<"null_wire"> {
   let summary = "Initial state of a wire.";
   let description = [{
     |0> - the initial state of a wire when first constructed. A wire is assumed

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -527,7 +527,7 @@ def quake_ResetOp : QuakeOp<"reset", [QuantumGate,
 // Sink
 //===----------------------------------------------------------------------===//
 
-def quake_SinkOp : QuakeOp<"sink", [QuantumGate]> {
+def quake_SinkOp : QuakeOp<"sink"> {
   let summary = "Sink for a qubit that is used but not measured.";
   let description = [{
     The `quake.sink` operation is used to mark a particular wire in the value

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -44,7 +44,9 @@ func.func @quantum_ops() {
   quake.wrap %18 to %4 : !quake.wire, !quake.ref
 
   // Control type conversion
-  %14 = quake.convert_ctrl %12 : (!quake.wire) -> !quake.control
+  %14 = quake.to_ctrl %12 : (!quake.wire) -> !quake.control
+  %a14 = quake.from_ctrl %14 : (!quake.control) -> !quake.wire
+  quake.sink %a14 : !quake.wire
 
   // Quantum operations, reference form
   quake.x %4 : (!quake.ref) -> ()
@@ -168,7 +170,9 @@ func.func @quantum_ops() {
 // CHECK:           %[[VAL_17:.*]] = quake.unwrap %[[VAL_5]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[VAL_18:.*]] = quake.reset %[[VAL_17]] : (!quake.wire) -> !quake.wire
 // CHECK:           quake.wrap %[[VAL_18]] to %[[VAL_5]] : !quake.wire, !quake.ref
-// CHECK:           %[[VAL_19:.*]] = quake.convert_ctrl %[[VAL_16]] : (!quake.wire) -> !quake.control
+// CHECK:           %[[VAL_19:.*]] = quake.to_ctrl %[[VAL_16]] : (!quake.wire) -> !quake.control
+// CHECK:           %[[WAL_19:.*]] = quake.from_ctrl %[[VAL_19]] : (!quake.control) -> !quake.wire
+// CHECK:           quake.sink %[[WAL_19]] : !quake.wire
 // CHECK:           quake.x %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:           quake.y %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:           quake.z %[[VAL_5]] : (!quake.ref) -> ()


### PR DESCRIPTION
This adds a quake.sink and quake.from_ctrl. Rename quake.convert_ctrl to quake.to_ctrl. Changes to deploy these new ops will be in a forthcoming PR.