### PR TITLE
Remove negative control handling from LowerToQIR to a standalone pass

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -29,7 +29,7 @@ template <bool QIRProfile = false>
 void addPipelineToQIR(mlir::PassManager &pm,
                       llvm::StringRef convertTo = "none") {
   pm.addNestedPass<mlir::func::FuncOp>(
-      cudaq::opt::createApplyControlNegationsPass());
+      cudaq::opt::createApplyControlNegations());
   cudaq::opt::addAggressiveEarlyInlining(pm);
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(cudaq::opt::createExpandMeasurementsPass());

--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -28,6 +28,8 @@ namespace cudaq::opt {
 template <bool QIRProfile = false>
 void addPipelineToQIR(mlir::PassManager &pm,
                       llvm::StringRef convertTo = "none") {
+  pm.addNestedPass<mlir::func::FuncOp>(
+      cudaq::opt::createApplyControlNegationsPass());
   cudaq::opt::addAggressiveEarlyInlining(pm);
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(cudaq::opt::createExpandMeasurementsPass());

--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -30,7 +30,6 @@ void registerAggressiveEarlyInlining();
 
 void registerUnrollingPipeline();
 
-std::unique_ptr<mlir::Pass> createApplyControlNegationsPass();
 std::unique_ptr<mlir::Pass> createApplyOpSpecializationPass();
 std::unique_ptr<mlir::Pass>
 createApplyOpSpecializationPass(bool computeActionOpt);

--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -30,6 +30,7 @@ void registerAggressiveEarlyInlining();
 
 void registerUnrollingPipeline();
 
+std::unique_ptr<mlir::Pass> createApplyControlNegationsPass();
 std::unique_ptr<mlir::Pass> createApplyOpSpecializationPass();
 std::unique_ptr<mlir::Pass>
 createApplyOpSpecializationPass(bool computeActionOpt);

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -11,6 +11,20 @@
 
 include "mlir/Pass/PassBase.td"
 
+
+def ApplyControlNegations : Pass<"apply-control-negations", "mlir::func::FuncOp"> {
+  let summary =
+    "Replace all operations with negative controls with positive controls and X operations.";
+
+  let description = [{
+    For every quantum operation with a negative control, replace that operation 
+    with an X operation on the control qubit, the controlled operation with positive 
+    polarity, and a final X operation on the control qubit. 
+  }];
+
+  let constructor = "cudaq::opt::createApplyControlNegationsPass()";
+}
+
 // ApplyOpSpecialization is a module pass because it may modify the ModuleOp
 // and add new FuncOps.
 def ApplySpecialization : Pass<"apply-op-specialization", "mlir::ModuleOp"> {

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -21,8 +21,6 @@ def ApplyControlNegations : Pass<"apply-control-negations", "mlir::func::FuncOp"
     with an X operation on the control qubit, the controlled operation with positive 
     polarity, and a final X operation on the control qubit. 
   }];
-
-  let constructor = "cudaq::opt::createApplyControlNegationsPass()";
 }
 
 // ApplyOpSpecialization is a module pass because it may modify the ModuleOp

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -410,8 +410,6 @@ public:
 
     // Convert the ctrl bits to an Array
     auto qirFunctionName = qirQisPrefix + instName + "__ctl";
-    auto negateFunctionName = qirQisPrefix + "x";
-    auto negatedQubitCtrls = instOp.getNegatedQubitControls();
 
     // Useful types we'll need
     auto qirArrayType = cudaq::opt::getArrayType(context);
@@ -432,9 +430,6 @@ public:
     Type type = control.getType();
     auto instOperands = adaptor.getOperands();
     if (numControls == 1 && type.isa<quake::VeqType>()) {
-      if (negatedQubitCtrls)
-        return instOp.emitError("unsupported controlled op " + instName +
-                                " with vector of ctrl qubits");
       // Operands are already an Array* and Qubit*.
       rewriter.replaceOpWithNewOp<LLVM::CallOp>(
           instOp, TypeRange{}, qirFunctionSymbolRef, instOperands);
@@ -501,31 +496,11 @@ public:
     }
 
     args.push_back(ctrlOpPointer);
-    FlatSymbolRefAttr negateFuncRef;
-    if (negatedQubitCtrls) {
-      negateFuncRef = cudaq::opt::factory::createLLVMFunctionSymbol(
-          negateFunctionName,
-          /*return type=*/LLVM::LLVMVoidType::get(context),
-          {cudaq::opt::getQubitType(context)}, parentModule);
-      for (auto v : llvm::enumerate(instOperands)) {
-        if ((v.index() < numControls) && (*negatedQubitCtrls)[v.index()])
-          rewriter.create<LLVM::CallOp>(loc, TypeRange{}, negateFuncRef,
-                                        v.value());
-        args.push_back(v.value());
-      }
-    } else {
-      args.append(instOperands.begin(), instOperands.end());
-    }
+    args.append(instOperands.begin(), instOperands.end());
 
     // Call our utility function.
     rewriter.replaceOpWithNewOp<LLVM::CallOp>(instOp, TypeRange{},
                                               applyMultiControlFunction, args);
-
-    if (negatedQubitCtrls)
-      for (auto v : llvm::enumerate(instOperands))
-        if ((v.index() < numControls) && (*negatedQubitCtrls)[v.index()])
-          rewriter.create<LLVM::CallOp>(loc, TypeRange{}, negateFuncRef,
-                                        v.value());
 
     return success();
   }
@@ -583,8 +558,6 @@ public:
     }
 
     qirFunctionName += "__ctl";
-    auto negateFunctionName = qirQisPrefix + "x";
-    auto negatedQubitCtrls = instOp.getNegatedQubitControls();
 
     // __quantum__qis__NAME__ctl(double, Array*, Qubit*) Type
     auto instOpQISFunctionType = LLVM::LLVMFunctionType::get(
@@ -602,9 +575,6 @@ public:
     Type type = control.getType();
     // If type is a VeqType, then we're good, just forward to the call op
     if (numControls == 1 && type.isa<quake::VeqType>()) {
-      if (negatedQubitCtrls)
-        return instOp.emitError("unsupported controlled op " + instName +
-                                " with vector of ctrl qubits");
 
       // Add the control array to the args.
       funcArgs.push_back(adaptor.getControls().front());
@@ -652,32 +622,11 @@ public:
     funcArgs.push_back(numControlOperands);
     funcArgs.push_back(isArrayAndLengthArr);
     funcArgs.push_back(ctrlOpPointer);
-
-    FlatSymbolRefAttr negateFuncRef;
-    if (negatedQubitCtrls) {
-      negateFuncRef = cudaq::opt::factory::createLLVMFunctionSymbol(
-          negateFunctionName,
-          /*return type=*/LLVM::LLVMVoidType::get(context),
-          {cudaq::opt::getQubitType(context)}, parentModule);
-      for (auto v : llvm::enumerate(instOperands)) {
-        if ((v.index() < numControls) && (*negatedQubitCtrls)[v.index()])
-          rewriter.create<LLVM::CallOp>(loc, TypeRange{}, negateFuncRef,
-                                        v.value());
-        funcArgs.push_back(v.value());
-      }
-    } else {
-      funcArgs.append(instOperands.begin(), instOperands.end());
-    }
+    funcArgs.append(instOperands.begin(), instOperands.end());
 
     // Call our utility function.
     rewriter.replaceOpWithNewOp<LLVM::CallOp>(
         instOp, TypeRange{}, applyMultiControlFunction, funcArgs);
-
-    if (negatedQubitCtrls)
-      for (auto v : llvm::enumerate(instOperands))
-        if ((v.index() < numControls) && (*negatedQubitCtrls)[v.index()])
-          rewriter.create<LLVM::CallOp>(loc, TypeRange{}, negateFuncRef,
-                                        v.value());
 
     return success();
   }

--- a/lib/Optimizer/Transforms/ApplyControlNegations.cpp
+++ b/lib/Optimizer/Transforms/ApplyControlNegations.cpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Builder/Factory.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "cudaq/Todo.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+
+namespace cudaq::opt {
+
+class ReplaceNegativeControl : public RewritePattern {
+public:
+  ReplaceNegativeControl(MLIRContext *context)
+      : RewritePattern(MatchInterfaceOpTypeTag(),
+                       quake::OperatorInterface::getInterfaceID(), 1, context) {
+  }
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    auto quantumOp = dyn_cast<quake::OperatorInterface>(op);
+    if (!quantumOp)
+      return failure();
+
+    quantumOp.dump();
+    return failure();
+  }
+};
+
+struct ApplyControlNegationsPass
+    : public cudaq::opt::ApplyControlNegationsBase<ApplyControlNegationsPass> {
+  using ApplyControlNegationsBase::ApplyControlNegationsBase;
+
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<ReplaceNegativeControl>(ctx);
+    ConversionTarget target(*ctx);
+    target.addLegalDialect<quake::QuakeDialect, cudaq::cc::CCDialect,
+                           arith::ArithDialect, LLVM::LLVMDialect>();
+
+    if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
+      funcOp->emitOpError("could not expand measurements");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace cudaq::opt
+
+std::unique_ptr<Pass> cudaq::opt::createApplyControlNegationsPass() {
+  return std::make_unique<ApplyControlNegationsPass>();
+}

--- a/lib/Optimizer/Transforms/ApplyControlNegations.cpp
+++ b/lib/Optimizer/Transforms/ApplyControlNegations.cpp
@@ -16,9 +16,12 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
 
-using namespace mlir;
-
 namespace cudaq::opt {
+#define GEN_PASS_DEF_APPLYCONTROLNEGATIONS
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+using namespace mlir;
 
 /// Replace any operations with negative controls with the same
 /// operation with negative controls and the addition of X operations
@@ -55,8 +58,11 @@ public:
   }
 };
 
+namespace {
+
 struct ApplyControlNegationsPass
-    : public cudaq::opt::ApplyControlNegationsBase<ApplyControlNegationsPass> {
+    : public cudaq::opt::impl::ApplyControlNegationsBase<
+          ApplyControlNegationsPass> {
   using ApplyControlNegationsBase::ApplyControlNegationsBase;
 
   void runOnOperation() override {
@@ -95,8 +101,4 @@ struct ApplyControlNegationsPass
     }
   }
 };
-} // namespace cudaq::opt
-
-std::unique_ptr<Pass> cudaq::opt::createApplyControlNegationsPass() {
-  return std::make_unique<ApplyControlNegationsPass>();
-}
+} // namespace

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 add_cudaq_library(OptTransforms
   AddDeallocs.cpp
   AggressiveEarlyInlining.cpp
+  ApplyControlNegations.cpp
   ApplyOpSpecialization.cpp
   BasisConversion.cpp
   CombineQuantumAlloc.cpp


### PR DESCRIPTION
Our current strategy for handling negative controls is to inject X operations around the un-controlled version of the operation. This is currently handled in the lowering to LLVM and introduces a fair amount of logic that needs to be kept track of. This PR pulls that logic out into a separate pass and adds that pass to the QIR lowering pipeline. 