### PR TITLE
Publish cuda-quantum images only to NGC, removing pushes to GHCR

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -332,8 +332,7 @@ jobs:
     outputs:
       tar_cache: ${{ steps.prereqs.outputs.tar_cache }}
       tar_archive: ${{ steps.prereqs.outputs.tar_archive }}
-      image_hash: ${{ format('{0}/{1}@{2}', steps.prereqs.outputs.registry, steps.prereqs.outputs.image_short_name, steps.copy_build.outputs.digest || steps.cudaq_build.outputs.digest) }}
-      ngc_image_hash: ${{ steps.prereqs.outputs.ngc_registry && format('{0}/{1}@{2}', steps.prereqs.outputs.ngc_registry, steps.prereqs.outputs.image_short_name, steps.cudaq_build.outputs.digest) || '' }}
+      image_hash: ${{ steps.prereqs.outputs.image_name }}@${{ steps.cudaq_build.outputs.digest }}
 
     environment:
       name: ${{ inputs.environment || 'default' }}
@@ -418,9 +417,8 @@ jobs:
           repo_owner=${{ github.repository_owner }}
           registry=${{ vars.registry || 'localhost:5000' }}/${repo_owner,,}
           ngc_registry=`${{ needs.metadata.outputs.push_to_ngc == 'true' }} && echo nvcr.io/${repo_owner,,}/nightly || echo ''`
-          image_short_name=cuda-quantum
-          dev_image_name=${registry}/${image_short_name}-dev
-          image_name=${ngc_registry:-$registry}/${image_short_name}
+          dev_image_name=${registry}/cuda-quantum-dev
+          image_name=${ngc_registry:-$registry}/cuda-quantum
           image_description="CUDA Quantum toolkit for heterogeneous quantum-classical workflows"
 
           platform_tag=${{ needs.metadata.outputs.platform_tag }}
@@ -436,9 +434,6 @@ jobs:
             image_tag+=`echo ${{ github.ref_name }} | tr '/' '-'`
           fi
 
-          echo "registry=$registry" >> $GITHUB_OUTPUT
-          echo "ngc_registry=$ngc_registry" >> $GITHUB_OUTPUT
-          echo "image_short_name=$image_short_name" >> $GITHUB_OUTPUT
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
           echo "image_tag=$image_tag" >> $GITHUB_OUTPUT
           echo "image_tag_suffix=-base" >> $GITHUB_OUTPUT
@@ -504,7 +499,7 @@ jobs:
         run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
 
       - name: Log in to NGC
-        if: steps.prereqs.outputs.ngc_registry != ''
+        if: needs.metadata.outputs.push_to_ngc == 'true'
         uses: docker/login-action@v2
         with:
           registry: nvcr.io
@@ -554,14 +549,14 @@ jobs:
           key: ${{ steps.prereqs.outputs.tar_cache }}
 
       - name: Sign image with GitHub OIDC Token
-        if: inputs.environment && steps.prereqs.outputs.ngc_registry == ''
+        if: inputs.environment && needs.metadata.outputs.push_to_ngc != 'true'
         env:
           DIGEST: ${{ steps.cudaq_build.outputs.digest }}
           TAGS: ${{ steps.cudaq_metadata.outputs.tags }}
         run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
 
       - name: Sign image with NGC CLI
-        if: inputs.environment && steps.prereqs.outputs.ngc_registry
+        if: inputs.environment && needs.metadata.outputs.push_to_ngc == 'true'
         env:
           TAGS: ${{ steps.cudaq_metadata.outputs.tags }}
           NGC_CLI_API_KEY: ${{ secrets.NGC_CREDENTIALS }}
@@ -577,55 +572,6 @@ jobs:
           unzip ngccli_linux.zip && chmod u+x ngc-cli/ngc
           echo "Signing ${TAGS}"
           ngc-cli/ngc registry image publish --source ${TAGS} ${TAGS} --sign
-
-      # If the cuda-quantum image is initially pushed to ngc we recreate it
-      # and push it to the registry defined in the deployment environment
-      - name: Log in to the container registry
-        if: vars.registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ vars.registry }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Set up additional deployment
-        id: copy
-        if: steps.prereqs.outputs.ngc_registry != ''
-        run: |
-          echo "FROM ${{ steps.prereqs.outputs.image_name }}@${{ steps.cudaq_build.outputs.digest }}" >> ngc.Dockerfile
-
-      - name: Update cuda-quantum metadata
-        id: updated_metadata
-        if: steps.copy.outcome != 'skipped'
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ steps.prereqs.outputs.registry }}/${{ steps.prereqs.outputs.image_short_name }}
-          flavor: |
-            latest=false
-            suffix=${{ steps.prereqs.outputs.image_tag_suffix }},onlatest=true
-          tags: type=raw,value=${{ steps.prereqs.outputs.image_tag }}
-          labels: |
-            org.opencontainers.image.title=cuda-quantum
-            org.opencontainers.image.description=${{ steps.prereqs.outputs.image_description }}
-
-      - name: Copy cuda-quantum NGC image
-        id: copy_build
-        if: steps.copy.outcome != 'skipped'
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ngc.Dockerfile
-          tags: ${{ steps.updated_metadata.outputs.tags }}
-          labels: ${{ steps.updated_metadata.outputs.labels }}
-          platforms: ${{ inputs.platforms }}
-          push: true
-
-      - name: Sign copy with GitHub OIDC Token
-        if: steps.copy.outcome != 'skipped'
-        env:
-          DIGEST: ${{ steps.copy_build.outputs.digest }}
-          TAGS: ${{ steps.updated_metadata.outputs.tags }}
-        run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
 
   documentation:
     name: Documentation
@@ -751,8 +697,8 @@ jobs:
             load_output=`docker load --input "${{ needs.cudaq_image.outputs.tar_archive }}"`
             cudaq_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
           else
-            docker pull ${{ needs.cudaq_image.outputs.image_hash }}
             cudaq_image=${{ needs.cudaq_image.outputs.image_hash }}
+            docker pull $cudaq_image
           fi
 
           docker run --rm -dit --name cuda-quantum $cudaq_image
@@ -789,7 +735,6 @@ jobs:
         run: |
           cudaqdev_hash=${{ needs.cudaqdev_image.outputs.image_hash }}
           cudaq_hash=${{ needs.cudaq_image.outputs.image_hash }}
-          cudaq_ngc_hash=${{ needs.cudaq_image.outputs.ngc_image_hash }}
           artifact_name=build_info
           echo "artifact_name=$artifact_name" >> $GITHUB_OUTPUT
           info_file="$artifact_name.txt"

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -287,51 +287,50 @@ jobs:
 
           build_info=${{ matrix.info_file }}*
           platforms=`cat $build_info | grep -o 'platforms: \S*' | cut -d ' ' -f 2`
-          cudaq_image=`cat $build_info | grep -o 'cuda-quantum-image: \S*' | cut -d ' ' -f 2`
-          cudaq_ngc_image=`cat $build_info | grep -o 'cuda-quantum-ngc-image: \S*' | cut -d ' ' -f 2`
+          cudaqbase_image=`cat $build_info | grep -o 'cuda-quantum-image: \S*' | cut -d ' ' -f 2`
           cudaqdev_image=`cat $build_info | grep -o 'cuda-quantum-dev-image: \S*' | cut -d ' ' -f 2`
           cudaqdevdeps_image=`cat $build_info | grep -o 'cuda-quantum-devdeps-image: \S*' | cut -d ' ' -f 2`
           for file in `ls *zip`; do unzip "$file" && rm "$file"; done && cd -
 
-          docker pull $cudaq_image
-          repo_owner=${{ github.repository_owner }}
-          image_short_name=cuda-quantum
-          base_tag=`docker inspect $cudaq_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"'`
-          image_title=`docker inspect $cudaq_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.title"'`
-          image_description=`docker inspect $cudaq_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.description"'`
-          docker image rm $cudaq_image
+          docker pull $cudaqbase_image
+          base_tag=`docker inspect $cudaqbase_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"'`
+          image_title=`docker inspect $cudaqbase_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.title"'`
+          image_description=`docker inspect $cudaqbase_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.description"'`
+          docker image rm $cudaqbase_image
           docker image prune --force
 
-          registry=${{ vars.registry || 'localhost:5000' }}/${repo_owner,,}
-          if [ -n "$(echo "$platforms" | grep ',')" ] && ${{ secrets.NGC_CREDENTIALS != '' }}; then
-            if [ -n "$cudaq_ngc_image" ]; then
-              ngc_registry=nvcr.io/${repo_owner,,}/nightly
-            fi
-          fi
+          registry=`echo $cudaqbase_image | rev | cut -d / -f2- | rev`
+          push_to_ngc=`([ "$registry" == "${registry#nvcr.io}" ] && echo false) || echo true`
 
           echo "release_id=$release_id" >> $GITHUB_OUTPUT
-          echo "registry=$registry" >> $GITHUB_OUTPUT
-          echo "ngc_registry=$ngc_registry" >> $GITHUB_OUTPUT
-          echo "image_short_name=$image_short_name" >> $GITHUB_OUTPUT
-          echo "image_name=${ngc_registry:-$registry}/$image_short_name" >> $GITHUB_OUTPUT
+          echo "push_to_ngc=$push_to_ngc" >> $GITHUB_OUTPUT
+          echo "image_name=$registry/cuda-quantum" >> $GITHUB_OUTPUT
           echo "image_tag=${base_tag%-base}" >> $GITHUB_OUTPUT
           echo "image_title=$image_title" >> $GITHUB_OUTPUT
           echo "image_description=$image_description" >> $GITHUB_OUTPUT
           echo "platforms=$platforms" >> $GITHUB_OUTPUT
-          echo "cudaq_image=$cudaq_image" >> $GITHUB_OUTPUT
+          echo "cudaqbase_image=$cudaqbase_image" >> $GITHUB_OUTPUT
           echo "cudaqdev_image=$cudaqdev_image" >> $GITHUB_OUTPUT
           echo "cudaqdevdeps_image=$cudaqdevdeps_image" >> $GITHUB_OUTPUT
           echo "assets_folder=$assets_folder" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.REPO_BOT_ACCESS_TOKEN }}
 
-      - name: Log in to the registry
-        if: steps.release_info.outputs.ngc_registry || vars.registry
+      - name: Log in to default registry
+        if: steps.release_info.outputs.push_to_ngc != 'true'
         uses: docker/login-action@v2
         with:
-          registry: ${{ steps.release_info.outputs.ngc_registry || vars.registry }}
-          username: ${{ (steps.release_info.outputs.ngc_registry && '$oauthtoken') || github.actor }}
-          password: ${{ (steps.release_info.outputs.ngc_registry && secrets.NGC_CREDENTIALS) || github.token }}
+          registry: ${{ vars.registry }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Log in to NGC registry
+        if: steps.release_info.outputs.push_to_ngc == 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: 'nvcr.io'
+          username: '$oauthtoken'
+          password: ${{ secrets.NGC_CREDENTIALS }}
 
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v2
@@ -354,7 +353,7 @@ jobs:
           context: .
           file: ./docker/release/cudaq.ext.Dockerfile
           build-args: |
-            base_image=${{ steps.release_info.outputs.cudaq_image }}
+            base_image=${{ steps.release_info.outputs.cudaqbase_image }}
             assets=${{ steps.release_info.outputs.assets_folder }}
             vscode_config=docker/release/config/.vscode
           tags: ${{ steps.metadata.outputs.tags }}
@@ -366,14 +365,14 @@ jobs:
         uses: sigstore/cosign-installer@v3.1.1
 
       - name: Sign image with GitHub OIDC Token
-        if: steps.release_info.outputs.ngc_registry == ''
+        if: steps.release_info.outputs.push_to_ngc != 'true'
         env:
           DIGEST: ${{ steps.cudaq_build.outputs.digest }}
           TAGS: ${{ steps.metadata.outputs.tags }}
         run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
 
       - name: Sign image with NGC CLI
-        if: steps.release_info.outputs.ngc_registry
+        if: steps.release_info.outputs.push_to_ngc == 'true'
         env:
           TAGS: ${{ steps.metadata.outputs.tags }}
           NGC_CLI_API_KEY: ${{ secrets.NGC_CREDENTIALS }}
@@ -390,62 +389,15 @@ jobs:
           echo "Signing ${TAGS}"
           ngc-cli/ngc registry image publish --source ${TAGS} ${TAGS} --sign
 
-      - name: Log in to the container registry
-        if: vars.registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ vars.registry }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Set up additional deployment
-        id: copy
-        if: steps.release_info.outputs.ngc_registry != ''
-        run: |
-          echo "FROM ${{ steps.release_info.outputs.image_name }}@${{ steps.cudaq_build.outputs.digest }}" >> ngc.Dockerfile
-          echo "image_name=${{ steps.release_info.outputs.registry }}/${{ steps.release_info.outputs.image_short_name }}" >> $GITHUB_OUTPUT
-
-      - name: Update cuda-quantum metadata
-        id: updated_metadata
-        if: steps.copy.outcome != 'skipped'
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ steps.copy.outputs.image_name }}
-          flavor: latest=false
-          tags: type=raw,value=${{ steps.release_info.outputs.image_tag }}
-          labels: |
-            org.opencontainers.image.title=${{ steps.release_info.outputs.image_title }}
-            org.opencontainers.image.description=${{ steps.release_info.outputs.image_description }}
-
-      - name: Copy cuda-quantum NGC image
-        id: copy_build
-        if: steps.copy.outcome != 'skipped'
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ngc.Dockerfile
-          tags: ${{ steps.updated_metadata.outputs.tags }}
-          labels: ${{ steps.updated_metadata.outputs.labels }}
-          platforms: ${{ steps.release_info.outputs.platforms }}
-          push: true
-
-      - name: Sign copy with GitHub OIDC Token
-        if: steps.copy.outcome != 'skipped'
-        env:
-          DIGEST: ${{ steps.copy_build.outputs.digest }}
-          TAGS: ${{ steps.updated_metadata.outputs.tags }}
-        run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
-
       - name: Update release information
         run: |
           release_id=${{ steps.release_info.outputs.release_id }}
           gh release view $release_id --json body --jq .body > rel_notes.txt
           header_length=`cat rel_notes.txt | grep -n "Release notes generated" | cut -d ':' -f 1`
           head -n $(($header_length - 1)) rel_notes.txt > new_notes.txt
-          image_copy=${{ steps.copy.outputs.image_name }}
           echo -e "\nImages for ${{ steps.release_info.outputs.platforms }}:\n" >> new_notes.txt
-          echo "- cuda-quantum (base image): ${{ steps.release_info.outputs.cudaq_image }}" >> new_notes.txt
-          echo "- cuda-quantum (with hpc components): ${{ steps.release_info.outputs.image_name }}@${{ steps.cudaq_build.outputs.digest }}${image_copy:+ or $image_copy@${{ steps.copy_build.outputs.digest }}}" >> new_notes.txt
+          echo "- cuda-quantum (base image): ${{ steps.release_info.outputs.cudaqbase_image }}" >> new_notes.txt
+          echo "- cuda-quantum (with hpc components): ${{ steps.release_info.outputs.image_name }}@${{ steps.cudaq_build.outputs.digest }}" >> new_notes.txt
           echo "- cuda-quantum-dev (for extension development): ${{ steps.release_info.outputs.cudaqdev_image }}" >> new_notes.txt
           echo "- cuda-quantum-devdeps (development dependencies only): ${{ steps.release_info.outputs.cudaqdevdeps_image }}" >> new_notes.txt
           (echo && tail -n +$header_length rel_notes.txt) >> new_notes.txt
@@ -459,8 +411,7 @@ jobs:
           matrix-step-name: docker_images
           matrix-key: ${{ matrix.info_file }}
           outputs: |
-            image_hash: ${{ format('{0}/{1}@{2}', steps.release_info.outputs.registry, steps.release_info.outputs.image_short_name, steps.copy_build.outputs.digest || steps.cudaq_build.outputs.digest) }}
-            ngc_image_hash: ${{ steps.release_info.outputs.ngc_registry && format('{0}/{1}@{2}', steps.release_info.outputs.ngc_registry, steps.release_info.outputs.image_short_name, steps.cudaq_build.outputs.digest) || '' }}
+            image_hash: ${{ steps.release_info.outputs.image_name }}@${{ steps.cudaq_build.outputs.digest }}
 
   cudaq_wheels:
     name: CUDA Quantum Python wheels


### PR DESCRIPTION
NGC publishing at this point looks stable, and images can be downloaded without having to create an account. 
There is hence no benefit to having them on GitHub since the only thing that changes to get them from NGC instead is the image name.

This PR hence removes the pushes to GHCR such that the image is only pushed to one location. All other images for development will continue to be pushed to GitHub.