### PR TITLE
[rt] Add missing openSSL guard for cudaq-qorca-qpu lib

### DIFF
--- a/runtime/cudaq/platform/CMakeLists.txt
+++ b/runtime/cudaq/platform/CMakeLists.txt
@@ -7,7 +7,9 @@
 # ============================================================================ #
 
 add_subdirectory(default)
-add_subdirectory(orca)
+if (OPENSSL_FOUND)
+  add_subdirectory(orca)
+endif()
 if (CUDA_FOUND AND CUSTATEVEC_ROOT)
   add_subdirectory(mqpu)
 endif()


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
The library depends on openssl, so it should only be build when its found (like the other rest-based platforms)
