### PR TITLE
Triage tests

### DIFF
--- a/test/AST-Quake/lambda_variable.cpp
+++ b/test/AST-Quake/lambda_variable.cpp
@@ -6,10 +6,12 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// FIXME: should not require C++20,
-// tracked in https://github.com/NVIDIA/cuda-quantum/issues/1102.
+// This test requires concepts, a C++20 language feature, and should never be
+// expected to compile as C++17. The REQUIRES line below is a workaround for the
+// CI.
+
 // REQUIRES: c++20
-// RUN: cudaq-quake %cpp_std %s | FileCheck %s
+// RUN: cudaq-quake %s | FileCheck %s
 
 // Test lambdas that are created within kernels and passed to user-defined
 // kernels as an argument. Since the lambda is an argument, it is not possible
@@ -37,6 +39,7 @@ struct test3_caller {
   }
 };
 
+// clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3_callee(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.callable<(!quake.ref) -> ()>{{.*}}, %[[VAL_1:.*]]: !quake.veq<?>{{.*}}) attributes {"cudaq-kernel"} {
 // CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_1]][0] : (!quake.veq<?>) -> !quake.ref
@@ -65,6 +68,7 @@ struct test3_caller {
 // CHECK:           quake.y %[[VAL_0]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
+// clang-format on
 
 // This is a template case (`auto`), so use the specialization that `callback`
 // is resolved to in the AST.
@@ -88,6 +92,7 @@ struct test4_caller {
   }
 };
 
+// clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test4_caller() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_1:.*]] = quake.relax_size %[[VAL_0]] : (!quake.veq<2>) -> !quake.veq<?>
@@ -116,3 +121,4 @@ struct test4_caller {
 // CHECK:           call @__nvqpp__mlirgen__ZN12test4_caller[[LAM]]_(%[[VAL_3]]) : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
+// clang-format on

--- a/test/AST-error/kernel_invalid_argument-2.cpp
+++ b/test/AST-error/kernel_invalid_argument-2.cpp
@@ -6,8 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// The error messages produced by a compiler using the -std=c++17 cannot be
-// expected to be the same.
+// The error messages produced by a compiler using the -std=c++17 option cannot
+// be expected to be the same.
 
 // REQUIRES: c++20
 // RUN: cudaq-quake -verify %s

--- a/test/AST-error/kernel_invalid_argument-2.cpp
+++ b/test/AST-error/kernel_invalid_argument-2.cpp
@@ -6,7 +6,11 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: cudaq-quake %cpp_std -verify %s
+// The error messages produced by a compiler using the -std=c++17 cannot be
+// expected to be the same.
+
+// REQUIRES: c++20
+// RUN: cudaq-quake -verify %s
 
 #include <bitset>
 #include <cudaq.h>

--- a/test/AST-error/negation_error.cpp
+++ b/test/AST-error/negation_error.cpp
@@ -6,8 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// The error messages produced by a compiler using the -std=c++17 cannot be
-// expected to be the same.
+// The error messages produced by a compiler using the -std=c++17 option cannot
+// be expected to be the same.
 
 // REQUIRES: c++20
 // RUN: cudaq-quake -verify %s

--- a/test/AST-error/negation_error.cpp
+++ b/test/AST-error/negation_error.cpp
@@ -6,14 +6,19 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: cudaq-quake %cpp_std -verify %s
+// The error messages produced by a compiler using the -std=c++17 cannot be
+// expected to be the same.
+
+// REQUIRES: c++20
+// RUN: cudaq-quake -verify %s
 
 #include <cudaq.h>
 
 struct NegationOperatorTest {
   void operator()() __qpu__ {
     cudaq::qvector qr(3);
-    x<cudaq::ctrl>(qr[0], qr[1], !qr[2]); // expected-error{{target qubit cannot be negated}}
+     // expected-error@+1{{target qubit cannot be negated}}
+    x<cudaq::ctrl>(qr[0], qr[1], !qr[2]);
     rz(2.0, !qr[0]); // expected-error{{target qubit cannot be negated}}
   }
 };

--- a/test/NVQPP/custom_pass.cpp
+++ b/test/NVQPP/custom_pass.cpp
@@ -5,11 +5,12 @@
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
+
+// REQUIRES: c++20
+
 // clang-format off
 // RUN: nvq++ -std=c++17 --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin.so --opt-pass 'func.func(cudaq-custom-pass)' %s -o %t && %t | FileCheck %s
-// RUN: if [ $(echo %cpp_std | cut -c4- ) -ge 20 ]; then \
-// RUN:   nvq++ --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin.so --opt-pass 'func.func(cudaq-custom-pass)'  %s -o %t && %t | FileCheck %s; \
-// RUN: fi
+// RUN: nvq++ --enable-mlir --opt-plugin %cudaq_lib_dir/CustomPassPlugin.so --opt-pass 'func.func(cudaq-custom-pass)'  %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/test/NVQPP/mapping_test-1.cpp
+++ b/test/NVQPP/mapping_test-1.cpp
@@ -6,11 +6,9 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// REQUIRES: c++20
-
-// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.code | FileCheck %s && FileCheck --check-prefix=QUAKE %s < %t.code && rm %t.code
-// RUN: nvq++ %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%p/../Supplemental/Adonis Variant.txt" --emulate && %t
-// RUN: nvq++ -std=c++17 --enable-mlir %s -o %t
+// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.code | FileCheck %s && FileCheck --check-prefix=QUAKE %s < %t.code && rm %t.code
+// RUN: nvq++ %cpp_std %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%p/../Supplemental/Adonis Variant.txt" --emulate && %t
+// RUN: nvq++ %cpp_std --enable-mlir %s -o %t
 
 #include <cudaq.h>
 #include <iostream>

--- a/test/NVQPP/mapping_test-1.cpp
+++ b/test/NVQPP/mapping_test-1.cpp
@@ -8,7 +8,7 @@
 
 // REQUIRES: c++20
 
-// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.code | FileCheck %s && FileCheck --check-prefix=QUAKE < %t.code && rm %t.code
+// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.code | FileCheck %s && FileCheck --check-prefix=QUAKE %s < %t.code && rm %t.code
 // RUN: nvq++ %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%p/../Supplemental/Adonis Variant.txt" --emulate && %t
 // RUN: nvq++ -std=c++17 --enable-mlir %s -o %t
 

--- a/test/NVQPP/mapping_test-1.cpp
+++ b/test/NVQPP/mapping_test-1.cpp
@@ -6,9 +6,11 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ %cpp_std -v %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t |& FileCheck %s
+// REQUIRES: c++20
+
+// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t | FileCheck %s
+// RUN: nvq++ %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%p/../Supplemental/Adonis Variant.txt" --emulate && %t
 // RUN: nvq++ -std=c++17 --enable-mlir %s -o %t
-// RUN: nvq++ %cpp_std %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%p/../Supplemental/Adonis Variant.txt" --emulate && %t
 
 #include <cudaq.h>
 #include <iostream>
@@ -35,16 +37,17 @@ int main() {
   return 0;
 }
 
-// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* null)
-// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
-// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
-// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
-// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// CHECK:         ret void
-// CHECK:         most_probable "101"
+// CHECK-LABEL: tail call void @__quantum__qis__x__body(%Qubit* null)
+// CHECK:       tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// CHECK:       tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// CHECK:       tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// CHECK:       tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+// CHECK:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
+// CHECK:       tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
+// CHECK:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
+// CHECK:       tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// CHECK:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// CHECK:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// CHECK:       ret void
+
+// CHECK-LABEL: most_probable "101"

--- a/test/NVQPP/mapping_test-1.cpp
+++ b/test/NVQPP/mapping_test-1.cpp
@@ -8,7 +8,7 @@
 
 // REQUIRES: c++20
 
-// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t | FileCheck %s
+// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.code | FileCheck %s && FileCheck --check-prefix=QUAKE < %t.code && rm %t.code
 // RUN: nvq++ %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%p/../Supplemental/Adonis Variant.txt" --emulate && %t
 // RUN: nvq++ -std=c++17 --enable-mlir %s -o %t
 
@@ -37,17 +37,17 @@ int main() {
   return 0;
 }
 
-// CHECK-LABEL: tail call void @__quantum__qis__x__body(%Qubit* null)
-// CHECK:       tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:       tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:       tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:       tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
-// CHECK:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
-// CHECK:       tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
-// CHECK:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
-// CHECK:       tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// CHECK:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// CHECK:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// CHECK:       ret void
+// QUAKE-LABEL: tail call void @__quantum__qis__x__body(%Qubit* null)
+// QUAKE:       tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
+// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
+// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
+// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// QUAKE:       ret void
 
 // CHECK-LABEL: most_probable "101"


### PR DESCRIPTION
Closes #1102.

  - lambda_variable.cpp will never compile as C++17.
  - Testing errors: one cannot expect identical error messages between different C++ standard settings.
  - Syntax in these tests uses C++20 features and will produce warnings.
  - As the runtime is compiled with C++20, a plugin pass compiled with C++17 may not behave correctly.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
