### PR TITLE
[experimental/python] Build kernel call graph and add all dependent kernels

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -6,6 +6,7 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 import ast
+import graphlib
 import sys
 from typing import Callable
 from collections import deque
@@ -2082,15 +2083,40 @@ def compile_to_mlir(astModule, **kwargs):
     vis.visit(astModule)
     depKernels = vis.depKernels
 
+    # Keep track of a kernel callgraph, we will
+    # sort this later after we build up the graph
+    callGraph = {vis.kernelName: {k for k, v in depKernels.items()}}
+
+    # Visit dependent kernels recursively to
+    # ensure we have all necessary kernels added to the
+    # module
+    transitiveDeps = depKernels
+    while len(transitiveDeps):
+        # For each found dependency, see if that kernel
+        # has further dependencies
+        for depKernelName, depKernelAst in transitiveDeps.items():
+            localVis = FindDepKernelsVisitor(bridge.ctx)
+            localVis.visit(depKernelAst)
+            # Append the found dependencies to our running tally
+            depKernels = {**depKernels, **localVis.depKernels}
+            # Reset for the next go around
+            transitiveDeps = localVis.depKernels
+            # Update the call graph
+            callGraph[localVis.kernelName] = {
+                k for k, v in localVis.depKernels.items()
+            }
+
+    # Sort the call graph topologically
+    callGraphSorter = graphlib.TopologicalSorter(callGraph)
+    sortedOrder = callGraphSorter.static_order()
+
     # Add all dependent kernels to the MLIR Module,
     # Do not check any 'dependent' kernels that
     # have the same name as the main kernel here, i.e.
     # ignore kernels that have the same name as this one.
-    [
-        bridge.visit(ast)
-        for depName, ast in depKernels.items()
-        if vis.kernelName != depName
-    ]
+    for funcName in sortedOrder:
+        if funcName != vis.kernelName:
+            bridge.visit(depKernels[funcName])
 
     # Build the MLIR Module for this kernel
     bridge.visit(astModule)

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2115,7 +2115,7 @@ def compile_to_mlir(astModule, **kwargs):
     # have the same name as the main kernel here, i.e.
     # ignore kernels that have the same name as this one.
     for funcName in sortedOrder:
-        if funcName != vis.kernelName:
+        if funcName != vis.kernelName and funcName in depKernels:
             bridge.visit(depKernels[funcName])
 
     # Build the MLIR Module for this kernel

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2083,7 +2083,7 @@ def compile_to_mlir(astModule, **kwargs):
     vis.visit(astModule)
     depKernels = vis.depKernels
 
-    # Keep track of a kernel callgraph, we will
+    # Keep track of a kernel call graph, we will
     # sort this later after we build up the graph
     callGraph = {vis.kernelName: {k for k, v in depKernels.items()}}
 


### PR DESCRIPTION
Fix issue where all dependent kernels were not added to MLIR ModuleOp

```python
    @cudaq.kernel()
    def func0(q : cudaq.qubit):
        x(q)

    @cudaq.kernel()
    def func1(q: cudaq.qubit):
        func0(q)

    @cudaq.kernel
    def func2(q: cudaq.qubit):
        func1(q)

    @cudaq.kernel()
    def callMe():
        q = cudaq.qubit()
        func2(q)
```
@marwafar 