### PR TITLE
Clarifying how to invoke GPU-simulators from Python

### DIFF
--- a/docker/release/cudaq.Dockerfile
+++ b/docker/release/cudaq.Dockerfile
@@ -66,7 +66,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libstdc++-12-dev \
         libcurl4-openssl-dev \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && python3 -m pip install --no-cache-dir numpy \
+    && python_modules=$([ -n "$MPI_ROOT" ] && echo "mpi4py~=3.1 numpy" || echo "numpy" ) \
+    && echo $python_modules | xargs python3 -m pip install --no-cache-dir \
     && ln -s /bin/python3 /bin/python
 
 ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/c++/12/:/usr/include/$(uname -m)-linux-gnu/c++/12"

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -30,7 +30,7 @@ switch to :code:`FP64`, specify the :code:`nvidia-fp64` target instead.
 
 .. note:: 
 
-    This backend requires an NVIDIA GPU and CUDA runtime libraries. See the section :ref:`dependencies-and-compatibility` for more information.
+    This backend requires an NVIDIA GPU and CUDA runtime libraries. If you are do not have these dependencies installed, you may encounter an error stating `Invalid simulator requested`. See the section :ref:`dependencies-and-compatibility` for more information about how to install dependencies.
 
 cuQuantum multi-node multi-GPU
 ++++++++++++++++++++++++++++++++++
@@ -54,7 +54,7 @@ In python, this can be specified with
 
 .. note:: 
 
-    This backend requires an NVIDIA GPU, CUDA runtime libraries, as well as an MPI installation. See the section :ref:`dependencies-and-compatibility` for more information.
+    This backend requires an NVIDIA GPU, CUDA runtime libraries, as well as an MPI installation. If you are do not have these dependencies installed, you may encounter an error stating `Invalid simulator requested`. See the section :ref:`dependencies-and-compatibility` for more information about how to install dependencies.
 
 OpenMP CPU-only
 ++++++++++++++++++++++++++++++++++
@@ -76,7 +76,7 @@ Multi-Node, Multi-GPU distribution of tensor operations required to evaluate and
 
 .. note:: 
 
-    This backend requires an NVIDIA GPU and CUDA runtime libraries. See the section :ref:`dependencies-and-compatibility` for more information.
+    This backend requires an NVIDIA GPU and CUDA runtime libraries. If you are do not have these dependencies installed, you may encounter an error stating `Invalid simulator requested`. See the section :ref:`dependencies-and-compatibility` for more information about how to install dependencies.
 
 This backend exposes a set of environment variables to configure specific aspects of the simulation:
 

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -58,7 +58,7 @@ The multi-node multi-GPU simulator expects to run within an MPI context. A progr
 
     mpirun -np 2 ./program.out
 
-To use the multi-node multi-GPU backend from Python, follow the instructions for installing dependencies in the `Project Description <https://pypi.org/project/cuda-quantum/|version|/#description>`__. 
+To use the multi-node multi-GPU backend from Python, follow the instructions for installing dependencies in the `Project Description <https://pypi.org/project/cuda-quantum/#description>`__. 
 Using `mpi4py <https://mpi4py.readthedocs.io/>`__, for example, a `program.py` can be invoked from the command line with
 
 .. code:: bash 

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -44,13 +44,26 @@ options to :code:`nvq++`
 
 .. code:: bash 
 
-    nvq++ --target nvidia-mgpu src.cpp ...
+    nvq++ --target nvidia-mgpu -o program.out src.cpp ...
 
-In python, this can be specified with 
+In Python, this can be specified with 
 
 .. code:: python 
 
     cudaq.set_target('nvidia-mgpu')
+
+The multi-node multi-GPU simulator expects to run within an MPI context. A program compiled with :code:`nvq++`, for example, is invoked with
+
+.. code:: bash 
+
+    mpirun -np 2 ./program.out
+
+To use the multi-node multi-GPU backend from Python, follow the instructions for installing dependencies in the `Project Description <https://pypi.org/project/cuda-quantum/|version|/#description>`__. 
+Using `mpi4py <https://mpi4py.readthedocs.io/>`__, for example, a `program.py` can be invoked from the command line with
+
+.. code:: bash 
+
+    mpiexec -np 2 python3.10 -m mpi4py program.py
 
 .. note:: 
 

--- a/python/README.md
+++ b/python/README.md
@@ -43,7 +43,7 @@ optional CUDA dependencies:
 arch=x86_64 # set this to sbsa for ARM processors
 sudo apt-get update && sudo apt-get install -y wget
 wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/$arch/cuda-keyring_1.0-1_all.deb
-sudo dpkg -i cuda-keyring_1.0-1_all.deb
+sudo dpkg -i cuda-keyring_1.0-1_all.deb && rm cuda-keyring_1.0-1_all.deb
 sudo apt-get update && sudo apt-get install -y cuda-toolkit-11.8
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -57,7 +57,7 @@ Ubuntu 22.04, for example, the following commands install the necessary MPI
 libraries:
 
 ```console
-  sudo apt-get update && sudo apt-get install -y openmpi-common openmpi-bin
+  sudo apt-get update && sudo apt-get install -y openmpi-common openmpi-bin libopenmpi-dev
 ```
 
 ## Running CUDA Quantum

--- a/python/README.md
+++ b/python/README.md
@@ -40,11 +40,11 @@ manager. On Ubuntu 22.04, for example, the following commands install all
 optional CUDA dependencies:
 
 ```console
-  arch=x86_64 # set this to sbsa for ARM processors
-  sudo apt-get update && sudo apt-get install -y wget
-  wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/$arch/cuda-keyring_1.0-1_all.deb
-  sudo dpkg -i cuda-keyring_1.0-1_all.deb
-  sudo apt-get update && sudo apt-get install -y cuda-toolkit-11.8
+arch=x86_64 # set this to sbsa for ARM processors
+sudo apt-get update && sudo apt-get install -y wget
+wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/$arch/cuda-keyring_1.0-1_all.deb
+sudo dpkg -i cuda-keyring_1.0-1_all.deb
+sudo apt-get update && sudo apt-get install -y cuda-toolkit-11.8
 ```
 
 Detailed instructions for how to install the complete CUDA toolkit on different
@@ -52,12 +52,14 @@ operating systems can be found in the [CUDA
 documentation](https://docs.nvidia.com/cuda/).
 
 If you have several GPUs available but no MPI installation yet, we recommend
-taking a look at the [OpenMPI documentation](https://docs.open-mpi.org/). On
-Ubuntu 22.04, for example, the following commands install the necessary MPI
+taking a look at the [OpenMPI documentation](https://docs.open-mpi.org/)
+and installing [mpi4py](https://mpi4py.readthedocs.io/).
+On Ubuntu 22.04, for example, the following commands install the necessary MPI
 libraries:
 
 ```console
-  sudo apt-get update && sudo apt-get install -y openmpi-common openmpi-bin libopenmpi-dev
+sudo apt-get update && sudo apt-get install -y libopenmpi-dev
+python3 -m pip install mpi4py
 ```
 
 ## Running CUDA Quantum


### PR DESCRIPTION
Trying out the latest installation, the error that is given when CUDA dependencies are missing can be a bit cryptic. I hence mention it explicitly in the note about dependencies for the simulator backends.

Also, properly documenting the mgpu backend.