### PR TITLE
Make C++ ASTBridge specification adherent for operation broadcasting 

### DIFF
--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -13,6 +13,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Types.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 namespace cudaq {
 namespace cc {
@@ -72,6 +73,13 @@ inline mlir::Block *addEntryBlock(mlir::LLVM::GlobalOp initVar) {
   return entry;
 }
 
+/// Return an i64 array where the kth element is N if the kth
+/// operand is veq<N> and 0 otherwise (e.g. is a ref).
+mlir::Value packIsArrayAndLengthArray(mlir::Location loc,
+                                      mlir::ConversionPatternRewriter &rewriter,
+                                      mlir::ModuleOp parentModule,
+                                      mlir::Value numOperands,
+                                      mlir::ValueRange operands);
 mlir::FlatSymbolRefAttr
 createLLVMFunctionSymbol(mlir::StringRef name, mlir::Type retType,
                          mlir::ArrayRef<mlir::Type> inArgTypes,

--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -29,6 +29,8 @@ constexpr static const char NVQIRInvokeWithControlBits[] =
     "invokeWithControlQubits";
 constexpr static const char NVQIRInvokeRotationWithControlBits[] =
     "invokeRotationWithControlQubits";
+constexpr static const char NVQIRInvokeWithControlRegisterOrBits[] =
+    "invokeWithControlRegisterOrQubits";
 constexpr static const char NVQIRPackSingleQubitInArray[] =
     "packSingleQubitInArray";
 constexpr static const char NVQIRReleasePackedQubitArray[] =

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -53,6 +53,8 @@ static clang::NamedDecl *getNamedDecl(clang::Expr *expr) {
 static std::pair<SmallVector<Value>, SmallVector<Value>>
 maybeUnpackOperands(OpBuilder &builder, Location loc, ValueRange operands,
                     bool isControl = false) {
+  // If this is not a controlled op, then we just keep all operands
+  // as targets.
   if (!isControl)
     return std::make_pair(operands, SmallVector<Value>{});
 

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -51,7 +51,11 @@ static clang::NamedDecl *getNamedDecl(clang::Expr *expr) {
 }
 
 static std::pair<SmallVector<Value>, SmallVector<Value>>
-maybeUnpackOperands(OpBuilder &builder, Location loc, ValueRange operands) {
+maybeUnpackOperands(OpBuilder &builder, Location loc, ValueRange operands,
+                    bool isControl = false) {
+  if (!isControl)
+    return std::make_pair(operands, SmallVector<Value>{});
+
   if (operands.size() > 1)
     return std::make_pair(SmallVector<Value>{operands.take_back()},
                           SmallVector<Value>{operands.drop_back(1)});
@@ -121,12 +125,12 @@ template <typename A, typename P = void>
 bool buildOp(OpBuilder &builder, Location loc, ValueRange operands,
              SmallVector<Value> &negations,
              llvm::function_ref<void()> reportNegateError,
-             bool isAdjoint = false) {
+             bool isAdjoint = false, bool isControl = false) {
   if constexpr (std::is_same_v<P, Param>) {
     assert(operands.size() >= 2 && "must be at least 2 operands");
     auto params = operands.take_front();
     auto [target, ctrls] =
-        maybeUnpackOperands(builder, loc, operands.drop_front(1));
+        maybeUnpackOperands(builder, loc, operands.drop_front(1), isControl);
     for (auto v : target)
       if (std::find(negations.begin(), negations.end(), v) != negations.end())
         reportNegateError();
@@ -151,13 +155,23 @@ bool buildOp(OpBuilder &builder, Location loc, ValueRange operands,
       };
       cudaq::opt::factory::createInvariantLoop(builder, loc, rank, bodyBuilder);
     } else {
-      auto [target, ctrls] = maybeUnpackOperands(builder, loc, operands);
+      auto [target, ctrls] =
+          maybeUnpackOperands(builder, loc, operands, isControl);
       for (auto v : target)
         if (std::find(negations.begin(), negations.end(), v) != negations.end())
           reportNegateError();
       auto negs =
           negatedControlsAttribute(builder.getContext(), ctrls, negations);
-      builder.create<A>(loc, isAdjoint, ValueRange(), ctrls, target, negs);
+      if (ctrls.empty())
+        // May have multiple targets, but no controls, op(q, r, s, ...)
+        for (auto t : target)
+          builder.create<A>(loc, isAdjoint, ValueRange(), ValueRange(), t,
+                            negs);
+      else {
+        assert(target.size() == 1 &&
+               "can only have a single target with control qubits.");
+        builder.create<A>(loc, isAdjoint, ValueRange(), ctrls, target, negs);
+      }
     }
   }
   return true;
@@ -1344,7 +1358,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
 
   if (isInNamespace(func, "cudaq")) {
     // Check and see if this quantum operation is adjoint
-    bool isAdjoint = false;
+    bool isAdjoint = false, isControl = false;
     auto *functionDecl = x->getCalleeDecl()->getAsFunction();
     if (auto *templateArgs = functionDecl->getTemplateSpecializationArgs())
       if (templateArgs->size() > 0) {
@@ -1352,8 +1366,10 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         if (gateModifierArg.getKind() == clang::TemplateArgument::ArgKind::Type)
           if (auto *structTy =
                   gateModifierArg.getAsType()->getAsStructureType())
-            if (auto structTypeAsRecord = structTy->getAsCXXRecordDecl())
+            if (auto structTypeAsRecord = structTy->getAsCXXRecordDecl()) {
               isAdjoint = structTypeAsRecord->getName() == "adj";
+              isControl = structTypeAsRecord->getName() == "ctrl";
+            }
       }
 
     if (funcName.equals("exp_pauli")) {
@@ -1419,23 +1435,23 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
     };
     if (funcName.equals("h") || funcName.equals("ch"))
       return buildOp<quake::HOp>(builder, loc, args, negations,
-                                 reportNegateError);
+                                 reportNegateError, false, isControl);
     if (funcName.equals("x") || funcName.equals("cnot") ||
         funcName.equals("cx") || funcName.equals("ccx"))
       return buildOp<quake::XOp>(builder, loc, args, negations,
-                                 reportNegateError);
+                                 reportNegateError, false, isControl);
     if (funcName.equals("y") || funcName.equals("cy"))
       return buildOp<quake::YOp>(builder, loc, args, negations,
-                                 reportNegateError);
+                                 reportNegateError, false, isControl);
     if (funcName.equals("z") || funcName.equals("cz"))
       return buildOp<quake::ZOp>(builder, loc, args, negations,
-                                 reportNegateError);
+                                 reportNegateError, false, isControl);
     if (funcName.equals("s") || funcName.equals("cs"))
       return buildOp<quake::SOp>(builder, loc, args, negations,
-                                 reportNegateError, isAdjoint);
+                                 reportNegateError, isAdjoint, isControl);
     if (funcName.equals("t") || funcName.equals("ct"))
       return buildOp<quake::TOp>(builder, loc, args, negations,
-                                 reportNegateError, isAdjoint);
+                                 reportNegateError, isAdjoint, isControl);
 
     if (funcName.equals("reset")) {
       if (!negations.empty())
@@ -1459,16 +1475,20 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
     }
     if (funcName.equals("p") || funcName.equals("r1"))
       return buildOp<quake::R1Op, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint);
+                                         reportNegateError, isAdjoint,
+                                         isControl);
     if (funcName.equals("rx"))
       return buildOp<quake::RxOp, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint);
+                                         reportNegateError, isAdjoint,
+                                         isControl);
     if (funcName.equals("ry"))
       return buildOp<quake::RyOp, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint);
+                                         reportNegateError, isAdjoint,
+                                         isControl);
     if (funcName.equals("rz"))
       return buildOp<quake::RzOp, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint);
+                                         reportNegateError, isAdjoint,
+                                         isControl);
 
     if (funcName.equals("control")) {
       // Expect the first argument to be an instance of a Callable. Need to

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -136,7 +136,14 @@ bool buildOp(OpBuilder &builder, Location loc, ValueRange operands,
         reportNegateError();
     auto negs =
         negatedControlsAttribute(builder.getContext(), ctrls, negations);
-    builder.create<A>(loc, isAdjoint, params, ctrls, target, negs);
+    if (ctrls.empty())
+      for (auto t : target)
+        builder.create<A>(loc, isAdjoint, params, ctrls, t, negs);
+    else {
+      assert(target.size() == 1 &&
+             "can only have a single target with control qubits.");
+      builder.create<A>(loc, isAdjoint, params, ctrls, target, negs);
+    }
   } else {
     assert(operands.size() >= 1 && "must be at least 1 operand");
     if ((operands.size() == 1) && operands[0].getType().isa<quake::VeqType>()) {

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -33,19 +33,20 @@ Value factory::packIsArrayAndLengthArray(Location loc,
   auto getSizeSymbolRef = cudaq::opt::factory::createLLVMFunctionSymbol(
       cudaq::opt::QIRArrayGetSize, i64Type, {cudaq::opt::getArrayType(context)},
       parentModule);
-  for (std::size_t i = 0; auto controlOperand : operands) {
-    Value idx = rewriter.create<arith::ConstantIntOp>(loc, i++, 64);
+  for (auto iter : llvm::enumerate(operands)) {
+    auto operand = iter.value();
+    auto i = iter.index();
+    Value idx = rewriter.create<arith::ConstantIntOp>(loc, i, 64);
     Value ptr = rewriter.create<LLVM::GEPOp>(loc, intPtrTy, isArrayAndLengthArr,
                                              ValueRange{idx});
     Value element;
-    if (controlOperand.getType() == cudaq::opt::getQubitType(context))
+    if (operand.getType() == cudaq::opt::getQubitType(context))
       element = zero;
     else
       // get array size with the runtime function
       element = rewriter
                     .create<LLVM::CallOp>(loc, rewriter.getI64Type(),
-                                          getSizeSymbolRef,
-                                          ValueRange{controlOperand})
+                                          getSizeSymbolRef, ValueRange{operand})
                     .getResult();
 
     rewriter.create<LLVM::StoreOp>(loc, element, ptr);

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -443,12 +443,12 @@ public:
 
     // Check if all controls are qubit types, if so
     // retain existing functionality
-    auto allControlsAreQubits = [&](auto controls) {
-      for (auto c : controls)
+    auto allControlsAreQubits = [&]() {
+      for (auto c : adaptor.getControls())
         if (c.getType() != qirQubitPointerType)
           return false;
       return true;
-    }(adaptor.getControls());
+    }();
 
     // Here we know we have multiple controls, we have to
     // check if we have all refs or a mix of ref / veq. If the
@@ -549,7 +549,7 @@ public:
     auto loc = instOp.getLoc();
     ModuleOp parentModule = instOp->template getParentOfType<ModuleOp>();
     auto context = parentModule->getContext();
-    auto qirQisPrefix = std::string(cudaq::opt::QIRQISPrefix);
+    std::string qirQisPrefix = cudaq::opt::QIRQISPrefix;
     auto qirFunctionName = qirQisPrefix + instName;
 
     auto qubitIndexType = cudaq::opt::getQubitType(context);
@@ -618,7 +618,7 @@ public:
       return success();
     }
 
-    // The remaining scenaries are best handled with the
+    // The remaining scenarios are best handled with the
     // invokeRotationWithControlQubits function.
 
     Value ctrlOpPointer = rewriter.create<LLVM::AddressOfOp>(

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -568,13 +568,12 @@ public:
     auto loc = instOp.getLoc();
     ModuleOp parentModule = instOp->template getParentOfType<ModuleOp>();
     auto context = parentModule->getContext();
-    auto qirFunctionName = std::string(cudaq::opt::QIRQISPrefix) + instName;
+    auto qirQisPrefix = std::string(cudaq::opt::QIRQISPrefix);
+    auto qirFunctionName = qirQisPrefix + instName;
 
-    SmallVector<Type> tmpArgTypes;
     auto qubitIndexType = cudaq::opt::getQubitType(context);
     auto qubitArrayType = cudaq::opt::getArrayType(context);
     auto paramType = FloatType::getF64(context);
-    tmpArgTypes.push_back(paramType);
 
     SmallVector<Value> funcArgs;
     auto castToDouble = [&](Value v) {
@@ -589,11 +588,10 @@ public:
 
     // If no controls, then this is easy
     if (numControls == 0) {
-      tmpArgTypes.push_back(qubitIndexType);
       FlatSymbolRefAttr symbolRef =
           cudaq::opt::factory::createLLVMFunctionSymbol(
               qirFunctionName, /*return type=*/LLVM::LLVMVoidType::get(context),
-              std::move(tmpArgTypes), parentModule);
+              {paramType, qubitIndexType}, parentModule);
 
       funcArgs.push_back(adaptor.getTargets().front());
 
@@ -604,41 +602,22 @@ public:
     }
 
     qirFunctionName += "__ctl";
-    auto negateFunctionName = qirFunctionName + "x";
+    auto negateFunctionName = qirQisPrefix + "x";
     auto negatedQubitCtrls = instOp.getNegatedQubitControls();
 
-    // All signatures will take an Array* for the controls
-    tmpArgTypes.push_back(qubitArrayType);
+    // __quantum__qis__NAME__ctl(double, Array*, Qubit*) Type
+    auto instOpQISFunctionType = LLVM::LLVMFunctionType::get(
+        LLVM::LLVMVoidType::get(context), {paramType, qubitArrayType, qubitIndexType});
+
+    // Get function pointer to ctrl operation
+    FlatSymbolRefAttr instSymbolRef =
+        cudaq::opt::factory::createLLVMFunctionSymbol(
+            qirFunctionName, /*return type=*/LLVM::LLVMVoidType::get(context),
+            {paramType, qubitArrayType, qubitIndexType}, parentModule);
 
     // We have >= 1 control, is the first a veq or a ref?
     auto control = *instOp.getControls().begin();
     Type type = control.getType();
-    // Return an error if the type is not a veq or ref.
-    if (!type.isa<quake::VeqType, quake::RefType>()) {
-      std::string typeName;
-      llvm::raw_string_ostream typeNameStream(typeName);
-      typeNameStream << type;
-      return instOp.emitError("unsupported control type for " + instName +
-                              ": " + typeName);
-    }
-
-    // If the control is a qubit, we need to pack it into an Array*
-    if (numControls == 1 && type.isa<quake::RefType>()) {
-      FlatSymbolRefAttr packingSymbolRef =
-          cudaq::opt::factory::createLLVMFunctionSymbol(
-              cudaq::opt::NVQIRPackSingleQubitInArray,
-              /*return type=*/qubitArrayType, {qubitIndexType}, parentModule);
-
-      // Pack the qubit into the array
-      Value result =
-          rewriter
-              .create<LLVM::CallOp>(loc, qubitArrayType, packingSymbolRef,
-                                    adaptor.getControls().front())
-              .getResult();
-      // The array result is what we want for the function args
-      funcArgs.push_back(result);
-    }
-
     // If type is a VeqType, then we're good, just forward to the call op
     if (numControls == 1 && type.isa<quake::VeqType>()) {
       if (negatedQubitCtrls)
@@ -647,94 +626,94 @@ public:
 
       // Add the control array to the args.
       funcArgs.push_back(adaptor.getControls().front());
-    }
 
-    // This is a single target op, add that type
-    tmpArgTypes.push_back(qubitIndexType);
+      // Add the target op
+      funcArgs.push_back(adaptor.getTargets().front());
 
-    // __quantum__qis__NAME__ctl(double, Array*, Qubit*) Type
-    auto instOpQISFunctionType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(context), tmpArgTypes);
-
-    // Get function pointer to ctrl operation
-    FlatSymbolRefAttr instSymbolRef =
-        cudaq::opt::factory::createLLVMFunctionSymbol(
-            qirFunctionName, /*return type=*/LLVM::LLVMVoidType::get(context),
-            std::move(tmpArgTypes), parentModule);
-
-    // Now we know we have the proper veq/ref type, we can
-    // handle multiple controls.
-    if (numControls > 1) {
-
-      // Get symbol for
-      // void invokeWithControlQubits(const std::size_t nControls, void
-      // (*QISFunction)(double, Array*, Qubit*), Qubit*, ...);
-      auto applyMultiControlFunction =
-          cudaq::opt::factory::createLLVMFunctionSymbol(
-              cudaq::opt::NVQIRInvokeRotationWithControlBits,
-              LLVM::LLVMVoidType::get(context),
-              {rewriter.getF64Type(), rewriter.getI64Type(),
-               LLVM::LLVMPointerType::get(instOpQISFunctionType)},
-              parentModule, true);
-
-      Value ctrlOpPointer = rewriter.create<LLVM::AddressOfOp>(
-          loc, LLVM::LLVMPointerType::get(instOpQISFunctionType),
-          instSymbolRef);
-
-      auto arraySize = rewriter.create<LLVM::ConstantOp>(
-          loc, rewriter.getI64Type(), numControls);
-
-      // This will need the numControls, function pointer, and all Qubit*
-      // operands
-      SmallVector<Value> args = {castToDouble(val), arraySize, ctrlOpPointer};
-      FlatSymbolRefAttr negateFuncRef;
-      if (negatedQubitCtrls) {
-        negateFuncRef = cudaq::opt::factory::createLLVMFunctionSymbol(
-            negateFunctionName,
-            /*return type=*/LLVM::LLVMVoidType::get(context),
-            {cudaq::opt::getQubitType(context)}, parentModule);
-        for (auto v : llvm::enumerate(instOperands)) {
-          if ((v.index() < numControls) && (*negatedQubitCtrls)[v.index()])
-            rewriter.create<LLVM::CallOp>(loc, TypeRange{}, negateFuncRef,
-                                          v.value());
-          args.push_back(v.value());
-        }
-      } else {
-        args.append(instOperands.begin(), instOperands.end());
-      }
-
-      // Call our utility function.
-      rewriter.replaceOpWithNewOp<LLVM::CallOp>(
-          instOp, TypeRange{}, applyMultiControlFunction, args);
-
-      if (negatedQubitCtrls) {
-        for (auto v : llvm::enumerate(instOperands))
-          if ((v.index() < numControls) && (*negatedQubitCtrls)[v.index()])
-            rewriter.create<LLVM::CallOp>(loc, TypeRange{}, negateFuncRef,
-                                          v.value());
-      }
-
+      // Here we already have and Array*, Qubit*
+      rewriter.replaceOpWithNewOp<LLVM::CallOp>(instOp, TypeRange{},
+                                                instSymbolRef, funcArgs);
       return success();
     }
 
-    // Add the target op
-    funcArgs.push_back(adaptor.getTargets().front());
+    Value ctrlOpPointer = rewriter.create<LLVM::AddressOfOp>(
+        loc, LLVM::LLVMPointerType::get(instOpQISFunctionType), instSymbolRef);
 
-    // Here we already have and Array*, Qubit*
-    rewriter.replaceOpWithNewOp<LLVM::CallOp>(instOp, TypeRange{},
-                                              instSymbolRef, funcArgs);
+    // Get symbol for
+    // void invokeRotationWithControlQubits(double param, const std::size_t
+    // numControlOperands, i64* isArrayAndLength, void (*QISFunction)(Array*,
+    // Qubit*), Qubit*, ...);
+    auto i64Type = rewriter.getI64Type();
+    auto applyMultiControlFunction =
+        cudaq::opt::factory::createLLVMFunctionSymbol(
+            cudaq::opt::NVQIRInvokeRotationWithControlBits,
+            LLVM::LLVMVoidType::get(context),
+            {paramType, i64Type, LLVM::LLVMPointerType::get(i64Type),
+             LLVM::LLVMPointerType::get(instOpQISFunctionType)},
+            parentModule, true);
 
-    // If the control was a ref, we need to release the control Array.
-    if (type.isa<quake::RefType>()) {
-      FlatSymbolRefAttr releaseSymbolRef =
-          cudaq::opt::factory::createLLVMFunctionSymbol(
-              cudaq::opt::NVQIRReleasePackedQubitArray,
-              /*return type=*/LLVM::LLVMVoidType::get(context),
-              {qubitArrayType}, parentModule);
-      Value ctrlArray = funcArgs[1];
-      rewriter.create<LLVM::CallOp>(loc, TypeRange{}, releaseSymbolRef,
-                                    ctrlArray);
+    // numControls could be more than num operands,
+    // e.g. ctrls = {veq<2>, ref} is 3 and not 2 controls
+    // We need an i64 array encoding 0 if control operand is a ref, and N if
+    // control operand is a veq<N>.
+    Value numControlOperands =
+        rewriter.create<LLVM::ConstantOp>(loc, i64Type, numControls);
+
+    // Create an integer array where the kth element is N if the kth
+    // control operand is a veq<N>, and 0 otherwise.
+    Value isArrayAndLengthArr = rewriter.create<LLVM::AllocaOp>(
+        loc, LLVM::LLVMPointerType::get(i64Type), numControlOperands);
+    auto intPtrTy = LLVM::LLVMPointerType::get(i64Type);
+    Value zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
+    auto getSizeSymbolRef = cudaq::opt::factory::createLLVMFunctionSymbol(
+        cudaq::opt::QIRArrayGetSize, i64Type,
+        {cudaq::opt::getArrayType(context)}, parentModule);
+    for (std::size_t i = 0; auto controlOperand : adaptor.getControls()) {
+      Value idx = rewriter.create<arith::ConstantIntOp>(loc, i++, 64);
+      Value ptr = rewriter.create<LLVM::GEPOp>(
+          loc, intPtrTy, isArrayAndLengthArr, ValueRange{idx});
+      Value element;
+      if (controlOperand.getType() == qubitIndexType)
+        element = zero;
+      else
+        // get array size with the runtime function
+        element = rewriter
+                      .create<LLVM::CallOp>(loc, rewriter.getI64Type(),
+                                            getSizeSymbolRef,
+                                            ValueRange{controlOperand})
+                      .getResult();
+
+      rewriter.create<LLVM::StoreOp>(loc, element, ptr);
     }
+    funcArgs.push_back(numControlOperands);
+    funcArgs.push_back(isArrayAndLengthArr);
+    funcArgs.push_back(ctrlOpPointer);
+
+    FlatSymbolRefAttr negateFuncRef;
+    if (negatedQubitCtrls) {
+      negateFuncRef = cudaq::opt::factory::createLLVMFunctionSymbol(
+          negateFunctionName,
+          /*return type=*/LLVM::LLVMVoidType::get(context),
+          {cudaq::opt::getQubitType(context)}, parentModule);
+      for (auto v : llvm::enumerate(instOperands)) {
+        if ((v.index() < numControls) && (*negatedQubitCtrls)[v.index()])
+          rewriter.create<LLVM::CallOp>(loc, TypeRange{}, negateFuncRef,
+                                        v.value());
+        funcArgs.push_back(v.value());
+      }
+    } else {
+      funcArgs.append(instOperands.begin(), instOperands.end());
+    }
+
+    // Call our utility function.
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+        instOp, TypeRange{}, applyMultiControlFunction, funcArgs);
+
+    if (negatedQubitCtrls)
+      for (auto v : llvm::enumerate(instOperands))
+        if ((v.index() < numControls) && (*negatedQubitCtrls)[v.index()])
+          rewriter.create<LLVM::CallOp>(loc, TypeRange{}, negateFuncRef,
+                                        v.value());
 
     return success();
   }

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -714,32 +714,45 @@ void invokeWithControlRegisterOrQubits(const std::size_t numControlOperands,
   va_end(args);
 }
 
-void invokeRotationWithControlQubits(double param, const std::size_t nControls,
-                                     void (*QISFunction)(double, Array *,
-                                                         Qubit *),
-                                     ...) {
+void invokeRotationWithControlQubits(double param, const std::size_t numControlOperands,
+                                       std::size_t *isArrayAndLength,
+                                       void (*QISFunction)(double, Array *, Qubit *),
+                                       ...) {
+  std::size_t numControls = 0;
+  for (std::size_t i = 0; i < numControlOperands; i++)
+    numControls += isArrayAndLength[i] ? isArrayAndLength[i] : 1;
+
   // Create the Control Array *, This should
   // be deallocated upon function exit.
-  auto ctrlArray = std::make_unique<Array>(nControls, sizeof(std::size_t));
+  auto ctrlArray = std::make_unique<Array>(numControls, sizeof(std::size_t));
 
   // Start up the variadic arg processing
   va_list args;
   va_start(args, QISFunction);
 
-  std::size_t nSetPointers = 0;
-  while (nSetPointers < nControls) {
-    // For each variadic arg, get it (its a Qubit*)
-    // and set it on the array.
-    Qubit *ctrli = va_arg(args, Qubit *);
-    auto ctrliRawPtr =
-        __quantum__rt__array_get_element_ptr_1d(ctrlArray.get(), nSetPointers);
-    cudaq::info("before reinterpret cast");
-    *reinterpret_cast<Qubit **>(ctrliRawPtr) = ctrli;
-    nSetPointers++;
+  for (std::size_t counter = 0, i = 0; i < numControlOperands; i++) {
+    if (auto numQubitsInArray = isArrayAndLength[i]) {
+      // this is an array
+      Array *array = va_arg(args, Array *);
+      for (std::size_t k = 0; k < numQubitsInArray; k++) {
+        auto qubitK = __quantum__rt__array_get_element_ptr_1d(array, k);
+        auto ctrliRawPtr =
+            __quantum__rt__array_get_element_ptr_1d(ctrlArray.get(), counter++);
+        *reinterpret_cast<Qubit **>(ctrliRawPtr) =
+            *reinterpret_cast<Qubit **>(qubitK);
+      }
+    } else {
+      // this is a qubit
+      Qubit *ctrli = va_arg(args, Qubit *);
+      auto ctrliRawPtr =
+          __quantum__rt__array_get_element_ptr_1d(ctrlArray.get(), counter++);
+      *reinterpret_cast<Qubit **>(ctrliRawPtr) = ctrli;
+    }
   }
 
-  // The next one will be the target
+  // Should be one more arg in there
   Qubit *target = va_arg(args, Qubit *);
+
   // Invoke the function
   QISFunction(param, ctrlArray.get(), target);
 

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -665,6 +665,55 @@ void invokeWithControlQubits(const std::size_t nControls,
   va_end(args);
 }
 
+/// @brief Utility function used by Quake->QIR to invoke a QIR QIS
+/// function with a variadic list of "quantum" arguments, where
+/// the control arguments can be either Array or Qubit types.
+void invokeWithControlRegisterOrQubits(const std::size_t numControlOperands,
+                                       std::size_t *isArrayAndLength,
+                                       void (*QISFunction)(Array *, Qubit *),
+                                       ...) {
+  std::size_t numControls = 0;
+  for (std::size_t i = 0; i < numControlOperands; i++)
+    numControls += isArrayAndLength[i] ? isArrayAndLength[i] : 1;
+
+  // Create the Control Array *, This should
+  // be deallocated upon function exit.
+  auto ctrlArray = std::make_unique<Array>(numControls, sizeof(std::size_t));
+
+  // Start up the variadic arg processing
+  va_list args;
+  va_start(args, QISFunction);
+
+  for (std::size_t counter = 0, i = 0; i < numControlOperands; i++) {
+    if (auto numQubitsInArray = isArrayAndLength[i]) {
+      // this is an array
+      Array *array = va_arg(args, Array *);
+      for (std::size_t k = 0; k < numQubitsInArray; k++) {
+        auto qubitK = __quantum__rt__array_get_element_ptr_1d(array, k);
+        auto ctrliRawPtr =
+            __quantum__rt__array_get_element_ptr_1d(ctrlArray.get(), counter++);
+        *reinterpret_cast<Qubit **>(ctrliRawPtr) =
+            *reinterpret_cast<Qubit **>(qubitK);
+      }
+    } else {
+      // this is a qubit
+      Qubit *ctrli = va_arg(args, Qubit *);
+      auto ctrliRawPtr =
+          __quantum__rt__array_get_element_ptr_1d(ctrlArray.get(), counter++);
+      *reinterpret_cast<Qubit **>(ctrliRawPtr) = ctrli;
+    }
+  }
+
+  // Should be one more arg in there
+  Qubit *target = va_arg(args, Qubit *);
+
+  // Invoke the function
+  QISFunction(ctrlArray.get(), target);
+
+  // End the var args processing and release the array.
+  va_end(args);
+}
+
 void invokeRotationWithControlQubits(double param, const std::size_t nControls,
                                      void (*QISFunction)(double, Array *,
                                                          Qubit *),

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -714,10 +714,10 @@ void invokeWithControlRegisterOrQubits(const std::size_t numControlOperands,
   va_end(args);
 }
 
-void invokeRotationWithControlQubits(double param, const std::size_t numControlOperands,
-                                       std::size_t *isArrayAndLength,
-                                       void (*QISFunction)(double, Array *, Qubit *),
-                                       ...) {
+void invokeRotationWithControlQubits(
+    double param, const std::size_t numControlOperands,
+    std::size_t *isArrayAndLength,
+    void (*QISFunction)(double, Array *, Qubit *), ...) {
   std::size_t numControls = 0;
   for (std::size_t i = 0; i < numControlOperands; i++)
     numControls += isArrayAndLength[i] ? isArrayAndLength[i] : 1;

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -714,6 +714,10 @@ void invokeWithControlRegisterOrQubits(const std::size_t numControlOperands,
   va_end(args);
 }
 
+/// @brief Utility function used by Quake->QIR to invoke a QIR QIS
+/// function with a variadic list of "quantum" arguments, where
+/// the control arguments can be either Array or Qubit types. This
+/// function is to be used for controlled rotations.
 void invokeRotationWithControlQubits(
     double param, const std::size_t numControlOperands,
     std::size_t *isArrayAndLength,

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -25,10 +25,10 @@ struct C {
       for (int i = 0; i < 10; ++i) {
 	 if (f1(i)) {
 	    cudaq::qubit q;
-	    x(q,r[0]);
+	    x<cudaq::ctrl>(q,r[0]);
 	    break;
 	 }
-	 x(r[0],r[1]);
+	 x<cudaq::ctrl>(r[0],r[1]);
 	 g2();
 	 if (f2(i)) {
 	    y(r[1]);
@@ -114,10 +114,10 @@ struct D {
       for (int i = 0; i < 10; ++i) {
 	 if (f1(i)) {
 	    cudaq::qubit q;
-	    x(q,r[0]);
+	    x<cudaq::ctrl>(q,r[0]);
 	    continue;
 	 }
-	 x(r[0],r[1]);
+	 x<cudaq::ctrl>(r[0],r[1]);
 	 g2();
 	 if (f2(i)) {
 	    y(r[1]);
@@ -203,10 +203,10 @@ struct E {
       for (int i = 0; i < 10; ++i) {
 	 if (f1(i)) {
 	    cudaq::qubit q;
-	    x(q,r[0]);
+	    x<cudaq::ctrl>(q,r[0]);
 	    return;
 	 }
-	 x(r[0],r[1]);
+	 x<cudaq::ctrl>(r[0],r[1]);
 	 g2();
 	 if (f2(i)) {
 	    y(r[1]);
@@ -291,10 +291,10 @@ struct F {
       for (int i = 0; i < 10; ++i) {
 	 if (f1(i)) {
 	    cudaq::qubit q;
-	    x(q,r[0]);
+	    x<cudaq::ctrl>(q,r[0]);
 	    continue;
 	 }
-	 x(r[0],r[1]);
+	 x<cudaq::ctrl>(r[0],r[1]);
 	 g2();
 	 if (f2(i)) {
 	    y(r[1]);

--- a/test/AST-Quake/if.cpp
+++ b/test/AST-Quake/if.cpp
@@ -16,7 +16,7 @@ struct kernel {
   __qpu__ int operator()(bool flag) {
     cudaq::qreg reg(2);
     if (flag) {
-      h(reg[0], reg[1]);
+      h<cudaq::ctrl>(reg[0], reg[1]);
     }
     return 0;
   }
@@ -40,9 +40,9 @@ struct kernel_else {
   __qpu__ int operator()(bool flag) {
     cudaq::qreg reg(2);
     if (flag) {
-      h(reg[0], reg[1]);
+      h<cudaq::ctrl>(reg[0], reg[1]);
     } else {
-      x(reg[1], reg[0]);
+      x<cudaq::ctrl>(reg[1], reg[0]);
     }
     return 0;
   }

--- a/test/AST-Quake/to_qir.cpp
+++ b/test/AST-Quake/to_qir.cpp
@@ -14,7 +14,7 @@ struct kernel {
     void operator()() __qpu__ {
         cudaq::qreg<3> q;
         h(q[1]);
-        x<cudaq::ctrl>(q[1],q[2]);
+        x<cudaq::ctrl>(q[1], q[2]);
 
         x<cudaq::ctrl>(q[0], q[1]);
         h(q[0]);

--- a/test/Quake-QIR/veq_or_qubit_control_args.qke
+++ b/test/Quake-QIR/veq_or_qubit_control_args.qke
@@ -1,0 +1,55 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt %s | cudaq-translate | FileCheck %s
+
+module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__function_fancyCnot._Z9fancyCnotRN5cudaq5quditILm2EEES2_ = "_Z9fancyCnotRN5cudaq5quditILm2EEES2_", __nvqpp__mlirgen__function_toffoli._Z7toffoliv = "_Z7toffoliv"}} {
+  func.func private @__nvqpp__mlirgen__function_fancyCnot._Z9fancyCnotRN5cudaq5quditILm2EEES2_.ctrl(%arg0: !quake.veq<?>, %arg1: !quake.ref, %arg2: !quake.ref) {
+    quake.x [%arg0, %arg1] %arg2 : (!quake.veq<?>, !quake.ref, !quake.ref) -> ()
+    return
+  }
+  func.func @__nvqpp__mlirgen__function_toffoli._Z7toffoliv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+    %0 = quake.alloca !quake.veq<3>
+    %1 = quake.extract_ref %0[0] : (!quake.veq<3>) -> !quake.ref
+    %2 = quake.extract_ref %0[2] : (!quake.veq<3>) -> !quake.ref
+    quake.x %1 : (!quake.ref) -> ()
+    quake.x %2 : (!quake.ref) -> ()
+    %3 = quake.extract_ref %0[1] : (!quake.veq<3>) -> !quake.ref
+    %4 = quake.extract_ref %0[2] : (!quake.veq<3>) -> !quake.ref
+    %5 = quake.concat %1 : (!quake.ref) -> !quake.veq<?>
+    call @__nvqpp__mlirgen__function_fancyCnot._Z9fancyCnotRN5cudaq5quditILm2EEES2_.ctrl(%5, %3, %4) : (!quake.veq<?>, !quake.ref, !quake.ref) -> ()
+    return
+  }
+}
+
+// CHECK:         %[[VAL_0:.*]] = tail call
+// CHECK:         %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 3)
+// CHECK:         %[[VAL_2:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
+// CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %[[VAL_4:.*]]**
+// CHECK:         %[[VAL_5:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_3]], align 8
+// CHECK:         %[[VAL_6:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 2)
+// CHECK:         %[[VAL_7:.*]] = bitcast i8* %[[VAL_6]] to %[[VAL_4]]**
+// CHECK:         %[[VAL_8:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_7]], align 8
+// CHECK:         tail call void @__quantum__qis__x(%[[VAL_4]]* %[[VAL_5]])
+// CHECK:         tail call void @__quantum__qis__x(%[[VAL_4]]* %[[VAL_8]])
+// CHECK:         %[[VAL_9:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 1)
+// CHECK:         %[[VAL_10:.*]] = bitcast i8* %[[VAL_9]] to %[[VAL_4]]**
+// CHECK:         %[[VAL_11:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_10]], align 8
+// CHECK:         %[[VAL_12:.*]] = tail call %[[VAL_1]]* @__quantum__rt__array_create_1d(i32 8, i64 1)
+// CHECK:         %[[VAL_13:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_12]], i64 0)
+// CHECK:         %[[VAL_14:.*]] = bitcast i8* %[[VAL_13]] to %[[VAL_4]]**
+// CHECK:         store %[[VAL_4]]* %[[VAL_5]], %[[VAL_4]]** %[[VAL_14]], align 8
+// CHECK:         %[[VAL_15:.*]] = alloca [2 x i64], align 8
+// CHECK:         %[[VAL_16:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_15]], i64 0, i64 0
+// CHECK:         %[[VAL_17:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_1]]* %[[VAL_12]])
+// CHECK:         store i64 %[[VAL_17]], i64* %[[VAL_16]], align 8
+// CHECK:         %[[VAL_18:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_15]], i64 0, i64 1
+// CHECK:         store i64 0, i64* %[[VAL_18]], align 8
+// CHECK:         call void (i64, i64*, void (%[[VAL_1]]*, %[[VAL_4]]*)*, ...) @invokeWithControlRegisterOrQubits(i64 2, i64* nonnull %[[VAL_16]], void (%[[VAL_1]]*, %[[VAL_4]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_1]]* %[[VAL_12]], %[[VAL_4]]* %[[VAL_11]], %[[VAL_4]]* %[[VAL_8]])
+// CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
+// CHECK:         ret void

--- a/unittests/backends/quantinuum/QuantinuumTester.cpp
+++ b/unittests/backends/quantinuum/QuantinuumTester.cpp
@@ -389,8 +389,8 @@ CUDAQ_TEST(QuantinuumTester, checkControlledRotations) {
     counts.dump();
 
     // Target qubit should have a 50/50 mix between |0> and |1>
-    EXPECT_EQ(counts.count("0000111111"), 505);
-    EXPECT_EQ(counts.count("0000111110"), 495);
+    EXPECT_TRUE(counts.count("0000111111") < 550);
+    EXPECT_TRUE(counts.count("0000111110") > 450);
   }
 
   {

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -1087,7 +1087,6 @@ CUDAQ_TEST(BuilderTester, checkControlledRotations) {
   }
 }
 
-
 #ifndef CUDAQ_BACKEND_DM
 
 CUDAQ_TEST(BuilderTester, checkCanProgressivelyBuild) {

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -1062,8 +1062,8 @@ CUDAQ_TEST(BuilderTester, checkControlledRotations) {
     counts.dump();
 
     // Target qubit should have a 50/50 mix between |0> and |1>
-    EXPECT_EQ(counts.count("111111"), 505);
-    EXPECT_EQ(counts.count("111110"), 495);
+    EXPECT_TRUE(counts.count("111111") < 550);
+    EXPECT_TRUE(counts.count("111110") > 450);
   }
 
   {

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -972,6 +972,122 @@ CUDAQ_TEST(BuilderTester, checkExpPauli) {
   }
 }
 
+CUDAQ_TEST(BuilderTester, checkControlledRotations) {
+  // rx: pi
+  {
+    auto kernel = cudaq::make_kernel();
+    auto controls1 = kernel.qalloc(2);
+    auto controls2 = kernel.qalloc(2);
+    auto control3 = kernel.qalloc();
+    auto target = kernel.qalloc();
+
+    // All of our controls in the 1-state.
+    kernel.x(controls1);
+    kernel.x(controls2);
+    kernel.x(control3);
+
+    kernel.rx<cudaq::ctrl>(M_PI, controls1, controls2, control3, target);
+
+    std::cout << kernel.to_quake() << "\n";
+
+    auto counts = cudaq::sample(kernel);
+    counts.dump();
+
+    // Target qubit should've been rotated to |1>.
+    EXPECT_EQ(counts.count("111111"), 1000);
+  }
+
+  // rx: 0.0
+  {
+    auto kernel = cudaq::make_kernel();
+    auto controls1 = kernel.qalloc(2);
+    auto controls2 = kernel.qalloc(2);
+    auto control3 = kernel.qalloc();
+    auto target = kernel.qalloc();
+
+    // All of our controls in the 1-state.
+    kernel.x(controls1);
+    kernel.x(controls2);
+    kernel.x(control3);
+
+    kernel.rx<cudaq::ctrl>(0.0, controls1, controls2, control3, target);
+
+    auto counts = cudaq::sample(kernel);
+    counts.dump();
+
+    // Target qubit should've stayed in |0>
+    EXPECT_EQ(counts.count("111110"), 1000);
+  }
+
+  // ry: pi
+  {
+    auto kernel = cudaq::make_kernel();
+    auto controls1 = kernel.qalloc(2);
+    auto controls2 = kernel.qalloc(2);
+    auto control3 = kernel.qalloc();
+    auto target = kernel.qalloc();
+
+    // All of our controls in the 1-state.
+    kernel.x(controls1);
+    kernel.x(controls2);
+    kernel.x(control3);
+
+    kernel.ry<cudaq::ctrl>(M_PI, controls1, controls2, control3, target);
+
+    auto counts = cudaq::sample(kernel);
+    counts.dump();
+
+    // Target qubit should've been rotated to |1>
+    EXPECT_EQ(counts.count("111111"), 1000);
+  }
+
+  // ry: pi / 2
+  {
+    cudaq::set_random_seed(4);
+
+    auto kernel = cudaq::make_kernel();
+    auto controls1 = kernel.qalloc(2);
+    auto controls2 = kernel.qalloc(2);
+    auto control3 = kernel.qalloc();
+    auto target = kernel.qalloc();
+
+    // All of our controls in the 1-state.
+    kernel.x(controls1);
+    kernel.x(controls2);
+    kernel.x(control3);
+
+    kernel.ry<cudaq::ctrl>(M_PI_2, controls1, controls2, control3, target);
+
+    auto counts = cudaq::sample(kernel);
+    counts.dump();
+
+    // Target qubit should have a 50/50 mix between |0> and |1>
+    EXPECT_EQ(counts.count("111111"), 505);
+    EXPECT_EQ(counts.count("111110"), 495);
+  }
+
+  {
+    auto kernel = cudaq::make_kernel();
+    auto controls1 = kernel.qalloc(3);
+    auto controls2 = kernel.qalloc(3);
+    auto control3 = kernel.qalloc();
+    auto target = kernel.qalloc();
+
+    kernel.x(controls1);
+    kernel.x(control3);
+    // Should do nothing.
+    kernel.x<cudaq::ctrl>(controls1, controls2, control3, target);
+    kernel.x(controls2);
+    // Should rotate `target`.
+    kernel.rx<cudaq::ctrl>(M_PI, controls1, controls2, control3, target);
+
+    auto counts = cudaq::sample(kernel);
+    counts.dump();
+    EXPECT_EQ(counts.count("11111111"), 1000);
+  }
+}
+
+
 #ifndef CUDAQ_BACKEND_DM
 
 CUDAQ_TEST(BuilderTester, checkCanProgressivelyBuild) {


### PR DESCRIPTION
This PR fixes a bug in the C++ ASTBridge whereby `QuantumOp(qubit...), sizeof...(qubit) > 1` was treated as a controlled operation when it should be treated as a `QuantumOp` applied to all qubits in the variadic argument list. #875 

This PR also fixes the issues raised in #805 and #867, whereby control operations with multiple control operands of differing type (`veq` and `ref`) were not lowered to LLVM correctly. 
