### PR TITLE
[test] Fix failing integration tests

### DIFF
--- a/test/NVQPP/bug_qubit.cpp
+++ b/test/NVQPP/bug_qubit.cpp
@@ -9,7 +9,10 @@
 // This code is from Issue 251.
 
 // clang-format off
-// RUN: nvq++ --enable-mlir -v %s --target quantinuum --emulate -o %t.x && %t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 // RUN: cudaq-quake %s | cudaq-opt --promote-qubit-allocation | FileCheck --check-prefixes=MLIR %s
 
 #include <cudaq.h>

--- a/test/NVQPP/callable_kernel_arg.cpp
+++ b/test/NVQPP/callable_kernel_arg.cpp
@@ -30,7 +30,7 @@ struct foo {
   __qpu__ void operator()(CallableKernel &&func, int size) {
     cudaq::qreg q(size);
     func(q[0]);
-    mz(q[0]);
+    auto result = mz(q[0]);
   }
 };
 

--- a/test/NVQPP/callable_kernel_arg.cpp
+++ b/test/NVQPP/callable_kernel_arg.cpp
@@ -7,7 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/cudaq_observe.cpp
+++ b/test/NVQPP/cudaq_observe.cpp
@@ -8,10 +8,12 @@
 
 // clang-format off
 // RUN: nvq++ %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 // 2 different IQM machines for 2 different topologies
-// RUN: nvq++ %s -o %basename_t.x --target iqm --iqm-machine Adonis --emulate && ./%basename_t.x | FileCheck %s
-// RUN: nvq++ %s -o %basename_t.x --target iqm --iqm-machine Apollo --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Apollo --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <cudaq/algorithm.h>

--- a/test/NVQPP/if_jit.cpp
+++ b/test/NVQPP/if_jit.cpp
@@ -8,7 +8,10 @@
 
 // This code is from Issue 296.
 
-// RUN: nvq++ %s --target quantinuum --emulate -o %t.x && %t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/if_jit.cpp
+++ b/test/NVQPP/if_jit.cpp
@@ -21,7 +21,7 @@ __qpu__ void foo(bool value) {
   if (value)
     x(q);
 
-  mz(q);
+  auto result = mz(q);
 }
 
 int main() {

--- a/test/NVQPP/int8_t.cpp
+++ b/test/NVQPP/int8_t.cpp
@@ -7,7 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/int8_t.cpp
+++ b/test/NVQPP/int8_t.cpp
@@ -19,7 +19,7 @@ struct variable_qreg {
   __qpu__ void operator()(std::uint8_t value) {
     cudaq::qreg qubits(value);
 
-    mz(qubits);
+    auto result = mz(qubits);
   }
 };
 

--- a/test/NVQPP/int8_t_free_func.cpp
+++ b/test/NVQPP/int8_t_free_func.cpp
@@ -7,7 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --target quantinuum --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/int8_t_free_func.cpp
+++ b/test/NVQPP/int8_t_free_func.cpp
@@ -18,7 +18,7 @@
 __qpu__ void variable_qreg(std::uint8_t value) {
   cudaq::qreg qubits(value);
 
-  mz(qubits);
+  auto result = mz(qubits);
 }
 
 int main() {

--- a/test/NVQPP/load_value.cpp
+++ b/test/NVQPP/load_value.cpp
@@ -7,9 +7,11 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// RUN: nvq++ %s -o %basename_t.x --target iqm --iqm-machine Adonis --emulate && ./%basename_t.x | FileCheck %s
-// RUN: nvq++ %s -o %basename_t.x --target iqm --iqm-machine Apollo --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Apollo --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/qir_if_base.cpp
+++ b/test/NVQPP/qir_if_base.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // Note: change |& to 2>&1 if running in bash
-// RUN: nvq++ -v %s -o %basename_t.x --target ionq --emulate && IONQ_API_KEY=0 ./%basename_t.x |& FileCheck %s
+// RUN: nvq++ -v %s -o %basename_t.x --target ionq --emulate && ./%basename_t.x |& FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/qir_string_labels.cpp
+++ b/test/NVQPP/qir_string_labels.cpp
@@ -8,7 +8,7 @@
 
 // Note: change |& to 2>&1 if running in bash
 // RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && CUDAQ_DUMP_JIT_IR=1 ./%basename_t.x |& FileCheck %s
-// RUN: nvq++ -v %s -o %basename_t.x --target ionq --emulate && IONQ_API_KEY=0 CUDAQ_DUMP_JIT_IR=1 ./%basename_t.x |& FileCheck --check-prefix IONQ %s
+// RUN: nvq++ -v %s -o %basename_t.x --target ionq --emulate && CUDAQ_DUMP_JIT_IR=1 ./%basename_t.x |& FileCheck --check-prefix IONQ %s
 // Note: iqm not currently tested because it does not currently use QIR
 
 #include <cudaq.h>

--- a/test/NVQPP/qspan_slices.cpp
+++ b/test/NVQPP/qspan_slices.cpp
@@ -7,9 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// RUN: nvq++ -v %s -o %basename_t.x --target iqm --iqm-machine Adonis --emulate && ./%basename_t.x | FileCheck %s
-// RUN: nvq++ -v %s -o %basename_t.x --target oqc --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 // Tests for --disable-qubit-mapping:
 // RUN: nvq++ -v %s -o %basename_t.x --target oqc --emulate --disable-qubit-mapping && CUDAQ_MLIR_PRINT_EACH_PASS=1 ./%basename_t.x |& FileCheck --check-prefix=DISABLE %s
 // RUN: nvq++ -v %s -o %basename_t.x --target iqm --iqm-machine Adonis --emulate --disable-qubit-mapping && CUDAQ_MLIR_PRINT_EACH_PASS=1 ./%basename_t.x |& FileCheck --check-prefix=DISABLE %s

--- a/test/NVQPP/sudoku_2x2-1.cpp
+++ b/test/NVQPP/sudoku_2x2-1.cpp
@@ -6,9 +6,10 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// clang-format off
-// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// RUN: nvq++ -v %s -o %basename_t.x --target oqc --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Apollo --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <algorithm>

--- a/test/NVQPP/sudoku_2x2-bit_names.cpp
+++ b/test/NVQPP/sudoku_2x2-bit_names.cpp
@@ -7,8 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// RUN: nvq++ -v %s -o %basename_t.x --target oqc --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Apollo --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <algorithm>

--- a/test/NVQPP/sudoku_2x2-reg_name.cpp
+++ b/test/NVQPP/sudoku_2x2-reg_name.cpp
@@ -7,8 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// RUN: nvq++ -v %s -o %basename_t.x --target oqc --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Apollo --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <algorithm>

--- a/test/NVQPP/sudoku_2x2.cpp
+++ b/test/NVQPP/sudoku_2x2.cpp
@@ -7,8 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
-// RUN: nvq++ -v %s -o %basename_t.x --target oqc --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Apollo --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <algorithm>

--- a/test/NVQPP/swap_gate.cpp
+++ b/test/NVQPP/swap_gate.cpp
@@ -22,7 +22,7 @@ int main() {
     x(q[0]);
     swap(q[0], q[1]);
 
-    mz(q);
+    auto result = mz(q);
   };
 
   auto counts = cudaq::sample(swapKernel);

--- a/test/NVQPP/swap_gate.cpp
+++ b/test/NVQPP/swap_gate.cpp
@@ -7,7 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include "cudaq.h"
 #include <iostream>

--- a/test/NVQPP/variable_size_qreg.cpp
+++ b/test/NVQPP/variable_size_qreg.cpp
@@ -7,7 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ -v %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target oqc                      --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
+// RUN: nvq++ --target quantinuum               --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/variable_size_qreg.cpp
+++ b/test/NVQPP/variable_size_qreg.cpp
@@ -18,7 +18,7 @@
 __qpu__ void variable_qreg(unsigned value) {
   cudaq::qreg qubits(value);
 
-  mz(qubits);
+  auto result = mz(qubits);
 }
 
 int main() {


### PR DESCRIPTION
[Last night's nightly integration test](https://github.com/NVIDIA/cuda-quantum/actions/runs/6740787337) had some issues. Some of them were caused by connection issues unrelated to our build (which have since been resolved), but some of them were true failures resulting from some of the mapping changes. This PR does the following to address those issues:

* Update some of our tests to properly name measurement results.
  *  Mapping requires measurement names in order to keep the results interpretable by the end user. (It throws errors if it encounters unnamed measurements, and that's what caused some of the integration tests to fail.)
* Update RUN lines in tests to include more targets (to help prevent this from happening again)
  * Related to this, also make IONQ_API_KEY env var not required for emulated tests.