### PR TITLE
Break ground on passing/return POD struct values.

### DIFF
--- a/.github/workflows/config/spellcheck_config.yml
+++ b/.github/workflows/config/spellcheck_config.yml
@@ -158,10 +158,10 @@ matrix:
       - open: '(?P<open>`+)'
         close: '(?P=open)'
       # Ignore the first word after \command or @command, which is a code artifact
-      - open: '[\\@]([acep])(?:\s\S+)?'
+      - open: '[\\@]([acep])(?:\s+\S)?'
         close: '(\s|$)'
       # Ignore the doxygen \param command and the code artifact after it.
-      - open: '[\\@]param(\s+\[[a-z]+\])?\s+(?:\S+)'
+      - open: '[\\@]param(\s+\[\w+\])?(?:\s+\S)?'
         close: '(\s|$)'
       # Ignore words that start with a \ or @, e.g. @param used in doc comments
       - open: '[\\@](\w|[\\@&\$#<>%"\.=|]|::|--|---)'

--- a/.github/workflows/config/spellcheck_config.yml
+++ b/.github/workflows/config/spellcheck_config.yml
@@ -157,11 +157,14 @@ matrix:
       # Ignore content between inline backticks
       - open: '(?P<open>`+)'
         close: '(?P=open)'
-      # Ignore the first lowercase word after @param, which is usually the parameter name
-      - open: '@param(?:\s[a-z]+)?'
+      # Ignore the first word after \command or @command, which is a code artifact
+      - open: '[\\@]([abcep]|em)(?:\s\S+)?'
         close: '(\s|$)'
-      # Ignore words that start with an @, e.g. @param used in doc comments
-      - open: '@\S'
+      # Ignore the doxygen \param command and the code artifact after it.
+      - open: '[\\@]param(\s+\[[a-z]+\])?\s+(?:\S+)'
+        close: '(\s|$)'
+      # Ignore words that start with a \ or @, e.g. @param used in doc comments
+      - open: '[\\@](\S+|[n\\@&\$#<>%"\.=|]|::|--|---)'
         close: '(\s|$)'
       # Ignore words before and after double columns
       - open: '([a-zA-Z0-9_])*::'

--- a/.github/workflows/config/spellcheck_config.yml
+++ b/.github/workflows/config/spellcheck_config.yml
@@ -166,7 +166,7 @@ matrix:
       # Ignore words that start with a \ or @, e.g. @param used in doc comments
       - open: '[\\@](\w|[\\@&\$#<>%"\.=|]|::|--|---)'
         close: '(\s|$)'
-      # Ignore words before and after double columns
+      # Ignore words before and after double colons
       - open: '([a-zA-Z0-9_])*::'
         close: '([^a-zA-Z0-9_:]|$)'
       # Ignore words that contain any underscores, numbers, or uppercase letters

--- a/.github/workflows/config/spellcheck_config.yml
+++ b/.github/workflows/config/spellcheck_config.yml
@@ -164,7 +164,7 @@ matrix:
       - open: '[\\@]param(\s+\[[a-z]+\])?\s+(?:\S+)'
         close: '(\s|$)'
       # Ignore words that start with a \ or @, e.g. @param used in doc comments
-      - open: '[\\@](\S+|[n\\@&\$#<>%"\.=|]|::|--|---)'
+      - open: '[\\@](\w|[\\@&\$#<>%"\.=|]|::|--|---)'
         close: '(\s|$)'
       # Ignore words before and after double columns
       - open: '([a-zA-Z0-9_])*::'

--- a/.github/workflows/config/spellcheck_config.yml
+++ b/.github/workflows/config/spellcheck_config.yml
@@ -158,7 +158,7 @@ matrix:
       - open: '(?P<open>`+)'
         close: '(?P=open)'
       # Ignore the first word after \command or @command, which is a code artifact
-      - open: '[\\@]([abcep]|em)(?:\s\S+)?'
+      - open: '[\\@]([acep])(?:\s\S+)?'
         close: '(\s|$)'
       # Ignore the doxygen \param command and the code artifact after it.
       - open: '[\\@]param(\s+\[[a-z]+\])?\s+(?:\S+)'

--- a/.github/workflows/config/spelling_allowlist.txt
+++ b/.github/workflows/config/spelling_allowlist.txt
@@ -163,6 +163,8 @@ subclassed
 subclasses
 subclassing
 subcommand
+subexpression
+subexpressions
 subfolder
 submodule
 subscriptable

--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -581,8 +581,7 @@ private:
 /// Clang AST analysis / processing workflow. The nested ASTBridgeConsumer
 /// drives the process of walking the Clang AST and translate pertinent nodes to
 /// an MLIR Op tree containing Quake, CC, and other MLIR dialect operations.
-/// This Action will generate this MLIR Module and rewrite the input source code
-/// (using the Clang `Rewriter` system) to define quantum kernels as `extern`.
+/// In short, this Action generates the MLIR Module.
 class ASTBridgeAction : public clang::ASTFrontendAction {
 public:
   using MangledKernelNamesMap = cudaq::MangledKernelNamesMap;

--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -106,13 +106,13 @@ std::string getCxxMangledDeclName(clang::GlobalDecl decl,
 std::string getCxxMangledTypeName(clang::QualType ty,
                                   clang::ItaniumMangleContext *mangler);
 
-/// Use this helper to convert a tag name to a nvqpp mangled name.
+/// Use this helper to convert a tag name to a `nvq++` mangled name.
 inline std::string getCudaqKernelName(const std::string &tag) {
   return runtime::cudaqGenPrefixName + tag;
 }
 
 /// Creates the tag name for a quantum kernel. The tag name is a name by which
-/// one can lookup a kernel at runtime. This name does not include the nvq++
+/// one can lookup a kernel at runtime. This name does not include the `nvq++`
 /// prefix nor the unique (C++ mangled) suffix.
 std::string getTagNameOfFunctionDecl(const clang::FunctionDecl *func,
                                      clang::ItaniumMangleContext *mangler);
@@ -131,10 +131,11 @@ bool ignoredClass(clang::RecordDecl *x);
 /// The general design is to walk the tree in a post-order traversal and
 /// assemble the IR from the leaves back down the tree. Traversals over types
 /// should push Type values to the type stack. Traversals over expressions
-/// should create IR in the ModuleOp as well as push subexpressions on the stack
-/// for parent nodes. A parent node always knows how many children it needs to
-/// be constructed correctly. The types of expressions are carried along with
-/// the expressions in the IR and need not be duplicated on the type stack.
+/// should create IR in the ModuleOp as well as push `subexpressions` on the
+/// stack for parent nodes. A parent node always knows how many children it
+/// needs to be constructed correctly. The types of expressions are carried
+/// along with the expressions in the IR and need not be duplicated on the type
+/// stack.
 ///
 /// Unfortunately, clang's RecursiveASTVisitor doesn't always visit nodes in the
 /// AST and can skip visiting types or even some expressions.
@@ -156,7 +157,7 @@ public:
         reachableFunctions(reachableFuncs), namesMap(namesMap),
         compilerInstance(ci), mangler(mangler) {}
 
-  /// nvq++ renames quantum kernels to differentiate them from classical C++
+  /// `nvq++` renames quantum kernels to differentiate them from classical C++
   /// code. This renaming is done on function names. \p tag makes it easier
   /// to identify the kernel class from which the function was extracted.
   std::string generateCudaqKernelName(const clang::FunctionDecl *func) {
@@ -306,6 +307,7 @@ public:
 
   bool TraverseMemberExpr(clang::MemberExpr *x,
                           DataRecursionQueue *q = nullptr);
+  bool VisitMemberExpr(clang::MemberExpr *x);
   bool TraverseBinaryOperator(clang::BinaryOperator *x,
                               DataRecursionQueue *q = nullptr);
   bool TraverseLambdaExpr(clang::LambdaExpr *x,
@@ -456,7 +458,7 @@ private:
   /// Returns true if \p decl is a function to lower to Quake.
   bool needToLowerFunction(const clang::FunctionDecl *decl);
 
-  // Helpers to convert an AST node's clang source range to an MLIR Location.
+  /// Helpers to convert an AST node's clang source range to an MLIR Location.
   template <typename A>
   mlir::Location toLocation(const A *x) {
     return toLocation(x->getSourceRange());
@@ -580,7 +582,7 @@ private:
 /// drives the process of walking the Clang AST and translate pertinent nodes to
 /// an MLIR Op tree containing Quake, CC, and other MLIR dialect operations.
 /// This Action will generate this MLIR Module and rewrite the input source code
-/// (using the Clang Rewriter system) to define quantum kernels as extern.
+/// (using the Clang `Rewriter` system) to define quantum kernels as `extern`.
 class ASTBridgeAction : public clang::ASTFrontendAction {
 public:
   using MangledKernelNamesMap = cudaq::MangledKernelNamesMap;
@@ -705,7 +707,7 @@ inline bool isCallOperator(clang::OverloadedOperatorKind kindValue) {
   return kindValue == clang::OverloadedOperatorKind::OO_Call;
 }
 
-// Is \p t of type `char *`?
+/// Is \p t of type `char *`?
 inline bool isCharPointerType(mlir::Type t) {
   if (auto ptrTy = dyn_cast<cc::PointerType>(t)) {
     mlir::Type eleTy = ptrTy.getElementType();

--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -131,7 +131,7 @@ bool ignoredClass(clang::RecordDecl *x);
 /// The general design is to walk the tree in a post-order traversal and
 /// assemble the IR from the leaves back down the tree. Traversals over types
 /// should push Type values to the type stack. Traversals over expressions
-/// should create IR in the ModuleOp as well as push `subexpressions` on the
+/// should create IR in the ModuleOp as well as push subexpressions on the
 /// stack for parent nodes. A parent node always knows how many children it
 /// needs to be constructed correctly. The types of expressions are carried
 /// along with the expressions in the IR and need not be duplicated on the type

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -90,10 +90,9 @@ void QuakeBridgeVisitor::addArgumentSymbols(
       // Transform pass-by-value arguments to stack slots.
       auto loc = toLocation(argVal);
       auto parmTy = entryBlock->getArgument(index).getType();
-      if (isa<FunctionType, cc::ArrayType, cc::CallableType, cc::PointerType,
-              cc::StdvecType, cc::StructType, LLVM::LLVMStructType,
-              quake::ControlType, quake::RefType, quake::VeqType,
-              quake::WireType>(parmTy)) {
+      if (isa<FunctionType, cc::CallableType, cc::PointerType, cc::StdvecType,
+              LLVM::LLVMStructType, quake::ControlType, quake::RefType,
+              quake::VeqType, quake::WireType>(parmTy)) {
         symbolTable.insert(name, entryBlock->getArgument(index));
       } else {
         auto stackSlot = builder.create<cc::AllocaOp>(loc, parmTy);

--- a/test/AST-Quake/struct.cpp
+++ b/test/AST-Quake/struct.cpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
+
+#include <cudaq.h>
+
+struct ResultThing {
+  bool m1;
+  bool m2_ok;
+  bool m2;
+  int x;
+};
+
+struct ArgumentThing {
+  int i;
+  int j;
+  double d;
+};
+
+void debug_the_thing(int first, int second, double cola) {
+  cola = cola + first + second;
+}
+
+ResultThing help_me_help_you();
+
+struct S0 {
+  ResultThing operator()(ArgumentThing arg) __qpu__ {
+    debug_the_thing(arg.i, arg.j, arg.d);
+    return help_me_help_you();
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__S0(
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<"ArgumentThing" {i32, i32, f64}>) -> !cc.struct<"ResultThing" {i1, i1, i1, i32}>
+// CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<"ArgumentThing" {i32, i32, f64}>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>
+// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_1]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_1]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<f64>
+// CHECK:           call @_Z15debug_the_thingiid(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) : (i32, i32, f64) -> ()
+// CHECK:           %[[VAL_8:.*]] = call @_Z16help_me_help_youv() : () -> !cc.struct<"ResultThing" {i1, i1, i1, i32}>
+// CHECK:           return %[[VAL_8]] : !cc.struct<"ResultThing" {i1, i1, i1, i32}>
+
+#if 0
+struct S1 {
+  ResultThing operator()(ArgumentThing arg) __qpu__ {
+    debug_the_thing(arg.i, arg.j, arg.d);
+    ResultThing result = {true, false, false, 42};
+    return result;
+  }
+};
+#endif
+
+#if 0
+struct S2 {
+  ResultThing operator()(ArgumentThing arg) __qpu__ {
+    debug_the_thing(arg.i, arg.j, arg.d);
+    return ResultThing(true, false, false, 42);
+  }
+};
+#endif
+
+#if 0
+struct S3 {
+  ResultThing operator()(ArgumentThing arg) __qpu__ {
+    debug_the_thing(arg.i, arg.j, arg.d);
+    return {true, false, false, 42};
+  }
+};
+#endif
+
+#if 0
+struct S4 {
+  ResultThing operator()(ArgumentThing arg) __qpu__ {
+     ResultThing result;
+     result.m1 = (arg.i > 2);
+     result.m2_ok = (arg.j > 4);
+     result.m2 = arg.d != 0.0;
+     result.x = arg.i - arg.j;
+    return result;
+  }
+};
+#endif

--- a/test/AST-Quake/struct.cpp
+++ b/test/AST-Quake/struct.cpp
@@ -40,11 +40,11 @@ struct S0 {
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<"ArgumentThing" {i32, i32, f64}>) -> !cc.struct<"ResultThing" {i1, i1, i1, i32}>
 // CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<"ArgumentThing" {i32, i32, f64}>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>
-// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_1]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_1]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_1]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_1]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64}>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_8:.*]] = call @_Z16help_me_help_youv() : () -> !cc.struct<"ResultThing" {i1, i1, i1, i32}>


### PR DESCRIPTION
There is more to do here. Most notably the bridge doesn't support the ctors and other AST artifacts needed to build struct values, pass them around, etc.

Supports a POD struct if it is created by some external at this point.
