### PR TITLE
Fix issue where list creation would not load pointers before adding them to the list

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -1817,6 +1817,13 @@ class PyASTBridge(ast.NodeVisitor):
                     quake.ConcatOp(self.getVeqType(), listElementValues).result)
             return
 
+        # We do not store lists of pointers
+        listElementValues = [
+            cc.LoadOp(ele).result
+            if cc.PointerType.isinstance(ele.type) else ele
+            for ele in listElementValues
+        ]
+
         # not a list of quantum types
         # Get the first element
         firstTy = listElementValues[0].type

--- a/python/cudaq/kernels/uccsd.py
+++ b/python/cudaq/kernels/uccsd.py
@@ -105,9 +105,7 @@ def uccsd_num_parameters(n_electrons, n_qubits):
 
     singles = length_alpha_singles + length_beta_singles
     doubles = length_mixed_doubles + length_alpha_doubles + length_beta_doubles
-    total = singles + doubles
-
-    return sum((singles, doubles, total))
+    return singles + doubles
 
 
 @cudaq.kernel

--- a/python/tests/domains/test_chemistry.py
+++ b/python/tests/domains/test_chemistry.py
@@ -128,6 +128,51 @@ def test_uccsd_kernel():
     print(energy, params)
 
 
+def test_doubles_alpha_bug():
+    # AST Bridge was not loading pointers
+    # when building lists, hence the following would
+    # break at runtime
+
+    n_occupied = 2
+    n_virtual = 4
+    occupied_alpha_indices = [i * 2 for i in range(n_occupied)]
+    virtual_alpha_indices = [i * 2 + 4 for i in range(n_virtual)]
+    lenOccA = 2
+    lenVirtA = 4
+    nEle = 6
+
+    @cudaq.kernel
+    def test() -> bool:
+        counter = 0
+        doubles_a = [[0, 0, 0, 0] for k in range(nEle)]
+        for p in range(lenOccA - 1):
+            for q in range(p + 1, lenOccA):
+                for r in range(lenVirtA - 1):
+                    for s in range(r + 1, lenVirtA):
+                        cudaq.dbg.ast.print_i64(p)
+                        cudaq.dbg.ast.print_i64(q)
+                        cudaq.dbg.ast.print_i64(r)
+                        cudaq.dbg.ast.print_i64(s)
+                        cudaq.dbg.ast.print_i64(occupied_alpha_indices[p])
+                        cudaq.dbg.ast.print_i64(occupied_alpha_indices[q])
+                        cudaq.dbg.ast.print_i64(virtual_alpha_indices[r])
+                        cudaq.dbg.ast.print_i64(virtual_alpha_indices[s])
+                        t = occupied_alpha_indices[p]
+                        u = occupied_alpha_indices[q]
+                        v = virtual_alpha_indices[r]
+                        w = virtual_alpha_indices[s]
+                        doubles_a[counter] = [
+                            occupied_alpha_indices[p], u, v, w
+                        ]
+                        for i in range(4):
+                            cudaq.dbg.ast.print_i64(doubles_a[counter][i])
+                        counter = counter + 1
+        return True
+
+    # Test is that this compiles and runs successfully
+    assert test()
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)


### PR DESCRIPTION
In the following code we have subscripting into existing lists, which returns a `cc.ptr` type. At runtime this translates into a garbage integer being added to the `doubles_a[counter]` list. This PR instead checks the list elements being added and if one is a `cc.ptr` then we call `cc.LoadOp` first. 

```python
doubles_a[counter] = [occupied_alpha_indices[p],occupied_alpha_indices[q],\
                                     virtual_alpha_indices[r],virtual_alpha_indices[s]]
```

Also, fixing an oversight in the number of UCCSD parameters function. 