### PR TITLE
Improve thread-safety of CUDAQ static variables

### DIFF
--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -20,6 +20,7 @@
 #include <filesystem>
 #include <map>
 #include <regex>
+#include <shared_mutex>
 #include <signal.h>
 #include <string>
 #include <vector>
@@ -212,6 +213,15 @@ std::string demangle_kernel(const char *name) {
 bool globalFalse = false;
 } // namespace cudaq::__internal__
 
+// Shared mutex to guard concurrent access to global kernel data (e.g.,
+// `quakeRegistry`, `kernelRegistry`, `argsCreators`, `lambdaNames`).
+// These global variables might be accessed (write or read) concurrently, e.g.,
+// async. execution of kernels or via CUDA Quantum API (e.g.,
+// `get_quake_by_name`). Note: currently, we use a single mutex for all static
+// global variables for simplicity since these containers are small and not
+// frequently accessed.
+static std::shared_mutex globalRegistryMutex;
+
 //===----------------------------------------------------------------------===//
 // Registry that maps device code keys to strings of device code. The map is
 // created at program startup and can be used to find code to be
@@ -221,6 +231,7 @@ bool globalFalse = false;
 static std::vector<std::pair<std::string, std::string>> quakeRegistry;
 
 void cudaq::registry::deviceCodeHolderAdd(const char *key, const char *code) {
+  std::unique_lock<std::shared_mutex> lock(globalRegistryMutex);
   quakeRegistry.emplace_back(key, code);
 }
 
@@ -237,21 +248,25 @@ static std::map<std::string, cudaq::KernelArgsCreator> argsCreators;
 static std::map<std::string, std::string> lambdaNames;
 
 void cudaq::registry::cudaqRegisterKernelName(const char *kernelName) {
+  std::unique_lock<std::shared_mutex> lock(globalRegistryMutex);
   kernelRegistry.emplace_back(kernelName);
 }
 
 void cudaq::registry::cudaqRegisterArgsCreator(const char *name,
                                                char *rawFunctor) {
+  std::unique_lock<std::shared_mutex> lock(globalRegistryMutex);
   argsCreators.insert(
       {std::string(name), reinterpret_cast<KernelArgsCreator>(rawFunctor)});
 }
 
 void cudaq::registry::cudaqRegisterLambdaName(const char *name,
                                               const char *value) {
+  std::unique_lock<std::shared_mutex> lock(globalRegistryMutex);
   lambdaNames.insert({std::string(name), std::string(value)});
 }
 
 bool cudaq::__internal__::isKernelGenerated(const std::string &kernelName) {
+  std::shared_lock<std::shared_mutex> lock(globalRegistryMutex);
   for (auto regName : kernelRegistry)
     if (kernelName == regName)
       return true;
@@ -277,6 +292,7 @@ void set_target_backend(const char *backend) {
 }
 
 KernelArgsCreator getArgsCreator(const std::string &kernelName) {
+  std::unique_lock<std::shared_mutex> lock(globalRegistryMutex);
   return argsCreators[kernelName];
 }
 
@@ -287,6 +303,7 @@ std::string get_quake_by_name(const std::string &kernelName,
 
   // Find the quake code
   std::optional<std::string> result;
+  std::shared_lock<std::shared_mutex> lock(globalRegistryMutex);
   for (auto [k, v] : quakeRegistry) {
     if (k == kernelName) {
       // Exact match. Return the code.


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
There are a couple of static variables in `cudaq.cpp` that might be accessed concurrently.

For example:

- Thread 1 calls `deviceCodeHolderAdd` (`.thunk` function) => `vector::emplace_back`

- Thread 2 calls `get_quake_by_name` => iterate over the same `vector` => BANG.

This PR adds a `mutex` to guard access to those vars.


