### PR TITLE
Modify Quake::ApplyOp to allow an indirect form of call in order to

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -446,9 +446,9 @@ def cc_ReturnOp : CCOp<"return", [Pure, ReturnLike, Terminator,
        ^entry(%arg0 : i32):
         ...
         cc.return
-      } : !cc.lambda<(i32) -> ()>
+      } : !cc.callable<(i32) -> ()>
       ...
-      cc.call_callable %lambda, %20 : (!cc.lambda<(i32) -> ()>, i32) -> ()
+      cc.call_callable %lambda, %20 : (!cc.callable<(i32) -> ()>, i32) -> ()
     ```
   }];
 
@@ -1119,9 +1119,9 @@ def cc_CreateLambdaOp : CCOp<"create_lambda",
        ^entry(%arg0 : i32):
         ...
         cc.return
-      } : !cc.lambda<(i32) -> ()>
+      } : !cc.callable<(i32) -> ()>
       ...
-      cc.call_callable %lambda, %20 : (!cc.lambda<(i32) -> ()>, i32) -> ()
+      cc.call_callable %lambda, %20 : (!cc.callable<(i32) -> ()>, i32) -> ()
     ```
   }];
 
@@ -1186,9 +1186,9 @@ def cc_CallCallableOp : CCOp<"call_callable", [CallOpInterface]> {
        ^entry(%arg0 : i32):
         ...
         cc.return
-      } : !cc.lambda<(i32) -> ()>
+      } : !cc.callable<(i32) -> ()>
       ...
-      cc.call_callable %lambda, %20 : (!cc.lambda<(i32) -> ()>, i32) -> ()
+      cc.call_callable %lambda, %20 : (!cc.callable<(i32) -> ()>, i32) -> ()
     ```
   }];
 
@@ -1233,6 +1233,10 @@ def cc_InstantiateCallableOp : CCOp<"instantiate_callable", [Pure]> {
     The InstantiateCallableOp constructs a pair. The pair is a pointer to the
     associated currying trampoline function and a tuple of the captured values.
 
+    When there are no captured values, such as when the callable is a plain old
+    function, the attribute `nocapture` should be used to build the callable
+    such that no unmarshalling trampoline is required. See below.
+
     Example:
 
     Take the following λ expression.
@@ -1244,7 +1248,7 @@ def cc_InstantiateCallableOp : CCOp<"instantiate_callable", [Pure]> {
        ^entry(%arg0 : i32):
         ... %88 ...
         cc.return
-      } : !cc.lambda<(i32) -> ()>
+      } : !cc.callable<(i32) -> ()>
     ```
 
     Since this λ expression captures the value %88 from the parent, we have to
@@ -1254,12 +1258,12 @@ def cc_InstantiateCallableOp : CCOp<"instantiate_callable", [Pure]> {
     outlined λ function in the following example.
 
     ```mlir
-      %lambda = cc.instantiate_callable @trampoline.54(%88) : (f64) -> !cc.lambda<(i32) -> ()>
+      %lambda = cc.instantiate_callable @trampoline.54(%88) : (f64) -> !cc.callable<(i32) -> ()>
       ...
 
       // Trampoline function
-      func.func private @trampoline.54(%arg0: !cc.lambda<(i32) -> ()>, %arg1: i32) {
-        %0 = cc.callable_closure %arg0: !cc.lambda<(i32) -> ()> -> f64
+      func.func private @trampoline.54(%arg0: !cc.callable<(i32) -> ()>, %arg1: i32) {
+        %0 = cc.callable_closure %arg0: !cc.callable<(i32) -> ()> -> f64
         call @lifted_lambda.54(%0, %arg1) : (f64, i32) -> ()
       }
 
@@ -1271,18 +1275,32 @@ def cc_InstantiateCallableOp : CCOp<"instantiate_callable", [Pure]> {
       }
     ```
 
+    In the case when the `nocapture` attribute is present, the closure pointer
+    value will be set to `nullptr`. A `cc.call_callable` can thus test the
+    closure value to determine whether to omit prepending the pointer to the
+    callable pair or not.
+
     See also CallCallableOp.
   }];
 
   let arguments = (ins
     SymbolRefAttr:$callee,
-    Variadic<AnyType>:$closure_data
+    Variadic<AnyType>:$closure_data,
+    OptionalAttr<UnitAttr>:$no_capture
   );
   let results = (outs cc_CallableType:$signature);
 
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$signature, "mlir::SymbolRefAttr":$callee,
+      "mlir::ValueRange":$closure_data), [{
+      return build($_builder, $_state, signature, callee, closure_data,
+        mlir::UnitAttr{});
+    }]> 
+  ];
+
   let assemblyFormat = [{
-    $callee `(` $closure_data `)`
-    `:` functional-type(operands, results) attr-dict
+    $callee `(` $closure_data `)` ( `nocapture` $no_capture^ )?
+      `:` functional-type(operands, results) attr-dict
   }];
 }
 
@@ -1296,10 +1314,10 @@ def cc_CallableFuncOp : CCOp<"callable_func", [Pure]> {
     Example:
 
     ```mlir
-      %0 = ... : !cc.lambda<(i32) -> i8>
+      %0 = ... : !cc.callable<(i32) -> i8>
       %1 = ... : i32
-      %2 = cc.callable_func %0 : (!cc.lambda<(i32) -> i8>) -> ((!cc.lambda<(i32) -> i8>, i32) -> i8)
-      %3 = call_indirect %2(%0, %1) : (!cc.lambda<(i32) -> i8>, i32) -> i8
+      %2 = cc.callable_func %0 : (!cc.callable<(i32) -> i8>) -> ((!cc.callable<(i32) -> i8>, i32) -> i8)
+      %3 = call_indirect %2(%0, %1) : (!cc.callable<(i32) -> i8>, i32) -> i8
     ```
 
     See also InstantiateCallableOp, CallableClosureOp.
@@ -1334,9 +1352,9 @@ def cc_CallableClosureOp : CCOp<"callable_closure", [Pure]> {
     Example:
 
     ```mlir
-      %0 = ... !cc.lambda<(i32) -> i8>
+      %0 = ... !cc.callable<(i32) -> i8>
       %1 = ... : i32
-      %2:2 = cc.callable_closure %0 : (!cc.lambda<(i32) -> i8>) -> (!quake.wire, i1)
+      %2:2 = cc.callable_closure %0 : (!cc.callable<(i32) -> i8>) -> (!quake.wire, i1)
       %3 = call @lifted_lambda.72(%2#0, %2#1, %1) : (!quake.wire, i1, i32) -> i8
     ```
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -391,17 +391,49 @@ def quake_ApplyOp : QuakeOp<"apply",
   }];
 
   let arguments = (ins
-    SymbolRefAttr:$callee,
+    OptionalAttr<SymbolRefAttr>:$callee,
+    Variadic<cc_CallableType>:$indirect_callee, // must be 0 or 1 element
     UnitAttr:$is_adj,
     Variadic<AnyQType>:$controls,
     Variadic<AnyType>:$args
   );
   let results = (outs Variadic<AnyType>);
 
-  let assemblyFormat = [{
-    (`<` `adj` $is_adj^ `>`)? $callee (`[` $controls^ `]`)? $args `:`
-      functional-type(operands,results) attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
+  let builders = [
+    OpBuilder<(ins "mlir::TypeRange":$retTy,
+                   "mlir::SymbolRefAttr":$callee,
+                   "mlir::UnitAttr":$is_adj,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$args), [{
+      return build($_builder, $_state, retTy, callee, mlir::ValueRange{},
+                   is_adj, controls, args);
+    }]>,
+    OpBuilder<(ins "mlir::TypeRange":$retTy,
+                   "mlir::SymbolRefAttr":$callee,
+                   "bool":$is_adj,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$args), [{
+      return build($_builder, $_state, retTy, callee, mlir::ValueRange{},
+                   is_adj, controls, args);
+    }]>,
+    OpBuilder<(ins "mlir::TypeRange":$retTy,
+                   "mlir::Value":$callable,
+                   "mlir::UnitAttr":$is_adj,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$args), [{
+      return build($_builder, $_state, retTy, mlir::SymbolRefAttr{},
+                   mlir::ValueRange{callable}, is_adj, controls, args);
+    }]>,
+    OpBuilder<(ins "mlir::TypeRange":$retTy,
+                   "mlir::Value":$callable,
+                   "bool":$is_adj,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$args), [{
+      return build($_builder, $_state, retTy, mlir::SymbolRefAttr{},
+                   mlir::ValueRange{callable}, is_adj, controls, args);
+    }]>
+  ];
 
   let extraClassDeclaration = [{
     static constexpr llvm::StringRef getCalleeAttrNameStr() { return "callee"; }

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -916,6 +916,74 @@ public:
   }
 };
 
+class CallCallableOpPattern
+    : public ConvertOpToLLVMPattern<cudaq::cc::CallCallableOp> {
+public:
+  using Base = ConvertOpToLLVMPattern<cudaq::cc::CallCallableOp>;
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(cudaq::cc::CallCallableOp call, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = call.getLoc();
+    auto calleeFuncTy =
+        cast<cudaq::cc::CallableType>(call.getCallee().getType())
+            .getSignature();
+    auto operands = adaptor.getOperands();
+    auto *ctx = rewriter.getContext();
+    auto structTy = dyn_cast<LLVM::LLVMStructType>(operands[0].getType());
+    auto ptr0Ty = structTy.getBody()[0];
+    auto zero = DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{0});
+    auto rawFuncPtr =
+        rewriter.create<LLVM::ExtractValueOp>(loc, ptr0Ty, operands[0], zero);
+    auto ptr1Ty = structTy.getBody()[1];
+    auto one = DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{1});
+    auto rawTuplePtr =
+        rewriter.create<LLVM::ExtractValueOp>(loc, ptr1Ty, operands[0], one);
+    Type funcPtrTy = getTypeConverter()->convertType(calleeFuncTy);
+    auto funcPtr = rewriter.create<LLVM::BitcastOp>(loc, funcPtrTy, rawFuncPtr);
+    auto zeroAttr = rewriter.getI64IntegerAttr(0);
+    auto i64Ty = rewriter.getI64Type();
+    auto zeroI64 = rewriter.create<LLVM::ConstantOp>(loc, i64Ty, zeroAttr);
+    auto rawTupleVal =
+        rewriter.create<LLVM::PtrToIntOp>(loc, i64Ty, rawTuplePtr);
+    auto isNullptr = rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::eq,
+                                                   rawTupleVal, zeroI64);
+    auto *initBlock = rewriter.getInsertionBlock();
+    auto initPos = rewriter.getInsertionPoint();
+    auto *endBlock = rewriter.splitBlock(initBlock, initPos);
+    auto *thenBlock = rewriter.createBlock(endBlock);
+    auto *elseBlock = rewriter.createBlock(endBlock);
+    SmallVector<Type> resultTy;
+    auto llvmFuncTy = cast<LLVM::LLVMFunctionType>(
+        cast<LLVM::LLVMPointerType>(funcPtrTy).getElementType());
+    if (!isa<LLVM::LLVMVoidType>(llvmFuncTy.getReturnType())) {
+      resultTy.push_back(llvmFuncTy.getReturnType());
+      endBlock->addArgument(resultTy[0], loc);
+    }
+    rewriter.setInsertionPointToEnd(initBlock);
+    rewriter.create<LLVM::CondBrOp>(loc, isNullptr, thenBlock, elseBlock);
+    rewriter.setInsertionPointToEnd(thenBlock);
+    SmallVector<Value> arguments1 = {funcPtr};
+    arguments1.append(operands.begin() + 1, operands.end());
+    auto call1 = rewriter.create<LLVM::CallOp>(loc, resultTy, arguments1);
+    rewriter.create<LLVM::BrOp>(loc, call1.getResults(), endBlock);
+    rewriter.setInsertionPointToEnd(elseBlock);
+    SmallVector<Type> argTys(operands.getTypes().begin(),
+                             operands.getTypes().end());
+    auto adjustedFuncTy =
+        LLVM::LLVMFunctionType::get(llvmFuncTy.getReturnType(), argTys);
+    auto adjustedFuncPtr = rewriter.create<LLVM::BitcastOp>(
+        loc, cudaq::opt::factory::getPointerType(adjustedFuncTy), funcPtr);
+    SmallVector<Value> arguments2 = {adjustedFuncPtr};
+    arguments2.append(operands.begin(), operands.end());
+    auto call2 = rewriter.create<LLVM::CallOp>(loc, resultTy, arguments2);
+    rewriter.create<LLVM::BrOp>(loc, call2.getResults(), endBlock);
+    rewriter.replaceOp(call, endBlock->getArguments());
+    return success();
+  }
+};
+
 class CastOpPattern : public ConvertOpToLLVMPattern<cudaq::cc::CastOp> {
 public:
   using Base = ConvertOpToLLVMPattern<cudaq::cc::CastOp>;
@@ -1092,26 +1160,39 @@ public:
     SmallVector<Type> tupleMemTys(adaptor.getOperands().getTypes().begin(),
                                   adaptor.getOperands().getTypes().end());
     auto tupleTy = LLVM::LLVMStructType::getLiteral(ctx, tupleMemTys);
-    Value tupleVal = rewriter.create<LLVM::UndefOp>(loc, tupleTy);
-    std::int64_t offsetVal = 0;
-    for (auto op : operands) {
-      auto offset =
-          DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{offsetVal});
-      tupleVal = rewriter.create<LLVM::InsertValueOp>(loc, tupleTy, tupleVal,
-                                                      op, offset);
-      offsetVal++;
-    }
-    auto oneAttr = rewriter.getI64IntegerAttr(1);
+    Value tmp;
     auto i64Ty = rewriter.getI64Type();
-    Value one = rewriter.create<LLVM::ConstantOp>(loc, i64Ty, oneAttr);
-    auto tuplePtrTy = cudaq::opt::factory::getPointerType(tupleTy);
-    auto tmp = rewriter.create<LLVM::AllocaOp>(loc, tuplePtrTy, one);
-    rewriter.create<LLVM::StoreOp>(loc, tupleVal, tmp);
     auto tupleArgTy = lambdaAsPairOfPointers(ctx);
+    if (callable.getNoCapture()) {
+      auto zeroAttr = rewriter.getI64IntegerAttr(0);
+      auto zero = rewriter.create<LLVM::ConstantOp>(loc, i64Ty, zeroAttr);
+      tmp =
+          rewriter.create<LLVM::IntToPtrOp>(loc, tupleArgTy.getBody()[1], zero);
+    } else {
+      Value tupleVal = rewriter.create<LLVM::UndefOp>(loc, tupleTy);
+      std::int64_t offsetVal = 0;
+      for (auto op : operands) {
+        auto offset =
+            DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{offsetVal});
+        tupleVal = rewriter.create<LLVM::InsertValueOp>(loc, tupleTy, tupleVal,
+                                                        op, offset);
+        offsetVal++;
+      }
+      auto oneAttr = rewriter.getI64IntegerAttr(1);
+      Value one = rewriter.create<LLVM::ConstantOp>(loc, i64Ty, oneAttr);
+      auto tuplePtrTy = cudaq::opt::factory::getPointerType(tupleTy);
+      tmp = rewriter.create<LLVM::AllocaOp>(loc, tuplePtrTy, one);
+      rewriter.create<LLVM::StoreOp>(loc, tupleVal, tmp);
+    }
     Value tupleArg = rewriter.create<LLVM::UndefOp>(loc, tupleArgTy);
     auto module = callable->getParentOfType<ModuleOp>();
-    auto calledFunc = module.lookupSymbol<func::FuncOp>(callable.getCallee());
-    Type sigTy = getTypeConverter()->convertType(calledFunc.getFunctionType());
+    auto *calledFuncOp = module.lookupSymbol(callable.getCallee());
+    auto sigTy = [&]() -> Type {
+      if (auto calledFunc = dyn_cast<func::FuncOp>(calledFuncOp))
+        return getTypeConverter()->convertType(calledFunc.getFunctionType());
+      return cudaq::opt::factory::getPointerType(
+          cast<LLVM::LLVMFuncOp>(calledFuncOp).getFunctionType());
+    }();
     auto tramp = rewriter.create<LLVM::AddressOfOp>(
         loc, sigTy, callable.getCallee().cast<FlatSymbolRefAttr>());
     auto trampoline =
@@ -1305,43 +1386,10 @@ public:
   ModuleOp getModule() { return getOperation(); }
 
   void runOnOperation() override final {
-    auto *context = getModule().getContext();
+    auto *context = &getContext();
     LLVMConversionTarget target{*context};
     LLVMTypeConverter typeConverter(&getContext());
-    typeConverter.addConversion(
-        [&](quake::VeqType type) { return cudaq::opt::getArrayType(context); });
-    typeConverter.addConversion(
-        [&](quake::RefType type) { return cudaq::opt::getQubitType(context); });
-    typeConverter.addConversion([&](cudaq::cc::CallableType type) {
-      return lambdaAsPairOfPointers(type.getContext());
-    });
-    typeConverter.addConversion([&](cudaq::cc::StdvecType type) {
-      return cudaq::opt::factory::stdVectorImplType(type.getElementType());
-    });
-    typeConverter.addConversion([&](cudaq::cc::PointerType type) {
-      auto eleTy = type.getElementType();
-      if (isa<NoneType>(eleTy))
-        return cudaq::opt::factory::getPointerType(context);
-      eleTy = typeConverter.convertType(eleTy);
-      if (auto arrTy = dyn_cast<cudaq::cc::ArrayType>(eleTy)) {
-        assert(arrTy.isUnknownSize());
-        return cudaq::opt::factory::getPointerType(
-            typeConverter.convertType(arrTy.getElementType()));
-      }
-      return cudaq::opt::factory::getPointerType(eleTy);
-    });
-    typeConverter.addConversion([&](cudaq::cc::ArrayType type) -> Type {
-      auto eleTy = typeConverter.convertType(type.getElementType());
-      if (type.isUnknownSize())
-        return type;
-      return LLVM::LLVMArrayType::get(eleTy, type.getSize());
-    });
-    typeConverter.addConversion([&](cudaq::cc::StructType type) -> Type {
-      SmallVector<Type> members;
-      for (auto t : type.getMembers())
-        members.push_back(typeConverter.convertType(t));
-      return LLVM::LLVMStructType::getLiteral(context, members);
-    });
+    initializeTypeConversions(typeConverter);
     RewritePatternSet patterns(context);
 
     populateAffineToStdConversionPatterns(patterns);
@@ -1356,10 +1404,10 @@ public:
         context);
     patterns.insert<
         AllocaOpRewrite, AllocaOpPattern, CallableClosureOpPattern,
-        CallableFuncOpPattern, CastOpPattern, ComputePtrOpPattern,
-        ConcatOpRewrite, DeallocOpRewrite, ExtractQubitOpRewrite,
-        ExtractValueOpPattern, FuncToPtrOpPattern, InsertValueOpPattern,
-        InstantiateCallableOpPattern, LoadOpPattern,
+        CallableFuncOpPattern, CallCallableOpPattern, CastOpPattern,
+        ComputePtrOpPattern, ConcatOpRewrite, DeallocOpRewrite,
+        ExtractQubitOpRewrite, ExtractValueOpPattern, FuncToPtrOpPattern,
+        InsertValueOpPattern, InstantiateCallableOpPattern, LoadOpPattern,
         MeasureRewrite<quake::MzOp>, OneTargetRewrite<quake::HOp>,
         OneTargetRewrite<quake::XOp>, OneTargetRewrite<quake::YOp>,
         OneTargetRewrite<quake::ZOp>, OneTargetRewrite<quake::SOp>,
@@ -1379,6 +1427,47 @@ public:
 
     if (failed(applyFullConversion(getModule(), target, std::move(patterns))))
       signalPassFailure();
+  }
+
+  void initializeTypeConversions(LLVMTypeConverter &typeConverter) {
+    typeConverter.addConversion([](quake::VeqType type) {
+      return cudaq::opt::getArrayType(type.getContext());
+    });
+    typeConverter.addConversion([](quake::RefType type) {
+      return cudaq::opt::getQubitType(type.getContext());
+    });
+    typeConverter.addConversion([](cudaq::cc::CallableType type) {
+      return lambdaAsPairOfPointers(type.getContext());
+    });
+    typeConverter.addConversion([](cudaq::cc::StdvecType type) {
+      return cudaq::opt::factory::stdVectorImplType(type.getElementType());
+    });
+    typeConverter.addConversion([&typeConverter](cudaq::cc::PointerType type) {
+      auto eleTy = type.getElementType();
+      if (isa<NoneType>(eleTy))
+        return cudaq::opt::factory::getPointerType(type.getContext());
+      eleTy = typeConverter.convertType(eleTy);
+      if (auto arrTy = dyn_cast<cudaq::cc::ArrayType>(eleTy)) {
+        assert(arrTy.isUnknownSize());
+        return cudaq::opt::factory::getPointerType(
+            typeConverter.convertType(arrTy.getElementType()));
+      }
+      return cudaq::opt::factory::getPointerType(eleTy);
+    });
+    typeConverter.addConversion(
+        [&typeConverter](cudaq::cc::ArrayType type) -> Type {
+          auto eleTy = typeConverter.convertType(type.getElementType());
+          if (type.isUnknownSize())
+            return type;
+          return LLVM::LLVMArrayType::get(eleTy, type.getSize());
+        });
+    typeConverter.addConversion(
+        [&typeConverter](cudaq::cc::StructType type) -> Type {
+          SmallVector<Type> members;
+          for (auto t : type.getMembers())
+            members.push_back(typeConverter.convertType(t));
+          return LLVM::LLVMStructType::getLiteral(type.getContext(), members);
+        });
   }
 };
 

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -110,6 +110,96 @@ void quake::AllocaOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 }
 
 //===----------------------------------------------------------------------===//
+// Apply
+//===----------------------------------------------------------------------===//
+
+void quake::ApplyOp::print(OpAsmPrinter &p) {
+  if (getIsAdj())
+    p << "<adj>";
+  p << ' ';
+  bool isDirect = getCallee().has_value();
+  if (isDirect)
+    p.printAttributeWithoutType(getCalleeAttr());
+  else
+    p << getIndirectCallee();
+  p << ' ';
+  if (!getControls().empty())
+    p << '[' << getControls() << "] ";
+  p << getArgs() << " : ";
+  SmallVector<Type> operandTys{(*this)->getOperandTypes().begin(),
+                               (*this)->getOperandTypes().end()};
+  p.printFunctionalType(ArrayRef<Type>{operandTys}.drop_front(isDirect ? 0 : 1),
+                        (*this)->getResultTypes());
+  p.printOptionalAttrDict(
+      (*this)->getAttrs(),
+      {"operand_segment_sizes", "is_adj", getCalleeAttrNameStr()});
+}
+
+ParseResult quake::ApplyOp::parse(OpAsmParser &parser, OperationState &result) {
+  if (succeeded(parser.parseOptionalLess())) {
+    if (parser.parseKeyword("adj") || parser.parseGreater())
+      return failure();
+    result.addAttribute("is_adj", parser.getBuilder().getUnitAttr());
+  }
+  SmallVector<OpAsmParser::UnresolvedOperand> calleeOperand;
+  if (parser.parseOperandList(calleeOperand))
+    return failure();
+  bool isDirect = calleeOperand.empty();
+  if (calleeOperand.size() > 1)
+    return failure();
+  if (isDirect) {
+    NamedAttrList attrs;
+    SymbolRefAttr funcAttr;
+    if (parser.parseCustomAttributeWithFallback(
+            funcAttr, parser.getBuilder().getType<NoneType>(),
+            getCalleeAttrNameStr(), attrs))
+      return failure();
+    result.addAttribute(getCalleeAttrNameStr(), funcAttr);
+  }
+
+  SmallVector<OpAsmParser::UnresolvedOperand> controlOperands;
+  if (succeeded(parser.parseOptionalLSquare()))
+    if (parser.parseOperandList(controlOperands) || parser.parseRSquare())
+      return failure();
+
+  SmallVector<OpAsmParser::UnresolvedOperand> miscOperands;
+  if (parser.parseOperandList(miscOperands) || parser.parseColon())
+    return failure();
+
+  FunctionType applyTy;
+  if (parser.parseType(applyTy) ||
+      parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+  result.addAttribute("operand_segment_sizes",
+                      parser.getBuilder().getDenseI32ArrayAttr(
+                          {static_cast<int32_t>(calleeOperand.size()),
+                           static_cast<int32_t>(controlOperands.size()),
+                           static_cast<int32_t>(miscOperands.size())}));
+  result.addTypes(applyTy.getResults());
+  if (isDirect) {
+    if (parser.resolveOperands(
+            llvm::concat<const OpAsmParser::UnresolvedOperand>(
+                calleeOperand, controlOperands, miscOperands),
+            applyTy.getInputs(), parser.getNameLoc(), result.operands))
+      return failure();
+  } else {
+    auto loc = parser.getNameLoc();
+    auto fnTy = parser.getBuilder().getFunctionType(
+        applyTy.getInputs().drop_front(controlOperands.size()),
+        applyTy.getResults());
+    auto callableTy = cudaq::cc::CallableType::get(parser.getContext(), fnTy);
+    if (parser.resolveOperands(calleeOperand, callableTy, loc,
+                               result.operands) ||
+        parser.resolveOperands(
+            llvm::concat<const OpAsmParser::UnresolvedOperand>(controlOperands,
+                                                               miscOperands),
+            applyTy.getInputs(), loc, result.operands))
+      return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Concat
 //===----------------------------------------------------------------------===//
 
@@ -375,7 +465,8 @@ void quake::VeqSizeOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 
 namespace {
 // If there is no operation that modifies the wire after it gets unwrapped and
-// before it is wrapped, then the wrap operation is a nop and can be eliminated.
+// before it is wrapped, then the wrap operation is a nop and can be
+// eliminated.
 struct KillDeadWrapPattern : public OpRewritePattern<quake::WrapOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -609,8 +700,8 @@ void quake::ZOp::getOperatorMatrix(Matrix &matrix) {
 //===----------------------------------------------------------------------===//
 
 /// Never inline a `quake.apply` of a variant form of a kernel. The apply
-/// operation must be rewritten to a call before it is inlined when the apply is
-/// a variant form.
+/// operation must be rewritten to a call before it is inlined when the apply
+/// is a variant form.
 bool cudaq::EnableInlinerInterface::isLegalToInline(Operation *call,
                                                     Operation *callable,
                                                     bool) const {
@@ -623,8 +714,8 @@ bool cudaq::EnableInlinerInterface::isLegalToInline(Operation *call,
 using EffectsVectorImpl =
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>;
 
-/// For an operation with modeless effects, the operation always has effects on
-/// the control and target quantum operands, whether those operands are in
+/// For an operation with modeless effects, the operation always has effects
+/// on the control and target quantum operands, whether those operands are in
 /// reference or value form. A operation with modeless effects is not removed
 /// when its result(s) is (are) unused.
 [[maybe_unused]] inline static void
@@ -641,12 +732,12 @@ getModelessEffectsImpl(EffectsVectorImpl &effects, ValueRange controls,
   }
 }
 
-/// For an operation with moded effects, the operation conditionally has effects
-/// on the control and target quantum operands. If those operands are in
-/// reference form, then the operation does have effects on those references.
-/// Control operands have a read effect, while target operands have both a read
-/// and write effect. If the operand is in value form, the operation introduces
-/// no effects on that operand.
+/// For an operation with moded effects, the operation conditionally has
+/// effects on the control and target quantum operands. If those operands are
+/// in reference form, then the operation does have effects on those
+/// references. Control operands have a read effect, while target operands
+/// have both a read and write effect. If the operand is in value form, the
+/// operation introduces no effects on that operand.
 inline static void getModedEffectsImpl(EffectsVectorImpl &effects,
                                        ValueRange controls,
                                        ValueRange targets) {

--- a/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -104,7 +104,7 @@ private:
 
   func::FuncOp lookupCallee(quake::ApplyOp apply) {
     auto callee = apply.getCallee();
-    return module.lookupSymbol<func::FuncOp>(callee);
+    return module.lookupSymbol<func::FuncOp>(*callee);
   }
 
   ModuleOp module;
@@ -171,7 +171,7 @@ struct ApplyOpPattern : public OpRewritePattern<quake::ApplyOp> {
   LogicalResult matchAndRewrite(quake::ApplyOp apply,
                                 PatternRewriter &rewriter) const override {
     auto calleeName = getVariantFunctionName(
-        apply, apply.getCallee().getRootReference().str());
+        apply, apply.getCallee()->getRootReference().str());
     auto *ctx = apply.getContext();
     auto consTy = quake::VeqType::getUnsized(ctx);
     SmallVector<Value> newArgs;
@@ -318,7 +318,7 @@ public:
         newControls.append(apply.getControls().begin(),
                            apply.getControls().end());
         auto newApply = builder.create<quake::ApplyOp>(
-            apply.getLoc(), apply.getResultTypes(), apply.getCallee(),
+            apply.getLoc(), apply.getResultTypes(), apply.getCalleeAttr(),
             apply.getIsAdjAttr(), newControls, apply.getArgs());
         apply->replaceAllUsesWith(newApply.getResults());
         apply->erase();

--- a/test/AST-Quake/control.cpp
+++ b/test/AST-Quake/control.cpp
@@ -39,7 +39,7 @@ struct ctrlHeisenberg {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_8:.*]] = quake.concat %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
-// CHECK:           quake.apply @__nvqpp__mlirgen__heisenbergU[%[[VAL_8]]] %{{.*}} : (!quake.veq<2>, !quake.veq<?>) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__heisenbergU [%[[VAL_8]]] %{{.*}} : (!quake.veq<2>, !quake.veq<?>) -> ()
 // CHECK:           return
 
 struct givens {
@@ -68,7 +68,7 @@ __qpu__ void qnppx(double theta, cudaq::qubit &q, cudaq::qubit &r,
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_qnppx
 // CHECK:           %[[VAL_7:.*]] = quake.concat %{{.*}}, %{{.*}} : (!quake.ref, !quake.ref) -> !quake.veq<2>
-// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %{{.*}}, %{{.*}} : (!quake.veq<2>, f64, !quake.ref, !quake.ref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__givens [%[[VAL_7]]] %{{.*}}, %{{.*}}, %{{.*}} : (!quake.veq<2>, f64, !quake.ref, !quake.ref) -> ()
 // CHECK:           return
 
 __qpu__ void magic_func(cudaq::qreg<> &q) {
@@ -95,7 +95,7 @@ struct ctrlHeisenbergVersion2 {
 // CHECK-SAME:      ._Z[[mangle:[^(]*]](
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ctrlHeisenbergVersion2(
-// CHECK:           quake.apply @__nvqpp__mlirgen__function_magic_func._Z[[mangle]]{{\[}}%{{.*}}] %{{.*}} : (!quake.ref, !quake.veq<?>) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__function_magic_func._Z[[mangle]] [%{{.*}}] %{{.*}} : (!quake.ref, !quake.veq<?>) -> ()
 // CHECK:           return
 
 __qpu__ void qnppx2(double theta, cudaq::qubit &q, cudaq::qubit &r,
@@ -111,7 +111,7 @@ __qpu__ void qnppx2(double theta, cudaq::qubit &q, cudaq::qubit &r,
 // CHECK-SAME:       %{{[^:]*}}: f64{{.*}}, %[[VAL_1:.*]]: !quake.ref{{.*}}, %[[VAL_2:.*]]: !quake.ref{{.*}}, %[[VAL_3:.*]]: !quake.ref{{.*}}, %[[VAL_4:.*]]: !quake.ref{{.*}})
 // CHECK:           %[[VAL_7:.*]] = quake.concat %[[VAL_1]], %[[VAL_4]] : (!quake.ref, !quake.ref) -> !quake.veq<2>
 // CHECK:           quake.x %[[VAL_4]]
-// CHECK:           quake.apply @__nvqpp__mlirgen__givens[%[[VAL_7]]] %{{.*}}, %[[VAL_2]], %[[VAL_3]] : (!quake.veq<2>, f64, !quake.ref, !quake.ref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__givens [%[[VAL_7]]] %{{.*}}, %[[VAL_2]], %[[VAL_3]] : (!quake.veq<2>, f64, !quake.ref, !quake.ref) -> ()
 // CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
 // CHECK:           quake.x [%[[VAL_2]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           quake.x [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()

--- a/test/AST-Quake/ctrl_vector.cpp
+++ b/test/AST-Quake/ctrl_vector.cpp
@@ -54,7 +54,7 @@ struct test_two_control_call {
 // CHECK:           } : !cc.callable<(!quake.ref) -> ()>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
-// CHECK:           quake.apply @__nvqpp__mlirgen__ZN21test_two_control_callcl[[LAMBDA:.*]]_[%[[VAL_2]]] %[[VAL_4]] : (!quake.veq<4>, !quake.ref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__ZN21test_two_control_callcl[[LAMBDA:.*]]_ [%[[VAL_2]]] %[[VAL_4]] : (!quake.veq<4>, !quake.ref) -> ()
 // CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> i1
 // CHECK:           return
 // CHECK:         }
@@ -64,3 +64,28 @@ struct test_two_control_call {
 // CHECK:          quake.h
 // CHECK:          quake.x
 // CHECK:          return
+
+struct unmarked_lambda {
+  void operator()() __qpu__ {
+    auto lambda = [](cudaq::qubit &qb) {
+      h<cudaq::ctrl>(qb);
+      y<cudaq::ctrl>(qb);
+    };
+    cudaq::qreg<4> qs;
+    cudaq::qubit qb;
+    cudaq::control(lambda, qs, qb);
+    mz(qb);
+  }
+};
+
+struct direct_unmarked_lambda {
+  void operator()() __qpu__ {
+    cudaq::qreg<4> qs;
+    cudaq::qubit qb;
+    cudaq::control([](cudaq::qubit &qb) {
+      h<cudaq::ctrl>(qb);
+      y<cudaq::ctrl>(qb);
+    }, qs, qb);
+    mz(qb);
+  }
+};

--- a/test/AST-Quake/ctrl_vector.cpp
+++ b/test/AST-Quake/ctrl_vector.cpp
@@ -78,6 +78,19 @@ struct unmarked_lambda {
   }
 };
 
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__unmarked_lambda() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[VAL_0:.*]] = cc.create_lambda {
+// CHECK:           ^bb0(%[[VAL_1:.*]]: !quake.ref):
+// CHECK:             quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:             quake.y %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           } : !cc.callable<(!quake.ref) -> ()>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.apply %[[VAL_0]] [%[[VAL_2]]] %[[VAL_3]] : (!quake.veq<4>, !quake.ref) -> ()
+// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> i1
+// CHECK:           return
+// CHECK:         }
+
 struct direct_unmarked_lambda {
   void operator()() __qpu__ {
     cudaq::qreg<4> qs;
@@ -89,3 +102,16 @@ struct direct_unmarked_lambda {
     mz(qb);
   }
 };
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__direct_unmarked_lambda() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_2:.*]] = cc.create_lambda {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: !quake.ref):
+// CHECK:             quake.h %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:             quake.y %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:           } : !cc.callable<(!quake.ref) -> ()>
+// CHECK:           quake.apply %[[VAL_2]] [%[[VAL_0]]] %[[VAL_1]] : (!quake.veq<4>, !quake.ref) -> ()
+// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1
+// CHECK:           return
+// CHECK:         }

--- a/test/AST-Quake/lambda_instance.cpp
+++ b/test/AST-Quake/lambda_instance.cpp
@@ -29,7 +29,7 @@ struct test0 {
 // CHECK:           } : !cc.callable<(!quake.ref) -> ()>
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           quake.apply @__nvqpp__mlirgen__ZN5test0[[LAM1:.*]]{{\[}}%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__ZN5test0[[LAM1:.*]] [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -54,7 +54,7 @@ struct test1 {
 // CHECK:           } : !cc.callable<(!quake.ref) -> ()>
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           quake.apply @__nvqpp__mlirgen__ZN5test1[[LAM1:.*]]{{\[}}%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__ZN5test1[[LAM1:.*]] [%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -319,7 +319,7 @@ int main() {
 // CHECK:                     %[[VAL_47:.*]] = cc.load %[[VAL_36]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_48:.*]] = arith.extsi %[[VAL_47]] : i32 to i64
 // CHECK:                     %[[VAL_49:.*]] = quake.extract_ref %[[VAL_20]]{{\[}}%[[VAL_48]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:                     quake.apply @__nvqpp__mlirgen__tgate{{\[}}%[[VAL_49]]] %[[VAL_26]] : (!quake.ref, !quake.veq<?>) -> ()
+// CHECK:                     quake.apply @__nvqpp__mlirgen__tgate [%[[VAL_49]]] %[[VAL_26]] : (!quake.ref, !quake.veq<?>) -> ()
 // CHECK:                     cc.continue
 // CHECK:                   } step {
 // CHECK:                     %[[VAL_50:.*]] = cc.load %[[VAL_40]] : !cc.ptr<i32>

--- a/test/AST-Quake/template_lambda.cpp
+++ b/test/AST-Quake/template_lambda.cpp
@@ -37,6 +37,6 @@ int main() {
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_6:.*]] = quake.extract_ref %{{.*}}[0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           %[[VAL_9:.*]] = quake.extract_ref %{{.*}}[1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           quake.apply @__nvqpp__mlirgen__Z4mainE3$_0[%[[VAL_6]]] %[[VAL_9]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.apply @__nvqpp__mlirgen__Z4mainE3$_0 [%[[VAL_6]]] %[[VAL_9]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           return
 

--- a/test/Quake-QIR/callable.qke
+++ b/test/Quake-QIR/callable.qke
@@ -1,0 +1,295 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-translate --convert-to=qir %s | FileCheck %s
+
+func.func private @bar(!cc.callable<(!quake.veq<3>) -> ()>, !quake.veq<3>)
+func.func private @corge(!quake.veq<3>)
+func.func private @waldo(!cc.callable<(!quake.veq<3>) -> i32>, !quake.veq<3>) -> i32
+func.func private @fred(!quake.veq<3>) -> i16
+func.func private @garply(!cc.callable<(!quake.veq<3>) -> f64>, !quake.veq<3>, i64) -> f64
+func.func private @plugh(!quake.veq<3>, i32) -> f32
+
+func.func @foo(%0: !cc.callable<(!quake.veq<3>) -> ()>) {
+  %1 = quake.alloca !quake.veq<3>
+  %2 = cc.callable_func %0 : (!cc.callable<(!quake.veq<3>) -> ()>) -> ((!quake.veq<3>) -> ())
+  call_indirect %2(%1) : (!quake.veq<3>) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @foo({ i8*, i8* } 
+// CHECK-SAME:                                %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_1:.*]] = tail call %[[VAL_2:.*]]* @__quantum__rt__qubit_allocate_array(i64 3)
+// CHECK:         %[[VAL_3:.*]] = tail call %[[VAL_2]]* @__quantum__rt__array_slice(%[[VAL_2]]* %[[VAL_1]], i32 1, i64 0, i64 1, i64 2)
+// CHECK:         %[[VAL_4:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 0
+// CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_4]] to void (%[[VAL_2]]*)*
+// CHECK:         tail call void %[[VAL_5]](%[[VAL_2]]* %[[VAL_3]])
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_2]]* %[[VAL_1]])
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @baz(%0: !cc.ptr<!cc.callable<(!quake.veq<3>) -> ()>>) {
+  %1 = cc.instantiate_callable @bar() : () -> !cc.callable<(!quake.veq<3>) -> ()>
+  cc.store %1 , %0 : !cc.ptr<!cc.callable<(!quake.veq<3>) -> ()>>
+  return
+}
+
+// CHECK-LABEL: define void @baz({ i8*, i8* }* nocapture writeonly 
+// CHECK-SAME:                                                     %[[VAL_0:.*]]) local_unnamed_addr #0 {
+// CHECK:         %[[VAL_1:.*]] = alloca {}, align 8
+// CHECK:         %[[VAL_2:.*]] = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i8* bitcast (void ({ i8*, i8* }, %[[VAL_3:.*]]*)* @bar to i8*), i8** %[[VAL_2]], align 8
+// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         %[[VAL_5:.*]] = bitcast i8** %[[VAL_4]] to {}**
+// CHECK:         store {}* %[[VAL_1]], {}** %[[VAL_5]], align 8
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @thud(%2 : !cc.ptr<!cc.callable<(!quake.veq<3>) -> ()>>) {
+  %0 = cc.instantiate_callable @corge() nocapture : () -> !cc.callable<(!quake.veq<3>) -> ()>
+  %1 = quake.alloca !quake.veq<3>
+  cc.store %0, %2 : !cc.ptr<!cc.callable<(!quake.veq<3>) -> ()>>
+  cc.call_callable %0, %1 : (!cc.callable<(!quake.veq<3>) -> ()>, !quake.veq<3>) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @thud({ i8*, i8* }* nocapture writeonly 
+// CHECK-SAME:                                                      %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_1:.*]] = tail call %[[VAL_2:.*]]* @__quantum__rt__qubit_allocate_array(i64 3)
+// CHECK:         %[[VAL_3:.*]] = tail call %[[VAL_2]]* @__quantum__rt__array_slice(%[[VAL_2]]* %[[VAL_1]], i32 1, i64 0, i64 1, i64 2)
+// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i8* bitcast (void (%[[VAL_2]]*)* @corge to i8*), i8** %[[VAL_4]], align 8
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store i8* null, i8** %[[VAL_5]], align 8
+// CHECK:         tail call void @corge(%[[VAL_2]]* %[[VAL_3]])
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_2]]* %[[VAL_1]])
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @qux(%0 : !cc.callable<(!quake.veq<3>) -> ()>, %1 : !quake.veq<3>) {
+  cc.call_callable %0, %1 : (!cc.callable<(!quake.veq<3>) -> ()>, !quake.veq<3>) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @qux({ i8*, i8* } 
+// CHECK-SAME:       %[[VAL_0:.*]], %[[VAL_1:.*]]* %[[VAL_2:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_3:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 0
+// CHECK:         %[[VAL_4:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 1
+// CHECK:         %[[VAL_5:.*]] = icmp eq i8* %[[VAL_4]], null
+// CHECK:         br i1 %[[VAL_5]], label %[[VAL_6:.*]], label %[[VAL_7:.*]]
+// CHECK:       6:                                                ; preds = %[[VAL_8:.*]]
+// CHECK:         %[[VAL_9:.*]] = bitcast i8* %[[VAL_3]] to void (%[[VAL_1]]*)*
+// CHECK:         tail call void %[[VAL_9]](%[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_10:.*]]
+// CHECK:       8:                                                ; preds = %[[VAL_8]]
+// CHECK:         %[[VAL_11:.*]] = bitcast i8* %[[VAL_3]] to void ({ i8*, i8* }, %[[VAL_1]]*)*
+// CHECK:         tail call void %[[VAL_11]]({ i8*, i8* } %[[VAL_0]], %[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_10]]
+// CHECK:       10:                                               ; preds = %[[VAL_6]], %[[VAL_7]]
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @grault(%0 : !cc.ptr<!cc.callable<(!quake.veq<3>) -> ()>>, %1 : !quake.veq<3>) {
+  %2 = cc.load %0 : !cc.ptr<!cc.callable<(!quake.veq<3>) -> ()>>
+  cc.call_callable %2, %1 : (!cc.callable<(!quake.veq<3>) -> ()>, !quake.veq<3>) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @grault({ i8*, i8* }* nocapture readonly 
+// CHECK-SAME:       %[[VAL_0:.*]], %[[VAL_1:.*]]* %[[VAL_2:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_3:.*]] = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         %[[VAL_4:.*]] = load i8*, i8** %[[VAL_3]], align 8
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         %[[VAL_6:.*]] = load i8*, i8** %[[VAL_5]], align 8
+// CHECK:         %[[VAL_7:.*]] = icmp eq i8* %[[VAL_6]], null
+// CHECK:         br i1 %[[VAL_7]], label %[[VAL_8:.*]], label %[[VAL_9:.*]]
+// CHECK:       4:                                                ; preds = %[[VAL_10:.*]]
+// CHECK:         %[[VAL_11:.*]] = bitcast i8* %[[VAL_4]] to void (%[[VAL_1]]*)*
+// CHECK:         tail call void %[[VAL_11]](%[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_12:.*]]
+// CHECK:       6:                                                ; preds = %[[VAL_10]]
+// CHECK:         %[[VAL_13:.*]] = insertvalue { i8*, i8* } poison, i8* %[[VAL_4]], 0
+// CHECK:         %[[VAL_14:.*]] = insertvalue { i8*, i8* } %[[VAL_13]], i8* %[[VAL_6]], 1
+// CHECK:         %[[VAL_15:.*]] = bitcast i8* %[[VAL_4]] to void ({ i8*, i8* }, %[[VAL_1]]*)*
+// CHECK:         tail call void %[[VAL_15]]({ i8*, i8* } %[[VAL_14]], %[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_12]]
+// CHECK:       10:                                               ; preds = %[[VAL_8]], %[[VAL_9]]
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @quux(%0 : !cc.callable<(!quake.veq<3>) -> i32>, %1 : !quake.veq<3>) -> i32 {
+  %2 = cc.call_callable %0, %1 : (!cc.callable<(!quake.veq<3>) -> i32>, !quake.veq<3>) -> i32
+  return %2 : i32
+}
+
+// CHECK-LABEL: define i32 @quux({ i8*, i8* } 
+// CHECK-SAME:     %[[VAL_0:.*]], %[[VAL_1:.*]]* %[[VAL_2:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_3:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 0
+// CHECK:         %[[VAL_4:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 1
+// CHECK:         %[[VAL_5:.*]] = icmp eq i8* %[[VAL_4]], null
+// CHECK:         br i1 %[[VAL_5]], label %[[VAL_6:.*]], label %[[VAL_7:.*]]
+// CHECK:       6:                                                ; preds = %[[VAL_8:.*]]
+// CHECK:         %[[VAL_9:.*]] = bitcast i8* %[[VAL_3]] to i32 (%[[VAL_1]]*)*
+// CHECK:         %[[VAL_10:.*]] = tail call i32 %[[VAL_9]](%[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_11:.*]]
+// CHECK:       9:                                                ; preds = %[[VAL_8]]
+// CHECK:         %[[VAL_12:.*]] = bitcast i8* %[[VAL_3]] to i32 ({ i8*, i8* }, %[[VAL_1]]*)*
+// CHECK:         %[[VAL_13:.*]] = tail call i32 %[[VAL_12]]({ i8*, i8* } %[[VAL_0]], %[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_11]]
+// CHECK:       12:                                               ; preds = %[[VAL_6]], %[[VAL_7]]
+// CHECK:         %[[VAL_14:.*]] = phi i32 [ %[[VAL_10]], %[[VAL_6]] ], [ %[[VAL_13]], %[[VAL_7]] ]
+// CHECK:         ret i32 %[[VAL_14]]
+// CHECK:       }
+
+func.func private @ae(!cc.callable<(!quake.veq<3>) -> i32>)
+
+func.func @aloha() {
+  %0 = arith.constant 32 : i32
+  %1 = cc.instantiate_callable @waldo(%0) : (i32) -> !cc.callable<(!quake.veq<3>) -> i32>
+  call @ae(%1) : (!cc.callable<(!quake.veq<3>) -> i32>) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @aloha() local_unnamed_addr {
+// CHECK:         %[[VAL_0:.*]] = alloca { i32 }, align 8
+// CHECK:         %[[VAL_1:.*]] = getelementptr inbounds { i32 }, { i32 }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i32 32, i32* %[[VAL_1]], align 8
+// CHECK:         %[[VAL_2:.*]] = bitcast { i32 }* %[[VAL_0]] to i8*
+// CHECK:         %[[VAL_3:.*]] = insertvalue { i8*, i8* } { i8* bitcast (i32 ({ i8*, i8* }, %[[VAL_4:.*]]*)* @waldo to i8*), i8* undef }, i8* %[[VAL_2]], 1
+// CHECK:         call void @ae({ i8*, i8* } %[[VAL_3]])
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @ahupuaa(%0 : !cc.callable<(!quake.veq<3>) -> i16>, %1 : !quake.veq<3>) -> i16 {
+  %2 = cc.call_callable %0, %1 : (!cc.callable<(!quake.veq<3>) -> i16>, !quake.veq<3>) -> i16
+  return %2 : i16
+}
+
+// CHECK-LABEL: define i16 @ahupuaa({ i8*, i8* } 
+// CHECK-SAME:      %[[VAL_0:.*]], %[[VAL_1:.*]]* %[[VAL_2:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_3:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 0
+// CHECK:         %[[VAL_4:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 1
+// CHECK:         %[[VAL_5:.*]] = icmp eq i8* %[[VAL_4]], null
+// CHECK:         br i1 %[[VAL_5]], label %[[VAL_6:.*]], label %[[VAL_7:.*]]
+// CHECK:       6:                                                ; preds = %[[VAL_8:.*]]
+// CHECK:         %[[VAL_9:.*]] = bitcast i8* %[[VAL_3]] to i16 (%[[VAL_1]]*)*
+// CHECK:         %[[VAL_10:.*]] = tail call i16 %[[VAL_9]](%[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_11:.*]]
+// CHECK:       9:                                                ; preds = %[[VAL_8]]
+// CHECK:         %[[VAL_12:.*]] = bitcast i8* %[[VAL_3]] to i16 ({ i8*, i8* }, %[[VAL_1]]*)*
+// CHECK:         %[[VAL_13:.*]] = tail call i16 %[[VAL_12]]({ i8*, i8* } %[[VAL_0]], %[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_11]]
+// CHECK:       12:                                               ; preds = %[[VAL_6]], %[[VAL_7]]
+// CHECK:         %[[VAL_14:.*]] = phi i16 [ %[[VAL_10]], %[[VAL_6]] ], [ %[[VAL_13]], %[[VAL_7]] ]
+// CHECK:         ret i16 %[[VAL_14]]
+// CHECK:       }
+
+func.func private @akamai(!cc.callable<(!quake.veq<3>) -> i16>)
+
+func.func @aina() {
+  %0 = cc.instantiate_callable @fred() nocapture : () -> !cc.callable<(!quake.veq<3>) -> i16>
+  call @akamai(%0) : (!cc.callable<(!quake.veq<3>) -> i16>) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @aina() local_unnamed_addr {
+// CHECK:         tail call void @akamai({ i8*, i8* } { i8* bitcast (i16 (%[[VAL_0:.*]]*)* @fred to i8*), i8* null })
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @akua(%0: !cc.callable<(!quake.veq<3>) -> f64>, %1: !quake.veq<3>, %2: i64) -> f64 {
+  %3 = cc.call_callable %0, %1 : (!cc.callable<(!quake.veq<3>) -> f64>, !quake.veq<3>) -> f64
+  return %3 : f64
+}
+
+// CHECK-LABEL: define double @akua({ i8*, i8* } 
+// CHECK-SAME:     %[[VAL_0:.*]], %[[VAL_1:.*]]* %[[VAL_2:.*]], i64 %[[VAL_3:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_4:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 0
+// CHECK:         %[[VAL_5:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 1
+// CHECK:         %[[VAL_6:.*]] = icmp eq i8* %[[VAL_5]], null
+// CHECK:         br i1 %[[VAL_6]], label %[[VAL_7:.*]], label %[[VAL_8:.*]]
+// CHECK:       7:                                                ; preds = %[[VAL_9:.*]]
+// CHECK:         %[[VAL_10:.*]] = bitcast i8* %[[VAL_4]] to double (%[[VAL_1]]*)*
+// CHECK:         %[[VAL_11:.*]] = tail call double %[[VAL_10]](%[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_12:.*]]
+// CHECK:       10:                                               ; preds = %[[VAL_9]]
+// CHECK:         %[[VAL_13:.*]] = bitcast i8* %[[VAL_4]] to double ({ i8*, i8* }, %[[VAL_1]]*)*
+// CHECK:         %[[VAL_14:.*]] = tail call double %[[VAL_13]]({ i8*, i8* } %[[VAL_0]], %[[VAL_1]]* %[[VAL_2]])
+// CHECK:         br label %[[VAL_12]]
+// CHECK:       13:                                               ; preds = %[[VAL_7]], %[[VAL_8]]
+// CHECK:         %[[VAL_15:.*]] = phi double [ %[[VAL_11]], %[[VAL_7]] ], [ %[[VAL_14]], %[[VAL_8]] ]
+// CHECK:         ret double %[[VAL_15]]
+// CHECK:       }
+
+func.func private @alii(!cc.callable<(!quake.veq<3>) -> f64>)
+
+func.func @ala(%0: i32, %1: i32) {
+  %2 = cc.instantiate_callable @garply(%0, %1) : (i32, i32) -> !cc.callable<(!quake.veq<3>) -> f64>
+  call @alii(%2) : (!cc.callable<(!quake.veq<3>) -> f64>) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @ala(i32 
+// CHECK-SAME:      %[[VAL_0:.*]], i32 %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_2:.*]] = alloca { i32, i32 }, align 8
+// CHECK:         %[[VAL_3:.*]] = getelementptr inbounds { i32, i32 }, { i32, i32 }* %[[VAL_2]], i64 0, i32 0
+// CHECK:         store i32 %[[VAL_0]], i32* %[[VAL_3]], align 8
+// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds { i32, i32 }, { i32, i32 }* %[[VAL_2]], i64 0, i32 1
+// CHECK:         store i32 %[[VAL_1]], i32* %[[VAL_4]], align 4
+// CHECK:         %[[VAL_5:.*]] = bitcast { i32, i32 }* %[[VAL_2]] to i8*
+// CHECK:         %[[VAL_6:.*]] = insertvalue { i8*, i8* } { i8* bitcast (double ({ i8*, i8* }, %[[VAL_7:.*]]*, i64)* @garply to i8*), i8* undef }, i8* %[[VAL_5]], 1
+// CHECK:         call void @alii({ i8*, i8* } %[[VAL_6]])
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @aole(%0 : !cc.callable<(!quake.veq<3>, i32) -> f32>, %1 : !quake.veq<3>, %2: i32) -> f32 {
+  %3 = cc.call_callable %0, %1, %2 : (!cc.callable<(!quake.veq<3>, i32) -> f32>, !quake.veq<3>, i32) -> f32
+  return %3 : f32
+}
+
+// CHECK-LABEL: define float @aole({ i8*, i8* } 
+// CHECK-SAME:      %[[VAL_0:.*]], %[[VAL_1:.*]]* %[[VAL_2:.*]], i32 %[[VAL_3:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_4:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 0
+// CHECK:         %[[VAL_5:.*]] = extractvalue { i8*, i8* } %[[VAL_0]], 1
+// CHECK:         %[[VAL_6:.*]] = icmp eq i8* %[[VAL_5]], null
+// CHECK:         br i1 %[[VAL_6]], label %[[VAL_7:.*]], label %[[VAL_8:.*]]
+// CHECK:       7:                                                ; preds = %[[VAL_9:.*]]
+// CHECK:         %[[VAL_10:.*]] = bitcast i8* %[[VAL_4]] to float (%[[VAL_1]]*, i32)*
+// CHECK:         %[[VAL_11:.*]] = tail call float %[[VAL_10]](%[[VAL_1]]* %[[VAL_2]], i32 %[[VAL_3]])
+// CHECK:         br label %[[VAL_12:.*]]
+// CHECK:       10:                                               ; preds = %[[VAL_9]]
+// CHECK:         %[[VAL_13:.*]] = bitcast i8* %[[VAL_4]] to float ({ i8*, i8* }, %[[VAL_1]]*, i32)*
+// CHECK:         %[[VAL_14:.*]] = tail call float %[[VAL_13]]({ i8*, i8* } %[[VAL_0]], %[[VAL_1]]* %[[VAL_2]], i32 %[[VAL_3]])
+// CHECK:         br label %[[VAL_12]]
+// CHECK:       13:                                               ; preds = %[[VAL_7]], %[[VAL_8]]
+// CHECK:         %[[VAL_15:.*]] = phi float [ %[[VAL_11]], %[[VAL_7]] ], [ %[[VAL_14]], %[[VAL_8]] ]
+// CHECK:         ret float %[[VAL_15]]
+// CHECK:       }
+
+func.func private @aumakua(!cc.callable<(!quake.veq<3>, i32) -> f32>)
+
+func.func @auau() {
+  %0 = cc.instantiate_callable @plugh() nocapture : () -> !cc.callable<(!quake.veq<3>, i32) -> f32>
+  call @aumakua(%0) : (!cc.callable<(!quake.veq<3>, i32) -> f32>) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @auau() local_unnamed_addr {
+// CHECK:         tail call void @aumakua({ i8*, i8* } { i8* bitcast (float (%[[VAL_0:.*]]*, i32)* @plugh to i8*), i8* null })
+// CHECK:         ret void
+// CHECK:       }
+
+// Using a function value is not (yet) supported.
+//
+// func.func @xyzzy(%0: (!quake.veq<3>) -> ()) {
+//   %0 = cc.instantiate_callable %0() : () -> !cc.callable<(!quake.veq<3>) -> ()>
+//   %1 = quake.alloca !quake.veq<3>
+//   cc.call_callable %0, %1 : (!cc.callable<(!quake.veq<3>) -> ()>, !quake.veq<3>) -> ()
+//   return
+// }
+

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -219,8 +219,8 @@ func.func @quantum_ops() {
 // CHECK:           %[[VAL_49:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_50:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.apply @apply_kernel %[[VAL_49]], %[[VAL_50]] : (i32, !quake.ref) -> ()
-// CHECK:           quake.apply @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.veq<2>, i32, !quake.ref) -> ()
-// CHECK:           quake.apply<adj> @apply_kernel{{\[}}%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.veq<2>, i32, !quake.ref) -> ()
+// CHECK:           quake.apply @apply_kernel [%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.veq<2>, i32, !quake.ref) -> ()
+// CHECK:           quake.apply<adj> @apply_kernel [%[[VAL_47]], %[[VAL_48]]] %[[VAL_49]], %[[VAL_50]] : (!quake.ref, !quake.veq<2>, i32, !quake.ref) -> ()
 // CHECK:           %[[VAL_51:.*]] = cc.undef !cc.callable<() -> ()> {compute_action = true}
 // CHECK:           %[[VAL_52:.*]] = cc.undef !cc.callable<() -> ()>
 // CHECK:           quake.compute_action %[[VAL_51]], %[[VAL_52]] : !cc.callable<() -> ()>, !cc.callable<() -> ()>


### PR DESCRIPTION
allow application to callables, such as lambda expressions.

Teach the bridge to lower lambda expressions to indirect apply calls when the lambda is not explicitly flagged with a `__qpu__` attribute but is an available lambda expression. (There is no reason not to allow this since the lambda expression is lowered by the bridge and readily available.)

Augment the cc.instantiate_callable operation to allow for wrapping plain old functions. Plain old functions are callable, but they do not have captures, do not need to create a closure, and do not need a thunk to unpack a closure. In short, they are a less complicated form. Supporting them now allows two flavors of CallableType. The original form, as constructed by lambda lifting, generates a pair of pointers consisting of a thunk function pointer and a closure pointer. The new degenerate form consists of a pair of pointers consisting of the plain old function pointer and a null pointer.

Add support for cc.call_callable to the code gen to QIR. In the event that an SSA value of CallableType is an indeterminant value, code gen will generate the code to test between the thunk form and the plain old function form, as described above, and generate the correct call to either the thunk function or directly to the regular function itself. Variants of this can be found in the test.

Update documentation.

Add tests.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
