### PR TITLE
Kernels with return values.

### DIFF
--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -19,6 +19,7 @@
 namespace cudaq {
 namespace cc {
 class LoopOp;
+class StructType;
 }
 
 namespace opt::factory {
@@ -39,6 +40,17 @@ inline mlir::Type getCharType(mlir::MLIRContext *ctx) {
 /// Return the LLVM-IR dialect `ptr` type.
 inline mlir::Type getPointerType(mlir::MLIRContext *ctx) {
   return mlir::LLVM::LLVMPointerType::get(getCharType(ctx));
+}
+
+/// The type of a dynamic buffer as returned via the runtime.
+cudaq::cc::StructType getDynamicBufferType(mlir::MLIRContext *ctx);
+
+/// Extract the element type of a sret return result.
+mlir::Type getSRetElementType(mlir::FunctionType funcTy);
+
+/// Do not use this yet. Opaque pointers are all or nothing.
+inline mlir::Type getOpaquePointerType(mlir::MLIRContext *ctx) {
+  return mlir::LLVM::LLVMPointerType::get(ctx, /*addressSpace=*/0);
 }
 
 /// Return the LLVM-IR dialect type: `ty*`.

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -45,7 +45,7 @@ inline mlir::Type getPointerType(mlir::MLIRContext *ctx) {
 /// The type of a dynamic buffer as returned via the runtime.
 cudaq::cc::StructType getDynamicBufferType(mlir::MLIRContext *ctx);
 
-/// Extract the element type of a sret return result.
+/// Extract the element type of a `sret` return result.
 mlir::Type getSRetElementType(mlir::FunctionType funcTy);
 
 /// Do not use this yet. Opaque pointers are all or nothing.

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -20,7 +20,7 @@ namespace cudaq {
 namespace cc {
 class LoopOp;
 class StructType;
-}
+} // namespace cc
 
 namespace opt::factory {
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -19,3 +19,18 @@
 
 #define GET_TYPEDEF_CLASSES
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h.inc"
+
+namespace quake {
+/// \returns true if \p ty is a quantum value or reference.
+inline bool isaQuantumType(mlir::Type ty) {
+  // NB: this intentionally excludes MeasureType.
+  return llvm::isa<quake::RefType, quake::VeqType, quake::WireType,
+                   quake::ControlType>(ty);
+}
+
+/// \returns true if \p ty is a Quake type.
+inline bool isQuakeType(mlir::Type ty) {
+  // This should correspond to the registered types in QuakeTypes.cpp.
+  return isaQuantumType(ty) || llvm::isa<quake::MeasureType>(ty);
+}
+} // namespace quake

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -21,14 +21,14 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h.inc"
 
 namespace quake {
-/// \returns true if \p ty is a quantum value or reference.
+/// \returns true if \p `ty` is a quantum value or reference.
 inline bool isaQuantumType(mlir::Type ty) {
   // NB: this intentionally excludes MeasureType.
   return llvm::isa<quake::RefType, quake::VeqType, quake::WireType,
                    quake::ControlType>(ty);
 }
 
-/// \returns true if \p ty is a Quake type.
+/// \returns true if \p `ty` is a Quake type.
 inline bool isQuakeType(mlir::Type ty) {
   // This should correspond to the registered types in QuakeTypes.cpp.
   return isaQuantumType(ty) || llvm::isa<quake::MeasureType>(ty);

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -167,9 +167,9 @@ def MeasureType : QuakeType<"Measure", "measure"> {
   let summary = "a classical result produced by a quantum measurement";
   let description = [{
     A quantum measurement captures the state of a qubit and returns a classical
-    value from the measurement. Depending on the target system this value may
-    have two or more logical states. Typically, a value of type `measure` is
-    considered a binary bit.
+    regular (not linear) value from the measurement. Depending on the target
+    system this value may have two or more logical states. Typically, a value of
+    type `measure` will be discriminated into a binary bit.
 
     ```mlir
       %m = quake.mz %0 : (!quake.ref) -> !quake.measure

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -11,15 +11,15 @@
 
 include "mlir/Pass/PassBase.td"
 
-
-def ApplyControlNegations : Pass<"apply-control-negations", "mlir::func::FuncOp"> {
+def ApplyControlNegations :
+    Pass<"apply-control-negations", "mlir::func::FuncOp"> {
   let summary =
     "Replace all operations with negative controls with positive controls and X operations.";
 
   let description = [{
     For every quantum operation with a negative control, replace that operation 
-    with an X operation on the control qubit, the controlled operation with positive 
-    polarity, and a final X operation on the control qubit. 
+    with an X operation on the control qubit, the controlled operation with
+    positive polarity, and a final X operation on the control qubit. 
   }];
 }
 

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -149,8 +149,15 @@ cudaq::cc::LoopOp factory::createInvariantLoop(
 }
 
 bool factory::hasHiddenSRet(FunctionType funcTy) {
-  return funcTy.getNumResults() == 1 &&
-         funcTy.getResult(0).isa<cudaq::cc::StdvecType>();
+  // If a function has more than 1 result, the results are promoted to a
+  // structured return argument. Otherwise, if there is 1 result and it is an
+  // aggregate type, then it is promoted to a structured return argument.
+  auto numResults = funcTy.getNumResults();
+  return numResults > 1 ||
+         (numResults == 1 &&
+          funcTy.getResult(0)
+              .isa<cudaq::cc::StdvecType, cudaq::cc::StructType,
+                   cudaq::cc::ArrayType, cudaq::cc::CallableType>());
 }
 
 // FIXME: We should get the underlying structure of a std::vector from the
@@ -162,27 +169,44 @@ static cudaq::cc::StructType stlVectorType(Type eleTy) {
   return cudaq::cc::StructType::get(ctx, eleTys);
 }
 
+cudaq::cc::StructType factory::getDynamicBufferType(MLIRContext *ctx) {
+  auto ptrTy = cudaq::cc::PointerType::get(IntegerType::get(ctx, 8));
+  return cudaq::cc::StructType::get(
+      ctx, ArrayRef<Type>{ptrTy, IntegerType::get(ctx, 64)});
+}
+
+Type factory::getSRetElementType(FunctionType funcTy) {
+  assert(funcTy.getNumResults() && "function type must have results");
+  auto *ctx = funcTy.getContext();
+  if (funcTy.getNumResults() > 1)
+    return cudaq::cc::StructType::get(ctx, funcTy.getResults());
+  if (isa<cudaq::cc::StdvecType>(funcTy.getResult(0)))
+    return getDynamicBufferType(ctx);
+  return funcTy.getResult(0);
+}
+
 FunctionType factory::toCpuSideFuncType(FunctionType funcTy, bool addThisPtr) {
   auto *ctx = funcTy.getContext();
   // When the kernel comes from a class, there is always a default "this"
   // argument to the kernel entry function. The CUDA Quantum language spec
   // doesn't allow the kernel object to contain data members (yet), so we can
   // ignore the `this` pointer.
-  auto ptrTy = cudaq::cc::PointerType::get(IntegerType::get(ctx, 8));
   SmallVector<Type> inputTys;
-  // If this kernel is a plain old function or a static member function, we
-  // don't want to add a hidden `this` argument.
-  if (addThisPtr)
-    inputTys.push_back(ptrTy);
   bool hasSRet = false;
   if (factory::hasHiddenSRet(funcTy)) {
     // When the kernel is returning a std::vector<T> result, the result is
     // returned via a sret argument in the first position. When this argument
     // is added, the this pointer becomes the second argument. Both are opaque
     // pointers at this point.
-    inputTys.push_back(ptrTy);
+    auto eleTy = getSRetElementType(funcTy);
+    inputTys.push_back(cudaq::cc::PointerType::get(eleTy));
     hasSRet = true;
   }
+  // If this kernel is a plain old function or a static member function, we
+  // don't want to add a hidden `this` argument.
+  auto ptrTy = cudaq::cc::PointerType::get(IntegerType::get(ctx, 8));
+  if (addThisPtr)
+    inputTys.push_back(ptrTy);
 
   // Add all the explicit (not hidden) arguments after the hidden ones.
   for (auto inTy : funcTy.getInputs()) {

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -762,12 +762,10 @@ public:
   // code.
   bool hasLegalType(FunctionType funTy) {
     for (auto ty : funTy.getInputs())
-      if (isa<quake::RefType, quake::VeqType, quake::WireType,
-              quake::ControlType>(ty))
+      if (quake::isaQuantumType(ty))
         return false;
     for (auto ty : funTy.getResults())
-      if (isa<quake::RefType, quake::VeqType, quake::WireType,
-              quake::ControlType>(ty))
+      if (quake::isaQuantumType(ty))
         return false;
     return true;
   }

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -334,6 +334,7 @@ public:
                           funcOp.getLoc());
     auto elePtrTy = cudaq::cc::PointerType::get(eleTy);
     auto insPt = builder.saveInsertionPoint();
+    SmallVector<Operation *> returnsToErase;
     // Update all func.return to store values to the sret block.
     funcOp->walk([&](func::ReturnOp retOp) {
       auto loc = retOp.getLoc();
@@ -375,8 +376,10 @@ public:
         builder.create<cudaq::cc::StoreOp>(loc, retOp.getOperands()[0], cast);
       }
       builder.create<func::ReturnOp>(loc);
-      retOp->erase();
+      returnsToErase.push_back(retOp);
     });
+    for (auto *op : returnsToErase)
+      op->erase();
     builder.restoreInsertionPoint(insPt);
     for (std::size_t i = 0, end = funcOp.getNumResults(); i != end; ++i)
       funcOp.eraseResult(0);

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -341,7 +341,7 @@ public:
       auto cast = builder.create<cudaq::cc::CastOp>(loc, elePtrTy,
                                                     funcOp.getArgument(0));
       if (funcOp.getNumResults() > 1) {
-        for (std::size_t i = 0, end = funcOp.getNumResults(); i != end; ++i) {
+        for (int i = 0, end = funcOp.getNumResults(); i != end; ++i) {
           auto mem = builder.create<cudaq::cc::ComputePtrOp>(
               loc, cudaq::cc::PointerType::get(funcTy.getResult(i)), cast,
               SmallVector<cudaq::cc::ComputePtrArg>{0, i});
@@ -436,7 +436,7 @@ public:
     auto structTy = structPtrTy.cast<cudaq::cc::PointerType>()
                         .getElementType()
                         .cast<cudaq::cc::StructType>();
-    auto offset = funcTy.getNumInputs();
+    int offset = funcTy.getNumInputs();
     if (hiddenSRet) {
       // Use the end of the argument block for the return values.
       auto eleTy = structTy.getMembers()[offset];

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -68,35 +68,35 @@ public:
                                         FunctionType funcTy) {
     auto *ctx = funcTy.getContext();
     SmallVector<Type> eleTys;
-    // Add all argument types, translating std::vector to a length.
-    for (auto inTy : funcTy.getInputs()) {
-      if (inTy.isa<cudaq::cc::CallableType, cudaq::cc::StructType>())
-        eleTys.push_back(IntegerType::get(ctx, 64));
-      else if (inTy.isa<cudaq::cc::StdvecType, quake::VeqType>())
-        eleTys.push_back(IntegerType::get(ctx, 64));
-      else
-        eleTys.push_back(inTy);
-    }
-    // Add all result types, translating std::vector to a length.
-    for (auto outTy : funcTy.getResults()) {
-      if (outTy.isa<cudaq::cc::CallableType, cudaq::cc::StructType>()) {
-        eleTys.push_back(IntegerType::get(ctx, 64));
-      } else if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(outTy)) {
-        eleTys.push_back(cudaq::cc::PointerType::get(vecTy.getElementType()));
-        eleTys.push_back(IntegerType::get(ctx, 64));
+    auto i64Ty = IntegerType::get(ctx, 64);
+    // Add all argument types, translating std::vector to a length or pointer
+    // and length.
+    auto pushType = [&](const bool isOutput, Type ty) {
+      if (isa<cudaq::cc::CallableType>(ty)) {
+        eleTys.push_back(cudaq::cc::PointerType::get(ctx));
+      } else if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(ty)) {
+        if (isOutput)
+          eleTys.push_back(cudaq::cc::PointerType::get(vecTy.getElementType()));
+        eleTys.push_back(i64Ty);
+      } else if (auto strTy = dyn_cast<cudaq::cc::StructType>(ty);
+                 strTy && strTy.getMembers().empty()) {
+        eleTys.push_back(i64Ty);
       } else {
-        eleTys.push_back(outTy);
+        eleTys.push_back(ty);
       }
-    }
+    };
+
+    for (auto inTy : funcTy.getInputs())
+      pushType(false, inTy);
+    for (auto outTy : funcTy.getResults())
+      pushType(true, outTy);
     return cudaq::cc::StructType::get(ctx, eleTys);
   }
 
   FunctionType getThunkType(MLIRContext *ctx) {
     auto ptrTy = cudaq::cc::PointerType::get(IntegerType::get(ctx, 8));
-    return FunctionType::get(
-        ctx, {ptrTy, IntegerType::get(ctx, 1)},
-        {cudaq::cc::StructType::get(
-            ctx, ArrayRef<Type>{ptrTy, IntegerType::get(ctx, 64)})});
+    return FunctionType::get(ctx, {ptrTy, IntegerType::get(ctx, 1)},
+                             {cudaq::opt::factory::getDynamicBufferType(ctx)});
   }
 
   /// Add LLVM code with the OpBuilder that computes the size in bytes
@@ -319,6 +319,69 @@ public:
     return argsCreatorFunc;
   }
 
+  void updateQPUKernelAsSRet(OpBuilder &builder, func::FuncOp funcOp,
+                             FunctionType newFuncTy) {
+    auto funcTy = funcOp.getFunctionType();
+    // We add exactly 1 sret argument regardless of how many fields are folded
+    // into it.
+    assert(newFuncTy.getNumInputs() == funcTy.getNumInputs() + 1 &&
+           "sret should be a single argument");
+    auto *ctx = funcOp.getContext();
+    auto eleTy = cudaq::opt::factory::getSRetElementType(funcTy);
+    NamedAttrList attrs;
+    attrs.set(LLVM::LLVMDialect::getStructRetAttrName(), TypeAttr::get(eleTy));
+    funcOp.insertArgument(0, newFuncTy.getInput(0), attrs.getDictionary(ctx),
+                          funcOp.getLoc());
+    auto elePtrTy = cudaq::cc::PointerType::get(eleTy);
+    auto insPt = builder.saveInsertionPoint();
+    // Update all func.return to store values to the sret block.
+    funcOp->walk([&](func::ReturnOp retOp) {
+      auto loc = retOp.getLoc();
+      builder.setInsertionPoint(retOp);
+      auto cast = builder.create<cudaq::cc::CastOp>(loc, elePtrTy,
+                                                    funcOp.getArgument(0));
+      if (funcOp.getNumResults() > 1) {
+        for (std::size_t i = 0, end = funcOp.getNumResults(); i != end; ++i) {
+          auto mem = builder.create<cudaq::cc::ComputePtrOp>(
+              loc, cudaq::cc::PointerType::get(funcTy.getResult(i)), cast,
+              SmallVector<cudaq::cc::ComputePtrArg>{0, i});
+          builder.create<cudaq::cc::StoreOp>(loc, retOp.getOperands()[i], mem);
+        }
+      } else if (auto stdvecTy =
+                     dyn_cast<cudaq::cc::StdvecType>(funcTy.getResult(0))) {
+        auto stdvec = retOp.getOperands()[0];
+        auto eleTy = [&]() -> Type {
+          // TODO: Fold this conversion into the StdvecDataOp builder. We will
+          // never get a data buffer which is not byte addressable and where
+          // the width is less than 8.
+          if (auto intTy = dyn_cast<IntegerType>(stdvecTy.getElementType()))
+            if (intTy.getWidth() < 8)
+              return builder.getI8Type();
+          return stdvecTy.getElementType();
+        }();
+        auto ptrTy = cudaq::cc::PointerType::get(eleTy);
+        auto data = builder.create<cudaq::cc::StdvecDataOp>(loc, ptrTy, stdvec);
+        auto mem0 = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, cudaq::cc::PointerType::get(ptrTy), cast,
+            SmallVector<cudaq::cc::ComputePtrArg>{0, 0});
+        builder.create<cudaq::cc::StoreOp>(loc, data, mem0);
+        auto i64Ty = builder.getI64Type();
+        auto size = builder.create<cudaq::cc::StdvecSizeOp>(loc, i64Ty, stdvec);
+        auto mem1 = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, cudaq::cc::PointerType::get(i64Ty), cast,
+            SmallVector<cudaq::cc::ComputePtrArg>{0, 1});
+        builder.create<cudaq::cc::StoreOp>(loc, size, mem1);
+      } else {
+        builder.create<cudaq::cc::StoreOp>(loc, retOp.getOperands()[0], cast);
+      }
+      builder.create<func::ReturnOp>(loc);
+      retOp->erase();
+    });
+    builder.restoreInsertionPoint(insPt);
+    for (std::size_t i = 0, end = funcOp.getNumResults(); i != end; ++i)
+      funcOp.eraseResult(0);
+  }
+
   /// Generate the thunk function. This function is called by the library
   /// callback function to "unpack" the arguments and pass them to the kernel
   /// function on the QPU side. The thunk will also save any return values to
@@ -359,6 +422,35 @@ public:
     // Unpack the arguments in the struct and build the argument list for
     // the call to the kernel code.
     SmallVector<Value> args;
+    const bool hiddenSRet = cudaq::opt::factory::hasHiddenSRet(funcTy);
+    FunctionType newFuncTy = [&]() {
+      if (hiddenSRet) {
+        auto sretPtrTy = cudaq::cc::PointerType::get(
+            cudaq::opt::factory::getSRetElementType(funcTy));
+        SmallVector<Type> inputTys = {sretPtrTy};
+        inputTys.append(funcTy.getInputs().begin(), funcTy.getInputs().end());
+        return FunctionType::get(ctx, inputTys, {});
+      }
+      return funcTy;
+    }();
+    auto structTy = structPtrTy.cast<cudaq::cc::PointerType>()
+                        .getElementType()
+                        .cast<cudaq::cc::StructType>();
+    auto offset = funcTy.getNumInputs();
+    if (hiddenSRet) {
+      // Use the end of the argument block for the return values.
+      auto eleTy = structTy.getMembers()[offset];
+      auto mem = builder.create<cudaq::cc::ComputePtrOp>(
+          loc, cudaq::cc::PointerType::get(eleTy), cast,
+          SmallVector<cudaq::cc::ComputePtrArg>{0, offset});
+      auto sretPtrTy = cudaq::cc::PointerType::get(
+          cudaq::opt::factory::getSRetElementType(funcTy));
+      auto sretMem = builder.create<cudaq::cc::CastOp>(loc, sretPtrTy, mem);
+      args.push_back(sretMem);
+
+      // Rewrite the original kernel's signature and return op(s).
+      updateQPUKernelAsSRet(builder, funcOp, newFuncTy);
+    }
     for (auto inp : llvm::enumerate(funcTy.getInputs())) {
       Type inTy = inp.value();
       std::int64_t idx = inp.index();
@@ -392,41 +484,25 @@ public:
             builder.create<cudaq::cc::ExtractValueOp>(loc, inTy, val, off));
       }
     }
-    auto call = builder.create<func::CallOp>(loc, funcTy.getResults(),
+    auto call = builder.create<func::CallOp>(loc, newFuncTy.getResults(),
                                              funcOp.getName(), args);
-    auto offset = funcTy.getNumInputs();
-    bool hasVectorResult = false;
-    // If and only if the kernel returns results, then take those values and
-    // store them in the results section of the struct. They will eventually
-    // be returned to the original caller.
-    for (auto res : llvm::enumerate(funcTy.getResults())) {
-      int off = res.index() + offset;
-      if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(res.value())) {
-        auto callResult = call.getResult(res.index());
-        auto ptrTy = cudaq::cc::PointerType::get(vecTy.getElementType());
-        auto gep0 = builder.create<cudaq::cc::ComputePtrOp>(
-            loc, cudaq::cc::PointerType::get(ptrTy), cast,
-            SmallVector<cudaq::cc::ComputePtrArg>{0, off});
-        auto pointer =
-            builder.create<cudaq::cc::StdvecDataOp>(loc, ptrTy, callResult);
-        builder.create<cudaq::cc::StoreOp>(loc, pointer, gep0);
-        auto lenTy = builder.getI64Type();
-        auto gep1 = builder.create<cudaq::cc::ComputePtrOp>(
-            loc, cudaq::cc::PointerType::get(lenTy), cast,
-            SmallVector<cudaq::cc::ComputePtrArg>{0, off + 1});
-        auto length =
-            builder.create<cudaq::cc::StdvecSizeOp>(loc, lenTy, callResult);
-        builder.create<cudaq::cc::StoreOp>(loc, length, gep1);
-        offset++;
-        hasVectorResult = true;
-      } else {
-        auto gep = builder.create<cudaq::cc::ComputePtrOp>(
-            loc, cudaq::cc::PointerType::get(res.value()), cast,
-            SmallVector<cudaq::cc::ComputePtrArg>{0, off});
-        builder.create<cudaq::cc::StoreOp>(loc, call.getResult(res.index()),
-                                           gep);
-      }
+    // If and only if the kernel returns non-sret results, then take those
+    // values and store them in the results section of the struct. They will
+    // eventually be returned to the original caller.
+    if (!hiddenSRet && funcTy.getNumResults() == 1) {
+      auto eleTy = structTy.getMembers()[offset];
+      auto mem = builder.create<cudaq::cc::ComputePtrOp>(
+          loc, cudaq::cc::PointerType::get(eleTy), cast,
+          SmallVector<cudaq::cc::ComputePtrArg>{0, offset});
+      builder.create<cudaq::cc::StoreOp>(loc, call.getResult(0), mem);
     }
+
+    // If the original result was a std::vector<T>, then depending on whether
+    // this is client-server or not, the thunk function packs the dynamic return
+    // data into a message buffer or just returns a pointer to the shared heap
+    // allocation, resp.
+    bool hasVectorResult = funcTy.getNumResults() == 1 &&
+                           isa<cudaq::cc::StdvecType>(funcTy.getResult(0));
     if (hasVectorResult) {
       auto *currentBlock = builder.getBlock();
       auto *reg = currentBlock->getParent();
@@ -437,20 +513,22 @@ public:
                                        elseBlock);
       builder.setInsertionPointToEnd(thenBlock);
       int offset = funcTy.getNumInputs();
-      auto structTy = structPtrTy.cast<cudaq::cc::PointerType>()
-                          .getElementType()
-                          .cast<cudaq::cc::StructType>();
       auto gepRes = builder.create<cudaq::cc::ComputePtrOp>(
           loc, cudaq::cc::PointerType::get(structTy.getMembers()[offset]), cast,
           SmallVector<cudaq::cc::ComputePtrArg>{0, offset});
       auto gepRes2 = builder.create<cudaq::cc::CastOp>(
           loc, cudaq::cc::PointerType::get(thunkTy.getResults()[0]), gepRes);
+      // createDynamicResult packs the input values and the dynamic results
+      // into a single buffer to pass back as a message.
       auto res = builder.create<func::CallOp>(
           loc, thunkTy.getResults()[0], "__nvqpp_createDynamicResult",
           ValueRange{thunkEntry->getArgument(0), structSize, gepRes2});
       builder.create<func::ReturnOp>(loc, res.getResult(0));
       builder.setInsertionPointToEnd(elseBlock);
     }
+    // zeroDynamicResult is used by models other than client-server. It assumes
+    // that no messages need to be sent, the CPU and QPU code share a memory
+    // space, and therefore skips making any copies.
     auto zeroRes =
         builder.create<func::CallOp>(loc, thunkTy.getResults()[0],
                                      "__nvqpp_zeroDynamicResult", ValueRange{});
@@ -474,10 +552,12 @@ public:
 
   static MutableArrayRef<BlockArgument>
   dropAnyHiddenArguments(MutableArrayRef<BlockArgument> args,
-                         FunctionType funcTy) {
+                         FunctionType funcTy, bool hasThisPointer) {
+    unsigned count = hasThisPointer ? 1 : 0;
+    if (cudaq::opt::factory::hasHiddenSRet(funcTy))
+      ++count;
     if (!args.empty() && isa<cudaq::cc::PointerType>(args[0].getType()))
-      return args.drop_front(cudaq::opt::factory::hasHiddenSRet(funcTy) ? 2
-                                                                        : 1);
+      return args.drop_front(count);
     return args;
   }
 
@@ -512,15 +592,15 @@ public:
     }
     auto rewriteEntry =
         builder.create<func::FuncOp>(loc, mangledAttr.getValue(), newFuncTy);
-    if (cudaq::opt::factory::hasHiddenSRet(funcTy)) {
+    const bool hiddenSRet = cudaq::opt::factory::hasHiddenSRet(funcTy);
+    if (hiddenSRet) {
       // The first argument should be a pointer type if this function has a
       // hidden sret.
       if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(
               rewriteEntry.getFunctionType().getInput(0))) {
-        auto eleTy = ptrTy.getElementType();
-        rewriteEntry.setArgAttr(0,
-                                mlir::LLVM::LLVMDialect::getStructRetAttrName(),
-                                mlir::TypeAttr::get(eleTy));
+        auto eleTy = cudaq::opt::factory::getSRetElementType(funcTy);
+        rewriteEntry.setArgAttr(0, LLVM::LLVMDialect::getStructRetAttrName(),
+                                TypeAttr::get(eleTy));
       }
     }
 
@@ -535,7 +615,7 @@ public:
     Value extraBytes = zero;
     bool hasTrailingData = false;
     for (auto inp : llvm::enumerate(dropAnyHiddenArguments(
-             rewriteEntryBlock->getArguments(), funcTy))) {
+             rewriteEntryBlock->getArguments(), funcTy, addThisPtr))) {
       Value arg = inp.value();
       Type inTy = arg.getType();
       std::int64_t idx = inp.index();
@@ -660,7 +740,17 @@ public:
         auto gep = builder.create<cudaq::cc::ComputePtrOp>(
             loc, cudaq::cc::PointerType::get(res.value()), temp,
             SmallVector<cudaq::cc::ComputePtrArg>{0, off});
-        results.push_back(builder.create<cudaq::cc::LoadOp>(loc, gep));
+        Value loadVal = builder.create<cudaq::cc::LoadOp>(loc, gep);
+        if (hiddenSRet) {
+          auto castPtr = builder.create<cudaq::cc::CastOp>(
+              loc, temp.getType(), rewriteEntryBlock->getArguments().front());
+          auto outPtr = builder.create<cudaq::cc::ComputePtrOp>(
+              loc, cudaq::cc::PointerType::get(res.value()), castPtr,
+              SmallVector<cudaq::cc::ComputePtrArg>{0, off});
+          builder.create<cudaq::cc::StoreOp>(loc, loadVal, outPtr);
+        } else {
+          results.push_back(loadVal);
+        }
       }
     }
     builder.create<func::ReturnOp>(loc, results);
@@ -672,10 +762,12 @@ public:
   // code.
   bool hasLegalType(FunctionType funTy) {
     for (auto ty : funTy.getInputs())
-      if (ty.isa<quake::RefType, quake::VeqType>())
+      if (isa<quake::RefType, quake::VeqType, quake::WireType,
+              quake::ControlType>(ty))
         return false;
     for (auto ty : funTy.getResults())
-      if (ty.isa<quake::RefType, quake::VeqType>())
+      if (isa<quake::RefType, quake::VeqType, quake::WireType,
+              quake::ControlType>(ty))
         return false;
     return true;
   }
@@ -692,6 +784,8 @@ public:
     auto builder = OpBuilder::atBlockEnd(module.getBody());
     auto mangledNameMap =
         module->getAttrOfType<DictionaryAttr>("quake.mangled_name_map");
+    if (mangledNameMap.empty())
+      return;
     auto irBuilder = cudaq::IRBuilder::atBlockEnd(module.getBody());
     if (failed(irBuilder.loadIntrinsic(module,
                                        cudaq::runtime::launchKernelFuncName))) {
@@ -770,6 +864,8 @@ public:
       auto argsCreatorFunc = genKernelArgsCreatorFunction(
           loc, builder, classNameStr, structPtrTy, funcTy);
 
+      if (!mangledNameMap.contains(funcOp.getName()))
+        continue;
       auto mangledAttr = mangledNameMap.getAs<StringAttr>(funcOp.getName());
       assert(mangledAttr && "funcOp must appear in mangled name map");
       auto thunkNameStr = thunk.getName().str();

--- a/test/Quake-QIR/return_values.qke
+++ b/test/Quake-QIR/return_values.qke
@@ -1,0 +1,470 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --add-dealloc --kernel-execution --canonicalize %s | \
+// RUN: cudaq-translate --convert-to=qir | FileCheck %s
+
+// NB: the mangled name map is required for the kernel-execution pass.
+module attributes{ quake.mangled_name_map = {
+  __nvqpp__mlirgen__test_0 = "test_0",
+  __nvqpp__mlirgen__test_1 = "test_1",
+  __nvqpp__mlirgen__test_2 = "test_2",
+  __nvqpp__mlirgen__test_3 = "test_3",
+  __nvqpp__mlirgen__test_4 = "test_4",
+  __nvqpp__mlirgen__test_5 = "test_5" }} {
+
+func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<i8> , %arg1: i64 , %arg2: i64 ) -> !cc.ptr<i8>
+
+func.func @__nvqpp__mlirgen__test_0(%arg0: i32) -> !cc.stdvec<i1> {
+  %c1_i64 = arith.constant 1 : i64
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %0 = cc.alloca i32
+  cc.store %arg0, %0 : !cc.ptr<i32>
+  %1 = cc.load %0 : !cc.ptr<i32>
+  %2 = arith.extsi %1 : i32 to i64
+  %3 = quake.alloca !quake.veq<?>[%2 : i64]
+  %4 = quake.veq_size %3 : (!quake.veq<?>) -> i64
+  %5 = arith.index_cast %4 : i64 to index
+  %6 = cc.loop while ((%arg1 = %c0) -> (index)) {
+    %12 = arith.cmpi slt, %arg1, %5 : index
+    cc.condition %12(%arg1 : index)
+  } do {
+  ^bb0(%arg1: index):
+    %12 = quake.extract_ref %3[%arg1] : (!quake.veq<?>, index) -> !quake.ref
+    quake.h %12 : (!quake.ref) -> ()
+    cc.continue %arg1 : index
+  } step {
+  ^bb0(%arg1: index):
+    %12 = arith.addi %arg1, %c1 : index
+    cc.continue %12 : index
+  } {invariant}
+  %measOut = quake.mz %3 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
+  %7 = quake.discriminate %measOut : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+  %8 = cc.stdvec_data %7 : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+  %9 = cc.stdvec_size %7 : (!cc.stdvec<i1>) -> i64
+  %10 = call @__nvqpp_vectorCopyCtor(%8, %9, %c1_i64) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+  %11 = cc.stdvec_init %10, %9 : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
+  return %11 : !cc.stdvec<i1>
+}
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_0({ i8*, i64 }* nocapture writeonly sret({ i8*, i64 })
+// CHECK-SAME:      %[[VAL_0:.*]], i32 %[[VAL_1:.*]])
+// CHECK:         %[[VAL_2:.*]] = sext i32 %[[VAL_1]] to i64
+// CHECK:         %[[VAL_3:.*]] = tail call %[[VAL_4:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_2]])
+// CHECK:         %[[VAL_5:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_4]]* %[[VAL_3]])
+// CHECK:         %[[VAL_6:.*]] = icmp sgt i64 %[[VAL_5]], 0
+// CHECK:         br i1 %[[VAL_6]], label %[[VAL_7:.*]], label %[[VAL_8:.*]]
+// CHECK:       .{{.*}}:                                           ; preds = %[[VAL_9:.*]], %[[VAL_7]]
+// CHECK:         %[[VAL_10:.*]] = phi i64 [ %[[VAL_11:.*]], %[[VAL_7]] ], [ 0, %[[VAL_9]] ]
+// CHECK:         %[[VAL_12:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_4]]* %[[VAL_3]], i64 %[[VAL_10]])
+// CHECK:         %[[VAL_13:.*]] = bitcast i8* %[[VAL_12]] to %[[VAL_14:.*]]**
+// CHECK:         %[[VAL_15:.*]] = load %[[VAL_14]]*, %[[VAL_14]]** %[[VAL_13]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_14]]* %[[VAL_15]])
+// CHECK:         %[[VAL_11]] = add nuw nsw i64 %[[VAL_10]], 1
+// CHECK:         %[[VAL_16:.*]] = icmp eq i64 %[[VAL_11]], %[[VAL_5]]
+// CHECK:         br i1 %[[VAL_16]], label %[[VAL_8]], label %[[VAL_7]]
+// CHECK:       .{{.*}}:                                      ; preds = %[[VAL_7]], %[[VAL_9]]
+// CHECK:         %[[VAL_17:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_4]]* %[[VAL_3]])
+// CHECK:         %[[VAL_18:.*]] = alloca i1, i64 %[[VAL_17]], align 1
+// CHECK:         %[[VAL_19:.*]] = icmp sgt i64 %[[VAL_17]], 0
+// CHECK:         br i1 %[[VAL_19]], label %[[VAL_20:.*]], label %[[VAL_21:.*]]
+// CHECK:       .{{.*}}:                                          ; preds = %[[VAL_8]], %[[VAL_20]]
+// CHECK:         %[[VAL_22:.*]] = phi i64 [ %[[VAL_23:.*]], %[[VAL_20]] ], [ 0, %[[VAL_8]] ]
+// CHECK:         %[[VAL_24:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_4]]* %[[VAL_3]], i64 %[[VAL_22]])
+// CHECK:         %[[VAL_25:.*]] = bitcast i8* %[[VAL_24]] to %[[VAL_14]]**
+// CHECK:         %[[VAL_26:.*]] = load %[[VAL_14]]*, %[[VAL_14]]** %[[VAL_25]], align 8
+// CHECK:         %[[VAL_27:.*]] = tail call %[[VAL_28:.*]]* @__quantum__qis__mz(%[[VAL_14]]* %[[VAL_26]])
+// CHECK:         %[[VAL_29:.*]] = bitcast %[[VAL_28]]* %[[VAL_27]] to i1*
+// CHECK:         %[[VAL_30:.*]] = load i1, i1* %[[VAL_29]], align 1
+// CHECK:         %[[VAL_31:.*]] = getelementptr i1, i1* %[[VAL_18]], i64 %[[VAL_22]]
+// CHECK:         store i1 %[[VAL_30]], i1* %[[VAL_31]], align 1
+// CHECK:         %[[VAL_23]] = add nuw nsw i64 %[[VAL_22]], 1
+// CHECK:         %[[VAL_32:.*]] = icmp eq i64 %[[VAL_23]], %[[VAL_17]]
+// CHECK:         br i1 %[[VAL_32]], label %[[VAL_21]], label %[[VAL_20]]
+// CHECK:       .{{.*}}:                                     ; preds = %[[VAL_20]], %[[VAL_8]]
+// CHECK:         %[[VAL_33:.*]] = bitcast i1* %[[VAL_18]] to i8*
+// CHECK:         %[[VAL_34:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_33]], i64 %[[VAL_17]], i64 1)
+// CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_4]]* %[[VAL_3]])
+// CHECK:         %[[VAL_35:.*]] = getelementptr { i8*, i64 }, { i8*, i64 }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i8* %[[VAL_34]], i8** %[[VAL_35]], align 8
+// CHECK:         %[[VAL_36:.*]] = getelementptr { i8*, i64 }, { i8*, i64 }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store i64 %[[VAL_17]], i64* %[[VAL_36]], align 8
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @__nvqpp__mlirgen__test_1() -> !cc.struct<{i1, i1}> {
+  %qubits = quake.alloca !quake.veq<2>
+  %q0 = quake.extract_ref %qubits[0] : (!quake.veq<2>) -> !quake.ref
+  %q1 = quake.extract_ref %qubits[1] : (!quake.veq<2>) -> !quake.ref
+  quake.h %q0 : (!quake.ref) -> ()
+  quake.x [%q0] %q1 : (!quake.ref, !quake.ref) -> ()
+  %m0 = quake.mz %q0 : (!quake.ref) -> !quake.measure
+  %m1 = quake.mz %q1 : (!quake.ref) -> !quake.measure
+  %rv = cc.undef !cc.struct<{i1, i1}>
+  %d1 = quake.discriminate %m0 : (!quake.measure) -> i1
+  %rv1 = cc.insert_value %d1, %rv[0] : (!cc.struct<{i1, i1}>, i1) -> !cc.struct<{i1, i1}>
+  %d2 = quake.discriminate %m1 : (!quake.measure) -> i1
+  %rv2 = cc.insert_value %d2, %rv1[1] : (!cc.struct<{i1, i1}>, i1) -> !cc.struct<{i1, i1}>
+  return %rv2 : !cc.struct<{i1, i1}>
+}
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_1({ i1, i1 }* nocapture writeonly sret({ i1, i1 })
+// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK:         %[[VAL_1:.*]] = tail call %[[VAL_2:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
+// CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 0)
+// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to %[[VAL_5:.*]]**
+// CHECK:         %[[VAL_6:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_4]], align 8
+// CHECK:         %[[VAL_7:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 1)
+// CHECK:         %[[VAL_8:.*]] = bitcast i8* %[[VAL_7]] to %[[VAL_5]]**
+// CHECK:         %[[VAL_9:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_8]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_5]]* %[[VAL_6]])
+// CHECK:         tail call void (i64, void (%[[VAL_2]]*, %[[VAL_5]]*)*, ...) @invokeWithControlQubits(i64 1, void (%[[VAL_2]]*, %[[VAL_5]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_5]]* %[[VAL_6]], %[[VAL_5]]* %[[VAL_9]])
+// CHECK:         %[[VAL_10:.*]] = tail call %[[VAL_11:.*]]* @__quantum__qis__mz(%[[VAL_5]]* %[[VAL_6]])
+// CHECK:         %[[VAL_12:.*]] = bitcast %[[VAL_11]]* %[[VAL_10]] to i1*
+// CHECK:         %[[VAL_13:.*]] = load i1, i1* %[[VAL_12]], align 1
+// CHECK:         %[[VAL_14:.*]] = tail call %[[VAL_11]]* @__quantum__qis__mz(%[[VAL_5]]* %[[VAL_9]])
+// CHECK:         %[[VAL_15:.*]] = bitcast %[[VAL_11]]* %[[VAL_14]] to i1*
+// CHECK:         %[[VAL_16:.*]] = load i1, i1* %[[VAL_15]], align 1
+// CHECK:         %[[VAL_17:.*]] = getelementptr inbounds { i1, i1 }, { i1, i1 }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i1 %[[VAL_13]], i1* %[[VAL_17]], align 1
+// CHECK:         %[[VAL_18:.*]] = getelementptr inbounds { i1, i1 }, { i1, i1 }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store i1 %[[VAL_16]], i1* %[[VAL_18]], align 1
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_2]]* %[[VAL_1]])
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @__nvqpp__mlirgen__test_2() -> !cc.struct<{i16, f32, f64, i64}> {
+  %rv = cc.undef !cc.struct<{i16, f32, f64, i64}>
+  %c1 = arith.constant 8 : i16
+  %rv1 = cc.insert_value %c1, %rv[0] : (!cc.struct<{i16, f32, f64, i64}>, i16) -> !cc.struct<{i16, f32, f64, i64}>
+  %c2 = arith.constant 5.4 : f32
+  %rv2 = cc.insert_value %c2, %rv1[1] : (!cc.struct<{i16, f32, f64, i64}>, f32) -> !cc.struct<{i16, f32, f64, i64}>
+  %c3 = arith.constant 37.83 : f64
+  %rv3 = cc.insert_value %c3, %rv2[2] : (!cc.struct<{i16, f32, f64, i64}>, f64) -> !cc.struct<{i16, f32, f64, i64}>
+  %c4 = arith.constant 1479 : i64
+  %rv4 = cc.insert_value %c4, %rv3[3] : (!cc.struct<{i16, f32, f64, i64}>, i64) -> !cc.struct<{i16, f32, f64, i64}>
+  return %rv4 : !cc.struct<{i16, f32, f64, i64}>
+}
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 }) 
+// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK:         store { i16, float, double, i64 } { i16 8, float {{.*}}, double 3{{.*}}, i64 1479 }, { i16, float, double, i64 }* %[[VAL_0]], align 8
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @__nvqpp__mlirgen__test_3() -> !cc.array<i64 x 5> {
+  %rv = cc.undef !cc.array<i64 x 5>
+  %c1 = arith.constant 5 : i64
+  %rv1 = cc.insert_value %c1, %rv[0] : (!cc.array<i64 x 5>, i64) -> !cc.array<i64 x 5>
+  %c2 = arith.constant 74 : i64
+  %rv2 = cc.insert_value %c2, %rv1[1] : (!cc.array<i64 x 5>, i64) -> !cc.array<i64 x 5>
+  %c3 = arith.constant 299 : i64
+  %rv3 = cc.insert_value %c3, %rv2[2] : (!cc.array<i64 x 5>, i64) -> !cc.array<i64 x 5>
+  %c4 = arith.constant 1659 : i64
+  %rv4 = cc.insert_value %c4, %rv3[3] : (!cc.array<i64 x 5>, i64) -> !cc.array<i64 x 5>
+  %c5 = arith.constant 61234 : i64
+  %rv5 = cc.insert_value %c5, %rv4[4] : (!cc.array<i64 x 5>, i64) -> !cc.array<i64 x 5>
+  return %rv5 : !cc.array<i64 x 5>
+}
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_3([5 x i64]* nocapture writeonly sret([5 x i64])
+// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK:         %[[VAL_1:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 0
+// CHECK:         store i64 5, i64* %[[VAL_1]], align 8
+// CHECK:         %[[VAL_2:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 1
+// CHECK:         store i64 74, i64* %[[VAL_2]], align 8
+// CHECK:         %[[VAL_3:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 2
+// CHECK:         store i64 299, i64* %[[VAL_3]], align 8
+// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 3
+// CHECK:         store i64 1659, i64* %[[VAL_4]], align 8
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 4
+// CHECK:         store i64 61234, i64* %[[VAL_5]], align 8
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @__nvqpp__mlirgen__test_4() -> (i64, f64) {
+  %c1 = arith.constant 537892 : i64
+  %c2 = arith.constant 94.2134 : f64
+  return %c1, %c2 : i64, f64
+}
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_4({ i64, double }* nocapture writeonly sret({ i64, double })
+// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK:         %[[VAL_1:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i64 537892, i64* %[[VAL_1]], align 8
+// CHECK:         %[[VAL_2:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store double {{.*}}, double* %[[VAL_2]], align 8
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @__nvqpp__mlirgen__test_5() -> (i64, f64) attributes {no_this} {
+  %c1 = arith.constant 537892 : i64
+  %c2 = arith.constant 94.2134 : f64
+  return %c1, %c2 : i64, f64
+}
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_5({ i64, double }* nocapture writeonly sret({ i64, double })
+// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK:         %[[VAL_1:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i64 537892, i64* %[[VAL_1]], align 8
+// CHECK:         %[[VAL_2:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store double {{.*}}, double* %[[VAL_2]], align 8
+// CHECK:         ret void
+// CHECK:       }
+
+}
+
+// CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* nocapture 
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i32*
+// CHECK:         %[[VAL_3:.*]] = load i32, i32* %[[VAL_2]], align 4
+// CHECK:         %[[VAL_4:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_5:.*]] = sext i32 %[[VAL_3]] to i64
+// CHECK:         %[[VAL_6:.*]] = tail call %[[VAL_7:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_5]])
+// CHECK:         %[[VAL_8:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_7]]* %[[VAL_6]])
+// CHECK:         %[[VAL_9:.*]] = icmp sgt i64 %[[VAL_8]], 0
+// CHECK:         br i1 %[[VAL_9]], label %[[VAL_10:.*]], label %[[VAL_11:.*]]
+// CHECK:       .{{.*}}:                                           ; preds = %[[VAL_12:.*]], %[[VAL_10]]
+// CHECK:         %[[VAL_13:.*]] = phi i64 [ %[[VAL_14:.*]], %[[VAL_10]] ], [ 0, %[[VAL_12]] ]
+// CHECK:         %[[VAL_15:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]]* %[[VAL_6]], i64 %[[VAL_13]])
+// CHECK:         %[[VAL_16:.*]] = bitcast i8* %[[VAL_15]] to %[[VAL_17:.*]]**
+// CHECK:         %[[VAL_18:.*]] = load %[[VAL_17]]*, %[[VAL_17]]** %[[VAL_16]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_17]]* %[[VAL_18]])
+// CHECK:         %[[VAL_14]] = add nuw nsw i64 %[[VAL_13]], 1
+// CHECK:         %[[VAL_19:.*]] = icmp eq i64 %[[VAL_14]], %[[VAL_8]]
+// CHECK:         br i1 %[[VAL_19]], label %[[VAL_11]], label %[[VAL_10]]
+// CHECK:       .{{.*}}:                                      ; preds = %[[VAL_10]], %[[VAL_12]]
+// CHECK:         %[[VAL_20:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_7]]* %[[VAL_6]])
+// CHECK:         %[[VAL_21:.*]] = alloca i1, i64 %[[VAL_20]], align 1
+// CHECK:         %[[VAL_22:.*]] = icmp sgt i64 %[[VAL_20]], 0
+// CHECK:         br i1 %[[VAL_22]], label %[[VAL_23:.*]], label %[[VAL_24:.*]]
+// CHECK:       .{{.*}}:                                          ; preds = %[[VAL_11]], %[[VAL_23]]
+// CHECK:         %[[VAL_25:.*]] = phi i64 [ %[[VAL_26:.*]], %[[VAL_23]] ], [ 0, %[[VAL_11]] ]
+// CHECK:         %[[VAL_27:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]]* %[[VAL_6]], i64 %[[VAL_25]])
+// CHECK:         %[[VAL_28:.*]] = bitcast i8* %[[VAL_27]] to %[[VAL_17]]**
+// CHECK:         %[[VAL_29:.*]] = load %[[VAL_17]]*, %[[VAL_17]]** %[[VAL_28]], align 8
+// CHECK:         %[[VAL_30:.*]] = tail call %[[VAL_31:.*]]* @__quantum__qis__mz(%[[VAL_17]]* %[[VAL_29]])
+// CHECK:         %[[VAL_32:.*]] = bitcast %[[VAL_31]]* %[[VAL_30]] to i1*
+// CHECK:         %[[VAL_33:.*]] = load i1, i1* %[[VAL_32]], align 1
+// CHECK:         %[[VAL_34:.*]] = getelementptr i1, i1* %[[VAL_21]], i64 %[[VAL_25]]
+// CHECK:         store i1 %[[VAL_33]], i1* %[[VAL_34]], align 1
+// CHECK:         %[[VAL_26]] = add nuw nsw i64 %[[VAL_25]], 1
+// CHECK:         %[[VAL_35:.*]] = icmp eq i64 %[[VAL_26]], %[[VAL_20]]
+// CHECK:         br i1 %[[VAL_35]], label %[[VAL_24]], label %[[VAL_23]]
+// CHECK:       .{{.*}}:                                     ; preds = %[[VAL_23]], %[[VAL_11]]
+// CHECK:         %[[VAL_36:.*]] = bitcast i1* %[[VAL_21]] to i8*
+// CHECK:         %[[VAL_37:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_36]], i64 %[[VAL_20]], i64 1)
+// CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_7]]* %[[VAL_6]])
+// CHECK:         %[[VAL_38:.*]] = bitcast i8* %[[VAL_4]] to i8**
+// CHECK:         store i8* %[[VAL_37]], i8** %[[VAL_38]], align 8
+// CHECK:         %[[VAL_39:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
+// CHECK:         %[[VAL_40:.*]] = bitcast i8* %[[VAL_39]] to i64*
+// CHECK:         store i64 %[[VAL_20]], i64* %[[VAL_40]], align 4
+// CHECK:         br i1 %[[VAL_1]], label %[[VAL_41:.*]], label %[[VAL_42:.*]]
+// CHECK:       :                                       ; preds = %[[VAL_24]], %[[VAL_41]]
+// CHECK:         %[[VAL_43:.*]] = phi { i8*, i64 } [ %[[VAL_44:.*]], %[[VAL_41]] ], [ zeroinitializer, %[[VAL_24]] ]
+// CHECK:         ret { i8*, i64 } %[[VAL_43]]
+// CHECK:       32:                                               ; preds = %[[VAL_24]]
+// CHECK:         %[[VAL_45:.*]] = add i64 %[[VAL_20]], 24
+// CHECK:         %[[VAL_46:.*]] = call i8* @malloc(i64 %[[VAL_45]])
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_46]], i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_0]], i64 24, i1 false)
+// CHECK:         %[[VAL_47:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 24
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_47]], i8* align 1 %[[VAL_37]], i64 %[[VAL_20]], i1 false)
+// CHECK:         %[[VAL_48:.*]] = insertvalue { i8*, i64 } undef, i8* %[[VAL_46]], 0
+// CHECK:         %[[VAL_44]] = insertvalue { i8*, i64 } %[[VAL_48]], i64 %[[VAL_45]], 1
+// CHECK:         br label %[[VAL_42]]
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_0({ i8*, i64 }* sret({ i8*, i64 }) 
+// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]], i32 %[[VAL_2:.*]])
+// CHECK:         %[[VAL_3:.*]] = alloca { i32, i1*, i64 }, align 8
+// CHECK:         %[[VAL_4:.*]] = bitcast { i32, i1*, i64 }* %[[VAL_3]] to i8*
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds { i32, i1*, i64 }, { i32, i1*, i64 }* %[[VAL_3]], i64 0, i32 0
+// CHECK:         store i32 %[[VAL_2]], i32* %[[VAL_5]], align 8
+// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_0.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_0.thunk to i8*), i8* nonnull %[[VAL_4]], i64 24, i64 8)
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds { i32, i1*, i64 }, { i32, i1*, i64 }* %[[VAL_3]], i64 0, i32 1
+// CHECK:         %[[VAL_7:.*]] = bitcast i1** %[[VAL_6]] to i8**
+// CHECK:         %[[VAL_8:.*]] = load i8*, i8** %[[VAL_7]], align 8
+// CHECK:         %[[VAL_9:.*]] = getelementptr inbounds { i32, i1*, i64 }, { i32, i1*, i64 }* %[[VAL_3]], i64 0, i32 2
+// CHECK:         %[[VAL_10:.*]] = load i64, i64* %[[VAL_9]], align 8
+// CHECK:         %[[VAL_11:.*]] = bitcast { i8*, i64 }* %[[VAL_0]] to i8*
+// CHECK:         call void @__nvqpp_initializer_list_to_vector_bool(i8* %[[VAL_11]], i8* %[[VAL_8]], i64 %[[VAL_10]])
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* nocapture writeonly 
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
+// CHECK:         %[[VAL_4:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_3]]* %[[VAL_2]], i64 0)
+// CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_4]] to %[[VAL_6:.*]]**
+// CHECK:         %[[VAL_7:.*]] = load %[[VAL_6]]*, %[[VAL_6]]** %[[VAL_5]], align 8
+// CHECK:         %[[VAL_8:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_3]]* %[[VAL_2]], i64 1)
+// CHECK:         %[[VAL_9:.*]] = bitcast i8* %[[VAL_8]] to %[[VAL_6]]**
+// CHECK:         %[[VAL_10:.*]] = load %[[VAL_6]]*, %[[VAL_6]]** %[[VAL_9]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_6]]* %[[VAL_7]])
+// CHECK:         tail call void (i64, void (%[[VAL_3]]*, %[[VAL_6]]*)*, ...) @invokeWithControlQubits(i64 1, void (%[[VAL_3]]*, %[[VAL_6]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_6]]* %[[VAL_7]], %[[VAL_6]]* %[[VAL_10]])
+// CHECK:         %[[VAL_11:.*]] = tail call %[[VAL_12:.*]]* @__quantum__qis__mz(%[[VAL_6]]* %[[VAL_7]])
+// CHECK:         %[[VAL_13:.*]] = bitcast %[[VAL_12]]* %[[VAL_11]] to i1*
+// CHECK:         %[[VAL_14:.*]] = load i1, i1* %[[VAL_13]], align 1
+// CHECK:         %[[VAL_15:.*]] = tail call %[[VAL_12]]* @__quantum__qis__mz(%[[VAL_6]]* %[[VAL_10]])
+// CHECK:         %[[VAL_16:.*]] = bitcast %[[VAL_12]]* %[[VAL_15]] to i1*
+// CHECK:         %[[VAL_17:.*]] = load i1, i1* %[[VAL_16]], align 1
+// CHECK:         %[[VAL_18:.*]] = bitcast i8* %[[VAL_0]] to i1*
+// CHECK:         store i1 %[[VAL_14]], i1* %[[VAL_18]], align 1
+// CHECK:         %[[VAL_19:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 1
+// CHECK:         %[[VAL_20:.*]] = bitcast i8* %[[VAL_19]] to i1*
+// CHECK:         store i1 %[[VAL_17]], i1* %[[VAL_20]], align 1
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
+// CHECK:         ret { i8*, i64 } zeroinitializer
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_1({ i1, i1 }* nocapture writeonly sret({ i1, i1 }) 
+// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]])
+// CHECK:         %[[VAL_2:.*]] = alloca [2 x i8], align 8
+// CHECK:         %[[VAL_3:.*]] = getelementptr inbounds [2 x i8], [2 x i8]* %[[VAL_2]], i64 0, i64 0
+// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_3]], i64 2, i64 0)
+// CHECK:         %[[VAL_4:.*]] = bitcast [2 x i8]* %[[VAL_2]] to i1*
+// CHECK:         %[[VAL_5:.*]] = load i1, i1* %[[VAL_4]], align 8
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds [2 x i8], [2 x i8]* %[[VAL_2]], i64 0, i64 1
+// CHECK:         %[[VAL_7:.*]] = bitcast i8* %[[VAL_6]] to i1*
+// CHECK:         %[[VAL_8:.*]] = load i1, i1* %[[VAL_7]], align 1
+// CHECK:         %[[VAL_9:.*]] = getelementptr inbounds { i1, i1 }, { i1, i1 }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i1 %[[VAL_5]], i1* %[[VAL_9]], align 1
+// CHECK:         %[[VAL_10:.*]] = getelementptr inbounds { i1, i1 }, { i1, i1 }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store i1 %[[VAL_8]], i1* %[[VAL_10]], align 1
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_2.thunk(i8* nocapture writeonly 
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]])
+// CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to { i16, float, double, i64 }*
+// CHECK:         store { i16, float, double, i64 } { i16 8, float {{.*}}, double 3{{.*}}, i64 1479 }, { i16, float, double, i64 }* %[[VAL_2]], align 8
+// CHECK:         ret { i8*, i64 } zeroinitializer
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 }) 
+// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]])
+// CHECK:         %[[VAL_2:.*]] = alloca { { i16, float, double, i64 } }, align 8
+// CHECK:         %[[VAL_3:.*]] = bitcast { { i16, float, double, i64 } }* %[[VAL_2]] to i8*
+// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_2.thunk to i8*), i8* nonnull %[[VAL_3]], i64 24, i64 0)
+// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds { { i16, float, double, i64 } }, { { i16, float, double, i64 } }* %[[VAL_2]], i64 0, i32 0, i32 0
+// CHECK:         %[[VAL_5:.*]] = load i16, i16* %[[VAL_4]], align 8
+// CHECK:         %[[VAL_6:.*]] = insertvalue { i16, float, double, i64 } poison, i16 %[[VAL_5]], 0
+// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { { i16, float, double, i64 } }, { { i16, float, double, i64 } }* %[[VAL_2]], i64 0, i32 0, i32 1
+// CHECK:         %[[VAL_8:.*]] = load float, float* %[[VAL_7]], align 4
+// CHECK:         %[[VAL_9:.*]] = insertvalue { i16, float, double, i64 } %[[VAL_6]], float %[[VAL_8]], 1
+// CHECK:         %[[VAL_10:.*]] = getelementptr inbounds { { i16, float, double, i64 } }, { { i16, float, double, i64 } }* %[[VAL_2]], i64 0, i32 0, i32 2
+// CHECK:         %[[VAL_11:.*]] = load double, double* %[[VAL_10]], align 8
+// CHECK:         %[[VAL_12:.*]] = insertvalue { i16, float, double, i64 } %[[VAL_9]], double %[[VAL_11]], 2
+// CHECK:         %[[VAL_13:.*]] = getelementptr inbounds { { i16, float, double, i64 } }, { { i16, float, double, i64 } }* %[[VAL_2]], i64 0, i32 0, i32 3
+// CHECK:         %[[VAL_14:.*]] = load i64, i64* %[[VAL_13]], align 8
+// CHECK:         %[[VAL_15:.*]] = insertvalue { i16, float, double, i64 } %[[VAL_12]], i64 %[[VAL_14]], 3
+// CHECK:         store { i16, float, double, i64 } %[[VAL_15]], { i16, float, double, i64 }* %[[VAL_0]], align 8
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_3.thunk(i8* nocapture writeonly 
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]])
+// CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
+// CHECK:         store i64 5, i64* %[[VAL_2]], align 4
+// CHECK:         %[[VAL_3:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to i64*
+// CHECK:         store i64 74, i64* %[[VAL_4]], align 4
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 16
+// CHECK:         %[[VAL_6:.*]] = bitcast i8* %[[VAL_5]] to i64*
+// CHECK:         store i64 299, i64* %[[VAL_6]], align 4
+// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 24
+// CHECK:         %[[VAL_8:.*]] = bitcast i8* %[[VAL_7]] to i64*
+// CHECK:         store i64 1659, i64* %[[VAL_8]], align 4
+// CHECK:         %[[VAL_9:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 32
+// CHECK:         %[[VAL_10:.*]] = bitcast i8* %[[VAL_9]] to i64*
+// CHECK:         store i64 61234, i64* %[[VAL_10]], align 4
+// CHECK:         ret { i8*, i64 } zeroinitializer
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_3([5 x i64]* nocapture writeonly sret([5 x i64]) 
+// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]])
+// CHECK:         %[[VAL_2:.*]] = alloca { [5 x i64] }, align 8
+// CHECK:         %[[VAL_3:.*]] = bitcast { [5 x i64] }* %[[VAL_2]] to i8*
+// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_3.thunk to i8*), i8* nonnull %[[VAL_3]], i64 40, i64 0)
+// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds { [5 x i64] }, { [5 x i64] }* %[[VAL_2]], i64 0, i32 0, i64 0
+// CHECK:         %[[VAL_5:.*]] = load i64, i64* %[[VAL_4]], align 8
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds { [5 x i64] }, { [5 x i64] }* %[[VAL_2]], i64 0, i32 0, i64 1
+// CHECK:         %[[VAL_7:.*]] = load i64, i64* %[[VAL_6]], align 8
+// CHECK:         %[[VAL_8:.*]] = getelementptr inbounds { [5 x i64] }, { [5 x i64] }* %[[VAL_2]], i64 0, i32 0, i64 2
+// CHECK:         %[[VAL_9:.*]] = load i64, i64* %[[VAL_8]], align 8
+// CHECK:         %[[VAL_10:.*]] = getelementptr inbounds { [5 x i64] }, { [5 x i64] }* %[[VAL_2]], i64 0, i32 0, i64 3
+// CHECK:         %[[VAL_11:.*]] = load i64, i64* %[[VAL_10]], align 8
+// CHECK:         %[[VAL_12:.*]] = getelementptr inbounds { [5 x i64] }, { [5 x i64] }* %[[VAL_2]], i64 0, i32 0, i64 4
+// CHECK:         %[[VAL_13:.*]] = load i64, i64* %[[VAL_12]], align 8
+// CHECK:         %[[VAL_14:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 0
+// CHECK:         store i64 %[[VAL_5]], i64* %[[VAL_14]], align 8
+// CHECK:         %[[VAL_15:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 1
+// CHECK:         store i64 %[[VAL_7]], i64* %[[VAL_15]], align 8
+// CHECK:         %[[VAL_16:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 2
+// CHECK:         store i64 %[[VAL_9]], i64* %[[VAL_16]], align 8
+// CHECK:         %[[VAL_17:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 3
+// CHECK:         store i64 %[[VAL_11]], i64* %[[VAL_17]], align 8
+// CHECK:         %[[VAL_18:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 4
+// CHECK:         store i64 %[[VAL_13]], i64* %[[VAL_18]], align 8
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_4.thunk(i8* nocapture writeonly 
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
+// CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
+// CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
+// CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to double*
+// CHECK:         store double {{.*}}, double* %[[VAL_4]], align 8
+// CHECK:         ret { i8*, i64 } zeroinitializer
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_4({ i64, double }* nocapture writeonly sret({ i64, double }) 
+// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]])
+// CHECK:         %[[VAL_2:.*]] = alloca { i64, double }, align 8
+// CHECK:         %[[VAL_3:.*]] = bitcast { i64, double }* %[[VAL_2]] to i8*
+// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_4.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_4.thunk to i8*), i8* nonnull %[[VAL_3]], i64 16, i64 0)
+// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_2]], i64 0, i32 0
+// CHECK:         %[[VAL_5:.*]] = load i64, i64* %[[VAL_4]], align 8
+// CHECK:         %[[VAL_6:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i64 %[[VAL_5]], i64* %[[VAL_6]], align 8
+// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_2]], i64 0, i32 1
+// CHECK:         %[[VAL_8:.*]] = load double, double* %[[VAL_7]], align 8
+// CHECK:         %[[VAL_9:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store double %[[VAL_8]], double* %[[VAL_9]], align 8
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_5.thunk(i8* nocapture writeonly 
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
+// CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
+// CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
+// CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to double*
+// CHECK:         store double {{.*}}, double* %[[VAL_4]], align 8
+// CHECK:         ret { i8*, i64 } zeroinitializer
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_5({ i64, double }* nocapture writeonly sret({ i64, double }) 
+// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK:         %[[VAL_2:.*]] = alloca { i64, double }, align 8
+// CHECK:         %[[VAL_3:.*]] = bitcast { i64, double }* %[[VAL_2]] to i8*
+// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_5.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_5.thunk to i8*), i8* nonnull %[[VAL_3]], i64 16, i64 0)
+// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_2]], i64 0, i32 0
+// CHECK:         %[[VAL_5:.*]] = load i64, i64* %[[VAL_4]], align 8
+// CHECK:         %[[VAL_6:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i64 %[[VAL_5]], i64* %[[VAL_6]], align 8
+// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_2]], i64 0, i32 1
+// CHECK:         %[[VAL_8:.*]] = load double, double* %[[VAL_7]], align 8
+// CHECK:         %[[VAL_9:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store double %[[VAL_8]], double* %[[VAL_9]], align 8
+// CHECK:         ret void
+// CHECK:       }
+

--- a/test/Quake/lambda_variable-1.qke
+++ b/test/Quake/lambda_variable-1.qke
@@ -11,44 +11,42 @@
 // Tests the basic functionality of passing closures as runtime values. Much of
 // the mechanism generated here is expected to be aggressively inlined.
 
-module attributes{ qtx.mangled_name_map = { __nvqpp__mlirgen__test3_callee = "_ZN12test3_calleeclEOSt8functionIFvRN4cudaq5quditILm2EEEEERNS1_4qregILm18446744073709551615ELm2EEE", __nvqpp__mlirgen__test3_caller = "_ZN12test3_callerclEv"}} {
-  func.func @__nvqpp__mlirgen__test3_callee(%arg0: !cc.callable<(!quake.ref) -> ()>, %arg1: !quake.veq<?>) attributes {"cudaq-kernel"} {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = arith.extsi %c0_i32 : i32 to i64
-    %1 = quake.extract_ref %arg1[%0] : (!quake.veq<?>,i64) -> !quake.ref
-    cc.call_callable %arg0, %1 : (!cc.callable<(!quake.ref) -> ()>, !quake.ref) -> ()
-    %c1_i32 = arith.constant 1 : i32
-    %2 = arith.extsi %c1_i32 : i32 to i64
-    %3 = quake.extract_ref %arg1[%2] : (!quake.veq<?>,i64) -> !quake.ref
-    cc.call_callable %arg0, %3 : (!cc.callable<(!quake.ref) -> ()>, !quake.ref) -> ()
-    return
-  }
-  func.func @__nvqpp__mlirgen__test3_caller() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-    %c2_i32 = arith.constant 2 : i32
-    %0 = arith.extsi %c2_i32 : i32 to i64
-    %1 = quake.alloca !quake.veq<?> [%0 : i64]
-    %2 = cc.undef !llvm.struct<"test3_callee", ()>
-    %3 = cc.create_lambda {
-    ^bb0(%arg0: !quake.ref):
-      cc.scope {
-        quake.h %arg0 : (!quake.ref) -> ()
-        quake.y %arg0 : (!quake.ref) -> ()
-      }
-    } : !cc.callable<(!quake.ref) -> ()>
-    call @__nvqpp__mlirgen__test3_callee(%3, %1) : (!cc.callable<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
-    return
-  }
+func.func @__nvqpp__mlirgen__test3_callee(%arg0: !cc.callable<(!quake.ref) -> ()>, %arg1: !quake.veq<?>) attributes {"cudaq-kernel"} {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = arith.extsi %c0_i32 : i32 to i64
+  %1 = quake.extract_ref %arg1[%0] : (!quake.veq<?>,i64) -> !quake.ref
+  cc.call_callable %arg0, %1 : (!cc.callable<(!quake.ref) -> ()>, !quake.ref) -> ()
+  %c1_i32 = arith.constant 1 : i32
+  %2 = arith.extsi %c1_i32 : i32 to i64
+  %3 = quake.extract_ref %arg1[%2] : (!quake.veq<?>,i64) -> !quake.ref
+  cc.call_callable %arg0, %3 : (!cc.callable<(!quake.ref) -> ()>, !quake.ref) -> ()
+  return
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_callee(
-// CHECK-SAME:        %[[VAL_0:.*]]: !cc.callable<(!quake.ref) -> ()>,
-// CHECK-SAME:        %[[VAL_1:.*]]: !quake.veq<?>)
+// CHECK-SAME:        %[[VAL_0:.*]]: !cc.callable<(!quake.ref) -> ()>, %[[VAL_1:.*]]: !quake.veq<?>)
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_1]][0] : (!quake.veq<?>) -> !quake.ref
 // CHECK:           %[[VAL_5:.*]] = cc.callable_func %[[VAL_0]] : (!cc.callable<(!quake.ref) -> ()>) -> ((!cc.callable<(!quake.ref) -> ()>, !quake.ref) -> ())
 // CHECK:           call_indirect %[[VAL_5]](%[[VAL_0]], %[[VAL_4]]) : (!cc.callable<(!quake.ref) -> ()>, !quake.ref) -> ()
 // CHECK:            %[[VAL_6:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<?>) -> !quake.ref
 // CHECK:           %[[VAL_7:.*]] = cc.callable_func %[[VAL_0]] : (!cc.callable<(!quake.ref) -> ()>) -> ((!cc.callable<(!quake.ref) -> ()>, !quake.ref) -> ())
 // CHECK:           call_indirect %[[VAL_7]](%[[VAL_0]], %[[VAL_6]]) : (!cc.callable<(!quake.ref) -> ()>, !quake.ref) -> ()
+
+func.func @__nvqpp__mlirgen__test3_caller() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %c2_i32 = arith.constant 2 : i32
+  %0 = arith.extsi %c2_i32 : i32 to i64
+  %1 = quake.alloca !quake.veq<?> [%0 : i64]
+  %2 = cc.undef !llvm.struct<"test3_callee", ()>
+  %3 = cc.create_lambda {
+  ^bb0(%arg0: !quake.ref):
+    cc.scope {
+      quake.h %arg0 : (!quake.ref) -> ()
+      quake.y %arg0 : (!quake.ref) -> ()
+    }
+  } : !cc.callable<(!quake.ref) -> ()>
+  call @__nvqpp__mlirgen__test3_callee(%3, %1) : (!cc.callable<(!quake.ref) -> ()>, !quake.veq<?>) -> ()
+  return
+}
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_caller()
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<2>


### PR DESCRIPTION
Round out the implementation of kernels that return values in the IR and carry that through to LLVM code generation (QIR). This extends the support for scalar numeric return values to include aggregate types. It also fixes some bugs, particularly with dynamically sized aggregate return values.

The principle changes are to GenKernelExecution, which now uses the sret convention to return aggregate values. This actually simplifies the generation of the thunk code since the sret buffer is preallocated and can be passed by pointer rather than having the thunk copy return values itself.

Add a regression test for !cc.stdvec, !cc.struct, !cc.array, and multiple return values.
