### PR TITLE
Enable use of single-term spin_op with kernel_builder::exp_pauli

### DIFF
--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -1139,34 +1139,11 @@ Args:
       .def(
           "exp_pauli",
           [](kernel_builder<> &self, py::object theta, const QuakeValue &qubits,
-             const std::string &pauliWord) {
+             const std::variant<std::string, spin_op> &term) {
             if (py::isinstance<py::float_>(theta))
-              self.exp_pauli(theta.cast<double>(), qubits, pauliWord);
+              self.exp_pauli(theta.cast<double>(), qubits, term);
             else if (py::isinstance<QuakeValue>(theta))
-              self.exp_pauli(theta.cast<QuakeValue &>(), qubits, pauliWord);
-            else
-              throw std::runtime_error(
-                  "Invalid `theta` argument type. Must be a "
-                  "`float` or a `QuakeValue`.");
-          },
-          "Apply a general Pauli tensor product rotation, `exp(i theta P)`, on "
-          "the specified qubit register. The Pauli tensor product is provided "
-          "as a string, e.g. `XXYX` for a 4-qubit term. The angle parameter "
-          "can be provided as a concrete float or a `QuakeValue`.")
-      .def(
-          "exp_pauli",
-          [](kernel_builder<> &self, py::object theta, const QuakeValue &qubits,
-             const spin_op &pauliWord) {
-            if (pauliWord.num_terms() > 1)
-              throw std::runtime_error(
-                  "exp_pauli requires SpinOperator with a single term.");
-                  
-            if (py::isinstance<py::float_>(theta))
-              self.exp_pauli(theta.cast<double>(), qubits,
-                             pauliWord.to_string(/*printCoeff*/ false));
-            else if (py::isinstance<QuakeValue>(theta))
-              self.exp_pauli(theta.cast<QuakeValue &>(), qubits,
-                             pauliWord.to_string(/*printCoeff*/ false));
+              self.exp_pauli(theta.cast<QuakeValue &>(), qubits, term);
             else
               throw std::runtime_error(
                   "Invalid `theta` argument type. Must be a "

--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -1152,6 +1152,29 @@ Args:
           "Apply a general Pauli tensor product rotation, `exp(i theta P)`, on "
           "the specified qubit register. The Pauli tensor product is provided "
           "as a string, e.g. `XXYX` for a 4-qubit term. The angle parameter "
+          "can be provided as a concrete float or a `QuakeValue`.")
+      .def(
+          "exp_pauli",
+          [](kernel_builder<> &self, py::object theta, const QuakeValue &qubits,
+             const spin_op &pauliWord) {
+            if (pauliWord.num_terms() > 1)
+              throw std::runtime_error(
+                  "exp_pauli requires SpinOperator with a single term.");
+                  
+            if (py::isinstance<py::float_>(theta))
+              self.exp_pauli(theta.cast<double>(), qubits,
+                             pauliWord.to_string(/*printCoeff*/ false));
+            else if (py::isinstance<QuakeValue>(theta))
+              self.exp_pauli(theta.cast<QuakeValue &>(), qubits,
+                             pauliWord.to_string(/*printCoeff*/ false));
+            else
+              throw std::runtime_error(
+                  "Invalid `theta` argument type. Must be a "
+                  "`float` or a `QuakeValue`.");
+          },
+          "Apply a general Pauli tensor product rotation, `exp(i theta P)`, on "
+          "the specified qubit register. The Pauli tensor product is provided "
+          "as a string, e.g. `XXYX` for a 4-qubit term. The angle parameter "
           "can be provided as a concrete float or a `QuakeValue`.");
 }
 

--- a/python/tests/unittests/test_kernel_builder.py
+++ b/python/tests/unittests/test_kernel_builder.py
@@ -916,6 +916,17 @@ def test_exp_pauli():
     want_exp = cudaq.observe(kernel, h, .11).expectation()
     assert np.isclose(want_exp, -1.13, atol=1e-2)
 
+    kernel, theta = cudaq.make_kernel(float)
+    qubits = kernel.qalloc(4)
+    kernel.x(qubits[0])
+    kernel.x(qubits[1])
+    kernel.exp_pauli(theta, qubits, cudaq.SpinOperator.from_word('XXXY'))
+    want_exp = cudaq.observe(kernel, h, .11).expectation()
+    assert np.isclose(want_exp, -1.13, atol=1e-2)
+
+    invalidOp = cudaq.SpinOperator.from_word('XXXY') + cudaq.SpinOperator.from_word("YYYX")
+    with pytest.raises(RuntimeError) as error:
+        kernel.exp_pauli(theta, qubits, invalidOp)
 
 def test_givens_rotation_op():
     cudaq.reset_target()

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -373,7 +373,7 @@ private:
   /// @brief The CUDA Quantum Quake function arguments stored as `QuakeValue`s.
   std::vector<QuakeValue> arguments;
 
-  /// @brief Return a string representation of a the given spin operator.
+  /// @brief Return a string representation of the given spin operator.
   /// Throw an exception if the spin operator provided is not a single term.
   auto toPauliWord(const std::variant<std::string, spin_op> &term) {
     if (term.index()) {

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -1037,6 +1037,16 @@ CUDAQ_TEST(BuilderTester, checkEntryPointAttribute) {
 }
 
 CUDAQ_TEST(BuilderTester, checkExpPauli) {
+  std::vector<double> h2_data{
+      3, 1, 1, 3, 0.0454063,  0,  2, 0, 0, 0, 0.17028,    0,
+      0, 0, 2, 0, -0.220041,  -0, 1, 3, 3, 1, 0.0454063,  0,
+      0, 0, 0, 0, -0.106477,  0,  0, 2, 0, 0, 0.17028,    0,
+      0, 0, 0, 2, -0.220041,  -0, 3, 3, 1, 1, -0.0454063, -0,
+      2, 2, 0, 0, 0.168336,   0,  2, 0, 2, 0, 0.1202,     0,
+      0, 2, 0, 2, 0.1202,     0,  2, 0, 0, 2, 0.165607,   0,
+      0, 2, 2, 0, 0.165607,   0,  0, 0, 2, 2, 0.174073,   0,
+      1, 1, 3, 3, -0.0454063, -0, 15};
+  cudaq::spin_op h(h2_data, 4);
   {
     auto [kernel, theta] = cudaq::make_kernel<double>();
     auto qubits = kernel.qalloc(4);
@@ -1044,16 +1054,16 @@ CUDAQ_TEST(BuilderTester, checkExpPauli) {
     kernel.x(qubits[1]);
     kernel.exp_pauli(theta, qubits, "XXXY");
     std::cout << kernel << "\n";
-    std::vector<double> h2_data{
-        3, 1, 1, 3, 0.0454063,  0,  2, 0, 0, 0, 0.17028,    0,
-        0, 0, 2, 0, -0.220041,  -0, 1, 3, 3, 1, 0.0454063,  0,
-        0, 0, 0, 0, -0.106477,  0,  0, 2, 0, 0, 0.17028,    0,
-        0, 0, 0, 2, -0.220041,  -0, 3, 3, 1, 1, -0.0454063, -0,
-        2, 2, 0, 0, 0.168336,   0,  2, 0, 2, 0, 0.1202,     0,
-        0, 2, 0, 2, 0.1202,     0,  2, 0, 0, 2, 0.165607,   0,
-        0, 2, 2, 0, 0.165607,   0,  0, 0, 2, 2, 0.174073,   0,
-        1, 1, 3, 3, -0.0454063, -0, 15};
-    cudaq::spin_op h(h2_data, 4);
+    const double e = cudaq::observe(kernel, h, 0.11);
+    EXPECT_NEAR(e, -1.13, 1e-2);
+  }
+  {
+    auto [kernel, theta] = cudaq::make_kernel<double>();
+    auto qubits = kernel.qalloc(4);
+    kernel.x(qubits[0]);
+    kernel.x(qubits[1]);
+    kernel.exp_pauli(theta, qubits, cudaq::spin_op::from_word("XXXY"));
+    std::cout << kernel << "\n";
     const double e = cudaq::observe(kernel, h, 0.11);
     EXPECT_NEAR(e, -1.13, 1e-2);
   }
@@ -1064,16 +1074,6 @@ CUDAQ_TEST(BuilderTester, checkExpPauli) {
     kernel.x(qubits[1]);
     kernel.exp_pauli(theta, qubits, "XXXY");
     std::cout << kernel << "\n";
-    std::vector<double> h2_data{
-        3, 1, 1, 3, 0.0454063,  0,  2, 0, 0, 0, 0.17028,    0,
-        0, 0, 2, 0, -0.220041,  -0, 1, 3, 3, 1, 0.0454063,  0,
-        0, 0, 0, 0, -0.106477,  0,  0, 2, 0, 0, 0.17028,    0,
-        0, 0, 0, 2, -0.220041,  -0, 3, 3, 1, 1, -0.0454063, -0,
-        2, 2, 0, 0, 0.168336,   0,  2, 0, 2, 0, 0.1202,     0,
-        0, 2, 0, 2, 0.1202,     0,  2, 0, 0, 2, 0.165607,   0,
-        0, 2, 2, 0, 0.165607,   0,  0, 0, 2, 2, 0.174073,   0,
-        1, 1, 3, 3, -0.0454063, -0, 15};
-    cudaq::spin_op h(h2_data, 4);
     cudaq::optimizers::cobyla optimizer;
     optimizer.max_eval = 30;
     auto [e, opt] = optimizer.optimize(1, [&](std::vector<double> x) -> double {
@@ -1090,16 +1090,6 @@ CUDAQ_TEST(BuilderTester, checkExpPauli) {
     kernel.x(qubits[1]);
     kernel.exp_pauli(theta, "XXXY", qubits[0], qubits[1], qubits[2], qubits[3]);
     std::cout << kernel << "\n";
-    std::vector<double> h2_data{
-        3, 1, 1, 3, 0.0454063,  0,  2, 0, 0, 0, 0.17028,    0,
-        0, 0, 2, 0, -0.220041,  -0, 1, 3, 3, 1, 0.0454063,  0,
-        0, 0, 0, 0, -0.106477,  0,  0, 2, 0, 0, 0.17028,    0,
-        0, 0, 0, 2, -0.220041,  -0, 3, 3, 1, 1, -0.0454063, -0,
-        2, 2, 0, 0, 0.168336,   0,  2, 0, 2, 0, 0.1202,     0,
-        0, 2, 0, 2, 0.1202,     0,  2, 0, 0, 2, 0.165607,   0,
-        0, 2, 2, 0, 0.165607,   0,  0, 0, 2, 2, 0.174073,   0,
-        1, 1, 3, 3, -0.0454063, -0, 15};
-    cudaq::spin_op h(h2_data, 4);
     cudaq::optimizers::cobyla optimizer;
     optimizer.max_eval = 30;
     auto [e, opt] = optimizer.optimize(1, [&](std::vector<double> x) -> double {


### PR DESCRIPTION
Currently, the Pauli word argument for `kernel_builder::exp_pauli` must be a string. Allow one to pass a single-term `spin_op`. 

Useful for use cases like in #1056 