### PR TITLE
Fix compiler crash when casting from floating to boolean

### DIFF
--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -664,7 +664,7 @@ bool QuakeBridgeVisitor::VisitImplicitCastExpr(clang::ImplicitCastExpr *x) {
     Value zero = builder.create<arith::ConstantFloatOp>(
         loc, llvm::APFloat(0.0), cast<FloatType>(last.getType()));
     return pushValue(builder.create<arith::CmpFOp>(
-        loc, arith::CmpFPredicate::ONE, last, zero));
+        loc, arith::CmpFPredicate::UNE, last, zero));
   }
   case clang::CastKind::CK_UserDefinedConversion: {
     auto sub = popValue();

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -659,6 +659,13 @@ bool QuakeBridgeVisitor::VisitImplicitCastExpr(clang::ImplicitCastExpr *x) {
     return pushValue(builder.create<arith::CmpIOp>(
         loc, arith::CmpIPredicate::ne, last, zero));
   }
+  case clang::CastKind::CK_FloatingToBoolean: {
+    auto last = popValue();
+    Value zero = builder.create<arith::ConstantFloatOp>(
+        loc, llvm::APFloat(0.0), cast<FloatType>(last.getType()));
+    return pushValue(builder.create<arith::CmpFOp>(
+        loc, arith::CmpFPredicate::ONE, last, zero));
+  }
   case clang::CastKind::CK_UserDefinedConversion: {
     auto sub = popValue();
     // castToTy is the converion function signature.

--- a/test/AST-Quake/cast.cpp
+++ b/test/AST-Quake/cast.cpp
@@ -32,7 +32,7 @@ struct testCast {
 // CHECK:           %[[VAL_5:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_7:.*]] = arith.cmpf one, %[[VAL_6]], %[[VAL_0]] : f64
+// CHECK:           %[[VAL_7:.*]] = arith.cmpf une, %[[VAL_6]], %[[VAL_0]] : f64
 // CHECK:           cc.if(%[[VAL_7]]) {
 // CHECK:             quake.x %[[VAL_2]] : (!quake.ref) -> ()
 // CHECK:           }

--- a/test/AST-Quake/cast.cpp
+++ b/test/AST-Quake/cast.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | FileCheck %s
+
+#include <cudaq.h>
+
+struct testCast {
+  void operator()() __qpu__ {
+    cudaq::qubit q0, q1;
+    h(q0);    
+    double bit = mz(q0);
+    // This tests implicit casting from double to bool
+    if (bit)
+      x(q1);
+    mz(q1);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__testCast() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_4:.*]] = arith.uitofp %[[VAL_3]] : i1 to f64
+// CHECK:           %[[VAL_5:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_7:.*]] = arith.cmpf one, %[[VAL_6]], %[[VAL_0]] : f64
+// CHECK:           cc.if(%[[VAL_7]]) {
+// CHECK:             quake.x %[[VAL_2]] : (!quake.ref) -> ()
+// CHECK:           }
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_2]] : (!quake.ref) -> i1
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
This adds `clang::CastKind::CK_FloatingToBoolean` to `QuakeBridgeVisitor::VisitImplicitCastExpr` in order to fix a compiler crash that could occur with code like this:
```cpp
double measure = mz(qubit);
if (measure)
  someOtherCode();
```

I believe this implementation is consistent with https://en.cppreference.com/w/cpp/language/implicit_conversion#Boolean_conversions.