### PR TITLE
Remove workaround for docker rootless

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -702,8 +702,6 @@ jobs:
             docker pull $cudaq_image
           fi
 
-          # Workaround for dockerd rootless
-          chown $(id -u):$(id -g) scripts/validate_container.sh
           docker run --rm -dit --name cuda-quantum $cudaq_image
           docker cp scripts/validate_container.sh cuda-quantum:"/home/cudaq/validate_container.sh"
           docker exec -e TERM=xterm cuda-quantum bash validate_container.sh > /tmp/validation.out


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This change was included in https://github.com/NVIDIA/cuda-quantum/pull/832 to support GHA runners using rootless docker, but we don't plan anymore to use rootless docker so we can remove it.
