### PR TITLE
[NFC] Disable warnings from the kernel_builder.

### DIFF
--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -45,8 +45,6 @@ class ExecutionEngine;
 class PassManager;
 } // namespace mlir
 
-using namespace mlir;
-
 namespace cudaq {
 std::string get_quake_by_name(const std::string &);
 
@@ -145,44 +143,46 @@ KernelBuilderType mapArgToType(cudaq::qvector<> &e);
 
 /// @brief Initialize the `MLIRContext`, return the raw pointer which we'll wrap
 /// in an `unique_ptr`.
-MLIRContext *initializeContext();
+mlir::MLIRContext *initializeContext();
 
 /// @brief Delete function for the context pointer, also given to the
 /// `unique_ptr`
-void deleteContext(MLIRContext *);
+void deleteContext(mlir::MLIRContext *);
 
 /// @brief Initialize the `OpBuilder`, return the raw pointer which we'll wrap
 /// in an `unique_ptr`.
-ImplicitLocOpBuilder *initializeBuilder(MLIRContext *,
-                                        std::vector<KernelBuilderType> &,
-                                        std::vector<QuakeValue> &,
-                                        std::string &kernelName);
+mlir::ImplicitLocOpBuilder *initializeBuilder(mlir::MLIRContext *,
+                                              std::vector<KernelBuilderType> &,
+                                              std::vector<QuakeValue> &,
+                                              std::string &kernelName);
 
 /// @brief Delete function for the builder pointer, also given to the
 /// `unique_ptr`
-void deleteBuilder(ImplicitLocOpBuilder *builder);
+void deleteBuilder(mlir::ImplicitLocOpBuilder *builder);
 
 /// @brief Delete function for the JIT pointer, also given to the `unique_ptr`
-void deleteJitEngine(ExecutionEngine *jit);
+void deleteJitEngine(mlir::ExecutionEngine *jit);
 
 /// @brief Allocate a single `qubit`
-QuakeValue qalloc(ImplicitLocOpBuilder &builder);
+QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder);
 
 /// @brief Allocate a `qvector`.
-QuakeValue qalloc(ImplicitLocOpBuilder &builder, const std::size_t nQubits);
+QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder,
+                  const std::size_t nQubits);
 
 /// @brief Allocate a `qvector` from existing `QuakeValue` size
-QuakeValue qalloc(ImplicitLocOpBuilder &builder, QuakeValue &size);
+QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder, QuakeValue &size);
 
 /// @brief Create a QuakeValue representing a constant floating-point number
-QuakeValue constantVal(ImplicitLocOpBuilder &builder, double val);
+QuakeValue constantVal(mlir::ImplicitLocOpBuilder &builder, double val);
 
 // In the following macros + instantiations, we define the functions that create
 // Quake Quantum Ops + Measures
 
 #define CUDAQ_DETAILS_QIS_DECLARATION(NAME)                                    \
-  void NAME(ImplicitLocOpBuilder &builder, std::vector<QuakeValue> &ctrls,     \
-            const QuakeValue &target, bool adjoint = false);
+  void NAME(mlir::ImplicitLocOpBuilder &builder,                               \
+            std::vector<QuakeValue> &ctrls, const QuakeValue &target,          \
+            bool adjoint = false);
 
 CUDAQ_DETAILS_QIS_DECLARATION(h)
 CUDAQ_DETAILS_QIS_DECLARATION(s)
@@ -192,9 +192,9 @@ CUDAQ_DETAILS_QIS_DECLARATION(y)
 CUDAQ_DETAILS_QIS_DECLARATION(z)
 
 #define CUDAQ_DETAILS_ONEPARAM_QIS_DECLARATION(NAME)                           \
-  void NAME(ImplicitLocOpBuilder &builder, QuakeValue &parameter,              \
+  void NAME(mlir::ImplicitLocOpBuilder &builder, QuakeValue &parameter,        \
             std::vector<QuakeValue> &ctrls, QuakeValue &target);               \
-  void NAME(ImplicitLocOpBuilder &builder, double &parameter,                  \
+  void NAME(mlir::ImplicitLocOpBuilder &builder, double &parameter,            \
             std::vector<QuakeValue> &ctrls, QuakeValue &target);
 
 CUDAQ_DETAILS_ONEPARAM_QIS_DECLARATION(rx)
@@ -203,23 +203,24 @@ CUDAQ_DETAILS_ONEPARAM_QIS_DECLARATION(rz)
 CUDAQ_DETAILS_ONEPARAM_QIS_DECLARATION(r1)
 
 #define CUDAQ_DETAILS_MEASURE_DECLARATION(NAME)                                \
-  QuakeValue NAME(ImplicitLocOpBuilder &builder, QuakeValue &target,           \
+  QuakeValue NAME(mlir::ImplicitLocOpBuilder &builder, QuakeValue &target,     \
                   std::string regName = "");
 
 CUDAQ_DETAILS_MEASURE_DECLARATION(mx)
 CUDAQ_DETAILS_MEASURE_DECLARATION(my)
 CUDAQ_DETAILS_MEASURE_DECLARATION(mz)
 
-void exp_pauli(ImplicitLocOpBuilder &builder, const QuakeValue &theta,
+void exp_pauli(mlir::ImplicitLocOpBuilder &builder, const QuakeValue &theta,
                const std::vector<QuakeValue> &qubits,
                const std::string &pauliWord);
 
-void swap(ImplicitLocOpBuilder &builder, const std::vector<QuakeValue> &ctrls,
+void swap(mlir::ImplicitLocOpBuilder &builder,
+          const std::vector<QuakeValue> &ctrls,
           const std::vector<QuakeValue> &targets, bool adjoint = false);
 
-void reset(ImplicitLocOpBuilder &builder, const QuakeValue &qubitOrQvec);
+void reset(mlir::ImplicitLocOpBuilder &builder, const QuakeValue &qubitOrQvec);
 
-void c_if(ImplicitLocOpBuilder &builder, QuakeValue &conditional,
+void c_if(mlir::ImplicitLocOpBuilder &builder, QuakeValue &conditional,
           std::function<void()> &thenFunctor);
 
 /// @brief Return the name of this `kernel_builder`, it is also the name of the
@@ -227,63 +228,63 @@ void c_if(ImplicitLocOpBuilder &builder, QuakeValue &conditional,
 std::string name(std::string_view kernelName);
 
 /// @brief Apply our MLIR passes before JIT execution
-void applyPasses(PassManager &);
+void applyPasses(mlir::PassManager &);
 
 /// @brief Create the `ExecutionEngine` and return a raw pointer, which we will
 /// wrap in a `unique_ptr`
-std::tuple<bool, ExecutionEngine *>
-jitCode(ImplicitLocOpBuilder &, ExecutionEngine *,
-        std::unordered_map<ExecutionEngine *, std::size_t> &, std::string,
+std::tuple<bool, mlir::ExecutionEngine *>
+jitCode(mlir::ImplicitLocOpBuilder &, mlir::ExecutionEngine *,
+        std::unordered_map<mlir::ExecutionEngine *, std::size_t> &, std::string,
         std::vector<std::string>);
 
 /// @brief Invoke the function with the given kernel name.
-void invokeCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
+void invokeCode(mlir::ImplicitLocOpBuilder &builder, mlir::ExecutionEngine *jit,
                 std::string kernelName, void **argsArray,
                 std::vector<std::string> extraLibPaths);
 
 /// @brief Invoke the provided kernel function.
-void call(ImplicitLocOpBuilder &builder, std::string &name,
+void call(mlir::ImplicitLocOpBuilder &builder, std::string &name,
           std::string &quakeCode, std::vector<QuakeValue> &values);
 
 /// @brief Apply the given kernel controlled on the provided qubit value.
-void control(ImplicitLocOpBuilder &builder, std::string &name,
+void control(mlir::ImplicitLocOpBuilder &builder, std::string &name,
              std::string &quakeCode, QuakeValue &control,
              std::vector<QuakeValue> &values);
 
 /// @brief Apply the adjoint of the given kernel
-void adjoint(ImplicitLocOpBuilder &builder, std::string &name,
+void adjoint(mlir::ImplicitLocOpBuilder &builder, std::string &name,
              std::string &quakeCode, std::vector<QuakeValue> &values);
 
 /// @brief Add a for loop that starts from the given `start` integer index, ends
 /// at the given `end` integer index, and applies the given `body` as a callable
 /// function. This callable function must take as input an index variable that
 /// can be used within the body.
-void forLoop(ImplicitLocOpBuilder &builder, std::size_t start, std::size_t end,
-             std::function<void(QuakeValue &)> &body);
+void forLoop(mlir::ImplicitLocOpBuilder &builder, std::size_t start,
+             std::size_t end, std::function<void(QuakeValue &)> &body);
 
 /// @brief Add a for loop that starts from the given `start` integer index, ends
 /// at the given `end` index, and applies the given `body` as a callable
 /// function. This callable function must take as input an index variable that
 /// can be used within the body.
-void forLoop(ImplicitLocOpBuilder &builder, std::size_t start, QuakeValue &end,
-             std::function<void(QuakeValue &)> &body);
+void forLoop(mlir::ImplicitLocOpBuilder &builder, std::size_t start,
+             QuakeValue &end, std::function<void(QuakeValue &)> &body);
 
 /// @brief Add a for loop that starts from the given `start` index, ends at the
 /// given `end` integer index, and applies the given `body` as a callable
 /// function. This callable function must take as input an index variable that
 /// can be used within the body.
-void forLoop(ImplicitLocOpBuilder &builder, QuakeValue &start, std::size_t end,
-             std::function<void(QuakeValue &)> &body);
+void forLoop(mlir::ImplicitLocOpBuilder &builder, QuakeValue &start,
+             std::size_t end, std::function<void(QuakeValue &)> &body);
 
 /// @brief Add a for loop that starts from the given `start` index, ends at the
 /// given `end` index, and applies the given `body` as a callable function. This
 /// callable function must take as input an index variable that can be used
 /// within the body.
-void forLoop(ImplicitLocOpBuilder &builder, QuakeValue &start, QuakeValue &end,
-             std::function<void(QuakeValue &)> &body);
+void forLoop(mlir::ImplicitLocOpBuilder &builder, QuakeValue &start,
+             QuakeValue &end, std::function<void(QuakeValue &)> &body);
 
 /// @brief Return the quake representation as a string
-std::string to_quake(ImplicitLocOpBuilder &builder);
+std::string to_quake(mlir::ImplicitLocOpBuilder &builder);
 
 /// @brief Returns `true` if the argument to the `kernel_builder` is a
 /// `cc::StdvecType`. Returns `false` otherwise.
@@ -362,20 +363,23 @@ class kernel_builder : public details::kernel_builder_base {
 private:
   /// @brief Handle to the MLIR Context, stored as a pointer here to keep
   /// implementation details out of CUDA Quantum code
-  std::unique_ptr<MLIRContext, void (*)(MLIRContext *)> context;
+  std::unique_ptr<mlir::MLIRContext, void (*)(mlir::MLIRContext *)> context;
 
   /// @brief Handle to the MLIR `OpBuilder`, stored as a pointer here to keep
   /// implementation details out of CUDA Quantum code
-  std::unique_ptr<ImplicitLocOpBuilder, void (*)(ImplicitLocOpBuilder *)>
+  std::unique_ptr<mlir::ImplicitLocOpBuilder,
+                  void (*)(mlir::ImplicitLocOpBuilder *)>
       opBuilder;
 
   /// @brief Handle to the MLIR `ExecutionEngine`, stored as a pointer here to
   /// keep implementation details out of CUDA Quantum code
-  std::unique_ptr<ExecutionEngine, void (*)(ExecutionEngine *)> jitEngine;
+  std::unique_ptr<mlir::ExecutionEngine, void (*)(mlir::ExecutionEngine *)>
+      jitEngine;
 
   /// @brief Map created ExecutionEngines to a unique hash of the
   /// ModuleOp they derive from.
-  std::unordered_map<ExecutionEngine *, std::size_t> jitEngineToModuleHash;
+  std::unordered_map<mlir::ExecutionEngine *, std::size_t>
+      jitEngineToModuleHash;
 
   /// @brief Name of the CUDA Quantum kernel Quake function
   std::string kernelName = "__nvqpp__mlirgen____nvqppBuilderKernel";
@@ -388,13 +392,13 @@ public:
   /// to create the MLIR function type
   kernel_builder(std::vector<details::KernelBuilderType> &types)
       : context(details::initializeContext(), details::deleteContext),
-        opBuilder(nullptr, [](ImplicitLocOpBuilder *) {}),
-        jitEngine(nullptr, [](ExecutionEngine *) {}) {
+        opBuilder(nullptr, [](mlir::ImplicitLocOpBuilder *) {}),
+        jitEngine(nullptr, [](mlir::ExecutionEngine *) {}) {
     auto *ptr =
         details::initializeBuilder(context.get(), types, arguments, kernelName);
-    opBuilder =
-        std::unique_ptr<ImplicitLocOpBuilder, void (*)(ImplicitLocOpBuilder *)>(
-            ptr, details::deleteBuilder);
+    opBuilder = std::unique_ptr<mlir::ImplicitLocOpBuilder,
+                                void (*)(mlir::ImplicitLocOpBuilder *)>(
+        ptr, details::deleteBuilder);
   }
 
   /// @brief Return the `QuakeValue` arguments
@@ -756,7 +760,8 @@ public:
 
     // Store for the next time if we haven't already
     if (!jitEngine)
-      jitEngine = std::unique_ptr<ExecutionEngine, void (*)(ExecutionEngine *)>(
+      jitEngine = std::unique_ptr<mlir::ExecutionEngine,
+                                  void (*)(mlir::ExecutionEngine *)>(
           ptr, details::deleteJitEngine);
   }
 

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -24,6 +24,15 @@
 #include <variant>
 #include <vector>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 // Goal here is to keep MLIR out of user code!
 namespace mlir {
 class Type;
@@ -833,3 +842,10 @@ auto make_kernel() {
 }
 
 } // namespace cudaq
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
The kernel builder still uses qreg, a deprecated type, which is generating a lot of warnings. This change silences the warnings. When qreg is finally removed, this change should be reverted.

See #75.
