### PR TITLE
Optimize logger implementation

### DIFF
--- a/runtime/common/Logger.cpp
+++ b/runtime/common/Logger.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -46,6 +46,19 @@ void debug(const std::string_view msg) {
 #ifdef CUDAQ_DEBUG
   spdlog::debug(msg);
 #endif
+}
+// These asserts are needed for should_log
+static_assert(static_cast<int>(LogLevel::debug) ==
+                  static_cast<int>(spdlog::level::debug),
+              "log level enum mismatch");
+static_assert(static_cast<int>(LogLevel::trace) ==
+                  static_cast<int>(spdlog::level::trace),
+              "log level enum mismatch");
+static_assert(static_cast<int>(LogLevel::info) ==
+                  static_cast<int>(spdlog::level::info),
+              "log level enum mismatch");
+bool should_log(const LogLevel logLevel) {
+  return spdlog::should_log(static_cast<spdlog::level::level_enum>(logLevel));
 }
 std::string pathToFileName(const std::string_view fullFilePath) {
   const std::filesystem::path file(fullFilePath);

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -935,7 +935,10 @@ public:
                                const std::vector<std::size_t> &targets) {
     flushAnySamplingTasks();
     QuantumOperation gate;
-    cudaq::info(gateToString(gate.name(), controls, angles, targets));
+    // This is a very hot section of code. Don't form the log string unless
+    // we're actually going to use it.
+    if (cudaq::details::should_log(cudaq::details::LogLevel::info))
+      cudaq::info(gateToString(gate.name(), controls, angles, targets));
     enqueueGate(gate.name(), gate.getGate(angles), controls, targets, angles);
   }
 


### PR DESCRIPTION
Bypass some processing if the current log level prevents the message from actually being logged.

For the most part, this means that we check the log level before calling `fmt::format()`. However, note that some log messages form strings outside of the `cudaq::info` structs and then pass the result into the `cudaq::info()` structs. We cannot optimize those out without more invasive code changes, which for the most part, I've left for a future task. The only exception to that was one particularly hot piece of code in `runtime/nvqir/CircuitSimulator.h`, where I've wrapped it in a new `cudaq::details::should_log()` function.

Testing on Gorby with some UCCSD benchmarks from @marwafar reveals these changes **reduce runtime by 17-32%**, but as always, YMMV.