### PR TITLE
Fixing build cache issue for non-main branches

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -62,7 +62,7 @@ jobs:
       llvm_commit: ${{ steps.repo_info.outputs.llvm_commit }}
       pybind11_commit: ${{ steps.repo_info.outputs.pybind11_commit }}
       cache_base: ${{ steps.build_info.outputs.cache_base }}
-      update_cache: ${{ steps.build_info.outputs.update_cache }}
+      cache_target: ${{ steps.build_info.outputs.cache_target }}
       multi_platform: ${{ steps.build_info.outputs.multi_platform }}
       platforms: ${{ steps.build_info.outputs.platforms }}
       environment: ${{ steps.build_info.outputs.environment }}
@@ -120,7 +120,7 @@ jobs:
           done
 
           cache_base=${{ (github.event_name == 'push' && 'main') || inputs.cache_base || steps.pr_info.outputs.pr_base }}
-          update_cache=${{ github.event_name != 'workflow_dispatch' || inputs.update_registry_cache }}
+          cache_target=${{ (! inputs.update_registry_cache && '') || steps.pr_info.outputs.pr_base || github.ref_name }}
           environment=${{ (github.event_name != 'workflow_run' && 'ghcr-deployment') || '' }}
 
           # Store deployment info
@@ -132,7 +132,7 @@ jobs:
           echo "release-version: $release_version" >> deployment_info.txt
 
           echo "cache_base=$cache_base" >> $GITHUB_OUTPUT
-          echo "update_cache=$update_cache" >> $GITHUB_OUTPUT
+          echo "cache_target=$cache_target" >> $GITHUB_OUTPUT
           echo "multi_platform=$(echo $multi_platform)" >> $GITHUB_OUTPUT
           echo "platforms=$(echo $platforms)" >> $GITHUB_OUTPUT
           echo "environment=$environment" >> $GITHUB_OUTPUT
@@ -174,7 +174,7 @@ jobs:
         llvm_commit=${{ needs.metadata.outputs.llvm_commit }}
         pybind11_commit=${{ needs.metadata.outputs.pybind11_commit }}
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
-      registry_cache_update: ${{ needs.metadata.outputs.update_cache == 'true' }}
+      update_registry_cache: ${{ needs.metadata.outputs.cache_target }}
       pull_request_number: ${{ needs.metadata.outputs.pull_request_number }}
       pull_request_commit: ${{ needs.metadata.outputs.pull_request_commit }}
       environment: ${{ needs.metadata.outputs.environment }}
@@ -202,7 +202,7 @@ jobs:
         llvm_commit=${{ needs.metadata.outputs.llvm_commit }}
         pybind11_commit=${{ needs.metadata.outputs.pybind11_commit }}
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
-      registry_cache_update: ${{ needs.metadata.outputs.update_cache == 'true' }}
+      update_registry_cache: ${{ needs.metadata.outputs.cache_target }}
       pull_request_number: ${{ needs.metadata.outputs.pull_request_number }}
       pull_request_commit: ${{ needs.metadata.outputs.pull_request_commit }}
       environment: ${{ needs.metadata.outputs.environment }}
@@ -222,7 +222,7 @@ jobs:
       platforms: ${{ fromJson(needs.metadata.outputs.multi_platform || needs.metadata.outputs.platforms)[format('{0}', matrix.platform)].docker_flag }}
       dockerfile: build/devdeps.ompi.Dockerfile
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
-      registry_cache_update: ${{ needs.metadata.outputs.update_cache == 'true' }}
+      update_registry_cache: ${{ needs.metadata.outputs.cache_target }}
       environment: ${{ needs.metadata.outputs.environment }}
       # needed only for the cloudposse GitHub action
       matrix_key: ${{ matrix.platform }}-ompi
@@ -286,7 +286,7 @@ jobs:
         base_image=${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-{1}', matrix.platform, needs.config.outputs.devdeps_toolchain)] }}
         ompidev_image=${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-ompi', matrix.platform)] }}
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
-      registry_cache_update: ${{ needs.metadata.outputs.update_cache == 'true' }}
+      update_registry_cache: ${{ needs.metadata.outputs.cache_target }}
       environment: ${{ needs.metadata.outputs.environment }}
       # needed only for the cloudposse GitHub action
       matrix_key: ${{ matrix.platform }}-ext

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       update_registry_cache:
         type: boolean
-        description: Create or update the build caches on the container registry.
+        description: Create or update the build caches on the container registry. The build terminates after that and no images are pushed.
         required: false
         default: false
       cache_base:
@@ -120,7 +120,7 @@ jobs:
           done
 
           cache_base=${{ (github.event_name == 'push' && 'main') || inputs.cache_base || steps.pr_info.outputs.pr_base }}
-          update_cache=${{ (github.event_name == 'workflow_dispatch' && inputs.update_registry_cache) || github.event_name == 'push' }}
+          update_cache=${{ github.event_name != 'workflow_dispatch' || inputs.update_registry_cache }}
           environment=${{ (github.event_name != 'workflow_run' && 'ghcr-deployment') || '' }}
 
           # Store deployment info
@@ -175,7 +175,6 @@ jobs:
         pybind11_commit=${{ needs.metadata.outputs.pybind11_commit }}
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
       registry_cache_update: ${{ needs.metadata.outputs.update_cache == 'true' }}
-      registry_cache_update_only: ${{ github.event_name == 'workflow_run' }}
       pull_request_number: ${{ needs.metadata.outputs.pull_request_number }}
       pull_request_commit: ${{ needs.metadata.outputs.pull_request_commit }}
       environment: ${{ needs.metadata.outputs.environment }}
@@ -204,7 +203,6 @@ jobs:
         pybind11_commit=${{ needs.metadata.outputs.pybind11_commit }}
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
       registry_cache_update: ${{ needs.metadata.outputs.update_cache == 'true' }}
-      registry_cache_update_only: ${{ github.event_name == 'workflow_run' }}
       pull_request_number: ${{ needs.metadata.outputs.pull_request_number }}
       pull_request_commit: ${{ needs.metadata.outputs.pull_request_commit }}
       environment: ${{ needs.metadata.outputs.environment }}
@@ -225,7 +223,6 @@ jobs:
       dockerfile: build/devdeps.ompi.Dockerfile
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
       registry_cache_update: ${{ needs.metadata.outputs.update_cache == 'true' }}
-      registry_cache_update_only: ${{ github.event_name == 'workflow_run' }}
       environment: ${{ needs.metadata.outputs.environment }}
       # needed only for the cloudposse GitHub action
       matrix_key: ${{ matrix.platform }}-ompi

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -24,10 +24,9 @@ on:
         required: false
         type: boolean
         default: false
-      registry_cache_update:
+      update_registry_cache:
         required: false
-        type: boolean
-        default: false
+        type: string
       additional_build_caches:
         required: false
         type: string
@@ -211,12 +210,6 @@ jobs:
           registry_cache_base=$(echo ${{ inputs.registry_cache_from || github.event.pull_request.base.ref || 'main' }} | tr / -)
           cache_id=$(echo ${{ needs.metadata.outputs.image_id }}${toolchain:+-$toolchain} | tr . -)
 
-          orig_gh_ref=${{ github.ref_name }}
-          if [ "$orig_gh_ref" != "${orig_gh_ref#pull-request/}" ]; then
-            # original branch prior to the move by copy-pr-bot
-            orig_gh_ref=${orig_gh_ref#pull-request/}/merge
-          fi
-
           # Local caches are always to and from a single location.
 
           platform_id=`echo "${{ inputs.platforms }}" | sed 's/linux\///g' | tr -d ' ' | tr ',' -`
@@ -226,16 +219,19 @@ jobs:
           if ${{ inputs.pull_request_number != '' }}; then
             local_buildcache_key="${{ inputs.pull_request_number }}/merge-cuda-quantum-${cache_id}-${platform_id}"
           else
-            local_cache_from=${{ inputs.local_cache_from }}
-            local_cache_from=$(echo ${local_cache_from:-$orig_gh_ref} | tr . -)
-            if ${{ inputs.local_cache_from == '' && github.event.pull_request.merged == true }}; then
+            if ${{ inputs.local_cache_from != '' }}; then
+              local_cache_from=${{ inputs.local_cache_from }}
+            elif ${{ github.event.pull_request.merged == true }}; then
               local_cache_from=${{ github.event.pull_request.number }}/merge
+            elif ${{ startsWith(github.ref_name, 'pull-request/') }}; then
+              local_cache_from=$(echo $ref_name | cut -d / -f2)/merge
             fi
+            local_cache_from=$(echo ${local_cache_from:-${{ github.ref_name }}} | tr . -)
             local_buildcache_key="${local_cache_from}-cuda-quantum-${cache_id}-${platform_id}"
           fi
 
-          if ${{ inputs.registry_cache_update }}; then
-            registry_cache_target=$(echo $orig_gh_ref | tr / -)
+          if ${{ inputs.update_registry_cache != '' }}; then
+            registry_cache_target=$(echo ${{ inputs.update_registry_cache }} | tr / -)
             build_cache="type=registry,ref=${registry_cache}-${cache_id}-${platform_id}:$registry_cache_target"
             cache_to="${build_cache},mode=max,ignore-error=false"
           elif ${{ inputs.create_local_cache }}; then
@@ -270,7 +266,7 @@ jobs:
           echo "cache_to=$cache_to" >> $GITHUB_OUTPUT
           echo "build_cache=$build_cache" >> $GITHUB_OUTPUT
           echo "registry_cache_base=$registry_cache_base" >> $GITHUB_OUTPUT
-          if ${{ inputs.environment && ! inputs.registry_cache_update }}; then
+          if ${{ inputs.environment && inputs.update_registry_cache == '' }}; then
             tar_archive=/tmp/${{ needs.metadata.outputs.image_id }}.tar
             echo "tar_cache=tar-${cache_id}-${platform_id}${local_buildcache_key_suffix}" >> $GITHUB_OUTPUT
             echo "tar_archive=$tar_archive" >> $GITHUB_OUTPUT
@@ -336,7 +332,7 @@ jobs:
 
       - name: Check for existing image
         id: uploaded_image
-        if: ! inputs.registry_cache_update
+        if: inputs.update_registry_cache == ''
         run: |
           if ${{ inputs.environment != '' }}; then
             image_hash=${{ needs.metadata.outputs.image_name }}@${{ steps.docker_build.outputs.digest }}
@@ -385,7 +381,7 @@ jobs:
 
       - name: Cache ${{ needs.metadata.outputs.image_title }} image
         id: cache_upload
-        if: ! inputs.registry_cache_update && steps.uploaded_image.outputs.image_hash == ''
+        if: inputs.update_registry_cache == '' && steps.uploaded_image.outputs.image_hash == ''
         uses: actions/cache/save@v3
         with:
           path: ${{ steps.cache.outputs.tar_archive }}

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -28,10 +28,6 @@ on:
         required: false
         type: boolean
         default: false
-      registry_cache_update_only:
-        required: false
-        type: boolean
-        default: false
       additional_build_caches:
         required: false
         type: string
@@ -238,7 +234,7 @@ jobs:
             local_buildcache_key="${local_cache_from}-cuda-quantum-${cache_id}-${platform_id}"
           fi
 
-          if ${{ inputs.registry_cache_update || inputs.registry_cache_update_only }}; then
+          if ${{ inputs.registry_cache_update }}; then
             registry_cache_target=$(echo $orig_gh_ref | tr / -)
             build_cache="type=registry,ref=${registry_cache}-${cache_id}-${platform_id}:$registry_cache_target"
             cache_to="${build_cache},mode=max,ignore-error=false"
@@ -274,7 +270,7 @@ jobs:
           echo "cache_to=$cache_to" >> $GITHUB_OUTPUT
           echo "build_cache=$build_cache" >> $GITHUB_OUTPUT
           echo "registry_cache_base=$registry_cache_base" >> $GITHUB_OUTPUT
-          if ${{ inputs.environment == '' && ! inputs.registry_cache_update_only }}; then
+          if ${{ inputs.environment && ! inputs.registry_cache_update }}; then
             tar_archive=/tmp/${{ needs.metadata.outputs.image_id }}.tar
             echo "tar_cache=tar-${cache_id}-${platform_id}${local_buildcache_key_suffix}" >> $GITHUB_OUTPUT
             echo "tar_archive=$tar_archive" >> $GITHUB_OUTPUT
@@ -308,15 +304,15 @@ jobs:
             ${{ steps.cache.outputs.cache_from_gh }}
             ${{ steps.cache.outputs.cache_from_registry }}
           cache-to: ${{ steps.cache.outputs.cache_to }}
-          push: ${{ inputs.environment && ! inputs.registry_cache_update_only || false }}
+          push: ${{ steps.cache.outputs.docker_output == '' }}
           outputs: ${{ steps.cache.outputs.docker_output }}
 
       - name: Install Cosign
-        if: inputs.environment
+        if: steps.cache.outputs.docker_output == ''
         uses: sigstore/cosign-installer@v3.1.1
 
       - name: Sign image with GitHub OIDC Token
-        if: inputs.environment
+        if: steps.cache.outputs.docker_output == ''
         env:
           DIGEST: ${{ steps.docker_build.outputs.digest }}
           TAGS: ${{ needs.metadata.outputs.image_tags }}
@@ -340,11 +336,12 @@ jobs:
 
       - name: Check for existing image
         id: uploaded_image
+        if: ! inputs.registry_cache_update
         run: |
-          if ${{ inputs.environment && ! inputs.registry_cache_update_only || false }}; then
+          if ${{ inputs.environment != '' }}; then
             image_hash=${{ needs.metadata.outputs.image_name }}@${{ steps.docker_build.outputs.digest }}
             echo "image_hash=$image_hash" >> $GITHUB_OUTPUT
-          elif ${{ steps.cache.outputs.docker_output != '' }}; then
+          else
             # Check if an image with the same layers exists on the registry.
             # If so, use that image instead of uploading a tar cache.
             load_output=`docker load --input "${{ steps.cache.outputs.tar_archive }}"`
@@ -388,7 +385,7 @@ jobs:
 
       - name: Cache ${{ needs.metadata.outputs.image_title }} image
         id: cache_upload
-        if: steps.cache.outputs.docker_output != '' && steps.uploaded_image.outputs.image_hash == ''
+        if: ! inputs.registry_cache_update && steps.uploaded_image.outputs.image_hash == ''
         uses: actions/cache/save@v3
         with:
           path: ${{ steps.cache.outputs.tar_archive }}


### PR DESCRIPTION
PR merges always updated the main build cache instead of the build cache of the target branch. 
I also took the opportunity to simplify the cache options - now a deployment either updates the build cache or it produces images, but never both, keeping it more comprehensive.