### PR TITLE
Workflow configs for feature branches

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        image_name: [cuda-quantum-assets, cuda-quantum-dev, cuda-quantum-devdeps, open-mpi]
+        image_name: [cuda-quantum, cuda-quantum-assets, cuda-quantum-dev, cuda-quantum-devdeps, open-mpi]
       fail-fast: false
 
     steps:

--- a/.github/workflows/config/ghcr_config.json
+++ b/.github/workflows/config/ghcr_config.json
@@ -1,4 +1,27 @@
 {
+    "internal_images":
+    [
+        {
+            "name": "cuda-quantum",
+            "tags_to_keep": 6
+        },
+        {
+            "name": "cuda-quantum-dev",
+            "tags_to_keep": 50
+        },
+        {
+            "name": "cuda-quantum-assets",
+            "tags_to_keep": 20
+        },
+        {
+            "name": "cuda-quantum-devdeps",
+            "tags_to_keep": 100
+        },
+        {
+            "name": "open-mpi",
+            "tags_to_keep": 10
+        }
+    ],    
     "external_images":
     [
         {

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -41,6 +41,7 @@ on:
     branches:
       - 'releases/*'
       - 'experimental/*'
+      - 'features/*'
 
 name: Deployments # do not change name without updating workflow_run triggers
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -98,6 +98,8 @@ jobs:
             elif ${{ github.event.workflow_run.name != 'CI' }} && [ "$head_branch" != "${head_branch#experimental/}" ]; then
               echo "Documentation for experimental features will not be published."
               echo "Instead, please edit the README in docker/release/ to describe the feature and link any additional resources."
+            elif ${{ github.event.workflow_run.name != 'CI' }} && [ "$head_branch" != "${head_branch#features/}" ]; then
+              echo "Documentation for feature branches will not be published."
             else
               version=`echo ${head_branch#releases/} | (egrep -o "^v?([0-9]{1,}\.)+[0-9]{1,}$" || true)`
               echo "target_folder=${version#v}" >> $GITHUB_OUTPUT

--- a/.github/workflows/gh_registry.yml
+++ b/.github/workflows/gh_registry.yml
@@ -15,6 +15,7 @@ jobs:
 
     outputs:
       external_images: ${{ steps.ghcr_config.outputs.external_images }}
+      internal_images: ${{ steps.ghcr_config.outputs.internal_images }}
 
     steps:
       - name: Checkout repository
@@ -41,6 +42,20 @@ jobs:
               external_images=`echo $external_images | jq ".tags |= . + [\"$source:$tag\"]"`
             done
           done
+
+          config=`cat .github/workflows/config/ghcr_config.json | jq ".internal_images"`
+          images=`echo "$config" | jq '.[].name'`
+          internal_images="{\"package_names\":[]}"
+          for image in $images; do
+            image_data=`echo "$config" | jq ".[] | select(.name==$image)"`
+            package_name=`echo $image_data | jq -r '.name'`
+            nr_tags_to_keep=`echo $image_data | jq -r '.tags_to_keep'`
+            internal_images=`echo $internal_images | jq ".package_names |= . + [\"$package_name\"]"`
+            info={\"$package_name\":{\"nr_tags_to_keep\":\"$nr_tags_to_keep\"}}
+            internal_images=`echo $internal_images | jq ". |= . + $info"`
+          done
+
+          echo "internal_images=$(echo $internal_images)" >> $GITHUB_OUTPUT
           echo "external_images=$(echo $external_images)" >> $GITHUB_OUTPUT
 
   delete_images:
@@ -136,3 +151,35 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: ${{ steps.metadata.outputs.platforms }}
           push: true
+
+  delete_internal_images:
+    name: Clean up internal images on GHCR
+    needs: ghcr_config
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    environment:
+      name: ghcr-deployment
+      url: ${{ vars.deployment_url }}
+
+    strategy:
+      matrix:
+        package_name: ${{ fromJson(needs.ghcr_config.outputs.internal_images).package_names }}
+      fail-fast: false
+
+    steps:
+      - name: Login to GitHub CR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Delete old images
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: ${{ matrix.package_name }}
+          package-type: 'container'
+          min-versions-to-keep: ${{ fromJson(needs.ghcr_config.outputs.internal_images)[format('{0}', matrix.package_name)].nr_tags_to_keep }}
+        continue-on-error: true

--- a/.github/workflows/prepare_deployment.yml
+++ b/.github/workflows/prepare_deployment.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
       - 'releases/*'
       - 'experimental/*'
+      - 'features/*'
 
 name: PR merged
 


### PR DESCRIPTION
These changes make sure that feature branches get their own build caches.
Given the increasingly larger number of tags we create, I've also added a job once a day that keeps only a certain number of tags for images on GHCR (exact number is defined in the ghcr_config.json file): https://github.com/NVIDIA/cuda-quantum/actions/runs/7585004562