### PR TITLE
Change CI workflow to use artifacts instead of caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [devdeps, wheeldeps]
 
-    outputs:
-      json: "${{ steps.read_json.outputs.result }}"
-
     steps:
-      - uses: cloudposse/github-action-matrix-outputs-read@0.1.1
-        id: read_json
-        with:
-          matrix-step-name: dev_environment
+      - name: Dummy configuration step to sync steps
+        run: |
+          echo "Dummy configuration step"
 
   build_and_test:
     name: Build and test
@@ -115,8 +111,8 @@ jobs:
     uses: ./.github/workflows/test_in_devenv.yml
     with:
       platform: linux/${{ matrix.platform }}
-      devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}-{1}', matrix.platform, matrix.toolchain)] }}
-      devdeps_archive: ${{ fromJson(needs.config.outputs.json).tar_archive[format('{0}-{1}', matrix.platform, matrix.toolchain)] }}
+      devdeps_cache: tar-devdeps-${{ matrix.toolchain }}-${{ matrix.platform }}-${{ github.sha }}
+      devdeps_archive: /tmp/devdeps.tar
       export_environment: ${{ github.event_name == 'workflow_dispatch' && inputs.export_environment }}
 
   docker_image:
@@ -129,8 +125,8 @@ jobs:
     uses: ./.github/workflows/docker_images.yml
     with:
       platforms: linux/${{ matrix.platform }}
-      devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}-llvm', matrix.platform)] }}
-      devdeps_archive: ${{ fromJson(needs.config.outputs.json).tar_archive[format('{0}-llvm', matrix.platform)] }}
+      devdeps_cache: tar-devdeps-llvm-${{ matrix.platform }}-${{ github.sha }}
+      devdeps_archive: /tmp/devdeps.tar
 
   python_wheels:
     name: Create Python wheels
@@ -144,8 +140,8 @@ jobs:
     with:
       platform: linux/${{ matrix.platform }}
       python_version: ${{ matrix.python_version }}
-      devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}-python', matrix.platform)] }}
-      devdeps_archive: ${{ fromJson(needs.config.outputs.json).tar_archive[format('{0}-python', matrix.platform)] }}
+      devdeps_cache: tar-devdeps-manylinux-gcc11-${{ matrix.platform }}-${{ github.sha }}
+      devdeps_archive: /tmp/devdeps.manylinux.tar
 
   clean_up:
     name: Prepare cache clean-up

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -281,7 +281,7 @@ jobs:
           fi
 
       - name: Check out local cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v3 # this fails most of the time, so ignore for now
         with:
           path: ${{ steps.cache.outputs.local_buildcache_path }}
           key: ${{ steps.cache.outputs.local_buildcache_key }}${{ steps.cache.outputs.local_buildcache_key_suffix }}
@@ -331,19 +331,23 @@ jobs:
             mv "$build_cache" "${{ steps.cache.outputs.local_buildcache_path }}"
           fi
 
-      - name: Upload build cache
+      - name: Upload build cache as artifact
         if: inputs.create_local_cache
-        uses: actions/cache/save@v3
+        uses: actions/upload-artifact@v3
         with:
+          name: ${{ steps.cache.outputs.local_buildcache_key }}${{ steps.cache.outputs.local_buildcache_key_suffix }}
           path: ${{ steps.cache.outputs.local_buildcache_path }}
-          key: ${{ steps.cache.outputs.local_buildcache_key }}${{ steps.cache.outputs.local_buildcache_key_suffix }}
+          retention-days: 5
+          if-no-files-found: error
 
-      - name: Cache ${{ needs.metadata.outputs.image_title }} image
+      - name: Upload artifact ${{ needs.metadata.outputs.image_title }}
         if: steps.cache.outputs.tar_cache && steps.cache.outputs.tar_archive
-        uses: actions/cache/save@v3
+        uses: actions/upload-artifact@v3
         with:
+          name: ${{ steps.cache.outputs.tar_cache }}
           path: ${{ steps.cache.outputs.tar_archive }}
-          key: ${{ steps.cache.outputs.tar_cache }}
+          retention-days: 5
+          if-no-files-found: error
 
   finalize:
     name: Finalize

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -170,12 +170,14 @@ jobs:
           TAGS: ${{ steps.metadata.outputs.tags }}
         run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
 
-      - name: Cache cuda-quantum image
+      - name: Upload cuda-quantum image artifact
         if: steps.build_info.outputs.tar_cache && steps.build_info.outputs.tar_archive
-        uses: actions/cache/save@v3
+        uses: actions/upload-artifact@v3
         with:
+          name: ${{ steps.build_info.outputs.tar_cache }}
           path: ${{ steps.build_info.outputs.tar_archive }}
-          key: ${{ steps.build_info.outputs.tar_cache }}
+          retention-days: 5
+          if-no-files-found: error
 
   cudaqdev_image:
     name: cuda-quantum-dev (debug)
@@ -217,17 +219,15 @@ jobs:
 
       - name: Restore build environment
         if: inputs.devdeps_cache && inputs.devdeps_archive
-        id: restore
-        uses: actions/cache/restore@v3
+        uses:  actions/download-artifact@v3
         with:
-          path: ${{ inputs.devdeps_archive }}
-          key: ${{ inputs.devdeps_cache }}
-          fail-on-cache-miss: true
+          name: ${{ inputs.devdeps_cache }}
+          path: /tmp
 
       - name: Load prerequisites
         id: prereqs
         run: |
-          if ${{ steps.restore.outcome != 'skipped' }}; then
+          if true; then
             load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
             base_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
             echo "Base image: $base_image" >> $GITHUB_STEP_SUMMARY
@@ -309,12 +309,14 @@ jobs:
           TAGS: ${{ steps.metadata.outputs.tags }}
         run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
 
-      - name: Cache cuda-quantum-dev image
+      - name: Upload cuda-quantum-dev image artifact
         if: steps.prereqs.outputs.tar_cache && steps.prereqs.outputs.tar_archive
-        uses: actions/cache/save@v3
+        uses: actions/upload-artifact@v3
         with:
+          name: ${{ steps.prereqs.outputs.tar_cache }}
           path: ${{ steps.prereqs.outputs.tar_archive }}
-          key: ${{ steps.prereqs.outputs.tar_cache }}
+          retention-days: 5
+          if-no-files-found: error
 
   cudaq_image:
     name: cuda-quantum (release)
@@ -359,17 +361,15 @@ jobs:
 
       - name: Restore build environment
         if: inputs.devdeps_cache && inputs.devdeps_archive
-        id: restore_devdeps
-        uses: actions/cache/restore@v3
+        uses:  actions/download-artifact@v3
         with:
-          path: ${{ inputs.devdeps_archive }}
-          key: ${{ inputs.devdeps_cache }}
-          fail-on-cache-miss: true
+          name: ${{ inputs.devdeps_cache }}
+          path: /tmp
 
       - name: Restore Open MPI dependencies
         id: restore_openmpi
         if: needs.ompi_image.outputs.tar_cache && needs.ompi_image.outputs.tar_archive
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v3 # Ignore Restore Open MPI dependencies for now
         with:
           path: ${{ needs.ompi_image.outputs.tar_archive }}
           key: ${{ needs.ompi_image.outputs.tar_cache }}
@@ -394,7 +394,7 @@ jobs:
             echo "Base image: $base_image" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if ${{ steps.restore_devdeps.outcome != 'skipped' }}; then
+          if true; then
             load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
             echo "$load_output"
             devdeps_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
@@ -539,12 +539,14 @@ jobs:
           push: ${{ inputs.environment != '' }}
           outputs: ${{ steps.prereqs.outputs.docker_output }}
 
-      - name: Cache cuda-quantum image
+      - name: Upload cuda-quantum image artifact
         if: steps.prereqs.outputs.tar_cache && steps.prereqs.outputs.tar_archive
-        uses: actions/cache/save@v3
+        uses: actions/upload-artifact@v3
         with:
+          name: ${{ steps.prereqs.outputs.tar_cache }}
           path: ${{ steps.prereqs.outputs.tar_archive }}
-          key: ${{ steps.prereqs.outputs.tar_cache }}
+          retention-days: 5
+          if-no-files-found: error
 
       - name: Sign image with GitHub OIDC Token
         if: inputs.environment && steps.prereqs.outputs.ngc_registry == ''
@@ -617,27 +619,23 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Restore CUDA Quantum build
-        id: restore_cudaqdev
         if: needs.cudaqdev_image.outputs.tar_cache && needs.cudaqdev_image.outputs.tar_archive
-        uses: actions/cache/restore@v3
+        uses:  actions/download-artifact@v3
         with:
-          path: ${{ needs.cudaqdev_image.outputs.tar_archive }}
-          key: ${{ needs.cudaqdev_image.outputs.tar_cache }}
-          fail-on-cache-miss: true
+          name: ${{ needs.cudaqdev_image.outputs.tar_cache }}
+          path: /tmp
 
       - name: Restore CUDA Quantum image
-        id: restore_cudaq
         if: needs.cudaq_image.outputs.tar_cache && needs.cudaq_image.outputs.tar_archive
-        uses: actions/cache/restore@v3
+        uses:  actions/download-artifact@v3
         with:
-          path: ${{ needs.cudaq_image.outputs.tar_archive }}
-          key: ${{ needs.cudaq_image.outputs.tar_cache }}
-          fail-on-cache-miss: true
+          name: ${{ needs.cudaq_image.outputs.tar_cache }}
+          path: /tmp
 
       - name: Build documentation
         id: docs_build
         run: |
-          if ${{ steps.restore_cudaq.outcome != 'skipped' }}; then
+          if true; then
             load_output=`docker load --input "${{ needs.cudaq_image.outputs.tar_archive }}"`
             cudaq_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
           else
@@ -650,7 +648,7 @@ jobs:
           docker image rm $cudaq_image
           docker image prune --force
 
-          if ${{ steps.restore_cudaqdev.outcome != 'skipped' }}; then
+          if true; then
             load_output=`docker load --input "${{ needs.cudaqdev_image.outputs.tar_archive }}"`
             cudaqdev_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
           else
@@ -712,17 +710,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Load cuda-quantum image
-        id: restore
         if: needs.cudaq_image.outputs.tar_cache && needs.cudaq_image.outputs.tar_archive
-        uses: actions/cache/restore@v3
+        uses:  actions/download-artifact@v3
         with:
-          path: ${{ needs.cudaq_image.outputs.tar_archive }}
-          key: ${{ needs.cudaq_image.outputs.tar_cache }}
-          fail-on-cache-miss: true
+          name: ${{ needs.cudaq_image.outputs.tar_cache }}
+          path: /tmp
 
       - name: Validate cuda-quantum image
         run: |
-          if ${{ steps.restore.outcome != 'skipped' }}; then
+          if true; then
             load_output=`docker load --input "${{ needs.cudaq_image.outputs.tar_archive }}"`
             cudaq_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
           else

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -48,17 +48,15 @@ jobs:
 
       - name: Restore build environment
         if: inputs.devdeps_cache && inputs.devdeps_archive
-        id: restore
-        uses: actions/cache/restore@v3
+        uses: actions/download-artifact@v3
         with:
-          path: ${{ inputs.devdeps_archive }}
-          key: ${{ inputs.devdeps_cache }}
-          fail-on-cache-miss: true
+          name: ${{ inputs.devdeps_cache }}
+          path: /tmp
 
       - name: Load prerequisites
         id: prereqs
         run: |
-          if ${{ steps.restore.outcome != 'skipped' }}; then
+          if true; then
             load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
             base_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
             echo "Base image: $base_image" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -28,12 +28,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Restore environment
-        uses: actions/cache/restore@v3
+      - name: Download artifact ${{ inputs.devdeps_archive }}
+        uses: actions/download-artifact@v3
         with:
-          path: ${{ inputs.devdeps_archive }}
-          key: ${{ inputs.devdeps_cache }}
-          fail-on-cache-miss: true
+          name: ${{ inputs.devdeps_cache }}
+          path: /tmp
 
       - name: Set up context for buildx
         run: |
@@ -107,12 +106,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Restore environment
-        uses: actions/cache/restore@v3
+      - name: Download artifact ${{ inputs.devdeps_archive }}
+        uses: actions/download-artifact@v3
         with:
-          path: ${{ inputs.devdeps_archive }}
-          key: ${{ inputs.devdeps_cache }}
-          fail-on-cache-miss: true
+          name: ${{ inputs.devdeps_cache }}
+          path: /tmp
 
       - name: Set up context for buildx
         run: |


### PR DESCRIPTION
Some of our CI jobs are failing due to cache quota exceedances, and this PR attempts to remedy that by changing the cache saves/restores to artifact uploads/downloads. This CI job takes ~45 minutes whereas the previous one took about 25 minutes; however, this one shouldn't intermittently fail like the current one. There are likely ways to further improve this, but I figured I'd post it and solicit feedback in case we feel the cache failures are hurting us too much.

Here is an example run with these updates: https://github.com/NVIDIA/cuda-quantum/actions/runs/6052806413