### PR TITLE
Minor cleanup.

### DIFF
--- a/test/Quake/compute_action.qke
+++ b/test/Quake/compute_action.qke
@@ -14,7 +14,7 @@
 //     quake.compute_action to a series of quake.apply calls.
 //   - lower-to-cfg and canonicalize then simplify the new lambdas so that we
 //     can produce the adjoint of the compute lambda.
-//   - quake-apply-rewrite generates the adjoint compute function.
+//   - apply-op-specialization generates the adjoint compute function.
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__t = "_Z1tv"}} {
   func.func @__nvqpp__mlirgen__t() attributes {"cudaq-entrypoint"} {

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -93,7 +93,7 @@ function show_help {
 --[no-]aggressive-early-inline
 	Enable/disable early inlining pass.
 
---[no-]quake-apply-specialization
+--[no-]apply-specialization
 	Enable/disable specialization of quake.apply ops.
 
 --[no-]lambda-lifting
@@ -342,10 +342,10 @@ while [ $# -ne 0 ]; do
 	--aggressive-early-inline)
 		ENABLE_AGGRESSIVE_EARLY_INLINE=true
 		;;
-	--no-quake-apply-specialization)
+	--no-apply-specialization)
 		ENABLE_APPLY_SPECIALIZATION=false
 		;;
-	--quake-apply-specialization)
+	--apply-specialization)
 		ENABLE_APPLY_SPECIALIZATION=true
 		;;
 	--no-lambda-lifting)


### PR DESCRIPTION
 - Remove the "quake" prefix from the driver script.
 - Update comment that referred to retired option.
