### PR TITLE
Move <filesystem> include to .cpp

### DIFF
--- a/runtime/common/Logger.cpp
+++ b/runtime/common/Logger.cpp
@@ -14,6 +14,7 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/spdlog.h>
+
 namespace cudaq {
 /// @brief This function will run at startup and initialize
 /// the logger for the runtime to use. It will set the log

--- a/runtime/common/Logger.cpp
+++ b/runtime/common/Logger.cpp
@@ -8,12 +8,12 @@
 
 #include "Logger.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
+#include <filesystem>
 #include <spdlog/cfg/env.h>
 #include <spdlog/cfg/helpers.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/spdlog.h>
-
 namespace cudaq {
 /// @brief This function will run at startup and initialize
 /// the logger for the runtime to use. It will set the log
@@ -45,6 +45,10 @@ void debug(const std::string_view msg) {
 #ifdef CUDAQ_DEBUG
   spdlog::debug(msg);
 #endif
+}
+std::string pathToFileName(const std::string_view fullFilePath) {
+  const std::filesystem::path file(fullFilePath);
+  return file.filename().string();
 }
 } // namespace details
 } // namespace cudaq

--- a/runtime/common/Logger.h
+++ b/runtime/common/Logger.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <filesystem>
+#include <chrono>
 
 // Be careful about fmt getting into public headers
 #include "common/FmtCore.h"
@@ -20,6 +20,7 @@ namespace details {
 void trace(const std::string_view msg);
 void info(const std::string_view msg);
 void debug(const std::string_view msg);
+std::string pathToFileName(const std::string_view fullFilePath);
 } // namespace details
 
 /// This type seeks to enable automated injection of the
@@ -43,9 +44,8 @@ void debug(const std::string_view msg);
       std::string name = funcName;                                             \
       auto start = name.find_first_of(" ");                                    \
       name = name.substr(start + 1, name.find_first_of("(") - start - 1);      \
-      std::filesystem::path file = fileName;                                   \
-      msg = "[" + file.filename().string() + ":" + std::to_string(lineNo) +    \
-            "] " + msg;                                                        \
+      msg = "[" + details::pathToFileName(fileName) + ":" +                    \
+            std::to_string(lineNo) + "] " + msg;                               \
       details::NAME(msg);                                                      \
     }                                                                          \
   };                                                                           \

--- a/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
+++ b/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
@@ -13,6 +13,7 @@
 #include "cudaq/platform/quantum_platform.h"
 #include "cudaq/qis/qubit_qis.h"
 #include "cudaq/spin_op.h"
+#include <filesystem>
 #include <fstream>
 
 /// This file defines the default, library mode, quantum platform.


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
There is an [issue](https://stackoverflow.com/questions/56615841/passing-stdfilesystempath-to-a-function-segfaults/56864842#56864842) with `<filesystem>` in the gcc 8 -> 9 transition.
Although we don't support gcc 8 for our build, some extensions (e.g., simulator backends) might be built with an older toolchain.
Having `<filesystem>` in the `Logger.h` (included everywhere) may expose this segfault issue at runtime when using these extensions. 