### PR TITLE
Trivial anchor link fix in docs

### DIFF
--- a/docs/sphinx/api/default_ops.rst
+++ b/docs/sphinx/api/default_ops.rst
@@ -382,7 +382,7 @@ The template argument :code:`cudaq::adj` can be used to invoke the
 
 The template argument :code:`cudaq::ctrl` can be used to apply the transformation
 conditional on the state of one or more control qubits, see also this 
-`Wikipedia entry <https://en.wikipedia.org/wiki/Quantum_logic_gate#Controlled_gatese>`__.
+`Wikipedia entry <https://en.wikipedia.org/wiki/Quantum_logic_gate#Controlled_gates>`__.
 
 .. tab:: C++
 


### PR DESCRIPTION
Clicking this link in question resolves to a page (so the CI's link checker though it was valid), but it was to a non-existent anchor, so the browser takes you to the top of the page rather than the desired anchor. This fixes that.