### PR TITLE
NVCF REST server to operate in per-request process context

### DIFF
--- a/docker/release/cudaq.nvqc.Dockerfile
+++ b/docker/release/cudaq.nvqc.Dockerfile
@@ -22,7 +22,7 @@ ENV CUDAQ_LOG_LEVEL=info
 # IMPORTANT: NVCF function must set container environment variable `NUM_GPUS` equal to the number of GPUs on the target platform.
 # This will allow clients to query the function capability (number of GPUs) by looking at function info.
 # The below entry point script helps prevent mis-configuration by checking that functions are created and deployed appropriately.
-RUN echo 'if [[ "$NUM_GPUS" == "$(nvidia-smi --list-gpus | wc -l)" ]]; then mpiexec -np $(nvidia-smi --list-gpus | wc -l) cudaq-qpud --type nvcf; else echo "Invalid Deployment: Number of GPUs does not match the hardware" && exit 1; fi' > launch.sh
+RUN echo 'if [[ "$NUM_GPUS" == "$(nvidia-smi --list-gpus | wc -l)" ]]; then while true; do mpiexec -np $(nvidia-smi --list-gpus | wc -l) cudaq-qpud --type nvcf; done; else echo "Invalid Deployment: Number of GPUs does not match the hardware" && exit 1; fi' > launch.sh
 
 # Start the cudaq-qpud service
 ENTRYPOINT ["bash", "-l", "launch.sh"]

--- a/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteServer.cpp
+++ b/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteServer.cpp
@@ -382,15 +382,9 @@ private:
           auto funcOp = dyn_cast<LLVM::LLVMFuncOp>(op);
           if (!funcOp)
             continue;
-          if (!funcOp.getName().startswith(
-                  cudaq::runtime::cudaqGenPrefixName)) {
-            // Looks like this is not something from the nvq++ frontend.
-            cudaq::info("Unexpected MLIR function name encountered: '{}'.",
-                        funcOp.getName().str());
-            continue;
+          if (funcOp.getName().startswith(cudaq::runtime::cudaqGenPrefixName)) {
+            allFuncs.emplace_back(funcOp.getName());
           }
-
-          allFuncs.emplace_back(funcOp.getName());
         }
         return allFuncs;
       }();


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- NVCF server subclass to initiate an exit (internal event loop) after serving each job request.

- Launch script (entry point) to loop the daemon service as it exits.

- Also, fixed some innocuous logs when doing IR validation.
