### PR TITLE
Optimize LLVM JIT for large circuits: apply #1261 to experimental/python

### DIFF
--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -66,6 +66,16 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
       throw std::runtime_error(
           "cudaq::builder failed to JIT compile the Quake representation.");
 
+    // The "fast" instruction selection compilation algorithm is actually very
+    // slow for large quantum circuits. Disable that here. Revisit this
+    // decision by testing large UCCSD circuits if jitCodeGenOptLevel is changed
+    // in the future. Also note that llvm::TargetMachine::setFastIsel() and
+    // setO0WantsFastISel() do not retain their values in our current version of
+    // LLVM. This use of LLVM command line parameters could be changed if the
+    // LLVM JIT ever supports the TargetMachine options in the future.
+    const char *argv[] = {"", "-fast-isel=0", nullptr};
+    llvm::cl::ParseCommandLineOptions(2, argv);
+
     ExecutionEngineOptions opts;
     opts.enableGDBNotificationListener = false;
     opts.enablePerfNotificationListener = false;


### PR DESCRIPTION
The experimental/python branch has an additional JIT point. Apply the same optimization from #1261 to that spot.