### PR TITLE
Legalization error in basis conversion.

### DIFF
--- a/lib/Optimizer/Transforms/BasisConversion.cpp
+++ b/lib/Optimizer/Transforms/BasisConversion.cpp
@@ -59,8 +59,9 @@ struct BasisTarget : public ConversionTarget {
       }
     }
 
-    addLegalDialect<func::FuncDialect, arith::ArithDialect,
-                    cf::ControlFlowDialect, cudaq::cc::CCDialect>();
+    addLegalDialect<arith::ArithDialect, cf::ControlFlowDialect,
+                    cudaq::cc::CCDialect, func::FuncDialect,
+                    math::MathDialect>();
     addDynamicallyLegalDialect<quake::QuakeDialect>([&](Operation *op) {
       if (auto optor = dyn_cast<quake::OperatorInterface>(op)) {
         auto name = optor->getName().stripDialect();


### PR DESCRIPTION
This allows legalization to pass in the basis conversion pass. The resulting code may not be executable on the final target, but the assumption is that the QIR profile validation pass will handle those cases.
