### PR TITLE
Deprecate exp_val_z/expectation_z in favor of `expectation`

### DIFF
--- a/docs/sphinx/examples/python/advanced_vqe.py
+++ b/docs/sphinx/examples/python/advanced_vqe.py
@@ -46,11 +46,11 @@ def objective_function(parameter_vector: List[float],
     # We define the call to `cudaq.observe` here as a lambda to
     # allow it to be passed into the gradient strategy as a
     # function. If you were using a gradient-free optimizer,
-    # you could purely define `cost = cudaq.observe().expectation_z()`.
+    # you could purely define `cost = cudaq.observe().expectation()`.
     get_result = lambda parameter_vector: cudaq.observe(
-        kernel, hamiltonian, parameter_vector, shots_count=100).expectation_z()
+        kernel, hamiltonian, parameter_vector, shots_count=100).expectation()
     # `cudaq.observe` returns a `cudaq.ObserveResult` that holds the
-    # counts dictionary and the `expectation_z`.
+    # counts dictionary and the `expectation`.
     cost = get_result(parameter_vector)
     print(f"<H> = {cost}")
     # Compute the gradient vector using `cudaq.gradients.STRATEGY.compute()`.

--- a/docs/sphinx/examples/python/tutorials/hybrid_qnns.ipynb
+++ b/docs/sphinx/examples/python/tutorials/hybrid_qnns.ipynb
@@ -221,7 +221,7 @@
     "        \"\"\"Excetute the quantum circuit to output an expectation value\"\"\"\n",
     "\n",
     "        expectation = torch.tensor(cudaq.observe(self.kernel, spin.z(0),\n",
-    "                                                 thetas).expectation_z(),\n",
+    "                                                 thetas).expectation(),\n",
     "                                   device=device)\n",
     "\n",
     "        return expectation"

--- a/docs/sphinx/examples/python/tutorials/single_qubit_rotation.ipynb
+++ b/docs/sphinx/examples/python/tutorials/single_qubit_rotation.ipynb
@@ -70,7 +70,7 @@
     "def cost(parameters):\n",
     "    \"\"\"Returns the expectation value as our cost.\"\"\"\n",
     "    expectation_value = cudaq.observe(kernel, hamiltonian,\n",
-    "                                      parameters).expectation_z()\n",
+    "                                      parameters).expectation()\n",
     "    cost_values.append(expectation_value)\n",
     "    return expectation_value"
    ]

--- a/docs/sphinx/snippets/python/using/cudaq/platform/observe_mqpu.py
+++ b/docs/sphinx/snippets/python/using/cudaq/platform/observe_mqpu.py
@@ -27,5 +27,5 @@ hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
 exp_val = cudaq.observe(kernel,
                         hamiltonian,
                         0.59,
-                        execution=cudaq.parallel.thread).expectation_z()
+                        execution=cudaq.parallel.thread).expectation()
 print("Expectation value: ", exp_val)

--- a/docs/sphinx/snippets/python/using/cudaq/platform/observe_mqpu_mpi.py
+++ b/docs/sphinx/snippets/python/using/cudaq/platform/observe_mqpu_mpi.py
@@ -23,7 +23,7 @@ hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
     0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)
 
 exp_val = cudaq.observe(kernel, hamiltonian, 0.59,
-                        execution=cudaq.parallel.mpi).expectation_z()
+                        execution=cudaq.parallel.mpi).expectation()
 if cudaq.mpi.rank() == 0:
     print("Expectation value: ", exp_val)
 

--- a/docs/sphinx/specification/cudaq/algorithmic_primitives.rst
+++ b/docs/sphinx/specification/cudaq/algorithmic_primitives.rst
@@ -85,7 +85,7 @@ CUDA Quantum specifies the following structure for :code:`cudaq::sample_result`:
           get_marginal(const std::vector<std::size_t> &&marginalIndices,
                  const std::string_view registerName = GlobalRegisterName);
 
-          double exp_val_z(const std::string_view registerName == GlobalRegisterName);
+          double expectation(const std::string_view registerName == GlobalRegisterName);
           double probability(std::string_view bitString, const std::string_view registerName == GlobalRegisterName);
           std::size_t size(const std::string_view registerName == GlobalRegisterName);
           
@@ -206,10 +206,10 @@ generated and used as part of that expectation value computation. The
 
         sample_results raw_data() { return data; };
         operator double();
-        double exp_val_z();
+        double expectation();
         
         template <typename SpinOpType>
-        double exp_val_z(SpinOpType term);
+        double expectation(SpinOpType term);
 
         template <typename SpinOpType>
         sample_result counts(SpinOpType term);
@@ -229,8 +229,8 @@ This return type can be used in the following way.
 
     // I require the result with all generated data 
     auto result = cudaq::observe(kernel, spinOp, args...);
-    auto expVal = result.exp_val_z();
-    auto X0X1Exp = result.exp_val_z(x(0)*x(1));
+    auto expVal = result.expectation();
+    auto X0X1Exp = result.expectation(x(0)*x(1));
     auto X0X1Data = result.counts(x(0)*x(1));
     result.dump();
 

--- a/python/runtime/common/py_ObserveResult.cpp
+++ b/python/runtime/common/py_ObserveResult.cpp
@@ -47,13 +47,46 @@ Args:
 Returns:
   :class:`SampleResult`: The measurement counts data for the individual `sub_term`.)#")
       .def(
-          "expectation_z",
-          [](observe_result &self) { return self.exp_val_z(); },
+          "expectation", [](observe_result &self) { return self.exp_val_z(); },
           "Return the expectation value of the `spin_operator` that was "
           "provided in :func:`observe`.")
       .def(
+          "expectation",
+          [](observe_result &self, spin_op &spin_term) {
+            return self.exp_val_z(spin_term);
+          },
+          py::arg("sub_term"),
+          R"#(Return the expectation value of an individual `sub_term` of the 
+global `spin_operator` that was passed to :func:`observe`.
+
+Args:
+  sub_term (:class:`SpinOperator`): An individual sub-term of the 
+    `spin_operator`.
+
+Returns:
+  float : The expectation value of the `sub_term` with respect to the 
+  :class:`Kernel` that was passed to :func:`observe`.)#");
+
+  .def(
+      "expectation_z",
+      [](observe_result &self) {
+        PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "expectation_z() is deprecated, use expectation() with the same "
+            "argument structure.",
+            1);
+        return self.exp_val_z();
+      },
+      "Return the expectation value of the `spin_operator` that was "
+      "provided in :func:`observe`.")
+      .def(
           "expectation_z",
           [](observe_result &self, spin_op &spin_term) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "expectation_z() is deprecated, use expectation() "
+                         "with the same "
+                         "argument structure.",
+                         1);
             return self.exp_val_z(spin_term);
           },
           py::arg("sub_term"),

--- a/python/runtime/common/py_ObserveResult.cpp
+++ b/python/runtime/common/py_ObserveResult.cpp
@@ -46,6 +46,7 @@ Args:
 
 Returns:
   :class:`SampleResult`: The measurement counts data for the individual `sub_term`.)#")
+
       .def(
           "expectation", [](observe_result &self) { return self.exp_val_z(); },
           "Return the expectation value of the `spin_operator` that was "
@@ -65,20 +66,20 @@ Args:
 
 Returns:
   float : The expectation value of the `sub_term` with respect to the 
-  :class:`Kernel` that was passed to :func:`observe`.)#");
+  :class:`Kernel` that was passed to :func:`observe`.)#")
 
-  .def(
-      "expectation_z",
-      [](observe_result &self) {
-        PyErr_WarnEx(
-            PyExc_DeprecationWarning,
-            "expectation_z() is deprecated, use expectation() with the same "
-            "argument structure.",
-            1);
-        return self.exp_val_z();
-      },
-      "Return the expectation value of the `spin_operator` that was "
-      "provided in :func:`observe`.")
+      .def(
+          "expectation_z",
+          [](observe_result &self) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "expectation_z() is deprecated, use expectation() "
+                         "with the same "
+                         "argument structure.",
+                         1);
+            return self.exp_val_z();
+          },
+          "Return the expectation value of the `spin_operator` that was "
+          "provided in :func:`observe`.")
       .def(
           "expectation_z",
           [](observe_result &self, spin_op &spin_term) {

--- a/python/runtime/common/py_ObserveResult.cpp
+++ b/python/runtime/common/py_ObserveResult.cpp
@@ -79,8 +79,11 @@ Returns:
                          1);
             return self.expectation();
           },
-          "Return the expectation value of the `spin_operator` that was "
-          "provided in :func:`observe`.")
+          R"#(Return the expectation value of the `spin_operator` that was
+provided in :func:`observe`.
+
+Note:
+  `expectation_z` has been deprecated in favor of `expectation`.)#")
       .def(
           "expectation_z",
           [](observe_result &self, spin_op &spin_term) {
@@ -94,6 +97,9 @@ Returns:
           py::arg("sub_term"),
           R"#(Return the expectation value of an individual `sub_term` of the 
 global `spin_operator` that was passed to :func:`observe`.
+
+Note:
+  `expectation_z` has been deprecated in favor of `expectation`.
 
 Args:
   sub_term (:class:`SpinOperator`): An individual sub-term of the 

--- a/python/runtime/common/py_ObserveResult.cpp
+++ b/python/runtime/common/py_ObserveResult.cpp
@@ -48,13 +48,14 @@ Returns:
   :class:`SampleResult`: The measurement counts data for the individual `sub_term`.)#")
 
       .def(
-          "expectation", [](observe_result &self) { return self.exp_val_z(); },
+          "expectation",
+          [](observe_result &self) { return self.expectation(); },
           "Return the expectation value of the `spin_operator` that was "
           "provided in :func:`observe`.")
       .def(
           "expectation",
           [](observe_result &self, spin_op &spin_term) {
-            return self.exp_val_z(spin_term);
+            return self.expectation(spin_term);
           },
           py::arg("sub_term"),
           R"#(Return the expectation value of an individual `sub_term` of the 
@@ -76,7 +77,7 @@ Returns:
                          "with the same "
                          "argument structure.",
                          1);
-            return self.exp_val_z();
+            return self.expectation();
           },
           "Return the expectation value of the `spin_operator` that was "
           "provided in :func:`observe`.")
@@ -88,7 +89,7 @@ Returns:
                          "with the same "
                          "argument structure.",
                          1);
-            return self.exp_val_z(spin_term);
+            return self.expectation(spin_term);
           },
           py::arg("sub_term"),
           R"#(Return the expectation value of an individual `sub_term` of the 

--- a/python/runtime/common/py_SampleResult.cpp
+++ b/python/runtime/common/py_SampleResult.cpp
@@ -80,10 +80,22 @@ Returns:
           },
           py::keep_alive<0, 1>(),
           "Iterate through the :class:`SampleResult` dictionary.\n")
-      .def("expectation_z", &sample_result::exp_val_z,
+      .def("expectation", &sample_result::exp_val_z,
            py::arg("register_name") = GlobalRegisterName,
            "Return the expectation value in the Z-basis of the :class:`Kernel` "
            "that was sampled.\n")
+      .def(
+          "expectation_z",
+          [](sample_result &self) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "expectation_z() is deprecated, use expectation() "
+                         "with the same "
+                         "argument structure.",
+                         1);
+            return self.exp_val_z();
+          } py::arg("register_name") = GlobalRegisterName,
+          "Return the expectation value in the Z-basis of the :class:`Kernel` "
+          "that was sampled.\n")
       .def("probability", &sample_result::probability,
            "Return the probability of observing the given bit string.\n",
            py::arg("bitstring"), py::arg("register_name") = GlobalRegisterName,

--- a/python/runtime/common/py_SampleResult.cpp
+++ b/python/runtime/common/py_SampleResult.cpp
@@ -80,7 +80,7 @@ Returns:
           },
           py::keep_alive<0, 1>(),
           "Iterate through the :class:`SampleResult` dictionary.\n")
-      .def("expectation", &sample_result::exp_val_z,
+      .def("expectation", &sample_result::expectation,
            py::arg("register_name") = GlobalRegisterName,
            "Return the expectation value in the Z-basis of the :class:`Kernel` "
            "that was sampled.\n")
@@ -92,7 +92,7 @@ Returns:
                          "with the same "
                          "argument structure.",
                          1);
-            return self.exp_val_z();
+            return self.expectation();
           },
           py::arg("register_name") = GlobalRegisterName,
           "Return the expectation value in the Z-basis of the :class:`Kernel` "

--- a/python/runtime/common/py_SampleResult.cpp
+++ b/python/runtime/common/py_SampleResult.cpp
@@ -86,14 +86,15 @@ Returns:
            "that was sampled.\n")
       .def(
           "expectation_z",
-          [](sample_result &self) {
+          [](sample_result &self, const std::string_view register_name) {
             PyErr_WarnEx(PyExc_DeprecationWarning,
                          "expectation_z() is deprecated, use expectation() "
                          "with the same "
                          "argument structure.",
                          1);
             return self.exp_val_z();
-          } py::arg("register_name") = GlobalRegisterName,
+          },
+          py::arg("register_name") = GlobalRegisterName,
           "Return the expectation value in the Z-basis of the :class:`Kernel` "
           "that was sampled.\n")
       .def("probability", &sample_result::probability,

--- a/python/runtime/cudaq/algorithms/py_observe.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe.cpp
@@ -156,7 +156,7 @@ observe_result pyObservePar(const PyParType &type, kernel_builder<> &kernel,
       localH, nQpus);
 
   // combine all the data via an all_reduce
-  auto exp_val = localRankResult.exp_val_z();
+  auto exp_val = localRankResult.expectation();
   auto globalExpVal = mpi::all_reduce(exp_val, std::plus<double>());
   return observe_result(globalExpVal, spin_operator);
 }
@@ -296,7 +296,7 @@ void bindObserve(py::module &mod) {
           // back into a vector of results.
           std::vector<observe_result> results;
           for (auto &o : std::get<std::vector<spin_op>>(spin_operator))
-            results.emplace_back(result[0].exp_val_z(o), o,
+            results.emplace_back(result[0].expectation(o), o,
                                  result[0].counts(o));
           return results;
         }

--- a/python/runtime/cudaq/algorithms/py_vqe.cpp
+++ b/python/runtime/cudaq/algorithms/py_vqe.cpp
@@ -35,7 +35,7 @@ optimization_result pyVQE(kernel_builder<> &kernel, spin_op &hamiltonian,
                                           std::vector<double> &grad_vec) {
     py::args params = py::make_tuple(x);
     observe_result result = pyObserve(kernel, hamiltonian, params, shots);
-    double energy = result.exp_val_z();
+    double energy = result.expectation();
     return energy;
   });
 }
@@ -54,7 +54,7 @@ optimization_result pyVQE(kernel_builder<> &kernel, spin_op &hamiltonian,
     else
       params = py::make_tuple(hasToBeTuple);
     observe_result result = pyObserve(kernel, hamiltonian, params, shots);
-    double energy = result.exp_val_z();
+    double energy = result.expectation();
     return energy;
   });
 }
@@ -81,7 +81,7 @@ optimization_result pyVQE(kernel_builder<> &kernel, cudaq::gradient &gradient,
       [&](std::vector<double> x) {
         py::args params = py::make_tuple(x);
         observe_result result = pyObserve(kernel, hamiltonian, params, shots);
-        double energy = result.exp_val_z();
+        double energy = result.expectation();
         return energy;
       };
   auto requires_grad = optimizer.requiresGradients();
@@ -115,7 +115,7 @@ optimization_result pyVQE(kernel_builder<> &kernel, cudaq::gradient &gradient,
         else
           params = py::make_tuple(hasToBeTuple);
         observe_result result = pyObserve(kernel, hamiltonian, params, shots);
-        double energy = result.exp_val_z();
+        double energy = result.expectation();
         return energy;
       };
   auto requires_grad = optimizer.requiresGradients();

--- a/python/tests/backends/test_IQM.py
+++ b/python/tests/backends/test_IQM.py
@@ -109,13 +109,13 @@ def test_iqm_observe():
     res = cudaq.observe(kernel, hamiltonian, 0.59, shots_count=shots)
     want_expectation_value = -1.71
 
-    assert assert_close(want_expectation_value, res.expectation_z(), 5e-2)
+    assert assert_close(want_expectation_value, res.expectation(), 5e-2)
 
     # Launch it asynchronously, enters the job into the queue
     future = cudaq.observe_async(kernel, hamiltonian, 0.59, shots_count=shots)
     # Retrieve the results (since we're on a mock server)
     res = future.get()
-    assert assert_close(want_expectation_value, res.expectation_z(), 5e-2)
+    assert assert_close(want_expectation_value, res.expectation(), 5e-2)
 
     # Launch the job async, job goes in the queue, and
     # we're free to dump the future to file
@@ -127,7 +127,7 @@ def test_iqm_observe():
     # the results from the term job ids.
     futureReadIn = cudaq.AsyncObserveResult(futureAsString, hamiltonian)
     res = futureReadIn.get()
-    assert assert_close(want_expectation_value, res.expectation_z(), 5e-2)
+    assert assert_close(want_expectation_value, res.expectation(), 5e-2)
 
 
 # leave for gdb debugging

--- a/python/tests/backends/test_IonQ.py
+++ b/python/tests/backends/test_IonQ.py
@@ -6,7 +6,6 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-
 import cudaq, pytest, os, time
 from cudaq import spin
 from multiprocessing import Process
@@ -18,6 +17,7 @@ except:
 
 # Define the port for the mock server
 port = 62455
+
 
 def assert_close(got) -> bool:
     return got < -1.5 and got > -1.9
@@ -42,10 +42,7 @@ def startUpMockServer():
 def configureTarget():
 
     # Set the targeted QPU
-    cudaq.set_target(
-        "ionq",
-        url="http://localhost:{}".format(port)
-    )
+    cudaq.set_target("ionq", url="http://localhost:{}".format(port))
 
     yield "Running the test."
     cudaq.reset_target()
@@ -114,13 +111,13 @@ def test_ionq_observe():
 
     # Run the observe task on IonQ synchronously
     res = cudaq.observe(kernel, hamiltonian, 0.59)
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
     # Launch it asynchronously, enters the job into the queue
     future = cudaq.observe_async(kernel, hamiltonian, 0.59)
     # Retrieve the results (since we're on a mock server)
     res = future.get()
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
     # Launch the job async, job goes in the queue, and
     # we're free to dump the future to file
@@ -133,7 +130,7 @@ def test_ionq_observe():
     # the results from the term job ids.
     futureReadIn = cudaq.AsyncObserveResult(futureAsString, hamiltonian)
     res = futureReadIn.get()
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
 
 # leave for gdb debugging

--- a/python/tests/backends/test_Quantinuum.py
+++ b/python/tests/backends/test_Quantinuum.py
@@ -6,7 +6,6 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-
 import cudaq, pytest, os, time
 from cudaq import spin
 from multiprocessing import Process
@@ -18,6 +17,7 @@ except:
 
 # Define the port for the mock server
 port = 62454
+
 
 def assert_close(got) -> bool:
     return got < -1.5 and got > -1.9
@@ -120,13 +120,13 @@ def test_quantinuum_observe():
 
     # Run the observe task on quantinuum synchronously
     res = cudaq.observe(kernel, hamiltonian, .59)
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
     # Launch it asynchronously, enters the job into the queue
     future = cudaq.observe_async(kernel, hamiltonian, .59)
     # Retrieve the results (since we're on a mock server)
     res = future.get()
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
     # Launch the job async, job goes in the queue, and
     # we're free to dump the future to file
@@ -139,7 +139,7 @@ def test_quantinuum_observe():
     # the results from the term job ids.
     futureReadIn = cudaq.AsyncObserveResult(futureAsString, hamiltonian)
     res = futureReadIn.get()
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
 
 # leave for gdb debugging

--- a/python/tests/backends/test_Quantinuum_LocalEmulation.py
+++ b/python/tests/backends/test_Quantinuum_LocalEmulation.py
@@ -6,7 +6,6 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-
 import cudaq, pytest, os, time
 from cudaq import spin
 from multiprocessing import Process
@@ -80,13 +79,14 @@ def test_quantinuum_observe():
 
     # Run the observe task on quantinuum synchronously
     res = cudaq.observe(kernel, hamiltonian, .59, shots_count=100000)
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
     # Launch it asynchronously, enters the job into the queue
     future = cudaq.observe_async(kernel, hamiltonian, .59, shots_count=100000)
     # Retrieve the results (since we're emulating)
     res = future.get()
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
+
 
 def test_quantinuum_exp_pauli():
     cudaq.set_random_seed(13)
@@ -102,13 +102,13 @@ def test_quantinuum_exp_pauli():
 
     # Run the observe task on quantinuum synchronously
     res = cudaq.observe(kernel, hamiltonian, .59, shots_count=100000)
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
     # Launch it asynchronously, enters the job into the queue
     future = cudaq.observe_async(kernel, hamiltonian, .59, shots_count=100000)
     # Retrieve the results (since we're emulating)
     res = future.get()
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
 
 # leave for gdb debugging

--- a/python/tests/backends/test_oqc.py
+++ b/python/tests/backends/test_oqc.py
@@ -115,13 +115,13 @@ def test_OQC_observe():
     # Run the observe task on OQC synchronously
     res = cudaq.observe(kernel, hamiltonian, .59)
     want_expectation_value = -1.71
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
     # Launch it asynchronously, enters the job into the queue
     future = cudaq.observe_async(kernel, hamiltonian, .59)
     # Retrieve the results (since we're on a mock server)
     res = future.get()
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
     # Launch the job async, job goes in the queue, and
     # we're free to dump the future to file
@@ -134,7 +134,7 @@ def test_OQC_observe():
     # the results from the term job ids.
     futureReadIn = cudaq.AsyncObserveResult(futureAsString, hamiltonian)
     res = futureReadIn.get()
-    assert assert_close(res.expectation_z())
+    assert assert_close(res.expectation())
 
 
 # leave for gdb debugging

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -269,7 +269,7 @@ def test_sample_control_qubit_args():
     # Simulate `kernel` and check its expectation value.
     result = cudaq.sample(kernel)
     want_expectation = 0.0
-    got_expectation = result.expectation_z()
+    got_expectation = result.expectation()
     assert np.isclose(want_expectation, got_expectation, atol=1e-1)
 
     # Check the MLIR.
@@ -400,7 +400,7 @@ def test_sample_apply_call_control():
     # Simulate `kernel` and check its expectation value.
     result = cudaq.sample(kernel)
     want_expectation = -1. / np.sqrt(2.)
-    got_expectation = result.expectation_z()
+    got_expectation = result.expectation()
     assert np.isclose(want_expectation, got_expectation, atol=1e-1)
 
     # Check the MLIR.

--- a/python/tests/domains/test_chemistry.py
+++ b/python/tests/domains/test_chemistry.py
@@ -60,6 +60,7 @@ def testUCCSD():
     print(energy, params)
     assert np.isclose(-1.137, energy, rtol=1e-3)
 
+
 def testHWE():
     geometry = [('H', (0., 0., 0.)), ('H', (0., 0., .7474))]
     molecule, data = cudaq.chemistry.create_molecular_hamiltonian(

--- a/python/tests/domains/test_qnn.py
+++ b/python/tests/domains/test_qnn.py
@@ -14,8 +14,7 @@ import cudaq
 
 skipIfNoMQPU = pytest.mark.skipif(
     not (cudaq.num_available_gpus() > 0 and cudaq.has_target('nvidia-mqpu')),
-    reason="nvidia-mqpu backend not available"
-)
+    reason="nvidia-mqpu backend not available")
 
 
 def test_simpleObserveN_QNN():
@@ -45,7 +44,7 @@ def test_simpleObserveN_QNN():
 
     exp_vals = cudaq.observe(kernel, h, parameters)
     assert len(exp_vals) == samples_count
-    data = np.asarray([e.expectation_z() for e in exp_vals])
+    data = np.asarray([e.expectation() for e in exp_vals])
     # Test a collection of computed exp vals.
     assert np.isclose(data[0], 0.44686141)
     assert np.isclose(data[1], 0.5014559)
@@ -53,6 +52,7 @@ def test_simpleObserveN_QNN():
     assert np.isclose(data[-3], 0.50511996)
     assert np.isclose(data[-2], 0.54314517)
     assert np.isclose(data[-1], 0.33752631)
+
 
 @skipIfNoMQPU
 def test_observeAsync_QNN():
@@ -90,7 +90,7 @@ def test_observeAsync_QNN():
 
     expvals = []
     for res in asyncresults:
-        expvals.append(res.get().expectation_z())
+        expvals.append(res.get().expectation())
 
     assert np.allclose(np.asarray([0.44686155, 0.50145603]),
                        np.asarray(expvals))

--- a/python/tests/parallel/test_mpi_mqpu.py
+++ b/python/tests/parallel/test_mpi_mqpu.py
@@ -11,9 +11,9 @@ from cudaq import spin
 import numpy as np
 
 skipIfUnsupported = pytest.mark.skipif(
-    not (cudaq.num_available_gpus() > 0 and cudaq.mpi.is_initialized() and cudaq.has_target('nvidia-mqpu')),
-    reason="nvidia-mqpu backend not available or mpi not found"
-)
+    not (cudaq.num_available_gpus() > 0 and cudaq.mpi.is_initialized() and
+         cudaq.has_target('nvidia-mqpu')),
+    reason="nvidia-mqpu backend not available or mpi not found")
 
 
 @skipIfUnsupported
@@ -41,10 +41,10 @@ def testMPI():
                                     hamiltonian,
                                     0.59,
                                     execution=cudaq.parallel.mpi)
-    expectation_value_no_shots = result_no_shots.expectation_z()
+    expectation_value_no_shots = result_no_shots.expectation()
     assert np.isclose(want_expectation_value, expectation_value_no_shots)
 
-    # Test all gather 
+    # Test all gather
     numRanks = cudaq.mpi.num_ranks()
     local = [1.0]
     globalList = cudaq.mpi.all_gather(numRanks, local)

--- a/python/tests/parallel/test_mqpu.py
+++ b/python/tests/parallel/test_mqpu.py
@@ -12,8 +12,7 @@ import numpy as np
 
 skipIfNoMQPU = pytest.mark.skipif(
     not (cudaq.num_available_gpus() > 0 and cudaq.has_target('nvidia-mqpu')),
-    reason="nvidia-mqpu backend not available"
-)
+    reason="nvidia-mqpu backend not available")
 
 
 # Helper function for asserting two values are within a
@@ -78,7 +77,7 @@ def testLargeProblem():
     e = cudaq.observe(kernel, H, execParams, execution=cudaq.parallel.thread)
     stop = timeit.default_timer()
     print("mqpu time = ", (stop - start))
-    assert assert_close(e.expectation_z(), e.expectation_z())
+    assert assert_close(e.expectation(), e.expectation())
 
     # Reset for the next tests.
     cudaq.reset_target()
@@ -105,8 +104,11 @@ def testAccuracy():
 
     # Get the `cudaq.ObserveResult` back from `cudaq.observe()`.
     # No shots provided.
-    result_no_shots = cudaq.observe(kernel, hamiltonian, 0.59, execution=cudaq.parallel.thread)
-    expectation_value_no_shots = result_no_shots.expectation_z()
+    result_no_shots = cudaq.observe(kernel,
+                                    hamiltonian,
+                                    0.59,
+                                    execution=cudaq.parallel.thread)
+    expectation_value_no_shots = result_no_shots.expectation()
     assert assert_close(want_expectation_value, expectation_value_no_shots)
 
     cudaq.reset_target()

--- a/python/tests/unittests/test_kernel_builder.py
+++ b/python/tests/unittests/test_kernel_builder.py
@@ -612,7 +612,7 @@ def test_from_state():
     kernel = cudaq.make_kernel()
     qubits = kernel.qalloc(2)
     cudaq.from_state(kernel, qubits, state)
-    energy = cudaq.observe(kernel, hamiltonian).expectation_z()
+    energy = cudaq.observe(kernel, hamiltonian).expectation()
     assert np.isclose(-1.748, energy, 1e-3)
 
     ss = cudaq.get_state(kernel)
@@ -638,7 +638,7 @@ def test_exp_pauli():
         1, 3, 3, -0.0454063, -0, 15
     ]
     h = cudaq.SpinOperator(h2_data, 4)
-    want_exp = cudaq.observe(kernel, h).expectation_z()
+    want_exp = cudaq.observe(kernel, h).expectation()
     assert np.isclose(want_exp, -1.13, atol=1e-2)
 
     kernel, theta = cudaq.make_kernel(float)
@@ -646,7 +646,7 @@ def test_exp_pauli():
     kernel.x(qubits[0])
     kernel.x(qubits[1])
     kernel.exp_pauli(theta, qubits, "XXXY")
-    want_exp = cudaq.observe(kernel, h, .11).expectation_z()
+    want_exp = cudaq.observe(kernel, h, .11).expectation()
     assert np.isclose(want_exp, -1.13, atol=1e-2)
 
 

--- a/python/tests/unittests/test_observe.py
+++ b/python/tests/unittests/test_observe.py
@@ -58,14 +58,13 @@ def test_observe_result():
         assert sum(sub_register_counts.values()) == shots_count
         # Check they have the same number of elements
         assert len(sub_register_counts) == len(sub_term_counts)
-        # Check `cudaq.ObserveResult::expectation_z(sub_term)`
+        # Check `cudaq.ObserveResult::expectation(sub_term)`
         # against each of the the expectation values returned
         # from `cudaq.SampleResult`.
-        expectation_z = observe_result.expectation_z(sub_term=sub_term)
-        assert assert_close(sub_register_counts.expectation_z(), expectation_z,
+        expectation = observe_result.expectation(sub_term=sub_term)
+        assert assert_close(sub_register_counts.expectation(), expectation,
                             1e-1)
-        assert assert_close(sub_term_counts.expectation_z(), expectation_z,
-                            1e-1)
+        assert assert_close(sub_term_counts.expectation(), expectation, 1e-1)
     observe_result.dump()
 
 
@@ -100,7 +99,7 @@ def test_observe_no_params(want_state, want_expectation, shots_count):
     observe_result = cudaq.observe(kernel=kernel,
                                    spin_operator=hamiltonian,
                                    shots_count=shots_count)
-    got_expectation = observe_result.expectation_z()
+    got_expectation = observe_result.expectation()
     assert want_expectation == got_expectation
 
     # If shots mode was enabled, check those results.
@@ -121,8 +120,8 @@ def test_observe_no_params(want_state, want_expectation, shots_count):
             sub_register_counts = sample_result.get_register_counts(got_name)
             # Sub-term should have the same expectation as the entire
             # system.
-            assert sub_term_counts.expectation_z() == want_expectation
-            assert sub_register_counts.expectation_z() == want_expectation
+            assert sub_term_counts.expectation() == want_expectation
+            assert sub_register_counts.expectation() == want_expectation
             # Should have `shots_count` results for each.
             assert sum(sub_term_counts.values()) == shots_count
             assert sum(sub_register_counts.values()) == shots_count
@@ -165,7 +164,7 @@ def test_observe_single_param(angle, want_state, want_expectation, shots_count):
                                    hamiltonian,
                                    angle,
                                    shots_count=shots_count)
-    got_expectation = observe_result.expectation_z()
+    got_expectation = observe_result.expectation()
     assert want_expectation == got_expectation
 
     # If shots mode was enabled, check those results.
@@ -186,9 +185,9 @@ def test_observe_single_param(angle, want_state, want_expectation, shots_count):
             sub_register_counts = sample_result.get_register_counts(got_name)
             # Sub-term should have an expectation value proportional to the
             # expectation over the entire system.
-            assert sub_term_counts.expectation_z(
+            assert sub_term_counts.expectation(
             ) == want_expectation / qubit_count
-            assert sub_register_counts.expectation_z(
+            assert sub_register_counts.expectation(
             ) == want_expectation / qubit_count
             # Should have `shots_count` results for each.
             assert sum(sub_term_counts.values()) == shots_count
@@ -244,7 +243,7 @@ def test_observe_multi_param(angle_0, angle_1, angles, want_state,
                                    angle_1,
                                    angles,
                                    shots_count=shots_count)
-    got_expectation = observe_result.expectation_z()
+    got_expectation = observe_result.expectation()
     assert want_expectation == got_expectation
 
     # If shots mode was enabled, check those results.
@@ -265,9 +264,9 @@ def test_observe_multi_param(angle_0, angle_1, angles, want_state,
             sub_register_counts = sample_result.get_register_counts(got_name)
             # Sub-term should have an expectation value proportional to the
             # expectation over the entire system.
-            assert sub_term_counts.expectation_z(
+            assert sub_term_counts.expectation(
             ) == want_expectation / qubit_count
-            assert sub_register_counts.expectation_z(
+            assert sub_register_counts.expectation(
             ) == want_expectation / qubit_count
             # Should have `shots_count` results for each.
             assert sum(sub_term_counts.values()) == shots_count
@@ -321,7 +320,7 @@ def test_observe_async_no_params(want_state, want_expectation, shots_count):
                                  qpu_id=0,
                                  shots_count=shots_count)
     observe_result = future.get()
-    got_expectation = observe_result.expectation_z()
+    got_expectation = observe_result.expectation()
     assert want_expectation == got_expectation
 
     # Test that this throws an exception, the problem here
@@ -363,7 +362,7 @@ def test_observe_async_single_param(angle, want_state, want_expectation,
                                  angle,
                                  shots_count=shots_count)
     observe_result = future.get()
-    got_expectation = observe_result.expectation_z()
+    got_expectation = observe_result.expectation()
     assert want_expectation == got_expectation
 
     # If shots mode was enabled, check those results.
@@ -384,9 +383,9 @@ def test_observe_async_single_param(angle, want_state, want_expectation,
             sub_register_counts = sample_result.get_register_counts(got_name)
             # Sub-term should have an expectation value proportional to the
             # expectation over the entire system.
-            assert sub_term_counts.expectation_z(
+            assert sub_term_counts.expectation(
             ) == want_expectation / qubit_count
-            assert sub_register_counts.expectation_z(
+            assert sub_register_counts.expectation(
             ) == want_expectation / qubit_count
             # Should have `shots_count` results for each.
             assert sum(sub_term_counts.values()) == shots_count
@@ -446,7 +445,7 @@ def test_observe_async_multi_param(angle_0, angle_1, angles, want_state,
                                  angles,
                                  shots_count=shots_count)
     observe_result = future.get()
-    got_expectation = observe_result.expectation_z()
+    got_expectation = observe_result.expectation()
     assert want_expectation == got_expectation
 
     # If shots mode was enabled, check those results.
@@ -467,9 +466,9 @@ def test_observe_async_multi_param(angle_0, angle_1, angles, want_state,
             sub_register_counts = sample_result.get_register_counts(got_name)
             # Sub-term should have an expectation value proportional to the
             # expectation over the entire system.
-            assert sub_term_counts.expectation_z(
+            assert sub_term_counts.expectation(
             ) == want_expectation / qubit_count
-            assert sub_register_counts.expectation_z(
+            assert sub_register_counts.expectation(
             ) == want_expectation / qubit_count
             # Should have `shots_count` results for each.
             assert sum(sub_term_counts.values()) == shots_count
@@ -534,7 +533,7 @@ def test_observe_numpy_array(angles, want_state, want_expectation):
                                    hamiltonian,
                                    numpy_angles,
                                    shots_count=10)
-    got_expectation = observe_result.expectation_z()
+    got_expectation = observe_result.expectation()
     assert want_expectation == got_expectation
 
     # Since shots mode was enabled, check the results.
@@ -554,8 +553,8 @@ def test_observe_numpy_array(angles, want_state, want_expectation):
         sub_register_counts = sample_result.get_register_counts(got_name)
         # Sub-term should have an expectation value proportional to the
         # expectation over the entire system.
-        assert sub_term_counts.expectation_z() == want_expectation / qubit_count
-        assert sub_register_counts.expectation_z(
+        assert sub_term_counts.expectation() == want_expectation / qubit_count
+        assert sub_register_counts.expectation(
         ) == want_expectation / qubit_count
         # Should have `shots_count` results for each.
         assert sum(sub_term_counts.values()) == shots_count
@@ -598,7 +597,7 @@ def test_observe_n():
     circuit.cx(q[1], q[0])
 
     results = cudaq.observe(circuit, hamiltonian, angles)
-    energies = np.array([r.expectation_z() for r in results])
+    energies = np.array([r.expectation() for r in results])
     print(energies)
     expected = np.array([
         12.250289999999993, 12.746369918061657, 13.130147571153335,
@@ -641,7 +640,7 @@ def test_observe_n():
 
     results = cudaq.observe(kernel, hamiltonian, runtimeAngles[:, 0],
                             runtimeAngles[:, 1])
-    energies = np.array([r.expectation_z() for r in results])
+    energies = np.array([r.expectation() for r in results])
     print(energies)
     assert len(energies) == 50
 
@@ -660,7 +659,7 @@ def test_observe_n():
     print(runtimeAngles)
 
     results = cudaq.observe(kernel, hamiltonian, runtimeAngles)
-    energies = np.array([r.expectation_z() for r in results])
+    energies = np.array([r.expectation() for r in results])
     print(energies)
     assert len(energies) == 50
 
@@ -681,7 +680,7 @@ def test_observe_list():
 
     sum = 5.907
     for r in results:
-        sum += r.expectation_z() * np.real(r.get_spin().get_coefficient())
+        sum += r.expectation() * np.real(r.get_spin().get_coefficient())
     print(sum)
     want_expectation_value = -1.7487948611472093
     assert assert_close(want_expectation_value, sum, tolerance=1e-2)

--- a/python/tests/unittests/test_sample.py
+++ b/python/tests/unittests/test_sample.py
@@ -57,10 +57,10 @@ def test_sample_result_single_register(qubit_count, shots_count):
         # `__len__`
         # Should have only measured 1 different state.
         assert len(counts) == 1
-        # `expectation_z`
+        # `expectation`
         # The `qubit_count` is always odd so we should always have
         # an expectation of -1. for the 1-state.
-        assert counts.expectation_z() == -1.
+        assert counts.expectation() == -1.
         # `probability`
         assert counts.probability(want_bitstring) == 1.
         # `most_probable`
@@ -71,7 +71,7 @@ def test_sample_result_single_register(qubit_count, shots_count):
         for qubit in range(qubit_count):
             marginal_counts = counts.get_marginal_counts([qubit])
             print(marginal_counts)
-            assert marginal_counts.expectation_z() == -1.
+            assert marginal_counts.expectation() == -1.
             # Should be in the 1-state.
             assert marginal_counts.probability("1") == 1
             assert marginal_counts.most_probable() == "1"
@@ -145,10 +145,10 @@ def test_sample_result_single_register_float_param(qubit_count, shots_count):
         # `__len__`
         # Should have only measured 1 different state.
         assert len(counts) == 1
-        # `expectation_z`
+        # `expectation`
         # The `qubit_count` is always odd so we should always have
         # an expectation of -1. for the 1-state.
-        assert counts.expectation_z() == -1.
+        assert counts.expectation() == -1.
         # `probability`
         assert counts.probability(want_bitstring) == 1.
         # `most_probable`
@@ -159,7 +159,7 @@ def test_sample_result_single_register_float_param(qubit_count, shots_count):
         for qubit in range(qubit_count):
             marginal_counts = counts.get_marginal_counts([qubit])
             print(marginal_counts)
-            assert marginal_counts.expectation_z() == -1.
+            assert marginal_counts.expectation() == -1.
             # Should be in the 1-state.
             assert marginal_counts.probability("1") == 1
             assert marginal_counts.most_probable() == "1"
@@ -233,10 +233,10 @@ def test_sample_result_single_register_list_param(qubit_count, shots_count):
         # `__len__`
         # Should have only measured 1 different state.
         assert len(counts) == 1
-        # `expectation_z`
+        # `expectation`
         # The `qubit_count` is always odd so we should always have
         # an expectation of -1. for the 1-state.
-        assert counts.expectation_z() == -1.
+        assert counts.expectation() == -1.
         # `probability`
         assert counts.probability(want_bitstring) == 1.
         # `most_probable`
@@ -247,7 +247,7 @@ def test_sample_result_single_register_list_param(qubit_count, shots_count):
         for qubit in range(qubit_count):
             marginal_counts = counts.get_marginal_counts([qubit])
             print(marginal_counts)
-            assert marginal_counts.expectation_z() == -1.
+            assert marginal_counts.expectation() == -1.
             # Should be in the 1-state.
             assert marginal_counts.probability("1") == 1
             assert marginal_counts.most_probable() == "1"
@@ -358,9 +358,9 @@ def test_sample_result_observe(shots_count):
             sub_register_counts = sample_result.get_register_counts(got_name)
             # Sub-term should have the an expectation proportional to the entire
             # system.
-            assert sub_term_counts.expectation_z(
+            assert sub_term_counts.expectation(
             ) == want_expectation / qubit_count
-            assert sub_register_counts.expectation_z(
+            assert sub_register_counts.expectation(
             ) == want_expectation / qubit_count
             # Should have `shots_count` results for each.
             assert sum(sub_term_counts.values()) == shots_count

--- a/runtime/common/Future.h
+++ b/runtime/common/Future.h
@@ -113,7 +113,7 @@ public:
     if constexpr (std::is_same_v<T, observe_result>) {
       auto checkRegName = spinOp->to_string(false);
       if (data.has_expectation(checkRegName))
-        return observe_result(data.exp_val_z(checkRegName), *spinOp, data);
+        return observe_result(data.expectation(checkRegName), *spinOp, data);
 
       if (!spinOp)
         throw std::runtime_error(
@@ -125,7 +125,7 @@ public:
         if (term.is_identity())
           sum += term.get_coefficient().real();
         else
-          sum += data.exp_val_z(term.to_string(false)) *
+          sum += data.expectation(term.to_string(false)) *
                  term.get_coefficient().real();
       });
 

--- a/runtime/common/MeasureCounts.cpp
+++ b/runtime/common/MeasureCounts.cpp
@@ -345,7 +345,31 @@ bool sample_result::has_expectation(const std::string_view registerName) {
   return iter->second.expectationValue.has_value();
 }
 
-double sample_result::exp_val_z(const std::string_view registerName) {
+double sample_result::expectation(const std::string_view registerName) {
+  double aver = 0.0;
+  auto iter = sampleResults.find(registerName.data());
+  if (iter == sampleResults.end())
+    return 0.0;
+
+  if (iter->second.expectationValue.has_value())
+    return iter->second.expectationValue.value();
+
+  auto counts = iter->second.counts;
+  for (auto &kv : counts) {
+    auto par = has_even_parity(kv.first);
+    auto p = probability(kv.first, registerName);
+    if (!par) {
+      p = -p;
+    }
+    aver += p;
+  }
+
+  return aver;
+}
+
+[[deprecated("`exp_val_z()` is deprecated. Use `expectation()` with the same "
+             "argument structure.")]] double
+sample_result::exp_val_z(const std::string_view registerName) {
   double aver = 0.0;
   auto iter = sampleResults.find(registerName.data());
   if (iter == sampleResults.end())

--- a/runtime/common/MeasureCounts.cpp
+++ b/runtime/common/MeasureCounts.cpp
@@ -367,9 +367,7 @@ double sample_result::expectation(const std::string_view registerName) {
   return aver;
 }
 
-[[deprecated("`exp_val_z()` is deprecated. Use `expectation()` with the same "
-             "argument structure.")]] double
-sample_result::exp_val_z(const std::string_view registerName) {
+double sample_result::exp_val_z(const std::string_view registerName) {
   double aver = 0.0;
   auto iter = sampleResults.find(registerName.data());
   if (iter == sampleResults.end())

--- a/runtime/common/MeasureCounts.h
+++ b/runtime/common/MeasureCounts.h
@@ -179,7 +179,9 @@ public:
   /// @return
   double expectation(const std::string_view registerName = GlobalRegisterName);
   /// @brief Deprecated: Return the expected value <Z...Z>
-  double exp_val_z(const std::string_view registerName = GlobalRegisterName);
+  [[deprecated("`exp_val_z()` is deprecated. Use `expectation()` with the same "
+               "argument structure.")]] double
+  exp_val_z(const std::string_view registerName = GlobalRegisterName);
 
   /// @brief Return the probability of observing the given bit string
   /// @param bitString

--- a/runtime/common/MeasureCounts.h
+++ b/runtime/common/MeasureCounts.h
@@ -177,6 +177,8 @@ public:
 
   /// @brief Return the expected value <Z...Z>
   /// @return
+  double expectation(const std::string_view registerName = GlobalRegisterName);
+  /// @brief Deprecated: Return the expected value <Z...Z>
   double exp_val_z(const std::string_view registerName = GlobalRegisterName);
 
   /// @brief Return the probability of observing the given bit string

--- a/runtime/cudaq/algorithms/observe.h
+++ b/runtime/cudaq/algorithms/observe.h
@@ -115,7 +115,7 @@ runObservation(KernelFunctor &&k, cudaq::spin_op &h, quantum_platform &platform,
       if (term.is_identity())
         sum += term.get_coefficient().real();
       else
-        sum += data.exp_val_z(term.to_string(false)) *
+        sum += data.expectation(term.to_string(false)) *
                term.get_coefficient().real();
     });
 
@@ -190,7 +190,7 @@ inline auto distributeComputations(
   for (auto &asyncResult : asyncResults) {
     auto res = asyncResult.get();
     auto incomingData = res.raw_data();
-    result += incomingData.exp_val_z();
+    result += incomingData.expectation();
     data += incomingData;
   }
 
@@ -247,7 +247,7 @@ std::vector<observe_result> observe(QuantumKernel &&kernel,
   // Convert back to a vector of results
   std::vector<observe_result> results;
   for (auto &o : termList)
-    results.emplace_back(result.exp_val_z(o), o, result.counts(o));
+    results.emplace_back(result.expectation(o), o, result.counts(o));
 
   return results;
 }
@@ -317,7 +317,7 @@ observe_result observe(std::size_t shots, QuantumKernel &&kernel, spin_op H,
         localH, nQpus);
 
     // combine all the data via an all_reduce
-    auto exp_val = localRankResult.exp_val_z();
+    auto exp_val = localRankResult.expectation();
     auto globalExpVal = mpi::all_reduce(exp_val, std::plus<double>());
     return observe_result(globalExpVal, H);
 

--- a/test/AST-Quake/simple.cpp
+++ b/test/AST-Quake/simple.cpp
@@ -92,7 +92,7 @@ int main() {
   }
 
   // can get <ZZ...Z> from counts too
-  printf("Exp: %lf\n", counts.exp_val_z());
+  printf("Exp: %lf\n", counts.expectation());
 
   return 0;
 }

--- a/test/AST-Quake/simple_qarray.cpp
+++ b/test/AST-Quake/simple_qarray.cpp
@@ -40,7 +40,7 @@ int main() {
   }
 
   // can get <ZZ...Z> from counts too
-  printf("Exp: %lf\n", counts.exp_val_z());
+  printf("Exp: %lf\n", counts.expectation());
 
   return 0;
 }

--- a/test/AST-Quake/vector.cpp
+++ b/test/AST-Quake/vector.cpp
@@ -51,7 +51,7 @@ int main() {
   }
 
   // can get <ZZ...Z> from counts too
-  printf("Exp: %lf\n", counts.exp_val_z());
+  printf("Exp: %lf\n", counts.expectation());
 
   std::vector<float> float_args = {0.64};
 
@@ -64,6 +64,6 @@ int main() {
   }
 
   // can get <ZZ...Z> from counts too
-  printf("Exp: %lf\n", float_counts.exp_val_z());
+  printf("Exp: %lf\n", float_counts.expectation());
   return 0;
 }

--- a/unittests/backends/ionq/IonQTester.cpp
+++ b/unittests/backends/ionq/IonQTester.cpp
@@ -108,8 +108,8 @@ CUDAQ_TEST(IonQTester, checkObserveSync) {
   auto result = cudaq::observe(kernel, h, .59);
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 CUDAQ_TEST(IonQTester, checkObserveAsync) {
@@ -133,8 +133,8 @@ CUDAQ_TEST(IonQTester, checkObserveAsync) {
   auto result = future.get();
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 CUDAQ_TEST(IonQTester, checkObserveAsyncLoadFromFile) {
@@ -171,8 +171,8 @@ CUDAQ_TEST(IonQTester, checkObserveAsyncLoadFromFile) {
   std::remove("saveMeObserve.json");
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 int main(int argc, char **argv) {

--- a/unittests/backends/oqc/OQCTester.cpp
+++ b/unittests/backends/oqc/OQCTester.cpp
@@ -109,8 +109,8 @@ CUDAQ_TEST(OQCTester, checkObserveSync) {
   auto result = cudaq::observe(kernel, h, .59);
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 CUDAQ_TEST(OQCTester, checkObserveAsync) {
@@ -134,8 +134,8 @@ CUDAQ_TEST(OQCTester, checkObserveAsync) {
   auto result = future.get();
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 CUDAQ_TEST(OQCTester, checkObserveAsyncLoadFromFile) {
@@ -172,8 +172,8 @@ CUDAQ_TEST(OQCTester, checkObserveAsyncLoadFromFile) {
   std::remove("saveMeObserve.json");
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 int main(int argc, char **argv) {

--- a/unittests/backends/quantinuum/QuantinuumTester.cpp
+++ b/unittests/backends/quantinuum/QuantinuumTester.cpp
@@ -161,8 +161,8 @@ CUDAQ_TEST(QuantinuumTester, checkObserveSync) {
   auto result = cudaq::observe(10000, kernel, h, .59);
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 CUDAQ_TEST(QuantinuumTester, checkObserveSyncEmulate) {
@@ -188,8 +188,8 @@ CUDAQ_TEST(QuantinuumTester, checkObserveSyncEmulate) {
   auto result = cudaq::observe(100000, kernel, h, .59);
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 CUDAQ_TEST(QuantinuumTester, checkObserveAsync) {
@@ -215,8 +215,8 @@ CUDAQ_TEST(QuantinuumTester, checkObserveAsync) {
   auto result = future.get();
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 CUDAQ_TEST(QuantinuumTester, checkObserveAsyncEmulate) {
@@ -244,8 +244,8 @@ CUDAQ_TEST(QuantinuumTester, checkObserveAsyncEmulate) {
   auto result = future.get();
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 CUDAQ_TEST(QuantinuumTester, checkObserveAsyncLoadFromFile) {
@@ -285,8 +285,8 @@ CUDAQ_TEST(QuantinuumTester, checkObserveAsyncLoadFromFile) {
   std::remove("saveMeObserve.json");
   result.dump();
 
-  printf("ENERGY: %lf\n", result.exp_val_z());
-  EXPECT_TRUE(isValidExpVal(result.exp_val_z()));
+  printf("ENERGY: %lf\n", result.expectation());
+  EXPECT_TRUE(isValidExpVal(result.expectation()));
 }
 
 int main(int argc, char **argv) {

--- a/unittests/common/MeasureCountsTester.cpp
+++ b/unittests/common/MeasureCountsTester.cpp
@@ -35,7 +35,7 @@ CUDAQ_TEST(MeasureCountsTester, checkCount) {
 CUDAQ_TEST(MeasureCountsTester, checkExpValZ) {
   ExecutionResult r{CountsDictionary{{"0", 400}, {"1", 600}}};
   cudaq::sample_result mc(r);
-  EXPECT_NEAR(-1. / 5., mc.exp_val_z(), 1e-9);
+  EXPECT_NEAR(-1. / 5., mc.expectation(), 1e-9);
 }
 
 // TEST Sample Result / sample_result serialize / deserialize

--- a/unittests/domains/ChemistryTester.cpp
+++ b/unittests/domains/ChemistryTester.cpp
@@ -171,8 +171,8 @@ CUDAQ_TEST(H2MoleculeTester, checkHWE) {
         cudaq::random_vector(-3.0, 3.0, numParams, std::mt19937::default_seed);
     std::vector<double> zeros(numParams);
     auto res2 = cudaq::observe(ansatz, H, zeros);
-    std::cout << "HF = " << std::setprecision(16) << res2.exp_val_z() << "\n";
-    EXPECT_NEAR(-1.116, res2.exp_val_z(), 1e-3);
+    std::cout << "HF = " << std::setprecision(16) << res2.expectation() << "\n";
+    EXPECT_NEAR(-1.116, res2.expectation(), 1e-3);
 
     auto res = cudaq::vqe(ansatz, H, optimizer, numParams);
     std::cout << "opt result = " << std::setprecision(16) << std::get<0>(res)

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -375,8 +375,8 @@ CUDAQ_TEST(BuilderTester, checkKernelControl) {
   printf("%s\n", hadamardTest.to_quake().c_str());
   auto counts = cudaq::sample(10000, hadamardTest);
   counts.dump();
-  printf("< 1 | X | 1 > = %lf\n", counts.exp_val_z());
-  EXPECT_NEAR(counts.exp_val_z(), 0.0, 1e-1);
+  printf("< 1 | X | 1 > = %lf\n", counts.expectation());
+  EXPECT_NEAR(counts.expectation(), 0.0, 1e-1);
 
   // Compute <1|H|1> = 1.
   auto hadamardTest2 = cudaq::make_kernel();
@@ -390,8 +390,8 @@ CUDAQ_TEST(BuilderTester, checkKernelControl) {
 
   printf("%s\n", hadamardTest2.to_quake().c_str());
   counts = cudaq::sample(10000, hadamardTest2);
-  printf("< 1 | H | 1 > = %lf\n", counts.exp_val_z());
-  EXPECT_NEAR(counts.exp_val_z(), -1.0 / std::sqrt(2.0), 1e-1);
+  printf("< 1 | H | 1 > = %lf\n", counts.expectation());
+  EXPECT_NEAR(counts.expectation(), -1.0 / std::sqrt(2.0), 1e-1);
 
   // Demonstrate can control on qvector
   auto kernel = cudaq::make_kernel();

--- a/unittests/integration/deuteron_variational_tester.cpp
+++ b/unittests/integration/deuteron_variational_tester.cpp
@@ -42,7 +42,7 @@ CUDAQ_TEST(D2VariationalTester, checkSimple) {
   auto results = cudaq::observe(ansatz2{}, asList, .59);
   double test = 5.907;
   for (auto &r : results) {
-    test += r.exp_val_z() * r.get_spin().get_coefficient().real();
+    test += r.expectation() * r.get_spin().get_coefficient().real();
   }
 
   printf("TEST: %.16lf\n", test);
@@ -85,7 +85,7 @@ CUDAQ_TEST(D2VariationalTester, checkBroadcast) {
     printf("results[%lu] = %.16lf\n", counter++, el);
 
   for (std::size_t counter = 0; auto &el : expected)
-    EXPECT_NEAR(results[counter++].exp_val_z(), el, 1e-3);
+    EXPECT_NEAR(results[counter++].expectation(), el, 1e-3);
 
   // Expect that providing the wrong number of args in the vector will
   // throw an exception.

--- a/unittests/integration/ghz_nisq_tester.cpp
+++ b/unittests/integration/ghz_nisq_tester.cpp
@@ -40,7 +40,7 @@ CUDAQ_TEST(GHZSampleTester, checkSimple) {
     EXPECT_TRUE(bits == "00000" || bits == "11111");
   }
   EXPECT_EQ(counter, 1000);
-  printf("Exp: %.16lf\n", counts.exp_val_z());
+  printf("Exp: %.16lf\n", counts.expectation());
 }
 
 CUDAQ_TEST(GHZSampleTester, checkBroadcast) {

--- a/unittests/integration/kernels_tester.cpp
+++ b/unittests/integration/kernels_tester.cpp
@@ -133,7 +133,7 @@ CUDAQ_TEST(KernelsTester, checkFromState) {
     using namespace cudaq::spin;
     auto H = 5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) +
              .21829 * z(0) - 6.125 * z(1);
-    auto energy = cudaq::observe(kernel, H).exp_val_z();
+    auto energy = cudaq::observe(kernel, H).expectation();
     EXPECT_NEAR(-1.748, energy, 1e-3);
 
     auto ss = cudaq::get_state(kernel);

--- a/unittests/integration/observe_result_tester.cpp
+++ b/unittests/integration/observe_result_tester.cpp
@@ -41,8 +41,8 @@ CUDAQ_TEST(ObserveResult, checkSimple) {
   printf("Get energy directly as double %lf\n", result);
 
   auto obs_res = cudaq::observe(ansatz, h, 0.59);
-  EXPECT_NEAR(obs_res.exp_val_z(), -1.7487, 1e-3);
-  printf("Energy from observe_result %lf\n", obs_res.exp_val_z());
+  EXPECT_NEAR(obs_res.expectation(), -1.7487, 1e-3);
+  printf("Energy from observe_result %lf\n", obs_res.expectation());
 
   // Observe using options w/ noise model. Note that the noise model is only
   // honored when using the Density Matrix backend.
@@ -66,14 +66,14 @@ CUDAQ_TEST(ObserveResult, checkSimple) {
 
   printf("\n\nLAST ONE!\n");
   auto obs_res2 = cudaq::observe(100000, ansatz, h, 0.59);
-  EXPECT_NEAR(obs_res2.exp_val_z(), -1.7, 1e-1);
-  printf("Energy from observe_result with shots %lf\n", obs_res2.exp_val_z());
+  EXPECT_NEAR(obs_res2.expectation(), -1.7, 1e-1);
+  printf("Energy from observe_result with shots %lf\n", obs_res2.expectation());
   obs_res2.dump();
 
   for (const auto &term : h) // td::size_t i = 0; i < h.num_terms(); i++)
     if (!term.is_identity())
       printf("Fine-grain data access: %s = %lf\n", term.to_string().data(),
-             obs_res2.exp_val_z(term));
+             obs_res2.expectation(term));
 
   auto x0x1Counts = obs_res2.counts(x(0) * x(1));
   x0x1Counts.dump();
@@ -96,15 +96,15 @@ CUDAQ_TEST(ObserveResult, checkExpValBug) {
   auto hamiltonian = z(0) + z(1);
 
   auto result = cudaq::observe(kernel, hamiltonian);
-  auto exp = result.exp_val_z(z(0));
+  auto exp = result.expectation(z(0));
   printf("exp %lf \n", exp);
   EXPECT_NEAR(exp, .79, 1e-1);
 
-  exp = result.exp_val_z(z(1));
+  exp = result.expectation(z(1));
   printf("exp %lf \n", exp);
   EXPECT_NEAR(exp, .62, 1e-1);
 
-  exp = result.exp_val_z(z(0) * i(1));
+  exp = result.expectation(z(0) * i(1));
   printf("exp %lf \n", exp);
   EXPECT_NEAR(exp, .79, 1e-1);
 }


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Closes #384

* Adds deprecation notices to the C++ source definitions of `exp_val_z`
* New `expectation` functions added to C++ in replacement of `exp_val_z`
* C++ tests/docs/examples updated to use the preferred "expectation"

* Adds deprecation notices to the Python source definitions of `expectation_z`
* *New `expectation` functions added to python in replacement of `expectation_z`
* Python tests/docs/examples updated to use the preferred "expectation"
