### PR TITLE
Various minor fixes

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           echo "Concurrency group: ${{ github.event.workflow_run.head_branch || github.ref_name }}"
 
-          requested_platforms=`echo ${{ inputs.platforms || 'linux/arm64 linux/amd64' }} | tr + ,`
+          requested_platforms=`echo "${{ inputs.platforms || 'linux/arm64 linux/amd64' }}" | tr + ,`
           if [ -n "$(echo "$requested_platforms" | egrep ',')" ]; then
             multi_platform="{\"ids\":[]}"
             platform_flag=`echo "$requested_platforms" | tr -d ' '`

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -74,6 +74,7 @@ jobs:
           shell: bash
           run: |
             cd $CUDAQ_REPO_ROOT
+            python3 -m pip install iqm-client
             ctest --output-on-failure --test-dir build -E ctest-nvqpp
             ctest_status=$?
             /opt/llvm/bin/llvm-lit -v --param nvqpp_site_config=build/test/lit.site.cfg.py build/test

--- a/docs/sphinx/using/cudaq/generic_functions.rst
+++ b/docs/sphinx/using/cudaq/generic_functions.rst
@@ -12,8 +12,7 @@ generic :code:`cudaq::` functions that take any CUDA Quantum kernel expression a
 
 Let's take a look at the first couple examples of this already implemented in CUDA Quantum.
 The first function we provide is :code:`cudaq::sample(...)`, which takes any
-kernel as input (with certain characteristics, see the `Specification
-<https://nvidia.github.io/cuda-quantum/latest/specification/cudaq/algorithmic_primitives.html#cudaq-sample>`__`)
+kernel as input (with certain characteristics, see the :doc:`specification <specification/cudaq/algorithmic_primitives>`)
 and samples the kernel's resultant state over a number of shots, returning a map
 of observed measurement bit strings to the corresponding number of times that
 configuration was observed. Using this function is straightforward:
@@ -82,7 +81,7 @@ arguments
 
 Another useful CUDA Quantum function in the variational context is
 :code:`cudaq::observe(...)`. This function takes any kernel expression
-(with suitable characteristics noted in the `Specification <https://nvidia.github.io/cuda-quantum/latest/specification/cudaq/algorithmic_primitives.html#cudaq-observe>`__),
+(with suitable characteristics noted in the :doc:`specification <specification/cudaq/algorithmic_primitives>`),
 a user-provided :code:`cudaq::spin_op` defining a general quantum mechanical spin operator, and
 any kernel runtime arguments to return the expected value of the spin operator
 with respect to the kernel ansatz at the provided runtime parameters. It can be

--- a/docs/sphinx/using/cudaq/generic_functions.rst
+++ b/docs/sphinx/using/cudaq/generic_functions.rst
@@ -12,7 +12,7 @@ generic :code:`cudaq::` functions that take any CUDA Quantum kernel expression a
 
 Let's take a look at the first couple examples of this already implemented in CUDA Quantum.
 The first function we provide is :code:`cudaq::sample(...)`, which takes any
-kernel as input (with certain characteristics, see the :doc:`specification <specification/cudaq/algorithmic_primitives>`)
+kernel as input (with certain characteristics, see the :doc:`specification </specification/cudaq/algorithmic_primitives>`)
 and samples the kernel's resultant state over a number of shots, returning a map
 of observed measurement bit strings to the corresponding number of times that
 configuration was observed. Using this function is straightforward:
@@ -81,7 +81,7 @@ arguments
 
 Another useful CUDA Quantum function in the variational context is
 :code:`cudaq::observe(...)`. This function takes any kernel expression
-(with suitable characteristics noted in the :doc:`specification <specification/cudaq/algorithmic_primitives>`),
+(with suitable characteristics noted in the :doc:`specification </specification/cudaq/algorithmic_primitives>`),
 a user-provided :code:`cudaq::spin_op` defining a general quantum mechanical spin operator, and
 any kernel runtime arguments to return the expected value of the spin operator
 with respect to the kernel ansatz at the provided runtime parameters. It can be

--- a/docs/sphinx/using/cudaq/kernel.rst
+++ b/docs/sphinx/using/cudaq/kernel.rst
@@ -33,8 +33,7 @@ for compilation and execution on the quantum device.
 CUDA Quantum distinguishes between two separate kinds of kernel expressions - entry-point
 and pure-device quantum kernels. Entry-point kernels are those that can be
 called from host code, while pure-device kernels are those that can only be
-called from other quantum kernel code. See the `specification
-<https://nvidia.github.io/cuda-quantum/latest/specification/cudaq/kernels.html#quantum-kernels>`__
+called from other quantum kernel code. See the :doc:`specification <specification/cudaq/kernels>`
 for more detail,  but here we note that the "typed" requirement can be relaxed
 for pure-device kernels:
 

--- a/docs/sphinx/using/cudaq/kernel.rst
+++ b/docs/sphinx/using/cudaq/kernel.rst
@@ -33,7 +33,7 @@ for compilation and execution on the quantum device.
 CUDA Quantum distinguishes between two separate kinds of kernel expressions - entry-point
 and pure-device quantum kernels. Entry-point kernels are those that can be
 called from host code, while pure-device kernels are those that can only be
-called from other quantum kernel code. See the :doc:`specification <specification/cudaq/kernels>`
+called from other quantum kernel code. See the :doc:`specification </specification/cudaq/kernels>`
 for more detail,  but here we note that the "typed" requirement can be relaxed
 for pure-device kernels:
 

--- a/docs/sphinx/using/cudaq/platform.rst
+++ b/docs/sphinx/using/cudaq/platform.rst
@@ -3,7 +3,7 @@ Taking Advantage of the Underlying Quantum Platform
 The CUDA Quantum machine model elucidates the various devices considered in the
 broader quantum-classical compute node context. One will have one or many
 host CPUs, zero or many NVIDIA GPUs, a classical QPU control space, and the
-quantum register itself. Moreover, the `specification <https://nvidia.github.io/cuda-quantum/latest/specification/cudaq/platform.html>`__
+quantum register itself. Moreover, the :doc:`specification <specification/cudaq/platform>`
 notes that the underlying platform may expose multiple QPUs. In the near-term,
 this will be unlikely with physical QPU instantiations, but the availability of
 GPU-based circuit simulators on NVIDIA multi-GPU architectures does give one an

--- a/docs/sphinx/using/cudaq/platform.rst
+++ b/docs/sphinx/using/cudaq/platform.rst
@@ -3,7 +3,7 @@ Taking Advantage of the Underlying Quantum Platform
 The CUDA Quantum machine model elucidates the various devices considered in the
 broader quantum-classical compute node context. One will have one or many
 host CPUs, zero or many NVIDIA GPUs, a classical QPU control space, and the
-quantum register itself. Moreover, the :doc:`specification <specification/cudaq/platform>`
+quantum register itself. Moreover, the :doc:`specification </specification/cudaq/platform>`
 notes that the underlying platform may expose multiple QPUs. In the near-term,
 this will be unlikely with physical QPU instantiations, but the availability of
 GPU-based circuit simulators on NVIDIA multi-GPU architectures does give one an


### PR DESCRIPTION
Specifically
- Fixing links in docs such that the link always point to the same version of the docs that someone is currently browsing
- Fixing a minor typo in the workflow when launching deployment manually
- Installing the iqm client for testing such that iqm server helper tests are not skipped.