### PR TITLE
Add a cmake variable to disable building the REST parts of the runtime.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,11 @@ if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
   set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()
 
+# Enable the REST code by default.
+if (NOT DEFINED CUDAQ_ENABLE_REST)
+  set(CUDAQ_ENABLE_REST ON)
+endif()
+
 # Generate a CompilationDatabase (compile_commands.json file) for our build,
 # for use by clang_complete, YouCompleteMe, etc.
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,8 +512,11 @@ endif()
 if (NOT CUDAQ_DISABLE_TOOLS)
   add_subdirectory(tools)
 endif()
-# Always add cudaq-qpud executable/tool (including Python wheels)
-add_subdirectory(tools/cudaq-qpud)
+
+if (CUDAQ_ENABLE_REST)
+  # Add cudaq-qpud executable/tool (including Python wheels)
+  add_subdirectory(tools/cudaq-qpud)
+endif()
 
 add_subdirectory(utils)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,15 +509,7 @@ add_subdirectory(lib)
 if (NOT CUDAQ_DISABLE_RUNTIME)
   add_subdirectory(runtime)
 endif()
-if (NOT CUDAQ_DISABLE_TOOLS)
-  add_subdirectory(tools)
-endif()
-
-if (CUDAQ_ENABLE_REST)
-  # Add cudaq-qpud executable/tool (including Python wheels)
-  add_subdirectory(tools/cudaq-qpud)
-endif()
-
+add_subdirectory(tools)
 add_subdirectory(utils)
 
 if (CUDAQ_ENABLE_PYTHON)

--- a/runtime/cudaq/platform/CMakeLists.txt
+++ b/runtime/cudaq/platform/CMakeLists.txt
@@ -10,5 +10,6 @@ add_subdirectory(default)
 if (OPENSSL_FOUND)
   add_subdirectory(orca)
 endif()
-
-add_subdirectory(mqpu)
+if (CUDAQ_ENABLE_REST)
+  add_subdirectory(mqpu)
+endif()

--- a/runtime/cudaq/platform/default/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/CMakeLists.txt
@@ -24,17 +24,21 @@ target_include_directories(${LIBRARY_NAME}
     PRIVATE . ../../)
 
 target_link_libraries(${LIBRARY_NAME}
-  PUBLIC pthread cudaq-em-default cudaq-spin cudaq-common PRIVATE fmt::fmt-header-only)
+  PUBLIC
+    pthread cudaq-em-default cudaq-spin cudaq-common
+  PRIVATE
+    fmt::fmt-header-only)
 
 install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
-install(TARGETS ${LIBRARY_NAME} EXPORT cudaq-platform-default-targets DESTINATION lib)
+install(TARGETS ${LIBRARY_NAME}
+  EXPORT cudaq-platform-default-targets DESTINATION lib)
 
 install(EXPORT cudaq-platform-default-targets
         FILE CUDAQPlatformDefaultTargets.cmake
         NAMESPACE cudaq::
         DESTINATION lib/cmake/cudaq)
 
-if (OPENSSL_FOUND)
+if (OPENSSL_FOUND AND CUDAQ_ENABLE_REST)
   add_subdirectory(rest)
   add_subdirectory(rest_server)
 endif()

--- a/runtime/cudaq/platform/mqpu/CMakeLists.txt
+++ b/runtime/cudaq/platform/mqpu/CMakeLists.txt
@@ -14,7 +14,8 @@ endif()
 add_subdirectory(remote)
 
 set(LIBRARY_NAME cudaq-platform-mqpu)
-add_library(${LIBRARY_NAME} SHARED MultiQPUPlatform.cpp ../common/QuantumExecutionQueue.cpp)
+add_library(${LIBRARY_NAME}
+  SHARED MultiQPUPlatform.cpp ../common/QuantumExecutionQueue.cpp)
 target_include_directories(${LIBRARY_NAME} 
     PUBLIC 
        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/runtime>
@@ -41,6 +42,7 @@ if (CUDA_FOUND AND CUSTATEVEC_ROOT)
 endif()
   
 install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
-install(TARGETS ${LIBRARY_NAME} EXPORT cudaq-platform-mqpu-targets DESTINATION lib)
+install(TARGETS ${LIBRARY_NAME}
+  EXPORT cudaq-platform-mqpu-targets DESTINATION lib)
 add_target_config(remote-mqpu)
 add_target_config(nvcf)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,12 +6,20 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-add_subdirectory(cudaq-opt)
-add_subdirectory(cudaq-translate)
+if (NOT CUDAQ_DISABLE_TOOLS)
+  add_subdirectory(cudaq-opt)
+  add_subdirectory(cudaq-translate)
 
-if (NOT CUDAQ_DISABLE_CPP_FRONTEND)
-  add_subdirectory(cudaq-lsp-server)
-  add_subdirectory(cudaq-quake)
-  add_subdirectory(fixup-linkage)
-  add_subdirectory(nvqpp)
+  if (NOT CUDAQ_DISABLE_CPP_FRONTEND)
+    add_subdirectory(cudaq-lsp-server)
+    add_subdirectory(cudaq-quake)
+    add_subdirectory(fixup-linkage)
+    add_subdirectory(nvqpp)
+  endif()
 endif()
+
+if (CUDAQ_ENABLE_REST)
+  # Add cudaq-qpud executable/tool (including Python wheels)
+  add_subdirectory(cudaq-qpud)
+endif()
+


### PR DESCRIPTION
Under some circumstances, it may be expediant to disable the building of the REST and REST Server libraries in the runtime. This adds a cmake variable, CUDAQ_ENABLE_REST, for exactly that purpose.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
