### PR TITLE
Fix local GPU `nvqpp_SampleAsync` test by changing `qreg` to `qvector`

### DIFF
--- a/docs/sphinx/snippets/cpp/using/cudaq/platform/get_state_async.cpp
+++ b/docs/sphinx/snippets/cpp/using/cudaq/platform/get_state_async.cpp
@@ -16,7 +16,7 @@
 int main() {
   // [Begin Documentation]
   auto kernelToRun = [](int runtimeParam) __qpu__ {
-    cudaq::qreg q(runtimeParam);
+    cudaq::qvector q(runtimeParam);
     h(q[0]);
     for (int i = 0; i < runtimeParam - 1; ++i)
       x<cudaq::ctrl>(q[i], q[i + 1]);

--- a/docs/sphinx/snippets/cpp/using/cudaq/platform/sample_async.cpp
+++ b/docs/sphinx/snippets/cpp/using/cudaq/platform/sample_async.cpp
@@ -16,7 +16,7 @@
 int main() {
   // [Begin Documentation]
   auto kernelToBeSampled = [](int runtimeParam) __qpu__ {
-    cudaq::qreg q(runtimeParam);
+    cudaq::qvector q(runtimeParam);
     h(q);
     mz(q);
   };


### PR DESCRIPTION
This test was accidentally broken by #1029 (relating to the deprecation of `qreg`). This change fixes the test by changing `qreg` to `qvector`.