### PR TITLE
Re-enable diagnostics for invalid kernel argument types.

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -336,7 +336,7 @@ public:
     // inferring a type.
     return TraverseType(t->desugar());
   }
-  bool TraverseNestedNameSpecifier(clang::NestedNameSpecifier *s) {
+  bool TraverseNestedNameSpecifier(clang::NestedNameSpecifier *) {
     return true;
   }
   bool TraverseDecltypeType(clang::DecltypeType *t) {

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -208,6 +208,16 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
         return pushType(refTy);
       return pushType(cc::PointerType::get(ctx, refTy));
     }
+    if (name.equals("basic_string")) {
+      if (allowUnknownRecordType) {
+        // Kernel argument list contains a `std::string` type. Intercept it and
+        // generate a clang diagnostic when returning out of determining the
+        // kernel's type signature.
+        return true;
+      }
+      TODO_x(toLocation(x), x, mangler, "std::string type");
+      return false;
+    }
     if (ignoredClass(x))
       return true;
     LLVM_DEBUG(llvm::dbgs()

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -218,6 +218,18 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
       TODO_x(toLocation(x), x, mangler, "std::string type");
       return false;
     }
+    if (name.equals("pair")) {
+      if (allowUnknownRecordType)
+        return true;
+      TODO_x(toLocation(x), x, mangler, "std::pair type");
+      return false;
+    }
+    if (name.equals("tuple")) {
+      if (allowUnknownRecordType)
+        return true;
+      TODO_x(toLocation(x), x, mangler, "std::tuple type");
+      return false;
+    }
     if (ignoredClass(x))
       return true;
     LLVM_DEBUG(llvm::dbgs()

--- a/lib/Frontend/nvqpp/ConvertType.cpp
+++ b/lib/Frontend/nvqpp/ConvertType.cpp
@@ -104,14 +104,16 @@ bool QuakeBridgeVisitor::TraverseRecordType(clang::RecordType *t) {
   if (!result)
     return false;
   if (typeStack.size() != typeStackDepth + 1) {
-    if (typeStack.size() != typeStackDepth) {
+    if (allowUnknownRecordType) {
+      // This is a kernel's type signature, so add a NoneType. When finally
+      // returning out of determining the kernel's type signature, a clang error
+      // diagnsotic will be reported.
+      pushType(noneTy);
+    } else if (typeStack.size() != typeStackDepth) {
       emitWarning(toLocation(recDecl),
                   "compiler encountered type traversal issue");
       return false;
-    }
-    if (allowUnknownRecordType)
-      pushType(noneTy);
-    else {
+    } else {
       recDecl->dump();
       emitFatalError(toLocation(recDecl), "expected a type");
     }

--- a/test/AST-error/kernel_invalid_argument-1.cpp
+++ b/test/AST-error/kernel_invalid_argument-1.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake -verify %s
+
+#include <cudaq.h>
+#include <string>
+#include <tuple>
+
+// expected-error@+1{{kernel argument type not supported}}
+void prepQubit(std::string basis, cudaq::qubit &q) __qpu__ {}
+
+// expected-error@+1{{kernel argument type not supported}}
+void RzArcTan2(bool input, std::string basis) __qpu__ {
+  cudaq::qubit aux;
+  cudaq::qubit resource;
+  cudaq::qubit target;
+  if (input) {
+    x(target);
+  }
+  prepQubit(basis, target);
+}
+
+int main() {
+  RzArcTan2(true, {});
+  return 0;
+}

--- a/test/AST-error/kernel_invalid_argument-2.cpp
+++ b/test/AST-error/kernel_invalid_argument-2.cpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake -verify %s
+
+#include <bitset>
+#include <cudaq.h>
+#include <iostream>
+#include <random>
+
+template <int nrOfBits>
+std::bitset<nrOfBits> random_bits() {
+
+  std::bitset<nrOfBits> randomBits;
+
+  std::default_random_engine generator;
+  std::uniform_real_distribution<float> distribution(0.0, 1.0);
+
+  float randNum;
+  for (size_t i = 0; i < nrOfBits; i++) {
+    randNum = distribution(generator);
+    if (randNum < 0.5) {
+      randNum = 0;
+    } else {
+      randNum = 1;
+    }
+    randomBits.set(i, randNum);
+  }
+  return randomBits;
+}
+
+template <int nrOfBits>
+struct oracle {
+  // expected-error@+1{{kernel argument type not supported}}
+  auto operator()(std::bitset<nrOfBits> bitvector, cudaq::qspan<> qs,
+                  cudaq::qubit &aux) __qpu__ {
+
+    for (size_t i = 0; i < nrOfBits; i++) {
+      if (bitvector[i] & 1) {
+        x<cudaq::ctrl>(qs[nrOfBits - i - 1], aux);
+      }
+    }
+  }
+};
+
+template <int nrOfBits>
+struct bernstein_vazirani {
+  // expected-error@+1{{kernel argument type not supported}}
+  auto operator()(std::bitset<nrOfBits> bitvector) __qpu__ {
+
+    cudaq::qreg<nrOfBits> qs;
+    cudaq::qubit aux;
+    h(aux);
+    z(aux);
+    h(qs);
+
+    oracle<nrOfBits>{}(bitvector, qs, aux);
+    h(qs);
+    mz(qs);
+  }
+};
+
+int main() {
+  // The number of qubits can be increased when targeting the `nvidia-mgpu`
+  // backend.
+  const int nr_qubits = 5;
+  auto bitvector = random_bits<nr_qubits>();
+  auto kernel = bernstein_vazirani<nr_qubits>{};
+  auto counts = cudaq::sample(kernel, bitvector);
+
+  if (!cudaq::mpi::is_initialized() || cudaq::mpi::rank() == 0) {
+    printf("Encoded bitstring:  %s\n", bitvector.to_string().c_str());
+    printf("Measured bitstring: %s\n\n", counts.most_probable().c_str());
+
+    for (auto &[bits, count] : counts) {
+      printf("observed %s (probability %u%%)\n", bits.data(),
+             100 * (uint)((double)count / 1000.));
+    }
+  }
+
+  return 0;
+}

--- a/test/AST-error/kernel_invalid_argument-3.cpp
+++ b/test/AST-error/kernel_invalid_argument-3.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake -verify %s
+
+#include <cudaq.h>
+#include <string>
+#include <tuple>
+
+// expected-error@+1{{kernel argument type not supported}}
+void prepQubit(std::pair<int, double> basis, cudaq::qubit &q) __qpu__ {}
+
+// expected-error@+1{{kernel argument type not supported}}
+void RzArcTan2(bool input, std::pair<int, double> basis) __qpu__ {
+  cudaq::qubit aux;
+  cudaq::qubit resource;
+  cudaq::qubit target;
+  if (input) {
+    x(target);
+  }
+  prepQubit(basis, target);
+}
+
+int main() {
+  RzArcTan2(true, {});
+  return 0;
+}

--- a/test/AST-error/kernel_invalid_argument-4.cpp
+++ b/test/AST-error/kernel_invalid_argument-4.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake -verify %s
+
+#include <cudaq.h>
+#include <string>
+#include <tuple>
+
+// expected-error@+1{{kernel argument type not supported}}
+void prepQubit(std::tuple<bool, float, unsigned> basis,
+               cudaq::qubit &q) __qpu__ {}
+
+// expected-error@+1{{kernel argument type not supported}}
+void RzArcTan2(bool input, std::tuple<bool, float, unsigned> basis) __qpu__ {
+  cudaq::qubit aux;
+  cudaq::qubit resource;
+  cudaq::qubit target;
+  if (input) {
+    x(target);
+  }
+  prepQubit(basis, target);
+}
+
+int main() {
+  RzArcTan2(true, {});
+  return 0;
+}


### PR DESCRIPTION
Add a couple of tests that issue clang diagnostics about unsupported kernel argument types. This re-enables functionality that had been disabled.
