### PR TITLE
Implement a loop peeling pass.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -182,6 +182,31 @@ def LoopNormalize : Pass<"cc-loop-normalize"> {
   ];
 }
 
+def LoopPeeling : Pass<"cc-loop-peeling"> {
+  let summary = "Peeling classical do-while loops.";
+  let description = [{
+    This loop peeling pass currently implements the transformation of a C++
+    do-while loop into a peeled body and while sequence.
+
+    ```c++
+    do {
+      body;
+    } while (condition);
+    ```
+    is transformed to
+    ```c++
+    body;
+    while (condition) {
+      body;
+    }
+    ```
+
+    Other cases of loop peeling may be implemented in the future.
+  }];
+
+  let dependentDialects = ["mlir::cf::ControlFlowDialect"];
+}
+
 def LoopUnroll : Pass<"cc-loop-unroll"> {
   let summary = "Unroll classical compute (C++) loops.";
   let description = [{

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_cudaq_library(OptTransforms
   LambdaLifting.cpp
   LoopAnalysis.cpp
   LoopNormalize.cpp
+  LoopPeeling.cpp
   LoopUnroll.cpp
   LowerToCFG.cpp
   LowerUnwind.cpp

--- a/lib/Optimizer/Transforms/LoopPeeling.cpp
+++ b/lib/Optimizer/Transforms/LoopPeeling.cpp
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_LOOPPEELING
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "cc-loop-peeling"
+
+using namespace mlir;
+
+namespace {
+class LoopPat : public OpRewritePattern<cudaq::cc::LoopOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::cc::LoopOp loop,
+                                PatternRewriter &rewriter) const override {
+    if (!loop.isPostConditional())
+      return failure();
+    // Peel do-while loop and convert it to a while loop.
+    LLVM_DEBUG(llvm::dbgs() << "will peel do-while loop:\n"; loop.dump());
+
+    // Split the block after loop, old-loop-block and after-block.
+    Operation *nextOp = loop->getNextNode();
+    auto *oldLoopBlock = rewriter.getInsertionBlock();
+    auto loopPos = rewriter.getInsertionPoint();
+    auto *afterBlock =
+        rewriter.splitBlock(oldLoopBlock, Block::iterator{nextOp});
+
+    // Add terminator to old-loop-block: thread results of loop to after-block's
+    // arguments and replace the loop results uses.
+    for (auto res : loop.getResults())
+      afterBlock->addArgument(res.getType(), loop.getLoc());
+    rewriter.setInsertionPointToEnd(oldLoopBlock);
+    auto finalBranch = rewriter.create<cf::BranchOp>(loop.getLoc(), afterBlock,
+                                                     loop.getResults());
+    // NB: the results of the original loop are now split between the peeled
+    // copy of body and the modified new loop. Introduce explicit block
+    // arguments for the phi node functionality.
+    for (auto iter : llvm::enumerate(loop.getResults())) {
+      Value v = iter.value();
+      v.replaceUsesWithIf(
+          finalBranch.getDestOperands()[iter.index()],
+          [branch = finalBranch.getOperation()](OpOperand &opnd) {
+            auto *op = opnd.getOwner();
+            return op != branch;
+          });
+    }
+
+    // Split the block before loop, before-block and new-loop-block. Add branch
+    // arguments to new-loop-block corresponding to loop's region arguments.
+    auto *beforeBlock = oldLoopBlock;
+    auto *newLoopBlock = rewriter.splitBlock(oldLoopBlock, loopPos);
+    for (auto res : loop.getResults())
+      newLoopBlock->addArgument(res.getType(), loop.getLoc());
+    SmallVector<Value> loopArgs = loop.getOperands();
+    loop.getInitialArgsMutable().assign(newLoopBlock->getArguments());
+
+    // Clone the body region. Add branch from before-loop to the entry block of
+    // the cloned CFG.
+    rewriter.cloneRegionBefore(loop.getBodyRegion(), newLoopBlock);
+    Block *firstBlock = beforeBlock->getNextNode();
+    rewriter.setInsertionPointToEnd(beforeBlock);
+    rewriter.create<cf::BranchOp>(loop.getLoc(), firstBlock, loopArgs);
+
+    // Replace continue ops with branches to the new-loop-block. Replace break
+    // ops with branches to the after-block.
+    auto rewriteBranch = [&](auto op, Block *dest) {
+      rewriter.setInsertionPointToEnd(op->getBlock());
+      rewriter.create<cf::BranchOp>(op.getLoc(), dest, op.getOperands());
+      rewriter.eraseOp(op);
+    };
+    for (Block *b = firstBlock; b != newLoopBlock; b = b->getNextNode())
+      for (auto &op : *b) {
+        if (auto contOp = dyn_cast<cudaq::cc::ContinueOp>(op)) {
+          rewriteBranch(contOp, newLoopBlock);
+          break;
+        } else if (auto brkOp = dyn_cast<cudaq::cc::BreakOp>(op)) {
+          rewriteBranch(brkOp, afterBlock);
+          break;
+        }
+      }
+
+    // Turn the do-while into a while loop.
+    loop.setPostCondition(/*do-while=*/false);
+    LLVM_DEBUG({
+      llvm::dbgs() << "peeled loop:\n";
+      for (Block *b = firstBlock; b != afterBlock; b = b->getNextNode())
+        b->dump();
+    });
+    return success();
+  }
+};
+
+class LoopPeelingPass
+    : public cudaq::opt::impl::LoopPeelingBase<LoopPeelingPass> {
+public:
+  using LoopPeelingBase::LoopPeelingBase;
+
+  void runOnOperation() override {
+    auto *op = getOperation();
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<LoopPat>(ctx);
+    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+      op->emitOpError("could not peel loop");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace

--- a/test/Quake/loop_peeling.qke
+++ b/test/Quake/loop_peeling.qke
@@ -1,0 +1,147 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --cc-loop-peeling %s | FileCheck %s
+
+func.func @peel_do_while() {
+  %c1_i32 = arith.constant 1 : i32
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c10_i32 = arith.constant 10 : i32
+  %0 = quake.alloca !quake.veq<10>
+  %1 = cc.alloca i32
+  cc.store %c0_i32, %1 : !cc.ptr<i32>
+  %2 = cc.alloca i1
+  cc.loop do {
+    %3 = cc.load %1 : !cc.ptr<i32>
+    %4 = arith.addi %3, %c1_i32 : i32
+    cc.store %4, %1 : !cc.ptr<i32>
+    %5 = arith.extui %3 : i32 to i64
+    %6 = quake.extract_ref %0[%5] : (!quake.veq<10>, i64) -> !quake.ref
+    %bits = quake.mz %6 : (!quake.ref) -> i1
+    cc.store %bits, %2 : !cc.ptr<i1>
+    cc.continue
+  } while {
+    %3 = cc.load %2 : !cc.ptr<i1>
+    %4 = arith.cmpi eq, %3, %false : i1
+    %5 = cc.if(%4) -> i1 {
+      cc.continue %false : i1
+    } else {
+      %6 = cc.load %1 : !cc.ptr<i32>
+      %7 = arith.cmpi ult, %6, %c10_i32 : i32
+      cc.continue %7 : i1
+    }
+    cc.condition %5
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @peel_do_while() {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 10 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.veq<10>
+// CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca i32
+// CHECK-DAG:       cc.store %[[VAL_2]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK-DAG:       %[[VAL_6:.*]] = cc.alloca i1
+// CHECK:           cf.br ^bb1
+// CHECK:         ^bb1:
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_7]], %[[VAL_0]] : i32
+// CHECK:           cc.store %[[VAL_8]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_9:.*]] = arith.extui %[[VAL_7]] : i32 to i64
+// CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_9]]] : (!quake.veq<10>, i64) -> !quake.ref
+// CHECK:           %[[VAL_11:.*]] = quake.mz %[[VAL_10]] : (!quake.ref) -> i1
+// CHECK:           cc.store %[[VAL_11]], %[[VAL_6]] : !cc.ptr<i1>
+// CHECK:           cf.br ^bb2
+// CHECK:         ^bb2:
+// CHECK:           cc.loop while {
+// CHECK:             cc.if(%
+// CHECK:             cc.condition %
+// CHECK:           } do {
+// CHECK:             %[[VAL_18:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_0]] : i32
+// CHECK:             cc.store %[[VAL_19]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:             %[[VAL_20:.*]] = arith.extui %[[VAL_18]] : i32 to i64
+// CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_20]]] : (!quake.veq<10>, i64) -> !quake.ref
+// CHECK:             %[[VAL_22:.*]] = quake.mz %[[VAL_21]] : (!quake.ref) -> i1
+// CHECK:             cc.store %[[VAL_22]], %[[VAL_6]] : !cc.ptr<i1>
+// CHECK:             cc.continue
+// CHECK:           }
+// CHECK:           cf.br ^bb3
+// CHECK:         ^bb3:
+// CHECK:           return
+// CHECK:         }
+
+func.func @peel_do_while_with_args() {
+  %c10_i32 = arith.constant 10 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %false = arith.constant false
+  %c1_i32 = arith.constant 1 : i32
+  %0 = quake.alloca !quake.veq<10>
+  %1 = cc.undef i32
+  %2 = cc.undef i1
+  %3:2 = cc.loop do ((%arg0 = %c0_i32, %arg1 = %2) -> (i32, i1)) {
+    %4 = arith.addi %arg0, %c1_i32 : i32
+    %5 = arith.extui %arg0 : i32 to i64
+    %6 = quake.extract_ref %0[%5] : (!quake.veq<10>, i64) -> !quake.ref
+    %bits = quake.mz %6 : (!quake.ref) -> i1
+    cc.continue %4, %bits : i32, i1
+  } while {
+  ^bb0(%arg0: i32, %arg1: i1):
+    %4 = arith.cmpi eq, %arg1, %false : i1
+    %5 = cc.if(%4) -> i1 {
+      cc.continue %false : i1
+    } else {
+      %6 = arith.cmpi ult, %arg0, %c10_i32 : i32
+      cc.continue %6 : i1
+    }
+    cc.condition %5(%arg0, %arg1 : i32, i1)
+  }
+  quake.dealloc %0 : !quake.veq<10>
+  return
+}
+
+// CHECK-LABEL:   func.func @peel_do_while_with_args() {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 10 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.veq<10>
+// CHECK:           cf.br ^bb1(%[[VAL_2]] : i32)
+// CHECK:         ^bb1(%[[VAL_5:.*]]: i32):
+// CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[VAL_0]] : i32
+// CHECK:           %[[VAL_7:.*]] = arith.extui %[[VAL_5]] : i32 to i64
+// CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.veq<10>, i64) -> !quake.ref
+// CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_8]] : (!quake.ref) -> i1
+// CHECK:           cf.br ^bb2(%[[VAL_6]], %[[VAL_9]] : i32, i1)
+// CHECK:         ^bb2(%[[VAL_10:.*]]: i32, %[[VAL_11:.*]]: i1):
+// CHECK:           %[[VAL_12:.*]]:2 = cc.loop while ((%[[VAL_13:.*]] = %[[VAL_10]], %[[VAL_14:.*]] = %[[VAL_11]]) -> (i32, i1)) {
+// CHECK:             %[[VAL_15:.*]] = arith.cmpi eq, %[[VAL_14]], %[[VAL_1]] : i1
+// CHECK:             %[[VAL_16:.*]] = cc.if(%[[VAL_15]]) -> i1 {
+// CHECK:               cc.continue %[[VAL_1]] : i1
+// CHECK:             } else {
+// CHECK:               %[[VAL_17:.*]] = arith.cmpi ult, %[[VAL_13]], %[[VAL_3]] : i32
+// CHECK:               cc.continue %[[VAL_17]] : i1
+// CHECK:             }
+// CHECK:             cc.condition %[[VAL_18:.*]](%[[VAL_13]], %[[VAL_14]] : i32, i1)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_19:.*]]: i32, %[[VAL_20:.*]]: i1):
+// CHECK:             %[[VAL_21:.*]] = arith.addi %[[VAL_19]], %[[VAL_0]] : i32
+// CHECK:             %[[VAL_22:.*]] = arith.extui %[[VAL_19]] : i32 to i64
+// CHECK:             %[[VAL_23:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_22]]] : (!quake.veq<10>, i64) -> !quake.ref
+// CHECK:             %[[VAL_24:.*]] = quake.mz %[[VAL_23]] : (!quake.ref) -> i1
+// CHECK:             cc.continue %[[VAL_21]], %[[VAL_24]] : i32, i1
+// CHECK:           }
+// CHECK:           cf.br ^bb3
+// CHECK:         ^bb3:
+// CHECK:           quake.dealloc %[[VAL_4]] : !quake.veq<10>
+// CHECK:           return
+// CHECK:         }
+


### PR DESCRIPTION
This pass only implements a very resricted form of loop peeling. Specifically, a do-while loop is peeled and converted into a copy of the body of the do and a succeeding while loop.

The purpose of this transformation is to allow do-while loops to be converted to while loops. Once unrolling of general while loops is enabled, the compiler will be able to fully unroll a wider range of styles of loop statements.
