### PR TITLE
Disable NGC signing

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -555,7 +555,8 @@ jobs:
         run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
 
       - name: Sign image with NGC CLI
-        if: inputs.environment && steps.prereqs.outputs.ngc_registry
+        # Temporarily disable NGC signing
+        if: false && inputs.environment && steps.prereqs.outputs.ngc_registry
         env:
           TAGS: ${{ steps.cudaq_metadata.outputs.tags }}
           NGC_CLI_API_KEY: ${{ secrets.NGC_CREDENTIALS }}

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -359,7 +359,8 @@ jobs:
         run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
 
       - name: Sign image with NGC CLI
-        if: steps.release_info.outputs.ngc_registry
+        # Temporarily disable NGC signing
+        if: false && steps.release_info.outputs.ngc_registry
         env:
           TAGS: ${{ steps.metadata.outputs.tags }}
           NGC_CLI_API_KEY: ${{ secrets.NGC_CREDENTIALS }}


### PR DESCRIPTION
NGC signing is failing as indicated in [this run](https://github.com/NVIDIA/cuda-quantum/actions/runs/6581235244/job/17906504495). This PR disables NGC signing in order to get deployments to work again.