### PR TITLE
[NFC] Move a transformation pass.

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -11,15 +11,6 @@
 
 include "mlir/Pass/PassBase.td"
 
-def PromoteRefToVeqAlloc : Pass<"promote-qubit-allocation"> {
-  let summary = "Promote single qubit allocations.";
-  let description = [{
-    This pass converts all single qubit allocations in the quake dialect to
-    allocations of vectors of qubits of length one. This conversion makes all
-    allocations uniform for the conversion to QIR.
-  }];
-}
-
 def QuakeToQIR : Pass<"quake-to-qir", "mlir::ModuleOp"> {
   let summary = "Lower Quake to QIR.";
   let description = [{

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -305,6 +305,27 @@ def MemToReg : Pass<"memtoreg", "mlir::func::FuncOp"> {
   ];
 }
 
+def ObserveAnsatz : Pass<"observe-ansatz", "mlir::func::FuncOp"> {
+ let summary = "Given spin_op input, append measures to the FuncOp";
+  let description = [{
+    Given an unmeasured Quake representation (i.e. a state prep ansatz), append
+    measures based on the given spin_op specified in binary symplectic form.
+  }];
+  let options = [
+    ListOption<"termBSF", "term-bsf", "unsigned",
+      "The measurement bases as a Pauli tensor product represented in binary symplectic form.">
+  ];
+}
+
+def PromoteRefToVeqAlloc : Pass<"promote-qubit-allocation"> {
+  let summary = "Promote single qubit allocations.";
+  let description = [{
+    This pass converts all single qubit allocations in the quake dialect to
+    allocations of vectors of qubits of length one. This conversion makes all
+    allocations uniform for the conversion to QIR.
+  }];
+}
+
 def PruneCtrlRelations : Pass<"pruned-ctrl-form", "mlir::func::FuncOp"> {
   let summary = "Removes artifical control constraints between quantum ops.";
   let description = [{
@@ -370,18 +391,6 @@ def QuakeAddMetadata : Pass<"quake-add-metadata", "mlir::func::FuncOp"> {
   }];
 
   let constructor = "cudaq::opt::createQuakeAddMetadata()";
-}
-
-def ObserveAnsatz : Pass<"observe-ansatz", "mlir::func::FuncOp"> {
- let summary = "Given spin_op input, append measures to the FuncOp";
-  let description = [{
-    Given an unmeasured Quake representation (i.e. a state prep ansatz), append
-    measures based on the given spin_op specified in binary symplectic form.
-  }];
-  let options = [
-    ListOption<"termBSF", "term-bsf", "unsigned",
-      "The measurement bases as a Pauli tensor product represented in binary symplectic form.">
-  ];
 }
 
 def RegToMem : Pass<"regtomem", "mlir::func::FuncOp"> {

--- a/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -14,7 +14,6 @@ add_cudaq_library(OptCodeGen
   LowerToQIRProfile.cpp
   LowerToQIR.cpp
   Passes.cpp
-  RefToVeqAlloc.cpp
   TranslateToIQMJson.cpp
   TranslateToOpenQASM.cpp
 

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -37,6 +37,7 @@ add_cudaq_library(OptTransforms
   PruneCtrlRelations.cpp
   QuakeAddMetadata.cpp
   QuakeSynthesizer.cpp
+  RefToVeqAlloc.cpp
   RegToMem.cpp
 
   DEPENDS

--- a/lib/Optimizer/Transforms/RefToVeqAlloc.cpp
+++ b/lib/Optimizer/Transforms/RefToVeqAlloc.cpp
@@ -7,8 +7,8 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
-#include "cudaq/Optimizer/Transforms/Passes.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 

--- a/lib/Optimizer/Transforms/RefToVeqAlloc.cpp
+++ b/lib/Optimizer/Transforms/RefToVeqAlloc.cpp
@@ -7,14 +7,14 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
-#include "cudaq/Optimizer/CodeGen/Passes.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
 namespace cudaq::opt {
 #define GEN_PASS_DEF_PROMOTEREFTOVEQALLOC
-#include "cudaq/Optimizer/CodeGen/Passes.h.inc"
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
 } // namespace cudaq::opt
 
 using namespace mlir;


### PR DESCRIPTION
Moves the transformation pass, ref to veq, from the CodeGen directory to the Transforms directory. This puts it the same place as related passes like factor quantum alloc and combine quantum alloc.
