### PR TITLE
Python Error Diagnostics. Bug fix for incrementing range generation

### DIFF
--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -221,13 +221,6 @@ jobs:
               echo "::error file=test_in_devenv.yml::Python tests failed with status $pytest_status."
               exit 1
             fi
-            CUDAQ_PYTEST_EAGER_MODE=ON python3 -m pytest -v python/tests/ \
-              --ignore python/tests/backends
-            pytest_status=$?
-            if [ ! $pytest_status -eq 0 ]; then
-              echo "::error file=test_in_devenv.yml::Python tests failed with status $pytest_status in eager mode."
-              exit 1
-            fi
             for backendTest in python/tests/backends/*.py; do
               python3 -m pytest -v $backendTest
               pytest_status=$?

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -521,7 +521,7 @@ To get started with DGX Cloud, you can
 `request access here <https://www.nvidia.com/en-us/data-center/dgx-cloud/trial/>`__.
 Once you have access, `sign in <https://ngc.nvidia.com/signin>`__ to your account,
 and `generate an API key <https://ngc.nvidia.com/setup/api-key>`__. 
-`Install the NGC CLI <https://ngc.nvidia.com/setup/cli>`__
+`Install the NGC CLI <https://ngc.nvidia.com/setup/installers/cli>`__
 and configure it with 
 
 .. code-block:: console

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -521,7 +521,7 @@ To get started with DGX Cloud, you can
 `request access here <https://www.nvidia.com/en-us/data-center/dgx-cloud/trial/>`__.
 Once you have access, `sign in <https://ngc.nvidia.com/signin>`__ to your account,
 and `generate an API key <https://ngc.nvidia.com/setup/api-key>`__. 
-`Install the NGC CLI <https://ngc.nvidia.com/setup/installers/cli>`__
+`Install the NGC CLI <https://ngc.nvidia.com/setup/cli>`__
 and configure it with 
 
 .. code-block:: console

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -118,6 +118,7 @@ def is_jit_enabled():
 # Expose chemistry domain functions
 from .domains import chemistry
 from .kernels import uccsd
+from .dbg import ast
 
 if not "CUDAQ_DYNLIBS" in os.environ:
     try:
@@ -144,5 +145,7 @@ if '--emulate' in sys.argv:
     initKwargs['emulate'] = True
 if '--eager-mode' in sys.argv:
     PyKernelDecorator.globalJIT = False
+if not '--cudaq-full-stack-trace' in sys.argv:
+    sys.tracebacklimit = 0
 
 cudaq_runtime.initialize_cudaq(**initKwargs)

--- a/python/cudaq/dbg/__init__.py
+++ b/python/cudaq/dbg/__init__.py
@@ -6,4 +6,4 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-from .ast import print_i64
+from .ast import print_i64, print_f64

--- a/python/cudaq/dbg/__init__.py
+++ b/python/cudaq/dbg/__init__.py
@@ -1,0 +1,9 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+from .ast import print_i64

--- a/python/cudaq/dbg/ast.py
+++ b/python/cudaq/dbg/ast.py
@@ -1,0 +1,17 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+
+def print_i64(value: int) -> None:
+    raise RuntimeError(
+        'cudaq.dbg.ast.print_i64 can only be called from a CUDA Quantum kernel')
+
+
+def print_f64(value: float) -> None:
+    raise RuntimeError(
+        'cudaq.dbg.ast.print_f64 can only be called from a CUDA Quantum kernel')

--- a/python/cudaq/kernel/analysis.py
+++ b/python/cudaq/kernel/analysis.py
@@ -254,6 +254,9 @@ class FindDepKernelsVisitor(ast.NodeVisitor):
                         moduleNames.append(value.id)
                         break
 
+                if all(x in moduleNames for x in ['cudaq', 'dbg', 'ast']):
+                    return
+
                 if len(moduleNames):
                     moduleNames.reverse()
                     # This will throw if the function / module is invalid

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -154,8 +154,8 @@ class PyASTBridge(ast.NodeVisitor):
         msg = codeFile + ":" + str(
             lineNumber
         ) + ": " + Color.RED + "error: " + Color.END + Color.BOLD + msg + (
-            "\n\t (offending source -> " + ast.unparse(astNode) +
-            ")" if astNode is not None else '') + Color.END
+            "\n\t (offending source -> " + ast.unparse(astNode) + ")" if
+            hasattr(ast, 'unparse') and astNode is not None else '') + Color.END
         raise CompilerError(msg)
 
     def validateArgumentAnnotations(self, astModule):

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -338,7 +338,7 @@ class PyASTBridge(ast.NodeVisitor):
 
             currentST = SymbolTable(self.module.operation)
             argsTy += [self.getIntegerType()]
-            # If printf is not in the module, or if it is but the last argument type is not an integer
+            # If `printf` is not in the module, or if it is but the last argument type is not an integer
             # then we have to add it
             if not 'printf' in currentST or not IntegerType.isinstance(
                     currentST['printf'].type.inputs[-1]):
@@ -357,7 +357,7 @@ class PyASTBridge(ast.NodeVisitor):
 
             currentST = SymbolTable(self.module.operation)
             argsTy += [self.getFloatType()]
-            # If printf is not in the module, or if it is but the last argument type is not an float
+            # If `printf` is not in the module, or if it is but the last argument type is not an float
             # then we have to add it
             if not 'printf' in currentST or not F64Type.isinstance(
                     currentST['printf'].type.inputs[-1]):
@@ -873,7 +873,7 @@ class PyASTBridge(ast.NodeVisitor):
                     break
 
             if all(x in moduleNames for x in ['cudaq', 'dbg', 'ast']):
-                # Handle a dbg print statement
+                # Handle a debug print statement
                 [self.visit(arg) for arg in node.args]
                 if len(self.valueStack) != 1:
                     self.emitFatalError(
@@ -913,7 +913,7 @@ class PyASTBridge(ast.NodeVisitor):
             [self.visit(arg) for arg in node.args]
             if node.func.id == "len":
                 listVal = self.popValue()
-                # FIXME could this be an array, anyway we need emitFatalError here
+                # FIXME could this be an array, anyway we need `emitFatalError` here
                 assert cc.StdvecType.isinstance(listVal.type)
                 self.pushValue(
                     cc.StdvecSizeOp(self.getIntegerType(), listVal).result)
@@ -1046,7 +1046,7 @@ class PyASTBridge(ast.NodeVisitor):
                             "could not infer enumerate tuple type ({})".format(
                                 iterable.type), node)
                 else:
-                    # FIXME this should be an emitFatalError
+                    # FIXME this should be an `emitFatalError`
                     assert len(
                         self.valueStack
                     ) == 2, 'Error in AST processing, should have 2 values on the stack for enumerate {}'.format(

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -538,7 +538,7 @@ class PyASTBridge(ast.NodeVisitor):
             arguments = node.args.args
             if len(arguments):
                 self.emitFatalError(
-                    "inner function defintions cannot have arguments.", node)
+                    "inner function definitions cannot have arguments.", node)
 
             ty = cc.CallableType.get(self.ctx, [])
             createLambda = cc.CreateLambdaOp(ty)

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -323,6 +323,10 @@ class PyASTBridge(ast.NodeVisitor):
             type) or ComplexType.isinstance(type)
 
     def __insertDbgStmt(self, value, dbgStmt):
+        """
+        Insert a debug print out statement if the programmer requested. Handles 
+        statements like `cudaq.dbg.ast.print_i64(i)`.
+        """
         printFunc = None
         printStr = '[cudaq-ast-dbg] '
         argsTy = [cc.PointerType.get(self.ctx, self.getIntegerType(8))]
@@ -2583,6 +2587,7 @@ def compile_to_mlir(astModule, **kwargs):
                          returnTypeIsFromPython=True,
                          locationOffset=lineNumberOffset)
 
+    # First validate the arguments, make sure they are annotated
     bridge.validateArgumentAnnotations(astModule)
 
     # First we need to find any dependent kernels, they have to be

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -57,6 +57,9 @@ class PyKernelDecorator(object):
         self.verbose = verbose
         self.name = kernelName if kernelName != None else self.kernelFunction.__name__
         self.argTypes = None
+        self.location = (inspect.getfile(self.kernelFunction),
+                         inspect.getsourcelines(self.kernelFunction)[1]
+                        ) if self.kernelFunction is not None else ('', 0)
 
         # check if the user requested JIT be used exclusively
         if self.globalJIT:
@@ -132,7 +135,8 @@ class PyKernelDecorator(object):
             self.module, self.argTypes = compile_to_mlir(
                 self.astModule,
                 verbose=self.verbose,
-                returnType=self.returnType)
+                returnType=self.returnType,
+                location=self.location)
             if self.metadata['conditionalOnMeasure']:
                 SymbolTable(
                     self.module.operation)[nvqppPrefix +

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -343,11 +343,23 @@ def test_decrementing_range():
     def test(q: int, p: int):
         qubits = cudaq.qvector(5)
         for k in range(q, p, -1):
+            cudaq.dbg.ast.print_i64(k)
             x(qubits[k])
 
     counts = cudaq.sample(test, 2, 0)
     counts.dump()
     assert '01100' in counts and len(counts) == 1
+
+    @cudaq.kernel
+    def test2(myList:List[int]):
+        q = cudaq.qvector(len(myList))
+        for i in range(0, len(myList), 2):
+            cudaq.dbg.ast.print_i64(i)
+            x(q[i])
+    
+    counts = cudaq.sample(test2, [0,1,2,3])
+    assert len(counts) == 1
+    assert '1010' in counts 
 
 
 def test_no_dynamic_Lists():

--- a/python/tests/kernel/test_observe_kernel.py
+++ b/python/tests/kernel/test_observe_kernel.py
@@ -136,7 +136,7 @@ def test_broadcast():
     assert len(energies) == 50
 
     @cudaq.kernel
-    def kernel(thetas: list):
+    def kernel(thetas: list[float]):
         qubits = cudaq.qvector(3)
         x(qubits[0])
         ry(thetas[0], qubits[1])

--- a/python/tests/kernel/test_sample_kernel.py
+++ b/python/tests/kernel/test_sample_kernel.py
@@ -131,7 +131,7 @@ def test_broadcast():
         assert '0' * testNpArray[i] in c and '1' * testNpArray[i] in c
 
     @cudaq.kernel
-    def circuit(angles: list):
+    def circuit(angles: list[float]):
         q = cudaq.qvector(2)
         rx(angles[0], q[0])
         ry(angles[1], q[0])

--- a/python/tests/kernel/test_sample_kernel.py
+++ b/python/tests/kernel/test_sample_kernel.py
@@ -6,13 +6,18 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-import os
+import os, sys
 
 import pytest
 import numpy as np
-from typing import Callable
+from typing import Callable, List
 
 import cudaq
+
+## [PYTHON_VERSION_FIX]
+skipIfPythonLessThan39 = pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="built-in collection types such as `list` not supported")
 
 
 @pytest.fixture(autouse=True)
@@ -129,6 +134,29 @@ def test_broadcast():
     for i, c in enumerate(allCounts):
         print(c)
         assert '0' * testNpArray[i] in c and '1' * testNpArray[i] in c
+
+    @cudaq.kernel
+    def circuit(angles: List[float]):
+        q = cudaq.qvector(2)
+        rx(angles[0], q[0])
+        ry(angles[1], q[0])
+        x.ctrl(q[0], q[1])
+
+    runtimeAngles = np.array([[1.41075134, 1.16822118], [1.4269374, 1.61847813],
+                              [2.67020804,
+                               2.05479927], [2.09230621, 1.11112451],
+                              [1.57397959, 2.27463287], [1.38422446, 2.4457557],
+                              [2.44441489,
+                               2.51129809], [1.98279822, 2.38289909],
+                              [2.48570709, 2.27008174], [3.05499814,
+                                                         1.4933275]])
+    allCounts = cudaq.sample(circuit, runtimeAngles)
+    for i, c in enumerate(allCounts):
+        print(runtimeAngles[i, :], c)
+        assert len(c) == 2
+
+@skipIfPythonLessThan39
+def test_broadcastPy39Plus():
 
     @cudaq.kernel
     def circuit(angles: list[float]):


### PR DESCRIPTION
Fixed a bug in incrementing ranges like the following
```python
for i in range(0, 4, 2):
  ...
```

Setup error diagnostics for AST compilation to MLIR. 

New error diagnostics for invalid code. Just a few examples to get an idea for what it looks like
```python 
@cudaq.kernel()
def ex0():
    l = [] # can't create an empty list 
```
```bash
cudaq.kernel.ast_bridge.CompilerError: tmp.py:11: error: CUDA Quantum does not support allocating lists of zero size (no dynamic memory allocation)
         (offending source -> l = [])
```
```python
@cudaq.kernel
def test(i : int, f:float):
    cudaq.dbg.ast.print_i64(i)
    q = cudaq.qvector(2)
    ry(f, q[f]) # qubit extraction with a float instead of int
```
```bash
cudaq.kernel.ast_bridge.CompilerError: tmp.py:11: error: invalid index variable type used for qvector extraction (f64)
         (offending source -> q[f])
```