### PR TITLE
Refactor Base Profile code in preparation for Adaptive Profile

### DIFF
--- a/docs/sphinx/using/advanced/cudaq_ir.rst
+++ b/docs/sphinx/using/advanced/cudaq_ir.rst
@@ -134,7 +134,7 @@ The tools available are
 
 1. :code:`cudaq-quake` - Lower C++ to Quake, can also output classical LLVM IR file
 2. :code:`cudaq-opt` - Process Quake with various MLIR Passes
-3. :code:`cudaq-translate` - Lower Quake to external representations like QIR (or Base Profile QIR)
+3. :code:`cudaq-translate` - Lower Quake to external representations like QIR
 
 CUDA Quantum and :code:`nvq++` rely on Quake for the core quantum intermediate representation.
 Quake represents an IR closer to the CUDA Quantum source language and models qubits and

--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -27,15 +27,15 @@ namespace cudaq::opt {
 std::unique_ptr<mlir::Pass> createConvertToQIRPass();
 void registerConvertToQIRPass();
 
-/// Convert (generic) QIR to the Base Profile QIR for a specific target.
-/// TODO: Decide how to convey the selected target information.
-void addBaseProfilePipeline(mlir::OpPassManager &pm);
-void registerBaseProfilePipeline();
+/// Convert (generic) QIR to the profile-specific QIR for a specific target.
+/// TODO: Decide how to convey the selected profile information.
+void addQIRProfilePipeline(mlir::OpPassManager &pm);
+void registerQIRProfilePipeline();
 
-// Use the addBaseProfilePipeline() for the following passes.
-std::unique_ptr<mlir::Pass> createQIRToBaseProfilePass();
+// Use the addQIRProfilePipeline() for the following passes.
+std::unique_ptr<mlir::Pass> createQIRToQIRProfilePass();
 std::unique_ptr<mlir::Pass> verifyBaseProfilePass();
-std::unique_ptr<mlir::Pass> createBaseProfilePreparationPass();
+std::unique_ptr<mlir::Pass> createQIRProfilePreparationPass();
 std::unique_ptr<mlir::Pass> createConvertToQIRFuncPass();
 
 // Functions to support removing measurements from QIR

--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -28,15 +28,20 @@ std::unique_ptr<mlir::Pass> createConvertToQIRPass();
 void registerConvertToQIRPass();
 
 /// Convert (generic) QIR to the profile-specific QIR for a specific target.
-/// TODO: Decide how to convey the selected profile information.
-void addQIRProfilePipeline(mlir::OpPassManager &pm);
-void registerQIRProfilePipeline();
+/// @param pm Pass Manager to add QIR passes to
+/// @param convertTo Expected to be "qir-base" or "qir-adaptive" (comes from the
+/// cudaq-translate command line `--convert-to` parameter)
+void addQIRProfilePipeline(mlir::OpPassManager &pm,
+                           const std::string &convertTo);
 
 // Use the addQIRProfilePipeline() for the following passes.
-std::unique_ptr<mlir::Pass> createQIRToQIRProfilePass();
-std::unique_ptr<mlir::Pass> verifyBaseProfilePass();
-std::unique_ptr<mlir::Pass> createQIRProfilePreparationPass();
-std::unique_ptr<mlir::Pass> createConvertToQIRFuncPass();
+std::unique_ptr<mlir::Pass>
+createQIRToQIRProfilePass(const std::string &convertTo);
+std::unique_ptr<mlir::Pass> verifyQIRProfilePass(const std::string &convertTo);
+std::unique_ptr<mlir::Pass>
+createQIRProfilePreparationPass(const std::string &convertTo);
+std::unique_ptr<mlir::Pass>
+createConvertToQIRFuncPass(const std::string &convertTo);
 
 // Functions to support removing measurements from QIR
 std::unique_ptr<mlir::Pass> createRemoveMeasurementsPass();

--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -37,8 +37,7 @@ void addQIRProfilePipeline(mlir::OpPassManager &pm, llvm::StringRef convertTo);
 std::unique_ptr<mlir::Pass>
 createQIRToQIRProfilePass(llvm::StringRef convertTo);
 std::unique_ptr<mlir::Pass> verifyQIRProfilePass(llvm::StringRef convertTo);
-std::unique_ptr<mlir::Pass>
-createQIRProfilePreparationPass(llvm::StringRef convertTo);
+std::unique_ptr<mlir::Pass> createQIRProfilePreparationPass();
 std::unique_ptr<mlir::Pass>
 createConvertToQIRFuncPass(llvm::StringRef convertTo);
 

--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -31,17 +31,16 @@ void registerConvertToQIRPass();
 /// @param pm Pass Manager to add QIR passes to
 /// @param convertTo Expected to be "qir-base" or "qir-adaptive" (comes from the
 /// cudaq-translate command line `--convert-to` parameter)
-void addQIRProfilePipeline(mlir::OpPassManager &pm,
-                           const std::string &convertTo);
+void addQIRProfilePipeline(mlir::OpPassManager &pm, llvm::StringRef convertTo);
 
 // Use the addQIRProfilePipeline() for the following passes.
 std::unique_ptr<mlir::Pass>
-createQIRToQIRProfilePass(const std::string &convertTo);
-std::unique_ptr<mlir::Pass> verifyQIRProfilePass(const std::string &convertTo);
+createQIRToQIRProfilePass(llvm::StringRef convertTo);
+std::unique_ptr<mlir::Pass> verifyQIRProfilePass(llvm::StringRef convertTo);
 std::unique_ptr<mlir::Pass>
-createQIRProfilePreparationPass(const std::string &convertTo);
+createQIRProfilePreparationPass(llvm::StringRef convertTo);
 std::unique_ptr<mlir::Pass>
-createConvertToQIRFuncPass(const std::string &convertTo);
+createConvertToQIRFuncPass(llvm::StringRef convertTo);
 
 // Functions to support removing measurements from QIR
 std::unique_ptr<mlir::Pass> createRemoveMeasurementsPass();

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -45,12 +45,7 @@ def QIRToQIRProfilePrep : Pass<"qir-profile-prep", "mlir::ModuleOp"> {
     conflicts when rewriting matching DAGs independently.
   }];
 
-  let options = [
-    Option<"convertTo", "convert-to", "llvm::StringRef", "\"qir-base\"",
-           "Which QIR profile to convert to (default is 'qir-base')">
-  ];
-
-  let constructor = "cudaq::opt::createQIRProfilePreparationPass(\"qir-base\")";
+  let constructor = "cudaq::opt::createQIRProfilePreparationPass()";
 }
 
 def VerifyQIRProfile : Pass<"verify-qir-profile", "mlir::LLVM::LLVMFuncOp"> {

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -32,19 +32,20 @@ def QuakeToQIR : Pass<"quake-to-qir", "mlir::ModuleOp"> {
   let constructor = "cudaq::opt::createConvertToQIRPass()";
 }
 
-def QIRToBaseQIRPrep : Pass<"qir-to-base-qir-prep", "mlir::ModuleOp"> {
-  let summary = "Prepare the IR for rewriting to the base profile";
+def QIRToQIRProfilePrep : Pass<"qir-profile-prep", "mlir::ModuleOp"> {
+  let summary =
+    "Prepare the IR for rewriting to the base profile or adaptive profile";
   let description = [{
-    This is a (module) subpass of the pipeline to convert to QIR Base Profile.
+    This is a (module) subpass of the pipeline to convert to a specific QIR Profile.
 
-    Before we can convert the functions to the base profile, we have to do
+    Before we can convert the functions to the specific profile, we have to do
     a bit of bookkeeping on the module itself. That preparation is done in
     this pass. Specifically, we create all the function declarations that we
     may need and add them to the ModuleOp a priori. This avoids multi-threading
     conflicts when rewriting matching DAGs independently.
   }];
 
-  let constructor = "cudaq::opt::createBaseProfilePreparationPass()";
+  let constructor = "cudaq::opt::createQIRProfilePreparationPass()";
 }
 
 def VerifyBaseProfile : Pass<"verify-base-profile", "mlir::LLVM::LLVMFuncOp"> {
@@ -57,11 +58,11 @@ def VerifyBaseProfile : Pass<"verify-base-profile", "mlir::LLVM::LLVMFuncOp"> {
   let constructor = "cudaq::opt::verifyBaseProfilePass()";
 }
 
-def QIRToBaseQIRFunc : Pass<"quake-to-base-qir-func",
+def QIRToQIRProfileFunc : Pass<"quake-to-qir-func",
                             "mlir::LLVM::LLVMFuncOp"> {
   let summary = "Analyze kernels and add attributes and record calls.";
   let description = [{
-    This is a (function) subpass of the pipeline to convert to QIR Base Profile.
+    This is a (function) subpass of the pipeline to convert to specific QIR Profile.
 
     Each function with a body is analyzed for qubit allocations and qubit
     measurements. Attributes for the total count of qubits are added to the
@@ -72,17 +73,17 @@ def QIRToBaseQIRFunc : Pass<"quake-to-base-qir-func",
   let constructor = "cudaq::opt::createConvertToQIRFuncPass()";
 }
 
-def QIRToBaseQIR : Pass<"qir-to-base-qir"> {
+def QIRToQIRProfile : Pass<"qir-to-qir-profile"> {
   let summary =
-    "After lowering a Quake kernel to QIR, lower further to the Base Profile.";
+    "After lowering a Quake kernel to QIR, lower further to the specific QIR Profile.";
   let description = [{
-    This is a subpass of the pipeline to convert to QIR Base Profile.
+    This is a subpass of the pipeline to convert to the specific QIR Profile.
 
-    This pass lowers various QIR DAGs to the QIR Base Profile. See
+    This pass lowers various QIR DAGs to the specific QIR Profile. See
     https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/7_Profiles.md
   }];
 
-  let constructor = "cudaq::opt::createQIRToBaseProfilePass()";
+  let constructor = "cudaq::opt::createQIRToQIRProfilePass()";
 }
 
 def RemoveMeasurements : Pass<"remove-measurements"> {

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -46,7 +46,7 @@ def QIRToQIRProfilePrep : Pass<"qir-profile-prep", "mlir::ModuleOp"> {
   }];
 
   let options = [
-    Option<"convertTo", "convert-to", "std::string", "\"qir-base\"",
+    Option<"convertTo", "convert-to", "llvm::StringRef", "\"qir-base\"",
            "Which QIR profile to convert to (default is 'qir-base')">
   ];
 
@@ -61,7 +61,7 @@ def VerifyQIRProfile : Pass<"verify-qir-profile", "mlir::LLVM::LLVMFuncOp"> {
   }];
 
   let options = [
-    Option<"convertTo", "convert-to", "std::string", "\"qir-base\"",
+    Option<"convertTo", "convert-to", "llvm::StringRef", "\"qir-base\"",
            "Which QIR profile to convert to (default is 'qir-base')">
   ];
 
@@ -81,7 +81,7 @@ def QIRToQIRProfileFunc : Pass<"quake-to-qir-func",
   }];
 
   let options = [
-    Option<"convertTo", "convert-to", "std::string", "\"qir-base\"",
+    Option<"convertTo", "convert-to", "llvm::StringRef", "\"qir-base\"",
            "Which QIR profile to convert to (default is 'qir-base')">
   ];
 
@@ -99,7 +99,7 @@ def QIRToQIRProfile : Pass<"convert-to-qir-profile"> {
   }];
 
   let options = [
-    Option<"convertTo", "convert-to", "std::string", "\"qir-base\"",
+    Option<"convertTo", "convert-to", "llvm::StringRef", "\"qir-base\"",
            "Which QIR profile to convert to (default is 'qir-base')">
   ];
 

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -45,17 +45,27 @@ def QIRToQIRProfilePrep : Pass<"qir-profile-prep", "mlir::ModuleOp"> {
     conflicts when rewriting matching DAGs independently.
   }];
 
-  let constructor = "cudaq::opt::createQIRProfilePreparationPass()";
+  let options = [
+    Option<"convertTo", "convert-to", "std::string", "\"qir-base\"",
+           "Which QIR profile to convert to (default is 'qir-base')">
+  ];
+
+  let constructor = "cudaq::opt::createQIRProfilePreparationPass(\"qir-base\")";
 }
 
-def VerifyBaseProfile : Pass<"verify-base-profile", "mlir::LLVM::LLVMFuncOp"> {
-  let summary = "Verify that the output conforms to the base profile";
+def VerifyQIRProfile : Pass<"verify-qir-profile", "mlir::LLVM::LLVMFuncOp"> {
+  let summary = "Verify that the output conforms to the specific profile";
   let description = [{
     This pass scans over functions in the LLVM-IR dialect to make sure they
-    conform to the QIR base profile.
+    conform to the QIR specific profile.
   }];
 
-  let constructor = "cudaq::opt::verifyBaseProfilePass()";
+  let options = [
+    Option<"convertTo", "convert-to", "std::string", "\"qir-base\"",
+           "Which QIR profile to convert to (default is 'qir-base')">
+  ];
+
+  let constructor = "cudaq::opt::verifyQIRProfilePass(\"qir-base\")";
 }
 
 def QIRToQIRProfileFunc : Pass<"quake-to-qir-func",
@@ -70,10 +80,15 @@ def QIRToQIRProfileFunc : Pass<"quake-to-qir-func",
     functions are added to the final block in the function.
   }];
 
-  let constructor = "cudaq::opt::createConvertToQIRFuncPass()";
+  let options = [
+    Option<"convertTo", "convert-to", "std::string", "\"qir-base\"",
+           "Which QIR profile to convert to (default is 'qir-base')">
+  ];
+
+  let constructor = "cudaq::opt::createConvertToQIRFuncPass(\"qir-base\")";
 }
 
-def QIRToQIRProfile : Pass<"qir-to-qir-profile"> {
+def QIRToQIRProfile : Pass<"convert-to-qir-profile"> {
   let summary =
     "After lowering a Quake kernel to QIR, lower further to the specific QIR Profile.";
   let description = [{
@@ -83,7 +98,12 @@ def QIRToQIRProfile : Pass<"qir-to-qir-profile"> {
     https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/7_Profiles.md
   }];
 
-  let constructor = "cudaq::opt::createQIRToQIRProfilePass()";
+  let options = [
+    Option<"convertTo", "convert-to", "std::string", "\"qir-base\"",
+           "Which QIR profile to convert to (default is 'qir-base')">
+  ];
+
+  let constructor = "cudaq::opt::createQIRToQIRProfilePass(\"qir-base\")";
 }
 
 def RemoveMeasurements : Pass<"remove-measurements"> {

--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -21,7 +21,7 @@
 namespace cudaq::opt {
 
 // Pipeline builder to convert Quake to QIR.
-template <bool BaseProfile = false>
+template <bool QIRProfile = false>
 void addPipelineToQIR(mlir::PassManager &pm) {
   cudaq::opt::addAggressiveEarlyInlining(pm);
   pm.addPass(mlir::createCanonicalizerPass());
@@ -41,8 +41,8 @@ void addPipelineToQIR(mlir::PassManager &pm) {
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
   pm.addPass(cudaq::opt::createConvertToQIRPass());
-  if constexpr (BaseProfile) {
-    cudaq::opt::addBaseProfilePipeline(pm);
+  if constexpr (QIRProfile) {
+    cudaq::opt::addQIRProfilePipeline(pm);
   }
 }
 

--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -28,7 +28,19 @@ namespace cudaq::opt {
 template <bool QIRProfile = false>
 void addPipelineToQIR(mlir::PassManager &pm,
                       llvm::StringRef convertTo = "qir-base") {
+  cudaq::opt::addAggressiveEarlyInlining(pm);
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(cudaq::opt::createExpandMeasurementsPass());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createClassicalMemToReg());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createUnwindLoweringPass());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLowerToCFGPass());
   pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLoopNormalize());
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLoopUnroll());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
   pm.addNestedPass<mlir::func::FuncOp>(
       cudaq::opt::createCombineQuantumAllocations());
   pm.addPass(mlir::createCanonicalizerPass());

--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -23,19 +23,7 @@ namespace cudaq::opt {
 // Pipeline builder to convert Quake to QIR.
 template <bool QIRProfile = false>
 void addPipelineToQIR(mlir::PassManager &pm) {
-  cudaq::opt::addAggressiveEarlyInlining(pm);
-  pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(cudaq::opt::createExpandMeasurementsPass());
-  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createClassicalMemToReg());
-  pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(mlir::createCSEPass());
-  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createUnwindLoweringPass());
-  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLowerToCFGPass());
   pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
-  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLoopNormalize());
-  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLoopUnroll());
-  pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(mlir::createCSEPass());
   pm.addNestedPass<mlir::func::FuncOp>(
       cudaq::opt::createCombineQuantumAllocations());
   pm.addPass(mlir::createCanonicalizerPass());

--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -27,7 +27,7 @@ namespace cudaq::opt {
 /// @param convertTo String name of qir profile (e.g., qir-base, qir-adaptive)
 template <bool QIRProfile = false>
 void addPipelineToQIR(mlir::PassManager &pm,
-                      const std::string &convertTo = "qir-base") {
+                      llvm::StringRef convertTo = "qir-base") {
   pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
   pm.addNestedPass<mlir::func::FuncOp>(
       cudaq::opt::createCombineQuantumAllocations());

--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -20,9 +20,14 @@
 
 namespace cudaq::opt {
 
-// Pipeline builder to convert Quake to QIR.
+/// @brief Pipeline builder to convert Quake to QIR. `convertTo` should be
+/// specified if `QIRProfile` is true.
+/// @param QIRProfile whether or not this is lowering to a specific QIR profile
+/// @param pm Pass manager to append passes to
+/// @param convertTo String name of qir profile (e.g., qir-base, qir-adaptive)
 template <bool QIRProfile = false>
-void addPipelineToQIR(mlir::PassManager &pm) {
+void addPipelineToQIR(mlir::PassManager &pm,
+                      const std::string &convertTo = "qir-base") {
   pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
   pm.addNestedPass<mlir::func::FuncOp>(
       cudaq::opt::createCombineQuantumAllocations());
@@ -30,7 +35,7 @@ void addPipelineToQIR(mlir::PassManager &pm) {
   pm.addPass(mlir::createCSEPass());
   pm.addPass(cudaq::opt::createConvertToQIRPass());
   if constexpr (QIRProfile) {
-    cudaq::opt::addQIRProfilePipeline(pm);
+    cudaq::opt::addQIRProfilePipeline(pm, convertTo);
   }
 }
 

--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -49,8 +49,8 @@ constexpr static const char QIRArrayConcatArray[] =
 constexpr static const char QIRArrayCreateArray[] =
     "__quantum__rt__array_create_1d";
 
-/// QIR Base Profile record output function names
-constexpr static const char QIRBaseProfileRecordOutput[] =
+/// QIR Base/Adaptive Profile record output function names
+constexpr static const char QIRRecordOutput[] =
     "__quantum__rt__result_record_output";
 
 inline mlir::Type getQuantumTypeByName(mlir::StringRef type,

--- a/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 add_cudaq_library(OptCodeGen
-  LowerToBaseProfileQIR.cpp
+  LowerToQIRProfile.cpp
   LowerToQIR.cpp
   Passes.cpp
   RefToVeqAlloc.cpp

--- a/lib/Optimizer/CodeGen/LowerToQIRProfile.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIRProfile.cpp
@@ -455,11 +455,6 @@ static const std::vector<std::string> measurementFunctionNames{
 struct QIRProfilePreparationPass
     : public cudaq::opt::QIRToQIRProfilePrepBase<QIRProfilePreparationPass> {
 
-  explicit QIRProfilePreparationPass(llvm::StringRef convertTo_)
-      : QIRToQIRProfilePrepBase() {
-    convertTo.setValue(convertTo_);
-  }
-
   void runOnOperation() override {
     ModuleOp module = getOperation();
     auto *ctx = module.getContext();
@@ -511,9 +506,8 @@ struct QIRProfilePreparationPass
 };
 } // namespace
 
-std::unique_ptr<Pass>
-cudaq::opt::createQIRProfilePreparationPass(llvm::StringRef convertTo) {
-  return std::make_unique<QIRProfilePreparationPass>(convertTo);
+std::unique_ptr<Pass> cudaq::opt::createQIRProfilePreparationPass() {
+  return std::make_unique<QIRProfilePreparationPass>();
 }
 
 //===----------------------------------------------------------------------===//
@@ -591,7 +585,7 @@ cudaq::opt::verifyQIRProfilePass(llvm::StringRef convertTo) {
 
 void cudaq::opt::addQIRProfilePipeline(OpPassManager &pm,
                                        llvm::StringRef convertTo) {
-  pm.addPass(createQIRProfilePreparationPass(convertTo));
+  pm.addPass(createQIRProfilePreparationPass());
   pm.addNestedPass<LLVM::LLVMFuncOp>(createConvertToQIRFuncPass(convertTo));
   pm.addPass(createQIRToQIRProfilePass(convertTo));
   pm.addNestedPass<LLVM::LLVMFuncOp>(verifyQIRProfilePass(convertTo));

--- a/lib/Optimizer/CodeGen/LowerToQIRProfile.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIRProfile.cpp
@@ -197,7 +197,7 @@ private:
 
 struct AddFuncAttribute : public OpRewritePattern<LLVM::LLVMFuncOp> {
   explicit AddFuncAttribute(MLIRContext *ctx, const FunctionAnalysisInfo &info,
-                            const std::string &convertTo_)
+                            llvm::StringRef convertTo_)
       : OpRewritePattern(ctx), infoMap(info), convertTo(convertTo_) {}
 
   LogicalResult matchAndRewrite(LLVM::LLVMFuncOp op,
@@ -209,7 +209,7 @@ struct AddFuncAttribute : public OpRewritePattern<LLVM::LLVMFuncOp> {
     rewriter.startRootUpdate(op);
     const auto &info = iter->second;
     nlohmann::json resultQubitJSON{info.resultQubitVals};
-    std::string profileName = "base_profile";
+    const char *profileName = "base_profile";
     if (convertTo == "qir-adaptive")
       profileName = "adaptive_profile";
 
@@ -266,7 +266,7 @@ struct AddFuncAttribute : public OpRewritePattern<LLVM::LLVMFuncOp> {
   }
 
   const FunctionAnalysisInfo &infoMap;
-  std::string convertTo;
+  llvm::StringRef convertTo;
 };
 
 struct AddCallAttribute : public OpRewritePattern<LLVM::CallOp> {
@@ -303,7 +303,7 @@ struct QIRToQIRProfileFuncPass
     : public cudaq::opt::QIRToQIRProfileFuncBase<QIRToQIRProfileFuncPass> {
   using QIRToQIRProfileFuncBase::QIRToQIRProfileFuncBase;
 
-  explicit QIRToQIRProfileFuncPass(const std::string &convertTo_)
+  explicit QIRToQIRProfileFuncPass(llvm::StringRef convertTo_)
       : QIRToQIRProfileFuncBase() {
     convertTo.setValue(convertTo_);
   }
@@ -340,7 +340,7 @@ struct QIRToQIRProfileFuncPass
 } // namespace
 
 std::unique_ptr<Pass>
-cudaq::opt::createConvertToQIRFuncPass(const std::string &convertTo) {
+cudaq::opt::createConvertToQIRFuncPass(llvm::StringRef convertTo) {
   return std::make_unique<QIRToQIRProfileFuncPass>(convertTo);
 }
 
@@ -407,8 +407,7 @@ struct QIRToQIRProfileQIRPass
 
   /// @brief Construct pass
   /// @param convertTo_ expected "qir-base" or "qir-adaptive"
-  QIRToQIRProfileQIRPass(const std::string &convertTo_)
-      : QIRToQIRProfileBase() {
+  QIRToQIRProfileQIRPass(llvm::StringRef convertTo_) : QIRToQIRProfileBase() {
     convertTo.setValue(convertTo_);
   }
 
@@ -434,7 +433,7 @@ private:
 } // namespace
 
 std::unique_ptr<Pass>
-cudaq::opt::createQIRToQIRProfilePass(const std::string &convertTo) {
+cudaq::opt::createQIRToQIRProfilePass(llvm::StringRef convertTo) {
   return std::make_unique<QIRToQIRProfileQIRPass>(convertTo);
 }
 
@@ -456,7 +455,7 @@ static const std::vector<std::string> measurementFunctionNames{
 struct QIRProfilePreparationPass
     : public cudaq::opt::QIRToQIRProfilePrepBase<QIRProfilePreparationPass> {
 
-  explicit QIRProfilePreparationPass(const std::string &convertTo_)
+  explicit QIRProfilePreparationPass(llvm::StringRef convertTo_)
       : QIRToQIRProfilePrepBase() {
     convertTo.setValue(convertTo_);
   }
@@ -513,7 +512,7 @@ struct QIRProfilePreparationPass
 } // namespace
 
 std::unique_ptr<Pass>
-cudaq::opt::createQIRProfilePreparationPass(const std::string &convertTo) {
+cudaq::opt::createQIRProfilePreparationPass(llvm::StringRef convertTo) {
   return std::make_unique<QIRProfilePreparationPass>(convertTo);
 }
 
@@ -525,7 +524,7 @@ namespace {
 /// not possibly defined in the QIR standard.
 struct VerifyQIRProfilePass
     : public cudaq::opt::VerifyQIRProfileBase<VerifyQIRProfilePass> {
-  explicit VerifyQIRProfilePass(const std::string &convertTo_)
+  explicit VerifyQIRProfilePass(llvm::StringRef convertTo_)
       : VerifyQIRProfileBase() {
     convertTo.setValue(convertTo_);
   }
@@ -584,14 +583,14 @@ struct VerifyQIRProfilePass
 } // namespace
 
 std::unique_ptr<Pass>
-cudaq::opt::verifyQIRProfilePass(const std::string &convertTo) {
+cudaq::opt::verifyQIRProfilePass(llvm::StringRef convertTo) {
   return std::make_unique<VerifyQIRProfilePass>(convertTo);
 }
 
 // The various passes defined here should be added as a pass pipeline.
 
 void cudaq::opt::addQIRProfilePipeline(OpPassManager &pm,
-                                       const std::string &convertTo) {
+                                       llvm::StringRef convertTo) {
   pm.addPass(createQIRProfilePreparationPass(convertTo));
   pm.addNestedPass<LLVM::LLVMFuncOp>(createConvertToQIRFuncPass(convertTo));
   pm.addPass(createQIRToQIRProfilePass(convertTo));

--- a/python/runtime/cudaq/target/py_testing_utils.cpp
+++ b/python/runtime/cudaq/target/py_testing_utils.cpp
@@ -16,7 +16,7 @@
 namespace py = pybind11;
 
 namespace nvqir {
-void toggleBaseProfile();
+void toggleDynamicQubitManagement();
 } // namespace nvqir
 
 namespace cudaq {
@@ -27,14 +27,15 @@ void bindTestUtils(py::module &mod, LinkedLibraryHolder &holder) {
 
   // Vision for all this
   //
-  // cudaq.testing.toggleBaseProfile()
+  // cudaq.testing.toggleDynamicQubitManagement()
   // qubits, context = cudaq.testing.initialize(numQubits, 1000)
   // .. use llvmlite.jit to execute kernel function
   // results = cudaq.testing.finalize(qubits, context);
   // results.dump()
 
   testingSubmodule.def(
-      "toggleBaseProfile", [&]() { nvqir::toggleBaseProfile(); }, "");
+      "toggleDynamicQubitManagement",
+      [&]() { nvqir::toggleDynamicQubitManagement(); }, "");
 
   testingSubmodule.def(
       "initialize", [&](std::size_t numQubits, std::size_t numShots) {
@@ -50,7 +51,7 @@ void bindTestUtils(py::module &mod, LinkedLibraryHolder &holder) {
                                        cudaq::ExecutionContext *context) {
     holder.getSimulator("qpp")->deallocateQubits(qubits);
     holder.getSimulator("qpp")->resetExecutionContext();
-    nvqir::toggleBaseProfile();
+    nvqir::toggleDynamicQubitManagement();
     // Pybind will delete the context bc its been wrapped in a unique_ptr
     return context->result;
   });

--- a/python/runtime/cudaq/target/py_testing_utils.h
+++ b/python/runtime/cudaq/target/py_testing_utils.h
@@ -16,7 +16,7 @@ namespace cudaq {
 
 class LinkedLibraryHolder;
 
-/// @brief Bind test utilities needed for mock qpu base profile simulation
+/// @brief Bind test utilities needed for mock qpu QIR profile simulation
 void bindTestUtils(py::module &mod, LinkedLibraryHolder &holder);
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -80,7 +80,8 @@ protected:
   /// @brief The name of the QPU being targeted
   std::string qpuName;
 
-  /// @brief Name of codegen translation (e.g. "qir", "qasm2", "iqm")
+  /// @brief Name of codegen translation (e.g. "qir-adaptive", "qir-base",
+  /// "qasm2", "iqm")
   std::string codegenTranslation = "";
 
   /// @brief Additional passes to run after the codegen-specific passes
@@ -295,7 +296,7 @@ public:
     // Form an output_names mapping from codeStr
     nlohmann::json output_names;
     std::vector<char> bitcode;
-    if (codegenTranslation == "qir") {
+    if (codegenTranslation.starts_with("qir")) {
       // decodeBase64 will throw a runtime exception if it fails
       if (llvm::decodeBase64(codeStr, bitcode)) {
         cudaq::info("Could not decode codeStr {}", codeStr);

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
@@ -109,7 +109,7 @@ void IonQServerHelper::initialize(BackendConfig config) {
     if (key.starts_with("output_names.")) {
       // Parse `val` into jobOutputNames.
       // Note: See `FunctionAnalysisData::resultQubitVals` of
-      // LowerToBaseProfileQIR.cpp for an example of how this was populated.
+      // LowerToQIRProfile.cpp for an example of how this was populated.
       OutputNamesType jobOutputNames;
       nlohmann::json outputNamesJSON = nlohmann::json::parse(val);
       for (const auto &el : outputNamesJSON[0]) {

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.config
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.config
@@ -19,7 +19,7 @@ LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 PLATFORM_LOWERING_CONFIG="expand-measurements,unrolling-pipeline,func.func(lower-to-cfg),canonicalize,func.func(quake-multicontrol-decomposition),ionq-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
-CODEGEN_EMISSION=qir
+CODEGEN_EMISSION=qir-base
 
 # Additional passes to run after lowering to QIR
 # This is required due to https://github.com/NVIDIA/cuda-quantum/issues/512

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.config
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.config
@@ -19,7 +19,7 @@ LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 PLATFORM_LOWERING_CONFIG="expand-measurements,unrolling-pipeline,func.func(lower-to-cfg),canonicalize,func.func(quake-multicontrol-decomposition),oqc-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
-CODEGEN_EMISSION=qir
+CODEGEN_EMISSION=qir-base
 
 # Library mode is only for simulators, 
 # and it is the default, physical backends must 

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.config
@@ -19,7 +19,7 @@ LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 PLATFORM_LOWERING_CONFIG="expand-measurements,unrolling-pipeline,func.func(lower-to-cfg),canonicalize,func.func(quake-multicontrol-decomposition),quantinuum-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
-CODEGEN_EMISSION=qir
+CODEGEN_EMISSION=qir-base
 
 # Physical backends must set library mode to false.
 LIBRARY_MODE=false

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -85,8 +85,12 @@ void setRandomSeed(std::size_t seed) {
   getCircuitSimulatorInternal()->setRandomSeed(seed);
 }
 
-thread_local static bool isBaseProfile = false;
-void toggleBaseProfile() { isBaseProfile = !isBaseProfile; }
+/// @brief The QIR spec allows for dynamic qubit management, where the qubit
+/// pointers are true pointers, but the Base Profile and Adaptive profiles
+/// require that qubits are identified by an integer value that is bitcast to a
+/// pointer.
+thread_local static bool qubitPtrIsIndex = false;
+void toggleDynamicQubitManagement() { qubitPtrIsIndex = !qubitPtrIsIndex; }
 
 /// @brief Tell the simulator we are about to finalize MPI.
 void tearDownBeforeMPIFinalize() {
@@ -124,7 +128,7 @@ std::vector<std::size_t> arrayToVectorSizeT(Array *arr) {
 
 /// @brief Utility function mapping a QIR Qubit pointer to its id
 std::size_t qubitToSizeT(Qubit *q) {
-  if (isBaseProfile)
+  if (qubitPtrIsIndex)
     return (intptr_t)q;
 
   return q->idx;

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --quake-add-deallocs | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt %s --aggressive-early-inlining | cudaq-translate --convert-to=qir | FileCheck %s
 
 module {
      func.func @test_func(%p : i32) {

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --aggressive-early-inlining | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt %s --quake-add-deallocs | cudaq-translate --convert-to=qir | FileCheck %s
 
 module {
      func.func @test_func(%p : i32) {

--- a/test/Quake/lambda_variable-2.qke
+++ b/test/Quake/lambda_variable-2.qke
@@ -7,8 +7,7 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt --lambda-lifting --canonicalize %s | FileCheck %s
-// RUN: cudaq-opt --lambda-lifting --aggressive-early-inlining --lower-to-cfg --quake-add-deallocs %s \
-// RUN:   | cudaq-translate --convert-to=qir | FileCheck --check-prefixes=QIR %s
+// RUN: cudaq-opt --lambda-lifting --canonicalize %s | cudaq-translate --convert-to=qir | FileCheck --check-prefixes=QIR %s
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_b(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.callable<() -> ()>)

--- a/test/Quake/lambda_variable-2.qke
+++ b/test/Quake/lambda_variable-2.qke
@@ -7,7 +7,7 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt --lambda-lifting --canonicalize %s | FileCheck %s
-// RUN: cudaq-opt --pass-pipeline='builtin.module(lambda-lifting,aggressive-early-inlining,func.func(lower-to-cfg),func.func(quake-add-deallocs))' %s \
+// RUN: cudaq-opt --lambda-lifting --aggressive-early-inlining --lower-to-cfg --quake-add-deallocs %s \
 // RUN:   | cudaq-translate --convert-to=qir | FileCheck --check-prefixes=QIR %s
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_b(

--- a/test/Quake/lambda_variable-2.qke
+++ b/test/Quake/lambda_variable-2.qke
@@ -7,7 +7,8 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt --lambda-lifting --canonicalize %s | FileCheck %s
-// RUN: cudaq-opt --lambda-lifting --canonicalize %s | cudaq-translate --convert-to=qir | FileCheck --check-prefixes=QIR %s
+// RUN: cudaq-opt --pass-pipeline='builtin.module(lambda-lifting,aggressive-early-inlining,func.func(lower-to-cfg),func.func(quake-add-deallocs))' %s \
+// RUN:   | cudaq-translate --convert-to=qir | FileCheck --check-prefixes=QIR %s
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_b(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.callable<() -> ()>)

--- a/tools/cudaq-opt/cudaq-opt.cpp
+++ b/tools/cudaq-opt/cudaq-opt.cpp
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
   cudaq::opt::registerOptTransformsPasses();
   cudaq::opt::registerAggressiveEarlyInlining();
   cudaq::opt::registerUnrollingPipeline();
-  cudaq::opt::registerBaseProfilePipeline();
+  cudaq::opt::registerQIRProfilePipeline();
   cudaq::opt::registerTargetPipelines();
 
   // See if we have been asked to load a pass plugin,

--- a/tools/cudaq-opt/cudaq-opt.cpp
+++ b/tools/cudaq-opt/cudaq-opt.cpp
@@ -60,7 +60,6 @@ int main(int argc, char **argv) {
   cudaq::opt::registerOptTransformsPasses();
   cudaq::opt::registerAggressiveEarlyInlining();
   cudaq::opt::registerUnrollingPipeline();
-  cudaq::opt::registerQIRProfilePipeline();
   cudaq::opt::registerTargetPipelines();
 
   // See if we have been asked to load a pass plugin,

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -164,8 +164,10 @@ int main(int argc, char **argv) {
 
   llvm::StringSwitch<std::function<void()>>(convertTo)
       .Case("qir", [&]() { cudaq::opt::addPipelineToQIR<>(pm); })
+      .Case("qir-adaptive",
+            [&]() { cudaq::opt::addPipelineToQIR</*QIRProfile=*/true>(pm); })
       .Case("qir-base",
-            [&]() { cudaq::opt::addPipelineToQIR</*baseProfile=*/true>(pm); })
+            [&]() { cudaq::opt::addPipelineToQIR</*QIRProfile=*/true>(pm); })
       .Case("openqasm",
             [&]() {
               targetUsesLlvm = false;

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -63,8 +63,8 @@ static llvm::cl::opt<std::string> convertTo(
     "convert-to",
     llvm::cl::desc(
         "Specify the translation output to be created. [Default: \"qir\"]"),
-    llvm::cl::value_desc("target dialect [\"qir\", \"qir-base\", "
-                         "\"openqasm\", \"iqm\"]"),
+    llvm::cl::value_desc("target dialect [\"qir\", \"qir-adaptive\", "
+                         "\"qir-base\", \"openqasm\", \"iqm\"]"),
     llvm::cl::init("qir"));
 
 static llvm::cl::opt<bool> emitLLVM(
@@ -164,10 +164,11 @@ int main(int argc, char **argv) {
 
   llvm::StringSwitch<std::function<void()>>(convertTo)
       .Case("qir", [&]() { cudaq::opt::addPipelineToQIR<>(pm); })
-      .Case("qir-adaptive",
-            [&]() { cudaq::opt::addPipelineToQIR</*QIRProfile=*/true>(pm); })
-      .Case("qir-base",
-            [&]() { cudaq::opt::addPipelineToQIR</*QIRProfile=*/true>(pm); })
+      .Cases("qir-adaptive", "qir-base",
+             [&]() {
+               cudaq::opt::addPipelineToQIR</*QIRProfile=*/true>(
+                   pm, convertTo.getValue());
+             })
       .Case("openqasm",
             [&]() {
               targetUsesLlvm = false;

--- a/utils/mock_qpu/ionq/__init__.py
+++ b/utils/mock_qpu/ionq/__init__.py
@@ -111,7 +111,7 @@ async def postJob(job: Job,
     kernel = ctypes.CFUNCTYPE(None)(funcPtr)
 
     # Invoke the Kernel
-    cudaq.testing.toggleBaseProfile()
+    cudaq.testing.toggleDynamicQubitManagement()
     qubits, context = cudaq.testing.initialize(numQubitsRequired, job.shots)
     kernel()
     results = cudaq.testing.finalize(qubits, context)

--- a/utils/mock_qpu/oqc/__init__.py
+++ b/utils/mock_qpu/oqc/__init__.py
@@ -114,7 +114,7 @@ async def postJob(
         kernel = ctypes.CFUNCTYPE(None)(funcPtr)
 
         # Invoke the Kernel
-        cudaq.testing.toggleBaseProfile()
+        cudaq.testing.toggleDynamicQubitManagement()
         qubits, context = cudaq.testing.initialize(numQubitsRequired, 1000)
         kernel()
         results = cudaq.testing.finalize(qubits, context)

--- a/utils/mock_qpu/quantinuum/__init__.py
+++ b/utils/mock_qpu/quantinuum/__init__.py
@@ -102,7 +102,7 @@ async def postJob(job: Job,
     kernel = ctypes.CFUNCTYPE(None)(funcPtr)
 
     # Invoke the Kernel
-    cudaq.testing.toggleBaseProfile()
+    cudaq.testing.toggleDynamicQubitManagement()
     qubits, context = cudaq.testing.initialize(numQubitsRequired, job.count)
     kernel()
     results = cudaq.testing.finalize(qubits, context)


### PR DESCRIPTION
### Summary

The Adaptive Profile shares a large number of features with the Base Profile. These changes will enable us to add support for the Adaptive Profile with minimal code changes (in a forthcoming PR). Many of the Adaptive Profile changes have already been done, but I figured it would be best to break this up into multiple PR's to help the review process and testing process.

### Description of Changes

1. **Rename a bunch of code from "Base Profile" to "QIR Profile".** Justification: The Adaptive Profile is a superset of the Base Profile, so lowering to the Adaptive Profile is very similar to the Base Profile except we will just disable a few checks and add a few new functions. In many places where we used to say "base profile", I changed it to either say "QIR profile" or "specific profile". Most of these changes are in 948576bff47cb52a6faf9a40cf2a1a4c38019543.
2. **Make a common pass pipeline to use in multiple places.** Justification: previously, our a) `cudaq-translate --convert-to=...`, b) runtime lowering to a target backend, and c) runtime lowering to emulation, all used slightly different pass pipelines in the code, which will be difficult to maintain. Aligning them to use a common `cudaq::opt::addPipelineToQIR()` function will help maintainability going forward. ~~Note that `cudaq-translate`'s pass pipeline previously had additional optimizations in it, so this is technically changing how `cudaq-translate` operates, but since the optimizations that were removed were already in other places (target-specific configuration files and/or the `nvq++` driver script), I don't think this actually changes any code that would go to a true backend. It only changes our intermediate test results.~~ _(Note: as described [here](https://github.com/NVIDIA/cuda-quantum/pull/724#discussion_r1344475435), some of these changes were removed as part of the PR review process, which has the effect of changing the passes run in QIR backends instead.)_ The changes are in 5f06dccaecb0c7dd380b84ddeb0fb1958d82cd23 (and 60d2fdb6 for PR review updates).
3. **Add `convert-to` pass options to many of the QIR passes** with the intent that the forthcoming Adaptive Profile updates will utilize them when making the updates that are only specifically intended for the Adaptive Profile. Most of these changes are in bda496c1674dcb1de3a6f34784696b0ecab18c0d.

### Test Notes

Since this particular PR is just a refactoring, there are no new tests. ~~However, since the behavior of `cudaq-translate --convert-to=...` has changed (due to Change Number 2 above), I did have to update how 2 specific `llvm-lit` tests were done.~~