### PR TITLE
[rt] Refactor

### DIFF
--- a/python/runtime/cudaq/target/py_testing_utils.cpp
+++ b/python/runtime/cudaq/target/py_testing_utils.cpp
@@ -48,13 +48,13 @@ void bindTestUtils(py::module &mod, LinkedLibraryHolder &holder) {
         auto simName = holder.getTarget().simulatorName;
         holder.getSimulator(simName)->setExecutionContext(context);
         return std::make_tuple(
-            holder.getSimulator(simName)->allocateQubits(numQubits), context);
+            holder.getSimulator(simName)->allocateQudits(numQubits), context);
       });
 
   testingSubmodule.def("finalize", [&](const std::vector<std::size_t> &qubits,
                                        cudaq::ExecutionContext *context) {
     auto simName = holder.getTarget().simulatorName;
-    holder.getSimulator(simName)->deallocateQubits(qubits);
+    holder.getSimulator(simName)->deallocateQudits(qubits);
     holder.getSimulator(simName)->resetExecutionContext();
     nvqir::toggleDynamicQubitManagement();
     // Pybind will delete the context bc its been wrapped in a unique_ptr

--- a/runtime/common/Resources.cpp
+++ b/runtime/common/Resources.cpp
@@ -17,20 +17,9 @@ namespace cudaq {
 
 Resources Resources::compute(const Trace &trace) {
   Resources resources;
-
-  auto convertToID = [](std::vector<QuditInfo> qudits) {
-    std::vector<std::size_t> ids;
-    ids.reserve(qudits.size());
-    std::transform(qudits.cbegin(), qudits.cend(), std::back_inserter(ids),
-                   [](auto &q) { return q.id; });
-    return ids;
-  };
-  for (const auto &inst : trace) {
-    auto controlIDs = convertToID(inst.controls);
-    auto targetIDs = convertToID(inst.targets);
+  for (const auto &inst : trace)
     resources.appendInstruction(
-        Instruction(inst.name, controlIDs, targetIDs[0]));
-  }
+        Instruction(inst.name, inst.controls, inst.targets[0]));
   return resources;
 }
 

--- a/runtime/common/Trace.cpp
+++ b/runtime/common/Trace.cpp
@@ -12,20 +12,31 @@
 
 namespace cudaq {
 
-void Trace::appendInstruction(std::string_view name, std::vector<double> params,
-                              std::vector<QuditInfo> controls,
-                              std::vector<QuditInfo> targets) {
+void Trace::appendInstruction(std::string_view name,
+                              const std::vector<double> &params,
+                              const std::vector<std::size_t> &controls,
+                              const std::vector<std::size_t> &targets) {
   assert(!targets.empty() && "A instruction must have at least one target");
-  auto findMaxID = [](const std::vector<QuditInfo> &qudits) -> std::size_t {
-    return std::max_element(qudits.cbegin(), qudits.cend(),
-                            [](auto &a, auto &b) { return a.id < b.id; })
-        ->id;
+  auto findMaxID = [](const std::vector<std::size_t> &qudits) -> std::size_t {
+    return *std::max_element(qudits.cbegin(), qudits.cend());
   };
   std::size_t maxID = findMaxID(targets);
   if (!controls.empty())
     maxID = std::max(maxID, findMaxID(controls));
   numQudits = std::max(numQudits, maxID + 1);
   instructions.emplace_back(name, params, controls, targets);
+}
+
+void Trace::appendInstruction(std::string_view name,
+                              const std::vector<float> &params,
+                              const std::vector<std::size_t> &controls,
+                              const std::vector<std::size_t> &targets) {
+  std::vector<double> converted_params;
+  converted_params.reserve(params.size());
+  std::transform(params.begin(), params.end(),
+                 std::back_inserter(converted_params),
+                 [](float p) { return static_cast<double>(p); });
+  appendInstruction(name, converted_params, controls, targets);
 }
 
 } // namespace cudaq

--- a/runtime/common/Trace.h
+++ b/runtime/common/Trace.h
@@ -24,17 +24,24 @@ public:
   struct Instruction {
     std::string name;
     std::vector<double> params;
-    std::vector<QuditInfo> controls;
-    std::vector<QuditInfo> targets;
+    std::vector<std::size_t> controls;
+    std::vector<std::size_t> targets;
 
-    Instruction(std::string_view name, std::vector<double> params,
-                std::vector<QuditInfo> controls, std::vector<QuditInfo> targets)
+    Instruction(std::string_view name, const std::vector<double> &params,
+                const std::vector<std::size_t> &controls,
+                const std::vector<std::size_t> &targets)
         : name(name), params(params), controls(controls), targets(targets) {}
   };
 
-  void appendInstruction(std::string_view name, std::vector<double> params,
-                         std::vector<QuditInfo> controls,
-                         std::vector<QuditInfo> targets);
+  void appendInstruction(std::string_view name,
+                         const std::vector<double> &params,
+                         const std::vector<std::size_t> &controls,
+                         const std::vector<std::size_t> &targets);
+
+  void appendInstruction(std::string_view name,
+                         const std::vector<float> &params,
+                         const std::vector<std::size_t> &controls,
+                         const std::vector<std::size_t> &targets);
 
   auto getNumQudits() const { return numQudits; }
 

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "common/QuditIdTracker.h"
 #include "cudaq/spin_op.h"
 #include <deque>
 #include <string_view>
@@ -76,22 +75,6 @@ using measure_result = bool;
 /// quantum instructions.
 class ExecutionManager {
 protected:
-  /// Available qudit indices
-  std::deque<std::size_t> availableIndices;
-
-  /// Total qudits available
-  std::size_t totalQudits;
-
-  /// Utility type tracking qudit unique identifiers as they are allocated and
-  /// deallocated.
-  QuditIdTracker tracker;
-
-  /// Internal - return the next qudit index
-  std::size_t getNextIndex() { return tracker.getNextIndex(); }
-
-  /// Internal - At qudit deallocation, return the qudit index
-  void returnIndex(std::size_t idx) { tracker.returnIndex(idx); }
-
 public:
   ExecutionManager() = default;
 
@@ -100,9 +83,6 @@ public:
 
   /// Deallocates a qudit.
   virtual void deallocateQudit(const QuditInfo &q) = 0;
-
-  /// Checker for qudits that were not deallocated
-  bool memoryLeaked() { return !tracker.allDeallocated(); }
 
   /// Provide an ExecutionContext for the current cudaq kernel
   virtual void setExecutionContext(cudaq::ExecutionContext *ctx) = 0;

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -94,9 +94,8 @@ public:
   /// qudits. Supports input of control qudits and rotational parameters. Can
   /// also optionally take a spin_op as input to affect a general Pauli
   /// rotation.
-  virtual void apply(const std::string_view gateName,
-                     const std::vector<double> &params,
-                     const std::vector<QuditInfo> &controls,
+  virtual void apply(std::string gateName, std::vector<double> params,
+                     std::vector<QuditInfo> controls,
                      const std::vector<QuditInfo> &targets,
                      bool isAdjoint = false, const spin_op op = spin_op()) = 0;
 
@@ -123,12 +122,6 @@ public:
   /// Measure the current state in the given Pauli basis, return the expectation
   /// value <term>.
   virtual SpinMeasureResult measure(cudaq::spin_op &op) = 0;
-
-  /// Synchronize - run all queue-ed instructions
-  virtual void synchronize() = 0;
-
-  /// Flush the gate queue (needed for accurate timing information)
-  virtual void flushGateQueue(){};
 
   virtual ~ExecutionManager() = default;
 };

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -95,8 +95,8 @@ protected:
 public:
   ExecutionManager() = default;
 
-  /// Return the next available qudit index
-  virtual std::size_t getAvailableIndex(std::size_t quditLevels = 2) = 0;
+  /// Allocates a qudit and returns its unique identifier.
+  virtual std::size_t allocateQudit(std::size_t quditLevels = 2) = 0;
 
   /// QuditInfo has been deallocated, return the qudit / id to the pool of
   /// qudits.

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -9,8 +9,6 @@
 #pragma once
 
 #include "cudaq/spin_op.h"
-#include <deque>
-#include <string_view>
 #include <vector>
 
 namespace cudaq {
@@ -121,7 +119,7 @@ public:
 
   /// Measure the current state in the given Pauli basis, return the expectation
   /// value <term>.
-  virtual SpinMeasureResult measure(cudaq::spin_op &op) = 0;
+  virtual SpinMeasureResult measure(const cudaq::spin_op &op) = 0;
 
   virtual ~ExecutionManager() = default;
 };

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -98,9 +98,8 @@ public:
   /// Allocates a qudit and returns its unique identifier.
   virtual std::size_t allocateQudit(std::size_t quditLevels = 2) = 0;
 
-  /// QuditInfo has been deallocated, return the qudit / id to the pool of
-  /// qudits.
-  virtual void returnQudit(const QuditInfo &q) = 0;
+  /// Deallocates a qudit.
+  virtual void deallocateQudit(const QuditInfo &q) = 0;
 
   /// Checker for qudits that were not deallocated
   bool memoryLeaked() { return !tracker.allDeallocated(); }

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -67,7 +67,7 @@ protected:
   virtual void allocateQudits(const std::vector<QuditInfo> &qudits) = 0;
 
   /// @brief Subtype specific qudit deallocation method
-  virtual void deallocateQudit(const QuditInfo &q) = 0;
+  virtual void doDeallocateQudit(const QuditInfo &q) = 0;
 
   /// @brief Subtype specific qudit deallocation, deallocate
   /// all qudits in the vector.
@@ -131,7 +131,7 @@ public:
     return new_id;
   }
 
-  void returnQudit(const QuditInfo &qid) override {
+  void deallocateQudit(const QuditInfo &qid) override {
     if (!executionContext) {
       deallocateQudit(qid);
       returnIndex(qid.id);

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -64,9 +64,6 @@ protected:
   virtual int measureQudit(const cudaq::QuditInfo &q,
                            const std::string &registerName) = 0;
 
-  /// @brief Measure the state in the basis described by the given `spin_op`.
-  virtual void measureSpinOp(const cudaq::spin_op &op) = 0;
-
   /// @brief Subtype-specific method for performing qudit reset.
   virtual void resetQudit(const QuditInfo &q) = 0;
 
@@ -165,12 +162,6 @@ public:
 
   int measure(const cudaq::QuditInfo &target) override {
     return measureQudit(target);
-  }
-
-  cudaq::SpinMeasureResult measure(cudaq::spin_op &op) override {
-    measureSpinOp(op);
-    return std::make_pair(executionContext->expectationValue.value(),
-                          executionContext->result);
   }
 
   void reset(const QuditInfo &target) override { resetQudit(target); }

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -60,13 +60,6 @@ protected:
   /// instruction.
   virtual void executeInstruction(const Instruction &inst) = 0;
 
-  /// @brief Subtype-specific method for performing qudit measurement.
-  virtual int measureQudit(const cudaq::QuditInfo &q,
-                           const std::string &registerName) = 0;
-
-  /// @brief Subtype-specific method for performing qudit reset.
-  virtual void resetQudit(const QuditInfo &q) = 0;
-
 public:
   BasicExecutionManager() = default;
   virtual ~BasicExecutionManager() = default;
@@ -159,11 +152,5 @@ public:
 
     executeInstruction({std::move(gateName), params, controls, targets, op});
   }
-
-  int measure(const cudaq::QuditInfo &target) override {
-    return measureQudit(target);
-  }
-
-  void reset(const QuditInfo &target) override { resetQudit(target); }
 };
 

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -38,9 +38,6 @@ protected:
   /// @brief `typedef` for a queue of instructions
   using InstructionQueue = std::vector<Instruction>;
 
-  /// @brief The current execution context, e.g. sampling or observation
-  cudaq::ExecutionContext *executionContext = nullptr;
-
   /// @brief When adjoint operations are requested we can store them here for
   /// delayed execution
   std::vector<InstructionQueue> adjointQueueStack;
@@ -49,13 +46,6 @@ protected:
   /// qudit ids.
   std::vector<std::size_t> extraControlIds;
 
-  /// @brief Subtype-specific handler for when the execution context changes
-  virtual void handleExecutionContextChanged() = 0;
-
-  /// @brief Subtype-specific handler for when the current execution context has
-  /// ended.
-  virtual void handleExecutionContextEnded() = 0;
-
   /// @brief Subtype-specific method for affecting the execution of a queued
   /// instruction.
   virtual void executeInstruction(const Instruction &inst) = 0;
@@ -63,21 +53,6 @@ protected:
 public:
   BasicExecutionManager() = default;
   virtual ~BasicExecutionManager() = default;
-
-  void setExecutionContext(cudaq::ExecutionContext *_ctx) override {
-    executionContext = _ctx;
-    handleExecutionContextChanged();
-  }
-
-  void resetExecutionContext() override {
-    if (!executionContext)
-      return;
-
-    // Do any final post-processing before
-    // we deallocate the qudits
-    handleExecutionContextEnded();
-    executionContext = nullptr;
-  }
 
   void startAdjointRegion() override { adjointQueueStack.emplace_back(); }
 

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -61,7 +61,7 @@ protected:
   std::vector<std::size_t> extraControlIds;
 
   /// @brief Subtype-specific qudit allocation method
-  virtual void allocateQudit(const QuditInfo &q) = 0;
+  virtual void doAllocateQudit(const QuditInfo &q) = 0;
 
   /// @brief Allocate a set of `qudits` with a single call.
   virtual void allocateQudits(const std::vector<QuditInfo> &qudits) = 0;
@@ -123,11 +123,11 @@ public:
     executionContext = nullptr;
   }
 
-  std::size_t getAvailableIndex(std::size_t quditLevels) override {
+  std::size_t allocateQudit(std::size_t quditLevels) override {
     auto new_id = getNextIndex();
     if (isInTracerMode())
       return new_id;
-    allocateQudit({quditLevels, new_id});
+    doAllocateQudit({quditLevels, new_id});
     return new_id;
   }
 

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -109,60 +109,8 @@ protected:
     return simulator()->mz(q.id);
   }
 
-  void measureSpinOp(const cudaq::spin_op &op) override {
-    simulator()->flushGateQueue();
-
-    if (executionContext->canHandleObserve) {
-      auto result = simulator()->observe(*executionContext->spin.value());
-      executionContext->expectationValue = result.expectation();
-      executionContext->result = result.raw_data();
-      return;
-    }
-
-    assert(op.num_terms() == 1 && "Number of terms is not 1.");
-
-    cudaq::info("Measure {}", op.to_string(false));
-    std::vector<std::size_t> qubitsToMeasure;
-    std::vector<std::function<void(bool)>> basisChange;
-    op.for_each_pauli([&](cudaq::pauli type, std::size_t qubitIdx) {
-      if (type != cudaq::pauli::I)
-        qubitsToMeasure.push_back(qubitIdx);
-
-      if (type == cudaq::pauli::Y)
-        basisChange.emplace_back([&, qubitIdx](bool reverse) {
-          simulator()->rx(!reverse ? M_PI_2 : -M_PI_2, qubitIdx);
-        });
-      else if (type == cudaq::pauli::X)
-        basisChange.emplace_back(
-            [&, qubitIdx](bool) { simulator()->h(qubitIdx); });
-    });
-
-    // Change basis, flush the queue
-    if (!basisChange.empty()) {
-      for (auto &basis : basisChange)
-        basis(false);
-
-      simulator()->flushGateQueue();
-    }
-
-    // Get whether this is shots-based
-    int shots = 0;
-    if (executionContext->shots > 0)
-      shots = executionContext->shots;
-
-    // Sample and give the data to the context
-    cudaq::ExecutionResult result = simulator()->sample(qubitsToMeasure, shots);
-    executionContext->expectationValue = result.expectationValue;
-    executionContext->result = cudaq::sample_result(result);
-
-    // Restore the state.
-    if (!basisChange.empty()) {
-      std::reverse(basisChange.begin(), basisChange.end());
-      for (auto &basis : basisChange)
-        basis(true);
-
-      simulator()->flushGateQueue();
-    }
+  cudaq::SpinMeasureResult measure(const cudaq::spin_op &op) override {
+    return simulator()->measure(op);
   }
 
 public:

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -52,12 +52,12 @@ private:
   }
 
 protected:
-  void allocateQudit(const cudaq::QuditInfo &q) override {
+  void doAllocateQudit(const cudaq::QuditInfo &q) override {
     requestedAllocations.emplace_back(2, q.id);
   }
 
   void allocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {
-    simulator()->allocateQubits(qudits.size());
+    simulator()->allocateQudits(qudits.size());
   }
 
   void deallocateQudit(const cudaq::QuditInfo &q) override {

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -39,14 +39,6 @@ private:
   }
 
 protected:
-  std::size_t allocateQudit(std::size_t n_levels) override {
-    return simulator()->allocateQudit();
-  }
-
-  void deallocateQudit(const cudaq::QuditInfo &q) override {
-    simulator()->deallocateQudit(q.id);
-  }
-
   void handleExecutionContextChanged() override {
     simulator()->setExecutionContext(executionContext);
   }
@@ -105,14 +97,6 @@ protected:
         })();
   }
 
-  int measureQudit(const cudaq::QuditInfo &q) override {
-    return simulator()->mz(q.id);
-  }
-
-  cudaq::SpinMeasureResult measure(const cudaq::spin_op &op) override {
-    return simulator()->measure(op);
-  }
-
 public:
   DefaultExecutionManager() {
     cudaq::info("[DefaultExecutionManager] Creating the {} backend.",
@@ -120,7 +104,23 @@ public:
   }
   virtual ~DefaultExecutionManager() = default;
 
-  void resetQudit(const cudaq::QuditInfo &q) override {
+  std::size_t allocateQudit(std::size_t n_levels) override {
+    return simulator()->allocateQudit();
+  }
+
+  void deallocateQudit(const cudaq::QuditInfo &q) override {
+    simulator()->deallocateQudit(q.id);
+  }
+
+  int measure(const cudaq::QuditInfo &q) override {
+    return simulator()->mz(q.id);
+  }
+
+  cudaq::SpinMeasureResult measure(const cudaq::spin_op &op) override {
+    return simulator()->measure(op);
+  }
+
+  void reset(const cudaq::QuditInfo &q) override {
     simulator()->resetQubit(q.id);
   }
 };

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -39,14 +39,6 @@ private:
   }
 
 protected:
-  void handleExecutionContextChanged() override {
-    simulator()->setExecutionContext(executionContext);
-  }
-
-  void handleExecutionContextEnded() override {
-    simulator()->resetExecutionContext();
-  }
-
   void executeInstruction(const Instruction &instruction) override {
     // Get the data, create the Qubit* targets
     auto [gateName, parameters, controls, targets, op] = instruction;
@@ -103,6 +95,14 @@ public:
                 simulator()->name());
   }
   virtual ~DefaultExecutionManager() = default;
+
+  void setExecutionContext(cudaq::ExecutionContext *context) override {
+    simulator()->setExecutionContext(context);
+  }
+
+  void resetExecutionContext() override {
+    simulator()->resetExecutionContext();
+  }
 
   std::size_t allocateQudit(std::size_t n_levels) override {
     return simulator()->allocateQudit();

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -6,20 +6,13 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "llvm/ADT/StringSwitch.h"
-
 #include "common/Logger.h"
 #include "cudaq/qis/managers/BasicExecutionManager.h"
-#include "cudaq/qis/qudit.h"
 #include "cudaq/spin_op.h"
 #include "cudaq/utils/cudaq_utils.h"
-#include <complex>
+#include "llvm/ADT/StringSwitch.h"
 #include <cstring>
 #include <functional>
-#include <map>
-#include <queue>
-#include <sstream>
-#include <stack>
 
 #include "nvqir/CircuitSimulator.h"
 
@@ -32,7 +25,6 @@ namespace {
 /// The DefaultExecutionManager will implement allocation, deallocation, and
 /// quantum instruction application via calls to the current CircuitSimulator
 class DefaultExecutionManager : public cudaq::BasicExecutionManager {
-
 private:
   nvqir::CircuitSimulator *simulator() {
     return nvqir::getCircuitSimulatorInternal();

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -60,7 +60,7 @@ protected:
     simulator()->allocateQudits(qudits.size());
   }
 
-  void deallocateQudit(const cudaq::QuditInfo &q) override {
+  void doDeallocateQudit(const cudaq::QuditInfo &q) override {
 
     // Before trying to deallocate, make sure the qudit hasn't
     // been requested but not allocated.
@@ -71,7 +71,7 @@ protected:
       return;
     }
 
-    simulator()->deallocate(q.id);
+    simulator()->deallocateQudit(q.id);
   }
 
   void deallocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {
@@ -86,7 +86,7 @@ protected:
       }
     }
 
-    simulator()->deallocateQubits(local);
+    simulator()->deallocateQudits(local);
   }
 
   void handleExecutionContextChanged() override {

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -56,7 +56,7 @@ protected:
   }
 
   /// @brief Qudit deallocation method
-  void deallocateQudit(const cudaq::QuditInfo &q) override {}
+  void doDeallocateQudit(const cudaq::QuditInfo &q) override {}
 
   /// @brief Deallocate a set of `qudits` with a single call.
   void deallocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {}

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -36,7 +36,7 @@ private:
 protected:
   /// @brief Qudit allocation method: a zeroState is first initialized, the
   /// following ones are added via kron operators
-  void allocateQudit(const cudaq::QuditInfo &q) override {
+  void doAllocateQudit(const cudaq::QuditInfo &q) override {
     if (state.size() == 0) {
       // qubit will give [1,0], qutrit will give [1,0,0] and so on...
       state = qpp::ket::Zero(q.levels);
@@ -52,7 +52,7 @@ protected:
   /// @brief Allocate a set of `qudits` with a single call.
   void allocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {
     for (auto &q : qudits)
-      allocateQudit(q);
+      doAllocateQudit(q);
   }
 
   /// @brief Qudit deallocation method

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -118,9 +118,6 @@ protected:
     return measurement_result;
   }
 
-  /// @brief Measure the state in the basis described by the given `spin_op`.
-  void measureSpinOp(const cudaq::spin_op &) override {}
-
   /// @brief Method for performing qudit reset.
   void resetQudit(const cudaq::QuditInfo &id) override {}
 
@@ -280,7 +277,7 @@ public:
 
   virtual ~PhotonicsExecutionManager() = default;
 
-  cudaq::SpinMeasureResult measure(cudaq::spin_op &op) override {
+  cudaq::SpinMeasureResult measure(const cudaq::spin_op &op) override {
     throw "spin_op observation (cudaq::observe()) is not supported for this "
           "photonics simulator";
   }

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -33,33 +33,26 @@ private:
   /// @brief Qudits to be sampled
   std::vector<cudaq::QuditInfo> sampleQudits;
 
+  std::size_t numQudits = 0;
+
 protected:
-  /// @brief Qudit allocation method: a zeroState is first initialized, the
-  /// following ones are added via kron operators
-  void doAllocateQudit(const cudaq::QuditInfo &q) override {
+  std::size_t allocateQudit(std::size_t n_levels) override {
+    numQudits += 1;
     if (state.size() == 0) {
       // qubit will give [1,0], qutrit will give [1,0,0] and so on...
-      state = qpp::ket::Zero(q.levels);
+      state = qpp::ket::Zero(n_levels);
       state(0) = 1.0;
-      return;
+      return numQudits;
     }
 
-    qpp::ket zeroState = qpp::ket::Zero(q.levels);
+    qpp::ket zeroState = qpp::ket::Zero(n_levels);
     zeroState(0) = 1.0;
     state = qpp::kron(state, zeroState);
-  }
-
-  /// @brief Allocate a set of `qudits` with a single call.
-  void allocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {
-    for (auto &q : qudits)
-      doAllocateQudit(q);
+    return numQudits;
   }
 
   /// @brief Qudit deallocation method
-  void doDeallocateQudit(const cudaq::QuditInfo &q) override {}
-
-  /// @brief Deallocate a set of `qudits` with a single call.
-  void deallocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {}
+  void deallocateQudit(const cudaq::QuditInfo &q) override {}
 
   /// @brief Handler for when the photonics execution context changes
   void handleExecutionContextChanged() override {}

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -57,8 +57,8 @@ public:
   // Syntactic sugar for negating a control
   qudit<Levels> &operator!() { return negate(); }
 
-  // Destructor, return the qudit so it can be reused
-  ~qudit() { getExecutionManager()->returnQudit({n_levels(), idx}); }
+  /// Destructs a qudit and request a deallocation to the execution manager.
+  ~qudit() { getExecutionManager()->deallocateQudit({n_levels(), idx}); }
 };
 
 // A qubit is a qudit with 2 levels.

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -26,8 +26,10 @@ class qudit {
   bool isNegativeControl = false;
 
 public:
-  /// Construct a qudit, will allocated a new unique index
-  qudit() : idx(getExecutionManager()->getAvailableIndex(n_levels())) {}
+  /// Construct a qudit. When constructing a qudit we request an allocation to
+  /// the exercution manager, and receive back an unique identifier for the
+  /// qudit.
+  qudit() : idx(getExecutionManager()->allocateQudit(n_levels())) {}
 
   // Qudits cannot be copied
   qudit(const qudit &q) = delete;

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -188,10 +188,10 @@ public:
   virtual cudaq::observe_result observe(const cudaq::spin_op &term) = 0;
 
   /// @brief Allocate a single qubit, return the qubit as a logical index
-  virtual std::size_t allocateQubit() = 0;
+  virtual std::size_t allocateQudit() = 0;
 
   /// @brief Allocate `count` qubits.
-  virtual std::vector<std::size_t> allocateQubits(const std::size_t count) = 0;
+  virtual std::vector<std::size_t> allocateQudits(const std::size_t count) = 0;
 
   /// @brief Deallocate the qubit with give unique index
   virtual void deallocate(const std::size_t qubitIdx) = 0;
@@ -770,8 +770,8 @@ public:
                              "observe(const cudaq::spin_op &).");
   }
 
-  /// @brief Allocate a single qubit, return the qubit as a logical index
-  std::size_t allocateQubit() override {
+  /// @brief Allocate a qudit, and returns its unique identifier.
+  std::size_t allocateQudit() override {
     // Get a new qubit index
     auto newIdx = tracker.getNextIndex();
 
@@ -805,9 +805,8 @@ public:
     return newIdx;
   }
 
-  /// @brief Allocate `count` qubits.
-  std::vector<std::size_t> allocateQubits(std::size_t count) override {
-    ScopedTraceWithContext("allocateQubits", count);
+  /// @brief Allocate `count` qudits.
+  std::vector<std::size_t> allocateQudits(std::size_t count) override {
     std::vector<std::size_t> qubits;
     for (std::size_t i = 0; i < count; i++)
       qubits.emplace_back(tracker.getNextIndex());

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -320,6 +320,8 @@ public:
   virtual bool mz(const std::size_t qubitIdx,
                   const std::string &registerName) = 0;
 
+  virtual cudaq::SpinMeasureResult measure(const cudaq::spin_op &op) = 0;
+
   /// @brief Reset the qubit to the |0> state
   virtual void resetQubit(const std::size_t qubitIdx) = 0;
 
@@ -1169,6 +1171,57 @@ public:
 
     // Return the result
     return measureResult;
+  }
+
+  cudaq::SpinMeasureResult measure(const cudaq::spin_op &op) override {
+    flushGateQueue();
+
+    if (executionContext->canHandleObserve) {
+      auto result = observe(*executionContext->spin.value());
+      return {*result.expectationValue, cudaq::sample_result(result)};
+    }
+
+    assert(op.num_terms() == 1 && "Number of terms is not 1.");
+
+    cudaq::info("Measure {}", op.to_string(false));
+    std::vector<std::size_t> qubitsToMeasure;
+    std::vector<std::function<void(bool)>> basisChange;
+    op.for_each_pauli([&](cudaq::pauli type, std::size_t qubitIdx) {
+      if (type != cudaq::pauli::I)
+        qubitsToMeasure.push_back(qubitIdx);
+
+      if (type == cudaq::pauli::Y)
+        basisChange.emplace_back([&, qubitIdx](bool reverse) {
+          rx(!reverse ? M_PI_2 : -M_PI_2, qubitIdx);
+        });
+      else if (type == cudaq::pauli::X)
+        basisChange.emplace_back([&, qubitIdx](bool) { h(qubitIdx); });
+    });
+
+    // Change basis, flush the queue
+    if (!basisChange.empty()) {
+      for (auto &basis : basisChange)
+        basis(false);
+      flushGateQueue();
+    }
+
+    // Get whether this is shots-based
+    int shots = 0;
+    if (executionContext->shots > 0)
+      shots = executionContext->shots;
+
+    // Sample and give the data to the context
+    cudaq::ExecutionResult result = sample(qubitsToMeasure, shots);
+
+    // Restore the state.
+    if (!basisChange.empty()) {
+      std::reverse(basisChange.begin(), basisChange.end());
+      for (auto &basis : basisChange)
+        basis(true);
+
+      flushGateQueue();
+    }
+    return {*result.expectationValue, cudaq::sample_result(result)};
   }
 }; // namespace nvqir
 } // namespace nvqir

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -180,7 +180,7 @@ void __quantum__rt__resetExecutionContext() {
 Array *__quantum__rt__qubit_allocate_array(uint64_t size) {
   ScopedTraceWithContext("NVQIR::qubit_allocate_array", size);
   __quantum__rt__initialize(0, nullptr);
-  auto qubitIdxs = nvqir::getCircuitSimulatorInternal()->allocateQubits(size);
+  auto qubitIdxs = nvqir::getCircuitSimulatorInternal()->allocateQudits(size);
   return vectorSizetToArray(qubitIdxs);
 }
 
@@ -207,7 +207,7 @@ void __quantum__rt__qubit_release_array(Array *arr) {
 Qubit *__quantum__rt__qubit_allocate() {
   ScopedTraceWithContext("NVQIR::allocate_qubit");
   __quantum__rt__initialize(0, nullptr);
-  auto qubitIdx = nvqir::getCircuitSimulatorInternal()->allocateQubit();
+  auto qubitIdx = nvqir::getCircuitSimulatorInternal()->allocateQudit();
   auto qubit = std::make_unique<Qubit>(qubitIdx);
   nvqir::allocatedSingleQubits.emplace_back(std::move(qubit));
   return nvqir::allocatedSingleQubits.back().get();

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -190,7 +190,7 @@ void __quantum__rt__qubit_release_array(Array *arr) {
   for (std::size_t i = 0; i < arr->size(); i++) {
     auto arrayPtr = (*arr)[i];
     Qubit *idxVal = *reinterpret_cast<Qubit **>(arrayPtr);
-    nvqir::getCircuitSimulatorInternal()->deallocate(idxVal->idx);
+    nvqir::getCircuitSimulatorInternal()->deallocateQudit(idxVal->idx);
     delete idxVal;
   }
   auto begin = nvqir::allocatedArrays.begin();
@@ -215,8 +215,8 @@ Qubit *__quantum__rt__qubit_allocate() {
 
 /// @brief Once done, release that qubit
 void __quantum__rt__qubit_release(Qubit *q) {
-  ScopedTraceWithContext("NVQIR::release_qubit");
-  nvqir::getCircuitSimulatorInternal()->deallocate(q->idx);
+  cudaq::ScopedTrace trace("NVQIR::release_qubit");
+  nvqir::getCircuitSimulatorInternal()->deallocateQudit(q->idx);
   auto begin = nvqir::allocatedSingleQubits.begin();
   auto end = nvqir::allocatedSingleQubits.end();
   nvqir::allocatedSingleQubits.erase(
@@ -228,7 +228,7 @@ void __quantum__rt__qubit_release(Qubit *q) {
 void __quantum__rt__deallocate_all(const std::size_t numQubits,
                                    const std::size_t *qubitIdxs) {
   std::vector<std::size_t> qubits(qubitIdxs, qubitIdxs + numQubits);
-  nvqir::getCircuitSimulatorInternal()->deallocateQubits(qubits);
+  nvqir::getCircuitSimulatorInternal()->deallocateQudits(qubits);
 }
 
 #define ONE_QUBIT_QIS_FUNCTION(GATENAME)                                       \

--- a/unittests/backends/QPPDMTester.cpp
+++ b/unittests/backends/QPPDMTester.cpp
@@ -72,7 +72,7 @@ CUDAQ_TEST(QPPTester, checkDensityOrderingBug) {
   {
     // Initialize QPP Backend 1 qubit at a time.
     QppNoiseCircuitSimulator qppBackend;
-    auto q0 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
     EXPECT_EQ(0, qppBackend.mz(q0));
 
     // Rotate to |1>
@@ -80,7 +80,7 @@ CUDAQ_TEST(QPPTester, checkDensityOrderingBug) {
     EXPECT_EQ(1, qppBackend.mz(q0));
 
     // Add another qubit. Individually, should be |0>.
-    auto q1 = qppBackend.allocateQubit();
+    auto q1 = qppBackend.allocateQudit();
     EXPECT_EQ(0, qppBackend.mz(q1));
 
     std::string got_bitstring = getSampledBitString(qppBackend, {0, 1});
@@ -92,8 +92,8 @@ CUDAQ_TEST(QPPTester, checkDensityOrderingBug) {
   {
     // Initialize QPP Backend with 2 qubits.
     QppNoiseCircuitSimulator qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
 
@@ -104,7 +104,7 @@ CUDAQ_TEST(QPPTester, checkDensityOrderingBug) {
     EXPECT_EQ(1, qppBackend.mz(q1));
 
     // Add another qubit. Individually, should be |0>.
-    auto q2 = qppBackend.allocateQubit();
+    auto q2 = qppBackend.allocateQudit();
     EXPECT_EQ(0, qppBackend.mz(q2));
 
     std::string got_bitstring = getSampledBitString(qppBackend, {0, 1, 2});
@@ -114,7 +114,7 @@ CUDAQ_TEST(QPPTester, checkDensityOrderingBug) {
     EXPECT_EQ(0, qppBackend.mz(q2));
 
     // Resize again with another new qubit.
-    auto q3 = qppBackend.allocateQubit();
+    auto q3 = qppBackend.allocateQudit();
     EXPECT_EQ(0, qppBackend.mz(q3));
 
     // // Apply more rotations to the qubits as extra checks.

--- a/unittests/backends/QPPTester.cpp
+++ b/unittests/backends/QPPTester.cpp
@@ -83,8 +83,8 @@ CUDAQ_TEST(QPPTester, checkInitialState) {
   // Initialize QPP Backend with 2 qubits
   const int num_qubits = 2;
   QppCircuitSimulator<qpp::ket> qppBackend;
-  auto q0 = qppBackend.allocateQubit();
-  auto q1 = qppBackend.allocateQubit();
+  auto q0 = qppBackend.allocateQudit();
+  auto q1 = qppBackend.allocateQudit();
 
   // Assert that we're starting in the 0-state.
   got_state = qppBackend.getStateVector();
@@ -119,8 +119,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Place just q0 in the 1-state with X-gate.
     qppBackend.x(q0);
@@ -177,8 +177,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Rotate just q0 with a Y-gate.
     qppBackend.y(q0);
@@ -233,8 +233,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Rotate just q0 with a Z-gate.
     qppBackend.z(q0);
@@ -269,8 +269,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Rotate just q0 with an H-gate.
     qppBackend.h(q0);
@@ -313,8 +313,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Rotate just q0 with a S-gate.
     qppBackend.s(q0);
@@ -351,8 +351,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Rotate just q0 with a T-gate.
     qppBackend.t(q0);
@@ -389,8 +389,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Rotate just q0 with a SDG-gate.
     qppBackend.sdg(q0);
@@ -427,8 +427,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Rotate just q0 with a TDG-gate.
     qppBackend.tdg(q0);
@@ -468,7 +468,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     // Initialize QPP Backend with 1 qubit
     QppCircuitSimulator<qpp::ket> qppBackend;
     const int num_qubits = 1;
-    auto q0 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
 
     // Rotate q0 by pi with an RX-gate.
     // Note: `RX(pi) = ((0,-i),(-i,0))`
@@ -509,7 +509,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     // Initialize QPP Backend with 1 qubit
     QppCircuitSimulator<qpp::ket> qppBackend;
     const int num_qubits = 1;
-    auto q0 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
 
     // Rotate q0 by pi with an RY-gate.
     // Note: `RY(pi) = ((0,1),(1,0))` which is equivalent to the
@@ -550,7 +550,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     // Initialize QPP Backend with 1 qubit
     QppCircuitSimulator<qpp::ket> qppBackend;
     const int num_qubits = 1;
-    auto q0 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
 
     // Rotate q0 by 0.0 with an RZ-gate.
     // Should be identity.
@@ -588,7 +588,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     std::string want_bitstring;
     // Initialize QPP Backend with 1 qubit
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
 
     // Rotate q0 with U gate at (theta,phi,lam)=(2pi, 0,0).
     // Note: `U(pi,0,0) = ((-1,0),(0,-1))`
@@ -604,7 +604,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
 
     // Reset q0 to 0 state.
     qppBackend.deallocate(q0);
-    q0 = qppBackend.allocateQubit();
+    q0 = qppBackend.allocateQudit();
 
     // Rotate the qubit to the 1-state, then rotate it
     // again with another u gate at the same params.
@@ -630,7 +630,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     std::string want_bitstring;
     // Initialize QPP Backend with 1 qubit
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
 
     // Rotate q0 about Z with u1 gate.
     // Note: `U1(pi) = ((1,0),(0,exp(i*pi)))`
@@ -671,7 +671,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     std::string want_bitstring;
     // Initialize QPP Backend with 1 qubit
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
 
     // Rotate q0 with U3 gate at (theta,phi,lam)=(2pi, 0,0).
     // Note: `U3(pi,0,0) = ((-1,0),(0,-1))`
@@ -685,7 +685,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
     qppBackend.deallocate(q0);
-    q0 = qppBackend.allocateQubit();
+    q0 = qppBackend.allocateQudit();
 
     // Reset system to all 0 state.
     // qppBackend.reset();
@@ -714,8 +714,8 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     std::string want_bitstring;
     // Initialize QPP Backend with 2 qubits
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Starting in state = `|0><0| = |00> = (1 0 0 0)`
     // Apply CPHASE between q0 and q1 at `theta=pi`
@@ -786,8 +786,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Starting in state = `|0><0| = |00> = (1 0 0 0)`
     // Apply controlled-X between q0 and q1
@@ -859,8 +859,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Starting in state = `|0><0| = |00> = (1 0 0 0)`
     // Apply controlled-Z between q0 and q1
@@ -934,8 +934,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Starting in state = `|0><0| = |00> = (1 0 0 0)`
     // Apply CH between q0 and q1
@@ -978,8 +978,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     // Reset system to `|00>`.
     qppBackend.deallocate(q0);
     qppBackend.deallocate(q1);
-    q0 = qppBackend.allocateQubit();
-    q1 = qppBackend.allocateQubit();
+    q0 = qppBackend.allocateQudit();
+    q1 = qppBackend.allocateQudit();
 
     // Flip q0 to the 1 state. Total system state is now `|10>`.
     qppBackend.x(q0);
@@ -1003,8 +1003,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     // Initialize QPP Backend with 2 qubits
     const int num_qubits = 2;
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Starting in state = `|0><0| = |00> = (1 0 0 0)`
     // Apply CS between q0 and q1
@@ -1068,8 +1068,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     std::string want_bitstring;
     // Initialize QPP Backend with 2 qubits
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Flip q0 to the 1 state.
     qppBackend.x(q0);
@@ -1109,7 +1109,7 @@ CUDAQ_TEST(QPPTester, checkReset) {
     std::string want_bitstring;
     // Initialize QPP Backend with 1 qubit
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
 
     // Place q0 in the 1 state
     qppBackend.x(q0);
@@ -1140,8 +1140,8 @@ CUDAQ_TEST(QPPTester, checkReset) {
     std::string want_bitstring;
     // Initialize QPP Backend with 2 qubits
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Place q0 in the 1 state
     qppBackend.x(q0);
@@ -1176,7 +1176,7 @@ CUDAQ_TEST(QPPTester, checkReset) {
     std::string want_bitstring;
     // Initialize QPP Backend with 1 qubit
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
 
     // Place q0 in the 1 state
     qppBackend.x(q0);
@@ -1207,8 +1207,8 @@ CUDAQ_TEST(QPPTester, checkReset) {
     std::string want_bitstring;
     // Initialize QPP Backend with 2 qubits
     QppCircuitSimulator<qpp::ket> qppBackend;
-    auto q0 = qppBackend.allocateQubit();
-    auto q1 = qppBackend.allocateQubit();
+    auto q0 = qppBackend.allocateQudit();
+    auto q1 = qppBackend.allocateQudit();
 
     // Place q0 in the 1 state
     qppBackend.x(q0);

--- a/unittests/backends/QPPTester.cpp
+++ b/unittests/backends/QPPTester.cpp
@@ -101,8 +101,8 @@ CUDAQ_TEST(QPPTester, checkInitialState) {
   got_bitstring = getSampledBitString(qppBackend, {0, 1});
   want_bitstring = std::string("00");
   EXPECT_EQ(want_bitstring, got_bitstring);
-  qppBackend.deallocate(q0);
-  qppBackend.deallocate(q1);
+  qppBackend.deallocateQudit(q0);
+  qppBackend.deallocateQudit(q1);
 }
 
 // Testing the accuracy of all non-parameterized single-qubit
@@ -163,8 +163,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking the single qubit Y-gate.
@@ -219,8 +219,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking the single qubit Z-gate.
@@ -257,8 +257,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking the single qubit Hadamard-gate.
@@ -299,8 +299,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     EXPECT_EQ_KETS(want_state, got_state);
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking the single qubit S-gate.
@@ -337,8 +337,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking the single qubit T-gate.
@@ -375,8 +375,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking the single qubit SDG-gate.
@@ -413,8 +413,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking the single qubit TDG-gate.
@@ -451,8 +451,8 @@ CUDAQ_TEST(QPPTester, checkSingleQGates) {
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 }
 
@@ -496,7 +496,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     EXPECT_EQ_KETS(want_state, got_state);
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
-    qppBackend.deallocate(q0);
+    qppBackend.deallocateQudit(q0);
   }
 
   // Checking RY gate.
@@ -537,7 +537,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     EXPECT_EQ_KETS(want_state, got_state);
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
-    qppBackend.deallocate(q0);
+    qppBackend.deallocateQudit(q0);
   }
 
   // Checking RZ gate.
@@ -576,7 +576,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     EXPECT_EQ_KETS(want_state, got_state);
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
-    qppBackend.deallocate(q0);
+    qppBackend.deallocateQudit(q0);
   }
 
   // Checking U gate.
@@ -603,7 +603,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     EXPECT_EQ(0, qppBackend.mz(q0));
 
     // Reset q0 to 0 state.
-    qppBackend.deallocate(q0);
+    qppBackend.deallocateQudit(q0);
     q0 = qppBackend.allocateQudit();
 
     // Rotate the qubit to the 1-state, then rotate it
@@ -659,7 +659,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     EXPECT_EQ(want_state, got_state);
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(1, qppBackend.mz(q0));
-    qppBackend.deallocate(q0);
+    qppBackend.deallocateQudit(q0);
   }
 
   // Checking U3 gate.
@@ -684,7 +684,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     EXPECT_EQ_KETS(want_state, got_state);
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
-    qppBackend.deallocate(q0);
+    qppBackend.deallocateQudit(q0);
     q0 = qppBackend.allocateQudit();
 
     // Reset system to all 0 state.
@@ -702,7 +702,7 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     EXPECT_EQ_KETS(want_state, got_state);
     EXPECT_EQ(want_bitstring, got_bitstring);
     EXPECT_EQ(1, qppBackend.mz(q0));
-    qppBackend.deallocate(q0);
+    qppBackend.deallocateQudit(q0);
   }
 
   // Checking CPHASE gate.
@@ -768,8 +768,8 @@ CUDAQ_TEST(QPPTester, checkParameterizedGates) {
     want_state = std::exp(im<> * M_PI) * getOneState(2);
     got_state = qppBackend.getStateVector();
     EXPECT_EQ(want_state, got_state);
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 }
 
@@ -845,8 +845,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     EXPECT_EQ(got_bitstring, want_bitstring);
     EXPECT_EQ(1, qppBackend.mz(q0));
     EXPECT_EQ(1, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking two-qubit controlled Z-gate.
@@ -920,8 +920,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     EXPECT_EQ(got_bitstring, want_bitstring);
     EXPECT_EQ(1, qppBackend.mz(q0));
     EXPECT_EQ(0, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking CH gate.
@@ -976,8 +976,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     EXPECT_EQ(want_state, got_state);
 
     // Reset system to `|00>`.
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
     q0 = qppBackend.allocateQudit();
     q1 = qppBackend.allocateQudit();
 
@@ -989,8 +989,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     got_state = qppBackend.getStateVector();
     EXPECT_EQ(want_state, got_state);
 
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking CS gate.
@@ -1055,8 +1055,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     want_state = im<> * getOneState(2);
     got_state = qppBackend.getStateVector();
     EXPECT_EQ(want_state, got_state);
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 
   // Checking SWAP gate.
@@ -1094,8 +1094,8 @@ CUDAQ_TEST(QPPTester, checkCtrlGates) {
     EXPECT_EQ(got_bitstring, want_bitstring);
     EXPECT_EQ(0, qppBackend.mz(q0));
     EXPECT_EQ(1, qppBackend.mz(q1));
-    qppBackend.deallocate(q0);
-    qppBackend.deallocate(q1);
+    qppBackend.deallocateQudit(q0);
+    qppBackend.deallocateQudit(q1);
   }
 }
 

--- a/unittests/backends/qpp_observe/QppObserveTester.cpp
+++ b/unittests/backends/qpp_observe/QppObserveTester.cpp
@@ -14,8 +14,8 @@
 CUDAQ_TEST(QPPBackendTester, checkBackendObserve) {
 
   cudaq::QppObserveTester qpp;
-  auto q0 = qpp.allocateQubit();
-  auto q1 = qpp.allocateQubit();
+  auto q0 = qpp.allocateQudit();
+  auto q1 = qpp.allocateQudit();
 
   qpp.x(q0);
   qpp.ry(.59, q1);

--- a/unittests/qis/QubitQISTester.cpp
+++ b/unittests/qis/QubitQISTester.cpp
@@ -26,8 +26,6 @@ CUDAQ_TEST(QubitQISTester, checkAllocateDeallocateSubRegister) {
     h(f, qq[2]);
   }
 
-  EXPECT_FALSE(cudaq::getExecutionManager()->memoryLeaked());
-
   {
     cudaq::qvector q(10);
     for (auto [i, q] : cudaq::enumerate(q)) {
@@ -40,7 +38,6 @@ CUDAQ_TEST(QubitQISTester, checkAllocateDeallocateSubRegister) {
 
     // out of scope, qubits returned
   }
-  EXPECT_FALSE(cudaq::getExecutionManager()->memoryLeaked());
 
   {
     cudaq::qvector q(15);
@@ -78,8 +75,6 @@ CUDAQ_TEST(QubitQISTester, checkAllocateDeallocateSubRegister) {
     EXPECT_EQ(slice_from_span[0].id(), 12);
     EXPECT_EQ(slice_from_span[1].id(), 13);
   }
-
-  EXPECT_FALSE(cudaq::getExecutionManager()->memoryLeaked());
 }
 
 CUDAQ_TEST(QubitQISTester, checkArray) {

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -34,27 +34,25 @@ private:
 
   std::vector<cudaq::QuditInfo> sampleQudits;
 
+  std::size_t numQudits = 0;
+
 protected:
-  void doAllocateQudit(const cudaq::QuditInfo &q) override {
+  std::size_t allocateQudit(std::size_t n_levels) override {
+    numQudits += 1;
     if (state.size() == 0) {
       // qubit will give [1,0], qutrit will give [1,0,0]
-      state = qpp::ket::Zero(q.levels);
+      state = qpp::ket::Zero(n_levels);
       state(0) = 1.0;
-      return;
+      return numQudits;
     }
 
-    qpp::ket zeroState = qpp::ket::Zero(q.levels);
+    qpp::ket zeroState = qpp::ket::Zero(n_levels);
     zeroState(0) = 1.0;
     state = qpp::kron(state, zeroState);
+    return numQudits;
   }
 
-  void allocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {
-    for (auto &q : qudits)
-      doAllocateQudit(q);
-  }
-
-  void doDeallocateQudit(const cudaq::QuditInfo &q) override {}
-  void deallocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {}
+  void deallocateQudit(const cudaq::QuditInfo &q) override {}
 
   void handleExecutionContextChanged() override {}
 

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -53,7 +53,7 @@ protected:
       doAllocateQudit(q);
   }
 
-  void deallocateQudit(const cudaq::QuditInfo &q) override {}
+  void doDeallocateQudit(const cudaq::QuditInfo &q) override {}
   void deallocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {}
 
   void handleExecutionContextChanged() override {}

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -35,7 +35,7 @@ private:
   std::vector<cudaq::QuditInfo> sampleQudits;
 
 protected:
-  void allocateQudit(const cudaq::QuditInfo &q) override {
+  void doAllocateQudit(const cudaq::QuditInfo &q) override {
     if (state.size() == 0) {
       // qubit will give [1,0], qutrit will give [1,0,0]
       state = qpp::ket::Zero(q.levels);
@@ -50,7 +50,7 @@ protected:
 
   void allocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {
     for (auto &q : qudits)
-      allocateQudit(q);
+      doAllocateQudit(q);
   }
 
   void deallocateQudit(const cudaq::QuditInfo &q) override {}

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -97,8 +97,6 @@ protected:
     return measurement_result;
   }
 
-  void measureSpinOp(const cudaq::spin_op &) override {}
-
 public:
   SimpleQuditExecutionManager() {
     instructions.emplace("plusGate", [&](const Instruction &inst) {
@@ -112,7 +110,7 @@ public:
   }
   virtual ~SimpleQuditExecutionManager() = default;
 
-  cudaq::SpinMeasureResult measure(cudaq::spin_op &op) override {
+  cudaq::SpinMeasureResult measure(const cudaq::spin_op &op) override {
     return cudaq::SpinMeasureResult();
   }
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
This PR aims to disentangle (pun intended) various components of the runtime.
Before talking about some of the changes, it will be helpful to broadly describe
what happens at runtime.

Broadly speaking, we can compile CUDA Quantum programs in two ways:

  1. Using an off-the-shelf C++ compiler, e.g., "clang" or "gcc." We call this
     case library mode, and it allows the user to use the full power of C++ when
     writing kernel. (While this ability is attractive for exploration and
     prototyping, it can be a double-edged sword as the user might end up with
     kernels incompatible with QPU execution).

  2. Compiled (or JIT) mode uses  "nvq++" MLIR pipeline. This pipeline
     translates kernel code into our MLIR dialects and translates them for QPU
     execution. (The subset of supported C++ is still growing, so the users
     might feel over-constrained by this method.)

The execution of a CUDA Quantum program changes depending on the chosen method.
The following diagram provides a bird's eye view of runtime events when 
targeting a QVM, i.e., a simulator.

```
                                      * Library mode:
┌──┬────────────────────────────────┐ When this kernel is called by one of the
│1 │#include <cudaq.h>              │ execution primitives. e.g., cudaq::sample,
│2 │                                │ the quantum instructions are processed by
│3 │using namespace cudaq;          │ the ExecutionManager.
│4 │                                │ 
│5 │__qpu__ void foo() {            │    ┌─────┐
│6 │  qvector q(2);                 │    │     │
│7 │  h(q[0]);                      │    │ QIS │
│8 │  x<cudaq::control>(q[0], q[1]);│    │     │
│9 │}                               │    └──┬──┘
└──┴────────────────────────────────┘    ┌──▽─────────────┐
                                         │ExecutionManager│
* Compiled (JIT) mode:                   └──┬─────────────┘
In this case, the kernel is compiled        │   The ExecutionManager main
by nvq++, and instructions become NVQIR     │   resposibility is to handle
calls:                                      │   regions, the control region and
                                            │   the adjoint region, which are
              ┌───────┐                     │   started by cudaq::control and
              │ NVQIR │                     │   cudaq::ajoint, respectively. It
              └┬──────┘                     │   also does other taks such as
               │                            │   queueing gates and allocations 
               │                            │   for later execution.
               │                            │
               │                            │
              ┌▽────────────────────────────▽┐    
              │       CircuitSimulator       │ The CircuitSimulator further
              └──────────────┬───────────────┘ processes instructions before
                             │                 sending them to the backend
                             │                 simulators.
              ┌──────────────▽───────────────┐              
              │          Simulator           │              
              └──────────────────────────────┘              
```

#### Changes
* We change a couple of API names to hide components' internal behavior. For example, the `qudit` is an RAI-like class that asks the `ExecutionManager` for quantum memory. It does not need to know how indices (unique identifiers) are managed, and thus, we change the name of the API from `getAvailableIndex` to `allocateQudit`. (We do something similar to deallocate.)
* The `CircuitSimulator` layer replicates many functionalities of the `ExecutionManager` e.g., queueing gates and deferring allocations. This is necessary because compiled kernels bypass it. We deduplicate these functionalities, leaving them only at the `CircuitSimulator` layer. (The `ExecutionManager` only needs to handle regions.) 
  * This simplification allows us to remove various indirections that become unnecessary.
* Move the tracer from the `ExecutionManager` to the `CircuitSimulator`. This enable its functionalities (or the ones based one it) to work with compiled (JITed) kernels.
* Move functionality that requires knowing that the `CircuitSimulator` queue gates from the `ExecutionManager`. The different pieces of the runtime should not know about the internal behavior of others.