### PR TITLE
Add dealloc adjustments to the lower-unwind pass.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -71,7 +71,9 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
     See DeallocOp.
   }];
 
-  let arguments = (ins Optional<AnySignlessInteger>:$size);
+  let arguments = (ins
+    Optional<AnySignlessInteger>:$size
+  );
   let results = (outs
     AnyRefType:$ref_or_vec
   );
@@ -101,6 +103,8 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
       return self->hasOneUse() &&
         mlir::isa<quake::InitializeStateOp>(*self->getUsers().begin());
     }
+
+    quake::InitializeStateOp getInitializedState();
   }];
 }
 

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -201,6 +201,15 @@ void quake::AllocaOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
   patterns.add<FuseConstantToAllocaPattern>(context);
 }
 
+quake::InitializeStateOp quake::AllocaOp::getInitializedState() {
+  auto *self = getOperation();
+  if (self->hasOneUse()) {
+    auto x = self->getUsers().begin();
+    return dyn_cast<quake::InitializeStateOp>(*x);
+  }
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 // Apply
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
These changes adjust the placement of quake.dealloc ops to account for the presence of state initializers in local scopes.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
