### PR TITLE
Implement improved error diagnostics for kernel_decorator and kernel_builder

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -12,7 +12,7 @@ from typing import Callable
 from collections import deque
 import numpy as np
 from .analysis import FindDepKernelsVisitor
-from .utils import globalAstRegistry, globalKernelRegistry, nvqppPrefix, mlirTypeFromAnnotation, mlirTypeFromPyType
+from .utils import globalAstRegistry, globalKernelRegistry, nvqppPrefix, mlirTypeFromAnnotation, mlirTypeFromPyType, Color
 from ..mlir.ir import *
 from ..mlir.passmanager import *
 from ..mlir.dialects import quake, cc
@@ -68,12 +68,6 @@ class CompilerError(RuntimeError):
 
     def __init__(self, *args, **kwargs):
         RuntimeError.__init__(self, *args, **kwargs)
-
-
-class Color:
-    RED = '\033[91m'
-    BOLD = '\033[1m'
-    END = '\033[0m'
 
 
 class PyASTBridge(ast.NodeVisitor):

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -45,6 +45,10 @@ class PyKernelDecorator(object):
                          inspect.getsourcelines(self.kernelFunction)[1]
                         ) if self.kernelFunction is not None else ('', 0)
 
+        # Get any global variables from parent scope.
+        self.globalScopedVars = dict(inspect.getmembers(
+            inspect.stack()[2][0]))['f_locals']
+
         if self.kernelFunction is None:
             if self.module is not None:
                 # Could be that we don't have a function
@@ -116,11 +120,13 @@ class PyKernelDecorator(object):
         if self.module != None:
             return
 
-        self.module, self.argTypes = compile_to_mlir(self.astModule,
-                                                     self.metadata,
-                                                     verbose=self.verbose,
-                                                     returnType=self.returnType,
-                                                     location=self.location)
+        self.module, self.argTypes = compile_to_mlir(
+            self.astModule,
+            self.metadata,
+            verbose=self.verbose,
+            returnType=self.returnType,
+            location=self.location,
+            parentVariables=self.globalScopedVars)
 
     def __str__(self):
         """

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -45,7 +45,7 @@ def emitFatalError(msg):
     print(Color.BOLD, end='')
     try:
         # Raise the exception so we can get the
-        # stack trace to instpec
+        # stack trace to inspect
         raise RuntimeError(msg)
     except RuntimeError as e:
         # Immediately grab the exception and

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -556,3 +556,13 @@ def test_sample_async_issue_args_processed():
     result = cudaq.sample_async(kernel, params, qpu_id=0)
     counts = result.get()
     assert len(counts) == 2 and '01' in counts and '10' in counts
+
+def test_capture_vars_disallowed():
+
+    n = 5 
+    @cudaq.kernel
+    def test():
+        q = cudaq.qvector(n)
+    
+    with pytest.raises(RuntimeError) as e:
+        test()


### PR DESCRIPTION
Also disallow capture variables 
```python 
n = 5 
@cudaq.kernel
def test():
    q = cudaq.qvector(n)
test()
```
```bash
cudaq.kernel.ast_bridge.CompilerError: z.py:9: error: Invalid variable requested - `n` was defined in the kernel's parent scope. CUDA Quantum does not support capturing variables from parent scope (variables must be defined as input arguments or within the kernel function body).
         (offending source -> n)
```