### PR TITLE
Let the CUDA_QUANTUM_VERSION set as an environment variable have

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -485,7 +485,7 @@ jobs:
           file: ./docker/build/cudaq.dev.Dockerfile
           build-args: |
             base_image=${{ steps.prereqs.outputs.devdeps_image }}
-            install="CMAKE_BUILD_TYPE=Release FORCE_COMPILE_GPU_COMPONENTS=true"
+            install="CMAKE_BUILD_TYPE=Release FORCE_COMPILE_GPU_COMPONENTS=true CUDA_QUANTUM_VERSION=${{ steps.prereqs.outputs.image_tag }}"
           tags: ${{ steps.cudaqdev_metadata.outputs.tags }}
           labels: ${{ steps.cudaqdev_metadata.outputs.labels }}
           platforms: ${{ inputs.platforms }}

--- a/include/cudaq/Support/CMakeLists.txt
+++ b/include/cudaq/Support/CMakeLists.txt
@@ -6,8 +6,15 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-execute_process(COMMAND git describe --tags --abbrev=0 --dirty=-developer
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE CUDA_QUANTUM_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (DEFINED ENV{CUDA_QUANTUM_VERSION})
+  # The version was defined by the user (likely a bot performing the build), so
+  # use the value provided as is.
+  set(CUDA_QUANTUM_VERSION "$ENV{CUDA_QUANTUM_VERSION}")
+else()
+  # Otherwise, create a version based on the nearest tag in the git repo.
+  execute_process(COMMAND git describe --tags --abbrev=0 --dirty=-developer
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE CUDA_QUANTUM_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
 configure_file("Version.h.in" "Version.h" @ONLY)


### PR DESCRIPTION
priority over generating a value for the version.

When the tools are built by the CI, the bot sets a version number. This vresion number is defined in an environment variable and that variable is used in various places in the build.

On the other hand, not all builds are done by bots and the version may not be defined in that way. Therefore have a fallback path that will generate a version number based on the nearest tag from git to the commit (+ changes) being built.
