### PR TITLE
Fix mismatch between new[] and delete

### DIFF
--- a/runtime/cudaq/matrix.h
+++ b/runtime/cudaq/matrix.h
@@ -23,7 +23,7 @@ public:
 
 private:
   /// @brief Pointer to an array of data representing the matrix
-  std::unique_ptr<value_type> internalOwnedData;
+  std::unique_ptr<value_type[]> internalOwnedData;
 
   /// @brief Raw pointer to the data, whether it is
   /// owned or not. This is what should be used primarily

--- a/runtime/cudaq/spin/matrix.cpp
+++ b/runtime/cudaq/spin/matrix.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -41,7 +41,7 @@ std::unordered_map<Eigen::MatrixXcd,
     generalEigenSolvers;
 
 complex_matrix::complex_matrix(const std::size_t rows, const std::size_t cols)
-    : internalOwnedData(std::unique_ptr<complex_matrix::value_type>(
+    : internalOwnedData(std::unique_ptr<complex_matrix::value_type[]>(
           new complex_matrix::value_type[rows * cols])),
       nRows(rows), nCols(cols) {
   internalData = internalOwnedData.get();


### PR DESCRIPTION
This change fixes the following issue when address sanitization is enabled:

```bash
[ RUN      ] SpinOpTester.checkGetMatrix
=================================================================
==37123==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x606000002c60
    #0 0x7fd52e01c3bd in operator delete(void*) /llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:152:3
    #1 0x55e4351ca64a in std::default_delete<std::complex<double>>::operator()(std::complex<double>*) const /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:95:2
    #2 0x55e4351ca58b in std::unique_ptr<std::complex<double>, std::default_delete<std::complex<double>>>::~unique_ptr() /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:396:4
    #3 0x55e4351b93e4 in cudaq::complex_matrix::~complex_matrix() /workspaces/cuda-quantum/runtime/cudaq/matrix.h:20:7
    #4 0x55e4351b0683 in SpinOpTester_checkGetMatrix_Test::TestBody() /workspaces/cuda-quantum/unittests/spin_op/SpinOpTester.cpp:195:3
    #5 0x55e4352be042 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2612:10
    #6 0x55e43525f86a in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2648:14
    #7 0x55e4352088e4 in testing::Test::Run() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2687:5
    #8 0x55e43520a719 in testing::TestInfo::Run() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2836:11
    #9 0x55e43520be94 in testing::TestSuite::Run() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:3015:30
    #10 0x55e43522fa1b in testing::internal::UnitTestImpl::RunAllTests() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:5920:44
    #11 0x55e4352c69f2 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2612:10
    #12 0x55e435266272 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2648:14
    #13 0x55e43522ed3b in testing::UnitTest::Run() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:5484:10
    #14 0x55e43519eaa0 in RUN_ALL_TESTS() /workspaces/cuda-quantum/tpls/googletest-src/googletest/include/gtest/gtest.h:2317:73
    #15 0x55e43519e9ea in main /workspaces/cuda-quantum/unittests/main.cpp:13:10
    #16 0x7fd52d651d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: c289da5071a3399de893d2af81d6a30c62646e1e)
    #17 0x7fd52d651e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: c289da5071a3399de893d2af81d6a30c62646e1e)
    #18 0x55e43519d494 in _start (/workspaces/cuda-quantum/build/unittests/test_spin+0x95494)

0x606000002c60 is located 0 bytes inside of 64-byte region [0x606000002c60,0x606000002ca0)
allocated by thread T0 here:
    #0 0x7fd52e01bc6d in operator new[](unsigned long) /llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:98:3
    #1 0x7fd52ddbca8c in cudaq::complex_matrix::complex_matrix(unsigned long, unsigned long) /workspaces/cuda-quantum/runtime/cudaq/spin/matrix.cpp:44:11
    #2 0x7fd52ddbd58f in cudaq::complex_matrix::operator*(cudaq::complex_matrix&) const /workspaces/cuda-quantum/runtime/cudaq/spin/matrix.cpp:74:18
    #3 0x55e4351b0313 in SpinOpTester_checkGetMatrix_Test::TestBody() /workspaces/cuda-quantum/unittests/spin_op/SpinOpTester.cpp:189:23
    #4 0x55e4352be042 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2612:10
    #5 0x55e43525f86a in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2648:14
    #6 0x55e4352088e4 in testing::Test::Run() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2687:5
    #7 0x55e43520a719 in testing::TestInfo::Run() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2836:11
    #8 0x55e43520be94 in testing::TestSuite::Run() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:3015:30
    #9 0x55e43522fa1b in testing::internal::UnitTestImpl::RunAllTests() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:5920:44
    #10 0x55e4352c69f2 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2612:10
    #11 0x55e435266272 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:2648:14
    #12 0x55e43522ed3b in testing::UnitTest::Run() /workspaces/cuda-quantum/tpls/googletest-src/googletest/src/gtest.cc:5484:10
    #13 0x55e43519eaa0 in RUN_ALL_TESTS() /workspaces/cuda-quantum/tpls/googletest-src/googletest/include/gtest/gtest.h:2317:73
    #14 0x55e43519e9ea in main /workspaces/cuda-quantum/unittests/main.cpp:13:10
    #15 0x7fd52d651d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: c289da5071a3399de893d2af81d6a30c62646e1e)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch /llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:152:3 in operator delete(void*)
```