### PR TITLE
Fix direct include of fmt (suppress warnings)

### DIFF
--- a/unittests/utils/UtilsTester.cpp
+++ b/unittests/utils/UtilsTester.cpp
@@ -8,8 +8,8 @@
 
 #include <gtest/gtest.h>
 
+#include "common/FmtCore.h"
 #include "cudaq/utils/cudaq_utils.h"
-#include <fmt/ranges.h>
 
 TEST(UtilsTester, checkRange) {
   {


### PR DESCRIPTION
Fix error in nightly CI where warning was emitted from direct inclusion of a `fmtlib` header. 