### PR TITLE
[Docs] Enhancement to the 'Defualt Simulator' section

### DIFF
--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -578,4 +578,4 @@ a long time for the CPU-only backend to simulate 28+ qubits! Cancel the executio
 You are now all set to start developing quantum applications using CUDA Quantum!
 Please proceed to :doc:`Using CUDA Quantum <using/cudaq>` to learn the basics.
 
-See :doc:`Default Simulator <using/simulators>` for information on default target.
+See the section :ref:`default-simulator` for information on default target.

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -663,7 +663,7 @@ To run the example, execute the command:
 
       python examples/python/bernstein_vazirani.py --size 5
 
-This will execute the program on the default simulator, which will use GPU-acceleration if 
+This will execute the program on the :ref:`default simulator <default-simulator>`, which will use GPU-acceleration if 
 a suitable GPU has been detected. To confirm that the GPU acceleration works, you can 
 increase the size of the secret string, and pass the target as a command line argument:
 
@@ -711,5 +711,3 @@ a long time for the CPU-only backend to simulate 28+ qubits! Cancel the executio
 
 You are now all set to start developing quantum applications using CUDA Quantum!
 Please proceed to :doc:`Using CUDA Quantum <using/cudaq>` to learn the basics.
-
-See the section :ref:`default-simulator` for information on default target.

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -267,6 +267,8 @@ Specific aspects of the simulation can be configured by defining the following e
   Setting random seed, via :code:`cudaq::set_random_seed`, is not supported for this backend due to a limitation of the :code:`cuTensorNet` library. This will be fixed in future release once this feature becomes available.
 
 
+.. _default-simulator:
+
 Default Simulator
 ==================================
 If no explicit target is set, i.e. if the code is compiled without any :code:`--target` flags, then CUDA Quantum makes a default choice for the simulator.
@@ -280,9 +282,19 @@ This environment variable can be set to any non-hardware backend. Any invalid va
 For CUDA Quantum Python API, the environment variable at the time when `cudaq` module is imported is relevant, not the value of the environment variable at the time when the simulator is invoked.
 
 For example,
-.. code:: bash
 
-    CUDAQ_DEFAULT_SIMULATOR=density-matrix-cpu nvq++ src.cpp
+.. tab:: C++
+
+    .. code:: bash 
+
+        CUDAQ_DEFAULT_SIMULATOR=density-matrix-cpu nvq++ program.cpp [...] -o program.x
+        ./program.x
+
+.. tab:: Python
+
+    .. code:: bash 
+
+        CUDAQ_DEFAULT_SIMULATOR=density-matrix-cpu python3 program.py [...]
 
 This will use the density matrix simulator target.
 


### PR DESCRIPTION
* Code block updated to use tabs for C++ and Python for sake of consistency with the rest of documentation.
* Fixed the link from 'Next Steps' section to 'Default Simulator'.

### Description
Follow-up to [PR#899](https://github.com/NVIDIA/cuda-quantum/pull/899)
