### PR TITLE
Fix #627: Code gen for IQM Json failure.

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -8,9 +8,10 @@
 
 #pragma once
 
-// The OptCodeGen library includes passes that lower the MLIR module for some
-// particular quantum target representation. There is a bevy of such targets
-// that provide targets on which the quantum code can be run.
+/// \file
+/// The OptCodeGen library includes passes that lower the MLIR module for some
+/// particular quantum target representation. There is a bevy of such targets
+/// that provide platforms on which the quantum code can be run.
 
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"

--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -1,0 +1,63 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// \file
+/// Define some pipeline instantiation functions that can be shared between
+/// the various tools and the runtime.
+
+#pragma once
+
+#include "cudaq/Optimizer/CodeGen/Passes.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace cudaq::opt {
+
+// Pipeline builder to convert Quake to QIR.
+template <bool BaseProfile = false>
+void addPipelineToQIR(mlir::PassManager &pm) {
+  cudaq::opt::addAggressiveEarlyInlining(pm);
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(cudaq::opt::createExpandMeasurementsPass());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createClassicalMemToReg());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createUnwindLoweringPass());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLowerToCFGPass());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLoopNormalize());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLoopUnroll());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
+  pm.addNestedPass<mlir::func::FuncOp>(
+      cudaq::opt::createCombineQuantumAllocations());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
+  pm.addPass(cudaq::opt::createConvertToQIRPass());
+  if constexpr (BaseProfile) {
+    cudaq::opt::addBaseProfilePipeline(pm);
+  }
+}
+
+inline void addPipelineToOpenQASM(mlir::PassManager &pm) {
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
+}
+
+inline void addPipelineToIQMJson(mlir::PassManager &pm) {
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createUnwindLoweringPass());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLowerToCFGPass());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
+  pm.addNestedPass<mlir::func::FuncOp>(
+      cudaq::opt::createCombineQuantumAllocations());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
+}
+} // namespace cudaq::opt

--- a/lib/Optimizer/CodeGen/TranslateToIQMJson.cpp
+++ b/lib/Optimizer/CodeGen/TranslateToIQMJson.cpp
@@ -14,25 +14,22 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/FormatAdapters.h"
-
 #include <algorithm>
 #include <cmath>
 #include <numeric>
 
 using namespace mlir;
 
-namespace cudaq {
+static LogicalResult emitOperation(nlohmann::json &json,
+                                   cudaq::Emitter &emitter, Operation &op);
 
-static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
-                                   Operation &op);
-
-static LogicalResult emitEntryPoint(nlohmann::json &json, Emitter &emitter,
-                                    func::FuncOp op) {
+static LogicalResult emitEntryPoint(nlohmann::json &json,
+                                    cudaq::Emitter &emitter, func::FuncOp op) {
   if (op.getBody().getBlocks().size() != 1)
     op.emitError("Cannot translate kernels with more than 1 block to IQM Json. "
                  "Must be a straight-line representation.");
 
-  Emitter::Scope scope(emitter, /*isEntryPoint=*/true);
+  cudaq::Emitter::Scope scope(emitter, /*isEntryPoint=*/true);
   json["name"] = op.getName().str();
   std::vector<nlohmann::json> instructions;
   for (Operation &op : op.getOps()) {
@@ -46,8 +43,8 @@ static LogicalResult emitEntryPoint(nlohmann::json &json, Emitter &emitter,
   return success();
 }
 
-static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
-                                   ModuleOp moduleOp) {
+static LogicalResult emitOperation(nlohmann::json &json,
+                                   cudaq::Emitter &emitter, ModuleOp moduleOp) {
   func::FuncOp entryPoint = nullptr;
   for (Operation &op : moduleOp) {
     if (op.hasAttr(cudaq::entryPointAttrName)) {
@@ -62,7 +59,8 @@ static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
   return emitEntryPoint(json, emitter, entryPoint);
 }
 
-static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
+static LogicalResult emitOperation(nlohmann::json &json,
+                                   cudaq::Emitter &emitter,
                                    quake::AllocaOp op) {
   Value refOrVeq = op.getRefOrVec();
   auto name = emitter.createName("QB", 1);
@@ -70,13 +68,14 @@ static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
   return success();
 }
 
-static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
+static LogicalResult emitOperation(nlohmann::json &json,
+                                   cudaq::Emitter &emitter,
                                    quake::ExtractRefOp op) {
   std::optional<int64_t> index = std::nullopt;
   if (op.hasConstantIndex())
     index = op.getConstantIndex();
   else
-    index = getIndexValueAsInt(op.getIndex());
+    index = cudaq::getIndexValueAsInt(op.getIndex());
 
   if (!index.has_value())
     return op.emitError("cannot translate runtime index to IQM Json");
@@ -85,7 +84,8 @@ static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
   return success();
 }
 
-static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
+static LogicalResult emitOperation(nlohmann::json &json,
+                                   cudaq::Emitter &emitter,
                                    quake::OperatorInterface optor) {
   auto name = optor->getName().stripDialect();
   std::vector<std::string> validInstructions{"z", "phased_rx"};
@@ -111,8 +111,10 @@ static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
     if (optor.getParameters().size() != 2)
       optor.emitError("IQM phased_rx gate expects exactly two parameters.");
 
-    auto parameter0 = getParameterValueAsDouble(optor.getParameters()[0]);
-    auto parameter1 = getParameterValueAsDouble(optor.getParameters()[1]);
+    auto parameter0 =
+        cudaq::getParameterValueAsDouble(optor.getParameters()[0]);
+    auto parameter1 =
+        cudaq::getParameterValueAsDouble(optor.getParameters()[1]);
 
     auto convertToFullTurns = [](double &angleInRadians) {
       return angleInRadians / (2 * M_PI);
@@ -131,8 +133,8 @@ static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
   return success();
 }
 
-static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
-                                   quake::MzOp op) {
+static LogicalResult emitOperation(nlohmann::json &json,
+                                   cudaq::Emitter &emitter, quake::MzOp op) {
   json["name"] = "measurement";
   std::vector<std::string> qubits;
   for (auto target : op.getTargets())
@@ -150,8 +152,8 @@ static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
   return success();
 }
 
-static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
-                                   Operation &op) {
+static LogicalResult emitOperation(nlohmann::json &json,
+                                   cudaq::Emitter &emitter, Operation &op) {
   using namespace quake;
   return llvm::TypeSwitch<Operation *, LogicalResult>(&op)
       .Case<ModuleOp>([&](auto op) { return emitOperation(json, emitter, op); })
@@ -177,13 +179,10 @@ static LogicalResult emitOperation(nlohmann::json &json, Emitter &emitter,
       });
 }
 
-mlir::LogicalResult translateToIQMJson(mlir::Operation *op,
-                                       llvm::raw_ostream &os) {
+LogicalResult cudaq::translateToIQMJson(Operation *op, llvm::raw_ostream &os) {
   nlohmann::json j;
   Emitter emitter(os);
   auto ret = emitOperation(j, emitter, *op);
   os << j.dump(4);
   return ret;
 }
-
-} // namespace cudaq

--- a/runtime/common/RuntimeMLIR.cpp
+++ b/runtime/common/RuntimeMLIR.cpp
@@ -10,46 +10,29 @@
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/CodeGen/IQMJsonEmitter.h"
 #include "cudaq/Optimizer/CodeGen/OpenQASMEmitter.h"
-#include "cudaq/Optimizer/CodeGen/Passes.h"
+#include "cudaq/Optimizer/CodeGen/Pipelines.h"
 #include "cudaq/Optimizer/CodeGen/QIRFunctionNames.h"
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
-#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
-#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
-#include "cudaq/Optimizer/Transforms/Passes.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Module.h"
 #include "llvm/MC/SubtargetFeature.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/Base64.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/Host.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/raw_ostream.h"
-#include "llvm/Target/TargetMachine.h"
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Affine/Passes.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/ExecutionEngine/ExecutionEngine.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
-#include "mlir/IR/AsmState.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/Verifier.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/InitAllTranslations.h"
 #include "mlir/Parser/Parser.h"
-#include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
-#include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Tools/ParseUtilities.h"
-#include "mlir/Transforms/Passes.h"
 
 using namespace mlir;
 
@@ -377,11 +360,16 @@ void registerToOpenQASMTranslation() {
         PassManager pm(op->getContext());
         if (printIntermediateMLIR)
           pm.enableIRPrinting();
+        cudaq::opt::addPipelineToOpenQASM(pm);
         if (failed(pm.run(op)))
-          throw std::runtime_error("Lowering failed.");
+          throw std::runtime_error("code generation failed.");
         auto passed = cudaq::translateToOpenQASM(op, output);
-        if (printIR)
-          llvm::errs() << output.str();
+        if (printIR) {
+          if (succeeded(passed))
+            llvm::errs() << output.str();
+          else
+            llvm::errs() << "failed to create OpenQASM file.";
+        }
         return passed;
       });
 }
@@ -391,12 +379,19 @@ void registerToIQMJsonTranslation() {
       "iqm", "translate from quake to IQM's json format",
       [](Operation *op, llvm::raw_string_ostream &output, bool printIR,
          bool printIntermediateMLIR) {
-        auto passed = cudaq::translateToIQMJson(op, output);
+        PassManager pm(op->getContext());
         if (printIntermediateMLIR)
-          llvm::errs() << "WARNING: printIntermediateMLIR not supported for "
-                          "IQM's json format\n";
-        if (printIR)
-          llvm::errs() << output.str();
+          pm.enableIRPrinting();
+        cudaq::opt::addPipelineToIQMJson(pm);
+        if (failed(pm.run(op)))
+          throw std::runtime_error("code generation failed.");
+        auto passed = cudaq::translateToIQMJson(op, output);
+        if (printIR) {
+          if (succeeded(passed))
+            llvm::errs() << output.str();
+          else
+            llvm::errs() << "failed to create IQM json file.";
+        }
         return passed;
       });
 }


### PR DESCRIPTION
These changes allow all the code gen backends to use a pass pipeline to fix up the code before the actual file is written. In the case of the bug, there was still Quake IR sitting in the Module that needed to be transformed before it could be emitted correctly.
