### PR TITLE
Refresh remote seeds for executions within a client session

### DIFF
--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -101,5 +101,9 @@ public:
     std::scoped_lock<std::mutex> lock(m_contextMutex);
     m_contexts.erase(std::this_thread::get_id());
   }
+
+  void onRandomSeedSet(std::size_t seed) override {
+    m_client->resetRemoteRandomSeed(seed);
+  }
 };
 } // namespace cudaq

--- a/runtime/common/RemoteKernelExecutor.h
+++ b/runtime/common/RemoteKernelExecutor.h
@@ -60,6 +60,10 @@ public:
   virtual void
   setConfig(const std::unordered_map<std::string, std::string> &configs) = 0;
 
+  // Reset the random seed sequence using for remote execution.
+  // This is triggered by a random seed value being set in CUDAQ runtime.
+  virtual void resetRemoteRandomSeed(std::size_t seed) = 0;
+
   // Delegate/send kernel execution to a remote server.
   // Subclass will implement necessary transport-layer serialization and
   // communication protocols. The `ExecutionContext` will be updated in-place as

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -384,6 +384,9 @@ thread_local static std::size_t cudaq_random_seed = 0;
 void set_random_seed(std::size_t seed) {
   cudaq_random_seed = seed;
   nvqir::setRandomSeed(seed);
+  auto &platform = cudaq::get_platform();
+  // Notify the platform that a new random seed value is set.
+  platform.onRandomSeedSet(seed);
 }
 
 std::size_t get_random_seed() { return cudaq_random_seed; }

--- a/runtime/cudaq/platform/mqpu/CMakeLists.txt
+++ b/runtime/cudaq/platform/mqpu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(${LIBRARY_NAME}
     cudaq-spin 
     cudaq-common 
   PRIVATE 
+    cudaq
     mqpu_util
     pthread
     spdlog::spdlog 

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -147,5 +147,9 @@ public:
   /// as a struct-packed void pointer and its corresponding size.
   virtual void launchKernel(const std::string &name, void (*kernelFunc)(void *),
                             void *args, std::uint64_t, std::uint64_t) = 0;
+
+  /// @brief Notify the QPU that a new random seed value is set.
+  /// By default do nothing, let subclasses override.
+  virtual void onRandomSeedSet(std::size_t seed) {}
 };
 } // namespace cudaq

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -141,6 +141,11 @@ void quantum_platform::launchKernel(std::string kernelName,
   qpu->launchKernel(kernelName, kernelFunc, args, voidStarSize, resultOffset);
 }
 
+void quantum_platform::onRandomSeedSet(std::size_t seed) {
+  // Send on the notification to all QPUs.
+  for (auto &qpu : platformQPUs)
+    qpu->onRandomSeedSet(seed);
+}
 } // namespace cudaq
 
 void cudaq::altLaunchKernel(const char *kernelName, void (*kernelFunc)(void *),

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -147,6 +147,10 @@ public:
   /// @param name
   virtual void setTargetBackend(const std::string &name) {}
 
+  /// @brief Called by the runtime to notify that a new random seed value is
+  /// set.
+  virtual void onRandomSeedSet(std::size_t seed);
+
 protected:
   /// The Platform QPUs, populated by concrete subtypes
   std::vector<std::unique_ptr<QPU>> platformQPUs;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Currently, when sending REST requests to a remote QPUD, the seed value is set to `cudaq::get_random_seed()`, hence all kernel executions will be using the same seed value. This deviates from the local execution model, whereby the static random number generator in the simulator is seeded **once** when `set_random_seed` is called. 

This PR fixed that difference by letting the client to seed the server using a random number generator seeded by `cudaq` seed value.

Note: in general, we don't expect an absolute seed value to have the same effect between local execution and remote execution. Hence, we can randomly generate the server seed using a random sequence seeded by the `cudaq` seed. 


