### PR TITLE
Downstream cross-platform backend builds for HPC docker image and Python wheels

### DIFF
--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -3,7 +3,6 @@ workflow:
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /^bot/ && $CI_COMMIT_TITLE =~ /^ghcr\.io\/nvidia\/cuda-quantum-dev@sha256:\S+$/'
       variables:
-        runner: hostname/xpl-dvt-55
         staged: "cuda-quantum-dev"
     - if: '$CI_COMMIT_BRANCH =~ /^bot/ && $CI_COMMIT_BRANCH =~ /arm64/ && $CI_COMMIT_TITLE =~ /^ghcr\.io\/nvidia\/cuda-quantum-devdeps@sha256:\S+$/'
       variables:
@@ -42,8 +41,82 @@ Python Wheels:
   tags:
     - $runner
   interruptible: false
+  artifacts:
+    paths:
+      - artifacts
+    expire_in: 1 day
+  parallel:
+    matrix:
+      - python_version: ["3.8", "3.9", "3.10", "3.11"]
   script:
-    - echo "Nothing implemented yet."
+    - echo "Building wheel for python${python_version}." 
+    - export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
+    - export python=python${python_version} 
+    - $python -m pip install --no-cache-dir cmake auditwheel cuquantum-cu11==23.6.0 
+    - if [[ $(uname -i) == x86_64 ]]; then echo $python -m pip install --no-cache-dir nvidia-cusolver-cu11; fi 
+    - cuquantum_location=`$python -m pip show cuquantum-cu11 | grep -e 'Location:\ .*$'`
+    - echo $cuquantum_location
+    - export CUQUANTUM_INSTALL_PREFIX="${cuquantum_location#Location:\ }/cuquantum"
+    - echo $CUQUANTUM_INSTALL_PREFIX
+    - export CUQUANTUM_ROOT=$CUQUANTUM_INSTALL_PREFIX 
+    - export CUTENSOR_ROOT="${cuquantum_location#Location:\ }/cutensor"
+    - ln -s $CUQUANTUM_INSTALL_PREFIX/lib/libcustatevec.so.1 $CUQUANTUM_INSTALL_PREFIX/lib/libcustatevec.so 
+    - ln -s $CUQUANTUM_INSTALL_PREFIX/lib/libcutensornet.so.2 $CUQUANTUM_INSTALL_PREFIX/lib/libcutensornet.so 
+    - ln -s $CUTENSOR_ROOT/lib/libcutensor.so.1 $CUTENSOR_ROOT/lib/libcutensor.so
+    - export CUDAQ_INSTALL_PREFIX=/opt/nvidia/cudaq
+    - export PROJECT_SRCS_DIR=$PWD/.. 
+    # Retrieve the upstream CUDA Quantum commit
+    - digest=${CI_COMMIT_TITLE#ghcr.io/nvidia/$staged@}
+    - build_info=`cat deployments/staging/$staged/${digest#sha256:}`
+    - source_commit=`echo "$build_info" | grep -s -o 'source-sha:\s*\S*' | rev | cut -d ' ' -f 1 | cut -d ':' -f 1 | rev`
+    - export CUDAQ_COMMIT=$source_commit
+    - echo "Checking out CUDA Quantum commit $CUDAQ_COMMIT"
+    - cd $PROJECT_SRCS_DIR && rm -rf cuda-quantum
+    - mkdir cuda-quantum && cd cuda-quantum && git init
+    - git fetch --depth 1 https://github.com/NVIDIA/cuda-quantum.git $CUDAQ_COMMIT && git checkout FETCH_HEAD
+    # Build cuda-quantum in self-contained mode to serve as base for other backends
+    - mkdir build && cd build
+    - cmake .. 
+        -DCMAKE_INSTALL_PREFIX=$CUDAQ_INSTALL_PREFIX
+        -DBLAS_LIBRARIES=/usr/local/blas/libblas.a
+        -DOPENSSL_ROOT_DIR=/usr/local/openssl
+        -DCUDAQ_BUILD_TESTS=FALSE
+        -DCUDAQ_BUILD_SELFCONTAINED=ON
+        -DCUDAQ_DISABLE_CPP_FRONTEND=TRUE
+        -DCUDAQ_DISABLE_TOOLS=TRUE
+    - make -j$(nproc) install
+    - cp -R $CUDAQ_INSTALL_PREFIX/lib64/cmake/fmt $CUDAQ_INSTALL_PREFIX/lib/cmake
+    # Tensornet Simulator
+    - cd $PROJECT_SRCS_DIR
+    - echo "Checking out commit $CUDAQ_TENSORNET_COMMIT on $CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO."
+    - mkdir cudaq_tensornet && cd cudaq_tensornet && git init
+    - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO $CUDAQ_TENSORNET_COMMIT && git checkout FETCH_HEAD
+    - (bash build_wheel.sh $READ_ACCESS_TOKEN && built=true) || built=false
+    - if $built; then `exit 0`; else `exit 1`; fi
+    # MGMN SV  Simulator
+    - cd $PROJECT_SRCS_DIR
+    - echo "Checking out commit $CUDAQ_MGMN_SVSIM_COMMIT on $CI_SERVER_HOST/$CUDAQ_MGMN_SVSIM_REPO."
+    - mkdir cudaq_mgmn_svsim && cd cudaq_mgmn_svsim && git init
+    - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_MGMN_SVSIM_REPO $CUDAQ_MGMN_SVSIM_COMMIT && git checkout FETCH_HEAD
+    - (bash build_wheel.sh $READ_ACCESS_TOKEN && built=true) || built=false
+    - if $built; then `exit 0`; else `exit 1`; fi
+    # Package the wheel
+    - cd $PROJECT_SRCS_DIR/cuda-quantum
+    # Add Tensornet and MGMN SV simulator to the packaged wheel
+    # via CUDAQ_EXTERNAL_NVQIR_SIMS cmake config
+    - export CUDAQ_EXTERNAL_NVQIR_SIMS="$PROJECT_SRCS_DIR/cudaq_tensornet/build/libnvqir-tensornet.so;$PROJECT_SRCS_DIR/cudaq_tensornet/build/tensornet.config;$PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/libnvqir-nvidia-mgpu.so;$PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/nvidia-mgpu.config"
+    - SETUPTOOLS_SCM_PRETEND_VERSION=${CUDA_QUANTUM_VERSION:-0.0.0} CUDAQ_BUILD_SELFCONTAINED=ON  CUDACXX="$CUDA_INSTALL_PREFIX/bin/nvcc" CUDAHOSTCXX=$CXX $python -m build --wheel
+    - LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/_skbuild/lib:dist/cuda_quantum-0.0.0/lib" $python -m auditwheel -v repair dist/cuda_quantum-*linux_*.whl 
+        --exclude libcustatevec.so.1 
+        --exclude libcutensornet.so.2 
+        --exclude libcublas.so.11 
+        --exclude libcublasLt.so.11 
+        --exclude libcusolver.so.11 
+        --exclude libcutensor.so.1 
+        --exclude libnvToolsExt.so.1 
+        --exclude libcudart.so.11.0
+    # Copy repaired wheel into the artifacts dir
+    - mkdir -p artifacts/wheels && cp wheelhouse/cuda_quantum-*linux_*.whl artifacts/wheels
 
 MGMN SV Simulator:
   rules:
@@ -51,19 +124,23 @@ MGMN SV Simulator:
   stage: build
   dependencies: []
   image: $CI_COMMIT_TITLE
+  parallel:
+    matrix:
+      - runner: [hostname/xpl-dvt-55, os/linux-arm]
   tags:
     - $runner
   interruptible: false
   artifacts:
     paths:
-      - artifacts/mgmn_svsim/
+      - artifacts/**/mgmn_svsim/
     expire_in: 1 day
   script:
+    - echo "Building mgmn_svsim for $(uname -m) architecture."
     - echo "Checking out commit $CUDAQ_MGMN_SVSIM_COMMIT on $CI_SERVER_HOST/$CUDAQ_MGMN_SVSIM_REPO."
     - mkdir cudaq_mgmn_svsim && cd cudaq_mgmn_svsim && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_MGMN_SVSIM_REPO $CUDAQ_MGMN_SVSIM_COMMIT && git checkout FETCH_HEAD
     - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
-    - mkdir -p ../artifacts/mgmn_svsim && mv artifacts/* ../artifacts/mgmn_svsim
+    - mkdir -p ../artifacts/$(uname -m)/mgmn_svsim && mv artifacts/* ../artifacts/$(uname -m)/mgmn_svsim
     - cd .. && rm -rf cudaq_mgmn_svsim
     - if $built; then `exit 0`; else `exit 1`; fi
 
@@ -75,9 +152,9 @@ Tensornet Simulator:
   image: $CI_COMMIT_TITLE
   parallel:
     matrix:
-      - runner_tag: [hostname/xpl-dvt-55, os/linux-arm]
+      - runner: [hostname/xpl-dvt-55, os/linux-arm]
   tags:
-    - $runner_tag
+    - $runner
   interruptible: false
   artifacts:
     paths:
@@ -127,8 +204,9 @@ Push to GitHub:
       fi
     - mkdir -p artifacts && cd artifacts
     - echo "$build_info" > "$info_file" && (echo -n "data-commit:" && echo " $CI_COMMIT_SHA") >> "$info_file"
-    - if [ -d mgmn_svsim ]; then zip -r mgmn_svsim.zip mgmn_svsim && upload+="mgmn_svsim.zip "; fi
-    - if [ -d tensornet ]; then zip -r tensornet.zip tensornet && upload+="tensornet.zip "; fi
+    - if [ -d x86_64 ]; then zip -r sims_amd64.zip x86_64 && upload+="sims_amd64.zip "; fi
+    - if [ -d aarch64 ]; then zip -r sims_aarch64.zip aarch64 && upload+="sims_aarch64.zip "; fi
+    - if [ -d wheels ]; then zip -r wheels.zip wheels && upload+="wheels.zip "; fi
     - echo $upload | xargs gh release upload $release_id -R $upstream_url --clobber "$info_file"
     - additional_notes="Release edited by [GitLab pipeline]($CI_PIPELINE_URL)." &&
       additional_notes+=$(echo "<br/>Triggered based on [this commit]($upstream_url/commit/$CI_COMMIT_SHA).")

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -47,7 +47,7 @@ Python Wheels:
     expire_in: 1 day
   parallel:
     matrix:
-      - python_version: ["3.8", "3.9", "3.10", "3.11"]
+      - python_version: ["3.10"]
   script:
     - echo "Building wheel for python${python_version}." 
     - export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
@@ -100,23 +100,8 @@ Python Wheels:
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_MGMN_SVSIM_REPO $CUDAQ_MGMN_SVSIM_COMMIT && git checkout FETCH_HEAD
     - (bash build_wheel.sh $READ_ACCESS_TOKEN && built=true) || built=false
     - if $built; then `exit 0`; else `exit 1`; fi
-    # Package the wheel
-    - cd $PROJECT_SRCS_DIR/cuda-quantum
-    # Add Tensornet and MGMN SV simulator to the packaged wheel
-    # via CUDAQ_EXTERNAL_NVQIR_SIMS cmake config
-    - export CUDAQ_EXTERNAL_NVQIR_SIMS="$PROJECT_SRCS_DIR/cudaq_tensornet/build/libnvqir-tensornet.so;$PROJECT_SRCS_DIR/cudaq_tensornet/build/tensornet.config;$PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/libnvqir-nvidia-mgpu.so;$PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/nvidia-mgpu.config"
-    - SETUPTOOLS_SCM_PRETEND_VERSION=${CUDA_QUANTUM_VERSION:-0.0.0} CUDAQ_BUILD_SELFCONTAINED=ON  CUDACXX="$CUDA_INSTALL_PREFIX/bin/nvcc" CUDAHOSTCXX=$CXX $python -m build --wheel
-    - LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/_skbuild/lib:dist/cuda_quantum-0.0.0/lib" $python -m auditwheel -v repair dist/cuda_quantum-*linux_*.whl 
-        --exclude libcustatevec.so.1 
-        --exclude libcutensornet.so.2 
-        --exclude libcublas.so.11 
-        --exclude libcublasLt.so.11 
-        --exclude libcusolver.so.11 
-        --exclude libcutensor.so.1 
-        --exclude libnvToolsExt.so.1 
-        --exclude libcudart.so.11.0
-    # Copy repaired wheel into the artifacts dir
-    - mkdir -p artifacts/wheels && cp wheelhouse/cuda_quantum-*linux_*.whl artifacts/wheels
+    # Copy artifacts
+    - mkdir -p artifacts/wheels_$(uname -m) && cp $PROJECT_SRCS_DIR/cudaq_tensornet/build/libnvqir-tensornet.so $PROJECT_SRCS_DIR/cudaq_tensornet/build/tensornet.config $PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/libnvqir-nvidia-mgpu.so $PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/nvidia-mgpu.config artifacts/wheels_$(uname -m)
 
 MGMN SV Simulator:
   rules:
@@ -206,7 +191,8 @@ Push to GitHub:
     - echo "$build_info" > "$info_file" && (echo -n "data-commit:" && echo " $CI_COMMIT_SHA") >> "$info_file"
     - if [ -d x86_64 ]; then zip -r sims_amd64.zip x86_64 && upload+="sims_amd64.zip "; fi
     - if [ -d aarch64 ]; then zip -r sims_aarch64.zip aarch64 && upload+="sims_aarch64.zip "; fi
-    - if [ -d wheels ]; then zip -r wheels.zip wheels && upload+="wheels.zip "; fi
+    - if [ -d wheels_x86_64 ]; then zip -r wheels_x86_64.zip wheels_x86_64 && upload+="wheels_x86_64.zip "; fi
+    - if [ -d wheels_aarch64 ]; then zip -r wheels_aarch64.zip wheels_aarch64 && upload+="wheels_aarch64.zip "; fi
     - echo $upload | xargs gh release upload $release_id -R $upstream_url --clobber "$info_file"
     - additional_notes="Release edited by [GitLab pipeline]($CI_PIPELINE_URL)." &&
       additional_notes+=$(echo "<br/>Triggered based on [this commit]($upstream_url/commit/$CI_COMMIT_SHA).")

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -84,13 +84,6 @@ Python Wheels:
     - export CUDAQ_INSTALL_PREFIX="${cudaq_location#Location:\ }"
     - cp -R $CUDAQ_INSTALL_PREFIX/lib64/cmake/fmt $CUDAQ_INSTALL_PREFIX/lib/cmake
     # Tensornet Simulator
-    # ==== REMOVE ==========
-    # once these commits are ready for deployment.
-    - export EXATN_REPO=dlyakh/exatn
-    - export EXATN_COMMIT=9c053ac1671c041827fee3aeb33cfc6bf43762eb
-    - export CUDAQ_TENSORNET_COMMIT=0ba55a7c523dde47f51f7e118211aafc6db2b8e6
-    - export CUDAQ_MGMN_SVSIM_COMMIT=1beb1d3e183cd5e7d5984b11c92740f607b6d5ba
-    # ======================
     - export ARTIFACTS_DIR=$PROJECT_SRCS_DIR/cuda-quantum/artifacts/wheels_$(uname -m)
     - mkdir -p $ARTIFACTS_DIR
     - cd $PROJECT_SRCS_DIR

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -81,14 +81,14 @@ Tensornet Simulator:
   interruptible: false
   artifacts:
     paths:
-      - artifacts/tensornet/
+      - artifacts/**/tensornet/
     expire_in: 1 day
   script:
     - echo "Checking out commit $CUDAQ_TENSORNET_COMMIT on $CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO."
     - mkdir cudaq_tensornet && cd cudaq_tensornet && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO $CUDAQ_TENSORNET_COMMIT && git checkout FETCH_HEAD
     - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
-    - mkdir -p ../artifacts/tensornet/$(uname -m) && mv artifacts/* ../artifacts/tensornet/$(uname -m)
+    - mkdir -p ../artifacts/$(uname -m)/tensornet && mv artifacts/* ../artifacts/$(uname -m)/tensornet
     - cd .. && rm -rf cudaq_tensornet
     - if $built; then `exit 0`; else `exit 1`; fi
 

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -45,9 +45,9 @@ Python Wheels:
     paths:
       - artifacts
     expire_in: 1 day
-  script:
-    - export PROJECT_SRCS_DIR=$PWD/.. 
-    # Install GitHub CLI
+  before_script:
+  # Download wheels from deployment artifacts 
+  # Install GitHub CLI
     - dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
     - dnf install -y gh jq
     - upstream_url=https://github.com/NVIDIA/cuda-quantum && export GH_TOKEN=$GITHUB_TOKEN
@@ -59,6 +59,7 @@ Python Wheels:
     - build_info=`cat deployments/staging/$staged/${digest#sha256:}`
     - artifacts_url=`echo "$build_info" | grep -s -o 'artifacts-url:\s*\S*' | rev | cut -d ' ' -f 1 | rev`
     - artifacts=$(gh api $artifacts_url -q '.artifacts[] | {name:.name, url:.archive_download_url}')
+    # Store wheels in a temporary directory 
     - mkdir -p /tmp/wheels
     - |
       for artifact in `echo "$artifacts"`; do 
@@ -74,41 +75,34 @@ Python Wheels:
           cd .. && rm -rf _pycudaq*
         fi
       done
+  script:
+    - export PROJECT_SRCS_DIR=$PWD/.. 
+    # Install CUDA Quantum wheel for a particular Python version (could be any version) 
     - export python=python3.10 
     - cd /tmp/wheels/ && $python -m pip install cuda_quantum-*-cp310-cp310-manylinux_*_$(uname -m).whl
     - cudaq_location=`$python -m pip show cuda-quantum | grep -e 'Location:\ .*$'`
     - export CUDAQ_INSTALL_PREFIX="${cudaq_location#Location:\ }"
     - cp -R $CUDAQ_INSTALL_PREFIX/lib64/cmake/fmt $CUDAQ_INSTALL_PREFIX/lib/cmake
-    - export EXATN_COMMIT=9c053ac1671c041827fee3aeb33cfc6bf43762eb
-    - export CUDAQ_TENSORNET_COMMIT=17dc530c4838b2e32125d427feabfd32c1fdd0fc
-    - export CUDAQ_MGMN_SVSIM_COMMIT=e8a6702a222c1a5f3fead4dc5efb11953967dd90
     # Tensornet Simulator
-    - cuquantum_location=`$python -m pip show cuquantum-cu11 | grep -e 'Location:\ .*$'`
-    - echo $cuquantum_location
-    - export CUQUANTUM_INSTALL_PREFIX="${cuquantum_location#Location:\ }/cuquantum"
-    - export CUQUANTUM_ROOT=$CUQUANTUM_INSTALL_PREFIX 
-    - export CUTENSOR_ROOT="${cuquantum_location#Location:\ }/cutensor"
-    - ln -s $CUQUANTUM_INSTALL_PREFIX/lib/libcustatevec.so.1 $CUQUANTUM_INSTALL_PREFIX/lib/libcustatevec.so 
-    - ln -s $CUQUANTUM_INSTALL_PREFIX/lib/libcutensornet.so.2 $CUQUANTUM_INSTALL_PREFIX/lib/libcutensornet.so 
-    - ln -s $CUTENSOR_ROOT/lib/libcutensor.so.1 $CUTENSOR_ROOT/lib/libcutensor.so
+    # REMOVE
+    - export EXATN_REPO=dlyakh/exatn
+    - export EXATN_COMMIT=9c053ac1671c041827fee3aeb33cfc6bf43762eb
+    - export CUDAQ_TENSORNET_COMMIT=fc1fa44498faf73294e5d294816bec3e45cd1595
+    - export CUDAQ_MGMN_SVSIM_COMMIT=1beb1d3e183cd5e7d5984b11c92740f607b6d5ba
+    # ======================
     - cd $PROJECT_SRCS_DIR
     - echo "Checking out commit $CUDAQ_TENSORNET_COMMIT on $CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO."
     - mkdir cudaq_tensornet && cd cudaq_tensornet && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO $CUDAQ_TENSORNET_COMMIT && git checkout FETCH_HEAD
     - export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
-    - (bash build_wheel.sh $READ_ACCESS_TOKEN && built=true) || built=false
-    - if $built; then `exit 0`; else `exit 1`; fi
+    - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
     # MGMN SV  Simulator
     - cd $PROJECT_SRCS_DIR
     - echo "Checking out commit $CUDAQ_MGMN_SVSIM_COMMIT on $CI_SERVER_HOST/$CUDAQ_MGMN_SVSIM_REPO."
     - mkdir cudaq_mgmn_svsim && cd cudaq_mgmn_svsim && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_MGMN_SVSIM_REPO $CUDAQ_MGMN_SVSIM_COMMIT && git checkout FETCH_HEAD
-    - (bash build_wheel.sh $READ_ACCESS_TOKEN && built=true) || built=false
+    - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
     - if $built; then `exit 0`; else `exit 1`; fi
-    # Copy artifacts
-    - cd $PROJECT_SRCS_DIR/cuda-quantum
-    - mkdir -p artifacts/wheels_$(uname -m) && cp $PROJECT_SRCS_DIR/cudaq_tensornet/build/libnvqir-tensornet.so $PROJECT_SRCS_DIR/cudaq_tensornet/build/tensornet.config $PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/libnvqir-nvidia-mgpu.so $PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/nvidia-mgpu.config artifacts/wheels_$(uname -m)
-    - mkdir -p artifacts/wheels_$(uname -m)/lib &&  cp -r /opt/nvidia/exatn/lib/*.so artifacts/wheels_$(uname -m)/lib
 
 MGMN SV Simulator:
   rules:

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -106,7 +106,9 @@ Python Wheels:
     - (bash build_wheel.sh $READ_ACCESS_TOKEN && built=true) || built=false
     - if $built; then `exit 0`; else `exit 1`; fi
     # Copy artifacts
+    - cd $PROJECT_SRCS_DIR/cuda-quantum
     - mkdir -p artifacts/wheels_$(uname -m) && cp $PROJECT_SRCS_DIR/cudaq_tensornet/build/libnvqir-tensornet.so $PROJECT_SRCS_DIR/cudaq_tensornet/build/tensornet.config $PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/libnvqir-nvidia-mgpu.so $PROJECT_SRCS_DIR/cudaq_mgmn_svsim/build/nvidia-mgpu.config artifacts/wheels_$(uname -m)
+    - mkdir -p artifacts/wheels_$(uname -m)/lib &&  cp -r /opt/nvidia/exatn/lib/*.so artifacts/wheels_$(uname -m)/lib
 
 MGMN SV Simulator:
   rules:

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -84,24 +84,29 @@ Python Wheels:
     - export CUDAQ_INSTALL_PREFIX="${cudaq_location#Location:\ }"
     - cp -R $CUDAQ_INSTALL_PREFIX/lib64/cmake/fmt $CUDAQ_INSTALL_PREFIX/lib/cmake
     # Tensornet Simulator
-    # REMOVE
+    # ==== REMOVE ==========
+    # once these commits are ready for deployment.
     - export EXATN_REPO=dlyakh/exatn
     - export EXATN_COMMIT=9c053ac1671c041827fee3aeb33cfc6bf43762eb
-    - export CUDAQ_TENSORNET_COMMIT=fc1fa44498faf73294e5d294816bec3e45cd1595
+    - export CUDAQ_TENSORNET_COMMIT=0ba55a7c523dde47f51f7e118211aafc6db2b8e6
     - export CUDAQ_MGMN_SVSIM_COMMIT=1beb1d3e183cd5e7d5984b11c92740f607b6d5ba
     # ======================
+    - export ARTIFACTS_DIR=$PROJECT_SRCS_DIR/cuda-quantum/artifacts/wheels_$(uname -m)
+    - mkdir -p $ARTIFACTS_DIR
     - cd $PROJECT_SRCS_DIR
     - echo "Checking out commit $CUDAQ_TENSORNET_COMMIT on $CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO."
     - mkdir cudaq_tensornet && cd cudaq_tensornet && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO $CUDAQ_TENSORNET_COMMIT && git checkout FETCH_HEAD
     - export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
     - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
+    - cp -R artifacts/* $ARTIFACTS_DIR
     # MGMN SV  Simulator
     - cd $PROJECT_SRCS_DIR
     - echo "Checking out commit $CUDAQ_MGMN_SVSIM_COMMIT on $CI_SERVER_HOST/$CUDAQ_MGMN_SVSIM_REPO."
     - mkdir cudaq_mgmn_svsim && cd cudaq_mgmn_svsim && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_MGMN_SVSIM_REPO $CUDAQ_MGMN_SVSIM_COMMIT && git checkout FETCH_HEAD
     - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
+    - cp -R artifacts/* $ARTIFACTS_DIR
     - if $built; then `exit 0`; else `exit 1`; fi
 
 MGMN SV Simulator:

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -1,10 +1,6 @@
 workflow:
   name: 'Staging'
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^bot/ && $CI_COMMIT_BRANCH =~ /arm64/ && $CI_COMMIT_TITLE =~ /^ghcr\.io\/nvidia\/cuda-quantum-dev@sha256:\S+$/'
-      variables:
-        runner: os/linux-arm
-        staged: "cuda-quantum-dev"
     - if: '$CI_COMMIT_BRANCH =~ /^bot/ && $CI_COMMIT_TITLE =~ /^ghcr\.io\/nvidia\/cuda-quantum-dev@sha256:\S+$/'
       variables:
         runner: hostname/xpl-dvt-55
@@ -77,8 +73,11 @@ Tensornet Simulator:
   stage: build
   dependencies: []
   image: $CI_COMMIT_TITLE
+  parallel:
+    matrix:
+      - runner_tag: [hostname/xpl-dvt-55, os/linux-arm]
   tags:
-    - $runner
+    - $runner_tag
   interruptible: false
   artifacts:
     paths:
@@ -89,7 +88,7 @@ Tensornet Simulator:
     - mkdir cudaq_tensornet && cd cudaq_tensornet && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO $CUDAQ_TENSORNET_COMMIT && git checkout FETCH_HEAD
     - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
-    - mkdir -p ../artifacts/tensornet && mv artifacts/* ../artifacts/tensornet
+    - mkdir -p ../artifacts/tensornet/$(uname -m) && mv artifacts/* ../artifacts/tensornet/$(uname -m)
     - cd .. && rm -rf cudaq_tensornet
     - if $built; then `exit 0`; else `exit 1`; fi
 

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -45,52 +45,54 @@ Python Wheels:
     paths:
       - artifacts
     expire_in: 1 day
-  parallel:
-    matrix:
-      - python_version: ["3.10"]
   script:
-    - echo "Building wheel for python${python_version}." 
-    - export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
-    - export python=python${python_version} 
-    - $python -m pip install --no-cache-dir cmake auditwheel cuquantum-cu11==23.6.0 
-    - if [[ $(uname -i) == x86_64 ]]; then echo $python -m pip install --no-cache-dir nvidia-cusolver-cu11; fi 
+    - export PROJECT_SRCS_DIR=$PWD/.. 
+    # Install GitHub CLI
+    - dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+    - dnf install -y gh jq
+    - upstream_url=https://github.com/NVIDIA/cuda-quantum && export GH_TOKEN=$GITHUB_TOKEN
+    - if [ -z "$(git remote -v | grep upstream)" ]; 
+      then git remote add upstream ${upstream_url}.git;
+      fi
+    # Retrieve the upstream CUDA Quantum artifacts
+    - digest=${CI_COMMIT_TITLE#ghcr.io/nvidia/$staged@}
+    - build_info=`cat deployments/staging/$staged/${digest#sha256:}`
+    - artifacts_url=`echo "$build_info" | grep -s -o 'artifacts-url:\s*\S*' | rev | cut -d ' ' -f 1 | rev`
+    - artifacts=$(gh api $artifacts_url -q '.artifacts[] | {name:.name, url:.archive_download_url}')
+    - mkdir -p /tmp/wheels
+    - |
+      for artifact in `echo "$artifacts"`; do 
+        name=`echo $artifact | jq -r '.name'`
+        if [ "${name#pycudaq-}" != "$name" ]; then
+          url=`echo $artifact | jq -r '.url'`
+          gh api $url > _pycudaq.zip
+          unzip -d _pycudaq _pycudaq.zip && cd _pycudaq
+          for wheel in `ls cuda_quantum-*-cp310-cp310-manylinux_*_$(uname -m).whl 2> /dev/null`; do
+            echo "Adding wheel $wheel."
+            mv $wheel "/tmp/wheels/$wheel"
+          done
+          cd .. && rm -rf _pycudaq*
+        fi
+      done
+    - export python=python3.10 
+    - cd /tmp/wheels/ && $python -m pip install cuda_quantum-*-cp310-cp310-manylinux_*_$(uname -m).whl
+    - cudaq_location=`$python -m pip show cuda-quantum | grep -e 'Location:\ .*$'`
+    - export CUDAQ_INSTALL_PREFIX="${cudaq_location#Location:\ }"
+    - cp -R $CUDAQ_INSTALL_PREFIX/lib64/cmake/fmt $CUDAQ_INSTALL_PREFIX/lib/cmake
+    # Tensornet Simulator
     - cuquantum_location=`$python -m pip show cuquantum-cu11 | grep -e 'Location:\ .*$'`
     - echo $cuquantum_location
     - export CUQUANTUM_INSTALL_PREFIX="${cuquantum_location#Location:\ }/cuquantum"
-    - echo $CUQUANTUM_INSTALL_PREFIX
     - export CUQUANTUM_ROOT=$CUQUANTUM_INSTALL_PREFIX 
     - export CUTENSOR_ROOT="${cuquantum_location#Location:\ }/cutensor"
     - ln -s $CUQUANTUM_INSTALL_PREFIX/lib/libcustatevec.so.1 $CUQUANTUM_INSTALL_PREFIX/lib/libcustatevec.so 
     - ln -s $CUQUANTUM_INSTALL_PREFIX/lib/libcutensornet.so.2 $CUQUANTUM_INSTALL_PREFIX/lib/libcutensornet.so 
     - ln -s $CUTENSOR_ROOT/lib/libcutensor.so.1 $CUTENSOR_ROOT/lib/libcutensor.so
-    - export CUDAQ_INSTALL_PREFIX=/opt/nvidia/cudaq
-    - export PROJECT_SRCS_DIR=$PWD/.. 
-    # Retrieve the upstream CUDA Quantum commit
-    - digest=${CI_COMMIT_TITLE#ghcr.io/nvidia/$staged@}
-    - build_info=`cat deployments/staging/$staged/${digest#sha256:}`
-    - source_commit=`echo "$build_info" | grep -s -o 'source-sha:\s*\S*' | rev | cut -d ' ' -f 1 | cut -d ':' -f 1 | rev`
-    - export CUDAQ_COMMIT=$source_commit
-    - echo "Checking out CUDA Quantum commit $CUDAQ_COMMIT"
-    - cd $PROJECT_SRCS_DIR && rm -rf cuda-quantum
-    - mkdir cuda-quantum && cd cuda-quantum && git init
-    - git fetch --depth 1 https://github.com/NVIDIA/cuda-quantum.git $CUDAQ_COMMIT && git checkout FETCH_HEAD
-    # Build cuda-quantum in self-contained mode to serve as base for other backends
-    - mkdir build && cd build
-    - cmake .. 
-        -DCMAKE_INSTALL_PREFIX=$CUDAQ_INSTALL_PREFIX
-        -DBLAS_LIBRARIES=/usr/local/blas/libblas.a
-        -DOPENSSL_ROOT_DIR=/usr/local/openssl
-        -DCUDAQ_BUILD_TESTS=FALSE
-        -DCUDAQ_BUILD_SELFCONTAINED=ON
-        -DCUDAQ_DISABLE_CPP_FRONTEND=TRUE
-        -DCUDAQ_DISABLE_TOOLS=TRUE
-    - make -j$(nproc) install
-    - cp -R $CUDAQ_INSTALL_PREFIX/lib64/cmake/fmt $CUDAQ_INSTALL_PREFIX/lib/cmake
-    # Tensornet Simulator
     - cd $PROJECT_SRCS_DIR
     - echo "Checking out commit $CUDAQ_TENSORNET_COMMIT on $CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO."
     - mkdir cudaq_tensornet && cd cudaq_tensornet && git init
     - git fetch --depth 1 https://$READ_ACCESS_TOKEN:$READ_ACCESS_TOKEN@$CI_SERVER_HOST/$CUDAQ_TENSORNET_REPO $CUDAQ_TENSORNET_COMMIT && git checkout FETCH_HEAD
+    - export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
     - (bash build_wheel.sh $READ_ACCESS_TOKEN && built=true) || built=false
     - if $built; then `exit 0`; else `exit 1`; fi
     # MGMN SV  Simulator

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -79,6 +79,9 @@ Python Wheels:
     - cudaq_location=`$python -m pip show cuda-quantum | grep -e 'Location:\ .*$'`
     - export CUDAQ_INSTALL_PREFIX="${cudaq_location#Location:\ }"
     - cp -R $CUDAQ_INSTALL_PREFIX/lib64/cmake/fmt $CUDAQ_INSTALL_PREFIX/lib/cmake
+    - export EXATN_COMMIT=9c053ac1671c041827fee3aeb33cfc6bf43762eb
+    - export CUDAQ_TENSORNET_COMMIT=17dc530c4838b2e32125d427feabfd32c1fdd0fc
+    - export CUDAQ_MGMN_SVSIM_COMMIT=e8a6702a222c1a5f3fead4dc5efb11953967dd90
     # Tensornet Simulator
     - cuquantum_location=`$python -m pip show cuquantum-cu11 | grep -e 'Location:\ .*$'`
     - echo $cuquantum_location


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

(1) Docker

Build Tensornet and MGMN SV cross-platform; package them into sims_amd64.zip and sims_aarch64.zip artifacts/assets to be uploaded to GitHub for the Docker image Packaging workflow.

Sample muti-platform docker build log: https://github.com/NVIDIA/cuda-quantum/actions/runs/6145961949/job/16675054084

```
#10 [linux/amd64 4/5] RUN for folder in `find "/opt/nvidia/cudaq/assets"/*$(uname -m)/* -maxdepth 0 -type d`;     do bash "/opt/nvidia/cudaq/bin/migrate_assets.sh" "$folder" && rm -rf "$folder"; done     && rm "/opt/nvidia/cudaq/bin/migrate_assets.sh"
#10 0.161 Migrating assets in /opt/nvidia/cudaq/assets/x86_64/mgmn_svsim.
#10 0.161 Using build configuration /opt/nvidia/cudaq/build_config.xml.
.....
```

```
#13 [linux/arm64 4/5] RUN for folder in `find "/opt/nvidia/cudaq/assets"/*$(uname -m)/* -maxdepth 0 -type d`;     do bash "/opt/nvidia/cudaq/bin/migrate_assets.sh" "$folder" && rm -rf "$folder"; done     && rm "/opt/nvidia/cudaq/bin/migrate_assets.sh"
#13 0.730 Migrating assets in /opt/nvidia/cudaq/assets/aarch64/mgmn_svsim.
```


(2) Python 

Download the wheel artifact from upstream deployment pipeline and install it to serve as the base CUDA Quantum installation to build other backends. Upload the resulting `.so` and `.config` along with dependencies.

Supersedes https://github.com/NVIDIA/cuda-quantum/pull/588

Related to https://github.com/NVIDIA/cuda-quantum/pull/642