### PR TITLE
Implement proper Pythonic capture of variables from parent scope

### DIFF
--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -110,6 +110,9 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
     if (returnType.isInteger(64)) {
       py::args returnVal = py::make_tuple(py::int_(0));
       packArgs(runtimeArgs, returnVal);
+    } else if (returnType.isInteger(1)) {
+      py::args returnVal = py::make_tuple(py::bool_(0));
+      packArgs(runtimeArgs, returnVal);
     } else if (isa<FloatType>(returnType)) {
       py::args returnVal = py::make_tuple(py::float_(0.0));
       packArgs(runtimeArgs, returnVal);
@@ -218,6 +221,10 @@ py::object pyAltLaunchKernelR(const std::string &name, MlirModule module,
     std::memcpy(&concrete, ((char *)rawArgs) + size - 8, 8);
     std::free(rawArgs);
     return py::int_(concrete);
+  } else if (unwrapped.isInteger(1)) {
+    bool concrete = false;
+    std::memcpy(&concrete, ((char *)rawArgs) + size - 1, 1);
+    return py::bool_(concrete);
   } else if (isa<FloatType>(unwrapped)) {
     double concrete;
     std::memcpy(&concrete, ((char *)rawArgs) + size - 8, 8);

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -14,6 +14,7 @@ from typing import Callable, List
 import sys
 
 import cudaq
+from cudaq import spin
 
 ## [PYTHON_VERSION_FIX]
 skipIfPythonLessThan39 = pytest.mark.skipif(
@@ -419,6 +420,12 @@ def test_simple_return_types():
         def kernel(a: int, b: int):  # No return type
             return a * b
 
+    @cudaq.kernel
+    def boolKernel() -> bool:
+        return True
+
+    assert boolKernel()
+
 
 def test_list_creation():
 
@@ -559,16 +566,113 @@ def test_sample_async_issue_args_processed():
     assert len(counts) == 2 and '01' in counts and '10' in counts
 
 
-def test_capture_vars_disallowed():
+def test_capture_vars():
 
     n = 5
+    f = 0.0
+    m = 5
+    hello = str()
 
     @cudaq.kernel
-    def test():
+    def kernel():
         q = cudaq.qvector(n)
+        x(q)
+        cudaq.dbg.ast.print_f64(f)
+        for qb in q:
+            rx(f, qb)
+
+    counts = cudaq.sample(kernel)
+    counts.dump()
+    assert '1' * n in counts
+
+    f = np.pi
+    counts = cudaq.sample(kernel)
+    counts.dump()
+    assert '0' * n in counts
+
+    n = 7
+    f = 0.0
+    counts = cudaq.sample(kernel)
+    counts.dump()
+    assert '1' * n in counts
+
+    counts = cudaq.sample(kernel)
+    counts.dump()
+    assert '1' * n in counts
+
+    n = 3
+    counts = cudaq.sample(kernel)
+    counts.dump()
+    assert '1' * n in counts
+
+    @cudaq.kernel
+    def testCanOnlyCaptureIntAndFloat():
+        i = hello
 
     with pytest.raises(RuntimeError) as e:
-        test()
+        testCanOnlyCaptureIntAndFloat()
+
+    b = True
+
+    @cudaq.kernel
+    def canCaptureBool():
+        q = cudaq.qubit()
+        if b:
+            x(q)
+
+    counts = cudaq.sample(canCaptureBool)
+    counts.dump()
+    assert len(counts) == 1 and '1' in counts
+
+    b = False
+    counts = cudaq.sample(canCaptureBool)
+    counts.dump()
+    assert len(counts) == 1 and '0' in counts
+
+    l = [.59]
+    li = [0, 1]
+
+    @cudaq.kernel
+    def canCaptureList():
+        q = cudaq.qvector(2)
+        firstIdx = li[0]
+        secondIdx = li[1]
+        x(q[firstIdx])
+        ry(l[firstIdx], q[secondIdx])
+        x.ctrl(q[secondIdx], q[firstIdx])
+
+    hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
+        0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)
+    assert np.isclose(-1.748,
+                      cudaq.observe(canCaptureList, hamiltonian).expectation(),
+                      atol=1e-3)
+
+
+def test_inner_function_capture():
+
+    n = 3
+    m = 5
+
+    def innerClassical():
+
+        @cudaq.kernel()
+        def foo():
+            q = cudaq.qvector(n)
+
+        def innerInnerClassical():
+
+            @cudaq.kernel()
+            def bar():
+                q = cudaq.qvector(m)
+                x(q)
+
+            return cudaq.sample(bar)
+
+        return cudaq.sample(foo), innerInnerClassical()
+
+    fooCounts, barCounts = innerClassical()
+    assert len(fooCounts) == 1 and '0' * n in fooCounts
+    assert len(barCounts) == 1 and '1' * m in barCounts
 
 
 def test_error_qubit_constructor():


### PR DESCRIPTION
Capture `int`, `float`, `bool`, or `list[int|float|bool]` from parent scope. Track potential variable changes and update the MLIR code accordingly. 
```python
n = 5
 
@cudaq.kernel
def kernel():
    q = cudaq.qvector(n)
    x(q)
 
counts = cudaq.sample(kernel)
assert '1' * n in counts

# Change the variable, code should reflect the change
n = 7
counts = cudaq.sample(kernel)
assert '1' * n in counts
```