### PR TITLE
Fix bug in the linear-ctrl-form pass.

### DIFF
--- a/test/Quake/linear_control.qke
+++ b/test/Quake/linear_control.qke
@@ -123,16 +123,16 @@ func.func @linear_expr1() {
 // CHECK:           %[[VAL_7:.*]] = quake.null_wire
 // CHECK:           %[[VAL_8:.*]] = quake.null_wire
 // CHECK:           %[[VAL_9:.*]] = quake.null_wire
-// CHECK:           %[[VAL_10:.*]]:3 = quake.x [%[[VAL_1]], %[[VAL_1]]] %[[VAL_2]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
+// CHECK:           %[[VAL_10:.*]]:3 = quake.x [%[[VAL_0]], %[[VAL_1]]] %[[VAL_2]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
 // CHECK:           %[[VAL_11:.*]]:3 = quake.x [%[[VAL_10]]#0, %[[VAL_10]]#1] %[[VAL_3]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
 // CHECK:           %[[VAL_12:.*]]:3 = quake.x [%[[VAL_11]]#0, %[[VAL_11]]#1] %[[VAL_4]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
 // CHECK:           %[[VAL_13:.*]]:3 = quake.x [%[[VAL_12]]#0, %[[VAL_12]]#1] %[[VAL_5]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
 // CHECK:           %[[VAL_14:.*]]:3 = quake.x [%[[VAL_13]]#0, %[[VAL_13]]#1] %[[VAL_6]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
-// CHECK:           %[[VAL_15:.*]]:2 = quake.x [%[[VAL_0]]] %[[VAL_7]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[VAL_16:.*]]:2 = quake.x [%[[VAL_14]]#0] %[[VAL_8]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[VAL_17:.*]]:3 = quake.x [%[[VAL_16]]#0, %[[VAL_14]]#1] %[[VAL_9]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
-// CHECK:           quake.sink %[[VAL_15]]#0 : !quake.wire
+// CHECK:           %[[VAL_15:.*]]:2 = quake.x [%[[VAL_14]]#0] %[[VAL_7]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_16:.*]]:2 = quake.x [%[[VAL_14]]#1] %[[VAL_8]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_17:.*]]:3 = quake.x [%[[VAL_15]]#0, %[[VAL_16]]#0] %[[VAL_9]] : (!quake.wire, !quake.wire, !quake.wire) -> (!quake.wire, !quake.wire, !quake.wire)
 // CHECK:           quake.sink %[[VAL_17]]#0 : !quake.wire
+// CHECK:           quake.sink %[[VAL_17]]#1 : !quake.wire
 // CHECK:           quake.sink %[[VAL_10]]#2 : !quake.wire
 // CHECK:           quake.sink %[[VAL_11]]#2 : !quake.wire
 // CHECK:           quake.sink %[[VAL_12]]#2 : !quake.wire
@@ -143,3 +143,4 @@ func.func @linear_expr1() {
 // CHECK:           quake.sink %[[VAL_17]]#2 : !quake.wire
 // CHECK:           return
 // CHECK:         }
+


### PR DESCRIPTION
This fixes a bug in the newly added linear-ctrl-form pass. The index of the operand to be replaced was being miscomputed which was producing incorrect results. Corrects the test.
