### PR TITLE
[experimental/python] Fix issue with finding kernel dependencies 

### DIFF
--- a/python/cudaq/kernel/analysis.py
+++ b/python/cudaq/kernel/analysis.py
@@ -237,6 +237,10 @@ class FindDepKernelsVisitor(ast.NodeVisitor):
                           ast.Name) and node.func.id in globalAstRegistry:
                 self.depKernels[node.func.id] = globalAstRegistry[node.func.id]
             elif isinstance(node.func, ast.Attribute):
+                if hasattr(
+                        node.func.value, 'id'
+                ) and node.func.value.id == 'cudaq' and node.func.attr == 'kernel':
+                    return
                 # May need to somehow import a library kernel, find
                 # all module names in a mod1.mod2.mod3.function type call
                 moduleNames = []

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -324,8 +324,8 @@ class PyASTBridge(ast.NodeVisitor):
                 opCtor([], parameters, [], [quantumValue])
             else:
                 raise Exception(
-                    'quantum operation on incorrect type {}.'.format(
-                        quantumValue.type))
+                    'quantum operation {} on incorrect type {}.'.format(
+                        opName, quantumValue.type))
         return
 
     def needsStackSlot(self, type):
@@ -454,6 +454,7 @@ class PyASTBridge(ast.NodeVisitor):
 
             globalKernelRegistry[node.name] = f
             self.symbolTable.clear()
+            self.valueStack.clear()
 
     # [RFC]:
     # Examine if we really want to extend Python with a dedicated syntax.

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -303,3 +303,35 @@ def test_transitive_dependencies():
 
     counts = cudaq.sample(callMe)
     assert len(counts) == 1 and '1' in counts
+
+    # This test is for a bug where by 
+    # vqe_kernel thought kernel was a 
+    # dependency because cudaq.kernel 
+    # is a Call node in the AST.
+    @cudaq.kernel
+    def kernel():
+        qubit=cudaq.qvector(2)
+        h(qubit[0])
+        x.ctrl(qubit[0],qubit[1])
+        mz(qubit)
+
+    result = cudaq.sample(kernel)
+    print(result)
+    assert len(result) == 2 and '00' in result and '11' in result
+
+
+    @cudaq.kernel
+    def vqe_kernel(nn:int):
+        qubit=cudaq.qvector(nn)
+
+        h(qubit[0])
+        x.ctrl(qubit[0],qubit[1])
+
+        mz(qubit)
+
+    print(vqe_kernel)
+    result = cudaq.sample(vqe_kernel, 2)
+    print(result)
+    assert len(result) == 2 and '00' in result and '11' in result
+
+


### PR DESCRIPTION
Make sure `cudaq.kernel()` is not found as a kernel dependency. Clear the MLIR value stack upon exit from the AST bridge visitor. 
