### PR TITLE
Ability to run qpud in QIR-only mode with `CallOp` verification

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -33,6 +33,9 @@ void registerConvertToQIRPass();
 /// cudaq-translate command line `--convert-to` parameter)
 void addQIRProfilePipeline(mlir::OpPassManager &pm, llvm::StringRef convertTo);
 
+/// @brief Verify that all `CallOp` targets are QIR- or NVQIR-defined functions.
+std::unique_ptr<mlir::Pass> createVerifyNVQIRCallOpsPass();
+
 // Use the addQIRProfilePipeline() for the following passes.
 std::unique_ptr<mlir::Pass>
 createQIRToQIRProfilePass(llvm::StringRef convertTo);

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -112,5 +112,15 @@ def RemoveMeasurements : Pass<"remove-measurements"> {
   let constructor = "cudaq::opt::createRemoveMeasurementsPass()";
 }
 
+def VerifyNVQIRCallOps : Pass<"verify-nvqir-call-ops", "mlir::LLVM::LLVMFuncOp"> {
+  let summary =
+    "Verify that all LLVM CallOps' callees are NVQIR compliant";
+  let description = [{
+    This is a function pass to verify that all function calls within the function body are 
+    referring to QIR functions, i.e., starting with a __quantum prefix, or NVQIR runtime functions.
+  }];
+
+  let constructor = "cudaq::opt::createVerifyNVQIRCallOpsPass()";
+}
 
 #endif // CUDAQ_OPT_OPTIMIZER_CODEGEN_PASSES

--- a/lib/Optimizer/CodeGen/LowerToQIRProfile.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIRProfile.cpp
@@ -617,7 +617,7 @@ struct VerifyNVQIRCallOpsPass
         if (!isKnownFunctionName(funcName)) {
           call.emitOpError("unexpected function call in NVQIR");
           passFailed = true;
-          return WalkResult::advance();
+          return WalkResult::interrupt();
         }
         return WalkResult::advance();
       }

--- a/lib/Optimizer/CodeGen/LowerToQIRProfile.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIRProfile.cpp
@@ -587,6 +587,54 @@ cudaq::opt::verifyQIRProfilePass(llvm::StringRef convertTo) {
   return std::make_unique<VerifyQIRProfilePass>(convertTo);
 }
 
+namespace {
+/// Verify that the QIR doesn't have any "bonus" calls to arbitrary code that is
+/// not possibly defined in the QIR standard or NVQIR runtime.
+struct VerifyNVQIRCallOpsPass
+    : public cudaq::opt::VerifyNVQIRCallOpsBase<VerifyNVQIRCallOpsPass> {
+  explicit VerifyNVQIRCallOpsPass() : VerifyNVQIRCallOpsBase() {}
+
+  void runOnOperation() override {
+    LLVM::LLVMFuncOp func = getOperation();
+    bool passFailed = false;
+    // Check that a function name is either QIR or NVQIR registered.
+    const auto isKnownFunctionName = [](llvm::StringRef functionName) -> bool {
+      if (functionName.startswith("__quantum_"))
+        return true;
+      static const std::vector<llvm::StringRef> NVQIR_FUNCS = {
+          cudaq::opt::NVQIRInvokeWithControlBits,
+          cudaq::opt::NVQIRInvokeRotationWithControlBits,
+          cudaq::opt::NVQIRInvokeWithControlRegisterOrBits,
+          cudaq::opt::NVQIRPackSingleQubitInArray,
+          cudaq::opt::NVQIRReleasePackedQubitArray};
+      return std::find(NVQIR_FUNCS.begin(), NVQIR_FUNCS.end(), functionName) !=
+             NVQIR_FUNCS.end();
+    };
+
+    func.walk([&](Operation *op) {
+      if (auto call = dyn_cast<LLVM::CallOp>(op)) {
+        auto funcName = call.getCalleeAttr().getValue();
+        if (!isKnownFunctionName(funcName)) {
+          call.emitOpError("unexpected function call in NVQIR");
+          passFailed = true;
+          return WalkResult::advance();
+        }
+        return WalkResult::advance();
+      }
+      return WalkResult::advance();
+    });
+    if (passFailed) {
+      emitError(func.getLoc(),
+                "function " + func.getName() + " not compatible with NVQIR.");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+std::unique_ptr<mlir::Pass> cudaq::opt::createVerifyNVQIRCallOpsPass() {
+  return std::make_unique<VerifyNVQIRCallOpsPass>();
+}
+
 // The various passes defined here should be added as a pass pipeline.
 
 void cudaq::opt::addQIRProfilePipeline(OpPassManager &pm,

--- a/runtime/cudaq/platform/mqpu/nvcf.config
+++ b/runtime/cudaq/platform/mqpu/nvcf.config
@@ -17,25 +17,8 @@ PLATFORM_LIBRARY=mqpu
 # QPU subtype
 PLATFORM_QPU=NvcfSimulatorQPU
 
-COMPILER_FLAGS="$COMPILER_FLAGS -DCUDAQ_REMOTE_SIM"
-
-if ${LIBRARY_MODE}; then
-	# In library mode, we enforce that no custom fallback host compiler has been set via `cmake-host-compiler` option.
-	# Note: even if another Clang-based compiler is set, we cannot guarantee that it is compatible with the LLVM version
-	# that the CUDA Quantum runtime is compiled against. Hence, we don't support custom host compiler for this platform.
-	if [[ "$CMAKE_FALLBACK_HOST_CXX" != "$CXX" ]]; then 
-		error_exit "Using remote simulation target in library mode with a custom cmake-host-compiler is unsupported. Please use the default nvq++ host compiler or enable MLIR mode."
-	fi 
-	
-	COMPILER_FLAGS="$COMPILER_FLAGS -fembed-bitcode=all"
-	# Clang made "out of line atomics" the default on arm64 targets (https://reviews.llvm.org/D93585);
-	# requiring to link against `libclang_rt.builtins` on the server side when JIT'ing. 
-	# Hence, disable it when using the remote platform. 
-	if [ "$(uname -m)" == "aarch64" ]; then
-		COMPILER_FLAGS="$COMPILER_FLAGS -mno-outline-atomics"
-	fi
-	LINKER_FLAGS="$LINKER_FLAGS -rdynamic"
-fi
+# Disable library mode
+LIBRARY_MODE=false
 
 PLATFORM_EXTRA_ARGS=""
 # NB: extra arguments always take the form:


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- `nvcf.config` to disable library mode + sanity check within the client to verify that.

- Add a subclass for server implementation to do server-side filtering for MLIR (lowered to QIR).

- Add a verification for `CallOp`: either QIR functions or NVQIR-known functions as defined in `QIRFunctionNames.h`
 
- Add a missing MLIR pass in the config.
