### PR TITLE
Move AST-to-MLIR compilation to the call operator.

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -77,6 +77,8 @@ testing = cudaq_runtime.testing
 
 
 def synthesize(kernel, *args):
+    # Compile if necessary, no-op if already compiled
+    kernel.compile()
     return PyKernelDecorator(None,
                              module=cudaq_runtime.synthesize(kernel, *args),
                              kernelName=kernel.name)

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2626,7 +2626,7 @@ class PyASTBridge(ast.NodeVisitor):
             node)
 
 
-def compile_to_mlir(astModule, **kwargs):
+def compile_to_mlir(astModule, metadata, **kwargs):
     """
     Compile the given Python AST Module for the CUDA Quantum 
     kernel FunctionDef to an MLIR `ModuleOp`. 
@@ -2713,4 +2713,12 @@ def compile_to_mlir(astModule, **kwargs):
 
     globalAstRegistry[bridge.name] = astModule
 
+    if metadata['conditionalOnMeasure']:
+        SymbolTable(
+            bridge.module.operation)[nvqppPrefix +
+                                    bridge.name].attributes.__setitem__(
+                                        'qubitMeasurementFeedback',
+                                        BoolAttr.get(
+                                            True,
+                                            context=bridge.ctx))
     return bridge.module, bridge.argTypes

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2716,9 +2716,7 @@ def compile_to_mlir(astModule, metadata, **kwargs):
     if metadata['conditionalOnMeasure']:
         SymbolTable(
             bridge.module.operation)[nvqppPrefix +
-                                    bridge.name].attributes.__setitem__(
-                                        'qubitMeasurementFeedback',
-                                        BoolAttr.get(
-                                            True,
-                                            context=bridge.ctx))
+                                     bridge.name].attributes.__setitem__(
+                                         'qubitMeasurementFeedback',
+                                         BoolAttr.get(True, context=bridge.ctx))
     return bridge.module, bridge.argTypes

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -10,6 +10,7 @@ from functools import partialmethod
 import random
 import string
 from .quake_value import QuakeValue
+from .kernel_decorator import PyKernelDecorator
 from .utils import mlirTypeFromPyType, nvqppPrefix
 from .common.givens import givens_builder
 from .common.fermionic_swap import fermionic_swap_builder
@@ -877,6 +878,8 @@ class PyKernel(object):
             kernel.mz(qubit))
         ```
         """
+        if isinstance(target, PyKernelDecorator):
+            target.compile()
         self.__applyControlOrAdjoint(target, False, [], *target_arguments)
 
     def c_if(self, measurement, function):

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -107,7 +107,6 @@ class PyKernelDecorator(object):
         # Store the AST for this kernel, it is needed for
         # building up call graphs
         globalAstRegistry[self.name] = self.astModule
-        
 
     def compile(self):
         """
@@ -135,16 +134,6 @@ class PyKernelDecorator(object):
         Invoke the CUDA Quantum kernel. JIT compilation of the 
         kernel AST to MLIR will occur here if it has not already occurred. 
         """
-
-        if self.kernelFunction is None:
-            if self.module is None:
-                raise RuntimeError(
-                    "this kernel is not callable (no function or MLIR Module found)"
-                )
-            if self.argTypes is None:
-                raise RuntimeError(
-                    "this kernel is not callable (no function and no MLIR argument types found)"
-                )
 
         if self.module == None:
             self.compile()

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -104,7 +104,7 @@ class PyKernelDecorator(object):
         analyzer.visit(self.astModule)
         self.metadata = {'conditionalOnMeasure': analyzer.hasMidCircuitMeasures}
 
-        # Store the AST for this kernel, it is needed for 
+        # Store the AST for this kernel, it is needed for
         # building up call graphs
         globalAstRegistry[self.name] = self.astModule
         
@@ -115,14 +115,14 @@ class PyKernelDecorator(object):
         if the kernel is already compiled. 
         """
         if self.module != None:
-            return 
-        
-        self.module, self.argTypes = compile_to_mlir(
-                self.astModule, self.metadata,
-                verbose=self.verbose,
-                returnType=self.returnType,
-                location=self.location)
-        
+            return
+
+        self.module, self.argTypes = compile_to_mlir(self.astModule,
+                                                     self.metadata,
+                                                     verbose=self.verbose,
+                                                     returnType=self.returnType,
+                                                     location=self.location)
+
     def __str__(self):
         """
         Return the MLIR Module string representation for this kernel.
@@ -148,7 +148,7 @@ class PyKernelDecorator(object):
 
         if self.module == None:
             self.compile()
-            
+
         if len(args) != len(self.argTypes):
             raise RuntimeError(
                 "Incorrect number of runtime arguments provided to kernel {} ({} required, {} provided)"

--- a/python/runtime/cudaq/algorithms/py_observe_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe_async.cpp
@@ -30,6 +30,8 @@ enum class PyParType { thread, mpi };
 /// CUDA Quantum specification adherence. Check that the kernel
 /// returns void and does not contain measurements.
 std::tuple<bool, std::string> isValidObserveKernel(py::object &kernel) {
+  if (py::hasattr(kernel, "compile"))
+    kernel.attr("compile")();
   auto kernelName = kernel.attr("name").cast<std::string>();
   auto kernelMod = kernel.attr("module").cast<MlirModule>();
 

--- a/python/runtime/cudaq/algorithms/py_observe_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe_async.cpp
@@ -70,6 +70,9 @@ void pyAltLaunchKernel(const std::string &, MlirModule, OpaqueArguments &,
 async_observe_result pyObserveAsync(py::object &kernel, spin_op &spin_operator,
                                     py::args &args, std::size_t qpu_id,
                                     int shots) {
+  if (py::hasattr(kernel, "compile"))
+    kernel.attr("compile")();
+
   auto kernelBlockArgs = kernel.attr("arguments");
   if (py::len(kernelBlockArgs) != args.size())
     throw std::runtime_error(
@@ -100,6 +103,9 @@ observe_result pyObservePar(const PyParType &type, py::object &kernel,
                             spin_op &spin_operator, py::args args = {},
                             int shots = defaultShotsValue,
                             std::optional<noise_model> noise = std::nullopt) {
+  if (py::hasattr(kernel, "compile"))
+    kernel.attr("compile")();
+
   // Ensure the user input is correct.
   // auto validatedArgs = validateInputArguments(kernel, args);
   auto &platform = cudaq::get_platform();

--- a/python/runtime/cudaq/algorithms/py_sample_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample_async.cpp
@@ -50,6 +50,8 @@ for more information on this programming pattern.)#")
           std::size_t qpu_id) {
         auto &platform = cudaq::get_platform();
         auto kernelName = kernel.attr("name").cast<std::string>();
+        if (py::hasattr(kernel, "compile"))
+          kernel.attr("compile")();
 
         auto *argData = new cudaq::OpaqueArguments();
         cudaq::packArgs(*argData, args);

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -37,6 +37,9 @@ void extractStateData(py::buffer_info &info, complex *data) {
 
 /// @brief Run `cudaq::get_state` on the provided kernel and spin operator.
 state pyGetState(py::object kernel, py::args args) {
+  if (py::hasattr(kernel, "compile"))
+    kernel.attr("compile")();
+
   auto kernelName = kernel.attr("name").cast<std::string>();
   args = simplifiedValidateInputArguments(args);
 
@@ -220,6 +223,8 @@ for more information on this programming pattern.)#")
   mod.def(
       "get_state_async",
       [](py::object kernel, py::args args, std::size_t qpu_id) {
+        if (py::hasattr(kernel, "compile"))
+          kernel.attr("compile")();
         auto &platform = cudaq::get_platform();
         auto kernelName = kernel.attr("name").cast<std::string>();
         args = simplifiedValidateInputArguments(args);

--- a/python/runtime/cudaq/algorithms/py_vqe.cpp
+++ b/python/runtime/cudaq/algorithms/py_vqe.cpp
@@ -62,6 +62,8 @@ observe_result pyObserve(py::object &kernel, spin_op &spin_operator,
   auto kernelName = kernel.attr("name").cast<std::string>();
   auto &platform = cudaq::get_platform();
   auto *argData = toOpaqueArgs(args);
+  if (py::hasattr(kernel, "compile"))
+    kernel.attr("compile")();
 
   auto kernelMod = kernel.attr("module").cast<MlirModule>();
   auto numKernelArgs = getNumArguments(kernelMod, kernelName);

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -342,6 +342,8 @@ void bindAltLaunchKernel(py::module &mod) {
   mod.def(
       "get_qir",
       [](py::object kernel, py::args runtimeArgs, std::string profile) {
+        if (py::hasattr(kernel, "compile"))
+          kernel.attr("compile")();
         MlirModule module = kernel.attr("module").cast<MlirModule>();
         auto name = kernel.attr("name").cast<std::string>();
         cudaq::OpaqueArguments args;

--- a/python/tests/kernel/test_ir_operations.py
+++ b/python/tests/kernel/test_ir_operations.py
@@ -27,6 +27,7 @@ def do_something():
 
 
 def test_synthesize():
+
     @cudaq.kernel
     def ghz(numQubits: int):
         qubits = cudaq.qvector(numQubits)

--- a/python/tests/kernel/test_ir_operations.py
+++ b/python/tests/kernel/test_ir_operations.py
@@ -27,7 +27,6 @@ def do_something():
 
 
 def test_synthesize():
-
     @cudaq.kernel
     def ghz(numQubits: int):
         qubits = cudaq.qvector(numQubits)

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -364,6 +364,7 @@ def test_no_dynamic_Lists():
         @cudaq.kernel
         def kernel(params: List[float]):
             params.append(1.0)
+
         kernel([])
 
     with pytest.raises(RuntimeError) as error:
@@ -392,6 +393,7 @@ def test_no_dynamic_lists():
         @cudaq.kernel
         def kernel(params: list[float]):
             params.append(1.0)
+
         print(kernel)
 
 

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -364,6 +364,7 @@ def test_no_dynamic_Lists():
         @cudaq.kernel
         def kernel(params: List[float]):
             params.append(1.0)
+        kernel([])
 
     with pytest.raises(RuntimeError) as error:
 
@@ -391,6 +392,7 @@ def test_no_dynamic_lists():
         @cudaq.kernel
         def kernel(params: list[float]):
             params.append(1.0)
+        print(kernel)
 
 
 def test_simple_return_types():


### PR DESCRIPTION
We really need to change when / where the actual AST-to-MLIR JIT happens. As of right now all library kernels are JIT compiled when they are imported - and this occurs even if they are not necessarily needed. For example, the UCCSD compilation time takes ~.9 seconds on my machine, and this occurs every time `import cudaq` is called. It would be better if the kernels JIT compiled when they were called. 

This PR updates the `PyKernelDecorator` class to do AST-to-MLIR JIT when the kernel is invoked. 