### PR TITLE
Restore build_info.txt in Docker images

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -310,6 +310,7 @@ jobs:
           build-args: |
             base_image=${{ steps.prereqs.outputs.base_image }}
             install="CMAKE_BUILD_TYPE=Debug"
+            git_source_sha=${{ github.sha }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: ${{ inputs.platforms }}
@@ -511,6 +512,7 @@ jobs:
           build-args: |
             base_image=${{ steps.prereqs.outputs.devdeps_image }}
             install="CMAKE_BUILD_TYPE=Release CUDA_QUANTUM_VERSION=${{ steps.prereqs.outputs.image_tag }}"
+            git_source_sha=${{ github.sha }}
           tags: ${{ steps.cudaqdev_metadata.outputs.tags }}
           labels: ${{ steps.cudaqdev_metadata.outputs.labels }}
           platforms: ${{ inputs.platforms }}
@@ -564,6 +566,7 @@ jobs:
             cudaqdev_image=${{ steps.prereqs.outputs.dev_image_name }}@${{ steps.release_build.outputs.digest }}
             base_image=${{ steps.prereqs.outputs.base_image }}
             release_version=${{ steps.prereqs.outputs.image_tag }}
+            git_source_sha=${{ github.sha }}
           tags: ${{ steps.cudaq_metadata.outputs.tags }}
           labels: ${{ steps.cudaq_metadata.outputs.labels }}
           platforms: ${{ inputs.platforms }}

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -566,7 +566,6 @@ jobs:
             cudaqdev_image=${{ steps.prereqs.outputs.dev_image_name }}@${{ steps.release_build.outputs.digest }}
             base_image=${{ steps.prereqs.outputs.base_image }}
             release_version=${{ steps.prereqs.outputs.image_tag }}
-            git_source_sha=${{ github.sha }}
           tags: ${{ steps.cudaq_metadata.outputs.tags }}
           labels: ${{ steps.cudaq_metadata.outputs.labels }}
           platforms: ${{ inputs.platforms }}

--- a/docker/build/cudaq.dev.Dockerfile
+++ b/docker/build/cudaq.dev.Dockerfile
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -47,6 +47,7 @@ RUN if [ -n "$mpi" ]; \
 # creates a dev image that can be used as argument to docker/release/cudaq.Dockerfile
 # to create the released cuda-quantum image.
 ARG install=
+ARG git_source_sha=xxxxxxxx
 RUN if [ -n "$install" ]; \
     then \
         expected_prefix=$CUDAQ_INSTALL_PREFIX; \
@@ -58,5 +59,6 @@ RUN if [ -n "$install" ]; \
             mkdir -p "$expected_prefix"; \
             mv "$CUDAQ_INSTALL_PREFIX"/* "$expected_prefix"; \
             rmdir "$CUDAQ_INSTALL_PREFIX"; \
-        fi \
+        fi; \
+        echo "source-sha: $git_source_sha" > "$CUDAQ_INSTALL_PREFIX/build_info.txt"; \
     fi

--- a/docker/release/cudaq.Dockerfile
+++ b/docker/release/cudaq.Dockerfile
@@ -88,7 +88,6 @@ RUN echo "$CUDA_QUANTUM_PATH" > /usr/local/lib/python$(python --version | egrep 
 
 # Some tools related to shell handling.
 
-ARG git_source_sha=xxxxxxxx
 ARG COPYRIGHT_NOTICE="=========================\n\
    NVIDIA CUDA Quantum   \n\
 =========================\n\n\
@@ -98,7 +97,6 @@ All rights reserved.\n\n\
 To run a command as administrator (user `root`), use `sudo <command>`.\n"
 RUN echo -e "$COPYRIGHT_NOTICE" > "$CUDA_QUANTUM_PATH/Copyright.txt"
 RUN echo 'cat "$CUDA_QUANTUM_PATH/Copyright.txt"' > /etc/profile.d/welcome.sh
-RUN echo "source-sha: $git_source_sha" > "$CUDA_QUANTUM_PATH/build_info.txt"
 
 # See also https://github.com/microsoft/vscode-remote-release/issues/4781
 RUN env | egrep -v "^(HOME=|USER=|MAIL=|LC_ALL=|LS_COLORS=|LANG=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)" \

--- a/docker/release/cudaq.Dockerfile
+++ b/docker/release/cudaq.Dockerfile
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -88,15 +88,17 @@ RUN echo "$CUDA_QUANTUM_PATH" > /usr/local/lib/python$(python --version | egrep 
 
 # Some tools related to shell handling.
 
+ARG git_source_sha=xxxxxxxx
 ARG COPYRIGHT_NOTICE="=========================\n\
    NVIDIA CUDA Quantum   \n\
 =========================\n\n\
 Version: ${CUDA_QUANTUM_VERSION}\n\n\
-Copyright (c) 2023 NVIDIA Corporation & Affiliates \n\
+Copyright (c) 2024 NVIDIA Corporation & Affiliates \n\
 All rights reserved.\n\n\
 To run a command as administrator (user `root`), use `sudo <command>`.\n"
 RUN echo -e "$COPYRIGHT_NOTICE" > "$CUDA_QUANTUM_PATH/Copyright.txt"
 RUN echo 'cat "$CUDA_QUANTUM_PATH/Copyright.txt"' > /etc/profile.d/welcome.sh
+RUN echo "source-sha: $git_source_sha" > "$CUDA_QUANTUM_PATH/build_info.txt"
 
 # See also https://github.com/microsoft/vscode-remote-release/issues/4781
 RUN env | egrep -v "^(HOME=|USER=|MAIL=|LC_ALL=|LS_COLORS=|LANG=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)" \

--- a/docker/release/cudaq.ext.Dockerfile
+++ b/docker/release/cudaq.ext.Dockerfile
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -15,6 +15,9 @@ USER root
 ARG assets=./assets
 COPY "$assets" "$CUDA_QUANTUM_PATH/assets/"
 ADD ./scripts/migrate_assets.sh "$CUDA_QUANTUM_PATH/bin/migrate_assets.sh"
+# Remove the base build_info.txt because the migration intentionally does not overwrite
+# existing files, but adds its own entries to the build info.
+RUN rm "$CUDA_QUANTUM_PATH/build_info.txt"
 RUN if [ -d "$CUDA_QUANTUM_PATH/assets/documentation" ]; then \
         rm -rf "$CUDA_QUANTUM_PATH/docs" && mkdir -p "$CUDA_QUANTUM_PATH/docs"; \
         mv "$CUDA_QUANTUM_PATH/assets/documentation"/* "$CUDA_QUANTUM_PATH/docs"; \


### PR DESCRIPTION
I believe PR #1010 accidentally got rid of the build_info.txt file in our Docker images. This PR brings it back (or at least the `source-sha` portion of that file, which is used in the nightly integration tests [[logs to error](https://github.com/NVIDIA/cuda-quantum/actions/runs/7720616344/job/21045804379)]).