### PR TITLE
Make runtime (and some tests) more repeatable

### DIFF
--- a/docs/sphinx/examples/cpp/algorithms/qaoa_maxcut.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/qaoa_maxcut.cpp
@@ -51,6 +51,8 @@ int main() {
 
   using namespace cudaq::spin;
 
+  cudaq::set_random_seed(13); // set for repeatability
+
   // Problem Hamiltonian
   const cudaq::spin_op Hp = 0.5 * z(0) * z(1) + 0.5 * z(1) * z(2) +
                             0.5 * z(0) * z(3) + 0.5 * z(2) * z(3);
@@ -64,8 +66,8 @@ int main() {
   cudaq::optimizers::cobyla optimizer; // gradient-free COBYLA
 
   // Set initial values for the optimization parameters
-  optimizer.initial_parameters =
-      cudaq::random_vector(-M_PI / 8.0, M_PI / 8.0, n_params);
+  optimizer.initial_parameters = cudaq::random_vector(
+      -M_PI / 8.0, M_PI / 8.0, n_params, std::mt19937::default_seed);
 
   // Call the optimizer
   auto [opt_val, opt_params] = cudaq::vqe(
@@ -74,8 +76,8 @@ int main() {
       });
 
   // Print the optimized value and the parameters
-  printf("Optimal value = %lf\n", opt_val);
-  printf("Optimal params = (%lf, %lf, %lf, %lf) \n", opt_params[0],
+  printf("Optimal value = %.16lf\n", opt_val);
+  printf("Optimal params = (%.16lf, %.16lf, %.16lf, %.16lf) \n", opt_params[0],
          opt_params[1], opt_params[2], opt_params[3]);
 
   // Sample the circuit using optimized parameters

--- a/docs/sphinx/examples/cpp/algorithms/vqe_h2.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/vqe_h2.cpp
@@ -99,7 +99,8 @@ int main() {
   printf("%d qubit hamiltonian -> %d parameters\n", n_qubits, n_params);
 
   // Run the VQE algorithm from specific initial parameters.
-  auto init_params = cudaq::random_vector(-1, 1, n_params);
+  auto init_params =
+      cudaq::random_vector(-1, 1, n_params, std::mt19937::default_seed);
 
   // Create the CUDA Quantum kernel
   so4_fabric ansatz;
@@ -116,5 +117,5 @@ int main() {
   auto [opt_val, opt_params] =
       cudaq::vqe(ansatz, gradient, H, optimizer, n_params, argMapper);
 
-  printf("Optimal value = %lf\n", opt_val);
+  printf("Optimal value = %.16lf\n", opt_val);
 }

--- a/docs/sphinx/examples/cpp/other/builder/qaoa_maxcut_builder.cpp
+++ b/docs/sphinx/examples/cpp/other/builder/qaoa_maxcut_builder.cpp
@@ -36,6 +36,8 @@ int main() {
 
   using namespace cudaq::spin;
 
+  cudaq::set_random_seed(13); // set for repeatability
+
   // Problem Hamiltonian
   const cudaq::spin_op Hp = 0.5 * z(0) * z(1) + 0.5 * z(1) * z(2) +
                             0.5 * z(0) * z(3) + 0.5 * z(2) * z(3);
@@ -73,17 +75,17 @@ int main() {
   cudaq::gradients::central_difference gradient(kernel); // grad vector
 
   // Set initial values for the optimization parameters
-  optimizer.initial_parameters =
-      cudaq::random_vector(-M_PI / 8.0, M_PI / 8.0, n_params);
+  optimizer.initial_parameters = cudaq::random_vector(
+      -M_PI / 8.0, M_PI / 8.0, n_params, std::mt19937::default_seed);
 
   // Optimization using gradient-based L-BFGS
   auto [opt_val, opt_params] =
       cudaq::vqe(kernel, gradient, Hp, optimizer, n_params);
 
   // Print the optimized value and the parameters
-  printf("Optimal value = %lf\n", opt_val);
-  printf("Optimal params = %lf %lf %lf %lf\n", opt_params[0], opt_params[1],
-         opt_params[2], opt_params[3]);
+  printf("Optimal value = %.16lf\n", opt_val);
+  printf("Optimal params = %.16lf %.16lf %.16lf %.16lf\n", opt_params[0],
+         opt_params[1], opt_params[2], opt_params[3]);
 
   // Sample the circuit using optimized parameters
   auto counts = cudaq::sample(kernel, opt_params);

--- a/docs/sphinx/examples/cpp/other/builder/vqe_h2_builder.cpp
+++ b/docs/sphinx/examples/cpp/other/builder/vqe_h2_builder.cpp
@@ -109,7 +109,8 @@ int main() {
   }
 
   // Run the VQE algorithm from specific initial parameters.
-  auto init_params = cudaq::random_vector(-1, 1, n_params);
+  auto init_params =
+      cudaq::random_vector(-1, 1, n_params, std::mt19937::default_seed);
 
   // Run VQE
   cudaq::optimizers::lbfgs optimizer;
@@ -118,5 +119,5 @@ int main() {
   optimizer.max_eval = 20;
   auto [opt_val, opt_params] =
       cudaq::vqe(kernel, gradient, H, optimizer, n_params);
-  printf("Optimal value = %lf\n", opt_val);
+  printf("Optimal value = %.16lf\n", opt_val);
 }

--- a/docs/sphinx/examples/python/advanced_vqe.py
+++ b/docs/sphinx/examples/python/advanced_vqe.py
@@ -61,8 +61,9 @@ def objective_function(parameter_vector: List[float],
     return cost, gradient_vector
 
 
+cudaq.set_random_seed(13) # make repeatable
 energy, parameter = optimizer.optimize(dimensions=1,
                                        function=objective_function)
 
-print(f"\nminimized <H> = {round(energy,3)}")
-print(f"optimal theta = {round(parameter[0],3)}")
+print(f"\nminimized <H> = {round(energy,16)}")
+print(f"optimal theta = {round(parameter[0],16)}")

--- a/docs/sphinx/examples/python/advanced_vqe.py
+++ b/docs/sphinx/examples/python/advanced_vqe.py
@@ -61,7 +61,7 @@ def objective_function(parameter_vector: List[float],
     return cost, gradient_vector
 
 
-cudaq.set_random_seed(13) # make repeatable
+cudaq.set_random_seed(13)  # make repeatable
 energy, parameter = optimizer.optimize(dimensions=1,
                                        function=objective_function)
 

--- a/docs/sphinx/examples/python/qaoa_maxcut.py
+++ b/docs/sphinx/examples/python/qaoa_maxcut.py
@@ -50,7 +50,7 @@ def kernel_qaoa() -> cudaq.Kernel:
     return kernel
 
 
-# Specify the optimizer and its initial parameters.
+# Specify the optimizer and its initial parameters. Make it repeatable.
 cudaq.set_random_seed(13)
 optimizer = cudaq.optimizers.COBYLA()
 np.random.seed(13)

--- a/docs/sphinx/examples/python/qaoa_maxcut.py
+++ b/docs/sphinx/examples/python/qaoa_maxcut.py
@@ -51,7 +51,9 @@ def kernel_qaoa() -> cudaq.Kernel:
 
 
 # Specify the optimizer and its initial parameters.
+cudaq.set_random_seed(13)
 optimizer = cudaq.optimizers.COBYLA()
+np.random.seed(13)
 optimizer.initial_parameters = np.random.uniform(-np.pi / 8.0, np.pi / 8.0,
                                                  parameter_count)
 print("Initial parameters = ", optimizer.initial_parameters)

--- a/docs/sphinx/examples/python/simple_vqe.py
+++ b/docs/sphinx/examples/python/simple_vqe.py
@@ -37,5 +37,5 @@ energy, parameter = cudaq.vqe(
     # list of parameters has length of 1:
     parameter_count=1)
 
-print(f"\nminimized <H> = {round(energy,3)}")
-print(f"optimal theta = {round(parameter[0],3)}")
+print(f"\nminimized <H> = {round(energy,16)}")
+print(f"optimal theta = {round(parameter[0],16)}")

--- a/runtime/cudaq/spin/spin_op.cpp
+++ b/runtime/cudaq/spin/spin_op.cpp
@@ -188,7 +188,9 @@ complex_matrix spin_op::to_matrix() const {
   complex_matrix A(dim, dim);
   A.set_zero();
   auto rawData = A.data();
+#ifdef CUDAQ_HAS_OPENMP
 #pragma omp parallel for shared(rawData)
+#endif
   for (std::size_t rowIdx = 0; rowIdx < dim; rowIdx++) {
     auto rowBitStr = getBitStrForIdx(rowIdx);
     for_each_term([&](spin_op &term) {
@@ -288,9 +290,9 @@ void spin_op::for_each_pauli(
   }
 }
 
-spin_op spin_op::random(std::size_t nQubits, std::size_t nTerms) {
-  std::random_device rd;
-  std::mt19937 gen(rd());
+spin_op spin_op::random(std::size_t nQubits, std::size_t nTerms,
+                        unsigned int seed) {
+  std::mt19937 gen(seed);
   std::vector<std::complex<double>> coeffs(nTerms, 1.0);
   std::vector<spin_op_term> randomTerms;
   for (std::size_t i = 0; i < nTerms; i++) {
@@ -398,7 +400,9 @@ spin_op &spin_op::operator*=(const spin_op &v) noexcept {
       theirRow++;
   }
 
+#ifdef CUDAQ_HAS_OPENMP
 #pragma omp parallel for shared(composition)
+#endif
   for (std::size_t i = 0; i < nElements; i++) {
     auto [j, k] = indexMap[i];
     auto s = terms.begin();

--- a/runtime/cudaq/spin_op.h
+++ b/runtime/cudaq/spin_op.h
@@ -13,6 +13,7 @@
 #include <complex>
 #include <functional>
 #include <map>
+#include <random>
 
 // Define friend functions for operations between spin_op and scalars.
 #define CUDAQ_SPIN_SCALAR_OPERATIONS(op, U)                                    \
@@ -215,8 +216,10 @@ public:
           const std::vector<std::complex<double>> &coeffs);
 
   /// @brief Return a random spin operator acting on the specified number of
-  /// qubits and composed of the given number of terms.
-  static spin_op random(std::size_t nQubits, std::size_t nTerms);
+  /// qubits and composed of the given number of terms. Override `seed` for
+  /// repeatability.
+  static spin_op random(std::size_t nQubits, std::size_t nTerms,
+                        unsigned int seed = std::random_device{}());
 
   /// @brief Return a `spin_op` representative of the input
   /// Pauli word, e.g. XYX for a `spin_op` on 3 qubits with

--- a/runtime/cudaq/utils/cudaq_utils.cpp
+++ b/runtime/cudaq/utils/cudaq_utils.cpp
@@ -23,10 +23,9 @@ std::vector<double> linspace(double a, double b, size_t N) {
 }
 
 std::vector<double> random_vector(const double l_range, const double r_range,
-                                  const std::size_t size) {
+                                  const std::size_t size, const uint32_t seed) {
   // Generate a random initial parameter set
-  std::random_device rnd_device;
-  std::mt19937 mersenne_engine{rnd_device()}; // Generates random integers
+  std::mt19937 mersenne_engine{seed};
   std::uniform_real_distribution<double> dist{l_range, r_range};
   auto gen = [&dist, &mersenne_engine]() { return dist(mersenne_engine); };
   std::vector<double> vec(size);

--- a/runtime/cudaq/utils/cudaq_utils.h
+++ b/runtime/cudaq/utils/cudaq_utils.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <memory>
 #include <numeric>
+#include <random>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -233,8 +234,11 @@ inline void trim(std::string &s) {
 }
 
 std::vector<double> linspace(const double a, const double b, std::size_t size);
+
+// Override the seed if you want repeatably random numbers
 std::vector<double> random_vector(const double l_range, const double r_range,
-                                  const std::size_t size);
+                                  const std::size_t size,
+                                  const uint32_t seed = std::random_device{}());
 
 inline std::vector<std::size_t> range(int N) {
   std::vector<std::size_t> vec(N);

--- a/runtime/nvqir/qpp/CMakeLists.txt
+++ b/runtime/nvqir/qpp/CMakeLists.txt
@@ -19,6 +19,7 @@ macro (AddQppBackend LIBRARY_NAME SOURCE_FILE)
     message(STATUS "OpenMP Found. Adding build flags to QPP Backend: ${OpenMP_CXX_FLAGS}.")
     list(APPEND QPP_DEPENDENCIES OpenMP::OpenMP_CXX)
     target_compile_definitions(${LIBRARY_NAME} PRIVATE -DHAS_OPENMP=1)
+    target_compile_definitions(${LIBRARY_NAME} PRIVATE CUDAQ_HAS_OPENMP)
   endif()
 
   target_include_directories(${LIBRARY_NAME}

--- a/unittests/domains/ChemistryTester.cpp
+++ b/unittests/domains/ChemistryTester.cpp
@@ -144,13 +144,16 @@ CUDAQ_TEST(H2MoleculeTester, checkHWE) {
       cudaq::hwe(q, numLayers, thetas);
     };
 
-    std::vector<double> params = cudaq::random_vector(-3.0, 3.0, numParams);
+    std::vector<double> params =
+        cudaq::random_vector(-3.0, 3.0, numParams, std::mt19937::default_seed);
     std::vector<double> zeros(numParams);
     auto res2 = cudaq::observe(ansatz, H, zeros);
-    std::cout << "HF = " << res2.exp_val_z() << "\n";
+    std::cout << "HF = " << std::setprecision(16) << res2.exp_val_z() << "\n";
     EXPECT_NEAR(-1.116, res2.exp_val_z(), 1e-3);
 
     auto res = cudaq::vqe(ansatz, H, optimizer, numParams);
+    std::cout << "opt result = " << std::setprecision(16) << std::get<0>(res)
+              << "\n";
     EXPECT_NEAR(-1.137, std::get<0>(res), 1e-3);
     optParams = std::get<1>(res);
   }

--- a/unittests/integration/ghz_nisq_tester.cpp
+++ b/unittests/integration/ghz_nisq_tester.cpp
@@ -38,15 +38,23 @@ CUDAQ_TEST(GHZSampleTester, checkSimple) {
     EXPECT_TRUE(bits == "00000" || bits == "11111");
   }
   EXPECT_EQ(counter, 1000);
-  printf("Exp: %lf\n", counts.exp_val_z());
+  printf("Exp: %.16lf\n", counts.exp_val_z());
 }
 
 CUDAQ_TEST(GHZSampleTester, checkBroadcast) {
+
+  // FIXME Issue-608 - I don't think this is enough to make it fully repeatable
+  // yet, even if you set OMP_NUM_THREADS=1
+  cudaq::set_random_seed(13);
 
   std::vector<int> sizeVals(8);
   std::iota(sizeVals.begin(), sizeVals.end(), 3);
   {
     auto allCounts = cudaq::sample(ghz{}, cudaq::make_argset(sizeVals));
+
+    std::cout << "allCounts size " << allCounts.size() << '\n';
+    for (auto &counts : allCounts)
+      counts.dump();
 
     int counter = 0;
     std::string first0 = "000", first1 = "111";
@@ -64,6 +72,10 @@ CUDAQ_TEST(GHZSampleTester, checkBroadcast) {
 
   {
     auto allCounts = cudaq::sample(2000, ghz{}, cudaq::make_argset(sizeVals));
+
+    std::cout << "allCounts size " << allCounts.size() << '\n';
+    for (auto &counts : allCounts)
+      counts.dump();
 
     int counter = 0;
     std::string first0 = "000", first1 = "111";

--- a/unittests/integration/kernels_tester.cpp
+++ b/unittests/integration/kernels_tester.cpp
@@ -155,7 +155,8 @@ CUDAQ_TEST(KernelsTester, checkFromState) {
   {
     // Random unitary state
     const std::size_t numQubits = 2;
-    auto randHam = cudaq::spin_op::random(numQubits, numQubits * numQubits);
+    auto randHam = cudaq::spin_op::random(numQubits, numQubits * numQubits,
+                                          std::mt19937::default_seed);
     auto eigenVectors = randHam.to_matrix().eigenvectors();
     // Map the ground state to a cudaq::state
     std::vector<std::complex<double>> expectedData(eigenVectors.rows());

--- a/unittests/mqpu/mqpu_tester.cpp
+++ b/unittests/mqpu/mqpu_tester.cpp
@@ -24,7 +24,7 @@ TEST(MQPUTester, checkSimple) {
 
   double result = cudaq::observe<cudaq::parallel::thread>(ansatz, h, 0.59);
   EXPECT_NEAR(result, -1.7487, 1e-3);
-  printf("Get energy directly as double %lf\n", result);
+  printf("Get energy directly as double %.16lf\n", result);
 }
 
 TEST(MQPUTester, checkLarge) {
@@ -34,7 +34,7 @@ TEST(MQPUTester, checkLarge) {
   printf("Num QPUs %lu\n", platform.num_qpus());
   int nQubits = 12;
   int nTerms = 1000; /// Scale this on multiple gpus to see speed up
-  auto H = cudaq::spin_op::random(nQubits, nTerms);
+  auto H = cudaq::spin_op::random(nQubits, nTerms, std::mt19937::default_seed);
 
   printf("Total Terms = %lu\n", H.num_terms());
   auto kernel = [](const int n_qubits, const int layers,
@@ -74,13 +74,12 @@ TEST(MQPUTester, checkLarge) {
   };
 
   int nLayers = 2;
-  auto execParams =
-      cudaq::random_vector(-M_PI, M_PI, nQubits * (3 * nLayers + 2));
+  auto execParams = cudaq::random_vector(
+      -M_PI, M_PI, nQubits * (3 * nLayers + 2), std::mt19937::default_seed);
 
   std::vector<int> cnot_pairs(nQubits);
   std::iota(cnot_pairs.begin(), cnot_pairs.end(), 0);
-  std::random_device rd;
-  std::mt19937 g(rd());
+  std::mt19937 g{std::mt19937::default_seed + 1};
   std::shuffle(cnot_pairs.begin(), cnot_pairs.end(), g);
 
   auto t1 = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
### Description
As described in Issue #608, many of our tests were not repeatable. This PR takes a significant first step towards addressing these issues, but some tests (like `GHZSampleTester.checkBroadcast`) are still not repeatable yet. The VQE and QAOA tests were some of the bigger offenders, and those are repeatable now.

Updates include:

[runtime] Wrap '#pragma omp' in appropriate #ifdefs 
* This PR does not disable OpenMP, but if one _were_ to disable it for testing, our build was failing. This fixes that.

[runtime] Modify omp reductions to get answer repeatability
* The variable order of operations in omp reductions will never be repeatable.
* This changes the expensive operations to occur in parallel, but the final sum is sequential.
* The final sum is not a significant runtime contributor, so this is a small price to pay for repeatability.

[runtime] Adds seed parameter to spin_op::random() and cudaq::random_vector().
* This allows callers to either a) get non-repeatable random numbers [by default], or b) specify a seed parameter to get repeatably random numbers.

[tests] Updated unit tests who use those parameters to override the seeds to constants.