### PR TITLE
Missing qpud in wheels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,9 @@ endif()
 if (NOT CUDAQ_DISABLE_TOOLS)
   add_subdirectory(tools)
 endif()
+# Always add cudaq-qpud executable/tool (including Python wheels)
+add_subdirectory(tools/cudaq-qpud)
+
 add_subdirectory(utils)
 
 if (CUDAQ_ENABLE_PYTHON)

--- a/python/tests/remote/test_remote_platform.py
+++ b/python/tests/remote/test_remote_platform.py
@@ -9,24 +9,10 @@ import pytest
 import os, math
 import cudaq
 
-
-def has_rest_server():
-    try:
-        import subprocess
-        subprocess.check_output(["which", "cudaq-qpud"])
-        return True
-    except:
-        return False
-
-
-skipIfNoRestServer = pytest.mark.skipif(not (has_rest_server()),
-                                        reason="cudaq-qpud not available")
-
 num_qpus = 3
 
 
 @pytest.fixture(scope="session", autouse=True)
-@skipIfNoRestServer
 def startUpMockServer():
     cudaq.set_target("remote-mqpu",
                      remote_execution=True,
@@ -35,14 +21,12 @@ def startUpMockServer():
     cudaq.reset_target()
 
 
-@skipIfNoRestServer
 def test_setup():
     target = cudaq.get_target()
     numQpus = target.num_qpus()
     assert numQpus == num_qpus
 
 
-@skipIfNoRestServer
 def test_sample():
     kernel = cudaq.make_kernel()
     qubits = kernel.qalloc(2)
@@ -64,7 +48,6 @@ def test_sample():
     assert "11" in counts
 
 
-@skipIfNoRestServer
 def test_observe():
     # Create the parameterized ansatz
     kernel, theta = cudaq.make_kernel(float)
@@ -89,7 +72,6 @@ def test_observe():
     assert abs(res.expectation() - expected_energy) < energy_tol
 
 
-@skipIfNoRestServer
 def test_multi_qpus():
     # Create the parameterized ansatz
     kernel, theta = cudaq.make_kernel(float)

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -82,11 +82,14 @@ cudaq::MPIPlugin *getMpiPlugin(bool unsafe) {
         // The mpi4py-based plugin
         const auto pyPluginLibFile =
             pluginsPath / fmt::format("libcudaq-py-comm-plugin.{}", libSuffix);
-        if (std::filesystem::exists(pluginLibFile)) {
+        if (std::filesystem::exists(pluginLibFile) &&
+            cudaq::MPIPlugin::isValidInterfaceLib(pluginLibFile.c_str())) {
           cudaq::info("Load builtin MPI comm plugin from  at '{}'",
                       pluginLibFile.c_str());
           g_plugin = std::make_unique<cudaq::MPIPlugin>(pluginLibFile.c_str());
-        } else if (std::filesystem::exists(pyPluginLibFile)) {
+        } else if (std::filesystem::exists(pyPluginLibFile) &&
+                   cudaq::MPIPlugin::isValidInterfaceLib(
+                       pyPluginLibFile.c_str())) {
           cudaq::info("Try loading mpi4py MPI comm plugin from  at '{}'",
                       pyPluginLibFile.c_str());
           g_plugin =

--- a/runtime/cudaq/distributed/mpi_plugin.cpp
+++ b/runtime/cudaq/distributed/mpi_plugin.cpp
@@ -23,6 +23,13 @@ namespace {
 } // namespace
 
 namespace cudaq {
+bool MPIPlugin::isValidInterfaceLib(
+    const std::string &distributedInterfaceLib) {
+  const bool dlOpenOk =
+      dlopen(distributedInterfaceLib.c_str(), RTLD_GLOBAL | RTLD_NOW);
+  return dlOpenOk;
+}
+
 MPIPlugin::MPIPlugin(const std::string &distributedInterfaceLib) {
   if (!dlopen(distributedInterfaceLib.c_str(), RTLD_GLOBAL | RTLD_NOW)) {
     const std::string errorMsg(dlerror());

--- a/runtime/cudaq/distributed/mpi_plugin.h
+++ b/runtime/cudaq/distributed/mpi_plugin.h
@@ -22,6 +22,9 @@ public:
       "getMpiCommunicator";
   static constexpr std::string_view DISTRIBUTED_INTERFACE_GETTER_SYMBOL_NAME =
       "getDistributedInterface";
+  // Static method to safely check whether a path contains an usable MPI
+  // inteface library.
+  static bool isValidInterfaceLib(const std::string &distributedInterfaceLib);
   MPIPlugin(const std::string &distributedInterfaceLib);
   cudaqDistributedInterface_t *get() { return m_distributedInterface; }
   cudaqDistributedCommunicator_t *getComm() { return m_comm; }

--- a/runtime/cudaq/platform/default/rest_server/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/rest_server/CMakeLists.txt
@@ -21,28 +21,26 @@ target_include_directories(${LIBRARY_NAME}
 target_link_libraries(${LIBRARY_NAME} PRIVATE cudaq cudaq-mlir-runtime fmt::fmt-header-only)
 install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
 
-if (NOT CUDAQ_DISABLE_TOOLS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-type-limits")
-  add_subdirectory(helpers/server_impl)
-  add_subdirectory(helpers/llvm_jit)
-  add_library(rest-remote-platform-server SHARED RemoteRuntimeServer.cpp helpers/RestRemoteServer.cpp)
-  target_include_directories(rest-remote-platform-server 
-    PUBLIC 
-       $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/runtime>
-       $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
-       $<INSTALL_INTERFACE:include>
-    PRIVATE . ../../)
-  target_link_libraries(rest-remote-platform-server
-    PRIVATE
-      rest_server_impl
-      jit_util
-      cudaq 
-      cudaq-em-default 
-      cudaq-mlir-runtime
-      cudaq-platform-default
-      nvqir
-      fmt::fmt-header-only
-  )
-  target_link_options(rest-remote-platform-server PRIVATE -Wl,--no-as-needed)
-  install(TARGETS rest-remote-platform-server DESTINATION lib)
-endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-type-limits")
+add_subdirectory(helpers/server_impl)
+add_subdirectory(helpers/llvm_jit)
+add_library(rest-remote-platform-server SHARED RemoteRuntimeServer.cpp helpers/RestRemoteServer.cpp)
+target_include_directories(rest-remote-platform-server 
+  PUBLIC 
+      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/runtime>
+      $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
+      $<INSTALL_INTERFACE:include>
+  PRIVATE . ../../)
+target_link_libraries(rest-remote-platform-server
+  PRIVATE
+    rest_server_impl
+    jit_util
+    cudaq 
+    cudaq-em-default 
+    cudaq-mlir-runtime
+    cudaq-platform-default
+    nvqir
+    fmt::fmt-header-only
+)
+target_link_options(rest-remote-platform-server PRIVATE -Wl,--no-as-needed)
+install(TARGETS rest-remote-platform-server DESTINATION lib)

--- a/runtime/cudaq/platform/mqpu/helpers/MQPUUtils.cpp
+++ b/runtime/cudaq/platform/mqpu/helpers/MQPUUtils.cpp
@@ -9,9 +9,11 @@
 #include "MQPUUtils.h"
 #include "common/Logger.h"
 #include "common/RestClient.h"
+#include "cudaq/utils/cudaq_utils.h"
 #include "llvm/Support/Program.h"
 #include <arpa/inet.h>
 #include <execinfo.h>
+#include <filesystem>
 #include <random>
 #include <signal.h>
 #include <sys/socket.h>
@@ -69,7 +71,11 @@ cudaq::AutoLaunchRestServerProcess::AutoLaunchRestServerProcess(
     int seed_offset) {
   cudaq::info("Auto launch REST server");
   const std::string serverExeName = "cudaq-qpud";
-  auto serverApp = llvm::sys::findProgramByName(serverExeName.c_str());
+  const std::filesystem::path cudaqLibPath{cudaq::getCUDAQLibraryPath()};
+  const auto binPath = cudaqLibPath.parent_path().parent_path() / "bin";
+  cudaq::info("Search for {} in {} directory.", serverExeName, binPath.c_str());
+  auto serverApp =
+      llvm::sys::findProgramByName(serverExeName.c_str(), {binPath.c_str()});
   if (!serverApp)
     throw std::runtime_error(
         "Unable to find CUDA Quantum REST server to launch.");

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,7 +15,3 @@ if (NOT CUDAQ_DISABLE_CPP_FRONTEND)
   add_subdirectory(fixup-linkage)
   add_subdirectory(nvqpp)
 endif()
-
-if (NOT CUDAQ_DISABLE_TOOLS)
-  add_subdirectory(cudaq-qpud)
-endif()


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
Try installing the wheel myself showed a bug: the qpud, as a tool, was missing from the wheel. 

Also fixed for wheels:

- Add `bin/` path to search for the qpud executable since we have no `PATH` to rely on.

- Gracefully check `dlopen` for MPI plugin. In Python wheel environment, there could be other deps missing if no mpi4py was install, e.g. libpython.

- Make sure the Python tests for `cudaq-mqpu` always run.

- Python `remote-mqpu` is now tested in the "Create Python wheels / Validate wheel" job. 