### PR TITLE
Fix qreg/qspan deprecation warnings in build

### DIFF
--- a/docs/sphinx/examples/cpp/algorithms/amplitude_estimation.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/amplitude_estimation.cpp
@@ -58,7 +58,7 @@ int num_oracles(std::vector<int> &vec, const int N_shots) {
 } // namespace mlae
 
 struct statePrep_A {
-  void operator()(cudaq::qreg<> &q, const double bmax) __qpu__ {
+  void operator()(cudaq::qvector<> &q, const double bmax) __qpu__ {
 
     int n = q.size();
     // all qubits sans auxiliary
@@ -75,7 +75,7 @@ struct statePrep_A {
 };
 
 struct S_0 {
-  void operator()(cudaq::qreg<> &q) __qpu__ {
+  void operator()(cudaq::qvector<> &q) __qpu__ {
 
     auto ctrl_qubits = q.front(q.size() - 1);
     auto &last_qubit = q.back();
@@ -93,7 +93,7 @@ struct run_circuit {
   auto operator()(const int n_qubits, const int n_itrs,
                   const double bmax) __qpu__ {
 
-    cudaq::qreg q(n_qubits + 1); // last is auxiliary
+    cudaq::qvector q(n_qubits + 1); // last is auxiliary
     auto &last_qubit = q.back();
 
     // State preparation

--- a/docs/sphinx/examples/cpp/algorithms/bernstein_vazirani.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/bernstein_vazirani.cpp
@@ -34,7 +34,7 @@ std::bitset<nrOfBits> random_bits(int seed) {
 
 template <int nrOfBits>
 struct oracle {
-  auto operator()(std::bitset<nrOfBits> bitvector, cudaq::qspan<> qs,
+  auto operator()(std::bitset<nrOfBits> bitvector, cudaq::qview<> qs,
                   cudaq::qubit &aux) __qpu__ {
 
     for (size_t i = 0; i < nrOfBits; i++) {
@@ -49,7 +49,7 @@ template <int nrOfBits>
 struct bernstein_vazirani {
   auto operator()(std::bitset<nrOfBits> bitvector) __qpu__ {
 
-    cudaq::qreg<nrOfBits> qs;
+    cudaq::qarray<nrOfBits> qs;
     cudaq::qubit aux;
     h(aux);
     z(aux);

--- a/docs/sphinx/examples/cpp/algorithms/grover.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/grover.cpp
@@ -5,7 +5,7 @@
 
 #include <cudaq.h>
 
-__qpu__ void reflect_about_uniform(cudaq::qspan<> q) {
+__qpu__ void reflect_about_uniform(cudaq::qview<> q) {
   auto ctrlQubits = q.front(q.size() - 1);
   auto &lastQubit = q.back();
 
@@ -20,7 +20,7 @@ struct run_grover {
   template <typename CallableKernel>
   __qpu__ auto operator()(const int n_qubits, const int n_iterations,
                           CallableKernel &&oracle) {
-    cudaq::qreg q(n_qubits);
+    cudaq::qvector q(n_qubits);
     h(q);
     for (int i = 0; i < n_iterations; i++) {
       oracle(q);
@@ -31,7 +31,7 @@ struct run_grover {
 };
 
 struct oracle {
-  void operator()(cudaq::qreg<> &q) __qpu__ {
+  void operator()(cudaq::qvector<> &q) __qpu__ {
     z<cudaq::ctrl>(q[0], q[2]);
     z<cudaq::ctrl>(q[1], q[2]);
   }

--- a/docs/sphinx/examples/cpp/algorithms/phase_estimation.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/phase_estimation.cpp
@@ -11,7 +11,7 @@
 
 // A pure device quantum kernel defined as a free function
 // (cannot be called from host code).
-__qpu__ void iqft(cudaq::qspan<> q) {
+__qpu__ void iqft(cudaq::qview<> q) {
   int N = q.size();
   // Swap qubits
   for (int i = 0; i < N / 2; ++i) {
@@ -44,7 +44,7 @@ struct qpe {
   void operator()(const int nCountingQubits, StatePrep &&state_prep,
                   Unitary &&oracle) __qpu__ {
     // Allocate a register of qubits
-    cudaq::qreg q(nCountingQubits + 1);
+    cudaq::qvector q(nCountingQubits + 1);
 
     // Extract sub-registers, one for the counting qubits
     // another for the eigenstate register

--- a/docs/sphinx/examples/cpp/algorithms/qaoa_maxcut.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/qaoa_maxcut.cpp
@@ -25,7 +25,7 @@
 struct ansatz {
   void operator()(std::vector<double> theta, const int n_qubits,
                   const int n_layers) __qpu__ {
-    cudaq::qreg q(n_qubits);
+    cudaq::qvector q(n_qubits);
 
     // Prepare the initial state by superposition
     h(q);

--- a/docs/sphinx/examples/cpp/algorithms/vqe_h2.cpp
+++ b/docs/sphinx/examples/cpp/algorithms/vqe_h2.cpp
@@ -46,7 +46,7 @@ __qpu__ void so4(cudaq::qubit &q, cudaq::qubit &r,
 struct so4_fabric {
   void operator()(std::vector<double> params, int n_qubits,
                   int n_layers) __qpu__ {
-    cudaq::qreg q(n_qubits);
+    cudaq::qvector q(n_qubits);
 
     x(q[0]);
     x(q[2]);

--- a/docs/sphinx/examples/cpp/basics/cuquantum_backends.cpp
+++ b/docs/sphinx/examples/cpp/basics/cuquantum_backends.cpp
@@ -17,7 +17,7 @@ struct ghz {
   auto operator()(const int N) __qpu__ {
 
     // Dynamic, vector-like `qreg`
-    cudaq::qreg q(N);
+    cudaq::qvector q(N);
     h(q[0]);
     for (int i = 0; i < N - 1; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/docs/sphinx/examples/cpp/basics/cutensornet_backends.cpp
+++ b/docs/sphinx/examples/cpp/basics/cutensornet_backends.cpp
@@ -19,7 +19,7 @@ struct ghz {
   auto operator()(const int N) __qpu__ {
 
     // Dynamic, vector-like `qreg`
-    cudaq::qreg q(N);
+    cudaq::qvector q(N);
     h(q[0]);
     for (int i = 0; i < N - 1; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/docs/sphinx/examples/cpp/basics/expectation_values.cpp
+++ b/docs/sphinx/examples/cpp/basics/expectation_values.cpp
@@ -11,7 +11,7 @@
 
 struct ansatz {
   auto operator()(double theta) __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     x(q[0]);
     ry(theta, q[1]);
     x<cudaq::ctrl>(q[1], q[0]);

--- a/docs/sphinx/examples/cpp/basics/mid_circuit_measurement.cpp
+++ b/docs/sphinx/examples/cpp/basics/mid_circuit_measurement.cpp
@@ -7,7 +7,7 @@
 
 struct kernel {
   void operator()() __qpu__ {
-    cudaq::qreg<3> q;
+    cudaq::qarray<3> q;
     // Initial state preparation
     x(q[0]);
 

--- a/docs/sphinx/examples/cpp/basics/multi_controlled_operations.cpp
+++ b/docs/sphinx/examples/cpp/basics/multi_controlled_operations.cpp
@@ -15,7 +15,7 @@ struct ApplyX {
 struct ccnot_test {
   // constrain the signature of the incoming kernel
   void operator()(cudaq::takes_qubit auto &&apply_x) __qpu__ {
-    cudaq::qreg qs(3);
+    cudaq::qvector qs(3);
 
     x(qs);
     x(qs[1]);
@@ -32,7 +32,7 @@ int main() {
   // We can achieve the same thing as above via
   // a lambda expression.
   auto ccnot = []() __qpu__ {
-    cudaq::qreg q(3);
+    cudaq::qvector q(3);
 
     x(q);
     x(q[1]);

--- a/docs/sphinx/examples/cpp/basics/static_kernel.cpp
+++ b/docs/sphinx/examples/cpp/basics/static_kernel.cpp
@@ -13,7 +13,7 @@ struct ghz {
   auto operator()() __qpu__ {
 
     // Compile-time, std::array-like `qreg`.
-    cudaq::qreg<N> q;
+    cudaq::qarray<N> q;
     h(q[0]);
     for (int i = 0; i < N - 1; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/docs/sphinx/examples/cpp/other/compute_actions.cpp
+++ b/docs/sphinx/examples/cpp/other/compute_actions.cpp
@@ -22,7 +22,7 @@
 
 struct ansatz_handcoded {
   void operator()(double theta) __qpu__ {
-    cudaq::qreg q(4);
+    cudaq::qvector q(4);
     x(q[0]);
     x(q[2]);
     rx(M_PI_2, q[0]);
@@ -47,7 +47,7 @@ struct ansatz_handcoded {
 // equivalent to the one defined in `ansatz_handcoded`.
 struct ansatz_compute_action {
   void operator()(std::vector<double> theta) __qpu__ {
-    cudaq::qreg q(4);
+    cudaq::qvector q(4);
     x(q[0]);
     x(q[2]);
 

--- a/docs/sphinx/examples/cpp/other/gradients.cpp
+++ b/docs/sphinx/examples/cpp/other/gradients.cpp
@@ -18,7 +18,7 @@
 
 struct deuteron_n3_ansatz {
   void operator()(double x0, double x1) __qpu__ {
-    cudaq::qreg q(3);
+    cudaq::qvector q(3);
     x(q[0]);
     ry(x0, q[1]);
     ry(x1, q[2]);

--- a/docs/sphinx/examples/cpp/other/iterative_qpe.cpp
+++ b/docs/sphinx/examples/cpp/other/iterative_qpe.cpp
@@ -15,7 +15,7 @@
 
 struct iqpe {
   void operator()() __qpu__ {
-    cudaq::qreg<2> q;
+    cudaq::qarray<2> q;
     h(q[0]);
     x(q[1]);
     for (int i = 0; i < 8; i++)

--- a/docs/sphinx/examples/cpp/other/random_walk_qpe.cpp
+++ b/docs/sphinx/examples/cpp/other/random_walk_qpe.cpp
@@ -22,7 +22,7 @@ struct rwpe {
     int iteration = 0;
 
     // Allocate the qubits
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
 
     // Alias them
     auto &aux = q.front();

--- a/docs/sphinx/examples/cpp/providers/ionq.cpp
+++ b/docs/sphinx/examples/cpp/providers/ionq.cpp
@@ -23,7 +23,7 @@
 struct ghz {
   // Maximally entangled state between 5 qubits.
   auto operator()() __qpu__ {
-    cudaq::qreg q(5);
+    cudaq::qvector q(5);
     h(q[0]);
     for (int i = 0; i < 4; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/docs/sphinx/examples/cpp/providers/iqm.cpp
+++ b/docs/sphinx/examples/cpp/providers/iqm.cpp
@@ -17,7 +17,7 @@ struct adonis_ghz {
   //       QB5
 
   void operator()() __qpu__ {
-    cudaq::qreg q(5);
+    cudaq::qvector q(5);
     h(q[0]);
 
     // Note that the CUDA Quantum compiler will automatically generate the

--- a/docs/sphinx/examples/cpp/providers/photonics.cpp
+++ b/docs/sphinx/examples/cpp/providers/photonics.cpp
@@ -9,7 +9,7 @@
 
 struct photonicsKernel {
   void operator()() __qpu__ {
-    cudaq::qreg<cudaq::dyn, 3> qutrits(2);
+    cudaq::qvector<3> qutrits(2);
     plus(qutrits[0]);
     plus(qutrits[1]);
     plus(qutrits[1]);

--- a/docs/sphinx/examples/cpp/providers/quantinuum.cpp
+++ b/docs/sphinx/examples/cpp/providers/quantinuum.cpp
@@ -14,7 +14,7 @@
 struct ghz {
   // Maximally entangled state between 5 qubits.
   auto operator()() __qpu__ {
-    cudaq::qreg q(5);
+    cudaq::qvector q(5);
     h(q[0]);
     for (int i = 0; i < 4; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -295,7 +295,9 @@ public:
           if (auto *id = decl->getIdentifier()) {
             auto name = id->getName();
             if (name.equals("qubit") || name.equals("qudit") ||
-                name.equals("qspan") || name.startswith("qreg"))
+                name.equals("qspan") || name.startswith("qreg") ||
+                name.startswith("qvector") || name.startswith("qarray") ||
+                name.startswith("qview"))
               cudaq::details::reportClangError(
                   x, mangler,
                   "may not use quantum types in non-kernel functions");

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1273,7 +1273,10 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
   }
 
   if (isInClassInNamespace(func, "qreg", "cudaq") ||
-      isInClassInNamespace(func, "qspan", "cudaq")) {
+      isInClassInNamespace(func, "qvector", "cudaq") ||
+      isInClassInNamespace(func, "qarray", "cudaq") ||
+      isInClassInNamespace(func, "qspan", "cudaq") ||
+      isInClassInNamespace(func, "qview", "cudaq")) {
     // This handles conversion of qreg.size()
     if (funcName.equals("size"))
       if (auto memberCall = dyn_cast<clang::CXXMemberCallExpr>(x))
@@ -2238,7 +2241,8 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
           return pushValue(builder.create<quake::AllocaOp>(
               loc, quake::VeqType::getUnsized(builder.getContext()), sizeVal));
         }
-        if (ctorName == "qspan" && isa<quake::VeqType>(peekValue().getType())) {
+        if ((ctorName == "qspan" || ctorName == "qview") &&
+            isa<quake::VeqType>(peekValue().getType())) {
           // One of the qspan ctors, which effectively just makes a copy. Here
           // we omit making a copy and just forward the veq argument.
           assert(isa<quake::VeqType>(ctorTy));

--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -91,7 +91,7 @@ Returns:
                 cudaq::qubit q;
                 return details::mapArgToType(q);
               } else if (name == "qreg") {
-                cudaq::qreg<cudaq::dyn, 2> q;
+                cudaq::qvector<> q;
                 return details::mapArgToType(q);
               } else
                 throw std::runtime_error("Invalid builder parameter type (must "

--- a/runtime/cudaq/algorithms/sample.h
+++ b/runtime/cudaq/algorithms/sample.h
@@ -120,7 +120,7 @@ runSampling(KernelFunctor &&wrappedKernel, quantum_platform &platform,
       ctx->result.clear();
       // Reset the context for the next round,
       // don't need to reset on the last exec
-      if (i < static_cast<unsigned>(shots) - 1)
+      if (i < shots - 1)
         platform.set_exec_ctx(ctx.get(), qpu_id);
     }
 

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -95,11 +95,6 @@ KernelBuilderType mapArgToType(cudaq::qubit &e) {
       [](MLIRContext *ctx) { return quake::RefType::get(ctx); });
 }
 
-KernelBuilderType mapArgToType(cudaq::qreg<> &e) {
-  return KernelBuilderType(
-      [](MLIRContext *ctx) { return quake::VeqType::getUnsized(ctx); });
-}
-
 KernelBuilderType mapArgToType(cudaq::qvector<> &e) {
   return KernelBuilderType(
       [](MLIRContext *ctx) { return quake::VeqType::getUnsized(ctx); });

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -10,7 +10,6 @@
 
 #include "cudaq/builder/QuakeValue.h"
 #include "cudaq/qis/modifiers.h"
-#include "cudaq/qis/qreg.h"
 #include "cudaq/qis/qvector.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include "host_config.h"
@@ -74,12 +73,11 @@ concept KernelBuilderArgTypeIsValid =
 // If you want to add to the list of valid kernel argument types first add it
 // here, then add `details::mapArgToType()` function
 #define CUDAQ_VALID_BUILDER_ARGS_FOLD()                                        \
-  requires(                                                                    \
-      KernelBuilderArgTypeIsValid<                                             \
-          Args, float, double, std::size_t, int, std::vector<int>,             \
-          std::vector<float>, std::vector<std::size_t>, std::vector<double>,   \
-          cudaq::qubit, cudaq::qreg<>, cudaq::qvector<>> &&                    \
-      ...)
+  requires(KernelBuilderArgTypeIsValid<                                        \
+               Args, float, double, std::size_t, int, std::vector<int>,        \
+               std::vector<float>, std::vector<std::size_t>,                   \
+               std::vector<double>, cudaq::qubit, cudaq::qvector<>> &&         \
+           ...)
 #else
 // Not C++ 2020: stub these out.
 #define QuakeValueOrNumericType typename
@@ -134,9 +132,6 @@ KernelBuilderType mapArgToType(std::vector<double> &e);
 
 /// Map a `qubit` to a `KernelBuilderType`
 KernelBuilderType mapArgToType(cudaq::qubit &e);
-
-/// @brief  Map a `qreg` to a `KernelBuilderType`
-KernelBuilderType mapArgToType(cudaq::qreg<> &e);
 
 /// @brief  Map a `qvector` to a `KernelBuilderType`
 KernelBuilderType mapArgToType(cudaq::qvector<> &e);

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -23,15 +23,6 @@
 #include <variant>
 #include <vector>
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
 // Goal here is to keep MLIR out of user code!
 namespace mlir {
 class Type;
@@ -842,10 +833,3 @@ auto make_kernel() {
 }
 
 } // namespace cudaq
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif

--- a/runtime/cudaq/domains/chemistry/uccsd.h
+++ b/runtime/cudaq/domains/chemistry/uccsd.h
@@ -50,7 +50,7 @@ void singletExcitation(KernelBuilder &&kernel, QuakeValue &qubits,
   kernel.exp_pauli(-0.5 * theta, "XY", qubits[r], qubits[p]);
 }
 
-__qpu__ void singletExcitation(cudaq::qspan<> qubits, double theta,
+__qpu__ void singletExcitation(cudaq::qview<> qubits, double theta,
                                const SingleIndices &indices) {
   auto r = indices.front();
   auto p = indices.back();
@@ -93,7 +93,7 @@ void doubletExcitation(KernelBuilder &kernel, QuakeValue &qubits,
                    qubits[p]);
 }
 
-__qpu__ void doubletExcitation(cudaq::qspan<> qubits, double theta,
+__qpu__ void doubletExcitation(cudaq::qview<> qubits, double theta,
                                const DoubleIndices &d1,
                                const DoubleIndices &d2) {
   auto s = d1.front();
@@ -173,7 +173,7 @@ void uccsd(KernelBuilder &kernel, QuakeValue &qubits, QuakeValue &thetas,
 /// given number of qubits and electrons. Takes a vector of rotation
 /// parameters as input, the size of which must correspond to the output of
 /// the `uccsd_num_parameters` function.
-__qpu__ void uccsd(cudaq::qspan<> qubits, std::vector<double> thetas,
+__qpu__ void uccsd(cudaq::qview<> qubits, std::vector<double> thetas,
                    std::size_t nElectrons) {
   auto [singles, doubles] = generateExcitations(nElectrons, qubits.size());
 

--- a/runtime/cudaq/qis/managers/photonics/photonics_qis.h
+++ b/runtime/cudaq/qis/managers/photonics/photonics_qis.h
@@ -11,7 +11,7 @@
 
 #include "common/ExecutionContext.h"
 #include "cudaq/qis/qarray.h"
-#include "cudaq/qis/qreg.h"
+#include "cudaq/qis/qvector.h"
 #include <vector>
 
 namespace cudaq {
@@ -47,7 +47,7 @@ int mz(cudaq::qudit<T> &q) {
 
 /// @brief Measure a vector of qudits
 template <std::size_t T>
-std::vector<int> mz(cudaq::qreg<cudaq::dyn, T> &q) {
+std::vector<int> mz(cudaq::qvector<T> &q) {
   std::vector<int> ret;
   for (auto &qq : q)
     ret.emplace_back(mz(qq));

--- a/runtime/cudaq/qis/qspan.h
+++ b/runtime/cudaq/qis/qspan.h
@@ -41,7 +41,7 @@ public:
   // Construct a span that refers to the qudits in `other`.
   template <typename R>
     requires(std::ranges::range<R>)
-  qspan(R && other) : qudits(other.begin(), other.end()) {}
+  qspan(R &&other) : qudits(other.begin(), other.end()) {}
 
   // Copy constructor
   qspan(qspan const &other) : qudits(other.qudits) {}
@@ -86,13 +86,13 @@ private:
   std::size_t qusize = 0;
 
 public:
-  qspan(value_type * otherQudits, std::size_t otherQusize)
+  qspan(value_type *otherQudits, std::size_t otherQusize)
       : qudits(otherQudits), qusize(otherQusize) {}
   template <typename Iterator>
-  qspan(Iterator && otherQudits, std::size_t otherQusize)
+  qspan(Iterator &&otherQudits, std::size_t otherQusize)
       : qudits(&*otherQudits), qusize(otherQusize) {}
   template <typename R>
-  qspan(R && other)
+  qspan(R &&other)
       : qudits(&*other.begin()),
         qusize(std::distance(other.begin(), other.end())) {}
   qspan(qspan const &other) : qudits(other.qudits), qusize(other.qusize) {}

--- a/runtime/cudaq/qis/qspan.h
+++ b/runtime/cudaq/qis/qspan.h
@@ -41,7 +41,7 @@ public:
   // Construct a span that refers to the qudits in `other`.
   template <typename R>
     requires(std::ranges::range<R>)
-  qspan(R &&other) : qudits(other.begin(), other.end()) {}
+  qspan(R && other) : qudits(other.begin(), other.end()) {}
 
   // Copy constructor
   qspan(qspan const &other) : qudits(other.qudits) {}
@@ -86,13 +86,13 @@ private:
   std::size_t qusize = 0;
 
 public:
-  qspan(value_type *otherQudits, std::size_t otherQusize)
+  qspan(value_type * otherQudits, std::size_t otherQusize)
       : qudits(otherQudits), qusize(otherQusize) {}
   template <typename Iterator>
-  qspan(Iterator &&otherQudits, std::size_t otherQusize)
+  qspan(Iterator && otherQudits, std::size_t otherQusize)
       : qudits(&*otherQudits), qusize(otherQusize) {}
   template <typename R>
-  qspan(R &&other)
+  qspan(R && other)
       : qudits(&*other.begin()),
         qusize(std::distance(other.begin(), other.end())) {}
   qspan(qspan const &other) : qudits(other.qudits), qusize(other.qusize) {}

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -11,7 +11,6 @@
 #include "common/MeasureCounts.h"
 #include "cudaq/qis/modifiers.h"
 #include "cudaq/qis/qarray.h"
-#include "cudaq/qis/qreg.h"
 #include "cudaq/qis/qvector.h"
 #include "cudaq/spin_op.h"
 #include "host_config.h"
@@ -498,7 +497,7 @@ template <typename T>
 concept takes_qubit = signature<T, void(qubit &)>;
 
 template <typename T>
-concept takes_qreg = signature<T, void(qreg<> &)>;
+concept takes_vector = signature<T, void(qvector<> &)>;
 #endif
 
 // Control the given cudaq kernel on the given control qubit

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -497,7 +497,7 @@ template <typename T>
 concept takes_qubit = signature<T, void(qubit &)>;
 
 template <typename T>
-concept takes_vector = signature<T, void(qvector<> &)>;
+concept takes_qvector = signature<T, void(qvector<> &)>;
 #endif
 
 // Control the given cudaq kernel on the given control qubit

--- a/runtime/cudaq/utils/cudaq_utils.h
+++ b/runtime/cudaq/utils/cudaq_utils.h
@@ -240,10 +240,21 @@ std::vector<double> random_vector(const double l_range, const double r_range,
                                   const std::size_t size,
                                   const uint32_t seed = std::random_device{}());
 
-inline std::vector<std::size_t> range(int N) {
-  std::vector<std::size_t> vec(N);
-  std::iota(vec.begin(), vec.end(), 0);
+template <typename ElementType>
+inline std::vector<ElementType> range(ElementType start, ElementType stop,
+                                      ElementType step = 1) {
+  std::vector<ElementType> vec;
+  auto val = start;
+  while ((step > 0) ? (val < stop) : (val > stop)) {
+    vec.push_back(val);
+    val += step;
+  }
   return vec;
+}
+
+template <typename ElementType = int>
+inline std::vector<ElementType> range(ElementType N) {
+  return range(ElementType(0), N);
 }
 
 inline std::vector<std::string> split(const std::string &s, char delim) {

--- a/runtime/cudaq/utils/cudaq_utils.h
+++ b/runtime/cudaq/utils/cudaq_utils.h
@@ -240,6 +240,10 @@ std::vector<double> random_vector(const double l_range, const double r_range,
                                   const std::size_t size,
                                   const uint32_t seed = std::random_device{}());
 
+/// @brief Return a vector of integers. The first element is the
+/// user-specified `start` value. The remaining values are all values
+/// incremented by `step` (defaults to 1) until the `stop` value is reached
+/// (exclusive).
 template <typename ElementType>
 inline std::vector<ElementType> range(ElementType start, ElementType stop,
                                       ElementType step = 1) {
@@ -252,7 +256,10 @@ inline std::vector<ElementType> range(ElementType start, ElementType stop,
   return vec;
 }
 
-template <typename ElementType = int>
+/// @brief Return a vector of integers. The first element is zero, and
+/// the remaining elements are all values incremented by 1 to the total
+/// size value provided (exclusive).
+template <typename ElementType>
 inline std::vector<ElementType> range(ElementType N) {
   return range(ElementType(0), N);
 }

--- a/test/AST-Quake/adjoint-1.cpp
+++ b/test/AST-Quake/adjoint-1.cpp
@@ -11,7 +11,7 @@
 #include <cudaq.h>
 
 struct k {
-  void operator()(cudaq::qspan<> q) __qpu__ {
+  void operator()(cudaq::qview<> q) __qpu__ {
     h(q[0]);
     ry(3.14, q[1]);
     t(q[2]);
@@ -27,7 +27,7 @@ struct k {
 
 struct ep {
   void operator()() __qpu__ {
-    cudaq::qreg<3> q;
+    cudaq::qarray<3> q;
     cudaq::adjoint(k{}, q);
   }
 };

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -12,7 +12,7 @@
 #include <cudaq.h>
 
 struct statePrep_A {
-  void operator()(cudaq::qreg<> &q, const double bmax) __qpu__ {
+  void operator()(cudaq::qvector<> &q, const double bmax) __qpu__ {
 
     int n = q.size();
     // all qubits sans ancilla
@@ -29,7 +29,7 @@ struct statePrep_A {
 };
 
 struct QernelZero {
-  void operator()(cudaq::qreg<> &q) __qpu__ {
+  void operator()(cudaq::qvector<> &q) __qpu__ {
 
     auto ctrl_qubits = q.front(q.size() - 1);
     auto &last_qubit = q.back();
@@ -68,7 +68,7 @@ struct run_circuit {
   auto operator()(const int n_qubits, const int n_itrs,
                   const double bmax) __qpu__ {
 
-    cudaq::qreg q(n_qubits + 1); // last is ancilla
+    cudaq::qvector q(n_qubits + 1); // last is ancilla
     auto &last_qubit = q.back();
 
     // State preparation

--- a/test/AST-Quake/adjoint-4.cpp
+++ b/test/AST-Quake/adjoint-4.cpp
@@ -10,9 +10,9 @@
 
 #include <cudaq.h>
 
-__qpu__ void init_state(cudaq::qreg<> &qubits, double theta) {}
+__qpu__ void init_state(cudaq::qvector<> &qubits, double theta) {}
 
-__qpu__ void reflect_uni(cudaq::qreg<> &ctrls, cudaq::qreg<> &qubits,
+__qpu__ void reflect_uni(cudaq::qvector<> &ctrls, cudaq::qvector<> &qubits,
                          double theta) {
   cudaq::adjoint(init_state, qubits, theta);
 }

--- a/test/AST-Quake/array.cpp
+++ b/test/AST-Quake/array.cpp
@@ -12,7 +12,7 @@
 
 struct T {
    void operator()(int N) __qpu__ {
-      cudaq::qreg Q(N);
+      cudaq::qvector Q(N);
       x(Q);
    }
 };

--- a/test/AST-Quake/auto_kernel-1.cpp
+++ b/test/AST-Quake/auto_kernel-1.cpp
@@ -15,7 +15,7 @@
 
 struct ak1 {
   auto operator()(int i) __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     auto vec = mz(q);
     return vec[0];
   }

--- a/test/AST-Quake/auto_kernel-2.cpp
+++ b/test/AST-Quake/auto_kernel-2.cpp
@@ -14,7 +14,7 @@
 
 struct ak2 {
   auto operator()() __qpu__ {
-    cudaq::qreg<5> q;
+    cudaq::qarray<5> q;
     h(q);
     return mz(q);
   }

--- a/test/AST-Quake/base_profile.cpp
+++ b/test/AST-Quake/base_profile.cpp
@@ -12,7 +12,7 @@
 
 struct kernel {
     void operator()() __qpu__ {
-        cudaq::qreg<3> q;
+        cudaq::qarray<3> q;
         h(q[1]);
         x<cudaq::ctrl>(q[1],q[2]);
 

--- a/test/AST-Quake/callable-1.cpp
+++ b/test/AST-Quake/callable-1.cpp
@@ -13,13 +13,13 @@
 struct MyKernel {
   template <typename StatePrep>
   void operator()(StatePrep &&statePrep) __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     statePrep(q);
   }
 };
 
 int main() {
-  auto bell = [](cudaq::qreg<> &q) __qpu__ {
+  auto bell = [](cudaq::qvector<> &q) __qpu__ {
     h(q[0]);
     x<cudaq::ctrl>(q[0], q[1]);
   };

--- a/test/AST-Quake/callable-2.cpp
+++ b/test/AST-Quake/callable-2.cpp
@@ -13,7 +13,7 @@
 
 struct test5_callee {
   void operator()(std::function<void(cudaq::qubit &)> &&callback,
-                  cudaq::qreg<> &s) __qpu__ {
+                  cudaq::qvector<> &s) __qpu__ {
      callback(s[0]);
      callback(s[1]);
      callback(s[2]);
@@ -31,7 +31,7 @@ struct test5_callable {
 
 struct test5_caller {
   void operator()() __qpu__ {
-    cudaq::qreg q(3);
+    cudaq::qvector q(3);
     test5_callee{}(test5_callable{}, q);
   }
 };

--- a/test/AST-Quake/compute_action-1.cpp
+++ b/test/AST-Quake/compute_action-1.cpp
@@ -18,7 +18,7 @@
 #endif
 
 void t() __qpu__ {
-	cudaq::qreg r(5);
+	cudaq::qvector r(5);
 	cudaq:: CALL (
 		[&](){ t(r[0]); x(r[1]); },
 		[&](){ h(r[2]); });

--- a/test/AST-Quake/compute_action-2.cpp
+++ b/test/AST-Quake/compute_action-2.cpp
@@ -11,7 +11,7 @@
 
 #include <cudaq.h>
 
-__qpu__ void magic_func(cudaq::qreg<> &q) {
+__qpu__ void magic_func(cudaq::qvector<> &q) {
   auto nQubits = q.size();
   for (int step = 0; step < 100; ++step) {
     for (int j = 0; j < nQubits; j++)
@@ -26,7 +26,7 @@ __qpu__ void magic_func(cudaq::qreg<> &q) {
 struct ctrlHeisenberg {
   void operator()(int nQubits) __qpu__ {
     cudaq::qubit ctrl1;
-    cudaq::qreg q(nQubits);
+    cudaq::qvector q(nQubits);
     cudaq::control(magic_func, ctrl1, q);
   }
 };

--- a/test/AST-Quake/control.cpp
+++ b/test/AST-Quake/control.cpp
@@ -11,7 +11,7 @@
 #include <cudaq.h>
 
 struct heisenbergU {
-  void operator()(cudaq::qreg<> &q) __qpu__ {
+  void operator()(cudaq::qvector<> &q) __qpu__ {
     auto nQubits = q.size();
     for (int step = 0; step < 100; ++step) {
       for (int j = 0; j < nQubits; j++)
@@ -27,7 +27,7 @@ struct heisenbergU {
 struct ctrlHeisenberg {
   void operator()(int nQubits) __qpu__ {
     cudaq::qubit ctrl1, ctrl2;
-    cudaq::qreg q(nQubits);
+    cudaq::qvector q(nQubits);
     cudaq::control(heisenbergU{}, {ctrl1, ctrl2}, q);
   }
 };
@@ -71,7 +71,7 @@ __qpu__ void qnppx(double theta, cudaq::qubit &q, cudaq::qubit &r,
 // CHECK:           quake.apply @__nvqpp__mlirgen__givens [%[[VAL_7]]] %{{.*}}, %{{.*}}, %{{.*}} : (!quake.veq<2>, f64, !quake.ref, !quake.ref) -> ()
 // CHECK:           return
 
-__qpu__ void magic_func(cudaq::qreg<> &q) {
+__qpu__ void magic_func(cudaq::qvector<> &q) {
   auto nQubits = q.size();
   for (int step = 0; step < 100; ++step) {
     for (int j = 0; j < nQubits; j++)
@@ -86,7 +86,7 @@ __qpu__ void magic_func(cudaq::qreg<> &q) {
 struct ctrlHeisenbergVersion2 {
   void operator()(int nQubits) __qpu__ {
     cudaq::qubit ctrl1;
-    cudaq::qreg q(nQubits);
+    cudaq::qvector q(nQubits);
     cudaq::control(magic_func, ctrl1, q);
   }
 };

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -20,7 +20,7 @@ void g4();
 
 struct C {
    void operator()() __qpu__ {
-      cudaq::qreg r(2);
+      cudaq::qvector r(2);
       g1();
       for (int i = 0; i < 10; ++i) {
 	 if (f1(i)) {
@@ -109,7 +109,7 @@ struct C {
 
 struct D {
    void operator()() __qpu__ {
-      cudaq::qreg r(2);
+      cudaq::qvector r(2);
       g1();
       for (int i = 0; i < 10; ++i) {
 	 if (f1(i)) {
@@ -198,7 +198,7 @@ struct D {
 
 struct E {
    void operator()() __qpu__ {
-      cudaq::qreg r(2);
+      cudaq::qvector r(2);
       g1();
       for (int i = 0; i < 10; ++i) {
 	 if (f1(i)) {
@@ -286,7 +286,7 @@ struct E {
 
 struct F {
    void operator()() __qpu__ {
-      cudaq::qreg r(2);
+      cudaq::qvector r(2);
       g1();
       for (int i = 0; i < 10; ++i) {
 	 if (f1(i)) {

--- a/test/AST-Quake/ctrl_vector.cpp
+++ b/test/AST-Quake/ctrl_vector.cpp
@@ -12,8 +12,8 @@
 
 struct lower_ctrl_as_qreg {
   void operator()() __qpu__ {
-    cudaq::qreg reg1(4); // group of controls
-    cudaq::qreg reg2(2); // some targets
+    cudaq::qvector reg1(4); // group of controls
+    cudaq::qvector reg2(2); // some targets
 
     h(reg1, reg2[0]);
     x(reg1, reg2[1]);
@@ -39,7 +39,7 @@ struct test_two_control_call {
       h<cudaq::ctrl>(qb);
       x<cudaq::ctrl>(qb);
     };
-    cudaq::qreg<4> qs;
+    cudaq::qarray<4> qs;
     cudaq::qubit qb;
     cudaq::control(lambda, qs, qb);
     mz(qb);
@@ -71,7 +71,7 @@ struct unmarked_lambda {
       h<cudaq::ctrl>(qb);
       y<cudaq::ctrl>(qb);
     };
-    cudaq::qreg<4> qs;
+    cudaq::qarray<4> qs;
     cudaq::qubit qb;
     cudaq::control(lambda, qs, qb);
     mz(qb);
@@ -93,7 +93,7 @@ struct unmarked_lambda {
 
 struct direct_unmarked_lambda {
   void operator()() __qpu__ {
-    cudaq::qreg<4> qs;
+    cudaq::qarray<4> qs;
     cudaq::qubit qb;
     cudaq::control([](cudaq::qubit &qb) {
       h<cudaq::ctrl>(qb);

--- a/test/AST-Quake/dealloc.cpp
+++ b/test/AST-Quake/dealloc.cpp
@@ -12,10 +12,10 @@
 
 __qpu__ void magic_func(int N) {
   {
-    cudaq::qreg q(N);
+    cudaq::qvector q(N);
     h(q[0]);
   }
-  cudaq::qreg w(N);
+  cudaq::qvector w(N);
   x(w[0]);
 }
 

--- a/test/AST-Quake/empty_step.cpp
+++ b/test/AST-Quake/empty_step.cpp
@@ -12,7 +12,7 @@
 
 __qpu__ void uma(cudaq::qubit &, cudaq::qubit &, cudaq::qubit &) {}
 
-__qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ void test(cudaq::qview<> a, cudaq::qview<> b) {
   for (uint32_t i = a.size(); i-- > 1ul;) {
     uma(a[i - 1ul], b[i - 1ul], a[i]);
   }

--- a/test/AST-Quake/exp-pauli-1.cpp
+++ b/test/AST-Quake/exp-pauli-1.cpp
@@ -12,7 +12,7 @@
 
 int main() {
   auto kernel = [](double theta) __qpu__ {
-    cudaq::qreg q(4);
+    cudaq::qvector q(4);
     x(q[0]);
     x(q[1]);
     exp_pauli(theta, q, "XXXY");

--- a/test/AST-Quake/exp-pauli-2.cpp
+++ b/test/AST-Quake/exp-pauli-2.cpp
@@ -12,7 +12,7 @@
 
 int main() {
   auto kernel2 = [](double theta, const char *pauli) __qpu__ {
-    cudaq::qreg q(4);
+    cudaq::qvector q(4);
     x(q[0]);
     x(q[1]);
     exp_pauli(theta, q, pauli);

--- a/test/AST-Quake/exp-pauli-3.cpp
+++ b/test/AST-Quake/exp-pauli-3.cpp
@@ -12,7 +12,7 @@
 
 int main() {
   auto kernel = [](double theta) __qpu__ {
-    cudaq::qreg q(4);
+    cudaq::qvector q(4);
     x(q[0]);
     x(q[1]);
     exp_pauli(theta, "XXXY", q[0], q[1], q[2], q[3]);

--- a/test/AST-Quake/has_conditionals.cpp
+++ b/test/AST-Quake/has_conditionals.cpp
@@ -15,7 +15,7 @@
 // CHECK-SAME: {{("cudaq-entrypoint".*qubitMeasurementFeedback = true.*[}])|([{].*qubitMeasurementFeedback = true.*"cudaq-entrypoint")}} {
 struct kernel {
     void operator()() __qpu__ {
-        cudaq::qreg<3> q;
+        cudaq::qarray<3> q;
         h(q[1]);
         x<cudaq::ctrl>(q[1],q[2]);
 
@@ -34,7 +34,7 @@ struct kernel {
 // CHECK-SAME: () attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
 struct kernelNoConditional {
     void operator()() __qpu__ {
-        cudaq::qreg<1> q;
+        cudaq::qarray<1> q;
         h(q[0]);
     }
 };
@@ -45,7 +45,7 @@ struct kernelNoConditional {
 struct kernelComplex {
   void operator()() __qpu__ {
     // Allocate the qubits
-    cudaq::qreg q(2), ancilla(2);
+    cudaq::qvector q(2), ancilla(2);
     h(q[0]);
     x<cudaq::ctrl>(q[0], q[1]);
 

--- a/test/AST-Quake/if.cpp
+++ b/test/AST-Quake/if.cpp
@@ -14,7 +14,7 @@
 
 struct kernel {
   __qpu__ int operator()(bool flag) {
-    cudaq::qreg reg(2);
+    cudaq::qvector reg(2);
     if (flag) {
       h<cudaq::ctrl>(reg[0], reg[1]);
     }
@@ -38,7 +38,7 @@ struct kernel {
 
 struct kernel_else {
   __qpu__ int operator()(bool flag) {
-    cudaq::qreg reg(2);
+    cudaq::qvector reg(2);
     if (flag) {
       h<cudaq::ctrl>(reg[0], reg[1]);
     } else {
@@ -68,7 +68,7 @@ struct kernel_else {
 
 struct kernel_short_circuit_and {
   __qpu__ int operator()() {
-    cudaq::qreg reg(3);
+    cudaq::qvector reg(3);
     if (mz(reg[0]) && mz(reg[1]))
       x(reg[2]);
     return 0;
@@ -100,7 +100,7 @@ struct kernel_short_circuit_and {
 
 struct kernel_short_circuit_or {
   __qpu__ int operator()() {
-    cudaq::qreg reg(3);
+    cudaq::qvector reg(3);
     if (mz(reg[0]) || mz(reg[1]))
       x(reg[2]);
     return 0;
@@ -132,7 +132,7 @@ struct kernel_short_circuit_or {
 
 struct kernel_ternary {
   __qpu__ int operator()() {
-    cudaq::qreg q(3);
+    cudaq::qvector q(3);
     auto measureResult = mz(q[0]) ? mz(q[1]) : mz(q[2]);
     return 0;
   }

--- a/test/AST-Quake/lambda_instance.cpp
+++ b/test/AST-Quake/lambda_instance.cpp
@@ -15,7 +15,7 @@
 
 struct test0 {
   void operator()() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     auto lz = [](cudaq::qubit &q) __qpu__ { x(q); };
     cudaq::control(lz, q[0], q[1]);
   }
@@ -41,7 +41,7 @@ struct test0 {
 
 struct test1 {
   void operator()() __qpu__ {
-    cudaq::qreg<2> q;
+    cudaq::qarray<2> q;
     cudaq::control([](cudaq::qubit &q) __qpu__ { x(q); }, q[0], q[1]);
   }
 };
@@ -66,7 +66,7 @@ struct test1 {
 
 struct test2a {
   template <typename C>
-  void operator()(C &&callme, cudaq::qreg<> &q) __qpu__ {
+  void operator()(C &&callme, cudaq::qvector<> &q) __qpu__ {
     callme(q[0]);
     callme(q[1]);
   }
@@ -74,7 +74,7 @@ struct test2a {
 
 struct test2b {
   void operator()() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     test2a{}(
         [](cudaq::qubit &q) __qpu__ {
           h(q);
@@ -106,9 +106,7 @@ struct test2b {
 
 struct test2a_c {
   template <typename C>
-  void operator()(C &&callme, cudaq::qreg<> &q) __qpu__ {
-    // void operator()(std::function<void(cudaq::qubit &)> &&callme,
-    //            cudaq::qreg<> &q) __qpu__ {
+  void operator()(C &&callme, cudaq::qvector<> &q) __qpu__ {
     callme(q[0]);
     callme(q[1]);
   }
@@ -116,7 +114,7 @@ struct test2a_c {
 
 struct test2c {
   void operator()() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     auto lz = [](cudaq::qubit &q) __qpu__ {
       h(q);
       z(q);
@@ -150,7 +148,7 @@ struct test2c {
 
 struct test3a {
   void operator()(std::function<void(cudaq::qubit &)> &&callme,
-		  cudaq::qreg<> &q) __qpu__ {
+		  cudaq::qvector<> &q) __qpu__ {
     callme(q[0]);
     callme(q[1]);
   }
@@ -158,7 +156,7 @@ struct test3a {
 
 struct test3 {
   void operator()() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     auto lz = [](cudaq::qubit &q) __qpu__ {
       h(q);
       z(q);
@@ -201,7 +199,7 @@ struct test3 {
 
 struct test4x2 {
   template <typename C>
-  void operator()(C &&callme, cudaq::qreg<> &q) __qpu__ {
+  void operator()(C &&callme, cudaq::qvector<> &q) __qpu__ {
     callme(q[0]);
     callme(q[1]);
   }
@@ -211,7 +209,7 @@ struct test4x2 {
 
 struct test4x4 {
   void operator()() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     test4x2{}(
         [](cudaq::qubit &q) __qpu__ {
           h(q);
@@ -243,7 +241,7 @@ struct test4x4 {
 
 struct test4x8 {
   void operator()() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     auto lz = [](cudaq::qubit &q) __qpu__ {
       h(q);
       z(q);

--- a/test/AST-Quake/lambda_variable.cpp
+++ b/test/AST-Quake/lambda_variable.cpp
@@ -16,7 +16,7 @@
 
 struct test3_callee {
   void operator()(std::function<void(cudaq::qubit &)> &&callback,
-                  cudaq::qreg<> &s) __qpu__ {
+                  cudaq::qvector<> &s) __qpu__ {
     callback(s[0]);
     callback(s[1]);
   }
@@ -24,7 +24,7 @@ struct test3_callee {
 
 struct test3_caller {
   void operator()() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     test3_callee{}(
         [](cudaq::qubit &r) __qpu__ {
           h(r);
@@ -67,7 +67,7 @@ struct test3_caller {
 // is resolved to in the AST.
 struct test4_callee {
    void operator()(cudaq::signature<void(cudaq::qubit &)> auto &&callback,
-                  cudaq::qreg<> &s) __qpu__ {
+                  cudaq::qvector<> &s) __qpu__ {
     callback(s[0]);
     callback(s[1]);
   }
@@ -75,7 +75,7 @@ struct test4_callee {
 
 struct test4_caller {
   void operator()() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     test4_callee{}(
         [](cudaq::qubit &r) __qpu__ {
           h(r);

--- a/test/AST-Quake/loop_normal.cpp
+++ b/test/AST-Quake/loop_normal.cpp
@@ -63,7 +63,7 @@ __qpu__ void foo2() {
 // CHECK:         }
 
 __qpu__ void foo3() {
-  cudaq::qreg q(10);
+  cudaq::qvector q(10);
   for (int i = 0; i < 10; i += 2)
     x(q[i]);
 }
@@ -88,7 +88,7 @@ __qpu__ void foo3() {
 // CHECK:             cc.continue %[[VAL_13]] : i32
 
 __qpu__ void foo4() {
-  cudaq::qreg q(10);
+  cudaq::qvector q(10);
   for (int i = 10; i > 0; i -= 2)
     x(q[i-1]);
 }
@@ -375,7 +375,7 @@ __qpu__ void linear_expr5b() {
 // CHECK:           } {normalized}
 
 __qpu__ void linear_expr6() {
-  cudaq::qreg q(100);
+  cudaq::qvector q(100);
   // 2 iterations: [(10-1)-(1+1)+(2*2)]/(2*2)
   for (int i = 1; 2 * i + 1 < 10; i += 2)
     x(q[i]);

--- a/test/AST-Quake/loop_unroll-1.cpp
+++ b/test/AST-Quake/loop_unroll-1.cpp
@@ -12,7 +12,7 @@
 
 struct C {
    void operator()() __qpu__ {
-      cudaq::qreg r(2);
+      cudaq::qvector r(2);
       cudaq::qubit w;
       auto singleQubit = mz(w);
       auto myRegister = mz(r);

--- a/test/AST-Quake/loop_unroll-2.cpp
+++ b/test/AST-Quake/loop_unroll-2.cpp
@@ -12,7 +12,7 @@
 #include <cudaq.h>
 
 struct test1 {
-  void operator()(cudaq::qreg<> &q) __qpu__ {
+  void operator()(cudaq::qvector<> &q) __qpu__ {
     for (unsigned i = 0; i < 3; i += 1) {
       h(q[i]);
       z(q[i]);
@@ -29,7 +29,7 @@ struct test1 {
 // CHECK:           return
 
 struct test2 {
-  void operator()(cudaq::qreg<> &q) __qpu__ {
+  void operator()(cudaq::qvector<> &q) __qpu__ {
     for (unsigned i = 0; i <= 3; ++i) {
       h(q[i]);
       y(q[i]);
@@ -47,7 +47,7 @@ struct test2 {
 // CHECK:           return
 
 struct test3 {
-  void operator()(cudaq::qreg<> &q) __qpu__ {
+  void operator()(cudaq::qvector<> &q) __qpu__ {
     // Do not expect this to unroll. Loop must be normalized.
     for (unsigned i = 7; i < 14; i += 3) {
       h(q[i]);
@@ -67,7 +67,7 @@ struct test3 {
 struct test4 {
   // Use post-increment.
   void operator()() __qpu__ {
-    cudaq::qreg reg(1);
+    cudaq::qvector reg(1);
     for (size_t i = 0; i < 3; i++) {
       h(reg[0]);
       y(reg[0]);
@@ -87,7 +87,7 @@ struct test4 {
 struct test5 {
   // Loop that decrements. Loop is not unrolled. It needs to be normalized.
   void operator()() __qpu__ {
-    cudaq::qreg reg(1);
+    cudaq::qvector reg(1);
     for (size_t i = 3; i > 0; --i)
       x(reg[0]);
     mz(reg);
@@ -104,7 +104,7 @@ struct test5 {
 struct test6 {
   // Loop that decrements. Loop is not unrolled. It needs to be normalized.
   void operator()() __qpu__ {
-    cudaq::qreg reg(1);
+    cudaq::qvector reg(1);
     for (size_t i = 3; i-- > 0;)
       x(reg[0]);
     mz(reg);
@@ -124,7 +124,7 @@ struct test6 {
 
 struct cannot_unroll_dynamic_iterations {
   void operator()(unsigned size) __qpu__ {
-    cudaq::qreg reg(1);
+    cudaq::qvector reg(1);
     for (size_t i = 0; i < size; ++i)
       x(reg[0]);
     for (size_t i = 0; i < size; i++)
@@ -152,7 +152,7 @@ struct cannot_unroll_dynamic_iterations {
 
 struct cannot_unroll_dynamic_iterations_2 {
   void operator()(unsigned size) __qpu__ {
-    cudaq::qreg reg(size);
+    cudaq::qvector reg(size);
     for (size_t i = 0; i < reg.size(); ++i)
       x(reg[i]);
     for (size_t i = 0; i < reg.size(); i++)
@@ -184,7 +184,7 @@ struct cannot_unroll_dynamic_iterations_2 {
 
 struct for_loop_3 {
   void operator()() __qpu__ {
-    cudaq::qreg reg(3);
+    cudaq::qvector reg(3);
     for (size_t i = 0; i < reg.size(); ++i)
       z(reg[i]);
     for (size_t i = 0; i < reg.size(); i++)
@@ -212,7 +212,7 @@ struct for_loop_3 {
 
 struct for_loop_4 {
   void operator()() __qpu__ {
-    cudaq::qreg reg(3);
+    cudaq::qvector reg(3);
     for (size_t i = 0, n = reg.size(); i < n; ++i)
       y(reg[i]);
     for (size_t i = 0, n = reg.size(); i < n; i++)

--- a/test/AST-Quake/loop_unroll-3.cpp
+++ b/test/AST-Quake/loop_unroll-3.cpp
@@ -19,7 +19,7 @@
 // exactly 10 measurements on $[0 \dots 9]$.
 
 __qpu__ void loop_peeling_and_unrolling_test() {
-  cudaq::qreg r(10);
+  cudaq::qvector r(10);
   unsigned i = 0;
 
   do {
@@ -56,7 +56,7 @@ __qpu__ void loop_peeling_and_unrolling_test() {
 // clang-format on
 
 __qpu__ void another_test() {
-  cudaq::qreg r(10);
+  cudaq::qvector r(10);
   unsigned i = 0;
 
   do {
@@ -92,7 +92,7 @@ __qpu__ void another_test() {
 struct Qernel {
   // Loop that decrements. Loop is not unrolled. It needs to be normalized.
   void operator()() __qpu__ {
-    cudaq::qreg reg(1);
+    cudaq::qvector reg(1);
     for (size_t i = 3; i-- > 0;)
       x(reg[0]);
     mz(reg);

--- a/test/AST-Quake/measure_bell.cpp
+++ b/test/AST-Quake/measure_bell.cpp
@@ -15,7 +15,7 @@
 
 struct bell {
   void operator()(int num_iters) __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     int n = 0;
     for (int i = 0; i < num_iters; i++) {
       h(q[0]);
@@ -81,7 +81,7 @@ struct bell {
 
 struct libertybell {
   void operator()(int num_iters) __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     int n = 0;
     for (int i = 0; i < num_iters; i++) {
       h(q[0]);
@@ -143,7 +143,7 @@ struct libertybell {
 
 struct tinkerbell {
   void operator()(int num_iters) __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     int n = 0;
     for (int i = 0; i < num_iters; i++) {
       h(q[0]);

--- a/test/AST-Quake/mz.cpp
+++ b/test/AST-Quake/mz.cpp
@@ -12,7 +12,7 @@
 
 struct S {
   void operator()() __qpu__ {
-    cudaq::qreg reg(20);
+    cudaq::qvector reg(20);
     mz(reg);
   }
 };
@@ -28,8 +28,8 @@ struct S {
 struct VectorOfStaticVeq {
   std::vector<bool> operator()() __qpu__ {
     cudaq::qubit q1;
-    cudaq::qreg reg1(4);
-    cudaq::qreg reg2(2);
+    cudaq::qvector reg1(4);
+    cudaq::qvector reg2(2);
     cudaq::qubit q2;
     return mz(q1, reg1, reg2, q2);
   }
@@ -53,8 +53,8 @@ struct VectorOfStaticVeq {
 struct VectorOfDynamicVeq {
   std::vector<bool> operator()(unsigned i, unsigned j) __qpu__ {
     cudaq::qubit q1;
-    cudaq::qreg reg1(i);
-    cudaq::qreg reg2(j);
+    cudaq::qvector reg1(i);
+    cudaq::qvector reg2(j);
     cudaq::qubit q2;
     return mz(q1, reg1, reg2, q2);
   }

--- a/test/AST-Quake/negation.cpp
+++ b/test/AST-Quake/negation.cpp
@@ -12,7 +12,7 @@
 
 struct NegationOperatorTest {
   void operator()() __qpu__ {
-    cudaq::qreg qr(3);
+    cudaq::qvector qr(3);
     x<cudaq::ctrl>(!qr[0], qr[1], qr[2]);
   }
 };

--- a/test/AST-Quake/passQregNToQSpan.cpp
+++ b/test/AST-Quake/passQregNToQSpan.cpp
@@ -10,13 +10,13 @@
 
 #include "cudaq.h"
 
-__qpu__ void mcx(cudaq::qspan<> qubits) {
+__qpu__ void mcx(cudaq::qview<> qubits) {
 
 }
 
 struct entry {
  void operator()() __qpu__ {
-    cudaq::qreg<3> q;
+    cudaq::qarray<3> q;
     mcx(q);
  }
 };
@@ -29,7 +29,7 @@ struct entry {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__entry() attributes {
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<3>
 // CHECK:           %[[VAL_2:.*]] = quake.relax_size %[[VAL_1]] : (!quake.veq<3>) -> !quake.veq<?>
-// CHECK:           call @__nvqpp__mlirgen__function_mcx._Z3mcxN5cudaq5qspan{{.*}}(%[[VAL_2]]) : (!quake.veq<?>) -> ()
+// CHECK:           call @__nvqpp__mlirgen__function_mcx._Z3mcxN5cudaq5{{.*}}(%[[VAL_2]]) : (!quake.veq<?>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/postfix_ops.cpp
+++ b/test/AST-Quake/postfix_ops.cpp
@@ -12,7 +12,7 @@
 
 void uma(cudaq::qubit&,cudaq::qubit&,cudaq::qubit&);
 
-__qpu__ void test(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ void test(cudaq::qview<> a, cudaq::qview<> b) {
    for (uint32_t i = a.size(); i-- > 1ul; (void)0) {
     uma(a[i - 1ul], b[i - 1ul], a[i]);
   }

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -20,7 +20,7 @@
 
 // Can define this as a free function since it is a pure device quantum kernel
 // (cannot be called from host code)
-__qpu__ void iqft(cudaq::qspan<> q) {
+__qpu__ void iqft(cudaq::qview<> q) {
   int N = q.size();
   // Swap qubits
   for (int i = 0; i < N / 2; ++i) {
@@ -42,7 +42,7 @@ __qpu__ void iqft(cudaq::qspan<> q) {
 // Define an oracle CUDA Quantum kernel
 struct tgate {
   // We do not own the qubits here, so just use a qspan.
-  void operator()(cudaq::qspan<> &q) __qpu__ { t(q); }
+  void operator()(cudaq::qview<> &q) __qpu__ { t(q); }
 };
 
 // CUDA Quantum Kernel call operators can be templated on input kernel
@@ -57,7 +57,7 @@ struct qpe {
   void operator()(const int nCountingQubits, const int nStateQubits,
                   StatePrep &&state_prep, Unitary &&oracle) __qpu__ {
     // Allocate a register of qubits
-    cudaq::qreg q(nCountingQubits + nStateQubits);
+    cudaq::qvector q(nCountingQubits + nStateQubits);
 
     // Extract sub-registers, one for the counting qubits another for the
     // eigenstate register
@@ -91,7 +91,7 @@ int main() {
   // Sample the QPE kernel for 3 counting qubits, 1 state qubit, a |1>
   // eigenstate preparation kernel, and a T gate unitary.
   auto counts = cudaq::sample(
-      qpe{}, 3, 1, [](cudaq::qspan<> &q) __qpu__ { x(q); }, tgate{});
+      qpe{}, 3, 1, [](cudaq::qview<> &q) __qpu__ { x(q); }, tgate{});
 
   // Fine grain access to the bits and counts
   for (auto &[bits, count] : counts) {

--- a/test/AST-Quake/ranged_for.cpp
+++ b/test/AST-Quake/ranged_for.cpp
@@ -289,7 +289,7 @@ struct Nesting {
 // clang-format on
 
 struct FreeRange {
-  void operator()(cudaq::qreg<> r, unsigned N) __qpu__ {
+  void operator()(cudaq::qvector<> r, unsigned N) __qpu__ {
     for (auto i : cudaq::range(N)) {
       h(r[i]);
     }

--- a/test/AST-Quake/ranged_for_qreg.cpp
+++ b/test/AST-Quake/ranged_for_qreg.cpp
@@ -11,7 +11,7 @@
 #include <cudaq.h>
 
 __qpu__ void range_qubit() {
-  cudaq::qreg<10> qr;
+  cudaq::qarray<10> qr;
 
   for (auto &q : qr) {
     bool weevil = mx(q);

--- a/test/AST-Quake/simple.cpp
+++ b/test/AST-Quake/simple.cpp
@@ -71,7 +71,7 @@
 // Define a quantum kernel
 struct ghz {
   auto operator()(const int N) __qpu__ {
-    cudaq::qreg q(N);
+    cudaq::qvector q(N);
     h(q[0]);
     for (int i = 0; i < N - 1; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/test/AST-Quake/simple_qarray.cpp
+++ b/test/AST-Quake/simple_qarray.cpp
@@ -17,7 +17,7 @@
 // Define a quantum kernel
 struct ghz {
   auto operator()() __qpu__ {
-    cudaq::qreg<5> q;
+    cudaq::qarray<5> q;
     h(q[0]);
     for (int i = 0; i < 4; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/test/AST-Quake/slice.cpp
+++ b/test/AST-Quake/slice.cpp
@@ -10,11 +10,11 @@
 
 #include <cudaq.h>
 
-__qpu__ void other(cudaq::qspan<>);
+__qpu__ void other(cudaq::qview<>);
 
 struct SliceTest {
    void operator()(int i1, int i2) __qpu__ {
-      cudaq::qreg reg(10);
+      cudaq::qvector reg(10);
       auto s = reg.slice(i1, i2);
       other(s);
    }

--- a/test/AST-Quake/template_kernel.cpp
+++ b/test/AST-Quake/template_kernel.cpp
@@ -33,7 +33,7 @@
 // Define a quantum kernel
 template <std::size_t N> struct ghz {
   auto operator()() __qpu__ {
-    cudaq::qreg<N> q;
+    cudaq::qarray<N> q;
     h(q[0]);
     for (int i = 0; i < N - 1; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/test/AST-Quake/template_lambda.cpp
+++ b/test/AST-Quake/template_lambda.cpp
@@ -17,7 +17,7 @@ struct thisWorks {
 struct test {
   template <typename Callable>
   void operator()(Callable &&callable) __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     cudaq::control(callable, q[0], q[1]);
   }
 };

--- a/test/AST-Quake/to_qir.cpp
+++ b/test/AST-Quake/to_qir.cpp
@@ -12,7 +12,7 @@
 
 struct kernel {
     void operator()() __qpu__ {
-        cudaq::qreg<3> q;
+        cudaq::qarray<3> q;
         h(q[1]);
         x<cudaq::ctrl>(q[1], q[2]);
 

--- a/test/AST-Quake/vector.cpp
+++ b/test/AST-Quake/vector.cpp
@@ -20,7 +20,7 @@ struct simple_double_rotation {
   auto operator()(std::vector<double> theta) __qpu__ {
     auto size = theta.size();
     bool empty = theta.empty();
-    cudaq::qreg q(1);
+    cudaq::qvector q(1);
     int test = q.size();
     rx(theta[0], q[0]);
     mz(q);
@@ -33,7 +33,7 @@ struct simple_float_rotation {
   auto operator()(std::vector<float> theta) __qpu__ {
     int size = theta.size();
     bool empty = theta.empty();
-    cudaq::qreg q(1);
+    cudaq::qvector q(1);
     rx(theta[0], q[0]);
     mz(q);
   }

--- a/test/AST-Quake/vector_bool.cpp
+++ b/test/AST-Quake/vector_bool.cpp
@@ -14,7 +14,7 @@
 
 struct t1 {
   bool operator()(std::vector<double> d) __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     auto vec = mz(q);
     return vec[0];
   }

--- a/test/AST-Quake/vector_ctor_initlist_int.cpp
+++ b/test/AST-Quake/vector_ctor_initlist_int.cpp
@@ -13,7 +13,7 @@
 #include "cudaq.h"
 
 __qpu__ void testInt() {
-  cudaq::qreg<3> q;
+  cudaq::qarray<3> q;
   std::vector<int> index{0, 1, 2};
   ry(M_PI_2, q[index[0]]);
   ry(M_PI_2, q[index[1]]);

--- a/test/AST-Quake/while-1.cpp
+++ b/test/AST-Quake/while-1.cpp
@@ -12,28 +12,28 @@
 
 void uma(cudaq::qubit&,cudaq::qubit&,cudaq::qubit&);
 
-__qpu__ void test1(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ void test1(cudaq::qview<> a, cudaq::qview<> b) {
   uint32_t i = a.size();
   while (1) {
     uma(a[i - 1ul], b[i - 1ul], a[i]);
   }
 }
 
-__qpu__ void test2(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ void test2(cudaq::qview<> a, cudaq::qview<> b) {
   uint32_t i = a.size();
   while (true) {
     uma(a[i - 1ul], b[i - 1ul], a[i]);
   }
 }
 
-__qpu__ void test3(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ void test3(cudaq::qview<> a, cudaq::qview<> b) {
   uint32_t i = a.size();
   do {
     uma(a[i - 1ul], b[i - 1ul], a[i]);
   } while (false);
 }
 
-__qpu__ double test4(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ double test4(cudaq::qview<> a, cudaq::qview<> b) {
   uint32_t i = a.size();
   double trouble = i;
   do {

--- a/test/AST-Quake/while-2.cpp
+++ b/test/AST-Quake/while-2.cpp
@@ -14,7 +14,7 @@ void fun(int);
 
 void uma(cudaq::qubit &, cudaq::qubit &, cudaq::qubit &);
 
-__qpu__ void test1(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ void test1(cudaq::qview<> a, cudaq::qview<> b) {
   uint32_t i = a.size();
   while (i > 0) {
     uma(a[i - 1ul], b[i - 1ul], a[i]);
@@ -22,7 +22,7 @@ __qpu__ void test1(cudaq::qspan<> a, cudaq::qspan<> b) {
   }
 }
 
-__qpu__ void test2(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ void test2(cudaq::qview<> a, cudaq::qview<> b) {
   uint32_t i = a.size();
   while (i > 0) {
     uma(a[i - 1ul], b[i - 1ul], a[i]);
@@ -34,7 +34,7 @@ __qpu__ void test2(cudaq::qspan<> a, cudaq::qspan<> b) {
   }
 }
 
-__qpu__ void test3(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ void test3(cudaq::qview<> a, cudaq::qview<> b) {
   uint32_t i = a.size();
   while (i > 0) {
     uma(a[i - 1ul], b[i - 1ul], a[i]);
@@ -42,7 +42,7 @@ __qpu__ void test3(cudaq::qspan<> a, cudaq::qspan<> b) {
   }
 }
 
-__qpu__ void test4(cudaq::qspan<> a, cudaq::qspan<> b) {
+__qpu__ void test4(cudaq::qview<> a, cudaq::qview<> b) {
   uint32_t i = a.size();
   while (i > 0) {
     uma(a[i - 1ul], b[i - 1ul], a[i]);

--- a/test/AST-error/quantum_types.cpp
+++ b/test/AST-error/quantum_types.cpp
@@ -11,10 +11,8 @@
 #include <cudaq.h>
 
 struct S1 {
-  // expected-warning@+3{{}}
-  // expected-note@* {{}}
   // expected-error@+1{{may not use quantum types in non-kernel functions}}
-  void operator()(cudaq::qspan<> q) {
+  void operator()(cudaq::qview<> q) {
     mz(q);
   }
 };
@@ -29,19 +27,15 @@ struct S2 {
 
 struct S3 {
   void operator()() {
-    // expected-warning@+3{{}}
-    // expected-note@* {{}}
     // expected-error@+1{{may not use quantum types in non-kernel functions}}
-    cudaq::qreg<4> r;
+    cudaq::qarray<4> r;
     mz(r);
   }
 };
 
 struct S4 {
-  // expected-warning@+3{{}}
-  // expected-note@* {{}}
   // expected-error@+1{{may not use quantum types in non-kernel functions}}
-  void operator()(cudaq::qreg<4> r) {
+  void operator()(cudaq::qarray<4> r) {
     mz(r);
   }
 };
@@ -49,7 +43,7 @@ struct S4 {
 struct S5 {
   void operator()() {
     // expected-error@+1{{may not use quantum types in non-kernel functions}}
-    cudaq::qreg r(10);
+    cudaq::qvector r(10);
     mz(r);
   }
 };

--- a/test/NVQPP/IQPE_conditionals.cpp
+++ b/test/NVQPP/IQPE_conditionals.cpp
@@ -14,7 +14,7 @@
 
 struct iqpe {
   void operator()() __qpu__ {
-    cudaq::qreg<2> q;
+    cudaq::qarray<2> q;
     h(q[0]);
     x(q[1]);
     for (int i = 0; i < 8; i++)

--- a/test/NVQPP/auto_kernel.cpp
+++ b/test/NVQPP/auto_kernel.cpp
@@ -18,7 +18,7 @@
 
 struct ak2 {
   auto operator()() __qpu__ {
-    cudaq::qreg<3> q;
+    cudaq::qarray<3> q;
     x(q[0]);
     h(q[1]);
     x<cudaq::ctrl>(q[1], q[2]);

--- a/test/NVQPP/callable_kernel_arg.cpp
+++ b/test/NVQPP/callable_kernel_arg.cpp
@@ -29,7 +29,7 @@ struct baz {
 struct foo {
   template <typename CallableKernel>
   __qpu__ void operator()(CallableKernel &&func, int size) {
-    cudaq::qreg q(size);
+    cudaq::qvector q(size);
     func(q[0]);
     auto result = mz(q[0]);
   }

--- a/test/NVQPP/conditional_sample.cpp
+++ b/test/NVQPP/conditional_sample.cpp
@@ -18,7 +18,7 @@
 
 struct kernel {
   void operator()() __qpu__ {
-    cudaq::qreg<3> q;
+    cudaq::qarray<3> q;
     // Initial state prep
     x(q[0]);
 

--- a/test/NVQPP/cudaq_observe.cpp
+++ b/test/NVQPP/cudaq_observe.cpp
@@ -24,7 +24,7 @@
 
 struct ansatz {
   auto operator()(double theta) __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     x(q[0]);
     ry(theta, q[1]);
     x<cudaq::ctrl>(q[1], q[0]);

--- a/test/NVQPP/device_code_loaded.cpp
+++ b/test/NVQPP/device_code_loaded.cpp
@@ -17,7 +17,7 @@
 // Define a quantum kernel
 struct ghz {
   auto operator()(const int N) __qpu__ {
-    cudaq::qreg q(N);
+    cudaq::qvector q(N);
     h(q[0]);
     for (int i = 0; i < N - 1; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/test/NVQPP/graph_coloring-1.cpp
+++ b/test/NVQPP/graph_coloring-1.cpp
@@ -16,7 +16,7 @@
 #include <unordered_set>
 
 struct init_state {
-  __qpu__ void operator()(cudaq::qreg<> &qubits, double theta) {
+  __qpu__ void operator()(cudaq::qvector<> &qubits, double theta) {
     ry(theta, qubits[0]);
     h<cudaq::ctrl>(qubits[0], qubits[1]);
     x(qubits[1]);
@@ -35,7 +35,7 @@ struct init_state {
   }
 };
 
-__qpu__ void reflect_uniform(cudaq::qreg<> &qubits, double theta) {
+__qpu__ void reflect_uniform(cudaq::qvector<> &qubits, double theta) {
   cudaq::adjoint(init_state{}, qubits, theta);
   x(qubits);
   z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3], qubits[4], qubits[5], qubits[6], qubits[7]);
@@ -49,7 +49,7 @@ bool oracle_classical(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3) {
   return c_01 && c_123;
 }
 
-__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+__qpu__ void oracle(cudaq::qvector<> &cs, cudaq::qubit &target) {
   x<cudaq::ctrl>(cs[0], !cs[1], cs[2], !cs[3], cs[5], target);
   x<cudaq::ctrl>(cs[0], !cs[1], cs[2], !cs[3], cs[7], target);
   x<cudaq::ctrl>(cs[0], !cs[1], !cs[3], cs[4], cs[7], target);
@@ -72,7 +72,7 @@ __qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
 }
 
 __qpu__ void grover(double theta) {
-  cudaq::qreg qubits(8);
+  cudaq::qvector qubits(8);
   cudaq::qubit ancilla;
 
   // Initialization

--- a/test/NVQPP/graph_coloring.cpp
+++ b/test/NVQPP/graph_coloring.cpp
@@ -15,7 +15,7 @@
 #include <iostream>
 #include <unordered_set>
 
-__qpu__ void init_state(cudaq::qreg<> &qubits, double theta) {
+__qpu__ void init_state(cudaq::qvector<> &qubits, double theta) {
   ry(theta, qubits[0]);
   h<cudaq::ctrl>(qubits[0], qubits[1]);
   x(qubits[1]);
@@ -34,7 +34,7 @@ __qpu__ void init_state(cudaq::qreg<> &qubits, double theta) {
 }
 
 // :(
-__qpu__ void init_state_adj(cudaq::qreg<> &qubits, double theta) {
+__qpu__ void init_state_adj(cudaq::qvector<> &qubits, double theta) {
   x(qubits[7]);
   h<cudaq::ctrl>(qubits[6], qubits[7]);
   ry<cudaq::adj>(theta, qubits[6]);
@@ -52,7 +52,7 @@ __qpu__ void init_state_adj(cudaq::qreg<> &qubits, double theta) {
   ry<cudaq::adj>(theta, qubits[0]);
 }
 
-__qpu__ void reflect_uniform(cudaq::qreg<> &qubits, double theta) {
+__qpu__ void reflect_uniform(cudaq::qvector<> &qubits, double theta) {
   // Don't work:
   // cudaq::adjoint(init_state, qubits, theta);
   init_state_adj(qubits, theta);
@@ -68,7 +68,7 @@ bool oracle_classical(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3) {
   return c_01 && c_123;
 }
 
-__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+__qpu__ void oracle(cudaq::qvector<> &cs, cudaq::qubit &target) {
   x<cudaq::ctrl>(cs[0], !cs[1], cs[2], !cs[3], cs[5], target);
   x<cudaq::ctrl>(cs[0], !cs[1], cs[2], !cs[3], cs[7], target);
   x<cudaq::ctrl>(cs[0], !cs[1], !cs[3], cs[4], cs[7], target);
@@ -91,7 +91,7 @@ __qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
 }
 
 __qpu__ void grover(double theta) {
-  cudaq::qreg qubits(8);
+  cudaq::qvector qubits(8);
   cudaq::qubit ancilla;
 
   // Initialization

--- a/test/NVQPP/int8_t.cpp
+++ b/test/NVQPP/int8_t.cpp
@@ -19,7 +19,7 @@
 
 struct variable_qreg {
   __qpu__ void operator()(std::uint8_t value) {
-    cudaq::qreg qubits(value);
+    cudaq::qvector qubits(value);
 
     auto result = mz(qubits);
   }

--- a/test/NVQPP/int8_t_free_func.cpp
+++ b/test/NVQPP/int8_t_free_func.cpp
@@ -18,7 +18,7 @@
 #include <iostream>
 
 __qpu__ void variable_qreg(std::uint8_t value) {
-  cudaq::qreg qubits(value);
+  cudaq::qvector qubits(value);
 
   auto result = mz(qubits);
 }

--- a/test/NVQPP/load_value.cpp
+++ b/test/NVQPP/load_value.cpp
@@ -19,7 +19,7 @@
 #include <iostream>
 
 __qpu__ void load_value(unsigned value) {
-  cudaq::qreg qubits(4);
+  cudaq::qvector qubits(4);
   for (std::size_t i = 0; i < 4; ++i) {
     // Doesn't work, even with: `if (value)`
     if (value & (1 << i))

--- a/test/NVQPP/phase_estimation.cpp
+++ b/test/NVQPP/phase_estimation.cpp
@@ -14,7 +14,7 @@
 
 // A pure device quantum kernel defined as a free function
 // (cannot be called from host code).
-__qpu__ void iqft(cudaq::qspan<> q) {
+__qpu__ void iqft(cudaq::qview<> q) {
   int N = q.size();
   // Swap qubits
   for (int i = 0; i < N / 2; ++i) {
@@ -47,7 +47,7 @@ struct qpe {
   void operator()(const int nCountingQubits, StatePrep &&state_prep,
                   Unitary &&oracle) __qpu__ {
     // Allocate a register of qubits
-    cudaq::qreg q(nCountingQubits + 1);
+    cudaq::qvector q(nCountingQubits + 1);
 
     // Extract sub-registers, one for the counting qubits
     // another for the eigenstate register

--- a/test/NVQPP/qir_range_err_compiler.cpp
+++ b/test/NVQPP/qir_range_err_compiler.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 
 __qpu__ void init_state() {
-  cudaq::qreg<5> q;
+  cudaq::qarray<5> q;
   x(q[0]);
   mz(q[99]); // compiler can flag this as an error
 };

--- a/test/NVQPP/qir_range_err_runtime.cpp
+++ b/test/NVQPP/qir_range_err_runtime.cpp
@@ -15,7 +15,7 @@
 #include <iostream>
 
 __qpu__ void init_state(int N) {
-  cudaq::qreg q(N);
+  cudaq::qvector q(N);
   x(q[0]);
   mz(q[99]); // compiler can't catch this error, but runtime can
 };

--- a/test/NVQPP/qpp_cpu_target.cpp
+++ b/test/NVQPP/qpp_cpu_target.cpp
@@ -16,7 +16,7 @@
 
 struct ghz {
   auto operator()(int N) __qpu__ {
-    cudaq::qreg q(N);
+    cudaq::qvector q(N);
     h(q[0]);
     for (int i = 0; i < N - 1; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/test/NVQPP/qspan_slices.cpp
+++ b/test/NVQPP/qspan_slices.cpp
@@ -19,14 +19,14 @@
 #include <cudaq.h>
 #include <iostream>
 
-__qpu__ void bar(cudaq::qspan<> qubits) {
+__qpu__ void bar(cudaq::qview<> qubits) {
   auto controls = qubits.front(qubits.size() - 1);
   auto &target = qubits.back();
   x<cudaq::ctrl>(controls, target);
 }
 
 __qpu__ void foo() {
-  cudaq::qreg qubits(4);
+  cudaq::qvector qubits(4);
   x(qubits);
   bar(qubits);
 

--- a/test/NVQPP/struct_arg.cpp
+++ b/test/NVQPP/struct_arg.cpp
@@ -19,7 +19,7 @@ struct baz {
 struct foo {
   template <typename CallableKernel>
   void operator()(CallableKernel &&func, int n) __qpu__ {
-    cudaq::qreg q(n);
+    cudaq::qvector q(n);
     func(q[0]);
     mz(q[0]);
   }

--- a/test/NVQPP/sudoku_2x2-1.cpp
+++ b/test/NVQPP/sudoku_2x2-1.cpp
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <unordered_set>
 
-__qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
+__qpu__ void reflect_uniform(cudaq::qvector<> &qubits) {
   h(qubits);
   x(qubits);
   z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3]);
@@ -26,13 +26,13 @@ __qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
   h(qubits);
 }
 
-__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+__qpu__ void oracle(cudaq::qvector<> &cs, cudaq::qubit &target) {
   x<cudaq::ctrl>(cs[0], !cs[1], !cs[2], cs[3], target);
   x<cudaq::ctrl>(!cs[0], cs[1], cs[2], !cs[3], target);
 }
 
 __qpu__ void grover() {
-  cudaq::qreg qubits(4);
+  cudaq::qvector qubits(4);
   cudaq::qubit ancilla;
 
   // Initialization

--- a/test/NVQPP/sudoku_2x2-bit_names.cpp
+++ b/test/NVQPP/sudoku_2x2-bit_names.cpp
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <unordered_set>
 
-__qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
+__qpu__ void reflect_uniform(cudaq::qvector<> &qubits) {
   h(qubits);
   x(qubits);
   z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3]);
@@ -27,13 +27,13 @@ __qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
   h(qubits);
 }
 
-__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+__qpu__ void oracle(cudaq::qvector<> &cs, cudaq::qubit &target) {
   x<cudaq::ctrl>(cs[0], !cs[1], !cs[2], cs[3], target);
   x<cudaq::ctrl>(!cs[0], cs[1], cs[2], !cs[3], target);
 }
 
 __qpu__ void grover() {
-  cudaq::qreg qubits(4);
+  cudaq::qvector qubits(4);
   cudaq::qubit ancilla;
 
   // Initialization

--- a/test/NVQPP/sudoku_2x2-reg_name.cpp
+++ b/test/NVQPP/sudoku_2x2-reg_name.cpp
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <unordered_set>
 
-__qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
+__qpu__ void reflect_uniform(cudaq::qvector<> &qubits) {
   h(qubits);
   x(qubits);
   z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3]);
@@ -26,13 +26,13 @@ __qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
   h(qubits);
 }
 
-__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+__qpu__ void oracle(cudaq::qvector<> &cs, cudaq::qubit &target) {
   x<cudaq::ctrl>(cs[0], !cs[1], !cs[2], cs[3], target);
   x<cudaq::ctrl>(!cs[0], cs[1], cs[2], !cs[3], target);
 }
 
 __qpu__ void grover() {
-  cudaq::qreg qubits(4);
+  cudaq::qvector qubits(4);
   cudaq::qubit ancilla;
 
   // Initialization

--- a/test/NVQPP/sudoku_2x2.cpp
+++ b/test/NVQPP/sudoku_2x2.cpp
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <unordered_set>
 
-__qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
+__qpu__ void reflect_uniform(cudaq::qvector<> &qubits) {
   h(qubits);
   x(qubits);
   z<cudaq::ctrl>(qubits[0], qubits[1], qubits[2], qubits[3]);
@@ -26,13 +26,13 @@ __qpu__ void reflect_uniform(cudaq::qreg<> &qubits) {
   h(qubits);
 }
 
-__qpu__ void oracle(cudaq::qreg<> &cs, cudaq::qubit &target) {
+__qpu__ void oracle(cudaq::qvector<> &cs, cudaq::qubit &target) {
   x<cudaq::ctrl>(cs[0], !cs[1], !cs[2], cs[3], target);
   x<cudaq::ctrl>(!cs[0], cs[1], cs[2], !cs[3], target);
 }
 
 __qpu__ void grover() {
-  cudaq::qreg qubits(4);
+  cudaq::qvector qubits(4);
   cudaq::qubit ancilla;
 
   // Initialization

--- a/test/NVQPP/swap_gate.cpp
+++ b/test/NVQPP/swap_gate.cpp
@@ -19,7 +19,7 @@
 int main() {
 
   auto swapKernel = []() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     x(q[0]);
     swap(q[0], q[1]);
 

--- a/test/NVQPP/template_introspection.cpp
+++ b/test/NVQPP/template_introspection.cpp
@@ -14,7 +14,7 @@
 template <std::size_t N>
 struct ghz {
   void operator()() __qpu__ {
-    cudaq::qreg<N> q;
+    cudaq::qarray<N> q;
     h(q[0]);
     // .. etc
   }

--- a/test/NVQPP/test-3.cpp
+++ b/test/NVQPP/test-3.cpp
@@ -15,7 +15,7 @@
 
 __qpu__ void init_state() {
   double theta = 2. * std::acos(1. / std::sqrt(3));
-  cudaq::qreg qubits(2);
+  cudaq::qvector qubits(2);
   ry(theta, qubits[0]);
   h<cudaq::ctrl>(qubits[0], qubits[1]);
   x(qubits[1]);

--- a/test/NVQPP/test-6.cpp
+++ b/test/NVQPP/test-6.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 
 __qpu__ void cccx_measure_cleanup() {
-  cudaq::qreg qubits(4);
+  cudaq::qvector qubits(4);
   // Initialize
   x(qubits[0]);
   x(qubits[1]);

--- a/test/NVQPP/to_integer.cpp
+++ b/test/NVQPP/to_integer.cpp
@@ -13,7 +13,7 @@
 
 struct test {
   int operator()(std::vector<int> applyX) __qpu__ {
-    cudaq::qreg q(applyX.size());
+    cudaq::qvector q(applyX.size());
 
     for (std::size_t i = 0; i < applyX.size(); i++) {
       if (applyX[i]) {

--- a/test/NVQPP/variable_size_qreg.cpp
+++ b/test/NVQPP/variable_size_qreg.cpp
@@ -18,7 +18,7 @@
 #include <iostream>
 
 __qpu__ void variable_qreg(unsigned value) {
-  cudaq::qreg qubits(value);
+  cudaq::qvector qubits(value);
 
   auto result = mz(qubits);
 }

--- a/test/Quake-QIR/negated_control.cpp
+++ b/test/Quake-QIR/negated_control.cpp
@@ -12,7 +12,7 @@
 
 struct Stuart {
    void operator() () __qpu__ {
-      cudaq::qreg<5> qreg;
+      cudaq::qarray<5> qreg;
       y<cudaq::ctrl>(!qreg[0], qreg[1], qreg[4]);
       z<cudaq::ctrl>(qreg[2], !qreg[3], qreg[4]);
    }

--- a/test/Target/IQM/for_loop.cpp
+++ b/test/Target/IQM/for_loop.cpp
@@ -15,7 +15,7 @@
 template <std::size_t N>
 struct ghz {
   auto operator()() __qpu__ {
-    cudaq::qreg<N> q;
+    cudaq::qarray<N> q;
     h(q[0]);
     for (int i = 0; i < N - 1; i++) {
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/test/Target/IQM/z_gate.cpp
+++ b/test/Target/IQM/z_gate.cpp
@@ -15,7 +15,7 @@
 template <std::size_t N>
 struct kernel_with_z {
   auto operator()() __qpu__ {
-    cudaq::qreg<N> q;
+    cudaq::qarray<N> q;
     z<cudaq::ctrl>(q[0], q[1]);
     auto result = mz(q[0]);
   }

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -178,6 +178,19 @@ target_link_libraries(test_photonics
   gtest_main)
 gtest_discover_tests(test_photonics)
 
+add_executable(test_utils main.cpp utils/UtilsTester.cpp)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
+  target_link_options(test_utils PRIVATE -Wl,--no-as-needed)
+endif()
+target_link_libraries(test_utils
+  PRIVATE 
+  cudaq
+  cudaq-platform-default
+  cudaq-em-photonics
+  nvqir-qpp fmt::fmt-header-only
+  gtest_main)
+gtest_discover_tests(test_utils)
+
 # Create an executable for MPI UnitTests
 # (only if MPI was found, i.e., the builtin plugin is available)
 if (MPI_CXX_FOUND)

--- a/unittests/domains/ChemistryTester.cpp
+++ b/unittests/domains/ChemistryTester.cpp
@@ -55,7 +55,7 @@ CUDAQ_TEST(H2MoleculeTester, checkHamiltonian) {
 
 CUDAQ_TEST(H2MoleculeTester, checkExpPauli) {
   auto kernel = [](double theta) __qpu__ {
-    cudaq::qreg q(4);
+    cudaq::qvector q(4);
     x(q[0]);
     x(q[1]);
     exp_pauli(theta, q, "XXXY");
@@ -82,7 +82,7 @@ CUDAQ_TEST(H2MoleculeTester, checkUCCSD) {
                                        {"H", {0., 0., .7474}}};
     auto molecule = cudaq::create_molecule(geometry, "sto-3g", 1, 0);
     auto ansatz = [&](std::vector<double> thetas) __qpu__ {
-      cudaq::qreg q(2 * molecule.n_orbitals);
+      cudaq::qvector q(2 * molecule.n_orbitals);
       x(q[0]);
       x(q[1]);
       cudaq::uccsd(q, thetas, molecule.n_electrons);
@@ -124,7 +124,7 @@ CUDAQ_TEST(H2MoleculeTester, checkUCCSD) {
     cudaq::molecular_geometry geometry(gen_random_h2_geometry());
     auto molecule = cudaq::create_molecule(geometry, "sto-3g", 1, 0);
     auto ansatz = [&](const std::vector<double> &thetas) __qpu__ {
-      cudaq::qreg q(2 * molecule.n_orbitals);
+      cudaq::qvector q(2 * molecule.n_orbitals);
       for (std::size_t qId = 0; qId < molecule.n_orbitals; ++qId) {
         x(q[qId]);
       }

--- a/unittests/integration/adjoint_tester.cpp
+++ b/unittests/integration/adjoint_tester.cpp
@@ -73,7 +73,7 @@ struct twoqbit_adjoint_test {
 };
 
 struct test_adjoint {
-  void operator()(cudaq::qspan<> q) __qpu__ {
+  void operator()(cudaq::qview<> q) __qpu__ {
     h(q[0]);
     t(q[1]);
     s(q[2]);
@@ -120,7 +120,7 @@ CUDAQ_TEST(AdjointTester, checkSimple) {
 CUDAQ_TEST(AdjointTester, checkNestedAdjoint) {
 
   struct xxxh_gates {
-    void operator()(cudaq::qspan<> &q) __qpu__ {
+    void operator()(cudaq::qview<> &q) __qpu__ {
       x(q[2]);
       x(q[0], q[1]);
       h(q[2]);
@@ -128,7 +128,7 @@ CUDAQ_TEST(AdjointTester, checkNestedAdjoint) {
   };
 
   struct S_0 {
-    void operator()(cudaq::qspan<> q) __qpu__ {
+    void operator()(cudaq::qview<> q) __qpu__ {
 
       cudaq::compute_action([&]() { xxxh_gates{}(q); },
                             [&]() { x(q[0], q[1], q[2]); });
@@ -136,11 +136,11 @@ CUDAQ_TEST(AdjointTester, checkNestedAdjoint) {
   };
 
   struct P {
-    void operator()(cudaq::qspan<> q) __qpu__ { h(q[0], q[1]); }
+    void operator()(cudaq::qview<> q) __qpu__ { h(q[0], q[1]); }
   };
 
   struct R {
-    void operator()(cudaq::qspan<> q) __qpu__ {
+    void operator()(cudaq::qview<> q) __qpu__ {
       ry(M_PI / 16.0, q[2]);
       ry<cudaq::ctrl>(M_PI / 8.0, q[0], q[2]);
       ry<cudaq::ctrl>(M_PI / 4.0, q[1], q[2]);
@@ -148,7 +148,7 @@ CUDAQ_TEST(AdjointTester, checkNestedAdjoint) {
   };
 
   struct A {
-    void operator()(cudaq::qspan<> q) __qpu__ {
+    void operator()(cudaq::qview<> q) __qpu__ {
 
       P{}(q);
       R{}(q);
@@ -156,7 +156,7 @@ CUDAQ_TEST(AdjointTester, checkNestedAdjoint) {
   };
 
   struct S_chi {
-    void operator()(cudaq::qspan<> q) __qpu__ { z(q[2]); }
+    void operator()(cudaq::qview<> q) __qpu__ { z(q[2]); }
   };
 
   struct run_circuit {

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -225,7 +225,7 @@ CUDAQ_TEST(BuilderTester, checkSimple) {
 // MPS doesn't support gates on more than 2 qubits
 CUDAQ_TEST(BuilderTester, checkRotations) {
 
-  // rx: entire qreg
+  // rx: entire qvector
   {
     cudaq::set_random_seed(4);
 
@@ -241,7 +241,7 @@ CUDAQ_TEST(BuilderTester, checkRotations) {
     EXPECT_EQ(counts.count("1110"), 1000);
   }
 
-  // ry: entire qreg
+  // ry: entire qvector
   {
     cudaq::set_random_seed(4);
 
@@ -257,7 +257,7 @@ CUDAQ_TEST(BuilderTester, checkRotations) {
     EXPECT_EQ(counts.count("1110"), 1000);
   }
 
-  // rz: entire qreg
+  // rz: entire qvector
   {
     cudaq::set_random_seed(4);
 
@@ -277,7 +277,7 @@ CUDAQ_TEST(BuilderTester, checkRotations) {
     EXPECT_EQ(counts.count("1110"), 1000);
   }
 
-  // r1: entire qreg
+  // r1: entire qvector
   {
     cudaq::set_random_seed(4);
 

--- a/unittests/integration/gate_library_tester.cpp
+++ b/unittests/integration/gate_library_tester.cpp
@@ -29,12 +29,12 @@ constexpr size_t NUM_ANGLES = 100;
 CUDAQ_TEST(GateLibraryTester, checkGivensRotation) {
   for (const auto &angle : cudaq::linspace(-M_PI, M_PI, NUM_ANGLES)) {
     auto test_01 = [](double theta) __qpu__ {
-      cudaq::qreg<2> q;
+      cudaq::qarray<2> q;
       x(q[0]);
       cudaq::givens_rotation(theta, q[0], q[1]);
     };
     auto test_10 = [](double theta) __qpu__ {
-      cudaq::qreg<2> q;
+      cudaq::qarray<2> q;
       x(q[1]);
       cudaq::givens_rotation(theta, q[0], q[1]);
     };
@@ -94,7 +94,7 @@ CUDAQ_TEST(GateLibraryTester, checkControlledGivensRotation) {
   for (const auto &angle : cudaq::linspace(-M_PI, M_PI, NUM_ANGLES)) {
     // Same check, with 2 control qubits
     auto test_01_on = [](double theta) __qpu__ {
-      cudaq::qreg<4> q;
+      cudaq::qarray<4> q;
       x(q[2]);
       x(q[0]);
       x(q[1]);
@@ -102,7 +102,7 @@ CUDAQ_TEST(GateLibraryTester, checkControlledGivensRotation) {
     };
 
     auto test_01_off = [](double theta) __qpu__ {
-      cudaq::qreg<4> q;
+      cudaq::qarray<4> q;
       x(q[2]);
       cudaq::control(cudaq::givens_rotation, {q[0], q[1]}, theta, q[2], q[3]);
       x(q[2]);
@@ -122,21 +122,21 @@ CUDAQ_TEST(GateLibraryTester, checkControlledGivensRotation) {
 CUDAQ_TEST(GateLibraryTester, checkFermionicSwap) {
   for (const auto &angle : cudaq::linspace(-M_PI, M_PI, NUM_ANGLES)) {
     auto test_00 = [](double theta) __qpu__ {
-      cudaq::qreg<2> q;
+      cudaq::qarray<2> q;
       cudaq::fermionic_swap(theta, q[0], q[1]);
     };
     auto test_01 = [](double theta) __qpu__ {
-      cudaq::qreg<2> q;
+      cudaq::qarray<2> q;
       x(q[0]);
       cudaq::fermionic_swap(theta, q[0], q[1]);
     };
     auto test_10 = [](double theta) __qpu__ {
-      cudaq::qreg<2> q;
+      cudaq::qarray<2> q;
       x(q[1]);
       cudaq::fermionic_swap(theta, q[0], q[1]);
     };
     auto test_11 = [](double theta) __qpu__ {
-      cudaq::qreg<2> q;
+      cudaq::qarray<2> q;
       x(q);
       cudaq::fermionic_swap(theta, q[0], q[1]);
     };

--- a/unittests/integration/grover_test.cpp
+++ b/unittests/integration/grover_test.cpp
@@ -12,7 +12,7 @@
 #include <numeric>
 
 struct reflect_about_uniform {
-  void operator()(cudaq::qspan<> q) __qpu__ {
+  void operator()(cudaq::qview<> q) __qpu__ {
     auto ctrl_qubits = q.front(q.size() - 1);
     auto &last_qubit = q.back();
 

--- a/unittests/integration/observe_result_tester.cpp
+++ b/unittests/integration/observe_result_tester.cpp
@@ -84,7 +84,7 @@ CUDAQ_TEST(ObserveResult, checkSimple) {
 CUDAQ_TEST(ObserveResult, checkExpValBug) {
 
   auto kernel = []() __qpu__ {
-    cudaq::qreg qubits(3);
+    cudaq::qvector qubits(3);
     rx(0.531, qubits[0]);
     ry(0.9, qubits[1]);
     rx(0.3, qubits[2]);

--- a/unittests/integration/tracer_tester.cpp
+++ b/unittests/integration/tracer_tester.cpp
@@ -14,7 +14,7 @@
 CUDAQ_TEST(TracerTester, checkBell) {
 
   auto bell = []() __qpu__ {
-    cudaq::qreg q(2);
+    cudaq::qvector q(2);
     h(q[0]);
     x<cudaq::ctrl>(q[0], q[1]);
   };
@@ -41,7 +41,7 @@ CUDAQ_TEST(TracerTester, checkBell) {
 CUDAQ_TEST(TracerTester, checkGHZ) {
 
   auto ghz = [](int i) __qpu__ {
-    cudaq::qreg q(i);
+    cudaq::qvector q(i);
     h(q[0]);
     for (int j = 0; j < i - 1; j++)
       x<cudaq::ctrl>(q[j], q[j + 1]);
@@ -82,7 +82,7 @@ CUDAQ_TEST(TracerTester, checkLargeTrace) {
 
   auto largeTrace = [&](int numQubits, int numLayers,
                         std::vector<int> cnotPairs) __qpu__ {
-    cudaq::qreg q(numQubits);
+    cudaq::qvector q(numQubits);
 
     for (int layer = 0; layer < numLayers; layer++) {
       // each layer should be composed of a set of random

--- a/unittests/photonics/PhotonicsTester.cpp
+++ b/unittests/photonics/PhotonicsTester.cpp
@@ -15,7 +15,7 @@ TEST(PhotonicsTester, checkSimple) {
 
   struct test {
     auto operator()() __qpu__ {
-      cudaq::qreg<cudaq::dyn, 3> qutrits(2);
+      cudaq::qvector<3> qutrits(2);
       plus(qutrits[0]);
       plus(qutrits[1]);
       plus(qutrits[1]);
@@ -25,7 +25,7 @@ TEST(PhotonicsTester, checkSimple) {
 
   struct test2 {
     void operator()() __qpu__ {
-      cudaq::qreg<cudaq::dyn, 3> qutrits(2);
+      cudaq::qvector<3> qutrits(2);
       plus(qutrits[0]);
       plus(qutrits[1]);
       plus(qutrits[1]);
@@ -51,7 +51,7 @@ TEST(PhotonicsTester, checkHOM) {
 
       constexpr std::array<std::size_t, 2> input_state{1, 1};
 
-      cudaq::qreg<cudaq::dyn, 3> quds(2); // |00>
+      cudaq::qvector<3> quds(2); // |00>
       for (std::size_t i = 0; i < 2; i++) {
         for (std::size_t j = 0; j < input_state[i]; j++) {
           plus(quds[i]); // setting to  |11>
@@ -93,7 +93,7 @@ TEST(PhotonicsTester, checkMZI) {
 
       constexpr std::array<std::size_t, 2> input_state{1, 0};
 
-      cudaq::qreg<cudaq::dyn, 3> quds(2); // |00>
+      cudaq::qvector<3> quds(2); // |00>
       for (std::size_t i = 0; i < 2; i++)
         for (std::size_t j = 0; j < input_state[i]; j++)
           plus(quds[i]); // setting to  |10>

--- a/unittests/qis/QubitQISTester.cpp
+++ b/unittests/qis/QubitQISTester.cpp
@@ -294,7 +294,7 @@ CUDAQ_TEST(QubitQISTester, checkAdjointRegions) {
   };
 
   struct test_adjoint {
-    void operator()(cudaq::qspan<> q) __qpu__ {
+    void operator()(cudaq::qview<> q) __qpu__ {
       h(q[0]);
       t(q[1]);
       s(q[2]);

--- a/unittests/utils/UtilsTester.cpp
+++ b/unittests/utils/UtilsTester.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "cudaq/utils/cudaq_utils.h"
+#include <fmt/ranges.h>
+
+TEST(UtilsTester, checkRange) {
+  {
+    auto v = cudaq::range(0, 10, 2);
+    std::cout << fmt::format("{}", fmt::join(v, ",")) << "\n";
+    EXPECT_EQ(5, v.size());
+    std::vector<int> expected{0, 2, 4, 6, 8};
+    EXPECT_EQ(expected, v);
+  }
+
+  {
+    auto v = cudaq::range(10);
+    std::cout << fmt::format("{}", fmt::join(v, ",")) << "\n";
+    EXPECT_EQ(10, v.size());
+    std::vector<int> expected{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(expected, v);
+  }
+
+  {
+    auto v = cudaq::range(10, 2, -1);
+    std::cout << fmt::format("{}", fmt::join(v, ",")) << "\n";
+    EXPECT_EQ(8, v.size());
+    std::vector<int> expected{10, 9, 8, 7, 6, 5, 4, 3};
+    EXPECT_EQ(expected, v);
+  }
+}


### PR DESCRIPTION
Fix #1025 #1026. 

Also update `cudaq::range()` to support stop and step values #1028 
