### PR TITLE
Remove dialect name from pass option name.

### DIFF
--- a/Developing.md
+++ b/Developing.md
@@ -48,7 +48,7 @@ to see its representation in the Quake MLIR dialect. To see its translation to
 
 ```bash
 cudaq-quake $CUDAQ_REPO_ROOT/docs/sphinx/examples/cpp/algorithms/grover.cpp |
-cudaq-opt --canonicalize --quake-add-deallocs |
+cudaq-opt --canonicalize --add-dealloc |
 quake-translate --convert-to=qir
 ```
 

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -23,9 +23,9 @@ def PromoteRefToVeqAlloc : Pass<"promote-qubit-allocation"> {
 def QuakeToQIR : Pass<"quake-to-qir", "mlir::ModuleOp"> {
   let summary = "Lower Quake to QIR.";
   let description = [{
-    Converts Quake to QIR (as LLVM-IR). The quake-add-deallocs pass should be
-    run before this pass in order to properly generate deallocations for
-    allocated qubits.
+    Converts Quake to QIR (as LLVM-IR). The add-dealloc pass should be run
+    before this pass in order to properly generate deallocations for allocated
+    QIR qubits.
   }];
 
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];
@@ -36,7 +36,8 @@ def QIRToQIRProfilePrep : Pass<"qir-profile-prep", "mlir::ModuleOp"> {
   let summary =
     "Prepare the IR for rewriting to the base profile or adaptive profile";
   let description = [{
-    This is a (module) subpass of the pipeline to convert to a specific QIR Profile.
+    This is a (module) subpass of the pipeline to convert to a specific QIR
+    Profile.
 
     Before we can convert the functions to the specific profile, we have to do
     a bit of bookkeeping on the module itself. That preparation is done in

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -314,11 +314,12 @@ def QuakeSynthesize : Pass<"quake-synth", "mlir::ModuleOp"> {
   let constructor = "cudaq::opt::createQuakeSynthesizer()";
 }
 
-def QuakeAddDeallocs : Pass<"quake-add-deallocs", "mlir::func::FuncOp"> {
+def QuakeAddDeallocs : Pass<"add-dealloc", "mlir::func::FuncOp"> {
  let summary = "Add quake deallocs to functions before they return.";
   let description = [{
     This pass ensures that a dealloc is inserted before functions return
-    if the function contains a AllocaOp. It should be run before quake-to-qir.
+    if the function contains a AllocaOp. It should be run before converting
+    to QIR, for example, in order to generate correct code.
   }];
 
   let constructor = "cudaq::opt::createQuakeAddDeallocs()";

--- a/lib/Optimizer/Transforms/AddDeallocs.cpp
+++ b/lib/Optimizer/Transforms/AddDeallocs.cpp
@@ -87,7 +87,7 @@ private:
     func->walk([this](Operation *o) {
       if (isa<cudaq::cc::UnwindBreakOp, cudaq::cc::UnwindContinueOp,
               cudaq::cc::UnwindReturnOp>(o)) {
-        o->emitError("must run unwind-lowering before quake-add-deallocs.");
+        o->emitError("must run unwind-lowering before add-dealloc.");
         hasErrors = true;
       } else if (auto alloc = dyn_cast<quake::AllocaOp>(o)) {
         auto *op = alloc.getOperation();

--- a/test/AST-Quake/dealloc.cpp
+++ b/test/AST-Quake/dealloc.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: cudaq-quake --no-simplify %s | cudaq-opt --quake-add-deallocs | FileCheck %s
+// RUN: cudaq-quake --no-simplify %s | cudaq-opt --add-dealloc | FileCheck %s
 
 #include <cudaq.h>
 

--- a/test/Quake-QIR/alloca_no_operand.qke
+++ b/test/Quake-QIR/alloca_no_operand.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --quake-add-deallocs --canonicalize | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt %s --add-dealloc --canonicalize | cudaq-translate --convert-to=qir | FileCheck %s
 
 module {
   func.func @adder_n4() {

--- a/test/Quake-QIR/base_profile-4.qke
+++ b/test/Quake-QIR/base_profile-4.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --quake-add-deallocs | cudaq-translate --convert-to=qir-base | FileCheck %s
+// RUN: cudaq-opt %s --add-dealloc | cudaq-translate --convert-to=qir-base | FileCheck %s
 
 module {
    // Test base profile lowering without combining quantum allocations.

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --quake-add-deallocs | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt %s --add-dealloc | cudaq-translate --convert-to=qir | FileCheck %s
 
 module {
      func.func @test_func(%p : i32) {

--- a/test/Quake-QIR/exp-pauli-qir-1.qke
+++ b/test/Quake-QIR/exp-pauli-qir-1.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --canonicalize --quake-add-deallocs | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt %s --canonicalize --add-dealloc | cudaq-translate --convert-to=qir | FileCheck %s
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_ZZ4mainENK3$_0clEd"}} {
   func.func @__nvqpp__mlirgen__Z4mainE3$_0(%arg0: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {

--- a/test/Quake-QIR/exp-pauli-qir-2.qke
+++ b/test/Quake-QIR/exp-pauli-qir-2.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --canonicalize --quake-add-deallocs | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt %s --canonicalize --add-dealloc | cudaq-translate --convert-to=qir | FileCheck %s
 
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_ZZ4mainENK3$_0clEdNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE"}} {

--- a/test/Quake-QIR/exp-pauli-qir-3.qke
+++ b/test/Quake-QIR/exp-pauli-qir-3.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --canonicalize --quake-add-deallocs | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt %s --canonicalize --add-dealloc | cudaq-translate --convert-to=qir | FileCheck %s
 
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_ZZ4mainENK3$_0clEd"}} {

--- a/test/Quake-QIR/ghz.qke
+++ b/test/Quake-QIR/ghz.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --canonicalize --quake-add-deallocs | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt %s --canonicalize --add-dealloc | cudaq-translate --convert-to=qir | FileCheck %s
 module {
 // CHECK:    %[[VAL_0:.*]] = zext i32
 // CHECK:    %[[VAL_1:.*]] to i64

--- a/test/Quake-QIR/measure.qke
+++ b/test/Quake-QIR/measure.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --quake-add-deallocs | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt %s --add-dealloc | cudaq-translate --convert-to=qir | FileCheck %s
 
 module {
   func.func @test_func2(){

--- a/test/Quake/test_add_dealloc.qke
+++ b/test/Quake/test_add_dealloc.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --quake-add-deallocs | FileCheck %s
+// RUN: cudaq-opt %s --add-dealloc | FileCheck %s
 
 // CHECK-LABEL:   func.func @ghz(
 // CHECK-SAME:                   %[[VAL_0:.*]]: i32) {


### PR DESCRIPTION
It's all quake now. The dialect name isn't needed any longer.
