### PR TITLE
Delay measurements (if necessary) for Base Profile programs

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -27,7 +27,7 @@ namespace cudaq::opt {
 /// @param convertTo String name of qir profile (e.g., qir-base, qir-adaptive)
 template <bool QIRProfile = false>
 void addPipelineToQIR(mlir::PassManager &pm,
-                      llvm::StringRef convertTo = "qir-base") {
+                      llvm::StringRef convertTo = "none") {
   cudaq::opt::addAggressiveEarlyInlining(pm);
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(cudaq::opt::createExpandMeasurementsPass());
@@ -45,6 +45,9 @@ void addPipelineToQIR(mlir::PassManager &pm,
       cudaq::opt::createCombineQuantumAllocations());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
+  if (convertTo == "qir-base")
+    pm.addNestedPass<mlir::func::FuncOp>(
+        cudaq::opt::createDelayMeasurementsPass());
   pm.addPass(cudaq::opt::createConvertToQIRPass());
   if constexpr (QIRProfile) {
     cudaq::opt::addQIRProfilePipeline(pm, convertTo);

--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -36,6 +36,7 @@ void registerUnrollingPipeline();
 std::unique_ptr<mlir::Pass> createApplyOpSpecializationPass();
 std::unique_ptr<mlir::Pass>
 createApplyOpSpecializationPass(bool computeActionOpt);
+std::unique_ptr<mlir::Pass> createDelayMeasurementsPass();
 std::unique_ptr<mlir::Pass> createExpandMeasurementsPass();
 std::unique_ptr<mlir::Pass> createLambdaLiftingPass();
 std::unique_ptr<mlir::Pass> createLowerToCFGPass();

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -75,6 +75,17 @@ def ConvertToDirectCalls :
   }];
 }
 
+def DelayMeasurements : Pass<"delay-measurements", "mlir::func::FuncOp"> {
+  let summary =
+    "Move measurements as late as possible";
+
+  let description = [{
+    Move measurements as late as possible. This is useful for a Base Profile QIR program.
+  }];
+
+  let constructor = "cudaq::opt::createDelayMeasurementsPass()";
+}
+
 def ExpandMeasurements : Pass<"expand-measurements"> {
   let summary = "Expand multi-ref measurements to series on single refs.";
   let description = [{

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_cudaq_library(OptTransforms
   CombineQuantumAlloc.cpp
   Decomposition.cpp
   DecompositionPatterns.cpp
+  DelayMeasurements.cpp
   ExpandMeasurements.cpp
   FactorQuantumAlloc.cpp
   GenKernelExecution.cpp

--- a/lib/Optimizer/Transforms/DelayMeasurements.cpp
+++ b/lib/Optimizer/Transforms/DelayMeasurements.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+
+#define DEBUG_TYPE "delay-measurements"
+
+using namespace mlir;
+
+namespace cudaq::opt {
+
+/// Delay Measurements
+///
+/// This pass delays measurements as long as possible. This reordering of
+/// instructions is useful for Base Profile programs where the user measures 1
+/// qubit early in the program and then performs quantum operations on other
+/// qubits later in the program.
+struct DelayMeasurementsPass
+    : public cudaq::opt::DelayMeasurementsBase<DelayMeasurementsPass> {
+  // explicit DelayMeasurementsPass() = default;
+
+  void runOnOperation() override {
+
+    auto func = getOperation();
+    auto &blocks = func.getBlocks();
+
+    if (blocks.size() == 0)
+      return;
+
+    if (blocks.size() > 1) {
+      func.emitError("DelayMeasurementsPass cannot handle multiple blocks. Do "
+                     "you have if statements in a Base Profile QIR program?");
+      signalPassFailure();
+      return;
+    }
+
+    moveMeasurementsToEnd(*blocks.begin());
+  }
+
+  /// @brief Add `op` and all of its users into `opsToMoveToEnd`
+  void
+  addOpAndUsersToList(Operation &op,
+                      llvm::SmallVector<mlir::Operation *> &opsToMoveToEnd) {
+    opsToMoveToEnd.push_back(&op);
+    for (auto user : op.getUsers())
+      addOpAndUsersToList(*user, opsToMoveToEnd);
+  }
+
+  /// @brief The Base Profile requires that irreversible operations (i.e.
+  /// measurements) come after reversible operations. This function enforces
+  /// that.
+  /// @param mainBlock block to process
+  void moveMeasurementsToEnd(mlir::Block &mainBlock) {
+    llvm::SmallVector<mlir::Operation *> opsToMoveToEnd;
+
+    // Keep track of which qubits have been measured as we're walking through
+    // the block
+    llvm::DenseSet<mlir::Value> measuredQubits;
+
+    // Step 1: Identify operations to move. Add to opsToMoveToEnd.
+    for (auto &op : mainBlock) {
+      if (op.hasTrait<QuantumMeasure>()) {
+        // Save the fact that we're measuring these qubits
+        for (auto operand : op.getOperands())
+          measuredQubits.insert(operand);
+      }
+
+      if (op.hasTrait<QuantumMeasure>() || isa<mlir::func::ReturnOp>(op) ||
+          isa<quake::DeallocOp>(op)) {
+        addOpAndUsersToList(op, opsToMoveToEnd);
+        continue;
+      }
+
+      // Check to see if this operation has arguments that were already
+      // measured. If so, add this operation to opsToMoveToEnd, too.
+      for (auto operand : op.getOperands()) {
+        if (measuredQubits.find(operand) != measuredQubits.end()) {
+          addOpAndUsersToList(op, opsToMoveToEnd);
+          break;
+        }
+      }
+    }
+
+    // Step 2: Sequentially move identified operations to the end of the block
+    for (mlir::Operation *opToMove : opsToMoveToEnd)
+      mainBlock.getOperations().splice(
+          mainBlock.end(), mainBlock.getOperations(), opToMove->getIterator());
+  }
+};
+} // namespace cudaq::opt
+
+std::unique_ptr<Pass> cudaq::opt::createDelayMeasurementsPass() {
+  return std::make_unique<DelayMeasurementsPass>();
+}

--- a/runtime/common/RuntimeMLIR.cpp
+++ b/runtime/common/RuntimeMLIR.cpp
@@ -518,7 +518,8 @@ std::unique_ptr<MLIRContext> initializeMLIR() {
   return context;
 }
 
-ExecutionEngine *createQIRJITEngine(ModuleOp &moduleOp) {
+ExecutionEngine *createQIRJITEngine(ModuleOp &moduleOp,
+                                    llvm::StringRef convertTo) {
   ExecutionEngineOptions opts;
   opts.transformer = [](llvm::Module *m) { return llvm::ErrorSuccess(); };
   opts.jitCodeGenOptLevel = llvm::CodeGenOpt::None;
@@ -531,7 +532,10 @@ ExecutionEngine *createQIRJITEngine(ModuleOp &moduleOp) {
     PassManager pm(context);
     std::string errMsg;
     llvm::raw_string_ostream errOs(errMsg);
-    cudaq::opt::addPipelineToQIR</*QIRProfile=*/false>(pm);
+    // Even though we're not lowering all the way to a real QIR profile for this
+    // emulated path, we need to pass in the `convertTo` in order to mimic what
+    // the non-emulated path would do.
+    cudaq::opt::addPipelineToQIR</*QIRProfile=*/false>(pm, convertTo);
     if (failed(pm.run(module)))
       throw std::runtime_error(
           "[createQIRJITEngine] Lowering to QIR for remote emulation failed.");

--- a/runtime/common/RuntimeMLIR.h
+++ b/runtime/common/RuntimeMLIR.h
@@ -45,7 +45,8 @@ void optimizeLLVM(llvm::Module *);
 /// @brief Lower ModuleOp to a full QIR LLVMIR representation
 /// and return an ExecutionEngine pointer for JIT function pointer
 /// execution. Clients are responsible for deleting this pointer.
-mlir::ExecutionEngine *createQIRJITEngine(mlir::ModuleOp &moduleOp);
+mlir::ExecutionEngine *createQIRJITEngine(mlir::ModuleOp &moduleOp,
+                                          llvm::StringRef convertTo);
 
 class Translation {
 public:

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -419,7 +419,8 @@ public:
       // and use that for execution
       for (auto &[name, module] : modules) {
         auto clonedModule = module.clone();
-        jitEngines.emplace_back(cudaq::createQIRJITEngine(clonedModule));
+        jitEngines.emplace_back(
+            cudaq::createQIRJITEngine(clonedModule, codegenTranslation));
       }
     }
 

--- a/test/NVQPP/qir_test_if_base.cpp
+++ b/test/NVQPP/qir_test_if_base.cpp
@@ -30,4 +30,4 @@ int main() {
   return 0;
 }
 
-// CHECK: error: 'llvm.cond_br' op QIR base profile does not support control-flow
+// CHECK: Do you have if statements in a Base Profile QIR program

--- a/test/NVQPP/qir_test_op3_after_measure.cpp
+++ b/test/NVQPP/qir_test_op3_after_measure.cpp
@@ -8,7 +8,6 @@
 
 // Note: change |& to 2>&1 if running in bash
 // RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x |& FileCheck %s
-// XFAIL: *
 
 #include <cudaq.h>
 #include <iostream>
@@ -19,10 +18,8 @@ __qpu__ void init_state() {
   x(q0);
   mz(q0);
   // The Base Profile spec technically allows a measurement like this because it
-  // isn't operating on an already-measured qubit, but that would require the
-  // compiler to reorder the q1 operation to be before the q0 measurement, and
-  // it currently doesn't do that, so the runtime will say that a program like
-  // this fails the runtime validation checks. Hence the XFAIL above.
+  // isn't operating on an already-measured qubit, but it requires that the
+  // compiler to reorder the q1 operation to be before the q0 measurement.
   x(q1);
   mz(q1);
 };


### PR DESCRIPTION
This fixes the `XFAIL` in `test/NVQPP/qir_test_op3_after_measure.cpp`. More specifically, it delays measurements as late as possible in order to maximize the likelihood that the resulting program will be compliant with the Base Profile specification. Base Profile programs prevent reversible operations (i.e. quantum operations) after irreversible operations (i.e. measurements), and this change adds smarts to the compiler to delay these types of measurements when targeting the Base Profile.

This will also be useful in the upcoming mapping pass because mapping has a tendency to generate Quake that needs this pass as well.

