### PR TITLE
Fix publishing failures by reducing size of test

### DIFF
--- a/docs/sphinx/examples/cpp/algorithms/bernstein_vazirani.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/bernstein_vazirani.cpp
@@ -4,12 +4,11 @@
 // mpirun -np 4 ./bv.x
 // ```
 
-// This example is meant to demonstrate the cuQuantum
-// GPU-accelerated multi-GPU backend. A state vector simulation for
-// up to 32 qubits can be run on a single GPU. Larger state vectors
-// can be simulated using the multi-GPU backend.
-// The amount of resources required for the simulation doubles with
-// with each additional qubit.
+// This example is meant to demonstrate the cuQuantum GPU-accelerated multi-GPU
+// backend. A state vector simulation for up to 32 qubits can be run on a single
+// GPU (if the GPU's memory is large enough). Larger state vectors can be
+// simulated using the multi-GPU backend. The amount of resources required for
+// the simulation doubles with with each additional qubit.
 
 #include <bitset>
 #include <cudaq.h>
@@ -61,9 +60,8 @@ struct bernstein_vazirani {
 int main(int argc, char *argv[]) {
   auto seed = 1 < argc ? atoi(argv[1]) : 1;
 
-  // The number of qubits can be increased when targeting
-  // the `nvidia-mgpu` backend.
-  const int nr_qubits = 32;
+  // The number of qubits can be >32 when targeting the `nvidia-mgpu` backend.
+  const int nr_qubits = 28;
   auto bitvector = random_bits<nr_qubits>(seed);
   auto kernel = bernstein_vazirani<nr_qubits>{};
   auto counts = cudaq::sample(kernel, bitvector);

--- a/docs/sphinx/examples/cpp/algorithms/bernstein_vazirani.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/bernstein_vazirani.cpp
@@ -6,7 +6,7 @@
 
 // This example is meant to demonstrate the cuQuantum GPU-accelerated multi-GPU
 // backend. A state vector simulation for up to 32 qubits can be run on a single
-// GPU (if the GPU's memory is large enough). Larger state vectors can be
+// GPU (if the GPU memory is large enough). Larger state vectors can be
 // simulated using the multi-GPU backend. The amount of resources required for
 // the simulation doubles with with each additional qubit.
 


### PR DESCRIPTION
This reduces the number of qubits used in the recently added `bernstein_vazirani.cpp` test from 32 to 28 in order to allow the CI to pass.