### PR TITLE
Add a MeasureType to Quake.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -147,8 +147,8 @@ def cc_CallableType : CCType<"Callable", "callable"> {
     A kernel may be a template function that takes a callable as an argument.
     The type of these callable instances is this proxy callable type. The
     instantiated template instance will resolve the callable instance, and this
-    resolved instance of the callable will be lowered in the specialized template
-    function.
+    resolved instance of the callable will be lowered in the specialized
+    template function.
   }];
   
   let parameters = (ins "mlir::FunctionType":$signature);
@@ -162,7 +162,7 @@ def cc_CallableType : CCType<"Callable", "callable"> {
   ];
 
   let extraClassDeclaration = [{
-    /// Create a callable type without a signature. This is for prototyping only.
+    /// Create a callable type without a signature, for prototyping only.
     [[deprecated]] static CallableType getNoSignature(mlir::MLIRContext *ctx);
   }];
 }

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -599,7 +599,7 @@ class Measurement<string mnemonic> : QuakeOp<mnemonic, [MeasurementInterface,
     OptionalAttr<StrAttr>:$registerName
   );
   let results = (outs
-    AnyTypeOf<[I1, StdvecOf<[I1]>]>:$bits,
+    AnyTypeOf<[MeasureType, StdvecOf<[MeasureType]>]>:$measOut,
     Variadic<WireType>:$wires
   );
 
@@ -659,6 +659,34 @@ def MzOp : Measurement<"mz"> {
     computation. Another option is to deallocate the qubit using `dealloc`.
   }];
   let extraClassDeclaration = OpBaseDeclaration;
+}
+
+def DiscriminateOp : QuakeOp<"discriminate", [Pure]> {
+  let summary = "Converts a measurement to a classical integral value.";
+  let description = [{
+    Quake's measurement operators return a value of type `!quake.measure`. The
+    discriminate operation converts a value of type measure to a classical
+    integral value. This value is typically an `i1` type, but might be `i2` for
+    qutrits, or even an `i8` for general qudits.
+
+    While a measurement of a wire changes/corrupts the state of the wire, the
+    model maintains that a `!quake.measure` value is non-volatile. Therefore,
+    multiple applications of discriminate on the same `!quake.measure` value
+    will yield the same result value for a given result type.
+  }];
+
+  let arguments = (ins
+    AnyTypeOf<[MeasureType, StdvecOf<[MeasureType]>]>:$measurement
+  );
+  let results = (outs
+    AnyTypeOf<[AnySignlessInteger, StdvecOf<[AnySignlessInteger]>]>
+  );
+
+  let assemblyFormat = [{
+    $measurement `:` functional-type(operands, results) attr-dict
+  }];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -23,14 +23,14 @@ class QuakeType<string name, string typeMnemonic, list<Trait> traits = [],
 }
 
 //===----------------------------------------------------------------------===//
-// Quantum value type
+// Wire type: quantum value type
 //===----------------------------------------------------------------------===//
 
 def WireType : QuakeType<"Wire", "wire"> {
   let description = [{
-    A `wire` is a primitive quantum "SSA-value" that differs from a traditional
-    SSA-value in that it can and will be modified when used in any target
-    position. That means quantum "SSA-values" are not true SSA values. `wire`
+    A `wire` is a primitive "quantum value" that differs from a traditional
+    SSA value in that it can and will be modified when used in any target
+    position. That means "quantum values" are not SSA values. `wire`
     values can only be used once and have somewhat similar properties to
     volatile memory. An operation that uses a `wire` in a target position is
     required to return a new `wire` value reflecting the updated/new state.
@@ -50,26 +50,43 @@ def WireType : QuakeType<"Wire", "wire"> {
   let genStorageClass = 0;
 }
 
+//===----------------------------------------------------------------------===//
+// Control type: quantum value type
+//===----------------------------------------------------------------------===//
+
 def ControlType : QuakeType<"Control", "control"> {
   let description = [{
-    A qubit of type control is a value of type wire used in a control position.
-    Using a qubit in a control position means the qubit is an SSA-value. It is
-    defined once and can be used multiple times (in multiple control positions)
-    without changing value.
+    A value having type `control` is quite similar to a value of type `wire`.
+    The distinction is that a value of type `control` must be used in a control
+    position of a quantum operator. Using a qubit in a control position means
+    the qubit \em{is} an SSA value. Values of type `control`, unlike values of
+    type `wire`, can be defined once and used multiple times (in multiple
+    control positions on distinct quantum operators) without changing value.
+
+    ```mlir
+      %10 = quake.to_ctrl %0 : (!quake.wire) -> !quake.control
+      %11 = quake.g1 [%10] %1 : (!quake.control, !quake.wire) -> !quake.wire
+      %12 = quake.g2 [%10] %2 : (!quake.control, !quake.wire) -> !quake.wire
+      %13 = quake.g3 [%10] %3 : (!quake.control, !quake.wire) -> !quake.wire
+      %20 = quake.from_ctrl %10 : (!quake.control) -> !quake.wire
+    ```
   }];
+
   let genStorageClass = 0;
 }
 
 //===----------------------------------------------------------------------===//
-// RefType
+// RefType: quantum reference type
 //===----------------------------------------------------------------------===//
 
 def RefType : QuakeType<"Ref", "ref"> {
-  let summary = "reference to a wire";
+  let summary = "reference to a quantum wire";
   let description = [{
-    A `ref` represents a reference to a wire.  One can view the values of
-    this type as the horizontal lines in the following a quantum circuit
-    diagram. A value of type `ref` is an SSA-value.
+    A `ref` represents a reference to a value of `wire` type.  One can view the
+    values of this type as the horizontal lines in the following quantum circuit
+    diagram. A value of type `ref` is an SSA value with reference semantics. A
+    quantum operator that uses a `ref` value implicitly performs an unwrap
+    (read), modify, and wrap (write) on the "wire" value referenced.
 
     ```
     q0 : ─────●────────── <--+
@@ -89,34 +106,34 @@ def RefType : QuakeType<"Ref", "ref"> {
       quake.gate2 (%q1)
     ```
 
-    The semantics is that `gate1` has quantum memory side-effects through the
-    reference `%q1` to the referent wire, which is modified (read and write).
-    (The reference does not change, but the wire it refers to is considered
-    volatile.) Similarly `gate2` has the same side-effects through the same
-    reference, `%q1`. Because these operations modify the same wire, they
-    cannot be reordered relative to one another.
+    In the example, `gate1` has quantum memory side-effects on the reference
+    `%q1 : !quake.ref`, which is assumed to be modified in place, similar to a
+    volatile memory location. The next operation, `gate2`, also has quantum
+    memory side-effects through the same reference, `%q1`. Because these
+    operations use the same reference, they cannot be reordered relative to one
+    another.
     
-    Furthermore, `gate1` implies only a quantum memory read side-effect on the
-    referent wire through the reference `%q0`. Because `%q0` appears in a
-    control position in `gate1`, the wire value is not updated.
-
-    Not all operations will have side-effects on the referent wire of the
-    reference value of `ref` type.
+    Furthermore, `gate1` implies \em{only} a quantum memory read side-effect on
+    the reference value `%q0`. This is because `%q0` appears in a control
+    position in `gate1`, as indicated by the square brackets.
   }];
+
   let genStorageClass = 0;
 }
 
 //===----------------------------------------------------------------------===//
-// VeqType
+// VeqType: quantum reference type
 //===----------------------------------------------------------------------===//
 
 def VeqType : QuakeType<"Veq", "veq"> {
-  let summary = "a aggregate of wire references";
+  let summary = "an aggregate of quantum references";
   let description = [{
     A value of type `veq` is a (linear) collection of values of type `ref`.
     These aggregates are a convenience for referring to an entire group of
-    references to wires. A `veq` value is a proper SSA-value. `ref` values
-    in a `veq` are not volatile.
+    quantum memory references. A `veq` value is an SSA value and can be defined
+    once and used multiple times. `ref` values in a `veq` are non-volatile, so
+    extracting a `ref` at the same index multiple times yields copies of the
+    same quantum memory reference.
   }];
 
   let parameters = (ins "std::size_t":$size);
@@ -130,6 +147,27 @@ def VeqType : QuakeType<"Veq", "veq"> {
       return VeqType::get(ctx, 0);
     }
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// MeasureType: classical data type
+//===----------------------------------------------------------------------===//
+
+def MeasureType : QuakeType<"Measure", "measure"> {
+  let summary = "a classical result produced by a quantum measurement";
+  let description = [{
+    A quantum measurement captures the state of a qubit and returns a classical
+    value from the measurement. Depending on the target system this value may
+    have two or more logical states. Typically, a value of type `measure` is
+    considered a binary bit.
+
+    ```mlir
+      %m = quake.mz %0 : (!quake.ref) -> !quake.measure
+      quake.dealloc %0 : !quake.ref
+    ```
+  }];
+
+  let genStorageClass = 0;
 }
 
 def AnyQTypeLike : TypeConstraint<Or<[WireType.predicate, VeqType.predicate,

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -751,7 +751,7 @@ public:
     auto context = parentModule->getContext();
 
     std::string qFunctionName = cudaq::opt::QIRMeasure;
-    Attribute regName = measure->getAttr("registerName");
+    Attribute regName = measure.getRegisterNameAttr();
     std::vector<Type> funcTypes{cudaq::opt::getQubitType(context)};
     std::vector<Value> args{adaptor.getOperands().front()};
 
@@ -889,8 +889,7 @@ public:
 
 class AllocaOpPattern : public ConvertOpToLLVMPattern<cudaq::cc::AllocaOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::AllocaOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   // Convert each cc::AllocaOp to an LLVM::AllocaOp.
   LogicalResult
@@ -918,8 +917,7 @@ public:
 class CallableClosureOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::CallableClosureOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::CallableClosureOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::CallableClosureOp callable, OpAdaptor adaptor,
@@ -946,8 +944,7 @@ public:
 class CallableFuncOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::CallableFuncOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::CallableFuncOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::CallableFuncOp callable, OpAdaptor adaptor,
@@ -969,8 +966,7 @@ public:
 class CallCallableOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::CallCallableOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::CallCallableOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::CallCallableOp call, OpAdaptor adaptor,
@@ -1035,8 +1031,7 @@ public:
 
 class CastOpPattern : public ConvertOpToLLVMPattern<cudaq::cc::CastOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::CastOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   // Convert each cc::CastOp to one of the flavors of LLVM casts.
   LogicalResult
@@ -1106,8 +1101,7 @@ public:
 class ComputePtrOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::ComputePtrOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::ComputePtrOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   // Convert each cc::ComputePtrOp to an LLVM::GEPOp.
   LogicalResult
@@ -1147,8 +1141,7 @@ public:
 class ExtractValueOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::ExtractValueOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::ExtractValueOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::ExtractValueOp extract, OpAdaptor adaptor,
@@ -1163,8 +1156,7 @@ public:
 class FuncToPtrOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::FuncToPtrOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::FuncToPtrOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   // This becomes a bitcast op.
   LogicalResult
@@ -1180,8 +1172,7 @@ public:
 class InsertValueOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::InsertValueOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::InsertValueOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::InsertValueOp insert, OpAdaptor adaptor,
@@ -1197,8 +1188,7 @@ public:
 class InstantiateCallableOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::InstantiateCallableOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::InstantiateCallableOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::InstantiateCallableOp callable, OpAdaptor adaptor,
@@ -1257,8 +1247,7 @@ public:
 
 class LoadOpPattern : public ConvertOpToLLVMPattern<cudaq::cc::LoadOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::LoadOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   // Convert each cc::LoadOp to an LLVM::LoadOp.
   LogicalResult
@@ -1274,8 +1263,7 @@ public:
 class StdvecDataOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::StdvecDataOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::StdvecDataOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::StdvecDataOp data, OpAdaptor adaptor,
@@ -1297,8 +1285,7 @@ public:
 class StdvecInitOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::StdvecInitOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::StdvecInitOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::StdvecInitOp init, OpAdaptor adaptor,
@@ -1325,8 +1312,7 @@ public:
 class StdvecSizeOpPattern
     : public ConvertOpToLLVMPattern<cudaq::cc::StdvecSizeOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::StdvecSizeOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::StdvecSizeOp size, OpAdaptor adaptor,
@@ -1379,8 +1365,7 @@ public:
 
 class StoreOpPattern : public ConvertOpToLLVMPattern<cudaq::cc::StoreOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::StoreOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   // Convert each cc::StoreOp to an LLVM::StoreOp.
   LogicalResult
@@ -1392,10 +1377,23 @@ public:
   }
 };
 
+class DiscriminateOpPattern
+    : public ConvertOpToLLVMPattern<quake::DiscriminateOp> {
+public:
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(quake::DiscriminateOp discr, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto m = discr.getMeasurement();
+    rewriter.replaceOp(discr, m);
+    return success();
+  }
+};
+
 class UndefOpPattern : public ConvertOpToLLVMPattern<cudaq::cc::UndefOp> {
 public:
-  using Base = ConvertOpToLLVMPattern<cudaq::cc::UndefOp>;
-  using Base::Base;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(cudaq::cc::UndefOp undef, OpAdaptor adaptor,
@@ -1487,26 +1485,26 @@ public:
 
     patterns.insert<GetVeqSizeOpRewrite, MxToMz, MyToMz, ReturnBitRewrite>(
         context);
-    patterns
-        .insert<AllocaOpRewrite, AllocaOpPattern, CallableClosureOpPattern,
-                CallableFuncOpPattern, CallCallableOpPattern, CastOpPattern,
-                ComputePtrOpPattern, ConcatOpRewrite, DeallocOpRewrite,
-                CreateStringLiteralOpPattern, ExtractQubitOpRewrite,
-                ExtractValueOpPattern, FuncToPtrOpPattern, InsertValueOpPattern,
-                InstantiateCallableOpPattern, LoadOpPattern, ExpPauliRewrite,
-                OneTargetRewrite<quake::HOp>, OneTargetRewrite<quake::XOp>,
-                OneTargetRewrite<quake::YOp>, OneTargetRewrite<quake::ZOp>,
-                OneTargetRewrite<quake::SOp>, OneTargetRewrite<quake::TOp>,
-                OneTargetOneParamRewrite<quake::R1Op>,
-                OneTargetTwoParamRewrite<quake::PhasedRxOp>,
-                OneTargetOneParamRewrite<quake::RxOp>,
-                OneTargetOneParamRewrite<quake::RyOp>,
-                OneTargetOneParamRewrite<quake::RzOp>,
-                OneTargetTwoParamRewrite<quake::U2Op>,
-                OneTargetTwoParamRewrite<quake::U3Op>, ResetRewrite,
-                StdvecDataOpPattern, StdvecInitOpPattern, StdvecSizeOpPattern,
-                StoreOpPattern, SubveqOpRewrite,
-                TwoTargetRewrite<quake::SwapOp>, UndefOpPattern>(typeConverter);
+    patterns.insert<
+        AllocaOpRewrite, AllocaOpPattern, CallableClosureOpPattern,
+        CallableFuncOpPattern, CallCallableOpPattern, CastOpPattern,
+        ComputePtrOpPattern, ConcatOpRewrite, DeallocOpRewrite,
+        CreateStringLiteralOpPattern, DiscriminateOpPattern,
+        ExtractQubitOpRewrite, ExtractValueOpPattern, FuncToPtrOpPattern,
+        InsertValueOpPattern, InstantiateCallableOpPattern, LoadOpPattern,
+        ExpPauliRewrite, OneTargetRewrite<quake::HOp>,
+        OneTargetRewrite<quake::XOp>, OneTargetRewrite<quake::YOp>,
+        OneTargetRewrite<quake::ZOp>, OneTargetRewrite<quake::SOp>,
+        OneTargetRewrite<quake::TOp>, OneTargetOneParamRewrite<quake::R1Op>,
+        OneTargetTwoParamRewrite<quake::PhasedRxOp>,
+        OneTargetOneParamRewrite<quake::RxOp>,
+        OneTargetOneParamRewrite<quake::RyOp>,
+        OneTargetOneParamRewrite<quake::RzOp>,
+        OneTargetTwoParamRewrite<quake::U2Op>,
+        OneTargetTwoParamRewrite<quake::U3Op>, ResetRewrite,
+        StdvecDataOpPattern, StdvecInitOpPattern, StdvecSizeOpPattern,
+        StoreOpPattern, SubveqOpRewrite, TwoTargetRewrite<quake::SwapOp>,
+        UndefOpPattern>(typeConverter);
     patterns.insert<MeasureRewrite<quake::MzOp>>(typeConverter, measureCounter);
 
     target.addLegalDialect<LLVM::LLVMDialect>();
@@ -1528,6 +1526,9 @@ public:
     });
     typeConverter.addConversion([](cudaq::cc::StdvecType type) {
       return cudaq::opt::factory::stdVectorImplType(type.getElementType());
+    });
+    typeConverter.addConversion([](quake::MeasureType type) {
+      return IntegerType::get(type.getContext(), 1);
     });
     typeConverter.addConversion([&typeConverter](cudaq::cc::PointerType type) {
       auto eleTy = type.getElementType();

--- a/lib/Optimizer/CodeGen/TranslateToIQMJson.cpp
+++ b/lib/Optimizer/CodeGen/TranslateToIQMJson.cpp
@@ -159,20 +159,22 @@ static LogicalResult emitOperation(nlohmann::json &json,
 
 static LogicalResult emitOperation(nlohmann::json &json,
                                    cudaq::Emitter &emitter, Operation &op) {
-  using namespace quake;
   return llvm::TypeSwitch<Operation *, LogicalResult>(&op)
       .Case<ModuleOp>([&](auto op) { return emitOperation(json, emitter, op); })
       // Quake
-      .Case<AllocaOp>([&](auto op) { return emitOperation(json, emitter, op); })
-      .Case<ExtractRefOp>(
+      .Case<quake::AllocaOp>(
           [&](auto op) { return emitOperation(json, emitter, op); })
-      .Case<OperatorInterface>(
-          [&](auto optor) { return emitOperation(json, emitter, optor); })
-      .Case<MzOp>([&](auto op) { return emitOperation(json, emitter, op); })
+      .Case<quake::ExtractRefOp>(
+          [&](auto op) { return emitOperation(json, emitter, op); })
+      .Case<quake::OperatorInterface>(
+          [&](auto op) { return emitOperation(json, emitter, op); })
+      .Case<quake::MzOp>(
+          [&](auto op) { return emitOperation(json, emitter, op); })
       // Ignore
-      .Case<DeallocOp>([&](auto op) { return success(); })
-      .Case<func::ReturnOp>([&](auto op) { return success(); })
-      .Case<arith::ConstantOp>([&](auto op) { return success(); })
+      .Case<quake::DiscriminateOp>([](auto) { return success(); })
+      .Case<quake::DeallocOp>([](auto) { return success(); })
+      .Case<func::ReturnOp>([](auto) { return success(); })
+      .Case<arith::ConstantOp>([](auto) { return success(); })
       .Default([&](Operation *) -> LogicalResult {
         // Allow LLVM and cc dialect ops (for storing measure results).
         if (op.getName().getDialectNamespace().equals("llvm") ||

--- a/lib/Optimizer/CodeGen/TranslateToOpenQASM.cpp
+++ b/lib/Optimizer/CodeGen/TranslateToOpenQASM.cpp
@@ -318,7 +318,7 @@ static LogicalResult emitOperation(Emitter &emitter, quake::MzOp op) {
       return op.emitError("cannot emmit measure on an unbounded veq");
     size = veq.getSize();
   }
-  auto bitsName = printClassicalAllocation(emitter, op.getBits(), size);
+  auto bitsName = printClassicalAllocation(emitter, op.getMeasOut(), size);
   emitter.os << "measure " << emitter.getOrAssignName(qrefOrVeq) << " -> "
              << bitsName << ";\n";
   return success();

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -593,32 +593,51 @@ static LogicalResult verifyMeasurements(Operation *const op,
                                         const Type bitsType) {
   bool mustBeStdvec =
       targetsType.size() > 1 ||
-      (targetsType.size() == 1 && targetsType[0].isa<quake::VeqType>());
+      (targetsType.size() == 1 && isa<quake::VeqType>(targetsType[0]));
   if (mustBeStdvec) {
-    if (!op->getResult(0).getType().isa<cudaq::cc::StdvecType>())
-      return op->emitOpError("must return `!cc.stdvec<i1>`, when measuring a "
-                             "qreg, a series of qubits, or both");
+    if (!isa<cudaq::cc::StdvecType>(op->getResult(0).getType()))
+      return op->emitOpError("must return `!cc.stdvec<!quake.measure>`, when "
+                             "measuring a qreg, a series of qubits, or both");
   } else {
-    if (!op->getResult(0).getType().isa<IntegerType>())
+    if (!isa<quake::MeasureType>(op->getResult(0).getType()))
       return op->emitOpError(
-          "must return `i1` when measuring exactly one qubit");
+          "must return `!quake.measure` when measuring exactly one qubit");
   }
   return success();
 }
 
 LogicalResult quake::MxOp::verify() {
   return verifyMeasurements(getOperation(), getTargets().getType(),
-                            getBits().getType());
+                            getMeasOut().getType());
 }
 
 LogicalResult quake::MyOp::verify() {
   return verifyMeasurements(getOperation(), getTargets().getType(),
-                            getBits().getType());
+                            getMeasOut().getType());
 }
 
 LogicalResult quake::MzOp::verify() {
   return verifyMeasurements(getOperation(), getTargets().getType(),
-                            getBits().getType());
+                            getMeasOut().getType());
+}
+
+//===----------------------------------------------------------------------===//
+// Discriminate
+//===----------------------------------------------------------------------===//
+
+LogicalResult quake::DiscriminateOp::verify() {
+  if (isa<cudaq::cc::StdvecType>(getMeasurement().getType())) {
+    auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(getResult().getType());
+    if (!stdvecTy || !isa<IntegerType>(stdvecTy.getElementType()))
+      return emitOpError("must return a !cc.stdvec<integral> type, when "
+                         "discriminating a qreg, a series of qubits, or both");
+  } else {
+    auto measTy = isa<quake::MeasureType>(getMeasurement().getType());
+    if (!measTy || !isa<IntegerType>(getResult().getType()))
+      return emitOpError(
+          "must return integral type when discriminating exactly one qubit");
+  }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -59,5 +59,5 @@ quake::VeqType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
 //===----------------------------------------------------------------------===//
 
 void quake::QuakeDialect::registerTypes() {
-  addTypes<VeqType, RefType, WireType, ControlType>();
+  addTypes<ControlType, MeasureType, RefType, VeqType, WireType>();
 }

--- a/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/lib/Optimizer/Transforms/MemToReg.cpp
@@ -560,7 +560,7 @@ public:
 
     if constexpr (quake::isMeasure<OP>) {
       // The result type of the bits is the same. Add the wire types.
-      SmallVector<Type> newTy = {op.getBits().getType()};
+      SmallVector<Type> newTy = {op.getMeasOut().getType()};
       SmallVector<Type> wireTys(unwrapTargs.size(), wireTy);
       newTy.append(wireTys.begin(), wireTys.end());
       auto newOp = rewriter.create<OP>(loc, newTy, unwrapTargs,

--- a/lib/Optimizer/Transforms/ObserveAnsatz.cpp
+++ b/lib/Optimizer/Transforms/ObserveAnsatz.cpp
@@ -225,7 +225,8 @@ struct AppendMeasurements : public OpRewritePattern<func::FuncOp> {
       // add the measure
       char regName[16];
       std::snprintf(regName, sizeof(regName), "r%05lu", measureNum);
-      builder.create<quake::MzOp>(loc, builder.getI1Type(), qubitToMeasure,
+      auto measTy = quake::MeasureType::get(builder.getContext());
+      builder.create<quake::MzOp>(loc, measTy, qubitToMeasure,
                                   builder.getStringAttr(regName));
     }
 

--- a/lib/Optimizer/Transforms/QuakeAddMetadata.cpp
+++ b/lib/Optimizer/Transforms/QuakeAddMetadata.cpp
@@ -69,7 +69,11 @@ private:
       // Look for Measure Ops, if the return value is used by a StoreOp
       // then get the memref.alloca value. Any loads from that alloca
       // that are used by conditionals is what we are looking for.
-      if (!isa<quake::MeasurementInterface>(op))
+      Operation *measOp = nullptr;
+      if (auto disc = dyn_cast_if_present<quake::DiscriminateOp>(op))
+        measOp = disc.getMeasurement().getDefiningOp();
+
+      if (!isa_and_present<quake::MeasurementInterface>(measOp))
         return WalkResult::skip();
 
       // Get the return bit value

--- a/lib/Optimizer/Transforms/RegToMem.cpp
+++ b/lib/Optimizer/Transforms/RegToMem.cpp
@@ -233,7 +233,7 @@ public:
       auto nameAttr = op.getRegisterNameAttr();
       eraseWrapUsers(op);
       auto newOp = rewriter.create<OP>(
-          loc, ArrayRef<Type>{op.getBits().getType()}, args, nameAttr);
+          loc, ArrayRef<Type>{op.getMeasOut().getType()}, args, nameAttr);
       op.getResult(0).replaceAllUsesWith(newOp.getResult(0));
       rewriter.eraseOp(op);
     } else if constexpr (std::is_same_v<OP, quake::ResetOp>) {

--- a/python/tests/compiler/adjoint.py
+++ b/python/tests/compiler/adjoint.py
@@ -238,7 +238,7 @@ def test_sample_adjoint_qubit():
 # CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
 # CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "" : (!quake.ref) -> i1
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "" : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 
@@ -306,7 +306,8 @@ def test_sample_adjoint_qreg():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_17:.*]]: index):
 # CHECK:             %[[VAL_18:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_17]]] : (!quake.veq<?>, index) -> !quake.ref
-# CHECK:             %[[VAL_19:.*]] = quake.mz %[[VAL_18]] name "" : (!quake.ref) -> i1
+# CHECK:             %[[VAL_119:.*]] = quake.mz %[[VAL_18]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:             %[[VAL_19:.*]] = quake.discriminate %[[VAL_119]] :
 # CHECK:             %[[VAL_20:.*]] = arith.index_cast %[[VAL_17]] : index to i64
 # CHECK:             %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_13]][%[[VAL_20]]] : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.ptr<i1>
 # CHECK:             cc.store %[[VAL_19]], %[[VAL_21]] : !cc.ptr<i1>

--- a/python/tests/compiler/conditional.py
+++ b/python/tests/compiler/conditional.py
@@ -56,10 +56,11 @@ def test_kernel_conditional():
 # CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_4]] name "measurement_" : (!quake.ref) -> i1
+# CHECK:           %[[VAL_106:.*]] = quake.mz %[[VAL_4]] name "measurement_" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_6:.*]] = quake.discriminate %[[VAL_106]] :
 # CHECK:           cc.if(%[[VAL_6]]) {
 # CHECK:             quake.x %[[VAL_5]] : (!quake.ref) -> ()
-# CHECK:             %[[VAL_7:.*]] = quake.mz %[[VAL_5]] name "" : (!quake.ref) -> i1
+# CHECK:             %[[VAL_7:.*]] = quake.mz %[[VAL_5]] name "" : (!quake.ref) -> !quake.measure
 # CHECK:           }
 # CHECK:           %[[VAL_8:.*]] = cc.loop while ((%[[VAL_9:.*]] = %[[VAL_2]]) -> (index)) {
 # CHECK:             %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_0]] : index
@@ -76,7 +77,7 @@ def test_kernel_conditional():
 # CHECK:           } {invariant}
 # CHECK:           cc.if(%[[VAL_6]]) {
 # CHECK:             quake.x %[[VAL_5]] : (!quake.ref) -> ()
-# CHECK:             %[[VAL_15:.*]] = quake.mz %[[VAL_5]] name "" : (!quake.ref) -> i1
+# CHECK:             %[[VAL_15:.*]] = quake.mz %[[VAL_5]] name "" : (!quake.ref) -> !quake.measure
 # CHECK:           }
 # CHECK:           return
 # CHECK:         }
@@ -115,7 +116,8 @@ def test_kernel_conditional_with_sample():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "auto_register_0" : (!quake.ref) -> i1
+# CHECK:           %[[VAL_11:.*]] = quake.mz %[[VAL_0]] name "auto_register_0" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_1:.*]] = quake.discriminate %[[VAL_11]] :
 # CHECK:           cc.if(%[[VAL_1]]) {
 # CHECK:             quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           }
@@ -157,7 +159,8 @@ def test_cif_extract_ref_bug():
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "measure0" : (!quake.ref) -> i1
+# CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_1]] name "measure0" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_12]] :
 # CHECK:           cc.if(%[[VAL_2]]) {
 # CHECK:             %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:             quake.x %[[VAL_3]] : (!quake.ref) -> ()

--- a/python/tests/compiler/control.py
+++ b/python/tests/compiler/control.py
@@ -283,7 +283,7 @@ def test_sample_control_qubit_args():
 # CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "" : (!quake.ref) -> i1
+# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "" : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 
@@ -348,7 +348,8 @@ def test_sample_control_qreg_args():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_12:.*]]: index):
 # CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_5]][%[[VAL_12]]] : (!quake.veq<2>, index) -> !quake.ref
-# CHECK:             %[[VAL_14:.*]] = quake.mz %[[VAL_13]] name "" : (!quake.ref) -> i1
+# CHECK:             %[[VAL_114:.*]] = quake.mz %[[VAL_13]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:             %[[VAL_14:.*]] = quake.discriminate %[[VAL_114]] :
 # CHECK:             %[[VAL_15:.*]] = arith.index_cast %[[VAL_12]] : index to i64
 # CHECK:             %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_8]][%[[VAL_15]]] : (!cc.ptr<!cc.array<i1 x 2>>, i64) -> !cc.ptr<i1>
 # CHECK:             cc.store %[[VAL_14]], %[[VAL_16]] : !cc.ptr<i1>
@@ -358,7 +359,7 @@ def test_sample_control_qreg_args():
 # CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_2]] : index
 # CHECK:             cc.continue %[[VAL_18]] : index
 # CHECK:           } {invariant}
-# CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_6]] name "" : (!quake.ref) -> i1
+# CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_6]] name "" : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 
@@ -414,7 +415,7 @@ def test_sample_apply_call_control():
 # CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "" : (!quake.ref) -> i1
+# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "" : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/compiler/measure.py
+++ b/python/tests/compiler/measure.py
@@ -42,12 +42,12 @@ def test_kernel_measure_1q():
 # CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][1] : (!quake.veq<2>) -> !quake.ref
-# CHECK:           %[[VAL_5:.*]] = quake.mx %[[VAL_3]] name "" : (!quake.ref) -> i1
-# CHECK:           %[[VAL_6:.*]] = quake.mx %[[VAL_4]] name "" : (!quake.ref) -> i1
-# CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] name "" : (!quake.ref) -> i1
-# CHECK:           %[[VAL_8:.*]] = quake.my %[[VAL_4]] name "" : (!quake.ref) -> i1
-# CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_3]] name "" : (!quake.ref) -> i1
-# CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_4]] name "" : (!quake.ref) -> i1
+# CHECK:           %[[VAL_5:.*]] = quake.mx %[[VAL_3]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_6:.*]] = quake.mx %[[VAL_4]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_8:.*]] = quake.my %[[VAL_4]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_3]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_4]] name "" : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 
@@ -81,7 +81,8 @@ def test_kernel_measure_qreg():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: index):
 # CHECK:             %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_9]]] : (!quake.veq<3>, index) -> !quake.ref
-# CHECK:             %[[VAL_11:.*]] = quake.mx %[[VAL_10]] name "" : (!quake.ref) -> i1
+# CHECK:             %[[VAL_111:.*]] = quake.mx %[[VAL_10]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:             %[[VAL_11:.*]] = quake.discriminate %[[VAL_111]] :
 # CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_9]] : index to i64
 # CHECK:             %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_5]][%[[VAL_12]]] : (!cc.ptr<!cc.array<i1 x 3>>, i64) -> !cc.ptr<i1>
 # CHECK:             cc.store %[[VAL_11]], %[[VAL_13]] : !cc.ptr<i1>
@@ -98,7 +99,8 @@ def test_kernel_measure_qreg():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_20:.*]]: index):
 # CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_20]]] : (!quake.veq<3>, index) -> !quake.ref
-# CHECK:             %[[VAL_22:.*]] = quake.my %[[VAL_21]] name "" : (!quake.ref) -> i1
+# CHECK:             %[[VAL_122:.*]] = quake.my %[[VAL_21]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:             %[[VAL_22:.*]] = quake.discriminate %[[VAL_122]] :
 # CHECK:             %[[VAL_23:.*]] = arith.index_cast %[[VAL_20]] : index to i64
 # CHECK:             %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_16]][%[[VAL_23]]] : (!cc.ptr<!cc.array<i1 x 3>>, i64) -> !cc.ptr<i1>
 # CHECK:             cc.store %[[VAL_22]], %[[VAL_24]] : !cc.ptr<i1>
@@ -115,7 +117,8 @@ def test_kernel_measure_qreg():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_31:.*]]: index):
 # CHECK:             %[[VAL_32:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_31]]] : (!quake.veq<3>, index) -> !quake.ref
-# CHECK:             %[[VAL_33:.*]] = quake.mz %[[VAL_32]] name "" : (!quake.ref) -> i1
+# CHECK:             %[[VAL_133:.*]] = quake.mz %[[VAL_32]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:             %[[VAL_33:.*]] = quake.discriminate %[[VAL_133]] :
 # CHECK:             %[[VAL_34:.*]] = arith.index_cast %[[VAL_31]] : index to i64
 # CHECK:             %[[VAL_35:.*]] = cc.compute_ptr %[[VAL_27]][%[[VAL_34]]] : (!cc.ptr<!cc.array<i1 x 3>>, i64) -> !cc.ptr<i1>
 # CHECK:             cc.store %[[VAL_33]], %[[VAL_35]] : !cc.ptr<i1>

--- a/python/tests/compiler/swap.py
+++ b/python/tests/compiler/swap.py
@@ -49,7 +49,8 @@ def test_swap_2q():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_11:.*]]: index):
 # CHECK:             %[[VAL_12:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_11]]] : (!quake.veq<2>, index) -> !quake.ref
-# CHECK:             %[[VAL_13:.*]] = quake.mz %[[VAL_12]] name "" : (!quake.ref) -> i1
+# CHECK:             %[[VAL_113:.*]] = quake.mz %[[VAL_12]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:             %[[VAL_13:.*]] = quake.discriminate %[[VAL_113]] :
 # CHECK:             %[[VAL_14:.*]] = arith.index_cast %[[VAL_11]] : index to i64
 # CHECK:             %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_7]][%[[VAL_14]]] : (!cc.ptr<!cc.array<i1 x 2>>, i64) -> !cc.ptr<i1>
 # CHECK:             cc.store %[[VAL_13]], %[[VAL_15]] : !cc.ptr<i1>

--- a/test/AST-Quake/auto_kernel-1.cpp
+++ b/test/AST-Quake/auto_kernel-1.cpp
@@ -26,8 +26,9 @@ struct ak1 {
 // CHECK:           %[[VAL_1:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_7:.*]] = quake.discriminate %[[VAL_3]] : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_7]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i1>
 // CHECK:           return %[[VAL_6]] : i1

--- a/test/AST-Quake/auto_kernel-2.cpp
+++ b/test/AST-Quake/auto_kernel-2.cpp
@@ -23,9 +23,10 @@ struct ak2 {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ak2
 // CHECK-SAME: () -> !cc.stdvec<i1> attributes {
 // CHECK:           %[[VAL_22:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_19:.*]] = quake.mz %{{.*}} : (!quake.veq<5>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_19]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_21:.*]] = cc.stdvec_size %[[VAL_19]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_19:.*]] = quake.mz %{{.*}} : (!quake.veq<5>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_1:.*]] = quake.discriminate %[[VAL_19]] : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_20:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_21:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_23:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_24:.*]] = cc.stdvec_init %[[VAL_23]], %[[VAL_21]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
 // CHECK:           return %[[VAL_24]] : !cc.stdvec<i1>

--- a/test/AST-Quake/bool_literal.cpp
+++ b/test/AST-Quake/bool_literal.cpp
@@ -27,8 +27,9 @@ struct testBoolLiteral {
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_2:.*]] = cc.alloca i1
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_2]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1
-// CHECK:           cc.store %[[VAL_3]], %[[VAL_2]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_9:.*]] = quake.discriminate %[[VAL_3]] : (!quake.measure) -> i1
+// CHECK:           cc.store %[[VAL_9]], %[[VAL_2]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i1>
 // CHECK:           return %[[VAL_4]] : i1
 

--- a/test/AST-Quake/cast.cpp
+++ b/test/AST-Quake/cast.cpp
@@ -27,8 +27,9 @@ struct testCast {
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1
-// CHECK:           %[[VAL_4:.*]] = arith.uitofp %[[VAL_3]] : i1 to f64
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_10:.*]] = quake.discriminate %[[VAL_3]] :
+// CHECK:           %[[VAL_4:.*]] = arith.uitofp %[[VAL_10]] : i1 to f64
 // CHECK:           %[[VAL_5:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
@@ -36,6 +37,6 @@ struct testCast {
 // CHECK:           cc.if(%[[VAL_7]]) {
 // CHECK:             quake.x %[[VAL_2]] : (!quake.ref) -> ()
 // CHECK:           }
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_2]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_2]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -103,7 +103,7 @@ struct C {
 // CHECK:             }
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -192,7 +192,7 @@ struct D {
 // CHECK:             }
 // CHECK:           }
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -280,7 +280,7 @@ struct E {
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb7:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<2>
 // CHECK:           return
 
@@ -370,6 +370,6 @@ struct F {
 // CHECK:           cf.br ^bb1
 // CHECK:         ^bb8:
 // CHECK:           call @_Z2g4v() : () -> ()
-// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_28:.*]] = quake.mz %[[VAL_6]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           quake.dealloc %[[VAL_6]] : !quake.veq<2>
 // CHECK:           return

--- a/test/AST-Quake/ctor-1.cpp
+++ b/test/AST-Quake/ctor-1.cpp
@@ -16,7 +16,7 @@ using namespace cudaq;
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Teste
 // CHECK-SAME: (%[[VAL_0:.*]]: !quake.ref{{.*}})
 // CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/ctrl_vector.cpp
+++ b/test/AST-Quake/ctrl_vector.cpp
@@ -29,7 +29,7 @@ struct lower_ctrl_as_qreg {
 // CHECK:           quake.h [%[[VAL_0]]] %[[VAL_2]] : (!quake.veq<4>, !quake.ref) -> ()
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_0]]] %[[VAL_3]] : (!quake.veq<4>, !quake.ref) -> ()
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -55,7 +55,7 @@ struct test_two_control_call {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.apply @__nvqpp__mlirgen__ZN21test_two_control_callcl[[LAMBDA:.*]]_ [%[[VAL_2]]] %[[VAL_4]] : (!quake.veq<4>, !quake.ref) -> ()
-// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }
 
@@ -87,7 +87,7 @@ struct unmarked_lambda {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.apply %[[VAL_0]] [%[[VAL_2]]] %[[VAL_3]] : (!quake.veq<4>, !quake.ref) -> ()
-// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }
 
@@ -112,6 +112,6 @@ struct direct_unmarked_lambda {
 // CHECK:             quake.y %[[VAL_3]] : (!quake.ref) -> ()
 // CHECK:           } : !cc.callable<(!quake.ref) -> ()>
 // CHECK:           quake.apply %[[VAL_2]] [%[[VAL_0]]] %[[VAL_1]] : (!quake.veq<4>, !quake.ref) -> ()
-// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/if.cpp
+++ b/test/AST-Quake/if.cpp
@@ -32,7 +32,7 @@ struct kernel {
 // CHECK:           cc.if(%[[VAL_4]]) {
 // CHECK:             %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:             %[[VAL_6:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:             quake.h {{\[}}%[[VAL_5]]] %[[VAL_6]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:             quake.h [%[[VAL_5]]] %[[VAL_6]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           }
 // CHECK:           return %[[VAL_1]] : i32
 
@@ -80,14 +80,16 @@ struct kernel_short_circuit_and {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<3>
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<3>) -> !quake.ref
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_4:.*]] = quake.discriminate %[[VAL_10]] :
 // CHECK:           %[[VAL_5:.*]] = arith.cmpi eq, %[[VAL_4]], %[[VAL_0]] : i1
 // CHECK:           %[[VAL_6:.*]] = cc.if(%[[VAL_5]]) -> i1 {
 // CHECK:             cc.continue %[[VAL_0]] : i1
 // CHECK:           } else {
 // CHECK:             %[[VAL_7:.*]] = quake.extract_ref %[[VAL_2]][1] : (!quake.veq<3>) -> !quake.ref
-// CHECK:             %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
-// CHECK:             cc.continue %[[VAL_8]] : i1
+// CHECK:             %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> !quake.measure
+// CHECK:             %[[VAL_81:.*]] = quake.discriminate %[[VAL_8]] :
+// CHECK:             cc.continue %[[VAL_81]] : i1
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_6]]) {
 // CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_2]][2] : (!quake.veq<3>) -> !quake.ref
@@ -110,14 +112,16 @@ struct kernel_short_circuit_or {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<3>
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<3>) -> !quake.ref
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_41:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_4:.*]] = quake.discriminate %[[VAL_41]] :
 // CHECK:           %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_4]], %[[VAL_0]] : i1
 // CHECK:           %[[VAL_6:.*]] = cc.if(%[[VAL_5]]) -> i1 {
 // CHECK:             cc.continue %[[VAL_5]] : i1
 // CHECK:           } else {
 // CHECK:             %[[VAL_7:.*]] = quake.extract_ref %[[VAL_2]][1] : (!quake.veq<3>) -> !quake.ref
-// CHECK:             %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
-// CHECK:             cc.continue %[[VAL_8]] : i1
+// CHECK:             %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> !quake.measure
+// CHECK:             %[[VAL_81:.*]] = quake.discriminate %[[VAL_8]] :
+// CHECK:             cc.continue %[[VAL_81]] : i1
 // CHECK:           }
 // CHECK:           cc.if(%[[VAL_6]]) {
 // CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_2]][2] : (!quake.veq<3>) -> !quake.ref
@@ -138,15 +142,18 @@ struct kernel_ternary {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<3>
 // CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_1]][0] : (!quake.veq<3>) -> !quake.ref
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.ref) -> i1
-// CHECK:           %[[VAL_4:.*]] = cc.if(%[[VAL_3]]) -> i1 {
+// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_31:.*]] = quake.discriminate %[[VAL_3]] :
+// CHECK:           %[[VAL_4:.*]] = cc.if(%[[VAL_31]]) -> i1 {
 // CHECK:             %[[VAL_5:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<3>) -> !quake.ref
-// CHECK:             %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
-// CHECK:             cc.continue %[[VAL_6]] : i1
+// CHECK:             %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> !quake.measure
+// CHECK:             %[[VAL_61:.*]] = quake.discriminate %[[VAL_6]] :
+// CHECK:             cc.continue %[[VAL_61]] : i1
 // CHECK:           } else {
 // CHECK:             %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][2] : (!quake.veq<3>) -> !quake.ref
-// CHECK:             %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
-// CHECK:             cc.continue %[[VAL_8]] : i1
+// CHECK:             %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> !quake.measure
+// CHECK:             %[[VAL_81:.*]] = quake.discriminate %[[VAL_8]] :
+// CHECK:             cc.continue %[[VAL_81]] : i1
 // CHECK:           }
 // CHECK:           %[[VAL_9:.*]] = cc.alloca i1
 // CHECK:           cc.store %[[VAL_4]], %[[VAL_9]] : !cc.ptr<i1>

--- a/test/AST-Quake/loop_unroll-1.cpp
+++ b/test/AST-Quake/loop_unroll-1.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: cudaq-quake %s | cudaq-opt --pass-pipeline='builtin.module(expand-measurements,unrolling-pipeline)' | FileCheck %s
+// RUN: cudaq-quake %s | cudaq-opt --expand-measurements --unrolling-pipeline | FileCheck %s
 
 #include <cudaq.h>
 
@@ -22,15 +22,17 @@ struct C {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__C()
 // CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
 // CHECK-DAG:       %[[VAL_10:.*]] = quake.alloca !quake.ref
-// CHECK-DAG:       %[[VAL_11:.*]] = quake.mz %[[VAL_10]] name "singleQubit" : (!quake.ref) -> i1
+// CHECK-DAG:       %[[VAL_11:.*]] = quake.mz %[[VAL_10]] name "singleQubit" : (!quake.ref) -> !quake.measure
 // CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.array<i1 x 2>
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] name "myRegister%0" : (!quake.ref) -> i1
-// CHECK:           cc.store %[[VAL_6]], %{{.*}} : !cc.ptr<i1>
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] name "myRegister%0" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_10:.*]] = quake.discriminate %[[VAL_6]] :
+// CHECK:           cc.store %[[VAL_10]], %{{.*}} : !cc.ptr<i1>
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] name "myRegister%1" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] name "myRegister%1" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_11:.*]] = quake.discriminate %[[VAL_8]] :
 // CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<i1 x 2>>) -> !cc.ptr<i1>
-// CHECK:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<i1>
+// CHECK:           cc.store %[[VAL_11]], %[[VAL_9]] : !cc.ptr<i1>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/loop_unroll-3.cpp
+++ b/test/AST-Quake/loop_unroll-3.cpp
@@ -32,25 +32,25 @@ __qpu__ void loop_peeling_and_unrolling_test() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_loop_peeling_and_unrolling_test
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<10>
 // CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_0]][2] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_0]][3] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][4] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_9]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_9]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_0]][5] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_11]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_11]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]][6] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]][7] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_15]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_15]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_0]][8] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_17]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_17]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_19:.*]] = quake.extract_ref %[[VAL_0]][9] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_20:.*]] = quake.mz %[[VAL_19]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_20:.*]] = quake.mz %[[VAL_19]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -67,25 +67,25 @@ __qpu__ void another_test() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_another_test
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<10>
 // CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_0]][2] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_0]][3] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][4] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_9]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_9]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_11:.*]] = quake.extract_ref %[[VAL_0]][5] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_11]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_11]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]][6] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]][7] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_15]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_15]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_0]][8] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_17]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_17]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_19:.*]] = quake.extract_ref %[[VAL_0]][9] : (!quake.veq<10>) -> !quake.ref
-// CHECK:           %[[VAL_20:.*]] = quake.mz %[[VAL_19]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_20:.*]] = quake.mz %[[VAL_19]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }
 
@@ -107,6 +107,6 @@ struct Qernel {
 // CHECK:           quake.x %[[VAL_2]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<1>) -> !quake.ref
 // CHECK:           quake.x %[[VAL_3]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<1>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/measure_bell.cpp
+++ b/test/AST-Quake/measure_bell.cpp
@@ -52,7 +52,8 @@ struct bell {
 // CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:               %[[VAL_12:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:               %[[VAL_12:.*]] = quake.discriminate %[[VAL_112]] :
 // CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
 // CHECK:               %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
 // CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<i1>
@@ -116,7 +117,8 @@ struct libertybell {
 // CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:               %[[VAL_12:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:               %[[VAL_12:.*]] = quake.discriminate %[[VAL_112]] :
 // CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
 // CHECK:               %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
 // CHECK-DAG:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<i1>) -> !cc.ptr<i1>
@@ -179,7 +181,8 @@ struct tinkerbell {
 // CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:               %[[VAL_12:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:               %[[VAL_12:.*]] = quake.discriminate %[[VAL_112]] :
 // CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
 // CHECK:               %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
 // CHECK-DAG:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<i1>) -> !cc.ptr<i1>

--- a/test/AST-Quake/mz.cpp
+++ b/test/AST-Quake/mz.cpp
@@ -20,7 +20,7 @@ struct S {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__S() attributes
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<20>
-// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<20>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_2]] : (!quake.veq<20>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -41,7 +41,8 @@ struct VectorOfStaticVeq {
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_81:.*]] = quake.mz %[[VAL_0]], %[[VAL_3]], %[[VAL_6]], %[[VAL_7]] : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_8:.*]] = quake.discriminate %[[VAL_81]] :
 // CHECK:           %[[VAL_9:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = cc.stdvec_size %[[VAL_8]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_12:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_9]], %[[VAL_10]], %[[VAL_11]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
@@ -74,7 +75,8 @@ struct VectorOfDynamicVeq {
 // CHECK:           %[[VAL_9:.*]] = arith.extui %[[VAL_8]] : i32 to i64
 // CHECK:           %[[VAL_10:.*]] = quake.alloca !quake.veq<?>[%[[VAL_9]] : i64]
 // CHECK:           %[[VAL_11:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_112:.*]] = quake.mz %[[VAL_4]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_12:.*]] = quake.discriminate %[[VAL_112]] :
 // CHECK:           %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_14:.*]] = cc.stdvec_size %[[VAL_12]] : (!cc.stdvec<i1>) -> i64
 // CHECK:           %[[VAL_16:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>

--- a/test/AST-Quake/qbit_arg.cpp
+++ b/test/AST-Quake/qbit_arg.cpp
@@ -11,7 +11,7 @@
 // CHECK-LABEL: func.func @__nvqpp__mlirgen__function_testFunc
 // CHECK-SAME:    (%[[VAL_0:.*]]: !quake.ref{{.*}})
 // CHECK: quake.h %[[VAL_0]] :
-// CHECK: %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1
+// CHECK: %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> !quake.measure
 // CHECK: return
 // CHECK: }
 

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -336,7 +336,7 @@ int main() {
 // CHECK:             }
 // CHECK:           }
 // CHECK:           call @__nvqpp__mlirgen__function_iqft{{.*}}(%[[VAL_20]]) : (!quake.veq<?>) -> ()
-// CHECK:           %[[VAL_54:.*]] = quake.mz %[[VAL_20]] : (!quake.veq<?>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_54:.*]] = quake.mz %[[VAL_20]] : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/ranged_for.cpp
+++ b/test/AST-Quake/ranged_for.cpp
@@ -62,7 +62,7 @@ struct Colonel {
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_20:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           quake.rx (%[[VAL_20]]) %[[VAL_4]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> !quake.measure
 // clang-format on
 
 struct Lt_Colonel {
@@ -117,7 +117,7 @@ struct Lt_Colonel {
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_20:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           quake.rx (%[[VAL_20]]) %[[VAL_4]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_21:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> !quake.measure
 // clang-format on
 
 struct Qernel {
@@ -213,7 +213,7 @@ struct Qernel {
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_38:.*]] = cc.load %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           quake.rx (%[[VAL_38]]) %[[VAL_5]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_39:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_39:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> !quake.measure
 // clang-format on
 
 struct Nesting {
@@ -283,7 +283,7 @@ struct Nesting {
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_35:.*]] = cc.load %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           quake.rx (%[[VAL_35]]) %[[VAL_5]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_36:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_36:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/test/AST-Quake/ranged_for_qreg.cpp
+++ b/test/AST-Quake/ranged_for_qreg.cpp
@@ -31,7 +31,8 @@ __qpu__ void range_qubit() {
 // CHECK:             %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
 // CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_8]]] : (!quake.veq<10>, i64) -> !quake.ref
 // CHECK:             cc.scope {
-// CHECK:               %[[VAL_10:.*]] = quake.mx %[[VAL_9]] : (!quake.ref) -> i1
+// CHECK:               %[[VAL_110:.*]] = quake.mx %[[VAL_9]] : (!quake.ref) -> !quake.measure
+// CHECK:               %[[VAL_10:.*]] = quake.discriminate %[[VAL_110]] :
 // CHECK:               %[[VAL_11:.*]] = cc.alloca i1
 // CHECK:               cc.store %[[VAL_10]], %[[VAL_11]] : !cc.ptr<i1>
 // CHECK:             }

--- a/test/AST-Quake/simple_qarray.cpp
+++ b/test/AST-Quake/simple_qarray.cpp
@@ -75,7 +75,7 @@ int main() {
 // CHECK:               cc.store %[[VAL_16]], %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_17:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<5>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_17:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<5>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/single_qubit_ctor.cpp
+++ b/test/AST-Quake/single_qubit_ctor.cpp
@@ -22,8 +22,9 @@
 // CHECK:     %[[V3:.*]] = cc.load %[[V0]] : !cc.ptr<f64>
 // CHECK:     %[[V4:.*]] = arith.divf %[[V3]], %[[cst]] : f64
 // CHECK:     quake.ry (%[[V4]]) %[[V1]] : (f64,
-// CHECK:     %[[V5:.*]] = quake.mz %[[V1]] : (!quake.ref) -> i1
-// CHECK:     return %[[V5]] : i1
+// CHECK:     %[[V5:.*]] = quake.mz %[[V1]] : (!quake.ref) -> !quake.measure
+// CHECK:     %[[VAL_6:.*]] = quake.discriminate %[[V5]] :
+// CHECK:     return %[[VAL_6]] : i1
 // CHECK:   }
 // CHECK: }
 

--- a/test/AST-Quake/vector_bool.cpp
+++ b/test/AST-Quake/vector_bool.cpp
@@ -23,7 +23,8 @@ struct t1 {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__t1(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.stdvec<f64>{{.*}}) -> i1 attributes
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_1]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_12]] :
 // CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i1>

--- a/test/Quake-QIR/alloca_no_operand.qke
+++ b/test/Quake-QIR/alloca_no_operand.qke
@@ -8,8 +8,60 @@
 
 // RUN: cudaq-opt %s --add-dealloc --canonicalize | cudaq-translate --convert-to=qir | FileCheck %s
 
-module {
-  func.func @adder_n4() {
+func.func @adder_n4() {
+  %0 = quake.alloca !quake.veq<4>
+  %1 = memref.alloc() : memref<4xi1>
+  %c0 = arith.constant 0 : index
+  %2 = quake.extract_ref %0[%c0] : (!quake.veq<4>, index) -> !quake.ref
+  quake.x %2 : (!quake.ref) -> ()
+  %c1 = arith.constant 1 : index
+  %3 = quake.extract_ref %0[%c1] : (!quake.veq<4>, index) -> !quake.ref
+  quake.x %3 : (!quake.ref) -> ()
+  %c3 = arith.constant 3 : index
+  %4 = quake.extract_ref %0[%c3] : (!quake.veq<4>, index) -> !quake.ref
+  quake.h %4 : (!quake.ref) -> ()
+  %c2 = arith.constant 2 : index
+  %5 = quake.extract_ref %0[%c2] : (!quake.veq<4>, index) -> !quake.ref
+  quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
+  quake.t %2 : (!quake.ref) -> ()
+  quake.t %3 : (!quake.ref) -> ()
+  quake.t %5 : (!quake.ref) -> ()
+  quake.t<adj> %4 : (!quake.ref) -> ()
+  quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
+  quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
+  quake.x [%4] %2 : (!quake.ref, !quake.ref) -> ()
+  quake.x [%3] %5 : (!quake.ref, !quake.ref) -> ()
+  quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
+  quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
+  quake.t<adj> %2 : (!quake.ref) -> ()
+  quake.t<adj> %3 : (!quake.ref) -> ()
+  quake.t<adj> %5 : (!quake.ref) -> ()
+  quake.t %4 : (!quake.ref) -> ()
+  quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
+  quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
+  quake.s %4 : (!quake.ref) -> ()
+  quake.x [%4] %2 : (!quake.ref, !quake.ref) -> ()
+  quake.h %4 : (!quake.ref) -> ()
+  %6 = quake.mz %2 : (!quake.ref) -> !quake.measure
+  %61 = quake.discriminate %6 : (!quake.measure) -> i1
+  %c0_0 = arith.constant 0 : index
+  memref.store %61, %1[%c0_0] : memref<4xi1>
+  %7 = quake.mz %3 : (!quake.ref) -> !quake.measure
+  %71 = quake.discriminate %7 : (!quake.measure) -> i1
+  %c1_1 = arith.constant 1 : index
+  memref.store %71, %1[%c1_1] : memref<4xi1>
+  %8 = quake.mz %5 : (!quake.ref) -> !quake.measure
+  %81 = quake.discriminate %8 : (!quake.measure) -> i1
+  %c2_2 = arith.constant 2 : index
+  memref.store %81, %1[%c2_2] : memref<4xi1>
+  %9 = quake.mz %4 : (!quake.ref) -> !quake.measure
+  %91 = quake.discriminate %9 : (!quake.measure) -> i1
+  %c3_3 = arith.constant 3 : index
+  memref.store %91, %1[%c3_3] : memref<4xi1>
+  return
+}
+
+// CHECK-LABEL: @adder_n4()
 // CHECK:    %[[VAL_0:.*]] = tail call
 // CHECK-SAME:    %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 4)
 // CHECK:         %[[VAL_2:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
@@ -53,51 +105,3 @@ module {
 // CHECK:         %[[VAL_19:.*]] = tail call %Result* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_11]])
 // CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
 // CHECK:         ret void
-    %0 = quake.alloca !quake.veq<4>
-    %1 = memref.alloc() : memref<4xi1>
-    %c0 = arith.constant 0 : index
-    %2 = quake.extract_ref %0[%c0] : (!quake.veq<4>, index) -> !quake.ref
-    quake.x %2 : (!quake.ref) -> ()
-    %c1 = arith.constant 1 : index
-    %3 = quake.extract_ref %0[%c1] : (!quake.veq<4>, index) -> !quake.ref
-    quake.x %3 : (!quake.ref) -> ()
-    %c3 = arith.constant 3 : index
-    %4 = quake.extract_ref %0[%c3] : (!quake.veq<4>, index) -> !quake.ref
-    quake.h %4 : (!quake.ref) -> ()
-    %c2 = arith.constant 2 : index
-    %5 = quake.extract_ref %0[%c2] : (!quake.veq<4>, index) -> !quake.ref
-    quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
-    quake.t %2 : (!quake.ref) -> ()
-    quake.t %3 : (!quake.ref) -> ()
-    quake.t %5 : (!quake.ref) -> ()
-    quake.t<adj> %4 : (!quake.ref) -> ()
-    quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
-    quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
-    quake.x [%4] %2 : (!quake.ref, !quake.ref) -> ()
-    quake.x [%3] %5 : (!quake.ref, !quake.ref) -> ()
-    quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
-    quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
-    quake.t<adj> %2 : (!quake.ref) -> ()
-    quake.t<adj> %3 : (!quake.ref) -> ()
-    quake.t<adj> %5 : (!quake.ref) -> ()
-    quake.t %4 : (!quake.ref) -> ()
-    quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
-    quake.x [%5] %4 : (!quake.ref, !quake.ref) -> ()
-    quake.s %4 : (!quake.ref) -> ()
-    quake.x [%4] %2 : (!quake.ref, !quake.ref) -> ()
-    quake.h %4 : (!quake.ref) -> ()
-    %6 = quake.mz %2 : (!quake.ref) -> i1
-    %c0_0 = arith.constant 0 : index
-    memref.store %6, %1[%c0_0] : memref<4xi1>
-    %7 = quake.mz %3 : (!quake.ref) -> i1
-    %c1_1 = arith.constant 1 : index
-    memref.store %7, %1[%c1_1] : memref<4xi1>
-    %8 = quake.mz %5 : (!quake.ref) -> i1
-    %c2_2 = arith.constant 2 : index
-    memref.store %8, %1[%c2_2] : memref<4xi1>
-    %9 = quake.mz %4 : (!quake.ref) -> i1
-    %c3_3 = arith.constant 3 : index
-    memref.store %9, %1[%c3_3] : memref<4xi1>
-    return
-  }
-}

--- a/test/Quake-QIR/base_profile-1.qke
+++ b/test/Quake-QIR/base_profile-1.qke
@@ -8,8 +8,28 @@
 
 // RUN: cudaq-translate --convert-to=qir-base %s | FileCheck %s
 
-module {
-  func.func @__nvqpp__mlirgen__ghz() {
+func.func @__nvqpp__mlirgen__ghz() {
+  %c2_i32 = arith.constant 2 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c1 = arith.constant 1 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c0 = arith.constant 0 : index
+  %c3_i32 = arith.constant 3 : i32
+  %0 = quake.alloca !quake.veq<3>
+  %1 = quake.extract_ref %0[%c0_i32] : (!quake.veq<3>,i32) -> !quake.ref
+  quake.h %1 : (!quake.ref) -> ()
+  %2 = quake.extract_ref %0[%c0] : (!quake.veq<3>, index) -> !quake.ref
+  %3 = quake.extract_ref %0[%c1_i32] : (!quake.veq<3>,i32) -> !quake.ref
+  quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
+  %4 = quake.extract_ref %0[%c1] : (!quake.veq<3>,index) -> !quake.ref
+  %5 = quake.extract_ref %0[%c2_i32] : (!quake.veq<3>,i32) -> !quake.ref
+  quake.x [%4] %5 : (!quake.ref, !quake.ref) -> ()
+  %6 = quake.mz %1 : (!quake.ref) -> !quake.measure
+  %7 = quake.mz %3 : (!quake.ref) -> !quake.measure
+  %8 = quake.mz %5 : (!quake.ref) -> !quake.measure
+  return
+}
+  
 // CHECK-LABEL: __nvqpp__mlirgen__ghz
 // CHECK: tail call void @__quantum__qis__h__body(%[[VAL_0:.*]]* null)
 // CHECK: tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
@@ -21,26 +41,6 @@ module {
 // CHECK: tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull
 // CHECK: tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull
 // CHECK: ret void
-    %c2_i32 = arith.constant 2 : i32
-    %c1_i32 = arith.constant 1 : i32
-    %c1 = arith.constant 1 : index
-    %c0_i32 = arith.constant 0 : i32
-    %c0 = arith.constant 0 : index
-    %c3_i32 = arith.constant 3 : i32
-    %0 = quake.alloca !quake.veq<3>
-    %1 = quake.extract_ref %0[%c0_i32] : (!quake.veq<3>,i32) -> !quake.ref
-    quake.h %1 : (!quake.ref) -> ()
-    %2 = quake.extract_ref %0[%c0] : (!quake.veq<3>, index) -> !quake.ref
-    %3 = quake.extract_ref %0[%c1_i32] : (!quake.veq<3>,i32) -> !quake.ref
-    quake.x [%2] %3 : (!quake.ref, !quake.ref) -> ()
-    %4 = quake.extract_ref %0[%c1] : (!quake.veq<3>,index) -> !quake.ref
-    %5 = quake.extract_ref %0[%c2_i32] : (!quake.veq<3>,i32) -> !quake.ref
-    quake.x [%4] %5 : (!quake.ref, !quake.ref) -> ()
-    %6 = quake.mz %1 : (!quake.ref) -> i1
-    %7 = quake.mz %3 : (!quake.ref) -> i1
-    %8 = quake.mz %5 : (!quake.ref) -> i1
-    return
-  }
-  // CHECK: attributes #0 = { "irreversible" }
-  // CHECK: attributes #1 = { "entry_point" "output_labeling_schema"="schema_id" "output_names"="{{.*}}" "qir_profiles"="base_profile" "requiredQubits"="3" "requiredResults"="3" }
-}
+
+// CHECK: attributes #0 = { "irreversible" }
+// CHECK: attributes #1 = { "entry_point" "output_labeling_schema"="schema_id" "output_names"="{{.*}}" "qir_profiles"="base_profile" "requiredQubits"="3" "requiredResults"="3" }

--- a/test/Quake-QIR/base_profile-2.qke
+++ b/test/Quake-QIR/base_profile-2.qke
@@ -8,18 +8,16 @@
 
 // RUN: cudaq-translate --convert-to=qir-base %s | FileCheck %s
 
-module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"}} {
-  func.func @__nvqpp__mlirgen__t1() attributes {"cudaq-entrypoint"} {
-    %c2_i32 = arith.constant 2 : i32
-    %0 = arith.extsi %c2_i32 : i32 to i64
-    %c2_i64 = arith.constant 2 : i64
-    %1 = quake.alloca !quake.veq<2>
-    %c1_i32 = arith.constant 1 : i32
-    %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.veq<2>,i64) -> !quake.ref
-    %4 = quake.mz %3 : (!quake.ref) -> i1
-    return
-  }
+func.func @__nvqpp__mlirgen__t1() {
+  %c2_i32 = arith.constant 2 : i32
+  %0 = arith.extsi %c2_i32 : i32 to i64
+  %c2_i64 = arith.constant 2 : i64
+  %1 = quake.alloca !quake.veq<2>
+  %c1_i32 = arith.constant 1 : i32
+  %2 = arith.extsi %c1_i32 : i32 to i64
+  %3 = quake.extract_ref %1[%2] : (!quake.veq<2>,i64) -> !quake.ref
+  %4 = quake.mz %3 : (!quake.ref) -> !quake.measure
+  return
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__t1()

--- a/test/Quake-QIR/base_profile-3.qke
+++ b/test/Quake-QIR/base_profile-3.qke
@@ -8,18 +8,16 @@
 
 // RUN: cudaq-translate --convert-to=qir-base %s | FileCheck %s
 
-module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__t1 = "_ZN2t1clEv"}} {
-  func.func @__nvqpp__mlirgen__t1() attributes {"cudaq-entrypoint"} {
-    %c2_i32 = arith.constant 2 : i32
-    %0 = arith.extsi %c2_i32 : i32 to i64
-    %c2_i64 = arith.constant 2 : i64
-    %1 = quake.alloca !quake.veq<2>
-    %c1_i32 = arith.constant 1 : i32
-    %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.extract_ref %1[%2] : (!quake.veq<2>,i64) -> !quake.ref
-    %4 = quake.mz %3 : (!quake.ref) -> i1 { registerName = "Bob" }
-    return
-  }
+func.func @__nvqpp__mlirgen__t1() {
+  %c2_i32 = arith.constant 2 : i32
+  %0 = arith.extsi %c2_i32 : i32 to i64
+  %c2_i64 = arith.constant 2 : i64
+  %1 = quake.alloca !quake.veq<2>
+  %c1_i32 = arith.constant 1 : i32
+  %2 = arith.extsi %c1_i32 : i32 to i64
+  %3 = quake.extract_ref %1[%2] : (!quake.veq<2>,i64) -> !quake.ref
+  %4 = quake.mz %3 name "Bob" : (!quake.ref) -> !quake.measure
+  return
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__t1()

--- a/test/Quake-QIR/base_profile-4.qke
+++ b/test/Quake-QIR/base_profile-4.qke
@@ -8,45 +8,43 @@
 
 // RUN: cudaq-opt %s --add-dealloc | cudaq-translate --convert-to=qir-base | FileCheck %s
 
-module {
-   // Test base profile lowering without combining quantum allocations.
-   func.func @sans_combine(){
+// Test base profile lowering without combining quantum allocations.
+func.func @sans_combine() {
 
-      %zero = arith.constant 0 : i32
-      %one = arith.constant 1 : i32
-      %neg = arith.constant -5 : i32
-      %two = arith.constant 2 : i32
-      %0 = quake.alloca !quake.veq<?>[%two : i32]
-     
-      %1 = quake.alloca !quake.veq<2>
-      
-      %qr1 = quake.extract_ref %0[%zero] : (!quake.veq<?>,i32) -> !quake.ref
-      %qr2 = quake.extract_ref %1[%one]  : (!quake.veq<2>,i32) -> !quake.ref
+   %zero = arith.constant 0 : i32
+   %one = arith.constant 1 : i32
+   %neg = arith.constant -5 : i32
+   %two = arith.constant 2 : i32
+   %0 = quake.alloca !quake.veq<?>[%two : i32]
+  
+   %1 = quake.alloca !quake.veq<2>
+   
+   %qr1 = quake.extract_ref %0[%zero] : (!quake.veq<?>,i32) -> !quake.ref
+   %qr2 = quake.extract_ref %1[%one]  : (!quake.veq<2>,i32) -> !quake.ref
 
-      %qr3 = quake.alloca !quake.ref
-      %2 = quake.alloca !quake.veq<?>[%one : i32]
-      %qr4 = quake.extract_ref %2[0] : (!quake.veq<?>) -> !quake.ref
+   %qr3 = quake.alloca !quake.ref
+   %2 = quake.alloca !quake.veq<?>[%one : i32]
+   %qr4 = quake.extract_ref %2[0] : (!quake.veq<?>) -> !quake.ref
 
-      %fl1 = arith.constant 0.43 : f64
-      %fl2 = arith.constant 0.33 : f64
-      %fl3 = arith.constant 0.73 : f64
-      quake.h %qr1 : (!quake.ref) -> ()  
-      quake.x [%qr1] %qr2 : (!quake.ref, !quake.ref) -> ()
-      quake.rx (%fl1) %qr1 : (f64, !quake.ref) -> ()
+   %fl1 = arith.constant 0.43 : f64
+   %fl2 = arith.constant 0.33 : f64
+   %fl3 = arith.constant 0.73 : f64
+   quake.h %qr1 : (!quake.ref) -> ()  
+   quake.x [%qr1] %qr2 : (!quake.ref, !quake.ref) -> ()
+   quake.rx (%fl1) %qr1 : (f64, !quake.ref) -> ()
 
-      quake.h %qr3 : (!quake.ref) -> ()  
-      quake.x [%qr3] %qr4 : (!quake.ref, !quake.ref) -> ()
-      quake.rx (%fl2) %qr3 : (f64, !quake.ref) -> ()
+   quake.h %qr3 : (!quake.ref) -> ()  
+   quake.x [%qr3] %qr4 : (!quake.ref, !quake.ref) -> ()
+   quake.rx (%fl2) %qr3 : (f64, !quake.ref) -> ()
 
-      quake.h %qr1 : (!quake.ref) -> ()  
-      quake.x [%qr1] %qr3 : (!quake.ref, !quake.ref) -> ()
-      %qr5 = quake.extract_ref %1[%zero] : (!quake.veq<2>,i32) -> !quake.ref
-      quake.rx (%fl3) %qr5 : (f64, !quake.ref) -> ()
+   quake.h %qr1 : (!quake.ref) -> ()  
+   quake.x [%qr1] %qr3 : (!quake.ref, !quake.ref) -> ()
+   %qr5 = quake.extract_ref %1[%zero] : (!quake.veq<2>,i32) -> !quake.ref
+   quake.rx (%fl3) %qr5 : (f64, !quake.ref) -> ()
 
-      quake.mz %qr1 : (!quake.ref) -> i1
-      quake.mz %qr5 : (!quake.ref) -> i1
-      return 
-    }
+   quake.mz %qr1 : (!quake.ref) -> !quake.measure
+   quake.mz %qr5 : (!quake.ref) -> !quake.measure
+   return 
 }
 
 // CHECK-LABEL: define void @sans_combine()

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -8,13 +8,12 @@
 
 // RUN: cudaq-opt %s --add-dealloc | cudaq-translate --convert-to=qir | FileCheck %s
 
-module {
-     func.func @test_func(%p : i32) {
-          %qv = quake.alloca !quake.veq<?>[%p : i32]
-          %t = arith.constant 2 : i32
-          %v = quake.alloca !quake.veq<?>[%t : i32]
-          return
-     }
+func.func @test_func(%p : i32) {
+  %qv = quake.alloca !quake.veq<?>[%p : i32]
+  %t = arith.constant 2 : i32
+  %v = quake.alloca !quake.veq<?>[%t : i32]
+  return
+}
 
 // CHECK-LABEL: define void @test_func(i32 
 // CHECK-SAME:                             %[[VAL_0:.*]]) local_unnamed_addr {
@@ -26,30 +25,28 @@ module {
 // CHECK:         ret void
 // CHECK:       }
 
-   func.func @test_func2(){
+func.func @test_func2(){
+  %zero = arith.constant 0 : i32
+  %one = arith.constant 1 : i32
+  %neg = arith.constant -5 : i32
+  %two = arith.constant 2 : i32
+  %0 = quake.alloca !quake.veq<?>[%two : i32]
 
-      %zero = arith.constant 0 : i32
-      %one = arith.constant 1 : i32
-      %neg = arith.constant -5 : i32
-      %two = arith.constant 2 : i32
-      %0 = quake.alloca !quake.veq<?>[%two : i32]
-     
-      %1 = quake.alloca !quake.veq<2>
-      %2 = quake.alloca !quake.veq<?>[%one : i32]
-      
-      %qr1 = quake.extract_ref %0[%zero] : (!quake.veq<?>,i32) -> !quake.ref
-      %qr2 = quake.extract_ref %1[%one]  : (!quake.veq<2>,i32) -> !quake.ref
+  %1 = quake.alloca !quake.veq<2>
+  %2 = quake.alloca !quake.veq<?>[%one : i32]
 
-      %fl = arith.constant 0.43 : f64
-      %fl2 = arith.constant 0.33 : f64
-      %fl3 = arith.constant 0.73 : f64
-      quake.h %qr1 : (!quake.ref) -> ()  
-      quake.x [%qr1] %qr2 : (!quake.ref, !quake.ref) -> ()
-      quake.rx (%fl) %qr1 : (f64, !quake.ref) -> ()
+  %qr1 = quake.extract_ref %0[%zero] : (!quake.veq<?>,i32) -> !quake.ref
+  %qr2 = quake.extract_ref %1[%one]  : (!quake.veq<2>,i32) -> !quake.ref
 
-      quake.mz %qr1 : (!quake.ref) -> i1
-      return 
-    }
+  %fl = arith.constant 0.43 : f64
+  %fl2 = arith.constant 0.33 : f64
+  %fl3 = arith.constant 0.73 : f64
+  quake.h %qr1 : (!quake.ref) -> ()  
+  quake.x [%qr1] %qr2 : (!quake.ref, !quake.ref) -> ()
+  quake.rx (%fl) %qr1 : (f64, !quake.ref) -> ()
+
+  quake.mz %qr1 : (!quake.ref) -> !quake.measure
+  return 
 }
 
 // CHECK-LABEL: define void @test_func2() local_unnamed_addr {

--- a/test/Quake-QIR/measure.qke
+++ b/test/Quake-QIR/measure.qke
@@ -8,20 +8,18 @@
 
 // RUN: cudaq-opt %s --add-dealloc | cudaq-translate --convert-to=qir | FileCheck %s
 
-module {
-  func.func @test_func2(){
-    %zero = arith.constant 0 : i32
-    %one = arith.constant 1 : i32
-    %two = arith.constant 2 : i32
-    %0 = quake.alloca !quake.veq<?>[%two : i32]
+func.func @test_func2(){
+  %zero = arith.constant 0 : i32
+  %one = arith.constant 1 : i32
+  %two = arith.constant 2 : i32
+  %0 = quake.alloca !quake.veq<?>[%two : i32]
 
-    %qr1 = quake.extract_ref %0[%zero] : (!quake.veq<?>,i32) -> !quake.ref
-    %qr2 = quake.extract_ref %0[%one] : (!quake.veq<?>,i32) -> !quake.ref
+  %qr1 = quake.extract_ref %0[%zero] : (!quake.veq<?>,i32) -> !quake.ref
+  %qr2 = quake.extract_ref %0[%one] : (!quake.veq<?>,i32) -> !quake.ref
 
-    quake.mx %qr1 : (!quake.ref) -> i1
-    quake.my %qr1 : (!quake.ref) -> i1
-    return 
-  }
+  quake.mx %qr1 : (!quake.ref) -> !quake.measure
+  quake.my %qr1 : (!quake.ref) -> !quake.measure
+  return 
 }
 
 // CHECK-LABEL: define void @test_func2

--- a/test/Quake/adjoint-2.qke
+++ b/test/Quake/adjoint-2.qke
@@ -11,7 +11,7 @@
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel_alpha = "_ZN12kernel_alphaclERN4cudaq5quditILm2EEE", __nvqpp__mlirgen__kernel_beta = "_ZN11kernel_betaclEv"}} {
   // expected-error @+1 {{cannot make adjoint of kernel with a measurement}}
   func.func @__nvqpp__mlirgen__kernel_alpha(%arg0: !quake.ref) attributes {"cudaq-kernel"} {
-    %0 = quake.mx %arg0 : (!quake.ref) -> i1
+    %0 = quake.mx %arg0 : (!quake.ref) -> !quake.measure
     return
   }
   func.func @__nvqpp__mlirgen__kernel_beta() attributes {"cudaq-entrypoint", "cudaq-kernel"} {

--- a/test/Quake/bell.qke
+++ b/test/Quake/bell.qke
@@ -19,8 +19,8 @@ module {
 
     quake.h %q0 : (!quake.ref) -> ()
     quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
-    quake.mz %q0 : (!quake.ref) -> i1
-    quake.mz %q1 : (!quake.ref) -> i1
+    quake.mz %q0 : (!quake.ref) -> !quake.measure
+    quake.mz %q1 : (!quake.ref) -> !quake.measure
     return
   }
 }
@@ -31,7 +31,7 @@ module {
 // CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
 // CHECK:           quake.x [%[[VAL_1]]] %[[VAL_2]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.ref) -> i1
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_2]] : (!quake.ref) -> i1
+// CHECK:           quake.mz %[[VAL_1]] : (!quake.ref) -> !quake.measure
+// CHECK:           quake.mz %[[VAL_2]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/canonical-3.qke
+++ b/test/Quake/canonical-3.qke
@@ -24,21 +24,25 @@ func.func @__nvqpp__mlirgen__super() attributes {"cudaq-entrypoint", "cudaq-kern
   quake.x [%3] %4 : (!quake.ref, !quake.ref) -> ()
   %5 = cc.alloca !cc.array<i1 x 4>
   %6 = quake.extract_ref %0[%c0] : (!quake.veq<4>, index) -> !quake.ref
-  %7 = quake.mz %6 : (!quake.ref) -> i1
+  %7 = quake.mz %6 : (!quake.ref) -> !quake.measure
   %8 = cc.compute_ptr %5[0] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
-  cc.store %7, %8 : !cc.ptr<i1>
+  %107 = quake.discriminate %7 : (!quake.measure) -> i1
+  cc.store %107, %8 : !cc.ptr<i1>
   %9 = quake.extract_ref %0[%c1] : (!quake.veq<4>, index) -> !quake.ref
-  %10 = quake.mz %9 : (!quake.ref) -> i1
+  %10 = quake.mz %9 : (!quake.ref) -> !quake.measure
   %11 = cc.compute_ptr %5[1] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
-  cc.store %10, %11 : !cc.ptr<i1>
+  %110 = quake.discriminate %10 : (!quake.measure) -> i1
+  cc.store %110, %11 : !cc.ptr<i1>
   %12 = quake.extract_ref %0[%c2] : (!quake.veq<4>, index) -> !quake.ref
-  %13 = quake.mz %12 : (!quake.ref) -> i1
+  %13 = quake.mz %12 : (!quake.ref) -> !quake.measure
   %14 = cc.compute_ptr %5[2] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
-  cc.store %13, %14 : !cc.ptr<i1>
+  %113 = quake.discriminate %13 : (!quake.measure) -> i1
+  cc.store %113, %14 : !cc.ptr<i1>
   %15 = quake.extract_ref %0[%c3] : (!quake.veq<4>, index) -> !quake.ref
-  %16 = quake.mz %15 : (!quake.ref) -> i1
+  %16 = quake.mz %15 : (!quake.ref) -> !quake.measure
+  %116 = quake.discriminate %16 : (!quake.measure) -> i1
   %17 = cc.compute_ptr %5[3] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
-  cc.store %16, %17 : !cc.ptr<i1>
+  cc.store %116, %17 : !cc.ptr<i1>
   return
 }
 
@@ -54,19 +58,23 @@ func.func @__nvqpp__mlirgen__super() attributes {"cudaq-entrypoint", "cudaq-kern
 // CHECK:           quake.x {{\[}}%[[VAL_3]]] %[[VAL_4]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           %[[VAL_5:.*]] = cc.alloca !cc.array<i1 x 4>
 // CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<4>) -> !quake.ref
-// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
-// CHECK:           cc.store %[[VAL_7]], %[[VAL_8]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_107:.*]] = quake.discriminate %[[VAL_7]] :
+// CHECK:           cc.store %[[VAL_107]], %[[VAL_8]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<4>) -> !quake.ref
-// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_9]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_9]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
-// CHECK:           cc.store %[[VAL_10]], %[[VAL_11]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_110:.*]] = quake.discriminate %[[VAL_10]] :
+// CHECK:           cc.store %[[VAL_110]], %[[VAL_11]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]][2] : (!quake.veq<4>) -> !quake.ref
-// CHECK:           %[[VAL_13:.*]] = quake.mz %[[VAL_12]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_113:.*]] = quake.mz %[[VAL_12]] : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_5]][2] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_13:.*]] = quake.discriminate %[[VAL_113]] :
 // CHECK:           cc.store %[[VAL_13]], %[[VAL_14]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_0]][3] : (!quake.veq<4>) -> !quake.ref
-// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_15]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_116:.*]] = quake.mz %[[VAL_15]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_16:.*]] = quake.discriminate %[[VAL_116]] :
 // CHECK:           %[[VAL_17:.*]] = cc.compute_ptr %[[VAL_5]][3] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_16]], %[[VAL_17]] : !cc.ptr<i1>
 // CHECK:           return

--- a/test/Quake/control_flow.qke
+++ b/test/Quake/control_flow.qke
@@ -285,8 +285,9 @@ func.func @test5(%arg0: !quake.veq<?>) {
       quake.h %4 : (!quake.ref) -> ()
       %5 = cc.load %2 : !cc.ptr<i64>
       %6 = quake.extract_ref %arg0[%5] : (!quake.veq<?>, i64) -> !quake.ref
-      %bits = quake.mz %6 : (!quake.ref) -> i1
-      cc.store %bits, %0 : !cc.ptr<i1>
+      %bits = quake.mz %6 : (!quake.ref) -> !quake.measure
+      %bit = quake.discriminate %bits : (!quake.measure) -> i1
+      cc.store %bit, %0 : !cc.ptr<i1>
       %7 = cc.load %0 : !cc.ptr<i1>
       cc.if(%7) {
         cc.unwind_break
@@ -323,7 +324,8 @@ func.func @test5(%arg0: !quake.veq<?>) {
 // CHECK:               quake.h %[[VAL_11]] : (!quake.ref) -> ()
 // CHECK:               %[[VAL_12:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i64>
 // CHECK:               %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_12]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_14:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> i1
+// CHECK:               %[[VAL_114:.*]] = quake.mz %[[VAL_13]] : (!quake.ref) -> !quake.measure
+// CHECK:               %[[VAL_14:.*]] = quake.discriminate %[[VAL_114]] :
 // CHECK:               cc.store %[[VAL_14]], %[[VAL_4]] : !cc.ptr<i1>
 // CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i1>
 // CHECK:               cf.cond_br %[[VAL_15]], ^bb[[then:.*]], ^bb[[else:.*]]
@@ -361,9 +363,10 @@ func.func @test6(%arg0: !quake.veq<?>) {
         quake.h %3 : (!quake.ref) -> ()
         %4 = cc.load %1 : !cc.ptr<i64>
         %5 = quake.extract_ref %arg0[%4] : (!quake.veq<?>, i64) -> !quake.ref
-        %bits = quake.mz %5 name "b" : (!quake.ref) -> i1
+        %bits = quake.mz %5 name "b" : (!quake.ref) -> !quake.measure
         %6 = cc.alloca i1
-        cc.store %bits, %6 : !cc.ptr<i1>
+	%bit = quake.discriminate %bits : (!quake.measure) -> i1
+        cc.store %bit, %6 : !cc.ptr<i1>
         %7 = cc.load %6 : !cc.ptr<i1>
         cc.if(%7) {
           cc.unwind_break
@@ -400,8 +403,9 @@ func.func @test6(%arg0: !quake.veq<?>) {
 // CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:               %[[VAL_11:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i64>
 // CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:               %[[VAL_13:.*]] = quake.mz %[[VAL_12]] name "b" : (!quake.ref) -> i1
+// CHECK:               %[[VAL_113:.*]] = quake.mz %[[VAL_12]] name "b" : (!quake.ref) -> !quake.measure
 // CHECK:               %[[VAL_14:.*]] = cc.alloca i1
+// CHECK:               %[[VAL_13:.*]] = quake.discriminate %[[VAL_113]] :
 // CHECK:               cc.store %[[VAL_13]], %[[VAL_14]] : !cc.ptr<i1>
 // CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<i1>
 // CHECK:               cf.cond_br %[[VAL_15]], ^bb1, ^bb2

--- a/test/Quake/cse.qke
+++ b/test/Quake/cse.qke
@@ -44,8 +44,9 @@ module {
 
 // CHECK-LABEL:   func.func @test_2() -> i1 {
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> i1
-// CHECK:           return %[[VAL_1]] : i1
+// CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] :
+// CHECK:           return %[[VAL_2]] : i1
 // CHECK:         }
 
   func.func @test_2() -> i1 {
@@ -53,8 +54,9 @@ module {
     %2 = quake.concat %1 : (!quake.ref) -> !quake.veq<?>
     %zero = arith.constant 0 : i32
     %3 = quake.extract_ref %2[%zero] : (!quake.veq<?>, i32) -> !quake.ref
-    %4 = quake.mz %3 : (!quake.ref) -> i1
-    return %4 : i1
+    %4 = quake.mz %3 : (!quake.ref) -> !quake.measure
+    %5 = quake.discriminate %4 : (!quake.measure) -> i1
+    return %5 : i1
   }
 }
 

--- a/test/Quake/custom-pass.qke
+++ b/test/Quake/custom-pass.qke
@@ -19,8 +19,8 @@ module {
 
         quake.h %q0 : (!quake.ref) -> ()
         quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
-        quake.mz %q0 : (!quake.ref) -> i1
-        quake.mz %q1 : (!quake.ref) -> i1
+        quake.mz %q0 : (!quake.ref) -> !quake.measure
+        quake.mz %q1 : (!quake.ref) -> !quake.measure
         return
     }
 }
@@ -34,7 +34,7 @@ module {
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_2]]] : (!quake.veq<?>, i32) -> !quake.ref
 // CHECK:           quake.s %[[VAL_4]] : (!quake.ref) -> ()
 // CHECK:           quake.x {{\[}}%[[VAL_4]]] %[[VAL_5]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> i1
-// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_5]] : (!quake.ref) -> i1
+// CHECK:           quake.mz %[[VAL_4]] : (!quake.ref) -> !quake.measure
+// CHECK:           quake.mz %[[VAL_5]] : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/deuteron.qke
+++ b/test/Quake/deuteron.qke
@@ -16,8 +16,8 @@
 // CHECK:    quake.x %[[a1]]
 // CHECK:    quake.ry (%[[arg0]]) %[[a2]] : (f64, !quake.ref) -> ()
 // CHECK:    quake.x [%[[a2]]] %[[a1]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:    %[[a3:.*]] = quake.mz %[[a1]] : (!quake.ref) -> i1
-// CHECK:    %[[a4:.*]] = quake.mz %[[a2]] : (!quake.ref) -> i1
+// CHECK:    quake.mz %[[a1]] : (!quake.ref) -> !quake.measure
+// CHECK:    quake.mz %[[a2]] : (!quake.ref) -> !quake.measure
 // CHECK:    return
 // CHECK:  }
 
@@ -34,8 +34,8 @@ module {
         quake.x %q0 : (!quake.ref) -> ()
         quake.ry (%theta) %q1  : (f64, !quake.ref) -> ()
         quake.x [%q1] %q0 : (!quake.ref, !quake.ref) -> ()
-        %measurements0 = quake.mz %q0 : (!quake.ref) -> i1
-        %measurements1 = quake.mz %q1 : (!quake.ref) -> i1
+        %measurements0 = quake.mz %q0 : (!quake.ref) -> !quake.measure
+        %measurements1 = quake.mz %q1 : (!quake.ref) -> !quake.measure
         return
     }
 }

--- a/test/Quake/inline.qke
+++ b/test/Quake/inline.qke
@@ -18,7 +18,7 @@ func.func @__nvqpp__mlirgen____nvqppBuilderKernel_202375922897() {
   quake.h %1 : (!quake.ref) -> ()
   quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127[%1] %0 : (!quake.ref, !quake.ref) -> ()
   quake.h %1 : (!quake.ref) -> ()
-  %2 = quake.mz %1 name "fido" : (!quake.ref) -> i1
+  %2 = quake.mz %1 name "fido" : (!quake.ref) -> !quake.measure
   return
 }
 func.func @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%arg0: !quake.ref) {
@@ -34,7 +34,7 @@ func.func @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%arg0: !quake.ref
 // CHECK:           %[[VAL_2:.*]] = quake.concat %[[VAL_1]] : (!quake.ref) -> !quake.veq<1>
 // CHECK:           quake.x [%[[VAL_2]]] %[[VAL_0]] :
 // CHECK:           quake.h %[[VAL_1]] :
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] name "fido" : (!quake.ref) -> i1
+// CHECK:           quake.mz %[[VAL_1]] name "fido" : (!quake.ref) -> !quake.measure
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/kernel_exec-1.qke
+++ b/test/Quake/kernel_exec-1.qke
@@ -62,7 +62,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__ghz = "_ZN3ghzclE
     } do {
     ^bb1 (%arg31 : index):
       %18 = quake.extract_ref %3[%arg31] : (!quake.veq<?>,index) -> !quake.ref
-      %19 = quake.mz %18 : (!quake.ref) -> i1
+      %19 = quake.mz %18 : (!quake.ref) -> !quake.measure
       cc.continue %arg31 : index
     } step {
     ^bb1 (%arg32 : index):

--- a/test/Quake/lambda_kernel_exec.qke
+++ b/test/Quake/lambda_kernel_exec.qke
@@ -26,8 +26,9 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHa
     %c0_i32_0 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32_0 : i32 to i64
     %5 = quake.extract_ref %1[%4] : (!quake.veq<?>, i64) -> !quake.ref
-    %6 = quake.mz %5 : (!quake.ref)->i1 {registerName = "b"} 
+    %16 = quake.mz %5 name "b" : (!quake.ref) -> !quake.measure
     %alloca = memref.alloca() : memref<i1>
+    %6 = quake.discriminate %16 : (!quake.measure) -> i1
     memref.store %6, %alloca[] : memref<i1>
     %7 = memref.load %alloca[] : memref<i1>
     cc.if(%7) {
@@ -41,7 +42,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHa
     %c1_i32 = arith.constant 1 : i32
     %8 = arith.extsi %c1_i32 : i32 to i64
     %9 = quake.extract_ref %1[%8] : (!quake.veq<?>,i64) -> !quake.ref
-    %10 = quake.mz %9 : (!quake.ref) -> i1
+    quake.mz %9 : (!quake.ref) -> !quake.measure
     return
   }
 
@@ -60,7 +61,8 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHa
     %c0_i32_0 = arith.constant 0 : i32
     %4 = arith.extsi %c0_i32_0 : i32 to i64
     %5 = quake.extract_ref %1[%4] : (!quake.veq<?>,i64) -> !quake.ref
-    %6 = quake.mz %5 : (!quake.ref) ->i1 {registerName = "b"} 
+    %16 = quake.mz %5 name "b" : (!quake.ref) -> !quake.measure
+    %6 = quake.discriminate %16 : (!quake.measure) -> i1
     %alloca = memref.alloca() : memref<i1>
     memref.store %6, %alloca[] : memref<i1>
     %7 = memref.load %alloca[] : memref<i1>
@@ -75,7 +77,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHa
     %c1_i32 = arith.constant 1 : i32
     %8 = arith.extsi %c1_i32 : i32 to i64
     %9 = quake.extract_ref %1[%8] : (!quake.veq<?>,i64) -> !quake.ref
-    %10 = quake.mz %9 : (!quake.ref) -> i1
+    quake.mz %9 : (!quake.ref) -> !quake.measure
     return
   }
 }

--- a/test/Quake/loop.qke
+++ b/test/Quake/loop.qke
@@ -412,7 +412,7 @@ func.func @empty_step() {
     } step {
     }
   }
-  %2 = quake.mz %1 : (!quake.veq<?>) -> !cc.stdvec<i1>
+  %2 = quake.mz %1 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
   return
 }
 

--- a/test/Quake/loop_peeling.qke
+++ b/test/Quake/loop_peeling.qke
@@ -23,8 +23,9 @@ func.func @peel_do_while() {
     cc.store %4, %1 : !cc.ptr<i32>
     %5 = arith.extui %3 : i32 to i64
     %6 = quake.extract_ref %0[%5] : (!quake.veq<10>, i64) -> !quake.ref
-    %bits = quake.mz %6 : (!quake.ref) -> i1
-    cc.store %bits, %2 : !cc.ptr<i1>
+    %bits = quake.mz %6 : (!quake.ref) -> !quake.measure
+    %bit = quake.discriminate %bits : (!quake.measure) -> i1
+    cc.store %bit, %2 : !cc.ptr<i1>
     cc.continue
   } while {
     %3 = cc.load %2 : !cc.ptr<i1>
@@ -57,8 +58,9 @@ func.func @peel_do_while() {
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_9:.*]] = arith.extui %[[VAL_7]] : i32 to i64
 // CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_9]]] : (!quake.veq<10>, i64) -> !quake.ref
-// CHECK:           %[[VAL_11:.*]] = quake.mz %[[VAL_10]] : (!quake.ref) -> i1
-// CHECK:           cc.store %[[VAL_11]], %[[VAL_6]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_11:.*]] = quake.mz %[[VAL_10]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_111:.*]] = quake.discriminate %[[VAL_11]] :
+// CHECK:           cc.store %[[VAL_111]], %[[VAL_6]] : !cc.ptr<i1>
 // CHECK:           cf.br ^bb2
 // CHECK:         ^bb2:
 // CHECK:           cc.loop while {
@@ -70,8 +72,9 @@ func.func @peel_do_while() {
 // CHECK:             cc.store %[[VAL_19]], %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_20:.*]] = arith.extui %[[VAL_18]] : i32 to i64
 // CHECK:             %[[VAL_21:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_20]]] : (!quake.veq<10>, i64) -> !quake.ref
-// CHECK:             %[[VAL_22:.*]] = quake.mz %[[VAL_21]] : (!quake.ref) -> i1
-// CHECK:             cc.store %[[VAL_22]], %[[VAL_6]] : !cc.ptr<i1>
+// CHECK:             %[[VAL_22:.*]] = quake.mz %[[VAL_21]] : (!quake.ref) -> !quake.measure
+// CHECK:             %[[VAL_122:.*]] = quake.discriminate %[[VAL_22]] :
+// CHECK:             cc.store %[[VAL_122]], %[[VAL_6]] : !cc.ptr<i1>
 // CHECK:             cc.continue
 // CHECK:           }
 // CHECK:           cf.br ^bb3
@@ -91,8 +94,9 @@ func.func @peel_do_while_with_args() {
     %4 = arith.addi %arg0, %c1_i32 : i32
     %5 = arith.extui %arg0 : i32 to i64
     %6 = quake.extract_ref %0[%5] : (!quake.veq<10>, i64) -> !quake.ref
-    %bits = quake.mz %6 : (!quake.ref) -> i1
-    cc.continue %4, %bits : i32, i1
+    %bits = quake.mz %6 : (!quake.ref) -> !quake.measure
+    %bit = quake.discriminate %bits : (!quake.measure) -> i1
+    cc.continue %4, %bit : i32, i1
   } while {
   ^bb0(%arg0: i32, %arg1: i1):
     %4 = arith.cmpi eq, %arg1, %false : i1
@@ -119,7 +123,8 @@ func.func @peel_do_while_with_args() {
 // CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_7:.*]] = arith.extui %[[VAL_5]] : i32 to i64
 // CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_7]]] : (!quake.veq<10>, i64) -> !quake.ref
-// CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_8]] : (!quake.ref) -> i1
+// CHECK:           %[[VAL_109:.*]] = quake.mz %[[VAL_8]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_9:.*]] = quake.discriminate %[[VAL_109]] :
 // CHECK:           cf.br ^bb2(%[[VAL_6]], %[[VAL_9]] : i32, i1)
 // CHECK:         ^bb2(%[[VAL_10:.*]]: i32, %[[VAL_11:.*]]: i1):
 // CHECK:           %[[VAL_12:.*]]:2 = cc.loop while ((%[[VAL_13:.*]] = %[[VAL_10]], %[[VAL_14:.*]] = %[[VAL_11]]) -> (i32, i1)) {
@@ -136,7 +141,8 @@ func.func @peel_do_while_with_args() {
 // CHECK:             %[[VAL_21:.*]] = arith.addi %[[VAL_19]], %[[VAL_0]] : i32
 // CHECK:             %[[VAL_22:.*]] = arith.extui %[[VAL_19]] : i32 to i64
 // CHECK:             %[[VAL_23:.*]] = quake.extract_ref %[[VAL_4]][%[[VAL_22]]] : (!quake.veq<10>, i64) -> !quake.ref
-// CHECK:             %[[VAL_24:.*]] = quake.mz %[[VAL_23]] : (!quake.ref) -> i1
+// CHECK:             %[[VAL_124:.*]] = quake.mz %[[VAL_23]] : (!quake.ref) -> !quake.measure
+// CHECK:             %[[VAL_24:.*]] = quake.discriminate %[[VAL_124]] :
 // CHECK:             cc.continue %[[VAL_21]], %[[VAL_24]] : i32, i1
 // CHECK:           }
 // CHECK:           cf.br ^bb3

--- a/test/Quake/memtoreg-2.qke
+++ b/test/Quake/memtoreg-2.qke
@@ -174,7 +174,7 @@ func.func @classical_if06(%veq : !quake.veq<2>, %c1: i1) {
     %q1 = quake.extract_ref %veq[%c_1] : (!quake.veq<2>, i32) -> !quake.ref
     quake.y %q1 : (!quake.ref) -> ()
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   return
 }
 
@@ -191,7 +191,7 @@ func.func @classical_if06(%veq : !quake.veq<2>, %c1: i1) {
 // CHECK:             %[[VAL_9:.*]] = quake.y %[[VAL_8]] : (!quake.wire) -> !quake.wire
 // CHECK:           } else {
 // CHECK:           }
-// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -206,7 +206,7 @@ func.func @classical_if07(%veq : !quake.veq<2>, %c1: i1, %c2: i1) {
       quake.reset %veq : (!quake.veq<2>) -> ()
     }
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   return
 }
 
@@ -226,7 +226,7 @@ func.func @classical_if07(%veq : !quake.veq<2>, %c1: i1, %c2: i1) {
 // CHECK:             }
 // CHECK:           } else {
 // CHECK:           }
-// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -319,7 +319,7 @@ func.func @scope_local_extract_and_vec_measurement(%veq : !quake.veq<2>) {
     %q1 = quake.extract_ref %veq[%c_1] : (!quake.veq<2>,i32) -> !quake.ref
     quake.y %q1 : (!quake.ref) -> ()
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   return
 }
 
@@ -334,7 +334,7 @@ func.func @scope_local_extract_and_vec_measurement(%veq : !quake.veq<2>) {
 // CHECK:             %[[VAL_6:.*]] = quake.unwrap %[[VAL_5]] : (!quake.ref) -> !quake.wire
 // CHECK:             %[[VAL_7:.*]] = quake.y %[[VAL_6]] : (!quake.wire) -> !quake.wire
 // CHECK:           }
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -346,7 +346,7 @@ func.func @vec_op_in_nested_scope(%veq : !quake.veq<2>) {
       quake.reset %veq : (!quake.veq<2>)-> ()
     }
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   return
 }
 
@@ -360,7 +360,7 @@ func.func @vec_op_in_nested_scope(%veq : !quake.veq<2>) {
 // CHECK:               quake.reset %[[VAL_0]] : (!quake.veq<2>) -> ()
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -374,7 +374,7 @@ func.func @vec_op_in_nested_scope_and_local_extraction(%veq : !quake.veq<2>) {
       quake.reset %veq : (!quake.veq<2>) -> ()
     }
   }
-  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
+  %reg = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   return
 }
 
@@ -391,7 +391,7 @@ func.func @vec_op_in_nested_scope_and_local_extraction(%veq : !quake.veq<2>) {
 // CHECK:               quake.reset %[[VAL_0]] : (!quake.veq<2>) -> ()
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -514,7 +514,7 @@ func.func @raw_cfg05(%c1: i1) {
 ^bb2:
   cf.br ^bb3
 ^bb3:
-  %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.stdvec<i1>
+  %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -531,7 +531,7 @@ func.func @raw_cfg05(%c1: i1) {
 // CHECK:         ^bb2:
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -552,7 +552,7 @@ func.func @raw_cfg06(%c1: i1) {
   %q2 = quake.extract_ref %veq[%c1_i64] : (!quake.veq<2>, i64) -> !quake.ref
   cf.br ^bb5
 ^bb5:
-  %reg = quake.mz %veq: (!quake.veq<2>)-> !cc.stdvec<i1>
+  %reg = quake.mz %veq: (!quake.veq<2>)-> !cc.stdvec<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -578,7 +578,7 @@ func.func @raw_cfg06(%c1: i1) {
 // CHECK:           %[[VAL_9:.*]] = quake.unwrap %[[VAL_8]] : (!quake.ref) -> !quake.wire
 // CHECK:           cf.br ^bb5
 // CHECK:         ^bb5:
-// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -595,7 +595,7 @@ func.func @raw_cfg07(%c1: i1) {
   quake.reset %veq: (!quake.veq<2>)->()
   cf.br ^bb3
 ^bb3:
-  %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.stdvec<i1>
+  %reg = quake.mz %veq: (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -616,7 +616,7 @@ func.func @raw_cfg07(%c1: i1) {
 // CHECK:           quake.reset %[[VAL_3]] : (!quake.veq<2>) -> ()
 // CHECK:           cf.br ^bb3
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -720,7 +720,7 @@ func.func @mz_and_reset_veq_with_extracted_refs() {
   %0 = quake.alloca !quake.veq<2>
   %q0 = quake.extract_ref %0[%c_0] : (!quake.veq<2>, i32) -> !quake.ref
   %q1 = quake.extract_ref %0[%c_1] : (!quake.veq<2>, i32) -> !quake.ref
-  %reg = quake.mz %0 : (!quake.veq<2>) -> !cc.stdvec<i1>
+  %reg = quake.mz %0 : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   quake.reset %0 : (!quake.veq<2>) -> ()
   quake.dealloc %0 : !quake.veq<2>
   return
@@ -734,7 +734,7 @@ func.func @mz_and_reset_veq_with_extracted_refs() {
 // CHECK:           %[[VAL_4:.*]] = quake.unwrap %[[VAL_3]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_1]]] : (!quake.veq<2>, i32) -> !quake.ref
 // CHECK:           %[[VAL_6:.*]] = quake.unwrap %[[VAL_5]] : (!quake.ref) -> !quake.wire
-// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_2]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           quake.reset %[[VAL_2]] : (!quake.veq<2>) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -811,7 +811,7 @@ func.func @floop_with_vector_and_qextract() {
     %4 = arith.addi %3, %c1_i64 : i64
     memref.store %4, %alloca[] : memref<i64>
   }
-  %2 = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
+  %2 = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -840,7 +840,7 @@ func.func @floop_with_vector_and_qextract() {
 // CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : i64
 // CHECK:             memref.store %[[VAL_13]], %[[VAL_6]][] : memref<i64>
 // CHECK:           }
-// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/memtoreg-3.qke
+++ b/test/Quake/memtoreg-3.qke
@@ -83,7 +83,7 @@ func.func @promote_induction_variable() {
     %4 = arith.addi %3, %c1_i64 : i64
     cc.store %4, %alloca : !cc.ptr<i64>
   }
-  %2 = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<i1>
+  %2 = quake.mz %veq : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
   quake.dealloc %veq : !quake.veq<2>
   return
 }
@@ -109,7 +109,7 @@ func.func @promote_induction_variable() {
 // CHECK:             %[[VAL_14:.*]] = arith.addi %[[VAL_13]], %[[VAL_1]] : i64
 // CHECK:             cc.continue %[[VAL_14]] : i64
 // CHECK:           }
-// CHECK:           %[[VAL_15:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// CHECK:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           quake.dealloc %[[VAL_3]] : !quake.veq<2>
 // CHECK:           return
 // CHECK:         }
@@ -133,7 +133,7 @@ func.func @promote_induction_variable() {
 // TOMEM:             %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_1]] : i64
 // TOMEM:             cc.continue %[[VAL_12]] : i64
 // TOMEM:           }
-// TOMEM:           %[[VAL_13:.*]] = quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<i1>
+// TOMEM:           quake.mz %[[VAL_3]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // TOMEM:           quake.dealloc %[[VAL_3]] : !quake.veq<2>
 // TOMEM:           return
 // TOMEM:         }

--- a/test/Quake/memtoreg-4.qke
+++ b/test/Quake/memtoreg-4.qke
@@ -56,9 +56,10 @@ func.func @t2(%arg0: !quake.veq<?>) {
       quake.h %3 : (!quake.ref) -> ()
       %4 = cc.load %1 : !cc.ptr<i64>
       %5 = quake.extract_ref %arg0[%4] : (!quake.veq<?>, i64) -> !quake.ref
-      %bits = quake.mz %5 name "b" : (!quake.ref) -> i1
+      %bits = quake.mz %5 name "b" : (!quake.ref) -> !quake.measure
+      %bit = quake.discriminate %bits : (!quake.measure) -> i1
       %6 = cc.alloca i1
-      cc.store %bits, %6 : !cc.ptr<i1>
+      cc.store %bit, %6 : !cc.ptr<i1>
       %7 = cc.load %6 : !cc.ptr<i1>
       cf.cond_br %7, ^bb1, ^bb2
     ^bb1:
@@ -93,9 +94,9 @@ func.func @t2(%arg0: !quake.veq<?>) {
 // CHECK:               quake.wrap %[[VAL_15]] to %[[VAL_13]] : !quake.wire, !quake.ref
 // CHECK:               %[[VAL_16:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_17:.*]] = quake.unwrap %[[VAL_16]] : (!quake.ref) -> !quake.wire
-// CHECK:               %[[VAL_18:.*]], %[[VAL_19:.*]] = quake.mz %[[VAL_17]] name "b" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:               %[[VAL_118:.*]], %[[VAL_19:.*]] = quake.mz %[[VAL_17]] name "b" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:               quake.wrap %[[VAL_19]] to %[[VAL_16]] : !quake.wire, !quake.ref
-// CHECK:               %[[VAL_20:.*]] = cc.undef i1
+// CHECK:               %[[VAL_18:.*]] = quake.discriminate %[[VAL_118]] :
 // CHECK:               cf.cond_br %[[VAL_18]], ^bb1(%[[VAL_11]] : i64), ^bb2(%[[VAL_11]] : i64)
 // CHECK:             ^bb1(%[[VAL_21:.*]]: i64):
 // CHECK:               cc.break %[[VAL_21]] : i64
@@ -130,9 +131,10 @@ func.func @t3(%arg0: !quake.veq<?>) {
       quake.h %3 : (!quake.ref) -> ()
       %4 = cc.load %1 : !cc.ptr<i64>
       %5 = quake.extract_ref %arg0[%4] : (!quake.veq<?>, i64) -> !quake.ref
-      %bits = quake.mz %5 name "b" : (!quake.ref) -> i1
+      %bits = quake.mz %5 name "b" : (!quake.ref) -> !quake.measure
+      %bit = quake.discriminate %bits : (!quake.measure) -> i1
       %6 = cc.alloca i1
-      cc.store %bits, %6 : !cc.ptr<i1>
+      cc.store %bit, %6 : !cc.ptr<i1>
       %7 = cc.load %6 : !cc.ptr<i1>
       cf.br ^bb2
     ^bb2:
@@ -165,8 +167,9 @@ func.func @t3(%arg0: !quake.veq<?>) {
 // CHECK:               quake.wrap %[[VAL_15]] to %[[VAL_13]] : !quake.wire, !quake.ref
 // CHECK:               %[[VAL_16:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:               %[[VAL_17:.*]] = quake.unwrap %[[VAL_16]] : (!quake.ref) -> !quake.wire
-// CHECK:               %[[VAL_18:.*]], %[[VAL_19:.*]] = quake.mz %[[VAL_17]] name "b" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:               %[[VAL_118:.*]], %[[VAL_19:.*]] = quake.mz %[[VAL_17]] name "b" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:               quake.wrap %[[VAL_19]] to %[[VAL_16]] : !quake.wire, !quake.ref
+// CHECK:               %[[VAL_18:.*]] = quake.discriminate %[[VAL_118]] :
 // CHECK:               %[[VAL_20:.*]] = cc.undef i1
 // CHECK:               cf.br ^bb1(%[[VAL_11]] : i64)
 // CHECK:             ^bb1(%[[VAL_21:.*]]: i64):

--- a/test/Quake/memtoreg-5.qke
+++ b/test/Quake/memtoreg-5.qke
@@ -27,13 +27,15 @@ func.func @__nvqpp__mlirgen__dummy() {
       %4 = quake.extract_ref %0[1] : (!quake.veq<2>) -> !quake.ref
       quake.x [%3] %4 : (!quake.ref, !quake.ref) -> ()
       %5 = quake.extract_ref %0[0] : (!quake.veq<2>) -> !quake.ref
-      %bits = quake.mz %5 name "b0" : (!quake.ref) -> i1
+      %bits = quake.mz %5 name "b0" : (!quake.ref) -> !quake.measure
+      %bit = quake.discriminate %bits : (!quake.measure) -> i1
       %6 = cc.alloca i1
-      cc.store %bits, %6 : !cc.ptr<i1>
+      cc.store %bit, %6 : !cc.ptr<i1>
       %7 = quake.extract_ref %0[1] : (!quake.veq<2>) -> !quake.ref
-      %bits_0 = quake.mz %7 name "b1" : (!quake.ref) -> i1
+      %bits_0 = quake.mz %7 name "b1" : (!quake.ref) -> !quake.measure
+      %bit_0 = quake.discriminate %bits_0 : (!quake.measure) -> i1
       %8 = cc.alloca i1
-      cc.store %bits_0, %8 : !cc.ptr<i1>
+      cc.store %bit_0, %8 : !cc.ptr<i1>
       %9 = cc.load %6 : !cc.ptr<i1>
       %10 = cc.load %8 : !cc.ptr<i1>
       %11 = arith.cmpi ne, %9, %10 : i1
@@ -79,10 +81,11 @@ func.func @__nvqpp__mlirgen__dummy() {
 // CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:               quake.x [%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:               %[[VAL_13:.*]] = quake.mz %[[VAL_12]] name "b0" : (!quake.ref) -> i1
-// CHECK:               %[[VAL_14:.*]] = cc.undef i1
+// CHECK:               %[[VAL_113:.*]] = quake.mz %[[VAL_12]] name "b0" : (!quake.ref) -> !quake.measure
+// CHECK:               %[[VAL_13:.*]] = quake.discriminate %[[VAL_113]] :
 // CHECK:               %[[VAL_15:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:               %[[VAL_16:.*]] = quake.mz %[[VAL_15]] name "b1" : (!quake.ref) -> i1
+// CHECK:               %[[VAL_116:.*]] = quake.mz %[[VAL_15]] name "b1" : (!quake.ref) -> !quake.measure
+// CHECK:               %[[VAL_16:.*]] = quake.discriminate %[[VAL_116]] :
 // CHECK:               %[[VAL_18:.*]] = arith.cmpi ne, %[[VAL_13]], %[[VAL_16]] : i1
 // CHECK:               cf.cond_br %[[VAL_18]], ^bb1(%[[VAL_8]] : i32), ^bb2(%[[VAL_13]], %[[VAL_16]], %[[VAL_8]] : i1, i1, i32)
 // CHECK:             ^bb1(%[[VAL_19:.*]]: i32):

--- a/test/Quake/merge_rotation.qke
+++ b/test/Quake/merge_rotation.qke
@@ -16,7 +16,7 @@ func.func @duplicate_rotation_check() {
   %c_angle = arith.constant 0.59 : f64
   quake.rx (%c_angle) %q0: (f64, !quake.ref) -> ()
   quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
-  %measurements0 = quake.mz %q0 : (!quake.ref) -> i1
+  %measurements0 = quake.mz %q0 : (!quake.ref) -> !quake.measure
   return
 }
 
@@ -25,7 +25,7 @@ func.func @duplicate_rotation_check() {
 // CHECK-DAG:       %[[VAL_1:.*]] = quake.null_wire
 // CHECK-DAG:       %[[VAL_2:.*]] = quake.null_wire
 // CHECK:           %[[VAL_4:.*]] = quake.rx (%[[VAL_0]]) %[[VAL_1]] : (f64, !quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = quake.mz %[[VAL_4]] : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = quake.mz %[[VAL_4]] : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK-DAG:       quake.sink %[[VAL_6]] : !quake.wire
 // CHECK-DAG:       quake.sink %[[VAL_2]] : !quake.wire
 // CHECK:           return
@@ -41,7 +41,7 @@ func.func @duplicate_rotation_check2() {
   quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
   quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
   quake.rx (%c_angle2) %q0 : (f64, !quake.ref) -> ()
-  %measurement = quake.mz %q0 : (!quake.ref) -> i1
+  %measurement = quake.mz %q0 : (!quake.ref) -> !quake.measure
   return
 }
 
@@ -50,7 +50,7 @@ func.func @duplicate_rotation_check2() {
 // CHECK-DAG:       %[[VAL_2:.*]] = quake.null_wire
 // CHECK-DAG:       %[[VAL_3:.*]] = quake.null_wire
 // CHECK:           %[[VAL_6:.*]] = quake.rx (%[[VAL_0]]) %[[VAL_2]] : (f64, !quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK-DAG:       quake.sink %[[VAL_8]] : !quake.wire
 // CHECK-DAG:       quake.sink %[[VAL_3]] : !quake.wire
 // CHECK:           return
@@ -74,7 +74,7 @@ func.func @duplicate_rotation_check3() {
   quake.rx (%c_angle) %q0 : (f64, !quake.ref) -> ()
   quake.rx (%new_angle2) %q0 : (f64, !quake.ref) -> ()
   quake.rx (%new_angle) %q0 : (f64, !quake.ref) -> ()
-  %measurement = quake.mz %q0 : (!quake.ref) -> i1
+  %measurement = quake.mz %q0 : (!quake.ref) -> !quake.measure
   return
 }
 
@@ -83,7 +83,7 @@ func.func @duplicate_rotation_check3() {
 // CHECK-DAG:       %[[VAL_3:.*]] = quake.null_wire
 // CHECK-DAG:       %[[VAL_4:.*]] = quake.null_wire
 // CHECK:           %[[VAL_7:.*]] = quake.rx (%[[VAL_0]]) %[[VAL_3]] : (f64, !quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = quake.mz %[[VAL_7]] : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK-DAG:       quake.sink %[[VAL_9]] : !quake.wire
 // CHECK-DAG:       quake.sink %[[VAL_4]] : !quake.wire
 // CHECK:           return

--- a/test/Quake/mz.qke
+++ b/test/Quake/mz.qke
@@ -13,7 +13,7 @@ func.func @static.mz_test() {
   %1 = quake.alloca  !quake.veq<4>
   %2 = quake.alloca  !quake.veq<2>
   %3 = quake.alloca  !quake.ref
-  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<i1>
+  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<!quake.measure>
   return
 }
 
@@ -22,7 +22,7 @@ func.func @static.mz_test() {
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.veq<4>, !quake.veq<2>, !quake.ref) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 
@@ -31,7 +31,7 @@ func.func @dynamic.mz_test(%arg0 : i32, %arg1 : i32) {
   %1 = quake.alloca !quake.veq<?>[%arg0 : i32]
   %2 = quake.alloca !quake.veq<?>[%arg1 : i32]
   %3 = quake.alloca  !quake.ref
-  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
+  quake.mz %0, %1, %2, %3 : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<!quake.measure>
   return
 }
 
@@ -41,7 +41,7 @@ func.func @dynamic.mz_test(%arg0 : i32, %arg1 : i32) {
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<?>[%[[VAL_0]] : i32]
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<?>[%[[VAL_1]] : i32]
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.ref
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (!quake.ref, !quake.veq<?>, !quake.veq<?>, !quake.ref) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/nullwire.qke
+++ b/test/Quake/nullwire.qke
@@ -16,7 +16,7 @@ func.func @do_not_merge() {
   %4:2 = quake.x [%3] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %5 = quake.h %2 : (!quake.wire) -> !quake.wire
   %6:2 = quake.x [%5] %4#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  %7:2 = quake.mz %6#1 : (!quake.wire) -> (i1, !quake.wire)
+  %7:2 = quake.mz %6#1 : (!quake.wire) -> (!quake.measure, !quake.wire)
   quake.sink %7#1 : !quake.wire
   quake.sink %6#0 : !quake.wire
   quake.sink %4#0 : !quake.wire
@@ -31,7 +31,7 @@ func.func @do_not_merge() {
 // CHECK:           %[[VAL_4:.*]]:2 = quake.x [%[[VAL_3]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_5:.*]] = quake.h %[[VAL_2]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_6:.*]]:2 = quake.x [%[[VAL_5]]] %[[VAL_4]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_6]]#1 : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_6]]#1 : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           quake.sink %[[VAL_8]] : !quake.wire
 // CHECK:           quake.sink %[[VAL_6]]#0 : !quake.wire
 // CHECK:           quake.sink %[[VAL_4]]#0 : !quake.wire

--- a/test/Quake/observeAnsatz.qke
+++ b/test/Quake/observeAnsatz.qke
@@ -6,9 +6,8 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(canonicalize,cse,observe-ansatz{term-bsf=1,1,0,0}),canonicalize)' %s | FileCheck %s
+// RUN: cudaq-opt --canonicalize --cse --observe-ansatz="term-bsf=1,1,0,0" --canonicalize %s | FileCheck %s
 
-module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__ansatz = "_ZN6ansatzclEd"}} {
   func.func @__nvqpp__mlirgen__ansatz(%arg0: f64) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
@@ -25,9 +24,8 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__ansatz = "_ZN6ans
     quake.x [%5] %6 : (!quake.ref,!quake.ref) -> ()
     return
   }
-}
 
 // CHECK: quake.h %
 // CHECK: quake.h %
-// CHECK: %{{.*}} = quake.mz %{{.*}} : (!quake.ref) -> i1
-// CHECK: %{{.*}} = quake.mz %{{.*}} : (!quake.ref) -> i1
+// CHECK: %{{.*}} = quake.mz %{{.*}} : (!quake.ref) -> !quake.measure
+// CHECK: %{{.*}} = quake.mz %{{.*}} : (!quake.ref) -> !quake.measure

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -68,9 +68,11 @@ func.func @quantum_ops() {
   %h = arith.constant 34.0 : f32
   quake.u3 (%f, %g, %h) %7 : (f32, f32, f32, !quake.ref) -> ()
 
-  %15 = quake.mx %4 : (!quake.ref) -> i1
-  %16 = quake.my %5 : (!quake.veq<?>) -> !cc.stdvec<i1>
-  %17 = quake.mz %6 : (!quake.veq<5>) -> !cc.stdvec<i1>
+  %15 = quake.mx %4 : (!quake.ref) -> !quake.measure
+  %16 = quake.my %5 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
+  %17 = quake.mz %6 : (!quake.veq<5>) -> !cc.stdvec<!quake.measure>
+  %z15 = quake.discriminate %15 : (!quake.measure) -> i1
+  %z16 = quake.discriminate %16 : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
 
   // Quantum operations, wire form
   %19 = cc.undef i32 {wires = true}
@@ -94,9 +96,9 @@ func.func @quantum_ops() {
   %35 = quake.u2 (%f, %g) %34 : (f32, f32, !quake.wire) -> !quake.wire
   %36 = quake.u3 (%f, %g, %h) %35 : (f32, f32, f32, !quake.wire) -> !quake.wire
 
-  %37:2 = quake.mx %29#0 : (!quake.wire) -> (i1, !quake.wire)
-  %38:2 = quake.my %20 : (!quake.wire) -> (i1, !quake.wire)
-  %39:2 = quake.mz %36 : (!quake.wire) -> (i1, !quake.wire)
+  %37:2 = quake.mx %29#0 : (!quake.wire) -> (!quake.measure, !quake.wire)
+  %38:2 = quake.my %20 : (!quake.wire) -> (!quake.measure, !quake.wire)
+  %39:2 = quake.mz %36 : (!quake.wire) -> (!quake.measure, !quake.wire)
 
   // CUDA Quantum model support
   %40 = quake.alloca !quake.ref { apply_variants = true }
@@ -195,9 +197,11 @@ func.func @quantum_ops() {
 // CHECK:           quake.u2 (%[[VAL_20]], %[[VAL_21]]) %[[VAL_10]] : (f32, f32, !quake.ref) -> ()
 // CHECK:           %[[VAL_22:.*]] = arith.constant 3.400000e+01 : f32
 // CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_10]] : (f32, f32, f32, !quake.ref) -> ()
-// CHECK:           %[[VAL_23:.*]] = quake.mx %[[VAL_5]] : (!quake.ref) -> i1
-// CHECK:           %[[VAL_24:.*]] = quake.my %[[VAL_8]] : (!quake.veq<?>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_25:.*]] = quake.mz %[[VAL_9]] : (!quake.veq<5>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_23:.*]] = quake.mx %[[VAL_5]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_24:.*]] = quake.my %[[VAL_8]] : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_25:.*]] = quake.mz %[[VAL_9]] : (!quake.veq<5>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_123:.*]] = quake.discriminate %[[VAL_23]] : (!quake.measure) -> i1
+// CHECK:           %[[VAL_124:.*]] = quake.discriminate %[[VAL_24]] : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_26:.*]] = cc.undef i32 {wires = true}
 // CHECK:           %[[VAL_27:.*]] = quake.null_wire
 // CHECK:           %[[VAL_28:.*]] = quake.null_wire
@@ -216,9 +220,9 @@ func.func @quantum_ops() {
 // CHECK:           %[[VAL_41:.*]] = quake.rz (%[[VAL_20]]) %[[VAL_40]] : (f32, !quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_42:.*]] = quake.u2 (%[[VAL_20]], %[[VAL_21]]) %[[VAL_41]] : (f32, f32, !quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_43:.*]] = quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) %[[VAL_42]] : (f32, f32, f32, !quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_44:.*]], %[[WAL_44:.*]] = quake.mx %[[VAL_36]]#0 : (!quake.wire) -> (i1, !quake.wire)
-// CHECK:           %[[VAL_45:.*]], %[[WAL_45:.*]] = quake.my %[[VAL_27]] : (!quake.wire) -> (i1, !quake.wire)
-// CHECK:           %[[VAL_46:.*]], %[[WAL_46:.*]] = quake.mz %[[VAL_43]] : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_44:.*]], %[[WAL_44:.*]] = quake.mx %[[VAL_36]]#0 : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_45:.*]], %[[WAL_45:.*]] = quake.my %[[VAL_27]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_46:.*]], %[[WAL_46:.*]] = quake.mz %[[VAL_43]] : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_47:.*]] = quake.alloca !quake.ref {apply_variants = true}
 // CHECK:           %[[VAL_48:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_49:.*]] = arith.constant 0 : i32

--- a/test/Quake/unroll_loop_with_break.qke
+++ b/test/Quake/unroll_loop_with_break.qke
@@ -22,9 +22,9 @@ func.func @loop_with_break(%arg0: i32) {
     } do {
     ^bb0(%arg1: i32):
       quake.h %2 : (!quake.ref) -> ()
-      %bits = quake.mz %2 name "q0result" : (!quake.ref) -> i1
-      %6 = cc.undef i1
-      cf.cond_br %bits, ^bb1(%arg1 : i32), ^bb2(%arg1 : i32)
+      %bits = quake.mz %2 name "q0result" : (!quake.ref) -> !quake.measure
+      %bit = quake.discriminate %bits : (!quake.measure) -> i1
+      cf.cond_br %bit, ^bb1(%arg1 : i32), ^bb2(%arg1 : i32)
     ^bb1(%7: i32):  // pred: ^bb0
       cc.break %7 : i32
     ^bb2(%9: i32):  // pred: ^bb0
@@ -42,83 +42,102 @@ func.func @loop_with_break(%arg0: i32) {
 // CHECK-SAME:                               %[[VAL_0:.*]]: i32) {
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_102:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_102]] :
 // CHECK:           cf.cond_br %[[VAL_2]], ^bb20, ^bb1
 // CHECK:         ^bb1:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_103:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_103]] :
 // CHECK:           cf.cond_br %[[VAL_3]], ^bb20, ^bb2
 // CHECK:         ^bb2:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_104:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_4:.*]] = quake.discriminate %[[VAL_104]] :
 // CHECK:           cf.cond_br %[[VAL_4]], ^bb20, ^bb3
 // CHECK:         ^bb3:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_105:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_5:.*]] = quake.discriminate %[[VAL_105]] :
 // CHECK:           cf.cond_br %[[VAL_5]], ^bb20, ^bb4
 // CHECK:         ^bb4:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_106:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_6:.*]] = quake.discriminate %[[VAL_106]] :
 // CHECK:           cf.cond_br %[[VAL_6]], ^bb20, ^bb5
 // CHECK:         ^bb5:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_107:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_7:.*]] = quake.discriminate %[[VAL_107]] :
 // CHECK:           cf.cond_br %[[VAL_7]], ^bb20, ^bb6
 // CHECK:         ^bb6:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_108:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_8:.*]] = quake.discriminate %[[VAL_108]] :
 // CHECK:           cf.cond_br %[[VAL_8]], ^bb20, ^bb7
 // CHECK:         ^bb7:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_109:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_9:.*]] = quake.discriminate %[[VAL_109]] :
 // CHECK:           cf.cond_br %[[VAL_9]], ^bb20, ^bb8
 // CHECK:         ^bb8:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_110:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_10:.*]] = quake.discriminate %[[VAL_110]] :
 // CHECK:           cf.cond_br %[[VAL_10]], ^bb20, ^bb9
 // CHECK:         ^bb9:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_11:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_111:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_11:.*]] = quake.discriminate %[[VAL_111]] :
 // CHECK:           cf.cond_br %[[VAL_11]], ^bb20, ^bb10
 // CHECK:         ^bb10:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_112:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_12:.*]] = quake.discriminate %[[VAL_112]] :
 // CHECK:           cf.cond_br %[[VAL_12]], ^bb20, ^bb11
 // CHECK:         ^bb11:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_13:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_113:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_13:.*]] = quake.discriminate %[[VAL_113]] :
 // CHECK:           cf.cond_br %[[VAL_13]], ^bb20, ^bb12
 // CHECK:         ^bb12:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_14:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_114:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_14:.*]] = quake.discriminate %[[VAL_114]] :
 // CHECK:           cf.cond_br %[[VAL_14]], ^bb20, ^bb13
 // CHECK:         ^bb13:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_15:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_115:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_15:.*]] = quake.discriminate %[[VAL_115]] :
 // CHECK:           cf.cond_br %[[VAL_15]], ^bb20, ^bb14
 // CHECK:         ^bb14:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_16:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_116:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_16:.*]] = quake.discriminate %[[VAL_116]] :
 // CHECK:           cf.cond_br %[[VAL_16]], ^bb20, ^bb15
 // CHECK:         ^bb15:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_17:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_117:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_17:.*]] = quake.discriminate %[[VAL_117]] :
 // CHECK:           cf.cond_br %[[VAL_17]], ^bb20, ^bb16
 // CHECK:         ^bb16:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_18:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_118:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_18:.*]] = quake.discriminate %[[VAL_118]] :
 // CHECK:           cf.cond_br %[[VAL_18]], ^bb20, ^bb17
 // CHECK:         ^bb17:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_119:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_19:.*]] = quake.discriminate %[[VAL_119]] :
 // CHECK:           cf.cond_br %[[VAL_19]], ^bb20, ^bb18
 // CHECK:         ^bb18:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_20:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_120:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
+// CHECK:           %[[VAL_20:.*]] = quake.discriminate %[[VAL_120]] :
 // CHECK:           cf.cond_br %[[VAL_20]], ^bb20, ^bb19
 // CHECK:         ^bb19:
 // CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_21:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> i1
+// CHECK:           %[[VAL_121:.*]] = quake.mz %[[VAL_1]] name "q0result" : (!quake.ref) -> !quake.measure
 // CHECK:           cf.br ^bb20
 // CHECK:         ^bb20:
 // CHECK:           return

--- a/test/Quake/wire_sink.qke
+++ b/test/Quake/wire_sink.qke
@@ -12,9 +12,9 @@
 func.func @measures(%a0: !quake.wire, %a1: !quake.wire, %a2: !quake.wire,
                     %a4: !quake.wire) {
   %0 = quake.x %a4 : (!quake.wire) -> !quake.wire		    
-  %1:2 = quake.mx %a0 : (!quake.wire) -> (i1, !quake.wire)
-  %2:2 = quake.my %a1 : (!quake.wire) -> (i1, !quake.wire)
-  %3:2 = quake.mz %a2 : (!quake.wire) -> (i1, !quake.wire)
+  %1:2 = quake.mx %a0 : (!quake.wire) -> (!quake.measure, !quake.wire)
+  %2:2 = quake.my %a1 : (!quake.wire) -> (!quake.measure, !quake.wire)
+  %3:2 = quake.mz %a2 : (!quake.wire) -> (!quake.measure, !quake.wire)
   quake.sink %1#1 : !quake.wire
   quake.sink %2#1 : !quake.wire
   quake.sink %3#1 : !quake.wire
@@ -25,9 +25,9 @@ func.func @measures(%a0: !quake.wire, %a1: !quake.wire, %a2: !quake.wire,
 // CHECK-LABEL:   func.func @measures(
 // CHECK-SAME:      %[[VAL_0:.*]]: !quake.wire, %[[VAL_1:.*]]: !quake.wire, %[[VAL_2:.*]]: !quake.wire, %[[VAL_3:.*]]: !quake.wire) {
 // CHECK: %[[VAL_10:.*]] = quake.x
-// CHECK:           %[[VAL7:.*]], %[[VAL_4:.*]] = quake.mx %[[VAL_0]] : (!quake.wire) -> (i1, !quake.wire)
-// CHECK:           %[[VAL_8:.*]], %[[VAL_5:.*]] = quake.my %[[VAL_1]] : (!quake.wire) -> (i1, !quake.wire)
-// CHECK:           %[[VAL_9:.*]], %[[VAL_6:.*]] = quake.mz %[[VAL_2]] : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL7:.*]], %[[VAL_4:.*]] = quake.mx %[[VAL_0]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_5:.*]] = quake.my %[[VAL_1]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_9:.*]], %[[VAL_6:.*]] = quake.mz %[[VAL_2]] : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK-DAG:       quake.sink %[[VAL_4]]
 // CHECK-DAG:       quake.sink %[[VAL_5]]
 // CHECK-DAG:       quake.sink %[[VAL_6]]

--- a/test/Target/IQM/basic.qke
+++ b/test/Target/IQM/basic.qke
@@ -32,10 +32,12 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__bell = "_ZN4bellc
 
     %8 = llvm.alloca %c2_i64 x i1 : (i64) -> !llvm.ptr<i1>
 
-    %bits = quake.mz %q0 : (!quake.ref) -> i1
+    %bit = quake.mz %q0 : (!quake.ref) -> !quake.measure
+    %bits = quake.discriminate %bit : (!quake.measure) -> i1
     llvm.store %bits, %8 : !llvm.ptr<i1>
 
-    %bits_4  = quake.mz %q1 : (!quake.ref) -> i1
+    %bit_4 = quake.mz %q1 : (!quake.ref) -> !quake.measure
+    %bits_4 = quake.discriminate %bit_4 : (!quake.measure) -> i1
     %9 = llvm.getelementptr %8[1] : (!llvm.ptr<i1>) -> !llvm.ptr<i1>
     llvm.store %bits_4, %9 : !llvm.ptr<i1>
     return

--- a/test/Target/IQM/extractOnConstant.qke
+++ b/test/Target/IQM/extractOnConstant.qke
@@ -18,7 +18,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__super = "_ZN5supe
     %cst_1 = arith.constant 1.5707963267948966 : f64
     quake.phased_rx (%cst_1, %cst_1) %1 : (f64, f64, !quake.ref) -> ()
     quake.phased_rx (%cst_0, %cst) %1 : (f64, f64, !quake.ref) -> ()
-    %2 = quake.mz %1 : (!quake.ref) -> i1
+    %2 = quake.mz %1 : (!quake.ref) -> !quake.measure
     return
   }
 }

--- a/test/Target/OpenQASM/basic.qke
+++ b/test/Target/OpenQASM/basic.qke
@@ -71,8 +71,8 @@ module {
 
     quake.apply @umaj %cout, %b0, %a0 : (!quake.ref, !quake.ref, !quake.ref) -> ()
 
-    %ans = quake.mz %b : (!quake.veq<4>) -> !cc.stdvec<i1>
-    %ans_cout = quake.mz %cout : (!quake.ref) -> i1
+    %ans = quake.mz %b : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+    %ans_cout = quake.mz %cout : (!quake.ref) -> !quake.measure
     return
   }
 }

--- a/test/Target/OpenQASM/bugReport_641.qke
+++ b/test/Target/OpenQASM/bugReport_641.qke
@@ -22,7 +22,7 @@ module {
     quake.h %arg0 : (!quake.ref) -> ()
     call @__nvqpp__mlirgen____nvqppBuilderKernel_093606261879(%arg0) : (!quake.ref) -> ()
     quake.h %arg0 : (!quake.ref) -> ()
-    %bits = quake.mz %arg0 name "" : (!quake.ref) -> i1
+    %bits = quake.mz %arg0 name "" : (!quake.ref) -> !quake.measure
     return
   }
   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_093606261879(%arg0: !quake.ref) {

--- a/test/Target/OpenQASM/callOp_380.qke
+++ b/test/Target/OpenQASM/callOp_380.qke
@@ -12,7 +12,7 @@ module {
   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_093606261879() attributes {"cudaq-entrypoint"} {
     %0 = quake.alloca !quake.ref
     call @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%0) : (!quake.ref) -> ()
-    %1 = quake.mz %0 : (!quake.ref) -> i1 {registerName = ""}
+    %1 = quake.mz %0 name "" : (!quake.ref) -> !quake.measure
     return
   }
   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%arg0: !quake.ref) {

--- a/test/Target/OpenQASM/topologicalSort_603.qke
+++ b/test/Target/OpenQASM/topologicalSort_603.qke
@@ -18,7 +18,7 @@ module {
     quake.h %arg0 : (!quake.ref) -> ()
     call @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%arg0) : (!quake.ref) -> ()
     quake.h %arg0 : (!quake.ref) -> ()
-    %0 = quake.mz %arg0 : (!quake.ref) -> i1 {registerName = ""}
+    %0 = quake.mz %arg0 name "" : (!quake.ref) -> !quake.measure
     return
   }
   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_367535629127(%arg0: !quake.ref) {

--- a/test/Transforms/delay_measurements.qke
+++ b/test/Transforms/delay_measurements.qke
@@ -14,11 +14,11 @@ func.func @delayCheckForValueSemantics() {
   %0 = quake.null_wire
   %1 = quake.null_wire
   %2 = quake.x %0 : (!quake.wire) -> !quake.wire
-  %bits, %wires = quake.mz %2 name "result0": (!quake.wire) -> (i1, !quake.wire)
+  %bits, %wires = quake.mz %2 name "result0": (!quake.wire) -> (!quake.measure, !quake.wire)
   %3 = quake.z %wires : (!quake.wire) -> !quake.wire
   quake.sink %3 : !quake.wire
   %4 = quake.x %1 : (!quake.wire) -> !quake.wire
-  %bits_0, %wires_1 = quake.mz %4 name "result1": (!quake.wire) -> (i1, !quake.wire)
+  %bits_0, %wires_1 = quake.mz %4 name "result1": (!quake.wire) -> (!quake.measure, !quake.wire)
   quake.sink %wires_1 : !quake.wire
   return
 }
@@ -28,10 +28,10 @@ func.func @delayCheckForValueSemantics() {
 // CHECK:           %[[VAL_1:.*]] = quake.null_wire
 // CHECK:           %[[VAL_2:.*]] = quake.x %[[VAL_0]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_3:.*]] = quake.x %[[VAL_1]] : (!quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = quake.mz %[[VAL_2]] name "result0" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = quake.mz %[[VAL_2]] name "result0" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_6:.*]] = quake.z %[[VAL_5]] : (!quake.wire) -> !quake.wire
 // CHECK:           quake.sink %[[VAL_6]] : !quake.wire
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_3]] name "result1" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_3]] name "result1" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           quake.sink %[[VAL_8]] : !quake.wire
 // CHECK:           return
 // CHECK:         }

--- a/test/Transforms/mapping_non_unitaries.qke
+++ b/test/Transforms/mapping_non_unitaries.qke
@@ -30,7 +30,7 @@ func.func @test_measurement() {
   %3:2 = quake.x [%1] %0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %4:2 = quake.x [%3#0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %5:2 = quake.x [%4#1] %3#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  %bits, %wires:3 = quake.mz %5#1, %4#0, %5#0 name "result": (!quake.wire, !quake.wire, !quake.wire) -> (!cc.stdvec<i1>, !quake.wire, !quake.wire, !quake.wire)
+  %bits, %wires:3 = quake.mz %5#1, %4#0, %5#0 name "result": (!quake.wire, !quake.wire, !quake.wire) -> (!cc.stdvec<!quake.measure>, !quake.wire, !quake.wire, !quake.wire)
   quake.sink %wires#0 : !quake.wire
   quake.sink %wires#1 : !quake.wire
   quake.sink %wires#2 : !quake.wire
@@ -45,7 +45,7 @@ func.func @test_measurement() {
 // CHECK:           %[[VAL_4:.*]]:2 = quake.x {{\[}}%[[VAL_3]]#0] %[[VAL_2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_5:.*]]:2 = quake.swap %[[VAL_4]]#1, %[[VAL_4]]#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_6:.*]]:2 = quake.x {{\[}}%[[VAL_5]]#1] %[[VAL_3]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]]:3 = quake.mz %[[VAL_6]]#1, %[[VAL_5]]#0, %[[VAL_6]]#0 name "result" : (!quake.wire, !quake.wire, !quake.wire) -> (!cc.stdvec<i1>, !quake.wire, !quake.wire, !quake.wire)
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]]:3 = quake.mz %[[VAL_6]]#1, %[[VAL_5]]#0, %[[VAL_6]]#0 name "result" : (!quake.wire, !quake.wire, !quake.wire) -> (!cc.stdvec<!quake.measure>, !quake.wire, !quake.wire, !quake.wire)
 // CHECK:           quake.sink %[[VAL_8]]#0 : !quake.wire
 // CHECK:           quake.sink %[[VAL_8]]#1 : !quake.wire
 // CHECK:           quake.sink %[[VAL_8]]#2 : !quake.wire

--- a/test/Transforms/mapping_phased_rx.qke
+++ b/test/Transforms/mapping_phased_rx.qke
@@ -22,7 +22,7 @@ module {
     %6:2 = quake.z [%3] %5 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     %7 = quake.phased_rx (%cst, %cst) %6#1 : (f64, f64, !quake.wire) -> !quake.wire
     %8 = quake.phased_rx (%cst_0, %cst_1) %7 : (f64, f64, !quake.wire) -> !quake.wire
-    %bits, %wires = quake.mz %6#0 name "result": (!quake.wire) -> (i1, !quake.wire)
+    %bits, %wires = quake.mz %6#0 name "result": (!quake.wire) -> (!quake.measure, !quake.wire)
     quake.sink %wires : !quake.wire
     quake.sink %8 : !quake.wire
     return
@@ -44,7 +44,7 @@ module {
 // CHECK:           %[[VAL_11:.*]]:2 = quake.z {{\[}}%[[VAL_10]]#1] %[[VAL_9]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_12:.*]] = quake.phased_rx (%[[VAL_0]], %[[VAL_0]]) %[[VAL_11]]#1 : (f64, f64, !quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_13:.*]] = quake.phased_rx (%[[VAL_1]], %[[VAL_2]]) %[[VAL_12]] : (f64, f64, !quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = quake.mz %[[VAL_11]]#0 name "result" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = quake.mz %[[VAL_11]]#0 name "result" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           quake.sink %[[VAL_15]] : !quake.wire
 // CHECK:           quake.sink %[[VAL_13]] : !quake.wire
 // CHECK:           return

--- a/test/Transforms/mapping_qspan.qke
+++ b/test/Transforms/mapping_qspan.qke
@@ -70,16 +70,20 @@ module {
     %52 = quake.t %50#0 : (!quake.wire) -> !quake.wire
     %53 = quake.h %47 : (!quake.wire) -> !quake.wire
     %54 = cc.alloca !cc.array<i1 x 4>
-    %bits, %wires = quake.mz %52 name "result%0" : (!quake.wire) -> (i1, !quake.wire)
+    %bit, %wires = quake.mz %52 name "result%0" : (!quake.wire) -> (!quake.measure, !quake.wire)
+    %bits = quake.discriminate %bit : (!quake.measure) -> i1
     %55 = cc.compute_ptr %54[0] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
     cc.store %bits, %55 : !cc.ptr<i1>
-    %bits_0, %wires_1 = quake.mz %51 name "result%1" : (!quake.wire) -> (i1, !quake.wire)
+    %bit_0, %wires_1 = quake.mz %51 name "result%1" : (!quake.wire) -> (!quake.measure, !quake.wire)
+    %bits_0 = quake.discriminate %bit_0 : (!quake.measure) -> i1
     %56 = cc.compute_ptr %54[1] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
     cc.store %bits_0, %56 : !cc.ptr<i1>
-    %bits_2, %wires_3 = quake.mz %37 name "result%2" : (!quake.wire) -> (i1, !quake.wire)
+    %bit_2, %wires_3 = quake.mz %37 name "result%2" : (!quake.wire) -> (!quake.measure, !quake.wire)
+    %bits_2 = quake.discriminate %bit_2 : (!quake.measure) -> i1
     %57 = cc.compute_ptr %54[2] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
     cc.store %bits_2, %57 : !cc.ptr<i1>
-    %bits_4, %wires_5 = quake.mz %38 name "result%3" : (!quake.wire) -> (i1, !quake.wire)
+    %bit_4, %wires_5 = quake.mz %38 name "result%3" : (!quake.wire) -> (!quake.measure, !quake.wire)
+    %bits_4 = quake.discriminate %bit_4 : (!quake.measure) -> i1
     %58 = cc.compute_ptr %54[3] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
     cc.store %bits_4, %58 : !cc.ptr<i1>
     quake.sink %53 : !quake.wire
@@ -159,16 +163,20 @@ module {
 // CHECK:           %[[VAL_64:.*]] = quake.t %[[VAL_62]]#0 : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_65:.*]] = quake.h %[[VAL_59]] : (!quake.wire) -> !quake.wire
 // CHECK:           quake.sink %[[VAL_65]] : !quake.wire
-// CHECK:           %[[VAL_66:.*]], %[[VAL_67:.*]] = quake.mz %[[VAL_47]] name "result%[[VAL_2]]" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_166:.*]], %[[VAL_67:.*]] = quake.mz %[[VAL_47]] name "result%[[VAL_2]]" : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_66:.*]] = quake.discriminate %[[VAL_166]] :
 // CHECK:           cc.store %[[VAL_66]], %[[VAL_14]] : !cc.ptr<i1>
 // CHECK:           quake.sink %[[VAL_67]] : !quake.wire
-// CHECK:           %[[VAL_68:.*]], %[[VAL_69:.*]] = quake.mz %[[VAL_42]]#0 name "result%[[VAL_3]]" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_168:.*]], %[[VAL_69:.*]] = quake.mz %[[VAL_42]]#0 name "result%[[VAL_3]]" : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_68:.*]] = quake.discriminate %[[VAL_168]] :
 // CHECK:           cc.store %[[VAL_68]], %[[VAL_15]] : !cc.ptr<i1>
 // CHECK:           quake.sink %[[VAL_69]] : !quake.wire
-// CHECK:           %[[VAL_70:.*]], %[[VAL_71:.*]] = quake.mz %[[VAL_64]] name "result%[[VAL_0]]" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_170:.*]], %[[VAL_71:.*]] = quake.mz %[[VAL_64]] name "result%[[VAL_0]]" : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_70:.*]] = quake.discriminate %[[VAL_170]] :
 // CHECK:           cc.store %[[VAL_70]], %[[VAL_12]] : !cc.ptr<i1>
 // CHECK:           quake.sink %[[VAL_71]] : !quake.wire
-// CHECK:           %[[VAL_72:.*]], %[[VAL_73:.*]] = quake.mz %[[VAL_63]] name "result%[[VAL_1]]" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_172:.*]], %[[VAL_73:.*]] = quake.mz %[[VAL_63]] name "result%[[VAL_1]]" : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_72:.*]] = quake.discriminate %[[VAL_172]] :
 // CHECK:           cc.store %[[VAL_72]], %[[VAL_13]] : !cc.ptr<i1>
 // CHECK:           quake.sink %[[VAL_73]] : !quake.wire
 // CHECK:           return

--- a/test/Transforms/mapping_with_meas-1.qke
+++ b/test/Transforms/mapping_with_meas-1.qke
@@ -16,9 +16,9 @@ module {
     %4 = quake.x %1 : (!quake.wire) -> !quake.wire
     %5:2 = quake.x [%3] %4 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
     %6:2 = quake.x [%5#0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-    %bits, %wires = quake.mz %6#0 name "q0result" : (!quake.wire) -> (i1, !quake.wire)
-    %bits_0, %wires_1 = quake.mz %5#1 name "q1result" : (!quake.wire) -> (i1, !quake.wire)
-    %bits_2, %wires_3 = quake.mz %6#1 name "q2result" : (!quake.wire) -> (i1, !quake.wire)
+    %bits, %wires = quake.mz %6#0 name "q0result" : (!quake.wire) -> (!quake.measure, !quake.wire)
+    %bits_0, %wires_1 = quake.mz %5#1 name "q1result" : (!quake.wire) -> (!quake.measure, !quake.wire)
+    %bits_2, %wires_3 = quake.mz %6#1 name "q2result" : (!quake.wire) -> (!quake.measure, !quake.wire)
     quake.sink %wires : !quake.wire
     quake.sink %wires_1 : !quake.wire
     quake.sink %wires_3 : !quake.wire
@@ -35,9 +35,9 @@ module {
 // CHECK:           %[[VAL_5:.*]]:2 = quake.x {{\[}}%[[VAL_3]]] %[[VAL_4]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_6:.*]]:2 = quake.swap %[[VAL_5]]#0, %[[VAL_5]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_7:.*]]:2 = quake.x {{\[}}%[[VAL_6]]#1] %[[VAL_2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = quake.mz %[[VAL_7]]#0 name "q0result" : (!quake.wire) -> (i1, !quake.wire)
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = quake.mz %[[VAL_6]]#0 name "q1result" : (!quake.wire) -> (i1, !quake.wire)
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = quake.mz %[[VAL_7]]#1 name "q2result" : (!quake.wire) -> (i1, !quake.wire)
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = quake.mz %[[VAL_7]]#0 name "q0result" : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = quake.mz %[[VAL_6]]#0 name "q1result" : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = quake.mz %[[VAL_7]]#1 name "q2result" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           quake.sink %[[VAL_9]] : !quake.wire
 // CHECK:           quake.sink %[[VAL_11]] : !quake.wire
 // CHECK:           quake.sink %[[VAL_13]] : !quake.wire


### PR DESCRIPTION
Adds a new type for the result of a measurement operation. A value of type `!quake.measurement` must be post-processed by the new operation `quake.discriminate` to convert that value to a classical integer value. `quake.discriminate`, like the previous measurement ops, can produce either a single integer (bit) or a `std::vector` of integers (bits).

This splits the measurement operation into two steps:
  - acquiring the measurement on a qubit(s)
  - converting the measurement results to a classical value(s).

Fix all the tests and passes to accept the new representation.

