### PR TITLE
Modifying default target to be GPU, if present

### DIFF
--- a/docs/sphinx/examples/python/tutorials/multi_gpu_workflows.ipynb
+++ b/docs/sphinx/examples/python/tutorials/multi_gpu_workflows.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "### Available Targets\n",
     "\n",
-    "- **default**: The default qpp based CPU backend which is multithreaded to maximise the usage of available cores on your system.\n",
+    "- **qpp-cpu**: The qpp based CPU backend which is multithreaded to maximize the usage of available cores on your system.\n",
     "\n",
     "- **nvidia**: GPU based backend which accelerates quantum circuit simulation on NVIDIA GPUs powered by cuQuantum.\n",
     "\n",
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Default CPU Backend"
+    "### QPP-based CPU Backend"
    ]
   },
   {
@@ -93,7 +93,7 @@
     }
    ],
    "source": [
-    "cpu_result = ghz_state(n_qubits=2, target=\"default\")\n",
+    "cpu_result = ghz_state(n_qubits=2, target=\"qpp-cpu\")\n",
     "\n",
     "cpu_result.dump()"
    ]

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -9,6 +9,7 @@
 import sys
 import os, os.path
 from ._packages import *
+from ._query_gpu import is_gpu_available
 
 if not "CUDAQ_DYNLIBS" in os.environ:
     try:
@@ -28,7 +29,9 @@ if not "CUDAQ_DYNLIBS" in os.environ:
 from ._pycudaq import *
 from .domains import chemistry
 
-initKwargs = {'target': 'default'}
+initKwargs = {'target': 'qpp-cpu'}
+if is_gpu_available():
+    initKwargs = {'target': 'nvidia'}
 
 if '-target' in sys.argv:
     initKwargs['target'] = sys.argv[sys.argv.index('-target') + 1]

--- a/python/cudaq/_query_gpu.py
+++ b/python/cudaq/_query_gpu.py
@@ -11,13 +11,16 @@ from pathlib import Path
 import subprocess
 
 # Install directory is wherever this script is and up one directory
-install_dir=Path(__file__).parent.parent.resolve()
+install_dir = Path(__file__).parent.parent.resolve()
+
 
 def is_gpu_available():
     try:
-        gpu_list = subprocess.check_output(["nvidia-smi", "-L"], encoding="utf-8")
+        gpu_list = subprocess.check_output(["nvidia-smi", "-L"],
+                                           encoding="utf-8")
         ngpus = len(gpu_list.splitlines())
-        lib_path = Path(os.path.join(install_dir, "lib/libnvqir-custatevec-fp32.so"))
+        lib_path = Path(
+            os.path.join(install_dir, "lib/libnvqir-custatevec-fp32.so"))
         if ngpus > 0 and lib_path.is_file():
             return True
     except Exception:

--- a/python/cudaq/_query_gpu.py
+++ b/python/cudaq/_query_gpu.py
@@ -1,0 +1,25 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import os
+from pathlib import Path
+import subprocess
+
+# Install directory is wherever this script is and up one directory
+install_dir=Path(__file__).parent.parent.resolve()
+
+def is_gpu_available():
+    try:
+        gpu_list = subprocess.check_output(["nvidia-smi", "-L"], encoding="utf-8")
+        ngpus = len(gpu_list.splitlines())
+        lib_path = Path(os.path.join(install_dir, "lib/libnvqir-custatevec-fp32.so"))
+        if ngpus > 0 and lib_path.is_file():
+            return True
+    except Exception:
+        pass
+    return False

--- a/python/runtime/cudaq/target/py_runtime_target.cpp
+++ b/python/runtime/cudaq/target/py_runtime_target.cpp
@@ -28,10 +28,10 @@ void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
       .def_readonly("simulator", &cudaq::RuntimeTarget::simulatorName,
                     "The name of the simulator this `cudaq.Target` leverages. "
                     "This will be empty for physical QPUs.")
-      .def_readonly("platform", &cudaq::RuntimeTarget::simulatorName,
+      .def_readonly("platform", &cudaq::RuntimeTarget::platformName,
                     "The name of the quantum_platform implementation this "
                     "`cudaq.Target` leverages.")
-      .def_readonly("description", &cudaq::RuntimeTarget::simulatorName,
+      .def_readonly("description", &cudaq::RuntimeTarget::description,
                     "A string describing the features for this `cudaq.Target`.")
       .def("num_qpus", &cudaq::RuntimeTarget::num_qpus,
            "Return the number of QPUs available in this `cudaq.Target`.")

--- a/python/tests/unittests/test_qpp_target.py
+++ b/python/tests/unittests/test_qpp_target.py
@@ -1,0 +1,28 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import pytest
+
+import cudaq
+
+def test_cpu_only_target():
+    """Tests the QPP-based CPU-only target"""
+
+    cudaq.set_target("qpp-cpu")
+    print(cudaq.get_target().name)
+
+    kernel = cudaq.make_kernel()
+    qubits = kernel.qalloc(2)
+    kernel.h(qubits[0])
+    kernel.cx(qubits[0], qubits[1])
+    kernel.mz(qubits)
+
+    result = cudaq.sample(kernel)
+    result.dump()
+    assert '00' in result
+    assert '11' in result

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -212,9 +212,9 @@ LinkedLibraryHolder::LinkedLibraryHolder() {
     }
   }
 
-  targets.emplace("default",
-                  RuntimeTarget{"default", "qpp", "default",
-                                "Default OpenMP CPU-only simulated QPU."});
+  targets.emplace("qpp-cpu",
+                  RuntimeTarget{"qpp-cpu", "qpp", "default",
+                                "QPP-based CPU-only simulated QPU."});
 
   if (disallowTargetModification)
     return;
@@ -253,15 +253,7 @@ LinkedLibraryHolder::getPlatform(const std::string &platformName) {
       std::string("getQuantumPlatform_") + platformName);
 }
 
-void LinkedLibraryHolder::resetTarget() {
-  // TODO: create config for default target and use setTarget("qpp") here,
-  // instead of having this be a code duplication of the logic below.
-  __nvqir__setCircuitSimulator(getSimulator("qpp"));
-  auto *platform = getPlatform("default");
-  platform->setTargetBackend("qpp");
-  setQuantumPlatformInternal(platform);
-  currentTarget = "default";
-}
+void LinkedLibraryHolder::resetTarget() { setTarget("qpp-cpu"); }
 
 RuntimeTarget LinkedLibraryHolder::getTarget(const std::string &name) const {
   auto iter = targets.find(name);

--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -65,7 +65,7 @@ protected:
   std::unordered_map<std::string, RuntimeTarget> targets;
 
   /// @brief Store the name of the current target
-  std::string currentTarget = "default";
+  std::string currentTarget = "qpp-cpu";
 
 public:
   LinkedLibraryHolder();

--- a/runtime/cudaq/platform/default/nvidia-fp64.config
+++ b/runtime/cudaq/platform/default/nvidia-fp64.config
@@ -1,3 +1,11 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
 msg=""
 
 gpu_found=$(query_gpu)

--- a/runtime/cudaq/platform/default/nvidia-fp64.config
+++ b/runtime/cudaq/platform/default/nvidia-fp64.config
@@ -1,19 +1,10 @@
 msg=""
-if [ -x "$(command -v nvidia-smi)" ]; then
-	# Make sure nvidia-smi works.
-	nvidia-smi -L | grep 'Failed\|Error\|error\|failed' >/dev/null 2>&1
-	if [ $? != 0 ]; then
-		ngpus=$(nvidia-smi -L | wc -l)
-		if [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ] && [ $((ngpus > 0)) != 0 ]; then
-			NVQIR_SIMULATION_BACKEND="custatevec-fp64"
-		else
-		    msg="libnvqir-custatevec-fp64 is not installed, or there are no NVIDIA GPUs."
-		fi
-	else
-	  msg="nvidia-smi failed with \"$(nvidia-smi -L)\""
-	fi
-else 
-    msg="nvidia-smi command not found."
+
+gpu_found=$(query_gpu)
+if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ]; then
+	NVQIR_SIMULATION_BACKEND="custatevec-fp64"
+else
+	msg="libnvqir-custatevec-fp64 is not installed, or there are no NVIDIA GPUs."
 fi
 
 if [ "${NVQIR_SIMULATION_BACKEND}" = "qpp" ]; then 

--- a/runtime/cudaq/platform/default/nvidia-fp64.config
+++ b/runtime/cudaq/platform/default/nvidia-fp64.config
@@ -1,7 +1,7 @@
 msg=""
 
 gpu_found=$(query_gpu)
-if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ]; then
+if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ]; then
 	NVQIR_SIMULATION_BACKEND="custatevec-fp64"
 else
 	msg="libnvqir-custatevec-fp64 is not installed, or there are no NVIDIA GPUs."

--- a/runtime/cudaq/platform/default/nvidia.config
+++ b/runtime/cudaq/platform/default/nvidia.config
@@ -1,3 +1,11 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
 msg=""
 
 gpu_found=$(query_gpu)

--- a/runtime/cudaq/platform/default/nvidia.config
+++ b/runtime/cudaq/platform/default/nvidia.config
@@ -1,19 +1,10 @@
 msg=""
-if [ -x "$(command -v nvidia-smi)" ]; then
-	# Make sure nvidia-smi works.
-	nvidia-smi -L | grep 'Failed\|Error\|error\|failed' >/dev/null 2>&1
-	if [ $? != 0 ]; then
-		ngpus=$(nvidia-smi -L | wc -l)
-		if [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ] && [ $((ngpus > 0)) != 0 ]; then
-			NVQIR_SIMULATION_BACKEND="custatevec-fp32"
-		else
-		    msg="libnvqir-custatevec-fp32 is not installed, or there are no NVIDIA GPUs."
-		fi
-	else
-	  msg="nvidia-smi failed with \"$(nvidia-smi -L)\""
-	fi
-else 
-    msg="nvidia-smi command not found."
+
+gpu_found=$(query_gpu)
+if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
+	NVQIR_SIMULATION_BACKEND="custatevec-fp32"
+else
+	msg="libnvqir-custatevec-fp32 is not installed, or there are no NVIDIA GPUs."
 fi
 
 if [ "${NVQIR_SIMULATION_BACKEND}" = "qpp" ]; then 

--- a/runtime/cudaq/platform/default/nvidia.config
+++ b/runtime/cudaq/platform/default/nvidia.config
@@ -1,7 +1,7 @@
 msg=""
 
 gpu_found=$(query_gpu)
-if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
+if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
 	NVQIR_SIMULATION_BACKEND="custatevec-fp32"
 else
 	msg="libnvqir-custatevec-fp32 is not installed, or there are no NVIDIA GPUs."

--- a/runtime/cudaq/platform/mqpu/nvidia-mqpu-fp64.config
+++ b/runtime/cudaq/platform/mqpu/nvidia-mqpu-fp64.config
@@ -1,3 +1,11 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
 msg=""
 
 gpu_found=$(query_gpu)

--- a/runtime/cudaq/platform/mqpu/nvidia-mqpu-fp64.config
+++ b/runtime/cudaq/platform/mqpu/nvidia-mqpu-fp64.config
@@ -1,19 +1,10 @@
 msg=""
-if [ -x "$(command -v nvidia-smi)" ]; then
-	# Make sure nvidia-smi works.
-	nvidia-smi -L | grep 'Failed\|Error\|error\|failed' >/dev/null 2>&1
-	if [ $? != 0 ]; then
-		ngpus=$(nvidia-smi -L | wc -l)
-		if [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ] && [ $((ngpus > 0)) != 0 ]; then
-			NVQIR_SIMULATION_BACKEND="custatevec-fp64"
-		else
-		    msg="libnvqir-custatevec-fp64 is not installed, or there are no NVIDIA GPUs."
-		fi
-	else
-	  msg="nvidia-smi failed with \"$(nvidia-smi -L)\""
-	fi
-else 
-    msg="nvidia-smi command not found."
+
+gpu_found=$(query_gpu)
+if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ]; then
+	NVQIR_SIMULATION_BACKEND="custatevec-fp64"
+else
+	msg="libnvqir-custatevec-fp64 is not installed, or there are no NVIDIA GPUs."
 fi
 
 if [ "${NVQIR_SIMULATION_BACKEND}" = "qpp" ]; then 

--- a/runtime/cudaq/platform/mqpu/nvidia-mqpu-fp64.config
+++ b/runtime/cudaq/platform/mqpu/nvidia-mqpu-fp64.config
@@ -1,7 +1,7 @@
 msg=""
 
 gpu_found=$(query_gpu)
-if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ]; then
+if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ]; then
 	NVQIR_SIMULATION_BACKEND="custatevec-fp64"
 else
 	msg="libnvqir-custatevec-fp64 is not installed, or there are no NVIDIA GPUs."

--- a/runtime/cudaq/platform/mqpu/nvidia-mqpu.config
+++ b/runtime/cudaq/platform/mqpu/nvidia-mqpu.config
@@ -1,6 +1,6 @@
 msg=""
 gpu_found=$(query_gpu)
-if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
+if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
 	NVQIR_SIMULATION_BACKEND="custatevec-fp32"
 else
 	msg="libnvqir-custatevec-fp32 is not installed, or there are no NVIDIA GPUs."

--- a/runtime/cudaq/platform/mqpu/nvidia-mqpu.config
+++ b/runtime/cudaq/platform/mqpu/nvidia-mqpu.config
@@ -1,19 +1,9 @@
 msg=""
-if [ -x "$(command -v nvidia-smi)" ]; then
-	# Make sure nvidia-smi works.
-	nvidia-smi -L | grep 'Failed\|Error\|error\|failed' >/dev/null 2>&1
-	if [ $? != 0 ]; then
-		ngpus=$(nvidia-smi -L | wc -l)
-		if [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ] && [ $((ngpus > 0)) != 0 ]; then
-			NVQIR_SIMULATION_BACKEND="custatevec-fp32"
-		else
-		    msg="libnvqir-custatevec-fp32 is not installed, or there are no NVIDIA GPUs."
-		fi
-	else
-	  msg="nvidia-smi failed with \"$(nvidia-smi -L)\""
-	fi
-else 
-    msg="nvidia-smi command not found."
+gpu_found=$(query_gpu)
+if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
+	NVQIR_SIMULATION_BACKEND="custatevec-fp32"
+else
+	msg="libnvqir-custatevec-fp32 is not installed, or there are no NVIDIA GPUs."
 fi
 
 if [ "${NVQIR_SIMULATION_BACKEND}" = "qpp" ]; then 

--- a/runtime/cudaq/platform/mqpu/nvidia-mqpu.config
+++ b/runtime/cudaq/platform/mqpu/nvidia-mqpu.config
@@ -1,3 +1,11 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
 msg=""
 gpu_found=$(query_gpu)
 if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then

--- a/runtime/nvqir/qpp/CMakeLists.txt
+++ b/runtime/nvqir/qpp/CMakeLists.txt
@@ -49,4 +49,5 @@ endmacro()
 AddQppBackend(nvqir-qpp QppCircuitSimulator.cpp)
 AddQppBackend(nvqir-dm QppDMCircuitSimulator.cpp)
 
+add_target_config(qpp-cpu)
 add_target_config(density-matrix-cpu)

--- a/runtime/nvqir/qpp/density-matrix-cpu.config
+++ b/runtime/nvqir/qpp/density-matrix-cpu.config
@@ -1,2 +1,10 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
 NVQIR_SIMULATION_BACKEND="dm"
 TARGET_DESCRIPTION="The Density Matrix CPU Target provides a simulated QPU via OpenMP-enabled, CPU-only density matrix emulation."

--- a/runtime/nvqir/qpp/qpp-cpu.config
+++ b/runtime/nvqir/qpp/qpp-cpu.config
@@ -1,0 +1,2 @@
+NVQIR_SIMULATION_BACKEND="qpp"
+TARGET_DESCRIPTION="QPP-based CPU-only backend target"

--- a/runtime/nvqir/qpp/qpp-cpu.config
+++ b/runtime/nvqir/qpp/qpp-cpu.config
@@ -1,2 +1,10 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
 NVQIR_SIMULATION_BACKEND="qpp"
 TARGET_DESCRIPTION="QPP-based CPU-only backend target"

--- a/test/NVQPP/qpp_cpu_target.cpp
+++ b/test/NVQPP/qpp_cpu_target.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ --target qpp-cpu %s -o %basename_t.x && ./%basename_t.x
+
+#include <cudaq.h>
+
+struct ghz {
+  auto operator()(int N) __qpu__ {
+    cudaq::qreg q(N);
+    h(q[0]);
+    for (int i = 0; i < N - 1; i++) {
+      x<cudaq::ctrl>(q[i], q[i + 1]);
+    }
+    mz(q);
+  }
+};
+
+int main() {
+  auto counts = cudaq::sample(ghz{}, 4);
+  counts.dump();
+  return 0;
+}

--- a/tools/nvqpp/backendConfig.cpp
+++ b/tools/nvqpp/backendConfig.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 /// This file is meant to be used by the nvq++ driver script, the
-/// NVQPP_QPUD_BACKEND_CONFIG string must be replaced (e.g. with sed)
+/// NVQPP_TARGET_BACKEND_CONFIG string must be replaced (e.g. with sed)
 /// with the actual target backend string.
 namespace cudaq {
 void set_target_backend(const char *);

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -43,6 +43,21 @@ function list_targets {
 	exit 0
 }
 
+function query_gpu {
+	if [ -x "$(command -v nvidia-smi)" ]; then
+		# Make sure nvidia-smi works.
+		nvidia-smi -L | grep 'Failed\|Error\|error\|failed' >/dev/null 2>&1
+		if [ $? != 0 ]; then
+			ngpus=$(nvidia-smi -L | wc -l)
+			if [ $((ngpus > 0)) != 0 ]; then
+				echo true
+				return
+			fi
+		fi
+	fi
+	echo false
+}
+
 function show_help {
 	cat - <<HELP
 --llvm-version=<vers>
@@ -211,10 +226,6 @@ then
   done 
 fi
 
-# Provide a default backend, user can override
-NVQIR_SIMULATION_BACKEND="qpp"
-NVQIR_LIBS="-lnvqir -lnvqir-"
-
 CUDAQ_EMULATE_REMOTE=false
 CLANG_VERBOSE=
 OUTPUTOPTS=
@@ -240,6 +251,15 @@ CUDAQ_QUAKE_DEBUG=
 SHOW_HELP=false
 LIST_TARGETS=false
 DISABLE_QUBIT_MAPPING=false
+NVQIR_LIBS="-lnvqir -lnvqir-"
+
+# Provide a default backend, user can override
+NVQIR_SIMULATION_BACKEND="qpp"
+# Check availability of NVIDA GPU(s)
+gpu_found=$(query_gpu)
+if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
+	NVQIR_SIMULATION_BACKEND="custatevec-fp32"
+fi
 
 # We default to LIBRARY_MODE, physical 
 # Quantum Targets can override this to turn on 

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -257,7 +257,7 @@ NVQIR_LIBS="-lnvqir -lnvqir-"
 NVQIR_SIMULATION_BACKEND="qpp"
 # Check availability of NVIDA GPU(s)
 gpu_found=$(query_gpu)
-if [ "$gpu_found" = true ] && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
+if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
 	NVQIR_SIMULATION_BACKEND="custatevec-fp32"
 fi
 


### PR DESCRIPTION
* Default to GPU state-vector simulator when GPU is detected and to the CPU simulator otherwise.
* Refactored the check for GPUs into a common function.

Checklist:
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] Works for CUDA Quantum in C++
- [x] Works for CUDA Quantum in Python


