### PR TITLE
Fix bug 1108 - race condition in sample_async

### DIFF
--- a/python/runtime/cudaq/algorithms/py_observe.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe.cpp
@@ -27,15 +27,6 @@ enum class PyParType { thread, mpi };
 /// @brief Default qpu id value set to 0
 constexpr int defaultQpuIdValue = 0;
 
-/// @brief Global cache map of OpaqueArguments
-///
-/// For asynchronous execution, we need to construct OpaqueArguments
-/// outside of the async lambda invocation. If we don't, then we will be
-/// using Python types outside of the current GIL context. Bad things happen
-/// then.
-std::unordered_map<std::size_t, std::unique_ptr<OpaqueArguments>>
-    asyncArgsHolder;
-
 /// @brief Run `cudaq::observe` on the provided kernel and spin operator.
 observe_result pyObserve(kernel_builder<> &kernel, spin_op &spin_operator,
                          py::args args, int shots,

--- a/python/runtime/cudaq/algorithms/py_observe.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe.cpp
@@ -73,37 +73,33 @@ async_observe_result pyObserveAsync(kernel_builder<> &kernel,
 
   // Ensure the user input is correct.
   auto validatedArgs = validateInputArguments(kernel, args);
-  std::hash<std::string> hasher;
-
-  // Create a unique integer key that combines the kernel name
-  // and the validated args.
-  std::size_t uniqueHash = hasher(kernel.name()) + hasher(py::str(args));
-
-  // Add the opaque args to the holder and pack the args into it.
-  // Note: this pyObserveAsync is executed in a loop (over spin_operator slices)
-  // on the main Python thread, while posting functors to other threads
-  // (runObservationAsync below). These functors are expected to operate on the
-  // same (kernel + params) configuration, hence, making sure that we don't
-  // overwrite asyncArgsHolder while running the spin_operator slicing loop
-  // (this pyObserveAsync function).
-  if (asyncArgsHolder.find(uniqueHash) == asyncArgsHolder.end()) {
-    asyncArgsHolder.emplace(uniqueHash, std::make_unique<OpaqueArguments>());
-    packArgs(*asyncArgsHolder.at(uniqueHash).get(), validatedArgs);
-  }
 
   // TODO: would like to handle errors in the case that
   // `kernel.num_qubits() >= spin_operator.num_qubits()`
+
+  // JIT the code
   kernel.jitCode();
+
+  // Get the kernel name
   auto name = kernel.name();
+
   // Get the platform, first check that the given qpu_id is valid
   auto &platform = cudaq::get_platform();
+  if (qpu_id >= platform.num_qpus())
+    throw std::runtime_error(
+        fmt::format("[observe_async] invalid qpu_id (num_qpus={}, qpu_id={})",
+                    platform.num_qpus(), qpu_id));
 
-  // Launch the asynchronous execution.
+  // Create the argument holder and pack the runtime arguments
+  auto argsHolder = std::make_unique<OpaqueArguments>();
+  packArgs(*argsHolder, validatedArgs);
+
+  // Launch the asynchronous task.
   return details::runObservationAsync(
-      [&kernel, uniqueHash]() mutable {
-        auto &argData = asyncArgsHolder.at(uniqueHash);
-        kernel.jitAndInvoke(argData->data());
-      },
+      detail::make_copyable_function(
+          [&kernel, argData = std::move(argsHolder)]() mutable {
+            kernel.jitAndInvoke(argData->data());
+          }),
       spin_operator, platform, shots, name, qpu_id);
 }
 

--- a/python/runtime/cudaq/algorithms/py_sample.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample.cpp
@@ -99,7 +99,7 @@ async_sample_result pySampleAsync(kernel_builder<> &builder,
   std::hash<std::string> hasher;
   // Create a unique integer key that combines the kernel name
   // and the validated args.
-  std::size_t uniqueHash = hasher(kernelName) + hasher(py::str(args));
+  std::size_t uniqueHash = hasher(kernelName) + hasher(py::str(args)) + qpu_id;
   // Add the opaque args to the holder and pack the args into it
   asyncArgsHolder.emplace(uniqueHash, std::make_unique<OpaqueArguments>());
   packArgs(*asyncArgsHolder.at(uniqueHash).get(), validatedArgs);

--- a/python/runtime/cudaq/algorithms/py_sample.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample.cpp
@@ -23,11 +23,6 @@
 
 namespace cudaq {
 
-/// @brief Global cache map of OpaqueArguments
-// Using the same cache map provided by py_observe (hence extern).
-extern std::unordered_map<std::size_t, std::unique_ptr<OpaqueArguments>>
-    asyncArgsHolder;
-
 /// @brief Sample the state produced by the provided builder.
 sample_result pySample(kernel_builder<> &builder, py::args args = {},
                        std::size_t shots = 1000,
@@ -94,20 +89,21 @@ async_sample_result pySampleAsync(kernel_builder<> &builder,
   auto validatedArgs = validateInputArguments(builder, args);
   auto &platform = cudaq::get_platform();
   cudaq::info("Asynchronously sampling the provided pythonic kernel.");
+
+  // JIT the code and get the kernel name
   builder.jitCode();
   auto kernelName = builder.name();
-  std::hash<std::string> hasher;
-  // Create a unique integer key that combines the kernel name
-  // and the validated args.
-  std::size_t uniqueHash = hasher(kernelName) + hasher(py::str(args)) + qpu_id;
-  // Add the opaque args to the holder and pack the args into it
-  asyncArgsHolder.emplace(uniqueHash, std::make_unique<OpaqueArguments>());
-  packArgs(*asyncArgsHolder.at(uniqueHash).get(), validatedArgs);
+
+  // Create the argument holder and pack the runtime arguments
+  auto argsHolder = std::make_unique<OpaqueArguments>();
+  packArgs(*argsHolder, validatedArgs);
+
+  // Launch the asynchronous task.
   return details::runSamplingAsync(
-      [&builder, uniqueHash]() mutable {
-        auto &argData = asyncArgsHolder.at(uniqueHash);
-        builder.jitAndInvoke(argData->data());
-      },
+      detail::make_copyable_function(
+          [&builder, argData = std::move(argsHolder)]() mutable {
+            builder.jitAndInvoke(argData->data());
+          }),
       platform, kernelName, shots, qpu_id);
 }
 

--- a/python/tests/parallel/test_mqpu.py
+++ b/python/tests/parallel/test_mqpu.py
@@ -146,10 +146,32 @@ def testGetStateAsync():
         state = handle.get()
         assert np.allclose(state, expected_state, atol=1e-3)
 
-        # Reset for the next tests.
-        cudaq.reset_target()
+    # Reset for the next tests.
+    cudaq.reset_target()
 
+@skipIfNoMQPU
+def test_race_condition_1108():
+    cudaq.set_target("nvidia-mqpu")
+    target = cudaq.get_target()
+    num_qpus = target.num_qpus()
+    kernel, runtime_param = cudaq.make_kernel(int)
+    qubits = kernel.qalloc(runtime_param)
+    kernel.h(qubits)
 
+    count_futures = []
+    for qpu in range(num_qpus):
+        count_futures.append(cudaq.sample_async(kernel, 2, qpu_id=qpu))
+    
+    for count_future in count_futures:
+        counts = count_future.get()
+        assert len(counts) == 4
+        assert '00' in counts
+        assert '01' in counts
+        assert '10' in counts
+        assert '11' in counts
+
+    cudaq.reset_target()
+    
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)


### PR DESCRIPTION
Race condition due to non-uniqueness of hash value for storage of opaque arguments in async multi-qpu scenario.