### PR TITLE
Make `nvq++ --version` work

### DIFF
--- a/test/NVQPP/testVersion.cpp
+++ b/test/NVQPP/testVersion.cpp
@@ -1,0 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Note: change |& to 2>&1| if running in bash
+// RUN: nvq++ --version |& FileCheck %s
+// CHECK: nvq++ Version

--- a/tools/cudaq-quake/cudaq-quake.cpp
+++ b/tools/cudaq-quake/cudaq-quake.cpp
@@ -299,6 +299,8 @@ int main(int argc, char **argv) {
   // Process the command-line options, including reading in a file.
   [[maybe_unused]] llvm::InitLLVM unused(argc, argv);
   cl::ParseCommandLineOptions(argc, argv, toolName);
+  if (showVersion)
+    llvm::errs() << "nvq++ Version " << cudaq::getVersion() << '\n';
   ErrorOr<std::unique_ptr<MemoryBuffer>> fileOrError =
       MemoryBuffer::getFileOrSTDIN(inputFilename);
   if (auto ec = fileOrError.getError()) {
@@ -340,10 +342,6 @@ int main(int argc, char **argv) {
     llvm::errs() << diag.getLocation() << ':' << severity << ": " << diag.str()
                  << '\n';
   });
-
-  if (showVersion) {
-    llvm::errs() << "nvq++ Version " << cudaq::getVersion() << '\n';
-  }
 
   // Process arguments.
   std::vector<std::string> clArgs = {"-std=c++20", "-resource-dir",

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -221,6 +221,7 @@ SRCS=
 ARGS=
 CUDAQ_QUAKE_ARGS=
 DO_LINK=true
+SHOW_VERSION=false
 ENABLE_DEVICE_CODE_LOADERS=true
 ENABLE_KERNEL_EXECUTION=true
 ENABLE_AGGRESSIVE_EARLY_INLINE=true
@@ -386,6 +387,7 @@ while [ $# -ne 0 ]; do
 		;;
 	--version)
 		CUDAQ_QUAKE_ARGS="--nvqpp-version ${CUDAQ_QUAKE_ARGS}"
+		SHOW_VERSION=true
 		;;
 	-v)
 		ECHO=true
@@ -505,6 +507,13 @@ if ${RUN_OPT}; then
 fi
 
 OPT_PASSES="builtin.module(${OPT_PASSES})"
+
+if ${SHOW_VERSION} && [ -z "$SRCS" ] && [ -z "$OBJS" ]; then
+	# If version is requested and no source files were provided, bypass the
+	# cudaq-quake path that expects to read code from stdin.
+	echo "" | ${TOOLBIN}cudaq-quake ${CUDAQ_QUAKE_ARGS}
+	DO_LINK=false
+fi
 
 for i in ${SRCS}; do
 	file=$(basename -s .cc -s .cpp $i)


### PR DESCRIPTION
#647 added the ability to report the cuda-quantum version, but it only works in conjunction with other command line arguments. This makes it work with a simple `nvq++ --version` command, as shown here:
```bash
[root@docker-desktop build (ch-version-rpt-improvements)]# nvq++ --version
nvq++ Version proto-0.5.0-developer
```
Whereas that simple command behaves like this in the main branch:
```bash
[root@docker-desktop build (main)]# nvq++ --version
ld.lld: error: undefined symbol: main
>>> referenced by /lib/x86_64-linux-gnu/Scrt1.o:(_start)
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
failed: "/opt/llvm/bin/clang++ --ld-path=/opt/llvm/bin/ld.lld -Wl,-rpath,/usr/local/cudaq/lib -Wl,-rpath,/usr/local/cudaq/lib/plugins -Wl,-rpath,/workspaces/cuda-quantum/build -L/usr/local/cudaq/lib -L/usr/local/cudaq/lib/plugins -L/usr/lib/gcc/x86_64-linux-gnu/12 -L/usr/lib/x86_64-linux-gnu -L/usr/lib -L/lib/x86_64-linux-gnu -L/lib -L/usr/local/gdrcopy/lib64 -lcudaq -lcudaq-common -lcudaq-mlir-runtime -lcudaq-builder -lcudaq-ensmallen -lcudaq-nlopt -lcudaq-spin -lcudaq-pyscf -lcudaq-em-default -lcudaq-platform-default -lnvqir -lnvqir-qpp"
```