### PR TITLE
Options for OQC Toshiko machine

### DIFF
--- a/.github/workflows/config/spelling_allowlist.txt
+++ b/.github/workflows/config/spelling_allowlist.txt
@@ -39,6 +39,7 @@ JIT
 JSON
 Jupyter
 JupyterLab
+Kagome
 Kraus
 LLVM
 LSB
@@ -88,6 +89,7 @@ SVD
 TCP
 TableGen
 Toffoli
+Toshiko
 VQE
 Vazirani
 WSL

--- a/docs/sphinx/examples/python/providers/oqc.py
+++ b/docs/sphinx/examples/python/providers/oqc.py
@@ -1,0 +1,55 @@
+import cudaq
+import os
+
+# You only have to set the target once! No need to redefine it
+# for every execution call on your kernel.
+# To use different targets in the same file, you must update
+# it via another call to `cudaq.set_target()`
+
+# To use the OQC target you will need to set the following env variables
+# OQC_URL
+# OQC_EMAIL
+# OQC_PASSWORD
+# To setup an account, contact oqc_qcaas_support@oxfordquantumcircuits.com
+
+cudaq.set_target("oqc")
+
+# Create the kernel we'd like to execute on OQC.
+kernel = cudaq.make_kernel()
+qubits = kernel.qalloc(2)
+kernel.h(qubits[0])
+kernel.cx(qubits[0], qubits[1])
+kernel.mz(qubits)
+
+# Option A:
+# By using the asynchronous `cudaq.sample_async`, the remaining
+# classical code will be executed while the job is being handled
+# by OQC. This is ideal when submitting via a queue over
+# the cloud.
+async_results = cudaq.sample_async(kernel)
+# ... more classical code to run ...
+
+# We can either retrieve the results later in the program with
+# ```
+# async_counts = async_results.get()
+# ```
+# or we can also write the job reference (`async_results`) to
+# a file and load it later or from a different process.
+file = open("future.txt", "w")
+file.write(str(async_results))
+file.close()
+
+# We can later read the file content and retrieve the job
+# information and results.
+same_file = open("future.txt", "r")
+retrieved_async_results = cudaq.AsyncSampleResult(str(same_file.read()))
+
+counts = retrieved_async_results.get()
+print(counts)
+
+# Option B:
+# By using the synchronous `cudaq.sample`, the execution of
+# any remaining classical code in the file will occur only
+# after the job has been returned from OQC.
+counts = cudaq.sample(kernel)
+print(counts)

--- a/docs/sphinx/examples/python/providers/oqc.py
+++ b/docs/sphinx/examples/python/providers/oqc.py
@@ -6,7 +6,7 @@ import os
 # To use different targets in the same file, you must update
 # it via another call to `cudaq.set_target()`
 
-# To use the OQC target you will need to set the following env variables
+# To use the OQC target you will need to set the following environment variables
 # OQC_URL
 # OQC_EMAIL
 # OQC_PASSWORD

--- a/docs/sphinx/using/hardware.rst
+++ b/docs/sphinx/using/hardware.rst
@@ -312,7 +312,8 @@ To see a complete example for using IQM server backends, take a look at our :ref
 OQC
 ==================================
 
-`Oxford Quantum Circuits <https://oxfordquantumcircuits.com/>`__ (OQC) is currently providing CUDA quantum integration for our 8 qubit ring topology Lucy device.
+`Oxford Quantum Circuits <https://oxfordquantumcircuits.com/>`__ (OQC) is currently providing CUDA quantum integration for both our Quantum Processing Unit types.
+Our 8 qubit ring topology Lucy device and our 32 qubit Kagome lattice topology Toshiko device are both supported via machine options described below.
 
 Setting Credentials
 `````````````````````````
@@ -356,7 +357,9 @@ This will emit any target specific compiler warnings and diagnostics, before run
 
 .. note::
 
-    There is currently no requirement to specify the machine in use. This is configured via the URL which points to the relevant system.
+    The oqc target supports a ``--oqc-machine`` option.
+    The default is the 8 qubit Lucy device.
+    You can set this to be either ``toshiko`` or ``lucy`` via this flag.
 
 .. note::
 
@@ -367,6 +370,7 @@ Submission from Python
 
 To set which OQC URL, set the :code:`url` parameter.
 To set which OQC email, set the :code:`email` parameter.
+To set which OQC machine, set the :code:`machine` parameter.
 
 .. code:: python
 
@@ -374,7 +378,7 @@ To set which OQC email, set the :code:`email` parameter.
     import cudaq
     # ...
     os.environ['OQC_PASSWORD'] = password
-    cudaq.set_target(target="oqc", url="")
+    cudaq.set_target("oqc", url=url, machine="lucy")
 
 You can then execute a kernel against the platform using the OQC Lucy device
 

--- a/docs/sphinx/using/hardware.rst
+++ b/docs/sphinx/using/hardware.rst
@@ -312,8 +312,8 @@ To see a complete example for using IQM server backends, take a look at our :ref
 OQC
 ==================================
 
-`Oxford Quantum Circuits <https://oxfordquantumcircuits.com/>`__ (OQC) is currently providing CUDA quantum integration for both our Quantum Processing Unit types.
-Our 8 qubit ring topology Lucy device and our 32 qubit Kagome lattice topology Toshiko device are both supported via machine options described below.
+`Oxford Quantum Circuits <https://oxfordquantumcircuits.com/>`__ (OQC) is currently providing CUDA quantum integration for multiple Quantum Processing Unit types.
+The 8 qubit ring topology Lucy device and the 32 qubit Kagome lattice topology Toshiko device are both supported via machine options described below.
 
 Setting Credentials
 `````````````````````````

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/CMakeLists.txt
@@ -12,3 +12,5 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/oqc.config
 target_sources(cudaq-rest-qpu PRIVATE OQCServerHelp.cpp)
 add_target_config(oqc)
 
+add_target_mapping_arch(oqc lucy.txt)
+add_target_mapping_arch(oqc toshiko.txt)

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -12,6 +12,7 @@
 #include <thread>
 #include <sstream>
 #include <map>
+#include <regex>
 
 namespace cudaq {
 
@@ -83,6 +84,10 @@ public:
   /// maps the results back to sample results.
   cudaq::sample_result processResults(ServerMessage &postJobResponse,
                                       std::string &jobID) override;
+
+  /// @brief Update `passPipeline` with architecture-specific pass options
+  void updatePassPipeline(const std::filesystem::path &platformPath,
+                              std::string &passPipeline) override;
 };
 
 namespace {
@@ -404,6 +409,16 @@ RestHeaders OQCServerHelper::getHeaders() {
   // Return the headers
   return headers;
 }
+
+void OQCServerHelper::updatePassPipeline(
+        const std::filesystem::path &platformPath, std::string &passPipeline) {
+    std::string pathToFile =
+            platformPath / std::string("mapping/oqc") /
+            (backendConfig["machine"] + std::string(".txt"));
+    passPipeline =
+            std::regex_replace(passPipeline, std::regex("%QPU_ARCH%"), pathToFile);
+  }
+
 
 } // namespace cudaq
 

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -108,7 +108,7 @@ std::string get_from_config(BackendConfig config, const std::string &key,
   return item;
 }
 
-void check_machine_allowed(std::string& machine){
+void check_machine_allowed(const std::string& machine){
   if(Machines.find(machine) == Machines.end()){
      std::string allowed;
      for (const auto &machine : Machines)

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/lucy.txt
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/lucy.txt
@@ -1,0 +1,31 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# The format of the file is as follows:
+# 1. You must specify the number of nodes
+Number of nodes: 8
+
+# 2. Specifying the number of edges is optional
+Number of edges: ?
+
+# 3. For each node, list the connections as:
+# <NodeNumber> --> { <ConnectedNode1>, <ConnectedNode2>, ... }
+# Notes:
+# - Node numbers are 0-based
+# - Each node's info must be entirely on one line.
+# - The nodes and lines do not have to be in order.
+# - Connections are assumed to be bidirectional.
+# - Any duplicates will be automatically removed.
+0 --> {7, 1}
+1 --> {0, 2}
+2 --> {1, 3}
+3 --> {2, 4}
+4 --> {3, 5}
+5 --> {4, 6}
+6 --> {5, 7}
+7 --> {6, 0}

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.config
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.config
@@ -17,7 +17,9 @@ LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline. Lucy has an 8-qubit ring topology, so mapping
 # uses ring(8).
-PLATFORM_LOWERING_CONFIG="expand-measurements,unrolling-pipeline,func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg,qubit-mapping{device=ring(8)},regtomem)"
+# Toshiko uses a Kagome lattice with 2-3 connectivity per qubit
+PLATFORM_LOWERING_CONFIG="expand-measurements,unrolling-pipeline,func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg,qubit-mapping{device=file(%QPU_ARCH%)},regtomem)"
+
 
 # Tell the rest-qpu that we are generating QIR.
 CODEGEN_EMISSION=qir-base

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.config
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.config
@@ -44,6 +44,9 @@ while [ $# -gt 1 ]; do
 	--oqc-url)
 		PLATFORM_EXTRA_ARGS="$PLATFORM_EXTRA_ARGS;url;$2"
 		;;
+	--oqc-machine)
+		PLATFORM_EXTRA_ARGS="$PLATFORM_EXTRA_ARGS;machine;$2"
+		;;
 	esac
 	shift 2
 done

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/toshiko.txt
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/toshiko.txt
@@ -1,0 +1,57 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# The format of the file is as follows:
+# 1. You must specify the number of nodes
+Number of nodes: 35
+
+# 2. Specifying the number of edges is optional
+Number of edges: ?
+
+# 3. For each node, list the connections as:
+# <NodeNumber> --> { <ConnectedNode1>, <ConnectedNode2>, ... }
+# Notes:
+# - Node numbers are 0-based
+# - Each node's info must be entirely on one line.
+# - The nodes and lines do not have to be in order.
+# - Connections are assumed to be bidirectional.
+# - Any duplicates will be automatically removed.
+# Theoretical connectivity for Toshiko. Reality is 32 of 35 will be enabled.
+0 --> {1, 9}
+1 --> {2, 8}
+2 --> {3}
+3 --> {4}
+4 --> {7, 5}
+5 --> {6}
+6 --> {15}
+7 --> {14}
+8 --> {11}
+9 --> {10}
+10 --> {18}
+11 --> {12}
+12 --> {13}
+13 --> {17, 14}
+15 --> {16}
+16 --> {24}
+17 --> {21}
+18 --> {19}
+19 --> {28}
+20 --> {21}
+20 --> {27}
+21 --> {22}
+23 --> {26}
+24 --> {25}
+25 --> {34}
+26 --> {33}
+27 --> {30}
+28 --> {29}
+29 --> {30}
+30 --> {31}
+31 --> {32}
+32 --> {33}
+33 --> {34}


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!
⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [x ] I have added tests to cover my changes.
- [x ] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Description
The current rest helper defaults to the OQC 8 qubit Lucy device. We now want to support 2 devices on the platform including the 32Q Toshiko coaxmon based super conducting qpu. 
