### PR TITLE
Only create tar cache for dev dependencies when they are modified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
     uses: ./.github/workflows/test_in_devenv.yml
     with:
       platform: linux/${{ matrix.platform }}
+      devdeps_image: ${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-{1}', matrix.platform, matrix.toolchain)] }}
       devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}-{1}', matrix.platform, matrix.toolchain)] }}
       devdeps_archive: ${{ fromJson(needs.config.outputs.json).tar_archive[format('{0}-{1}', matrix.platform, matrix.toolchain)] }}
       export_environment: ${{ github.event_name == 'workflow_dispatch' && inputs.export_environment }}
@@ -129,6 +130,7 @@ jobs:
     uses: ./.github/workflows/docker_images.yml
     with:
       platforms: linux/${{ matrix.platform }}
+      devdeps_image: ${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-llvm', matrix.platform)] }}
       devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}-llvm', matrix.platform)] }}
       devdeps_archive: ${{ fromJson(needs.config.outputs.json).tar_archive[format('{0}-llvm', matrix.platform)] }}
 
@@ -144,6 +146,7 @@ jobs:
     with:
       platform: linux/${{ matrix.platform }}
       python_version: ${{ matrix.python_version }}
+      devdeps_image: ${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-python', matrix.platform)] }}
       devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}-python', matrix.platform)] }}
       devdeps_archive: ${{ fromJson(needs.config.outputs.json).tar_archive[format('{0}-python', matrix.platform)] }}
 

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -371,6 +371,16 @@ jobs:
               docker_manifest="$regctl image manifest"
               platform_sha=`$docker_manifest $remote_image@$remote_sha --format='{{json .}}' | jq -r '.manifests[] | select(.platform.architecture=="${{ needs.metadata.outputs.platform_tag }}").digest'`
               existing_layers=`$docker_manifest $remote_image@$platform_sha --format='{{json .}}' | jq '.layers[].digest'`
+
+              # With docker manifest inspect or regctl image manifest we get the sha of the compressed layers
+              # whereas the docker inspect command for the RootFS lists the sha for the uncompressed archive.
+              # See also https://stackoverflow.com/questions/61366738/how-are-the-docker-image-layer-ids-derived/69688979#69688979
+              # I haven't found a way to get the sha for the compressed layers for a local images, 
+              # and hence needed to download the one from the registry to compare the uncompressed ones.
+              # See also https://github.com/docker/cli/issues/3350.
+
+              docker pull $remote_image@$remote_sha
+              existing_layers=`docker inspect $remote_image@$remote_sha --format='{{json .RootFS}}' | jq '.Layers[]'`
             fi
 
             image_metadata=${{ steps.docker_build.outcome.Metadata }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -350,8 +350,9 @@ jobs:
           elif ${{ steps.cache.outputs.docker_output != '' }}; then
             # Check if an image with the same layers exists on the registry.
             # If so, use that image instead of uploading a tar cache.
-            docker load --input "${{ steps.cache.outputs.tar_archive }}"
-            expected_layers=`docker inspect ${{ steps.docker_build.outputs.digest }} --format='{{json .RootFS}}' | jq '.Layers[]'`
+            load_output=`docker load --input "${{ steps.cache.outputs.tar_archive }}"`
+            built_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
+            expected_layers=`docker inspect $built_image --format='{{json .RootFS}}' | jq '.Layers[]'`
 
             platform_tag=${{ needs.metadata.outputs.platform_tag }}
             remote_tag=`echo ${{ needs.metadata.outputs.tag_prefix }}${{ steps.cache.outputs.registry_cache_base }}${{ needs.metadata.outputs.tag_suffix }} | sed s/"${platform_tag:+$platform_tag-}"//`

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -348,51 +348,44 @@ jobs:
             image_hash=${{ needs.metadata.outputs.image_name }}@${{ steps.docker_build.outputs.digest }}
             echo "image_hash=$image_hash" >> $GITHUB_OUTPUT
           elif ${{ steps.cache.outputs.docker_output != '' }}; then
-
-            mkdir archive && tar xf "${{ steps.cache.outputs.tar_archive }}" -C archive
-            config=`cat archive/manifest.json | jq -r '.[].Config'`
-            echo "MANIFEST FROM ARCHIVE:"
-            cat "archive/$config" && rm -rf archive
-
             # Check if an image with the same layers exists on the registry.
             # If so, use that image instead of uploading a tar cache.
             load_output=`docker load --input "${{ steps.cache.outputs.tar_archive }}"`
             built_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
             expected_layers=`docker inspect $built_image --format='{{json .RootFS}}' | jq '.Layers[]'`
 
+            # While we can inspect an image manifest without pulling the image using either
+            # `docker manifest inspect` for new enough docker versions, or `regctl image manifest`,
+            # the digests for the layers are computed based on the *compressed* layers (blobs on the registry).
+            # It is not possible to compare those to the layers listed for the local tar archive, 
+            # since inspecting the local image necessarily identifies layers based on the content of the 
+            # *uncompressed* archive. To compare a local image against one pushed to the registry, 
+            # we hence first need to download the one from the registry.
+            # See also:
+            # - https://stackoverflow.com/questions/61366738/how-are-the-docker-image-layer-ids-derived/69688979#69688979
+            # - https://github.com/docker/cli/issues/3350.
+
             remote_image=ghcr.io/${{ needs.metadata.outputs.owner }}/${{ needs.metadata.outputs.image_title }}
-            platform_tag=${{ needs.metadata.outputs.platform_tag }}
-            remote_tag=`echo ${{ needs.metadata.outputs.tag_prefix }}${{ steps.cache.outputs.registry_cache_base }}${{ needs.metadata.outputs.tag_suffix }} | sed s/"${platform_tag:+$platform_tag-}"//`
-            regctl="docker container run -i --rm ghcr.io/regclient/regctl@sha256:f566dcdb1c64a93980b23ee342a5800ccf7437e17c329447b9dcdf35b81162b0"
-            remote_sha=`$regctl image digest --list $remote_image:$remote_tag || true`
-            echo "Checking layers of remote image $remote_image:$remote_tag (sha: $remote_sha)."
-            if [ "$remote_sha" != "" ]; then
-              # With newer docker versions, we could use docker manifest inspect instead.
-              docker_manifest="$regctl image manifest"
-              platform_sha=`$docker_manifest $remote_image@$remote_sha --format='{{json .}}' | jq -r '.manifests[] | select(.platform.architecture=="${{ needs.metadata.outputs.platform_tag }}").digest'`
-              existing_layers=`$docker_manifest $remote_image@$platform_sha --format='{{json .}}' | jq '.layers[].digest'`
-
-              # With docker manifest inspect or regctl image manifest we get the sha of the compressed layers
-              # whereas the docker inspect command for the RootFS lists the sha for the uncompressed archive.
-              # See also https://stackoverflow.com/questions/61366738/how-are-the-docker-image-layer-ids-derived/69688979#69688979
-              # I haven't found a way to get the sha for the compressed layers for a local images, 
-              # and hence needed to download the one from the registry to compare the uncompressed ones.
-              # See also https://github.com/docker/cli/issues/3350.
-
-              docker pull $remote_image@$remote_sha
-              existing_layers=`docker inspect $remote_image@$remote_sha --format='{{json .RootFS}}' | jq '.Layers[]'`
+            remote_tag=${{ needs.metadata.outputs.tag_prefix }}${{ steps.cache.outputs.registry_cache_base }}${{ needs.metadata.outputs.tag_suffix }}
+            echo "Trying to pull remote tag $remote_image:$remote_tag."
+            docker pull $remote_image:$remote_tag || true
+            if [ "$(docker images -q $remote_image:$remote_tag 2> /dev/null)" == "" ]; then
+              platform_tag=${{ needs.metadata.outputs.platform_tag }}
+              remote_tag=`echo $remote_tag | sed s/"${platform_tag:+$platform_tag-}"//`
+              echo "Trying to pull remote tag $remote_image:$remote_tag."
+              docker pull $remote_image:$remote_tag || true
             fi
 
-            image_metadata=${{ steps.docker_build.outcome.Metadata }}
-            echo "## $(echo "$image_metadata" | jq -r '."image.name"')" >> $GITHUB_STEP_SUMMARY
-            echo "Image layers: " >> $GITHUB_STEP_SUMMARY
-            echo "$expected_layers" >> $GITHUB_STEP_SUMMARY
-            echo "Latest version on GHCR: " >> $GITHUB_STEP_SUMMARY
-            echo "$existing_layers" >> $GITHUB_STEP_SUMMARY
+            if [ "$(docker images -q $remote_image:$remote_tag 2> /dev/null)" != "" ]; then
+              remote_hash=`docker inspect $remote_image:$remote_tag --format='{{index .RepoDigests 0}}'`
+              echo "Checking layers of pulled image $remote_hash."
+              existing_layers=`docker inspect $remote_hash --format='{{json .RootFS}}' | jq '.Layers[]'`
 
-            if [ "$expected_layers" == "$existing_layers" ]; then 
-              image_hash=$remote_image@$remote_sha
-              echo "image_hash=$image_hash" >> $GITHUB_OUTPUT
+              echo "Required image layers:" && echo "$expected_layers"
+              echo "Latest version on GHCR:" && echo "$existing_layers"
+              if [ "$expected_layers" == "$existing_layers" ]; then 
+                echo "image_hash=$remote_hash" >> $GITHUB_OUTPUT
+              fi  
             fi
           fi
 

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -357,12 +357,22 @@ jobs:
             remote_image=ghcr.io/${{ needs.metadata.outputs.owner }}/${{ needs.metadata.outputs.image_title }}
             platform_tag=${{ needs.metadata.outputs.platform_tag }}
             remote_tag=`echo ${{ needs.metadata.outputs.tag_prefix }}${{ steps.cache.outputs.registry_cache_base }}${{ needs.metadata.outputs.tag_suffix }} | sed s/"${platform_tag:+$platform_tag-}"//`
-            remote_sha=`docker container run -i --rm ghcr.io/regclient/regctl@sha256:f566dcdb1c64a93980b23ee342a5800ccf7437e17c329447b9dcdf35b81162b0 image digest --list $remote_image:$remote_tag || true`
+            regctl="docker container run -i --rm ghcr.io/regclient/regctl@sha256:f566dcdb1c64a93980b23ee342a5800ccf7437e17c329447b9dcdf35b81162b0"
+            remote_sha=`$regctl image digest --list $remote_image:$remote_tag || true`
             echo "Checking layers of remote image $remote_image:$remote_tag (sha: $remote_sha)."
             if [ "$remote_sha" != "" ]; then
-              platform_sha=`docker manifest inspect $remote_image@$remote_sha | jq -r '.manifests[] | select(.platform.architecture=="${{ needs.metadata.outputs.platform_tag }}").digest'`
-              existing_layers=`docker manifest inspect ghcr.io/nvidia/cuda-quantum@$platform_sha | jq '.layers[].digest'`
+              # With newer docker versions, we could use docker manifest inspect instead.
+              docker_manifest="$regctl image manifest"
+              platform_sha=`$docker_manifest $remote_image@$remote_sha --format='{{json .}}' | jq -r '.manifests[] | select(.platform.architecture=="${{ needs.metadata.outputs.platform_tag }}").digest'`
+              existing_layers=`$docker_manifest $remote_image@$platform_sha --format='{{json .}}' | jq '.layers[].digest'`
             fi
+
+            image_metadata=${{ fromJson(steps.docker_build.outcome.Metadata) }}
+            echo "## $(echo "$image_metadata" | jq -r '."image.name"')" >> $GITHUB_STEP_SUMMARY
+            echo "Image layers: " >> $GITHUB_STEP_SUMMARY
+            echo "$expected_layers" >> $GITHUB_STEP_SUMMARY
+            echo "Latest version on GHCR: " >> $GITHUB_STEP_SUMMARY
+            echo "$existing_layers" >> $GITHUB_STEP_SUMMARY
 
             if [ "$expected_layers" == "$existing_layers" ]; then 
               image_hash=$remote_image@$remote_sha

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -354,17 +354,18 @@ jobs:
             built_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
             expected_layers=`docker inspect $built_image --format='{{json .RootFS}}' | jq '.Layers[]'`
 
+            remote_image=ghcr.io/${{ needs.metadata.outputs.owner }}/${{ needs.metadata.outputs.image_title }}
             platform_tag=${{ needs.metadata.outputs.platform_tag }}
             remote_tag=`echo ${{ needs.metadata.outputs.tag_prefix }}${{ steps.cache.outputs.registry_cache_base }}${{ needs.metadata.outputs.tag_suffix }} | sed s/"${platform_tag:+$platform_tag-}"//`
-            remote_sha=`docker container run -i --rm ghcr.io/regclient/regctl@sha256:f566dcdb1c64a93980b23ee342a5800ccf7437e17c329447b9dcdf35b81162b0 image digest --list ${{ needs.metadata.outputs.image_name }}:$remote_tag || true`
-            echo "Checking layers of remote image ${{ needs.metadata.outputs.image_name }}:$remote_tag (sha: $remote_sha)."
+            remote_sha=`docker container run -i --rm ghcr.io/regclient/regctl@sha256:f566dcdb1c64a93980b23ee342a5800ccf7437e17c329447b9dcdf35b81162b0 image digest --list $remote_image:$remote_tag || true`
+            echo "Checking layers of remote image $remote_image:$remote_tag (sha: $remote_sha)."
             if [ "$remote_sha" != "" ]; then
-              platform_sha=`docker manifest inspect ${{ needs.metadata.outputs.image_name }}@$remote_sha | jq -r '.manifests[] | select(.platform.architecture=="${{ needs.metadata.outputs.platform_tag }}").digest'`
+              platform_sha=`docker manifest inspect $remote_image@$remote_sha | jq -r '.manifests[] | select(.platform.architecture=="${{ needs.metadata.outputs.platform_tag }}").digest'`
               existing_layers=`docker manifest inspect ghcr.io/nvidia/cuda-quantum@$platform_sha | jq '.layers[].digest'`
             fi
 
             if [ "$expected_layers" == "$existing_layers" ]; then 
-              image_hash=${{ needs.metadata.outputs.image_name }}@$remote_sha
+              image_hash=$remote_image@$remote_sha
               echo "image_hash=$image_hash" >> $GITHUB_OUTPUT
             fi
           fi

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -81,6 +81,8 @@ jobs:
     outputs:
       runner: ${{ steps.build_info.outputs.runner }}
       platform_tag: ${{ steps.build_info.outputs.platform_tag }}
+      tag_prefix: ${{ steps.build_info.outputs.tag_prefix }}
+      tag_suffix: ${{ steps.build_info.outputs.tag_suffix }}
       dockerfile: ${{ steps.build_info.outputs.dockerfile }}
       owner: ${{ steps.build_info.outputs.owner }}
       image_name: ${{ steps.build_info.outputs.image_name }}
@@ -175,10 +177,10 @@ jobs:
       id-token: write
 
     outputs:
-      tar_cache: ${{ steps.cache.outputs.tar_cache }}
-      tar_archive: ${{ steps.cache.outputs.tar_archive }}
+      tar_cache: ${{ steps.cache_upload.outcome != 'skipped' && steps.cache.outputs.tar_cache || '' }}
+      tar_archive: ${{ steps.cache_upload.outcome != 'skipped' && steps.cache.outputs.tar_archive || '' }}
       build_cache: ${{ steps.cache.outputs.build_cache }}
-      image_hash: ${{ needs.metadata.outputs.image_name }}@${{ steps.docker_build.outputs.digest }}
+      image_hash: ${{ steps.uploaded_image.outputs.image_hash }}
 
     environment:
       name: ${{ inputs.environment || 'default' }}
@@ -206,7 +208,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Create cache locations
+      - name: Determine cache locations
         id: cache
         run: |
           toolchain=${{ inputs.toolchain }}
@@ -273,6 +275,7 @@ jobs:
 
           echo "cache_to=$cache_to" >> $GITHUB_OUTPUT
           echo "build_cache=$build_cache" >> $GITHUB_OUTPUT
+          echo "registry_cache_base=$registry_cache_base" >> $GITHUB_OUTPUT
           if ${{ inputs.environment == '' && ! inputs.registry_cache_update_only }}; then
             tar_archive=/tmp/${{ needs.metadata.outputs.image_id }}.tar
             echo "tar_cache=tar-${cache_id}-${platform_id}${local_buildcache_key_suffix}" >> $GITHUB_OUTPUT
@@ -338,8 +341,36 @@ jobs:
           path: ${{ steps.cache.outputs.local_buildcache_path }}
           key: ${{ steps.cache.outputs.local_buildcache_key }}${{ steps.cache.outputs.local_buildcache_key_suffix }}
 
+      - name: Check for existing image
+        id: uploaded_image
+        run: |
+          if ${{ inputs.environment && ! inputs.registry_cache_update_only || false }}; then
+            image_hash=${{ needs.metadata.outputs.image_name }}@${{ steps.docker_build.outputs.digest }}
+            echo "image_hash=$image_hash" >> $GITHUB_OUTPUT
+          elif ${{ steps.cache.outputs.docker_output != '' }}; then
+            # Check if an image with the same layers exists on the registry.
+            # If so, use that image instead of uploading a tar cache.
+            docker load --input "${{ steps.cache.outputs.tar_archive }}"
+            expected_layers=`docker inspect ${{ steps.docker_build.outputs.digest }} --format='{{json .RootFS}}' | jq '.Layers[]'`
+
+            platform_tag=${{ needs.metadata.outputs.platform_tag }}
+            remote_tag=`echo ${{ needs.metadata.outputs.tag_prefix }}${{ steps.cache.outputs.registry_cache_base }}${{ needs.metadata.outputs.tag_suffix }} | sed s/"${platform_tag:+$platform_tag-}"//`
+            remote_sha=`docker container run -i --rm ghcr.io/regclient/regctl@sha256:f566dcdb1c64a93980b23ee342a5800ccf7437e17c329447b9dcdf35b81162b0 image digest --list ${{ needs.metadata.outputs.image_name }}:$remote_tag || true`
+            echo "Checking layers of remote image ${{ needs.metadata.outputs.image_name }}:$remote_tag (sha: $remote_sha)."
+            if [ "$remote_sha" != "" ]; then
+              platform_sha=`docker manifest inspect ${{ needs.metadata.outputs.image_name }}@$remote_sha | jq -r '.manifests[] | select(.platform.architecture=="${{ needs.metadata.outputs.platform_tag }}").digest'`
+              existing_layers=`docker manifest inspect ghcr.io/nvidia/cuda-quantum@$platform_sha | jq '.layers[].digest'`
+            fi
+
+            if [ "$expected_layers" == "$existing_layers" ]; then 
+              image_hash=${{ needs.metadata.outputs.image_name }}@$remote_sha
+              echo "image_hash=$image_hash" >> $GITHUB_OUTPUT
+            fi
+          fi
+
       - name: Cache ${{ needs.metadata.outputs.image_title }} image
-        if: steps.cache.outputs.tar_cache && steps.cache.outputs.tar_archive
+        id: cache_upload
+        if: steps.cache.outputs.docker_output != '' && steps.uploaded_image.outputs.image_hash == ''
         uses: actions/cache/save@v3
         with:
           path: ${{ steps.cache.outputs.tar_archive }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -348,6 +348,12 @@ jobs:
             image_hash=${{ needs.metadata.outputs.image_name }}@${{ steps.docker_build.outputs.digest }}
             echo "image_hash=$image_hash" >> $GITHUB_OUTPUT
           elif ${{ steps.cache.outputs.docker_output != '' }}; then
+
+            mkdir archive && tar xf "${{ steps.cache.outputs.tar_archive }}" -C archive
+            config=`cat archive/manifest.json | jq -r '.[].Config'`
+            echo "MANIFEST FROM ARCHIVE:"
+            cat "archive/$config" && rm -rf archive
+
             # Check if an image with the same layers exists on the registry.
             # If so, use that image instead of uploading a tar cache.
             load_output=`docker load --input "${{ steps.cache.outputs.tar_archive }}"`

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -367,7 +367,7 @@ jobs:
               existing_layers=`$docker_manifest $remote_image@$platform_sha --format='{{json .}}' | jq '.layers[].digest'`
             fi
 
-            image_metadata=${{ fromJson(steps.docker_build.outcome.Metadata) }}
+            image_metadata=${{ steps.docker_build.outcome.Metadata }}
             echo "## $(echo "$image_metadata" | jq -r '."image.name"')" >> $GITHUB_STEP_SUMMARY
             echo "Image layers: " >> $GITHUB_STEP_SUMMARY
             echo "$expected_layers" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -5,6 +5,9 @@ on:
         type: string
         required: false
         default: linux/amd64
+      devdeps_image:
+        required: false
+        type: string
       devdeps_cache:
         required: true
         type: string
@@ -29,6 +32,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Restore environment
+        id: restore_devdeps
+        if: inputs.devdeps_image == ''
         uses: actions/cache/restore@v3
         with:
           path: ${{ inputs.devdeps_archive }}
@@ -47,17 +52,20 @@ jobs:
       - name: Build CUDA Quantum
         id: cudaq_build
         run: |
-          load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
-          base_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
-          devdeps_tag=`echo $base_image | rev | cut -d ":" -f 1 | rev`
+          if ${{ steps.restore_devdeps.outcome != 'skipped' }}; then
+            load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
+            base_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
+          elif ${{ inputs.devdeps_image != '' }}; then
+            base_image=${{ inputs.devdeps_image }}
+          else
+            echo "::error file=test_in_devenv.yml::Missing configuration for development dependencies. Either specify the image (i.e. provide devdeps_image) or cache (i.e. provide devdeps_cache and devdeps_archive) that should be used for the build."
+            exit 1
+          fi
 
           DOCKER_BUILDKIT=1 docker build --platform ${{ inputs.platform }} \
             -t cuda-quantum-dev:local -f docker/build/cudaq.dev.Dockerfile . \
             --build-arg base_image=$base_image \
             --build-arg install="CMAKE_BUILD_TYPE=Debug"
-          
-          tag_prefix=`echo $devdeps_tag | cut -d "_" -f 1`
-          echo "tag_prefix=$tag_prefix" >> $GITHUB_OUTPUT
 
       - name: Test CUDA Quantum
         uses: addnab/docker-run-action@v3
@@ -80,7 +88,8 @@ jobs:
         if: inputs.export_environment
         run: |
           output_directory=/tmp
-          filename=${{ steps.cudaq_build.outputs.tag_prefix }}_build
+          platform_id=`echo ${{ inputs.platform }} | sed 's/linux\///g' | tr -d ' '`
+          filename=${platform_id}_debug_build
 
           docker run --name cuda-quantum-dev cuda-quantum-dev:local
           docker export cuda-quantum-dev > $output_directory/$filename.tar
@@ -108,6 +117,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Restore environment
+        id: restore_devdeps
+        if: inputs.devdeps_image == ''
         uses: actions/cache/restore@v3
         with:
           path: ${{ inputs.devdeps_archive }}
@@ -126,16 +137,19 @@ jobs:
       - name: Set up dev environment
         id: dev_env
         run: |
-          load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
-          base_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
-          devdeps_tag=`echo $base_image | rev | cut -d ":" -f 1 | rev`
+          if ${{ steps.restore_devdeps.outcome != 'skipped' }}; then
+            load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
+            base_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
+          elif ${{ inputs.devdeps_image != '' }}; then
+            base_image=${{ inputs.devdeps_image }}
+          else
+            echo "::error file=test_in_devenv.yml::Missing configuration for development dependencies. Either specify the image (i.e. provide devdeps_image) or cache (i.e. provide devdeps_cache and devdeps_archive) that should be used for the build."
+            exit 1
+          fi
 
           DOCKER_BUILDKIT=1 docker build --platform ${{ inputs.platform }} \
             -t dev_env:local -f docker/build/cudaq.dev.Dockerfile . \
             --build-arg base_image=$base_image 
-
-          tag_prefix=`echo $devdeps_tag | cut -d "_" -f 1`
-          echo "tag_prefix=py_$tag_prefix" >> $GITHUB_OUTPUT
 
       - name: Build and test CUDA Quantum (Python)
         uses: addnab/docker-run-action@v3
@@ -171,7 +185,8 @@ jobs:
         if: inputs.export_environment
         run: |
           output_directory=/tmp
-          filename=${{ steps.dev_env.outputs.tag_prefix }}_build
+          platform_id=`echo ${{ inputs.platform }} | sed 's/linux\///g' | tr -d ' '`
+          filename=${platform_id}_python_build
 
           docker run --name dev_env dev_env:local
           docker export dev_env > $output_directory/$filename.tar


### PR DESCRIPTION
This PR adds a step to the dev_environment.yml workflow that checks if the latest image on the GHCR registry match the layers needed for the build. If they do, it omits pushing them into the GH cache to reduce cache usage and instead uses the image from the registry in subsequent steps. This should address the issue that the cache upload occasionally failed due to hitting the 10GB/5min limit that GitHub sets, resulting in pipeline failures. Build times remain the same. We are still using the GH cache for the CUDA Quantum builds that are shared between different jobs of the python wheel validation and the docker image validation during CI. However, the dev dependencies make up most of the cache usage, such that relying on the cache should be fine for those.