### PR TITLE
Make unwind lowering of scopes less conservative.

### DIFF
--- a/lib/Optimizer/Transforms/LowerUnwind.cpp
+++ b/lib/Optimizer/Transforms/LowerUnwind.cpp
@@ -83,9 +83,7 @@ private:
       for (Operation *parent = unwindOp->getParentOp();
            !isa<cudaq::cc::LoopOp>(parent) && !asPrimitive;
            parent = parent->getParentOp())
-        asPrimitive =
-            isa<func::FuncOp, cudaq::cc::CreateLambdaOp, cudaq::cc::ScopeOp>(
-                parent);
+        asPrimitive = isa<func::FuncOp, cudaq::cc::CreateLambdaOp>(parent);
     }
     auto *op = unwindOp.getOperation();
     infoMap.opParentMap.insert({op, {parent, asPrimitive}});
@@ -309,6 +307,20 @@ populateTerminatorAllocaMap(const SmallVector<Operation *> &terminators,
   return results;
 }
 
+static bool anyPrimitiveAncestor(
+    const DenseMap<Operation *, UnwindGotoAsPrimitive> &opParentMap,
+    Operation *op) {
+  for (auto iter = opParentMap.find(op); iter != opParentMap.end();) {
+    auto *parent = iter->second.parent;
+    if (iter->second.asPrimitive)
+      return true;
+    if (!parent)
+      break;
+    iter = opParentMap.find(parent);
+  }
+  return false;
+}
+
 namespace {
 /// A scope op that contains an unwind op and is contained by a loop (for break
 /// or continue) or for return always, dictates that the unwind op must transfer
@@ -323,7 +335,9 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
   LogicalResult matchAndRewrite(cudaq::cc::ScopeOp scope,
                                 PatternRewriter &rewriter) const override {
     [[maybe_unused]] auto iter = infoMap.opParentMap.find(scope.getOperation());
-    assert(iter != infoMap.opParentMap.end() && iter->second.asPrimitive);
+    assert(iter != infoMap.opParentMap.end());
+    bool asPrimitive =
+        anyPrimitiveAncestor(infoMap.opParentMap, scope.getOperation());
     LLVM_DEBUG(llvm::dbgs() << "replacing scope @" << scope.getLoc() << '\n');
     auto loc = scope.getLoc();
     auto *initBlock = rewriter.getInsertionBlock();
@@ -367,8 +381,12 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
         rewriter.setInsertionPointToEnd(blk);
         for (auto a : llvm::reverse(qallocas))
           rewriter.create<quake::DeallocOp>(a->getLoc(), a->getResult(0));
-        Block *landingPad = getLandingPad(infoMap, scope).continueBlock;
-        rewriter.create<cf::BranchOp>(loc, landingPad, blk->getArguments());
+        if (asPrimitive) {
+          Block *landingPad = getLandingPad(infoMap, scope).continueBlock;
+          rewriter.create<cf::BranchOp>(loc, landingPad, blk->getArguments());
+        } else {
+          rewriter.create<cudaq::cc::ContinueOp>(loc, blk->getArguments());
+        }
         scope.getInitRegion().push_back(blk);
       }
       // Loop break from within scope with deallocations.
@@ -376,8 +394,12 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
         rewriter.setInsertionPointToEnd(blk);
         for (auto a : llvm::reverse(qallocas))
           rewriter.create<quake::DeallocOp>(a->getLoc(), a->getResult(0));
-        rewriter.create<cf::BranchOp>(
-            loc, getLandingPad(infoMap, scope).breakBlock, blk->getArguments());
+        if (asPrimitive) {
+          Block *landingPad = getLandingPad(infoMap, scope).breakBlock;
+          rewriter.create<cf::BranchOp>(loc, landingPad, blk->getArguments());
+        } else {
+          rewriter.create<cudaq::cc::BreakOp>(loc, blk->getArguments());
+        }
         scope.getInitRegion().push_back(blk);
       }
       // Function return from within scope with deallocations.
@@ -385,9 +407,9 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
         rewriter.setInsertionPointToEnd(blk);
         for (auto a : llvm::reverse(qallocas))
           rewriter.create<quake::DeallocOp>(a->getLoc(), a->getResult(0));
-        rewriter.create<cf::BranchOp>(loc,
-                                      getLandingPad(infoMap, scope).returnBlock,
-                                      blk->getArguments());
+        assert(asPrimitive);
+        Block *landingPad = getLandingPad(infoMap, scope).returnBlock;
+        rewriter.create<cf::BranchOp>(loc, landingPad, blk->getArguments());
         scope.getInitRegion().push_back(blk);
       }
     }
@@ -506,7 +528,7 @@ struct IfOpPattern : public OpRewritePattern<cudaq::cc::IfOp> {
     // continue, break, and/or return blocks of the parent. Otherwise, the
     // control-flow will be within the region of the parent and the branches
     // aren't needed.
-    if (iter->second.asPrimitive) {
+    if (anyPrimitiveAncestor(infoMap.opParentMap, ifOp.getOperation())) {
       // Append blocks to tailRegion.
       auto &tailRegion = hasElse ? ifOp.getElseRegion() : ifOp.getThenRegion();
       auto blockMapIter = infoMap.blockDetails.find(ifOp.getOperation());
@@ -738,7 +760,8 @@ LogicalResult intraLoopJump(FROM op, PatternRewriter &rewriter,
   auto *blk = rewriter.getInsertionBlock();
   auto pos = rewriter.getInsertionPoint();
   rewriter.splitBlock(blk, std::next(pos));
-  if (iter->second.asPrimitive)
+  if (isa<cudaq::cc::ScopeOp>(iter->second.parent) ||
+      anyPrimitiveAncestor(infoMap.opParentMap, op.getOperation()))
     rewriter.replaceOpWithNewOp<cf::BranchOp>(op, getLandingPad(op, infoMap),
                                               op.getOperands());
   else
@@ -799,17 +822,17 @@ public:
     ConversionTarget target(*ctx);
     target.addIllegalOp<cudaq::cc::UnwindBreakOp, cudaq::cc::UnwindContinueOp,
                         cudaq::cc::UnwindReturnOp>();
-    target.addDynamicallyLegalOp<cudaq::cc::LoopOp, cudaq::cc::ScopeOp>(
+    target.addDynamicallyLegalOp<cudaq::cc::LoopOp>([&](Operation *op) {
+      auto iter = unwindInfo.opParentMap.find(op);
+      if (iter == unwindInfo.opParentMap.end())
+        return true;
+      return !iter->second.asPrimitive;
+    });
+    target.addDynamicallyLegalOp<cudaq::cc::IfOp, cudaq::cc::ScopeOp>(
         [&](Operation *op) {
           auto iter = unwindInfo.opParentMap.find(op);
-          if (iter == unwindInfo.opParentMap.end())
-            return true;
-          return !iter->second.asPrimitive;
+          return iter == unwindInfo.opParentMap.end();
         });
-    target.addDynamicallyLegalOp<cudaq::cc::IfOp>([&](Operation *op) {
-      auto iter = unwindInfo.opParentMap.find(op);
-      return iter == unwindInfo.opParentMap.end();
-    });
     target.addDynamicallyLegalOp<func::FuncOp, cudaq::cc::CreateLambdaOp>(
         [&](Operation *op) {
           if (!unwindInfo.opParentMap.count(op))

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -44,69 +44,66 @@ struct C {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__C()
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
-// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 10 : i32
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_6:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_9:.*]] = cc.alloca i32
-// CHECK:             cc.store %[[VAL_7]], %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             cf.br ^bb1
-// CHECK:           ^bb1:
-// CHECK:             %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i32
-// CHECK:             cf.cond_br %[[VAL_11]], ^bb2, ^bb8
-// CHECK:           ^bb2:
-// CHECK:             %[[VAL_12:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             %[[VAL_13:.*]] = func.call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
-// CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
-// CHECK:           ^bb3:
-// CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:             quake.dealloc %[[VAL_14]] : !quake.ref
-// CHECK:             cf.br ^bb8
-// CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref,
-// CHECK:             func.call @_Z2g2v() : () -> ()
-// CHECK:             %[[VAL_18:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
-// CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
-// CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:             quake.y %[[VAL_20]] :
-// CHECK:             cf.br ^bb7
-// CHECK:           ^bb6:
-// CHECK:             func.call @_Z2g3v() : () -> ()
-// CHECK:             %[[VAL_21:.*]] = cc.loop while ((%[[VAL_22:.*]] = %[[VAL_4]]) -> (index)) {
-// CHECK:               %[[VAL_23:.*]] = arith.cmpi slt, %[[VAL_22]], %[[VAL_0]] : index
-// CHECK:               cc.condition %[[VAL_23]](%[[VAL_22]] : index)
+// CHECK:             %[[VAL_7:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_5]], %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:             cc.loop while {
+// CHECK:               %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_4]] : i32
+// CHECK:               cc.condition %[[VAL_9]]
 // CHECK:             } do {
-// CHECK:             ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.veq<2>, index) -> !quake.ref
-// CHECK:               quake.z %[[VAL_25]] : (!quake.ref) -> ()
-// CHECK:               cc.continue %[[VAL_24]] : index
+// CHECK:               %[[VAL_10:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_11:.*]] = func.call @_Z2f1i(%[[VAL_10]]) : (i32) -> i1
+// CHECK:               cf.cond_br %[[VAL_11]], ^bb1, ^bb2
+// CHECK:             ^bb1:
+// CHECK:               %[[VAL_12:.*]] = quake.alloca !quake.ref
+// CHECK:               %[[VAL_13:.*]] = quake.extract_ref %[[VAL_6]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:               quake.x {{\[}}%[[VAL_12]]] %[[VAL_13]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:               quake.dealloc %[[VAL_12]] : !quake.ref
+// CHECK:               cc.break
+// CHECK:             ^bb2:
+// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_6]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:               %[[VAL_15:.*]] = quake.extract_ref %[[VAL_6]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:               quake.x {{\[}}%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:               func.call @_Z2g2v() : () -> ()
+// CHECK:               %[[VAL_16:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_17:.*]] = func.call @_Z2f2i(%[[VAL_16]]) : (i32) -> i1
+// CHECK:               cf.cond_br %[[VAL_17]], ^bb3, ^bb4
+// CHECK:             ^bb3:
+// CHECK:               %[[VAL_18:.*]] = quake.extract_ref %[[VAL_6]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:               quake.y %[[VAL_18]] : (!quake.ref) -> ()
+// CHECK:               cc.continue
+// CHECK:             ^bb4:
+// CHECK:               func.call @_Z2g3v() : () -> ()
+// CHECK:               %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (index)) {
+// CHECK:                 %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : index
+// CHECK:                 cc.condition %[[VAL_21]](%[[VAL_20]] : index)
+// CHECK:               } do {
+// CHECK:               ^bb0(%[[VAL_22:.*]]: index):
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]]{{\[}}%[[VAL_22]]] : (!quake.veq<2>, index) -> !quake.ref
+// CHECK:                 quake.z %[[VAL_23]] : (!quake.ref) -> ()
+// CHECK:                 cc.continue %[[VAL_22]] : index
+// CHECK:               } step {
+// CHECK:               ^bb0(%[[VAL_24:.*]]: index):
+// CHECK:                 %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : index
+// CHECK:                 cc.continue %[[VAL_25]] : index
+// CHECK:               } {invariant}
+// CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:             ^bb0(%[[VAL_26:.*]]: index):
-// CHECK:               %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : index
-// CHECK:               cc.continue %[[VAL_27]] : index
-// CHECK:             } {invariant}
-// CHECK:             cf.br ^bb7
-// CHECK:           ^bb7:
-// CHECK:             %[[VAL_28:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_5]] : i32
-// CHECK:             cc.store %[[VAL_29]], %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             cf.br ^bb1
-// CHECK:           ^bb8:
-// CHECK:             cc.continue
+// CHECK:               %[[VAL_26:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : i32
+// CHECK:               cc.store %[[VAL_27]], %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:             }
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 
@@ -134,71 +131,68 @@ struct D {
    }
 };
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__D()
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__D() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 10 : i32
-// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<2>
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 10 : i32
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_6:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           call @_Z2g1v() : () -> ()
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_9:.*]] = cc.alloca i32
-// CHECK:             cc.store %[[VAL_7]], %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             cf.br ^bb1
-// CHECK:           ^bb1:
-// CHECK:             %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i32
-// CHECK:             cf.cond_br %[[VAL_11]], ^bb2, ^bb8
-// CHECK:           ^bb2:
-// CHECK:             %[[VAL_12:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             %[[VAL_13:.*]] = func.call @_Z2f1i(%[[VAL_12]]) : (i32) -> i1
-// CHECK:             cf.cond_br %[[VAL_13]], ^bb3, ^bb4
-// CHECK:           ^bb3:
-// CHECK:             %[[VAL_14:.*]] = quake.alloca !quake.ref
-// CHECK:             %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:             quake.x [%[[VAL_14]]] %[[VAL_15]] :
-// CHECK:             quake.dealloc %[[VAL_14]] : !quake.ref
-// CHECK:             cf.br ^bb7
-// CHECK:           ^bb4:
-// CHECK:             %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:             %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:             quake.x [%[[VAL_16]]] %[[VAL_17]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:             func.call @_Z2g2v() : () -> ()
-// CHECK:             %[[VAL_18:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             %[[VAL_19:.*]] = func.call @_Z2f2i(%[[VAL_18]]) : (i32) -> i1
-// CHECK:             cf.cond_br %[[VAL_19]], ^bb5, ^bb6
-// CHECK:           ^bb5:
-// CHECK:             %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:             quake.y %[[VAL_20]]
-// CHECK:             cf.br ^bb8
-// CHECK:           ^bb6:
-// CHECK:             func.call @_Z2g3v() : () -> ()
-// CHECK:             %[[VAL_21:.*]] = cc.loop while ((%[[VAL_22:.*]] = %[[VAL_4]]) -> (index)) {
-// CHECK:               %[[VAL_23:.*]] = arith.cmpi slt, %[[VAL_22]], %[[VAL_0]] : index
-// CHECK:               cc.condition %[[VAL_23]](%[[VAL_22]] : index)
+// CHECK:             %[[VAL_7:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[VAL_5]], %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:             cc.loop while {
+// CHECK:               %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_4]] : i32
+// CHECK:               cc.condition %[[VAL_9]]
 // CHECK:             } do {
-// CHECK:             ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:               %[[VAL_25:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_24]]] : (!quake.veq<2>, index) -> !quake.ref
-// CHECK:               quake.z %[[VAL_25]] : (!quake.ref) -> ()
-// CHECK:               cc.continue %[[VAL_24]] : index
+// CHECK:               %[[VAL_10:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_11:.*]] = func.call @_Z2f1i(%[[VAL_10]]) : (i32) -> i1
+// CHECK:               cf.cond_br %[[VAL_11]], ^bb1, ^bb2
+// CHECK:             ^bb1:
+// CHECK:               %[[VAL_12:.*]] = quake.alloca !quake.ref
+// CHECK:               %[[VAL_13:.*]] = quake.extract_ref %[[VAL_6]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:               quake.x {{\[}}%[[VAL_12]]] %[[VAL_13]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:               quake.dealloc %[[VAL_12]] : !quake.ref
+// CHECK:               cc.continue
+// CHECK:             ^bb2:
+// CHECK:               %[[VAL_14:.*]] = quake.extract_ref %[[VAL_6]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:               %[[VAL_15:.*]] = quake.extract_ref %[[VAL_6]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:               quake.x {{\[}}%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:               func.call @_Z2g2v() : () -> ()
+// CHECK:               %[[VAL_16:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_17:.*]] = func.call @_Z2f2i(%[[VAL_16]]) : (i32) -> i1
+// CHECK:               cf.cond_br %[[VAL_17]], ^bb3, ^bb4
+// CHECK:             ^bb3:
+// CHECK:               %[[VAL_18:.*]] = quake.extract_ref %[[VAL_6]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:               quake.y %[[VAL_18]] : (!quake.ref) -> ()
+// CHECK:               cc.break
+// CHECK:             ^bb4:
+// CHECK:               func.call @_Z2g3v() : () -> ()
+// CHECK:               %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (index)) {
+// CHECK:                 %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : index
+// CHECK:                 cc.condition %[[VAL_21]](%[[VAL_20]] : index)
+// CHECK:               } do {
+// CHECK:               ^bb0(%[[VAL_22:.*]]: index):
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]]{{\[}}%[[VAL_22]]] : (!quake.veq<2>, index) -> !quake.ref
+// CHECK:                 quake.z %[[VAL_23]] : (!quake.ref) -> ()
+// CHECK:                 cc.continue %[[VAL_22]] : index
+// CHECK:               } step {
+// CHECK:               ^bb0(%[[VAL_24:.*]]: index):
+// CHECK:                 %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : index
+// CHECK:                 cc.continue %[[VAL_25]] : index
+// CHECK:               } {invariant}
+// CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:             ^bb0(%[[VAL_26:.*]]: index):
-// CHECK:               %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : index
-// CHECK:               cc.continue %[[VAL_27]] : index
-// CHECK:             } {invariant}
-// CHECK:             cf.br ^bb7
-// CHECK:           ^bb7:
-// CHECK:             %[[VAL_28:.*]] = cc.load %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_5]] : i32
-// CHECK:             cc.store %[[VAL_29]], %[[VAL_9]] : !cc.ptr<i32>
-// CHECK:             cf.br ^bb1
-// CHECK:           ^bb8:
-// CHECK:             cc.continue
+// CHECK:               %[[VAL_26:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:               %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : i32
+// CHECK:               cc.store %[[VAL_27]], %[[VAL_7]] : !cc.ptr<i32>
+// CHECK:             }
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_30:.*]] = quake.mz %[[VAL_8]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<i1>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/control_flow.qke
+++ b/test/Quake/control_flow.qke
@@ -87,30 +87,31 @@ func.func @test2(%i : i32) {
 } 
 
 // CHECK-LABEL:   func.func @test2(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) {
+// CHECK-SAME:                     %[[VAL_0:.*]]: i32) {
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 12 : i32
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 5 : i32
 // CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           cf.br ^bb1(%[[VAL_0]] : i32)
-// CHECK:         ^bb1(%[[VAL_5:.*]]: i32):
-// CHECK:           %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_2]] : i32
-// CHECK:           cf.cond_br %[[VAL_6]], ^bb2(%[[VAL_5]] : i32), ^bb6
-// CHECK:         ^bb2(%[[VAL_7:.*]]: i32):
-// CHECK:           %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           cf.cond_br %[[VAL_8]], ^bb3, ^bb4
-// CHECK:         ^bb3:
-// CHECK:           %[[VAL_9:.*]] = quake.alloca !quake.veq<5>
-// CHECK:           quake.dealloc %[[VAL_9]] : !quake.veq<5>
-// CHECK:           cf.br ^bb5(%[[VAL_3]] : i32)
-// CHECK:         ^bb4:
-// CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<6>
-// CHECK:           quake.dealloc %[[VAL_10]] : !quake.veq<6>
-// CHECK:           cf.br ^bb5(%[[VAL_7]] : i32)
-// CHECK:         ^bb5(%[[VAL_11:.*]]: i32):
-// CHECK:           %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_1]] : i32
-// CHECK:           cf.br ^bb1(%[[VAL_12]] : i32)
-// CHECK:         ^bb6:
+// CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_0]]) -> (i32)) {
+// CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_2]] : i32
+// CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : i32)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i32):
+// CHECK:             %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:             cf.cond_br %[[VAL_9]], ^bb1, ^bb2
+// CHECK:           ^bb1:
+// CHECK:             %[[VAL_10:.*]] = quake.alloca !quake.veq<5>
+// CHECK:             quake.dealloc %[[VAL_10]] : !quake.veq<5>
+// CHECK:             cc.continue %[[VAL_3]] : i32
+// CHECK:           ^bb2:
+// CHECK:             %[[VAL_11:.*]] = quake.alloca !quake.veq<6>
+// CHECK:             quake.dealloc %[[VAL_11]] : !quake.veq<6>
+// CHECK:             cc.continue %[[VAL_8]] : i32
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_12:.*]]: i32):
+// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : i32
+// CHECK:             cc.continue %[[VAL_13]] : i32
+// CHECK:           }
 // CHECK:           return
 
 func.func @test3(%i : i32) {
@@ -152,23 +153,26 @@ func.func @test3(%i : i32) {
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 5 : i32
 // CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           cf.br ^bb1(%[[VAL_0]] : i32)
-// CHECK:         ^bb1(%[[VAL_5:.*]]: i32):
-// CHECK:           %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_2]] : i32
-// CHECK:           cf.cond_br %[[VAL_6]], ^bb2(%[[VAL_5]] : i32), ^bb5
-// CHECK:         ^bb2(%[[VAL_7:.*]]: i32):
-// CHECK:           %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           cf.cond_br %[[VAL_8]], ^bb3, ^bb4
-// CHECK:         ^bb3:
-// CHECK:           %[[VAL_9:.*]] = quake.alloca !quake.veq<6>
-// CHECK:           quake.dealloc %[[VAL_9]] : !quake.veq<6>
-// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_7]], %[[VAL_1]] : i32
-// CHECK:           cf.br ^bb1(%[[VAL_10]] : i32)
-// CHECK:         ^bb4:
-// CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.veq<5>
-// CHECK:           quake.dealloc %[[VAL_11]] : !quake.veq<5>
-// CHECK:           cf.br ^bb5
-// CHECK:         ^bb5:
+// CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_0]]) -> (i32)) {
+// CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_2]] : i32
+// CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : i32)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i32):
+// CHECK:             %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:             cf.cond_br %[[VAL_9]], ^bb1, ^bb2
+// CHECK:           ^bb1:
+// CHECK:             %[[VAL_10:.*]] = quake.alloca !quake.veq<6>
+// CHECK:             quake.dealloc %[[VAL_10]] : !quake.veq<6>
+// CHECK:             cc.continue %[[VAL_8]] : i32
+// CHECK:           ^bb2:
+// CHECK:             %[[VAL_11:.*]] = quake.alloca !quake.veq<5>
+// CHECK:             quake.dealloc %[[VAL_11]] : !quake.veq<5>
+// CHECK:             cc.break %[[VAL_3]] : i32
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_12:.*]]: i32):
+// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : i32
+// CHECK:             cc.continue %[[VAL_13]] : i32
+// CHECK:           }
 // CHECK:           return
 
 func.func @test4() {
@@ -331,6 +335,84 @@ func.func @test5(%arg0: !quake.veq<?>) {
 // CHECK:               %[[VAL_16:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i64>
 // CHECK:               %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_3]] : i64
 // CHECK:               cc.store %[[VAL_17]], %[[VAL_6]] : !cc.ptr<i64>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+func.func @test6(%arg0: !quake.veq<?>) {
+  %c0_i64 = arith.constant 0 : i64
+  %c10_i64 = arith.constant 10 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %0 = cc.alloca i64
+  cc.store %c10_i64, %0 : !cc.ptr<i64>
+  cc.scope {
+    %1 = cc.alloca i64
+    cc.store %c0_i64, %1 : !cc.ptr<i64>
+    cc.loop while {
+      %2 = cc.load %1 : !cc.ptr<i64>
+      %3 = cc.load %0 : !cc.ptr<i64>
+      %4 = arith.cmpi ult, %2, %3 : i64
+      cc.condition %4
+    } do {
+      cc.scope {
+        %2 = cc.load %1 : !cc.ptr<i64>
+        %3 = quake.extract_ref %arg0[%2] : (!quake.veq<?>, i64) -> !quake.ref
+        quake.h %3 : (!quake.ref) -> ()
+        %4 = cc.load %1 : !cc.ptr<i64>
+        %5 = quake.extract_ref %arg0[%4] : (!quake.veq<?>, i64) -> !quake.ref
+        %bits = quake.mz %5 name "b" : (!quake.ref) -> i1
+        %6 = cc.alloca i1
+        cc.store %bits, %6 : !cc.ptr<i1>
+        %7 = cc.load %6 : !cc.ptr<i1>
+        cc.if(%7) {
+          cc.unwind_break
+        }
+      }
+      cc.continue
+    } step {
+      %2 = cc.load %1 : !cc.ptr<i64>
+      %3 = arith.addi %2, %c1_i64 : i64
+      cc.store %3, %1 : !cc.ptr<i64>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @test6(
+// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>)
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 10 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca i64
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_4]] : !cc.ptr<i64>
+// CHECK:           cc.scope {
+// CHECK:             %[[VAL_5:.*]] = cc.alloca i64
+// CHECK:             cc.store %[[VAL_1]], %[[VAL_5]] : !cc.ptr<i64>
+// CHECK:             cc.loop while {
+// CHECK-DAG:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i64>
+// CHECK-DAG:           %[[VAL_7:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
+// CHECK:               %[[VAL_8:.*]] = arith.cmpi ult, %[[VAL_6]], %[[VAL_7]] : i64
+// CHECK:               cc.condition %[[VAL_8]]
+// CHECK:             } do {
+// CHECK:               %[[VAL_9:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i64>
+// CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_9]]] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
+// CHECK:               %[[VAL_11:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i64>
+// CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:               %[[VAL_13:.*]] = quake.mz %[[VAL_12]] name "b" : (!quake.ref) -> i1
+// CHECK:               %[[VAL_14:.*]] = cc.alloca i1
+// CHECK:               cc.store %[[VAL_13]], %[[VAL_14]] : !cc.ptr<i1>
+// CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<i1>
+// CHECK:               cf.cond_br %[[VAL_15]], ^bb1, ^bb2
+// CHECK:             ^bb1:
+// CHECK:               cc.break
+// CHECK:             ^bb2:
+// CHECK:               cc.continue
+// CHECK:             } step {
+// CHECK:               %[[VAL_16:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i64>
+// CHECK:               %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_3]] : i64
+// CHECK:               cc.store %[[VAL_17]], %[[VAL_5]] : !cc.ptr<i64>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return


### PR DESCRIPTION
Similar to the unwind lowering of cc.if ops, these changes allow a cc.scope to be lowered to a CFG without necessarily lowering the surrounding cc.loop to a CFG as well.

Update the tests to reflect the new reality.
