### PR TITLE
[rt] Add `Trace` class

### DIFF
--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -59,6 +59,8 @@ Common
 .. doxygenclass:: cudaq::complex_matrix
     :members:
 
+.. doxygenclass:: cudaq::Trace
+
 .. doxygenclass:: cudaq::Resources
 
 .. doxygentypedef:: cudaq::complex_matrix::value_type

--- a/runtime/common/CMakeLists.txt
+++ b/runtime/common/CMakeLists.txt
@@ -15,6 +15,7 @@ set(COMMON_RUNTIME_SRC
   NoiseModel.cpp 
   ServerHelper.cpp 
   Resources.cpp
+  Trace.cpp
   Future.cpp
 )
 

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -11,7 +11,7 @@
 #include "Future.h"
 #include "MeasureCounts.h"
 #include "NoiseModel.h"
-#include "Resources.h"
+#include "Trace.h"
 #include <optional>
 #include <string_view>
 
@@ -68,7 +68,7 @@ public:
 
   /// @brief When run under the tracer context, persist the
   /// traced quantum resources here.
-  Resources kernelResources;
+  Trace kernelTrace;
 
   /// @brief The name of the kernel being executed.
   std::string kernelName = "";

--- a/runtime/common/Resources.cpp
+++ b/runtime/common/Resources.cpp
@@ -15,6 +15,25 @@
 
 namespace cudaq {
 
+Resources Resources::compute(const Trace &trace) {
+  Resources resources;
+
+  auto convertToID = [](std::vector<QuditInfo> qudits) {
+    std::vector<std::size_t> ids;
+    ids.reserve(qudits.size());
+    std::transform(qudits.cbegin(), qudits.cend(), std::back_inserter(ids),
+                   [](auto &q) { return q.id; });
+    return ids;
+  };
+  for (const auto &inst : trace) {
+    auto controlIDs = convertToID(inst.controls);
+    auto targetIDs = convertToID(inst.targets);
+    resources.appendInstruction(
+        Instruction(inst.name, controlIDs, targetIDs[0]));
+  }
+  return resources;
+}
+
 std::size_t
 Resources::InstructionHash::operator()(const Instruction &instruction) const {
   std::size_t seed = 0;

--- a/runtime/common/Resources.h
+++ b/runtime/common/Resources.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Trace.h"
 #include <ostream>
 #include <unordered_map>
 #include <vector>
@@ -28,6 +29,8 @@ private:
   };
 
 public:
+  static Resources compute(const Trace &trace);
+
   /// @brief The Resources::Instruction is a data type that
   /// encapsulates the name of a quantum operation, the set of
   /// optional control indices, and the target qubit index.

--- a/runtime/common/Trace.cpp
+++ b/runtime/common/Trace.cpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "Trace.h"
+#include <algorithm>
+#include <cassert>
+
+namespace cudaq {
+
+void Trace::appendInstruction(std::string_view name, std::vector<double> params,
+                              std::vector<QuditInfo> controls,
+                              std::vector<QuditInfo> targets) {
+  assert(!targets.empty() && "A instruction must have at least one target");
+  auto findMaxID = [](const std::vector<QuditInfo> &qudits) -> std::size_t {
+    return std::max_element(qudits.cbegin(), qudits.cend(),
+                            [](auto &a, auto &b) { return a.id < b.id; })
+        ->id;
+  };
+  std::size_t maxID = findMaxID(targets);
+  if (!controls.empty())
+    maxID = std::max(maxID, findMaxID(controls));
+  numQudits = std::max(numQudits, maxID + 1);
+  instructions.emplace_back(name, params, controls, targets);
+}
+
+} // namespace cudaq

--- a/runtime/common/Trace.h
+++ b/runtime/common/Trace.h
@@ -1,0 +1,50 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/qis/execution_manager.h"
+#include <string>
+#include <vector>
+
+namespace cudaq {
+
+/// @brief A trace is a circuit representation of the executed computation, as
+/// seen by the execution manager. (Here, a circuit is represented as a list
+/// of instructions on qudits). Since the execution manager cannot "see" control
+/// flow, the trace of a kernel with control flow represents a single execution
+/// path, and thus two calls to the same kernel might produce traces.
+class Trace {
+public:
+  struct Instruction {
+    std::string name;
+    std::vector<double> params;
+    std::vector<QuditInfo> controls;
+    std::vector<QuditInfo> targets;
+
+    Instruction(std::string_view name, std::vector<double> params,
+                std::vector<QuditInfo> controls, std::vector<QuditInfo> targets)
+        : name(name), params(params), controls(controls), targets(targets) {}
+  };
+
+  void appendInstruction(std::string_view name, std::vector<double> params,
+                         std::vector<QuditInfo> controls,
+                         std::vector<QuditInfo> targets);
+
+  auto getNumQudits() const { return numQudits; }
+
+  auto begin() const { return instructions.begin(); }
+
+  auto end() const { return instructions.end(); }
+
+private:
+  std::size_t numQudits = 0;
+  std::vector<Instruction> instructions;
+};
+
+} // namespace cudaq

--- a/runtime/cudaq/algorithms/resource_estimation.h
+++ b/runtime/cudaq/algorithms/resource_estimation.h
@@ -9,8 +9,7 @@
 #pragma once
 
 #include "common/ExecutionContext.h"
-#include "common/MeasureCounts.h"
-#include "cudaq/concepts.h"
+#include "common/Resources.h"
 #include "cudaq/platform.h"
 
 namespace cudaq {
@@ -27,7 +26,7 @@ auto estimate_resources(QuantumKernel &&kernel, Args &&...args) {
   platform.set_exec_ctx(&context);
   kernel(args...);
   platform.reset_exec_ctx();
-  return context.kernelResources;
+  return cudaq::Resources::compute(context.kernelTrace);
 }
 
 } // namespace cudaq

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -221,17 +221,14 @@ public:
 
   void synchronize() override {
     for (auto &instruction : instructionQueue) {
-      if (isInTracerMode()) {
-        auto [gateName, params, controls, targets, op] = instruction;
-        std::vector<std::size_t> controlIds;
-        std::transform(controls.begin(), controls.end(),
-                       std::back_inserter(controlIds),
-                       [](const auto &el) { return el.id; });
-        executionContext->kernelResources.appendInstruction(
-            cudaq::Resources::Instruction(gateName, controlIds, targets[0].id));
-      } else {
+      if (!isInTracerMode()) {
         executeInstruction(instruction);
+        continue;
       }
+
+      auto &&[name, params, controls, targets, op] = instruction;
+      executionContext->kernelTrace.appendInstruction(name, params, controls,
+                                                      targets);
     }
     instructionQueue.clear();
   }


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
The execution of a kernel in the `tracer` context will produce a `Trace` object: a netlist representation of the executed computation as seen by the execution manager. This object can then be used for analysis, e.g., `cudaq::estimate_resoruces` can compute number of operations or a circuit be drawn (this functionality will be added by a later PR).

With this `Trace` class, we can improve the `cudaq::Resource` one. However, that abstraction is leaky and would require braking changes that are out-of-scope for the present PR.

Depends on #1176 
