### PR TITLE
Fixes for the lower to QIR pass.

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/CMakeLists.txt
+++ b/include/cudaq/Optimizer/CodeGen/CMakeLists.txt
@@ -6,6 +6,9 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
+add_cudaq_dialect(CodeGen codegen)
+add_cudaq_dialect_doc(CodeGenDialect codegen)
+
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name OptCodeGen)
 add_public_tablegen_target(OptCodeGenPassIncGen)
@@ -13,4 +16,3 @@ add_public_tablegen_target(OptCodeGenPassIncGen)
 set(LLVM_TARGET_DEFINITIONS Peephole.td)
 mlir_tablegen(Peephole.inc -gen-rewriters)
 add_public_tablegen_target(OptPeepholeIncGen)
-

--- a/include/cudaq/Optimizer/CodeGen/CodeGenDialect.td
+++ b/include/cudaq/Optimizer/CodeGen/CodeGenDialect.td
@@ -1,0 +1,34 @@
+/********************************************************** -*- tablegen -*- ***
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifndef CUDAQ_OPTIMIZER_CODEGEN_DIALECT
+#define CUDAQ_OPTIMIZER_CODEGEN_DIALECT
+
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+//===----------------------------------------------------------------------===//
+// Dialect definition.
+//===----------------------------------------------------------------------===//
+
+def CodeGenDialect : Dialect {
+  let name = "codegen";
+  let summary = "Code generation helpers";
+  let description = [{
+    Do not use this dialect outside of code generation.
+  }];
+
+  let cppNamespace = "cudaq::codegen";
+  let useDefaultTypePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
+
+  let extraClassDeclaration = [{
+    void registerTypes(); // register at least a bogo type.
+  }];
+}
+
+#endif

--- a/include/cudaq/Optimizer/CodeGen/CodeGenOps.td
+++ b/include/cudaq/Optimizer/CodeGen/CodeGenOps.td
@@ -1,0 +1,47 @@
+/********************************************************** -*- tablegen -*- ***
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifndef CUDAQ_OPTIMIZER_CODEGEN_OPS
+#define CUDAQ_OPTIMIZER_CODEGEN_OPS
+
+include "cudaq/Optimizer/CodeGen/CodeGenDialect.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "cudaq/Optimizer/Dialect/Common/Traits.td"
+include "cudaq/Optimizer/Dialect/CC/CCTypes.td"
+include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.td"
+
+//===----------------------------------------------------------------------===//
+// The codegen quake dialect is a transitory set of operations used exclusively
+// during codegen. The ops defined here make the process of converting the Quake
+// code to a another target dialect (e.g. LLVM-IR) easier. They should not be
+// used outside of the codegen passes.
+//===----------------------------------------------------------------------===//
+
+class CGQOp<string mnemonic, list<Trait> traits = []>
+    : Op<CodeGenDialect, mnemonic, traits>;
+
+def cgq_RAIIOp : CGQOp<"qmem_raii", [MemoryEffects<[MemAlloc, MemWrite]>]> {
+  let summary = "Combine allocation and initialization of set of qubits.";
+  let description = [{
+    Used only in QIR code generation.
+  }];
+
+  let arguments = (ins
+    cc_PointerType:$initState,
+    TypeAttr:$allocType,
+    Optional<AnySignlessIntegerOrIndex>:$allocSize
+  );
+  let results = (outs VeqType);
+
+  let assemblyFormat = [{
+    $initState `(` $allocType ( `[` $allocSize^ `]` )? `)` `:`
+    functional-type(operands, results) attr-dict
+  }];
+}
+
+#endif

--- a/include/cudaq/Optimizer/CodeGen/CodeGenTypes.td
+++ b/include/cudaq/Optimizer/CodeGen/CodeGenTypes.td
@@ -1,0 +1,34 @@
+/********************************************************** -*- tablegen -*- ***
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifndef CUDAQ_OPTIMIZER_CODEGEN_TYPES
+#define CUDAQ_OPTIMIZER_CODEGEN_TYPES
+
+include "cudaq/Optimizer/CodeGen/CodeGenDialect.td"
+include "mlir/Interfaces/DataLayoutInterfaces.td"
+include "mlir/IR/AttrTypeBase.td"
+
+//===----------------------------------------------------------------------===//
+// BaseType
+//===----------------------------------------------------------------------===//
+
+class CodeGenType<string name, string typeMnemonic, list<Trait> traits = [],
+             string base = "mlir::Type">
+    : TypeDef<CodeGenDialect, name, traits, base> {
+  let mnemonic = typeMnemonic;
+}
+
+// There are no codegen dialect types, but the dialect tablegen generates type
+// boilerplate for the dialect anyway.
+
+def codegen_DoNotUseType : CodeGenType<"DoNotUse", "dummy"> {
+  let summary = "";
+  let description = [{ }];
+}
+
+#endif // CUDAQ_OPTIMIZER_CODEGEN_TYPES

--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -52,4 +52,4 @@ void registerTargetPipelines();
 #define GEN_PASS_REGISTRATION
 #include "cudaq/Optimizer/CodeGen/Passes.h.inc"
 
-} // namespace cudaq
+} // namespace cudaq::opt

--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -52,4 +52,4 @@ void registerTargetPipelines();
 #define GEN_PASS_REGISTRATION
 #include "cudaq/Optimizer/CodeGen/Passes.h.inc"
 
-} // namespace cudaq::opt
+} // namespace cudaq

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -19,7 +19,9 @@ def QuakeToQIR : Pass<"quake-to-qir", "mlir::ModuleOp"> {
     QIR qubits.
   }];
 
-  let dependentDialects = ["mlir::LLVM::LLVMDialect"];
+  let dependentDialects = [
+    "cudaq::codegen::CodeGenDialect", "mlir::LLVM::LLVMDialect"
+  ];
   let constructor = "cudaq::opt::createConvertToQIRPass()";
 }
 

--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -57,9 +57,6 @@ void addPipelineToQIR(mlir::PassManager &pm,
   if constexpr (QIRProfile) {
     cudaq::opt::addQIRProfilePipeline(pm, convertTo);
   }
-
-  // Make sure we don't have any leftover dead code
-  pm.addPass(mlir::createCanonicalizerPass());
 }
 
 inline void addPipelineToOpenQASM(mlir::PassManager &pm) {

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -72,7 +72,9 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
   }];
 
   let arguments = (ins Optional<AnySignlessInteger>:$size);
-  let results = (outs AnyRefType:$ref_or_vec);
+  let results = (outs
+    AnyRefType:$ref_or_vec
+  );
 
   let builders = [
     OpBuilder<(ins ), [{
@@ -92,6 +94,14 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
 
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    bool hasInitializedState() {
+      auto *self = getOperation();
+      return self->hasOneUse() &&
+        mlir::isa<quake::InitializeStateOp>(*self->getUsers().begin());
+    }
+  }];
 }
 
 def quake_ConcatOp : QuakeOp<"concat", [Pure]> {
@@ -281,7 +291,8 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
   }];
 }
 
-def InitializeStateOp : QuakeOp<"qinit"> {
+def quake_InitializeStateOp : QuakeOp<"init_state", [MemoryEffects<[MemAlloc,
+    MemWrite]>]> {
   let summary = "Initialize the quantum state to a specific complex vector.";
   let description = [{
     Given a !cc.ptr pointing to a complex data array of size 2**N, where N is
@@ -293,13 +304,13 @@ def InitializeStateOp : QuakeOp<"qinit"> {
   }];
 
   let arguments = (ins
-    VeqType:$targets, 
+    VeqType:$targets,
     cc_PointerType:$state
   );
-  let results = (outs VeqType:$initializedState);
+  let results = (outs VeqType);
 
   let assemblyFormat = [{
-    `(` $targets `,` $state `)` `:` functional-type(operands, results) attr-dict
+    $targets `,` $state `:` functional-type(operands, results) attr-dict
   }];
 }
 

--- a/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -11,6 +11,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 add_cudaq_library(OptCodeGen
+  CodeGenDialect.cpp
+  CodeGenOps.cpp
+  CodeGenTypes.cpp
   LowerToQIRProfile.cpp
   LowerToQIR.cpp
   Passes.cpp
@@ -19,6 +22,9 @@ add_cudaq_library(OptCodeGen
 
   DEPENDS
     CCDialect
+    CodeGenDialectIncGen
+    CodeGenOpsIncGen
+    CodeGenTypesIncGen
     OptCodeGenPassIncGen
     OptPeepholeIncGen
     OptTransformsPassIncGen

--- a/lib/Optimizer/CodeGen/CodeGenDialect.cpp
+++ b/lib/Optimizer/CodeGen/CodeGenDialect.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "CodeGenDialect.h"
+#include "CodeGenOps.h"
+#include "mlir/IR/DialectImplementation.h"
+
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
+
+#include "cudaq/Optimizer/CodeGen/CodeGenDialect.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+
+void cudaq::codegen::CodeGenDialect::initialize() {
+  registerTypes();
+  addOperations<
+#define GET_OP_LIST
+#include "cudaq/Optimizer/CodeGen/CodeGenOps.cpp.inc"
+      >();
+}

--- a/lib/Optimizer/CodeGen/CodeGenDialect.h
+++ b/lib/Optimizer/CodeGen/CodeGenDialect.h
@@ -8,19 +8,10 @@
 
 #pragma once
 
-#include "CodeGenDialect.h"
-#include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
-#include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/OpenACC/OpenACC.h"
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassRegistry.h"
+#include "mlir/IR/Dialect.h"
 
-namespace cudaq::opt {
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
 
-#define GEN_PASS_CLASSES
-#include "cudaq/Optimizer/CodeGen/Passes.h.inc"
-
-} // namespace cudaq::opt
+#include "cudaq/Optimizer/CodeGen/CodeGenDialect.h.inc"

--- a/lib/Optimizer/CodeGen/CodeGenOps.cpp
+++ b/lib/Optimizer/CodeGen/CodeGenOps.cpp
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "CodeGenOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
+
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
+
+#define GET_OP_CLASSES
+#include "cudaq/Optimizer/CodeGen/CodeGenOps.cpp.inc"

--- a/lib/Optimizer/CodeGen/CodeGenOps.h
+++ b/lib/Optimizer/CodeGen/CodeGenOps.h
@@ -8,19 +8,16 @@
 
 #pragma once
 
-#include "CodeGenDialect.h"
-#include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
-#include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/OpenACC/OpenACC.h"
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassRegistry.h"
+#include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
+#include "cudaq/Optimizer/Dialect/Common/Traits.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
 
-namespace cudaq::opt {
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
 
-#define GEN_PASS_CLASSES
-#include "cudaq/Optimizer/CodeGen/Passes.h.inc"
-
-} // namespace cudaq::opt
+#define GET_OP_CLASSES
+#include "cudaq/Optimizer/CodeGen/CodeGenOps.h.inc"

--- a/lib/Optimizer/CodeGen/CodeGenTypes.cpp
+++ b/lib/Optimizer/CodeGen/CodeGenTypes.cpp
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "CodeGenTypes.h"
+#include "CodeGenDialect.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
+
+#define GET_TYPEDEF_CLASSES
+#include "cudaq/Optimizer/CodeGen/CodeGenTypes.cpp.inc"
+
+void cudaq::codegen::CodeGenDialect::registerTypes() {
+   addTypes<DoNotUseType>();
+}

--- a/lib/Optimizer/CodeGen/CodeGenTypes.cpp
+++ b/lib/Optimizer/CodeGen/CodeGenTypes.cpp
@@ -20,5 +20,5 @@
 #include "cudaq/Optimizer/CodeGen/CodeGenTypes.cpp.inc"
 
 void cudaq::codegen::CodeGenDialect::registerTypes() {
-   addTypes<DoNotUseType>();
+  addTypes<DoNotUseType>();
 }

--- a/lib/Optimizer/CodeGen/CodeGenTypes.h
+++ b/lib/Optimizer/CodeGen/CodeGenTypes.h
@@ -8,19 +8,13 @@
 
 #pragma once
 
-#include "CodeGenDialect.h"
-#include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
-#include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/OpenACC/OpenACC.h"
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassRegistry.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Types.h"
 
-namespace cudaq::opt {
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
 
-#define GEN_PASS_CLASSES
-#include "cudaq/Optimizer/CodeGen/Passes.h.inc"
-
-} // namespace cudaq::opt
+#define GET_TYPEDEF_CLASSES
+#include "cudaq/Optimizer/CodeGen/CodeGenTypes.h.inc"

--- a/lib/Optimizer/Dialect/CC/CCTypes.cpp
+++ b/lib/Optimizer/Dialect/CC/CCTypes.cpp
@@ -135,14 +135,14 @@ void cc::ArrayType::print(AsmPrinter &printer) const {
 
 //===----------------------------------------------------------------------===//
 
-namespace cudaq {
+namespace cudaq::cc {
 
-cc::CallableType cc::CallableType::getNoSignature(MLIRContext *ctx) {
+CallableType CallableType::getNoSignature(MLIRContext *ctx) {
   return CallableType::get(ctx, FunctionType::get(ctx, {}, {}));
 }
 
-void cc::CCDialect::registerTypes() {
+void CCDialect::registerTypes() {
   addTypes<ArrayType, CallableType, PointerType, StdvecType, StructType>();
 }
 
-} // namespace cudaq
+} // namespace cudaq::cc

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -94,7 +94,7 @@ bool quake::isSupportedMappingOperation(Operation *op) {
   return isa<OperatorInterface, MeasurementInterface, SinkOp>(op);
 }
 
-mlir::ValueRange quake::getQuantumTypesFromRange(mlir::ValueRange range) {
+ValueRange quake::getQuantumTypesFromRange(ValueRange range) {
 
   // Skip over classical types at the beginning
   int numClassical = 0;
@@ -105,7 +105,7 @@ mlir::ValueRange quake::getQuantumTypesFromRange(mlir::ValueRange range) {
       break;
   }
 
-  mlir::ValueRange retVals = range.drop_front(numClassical);
+  ValueRange retVals = range.drop_front(numClassical);
 
   // Make sure all remaining operands are quantum
   for (auto operand : retVals)
@@ -115,17 +115,16 @@ mlir::ValueRange quake::getQuantumTypesFromRange(mlir::ValueRange range) {
   return retVals;
 }
 
-mlir::ValueRange quake::getQuantumResults(Operation *op) {
+ValueRange quake::getQuantumResults(Operation *op) {
   return getQuantumTypesFromRange(op->getResults());
 }
 
-mlir::ValueRange quake::getQuantumOperands(Operation *op) {
+ValueRange quake::getQuantumOperands(Operation *op) {
   return getQuantumTypesFromRange(op->getOperands());
 }
 
 LogicalResult quake::setQuantumOperands(Operation *op, ValueRange quantumVals) {
-  mlir::ValueRange quantumOperands =
-      getQuantumTypesFromRange(op->getOperands());
+  ValueRange quantumOperands = getQuantumTypesFromRange(op->getOperands());
 
   if (quantumOperands.size() != quantumVals.size())
     return failure();
@@ -183,6 +182,14 @@ LogicalResult quake::AllocaOp::verify() {
       }
     }
   }
+
+  // Check the uses. If any use is a InitializeStateOp, then it must be the only
+  // use.
+  Operation *self = getOperation();
+  if (!self->getUsers().empty() && !self->hasOneUse())
+    for (auto *op : self->getUsers())
+      if (isa<quake::InitializeStateOp>(op))
+        return emitOpError("init_state must be the only use");
   return success();
 }
 
@@ -694,8 +701,8 @@ static LogicalResult getParameterAsDouble(Value parameter, double &result) {
   auto paramDefOp = parameter.getDefiningOp();
   if (!paramDefOp)
     return failure();
-  if (auto constOp = mlir::dyn_cast<mlir::arith::ConstantOp>(paramDefOp)) {
-    if (auto value = dyn_cast<mlir::FloatAttr>(constOp.getValue())) {
+  if (auto constOp = dyn_cast<arith::ConstantOp>(paramDefOp)) {
+    if (auto value = dyn_cast<FloatAttr>(constOp.getValue())) {
       result = value.getValueAsDouble();
       return success();
     }

--- a/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -165,7 +165,7 @@ public:
     for (auto &block : func.getRegion())
       for (auto &op : block) {
         if (auto alloc = dyn_cast_or_null<quake::AllocaOp>(&op)) {
-          if (alloc.getSize())
+          if (alloc.getSize() || alloc.hasInitializedState())
             return;
           analysis.allocations.push_back(alloc);
           auto size = allocationSize(alloc);

--- a/test/AST-Quake/qalloc_initialization.cpp
+++ b/test/AST-Quake/qalloc_initialization.cpp
@@ -28,7 +28,7 @@ struct Vanilla {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Vanilla() -> !cc.stdvec<i1>
 // CHECK:           %[[VAL_4:.*]] = cc.address_of @__nvqpp__rodata_init_0 : !cc.ptr<!cc.array<f64 x 4>>
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %[[VAL_6:.*]] = quake.qinit(%[[VAL_5]], %[[VAL_4]]) : (!quake.veq<4>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<4>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<4>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<4>
 
 // CHECK:         cc.global constant @__nvqpp__rodata_init_0 (dense<[0.0{{.*}}, 1.0{{.*}}, 1.0{{.*}}, 0.0{{.*}}]> : tensor<4xf64>) : !cc.array<f64 x 4>
 
@@ -36,7 +36,7 @@ struct Vanilla {
 // QIR-LABEL: @__nvqpp__rodata_init_0 = private constant [4 x double] [double 0.000000e+00, double 1.000000e+00, double 1.000000e+00, double 0.000000e+00]
 
 // QIR-LABEL: define { i1*, i64 } @__nvqpp__mlirgen__Vanilla() local_unnamed_addr {
-// QIR-NEXT:    %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array_with_state(i64 4, [4 x double]* nonnull @__nvqpp__rodata_init_0)
+// QIR-NEXT:    %[[VAL_0:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array_with_state(i64 4, i8* nonnull bitcast ([4 x double]* @__nvqpp__rodata_init_0 to i8*))
 
 
 

--- a/test/Quake/add_dealloc-1.qke
+++ b/test/Quake/add_dealloc-1.qke
@@ -15,7 +15,7 @@ module {
     %c0 = arith.constant 0 : index
     %0 = cc.address_of @__nvqpp__rodata_init_0 : !cc.ptr<!cc.array<f64 x 4>>
     %1 = quake.alloca !quake.veq<4>
-    %2 = quake.qinit(%1, %0) : (!quake.veq<4>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<4>
+    %2 = quake.init_state %1, %0 : (!quake.veq<4>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<4>
     %3 = cc.loop while ((%arg0 = %c0) -> (index)) {
       %4 = arith.cmpi slt, %arg0, %c4 : index
       cc.condition %4(%arg0 : index)
@@ -37,7 +37,7 @@ module {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__FromState() {
 // CHECK:           %[[VAL_3:.*]] = cc.address_of @__nvqpp__rodata_init_0 : !cc.ptr<!cc.array<f64 x 4>>
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %[[VAL_5:.*]] = quake.qinit(%[[VAL_4]], %[[VAL_3]]) : (!quake.veq<4>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<4>
+// CHECK:           %[[VAL_5:.*]] = quake.init_state %[[VAL_4]], %[[VAL_3]] : (!quake.veq<4>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<4>
 // CHECK:           quake.dealloc %[[VAL_5]] : !quake.veq<4>
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
  - Splits subgraph matching from the conversion pass. The conversion rewriter doesn't really let one do both at the same time given the way it traversing the IR.
  - Add a new codegen dialect. Only used in codegen. Part of the previous bullet. The dialect will be the logical point to add any future combination ops.
  - Removes the extra canonicalizer pass

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
