### PR TITLE
Fix #781 Loop unrolling with break statement and mid-circuit measurem…

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -38,7 +38,9 @@ void addPipelineToQIR(mlir::PassManager &pm,
   pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLowerToCFGPass());
   pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
   pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLoopNormalize());
-  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLoopUnroll());
+  cudaq::opt::LoopUnrollOptions luo;
+  luo.allowBreak = convertTo.equals("qir-adaptive");
+  pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createLoopUnroll(luo));
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
   pm.addNestedPass<mlir::func::FuncOp>(

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -782,6 +782,7 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
 
   PassManager pm(context);
   OpPassManager &optPM = pm.nest<func::FuncOp>();
+  optPM.addPass(cudaq::opt::createUnwindLoweringPass());
   cudaq::opt::addAggressiveEarlyInlining(pm);
   pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createApplyOpSpecializationPass());
@@ -793,7 +794,6 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
   pm.addPass(createCanonicalizerPass());
   optPM.addPass(cudaq::opt::createQuakeAddDeallocs());
   optPM.addPass(cudaq::opt::createQuakeAddMetadata());
-  optPM.addPass(cudaq::opt::createUnwindLoweringPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -284,6 +284,11 @@ public:
         postCodeGenPasses = match[1].str();
       }
     }
+    std::string allowEarlyExitSetting =
+        (codegenTranslation == "qir-adaptive") ? "1" : "0";
+    passPipelineConfig =
+        std::string("func.func(cc-loop-unroll{allow-early-exit=") +
+        allowEarlyExitSetting + "})," + passPipelineConfig;
 
     // Set the qpu name
     qpuName = mutableBackend;

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -122,12 +122,12 @@ struct run_circuit {
 // ADJOINT:           %[[VAL_33:.*]] = arith.subi %[[VAL_32]], %[[VAL_25]] : i32
 // ADJOINT:           %[[VAL_34:.*]] = arith.addi %[[VAL_7]], %[[VAL_33]] : i32
 // ADJOINT:           %[[VAL_35:.*]] = arith.constant 0 : i32
-// ADJOINT:           %[[VAL_36:.*]]:4 = cc.loop while ((%[[VAL_37:.*]] = %[[VAL_34]], %[[VAL_38:.*]] = %[[VAL_9]], %[[VAL_39:.*]] = %[[VAL_1]], %[[VAL_40:.*]] = %[[VAL_32]]) -> (i32, i32, f64, i32)) {
+// ADJOINT:           %[[VAL_36:.*]]:2 = cc.loop while ((%[[VAL_37:.*]] = %[[VAL_34]], %[[VAL_40:.*]] = %[[VAL_32]]) -> (i32, i32)) {
 // ADJOINT:             %[[VAL_41:.*]] = arith.cmpi slt, %[[VAL_37]], %[[VAL_9]] : i32
 // ADJOINT:             %[[VAL_42:.*]] = arith.cmpi sgt, %[[VAL_40]], %[[VAL_35]] : i32
-// ADJOINT:             cc.condition %[[VAL_42]](%[[VAL_37]], %[[VAL_9]], %[[VAL_1]], %[[VAL_40]] : i32, i32, f64, i32)
+// ADJOINT:             cc.condition %[[VAL_42]](%[[VAL_37]], %[[VAL_40]] : i32, i32)
 // ADJOINT:           } do {
-// ADJOINT:           ^bb0(%[[VAL_43:.*]]: i32, %[[VAL_44:.*]]: i32, %[[VAL_45:.*]]: f64, %[[VAL_46:.*]]: i32):
+// ADJOINT:           ^bb0(%[[VAL_43:.*]]: i32, %[[VAL_46:.*]]: i32):
 // ADJOINT:             %[[VAL_47:.*]] = arith.subi %[[VAL_9]], %[[VAL_43]] : i32
 // ADJOINT:             %[[VAL_48:.*]] = arith.subi %[[VAL_47]], %[[VAL_7]] : i32
 // ADJOINT:             %[[VAL_50:.*]] = math.fpowi %[[VAL_2]], %[[VAL_48]] : f64, i32
@@ -139,15 +139,15 @@ struct run_circuit {
 // ADJOINT:             %[[VAL_56:.*]] = arith.extsi %[[VAL_55]] : i32 to i64
 // ADJOINT:             %[[VAL_57:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_56]]] : (!quake.veq<?>, i64) -> !quake.ref
 // ADJOINT:             %[[VAL_58:.*]] = arith.negf %[[VAL_51]] : f64
-// ADJOINT:             quake.ry (%[[VAL_58]]) {{\[}}%[[VAL_54]]] %[[VAL_57]] : (f64, !quake.ref, !quake.ref) -> ()
-// ADJOINT:             cc.continue %[[VAL_43]], %[[VAL_44]], %[[VAL_45]], %[[VAL_46]] : i32, i32, f64, i32
+// ADJOINT:             quake.ry (%[[VAL_58]]) [%[[VAL_54]]] %[[VAL_57]] : (f64, !quake.ref, !quake.ref) -> ()
+// ADJOINT:             cc.continue %[[VAL_43]], %[[VAL_46]] : i32, i32
 // ADJOINT:           } step {
-// ADJOINT:           ^bb0(%[[VAL_59:.*]]: i32, %[[VAL_60:.*]]: i32, %[[VAL_61:.*]]: f64, %[[VAL_62:.*]]: i32):
+// ADJOINT:           ^bb0(%[[VAL_59:.*]]: i32, %[[VAL_62:.*]]: i32):
 // ADJOINT:             %[[VAL_63:.*]] = arith.addi %[[VAL_59]], %[[VAL_7]] : i32
 // ADJOINT:             %[[VAL_64:.*]] = arith.subi %[[VAL_59]], %[[VAL_7]] : i32
 // ADJOINT:             %[[VAL_65:.*]] = arith.constant 1 : i32
 // ADJOINT:             %[[VAL_66:.*]] = arith.subi %[[VAL_62]], %[[VAL_65]] : i32
-// ADJOINT:             cc.continue %[[VAL_64]], %[[VAL_9]], %[[VAL_1]], %[[VAL_66]] : i32, i32, f64, i32
+// ADJOINT:             cc.continue %[[VAL_64]], %[[VAL_66]] : i32, i32
 // ADJOINT:           }
 // ADJOINT:           %[[VAL_67:.*]] = arith.negf %[[VAL_19]] : f64
 // ADJOINT:           quake.ry (%[[VAL_67]]) %[[VAL_22]] : (f64, !quake.ref) -> ()

--- a/test/NVQPP/qir_test_cond_for_break.cpp
+++ b/test/NVQPP/qir_test_cond_for_break.cpp
@@ -6,11 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// clang-format off
-// RUN: nvq++ --target quantinuum --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
-// XFAIL: *
-// ^^^^^ Produces error: 'cc.loop' op not a simple counted loop
-// clang-format on
+// RUN: nvq++ --target quantinuum --emulate %s -o %basename_t.x && \
+// RUN: ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/Quake/memtoreg-4.qke
+++ b/test/Quake/memtoreg-4.qke
@@ -80,13 +80,13 @@ func.func @t2(%arg0: !quake.veq<?>) {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 10 : i64
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_4:.*]] = cc.undef i64
-// CHECK:           %[[VAL_5:.*]] = cc.scope -> (i64) {
+// CHECK:           cc.scope {
 // CHECK:             %[[VAL_6:.*]] = cc.undef i64
-// CHECK:             %[[VAL_7:.*]]:2 = cc.loop while ((%[[VAL_8:.*]] = %[[VAL_1]], %[[VAL_9:.*]] = %[[VAL_2]]) -> (i64, i64)) {
-// CHECK:               %[[VAL_10:.*]] = arith.cmpi ult, %[[VAL_8]], %[[VAL_9]] : i64
-// CHECK:               cc.condition %[[VAL_10]](%[[VAL_8]], %[[VAL_9]] : i64, i64)
+// CHECK:             %[[VAL_7:.*]] = cc.loop while ((%[[VAL_8:.*]] = %[[VAL_1]]) -> (i64)) {
+// CHECK:               %[[VAL_10:.*]] = arith.cmpi ult, %[[VAL_8]], %[[VAL_2]] : i64
+// CHECK:               cc.condition %[[VAL_10]](%[[VAL_8]] : i64)
 // CHECK:             } do {
-// CHECK:             ^bb0(%[[VAL_11:.*]]: i64, %[[VAL_12:.*]]: i64):
+// CHECK:             ^bb0(%[[VAL_11:.*]]: i64):
 // CHECK:               %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_14:.*]] = quake.unwrap %[[VAL_13]] : (!quake.ref) -> !quake.wire
 // CHECK:               %[[VAL_15:.*]] = quake.h %[[VAL_14]] : (!quake.wire) -> !quake.wire
@@ -96,17 +96,16 @@ func.func @t2(%arg0: !quake.veq<?>) {
 // CHECK:               %[[VAL_18:.*]], %[[VAL_19:.*]] = quake.mz %[[VAL_17]] name "b" : (!quake.wire) -> (i1, !quake.wire)
 // CHECK:               quake.wrap %[[VAL_19]] to %[[VAL_16]] : !quake.wire, !quake.ref
 // CHECK:               %[[VAL_20:.*]] = cc.undef i1
-// CHECK:               cf.cond_br %[[VAL_18]], ^bb1(%[[VAL_11]], %[[VAL_12]] : i64, i64), ^bb2(%[[VAL_11]], %[[VAL_12]] : i64, i64)
-// CHECK:             ^bb1(%[[VAL_21:.*]]: i64, %[[VAL_22:.*]]: i64):
-// CHECK:               cc.break %[[VAL_21]], %[[VAL_22]] : i64, i64
-// CHECK:             ^bb2(%[[VAL_23:.*]]: i64, %[[VAL_24:.*]]: i64):
-// CHECK:               cc.continue %[[VAL_23]], %[[VAL_24]] : i64, i64
+// CHECK:               cf.cond_br %[[VAL_18]], ^bb1(%[[VAL_11]] : i64), ^bb2(%[[VAL_11]] : i64)
+// CHECK:             ^bb1(%[[VAL_21:.*]]: i64):
+// CHECK:               cc.break %[[VAL_21]] : i64
+// CHECK:             ^bb2(%[[VAL_23:.*]]: i64):
+// CHECK:               cc.continue %[[VAL_23]] : i64
 // CHECK:             } step {
-// CHECK:             ^bb0(%[[VAL_25:.*]]: i64, %[[VAL_26:.*]]: i64):
+// CHECK:             ^bb0(%[[VAL_25:.*]]: i64):
 // CHECK:               %[[VAL_27:.*]] = arith.addi %[[VAL_25]], %[[VAL_3]] : i64
-// CHECK:               cc.continue %[[VAL_27]], %[[VAL_26]] : i64, i64
+// CHECK:               cc.continue %[[VAL_27]] : i64
 // CHECK:             }
-// CHECK:             cc.continue %[[VAL_28:.*]]#1 : i64
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }
@@ -153,13 +152,13 @@ func.func @t3(%arg0: !quake.veq<?>) {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 10 : i64
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_4:.*]] = cc.undef i64
-// CHECK:           %[[VAL_5:.*]] = cc.scope -> (i64) {
+// CHECK:           cc.scope {
 // CHECK:             %[[VAL_6:.*]] = cc.undef i64
-// CHECK:             %[[VAL_7:.*]]:2 = cc.loop while ((%[[VAL_8:.*]] = %[[VAL_1]], %[[VAL_9:.*]] = %[[VAL_2]]) -> (i64, i64)) {
-// CHECK:               %[[VAL_10:.*]] = arith.cmpi ult, %[[VAL_8]], %[[VAL_9]] : i64
-// CHECK:               cc.condition %[[VAL_10]](%[[VAL_8]], %[[VAL_9]] : i64, i64)
+// CHECK:             %[[VAL_7:.*]] = cc.loop while ((%[[VAL_8:.*]] = %[[VAL_1]]) -> (i64)) {
+// CHECK:               %[[VAL_10:.*]] = arith.cmpi ult, %[[VAL_8]], %[[VAL_2]] : i64
+// CHECK:               cc.condition %[[VAL_10]](%[[VAL_8]] : i64)
 // CHECK:             } do {
-// CHECK:             ^bb0(%[[VAL_11:.*]]: i64, %[[VAL_12:.*]]: i64):
+// CHECK:             ^bb0(%[[VAL_11:.*]]: i64):
 // CHECK:               %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_14:.*]] = quake.unwrap %[[VAL_13]] : (!quake.ref) -> !quake.wire
 // CHECK:               %[[VAL_15:.*]] = quake.h %[[VAL_14]] : (!quake.wire) -> !quake.wire
@@ -169,15 +168,14 @@ func.func @t3(%arg0: !quake.veq<?>) {
 // CHECK:               %[[VAL_18:.*]], %[[VAL_19:.*]] = quake.mz %[[VAL_17]] name "b" : (!quake.wire) -> (i1, !quake.wire)
 // CHECK:               quake.wrap %[[VAL_19]] to %[[VAL_16]] : !quake.wire, !quake.ref
 // CHECK:               %[[VAL_20:.*]] = cc.undef i1
-// CHECK:               cf.br ^bb1(%[[VAL_11]], %[[VAL_12]] : i64, i64)
-// CHECK:             ^bb1(%[[VAL_21:.*]]: i64, %[[VAL_22:.*]]: i64):
-// CHECK:               cc.continue %[[VAL_21]], %[[VAL_22]] : i64, i64
+// CHECK:               cf.br ^bb1(%[[VAL_11]] : i64)
+// CHECK:             ^bb1(%[[VAL_21:.*]]: i64):
+// CHECK:               cc.continue %[[VAL_21]] : i64
 // CHECK:             } step {
-// CHECK:             ^bb0(%[[VAL_23:.*]]: i64, %[[VAL_24:.*]]: i64):
+// CHECK:             ^bb0(%[[VAL_23:.*]]: i64):
 // CHECK:               %[[VAL_25:.*]] = arith.addi %[[VAL_23]], %[[VAL_3]] : i64
-// CHECK:               cc.continue %[[VAL_25]], %[[VAL_24]] : i64, i64
+// CHECK:               cc.continue %[[VAL_25]] : i64
 // CHECK:             }
-// CHECK:             cc.continue %[[VAL_26:.*]]#1 : i64
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
…ent.

Due to an interaction between the revised memtoreg pass and loop unrolling, the test with a mid-circuit measurement and a break statement still wasn't being unrolled. These changes fix that issue.

Primarily, these changes allow structured operations that accept region arguments to straddle the fence and allow some values to be promoted as dominating uses (when only used) while other values to be threaded as region arguments exactly as before (when written). This change simplifies the register-semantics IR. There may be a bit of performance lossage in memtoreg as a result however as promoted values may later be discovered to be written and the changes will need to be reapplied.
