### PR TITLE
Update NGC CLI URL in Install Guide

### DIFF
--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -528,7 +528,7 @@ To get started with DGX Cloud, you can
 `request access here <https://www.nvidia.com/en-us/data-center/dgx-cloud/trial/>`__.
 Once you have access, `sign in <https://ngc.nvidia.com/signin>`__ to your account,
 and `generate an API key <https://ngc.nvidia.com/setup/api-key>`__. 
-`Install the NGC CLI <https://ngc.nvidia.com/setup/installers/cli>`__
+`Install the NGC CLI <https://ngc.nvidia.com/setup/cli>`__
 and configure it with 
 
 .. code-block:: console


### PR DESCRIPTION
The NGC CLI URL has changed. The team will make a redirect for the old URL, but we should probably use the new URL going forward.