### PR TITLE
Lower the ctrl-swap operations to QIR.

### DIFF
--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -86,7 +86,7 @@ func.func @test_ctrl_swap_basic() {
 // CHECK:         %[[VAL_11:.*]] = load %Qubit*, %Qubit** %[[VAL_10]], align 8
 // CHECK:         %[[VAL_12:.*]] = alloca i64, align 8
 // CHECK:         store i64 0, i64* %[[VAL_12]], align 8
-// CHECK:         call void (i64, i64*, i64, void (%Array*, %Qubit*)*, ...) @invokeWithControlRegisterOrQubits(i64 1, i64* nonnull %[[VAL_12]], i64 2, void (%Array*, %Qubit*)* nonnull @__quantum__qis__swap__ctl, %Qubit* %[[VAL_5]], %Qubit* %[[VAL_8]], %Qubit* %[[VAL_11]])
+// CHECK:         call void (i64, i64*, i64, void (%Array*, %Qubit*, %Qubit*)*, ...) @invokeWithControlRegisterOrQubits(i64 1, i64* nonnull %[[VAL_12]], i64 2, void (%Array*, %Qubit*, %Qubit*)* nonnull @__quantum__qis__swap__ctl, %Qubit* %[[VAL_5]], %Qubit* %[[VAL_8]], %Qubit* %[[VAL_11]])
 // CHECK:         call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
 // CHECK:         ret void
 // CHECK:       }

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -65,3 +65,71 @@ func.func @test_func2(){
 // CHECK:         ret void
 // CHECK:       }
 
+func.func @test_ctrl_swap_basic() {
+  %0 = quake.alloca !quake.ref
+  %1 = quake.alloca !quake.ref
+  %2 = quake.alloca !quake.ref
+  quake.swap [%0] %1, %2 : (!quake.ref, !quake.ref, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @test_ctrl_swap_basic() local_unnamed_addr {
+// CHECK:         %[[VAL_0:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 3)
+// CHECK:         %[[VAL_2:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 0)
+// CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %Qubit**
+// CHECK:         %[[VAL_5:.*]] = load %Qubit*, %Qubit** %[[VAL_3]], align 8
+// CHECK:         %[[VAL_6:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 1)
+// CHECK:         %[[VAL_7:.*]] = bitcast i8* %[[VAL_6]] to %Qubit**
+// CHECK:         %[[VAL_8:.*]] = load %Qubit*, %Qubit** %[[VAL_7]], align 8
+// CHECK:         %[[VAL_9:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 2)
+// CHECK:         %[[VAL_10:.*]] = bitcast i8* %[[VAL_9]] to %Qubit**
+// CHECK:         %[[VAL_11:.*]] = load %Qubit*, %Qubit** %[[VAL_10]], align 8
+// CHECK:         %[[VAL_12:.*]] = alloca i64, align 8
+// CHECK:         store i64 0, i64* %[[VAL_12]], align 8
+// CHECK:         call void (i64, i64*, i64, void (%Array*, %Qubit*)*, ...) @invokeWithControlRegisterOrQubits(i64 1, i64* nonnull %[[VAL_12]], i64 2, void (%Array*, %Qubit*)* nonnull @__quantum__qis__swap__ctl, %Qubit* %[[VAL_5]], %Qubit* %[[VAL_8]], %Qubit* %[[VAL_11]])
+// CHECK:         call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @test_ctrl_swap_complex() {
+  %0 = quake.alloca !quake.veq<4>
+  %1 = quake.alloca !quake.ref
+  %2 = quake.alloca !quake.ref
+  %3 = quake.alloca !quake.ref
+  quake.swap [%0] %1, %2 : (!quake.veq<4>, !quake.ref, !quake.ref) -> ()
+  quake.swap [%1, %0] %2, %3 : (!quake.ref, !quake.veq<4>, !quake.ref, !quake.ref) -> ()
+  quake.swap [%0, %2] %1, %3 : (!quake.veq<4>, !quake.ref, !quake.ref, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @test_ctrl_swap_complex() local_unnamed_addr {
+// CHECK:         %[[VAL_0:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 7)
+// CHECK:         %[[VAL_2:.*]] = tail call %Array* @__quantum__rt__array_slice(%Array* %[[VAL_0]], i32 1, i64 0, i64 1, i64 3)
+// CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 4)
+// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to %Qubit**
+// CHECK:         %[[VAL_6:.*]] = load %Qubit*, %Qubit** %[[VAL_4]], align 8
+// CHECK:         %[[VAL_7:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 5)
+// CHECK:         %[[VAL_8:.*]] = bitcast i8* %[[VAL_7]] to %Qubit**
+// CHECK:         %[[VAL_9:.*]] = load %Qubit*, %Qubit** %[[VAL_8]], align 8
+// CHECK:         %[[VAL_10:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 6)
+// CHECK:         %[[VAL_11:.*]] = bitcast i8* %[[VAL_10]] to %Qubit**
+// CHECK:         %[[VAL_12:.*]] = load %Qubit*, %Qubit** %[[VAL_11]], align 8
+// CHECK:         tail call void @__quantum__qis__swap__ctl(%Array* %[[VAL_2]], %Qubit* %[[VAL_6]], %Qubit* %[[VAL_9]])
+// CHECK:         %[[VAL_13:.*]] = alloca [2 x i64], align 8
+// CHECK:         %[[VAL_14:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_13]], i64 0, i64 0
+// CHECK:         store i64 0, i64* %[[VAL_14]], align 8
+// CHECK:         %[[VAL_15:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_13]], i64 0, i64 1
+// CHECK:         %[[VAL_16:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%Array* %[[VAL_2]])
+// CHECK:         store i64 %[[VAL_16]], i64* %[[VAL_15]], align 8
+// CHECK:         call void (i64, i64*, i64, void (%Array*, %Qubit*, %Qubit*)*, ...) @invokeWithControlRegisterOrQubits(i64 2, i64* nonnull %[[VAL_14]], i64 2, void (%Array*, %Qubit*, %Qubit*)* nonnull @__quantum__qis__swap__ctl, %Qubit* %[[VAL_6]], %Array* %[[VAL_2]], %Qubit* %[[VAL_9]], %Qubit* %[[VAL_12]])
+// CHECK:         %[[VAL_17:.*]] = alloca [2 x i64], align 8
+// CHECK:         %[[VAL_18:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_17]], i64 0, i64 0
+// CHECK:         %[[VAL_19:.*]] = call i64 @__quantum__rt__array_get_size_1d(%Array* %[[VAL_2]])
+// CHECK:         store i64 %[[VAL_19]], i64* %[[VAL_18]], align 8
+// CHECK:         %[[VAL_20:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_17]], i64 0, i64 1
+// CHECK:         store i64 0, i64* %[[VAL_20]], align 8
+// CHECK:         call void (i64, i64*, i64, void (%Array*, %Qubit*, %Qubit*)*, ...) @invokeWithControlRegisterOrQubits(i64 2, i64* nonnull %[[VAL_18]], i64 2, void (%Array*, %Qubit*, %Qubit*)* nonnull @__quantum__qis__swap__ctl, %Array* %[[VAL_2]], %Qubit* %[[VAL_9]], %Qubit* %[[VAL_6]], %Qubit* %[[VAL_12]])
+// CHECK:         call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
+// CHECK:         ret void
+// CHECK:       }
+

--- a/test/Quake-QIR/veq_or_qubit_control_args.qke
+++ b/test/Quake-QIR/veq_or_qubit_control_args.qke
@@ -50,6 +50,6 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__function_fancyCno
 // CHECK:         store i64 %[[VAL_17]], i64* %[[VAL_16]], align 8
 // CHECK:         %[[VAL_18:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_15]], i64 0, i64 1
 // CHECK:         store i64 0, i64* %[[VAL_18]], align 8
-// CHECK:         call void (i64, i64*, void (%[[VAL_1]]*, %[[VAL_4]]*)*, ...) @invokeWithControlRegisterOrQubits(i64 2, i64* nonnull %[[VAL_16]], void (%[[VAL_1]]*, %[[VAL_4]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_1]]* %[[VAL_12]], %[[VAL_4]]* %[[VAL_11]], %[[VAL_4]]* %[[VAL_8]])
+// CHECK:         call void (i64, i64*, i64, void (%[[VAL_1]]*, %[[VAL_4]]*)*, ...) @invokeWithControlRegisterOrQubits(i64 2, i64* nonnull %[[VAL_16]], i64 1, void (%[[VAL_1]]*, %[[VAL_4]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_1]]* %[[VAL_12]], %[[VAL_4]]* %[[VAL_11]], %[[VAL_4]]* %[[VAL_8]])
 // CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
 // CHECK:         ret void


### PR DESCRIPTION
Extend and generalize the invoke* code.

Closes #806
