### PR TITLE
[experimental/python] Fix for deployment on Python v3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = { file="LICENSE" }
 dependencies = [
   'astpretty ~= 3.0',
   'cuquantum-cu11 ~= 23.10',
-  'numpy ~= 1.26'
+  'numpy >= 1.24'
 ]
 
 [project.urls]


### PR DESCRIPTION
`numpy` is required by modules like `python/cudaq/kernel/ast_bridge.py` and `python/cudaq/kernel/quake_value.py`

### Description
<!-- Include relevant issues here, describe what changed and why -->
While installing wheel on Python v3.8 we get `ERROR: No matching distribution found for numpy~=1.26`
