### PR TITLE
Pass name cleanup.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -19,9 +19,6 @@
 namespace cudaq::opt {
 
 /// Pass to generate the device code loading stubs.
-std::unique_ptr<mlir::Pass> createGenerateKernelExecution();
-
-/// Pass to generate the device code loading stubs.
 std::unique_ptr<mlir::Pass>
 createGenerateDeviceCodeLoader(bool genAsQuake = false);
 
@@ -40,10 +37,9 @@ std::unique_ptr<mlir::Pass> createDelayMeasurementsPass();
 std::unique_ptr<mlir::Pass> createExpandMeasurementsPass();
 std::unique_ptr<mlir::Pass> createLambdaLiftingPass();
 std::unique_ptr<mlir::Pass> createLowerToCFGPass();
+std::unique_ptr<mlir::Pass> createObserveAnsatzPass(std::vector<bool> &);
 std::unique_ptr<mlir::Pass> createQuakeAddMetadata();
 std::unique_ptr<mlir::Pass> createQuakeAddDeallocs();
-std::unique_ptr<mlir::Pass> createQuakeObserveAnsatzPass();
-std::unique_ptr<mlir::Pass> createQuakeObserveAnsatzPass(std::vector<bool> &);
 std::unique_ptr<mlir::Pass> createQuakeSynthesizer();
 std::unique_ptr<mlir::Pass> createQuakeSynthesizer(std::string_view, void *);
 std::unique_ptr<mlir::Pass> createRaiseToAffinePass();

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -143,7 +143,6 @@ def GenerateKernelExecution : Pass<"kernel-execution", "mlir::ModuleOp"> {
   }];
 
   let dependentDialects = ["cudaq::cc::CCDialect", "mlir::LLVM::LLVMDialect"];
-  let constructor = "cudaq::opt::createGenerateKernelExecution()";
 
   let options = [
     Option<"outputFilename", "output-filename", "std::string",
@@ -348,14 +347,12 @@ def QuakeAddMetadata : Pass<"quake-add-metadata", "mlir::func::FuncOp"> {
   let constructor = "cudaq::opt::createQuakeAddMetadata()";
 }
 
-def QuakeObserveAnsatz : Pass<"observe-ansatz", "mlir::func::FuncOp"> {
- let summary = "Given spin_op input, append measures to the Quake FuncOp";
+def ObserveAnsatz : Pass<"observe-ansatz", "mlir::func::FuncOp"> {
+ let summary = "Given spin_op input, append measures to the FuncOp";
   let description = [{
-    Given an unmeasured Quake representation (i.e. a state prep
-    ansatz), append measures based on the given spin_op specified in
-    binary symplectic form.
+    Given an unmeasured Quake representation (i.e. a state prep ansatz), append
+    measures based on the given spin_op specified in binary symplectic form.
   }];
-  let constructor = "cudaq::opt::createQuakeObserveAnsatzPass()";
   let options = [
     ListOption<"termBSF", "term-bsf", "unsigned",
       "The measurement bases as a Pauli tensor product represented in binary symplectic form.">

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -31,9 +31,9 @@ add_cudaq_library(OptTransforms
   LowerUnwind.cpp
   MemToReg.cpp
   MultiControlDecomposition.cpp
+  ObserveAnsatz.cpp
   PruneCtrlRelations.cpp
   QuakeAddMetadata.cpp
-  QuakeObserveAnsatz.cpp
   QuakeSynthesizer.cpp
   RegToMem.cpp
 

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -23,6 +23,11 @@
 #include <cxxabi.h>
 #include <regex>
 
+namespace cudaq::opt {
+#define GEN_PASS_DEF_GENERATEKERNELEXECUTION
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
 #define DEBUG_TYPE "quake-kernel-exec"
 
 using namespace mlir;
@@ -39,9 +44,10 @@ static constexpr const char cudaqRegisterKernelName[] =
 static constexpr std::size_t NoResultOffset = ~0u >> 1;
 
 class GenerateKernelExecution
-    : public cudaq::opt::GenerateKernelExecutionBase<GenerateKernelExecution> {
+    : public cudaq::opt::impl::GenerateKernelExecutionBase<
+          GenerateKernelExecution> {
 public:
-  GenerateKernelExecution() = default;
+  using GenerateKernelExecutionBase::GenerateKernelExecutionBase;
 
   /// Build an LLVM struct type with all the arguments and then all the results.
   /// If the type is a std::vector, then add an i64 to the struct for the
@@ -847,7 +853,3 @@ public:
   }
 };
 } // namespace
-
-std::unique_ptr<Pass> cudaq::opt::createGenerateKernelExecution() {
-  return std::make_unique<GenerateKernelExecution>();
-}

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -413,7 +413,7 @@ public:
         PassManager pm(&context);
         OpPassManager &optPM = pm.nest<func::FuncOp>();
         optPM.addPass(
-            cudaq::opt::createQuakeObserveAnsatzPass(binarySymplecticForm[0]));
+            cudaq::opt::createObserveAnsatzPass(binarySymplecticForm[0]));
         if (failed(pm.run(tmpModuleOp)))
           throw std::runtime_error("Could not apply measurements to ansatz.");
         runPassPipeline(passPipelineConfig, tmpModuleOp);


### PR DESCRIPTION
- Rename QuakeObserveAnsatz to ObserveAnsatz
- Clean up the file to use MLIR coding style
- Convert GenerateKernelExecution and ObserveAnsatz to use the newer tablegen pass generators.
