### PR TITLE
Introduce pauli_word in the ASTBridge, kernel_builder, and Python

### DIFF
--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -7,6 +7,9 @@ Operators
 .. doxygenclass:: cudaq::spin_op
     :members:
 
+.. doxygenclass:: cudaq::pauli_word 
+    :members:
+
 Quantum
 =========
 

--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -103,7 +103,7 @@ Data Types
     :special-members: __getitem__, __str__
 
 .. autoclass:: cudaq::pauli_word
-    :special-members: __getitem__, __str__
+    :special-members: __str__
 
 .. autoclass:: cudaq::SpinOperator
     :members:

--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -102,6 +102,9 @@ Data Types
     :members:
     :special-members: __getitem__, __str__
 
+.. autoclass:: cudaq::pauli_word
+    :special-members: __getitem__, __str__
+
 .. autoclass:: cudaq::SpinOperator
     :members:
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -833,7 +833,7 @@ def ExpPauliOp : QuakeOp<"exp_pauli"> {
   let arguments = (ins
     AnyFloat:$parameter,
     VeqType:$qubits,
-    cc_PointerType:$pauli
+    AnyTypeOf<[cc_PointerType, PauliWordType]>:$pauli
   );
   let results = (outs);
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -160,6 +160,17 @@ def VeqType : QuakeType<"Veq", "veq"> {
 }
 
 //===----------------------------------------------------------------------===//
+// PauliWordType: Pauli tensor product representation
+//===----------------------------------------------------------------------===//
+
+def PauliWordType : QuakeType<"PauliWord", "pauli_word"> {
+  let summary = "a representation of a single Pauli tensor product term";
+  let description = [{
+    A Pauli word represents a single term in a CUDA Quantum spin operator. 
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // MeasureType: classical data type
 //===----------------------------------------------------------------------===//
 

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -91,8 +91,8 @@ void QuakeBridgeVisitor::addArgumentSymbols(
       auto loc = toLocation(argVal);
       auto parmTy = entryBlock->getArgument(index).getType();
       if (isa<FunctionType, cc::CallableType, cc::PointerType, cc::StdvecType,
-              LLVM::LLVMStructType, quake::ControlType, quake::RefType,
-              quake::VeqType, quake::WireType>(parmTy)) {
+              LLVM::LLVMStructType, quake::ControlType, quake::PauliWordType,
+              quake::RefType, quake::VeqType, quake::WireType>(parmTy)) {
         symbolTable.insert(name, entryBlock->getArgument(index));
       } else {
         auto stackSlot = builder.create<cc::AllocaOp>(loc, parmTy);

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -171,6 +171,8 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
     // qvector<LEVEL>, qview<LEVEL>
     if (name.equals("qvector") || name.equals("qview"))
       return pushType(quake::VeqType::getUnsized(ctx));
+    if (name.equals("pauli_word"))
+      return pushType(quake::PauliWordType::get(ctx));
     auto loc = toLocation(x);
     TODO_loc(loc, "unhandled type, " + name + ", in cudaq namespace");
   }

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1421,6 +1421,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto ptrEleTy = computePtr.getType().getElementType();
           Value loaded = builder.create<cudaq::cc::LoadOp>(loc, ptrEleTy, v);
           processedArgs.push_back(loaded);
+        } else if (isa<quake::PauliWordType>(v.getType())) {
+          processedArgs.push_back(v);
         } else {
           reportClangError(x, mangler, "could not determine string argument");
         }

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1412,7 +1412,6 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         // The C-string argument (char*) may be loaded by an lvalue to rvalue
         // cast. Here, we must pass the pointer and not the first character's
         // value.
-        v.dump();
         if (isCharPointerType(v.getType())) {
           processedArgs.push_back(v);
         } else if (auto load = v.getDefiningOp<cudaq::cc::LoadOp>()) {

--- a/lib/Frontend/nvqpp/ConvertType.cpp
+++ b/lib/Frontend/nvqpp/ConvertType.cpp
@@ -21,7 +21,7 @@ static bool isArithmeticType(Type t) { return isa<IntegerType, FloatType>(t); }
 /// Is \p t a quantum reference type. In the bridge, quantum types are always
 /// reference types.
 static bool isQuantumType(Type t) {
-  return isa<quake::VeqType, quake::RefType>(t);
+  return isa<quake::VeqType, quake::RefType, quake::PauliWordType>(t);
 }
 
 /// Allow `array of [array of]* T`, where `T` is arithmetic.
@@ -60,7 +60,8 @@ static bool isStaticArithmeticProductType(Type t) {
 static bool isArithmeticSequenceType(Type t) {
   if (auto vec = dyn_cast<cudaq::cc::StdvecType>(t)) {
     auto eleTy = vec.getElementType();
-    return isArithmeticType(eleTy) || isStaticArithmeticProductType(eleTy) ||
+    return isa<quake::PauliWordType>(eleTy) || isArithmeticType(eleTy) ||
+           isStaticArithmeticProductType(eleTy) ||
            isArithmeticSequenceType(eleTy);
   }
   return isStaticArithmeticSequenceType(t);

--- a/lib/Frontend/nvqpp/ConvertType.cpp
+++ b/lib/Frontend/nvqpp/ConvertType.cpp
@@ -60,8 +60,7 @@ static bool isStaticArithmeticProductType(Type t) {
 static bool isArithmeticSequenceType(Type t) {
   if (auto vec = dyn_cast<cudaq::cc::StdvecType>(t)) {
     auto eleTy = vec.getElementType();
-    return isa<quake::PauliWordType>(eleTy) || isArithmeticType(eleTy) ||
-           isStaticArithmeticProductType(eleTy) ||
+    return isArithmeticType(eleTy) || isStaticArithmeticProductType(eleTy) ||
            isArithmeticSequenceType(eleTy);
   }
   return isStaticArithmeticSequenceType(t);
@@ -76,7 +75,8 @@ static bool isRecursiveArithmeticProductType(Type t);
 static bool isRecursiveArithmeticSequenceType(Type t) {
   if (auto vec = dyn_cast<cudaq::cc::StdvecType>(t)) {
     auto eleTy = vec.getElementType();
-    return isArithmeticType(eleTy) || isRecursiveArithmeticProductType(eleTy) ||
+    return isa<quake::PauliWordType>(eleTy) || isArithmeticType(eleTy) ||
+           isRecursiveArithmeticProductType(eleTy) ||
            isRecursiveArithmeticSequenceType(eleTy);
   }
   return isStaticArithmeticSequenceType(t);

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -1545,6 +1545,10 @@ public:
     typeConverter.addConversion([](quake::RefType type) {
       return cudaq::opt::getQubitType(type.getContext());
     });
+    typeConverter.addConversion([](quake::PauliWordType type) {
+      return cudaq::opt::factory::getPointerType(
+          IntegerType::get(type.getContext(), 8));
+    });
     typeConverter.addConversion([](cudaq::cc::CallableType type) {
       return lambdaAsPairOfPointers(type.getContext());
     });

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -59,5 +59,6 @@ quake::VeqType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
 //===----------------------------------------------------------------------===//
 
 void quake::QuakeDialect::registerTypes() {
-  addTypes<ControlType, MeasureType, RefType, VeqType, WireType>();
+  addTypes<ControlType, MeasureType, PauliWordType, RefType, VeqType,
+           WireType>();
 }

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -474,8 +474,11 @@ public:
     auto ptrI8Ty = cudaq::cc::PointerType::get(builder.getI8Type());
     Type eleTy = stdvecTy.getElementType();
     auto innerStdvecTy = dyn_cast<cudaq::cc::StdvecType>(eleTy);
-    std::size_t eleSize =
-        innerStdvecTy ? /*(i64Type/8)*/ 8 : dataLayout->getTypeSize(eleTy);
+    std::size_t eleSize = [&]() -> std::size_t {
+      if (isa<quake::PauliWordType>(eleTy))
+        return 8;
+      return innerStdvecTy ? /*(i64Type/8)*/ 8 : dataLayout->getTypeSize(eleTy);
+    }();
     auto eleSizeVal = [&]() -> Value {
       if (eleSize)
         return builder.create<arith::ConstantIntOp>(loc, eleSize, 64);

--- a/python/runtime/cudaq/builder/py_QuakeValue.cpp
+++ b/python/runtime/cudaq/builder/py_QuakeValue.cpp
@@ -20,6 +20,9 @@ void bindQuakeValue(py::module &mod) {
       "can hold values of the following types: int, float, list/List, "
       ":class:`qubit`, or :class:`qreg`. The :class:`QuakeValue` can also hold "
       "kernel operations such as qubit allocations and measurements.\n")
+      .def("size", &QuakeValue::size,
+           "For a `QuakeValue` of type `Stdvec` or `Veq`, add code to the MLIR "
+           "representation that computes the size of the sequence.")
       /// @brief Bind the indexing operator for cudaq::QuakeValue
       .def(
           "__getitem__",

--- a/python/runtime/cudaq/builder/py_kernel_builder.cpp
+++ b/python/runtime/cudaq/builder/py_kernel_builder.cpp
@@ -1186,6 +1186,23 @@ Args:
           "Apply a general Pauli tensor product rotation, `exp(i theta P)`, on "
           "the specified qubit register. The Pauli tensor product is provided "
           "as a `QuakeValue`. The angle parameter can be provided as a "
+          "concrete float or a `QuakeValue`.")
+      .def(
+          "exp_pauli",
+          [](kernel_builder<> &self, py::object theta, const QuakeValue &qubits,
+             pauli_word &pauliWord) {
+            if (py::isinstance<py::float_>(theta))
+              self.exp_pauli(theta.cast<double>(), qubits, pauliWord);
+            else if (py::isinstance<QuakeValue>(theta))
+              self.exp_pauli(theta.cast<QuakeValue &>(), qubits, pauliWord);
+            else
+              throw std::runtime_error(
+                  "Invalid `theta` argument type. Must be a "
+                  "`float` or a `QuakeValue`.");
+          },
+          "Apply a general Pauli tensor product rotation, `exp(i theta P)`, on "
+          "the specified qubit register. The Pauli tensor product is provided "
+          "as a `pauli_word`. The angle parameter can be provided as a "
           "concrete float or a `QuakeValue`.");
 }
 

--- a/python/runtime/cudaq/spin/py_spin_op.cpp
+++ b/python/runtime/cudaq/spin/py_spin_op.cpp
@@ -172,6 +172,7 @@ void bindSpinOperator(py::module &mod) {
            "`Tuple[list[complex], list[int], list[int]]`, encoding the "
            "non-zero values, rows, and columns of the matrix. "
            "This format is supported by `scipy.sparse.csr_array`.")
+      .def("to_words", &spin_op::to_words, "")
       .def(
           "__iter__",
           [](spin_op &self) {

--- a/python/runtime/cudaq/spin/py_spin_op.cpp
+++ b/python/runtime/cudaq/spin/py_spin_op.cpp
@@ -172,7 +172,9 @@ void bindSpinOperator(py::module &mod) {
            "`Tuple[list[complex], list[int], list[int]]`, encoding the "
            "non-zero values, rows, and columns of the matrix. "
            "This format is supported by `scipy.sparse.csr_array`.")
-      .def("to_words", &spin_op::to_words, "")
+      .def("to_words", &spin_op::to_words,
+           "Return the `pauli_word` instance that represent this "
+           "`SpinOperator`.")
       .def(
           "__iter__",
           [](spin_op &self) {

--- a/python/tests/unittests/test_kernel_builder.py
+++ b/python/tests/unittests/test_kernel_builder.py
@@ -960,6 +960,15 @@ def test_exp_pauli():
     print(want_exp)
     assert np.isclose(want_exp, -1.74, atol=1e-2)
 
+    kernel = cudaq.make_kernel()
+    qubits = kernel.qalloc(2)
+    kernel.x(qubits[0])
+    kernel.exp_pauli(angles[0], qubits, pauliWords[0])
+    kernel.exp_pauli(angles[1], qubits, pauliWords[1])
+    want_exp = cudaq.observe(kernel, hamiltonian).expectation()
+    print(want_exp)
+    assert np.isclose(want_exp, -1.74, atol=1e-2)
+
 
 def test_givens_rotation_op():
     cudaq.reset_target()

--- a/python/tests/unittests/test_kernel_builder.py
+++ b/python/tests/unittests/test_kernel_builder.py
@@ -961,9 +961,6 @@ def test_exp_pauli():
     assert np.isclose(want_exp, -1.74, atol=1e-2)
 
 
-
-
-
 def test_givens_rotation_op():
     cudaq.reset_target()
     angle = 0.2

--- a/python/tests/unittests/test_kernel_builder.py
+++ b/python/tests/unittests/test_kernel_builder.py
@@ -930,6 +930,39 @@ def test_exp_pauli():
     with pytest.raises(RuntimeError) as error:
         kernel.exp_pauli(theta, qubits, invalidOp)
 
+    # Test we can construct a list[str] arg and pass to exp_pauli
+    hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
+        0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)
+
+    kernel, thetas, paulisArg = cudaq.make_kernel(list[float], list[cudaq.pauli_word])
+    qubits = kernel.qalloc(2)
+    kernel.x(qubits[0])
+    kernel.for_loop(
+        0, paulisArg.size(),
+        lambda idx: kernel.exp_pauli(thetas[idx], qubits, paulisArg[idx]))
+
+    print(kernel)
+    want_exp = cudaq.observe(kernel, hamiltonian, [-.1744, .1223],
+                             ['XY', 'YX']).expectation()
+    print(want_exp)
+    assert np.isclose(want_exp, -1.74, atol=1e-2)
+
+    tmp = spin.x(0)*spin.y(1) + spin.y(0)*spin.x(1)
+    pauliWords = tmp.to_words()
+    angles = []
+    for p in pauliWords:
+        print(p)
+        if str(p) == 'XY': angles.append(-.1744)
+        else: angles.append(.1223)
+    
+    want_exp = cudaq.observe(kernel, hamiltonian, angles,
+                             pauliWords).expectation()
+    print(want_exp)
+    assert np.isclose(want_exp, -1.74, atol=1e-2)
+
+
+
+
 
 def test_givens_rotation_op():
     cudaq.reset_target()

--- a/runtime/cudaq/spin/spin_op.cpp
+++ b/runtime/cudaq/spin/spin_op.cpp
@@ -331,6 +331,29 @@ spin_op spin_op::from_word(const std::string &word) {
   return spin_op(term, 1.0);
 }
 
+std::vector<pauli_word> spin_op::to_words() {
+  if (num_terms() == internalPauliWordStorage.size())
+    return internalPauliWordStorage;
+
+  // FIXME maybe also check some unique hash code
+  for (auto &word : internalPauliWordStorage) {
+    delete[] word.term;
+  }
+
+  internalPauliWordStorage.clear();
+
+  internalPauliWordStorage.resize(num_terms());
+  std::size_t counter = 0;
+  for_each_term([&](spin_op &term) {
+    auto termStr = term.to_string(false);
+    internalPauliWordStorage[counter].term = new char[termStr.length() + 1];
+    std::strncpy(const_cast<char *>(internalPauliWordStorage[counter].term),
+                 termStr.c_str(), termStr.size() + 1);
+    counter++;
+  });
+  return internalPauliWordStorage;
+}
+
 void spin_op::expandToNQubits(const std::size_t numQubits) {
   auto iter = terms.begin();
   while (iter != terms.end()) {

--- a/runtime/cudaq/spin_op.h
+++ b/runtime/cudaq/spin_op.h
@@ -91,6 +91,7 @@ public:
   const char *term = nullptr;
   pauli_word() = default;
   pauli_word(const char *c) : term(c) {}
+  std::string str() { return std::string(term); }
 };
 
 /// @brief Utility enum representing Paulis.

--- a/test/AST-Quake/cudaq-pauli-word.cpp
+++ b/test/AST-Quake/cudaq-pauli-word.cpp
@@ -18,14 +18,14 @@ __qpu__ void test0(double theta, std::vector<cudaq::pauli_word> paulis) {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test0._Z5test0dSt6vectorIN5cudaq10pauli_wordESaIS1_EE(
 // CHECK-SAME:                                                                                                %[[VAL_0:.*]]: f64,
-// CHECK-SAME:                                                                                                %[[VAL_1:.*]]: !cc.stdvec<!cc.ptr<i8>>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK-SAME:                                                                                                %[[VAL_1:.*]]: !cc.stdvec<!quake.pauli_word>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_4:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_6:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<!cc.ptr<i8>>) -> i64
-// CHECK:           %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<!cc.ptr<i8>>) -> !cc.ptr<!cc.array<!cc.ptr<i8> x ?>>
+// CHECK:           %[[VAL_6:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<!quake.pauli_word>) -> i64
+// CHECK:           %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<!quake.pauli_word>) -> !cc.ptr<!cc.array<!quake.pauli_word x ?>>
 // CHECK:           %[[VAL_8:.*]] = arith.index_cast %[[VAL_6]] : i64 to index
 // CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_3]]) -> (index)) {
 // CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_8]] : index
@@ -33,10 +33,10 @@ __qpu__ void test0(double theta, std::vector<cudaq::pauli_word> paulis) {
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_12:.*]]: index):
 // CHECK:             %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
-// CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>, i64) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.array<!quake.pauli_word x ?>>, i64) -> !cc.ptr<!quake.pauli_word>
 // CHECK:             %[[VAL_15:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
-// CHECK:             %[[VAL_16:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:             quake.exp_pauli(%[[VAL_15]]) %[[VAL_5]], %[[VAL_16]] : (f64, !quake.veq<2>, !cc.ptr<i8>) -> ()
+// CHECK:             %[[VAL_16:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!quake.pauli_word>
+// CHECK:             quake.exp_pauli(%[[VAL_15]]) %[[VAL_5]], %[[VAL_16]] : (f64, !quake.veq<2>, !quake.pauli_word) -> ()
 // CHECK:             cc.continue %[[VAL_12]] : index
 // CHECK:           } step {
 // CHECK:           ^bb0(%[[VAL_17:.*]]: index):
@@ -53,10 +53,10 @@ __qpu__ void test1(double theta, cudaq::qview<> q, cudaq::pauli_word term) {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test1._Z5test1dN5cudaq5qviewILm2EEENS_10pauli_wordE(
 // CHECK-SAME:                                                                                              %[[VAL_0:.*]]: f64,
 // CHECK-SAME:                                                                                              %[[VAL_1:.*]]: !quake.veq<?>,
-// CHECK-SAME:                                                                                              %[[VAL_2:.*]]: !cc.ptr<i8>) attributes {"cudaq-kernel", no_this} {
+// CHECK-SAME:                                                                                              %[[VAL_2:.*]]: !quake.pauli_word) attributes {"cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_3:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<f64>
-// CHECK:           quake.exp_pauli(%[[VAL_4]]) %[[VAL_1]], %[[VAL_2]] : (f64, !quake.veq<?>, !cc.ptr<i8>) -> ()
+// CHECK:           quake.exp_pauli(%[[VAL_4]]) %[[VAL_1]], %[[VAL_2]] : (f64, !quake.veq<?>, !quake.pauli_word) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/cudaq-pauli-word.cpp
+++ b/test/AST-Quake/cudaq-pauli-word.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck %s
 
 #include "cudaq.h"
 

--- a/test/AST-Quake/cudaq-pauli-word.cpp
+++ b/test/AST-Quake/cudaq-pauli-word.cpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
+
+#include "cudaq.h"
+
+__qpu__ void test0(double theta, std::vector<cudaq::pauli_word> paulis) {
+  cudaq::qvector q(2);
+  for (auto &p : paulis)
+    exp_pauli(theta, q, p);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test0._Z5test0dSt6vectorIN5cudaq10pauli_wordESaIS1_EE(
+// CHECK-SAME:                                                                                                %[[VAL_0:.*]]: f64,
+// CHECK-SAME:                                                                                                %[[VAL_1:.*]]: !cc.stdvec<!cc.ptr<i8>>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_4:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_6:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<!cc.ptr<i8>>) -> i64
+// CHECK:           %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<!cc.ptr<i8>>) -> !cc.ptr<!cc.array<!cc.ptr<i8> x ?>>
+// CHECK:           %[[VAL_8:.*]] = arith.index_cast %[[VAL_6]] : i64 to index
+// CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_3]]) -> (index)) {
+// CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_8]] : index
+// CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : index)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_12:.*]]: index):
+// CHECK:             %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
+// CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>, i64) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:             %[[VAL_15:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
+// CHECK:             %[[VAL_16:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:             quake.exp_pauli(%[[VAL_15]]) %[[VAL_5]], %[[VAL_16]] : (f64, !quake.veq<2>, !cc.ptr<i8>) -> ()
+// CHECK:             cc.continue %[[VAL_12]] : index
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_17:.*]]: index):
+// CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_2]] : index
+// CHECK:             cc.continue %[[VAL_18]] : index
+// CHECK:           } {invariant}
+// CHECK:           return
+// CHECK:         }
+
+__qpu__ void test1(double theta, cudaq::qview<> q, cudaq::pauli_word term) {
+  exp_pauli(theta, q, term);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test1._Z5test1dN5cudaq5qviewILm2EEENS_10pauli_wordE(
+// CHECK-SAME:                                                                                              %[[VAL_0:.*]]: f64,
+// CHECK-SAME:                                                                                              %[[VAL_1:.*]]: !quake.veq<?>,
+// CHECK-SAME:                                                                                              %[[VAL_2:.*]]: !cc.ptr<i8>) attributes {"cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_3:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<f64>
+// CHECK:           quake.exp_pauli(%[[VAL_4]]) %[[VAL_1]], %[[VAL_2]] : (f64, !quake.veq<?>, !cc.ptr<i8>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -941,6 +941,51 @@ CUDAQ_TEST(BuilderTester, checkForLoop) {
   }
 }
 
+CUDAQ_TEST(BuilderTester, checkVecCharPtr) {
+  {
+    // Check it compiles and executes
+    auto [kernel, paulis] =
+        cudaq::make_kernel<std::vector<cudaq::pauli_word>>();
+    auto qubits = kernel.qalloc(2);
+    kernel.exp_pauli(M_PI_2, qubits, paulis[0]);
+    std::cout << kernel << "\n";
+    std::vector<cudaq::pauli_word> pauliVec{"XX", "YY"};
+    kernel(pauliVec);
+  }
+  {
+    // Check it compiles and executes
+    auto [kernel, paulis] =
+        cudaq::make_kernel<std::vector<cudaq::pauli_word>>();
+    auto qubits = kernel.qalloc(2);
+    kernel.for_loop(0, paulis.size(), [&](auto idx) {
+      kernel.exp_pauli(M_PI_2, qubits, paulis[idx]);
+    });
+    std::cout << kernel << "\n";
+    std::vector<cudaq::pauli_word> pauliVec{"XX", "YY"};
+    kernel(pauliVec);
+  }
+  {
+    // Check correctness
+    auto [kernel, thetas, paulis] =
+        cudaq::make_kernel<std::vector<double>,
+                           std::vector<cudaq::pauli_word>>();
+    auto qubits = kernel.qalloc(2);
+    kernel.x(qubits[0]);
+    kernel.for_loop(0, paulis.size(), [&](auto idx) {
+      kernel.exp_pauli(thetas[idx], qubits, paulis[idx]);
+    });
+    std::cout << kernel << "\n";
+    using namespace cudaq::spin;
+    std::vector<cudaq::pauli_word> pauliVec{"XY", "YX"};
+
+    cudaq::spin_op h = 5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) +
+                       .21829 * z(0) - 6.125 * z(1);
+    double energy =
+        cudaq::observe(kernel, h, std::vector<double>{-.1744, .1223}, pauliVec);
+    EXPECT_NEAR(energy, -1.74, 1e-2);
+  }
+}
+
 // Conditional execution (including reset) on the tensornet backend is slow for
 // a large number of shots.
 #ifndef CUDAQ_BACKEND_TENSORNET

--- a/unittests/spin_op/SpinOpTester.cpp
+++ b/unittests/spin_op/SpinOpTester.cpp
@@ -243,3 +243,22 @@ TEST(SpinOpTester, checkDistributeTerms) {
   EXPECT_EQ(distributed[0].num_terms(), 2);
   EXPECT_EQ(distributed[1].num_terms(), 3);
 }
+
+TEST(SpinOpTester, checkToWords) {
+  auto H = 5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) + .21829 * z(0) -
+           6.125 * z(1);
+
+  auto fakeKernel = [](std::vector<cudaq::pauli_word> paulis) {
+    for (auto &p : paulis)
+      printf("%s\n", p.term);
+  };
+
+  auto words = H.to_words();
+  EXPECT_EQ(5, words.size());
+  for (auto &w : words)
+    EXPECT_TRUE(std::string(w.term) == "II" || std::string(w.term) == "YY" ||
+                std::string(w.term) == "XX" || std::string(w.term) == "ZI" ||
+                std::string(w.term) == "IZ");
+
+  fakeKernel(words);
+}


### PR DESCRIPTION
#1098

Enable 

```cpp
__qpu__ void test(double theta, std::vector<cudaq::pauli_word> paulis) {
  cudaq::qvector q(2);
  for (auto &p : paulis)
    exp_pauli(theta, q, p);
}

void useTest() {
  spin_op op = ... ;
  auto words = op.to_pauli_words();
  auto results = cudaq::sample(test, M_PI_2, words);
}
```
```python
kernel, thetas, paulisArg = cudaq.make_kernel(list[float], list[cudaq.pauli_word])
qubits = kernel.qalloc(2)
kernel.x(qubits[0])
kernel.for_loop(
     0, paulisArg.size(),
     lambda idx: kernel.exp_pauli(thetas[idx], qubits, paulisArg[idx]))
```
