### PR TITLE
Add library mode and kernel_builder state allocation with initialization

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -57,6 +57,7 @@ void addPipelineToQIR(mlir::PassManager &pm,
   if constexpr (QIRProfile) {
     cudaq::opt::addQIRProfilePipeline(pm, convertTo);
   }
+  pm.addPass(mlir::createCanonicalizerPass());
 }
 
 inline void addPipelineToOpenQASM(mlir::PassManager &pm) {

--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -57,6 +57,8 @@ void addPipelineToQIR(mlir::PassManager &pm,
   if constexpr (QIRProfile) {
     cudaq::opt::addQIRProfilePipeline(pm, convertTo);
   }
+
+  // Make sure we don't have any leftover dead code
   pm.addPass(mlir::createCanonicalizerPass());
 }
 

--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -41,6 +41,8 @@ constexpr static const char QIRArrayGetElementPtr1d[] =
     "__quantum__rt__array_get_element_ptr_1d";
 constexpr static const char QIRArrayQubitAllocateArray[] =
     "__quantum__rt__qubit_allocate_array";
+    constexpr static const char QIRArrayQubitAllocateArrayWithState[] =
+    "__quantum__rt__qubit_allocate_array_with_state";
 constexpr static const char QIRQubitAllocate[] =
     "__quantum__rt__qubit_allocate";
 constexpr static const char QIRArrayQubitReleaseArray[] =

--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -41,7 +41,7 @@ constexpr static const char QIRArrayGetElementPtr1d[] =
     "__quantum__rt__array_get_element_ptr_1d";
 constexpr static const char QIRArrayQubitAllocateArray[] =
     "__quantum__rt__qubit_allocate_array";
-    constexpr static const char QIRArrayQubitAllocateArrayWithState[] =
+constexpr static const char QIRArrayQubitAllocateArrayWithState[] =
     "__quantum__rt__qubit_allocate_array_with_state";
 constexpr static const char QIRQubitAllocate[] =
     "__quantum__rt__qubit_allocate";

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -281,6 +281,26 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
   }];
 }
 
+def InitializeStateOp : QuakeOp<"qinit"> {
+  let summary = "Initialize the quantum state to a specific complex vector.";
+  let description = [{
+    Given a !cc.ptr pointing to a complex data array of size 2**N, where N is the number of qubits 
+    in the targets operand, initialize the state of those target qubits to 
+    the provided state vector. This operation returns a new quake.veq instance 
+    and subsequent uses of the original veq should be replaced during code generation. 
+    This is to support the immediate use of this operation after an initial allocation.
+  }];
+
+  let arguments = (ins VeqType:$targets, 
+                       cc_PointerType:$state);
+  let results = (outs VeqType:$initializedState);
+
+  let assemblyFormat = [{
+    `(` $targets `,` $state `)` `:` functional-type(operands, results) attr-dict
+  }];
+
+}
+
 def quake_RelaxSizeOp : QuakeOp<"relax_size", [Pure]> {
   let summary = "Relax the constant size on a !veq to be unknown.";
   let description = [{

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -298,7 +298,6 @@ def InitializeStateOp : QuakeOp<"qinit"> {
   let assemblyFormat = [{
     `(` $targets `,` $state `)` `:` functional-type(operands, results) attr-dict
   }];
-
 }
 
 def quake_RelaxSizeOp : QuakeOp<"relax_size", [Pure]> {

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -31,7 +31,6 @@
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
-#include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -94,9 +93,9 @@ public:
       }
       if (maybeInit) {
         if (count - numDeallocs != 1)
-          return alloca->emitOpError(
-              "Invalid IR detected in LLVM lowering. quake.qinit op must be first "
-              "user of quake.alloca");
+          return alloca->emitOpError("Invalid IR detected in LLVM lowering. "
+                                     "quake.qinit op must be first "
+                                     "user of quake.alloca");
 
         rewriter.replaceOp(alloca, maybeInit.getResult());
         return success();

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -546,8 +546,10 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder, std::size_t hash,
       builder.create<LLVM::GEPOp>(LLVM::LLVMPointerType::get(llvmComplexPtrTy),
                                   addr, SmallVector<Value>{zero, zero});
   auto loaded = builder.create<LLVM::LoadOp>(llvmComplexPtrTy, dataPtr);
-  auto casted = builder.create<cudaq::cc::CastOp>(cudaq::cc::PointerType::get(
-      cudaq::cc::StructType::get(context, SmallVector<Type>{f64Ty, f64Ty})), loaded);
+  auto casted = builder.create<cudaq::cc::CastOp>(
+      cudaq::cc::PointerType::get(
+          cudaq::cc::StructType::get(context, SmallVector<Type>{f64Ty, f64Ty})),
+      loaded);
   qubits = builder.create<quake::InitializeStateOp>(qubits.getType(), qubits,
                                                     casted);
   return QuakeValue(builder, qubits);
@@ -902,7 +904,7 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
   pm.addPass(createCSEPass());
   pm.addPass(cudaq::opt::createConvertToQIRPass());
   pm.addPass(createCanonicalizerPass());
-  
+
   if (failed(pm.run(module)))
     throw std::runtime_error(
         "cudaq::builder failed to JIT compile the Quake representation.");

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -840,7 +840,8 @@ void tagEntryPoint(ImplicitLocOpBuilder &builder, ModuleOp &module,
 std::tuple<bool, ExecutionEngine *>
 jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
         std::unordered_map<ExecutionEngine *, std::size_t> &jitHash,
-        std::string kernelName, std::vector<std::string> extraLibPaths, StateVectorStorage& stateVectorStorage) {
+        std::string kernelName, std::vector<std::string> extraLibPaths,
+        StateVectorStorage &stateVectorStorage) {
 
   // Start of by getting the current ModuleOp
   auto block = builder.getBlock();
@@ -910,10 +911,10 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
   pm.addPass(cudaq::opt::createGenerateDeviceCodeLoader(/*genAsQuake=*/true));
   pm.addPass(cudaq::opt::createGenerateKernelExecution());
   optPM.addPass(cudaq::opt::createLowerToCFGPass());
-  // We want quantum allocations to stay where they are if 
+  // We want quantum allocations to stay where they are if
   // we are simulating and have user-provided state vectors.
-  // This check could be better / smarter probably, in tandem 
-  // with some synth strategy to rewrite initState with circuit 
+  // This check could be better / smarter probably, in tandem
+  // with some synth strategy to rewrite initState with circuit
   // synthesis result
   if (stateVectorStorage.empty())
     optPM.addPass(cudaq::opt::createCombineQuantumAllocations());

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -840,7 +840,7 @@ void tagEntryPoint(ImplicitLocOpBuilder &builder, ModuleOp &module,
 std::tuple<bool, ExecutionEngine *>
 jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
         std::unordered_map<ExecutionEngine *, std::size_t> &jitHash,
-        std::string kernelName, std::vector<std::string> extraLibPaths) {
+        std::string kernelName, std::vector<std::string> extraLibPaths, StateVectorStorage& stateVectorStorage) {
 
   // Start of by getting the current ModuleOp
   auto block = builder.getBlock();
@@ -910,7 +910,13 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
   pm.addPass(cudaq::opt::createGenerateDeviceCodeLoader(/*genAsQuake=*/true));
   pm.addPass(cudaq::opt::createGenerateKernelExecution());
   optPM.addPass(cudaq::opt::createLowerToCFGPass());
-  optPM.addPass(cudaq::opt::createCombineQuantumAllocations());
+  // We want quantum allocations to stay where they are if 
+  // we are simulating and have user-provided state vectors.
+  // This check could be better / smarter probably, in tandem 
+  // with some synth strategy to rewrite initState with circuit 
+  // synthesis result
+  if (stateVectorStorage.empty())
+    optPM.addPass(cudaq::opt::createCombineQuantumAllocations());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
   pm.addPass(cudaq::opt::createConvertToQIRPass());

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -162,7 +162,8 @@ QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder,
 /// @brief Allocate a `qvector` from existing `QuakeValue` size
 QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder, QuakeValue &size);
 
-QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder, std::size_t hash, std::size_t size);
+QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder, std::size_t hash,
+                  std::size_t size);
 
 /// @brief Create a QuakeValue representing a constant floating-point number
 QuakeValue constantVal(mlir::ImplicitLocOpBuilder &builder, double val);
@@ -231,7 +232,8 @@ jitCode(mlir::ImplicitLocOpBuilder &, mlir::ExecutionEngine *,
 /// @brief Invoke the function with the given kernel name.
 void invokeCode(mlir::ImplicitLocOpBuilder &builder, mlir::ExecutionEngine *jit,
                 std::string kernelName, void **argsArray,
-                std::vector<std::string> extraLibPaths, StateVectorStorage& storage);
+                std::vector<std::string> extraLibPaths,
+                StateVectorStorage &storage);
 
 /// @brief Invoke the provided kernel function.
 void call(mlir::ImplicitLocOpBuilder &builder, std::string &name,
@@ -394,7 +396,8 @@ private:
   std::size_t hashStateVector(const std::vector<cudaq::complex> &vec) const {
     auto seed = vec.size();
     for (auto &v : vec)
-      seed ^= std::hash<double>()(v.real()) + std::hash<double>()(v.imag()) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+      seed ^= std::hash<double>()(v.real()) + std::hash<double>()(v.imag()) +
+              0x9e3779b9 + (seed << 6) + (seed >> 2);
     return seed;
   }
 

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -229,7 +229,7 @@ void applyPasses(mlir::PassManager &);
 std::tuple<bool, mlir::ExecutionEngine *>
 jitCode(mlir::ImplicitLocOpBuilder &, mlir::ExecutionEngine *,
         std::unordered_map<mlir::ExecutionEngine *, std::size_t> &, std::string,
-        std::vector<std::string>);
+        std::vector<std::string>, StateVectorStorage&);
 
 /// @brief Invoke the function with the given kernel name.
 void invokeCode(mlir::ImplicitLocOpBuilder &builder, mlir::ExecutionEngine *jit,
@@ -823,7 +823,7 @@ public:
   void jitCode(std::vector<std::string> extraLibPaths = {}) override {
     auto [wasChanged, ptr] =
         details::jitCode(*opBuilder, jitEngine.get(), jitEngineToModuleHash,
-                         kernelName, extraLibPaths);
+                         kernelName, extraLibPaths, stateVectorStorage);
     // If we had a jitEngine, but the code changed, delete the one we had.
     if (jitEngine && wasChanged)
       details::deleteJitEngine(jitEngine.release());

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -453,7 +453,7 @@ public:
 
   // @brief Return a `QuakeValue` representing the allocated
   // quantum register, initialized to the given state vector.
-  // Note - input argument os not const here, user has to own the data.
+  // Note - input argument is not const here, user has to own the data.
   QuakeValue qalloc(std::vector<cudaq::complex> &state) {
     auto hash = hashStateVector(state);
     auto value = details::qalloc(*opBuilder.get(), hash, state.size());

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -229,7 +229,7 @@ void applyPasses(mlir::PassManager &);
 std::tuple<bool, mlir::ExecutionEngine *>
 jitCode(mlir::ImplicitLocOpBuilder &, mlir::ExecutionEngine *,
         std::unordered_map<mlir::ExecutionEngine *, std::size_t> &, std::string,
-        std::vector<std::string>, StateVectorStorage&);
+        std::vector<std::string>, StateVectorStorage &);
 
 /// @brief Invoke the function with the given kernel name.
 void invokeCode(mlir::ImplicitLocOpBuilder &builder, mlir::ExecutionEngine *jit,

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -77,6 +77,9 @@ concept KernelBuilderArgTypeIsValid =
 
 namespace details {
 
+using StateVectorStorage =
+    std::map<std::size_t, std::pair<QuakeValue, cudaq::complex *>>;
+
 // Define a `mlir::Type` generator in the `cudaq` namespace, this helps us keep
 // MLIR out of this public header
 
@@ -159,6 +162,8 @@ QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder,
 /// @brief Allocate a `qvector` from existing `QuakeValue` size
 QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder, QuakeValue &size);
 
+QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder, std::size_t hash, std::size_t size);
+
 /// @brief Create a QuakeValue representing a constant floating-point number
 QuakeValue constantVal(mlir::ImplicitLocOpBuilder &builder, double val);
 
@@ -226,7 +231,7 @@ jitCode(mlir::ImplicitLocOpBuilder &, mlir::ExecutionEngine *,
 /// @brief Invoke the function with the given kernel name.
 void invokeCode(mlir::ImplicitLocOpBuilder &builder, mlir::ExecutionEngine *jit,
                 std::string kernelName, void **argsArray,
-                std::vector<std::string> extraLibPaths);
+                std::vector<std::string> extraLibPaths, StateVectorStorage& storage);
 
 /// @brief Invoke the provided kernel function.
 void call(mlir::ImplicitLocOpBuilder &builder, std::string &name,
@@ -386,9 +391,19 @@ private:
     return std::get<std::string>(term);
   }
 
+  std::size_t hashStateVector(const std::vector<cudaq::complex> &vec) const {
+    auto seed = vec.size();
+    for (auto &v : vec)
+      seed ^= std::hash<double>()(v.real()) + std::hash<double>()(v.imag()) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    return seed;
+  }
+
+  std::map<std::size_t, std::pair<QuakeValue, cudaq::complex *>>
+      stateVectorStorage;
+
 public:
-  /// @brief The constructor, takes the input `KernelBuilderType`s which is used
-  /// to create the MLIR function type
+  /// @brief The constructor, takes the input `KernelBuilderType`s which is
+  /// used to create the MLIR function type
   kernel_builder(std::vector<details::KernelBuilderType> &types)
       : context(details::initializeContext(), details::deleteContext),
         opBuilder(nullptr, [](mlir::ImplicitLocOpBuilder *) {}),
@@ -430,6 +445,14 @@ public:
     return details::qalloc(*opBuilder.get(), size);
   }
 
+  // Not const here, user has to own the data.
+  QuakeValue qalloc(std::vector<cudaq::complex> &state) {
+    // Store the state here internally, need some unique key for it
+    auto hash = hashStateVector(state);
+    auto value = details::qalloc(*opBuilder.get(), hash, state.size());
+    stateVectorStorage.insert({hash, {value, state.data()}});
+    return value;
+  }
   /// @brief Return a `QuakeValue` representing the constant floating-point
   /// value.
   QuakeValue constantVal(double val) {
@@ -817,7 +840,7 @@ public:
       jitCode(extraLibPaths);
     }
     details::invokeCode(*opBuilder, jitEngine.get(), kernelName, argsArray,
-                        extraLibPaths);
+                        extraLibPaths, stateVectorStorage);
   }
 
   /// @brief The call operator for the kernel_builder, takes as input the

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -103,6 +103,8 @@ public:
   /// Reset the execution context
   virtual void resetExecutionContext() = 0;
 
+  /// @brief Initialize the state of the given qudits to the provided
+  /// state vector.
   virtual void initializeState(const std::vector<QuditInfo> &targets,
                                const complex *state) = 0;
 

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -103,7 +103,6 @@ public:
   /// Reset the execution context
   virtual void resetExecutionContext() = 0;
 
-
   virtual void initializeState(const std::vector<QuditInfo> &targets,
                                const complex *state) = 0;
 

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -17,6 +17,7 @@
 namespace cudaq {
 class ExecutionContext;
 using SpinMeasureResult = std::pair<double, sample_result>;
+using complex = std::complex<double>;
 
 /// A QuditInfo is a type encoding the number of \a levels and the \a id of the
 /// qudit to the ExecutionManager.
@@ -101,6 +102,10 @@ public:
 
   /// Reset the execution context
   virtual void resetExecutionContext() = 0;
+
+
+  virtual void initializeState(const std::vector<QuditInfo> &targets,
+                               const complex *state) = 0;
 
   /// Apply the quantum instruction with the given name, on the provided target
   /// qudits. Supports input of control qudits and rotational parameters. Can

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -60,7 +60,6 @@ protected:
     simulator()->allocateQubits(qudits.size());
   }
 
-  // FIXME maybe allocateAndInitialize
   void initializeState(const std::vector<cudaq::QuditInfo> &targets,
                        const cudaq::complex *state) override {
     // Here we have qubits in requestedAllocations

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -60,6 +60,15 @@ protected:
     simulator()->allocateQubits(qudits.size());
   }
 
+  // FIXME maybe allocateAndInitialize
+  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
+                       const cudaq::complex *state) override {
+    // Here we have qubits in requestedAllocations
+    // want to allocate and set state
+    simulator()->allocateQubits(requestedAllocations.size(), state);
+    requestedAllocations.clear();
+  }
+
   void deallocateQudit(const cudaq::QuditInfo &q) override {
 
     // Before trying to deallocate, make sure the qudit hasn't

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -59,6 +59,11 @@ protected:
       allocateQudit(q);
   }
 
+  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
+                       const cudaq::complex *state) override {
+    throw std::runtime_error("initializeState not implemented.");
+  }
+
   /// @brief Qudit deallocation method
   void deallocateQudit(const cudaq::QuditInfo &q) override {}
 

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -49,7 +49,7 @@ public:
     if (std::fabs(1.0 - norm) > 1e-12)
       throw std::runtime_error("Invalid vector norm for qudit allocation.");
 
-    // FIXME Perform the initialization
+    // Perform the initialization
     getExecutionManager()->initializeState({QuditInfo(n_levels(), idx)},
                                            state.data());
   }

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -29,7 +29,33 @@ private:
 public:
   /// @brief Construct a `qvector` with `size` qudits in the |0> state.
   qvector(std::size_t size) : qudits(size) {}
+  qvector(const std::vector<complex> &vector)
+      : qudits(std::log2(vector.size())) {
+    if (Levels == 2) {
+      auto numElements = std::log2(vector.size());
+      if (std::floor(numElements) != numElements)
+        throw std::runtime_error(
+          "Invalid state vector passed to qvector initialization - number of "
+            "elements must be power of 2.");
+    }
 
+    auto norm = std::inner_product(
+        vector.begin(), vector.end(), vector.begin(), complex{0., 0.},
+        [](auto a, auto b) { return a + b; },
+        [](auto a, auto b) { return std::conj(a) * b; });
+    if (std::fabs(1.0 - norm) > 1e-12)
+      throw std::runtime_error("Invalid vector norm for qudit allocation.");
+
+    std::vector<QuditInfo> targets;
+    for (auto &q : qudits)
+      targets.emplace_back(QuditInfo{Levels, q.id()});
+    getExecutionManager()->initializeState(targets, vector.data());
+  }
+
+  qvector(const std::initializer_list<double> &list)
+      : qvector({list.begin(), list.end()}) {}
+  qvector(const std::initializer_list<complex> &list)
+      : qvector({list.begin(), list.end()}) {}
   /// @cond
   /// Nullary constructor
   /// meant to be used with `kernel_builder<cudaq::qvector<>>`

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -35,7 +35,7 @@ public:
       auto numElements = std::log2(vector.size());
       if (std::floor(numElements) != numElements)
         throw std::runtime_error(
-          "Invalid state vector passed to qvector initialization - number of "
+            "Invalid state vector passed to qvector initialization - number of "
             "elements must be power of 2.");
     }
 

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -132,7 +132,9 @@ public:
   virtual std::size_t allocateQubit() = 0;
 
   /// @brief Allocate `count` qubits.
-  virtual std::vector<std::size_t> allocateQubits(const std::size_t count) = 0;
+  virtual std::vector<std::size_t>
+  allocateQubits(std::size_t count,
+                 const std::complex<double> *state = nullptr) = 0;
 
   /// @brief Deallocate the qubit with give unique index
   virtual void deallocate(const std::size_t qubitIdx) = 0;
@@ -532,7 +534,11 @@ protected:
   }
 
   /// @brief Add the given number of qubits to the state.
-  virtual void addQubitsToState(std::size_t count) {
+  virtual void addQubitsToState(std::size_t count,
+                                const std::complex<double> *state = nullptr) {
+    if (state != nullptr)
+      throw std::runtime_error("State initialization must be handled by "
+                               "subclasses, override addQubitsToState.");
     for (std::size_t i = 0; i < count; i++)
       addQubitToState();
   }
@@ -753,7 +759,9 @@ public:
   }
 
   /// @brief Allocate `count` qubits.
-  std::vector<std::size_t> allocateQubits(std::size_t count) override {
+  std::vector<std::size_t>
+  allocateQubits(std::size_t count,
+                 const std::complex<double> *state = nullptr) override {
     std::vector<std::size_t> qubits;
     for (std::size_t i = 0; i < count; i++)
       qubits.emplace_back(tracker.getNextIndex());
@@ -778,7 +786,7 @@ public:
     stateDimension = calculateStateDim(nQubitsAllocated);
 
     // Tell the subtype to allocate more qubits
-    addQubitsToState(count);
+    addQubitsToState(count, state);
 
     // May be that the state grows enough that we
     // want to handle observation via sampling

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -181,6 +181,13 @@ Array *__quantum__rt__qubit_allocate_array(uint64_t size) {
   return vectorSizetToArray(qubitIdxs);
 }
 
+Array *__quantum__rt__qubit_allocate_array_with_state(uint64_t size, std::complex<double> * data) {
+  cudaq::ScopedTrace trace("NVQIR::qubit_allocate_array_with_data", size);
+  __quantum__rt__initialize(0, nullptr);
+  auto qubitIdxs = nvqir::getCircuitSimulatorInternal()->allocateQubits(size, data);
+  return vectorSizetToArray(qubitIdxs);
+}
+
 /// @brief Once done, release the QIR qubit array
 void __quantum__rt__qubit_release_array(Array *arr) {
   cudaq::ScopedTrace trace("NVQIR::qubit_release_array", arr->size());

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -181,10 +181,13 @@ Array *__quantum__rt__qubit_allocate_array(uint64_t size) {
   return vectorSizetToArray(qubitIdxs);
 }
 
-Array *__quantum__rt__qubit_allocate_array_with_state(uint64_t size, std::complex<double> * data) {
+Array *
+__quantum__rt__qubit_allocate_array_with_state(uint64_t size,
+                                               std::complex<double> *data) {
   cudaq::ScopedTrace trace("NVQIR::qubit_allocate_array_with_data", size);
   __quantum__rt__initialize(0, nullptr);
-  auto qubitIdxs = nvqir::getCircuitSimulatorInternal()->allocateQubits(size, data);
+  auto qubitIdxs =
+      nvqir::getCircuitSimulatorInternal()->allocateQubits(size, data);
   return vectorSizetToArray(qubitIdxs);
 }
 

--- a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
+++ b/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
@@ -190,9 +190,13 @@ protected:
   }
 
   /// @brief Increase the state size by the given number of qubits.
-  void addQubitsToState(std::size_t count) override {
+  void addQubitsToState(std::size_t count,
+                        const std::complex<double> *state = nullptr) override {
     if (count == 0)
       return;
+
+    if (state != nullptr)
+      throw std::runtime_error("init state not implemented here yet.");
 
     int dev;
     HANDLE_CUDA_ERROR(cudaGetDevice(&dev));

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -114,23 +114,36 @@ protected:
 
   /// @brief Override the default sized allocation of qubits
   /// here to be a bit more efficient than the default implementation
-  void addQubitsToState(std::size_t count) override {
+  void
+  addQubitsToState(std::size_t count,
+                   const std::complex<double> *stateData = nullptr) override {
     if (count == 0)
       return;
 
     if (state.size() == 0) {
       // If this is the first time, allocate the state
-      state = qpp::ket::Zero(stateDimension);
-      state(0) = 1.0;
+      if (stateData == nullptr) {
+        state = qpp::ket::Zero(stateDimension);
+        state(0) = 1.0;
+      } else
+        state = qpp::ket::Map(const_cast<std::complex<double> *>(stateData),
+                              stateDimension);
+
       return;
     }
 
     // If we are resizing an existing, allocate
     // a zero state on a n qubit, and Kron-prod
     // that with the existing state.
-    qpp::ket zero_state = qpp::ket::Zero((1UL << count));
-    zero_state(0) = 1.0;
-    state = qpp::kron(state, zero_state);
+    if (stateData == nullptr) {
+      qpp::ket zero_state = qpp::ket::Zero((1UL << count));
+      zero_state(0) = 1.0;
+      state = qpp::kron(state, zero_state);
+    } else {
+      qpp::ket initState =
+          qpp::ket::Map(const_cast<std::complex<double> *>(stateData), count);
+      state = qpp::kron(state, initState);
+    }
 
     return;
   }

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -75,9 +75,13 @@ protected:
     state = qpp::kron(state, zero_state);
   }
 
-  void addQubitsToState(std::size_t count) override {
+  void addQubitsToState(std::size_t count,
+                        const std::complex<double> *data = nullptr) override {
     if (count == 0)
       return;
+
+    if (data != nullptr)
+      throw std::runtime_error("init state not implemented for dm sim");
 
     if (state.size() == 0) {
       // If this is the first time, allocate the state

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -1221,6 +1221,25 @@ CUDAQ_TEST(BuilderTester, checkControlledRotations) {
 
 #ifndef CUDAQ_BACKEND_DM
 
+// FIXME Get other backends updated to support this
+// TEST(BuilderTester, checkFromStateVector) {
+//   {
+//     std::vector<cudaq::complex> vec{M_SQRT1_2, 0., 0., M_SQRT1_2};
+//     auto kernel = cudaq::make_kernel();
+//     auto qubits = kernel.qalloc(vec);
+//     std::cout << kernel << "\n";
+//     auto counts = cudaq::sample(kernel);
+//     counts.dump();
+//     EXPECT_EQ(counts.size(), 2);
+//     std::size_t counter = 0;
+//     for (auto &[k, v] : counts) {
+//       counter += v;
+//       EXPECT_TRUE(k == "00" || k == "11");
+//     }
+//     EXPECT_EQ(counter, 1000);
+//   }
+// }
+
 CUDAQ_TEST(BuilderTester, checkCanProgressivelyBuild) {
   auto kernel = cudaq::make_kernel();
   auto q = kernel.qalloc(2);

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -116,7 +116,10 @@ public:
   cudaq::SpinMeasureResult measure(cudaq::spin_op &op) override {
     return cudaq::SpinMeasureResult();
   }
-
+  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
+                       const cudaq::complex *state) override {
+    throw std::runtime_error("initializeState not implemented.");
+  }
   void resetQudit(const cudaq::QuditInfo &id) override {}
 };
 


### PR DESCRIPTION
This moves the work in PR #1090 into this new feature branch. Work by others will build off of this. 


Things that still need to be done: 

- [ ] Python bindings
- [ ] Testing 
- [ ] Update simulators to set state data (custatevec, cutensornet, mgpu)
- [ ] Hook up the ASTBridge 
- [ ] Review / refactor InitializeStateOp and LowerToQIR.cpp updates (@schweitzpgi) 
- [ ] Verify bit ordering (@boschmitt)
