### PR TITLE
Support Volta+ arch in custatevec backend

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -583,31 +583,23 @@ jobs:
             if [ -n "$(cat $file | grep "GPU_REQUIREMENTS")" ]; then
               target=`basename $file | cut -d "." -f 1`
               echo "## Execute on $target target" >> $GITHUB_STEP_SUMMARY
-              for file in `find /home/cudaq/examples -name '*.cpp' -not -path '*/providers/*'`; do
-                case $file in
-                  /home/cudaq/examples/cpp/other/gradients.cpp)
-                    echo ":white_flag: Issue: https://github.com/NVIDIA/cuda-quantum/issues/622. Test skipped." >> $GITHUB_STEP_SUMMARY ;;
-                  /home/cudaq/examples/cpp/algorithms/qaoa_maxcut.cpp)
-                    echo ":white_flag: Issue: https://github.com/NVIDIA/cuda-quantum/issues/623. Test skipped." >> $GITHUB_STEP_SUMMARY ;;
-                  *)
-                    ex=$(basename -- "$file")
-                    echo "Validating $ex:"
-                    nvq++ $file --target $target
-                    status=$?
-                    if [ $status -eq 0 ]; then
-                      ./a.out
-                      status=$?
-                      if [ $status -eq 0 ]; then
-                        echo ":white_check_mark: Successfully ran $ex." >> $GITHUB_STEP_SUMMARY
-                      else
-                        echo ":x: Failed to execute $ex." >> $GITHUB_STEP_SUMMARY
-                        status_sum=$((status_sum+1))
-                      fi
-                    else
-                      echo ":x: Compilation failed for $ex." >> $GITHUB_STEP_SUMMARY
-                      status_sum=$((status_sum+1))
-                    fi ;;
-                esac
+              for ex in `find /home/cudaq/examples -name '*.cpp' -not -path '*/providers/*'`; do
+                filename=$(basename -- "$ex")
+                nvq++ $ex --target $target
+                status=$?
+                if [ $status -eq 0 ]; then
+                  ./a.out
+                  status=$?
+                  if [ $status -eq 0 ]; then
+                    echo ":white_check_mark: Successfully ran $filename." >> $GITHUB_STEP_SUMMARY
+                  else
+                    echo ":x: Failed to execute $filename." >> $GITHUB_STEP_SUMMARY
+                    status_sum=$((status_sum+1))
+                  fi
+                else
+                  echo ":x: Compilation failed for $filename." >> $GITHUB_STEP_SUMMARY
+                  status_sum=$((status_sum+1))
+                fi
               done
             fi
           done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,11 +357,31 @@ target_compile_options(spdlog PRIVATE -Wno-covered-switch-default)
 include(CheckLanguage)
 check_language(CUDA)
 set(CUDA_FOUND FALSE)
+# Generate -gencode arch=compute_XX,code=sm_XX for list of supported
+# arch values.
+# List should be sorted in increasing order.
+function(CUDA_get_gencode_args out_args_string arch_values)
+  # allow the user to pass the list like a normal variable
+  set(arch_list ${arch_values} ${ARGN})
+  set(out "")
+  foreach(arch IN LISTS arch_list)
+    set(out "${out} -gencode arch=compute_${arch},code=sm_${arch}")
+  endforeach(arch)
+
+  # Repeat the last one as to ensure the generation of PTX for most
+  # recent virtual architecture for forward compatibility
+  list(GET arch_list -1 last_arch)
+  set(out "${out} -gencode arch=compute_${last_arch},code=compute_${last_arch}")
+  set(${out_args_string} ${out} PARENT_SCOPE)
+endfunction()
+
 if(CMAKE_CUDA_COMPILER)
-  if (NOT CUDA_ARCH_BIN)
-    set(CUDA_ARCH_BIN 80)
+  if (NOT CUDA_TARGET_ARCHS)
+    # Volta, Ampere, Hopper
+    set(CUDA_TARGET_ARCHS  "70;80;90")
   endif()
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -shared -std=c++17 -gencode arch=compute_${CUDA_ARCH_BIN},code=sm_${CUDA_ARCH_BIN}  --compiler-options -fPIC")
+  CUDA_get_gencode_args(CUDA_gencode_flags ${CUDA_TARGET_ARCHS})
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -shared -std=c++17 ${CUDA_gencode_flags} --compiler-options -fPIC")
 
   enable_language(CUDA)
   set(CUDA_FOUND TRUE)


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

We fixed the `-gencode` option to `sm_80` (Ampere/A100) while the `CuStateVecCircuitSimulator.cu` does have some CUDA kernels (e.g.,  `__global__ void initializeDeviceStateVector`). Hence, the generated binary is not compatible with the V100 GPU.

In this case, the `initializeDeviceStateVector` was not executed since the runtime couldn't find a compatible binary to run; hence the state vector was left uninitialized (all 0.0's).

Fixed by modifying the `-gencode` to support more architectures: same level of compatibility as the cuquantum library.



Should fix the issues reported in https://github.com/NVIDIA/cuda-quantum/issues/623; https://github.com/NVIDIA/cuda-quantum/issues/622; https://github.com/NVIDIA/cuda-quantum/issues/583
