### PR TITLE
Ability to pass custom passes from `nvq++`

### DIFF
--- a/test/NVQPP/custom_pass.cpp
+++ b/test/NVQPP/custom_pass.cpp
@@ -6,8 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 // clang-format off
-// RUN: nvq++ --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin.so --opt-func-pass cudaq-custom-pass  %s -o %t && %t | FileCheck %s
-// RUN: nvq++ -std=c++17 --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin.so --opt-func-pass cudaq-custom-pass %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin.so --opt-pass 'func.func(cudaq-custom-pass)'  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ -std=c++17 --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin.so --opt-pass 'func.func(cudaq-custom-pass)' %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/test/NVQPP/custom_pass.cpp
+++ b/test/NVQPP/custom_pass.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+// clang-format off
+// RUN: nvq++ --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin.so --opt-func-pass cudaq-custom-pass  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ -std=c++17 --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin.so --opt-func-pass cudaq-custom-pass %s -o %t && %t | FileCheck %s
+// clang-format on
+
+#include <cudaq.h>
+#include <iostream>
+
+void kernel() __qpu__ {
+  cudaq::qarray<2> q;
+  h(q[0]);
+  x<cudaq::ctrl>(q[0], q[1]);
+  mz(q);
+}
+
+int main() {
+  auto result = cudaq::sample(1000, kernel);
+  for (auto &&[bits, counts] : result) {
+    std::cout << bits << '\n';
+  }
+  return 0;
+}
+
+// The custom pass replace H with S, hence not a Bell state anymore.
+// CHECK: 00

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -135,11 +135,8 @@ function show_help {
 --opt-plugin <dynamic library file>
 	Load pass plugin by specifying its dynamic library.
 
---opt-func-pass <pass name>
-	Append a function pass to the pass pipeline.	
-
---opt-module-pass <pass name>
-	Append a module pass to the pass pipeline.
+--opt-pass <pass name>
+	Append a pass to the pass pipeline by specifying its name in the pass pipeline syntax, e.g. <dialect>.<opname>(passname).
 
 --save-temps
 	Save temporary files.
@@ -424,11 +421,7 @@ while [ $# -ne 0 ]; do
 		CUDAQ_OPT_PLUGIN_ARGS="${CUDAQ_OPT_PLUGIN_ARGS} --load-cudaq-plugin $2"
 		shift
 		;;
-	--opt-func-pass)
-		CUDAQ_OPT_EXTRA_PASSES=$(add_pass_to_pipeline "${CUDAQ_OPT_EXTRA_PASSES}" "func.func($2)") 
-		shift
-		;;
-	--opt-module-pass)
+	--opt-pass)
 		CUDAQ_OPT_EXTRA_PASSES=$(add_pass_to_pipeline "${CUDAQ_OPT_EXTRA_PASSES}" "$2") 
 		shift
 		;;

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -132,6 +132,15 @@ function show_help {
 --[no-]lambda-lifting
 	Enable/disable lambda lifting pass.
 
+--opt-plugin <dynamic library file>
+	Load pass plugin by specifying its dynamic library.
+
+--opt-func-pass <pass name>
+	Append a function pass to the pass pipeline.	
+
+--opt-module-pass <pass name>
+	Append a module pass to the pass pipeline.
+
 --save-temps
 	Save temporary files.
 
@@ -269,6 +278,8 @@ LIST_TARGETS=false
 DISABLE_QUBIT_MAPPING=false
 NVQIR_LIBS="-lnvqir -lnvqir-"
 CPPSTD=-std=c++20
+CUDAQ_OPT_PLUGIN_ARGS=
+CUDAQ_OPT_EXTRA_PASSES=
 
 # Provide a default backend, user can override
 NVQIR_SIMULATION_BACKEND="qpp"
@@ -408,6 +419,18 @@ while [ $# -ne 0 ]; do
 		;;
 	--lambda-lifting)
 		ENABLE_LAMBDA_LIFTING=true
+		;;
+	--opt-plugin)
+		CUDAQ_OPT_PLUGIN_ARGS="${CUDAQ_OPT_PLUGIN_ARGS} --load-cudaq-plugin $2"
+		shift
+		;;
+	--opt-func-pass)
+		CUDAQ_OPT_EXTRA_PASSES=$(add_pass_to_pipeline "${CUDAQ_OPT_EXTRA_PASSES}" "func.func($2)") 
+		shift
+		;;
+	--opt-module-pass)
+		CUDAQ_OPT_EXTRA_PASSES=$(add_pass_to_pipeline "${CUDAQ_OPT_EXTRA_PASSES}" "$2") 
+		shift
 		;;
 	--save-temps)
 		DELETE_TEMPS=false
@@ -589,6 +612,10 @@ if ${RUN_OPT}; then
 	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "canonicalize,cse")
 fi
 
+if [ ! -z "$CUDAQ_OPT_EXTRA_PASSES" ]; then
+	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "$CUDAQ_OPT_EXTRA_PASSES")
+fi
+
 OPT_PASSES="builtin.module(${OPT_PASSES})"
 
 if ${SHOW_VERSION} && [ -z "$SRCS" ] && [ -z "$OBJS" ]; then
@@ -622,7 +649,7 @@ for i in ${SRCS}; do
 		if ${RUN_OPT}; then
 			DCL_FILE=$(mktemp ${file}.qke.XXXXXX)
 			TMPFILES="${TMPFILES} ${DCL_FILE} ${DCL_FILE}.o"
-			run ${TOOLBIN}cudaq-opt --pass-pipeline="${OPT_PASSES}" ${QUAKE_IN} -o ${DCL_FILE}
+			run ${TOOLBIN}cudaq-opt ${CUDAQ_OPT_PLUGIN_ARGS} --pass-pipeline="${OPT_PASSES}" ${QUAKE_IN} -o ${DCL_FILE}
 			QUAKE_IN=${DCL_FILE}
 		fi
 		QUAKELL_FILE=$(mktemp ${file}.ll.XXXXXX)


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Ability to pass custom pass plugins (as `.so` files) from `nvq++` to `cudaq-opt` and adding its passes to the pipeline.

Resolved https://github.com/NVIDIA/cuda-quantum/issues/969
