### PR TITLE
Add more supports for `QuakeValue` in Python

### DIFF
--- a/docs/sphinx/examples/python/tutorials/executing_circuits.ipynb
+++ b/docs/sphinx/examples/python/tutorials/executing_circuits.ipynb
@@ -69,9 +69,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<H> = 0.0\n"
+     ]
+    }
+   ],
    "source": [
     "import cudaq\n",
     "from cudaq import spin\n",
@@ -96,7 +104,10 @@
     "# Define a Hamiltonian in terms of Pauli Spin operators.\n",
     "hamiltonian = spin.z(0) + spin.y(1) + spin.x(0) * spin.z(0)\n",
     "\n",
-    "result = cudaq.observe(kernel, hamiltonian)"
+    "# Compute the expectation value given the state prepared by the kernel.\n",
+    "result = cudaq.observe(kernel, hamiltonian).expectation()\n",
+    "\n",
+    "print('<H> =', result)"
    ]
   }
  ],

--- a/python/runtime/cudaq/builder/py_QuakeValue.cpp
+++ b/python/runtime/cudaq/builder/py_QuakeValue.cpp
@@ -116,6 +116,48 @@ Raises:
 	# Example:
 	kernel, value = cudaq.make_kernel(float)
 	new_value: QuakeValue = 5.0 * value)#")
+      /// Division overloads:
+      .def(
+          "__truediv__",
+          py::overload_cast<const double>(&QuakeValue::operator/),
+          py::arg("other"),
+          R"#(Return the division of `self` (:class:`QuakeValue`) with `other` (float).
+
+Raises:
+	RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+
+.. code-block:: python
+
+	# Example:
+	kernel, value = cudaq.make_kernel(float)
+	new_value: QuakeValue = value / 5.0)#")
+      .def("__truediv__", py::overload_cast<QuakeValue>(&QuakeValue::operator/),
+           py::arg("other"),
+           R"#(Return the division of `self` (:class:`QuakeValue`) with `other`
+(:class:`QuakeValue`).
+
+Raises:
+	RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+
+.. code-block:: python
+
+	# Example:
+	kernel, values = cudaq.make_kernel(list)
+	new_value: QuakeValue = values[0] / values[1])#")
+      .def(
+          "__rtruediv__",
+          [](QuakeValue &self, double other) { return self.inverse() * other; },
+          py::arg("other"),
+          R"#(Return the division of `other` (float) with `self` (:class:`QuakeValue`).
+
+Raises:
+	RuntimeError: if the underlying :class:`QuakeValue` type is not a float.
+
+.. code-block:: python
+
+	# Example:
+	kernel, value = cudaq.make_kernel(float)
+	new_value: QuakeValue = 5.0 / value)#")
       // Addition overloads:
       .def(
           "__add__", py::overload_cast<const double>(&QuakeValue::operator+),

--- a/python/tests/unittests/test_quake_value.py
+++ b/python/tests/unittests/test_quake_value.py
@@ -9,6 +9,7 @@
 import pytest
 
 import cudaq
+import numpy as np
 
 
 @pytest.mark.parametrize("type_", [float, int])
@@ -77,3 +78,53 @@ def test_QuakeValueLifetimeAndPrint():
     s = str(circuit)
     print(s)
     assert s.count('quake.x') == 2
+
+
+def test_QuakeValueDivOp():
+    """Tests division operators"""
+    kernel1, theta = cudaq.make_kernel(list)
+    qubit1 = kernel1.qalloc(1)
+    # Division of a QuakeValue
+    kernel1.rx(theta[0] / 8.0, qubit1[0])
+    state1 = cudaq.get_state(kernel1, [np.pi])
+    # Verification
+    kernel2 = cudaq.make_kernel()
+    qubit2 = kernel2.qalloc(1)
+    kernel2.rx(np.pi / 8.0, qubit2[0])
+    state2 = cudaq.get_state(kernel2)
+    print(np.allclose(state1, state2))
+
+    # RHS division: float/QuakeValue
+    kernel3, factor = cudaq.make_kernel(list)
+    qubit3 = kernel3.qalloc(1)
+    kernel3.rx(np.pi / factor[0], qubit3[0])
+    state3 = cudaq.get_state(kernel3, [8.0])
+    print(np.allclose(state3, state2))
+
+    # QuakeValue/QuakeValue division
+    kernel4, kernel4_args = cudaq.make_kernel(list)
+    qubit4 = kernel4.qalloc(1)
+    kernel4.rx(kernel4_args[0] / kernel4_args[1], qubit4[0])
+    state4 = cudaq.get_state(kernel4, [np.pi, 8.0])
+    print(np.allclose(state4, state2))
+
+
+def test_QuakeValueInForLoop():
+    """Tests QuakeValue used in as loop indices"""
+    kernel, start, stop = cudaq.make_kernel(int, int)
+    qubits = kernel.qalloc(stop)
+    kernel.h(qubits[0])
+
+    def foo(index: int):
+        """A function that will be applied to `kernel` in a for loop."""
+        kernel.x(qubits[index])
+
+    # `QuakeValue`` as start index
+    kernel.for_loop(start, 1, foo)
+    kernel.for_loop(start, stop - 1, foo)
+    print(kernel)
+
+    # Execute the kernel, passing along concrete values for the
+    # `start` and `stop` arguments.
+    counts = cudaq.sample(kernel, 0, 8)
+    print(counts)

--- a/python/tests/unittests/test_quake_value.py
+++ b/python/tests/unittests/test_quake_value.py
@@ -119,7 +119,7 @@ def test_QuakeValueInForLoop():
         """A function that will be applied to `kernel` in a for loop."""
         kernel.x(qubits[index])
 
-    # `QuakeValue`` as start index
+    # `QuakeValue` as start index
     kernel.for_loop(start, 1, foo)
     kernel.for_loop(start, stop - 1, foo)
     print(kernel)

--- a/python/tests/unittests/test_quake_value.py
+++ b/python/tests/unittests/test_quake_value.py
@@ -92,21 +92,21 @@ def test_QuakeValueDivOp():
     qubit2 = kernel2.qalloc(1)
     kernel2.rx(np.pi / 8.0, qubit2[0])
     state2 = cudaq.get_state(kernel2)
-    print(np.allclose(state1, state2))
+    assert np.allclose(state1, state2)
 
     # RHS division: float/QuakeValue
     kernel3, factor = cudaq.make_kernel(list)
     qubit3 = kernel3.qalloc(1)
     kernel3.rx(np.pi / factor[0], qubit3[0])
     state3 = cudaq.get_state(kernel3, [8.0])
-    print(np.allclose(state3, state2))
+    assert np.allclose(state3, state2)
 
     # QuakeValue/QuakeValue division
     kernel4, kernel4_args = cudaq.make_kernel(list)
     qubit4 = kernel4.qalloc(1)
     kernel4.rx(kernel4_args[0] / kernel4_args[1], qubit4[0])
     state4 = cudaq.get_state(kernel4, [np.pi, 8.0])
-    print(np.allclose(state4, state2))
+    assert np.allclose(state4, state2)
 
 
 def test_QuakeValueInForLoop():

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -422,4 +422,14 @@ QuakeValue QuakeValue::operator-(QuakeValue other) {
   Value subtracted = opBuilder.create<arith::SubFOp>(v.getType(), v, otherV);
   return QuakeValue(opBuilder, subtracted);
 }
+
+QuakeValue QuakeValue::inverse() const {
+  auto v = value->asMLIR();
+  if (!v.getType().isIntOrFloat())
+    throw std::runtime_error("Can only inverse double/float QuakeValues.");
+  Value constantOne = opBuilder.create<arith::ConstantFloatOp>(
+      llvm::APFloat(1.0), opBuilder.getF64Type());
+  Value inv = opBuilder.create<arith::DivFOp>(v.getType(), constantOne, v);
+  return QuakeValue(opBuilder, inv);
+}
 } // namespace cudaq

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -168,5 +168,7 @@ QuakeValue operator-(IsNumericType auto &&d, IsQuakeValue auto &&q) {
 QuakeValue operator+(IsNumericType auto &&d, IsQuakeValue auto &&q) {
   return q + d;
 }
-
+QuakeValue operator/(IsNumericType auto &&d, IsQuakeValue auto &&q) {
+  return q.inverse() * d;
+}
 } // namespace cudaq

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -141,6 +141,9 @@ public:
 
   /// @brief Subtract the given QuakeValue from this QuakeValue
   QuakeValue operator-(QuakeValue other);
+
+  /// @brief Return the inverse (1/x) of this QuakeValue
+  QuakeValue inverse() const;
 };
 
 /// @brief Concept constraining the input type below to be a QuakeValue

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -410,7 +410,7 @@ void forLoop(ImplicitLocOpBuilder &builder, Value &startVal, Value &end,
           Block &block) {
         Value iv = block.getArgument(0);
         // shift iv -> iv + start
-        iv = builder.create<arith::AddIOp>(iv.getType(), iv, startVal);
+        iv = builder.create<arith::AddIOp>(iv.getType(), iv, castStart);
         OpBuilder::InsertionGuard guard(nestedBuilder);
         QuakeValue idxQuakeVal(builder, iv);
         body(idxQuakeVal);


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
- Support division (resolved https://github.com/NVIDIA/cuda-quantum/issues/754)

- Fix bug in Quake `for_loop`: we missed a cast to index type when the start index is a `QuakeValue`.

- Also, fix first tutorial, showing the use of `expectation()` to retrieve the expectation result (dumping the result will show empty counts distribution since we don't do shots-based sampling).
