### PR TITLE
Edit to variable name in docs

### DIFF
--- a/Developing.md
+++ b/Developing.md
@@ -20,7 +20,7 @@ and examples using your local build. If you edit [this
 file](./runtime/nvqir/CircuitSimulator.h) to add a print statement
 
 ```c++
-std::cout << "Custom registration of " << #NAME << "\n" << std::endl;
+std::cout << "Custom registration of " << #PRINTED_NAME << "\n" << std::endl;
 ```
 
 to the definition of the `NVQIR_REGISTER_SIMULATOR` macro, you should see this


### PR DESCRIPTION
Changed the documentation to reflect the variable name that is in the macro, "#NAME" to "#PRINTED_NAME". Closes #959.