### PR TITLE
Fix bug when rewriting measurement type ops.

### DIFF
--- a/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/lib/Optimizer/Transforms/MemToReg.cpp
@@ -233,9 +233,9 @@ public:
 
     auto threadWires = [&](const SmallVectorImpl<Value> &wireOperands,
                            auto newOp, unsigned addend) {
+      unsigned count = 0;
       for (auto i : llvm::enumerate(wireOperands)) {
         auto opndTy = i.value().getType();
-        unsigned count = 0;
         auto offset = i.index() + addend;
         if (opndTy == qrefTy) {
           rewriter.create<quake::WrapOp>(loc, newOp.getResult(offset),

--- a/lib/Optimizer/Transforms/RegToMem.cpp
+++ b/lib/Optimizer/Transforms/RegToMem.cpp
@@ -226,8 +226,11 @@ public:
     if constexpr (quake::isMeasure<OP>) {
       auto args = collect(op.getOperands());
       auto nameAttr = op.getRegisterNameAttr();
-      rewriter.replaceOpWithNewOp<OP>(
-          op, ArrayRef<Type>{op.getBits().getType()}, args, nameAttr);
+      eraseWrapUsers(op);
+      auto newOp = rewriter.create<OP>(
+          loc, ArrayRef<Type>{op.getBits().getType()}, args, nameAttr);
+      op.getResult(0).replaceAllUsesWith(newOp.getResult(0));
+      rewriter.eraseOp(op);
     } else if constexpr (std::is_same_v<OP, quake::ResetOp>) {
       // Reset is a special case.
       auto targ = findLookupValue(op.getTargets());

--- a/lib/Optimizer/Transforms/RegToMem.cpp
+++ b/lib/Optimizer/Transforms/RegToMem.cpp
@@ -144,8 +144,9 @@ private:
     });
     func.walk([&](Operation *op) {
       if (isa<RAW_MEASURE_OPS>(op)) {
-        for (auto v : op->getOperands())
-          insertToEqClass(v);
+        for (auto [t, r] :
+             llvm::zip(op->getOperands(), op->getResults().drop_front()))
+          insertToEqClass(t, r);
       } else if (isa<RAW_GATE_OPS>(op)) {
         auto gate = cast<quake::OperatorInterface>(op);
         for (auto c : gate.getControls())


### PR DESCRIPTION
Measurements now thread the wires as well as the bool result value in the value semantics. Each wire needs to be forwarded correctly.
