### PR TITLE
Add `sret` attribute for entry point function if needed

### DIFF
--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -512,6 +512,18 @@ public:
     }
     auto rewriteEntry =
         builder.create<func::FuncOp>(loc, mangledAttr.getValue(), newFuncTy);
+    if (cudaq::opt::factory::hasHiddenSRet(funcTy)) {
+      // The first argument should be a pointer type if this function has a
+      // hidden sret.
+      if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(
+              rewriteEntry.getFunctionType().getInput(0))) {
+        auto eleTy = ptrTy.getElementType();
+        rewriteEntry.setArgAttr(0,
+                                mlir::LLVM::LLVMDialect::getStructRetAttrName(),
+                                mlir::TypeAttr::get(eleTy));
+      }
+    }
+
     auto insPt = builder.saveInsertionPoint();
     auto *rewriteEntryBlock = rewriteEntry.addEntryBlock();
     builder.setInsertionPointToStart(rewriteEntryBlock);

--- a/test/NVQPP/auto_kernel.cpp
+++ b/test/NVQPP/auto_kernel.cpp
@@ -9,7 +9,6 @@
 // FIXME: enable this for all architectures,
 // see https://github.com/NVIDIA/cuda-quantum/issues/553.
 
-// REQUIRES: x64_86-registered-target
 // RUN: nvq++ --enable-mlir -v %s -o out_auto_kernel.x && ./out_auto_kernel.x | FileCheck %s
 
 #include <cudaq.h>

--- a/test/NVQPP/auto_kernel.cpp
+++ b/test/NVQPP/auto_kernel.cpp
@@ -6,9 +6,6 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// FIXME: enable this for all architectures,
-// see https://github.com/NVIDIA/cuda-quantum/issues/553.
-
 // RUN: nvq++ --enable-mlir -v %s -o out_auto_kernel.x && ./out_auto_kernel.x | FileCheck %s
 
 #include <cudaq.h>


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
The root cause is ABI differences b/w ARM and x86 as explained [here](https://github.com/NVIDIA/cuda-quantum/issues/553#issuecomment-1800311727).

Hence, this PR adds the `sret` attribute to the first (hidden) argument if the entry point function is returning one and re-enables the `auto_kernel.cpp` test on ARM. 

Resolved: https://github.com/NVIDIA/cuda-quantum/issues/553
