### PR TITLE
Kernel builder JIT cache optimizations

### DIFF
--- a/python/runtime/cudaq/algorithms/py_observe.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -39,7 +39,6 @@ observe_result pyObserve(kernel_builder<> &kernel, spin_op &spin_operator,
 
   // TODO: would like to handle errors in the case that
   // `kernel.num_qubits() >= spin_operator.num_qubits()`
-  kernel.jitCode();
   auto name = kernel.name();
 
   // Launch the observation task
@@ -67,9 +66,6 @@ async_observe_result pyObserveAsync(kernel_builder<> &kernel,
 
   // TODO: would like to handle errors in the case that
   // `kernel.num_qubits() >= spin_operator.num_qubits()`
-
-  // JIT the code
-  kernel.jitCode();
 
   // Get the kernel name
   auto name = kernel.name();
@@ -169,7 +165,6 @@ pyObserveN(kernel_builder<> &kernel, spin_op &op, py::args args = {},
   auto &platform = cudaq::get_platform();
   if (noise)
     platform.set_noise(&*noise);
-  kernel.jitCode();
   auto name = kernel.name();
   std::vector<observe_result> results;
   for (std::size_t currentIter = 0; auto &a : argSet) {

--- a/python/runtime/cudaq/algorithms/py_sample.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -31,7 +31,6 @@ sample_result pySample(kernel_builder<> &builder, py::args args = {},
   auto validatedArgs = validateInputArguments(builder, args);
 
   cudaq::info("Sampling the provided pythonic kernel.");
-  builder.jitCode();
   auto kernelName = builder.name();
 
   // Map py::args to OpaqueArguments handle
@@ -57,7 +56,6 @@ pySampleN(kernel_builder<> &kernel, py::args args = {},
           std::optional<noise_model> noise = std::nullopt) {
   auto argSet = createArgumentSet(args);
   auto N = argSet.size();
-  kernel.jitCode();
   auto name = kernel.name();
   auto &platform = cudaq::get_platform();
   if (noise)
@@ -90,8 +88,7 @@ async_sample_result pySampleAsync(kernel_builder<> &builder,
   auto &platform = cudaq::get_platform();
   cudaq::info("Asynchronously sampling the provided pythonic kernel.");
 
-  // JIT the code and get the kernel name
-  builder.jitCode();
+  // Get the kernel name
   auto kernelName = builder.name();
 
   // Create the argument holder and pack the runtime arguments

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -35,7 +35,6 @@ void extractStateData(py::buffer_info &info, complex *data) {
 state pyGetState(kernel_builder<> &kernel, py::args args) {
   // Ensure the user input is correct.
   auto validatedArgs = validateInputArguments(kernel, args);
-  kernel.jitCode();
   OpaqueArguments argData;
   packArgs(argData, validatedArgs);
   return details::extractState(


### PR DESCRIPTION
This PR introduces 2 optimizations:

1. This changes the JIT cache key calculation from `std::hash<std::string>{}(modulePrintOut)` to one using `llvm::hash_code`. In my timing tests, the latter is ~27-29x faster than the former. (The generation of the `modulePrintOut` was the slow part, not the `std::hash`.)
2. Additionally, this eliminates redundant calls to `kernel_builder::jitCode()` when it is subsequently followed up with calls to `kernel_builder::jitAndInvoke()`. With the JIT cache key calculation change (above), this change is less important, but the redundant calls should not be needed, and are hence removed anyway.

Under some VQE test code, the combination of these two optimizations reduces the overall simulation runtime by ~50%, but YMMV.