### PR TITLE
Add reverse proxy for NVQC

### DIFF
--- a/docker/release/cudaq.nvqc.Dockerfile
+++ b/docker/release/cudaq.nvqc.Dockerfile
@@ -18,11 +18,13 @@ FROM $base_image as nvcf_image
 
 ENV CUDAQ_LOG_LEVEL=info
 
+ADD scripts/nvqc_proxy.py /
+
 # Launch script: launch cudaq-qpud (nvcf mode) with MPI ranks == Number of NVIDIA GPUs
 # IMPORTANT: NVCF function must set container environment variable `NUM_GPUS` equal to the number of GPUs on the target platform.
 # This will allow clients to query the function capability (number of GPUs) by looking at function info.
 # The below entry point script helps prevent mis-configuration by checking that functions are created and deployed appropriately.
-RUN echo 'if [[ "$NUM_GPUS" == "$(nvidia-smi --list-gpus | wc -l)" ]]; then while true; do mpiexec -np $(nvidia-smi --list-gpus | wc -l) cudaq-qpud --type nvcf; done; else echo "Invalid Deployment: Number of GPUs does not match the hardware" && exit 1; fi' > launch.sh
+RUN echo 'python3 /nvqc_proxy.py & if [[ "$NUM_GPUS" == "$(nvidia-smi --list-gpus | wc -l)" ]]; then while true; do mpiexec -np $(nvidia-smi --list-gpus | wc -l) cudaq-qpud --type nvcf --port 3031; done; else echo "Invalid Deployment: Number of GPUs does not match the hardware" && exit 1; fi' > launch.sh
 
 # Start the cudaq-qpud service
 ENTRYPOINT ["bash", "-l", "launch.sh"]

--- a/docker/release/cudaq.nvqc.Dockerfile
+++ b/docker/release/cudaq.nvqc.Dockerfile
@@ -21,10 +21,17 @@ ENV CUDAQ_LOG_LEVEL=info
 ADD scripts/nvqc_proxy.py /
 
 # Launch script: launch cudaq-qpud (nvcf mode) with MPI ranks == Number of NVIDIA GPUs
-# IMPORTANT: NVCF function must set container environment variable `NUM_GPUS` equal to the number of GPUs on the target platform.
-# This will allow clients to query the function capability (number of GPUs) by looking at function info.
-# The below entry point script helps prevent mis-configuration by checking that functions are created and deployed appropriately.
-RUN echo 'python3 /nvqc_proxy.py & if [[ "$NUM_GPUS" == "$(nvidia-smi --list-gpus | wc -l)" ]]; then while true; do mpiexec -np $(nvidia-smi --list-gpus | wc -l) cudaq-qpud --type nvcf --port 3031; done; else echo "Invalid Deployment: Number of GPUs does not match the hardware" && exit 1; fi' > launch.sh
+# IMPORTANT: NVCF function must set container environment variable `NUM_GPUS`
+# equal to the number of GPUs on the target platform. This will allow clients to query
+# the function capability (number of GPUs) by looking at function info. The below
+# entry point script helps prevent mis-configuration by checking that functions are
+# created and deployed appropriately.
+RUN echo 'cat /opt/nvidia/cudaq/build_info.txt; python3 /nvqc_proxy.py & ' \
+    'if [[ "$NUM_GPUS" == "$(nvidia-smi --list-gpus | wc -l)" ]]; then ' \
+      'while true; do ' \
+        'mpiexec -np $(nvidia-smi --list-gpus | wc -l) cudaq-qpud --type nvcf --port 3031;' \
+      'done; ' \
+     'else echo "Invalid Deployment: Number of GPUs does not match the hardware" && exit 1; fi' > launch.sh
 
 # Start the cudaq-qpud service
 ENTRYPOINT ["bash", "-l", "launch.sh"]

--- a/scripts/nvqc_proxy.py
+++ b/scripts/nvqc_proxy.py
@@ -13,7 +13,7 @@ import time
 
 # This reverse proxy application is needed to span the small gaps when
 # `cudaq-qpud` is shutting down and starting up again. This small reverse proxy
-# allows the NVCF port (3030) to remain up while allowing the main cudaq-qpud
+# allows the NVCF port (3030) to remain up while allowing the main `cudaq-qpud`
 # application to restart if necessary.
 
 # Queue for storing requests
@@ -22,7 +22,7 @@ request_queue = queue.Queue()
 # NVCF max payload is ~250KB. Round up to 1MB.
 MAX_SIZE_BYTES = 1000000
 NVCF_PORT = 3030
-CUDAQ_QPUD_PORT = 3031  # see cudaq.nvqc.Dockerfile
+CUDAQ_QPUD_PORT = 3031  # see `docker/build/cudaq.nvqc.Dockerfile`
 
 
 # Handle incoming client connections and queue their requests
@@ -31,14 +31,13 @@ def handle_client(client_socket):
     request_queue.put((client_socket, request))
 
 
-# Forward requests from the queue to cudaq-qpud
+# Forward requests from the queue to `cudaq-qpud`
 def forward_requests_to_application():
     retry_count = 0
     while True:
         if not request_queue.empty():
             client_socket, request = request_queue.get(block=True, timeout=None)
             try:
-                # Assuming your application listens on localhost
                 with socket.create_connection(
                     ("localhost", CUDAQ_QPUD_PORT)) as app_socket:
                     app_socket.sendall(request)
@@ -69,7 +68,6 @@ def start_proxy_server():
 
         while True:
             client_socket, addr = server_socket.accept()
-            #print(f"Accepted connection from {addr}")
             Thread(target=handle_client, args=(client_socket,)).start()
 
 

--- a/scripts/nvqc_proxy.py
+++ b/scripts/nvqc_proxy.py
@@ -1,0 +1,77 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import socket
+from threading import Thread
+import queue
+import time
+
+# This reverse proxy application is needed to span the small gaps when
+# `cudaq-qpud` is shutting down and starting up again. This small reverse proxy
+# allows the NVCF port (3030) to remain up while allowing the main cudaq-qpud
+# application to restart if necessary.
+
+# Queue for storing requests
+request_queue = queue.Queue()
+
+# NVCF max payload is ~250KB. Round up to 1MB.
+MAX_SIZE_BYTES = 1000000
+NVCF_PORT = 3030
+CUDAQ_QPUD_PORT = 3031  # see cudaq.nvqc.Dockerfile
+
+
+# Handle incoming client connections and queue their requests
+def handle_client(client_socket):
+    request = client_socket.recv(MAX_SIZE_BYTES)
+    request_queue.put((client_socket, request))
+
+
+# Forward requests from the queue to cudaq-qpud
+def forward_requests_to_application():
+    retry_count = 0
+    while True:
+        if not request_queue.empty():
+            client_socket, request = request_queue.get(block=True, timeout=None)
+            try:
+                # Assuming your application listens on localhost
+                with socket.create_connection(
+                    ("localhost", CUDAQ_QPUD_PORT)) as app_socket:
+                    app_socket.sendall(request)
+                    response = app_socket.recv(MAX_SIZE_BYTES)
+                    client_socket.sendall(response)
+                    client_socket.close()
+                    retry_count = 0
+            except ConnectionRefusedError:
+                print(
+                    "Main application is down, retrying (retry_count = {})...".
+                    format(retry_count))
+                retry_count += 1
+                request_queue.put(
+                    (client_socket,
+                     request))  # Put back the request in the queue
+        time.sleep(0.1)  # Throttle the retries
+
+
+# Listen for incoming connections
+def start_proxy_server():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
+        server_socket.bind(("0.0.0.0", NVCF_PORT))
+        server_socket.listen(5)  # max backlog
+        print("Proxy server listening on port {}...".format(NVCF_PORT))
+
+        # Start a thread to forward requests from the queue to the application
+        Thread(target=forward_requests_to_application, daemon=True).start()
+
+        while True:
+            client_socket, addr = server_socket.accept()
+            #print(f"Accepted connection from {addr}")
+            Thread(target=handle_client, args=(client_socket,)).start()
+
+
+if __name__ == "__main__":
+    start_proxy_server()


### PR DESCRIPTION
Make a reverse proxy for NVCF that is always up, so that `cudaq-qpud` cycles do not affect NVCF communications.