### PR TITLE
Deprecate builder ctrl gates that are not specification compliant

### DIFF
--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -208,7 +208,7 @@ and rotations and return a valid, callable, CUDA Quantum kernel.
           [](kernel_builder<> &self, QuakeValue &control,                      \
              QuakeValue &target) {                                             \
             std::vector<QuakeValue> controls{control};                         \
-            self.NAME(controls, target);                                       \
+            self.NAME<cudaq::ctrl>(controls, target);                          \
           },                                                                   \
           py::arg("control"), py::arg("target"),                               \
           "Apply a controlled-" #NAME " operation"                             \
@@ -230,7 +230,9 @@ and rotations and return a valid, callable, CUDA Quantum kernel.
       .def(                                                                    \
           "c" #NAME,                                                           \
           [](kernel_builder<> &self, std::vector<QuakeValue> &controls,        \
-             QuakeValue &target) { self.NAME(controls, target); },             \
+             QuakeValue &target) {                                             \
+            self.NAME<cudaq::ctrl>(controls, target);                          \
+          },                                                                   \
           py::arg("controls"), py::arg("target"),                              \
           "Apply a controlled-" #NAME " operation"                             \
           " to the given target qubits, with the provided list of control "    \
@@ -349,8 +351,9 @@ and rotations and return a valid, callable, CUDA Quantum kernel.
       .def(                                                                    \
           "c" #NAME,                                                           \
           [](kernel_builder<> &self, QuakeValue &parameter,                    \
-             std::vector<QuakeValue> &controls,                                \
-             QuakeValue &target) { self.NAME(parameter, controls, target); },  \
+             std::vector<QuakeValue> &controls, QuakeValue &target) {          \
+            self.NAME<cudaq::ctrl>(parameter, controls, target);               \
+          },                                                                   \
           py::arg("parameter"), py::arg("controls"), py::arg("target"),        \
           "Apply a controlled-" #NAME " operation"                             \
           " to the given target qubit, with the provided list of control "     \
@@ -374,8 +377,9 @@ and rotations and return a valid, callable, CUDA Quantum kernel.
       .def(                                                                    \
           "c" #NAME,                                                           \
           [](kernel_builder<> &self, double &parameter,                        \
-             std::vector<QuakeValue> &controls,                                \
-             QuakeValue &target) { self.NAME(parameter, controls, target); },  \
+             std::vector<QuakeValue> &controls, QuakeValue &target) {          \
+            self.NAME<cudaq::ctrl>(parameter, controls, target);               \
+          },                                                                   \
           py::arg("parameter"), py::arg("controls"), py::arg("target"),        \
           "Apply a controlled-" #NAME " operation"                             \
           " to the given target qubit, with the provided list of control "     \

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -433,6 +433,17 @@ public:
     details::NAME(*opBuilder, empty, qubit);                                   \
   }                                                                            \
   void NAME(QuakeValue &&qubit) { NAME(qubit); }                               \
+  [[deprecated("In the future, passing `ctrls` to " #NAME                      \
+               " will require an explicit `<cudaq::ctrl>` template argument. " \
+               "Upon the next release, this will be interpreted as a single "  \
+               "qubit gate broadcast across all input qubits, per the CUDA "   \
+               "Quantum Specification.")]] void                                \
+  NAME(std::vector<QuakeValue> &ctrls, QuakeValue &target) {                   \
+    details::NAME(*opBuilder, ctrls, target);                                  \
+  }                                                                            \
+  template <typename mod,                                                      \
+            typename =                                                         \
+                typename std::enable_if_t<std::is_same_v<mod, cudaq::ctrl>>>   \
   void NAME(std::vector<QuakeValue> &ctrls, QuakeValue &target) {              \
     details::NAME(*opBuilder, ctrls, target);                                  \
   }                                                                            \
@@ -446,7 +457,7 @@ public:
     if constexpr (std::is_same_v<mod, cudaq::ctrl>) {                          \
       std::vector<QuakeValue> ctrls(values.begin(), values.end() - 1);         \
       auto &target = values.back();                                            \
-      NAME(ctrls, target);                                                     \
+      NAME<cudaq::ctrl>(ctrls, target);                                        \
       return;                                                                  \
     }                                                                          \
     for (auto &v : values) {                                                   \
@@ -473,10 +484,34 @@ public:
     std::vector<QuakeValue> empty;                                             \
     details::NAME(*opBuilder, parameter, empty, qubit);                        \
   }                                                                            \
+  [[deprecated("In the future, passing `ctrls` to " #NAME                      \
+               " will require an explicit `<cudaq::ctrl>` template argument. " \
+               "Upon the next release, this will be interpreted as a single "  \
+               "qubit gate broadcast across all input qubits, per the CUDA "   \
+               "Quantum Specification.")]] void                                \
+  NAME(QuakeValue parameter, std::vector<QuakeValue> &ctrls,                   \
+       QuakeValue &target) {                                                   \
+    details::NAME(*opBuilder, parameter, ctrls, target);                       \
+  }                                                                            \
+  template <typename mod,                                                      \
+            typename =                                                         \
+                typename std::enable_if_t<std::is_same_v<mod, cudaq::ctrl>>>   \
   void NAME(QuakeValue parameter, std::vector<QuakeValue> &ctrls,              \
             QuakeValue &target) {                                              \
     details::NAME(*opBuilder, parameter, ctrls, target);                       \
   }                                                                            \
+  [[deprecated("In the future, passing `ctrls` to " #NAME                      \
+               " will require an explicit `<cudaq::ctrl>` template argument. " \
+               "Upon the next release, this will be interpreted as a single "  \
+               "qubit gate broadcast across all input qubits, per the CUDA "   \
+               "Quantum Specification.")]] void                                \
+  NAME(double parameter, std::vector<QuakeValue> &ctrls, QuakeValue &target) { \
+    QuakeValue v(*opBuilder, parameter);                                       \
+    details::NAME(*opBuilder, v, ctrls, target);                               \
+  }                                                                            \
+  template <typename mod,                                                      \
+            typename =                                                         \
+                typename std::enable_if_t<std::is_same_v<mod, cudaq::ctrl>>>   \
   void NAME(double parameter, std::vector<QuakeValue> &ctrls,                  \
             QuakeValue &target) {                                              \
     QuakeValue v(*opBuilder, parameter);                                       \
@@ -505,9 +540,9 @@ public:
       std::vector<QuakeValue> ctrls(values.begin(), values.end() - 1);         \
       auto &target = values.back();                                            \
       if constexpr (std::is_floating_point_v<ParamT>)                          \
-        NAME(QuakeValue(*opBuilder, parameter), ctrls, target);                \
+        NAME<cudaq::ctrl>(QuakeValue(*opBuilder, parameter), ctrls, target);   \
       else                                                                     \
-        NAME(parameter, ctrls, target);                                        \
+        NAME<cudaq::ctrl>(parameter, ctrls, target);                           \
       return;                                                                  \
     }                                                                          \
   }

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -314,9 +314,9 @@ CUDAQ_TEST(BuilderTester, checkRotations) {
     std::vector<cudaq::QuakeValue> ctrls{q1, q2, q3};
 
     // Overload 1: `QuakeValue` parameter.
-    kernel.rx(val, ctrls, target);
+    kernel.rx<cudaq::ctrl>(val, ctrls, target);
     // Overload 2: `double` parameter.
-    kernel.rx(M_PI, ctrls, target);
+    kernel.rx<cudaq::ctrl>(M_PI, ctrls, target);
 
     auto counts = cudaq::sample(kernel, M_PI);
     counts.dump();
@@ -343,9 +343,9 @@ CUDAQ_TEST(BuilderTester, checkRotations) {
     std::vector<cudaq::QuakeValue> ctrls{q1, q2, q3};
 
     // Overload 1: `QuakeValue` parameter.
-    kernel.rx(val, ctrls, target);
+    kernel.rx<cudaq::ctrl>(val, ctrls, target);
     // Overload 2: `double` parameter.
-    kernel.rx(M_PI, ctrls, target);
+    kernel.rx<cudaq::ctrl>(M_PI, ctrls, target);
 
     auto counts = cudaq::sample(kernel, M_PI);
     counts.dump();
@@ -376,9 +376,9 @@ CUDAQ_TEST(BuilderTester, checkRotations) {
     std::vector<cudaq::QuakeValue> ctrls{q1, q2, q3};
 
     // Overload 1: `QuakeValue` parameter.
-    kernel.rz(val, ctrls, target);
+    kernel.rz<cudaq::ctrl>(val, ctrls, target);
     // Overload 2: `double` parameter.
-    kernel.rz(-M_PI_2, ctrls, target);
+    kernel.rz<cudaq::ctrl>(-M_PI_2, ctrls, target);
 
     // Hadamard the target again.
     kernel.h(target);
@@ -412,9 +412,9 @@ CUDAQ_TEST(BuilderTester, checkRotations) {
     std::vector<cudaq::QuakeValue> ctrls{q1, q2, q3};
 
     // Overload 1: `QuakeValue` parameter.
-    kernel.r1(val, ctrls, target);
+    kernel.r1<cudaq::ctrl>(val, ctrls, target);
     // Overload 2: `double` parameter.
-    kernel.r1(-M_PI_2, ctrls, target);
+    kernel.r1<cudaq::ctrl>(-M_PI_2, ctrls, target);
 
     // Hadamard the target again.
     kernel.h(target);


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

With (PR #[876](https://github.com/NVIDIA/cuda-quantum/commit/d83bdd24bedd3abcc46d44a65cacc31ea803d6c8)), we are now enforcing the use of `cudaq::ctrl` when a programmer intends to run a control gate. This behavior must be matched in the kernel builder to remain specification compliant.

As is, this deprecates the old functions with a stern warning, and replaces them with new templated versions. Depending on when this PR is merged, the deprecated functions should be removed for the following release cycle.

Note: this has no impact on the Python API, only the C++ kernel builder.

Old behavior that will now show a deprecation notice:

```
auto [kernel, value] = cudaq::make_kernel<float>();
std::vector<cudaq::QuakeValue> ctrls{kernel.qalloc(), kernel.qalloc()};
auto target = kernel.qalloc();

// Now deprecated:
kernel.x(ctrls, target);
kernel.x(value, ctrls, target);
kernel.rx(3.14, ctrls, target);
```

The preferred method moving forward is
```
kernel.x<cudaq::ctrl>(ctrls, target);
kernel.x<cudaq::ctrl>(value, ctrls, target);
kernel.rx<cudaq::ctrl>(3.14, ctrls, target);
```

