### PR TITLE
Implement proper Pythonic capture of variables from parent scope

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2762,9 +2762,8 @@ class PyASTBridge(ast.NodeVisitor):
                     self.pushValue(mlirVal)
                     return
 
-            print(type(value))
             self.emitFatalError(
-                "Invalid type for variable captured from parent scope (only int, bool, float, and list[int|bool|float] accepted).",
+                f"Invalid type for variable ({node.id}) captured from parent scope (only int, bool, float, and list[int|bool|float] accepted, type was {type(value)}).",
                 node)
 
         # Throw an exception for the case that the name is not

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -46,8 +46,18 @@ class PyKernelDecorator(object):
                         ) if self.kernelFunction is not None else ('', 0)
 
         # Get any global variables from parent scope.
-        self.globalScopedVars = dict(inspect.getmembers(
-            inspect.stack()[2][0]))['f_locals']
+        # We filter only types we accept: integers and floats.
+        # Note here we assume that the parent scope is 2 stack frames up
+        self.parentFrame = inspect.stack()[2].frame
+        self.globalScopedVars = {
+            k: v for k, v in dict(inspect.getmembers(self.parentFrame))
+            ['f_locals'].items()
+        }
+
+        # Once the kernel is compiled to MLIR, we
+        # want to know what capture variables, if any, were
+        # used in the kernel. We need to track these.
+        self.dependentCaptures = None
 
         if self.kernelFunction is None:
             if self.module is not None:
@@ -121,13 +131,17 @@ class PyKernelDecorator(object):
         if self.module != None:
             return
 
-        self.module, self.argTypes = compile_to_mlir(
+        self.module, self.argTypes, extraMetadata = compile_to_mlir(
             self.astModule,
             self.metadata,
             verbose=self.verbose,
             returnType=self.returnType,
             location=self.location,
             parentVariables=self.globalScopedVars)
+
+        # Grab the dependent capture variables, if any
+        self.dependentCaptures = extraMetadata[
+            'dependent_captures'] if 'dependent_captures' in extraMetadata else None
 
     def __str__(self):
         """
@@ -142,8 +156,28 @@ class PyKernelDecorator(object):
         kernel AST to MLIR will occur here if it has not already occurred. 
         """
 
-        if self.module == None:
-            self.compile()
+        # Before we can execute, we need to make sure
+        # variables from the parent frame that we captured
+        # have not changed. If they have changed, we need to
+        # recompile with the new values.
+        for i, s in enumerate(inspect.stack()):
+            if s.frame == self.parentFrame:
+                # We found the parent frame, now
+                # see if any of the variables we depend
+                # on have changed.
+                self.globalScopedVars = {
+                    k: v for k, v in dict(inspect.getmembers(s.frame))
+                    ['f_locals'].items()
+                }
+                if self.dependentCaptures != None:
+                    for k, v in self.dependentCaptures.items():
+                        if self.globalScopedVars[k] != v:
+                            # Need to recompile
+                            self.module = None
+                            break
+
+        # Compile, no-op if the module is not None
+        self.compile()
 
         if len(args) != len(self.argTypes):
             emitFatalError(

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -110,6 +110,9 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
     if (returnType.isInteger(64)) {
       py::args returnVal = py::make_tuple(py::int_(0));
       packArgs(runtimeArgs, returnVal);
+    } else if (returnType.isInteger(1)) {
+      py::args returnVal = py::make_tuple(py::bool_(0));
+      packArgs(runtimeArgs, returnVal);
     } else if (isa<FloatType>(returnType)) {
       py::args returnVal = py::make_tuple(py::float_(0.0));
       packArgs(runtimeArgs, returnVal);
@@ -218,6 +221,10 @@ py::object pyAltLaunchKernelR(const std::string &name, MlirModule module,
     std::memcpy(&concrete, ((char *)rawArgs) + size - 8, 8);
     std::free(rawArgs);
     return py::int_(concrete);
+  } else if (unwrapped.isInteger(1)) {
+    bool concrete = false;
+    std::memcpy(&concrete, ((char *)rawArgs) + size - 1, 1);
+    return py::bool_(concrete);
   } else if (isa<FloatType>(unwrapped)) {
     double concrete;
     std::memcpy(&concrete, ((char *)rawArgs) + size - 8, 8);

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -651,6 +651,7 @@ def test_capture_vars():
 def test_inner_function_capture():
 
     n = 3
+    m = 5
 
     def innerClassical():
 
@@ -658,12 +659,20 @@ def test_inner_function_capture():
         def foo():
             q = cudaq.qvector(n)
 
-        counts = cudaq.sample(foo)
-        counts.dump()
-        return counts
+        def innerInnerClassical():
 
-    counts = innerClassical()
-    assert len(counts) == 1 and '0' * n in counts
+            @cudaq.kernel()
+            def bar():
+                q = cudaq.qvector(m)
+                x(q)
+
+            return cudaq.sample(bar)
+
+        return cudaq.sample(foo), innerInnerClassical()
+
+    fooCounts, barCounts = innerClassical()
+    assert len(fooCounts) == 1 and '0' * n in fooCounts
+    assert len(barCounts) == 1 and '1' * m in barCounts
 
 
 def test_error_qubit_constructor():

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -578,7 +578,8 @@ def test_capture_vars():
         q = cudaq.qvector(n)
         x(q)
         cudaq.dbg.ast.print_f64(f)
-        rx(f, q[0])
+        for qb in q:
+            rx(f, qb)
 
     counts = cudaq.sample(kernel)
     counts.dump()
@@ -590,6 +591,7 @@ def test_capture_vars():
     assert '0' * n in counts
 
     n = 7
+    f = 0.0
     counts = cudaq.sample(kernel)
     counts.dump()
     assert '1' * n in counts

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -578,16 +578,16 @@ def test_capture_vars():
         q = cudaq.qvector(n)
         x(q)
         cudaq.dbg.ast.print_f64(f)
-        ry(f, q[0])
+        rx(f, q[0])
 
     counts = cudaq.sample(kernel)
     counts.dump()
     assert '1' * n in counts
 
-    f = 2 * np.pi
+    f = np.pi
     counts = cudaq.sample(kernel)
     counts.dump()
-    assert '1' * n in counts
+    assert '0' * n in counts
 
     n = 7
     counts = cudaq.sample(kernel)
@@ -644,6 +644,24 @@ def test_capture_vars():
     assert np.isclose(-1.748,
                       cudaq.observe(canCaptureList, hamiltonian).expectation(),
                       atol=1e-3)
+
+
+def test_inner_function_capture():
+
+    n = 3
+
+    def innerClassical():
+
+        @cudaq.kernel()
+        def foo():
+            q = cudaq.qvector(n)
+
+        counts = cudaq.sample(foo)
+        counts.dump()
+        return counts
+
+    counts = innerClassical()
+    assert len(counts) == 1 and '0' * n in counts
 
 
 def test_error_qubit_constructor():
@@ -794,7 +812,7 @@ def test_aug_assign_add():
         f = 5.
         f += 5.
         return f
-    
+
     assert test() == 10.
 
     @cudaq.kernel


### PR DESCRIPTION
Capture `int`, `float`, `bool`, or `list[int|float|bool]` from parent scope. Track potential variable changes and update the MLIR code accordingly. 
```python
n = 5
 
@cudaq.kernel
def kernel():
    q = cudaq.qvector(n)
    x(q)
 
counts = cudaq.sample(kernel)
assert '1' * n in counts

# Change the variable, code should reflect the change
n = 7
counts = cudaq.sample(kernel)
assert '1' * n in counts
```