### PR TITLE
Added missing GIL-safe implementation for `pySampleAsync`

### DIFF
--- a/python/runtime/cudaq/algorithms/py_observe.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe.cpp
@@ -79,9 +79,17 @@ async_observe_result pyObserveAsync(kernel_builder<> &kernel,
   // and the validated args.
   std::size_t uniqueHash = hasher(kernel.name()) + hasher(py::str(args));
 
-  // Add the opaque args to the holder and pack the args into it
-  asyncArgsHolder.emplace(uniqueHash, std::make_unique<OpaqueArguments>());
-  packArgs(*asyncArgsHolder.at(uniqueHash).get(), validatedArgs);
+  // Add the opaque args to the holder and pack the args into it.
+  // Note: this pyObserveAsync is executed in a loop (over spin_operator slices)
+  // on the main Python thread, while posting functors to other threads
+  // (runObservationAsync below). These functors are expected to operate on the
+  // same (kernel + params) configuration, hence, making sure that we don't
+  // overwrite asyncArgsHolder while running the spin_operator slicing loop
+  // (this pyObserveAsync function).
+  if (asyncArgsHolder.find(uniqueHash) == asyncArgsHolder.end()) {
+    asyncArgsHolder.emplace(uniqueHash, std::make_unique<OpaqueArguments>());
+    packArgs(*asyncArgsHolder.at(uniqueHash).get(), validatedArgs);
+  }
 
   // TODO: would like to handle errors in the case that
   // `kernel.num_qubits() >= spin_operator.num_qubits()`

--- a/python/runtime/cudaq/algorithms/py_observe.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe.cpp
@@ -27,7 +27,9 @@ enum class PyParType { thread, mpi };
 /// @brief Default qpu id value set to 0
 constexpr int defaultQpuIdValue = 0;
 
-/// @brief For asynchronous execution, we need to construct OpaqueArguments
+/// @brief Global cache map of OpaqueArguments
+///
+/// For asynchronous execution, we need to construct OpaqueArguments
 /// outside of the async lambda invocation. If we don't, then we will be
 /// using Python types outside of the current GIL context. Bad things happen
 /// then.

--- a/python/runtime/cudaq/algorithms/py_sample.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample.cpp
@@ -23,10 +23,8 @@
 
 namespace cudaq {
 
-/// @brief For asynchronous execution, we need to construct OpaqueArguments
-/// outside of the async lambda invocation. If we don't, then we will be
-/// using Python types outside of the current GIL context. Bad things happen
-/// then. Using the same cache map provided by py_observe (hence extern).
+/// @brief Global cache map of OpaqueArguments
+// Using the same cache map provided by py_observe (hence extern).
 extern std::unordered_map<std::size_t, std::unique_ptr<OpaqueArguments>>
     asyncArgsHolder;
 

--- a/python/runtime/cudaq/algorithms/py_sample.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample.cpp
@@ -23,6 +23,13 @@
 
 namespace cudaq {
 
+/// @brief For asynchronous execution, we need to construct OpaqueArguments
+/// outside of the async lambda invocation. If we don't, then we will be
+/// using Python types outside of the current GIL context. Bad things happen
+/// then. Using the same cache map provided by py_observe (hence extern).
+extern std::unordered_map<std::size_t, std::unique_ptr<OpaqueArguments>>
+    asyncArgsHolder;
+
 /// @brief Sample the state produced by the provided builder.
 sample_result pySample(kernel_builder<> &builder, py::args args = {},
                        std::size_t shots = 1000,
@@ -91,12 +98,17 @@ async_sample_result pySampleAsync(kernel_builder<> &builder,
   cudaq::info("Asynchronously sampling the provided pythonic kernel.");
   builder.jitCode();
   auto kernelName = builder.name();
-
+  std::hash<std::string> hasher;
+  // Create a unique integer key that combines the kernel name
+  // and the validated args.
+  std::size_t uniqueHash = hasher(kernelName) + hasher(py::str(args));
+  // Add the opaque args to the holder and pack the args into it
+  asyncArgsHolder.emplace(uniqueHash, std::make_unique<OpaqueArguments>());
+  packArgs(*asyncArgsHolder.at(uniqueHash).get(), validatedArgs);
   return details::runSamplingAsync(
-      [&, a = std::move(validatedArgs)]() mutable {
-        OpaqueArguments argData;
-        packArgs(argData, a);
-        builder.jitAndInvoke(argData.data());
+      [&builder, uniqueHash]() mutable {
+        auto &argData = asyncArgsHolder.at(uniqueHash);
+        builder.jitAndInvoke(argData->data());
       },
       platform, kernelName, shots, qpu_id);
 }

--- a/python/tests/unittests/test_state.py
+++ b/python/tests/unittests/test_state.py
@@ -273,22 +273,22 @@ def test_state_vector_async():
 
     kernel, theta, phi = cudaq.make_kernel(float, float)
     qubits = kernel.qalloc(2)
-    kernel.rx(theta, qubits[0])
     kernel.ry(phi, qubits[0])
+    kernel.rx(theta, qubits[0])
     kernel.cx(qubits[0], qubits[1])
-    kernel.mz(qubits)
 
     # Creating the bell state with rx and ry instead of hadamard
     # need a pi rotation and a pi/2 rotation
+    # Note: rx(pi)ry(pi/2) == -i*H (with a global phase)
     future = cudaq.get_state_async(kernel, np.pi, np.pi / 2.)
-    want_state = np.array([1. / np.sqrt(2.), 0., 0., 1. / np.sqrt(2.)],
+    want_state = np.array([-1j / np.sqrt(2.), 0., 0., -1j / np.sqrt(2.)],
                           dtype=np.complex128)
     state = future.get()
-    assert np.allclose(want_state, want_state, atol=1e-3)
+    assert np.allclose(state, want_state, atol=1e-3)
     # Check invalid qpu_id
     with pytest.raises(Exception) as error:
         # Invalid qpu_id type.
-        result = cudaq.sample_async(kernel, 0.0, 0.0, qpu_id=12)
+        result = cudaq.get_state_async(kernel, 0.0, 0.0, qpu_id=12)
 
 
 # leave for gdb debugging

--- a/runtime/cudaq/algorithms/state.h
+++ b/runtime/cudaq/algorithms/state.h
@@ -107,8 +107,9 @@ auto runGetStateAsync(KernelFunctor &&wrappedKernel,
         context.asyncExec = true;
         // Set the platform and the qpu id.
         platform.set_exec_ctx(&context, qpu_id);
+        platform.set_current_qpu(qpu_id);
         func();
-        platform.reset_exec_ctx();
+        platform.reset_exec_ctx(qpu_id);
         // Extract state data
         p.set_value(state(context.simulationData));
       });

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -699,7 +699,7 @@ public:
                     std::vector<std::string> extraLibPaths = {}) {
     static std::mutex jitMutex;
     {
-      std::scoped_lock lock(jitMutex);
+      std::scoped_lock<std::mutex> lock(jitMutex);
       // Scoped locking since jitCode is not thread-safe while this jitAndInvoke
       // can be invoked by kernel_builder::operator()(Args... args) in a
       // multi-threaded context.

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -16,6 +16,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <variant>
@@ -696,7 +697,14 @@ public:
   /// @brief Invoke JIT compilation and extract a function pointer and execute.
   void jitAndInvoke(void **argsArray,
                     std::vector<std::string> extraLibPaths = {}) {
-    jitCode(extraLibPaths);
+    static std::mutex jitMutex;
+    {
+      std::scoped_lock lock(jitMutex);
+      // Scoped locking since jitCode is not thread-safe while this jitAndInvoke
+      // can be invoked by kernel_builder::operator()(Args... args) in a
+      // multi-threaded context.
+      jitCode(extraLibPaths);
+    }
     details::invokeCode(*opBuilder, jitEngine.get(), kernelName, argsArray,
                         extraLibPaths);
   }

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -95,6 +95,7 @@ if (CUSTATEVEC_ROOT AND CUDA_FOUND)
   target_link_libraries(test_mqpu
     PRIVATE 
     cudaq
+    cudaq-builder
     cudaq-platform-mqpu
     nvqir-custatevec-fp64
     gtest_main)


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Converting Python args to native data before passing it to the async sample functor. We've implemented it for `observe_async`, hence adopting it for `pySampleAsync`.

Addressed https://github.com/NVIDIA/cuda-quantum/issues/640.