### PR TITLE
Identify incomplete processing in OQC server helper

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -251,7 +251,7 @@ bool OQCServerHelper::jobIsDone(ServerMessage &getJobResponse) {
     throw std::runtime_error("ServerMessage doesn't contain 'results' key.");
 
   // Return whether the job is completed
-  return getJobResponse.at("results") != NULL;
+  return !getJobResponse.at("results").is_null();
 }
 
 // Process the results from a job


### PR DESCRIPTION
json null previously matched against c++ NULL 0. This allowed the future to terminate and fetch results before processing had finished.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ x] I have added tests to cover my changes.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
