### PR TITLE
Extend the cc-loop-unroll pass.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -163,6 +163,13 @@ def LoopNormalize : Pass<"cc-loop-normalize"> {
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect"];
+
+  let options = [
+    Option<"allowClosedInterval", "allow-closed-iterval", "bool",
+      /*default=*/"true", "Allow loop iterations on a closed interval.">,
+    Option<"allowBreak", "allow-early-exit", "bool", /*default=*/"true",
+      "Allow unrolling of loop with early exit (i.e. break statement).">
+  ];
 }
 
 def LoopUnroll : Pass<"cc-loop-unroll"> {
@@ -186,7 +193,9 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
       "Maximum iterations to unroll.">,
     Option<"signalFailure",
       "signal-failure-if-any-loop-cannot-be-completely-unrolled", "bool",
-      /*default=*/"false", "Signal failure if pass can't unroll all loops.">
+      /*default=*/"false", "Signal failure if pass can't unroll all loops.">,
+    Option<"allowBreak", "allow-early-exit", "bool", /*default=*/"false",
+      "Allow unrolling of loop with early exit (i.e. break statement).">
   ];
 }
 

--- a/lib/Optimizer/Transforms/LoopAnalysis.h
+++ b/lib/Optimizer/Transforms/LoopAnalysis.h
@@ -60,6 +60,9 @@ bool isUnsignedPredicate(mlir::arith::CmpIPredicate p);
 /// as a canonical counted loop.
 bool isaCountedLoop(cc::LoopOp op, bool allowClosedInterval = true);
 
+bool loopContainsBreak(cc::LoopOp op);
+bool isaConstantUpperBoundLoop(cc::LoopOp op, bool allowClosedInterval = true);
+
 /// An invariant loop is defined to be a loop that will execute some run-time
 /// invariant number of iterations. We recognize a normalized, semi-open iterval
 /// loop such as
@@ -69,7 +72,7 @@ bool isaCountedLoop(cc::LoopOp op, bool allowClosedInterval = true);
 /// as a canonical invariant loop. If \p c is not null and the loop is
 /// invariant, then the loop components will be returned via \p c.
 bool isaInvariantLoop(cc::LoopOp op, bool allowClosedInterval = true,
-                      LoopComponents *c = nullptr);
+                      bool allowEarlyExit = false, LoopComponents *c = nullptr);
 bool isaInvariantLoop(const LoopComponents &c, bool allowClosedInterval);
 
 // We expect the loop control value to have the following form.
@@ -111,7 +114,8 @@ bool hasMonotonicControlInduction(cc::LoopOp loop, LoopComponents *c = nullptr);
 /// ```
 /// If \p c is not null and the loop is invariant, then the loop components will
 /// be returned via \p c.
-bool isaMonotonicLoop(mlir::Operation *op, LoopComponents *c = nullptr);
+bool isaMonotonicLoop(mlir::Operation *op, bool allowEarlyExit = false,
+                      LoopComponents *c = nullptr);
 
 /// Recover the different subexpressions from the loop if it conforms to the
 /// pattern. Given a LoopOp where induction is in a register:

--- a/test/NVQPP/phase_estimation.cpp
+++ b/test/NVQPP/phase_estimation.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ %s -o %basename_t.x --target quantinuum --emulate && CUDAQ_DUMP_JIT_IR=1 ./%basename_t.x &> %basename_t.txt && cat %basename_t.txt | FileCheck %s
+// RUN: nvq++ --target quantinuum --emulate %s -o %basename_t.x && CUDAQ_DUMP_JIT_IR=1 ./%basename_t.x &> %basename_t.ir && cat %basename_t.ir | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/Quake/unroll_loop_with_break.qke
+++ b/test/Quake/unroll_loop_with_break.qke
@@ -1,0 +1,125 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --cc-loop-unroll="allow-early-exit=1 signal-failure-if-any-loop-cannot-be-completely-unrolled=1" %s | cudaq-opt | FileCheck %s
+
+func.func @loop_with_break(%arg0: i32) {
+  %c1_i32 = arith.constant 1 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c20_i32 = arith.constant 20 : i32
+  %0 = cc.undef i32
+  %1 = cc.undef i32
+  %2 = quake.alloca !quake.ref
+  cc.scope {
+    %5 = cc.loop while ((%arg1 = %c0_i32) -> (i32)) {
+      %6 = arith.cmpi slt, %arg1, %c20_i32 : i32
+      cc.condition %6(%arg1 : i32)
+    } do {
+    ^bb0(%arg1: i32):
+      quake.h %2 : (!quake.ref) -> ()
+      %bits = quake.mz %2 name "q0result" : (!quake.ref) -> i1
+      %6 = cc.undef i1
+      cf.cond_br %bits, ^bb1(%arg1 : i32), ^bb2(%arg1 : i32)
+    ^bb1(%7: i32):  // pred: ^bb0
+      cc.break %7 : i32
+    ^bb2(%9: i32):  // pred: ^bb0
+      cc.continue %9 : i32
+    } step {
+    ^bb0(%arg1: i32):
+      %6 = arith.addi %arg1, %c1_i32 : i32
+      cc.continue %6 : i32
+    }
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @loop_with_break(
+// CHECK-SAME:                               %[[VAL_0:.*]]: i32) {
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_2]], ^bb20, ^bb1
+// CHECK:         ^bb1:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_3]], ^bb20, ^bb2
+// CHECK:         ^bb2:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_4]], ^bb20, ^bb3
+// CHECK:         ^bb3:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_5]], ^bb20, ^bb4
+// CHECK:         ^bb4:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_6]], ^bb20, ^bb5
+// CHECK:         ^bb5:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_7]], ^bb20, ^bb6
+// CHECK:         ^bb6:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_8]], ^bb20, ^bb7
+// CHECK:         ^bb7:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_9]], ^bb20, ^bb8
+// CHECK:         ^bb8:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_10]], ^bb20, ^bb9
+// CHECK:         ^bb9:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_11:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_11]], ^bb20, ^bb10
+// CHECK:         ^bb10:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_12]], ^bb20, ^bb11
+// CHECK:         ^bb11:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_13:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_13]], ^bb20, ^bb12
+// CHECK:         ^bb12:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_14]], ^bb20, ^bb13
+// CHECK:         ^bb13:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_15:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_15]], ^bb20, ^bb14
+// CHECK:         ^bb14:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_16]], ^bb20, ^bb15
+// CHECK:         ^bb15:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_17:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_17]], ^bb20, ^bb16
+// CHECK:         ^bb16:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_18]], ^bb20, ^bb17
+// CHECK:         ^bb17:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_19]], ^bb20, ^bb18
+// CHECK:         ^bb18:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_20:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.cond_br %[[VAL_20]], ^bb20, ^bb19
+// CHECK:         ^bb19:
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_21:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           cf.br ^bb20
+// CHECK:         ^bb20:
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
Add an option to the unrolling pass and unrolling pass pipeline to allow loops with `break` statements to be fully unrolled, so long as the loop is otherwise, structurally speaking, like a regular counted loop. Since the total number of executions is a variable, the option allows one to selectively enable/disable the unrolling of these variable iteration, constant upper bound loops.
