### PR TITLE
Update Docker actions from v4 to v5

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Extract metadata for Docker image
         id: metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.build_info.outputs.image_name }}
           flavor: |
@@ -294,7 +294,7 @@ jobs:
 
       - name: Build ${{ needs.metadata.outputs.image_title }} image
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/${{ needs.metadata.outputs.dockerfile }}

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Extract metadata
         id: metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.build_info.outputs.image_name }}
           flavor:
@@ -145,7 +145,7 @@ jobs:
 
       - name: Build Open MPI
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/build/devdeps.ext.Dockerfile
@@ -275,7 +275,7 @@ jobs:
 
       - name: Extract metadata
         id: metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.prereqs.outputs.image_name }}
           flavor: latest=false
@@ -286,7 +286,7 @@ jobs:
 
       - name: Build cuda-quantum-dev image (debug)
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/build/cudaq.dev.Dockerfile
@@ -465,7 +465,7 @@ jobs:
 
       - name: Extract cuda-quantum-dev metadata
         id: cudaqdev_metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.prereqs.outputs.dev_image_name }}
           flavor: |
@@ -479,7 +479,7 @@ jobs:
       - name: Build cuda-quantum-dev image (release)
         id: release_build
         if: success() && !cancelled()
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/build/cudaq.dev.Dockerfile
@@ -512,7 +512,7 @@ jobs:
 
       - name: Extract cuda-quantum metadata
         id: cudaq_metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.prereqs.outputs.image_name }}
           flavor: |
@@ -526,7 +526,7 @@ jobs:
       - name: Build cuda-quantum image
         id: cudaq_build
         if: success() && !cancelled()
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/release/cudaq.Dockerfile
@@ -591,7 +591,7 @@ jobs:
       - name: Update cuda-quantum metadata
         id: updated_metadata
         if: steps.copy.outcome != 'skipped'
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.prereqs.outputs.registry }}/${{ steps.prereqs.outputs.image_short_name }}
           flavor: |
@@ -605,7 +605,7 @@ jobs:
       - name: Copy cuda-quantum NGC image
         id: copy_build
         if: steps.copy.outcome != 'skipped'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ngc.Dockerfile

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -325,7 +325,7 @@ jobs:
 
       - name: Extract cuda-quantum metadata
         id: metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.release_info.outputs.image_name }}
           flavor: latest=false
@@ -336,7 +336,7 @@ jobs:
 
       - name: Build cuda-quantum image
         id: cudaq_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/release/cudaq.ext.Dockerfile
@@ -394,7 +394,7 @@ jobs:
       - name: Update cuda-quantum metadata
         id: updated_metadata
         if: steps.copy.outcome != 'skipped'
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.copy.outputs.image_name }}
           flavor: latest=false
@@ -406,7 +406,7 @@ jobs:
       - name: Copy cuda-quantum NGC image
         id: copy_build
         if: steps.copy.outcome != 'skipped'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ngc.Dockerfile
@@ -517,7 +517,7 @@ jobs:
 
       - name: Build cuda-quantum wheel
         id: build_wheel
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/build/cudaq.wheel.Dockerfile

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Build wheel
         id: wheel_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/build/cudaq.wheel.Dockerfile


### PR DESCRIPTION
This is an attempt to fix the following newly appearing CI issues:
```
ERROR: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "sysfs" to rootfs at "/sys": mount sysfs:/sys (via /proc/self/fd/6), flags: 0xe: operation not permitted: unknown
```