### PR TITLE
Add deprecated attributes to qreg and qspan.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
   set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
 
 # Generate a CompilationDatabase (compile_commands.json file) for our build,
 # for use by clang_complete, YouCompleteMe, etc.

--- a/runtime/cudaq/qis/qreg.h
+++ b/runtime/cudaq/qis/qreg.h
@@ -11,11 +11,20 @@
 #include "cudaq/qis/qspan.h"
 #include "host_config.h"
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 namespace cudaq {
 
 #if CUDAQ_USE_STD20
 namespace details {
-/// `qreg`<N> for N < 1 should be a compile error
+/// `qreg<N>` for N < 1 should be a compile error
 template <std::size_t N>
 concept ValidQregSize = N > 0;
 } // namespace details
@@ -32,7 +41,9 @@ template <std::size_t N = dyn, std::size_t Levels = 2>
 template <std::size_t N = dyn, std::size_t Levels = 2,
           typename = std::enable_if_t<(N > 0)>>
 #endif
-class qreg {
+class [[deprecated(
+    "The qreg type is deprecated in favor of qvector (for dynamic lengths) and "
+    "qarray (for constant lengths).")]] qreg {
 public:
   /// @brief Useful typedef indicating the underlying qudit type
   using value_type = qudit<Levels>;
@@ -134,3 +145,10 @@ qreg<dyn, 2>::qreg() : qudits(1) {}
 // Provide the default qreg q(SIZE) deduction guide
 qreg(std::size_t) -> qreg<dyn, 2>;
 } // namespace cudaq
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/runtime/cudaq/qis/qspan.h
+++ b/runtime/cudaq/qis/qspan.h
@@ -26,7 +26,7 @@ inline constexpr std::size_t dyn = ~0;
 // it models both dynamically allocated qudit registers as well as
 // compile-time sized qudit registers.
 template <std::size_t N = dyn, std::size_t Levels = 2>
-class qspan {
+class [[deprecated("The qspan type is deprecated in favor of qview.")]] qspan {
 public:
   // Useful typedef exposing the underlying qudit type
   // that this span contains.

--- a/test/AST-error/bad_sample_signature.cpp
+++ b/test/AST-error/bad_sample_signature.cpp
@@ -12,13 +12,17 @@
 
 struct bad {
   int operator()(int i) __qpu__ {
-    cudaq::qreg q(i);
+    cudaq::qvector q(i);
     h(q);
     mz(q);
     return i;
   }
 };
 
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}
 // expected-note@* {{}}
 // expected-note@* {{}}
 // expected-note@* {{}}

--- a/test/AST-error/capture_list.cpp
+++ b/test/AST-error/capture_list.cpp
@@ -27,3 +27,8 @@ struct LambdaCaptureList {
      D{}([i](cudaq::qubit& q) { h(q); }); // expected-error{{lambda expression with explicit captures is not yet supported}}
   }
 };
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/inaccessible_variable.cpp
+++ b/test/AST-error/inaccessible_variable.cpp
@@ -20,7 +20,7 @@ struct Kernel {
 int main() {
   int i;
   auto f = [&]() __qpu__ { // expected-remark{{An inaccessible symbol}}
-    cudaq::qreg q(i);
+    cudaq::qvector q(i);
     // expected-error@-1 {{symbol is not accessible in this kernel}}
     // expected-error@-2 {{statement not supported in qpu kernel}}
     mz(q);
@@ -30,3 +30,8 @@ int main() {
   Kernel{}(f);
   return 0;
 }
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/invalid_code.cpp
+++ b/test/AST-error/invalid_code.cpp
@@ -18,3 +18,8 @@ __qpu__ void invalid_code() {
     x(reg[i]);
   }
 }
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/invalid_kernel.cpp
+++ b/test/AST-error/invalid_kernel.cpp
@@ -13,43 +13,48 @@
 
 struct InvalidKernel1 {
   void operator()(void *m) __qpu__ { // expected-error{{kernel argument type not supported}}
-    cudaq::qreg reg(4);
+    cudaq::qvector reg(4);
     x(reg);
   }
 };
 
 struct InvalidKernel2 {
   void operator()(int *m) __qpu__ { // expected-error{{kernel argument type not supported}}
-    cudaq::qreg reg(4);
+    cudaq::qvector reg(4);
     x(reg);
   }
 };
 
 struct InvalidKernel2_1 {
   void operator()(int &m) __qpu__ { // expected-error{{kernel argument type not supported}}
-    cudaq::qreg reg(4);
+    cudaq::qvector reg(4);
     x(reg);
   }
 };
 
 struct InvalidKernel2_2 {
   void operator()(const int &m) __qpu__ { // expected-error{{kernel argument type not supported}}
-    cudaq::qreg reg(4);
+    cudaq::qvector reg(4);
     x(reg);
   }
 };
 
 struct InvalidKernel3_1 {
   void operator()(const std::set<int> &m) __qpu__ { // expected-error{{kernel argument type not supported}}
-    cudaq::qreg reg(4);
+    cudaq::qvector reg(4);
     x(reg);
   }
 };
 
 struct InvalidKernel4 {
    std::vector<int*> operator()() __qpu__ { // expected-error{{kernel result type not supported}}
-    cudaq::qreg reg(4);
+    cudaq::qvector reg(4);
     x(reg);
     return {};
   }
 };
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/kernel_data_members.cpp
+++ b/test/AST-error/kernel_data_members.cpp
@@ -23,3 +23,8 @@ struct D : public C { // expected-error{{class inheritance is not allowed for CU
     h(q);
   }
 };
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/kernel_invalid_argument-1.cpp
+++ b/test/AST-error/kernel_invalid_argument-1.cpp
@@ -30,3 +30,8 @@ int main() {
   RzArcTan2(true, {});
   return 0;
 }
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/kernel_invalid_argument-2.cpp
+++ b/test/AST-error/kernel_invalid_argument-2.cpp
@@ -37,7 +37,7 @@ std::bitset<nrOfBits> random_bits() {
 template <int nrOfBits>
 struct oracle {
   // expected-error@+1{{kernel argument type not supported}}
-  auto operator()(std::bitset<nrOfBits> bitvector, cudaq::qspan<> qs,
+  auto operator()(std::bitset<nrOfBits> bitvector, cudaq::qview<> qs,
                   cudaq::qubit &aux) __qpu__ {
 
     for (size_t i = 0; i < nrOfBits; i++) {
@@ -53,7 +53,7 @@ struct bernstein_vazirani {
   // expected-error@+1{{kernel argument type not supported}}
   auto operator()(std::bitset<nrOfBits> bitvector) __qpu__ {
 
-    cudaq::qreg<nrOfBits> qs;
+    cudaq::qarray<nrOfBits> qs;
     cudaq::qubit aux;
     h(aux);
     z(aux);
@@ -85,3 +85,8 @@ int main() {
 
   return 0;
 }
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/kernel_invalid_argument-3.cpp
+++ b/test/AST-error/kernel_invalid_argument-3.cpp
@@ -30,3 +30,8 @@ int main() {
   RzArcTan2(true, {});
   return 0;
 }
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/kernel_invalid_argument-4.cpp
+++ b/test/AST-error/kernel_invalid_argument-4.cpp
@@ -31,3 +31,8 @@ int main() {
   RzArcTan2(true, {});
   return 0;
 }
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/multiple_methods.cpp
+++ b/test/AST-error/multiple_methods.cpp
@@ -21,3 +21,8 @@ struct Sylvester {
 void foo() {
    Sylvester sylvester;
 }
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/negation_error.cpp
+++ b/test/AST-error/negation_error.cpp
@@ -12,8 +12,13 @@
 
 struct NegationOperatorTest {
   void operator()() __qpu__ {
-    cudaq::qreg qr(3);
+    cudaq::qvector qr(3);
     x<cudaq::ctrl>(qr[0], qr[1], !qr[2]); // expected-error{{target qubit cannot be negated}}
     rz(2.0, !qr[0]); // expected-error{{target qubit cannot be negated}}
   }
 };
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/quantum_types.cpp
+++ b/test/AST-error/quantum_types.cpp
@@ -10,35 +10,52 @@
 
 #include <cudaq.h>
 
+// expected-warning@*{{}}
+// expected-note@* {{}}
+
 struct S1 {
-  void operator()(cudaq::qspan<> q) { // expected-error{{may not use quantum types in non-kernel functions}}
+  // expected-warning@+3{{}}
+  // expected-note@* {{}}
+  // expected-error@+1{{may not use quantum types in non-kernel functions}}
+  void operator()(cudaq::qspan<> q) {
     mz(q);
   }
 };
 
 struct S2 {
   void operator()() {
-    cudaq::qubit b; // expected-error{{may not use quantum types in non-kernel functions}}
+    // expected-error@+1{{may not use quantum types in non-kernel functions}}
+    cudaq::qubit b;
     mz(b);
   }
 };
 
 struct S3 {
   void operator()() {
-    cudaq::qreg<4> r; // expected-error{{may not use quantum types in non-kernel functions}}
+    // expected-warning@+3{{}}
+    // expected-note@* {{}}
+    // expected-error@+1{{may not use quantum types in non-kernel functions}}
+    cudaq::qreg<4> r;
     mz(r);
   }
 };
 
 struct S4 {
-  void operator()(cudaq::qreg<4> r) { // expected-error{{may not use quantum types in non-kernel functions}}
+  // expected-warning@+3{{}}
+  // expected-note@* {{}}
+  // expected-error@+1{{may not use quantum types in non-kernel functions}}
+  void operator()(cudaq::qreg<4> r) {
     mz(r);
   }
 };
 
 struct S5 {
   void operator()() {
-     cudaq::qreg r(10); // expected-error{{may not use quantum types in non-kernel functions}}
+    // expected-warning@*{{}}
+    // expected-note@* {{}}
+    // expected-error@+1{{may not use quantum types in non-kernel functions}}
+    cudaq::qreg r(10);
     mz(r);
   }
 };
+

--- a/test/AST-error/statements.cpp
+++ b/test/AST-error/statements.cpp
@@ -57,3 +57,8 @@ struct S6 {
     printf("Hello\n");
   }
 };
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}

--- a/test/AST-error/wall.cpp
+++ b/test/AST-error/wall.cpp
@@ -18,3 +18,8 @@ struct S {
       foo();
    }
 };
+
+// expected-warning@* {{}}
+// expected-warning@* {{}}
+// expected-note@* {{}}
+// expected-note@* {{}}


### PR DESCRIPTION
Closes #75. Taking action on the old RFC.
