### PR TITLE
More bridge work.

### DIFF
--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1790,7 +1790,8 @@ bool QuakeBridgeVisitor::TraverseInitListExpr(clang::InitListExpr *x,
   }
 
   // If the initializer-list is possibly a Callable type, preemptively add the
-  // signature of call operation (`operator()`) to the Module if not present.
+  // signature of the call operation (`operator()`) to the Module if not
+  // present.
   if (auto *ty = x->getType().getTypePtr())
     if (auto *tyDecl = ty->getAsRecordDecl())
       maybeAddCallOperationSignature(tyDecl);

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1781,33 +1781,48 @@ bool QuakeBridgeVisitor::TraverseInitListExpr(clang::InitListExpr *x,
                                               DataRecursionQueue *) {
   if (x->isSyntacticForm()) {
     // The syntactic form is the surface level syntax as typed by the user. This
-    // isn't really all the helpful during the lowering process. We want to deal
-    // with the semantic form. See below.
+    // isn't really all that helpful during the lowering process. We want to
+    // deal with the semantic form. See below.
     auto loc = toLocation(x);
     if (x->getNumInits() != 0)
       TODO_loc(loc, "initializer list containing elements");
     return true;
   }
 
+  // If the initializer-list is possibly a Callable type, preemptively add the
+  // signature of call operation (`operator()`) to the Module if not present.
   if (auto *ty = x->getType().getTypePtr())
     if (auto *tyDecl = ty->getAsRecordDecl())
       maybeAddCallOperationSignature(tyDecl);
+
+  // Since an initializer-list can be empty (no objects), push the type on the
+  // type stack. This will allow VisitInitListExpr, etc. to know what to do when
+  // there are no values.
+  [[maybe_unused]] auto typeStackDepth = typeStack.size();
   if (!TraverseType(x->getType()))
     return false;
+  assert(typeStack.size() == typeStackDepth + 1 &&
+         "expected a type for initializer-list");
+
+  // Now visit the elements of the list, if any.
   for (auto *subStmt : x->children())
     if (!TraverseStmt(subStmt))
       return false;
-  return WalkUpFromInitListExpr(x);
+
+  // And finish the post-order traversal.
+  auto result = WalkUpFromInitListExpr(x);
+  assert(typeStack.size() == typeStackDepth && "expected type to be consumed");
+  return result;
 }
 
 bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
   auto loc = toLocation(x);
   auto size = x->getNumInits();
+  auto initListTy = popType();
   if (size == 0) {
     // TODO: Maybe check that this is an instance of a callable class, if it is
     // a CXXRecordType.
-    auto ty = popType();
-    return pushValue(builder.create<cc::AllocaOp>(loc, ty));
+    return pushValue(builder.create<cc::AllocaOp>(loc, initListTy));
   }
 
   // List has 1 or more members.
@@ -1840,26 +1855,26 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
   }
 
   // Let's allocate some memory and store the init list elements there.
-
-  // Clear the types for the init expr, one for the vector<T> type
-  // and another for the type of the initializer_list elements
-  popType();
-  popType();
-
-  // This is a initlist on ints or floats, get which one
-  Type dataType = last.front().getType();
-
   // Add the array size value
   Value arrSize =
       getConstantInt(builder, loc, last.size(), builder.getI64Type());
 
-  // Allocate the required memory chunk
-  Value alloca = builder.create<cc::AllocaOp>(loc, dataType, arrSize);
+  // Allocate the required memory chunk.
+  // TODO: If the type is correctly constructed here it will be something like
+  // !cc.array<i32 x 4>. If that is the case, then we can drop the creation of
+  // the `arrSize` value altogether here. The size must be a compile-time
+  // constant as this is coming from a semantic-form of an initializer-list.
+  Type eleTy = [&]() {
+    if (auto arrTy = dyn_cast<cc::ArrayType>(initListTy))
+      return arrTy.getElementType();
+    return initListTy;
+  }();
+  Value alloca = builder.create<cc::AllocaOp>(loc, eleTy, arrSize);
 
   // Store the values in the allocated memory
   for (std::size_t i = 0; auto v : last) {
     Value ptr = builder.create<cc::ComputePtrOp>(
-        loc, cc::PointerType::get(dataType), alloca,
+        loc, cc::PointerType::get(eleTy), alloca,
         getConstantInt(builder, loc, i++, builder.getI64Type()));
     builder.create<cc::StoreOp>(loc, v, ptr);
   }


### PR DESCRIPTION
An initializer-list may be 0 or more elements in length. The elements are pushed as values on the value stack of the bridge. Because a list of length 0 has no elements, the type is *explicitly* visited for an initializer-list. That visit must push exactly 1 type at traversal and pop that type at visitation.

This change adds the assertions to check the above invariants. It also tweaks the visit method to make sure the type is always consumed.

Add more comments to indicate what is going on.

TODO: the concrete Quake type for an initializer-list ought to be `!cc.array<T x c>` where `c` is a compile-time constant. At present the type travsersal is pushing just the element type: `T`.
