### PR TITLE
Workflow to delete draft releases and clean up GHCR docker images and signatures

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -1,5 +1,11 @@
 on:
   workflow_dispatch:
+    inputs:
+      delete_draft_releases:
+        type: boolean
+        description: Delete all draft releases on GitHub (this may impact publishing).
+        required: false
+        default: false
   schedule:
   - cron: "*/5 * * * *"
   pull_request_target:
@@ -9,6 +15,25 @@ on:
 name: Clean up
 
 jobs:
+  draft_releases:
+    name: Delete draft release
+    if: github.event_name == 'workflow_dispatch' && inputs.delete_draft_releases
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          gh release list -L 100 -R ${{ github.repository }} > rels.txt
+          while read rel _; do 
+            isDraft=`gh release view $rel -R ${{ github.repository }} --json isDraft --jq '.isDraft'`
+            isPrerelease=`gh release view 0.4.0 -R ${{ github.repository }} --json isPrerelease --jq '.isPrerelease'`
+            if $isDraft && $isPrerelease; then
+              echo "Deleting release $rel."
+              gh release delete $rel -R ${{ github.repository }} -y
+            fi 
+          done < rels.txt
+        env:
+          GH_TOKEN: ${{ secrets.REPO_BOT_ACCESS_TOKEN }}
+
   # We use environments to deploy to a public registry after PRs are merged.
   # Since we use the same workflows during CI, a default environment that defines
   # the necessary variables is used instead. Unfortunately, this automatically

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -71,15 +71,15 @@ jobs:
           nr_sigs=100 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
             echo "Looking for image $image@sha256:${sig:8:-5} (tag $sig)"
-            (skopeo inspect $image@sha256:${sig:8:-5} --query-tags=false &> /dev/null) && exists=true || exists=false
+            (skopeo inspect $image@sha256:${sig:8:-5} &> /dev/null) && exists=true || exists=false
             if [ $exists ]; then 
-              created=`skopeo inspect $image@sha256:${sig:8:-5} --query-tags=false | jq '.Created'`
+              created=`skopeo inspect $image@sha256:${sig:8:-5} | jq '.Created'`
               exists=`[ -n "$created" ] && [ $created != null ] && echo true || echo false`
             fi
-            if [ ! $exists ] && [ $nr_sig -gt 0 ]; then
+            if [ ! $exists ] && [ $nr_sigs -gt 0 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"
-              nr_sig=$((nr_sig-1))
+              nr_sigs=$((nr_sigs-1))
             fi
           done
           echo "[${delete:1}]"

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -86,8 +86,10 @@ jobs:
           curl -X GET -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions > packages.json
           for tag in ${{ steps.sig_files.outputs.tags_to_remove }}; do
             version_id=`cat packages.json | jq ".[] | select(.metadata.package_type==\"container\" and (.metadata.container.tags[] | contains(\"${tag%,}\")))" | jq '.id'`
+            echo "Marking version $version_id for deletion."
             delete+=", $version_id"
           done
+          echo "[${delete:2}]"
           echo "versions_to_remove=${delete:2}" >> $GITHUB_OUTPUT
 
       - name: Delete matching signatures

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -64,7 +64,6 @@ jobs:
 
       - name: Find matching signatures files
         id: sig_files
-        shell: bash
         run: |
           regctl="docker run ghcr.io/regclient/regctl@sha256:f25e95d626ee8858ef13fd1a45c6a865dfeb647b15210f1b6cc8547e49e9d95f"
           image=ghcr.io/nvidia/${{ matrix.image_name }}
@@ -81,6 +80,11 @@ jobs:
             fi
           done
           echo "tags_to_remove=${delete:2}" >> $GITHUB_OUTPUT
+
+      - name: Look up version numbers
+        id: packages
+        run: |
+          curl -X GET -H "Authorization: Bearer ${{env.GITHUB_TOKEN}}" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions
 
       - name: Delete matching signatures
         if: steps.sig_files.outputs.tags_to_remove

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Delete untagged cuda-quantum-devdeps images
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v3
+        continue-on-error: true
         with: 
           package-name: ${{ matrix.image_name }}
-          package-type: 'container'
           min-versions-to-keep: 20
           delete-only-untagged-versions: 'true'
 
@@ -83,10 +83,10 @@ jobs:
 
       - name: Delete matching signatures
         if: steps.sig_files.outputs.tags_to_remove
-        uses: actions/delete-package-versions@v4
+        continue-on-error: true
+        uses: actions/delete-package-versions@v3
         with: 
           package-name: ${{ matrix.image_name }}
-          package-type: 'container'
           package-version-ids: '${{ steps.sig_files.outputs.tags_to_remove }}'
 
   # We use environments to deploy to a public registry after PRs are merged.

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Find matching signatures files
         id: sig_files
+        shell: bash
         run: |
           regctl="docker run ghcr.io/regclient/regctl@sha256:f25e95d626ee8858ef13fd1a45c6a865dfeb647b15210f1b6cc8547e49e9d95f"
           image=ghcr.io/nvidia/${{ matrix.image_name }}

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -54,6 +54,18 @@ jobs:
           min-versions-to-keep: 20
           delete-only-untagged-versions: 'true'
 
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Delete matching signatures files
+        run: |
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends skopeo
+          skopeo inspect docker://ghcr.io/nvidia/cuda-quantum/cuda-quantum | jq '.RepoTags'
+
   # We use environments to deploy to a public registry after PRs are merged.
   # Since we use the same workflows during CI, a default environment that defines
   # the necessary variables is used instead. Unfortunately, this automatically

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -67,17 +67,23 @@ jobs:
           image=docker://ghcr.io/nvidia/${{ matrix.image_name }}
           skopeo inspect $image | jq '.RepoTags' > tags.txt
           sig_tags=`cat tags.txt | (egrep -o 'sha256-\S+\.sig"' || true)`
+          echo $sig_tags
+
+          nr_sigs=100 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
+            echo "checking tag $sig"
             skopeo inspect $image@${sig:7:-5} &> /dev/null
-            if [ ! $? -eq 0 ]; then
+            if [ ! $? -eq 0 ] && [ $nr_sig -lt 100 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"
+              nr_sig=$((nr_sig+1))
             fi
           done
           echo "[${sig:1}]"
           echo "tags_to_remove=${sig:1}" >> $GITHUB_OUTPUT
 
       - name: Delete matching signatures
+        if: steps.sig_files.outputs.tags_to_remove
         uses: actions/delete-package-versions@v4
         with: 
           package-name: ${{ matrix.image_name }}

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -71,10 +71,10 @@ jobs:
 
           nr_sigs=10 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
-            found=`($regctl image manifest $image@sha256:${sig:7:-4} && echo true) || echo false`
+            found=`($regctl image manifest $image@sha256:${sig:7:-4} 1> /dev/null && echo true) || echo false`
             exists=`($found && [ -z "$($regctl image manifest $image@sha256:${sig:7:-4} | grep application/vnd.in-toto+json)" ] && echo true) || echo false`
             echo "Image $image@sha256:${sig:7:-4} (exists: $exists, found: $found)"
-            if [ ! $exists ] && [ $nr_sigs -gt 0 ]; then
+            if ! $exists && [ $nr_sigs -gt 0 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"
               nr_sigs=$(($nr_sigs-1))

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Delete untagged cuda-quantum-devdeps images
-        uses: actions/delete-package-versions@v3
+        uses: actions/delete-package-versions@v4
         with: 
           package-name: ${{ matrix.image_name }}
           package-type: 'container'
@@ -75,15 +75,15 @@ jobs:
             exists=`($found && [ -z "$($regctl image manifest $image@sha256:${sig:7:-4} | grep application/vnd.in-toto+json)" ] && echo true) || echo false`
             if ! $exists; then
               echo "Marking signature $sig for deletion."
-              delete+=",$sig"
+              delete+=", $sig"
               nr_sigs=$(($nr_sigs-1))
             fi
           done
-          echo "tags_to_remove=${delete:1}" >> $GITHUB_OUTPUT
+          echo "tags_to_remove=${delete:2}" >> $GITHUB_OUTPUT
 
       - name: Delete matching signatures
         if: steps.sig_files.outputs.tags_to_remove
-        uses: actions/delete-package-versions@v3
+        uses: actions/delete-package-versions@v4
         with: 
           package-name: ${{ matrix.image_name }}
           package-type: 'container'

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -47,10 +47,11 @@ jobs:
 
     steps:
       - name: Delete untagged cuda-quantum-devdeps images
-        uses: actions/delete-package-versions@v3
+        uses: actions/delete-package-versions@v4
         continue-on-error: true
         with: 
           package-name: ${{ matrix.image_name }}
+          package-type: 'container'
           min-versions-to-keep: 20
           delete-only-untagged-versions: 'true'
 
@@ -84,9 +85,10 @@ jobs:
       - name: Delete matching signatures
         if: steps.sig_files.outputs.tags_to_remove
         continue-on-error: true
-        uses: actions/delete-package-versions@v3
+        uses: actions/delete-package-versions@v4
         with: 
           package-name: ${{ matrix.image_name }}
+          package-type: 'container'
           package-version-ids: '${{ steps.sig_files.outputs.tags_to_remove }}'
 
   # We use environments to deploy to a public registry after PRs are merged.

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Delete matching signatures files
         run: |
           sudo apt-get update && sudo apt-get install -y --no-install-recommends skopeo
-          skopeo inspect docker://ghcr.io/nvidia/cuda-quantum/cuda-quantum | jq '.RepoTags'
+          skopeo inspect docker://ghcr.io/nvidia/${{ matrix.image_name }} | jq '.RepoTags'
 
   # We use environments to deploy to a public registry after PRs are merged.
   # Since we use the same workflows during CI, a default environment that defines

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Delete untagged cuda-quantum-devdeps images
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v3
         with: 
           package-name: ${{ matrix.image_name }}
           package-type: 'container'
@@ -83,7 +83,7 @@ jobs:
 
       - name: Delete matching signatures
         if: steps.sig_files.outputs.tags_to_remove
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v3
         with: 
           package-name: ${{ matrix.image_name }}
           package-type: 'container'

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -66,21 +66,20 @@ jobs:
         run: |
           image=docker://ghcr.io/nvidia/${{ matrix.image_name }}
           skopeo list-tags $image | jq '.Tags' > tags.txt
-          sig_tags=`cat tags.txt | (egrep -o 'sha256-\S+\.sig"' || true)`
-          echo $sig_tags
+          sig_tags=`cat tags.txt | (egrep -o '"sha256-\S+\.sig"' || true)`
 
           nr_sigs=100 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
             echo "checking tag $sig"
-            (skopeo inspect $image@sha256:${sig:7:-5} --query-tags=false &> /dev/null) && exists=true || exists=false
+            (skopeo inspect $image@sha256:${sig:8:-5} --query-tags=false &> /dev/null) && exists=true || exists=false
             if [ ! $exists ] && [ $nr_sig -gt 0 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"
               nr_sig=$((nr_sig-1))
             fi
           done
-          echo "[${sig:1}]"
-          echo "tags_to_remove=${sig:1}" >> $GITHUB_OUTPUT
+          echo "[${delete:1}]"
+          echo "tags_to_remove=${delete:1}" >> $GITHUB_OUTPUT
 
       - name: Delete matching signatures
         if: steps.sig_files.outputs.tags_to_remove

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Look up version numbers
         id: packages
         run: |
-          curl -X GET -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions > packages.json
+          gh api --paginate --method GET https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions > packages.json
           cat packages.json
           for tag in ${{ steps.sig_files.outputs.tags_to_remove }}; do
             echo "Finding version id for tag ${tag%,}."
@@ -95,9 +95,11 @@ jobs:
           done
           echo "[${delete:2}]"
           echo "versions_to_remove=${delete:2}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Delete matching signatures
-        if: steps.sig_files.outputs.tags_to_remove
+        if: steps.packages.outputs.versions_to_remove
         uses: actions/delete-package-versions@v4
         with: 
           package-name: ${{ matrix.image_name }}

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -70,7 +70,7 @@ jobs:
 
           nr_sigs=100 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
-            echo "checking tag $sig"
+            echo "Looking for image $image@sha256:${sig:8:-5} (tag $sig)"
             (skopeo inspect $image@sha256:${sig:8:-5} --query-tags=false &> /dev/null) && exists=true || exists=false
             if [ ! $exists ] && [ $nr_sig -gt 0 ]; then
               echo "Marking signature $sig for deletion."

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -67,23 +67,18 @@ jobs:
         run: |
           regctl="docker run ghcr.io/regclient/regctl@sha256:f25e95d626ee8858ef13fd1a45c6a865dfeb647b15210f1b6cc8547e49e9d95f"
           image=ghcr.io/nvidia/${{ matrix.image_name }}
-          sig_tags=`$regctl tag ls $image | (egrep -o '^sha256-\S+\.sig$' || true)`
-
-          nr_sigs=10 # limit how much we delete at a time to avoid exceededing the service rate limit
+          sig_tags=`($regctl tag ls $image || echo) | (egrep -o '^sha256-\S+\.sig$' || true)`
+          nr_sigs=100 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
-            found=`($regctl image manifest $image@sha256:${sig:7:-4} 1> /dev/null && echo true) || echo false`
+            if [ $nr_sigs -lt 1 ]; then continue; fi
+            found=`($regctl image manifest $image@sha256:${sig:7:-4} &> /dev/null && echo true) || echo false`
             exists=`($found && [ -z "$($regctl image manifest $image@sha256:${sig:7:-4} | grep application/vnd.in-toto+json)" ] && echo true) || echo false`
-            echo "Image $image@sha256:${sig:7:-4} (exists: $exists, found: $found)"
-            if ! $exists && [ $nr_sigs -gt 0 ]; then
+            if ! $exists; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"
               nr_sigs=$(($nr_sigs-1))
-            else
-              echo "Keeping $sig."
             fi
           done
-
-          echo "[${delete:1}]"
           echo "tags_to_remove=${delete:1}" >> $GITHUB_OUTPUT
 
       - name: Delete matching signatures

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -86,9 +86,12 @@ jobs:
           curl -X GET -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions > packages.json
           cat packages.json
           for tag in ${{ steps.sig_files.outputs.tags_to_remove }}; do
+            echo "Finding version id for tag ${tag%,}."
             version_id=`cat packages.json | jq ".[] | select(.metadata.package_type==\"container\" and (.metadata.container.tags[] | contains(\"${tag%,}\")))" | jq '.id'`
-            echo "Marking version $version_id for deletion."
-            delete+=", $version_id"
+            if [ -n "$version_id" ]; then
+              echo "Marking version $version_id for deletion."
+              delete+=", $version_id"
+            fi
           done
           echo "[${delete:2}]"
           echo "versions_to_remove=${delete:2}" >> $GITHUB_OUTPUT

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -70,10 +70,8 @@ jobs:
 
           nr_sigs=10 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
-            ($regctl image manifest $image@sha256:${sig:7:-4} &> /dev/null \
-              && [ -z "$($regctl image manifest $image@sha256:${sig:7:-4} | grep application/vnd.in-toto+json)" ] \
-              && exists=true) \
-            || exists=false
+            found=`$regctl image manifest $image@sha256:${sig:7:-4} && echo true || echo false`
+            exists=`$found && [ -z "$($regctl image manifest $image@sha256:${sig:7:-4} | grep application/vnd.in-toto+json)" ] && echo true || echo false`
             echo "Image $image@sha256:${sig:7:-4} exists: $exists"
             if [ ! $exists ] && [ $nr_sigs -gt 0 ]; then
               echo "Marking signature $sig for deletion."

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -65,18 +65,18 @@ jobs:
         id: sig_files
         run: |
           image=docker://ghcr.io/nvidia/${{ matrix.image_name }}
-          skopeo inspect $image | jq '.RepoTags' > tags.txt
+          skopeo list-tags $image | jq '.Tags' > tags.txt
           sig_tags=`cat tags.txt | (egrep -o 'sha256-\S+\.sig"' || true)`
           echo $sig_tags
 
           nr_sigs=100 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
             echo "checking tag $sig"
-            skopeo inspect $image@${sig:7:-5} &> /dev/null
-            if [ ! $? -eq 0 ] && [ $nr_sig -lt 100 ]; then
+            (skopeo inspect $image@sha256:${sig:7:-5} --query-tags=false &> /dev/null) && exists=true || exists=false
+            if [ ! $exists ] && [ $nr_sig -gt 0 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"
-              nr_sig=$((nr_sig+1))
+              nr_sig=$((nr_sig-1))
             fi
           done
           echo "[${sig:1}]"

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -29,6 +29,8 @@ jobs:
             if $isDraft && $isPrerelease; then
               echo "Deleting release $rel."
               gh release delete $rel -R ${{ github.repository }} -y
+            else
+              echo "Skipping release $rel (is draft: $isDraft, is prerelease: $isPrerelease)."
             fi 
           done < rels.txt
         env:

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -25,12 +25,12 @@ jobs:
           gh release list -L 100 -R ${{ github.repository }} > rels.txt
           while read rel _; do 
             isDraft=`gh release view $rel -R ${{ github.repository }} --json isDraft --jq '.isDraft'`
-            isPrerelease=`gh release view 0.4.0 -R ${{ github.repository }} --json isPrerelease --jq '.isPrerelease'`
+            isPrerelease=`gh release view $rel -R ${{ github.repository }} --json isPrerelease --jq '.isPrerelease'`
             if $isDraft && $isPrerelease; then
               echo "Deleting release $rel."
               gh release delete $rel -R ${{ github.repository }} -y
             else
-              echo "Skipping release $rel (is draft: $isDraft, is prerelease: $isPrerelease)."
+              echo "Skipping release $rel."
             fi 
           done < rels.txt
         env:

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -64,24 +64,20 @@ jobs:
       - name: Find matching signatures files
         id: sig_files
         run: |
-          image=docker://ghcr.io/nvidia/${{ matrix.image_name }}
-          skopeo list-tags $image | jq '.Tags' > tags.txt
-          sig_tags=`cat tags.txt | (egrep -o '"sha256-\S+\.sig"' || true)`
+          regctl="docker run ghcr.io/regclient/regctl@sha256:f25e95d626ee8858ef13fd1a45c6a865dfeb647b15210f1b6cc8547e49e9d95f"
+          image=ghcr.io/nvidia/${{ matrix.image_name }}
+          sig_tags=`$regctl tag ls $image | (egrep -o '^sha256-\S+\.sig$' || true)`
 
           nr_sigs=100 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
-            echo "Looking for image $image@sha256:${sig:8:-5} (tag $sig)"
-            (skopeo inspect $image@sha256:${sig:8:-5} &> /dev/null) && exists=true || exists=false
-            if [ $exists ]; then 
-              created=`skopeo inspect $image@sha256:${sig:8:-5} | jq '.Created'`
-              exists=`[ -n "$created" ] && [ $created != null ] && echo true || echo false`
-            fi
+            ($regctl image manifest $image@sha256:${sig:7:-4} &> /dev/null) && exists=true || exists=false
             if [ ! $exists ] && [ $nr_sigs -gt 0 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"
               nr_sigs=$((nr_sigs-1))
             fi
           done
+
           echo "[${delete:1}]"
           echo "tags_to_remove=${delete:1}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -48,7 +48,6 @@ jobs:
     steps:
       - name: Delete untagged cuda-quantum-devdeps images
         uses: actions/delete-package-versions@v4
-        continue-on-error: true
         with: 
           package-name: ${{ matrix.image_name }}
           package-type: 'container'
@@ -84,11 +83,10 @@ jobs:
       - name: Look up version numbers
         id: packages
         run: |
-          curl -X GET -H "Authorization: Bearer ${{env.GITHUB_TOKEN}}" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions
+          curl -X GET -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions
 
       - name: Delete matching signatures
         if: steps.sig_files.outputs.tags_to_remove
-        continue-on-error: true
         uses: actions/delete-package-versions@v4
         with: 
           package-name: ${{ matrix.image_name }}

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -85,7 +85,6 @@ jobs:
         run: |
           gh api -X GET --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
             /orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions >> packages.json
-          cat packages.json
           for tag in ${{ steps.sig_files.outputs.tags_to_remove }}; do
             echo "Finding version id for tag ${tag%,}."
             version_id=`cat packages.json | jq ".[] | select(.metadata.package_type==\"container\" and (.metadata.container.tags[] | contains(\"${tag%,}\")))" | jq '.id'`

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -71,9 +71,9 @@ jobs:
 
           nr_sigs=10 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
-            found=`$regctl image manifest $image@sha256:${sig:7:-4} && echo true || echo false`
-            exists=`$found && [ -z "$($regctl image manifest $image@sha256:${sig:7:-4} | grep application/vnd.in-toto+json)" ] && echo true || echo false`
-            echo "Image $image@sha256:${sig:7:-4} exists: $exists"
+            found=`($regctl image manifest $image@sha256:${sig:7:-4} && echo true) || echo false`
+            exists=`($found && [ -z "$($regctl image manifest $image@sha256:${sig:7:-4} | grep application/vnd.in-toto+json)" ] && echo true) || echo false`
+            echo "Image $image@sha256:${sig:7:-4} (exists: $exists, found: $found)"
             if [ ! $exists ] && [ $nr_sigs -gt 0 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -84,6 +84,7 @@ jobs:
         id: packages
         run: |
           curl -X GET -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions > packages.json
+          cat packages.json
           for tag in ${{ steps.sig_files.outputs.tags_to_remove }}; do
             version_id=`cat packages.json | jq ".[] | select(.metadata.package_type==\"container\" and (.metadata.container.tags[] | contains(\"${tag%,}\")))" | jq '.id'`
             echo "Marking version $version_id for deletion."

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -83,7 +83,8 @@ jobs:
       - name: Look up version numbers
         id: packages
         run: |
-          gh api --paginate --method GET https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions > packages.json
+          gh api -X GET --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+            /orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions >> packages.json
           cat packages.json
           for tag in ${{ steps.sig_files.outputs.tags_to_remove }}; do
             echo "Finding version id for tag ${tag%,}."

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -61,10 +61,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Delete matching signatures files
+      - name: Find matching signatures files
+        id: sig_files
         run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends skopeo
-          skopeo inspect docker://ghcr.io/nvidia/${{ matrix.image_name }} | jq '.RepoTags'
+          image=docker://ghcr.io/nvidia/${{ matrix.image_name }}
+          skopeo inspect $image | jq '.RepoTags' > tags.txt
+          sig_tags=`cat tags.txt | (egrep -o 'sha256-\S+\.sig"' || true)`
+          for sig in $sig_tags; do 
+            skopeo inspect $image@${sig:7:-5} &> /dev/null
+            if [ ! $? -eq 0 ]; then
+              echo "Marking signature $sig for deletion."
+              delete+=",$sig"
+            fi
+          done
+          echo "[${sig:1}]"
+          echo "tags_to_remove=${sig:1}" >> $GITHUB_OUTPUT
+
+      - name: Delete matching signatures
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: ${{ matrix.image_name }}
+          package-type: 'container'
+          package-version-ids: '${{ steps.sig_files.outputs.tags_to_remove }}'
 
   # We use environments to deploy to a public registry after PRs are merged.
   # Since we use the same workflows during CI, a default environment that defines

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -70,10 +70,11 @@ jobs:
 
           nr_sigs=10 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
-            ($regctl image manifest $image@sha256:${sig:7:-4} > /dev/null \
+            ($regctl image manifest $image@sha256:${sig:7:-4} &> /dev/null \
               && [ -z "$($regctl image manifest $image@sha256:${sig:7:-4} | grep application/vnd.in-toto+json)" ] \
               && exists=true) \
             || exists=false
+            echo "Image $image@sha256:${sig:7:-4} exists: $exists"
             if [ ! $exists ] && [ $nr_sigs -gt 0 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -36,6 +36,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.REPO_BOT_ACCESS_TOKEN }}
 
+  ghcr_images:
+    name: Clean up GHCR images
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image_name: [cuda-quantum-dev, cuda-quantum-devdeps, open-mpi] # cuda-quantum
+      fail-fast: false
+
+    steps:
+      - name: Delete untagged cuda-quantum-devdeps images
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: ${{ matrix.image_name }}
+          package-type: 'container'
+          min-versions-to-keep: 20
+          delete-only-untagged-versions: 'true'
+
   # We use environments to deploy to a public registry after PRs are merged.
   # Since we use the same workflows during CI, a default environment that defines
   # the necessary variables is used instead. Unfortunately, this automatically

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -83,7 +83,12 @@ jobs:
       - name: Look up version numbers
         id: packages
         run: |
-          curl -X GET -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions
+          curl -X GET -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions > packages.json
+          for tag in ${{ steps.sig_files.outputs.tags_to_remove }}; do
+            version_id=`cat packages.json | jq ".[] | select(.metadata.package_type==\"container\" and (.metadata.container.tags[] | contains(\"${tag%,}\")))" | jq '.id'`
+            delete+=", $version_id"
+          done
+          echo "versions_to_remove=${delete:2}" >> $GITHUB_OUTPUT
 
       - name: Delete matching signatures
         if: steps.sig_files.outputs.tags_to_remove
@@ -91,7 +96,7 @@ jobs:
         with: 
           package-name: ${{ matrix.image_name }}
           package-type: 'container'
-          package-version-ids: '${{ steps.sig_files.outputs.tags_to_remove }}'
+          package-version-ids: '${{ steps.packages.outputs.versions_to_remove }}'
 
   # We use environments to deploy to a public registry after PRs are merged.
   # Since we use the same workflows during CI, a default environment that defines

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -72,6 +72,10 @@ jobs:
           for sig in $sig_tags; do 
             echo "Looking for image $image@sha256:${sig:8:-5} (tag $sig)"
             (skopeo inspect $image@sha256:${sig:8:-5} --query-tags=false &> /dev/null) && exists=true || exists=false
+            if [ $exists ]; then 
+              created=`skopeo inspect $image@sha256:${sig:8:-5} --query-tags=false | jq '.Created'`
+              exists=`[ -n "$created" ] && [ $created != null ] && echo true || echo false`
+            fi
             if [ ! $exists ] && [ $nr_sig -gt 0 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -68,13 +68,18 @@ jobs:
           image=ghcr.io/nvidia/${{ matrix.image_name }}
           sig_tags=`$regctl tag ls $image | (egrep -o '^sha256-\S+\.sig$' || true)`
 
-          nr_sigs=100 # limit how much we delete at a time to avoid exceededing the service rate limit
+          nr_sigs=10 # limit how much we delete at a time to avoid exceededing the service rate limit
           for sig in $sig_tags; do 
-            ($regctl image manifest $image@sha256:${sig:7:-4} &> /dev/null) && exists=true || exists=false
+            ($regctl image manifest $image@sha256:${sig:7:-4} > /dev/null \
+              && [ -z "$($regctl image manifest $image@sha256:${sig:7:-4} | grep application/vnd.in-toto+json)" ] \
+              && exists=true) \
+            || exists=false
             if [ ! $exists ] && [ $nr_sigs -gt 0 ]; then
               echo "Marking signature $sig for deletion."
               delete+=",$sig"
-              nr_sigs=$((nr_sigs-1))
+              nr_sigs=$(($nr_sigs-1))
+            else
+              echo "Keeping $sig."
             fi
           done
 

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -165,7 +165,7 @@ jobs:
         uses: sigstore/cosign-installer@v3.1.1
 
       - name: Sign image with GitHub OIDC Token
-        if: inputs.environment
+        if: inputs.environment && false # Signing is disabled as long as the package is private, since we can't clean up signatures in that case
         env:
           DIGEST: ${{ steps.docker_build.outputs.digest }}
           TAGS: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -224,6 +224,7 @@ jobs:
           GH_TOKEN: ${{ secrets.REPO_BOT_ACCESS_TOKEN }}
   
       - name: Upload assets
+        if: steps.artifacts.outputs.releases
         uses: actions/upload-artifact@v3
         with:
           name: downstream_assets

--- a/docker/release/cudaq.Dockerfile
+++ b/docker/release/cudaq.Dockerfile
@@ -66,8 +66,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libstdc++-12-dev \
         libcurl4-openssl-dev \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && python_modules=$([ -n "$MPI_ROOT" ] && echo "mpi4py~=3.1 numpy" || echo "numpy" ) \
-    && echo $python_modules | xargs python3 -m pip install --no-cache-dir \
+    && python3 -m pip install --no-cache-dir numpy \
     && ln -s /bin/python3 /bin/python
 
 ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/c++/12/:/usr/include/$(uname -m)-linux-gnu/c++/12"

--- a/docker/release/cudaq.ext.Dockerfile
+++ b/docker/release/cudaq.ext.Dockerfile
@@ -23,7 +23,11 @@ RUN for folder in `find "$CUDA_QUANTUM_PATH/assets"/*$(uname -m)/* -maxdepth 0 -
 RUN apt-get install -y --no-install-recommends \
         cuda-nvtx-11-8 libcusolver-11-8 libopenblas-openmp-dev \
         # just here for convenience:
-        curl jq
+        curl jq 
+RUN if [ -n "$MPI_ROOT" ] && [ -x "$(command -v pip)" ]; then \
+         apt-get install -y --no-install-recommends gcc \
+         && pip install --no-cache-dir mpi4py~=3.1; \
+    fi
 
 # Make sure that apt-get remains updated at the end!;
 # If we don't do that, then apt-get will get confused when some CUDA

--- a/python/README.md
+++ b/python/README.md
@@ -58,7 +58,7 @@ On Ubuntu 22.04, for example, the following commands install the necessary MPI
 libraries:
 
 ```console
-sudo apt-get update && sudo apt-get install -y libopenmpi-dev
+sudo apt-get update && sudo apt-get install -y libopenmpi-dev libpython3-dev gcc
 python3 -m pip install mpi4py
 ```
 


### PR DESCRIPTION
We use draft releases to exchange data between GitHub and GitLab. In principle, these draft releases are automatically cleaned up by the workflow. However, draft releases can get left behind when there is a bug or when updating the workflow. I hence added the input option to delete all draft releases in the clean-up workflow for convenience.

Works as it should: 
- https://github.com/NVIDIA/cuda-quantum/actions/runs/6393624866/job/17353240380
- https://github.com/NVIDIA/cuda-quantum/actions/runs/6405654128