### PR TITLE
[nvq++] Accept command line arguments specified as '--arg=value'

### DIFF
--- a/test/NVQPP/qpp_cpu_target.cpp
+++ b/test/NVQPP/qpp_cpu_target.cpp
@@ -6,6 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+// RUN: nvq++ --target=qpp-cpu %s -o %t
 // RUN: nvq++ --target qpp-cpu %s -o %t && CUDAQ_LOG_LEVEL=info %t | FileCheck --check-prefix=CHECK-QPP %s
 // RUN: CUDAQ_DEFAULT_SIMULATOR="density-matrix-cpu" nvq++ %s -o %t && CUDAQ_LOG_LEVEL=info %t | FileCheck --check-prefix=CHECK-DM %s
 // RUN: CUDAQ_DEFAULT_SIMULATOR="foo" nvq++ %s -o %t && CUDAQ_LOG_LEVEL=info %t | FileCheck %s

--- a/test/NVQPP/qpp_cpu_target.cpp
+++ b/test/NVQPP/qpp_cpu_target.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --target=qpp-cpu %s -o %t
+// RUN: nvq++ --target=qpp-cpu %s -o=%t
 // RUN: nvq++ --target qpp-cpu %s -o %t && CUDAQ_LOG_LEVEL=info %t | FileCheck --check-prefix=CHECK-QPP %s
 // RUN: CUDAQ_DEFAULT_SIMULATOR="density-matrix-cpu" nvq++ %s -o %t && CUDAQ_LOG_LEVEL=info %t | FileCheck --check-prefix=CHECK-DM %s
 // RUN: CUDAQ_DEFAULT_SIMULATOR="foo" nvq++ %s -o %t && CUDAQ_LOG_LEVEL=info %t | FileCheck %s

--- a/test/Target/IQM/z_gate.cpp
+++ b/test/Target/IQM/z_gate.cpp
@@ -9,7 +9,7 @@
 #include <cudaq.h>
 
 // RUN: nvq++ %s --target iqm --emulate --iqm-machine Apollo -o %t.x && %t.x | FileCheck %s
-
+// RUN: nvq++ %s --target iqm --emulate --iqm-machine=Apollo -o %t.x && %t.x | FileCheck %s
 // CHECK: { 0:1000 }
 
 template <std::size_t N>

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -366,7 +366,6 @@ while [ $# -ne 0 ]; do
 		shift
 		;;
 	--target=* | -target=*)
-		echo "${arg#*=}"
 		;;
 	--emit-qir | -emit-qir)
 		EMIT_QIR=true

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -312,57 +312,61 @@ TARGET_ARGS=
 if [[ $# -eq 0 ]]; then
     SHOW_HELP=true
 fi
-# Handle arguments with '='
-N=$#
-cmd_params=("$@")
-for i in "${!cmd_params[@]}"; do
-	arg="${cmd_params[$i]}"
-	if [[ "$arg" == *=* ]]; then
-		key="${arg%=*}"
-		val="${arg#*=}"
-		if [[ $i -eq 0 ]]; then
-			cmd_params=( "$key" "$val" "${cmd_params[@]:1}" )
-		elif [[ $i -eq $N-1 ]]; then
-			cmd_params=( "${cmd_params[@]:0:i-1}" "$key" "$val" )
-		else
-			cmd_params=( "${cmd_params[@]:0:i-1}" "$key" "$val" "${cmd_params[@]:i+1}" )
-		fi
-	fi
-done
-set -- "${cmd_params[@]}"
 
 # First, find the target option. The name is needed since it is the prefix for
 # any target specific options.
 N=$#
 for (( i=1; i<=$N; i++ )); do
-	if [[ ${@:$i:1} == --target ]] || [[ ${@:$i:1} == -target ]]; then
+	arg=${@:$i:1}
+	if [[ "${arg}" == --target ]] || [[ "${arg}" == -target ]]; then
 		TARGET_CONFIG="${@:$i+1:1}"
+		break
+	fi
+	if [[ "${arg}" == --target=* ]] || [[ "${arg}" == -target=* ]]; then
+		TARGET_CONFIG="${arg#*=}"
 		break
 	fi
 done
 
 while [ $# -ne 0 ]; do
 	# Filter out any target-specific options.
-	if [[ $# -gt 1 ]] && [[ -n "${TARGET_CONFIG}" ]] && \
-	     [[ "$1" = --${TARGET_CONFIG}-* ]]; then
-		# Assume always has an additional value
-		TARGET_ARGS="${TARGET_ARGS} $1 $2"
-		shift 2
-		continue
+	if [[ $# -gt 1 ]] && [[ -n "${TARGET_CONFIG}" ]]; then
+		if [[ "$1" = --${TARGET_CONFIG}-* ]]; then
+			# Assume always has an additional value
+			TARGET_ARGS="${TARGET_ARGS} $1 $2"
+			shift 2
+			continue
+		elif [[ "$1" = --${TARGET_CONFIG}-*=* ]]; then
+			# Separate the value of argument
+			param="$1"
+			TARGET_ARGS="${TARGET_ARGS} ${param%=*} ${param#*=}"
+			shift 1
+			continue
+		fi
 	fi
 
+	arg="$1"
 	# Otherwise, process the argument.
 	case "$1" in
 	--llvm-version)
 		llvm_suffix="$2"
 		shift
 		;;
+	--llvm-version=*)
+		llvm_suffix="${arg#*=}"
+		;;
 	--execution-manager | -em | -execution-manager)
 		LIBRARY_MODE_EXECUTION_MANAGER="$2"
 		shift
 		;;
+	--execution-manager=* | -em=* | -execution-manager=*)
+		LIBRARY_MODE_EXECUTION_MANAGER="${arg#*=}"
+		;;
 	--target | -target)
 		shift
+		;;
+	--target=* | -target=*)
+		echo "${arg#*=}"
 		;;
 	--emit-qir | -emit-qir)
 		EMIT_QIR=true
@@ -384,13 +388,22 @@ while [ $# -ne 0 ]; do
 		PLATFORM_LIBRARY="$2"
 		shift
 		;;
+	--platform=* | -platform=*)
+		PLATFORM_LIBRARY="${arg#*=}"
+		;;
 	--load | -load)
 		LINKLIBS="${LINKLIBS} -lcudaq-$2"
 		shift
 		;;
+	--load=* | -load=*)
+		LINKLIBS="${LINKLIBS} -lcudaq-${arg#*=}"
+		;;
 	--cmake-host-compiler)
 		CMAKE_FALLBACK_HOST_CXX="$2"
 		shift
+		;;
+	--cmake-host-compiler=*)
+		CMAKE_FALLBACK_HOST_CXX="${arg#*=}"
 		;;
 	-g)
 		COMPILER_FLAGS="${COMPILER_FLAGS} -g"
@@ -460,6 +473,10 @@ while [ $# -ne 0 ]; do
 		OUTPUTOPTS="-o $2"
 		OUTPUTFILE="$2"
 		shift
+		;;
+	-o=*)
+		OUTPUTOPTS="-o ${arg#*=}"
+		OUTPUTFILE="${arg#*=}"
 		;;
 	-D*)
 		DEFINED_VAR=$1

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -311,6 +311,24 @@ TARGET_ARGS=
 if [[ $# -eq 0 ]]; then
     SHOW_HELP=true
 fi
+# Handle arguments with '='
+N=$#
+cmd_params=("$@")
+for i in "${!cmd_params[@]}"; do
+	arg="${cmd_params[$i]}"
+	if [[ "$arg" == *=* ]]; then
+		key="${arg%=*}"
+		val="${arg#*=}"
+		if [[ $i -eq 0 ]]; then
+			cmd_params=( "$key" "$val" "${cmd_params[@]:1}" )
+		elif [[ $i -eq $N-1 ]]; then
+			cmd_params=( "${cmd_params[@]:0:i-1}" "$key" "$val" )
+		else
+			cmd_params=( "${cmd_params[@]:0:i-1}" "$key" "$val" "${cmd_params[@]:i+1}" )
+		fi
+	fi
+done
+set -- "${cmd_params[@]}"
 
 # First, find the target option. The name is needed since it is the prefix for
 # any target specific options.


### PR DESCRIPTION
The nvq++ documentation says that it accepts command line arguments such as '--target=<value>', but does not correctly process them resulting in an error (as they pass through to clang).
This change attempts to fix this behavior.
