### PR TITLE
Fix kernel builder c_if qubit extraction bug

### DIFF
--- a/python/tests/compiler/conditional.py
+++ b/python/tests/compiler/conditional.py
@@ -43,38 +43,40 @@ def test_kernel_conditional():
     kernel()
     assert kernel.arguments == []
     assert kernel.argument_count == 0
+
+    # Check the MLIR.
     print(kernel)
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
-# CHECK:           %[[VAL_0:.*]] = arith.constant 2 : index
-# CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
-# CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-# CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
-# CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]][0] : (!quake.veq<2>) -> !quake.ref
-# CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]][1] : (!quake.veq<2>) -> !quake.ref
-# CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_6]] name "measurement_" : (!quake.ref) -> i1
-# CHECK:           cc.if(%[[VAL_8]]) {
-# CHECK:             quake.x %[[VAL_7]] : (!quake.ref) -> ()
-# CHECK:             %[[VAL_9:.*]] = quake.mz %[[VAL_7]] name "" : (!quake.ref) -> i1
+# CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
+# CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
+# CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+# CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
+# CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
+# CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
+# CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_4]] name "measurement_" : (!quake.ref) -> i1
+# CHECK:           cc.if(%[[VAL_6]]) {
+# CHECK:             quake.x %[[VAL_5]] : (!quake.ref) -> ()
+# CHECK:             %[[VAL_7:.*]] = quake.mz %[[VAL_5]] name "" : (!quake.ref) -> i1
 # CHECK:           }
-# CHECK:           %[[VAL_10:.*]] = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_2]]) -> (index)) {
-# CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_0]] : index
-# CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : index)
+# CHECK:           %[[VAL_8:.*]] = cc.loop while ((%[[VAL_9:.*]] = %[[VAL_2]]) -> (index)) {
+# CHECK:             %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_0]] : index
+# CHECK:             cc.condition %[[VAL_10]](%[[VAL_9]] : index)
 # CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_13:.*]]: index):
-# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_5]][%[[VAL_13]]] : (!quake.veq<2>, index) -> !quake.ref
-# CHECK:             quake.x %[[VAL_14]] : (!quake.ref) -> ()
-# CHECK:             cc.continue %[[VAL_13]] : index
+# CHECK:           ^bb0(%[[VAL_11:.*]]: index):
+# CHECK:             %[[VAL_12:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_11]]] : (!quake.veq<2>, index) -> !quake.ref
+# CHECK:             quake.x %[[VAL_12]] : (!quake.ref) -> ()
+# CHECK:             cc.continue %[[VAL_11]] : index
 # CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_15:.*]]: index):
-# CHECK:             %[[VAL_16:.*]] = arith.addi %[[VAL_15]], %[[VAL_1]] : index
-# CHECK:             cc.continue %[[VAL_16]] : index
+# CHECK:           ^bb0(%[[VAL_13:.*]]: index):
+# CHECK:             %[[VAL_14:.*]] = arith.addi %[[VAL_13]], %[[VAL_1]] : index
+# CHECK:             cc.continue %[[VAL_14]] : index
 # CHECK:           } {invariant}
-# CHECK:           cc.if(%[[VAL_8]]) {
-# CHECK:             quake.x %[[VAL_7]] : (!quake.ref) -> ()
-# CHECK:             %[[VAL_17:.*]] = quake.mz %[[VAL_7]] name "" : (!quake.ref) -> i1
+# CHECK:           cc.if(%[[VAL_6]]) {
+# CHECK:             quake.x %[[VAL_5]] : (!quake.ref) -> ()
+# CHECK:             %[[VAL_15:.*]] = quake.mz %[[VAL_5]] name "" : (!quake.ref) -> i1
 # CHECK:           }
 # CHECK:           return
 # CHECK:         }
@@ -98,10 +100,9 @@ def test_kernel_conditional_with_sample():
     # Apply `then_function` to the `kernel` if
     # the qubit was measured in the 1-state.
     kernel.c_if(measurement_, then_function)
-    print(kernel)
+
     # Measure the qubit again.
     result = cudaq.sample(kernel, shots_count=10)
-    result.dump()
     assert len(result) == 1
     # Qubit should be in the 0-state after undergoing
     # two X rotations.
@@ -118,6 +119,52 @@ def test_kernel_conditional_with_sample():
 # CHECK:           cc.if(%[[VAL_1]]) {
 # CHECK:             quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           }
+# CHECK:           return
+# CHECK:         }
+
+
+def test_cif_extract_ref_bug():
+    """
+    Tests a previous bug where the `extract_ref` for a qubit
+    would get hidden within a conditional. This would result in
+    the runtime error "operator #0 does not dominate this use".
+    """
+    kernel = cudaq.make_kernel()
+    qubits = kernel.qalloc(2)
+
+    kernel.x(qubits[0])
+    measure = kernel.mz(qubits[0], "measure0")
+
+    def then():
+        kernel.x(qubits[1])
+
+    kernel.c_if(measure, then)
+
+    # With bug, any use of `qubits[1]` again would throw a
+    # runtime error.
+    kernel.x(qubits[1])
+    kernel.x(qubits[1])
+
+    result = cudaq.sample(kernel)
+    # Should have measured everything in the |11> state at the end.
+    assert result.get_register_counts("__global__")["11"] == 1000
+
+    # Check the MLIR.
+    print(kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
+# CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<2>) -> !quake.ref
+# CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
+# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "measure0" : (!quake.ref) -> i1
+# CHECK:           cc.if(%[[VAL_2]]) {
+# CHECK:             %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
+# CHECK:             quake.x %[[VAL_3]] : (!quake.ref) -> ()
+# CHECK:           }
+# CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
+# CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
+# CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/parallel/test_mqpu.py
+++ b/python/tests/parallel/test_mqpu.py
@@ -113,6 +113,7 @@ def testAccuracy():
 
     cudaq.reset_target()
 
+
 @skipIfNoMQPU
 def testGetStateAsync():
     cudaq.set_target("nvidia-mqpu")
@@ -134,18 +135,20 @@ def testGetStateAsync():
     asyns_handles = []
     trotter_iters = 1
     for qpu in range(num_qpus):
-        asyns_handles.append(cudaq.get_state_async(kernel, trotter_iters, qpu_id=qpu))
+        asyns_handles.append(
+            cudaq.get_state_async(kernel, trotter_iters, qpu_id=qpu))
         trotter_iters += 1
 
     angle = 0.0
     for handle in asyns_handles:
         angle += 0.2
-        expected_state = [np.cos(angle/2), -1j*np.sin(angle/2)]
+        expected_state = [np.cos(angle / 2), -1j * np.sin(angle / 2)]
         state = handle.get()
         assert np.allclose(state, expected_state, atol=1e-3)
 
         # Reset for the next tests.
         cudaq.reset_target()
+
 
 # leave for gdb debugging
 if __name__ == "__main__":

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -155,9 +155,6 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
   if (type.isa<quake::VeqType>()) {
     Value extractedQubit =
         opBuilder.create<quake::ExtractRefOp>(vectorValue, indexVar);
-    // auto ret = extractedFromValue.emplace(
-    //     std::make_pair(opaquePtr, QuakeValue(opBuilder, extractedQubit)));
-    // return ret.first->second;
     return QuakeValue(opBuilder, extractedQubit);
   }
 
@@ -176,9 +173,6 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
   Value eleAddr = opBuilder.create<cc::ComputePtrOp>(
       elePtrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{indexVar});
   Value loaded = opBuilder.create<cc::LoadOp>(eleAddr);
-  // auto ret = extractedFromValue.emplace(
-  //     std::make_pair(opaquePtr, QuakeValue(opBuilder, loaded)));
-  // return ret.first->second;
   return QuakeValue(opBuilder, loaded);
 }
 

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -100,9 +100,9 @@ std::size_t QuakeValue::getRequiredElements() {
 }
 
 QuakeValue QuakeValue::operator[](const std::size_t idx) {
-  auto iter = extractedFromIndex.find(idx);
-  if (iter != extractedFromIndex.end())
-    return iter->second;
+  // auto iter = extractedFromIndex.find(idx);
+  // if (iter != extractedFromIndex.end())
+  //   return iter->second;
 
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
@@ -122,9 +122,10 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
   if (type.isa<quake::VeqType>()) {
     Value extractedQubit =
         opBuilder.create<quake::ExtractRefOp>(vectorValue, indexVar);
-    auto ret = extractedFromIndex.emplace(
-        std::make_pair(idx, QuakeValue(opBuilder, extractedQubit)));
-    return ret.first->second;
+    // auto ret = extractedFromIndex.emplace(
+    //     std::make_pair(idx, QuakeValue(opBuilder, extractedQubit)));
+    // return ret.first->second;
+    return QuakeValue(opBuilder, extractedQubit);
   }
 
   // must be a std vec type
@@ -139,16 +140,17 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
   Value eleAddr = opBuilder.create<cc::ComputePtrOp>(
       elePtrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{idx32});
   Value loaded = opBuilder.create<cc::LoadOp>(eleAddr);
-  auto ret = extractedFromIndex.emplace(
-      std::make_pair(idx, QuakeValue(opBuilder, loaded)));
-  return ret.first->second;
+  // auto ret = extractedFromIndex.emplace(
+  //     std::make_pair(idx, QuakeValue(opBuilder, loaded)));
+  // return ret.first->second;
+  return QuakeValue(opBuilder, loaded);
 }
 
 QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
-  auto opaquePtr = idx.getValue().getAsOpaquePointer();
-  auto iter = extractedFromValue.find(opaquePtr);
-  if (iter != extractedFromValue.end())
-    return iter->second;
+  // auto opaquePtr = idx.getValue().getAsOpaquePointer();
+  // auto iter = extractedFromValue.find(opaquePtr);
+  // if (iter != extractedFromValue.end())
+  //   return iter->second;
 
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
@@ -168,9 +170,10 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
   if (type.isa<quake::VeqType>()) {
     Value extractedQubit =
         opBuilder.create<quake::ExtractRefOp>(vectorValue, indexVar);
-    auto ret = extractedFromValue.emplace(
-        std::make_pair(opaquePtr, QuakeValue(opBuilder, extractedQubit)));
-    return ret.first->second;
+    // auto ret = extractedFromValue.emplace(
+    //     std::make_pair(opaquePtr, QuakeValue(opBuilder, extractedQubit)));
+    // return ret.first->second;
+    return QuakeValue(opBuilder, extractedQubit);
   }
 
   if (indexVar.getType().isa<IndexType>())
@@ -188,9 +191,10 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
   Value eleAddr = opBuilder.create<cc::ComputePtrOp>(
       elePtrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{indexVar});
   Value loaded = opBuilder.create<cc::LoadOp>(eleAddr);
-  auto ret = extractedFromValue.emplace(
-      std::make_pair(opaquePtr, QuakeValue(opBuilder, loaded)));
-  return ret.first->second;
+  // auto ret = extractedFromValue.emplace(
+  //     std::make_pair(opaquePtr, QuakeValue(opBuilder, loaded)));
+  // return ret.first->second;
+  return QuakeValue(opBuilder, loaded);
 }
 
 QuakeValue QuakeValue::size() {

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -100,10 +100,6 @@ std::size_t QuakeValue::getRequiredElements() {
 }
 
 QuakeValue QuakeValue::operator[](const std::size_t idx) {
-  // auto iter = extractedFromIndex.find(idx);
-  // if (iter != extractedFromIndex.end())
-  //   return iter->second;
-
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
   if (!type.isa<cc::StdvecType, quake::VeqType>()) {
@@ -122,9 +118,6 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
   if (type.isa<quake::VeqType>()) {
     Value extractedQubit =
         opBuilder.create<quake::ExtractRefOp>(vectorValue, indexVar);
-    // auto ret = extractedFromIndex.emplace(
-    //     std::make_pair(idx, QuakeValue(opBuilder, extractedQubit)));
-    // return ret.first->second;
     return QuakeValue(opBuilder, extractedQubit);
   }
 
@@ -140,18 +133,10 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
   Value eleAddr = opBuilder.create<cc::ComputePtrOp>(
       elePtrTy, vecPtr, ArrayRef<cc::ComputePtrArg>{idx32});
   Value loaded = opBuilder.create<cc::LoadOp>(eleAddr);
-  // auto ret = extractedFromIndex.emplace(
-  //     std::make_pair(idx, QuakeValue(opBuilder, loaded)));
-  // return ret.first->second;
   return QuakeValue(opBuilder, loaded);
 }
 
 QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
-  // auto opaquePtr = idx.getValue().getAsOpaquePointer();
-  // auto iter = extractedFromValue.find(opaquePtr);
-  // if (iter != extractedFromValue.end())
-  //   return iter->second;
-
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
   if (!type.isa<cc::StdvecType, quake::VeqType>()) {

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -44,11 +44,11 @@ protected:
 
   /// @brief Keep track of previously extracted QuakeValues from
   /// a concrete index value
-  std::map<std::size_t, QuakeValue> extractedFromIndex;
+  // std::map<std::size_t, QuakeValue> extractedFromIndex;
 
   /// @brief Keep track of previously extracted QuakeValues from
   /// another QuakeValue (represented by its unique opaque pointer)
-  std::map<void *, QuakeValue> extractedFromValue;
+  // std::map<void *, QuakeValue> extractedFromValue;
 
 public:
   /// @brief Return the actual MLIR Value

--- a/runtime/cudaq/builder/QuakeValue.h
+++ b/runtime/cudaq/builder/QuakeValue.h
@@ -42,14 +42,6 @@ protected:
   /// is equal to the number provided as input at runtime.
   bool canValidateVectorNumElements = true;
 
-  /// @brief Keep track of previously extracted QuakeValues from
-  /// a concrete index value
-  // std::map<std::size_t, QuakeValue> extractedFromIndex;
-
-  /// @brief Keep track of previously extracted QuakeValues from
-  /// another QuakeValue (represented by its unique opaque pointer)
-  // std::map<void *, QuakeValue> extractedFromValue;
-
 public:
   /// @brief Return the actual MLIR Value
   mlir::Value getValue() const;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->


* Fixes an issue where qubits that are extracted in a `then` function were not getting a unique `extract_ref` if used outside of the conditional
* Adds new python and C++ tests to test for this bug
