### PR TITLE
Fixed a fallout from the recent merge

### DIFF
--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -41,6 +41,9 @@ public:
     return execution_queue->getExecutionThreadId();
   }
 
+  // Conditional feedback is handled by the server side.
+  virtual bool supportsConditionalFeedback() override { return true; }
+
   virtual void setTargetBackend(const std::string &backend) override {
     auto parts = cudaq::split(backend, ';');
     if (parts.size() % 2 != 0)
@@ -75,6 +78,11 @@ public:
         return nullptr;
       return iter->second;
     }();
+
+    if (executionContextPtr && executionContextPtr->name == "tracer") {
+      return;
+    }
+
     // Default context for a 'fire-and-ignore' kernel launch; i.e., no context
     // was set before launching the kernel. Use a static variable per thread to
     // set up a single-shot execution context for this case.


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Publishing validation failed for `mid_circuit_measurement.cpp`: https://github.com/NVIDIA/cuda-quantum/actions/runs/8102260968/job/22146719182


We've probably missed a couple of changes when refactoring `RemoteSimulatorQPU`  -> `BaseRemoteSimulatorQPU`.

Perhaps, these changes went into main's `RemoteSimulatorQPU` after the refactoring and have not been copied over to  `BaseRemoteSimulatorQPU`.

Tested by: running this `mid_circuit_measurement.cpp` locally after the fix for both `remote-mqpu` and `nvqc`.