### PR TITLE
Fix default llvm path in `build_cudaq.sh` script.

### DIFF
--- a/scripts/build_cudaq.sh
+++ b/scripts/build_cudaq.sh
@@ -34,7 +34,7 @@
 # By default, the CUDA Quantum is done with warnings-as-errors turned on.
 # You can turn this setting off by defining the environment variable CUDAQ_WERROR=OFF.
 
-LLVM_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX:-/opt/llvm}
+LLVM_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX:-$HOME/.llvm}
 CUQUANTUM_INSTALL_PREFIX=${CUQUANTUM_INSTALL_PREFIX:-/opt/nvidia/cuquantum}
 CUDAQ_INSTALL_PREFIX=${CUDAQ_INSTALL_PREFIX:-"$HOME/.cudaq"}
 
@@ -118,6 +118,7 @@ fi
 echo "Preparing CUDA Quantum build with LLVM installation in $LLVM_INSTALL_PREFIX..."
 cmake_args="-G Ninja "$repo_root" \
   -DCMAKE_INSTALL_PREFIX="$CUDAQ_INSTALL_PREFIX" \
+  -DLLVM_DIR="$LLVM_INSTALL_PREFIX/lib/cmake/llvm" \
   -DNVQPP_LD_PATH="$NVQPP_LD_PATH" \
   -DCMAKE_CUDA_HOST_COMPILER="$CXX" \
   -DCMAKE_BUILD_TYPE=$build_configuration \


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
The `build_llvm.sh` script uses the `$HOME/.llmv` as default LLVM install prefix. Therefore, `build_cudaq.sh` should do the same, otherwise the combination of both scripts won't work by default.
