### PR TITLE
Support 2-d broadcast for observe

### DIFF
--- a/python/runtime/cudaq/algorithms/py_observe.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe.cpp
@@ -330,6 +330,8 @@ with respect to `kernel(*arguments)`. Each argument in `arguments` provided
 can be a list or ndarray of arguments of the specified kernel argument
 type, and in this case, the `observe` functionality will be broadcasted over
 all argument sets and a list of `observe_result` instances will be returned.
+If both the input `spin_operator` and `arguments` are broadcast lists, 
+a nested list of results over `arguments` then `spin_operator` will be returned.
 
 Args:
   kernel (:class:`Kernel`): The :class:`Kernel` to evaluate the 

--- a/python/runtime/cudaq/algorithms/py_observe.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe.cpp
@@ -302,7 +302,6 @@ void bindObserve(py::module &mod) {
           return results;
         }
 
-        // Return the vector of results, this is for observe_n
         // Check if this is a nested broadcast (sweeping both spin_op and
         // params). If so, peel the results: first index is param sweep, second
         // index is spin_op.
@@ -317,6 +316,7 @@ void bindObserve(py::module &mod) {
           }
           return results;
         }
+        // Return the vector of results, this is for observe_n
         return {result};
       },
       py::arg("kernel"), py::arg("spin_operator"), py::kw_only(),


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
We infer the type of broadcasting in `args` vs. array of `args` and `spin_op` vs. array of `spin_op` when handling Python `observe`.
However, we didn't handle a combination of them. 

This PR:

- Allow Python `observe` to return a nested vector. Peel off the `spin_op` sum result to construct the nested result.

- Add a unit test case.

Resolved https://github.com/NVIDIA/cuda-quantum/issues/776