### PR TITLE
Elevate capture vars to stack slot at function entry block start

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -42,6 +42,12 @@ class PyScopedSymbolTable(object):
     def popScope(self):
         self.symbolTable.pop()
 
+    def add(self, symbol, value, level=-1):
+        """
+        Add a symbol to the scoped symbol table at any scope level.
+        """
+        self.symbolTable[level][symbol] = value
+
     def __contains__(self, symbol):
         for st in reversed(self.symbolTable):
             if symbol in st:
@@ -50,7 +56,8 @@ class PyScopedSymbolTable(object):
         return False
 
     def __setitem__(self, symbol, value):
-        self.symbolTable[-1][symbol] = value
+        # default to nearest surrounding scope
+        self.add(symbol, value)
         return
 
     def __getitem__(self, symbol):
@@ -325,6 +332,15 @@ class PyASTBridge(ast.NodeVisitor):
         return IntegerType.isinstance(type) or F64Type.isinstance(
             type) or ComplexType.isinstance(type)
 
+    def ifPointerThenLoad(self, value):
+        """
+        If the given value is of pointer type, load the pointer 
+        and return that new value.
+        """
+        if cc.PointerType.isinstance(value.type):
+            return cc.LoadOp(value).result
+        return value
+
     def __createStdvecWithKnownValues(self, size, listElementValues):
         # Turn this List into a StdVec<T>
         arrSize = self.getConstantInt(size)
@@ -353,6 +369,7 @@ class PyASTBridge(ast.NodeVisitor):
         Insert a debug print out statement if the programmer requested. Handles 
         statements like `cudaq.dbg.ast.print_i64(i)`.
         """
+        value = self.ifPointerThenLoad(value)
         printFunc = None
         printStr = '[cudaq-ast-dbg] '
         argsTy = [cc.PointerType.get(self.ctx, self.getIntegerType(8))]
@@ -378,7 +395,7 @@ class PyASTBridge(ast.NodeVisitor):
         elif dbgStmt == 'print_f64':
             if not F64Type.isinstance(value.type):
                 self.emitFatalError(
-                    f"print_f64 requested, but value is not of integer type (type was {value.type})."
+                    f"print_f64 requested, but value is not of float type (type was {value.type})."
                 )
 
             currentST = SymbolTable(self.module.operation)
@@ -1418,6 +1435,7 @@ class PyASTBridge(ast.NodeVisitor):
                         qubits = quake.AllocaOp(ty)
                     else:
                         ty = self.getVeqType()
+                        size = self.ifPointerThenLoad(size)
                         qubits = quake.AllocaOp(ty, size=size)
                     self.pushValue(qubits.results[0])
                     return
@@ -2411,6 +2429,7 @@ class PyASTBridge(ast.NodeVisitor):
         self.currentAssignVariableName = None
 
         condition = self.popValue()
+        condition = self.ifPointerThenLoad(condition)
 
         if self.getIntegerType(1) != condition.type:
             # not equal to 0, then compare with 1
@@ -2472,6 +2491,8 @@ class PyASTBridge(ast.NodeVisitor):
         if result.owner.parent != self.kernelFuncOp:
             cc.UnwindReturnOp([result])
             return
+
+        result = self.ifPointerThenLoad(result)
 
         if result.type != self.knownResultType:
             # FIXME consider auto-casting where possible
@@ -2733,27 +2754,6 @@ class PyASTBridge(ast.NodeVisitor):
         if node.id in self.capturedVars:
             # Only support a small subset of types here
             value = self.capturedVars[node.id]
-            if isinstance(value, int):
-                self.dependentCaptureVars[node.id] = value
-                mlirVal = self.getConstantInt(value)
-                self.symbolTable[node.id] = mlirVal
-                self.pushValue(mlirVal)
-                return
-
-            if isinstance(value, bool):
-                self.dependentCaptureVars[node.id] = value
-                mlirVal = self.getConstantInt(value, 1)
-                self.symbolTable[node.id] = mlirVal
-                self.pushValue(mlirVal)
-                return
-
-            if isinstance(value, float):
-                self.dependentCaptureVars[node.id] = value
-                mlirVal = self.getConstantFloat(value)
-                self.symbolTable[node.id] = mlirVal
-                self.pushValue(mlirVal)
-                return
-
             if isinstance(value, list) and isinstance(value[0],
                                                       (int, bool, float)):
                 elementValues = None
@@ -2768,8 +2768,29 @@ class PyASTBridge(ast.NodeVisitor):
                     self.dependentCaptureVars[node.id] = value
                     mlirVal = self.__createStdvecWithKnownValues(
                         len(value), elementValues)
-                    self.symbolTable[node.id] = mlirVal
+                    self.symbolTable.add(node.id, mlirVal, 0)
                     self.pushValue(mlirVal)
+                    return
+
+            mlirValCreator = None
+            self.dependentCaptureVars[node.id] = value
+            if isinstance(value, int):
+                mlirValCreator = lambda: self.getConstantInt(value)
+            elif isinstance(value, bool):
+                mlirValCreator = lambda: self.getConstantInt(value, 1)
+            elif isinstance(value, float):
+                mlirValCreator = lambda: self.getConstantFloat(value)
+
+            if mlirValCreator != None:
+                with InsertionPoint.at_block_begin(self.entry):
+                    mlirVal = mlirValCreator()
+                    stackSlot = cc.AllocaOp(
+                        cc.PointerType.get(self.ctx, mlirVal.type),
+                        TypeAttr.get(mlirVal.type)).result
+                    cc.StoreOp(mlirVal, stackSlot)
+                    # Store at the top-level
+                    self.symbolTable.add(node.id, stackSlot, 0)
+                    self.pushValue(stackSlot)
                     return
 
             self.emitFatalError(

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -1017,6 +1017,10 @@ class PyASTBridge(ast.NodeVisitor):
                     endVal = self.popValue()
                     startVal = zero
 
+                startVal = self.ifPointerThenLoad(startVal)
+                endVal = self.ifPointerThenLoad(endVal)
+                stepVal = self.ifPointerThenLoad(stepVal)
+
                 # The total number of elements in the iterable
                 # we are generating should be `N == endVal - startVal`
                 totalSize = math.AbsIOp(arith.SubIOp(endVal,

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -226,7 +226,7 @@ def test_dynamic_circuit():
             x(q[1])
         mz(q)
 
-    counts = cudaq.sample(simple)
+    counts = cudaq.sample(simple, shots_count=100)
     counts.dump()
     c0 = counts.get_register_counts('c0')
     assert '0' in c0 and '1' in c0
@@ -648,6 +648,20 @@ def test_capture_vars():
                       atol=1e-3)
 
 
+def test_capture_change_variable():
+
+    n = 3
+
+    @cudaq.kernel(verbose=True)
+    def kernel() -> int:
+        if True:
+            n = 4
+        return n
+
+    print(kernel)
+    assert n != kernel()
+
+
 def test_inner_function_capture():
 
     n = 3
@@ -659,6 +673,8 @@ def test_inner_function_capture():
         def foo():
             q = cudaq.qvector(n)
 
+        print(foo)
+
         def innerInnerClassical():
 
             @cudaq.kernel()
@@ -666,11 +682,15 @@ def test_inner_function_capture():
                 q = cudaq.qvector(m)
                 x(q)
 
+            print(bar)
+
             return cudaq.sample(bar)
 
         return cudaq.sample(foo), innerInnerClassical()
 
     fooCounts, barCounts = innerClassical()
+    print('foo counts ', fooCounts)
+    print('bar counts ', barCounts)
     assert len(fooCounts) == 1 and '0' * n in fooCounts
     assert len(barCounts) == 1 and '1' * m in barCounts
 

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -650,23 +650,26 @@ def test_capture_vars():
 
 def test_capture_change_variable():
 
-    # This tests that variables can be captured, 
-    # that those captured variables can be modified 
-    # and adhere to capture-by-value semantics, 
-    # and that captures are not defined in 
-    # an inner scope, but are defined at the 
-    # function entry block, thus usable 
-    # in other spots in the kernel. 
+    # This tests that variables can be captured,
+    # that those captured variables can be modified
+    # and adhere to capture-by-value semantics,
+    # and that captures are not defined in
+    # an inner scope, but are defined at the
+    # function entry block, thus usable
+    # in other spots in the kernel.
 
     n = 3
 
-    @cudaq.kernel(verbose=True)
+    @cudaq.kernel
     def kernel() -> int:
         if True:
+            cudaq.dbg.ast.print_i64(n)
+            # Change n
             n = 4
+        # Return n
         return n
 
-    assert n != kernel()
+    assert n == 3 and 4 == kernel()
 
 
 def test_inner_function_capture():

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -657,7 +657,7 @@ def test_capture_change_variable():
     # an inner scope, but are defined at the 
     # function entry block, thus usable 
     # in other spots in the kernel. 
-    
+
     n = 3
 
     @cudaq.kernel(verbose=True)
@@ -666,7 +666,6 @@ def test_capture_change_variable():
             n = 4
         return n
 
-    print(kernel)
     assert n != kernel()
 
 
@@ -681,8 +680,6 @@ def test_inner_function_capture():
         def foo():
             q = cudaq.qvector(n)
 
-        print(foo)
-
         def innerInnerClassical():
 
             @cudaq.kernel()
@@ -690,15 +687,11 @@ def test_inner_function_capture():
                 q = cudaq.qvector(m)
                 x(q)
 
-            print(bar)
-
             return cudaq.sample(bar)
 
         return cudaq.sample(foo), innerInnerClassical()
 
     fooCounts, barCounts = innerClassical()
-    print('foo counts ', fooCounts)
-    print('bar counts ', barCounts)
     assert len(fooCounts) == 1 and '0' * n in fooCounts
     assert len(barCounts) == 1 and '1' * m in barCounts
 

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -650,6 +650,14 @@ def test_capture_vars():
 
 def test_capture_change_variable():
 
+    # This tests that variables can be captured, 
+    # that those captured variables can be modified 
+    # and adhere to capture-by-value semantics, 
+    # and that captures are not defined in 
+    # an inner scope, but are defined at the 
+    # function entry block, thus usable 
+    # in other spots in the kernel. 
+    
     n = 3
 
     @cudaq.kernel(verbose=True)


### PR DESCRIPTION
Previously, captured variables were treated as constant MLIR values created in whatever scope they were first used. This means they cannot be used in other function scopes and they can't be set / changed (though they are still captured by value). This PR fixes this by elevating capture variables to stack variables at the start of the kernel entry block. 