### PR TITLE
Simplify lambda expressions.

### DIFF
--- a/runtime/cudaq/algorithms/observe.h
+++ b/runtime/cudaq/algorithms/observe.h
@@ -50,12 +50,12 @@ concept ObserveCallValid =
     ValidArgumentsPassed<QuantumKernel, Args...> &&
     HasVoidReturnType<std::invoke_result_t<QuantumKernel, Args...>>;
 
-/// \brief Observe options to provide to the observe() / async_observe()
-/// functions
+/// Observe options to provide as an argument to the `observe()`,
+/// `async_observe()` functions.
 ///
-/// \param shots number of shots to run for the given kernel. The default of -1
-/// means direct calculations for simulation backends.
-/// \param noise noise model to use for the observe operation
+/// \p shots is the number of shots to run for the given kernel. The default of
+/// -1 means direct calculations for simulation backends. \p noise is the noise
+/// model to use for the observe operation.
 struct observe_options {
   int shots = -1;
   cudaq::noise_model noise;
@@ -168,7 +168,7 @@ auto runObservationAsync(KernelFunctor &&wrappedKernel, spin_op &H,
 
 /// @brief Distribute the expectation value computations among the
 /// available platform QPUs. The `asyncLauncher` functor takes as input the
-/// qpu index and the `spin_op` chunk and returns an `async_observe_result`.
+/// QPU index and the `spin_op` chunk and returns an `async_observe_result`.
 inline auto distributeComputations(
     std::function<async_observe_result(std::size_t, spin_op &)> &&asyncLauncher,
     spin_op &H, std::size_t nQpus) {
@@ -250,9 +250,9 @@ std::vector<observe_result> observe(QuantumKernel &&kernel,
 }
 
 /// @brief Compute the expected value of `H` with respect to `kernel(Args...)`.
-/// Distribute the work amongst available QPUs on the platform in parallel. This
-/// distribution can occur on multi-gpu multi-node platforms, multi-gpu
-/// single-node platforms, or multi-node no-gpu platforms. Programmers must
+/// Distribute the work `amongst` available QPUs on the platform in parallel.
+/// This distribution can occur on multi-GPU multi-node platforms, multi-GPU
+/// single-node platforms, or multi-node no-GPU platforms. Programmers must
 /// indicate the distribution type via the corresponding template types
 /// (cudaq::mgmn, cudaq::mgsn, cudaq::mn).
 template <typename DistributionType, typename QuantumKernel, typename... Args>

--- a/runtime/cudaq/algorithms/sample.h
+++ b/runtime/cudaq/algorithms/sample.h
@@ -209,9 +209,7 @@ sample_result sample(QuantumKernel &&kernel, Args &&...args) {
   auto shots = platform.get_shots().value_or(1000);
   auto kernelName = cudaq::getKernelName(kernel);
   return details::runSampling(
-             [&kernel, ... args = std::forward<Args>(args)]() mutable {
-               kernel(std::forward<Args>(args)...);
-             },
+             [&kernel, &args...]() { kernel(std::forward<Args>(args)...); },
              platform, kernelName, shots)
       .value();
 }
@@ -243,9 +241,7 @@ auto sample(std::size_t shots, QuantumKernel &&kernel, Args &&...args) {
   auto &platform = cudaq::get_platform();
   auto kernelName = cudaq::getKernelName(kernel);
   return details::runSampling(
-             [&kernel, ... args = std::forward<Args>(args)]() mutable {
-               kernel(std::forward<Args>(args)...);
-             },
+             [&kernel, &args...]() { kernel(std::forward<Args>(args)...); },
              platform, kernelName, shots)
       .value();
 }
@@ -279,9 +275,7 @@ sample_result sample(const sample_options &options, QuantumKernel &&kernel,
   auto kernelName = cudaq::getKernelName(kernel);
   platform.set_noise(&options.noise);
   auto ret = details::runSampling(
-                 [&kernel, ... args = std::forward<Args>(args)]() mutable {
-                   kernel(std::forward<Args>(args)...);
-                 },
+                 [&kernel, &args...]() { kernel(std::forward<Args>(args)...); },
                  platform, kernelName, shots)
                  .value();
 
@@ -319,10 +313,8 @@ async_sample_result sample_async(const std::size_t qpu_id,
   auto kernelName = cudaq::getKernelName(kernel);
 
   return details::runSamplingAsync(
-      [&kernel, ... args = std::forward<Args>(args)]() mutable {
-        kernel(std::forward<Args>(args)...);
-      },
-      platform, kernelName, shots, qpu_id);
+      [&kernel, &args...]() { kernel(std::forward<Args>(args)...); }, platform,
+      kernelName, shots, qpu_id);
 }
 
 /// @brief Sample the given kernel expression asynchronously and return
@@ -355,10 +347,8 @@ async_sample_result sample_async(std::size_t shots, std::size_t qpu_id,
   auto kernelName = cudaq::getKernelName(kernel);
 
   return details::runSamplingAsync(
-      [&kernel, ... args = std::forward<Args>(args)]() mutable {
-        kernel(std::forward<Args>(args)...);
-      },
-      platform, kernelName, shots, qpu_id);
+      [&kernel, &args...]() { kernel(std::forward<Args>(args)...); }, platform,
+      kernelName, shots, qpu_id);
 }
 
 /// @brief Sample the given kernel expression asynchronously and return
@@ -403,12 +393,12 @@ std::vector<sample_result> sample(QuantumKernel &&kernel,
           Args &...singleIterParameters) -> sample_result {
     auto shots = platform.get_shots().value_or(1000);
     auto kernelName = cudaq::getKernelName(kernel);
-    auto ret =
-        details::runSampling(
-            [&kernel, ... args = std::forward<decltype(singleIterParameters)>(
-                          singleIterParameters)]() mutable { kernel(args...); },
-            platform, kernelName, shots, qpuId, nullptr, counter, N)
-            .value();
+    auto ret = details::runSampling(
+                   [&kernel, &singleIterParameters...]() {
+                     kernel(std::forward<Args>(singleIterParameters)...);
+                   },
+                   platform, kernelName, shots, qpuId, nullptr, counter, N)
+                   .value();
     return ret;
   };
 
@@ -439,12 +429,12 @@ std::vector<sample_result> sample(std::size_t shots, QuantumKernel &&kernel,
       [&](std::size_t qpuId, std::size_t counter, std::size_t N,
           Args &...singleIterParameters) -> sample_result {
     auto kernelName = cudaq::getKernelName(kernel);
-    auto ret =
-        details::runSampling(
-            [&kernel, ... args = std::forward<decltype(singleIterParameters)>(
-                          singleIterParameters)]() mutable { kernel(args...); },
-            platform, kernelName, shots, qpuId, nullptr, counter, N)
-            .value();
+    auto ret = details::runSampling(
+                   [&kernel, &singleIterParameters...]() {
+                     kernel(std::forward<Args>(singleIterParameters)...);
+                   },
+                   platform, kernelName, shots, qpuId, nullptr, counter, N)
+                   .value();
     return ret;
   };
 
@@ -479,12 +469,12 @@ std::vector<sample_result> sample(const sample_options &options,
       [&](std::size_t qpuId, std::size_t counter, std::size_t N,
           Args &...singleIterParameters) -> sample_result {
     auto kernelName = cudaq::getKernelName(kernel);
-    auto ret =
-        details::runSampling(
-            [&kernel, ... args = std::forward<decltype(singleIterParameters)>(
-                          singleIterParameters)]() mutable { kernel(args...); },
-            platform, kernelName, shots, qpuId, nullptr, counter, N)
-            .value();
+    auto ret = details::runSampling(
+                   [&kernel, &singleIterParameters...]() {
+                     kernel(std::forward<Args>(singleIterParameters)...);
+                   },
+                   platform, kernelName, shots, qpuId, nullptr, counter, N)
+                   .value();
     return ret;
   };
 
@@ -518,12 +508,12 @@ sample_n(QuantumKernel &&kernel, ArgumentSet<Args...> &&params) {
           Args &...singleIterParameters) -> sample_result {
     auto shots = platform.get_shots().value_or(1000);
     auto kernelName = cudaq::getKernelName(kernel);
-    auto ret =
-        details::runSampling(
-            [&kernel, ... args = std::forward<decltype(singleIterParameters)>(
-                          singleIterParameters)]() mutable { kernel(args...); },
-            platform, kernelName, shots, qpuId, nullptr, counter, N)
-            .value();
+    auto ret = details::runSampling(
+                   [&kernel, &singleIterParameters...]() {
+                     kernel(std::forward<Args>(singleIterParameters)...);
+                   },
+                   platform, kernelName, shots, qpuId, nullptr, counter, N)
+                   .value();
     return ret;
   };
 
@@ -555,12 +545,12 @@ sample_n(std::size_t shots, QuantumKernel &&kernel,
       [&](std::size_t qpuId, std::size_t counter, std::size_t N,
           Args &...singleIterParameters) -> sample_result {
     auto kernelName = cudaq::getKernelName(kernel);
-    auto ret =
-        details::runSampling(
-            [&kernel, ... args = std::forward<decltype(singleIterParameters)>(
-                          singleIterParameters)]() mutable { kernel(args...); },
-            platform, kernelName, shots, qpuId, nullptr, counter, N)
-            .value();
+    auto ret = details::runSampling(
+                   [&kernel, &singleIterParameters...]() {
+                     kernel(std::forward<Args>(singleIterParameters)...);
+                   },
+                   platform, kernelName, shots, qpuId, nullptr, counter, N)
+                   .value();
     return ret;
   };
 

--- a/runtime/cudaq/algorithms/sample.h
+++ b/runtime/cudaq/algorithms/sample.h
@@ -209,7 +209,9 @@ sample_result sample(QuantumKernel &&kernel, Args &&...args) {
   auto shots = platform.get_shots().value_or(1000);
   auto kernelName = cudaq::getKernelName(kernel);
   return details::runSampling(
-             [&kernel, &args...]() { kernel(std::forward<Args>(args)...); },
+             [&kernel, ... args = std::forward<Args>(args)]() mutable {
+               kernel(std::forward<Args>(args)...);
+             },
              platform, kernelName, shots)
       .value();
 }
@@ -241,7 +243,9 @@ auto sample(std::size_t shots, QuantumKernel &&kernel, Args &&...args) {
   auto &platform = cudaq::get_platform();
   auto kernelName = cudaq::getKernelName(kernel);
   return details::runSampling(
-             [&kernel, &args...]() { kernel(std::forward<Args>(args)...); },
+             [&kernel, ... args = std::forward<Args>(args)]() mutable {
+               kernel(std::forward<Args>(args)...);
+             },
              platform, kernelName, shots)
       .value();
 }
@@ -275,7 +279,9 @@ sample_result sample(const sample_options &options, QuantumKernel &&kernel,
   auto kernelName = cudaq::getKernelName(kernel);
   platform.set_noise(&options.noise);
   auto ret = details::runSampling(
-                 [&kernel, &args...]() { kernel(std::forward<Args>(args)...); },
+                 [&kernel, ... args = std::forward<Args>(args)]() mutable {
+                   kernel(std::forward<Args>(args)...);
+                 },
                  platform, kernelName, shots)
                  .value();
 
@@ -313,8 +319,10 @@ async_sample_result sample_async(const std::size_t qpu_id,
   auto kernelName = cudaq::getKernelName(kernel);
 
   return details::runSamplingAsync(
-      [&kernel, &args...]() { kernel(std::forward<Args>(args)...); }, platform,
-      kernelName, shots, qpu_id);
+      [&kernel, ... args = std::forward<Args>(args)]() mutable {
+        kernel(std::forward<Args>(args)...);
+      },
+      platform, kernelName, shots, qpu_id);
 }
 
 /// @brief Sample the given kernel expression asynchronously and return
@@ -347,8 +355,10 @@ async_sample_result sample_async(std::size_t shots, std::size_t qpu_id,
   auto kernelName = cudaq::getKernelName(kernel);
 
   return details::runSamplingAsync(
-      [&kernel, &args...]() { kernel(std::forward<Args>(args)...); }, platform,
-      kernelName, shots, qpu_id);
+      [&kernel, ... args = std::forward<Args>(args)]() mutable {
+        kernel(std::forward<Args>(args)...);
+      },
+      platform, kernelName, shots, qpu_id);
 }
 
 /// @brief Sample the given kernel expression asynchronously and return


### PR DESCRIPTION
These changes simplify some of the lambda expressions in the cudaq headers. It eliminates some of the more complicated capture expressions and uses simple reference capture. It also removes the `mutable` modifier which does not appear to be necessary in these cases.
