### PR TITLE
Publishing workflow with cross-platform downstream assets

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -363,6 +363,7 @@ jobs:
     strategy:
       matrix:
         info_file: ${{ fromJson(needs.assets.outputs.python_wheels).info_files }}
+        python_version: ['3.8', '3.9', '3.10', '3.11']
       fail-fast: false
 
     steps:
@@ -398,11 +399,10 @@ jobs:
           echo "platform_arch=$platform_arch" >> $GITHUB_OUTPUT
           echo "cudaqwheeldeps_image=$cudaqwheeldeps_image" >> $GITHUB_OUTPUT
           echo "assets_folder=$assets_folder" >> $GITHUB_OUTPUT
+          echo "docker_output=type=local,dest=/tmp/wheels" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.REPO_BOT_ACCESS_TOKEN }}
 
-      # TODO: Create python wheels that include simulator extensions.
-      # For now, we just download the already built wheels from the deployment run.
       - name: Build cuda-quantum wheel
         id: build_wheel
         uses: docker/build-push-action@v4
@@ -410,11 +410,11 @@ jobs:
           context: .
           file: ./docker/build/cudaq.wheel.Dockerfile
           build-args: |
-            base_image=${{ steps.prereqs.outputs.base_image }}
-            release_version=${{ steps.prereqs.outputs.cudaq_version }}
+            base_image=${{ steps.release_info.outputs.cudaqwheeldeps_image }}  
+            release_version=${{steps.release_info.outputs.release_id  }}
             assets=${{ steps.release_info.outputs.assets_folder }}
-            python_version=${{ inputs.python_version }}
-          outputs: ${{ steps.prereqs.outputs.docker_output }}
+            python_version=$python_version
+          outputs: ${{ steps.release_info.outputs.docker_output }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -405,26 +405,16 @@ jobs:
       # For now, we just download the already built wheels from the deployment run.
       - name: Build cuda-quantum wheel
         id: build_wheel
-        run: |
-          artifacts_url=${{ needs.assets.outputs.artifacts_url }}
-          artifacts=$(gh api $artifacts_url -q '.artifacts[] | {name: .name, url: .archive_download_url}')
-
-          mkdir -p /tmp/wheels
-          for artifact in `echo "$artifacts"`; do
-            name=`echo $artifact | jq -r '.name'`
-            if [ "${name#pycudaq-}" != "$name" ]; then
-              url=`echo $artifact | jq -r '.url'`
-              gh api $url > _pycudaq.zip
-              unzip -d _pycudaq _pycudaq.zip && cd _pycudaq
-              for wheel in `ls cuda_quantum-*-manylinux_*_${{ steps.release_info.outputs.platform_arch }}.whl 2> /dev/null`; do
-                echo "Adding wheel $wheel."
-                mv $wheel "/tmp/wheels/$wheel"
-              done
-              cd .. && rm -rf _pycudaq*
-            fi
-          done
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./docker/build/cudaq.wheel.Dockerfile
+          build-args: |
+            base_image=${{ steps.prereqs.outputs.base_image }}
+            release_version=${{ steps.prereqs.outputs.cudaq_version }}
+            assets=${{ steps.release_info.outputs.assets_folder }}
+            python_version=${{ inputs.python_version }}
+          outputs: ${{ steps.prereqs.outputs.docker_output }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/docker/build/cudaq.wheel.Dockerfile
+++ b/docker/build/cudaq.wheel.Dockerfile
@@ -23,8 +23,28 @@ ARG workspace=.
 ARG destination=cuda-quantum
 ADD "$workspace" "$destination"
 
+ARG assets=./assets
+COPY "$assets/" "$workspace/assets/"
+ENV CUDAQ_EXTERNAL_NVQIR_SIMS=""
+
 ARG python_version=3.10
-RUN echo "Building wheel for python${python_version}." \
+RUN echo "Finding external NVQIR simulators." \
+    && \
+    for config_file in `find $workspace/assets/wheels_$(uname -m)/*.config -maxdepth 0 -type f`; \
+        do \
+            current_dir="$(dirname "${config_file}")" \
+            && current_dir=$(cd $current_dir; pwd) \
+            && target_name=${config_file##*/} \
+            && target_name=${target_name%.config} \
+            && \
+                if [ -n "$CUDAQ_EXTERNAL_NVQIR_SIMS" ]; then \
+                    export CUDAQ_EXTERNAL_NVQIR_SIMS="$CUDAQ_EXTERNAL_NVQIR_SIMS;$current_dir/libnvqir-$target_name.so;$current_dir/$target_name.config"; \
+                else \
+                    export CUDAQ_EXTERNAL_NVQIR_SIMS="$current_dir/libnvqir-$target_name.so;$current_dir/$target_name.config"; \
+                fi \
+        done \
+    && echo "External NVQIR simulators: '$CUDAQ_EXTERNAL_NVQIR_SIMS'" \
+    && echo "Building wheel for python${python_version}." \
     && cd cuda-quantum && python=python${python_version} \
     && $python -m pip install --no-cache-dir \
         cmake auditwheel \
@@ -37,12 +57,16 @@ RUN echo "Building wheel for python${python_version}." \
         CUDAQ_BUILD_SELFCONTAINED=ON \
         CUDACXX="$CUDA_INSTALL_PREFIX/bin/nvcc" CUDAHOSTCXX=$CXX \
         $python -m build --wheel \
-    && LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/_skbuild/lib" \
+    && LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/_skbuild/lib:$workspace/assets/wheels_$(uname -m)/lib" \
         $python -m auditwheel -v repair dist/cuda_quantum-*linux_*.whl \
             --exclude libcustatevec.so.1 \
             --exclude libcutensornet.so.2 \
             --exclude libcublas.so.11 \
-            --exclude libcublasLt.so.11
+            --exclude libcublasLt.so.11 \
+            --exclude libcusolver.so.11 \
+            --exclude libcutensor.so.1 \
+            --exclude libnvToolsExt.so.1 \ 
+            --exclude libcudart.so.11.0 
 
 FROM scratch
 COPY --from=wheelbuild /cuda-quantum/wheelhouse/*manylinux*.whl . 

--- a/docker/release/cudaq.ext.Dockerfile
+++ b/docker/release/cudaq.ext.Dockerfile
@@ -15,7 +15,7 @@ ARG assets=./assets
 COPY "$assets" "$CUDA_QUANTUM_PATH/assets/"
 
 ADD ./scripts/migrate_assets.sh "$CUDA_QUANTUM_PATH/bin/migrate_assets.sh"
-RUN for folder in `find "$CUDA_QUANTUM_PATH/assets"/* -maxdepth 0 -type d`; \
+RUN for folder in `find "$CUDA_QUANTUM_PATH/assets"/*$(uname -m) -maxdepth 0 -type d`; \
     do bash "$CUDA_QUANTUM_PATH/bin/migrate_assets.sh" "$folder" && rm -rf "$folder"; done \
     && rm "$CUDA_QUANTUM_PATH/bin/migrate_assets.sh"
 

--- a/docker/release/cudaq.ext.Dockerfile
+++ b/docker/release/cudaq.ext.Dockerfile
@@ -15,7 +15,7 @@ ARG assets=./assets
 COPY "$assets" "$CUDA_QUANTUM_PATH/assets/"
 
 ADD ./scripts/migrate_assets.sh "$CUDA_QUANTUM_PATH/bin/migrate_assets.sh"
-RUN for folder in `find "$CUDA_QUANTUM_PATH/assets"/*$(uname -m) -maxdepth 0 -type d`; \
+RUN for folder in `find "$CUDA_QUANTUM_PATH/assets"/*$(uname -m)/* -maxdepth 0 -type d`; \
     do bash "$CUDA_QUANTUM_PATH/bin/migrate_assets.sh" "$folder" && rm -rf "$folder"; done \
     && rm "$CUDA_QUANTUM_PATH/bin/migrate_assets.sh"
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This is the change associated with the proposed downstream GitLab CI update in https://github.com/NVIDIA/cuda-quantum/pull/588/.

(1) For docker images: the only change is using the directory `"$CUDA_QUANTUM_PATH/assets"/*$(uname -m)/*` to look for the assets to be migrated. When https://github.com/NVIDIA/cuda-quantum/pull/588/ is in, we'd have `sims_x86_64.zip` and `sims_aarch64.zip` contain assets for the corresponding platform.

(2) For Python wheels, we'll need to incorporate the assets into the wheel build, using the CMake utils in https://github.com/NVIDIA/cuda-quantum/pull/584. Hence, modifying `cudaq.wheel.Dockerfile` to construct  `CUDAQ_EXTERNAL_NVQIR_SIMS` by inspecting the `assets` directory.

Add extra dir to `LD_LIBRARY_PATH` during `auditwheel repair` so that dependencies are pulled into the wheel appropriately. 

Only tested locally by manually executing https://github.com/NVIDIA/cuda-quantum/pull/588/ pipeline to produce assets then building the dockerfile.