### PR TITLE
Changes to harden the processing of VarDecls.

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -540,7 +540,6 @@ private:
   clang::ItaniumMangleContext *mangler;
   std::string loweredFuncName;
   llvm::SmallVector<mlir::Value> negations;
-  std::size_t typeStackDepth = 0;
   bool skipCompoundScope : 1 = false;
   bool isEntry : 1 = false;
   /// If there is a catastrophic error in the bridge (there is no rational way

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1888,7 +1888,7 @@ bool QuakeBridgeVisitor::TraverseCXXConstructExpr(clang::CXXConstructExpr *x,
   if (x->isElidable())
     return true;
   [[maybe_unused]] auto typeStackDepth = typeStack.size();
-  if (auto *ctorDecl = x->getConstructor()) {
+  if (x->getConstructor()) {
     if (!TraverseType(x->getType()))
       return false;
     assert(typeStack.size() == typeStackDepth + 1);

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1887,36 +1887,57 @@ bool QuakeBridgeVisitor::TraverseCXXConstructExpr(clang::CXXConstructExpr *x,
                                                   DataRecursionQueue *) {
   if (x->isElidable())
     return true;
-  if (auto *ctor = x->getConstructor()) {
-    auto ctorName = ctor->getNameAsString();
-    // In the std::function constructor case, we want to traverse the type
-    // returned by the constructor since it is a high-level type and we cannot
-    // traverse any of the arguments from the visit method. This extra type will
-    // be popped from the stack in the visit method.
-    if (isInNamespace(ctor, "std") && ctorName == "function")
-      if (!TraverseType(x->getType()))
-        return false;
+  [[maybe_unused]] auto typeStackDepth = typeStack.size();
+  if (auto *ctorDecl = x->getConstructor()) {
+    if (!TraverseType(x->getType()))
+      return false;
+    assert(typeStack.size() == typeStackDepth + 1);
   }
-  return Base::TraverseCXXConstructExpr(x);
+  auto result = Base::TraverseCXXConstructExpr(x);
+  assert(typeStack.size() == typeStackDepth || raisedError);
+  return result;
 }
 
 bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
   auto loc = toLocation(x);
   if (auto *ctor = x->getConstructor()) {
+    // FIXME: shouldn't the ctor type be a function?
+    [[maybe_unused]] auto ctorTy = popType();
     auto ctorName = ctor->getNameAsString();
     if (isInNamespace(ctor, "cudaq")) {
-      if (ctorName == "qreg" || ctorName == "qspan") {
-        // This is a qreg q(N);
-        auto sizeVal = popValue();
-        if (isa<quake::VeqType>(sizeVal.getType()))
-          return pushValue(sizeVal);
-        assert(isa<IntegerType>(sizeVal.getType()));
-        return pushValue(builder.create<quake::AllocaOp>(
-            loc, quake::VeqType::getUnsized(builder.getContext()), sizeVal));
-      }
-      if (ctorName == "qudit") {
-        // This is a "cudaq::qudit/qubit q;"
-        return pushValue(builder.create<quake::AllocaOp>(loc));
+      if (x->getNumArgs() == 0) {
+        if (ctorName == "qudit") {
+          // This is a single qubit.
+          assert(isa<quake::RefType>(ctorTy));
+          return pushValue(builder.create<quake::AllocaOp>(loc));
+        }
+        // These classes have template arguments that may give a compile-time
+        // constant size. qarray is the only one that requires it, however.
+        if (ctorName == "qreg" || ctorName == "qarray" || ctorName == "qspan") {
+          [[maybe_unused]] auto veqTy = cast<quake::VeqType>(ctorTy);
+          assert(veqTy.hasSpecifiedSize());
+          return pushValue(builder.create<quake::AllocaOp>(loc, ctorTy));
+        }
+        if (ctorName == "qvector") {
+          // The default qvector ctor creates a veq of size 1.
+          assert(isa<quake::VeqType>(ctorTy));
+          auto veq1Ty = quake::VeqType::get(builder.getContext(), 1);
+          return pushValue(builder.create<quake::AllocaOp>(loc, veq1Ty));
+        }
+      } else if (x->getNumArgs() == 1) {
+        if (ctorName == "qreg" || ctorName == "qvector") {
+          // This is a cudaq::qreg(std::size_t).
+          auto sizeVal = popValue();
+          assert(isa<IntegerType>(sizeVal.getType()));
+          return pushValue(builder.create<quake::AllocaOp>(
+              loc, quake::VeqType::getUnsized(builder.getContext()), sizeVal));
+        }
+        if (ctorName == "qspan" && isa<quake::VeqType>(peekValue().getType())) {
+          // One of the qspan ctors, which effectively just makes a copy. Here
+          // we omit making a copy and just forward the veq argument.
+          assert(isa<quake::VeqType>(ctorTy));
+          return true;
+        }
       }
     } else if (isInNamespace(ctor, "std")) {
       auto isVectorOfQubitRefs = [&]() {
@@ -1937,7 +1958,6 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
         // Are we converting a lambda expr to a std::function?
         auto backVal = peekValue();
         auto backTy = backVal.getType();
-        auto ctorTy = popType();
         if (auto ptrTy = dyn_cast<cc::PointerType>(backTy))
           backTy = ptrTy.getElementType();
         if (backTy.isa<cc::CallableType>()) {
@@ -2023,15 +2043,19 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
             // This is an integer argument, and the value on the stack
             // is an integer, so let's connect them up
             auto arrSize = popValue();
-            auto dataType = popType();
+            auto eleTy = [&]() {
+              if (auto stdvecTy = dyn_cast<cc::StdvecType>(ctorTy))
+                return stdvecTy.getElementType();
+              return ctorTy;
+            }();
 
             // create stdvec init op without a buffer.
             // Allocate the required memory chunk
-            Value alloca = builder.create<cc::AllocaOp>(loc, dataType, arrSize);
+            Value alloca = builder.create<cc::AllocaOp>(loc, eleTy, arrSize);
 
             // Create the stdvec_init op
             return pushValue(builder.create<cc::StdvecInitOp>(
-                loc, cc::StdvecType::get(dataType), alloca, arrSize));
+                loc, cc::StdvecType::get(eleTy), alloca, arrSize));
           }
 
         // Disallow any default vector construction bc we don't

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -585,8 +585,8 @@ bool QuakeBridgeVisitor::VisitImplicitCastExpr(clang::ImplicitCastExpr *x) {
     return pushValue(subValue);
   }
   case clang::CastKind::CK_FloatingCast: {
-    auto dstType = x->getType();
-    auto val = x->getSubExpr();
+    [[maybe_unused]] auto dstType = x->getType();
+    [[maybe_unused]] auto val = x->getSubExpr();
     assert(val->getType()->isFloatingType() && dstType->isFloatingType());
     auto value = popValue();
     auto toType = cast<FloatType>(castToTy);

--- a/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -598,7 +598,7 @@ public:
           op->setAttr("is_adj", builder.getUnitAttr());
       }
 
-      auto *newOp = builder.clone(*op, mapper);
+      [[maybe_unused]] auto *newOp = builder.clone(*op, mapper);
       assert(newOp->getNumResults() == 0);
       op->erase();
     }

--- a/lib/Optimizer/Transforms/LowerUnwind.cpp
+++ b/lib/Optimizer/Transforms/LowerUnwind.cpp
@@ -321,7 +321,7 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
 
   LogicalResult matchAndRewrite(cudaq::cc::ScopeOp scope,
                                 PatternRewriter &rewriter) const override {
-    auto iter = infoMap.opParentMap.find(scope.getOperation());
+    [[maybe_unused]] auto iter = infoMap.opParentMap.find(scope.getOperation());
     assert(iter != infoMap.opParentMap.end() && iter->second.asPrimitive);
     LLVM_DEBUG(llvm::dbgs() << "replacing scope @" << scope.getLoc() << '\n');
     auto loc = scope.getLoc();
@@ -711,7 +711,7 @@ struct UnwindReturnOpPattern
 
   LogicalResult matchAndRewrite(cudaq::cc::UnwindReturnOp retOp,
                                 PatternRewriter &rewriter) const override {
-    auto iter = infoMap.opParentMap.find(retOp.getOperation());
+    [[maybe_unused]] auto iter = infoMap.opParentMap.find(retOp.getOperation());
     assert(iter != infoMap.opParentMap.end());
     auto *blk = rewriter.getInsertionBlock();
     auto pos = rewriter.getInsertionPoint();

--- a/test/AST-Quake/ctrl_vector.cpp
+++ b/test/AST-Quake/ctrl_vector.cpp
@@ -53,9 +53,8 @@ struct test_two_control_call {
 // CHECK:             quake.x %[[VAL_1]] : (!quake.ref) -> ()
 // CHECK:           } : !cc.callable<(!quake.ref) -> ()>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %[[VAL_3:.*]] = quake.relax_size %[[VAL_2]] : (!quake.veq<4>) -> !quake.veq<?>
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
-// CHECK:           quake.apply @__nvqpp__mlirgen__ZN21test_two_control_callcl[[LAMBDA:.*]]_[%[[VAL_3]]] %[[VAL_4]] : (!quake.veq<?>, !quake.ref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__ZN21test_two_control_callcl[[LAMBDA:.*]]_[%[[VAL_2]]] %[[VAL_4]] : (!quake.veq<4>, !quake.ref) -> ()
 // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> i1
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
Copies and customizes the traversal code from RecursiveASTVisitor to make the traversal uniform. Since much of the code in the nested macros of the visitor cannot be overridden, we have to resort to copying. [Issue raised on discourse. https://tinyurl.com/m9wbr9jm]

The traversal changes make it possible to have predictable behavior with respect to the type and value stacks which allows assertions to be added to enforce that visiting a type does, in fact, add 1 type to the top of the stack.

Also add more support for the newer cudaq classes to the bridge.

