### PR TITLE
Add new pass, linear-ctrl-form.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -35,6 +35,37 @@ def ApplySpecialization : Pass<"apply-op-specialization", "mlir::ModuleOp"> {
   ];
 }
 
+def BasisConversionPass: Pass<"basis-conversion", "mlir::ModuleOp"> {
+  let summary = "Converts kernels to a set of basis operations.";
+  let description = [{
+    This pass takes as input a list of target (allowed) quantum operations.
+    It builds a conversion target, and uses it, together with the dialect
+    conversion driver, to try converting all operations into the defined basis.
+
+    The `basis` option takes a comma-separated list of elements identifying
+    specific quantum operations as input. Each element must have the
+    following format:
+
+    ```
+    <op-name>(`(` [<number-of-controls> | `n`] `)` )?
+    ```
+
+    Examples:
+    - `x` means targeting pauli-x operations without controls  (aka, `not`)
+    - `x(1)` means targeting pauli-x operations with one control (aka, `cx`)
+    - `x(n)` means targeting pauli-x operation with unbounded number of controls
+    - `x,x(1)` means targeting both `not` and `cx` operations
+  }];
+  let options = [
+    ListOption<"basis", "basis", "std::string", "Set of basis operations">,
+    ListOption<"disabledPatterns", "disable-patterns", "std::string",
+               "Labels of decomposition patterns that should be filtered out">,
+    ListOption<"enabledPatterns", "enable-patterns", "std::string",
+               "Labels of decomposition patterns that should be used, all "
+               "other patterns are filtered out">,
+  ];
+}
+
 def CheckKernelCalls : Pass<"check-kernel-calls", "mlir::func::FuncOp"> {
   let summary = "Check calls between quantum kernels have been inlined.";
   let description = [{
@@ -84,6 +115,30 @@ def DelayMeasurements : Pass<"delay-measurements", "mlir::func::FuncOp"> {
   }];
 
   let constructor = "cudaq::opt::createDelayMeasurementsPass()";
+}
+
+def DecompositionPass: Pass<"decomposition", "mlir::ModuleOp"> {
+  let summary = "Break down quantum operations.";
+  let description = [{
+    This pass performs decomposition over a set of operations by iteratively
+    applying decomposition patterns until either a fixpoint is reached or the
+    maximum number of iterations/rewrites is exhausted. Decomposition is
+    best-effort and does not guarantee that the entire IR is decomposed after
+    running this pass.
+
+    NOTE: The current implementation is conservative w.r.t global phase, which
+    means no decomposition will take place under the presence of controlled
+    `quake.apply` operations in the module.
+  }];
+  let options = [
+    ListOption<"disabledPatterns", "disable-patterns", "std::string",
+               "Labels of decomposition patterns that should be filtered out">,
+    ListOption<"enabledPatterns", "enable-patterns", "std::string",
+               "Labels of decomposition patterns that should be used, all "
+               "other patterns are filtered out">,
+    Option<"testConvergence", "test-convergence", "bool", /*default=*/"false",
+           "Test only: Fail pass on non-convergence to detect cyclic patterns">,
+  ];
 }
 
 def ExpandMeasurements : Pass<"expand-measurements"> {
@@ -165,6 +220,38 @@ def LambdaLifting : Pass<"lambda-lifting", "mlir::ModuleOp"> {
   let constructor = "cudaq::opt::createLambdaLiftingPass()";
 }
 
+def LinearCtrlRelations : Pass<"linear-ctrl-form", "mlir::func::FuncOp"> {
+  let summary = "Removes control type values between quantum ops.";
+  let description = [{
+    In the value semantics, quantum gates may be factored in terms of control
+    qubits by the introduction of values of type `!quake.control`. These
+    relaxed constraints can be removed within the IR to get a linear and overly
+    constrained representation of the dataflow of the *logical* qubits. The
+    overly constrained representation may be better suited to certain
+    transformations.
+
+    The following example is a factored value semantics. The wire type value is
+    converted to a control type value, `%ctrl`, which is a proper SSA-value
+    until it is converted back to a wire type, `%new.0`.
+    ```mlir
+      %ctrl = to_ctrl %old.0 : (!wire) -> !control
+      %3 = x [%ctrl] %1 : (!control, !wire) -> !wire
+      %4 = h [%ctrl] %2 : (!control, !wire) -> !wire
+      %5 = y [%ctrl] %3 : (!control, !wire) -> !wire
+      %new.0 = from_ctrl %ctrl : (!control) -> !wire
+    ```
+
+    Linearizing these control type values increases the coarity of the quantum
+    operations and prevents reordering the operations without rewiring the
+    use-def chains of wire values in control positions.
+    ```mlir
+      %3:2 = x [%0] %1 : (!wire, !wire) -> (!wire, !wire)
+      %4:2 = h [%3#0] %2 : (!wire, !wire) -> (!wire, !wire)
+      %5:2 = y [%4#0] %3#1 : (!wire, !wire) -> (!wire, !wire)
+    ```
+  }];
+}
+
 def LoopNormalize : Pass<"cc-loop-normalize"> {
   let summary = "Normalize classical compute (C++) loops.";
   let description = [{
@@ -234,14 +321,6 @@ def LoopUnroll : Pass<"cc-loop-unroll"> {
   ];
 }
 
-def UpdateRegisterNames : Pass<"update-register-names", "mlir::ModuleOp"> {
-  let summary = "Update classical register names";
-  let description = [{
-    After loop unrolling, there may be duplicate registerName attributes. Run
-    this pass to give them unique attribute values.
-  }];
-}
-
 def LowerToCFG : Pass<"lower-to-cfg", "mlir::func::FuncOp"> {
   let summary = "Erase CLoop, CIf, etc. ops, replacing them with a CFG.";
   let description = [{
@@ -280,6 +359,29 @@ def LowerToCFG : Pass<"lower-to-cfg", "mlir::func::FuncOp"> {
   let constructor = "cudaq::opt::createLowerToCFGPass()";
 }
 
+def MappingPass: Pass<"qubit-mapping", "mlir::func::FuncOp"> {
+  let summary = "Perform qubit mapping to account for connectivity constraints";
+  let description = [{
+    Some backends cannot support any-to-any multi-qubit operations, so this pass
+    performs mapping of the qubits by inserting the necessary swap operations
+    into the Quake IR.
+
+    Note: this pass requires strictly value semantics for any quantum
+    operations. It will throw an error if any memory reference semantics are
+    present on quantum operations.
+  }];
+
+  let options = [
+    Option<"device", "device", "std::string", /*default=*/"\"-\"",
+      "Device topology: path(N), ring(N), star(N), star(N,c), grid(w,h), file(/path/to/file), bypass">,
+    Option<"debug", "debug", "bool", /*default=*/"false", "Enable debug for qubit-mapping pass algorithm">,
+    Option<"extendedLayerSize", "extendedLayerSize", "unsigned", /*default=*/"20", "Extended layer size">,
+    Option<"extendedLayerWeight", "extendedLayerWeight", "float", /*default=*/"0.5", "Extended layer weight">,
+    Option<"decayDelta", "decayDelta", "float", /*default=*/"0.5", "Decay delta">,
+    Option<"roundsDecayReset", "roundsDecayReset", "unsigned", /*default=*/"5", "Number of rounds before decay is reset">
+  ];
+}
+
 def MemToReg : Pass<"memtoreg", "mlir::func::FuncOp"> {
   let summary = "Converts memory-SSA to register-SSA form.";
   let description = [{
@@ -303,6 +405,22 @@ def MemToReg : Pass<"memtoreg", "mlir::func::FuncOp"> {
     Option<"quantumValues", "quantum", "bool",
       /*default=*/"true", "Promote of quantum values.">
   ];
+}
+
+def MultiControlDecompositionPass: Pass<"multicontrol-decomposition",
+                                        "mlir::func::FuncOp"> {
+  let summary = "Break down multi-control quantum operations.";
+  let description = [{
+    This pass decomposes multi-control quantum operations. The decompostion
+    involves allocating new qubits to hold intermediate results. The number of
+    extra qubits depends on the particular operation being decomposed.
+    Pauli-X and Pauli-Z operations add _N_ - 2 qubits, while other operations
+    add _N_ - 1 qubits, where _N_ is the number of controls.
+
+    Note: When a `veq` is used as control, we need to know its size to be able
+    to decompose. In such cases, all qubits will be extracted. If the size is
+    unknown at compilation-time, the pass leaves the operation as-is.
+  }];
 }
 
 def ObserveAnsatz : Pass<"observe-ansatz", "mlir::func::FuncOp"> {
@@ -355,7 +473,6 @@ def PruneCtrlRelations : Pass<"pruned-ctrl-form", "mlir::func::FuncOp"> {
       %new.0 = from_ctrl %ctrl : (!control) -> !wire
     ```
   }];
-  let dependentDialects = ["quake::QuakeDialect"];
 }
 
 def QuakeSynthesize : Pass<"quake-synth", "mlir::ModuleOp"> {
@@ -434,97 +551,12 @@ def UnwindLowering : Pass<"unwind-lowering", "mlir::func::FuncOp"> {
   let constructor = "cudaq::opt::createUnwindLoweringPass()";
 }
 
-def BasisConversionPass: Pass<"basis-conversion", "mlir::ModuleOp"> {
-  let summary = "Converts kernels to a set of basis operations.";
+def UpdateRegisterNames : Pass<"update-register-names"> {
+  let summary = "Update classical register names";
   let description = [{
-    This pass takes as input a list of target (allowed) quantum operations.
-    It builds a conversion target, and uses it, together with the dialect
-    conversion driver, to try converting all operations into the defined basis.
-
-    The `basis` option takes a comma-separated list of elements identifying
-    specific quantum operations as input. Each element must have the
-    following format:
-
-    ```
-    <op-name>(`(` [<number-of-controls> | `n`] `)` )?
-    ```
-
-    Examples:
-    - `x` means targeting pauli-x operations without controls  (aka, `not`)
-    - `x(1)` means targeting pauli-x operations with one control (aka, `cx`)
-    - `x(n)` means targeting pauli-x operation with unbounded number of controls
-    - `x,x(1)` means targeting both `not` and `cx` operations
+    After loop unrolling, there may be duplicate registerName attributes. Run
+    this pass to give them unique attribute values.
   }];
-  let options = [
-    ListOption<"basis", "basis", "std::string", "Set of basis operations">,
-    ListOption<"disabledPatterns", "disable-patterns", "std::string",
-               "Labels of decomposition patterns that should be filtered out">,
-    ListOption<"enabledPatterns", "enable-patterns", "std::string",
-               "Labels of decomposition patterns that should be used, all "
-               "other patterns are filtered out">,
-  ];
-}
-
-def DecompositionPass: Pass<"decomposition", "mlir::ModuleOp"> {
-  let summary = "Break down quantum operations.";
-  let description = [{
-    This pass performs decomposition over a set of operations by iteratively
-    applying decomposition patterns until either a fixpoint is reached or the
-    maximum number of iterations/rewrites is exhausted. Decomposition is
-    best-effort and does not guarantee that the entire IR is decomposed after
-    running this pass.
-
-    NOTE: The current implementation is conservative w.r.t global phase, which
-    means no decomposition will take place under the presence of controlled
-    `quake.apply` operations in the module.
-  }];
-  let options = [
-    ListOption<"disabledPatterns", "disable-patterns", "std::string",
-               "Labels of decomposition patterns that should be filtered out">,
-    ListOption<"enabledPatterns", "enable-patterns", "std::string",
-               "Labels of decomposition patterns that should be used, all "
-               "other patterns are filtered out">,
-    Option<"testConvergence", "test-convergence", "bool", /*default=*/"false",
-           "Test only: Fail pass on non-convergence to detect cyclic patterns">,
-  ];
-}
-
-def MultiControlDecompositionPass: Pass<"multicontrol-decomposition",
-                                        "mlir::func::FuncOp"> {
-  let summary = "Break down multi-control quantum operations.";
-  let description = [{
-    This pass decomposes multi-control quantum operations. The decompostion
-    involves allocating new qubits to hold intermediate results. The number of
-    extra qubits depends on the particular operation being decomposed.
-    Pauli-X and Pauli-Z operations add _N_ - 2 qubits, while other operations
-    add _N_ - 1 qubits, where _N_ is the number of controls.
-
-    Note: When a `veq` is used as control, we need to know its size to be able
-    to decompose. In such cases, all qubits will be extracted. If the size is
-    unknown at compilation-time, the pass leaves the operation as-is.
-  }];
-}
-
-def MappingPass: Pass<"qubit-mapping", "mlir::func::FuncOp"> {
-  let summary = "Perform qubit mapping to account for connectivity constraints";
-  let description = [{
-    Some backends cannot support any-to-any multi-qubit operations, so this pass
-    performs mapping of the qubits by inserting the necessary swap operations
-    into the Quake IR.
-
-    Note: this pass requires strictly value semantics for any quantum
-    operations. It will throw an error if any memory reference semantics are
-    present on quantum operations.
-  }];
-  let options = [
-    Option<"device", "device", "std::string", /*default=*/"\"-\"",
-      "Device topology: path(N), ring(N), star(N), star(N,c), grid(w,h), file(/path/to/file), bypass">,
-    Option<"debug", "debug", "bool", /*default=*/"false", "Enable debug for qubit-mapping pass algorithm">,
-    Option<"extendedLayerSize", "extendedLayerSize", "unsigned", /*default=*/"20", "Extended layer size">,
-    Option<"extendedLayerWeight", "extendedLayerWeight", "float", /*default=*/"0.5", "Extended layer weight">,
-    Option<"decayDelta", "decayDelta", "float", /*default=*/"0.5", "Decay delta">,
-    Option<"roundsDecayReset", "roundsDecayReset", "unsigned", /*default=*/"5", "Number of rounds before decay is reset">
-  ];
 }
 
 #endif // CUDAQ_OPT_OPTIMIZER_TRANSFORMS_PASSES

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ add_cudaq_library(OptTransforms
   GenKernelExecution.cpp
   GenDeviceCodeLoader.cpp
   LambdaLifting.cpp
+  LinearCtrlRelations.cpp
   LoopAnalysis.cpp
   LoopNormalize.cpp
   LoopPeeling.cpp

--- a/lib/Optimizer/Transforms/LinearCtrlRelations.cpp
+++ b/lib/Optimizer/Transforms/LinearCtrlRelations.cpp
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_LINEARCTRLRELATIONS
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "linear-ctrl-relations"
+
+using namespace mlir;
+
+namespace {
+class ThreadControl : public OpRewritePattern<quake::ToControlOp> {
+public:
+  explicit ThreadControl(MLIRContext *ctx, DominanceInfo &di)
+      : OpRewritePattern(ctx), dom(di) {}
+
+  LogicalResult matchAndRewrite(quake::ToControlOp toCtrl,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<Operation *> users(toCtrl->getUsers().begin(),
+                                   toCtrl->getUsers().end());
+    auto numUsers = users.size();
+
+    // Check the trivial cases.
+    if (numUsers < 1)
+      return failure();
+    if (numUsers == 1) {
+      // User must be a FromControlOp. We can erase them both.
+      if (auto fromCtrl =
+              dyn_cast_if_present<quake::FromControlOp>(users.front())) {
+        fromCtrl.replaceAllUsesWith(toCtrl.getQubit());
+        rewriter.eraseOp(fromCtrl);
+        rewriter.eraseOp(toCtrl);
+        return success();
+      }
+      // The IR must be broken.
+      return failure();
+    }
+
+    // Now, we can rethread the more interesting case when a value of type
+    // !quake.control is used in actual operations.
+    //
+    // 1. Get a list of the users in dominance order. We have to thread the
+    // !quake.wire value respecting the dominance of the users.
+    SmallVector<Operation *, 8> orderedUsers;
+    for (auto *user : users) {
+      assert(user);
+      if ([&]() {
+            for (auto iter = orderedUsers.begin(), iterEnd = orderedUsers.end();
+                 iter != iterEnd; ++iter) {
+              assert(*iter);
+              if (dom.dominates(user, *iter)) {
+                orderedUsers.insert(iter, user);
+                return false;
+              }
+            }
+            return true;
+          }())
+        orderedUsers.push_back(user);
+    }
+
+    // 2. Thread the wire value to each successive user.
+    Value wireDef = toCtrl.getQubit();
+    auto *ctx = rewriter.getContext();
+    auto wireTy = quake::WireType::get(ctx);
+    for (auto *user : orderedUsers) {
+      assert(user);
+      if (isa<quake::FromControlOp>(user)) {
+        assert(user == orderedUsers.back() &&
+               "FromControlOp must post-dominate all the users");
+        rewriter.replaceOp(user, wireDef);
+        continue;
+      }
+      const auto coarity = user->getResults().size();
+      std::size_t position = 0; // Position of new wire in result tuple.
+      for (Value opnd : user->getOperands()) {
+        if (isa<quake::WireType>(opnd.getType())) {
+          position++;
+          continue;
+        }
+        if (auto x = opnd.getDefiningOp<quake::ToControlOp>()) {
+          if (x.getOperation() == toCtrl.getOperation())
+            break;
+        }
+      }
+
+      // Add a !quake.wire to the return type of `user`.
+      SmallVector<Type> wireTys{coarity + 1, wireTy};
+      SmallVector<Value> operands = user->getOperands();
+      // Replace the use of `toCtrl` with `wireDef` in `user`.
+      operands[position] = wireDef;
+      auto attrs = user->getAttrs();
+      auto name = user->getName().getIdentifier();
+      auto loc = user->getLoc();
+      rewriter.setInsertionPoint(user);
+      auto newUser = rewriter.create(loc, name, operands, wireTys, attrs);
+      // Update `wireDef` with the new result just added to `user`.
+      wireDef = newUser->getResult(position);
+      SmallVector<Value> newUserResults = newUser->getResults();
+      newUserResults.erase(newUserResults.begin() + position);
+      // Replace `user` with `newUser`, omitting the new result which will be
+      // threaded on the next iteration of this loop.
+      rewriter.replaceOp(user, newUserResults);
+    }
+    return success();
+  }
+
+  DominanceInfo &dom;
+};
+} // namespace
+
+namespace {
+class LinearCtrlRelationsPass
+    : public cudaq::opt::impl::LinearCtrlRelationsBase<
+          LinearCtrlRelationsPass> {
+public:
+  using LinearCtrlRelationsBase::LinearCtrlRelationsBase;
+
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+    auto func = getOperation();
+    DominanceInfo domInfo(func);
+    RewritePatternSet patterns(ctx);
+    patterns.insert<ThreadControl>(ctx, domInfo);
+    if (failed(applyPatternsAndFoldGreedily(func.getOperation(),
+                                            std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace

--- a/lib/Optimizer/Transforms/LoopUnroll.cpp
+++ b/lib/Optimizer/Transforms/LoopUnroll.cpp
@@ -278,11 +278,11 @@ public:
   using UpdateRegisterNamesBase::UpdateRegisterNamesBase;
 
   void runOnOperation() override {
-    auto mod = getOperation();
+    auto *mod = getOperation();
 
     // First save the op's that contain a registerName attribute
     DenseMap<StringRef, SmallVector<Operation *>> regOps;
-    mod.walk([&](mlir::Operation *walkOp) {
+    mod->walk([&](mlir::Operation *walkOp) {
       if (auto prevAttr = walkOp->getAttr("registerName")) {
         auto registerName = prevAttr.cast<StringAttr>().getValue();
         regOps[registerName].push_back(walkOp);

--- a/lib/Optimizer/Transforms/PruneCtrlRelations.cpp
+++ b/lib/Optimizer/Transforms/PruneCtrlRelations.cpp
@@ -101,9 +101,9 @@ public:
 
 /// Simple forwarding of `!quake.control` values. If the argument to a
 /// `quake.to_ctrl` operation is coming from a `quake.from_ctrl` operation, then
-/// both operations can be bypassed and the input to the
-/// `quake.from_control` can be forwarded directly to the users of the
-/// `quake.to_ctrl`. There are no intervening ops on the wire by definition.
+/// both operations can be bypassed and the input to the `quake.from_ctrl` can
+/// be forwarded directly to the users of the `quake.to_ctrl`. There are no
+/// intervening ops on the wire by definition.
 class ForwardControl : public OpRewritePattern<quake::ToControlOp> {
 public:
   using OpRewritePattern::OpRewritePattern;

--- a/test/Quake/linear_control.qke
+++ b/test/Quake/linear_control.qke
@@ -1,0 +1,145 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --linear-ctrl-form %s | FileCheck %s
+
+// Test the conversion from pruned control form back to linear control form.
+func.func @__nvqpp__mlirgen__function_linear_expr0() {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2 = quake.null_wire
+  %3 = quake.null_wire
+  %4 = quake.null_wire
+  %5 = quake.null_wire
+  %6 = quake.null_wire
+  %7 = quake.null_wire
+  %8 = quake.null_wire
+  %9 = quake.null_wire
+  %10 = quake.to_ctrl %0 : (!quake.wire) -> !quake.control
+  %11 = quake.x [%10] %1 : (!quake.control, !quake.wire) -> !quake.wire
+  %12 = quake.x [%10] %2 : (!quake.control, !quake.wire) -> !quake.wire
+  %13 = quake.x [%10] %3 : (!quake.control, !quake.wire) -> !quake.wire
+  %14 = quake.x [%10] %4 : (!quake.control, !quake.wire) -> !quake.wire
+  %15 = quake.x [%10] %5 : (!quake.control, !quake.wire) -> !quake.wire
+  %16 = quake.x [%10] %6 : (!quake.control, !quake.wire) -> !quake.wire
+  %17 = quake.x [%10] %7 : (!quake.control, !quake.wire) -> !quake.wire
+  %18 = quake.x [%10] %8 : (!quake.control, !quake.wire) -> !quake.wire
+  %19 = quake.x [%10] %9 : (!quake.control, !quake.wire) -> !quake.wire
+  %20 = quake.from_ctrl %10 : (!quake.control) -> !quake.wire
+  quake.sink %20 : !quake.wire
+  quake.sink %11 : !quake.wire
+  quake.sink %12 : !quake.wire
+  quake.sink %13 : !quake.wire
+  quake.sink %14 : !quake.wire
+  quake.sink %15 : !quake.wire
+  quake.sink %16 : !quake.wire
+  quake.sink %17 : !quake.wire
+  quake.sink %18 : !quake.wire
+  quake.sink %19 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_linear_expr0() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK:           %[[VAL_1:.*]] = quake.null_wire
+// CHECK:           %[[VAL_2:.*]] = quake.null_wire
+// CHECK:           %[[VAL_3:.*]] = quake.null_wire
+// CHECK:           %[[VAL_4:.*]] = quake.null_wire
+// CHECK:           %[[VAL_5:.*]] = quake.null_wire
+// CHECK:           %[[VAL_6:.*]] = quake.null_wire
+// CHECK:           %[[VAL_7:.*]] = quake.null_wire
+// CHECK:           %[[VAL_8:.*]] = quake.null_wire
+// CHECK:           %[[VAL_9:.*]] = quake.null_wire
+// CHECK:           %[[VAL_10:.*]]:2 = quake.x [%[[VAL_0]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_11:.*]]:2 = quake.x [%[[VAL_10]]#0] %[[VAL_2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_12:.*]]:2 = quake.x [%[[VAL_11]]#0] %[[VAL_3]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_13:.*]]:2 = quake.x [%[[VAL_12]]#0] %[[VAL_4]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_14:.*]]:2 = quake.x [%[[VAL_13]]#0] %[[VAL_5]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_15:.*]]:2 = quake.x [%[[VAL_14]]#0] %[[VAL_6]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_16:.*]]:2 = quake.x [%[[VAL_15]]#0] %[[VAL_7]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_17:.*]]:2 = quake.x [%[[VAL_16]]#0] %[[VAL_8]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_18:.*]]:2 = quake.x [%[[VAL_17]]#0] %[[VAL_9]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           quake.sink %[[VAL_18]]#0 : !quake.wire
+// CHECK:           quake.sink %[[VAL_10]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_11]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_12]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_13]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_14]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_15]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_16]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_17]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_18]]#1 : !quake.wire
+// CHECK:           return
+
+func.func @linear_expr1() {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2 = quake.null_wire
+  %3 = quake.null_wire
+  %4 = quake.null_wire
+  %5 = quake.null_wire
+  %6 = quake.null_wire
+  %7 = quake.null_wire
+  %8 = quake.null_wire
+  %9 = quake.null_wire
+  %10 = quake.to_ctrl %0 : (!quake.wire) -> !quake.control
+  %11 = quake.to_ctrl %1 : (!quake.wire) -> !quake.control
+  %12 = quake.x [%10, %11] %2 : (!quake.control, !quake.control, !quake.wire) -> !quake.wire
+  %13 = quake.x [%10, %11] %3 : (!quake.control, !quake.control, !quake.wire) -> !quake.wire
+  %14 = quake.x [%10, %11] %4 : (!quake.control, !quake.control, !quake.wire) -> !quake.wire
+  %15 = quake.x [%10, %11] %5 : (!quake.control, !quake.control, !quake.wire) -> !quake.wire
+  %16 = quake.x [%10, %11] %6 : (!quake.control, !quake.control, !quake.wire) -> !quake.wire
+  %17 = quake.x [%10] %7 : (!quake.control, !quake.wire) -> !quake.wire
+  %18 = quake.x [%11] %8 : (!quake.control, !quake.wire) -> !quake.wire
+  %19 = quake.x [%10, %11] %9 : (!quake.control, !quake.control, !quake.wire) -> !quake.wire
+  %20 = quake.from_ctrl %10 : (!quake.control) -> !quake.wire
+  %21 = quake.from_ctrl %11 : (!quake.control) -> !quake.wire
+  quake.sink %20 : !quake.wire
+  quake.sink %21 : !quake.wire
+  quake.sink %12 : !quake.wire
+  quake.sink %13 : !quake.wire
+  quake.sink %14 : !quake.wire
+  quake.sink %15 : !quake.wire
+  quake.sink %16 : !quake.wire
+  quake.sink %17 : !quake.wire
+  quake.sink %18 : !quake.wire
+  quake.sink %19 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @linear_expr1() {
+// CHECK:           %[[VAL_0:.*]] = quake.null_wire
+// CHECK:           %[[VAL_1:.*]] = quake.null_wire
+// CHECK:           %[[VAL_2:.*]] = quake.null_wire
+// CHECK:           %[[VAL_3:.*]] = quake.null_wire
+// CHECK:           %[[VAL_4:.*]] = quake.null_wire
+// CHECK:           %[[VAL_5:.*]] = quake.null_wire
+// CHECK:           %[[VAL_6:.*]] = quake.null_wire
+// CHECK:           %[[VAL_7:.*]] = quake.null_wire
+// CHECK:           %[[VAL_8:.*]] = quake.null_wire
+// CHECK:           %[[VAL_9:.*]] = quake.null_wire
+// CHECK:           %[[VAL_10:.*]]:3 = quake.x [%[[VAL_1]], %[[VAL_1]]] %[[VAL_2]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
+// CHECK:           %[[VAL_11:.*]]:3 = quake.x [%[[VAL_10]]#0, %[[VAL_10]]#1] %[[VAL_3]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
+// CHECK:           %[[VAL_12:.*]]:3 = quake.x [%[[VAL_11]]#0, %[[VAL_11]]#1] %[[VAL_4]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
+// CHECK:           %[[VAL_13:.*]]:3 = quake.x [%[[VAL_12]]#0, %[[VAL_12]]#1] %[[VAL_5]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
+// CHECK:           %[[VAL_14:.*]]:3 = quake.x [%[[VAL_13]]#0, %[[VAL_13]]#1] %[[VAL_6]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
+// CHECK:           %[[VAL_15:.*]]:2 = quake.x [%[[VAL_0]]] %[[VAL_7]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_16:.*]]:2 = quake.x [%[[VAL_14]]#0] %[[VAL_8]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_17:.*]]:3 = quake.x [%[[VAL_16]]#0, %[[VAL_14]]#1] %[[VAL_9]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
+// CHECK:           quake.sink %[[VAL_15]]#0 : !quake.wire
+// CHECK:           quake.sink %[[VAL_17]]#0 : !quake.wire
+// CHECK:           quake.sink %[[VAL_10]]#2 : !quake.wire
+// CHECK:           quake.sink %[[VAL_11]]#2 : !quake.wire
+// CHECK:           quake.sink %[[VAL_12]]#2 : !quake.wire
+// CHECK:           quake.sink %[[VAL_13]]#2 : !quake.wire
+// CHECK:           quake.sink %[[VAL_14]]#2 : !quake.wire
+// CHECK:           quake.sink %[[VAL_15]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_16]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_17]]#2 : !quake.wire
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
This pass converts the "value semantics" form of the quake dialect from the "pruned control relations" form to the "linear control relations" form. The pruned form is the less constrained IR representation while the latter is overly constrained. The following examples illustrate the distinction.

This is a sequence of ctrl-x ops in pruned form:

    %10 = quake.to_ctrl %0 : (!quake.wire) -> !quake.control
    %11 = quake.x [%10] %1 : (!quake.control, !quake.wire) -> !quake.wire
    %12 = quake.x [%10] %2 : (!quake.control, !quake.wire) -> !quake.wire
    %13 = quake.x [%10] %3 : (!quake.control, !quake.wire) -> !quake.wire
    %14 = quake.x [%10] %4 : (!quake.control, !quake.wire) -> !quake.wire
    %15 = quake.x [%10] %5 : (!quake.control, !quake.wire) -> !quake.wire
    %16 = quake.x [%10] %6 : (!quake.control, !quake.wire) -> !quake.wire
    %17 = quake.x [%10] %7 : (!quake.control, !quake.wire) -> !quake.wire
    %18 = quake.x [%10] %8 : (!quake.control, !quake.wire) -> !quake.wire
    %19 = quake.x [%10] %9 : (!quake.control, !quake.wire) -> !quake.wire
    %20 = quake.from_ctrl %10 : (!quake.control) -> !quake.wire

This is the same sequence in linear form:

    %10:2 = quake.x [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
    %11:2 = quake.x [%10#0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
    %12:2 = quake.x [%11#0] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
    %13:2 = quake.x [%12#0] %4 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
    %14:2 = quake.x [%13#0] %5 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
    %15:2 = quake.x [%14#0] %6 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
    %16:2 = quake.x [%15#0] %7 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
    %17:2 = quake.x [%16#0] %8 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
    %18:2 = quake.x [%17#0] %9 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)

Notice that the pruned form makes it apparent that any permutation for scheduling these operations is legal and should give the same result. The linear form does not.

Reorganize the passes in the tablegen file, putting them back in alphabetical order.
