### PR TITLE
Fix for Issue#977

### DIFF
--- a/python/tests/backends/test_IonQ.py
+++ b/python/tests/backends/test_IonQ.py
@@ -27,6 +27,9 @@ def assert_close(got) -> bool:
 def startUpMockServer():
     os.environ["IONQ_API_KEY"] = "00000000000000000000000000000000"
 
+    # Set the targeted QPU
+    cudaq.set_target("ionq", url="http://localhost:{}".format(port))
+    
     # Launch the Mock Server
     p = Process(target=startServer, args=(port,))
     p.start()

--- a/python/tests/backends/test_Quantinuum.py
+++ b/python/tests/backends/test_Quantinuum.py
@@ -32,6 +32,9 @@ def startUpMockServer():
     f.close()
 
     cudaq.set_random_seed(13)
+    
+    # Set the targeted QPU
+    cudaq.set_target('quantinuum', url='http://localhost:{}'.format(port))
 
     # Launch the Mock Server
     p = Process(target=startServer, args=(port,))
@@ -48,7 +51,7 @@ def startUpMockServer():
 @pytest.fixture(scope="function", autouse=True)
 def configureTarget(startUpMockServer):
 
-    # Set the targeted QPU
+    # Set the targeted QPU with credentials
     cudaq.set_target('quantinuum',
                      url='http://localhost:{}'.format(port),
                      credentials=startUpMockServer)

--- a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
+++ b/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
@@ -195,7 +195,7 @@ protected:
       return;
 
     int dev;
-    cudaGetDevice(&dev);
+    HANDLE_CUDA_ERROR(cudaGetDevice(&dev));
     cudaq::info("GPU {} Allocating new qubit array of size {}.", dev, count);
 
     if (!deviceStateVector) {


### PR DESCRIPTION
* Some Python backend tests fail by reporting `custatevec` errors when running on a machine with GPUs
  - Set the target in test fixture that starts mock server 
  -  Wrap the call to `cudaGetDevice` in CUDA error handler for early catching


### Description
Addresses https://github.com/NVIDIA/cuda-quantum/issues/977
