### PR TITLE
[quake] Introduce linear type constraints, part 1.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -39,14 +39,14 @@ class QuakeOp<string mnemonic, list<Trait> traits = []> :
 def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
   let summary = "Allocates a reference or collection of references to wires.";
   let description = [{
-    The `alloca` operation allocates either a single wire reference or a vector
-    of references to wires. The size of the vector may be provided either
+    The `alloca` operation allocates either a single quantum reference or a
+    vector of quantum references. The size of the vector may be provided either
     statically as part of the type or dynamically as an integer-like argument,
     `size`. The return value will be a quantum reference, type `!quake.ref`,
     or a vector of such, type `!quake.veq<N>`.
 
-    All wires are assumed to be initialized to the value `|0>` initially. See
-    the `null_wire` op.
+    All references are assumed to be initialized to the value `|0>` initially.
+    See also the `null_wire` op.
 
     The `QuakeAddDeallocs` and `UnwindLowering` passes will insert deallocation
     ops for the scopes in which allocations appear automatically. This is
@@ -179,6 +179,7 @@ def quake_FromControlOp : QuakeOp<"from_ctrl", [Pure]> {
 
   let arguments = (ins ControlType:$ctrlbit);
   let results = (outs WireType);
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     $ctrlbit `:` functional-type(operands, results) attr-dict
@@ -192,11 +193,11 @@ def quake_FromControlOp : QuakeOp<"from_ctrl", [Pure]> {
 def quake_DeallocOp : QuakeOp<"dealloc"> {
   let summary = "Deallocates a collection of qubits.";
   let description = [{
-    The `dealloc` operation deallocates a references to wires. The deallocation
-    can be a single wire, type `!quake.ref`, or a vector of references, type
-    `!quake.veq<N>`.
+    The `dealloc` operation deallocates a quantum reference. The deallocation
+    can be a single quantum reference, `!quake.ref`, or a vector of quantum
+    references, `!quake.veq<N>`.
 
-    Deallocations are automatically inserted by the `QuakeAddDeallocs` and
+    Deallocations are automatically inserted by the `AddDeallocs` and
     `UnwindLowering` passes.
 
     Example:
@@ -224,7 +225,7 @@ def quake_DeallocOp : QuakeOp<"dealloc"> {
 //===----------------------------------------------------------------------===//
 
 def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
-  let summary = "Get a reference to a single wire.";
+  let summary = "Extract a quantum reference from a quantum vector.";
   let description = [{
     The `extract_ref` operation extracts a quantum reference from a vector of
     quantum references.
@@ -486,6 +487,8 @@ def quake_UnwrapOp : QuakeOp<"unwrap"> {
 
   let arguments = (ins Arg<RefType,"",[MemRead]>:$ref_value);
   let results = (outs WireType);
+  let hasVerifier = 1;
+
   let assemblyFormat = [{
     $ref_value `:` functional-type(operands, results) attr-dict
   }];
@@ -519,6 +522,7 @@ def quake_NullWireOp : QuakeOp<"null_wire"> {
   }];
 
   let results = (outs WireType);
+  let hasVerifier = 1;
   let assemblyFormat = "attr-dict";
 }
 
@@ -542,11 +546,12 @@ def quake_ResetOp : QuakeOp<"reset", [QuantumGate,
   }];
 
   let arguments = (ins
-    AnyQType:$targets
+    AnyQTargetType:$targets
   );
   let results = (outs
     Variadic<WireType>:$wires
   );
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
      $targets `:` functional-type(operands, results) attr-dict
@@ -595,7 +600,7 @@ def quake_SinkOp : QuakeOp<"sink"> {
 class Measurement<string mnemonic> : QuakeOp<mnemonic, [MeasurementInterface,
     QuantumMeasure, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let arguments = (ins
-    Variadic<AnyQType>:$targets,
+    Variadic<AnyQTargetType>:$targets,
     OptionalAttr<StrAttr>:$registerName
   );
   let results = (outs
@@ -702,7 +707,7 @@ class QuakeOperator<string mnemonic, list<Trait> traits = []>
     UnitAttr:$is_adj,
     Variadic<AnyFloat>:$parameters,
     Variadic<AnyQType>:$controls,
-    Variadic<AnyQType>:$targets,
+    Variadic<AnyQTargetType>:$targets,
     OptionalAttr<DenseBoolArrayAttr>:$negated_qubit_controls
   );
   let results = (outs
@@ -764,6 +769,8 @@ class QuakeOperator<string mnemonic, list<Trait> traits = []>
     $targets `:` functional-type(operands, results) attr-dict
   }];
 
+  let hasVerifier = 1;
+
   code extraClassDeclaration = [{
     //===------------------------------------------------------------------===//
     // MemoryEffects interface
@@ -819,15 +826,20 @@ def ExpPauliOp : QuakeOp<"exp_pauli"> {
   let description = [{
     This operation affects a general Pauli tensor product rotation on 
     the input qubits. The number of Pauli characters in the input Pauli word 
-    string must equal the number of qubits in the veq. Mathematically, this operation 
-    applies exp(i theta P) where P is a general Pauli tensor product. 
+    string must equal the number of qubits in the veq. Mathematically, this
+    operation applies exp(i theta P) where P is a general Pauli tensor product. 
   }];
   
-  let arguments = (ins AnyFloat:$parameter, VeqType:$qubits, cc_PointerType:$pauli);
-  let results = (outs );
+  let arguments = (ins
+    AnyFloat:$parameter,
+    VeqType:$qubits,
+    cc_PointerType:$pauli
+  );
+  let results = (outs);
 
   let assemblyFormat = [{
-    `(` $parameter `)` $qubits `,` $pauli `:` functional-type(operands, results) attr-dict
+    `(` $parameter `)` $qubits `,` $pauli `:` functional-type(operands,
+      results) attr-dict
   }];
 }
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -28,20 +28,30 @@ class QuakeType<string name, string typeMnemonic, list<Trait> traits = [],
 
 def WireType : QuakeType<"Wire", "wire"> {
   let description = [{
-    A `wire` is a primitive "quantum value" that differs from a traditional
-    SSA value in that it can and will be modified when used in any target
-    position. That means "quantum values" are not SSA values. `wire`
-    values can only be used once and have somewhat similar properties to
-    volatile memory. An operation that uses a `wire` in a target position is
-    required to return a new `wire` value reflecting the updated/new state.
+    A `wire` is a primitive quantum "SSA-value" that differs from a traditional
+    SSA-value in that it can and will be modified when used in any target
+    position. That means quantum "SSA-values" are not true SSA values. To
+    enforce this property a `wire` type is a linear type. Therefore, `wire`
+    values must be used exactly once. A `wire` value might be thought of as
+    having somewhat similar properties to volatile memory. An operation that
+    uses a `wire` is required to return a new `wire` value reflecting the
+    updated/new state and propagating the linear type.
 
     The following is a simple example of using `wire` values.
 
     ```mlir
+      // Create two wires.
       %q0 = ... : !quake.wire
       %q1 = ... : !quake.wire
-      %q2 = quake.gate1 [%q0] %q1 : (!quake.wire, !quake.wire) -> !quake.wire
-      %q3 = quake.gate2 %q2 : (!quake.wire) -> !quake.wire
+
+      // Apply some quantum gates.
+      %q2:2 = quake.gate1 [%q0] %q1 : (!quake.wire, !quake.wire) ->
+                 (!quake.wire, !quake.wire)
+      %q3 = quake.gate2 %q2#0 : (!quake.wire) -> !quake.wire
+
+      // Final use of the wires.
+      quake.sink %q3 : !quake.wire
+      quake.wrap %q2#1 to %r0 : !quake.wire, !quake.ref
     ```
 
     See also the description of the `ref` type.
@@ -173,6 +183,9 @@ def MeasureType : QuakeType<"Measure", "measure"> {
 def AnyQTypeLike : TypeConstraint<Or<[WireType.predicate, VeqType.predicate,
         ControlType.predicate, RefType.predicate]>, "quake quantum types">;
 def AnyQType : Type<AnyQTypeLike.predicate, "quantum type">;
+def AnyQTargetTypeLike : TypeConstraint<Or<[WireType.predicate,
+        VeqType.predicate, RefType.predicate]>, "quake quantum target types">;
+def AnyQTargetType : Type<AnyQTargetTypeLike.predicate, "quantum target type">;
 def AnyRefTypeLike : TypeConstraint<Or<[VeqType.predicate,
         RefType.predicate]>, "quake quantum reference types">;
 def AnyRefType : Type<AnyRefTypeLike.predicate, "quantum reference type">;

--- a/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/lib/Optimizer/Transforms/MemToReg.cpp
@@ -631,7 +631,7 @@ public:
     for (auto wrap : wrapOps) {
       auto ref = wrap.getRefValue();
       auto wire = wrap.getWireValue();
-      if (!ref || wire.getUses().empty()) {
+      if (!ref || !wire.hasOneUse()) {
         LLVM_DEBUG(llvm::dbgs() << "erasing: "; wrap->dump();
                    llvm::dbgs() << '\n');
         wrap->dropAllUses();

--- a/test/NVQPP/cudaq_observe.cpp
+++ b/test/NVQPP/cudaq_observe.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ %s -o %basename_t.x --target quantinuum --emulate && ./%basename_t.x | FileCheck %s
 // RUN: nvq++ --target ionq                     --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s
 // 2 different IQM machines for 2 different topologies
 // RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %basename_t.x && ./%basename_t.x | FileCheck %s

--- a/test/Quake/basic.qke
+++ b/test/Quake/basic.qke
@@ -84,6 +84,7 @@ func.func @apply_cx_v() {
   %q3 = quake.unwrap %q1 : (!quake.ref) -> !quake.wire
   // CHECK: %{{.*}} = quake.x [%{{.*}}] %{{.*}} : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %q5:2 = quake.x [%q2] %q3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.wrap %q5 to %q1 : !quake.wire, !quake.ref
+  quake.wrap %q5#1 to %q1 : !quake.wire, !quake.ref
+  quake.wrap %q5#0 to %q0 : !quake.wire, !quake.ref
   return
 }

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -97,8 +97,11 @@ func.func @quantum_ops() {
   %36 = quake.u3 (%f, %g, %h) %35 : (f32, f32, f32, !quake.wire) -> !quake.wire
 
   %37:2 = quake.mx %29#0 : (!quake.wire) -> (!quake.measure, !quake.wire)
+  quake.sink %37#1 : !quake.wire
   %38:2 = quake.my %20 : (!quake.wire) -> (!quake.measure, !quake.wire)
+  quake.sink %38#1 : !quake.wire
   %39:2 = quake.mz %36 : (!quake.wire) -> (!quake.measure, !quake.wire)
+  quake.sink %39#1 : !quake.wire
 
   // CUDA Quantum model support
   %40 = quake.alloca !quake.ref { apply_variants = true }
@@ -633,7 +636,7 @@ func.func @wire_type() -> !quake.wire {
 // CHECK:           %[[VAL_1:.*]] = quake.unwrap %[[VAL_0]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[VAL_2:.*]] = quake.null_wire
 // CHECK:           %[[VAL_3:.*]]:2 = quake.x [%[[VAL_2]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           quake.wrap %[[VAL_3]]#0 to %[[VAL_0]] : !quake.wire, !quake.ref
+// CHECK:           quake.wrap %[[VAL_3]]#1 to %[[VAL_0]] : !quake.wire, !quake.ref
 // CHECK:           return
 // CHECK:         }
 
@@ -641,7 +644,8 @@ func.func @unwrap_wrap(%0 : !quake.ref) {
   %1 = quake.unwrap %0 : (!quake.ref) -> !quake.wire
   %3 = quake.null_wire
   %2:2 = quake.x [%3] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.wrap %2 to %0 : !quake.wire, !quake.ref
+  quake.wrap %2#1 to %0 : !quake.wire, !quake.ref
+  quake.sink %2#0 : !quake.wire
   return
 }
 

--- a/test/Quake/wire_sink.qke
+++ b/test/Quake/wire_sink.qke
@@ -41,6 +41,8 @@ func.func @red_button(%arg0: !quake.wire, %arg1: !quake.wire) {
   %1 = quake.reset %0 : (!quake.wire) -> !quake.wire
   %2 = quake.h %arg1 : (!quake.wire) -> !quake.wire
   quake.sink %1 : !quake.wire
+  %r = cc.undef !quake.ref
+  quake.wrap %2 to %r : !quake.wire, !quake.ref
   return
 }
 

--- a/test/Transforms/mapping_unitaries.qke
+++ b/test/Transforms/mapping_unitaries.qke
@@ -35,10 +35,10 @@ func.func @test_01() {
   %10:2 = quake.x [%9#0] %7#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %11:2 = quake.x [%9#1] %10#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %12:2 = quake.x [%8#0] %10#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.sink %12#0 : !quake.wire
   %13:2 = quake.x [%11#1] %11#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %14:2 = quake.x [%12#1] %13#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %15:2 = quake.x [%13#1] %14#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %13#0 : !quake.wire
   quake.sink %14#0 : !quake.wire
   quake.sink %15#0 : !quake.wire
   quake.sink %15#1 : !quake.wire
@@ -50,19 +50,17 @@ func.func @test_02() {
   %1 = quake.null_wire
   %2 = quake.null_wire
   %3 = quake.null_wire
-  %4 = quake.null_wire
   %5 = quake.null_wire
   %6:2 = quake.x [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %7:2 = quake.x [%6#1] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %8:2 = quake.x [%7#0] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %9:2 = quake.x [%7#1] %5 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %10:2 = quake.x [%6#0] %8#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.sink %10#0 : !quake.wire
   %11:2 = quake.x [%10#1] %9#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  %12:2 = quake.x [%11#0] %8#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %5 : !quake.wire
-  quake.sink %9#1 : !quake.wire
-  quake.sink %10#1 : !quake.wire
   quake.sink %11#1 : !quake.wire
+  %12:2 = quake.x [%11#0] %8#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.sink %9#1 : !quake.wire
   quake.sink %12#0 : !quake.wire
   quake.sink %12#1 : !quake.wire
   return
@@ -186,13 +184,13 @@ func.func @test_07() {
   %2 = quake.null_wire
   %3 = quake.null_wire
   %4 = quake.null_wire
-  %5 = quake.null_wire
+  %5 = quake.null_wire  
+  quake.sink %5 : !quake.wire
   %6:2 = quake.x [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %7:2 = quake.x [%6#1] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %8:2 = quake.x [%7#1] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %9:2 = quake.x [%8#1] %4 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %10:2 = quake.x [%6#0] %9#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %6#0 : !quake.wire
   quake.sink %7#0 : !quake.wire
   quake.sink %8#0 : !quake.wire
   quake.sink %9#0 : !quake.wire


### PR DESCRIPTION
These changes make !quake.wire a linear type and impose the "must be used exactly once" constraint in the IR.

Leaves work on cc.if as a TODO.
