### PR TITLE
Disallow assignment to captured variables

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -820,6 +820,11 @@ class PyASTBridge(ast.NodeVisitor):
                     value.type) or cc.CallableType.isinstance(value.type):
                 self.symbolTable[varNames[i]] = value
             elif varNames[i] in self.symbolTable:
+                if varNames[i] in self.capturedVars:
+                    self.emitFatalError(
+                        f"CUDA Quantum does not allow assignment to variables captured from parent scope.",
+                        node)
+
                 cc.StoreOp(value, self.symbolTable[varNames[i]])
             elif cc.PointerType.isinstance(value.type):
                 self.symbolTable[varNames[i]] = value

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -648,7 +648,7 @@ def test_capture_vars():
                       atol=1e-3)
 
 
-def test_capture_change_variable():
+def test_capture_disallow_change_variable():
 
     # This tests that variables can be captured,
     # that those captured variables can be modified
@@ -669,7 +669,8 @@ def test_capture_change_variable():
         # Return n
         return n
 
-    assert n == 3 and 4 == kernel()
+    with pytest.raises(RuntimeError) as e:
+        kernel()
 
 
 def test_inner_function_capture():

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -649,24 +649,15 @@ def test_capture_vars():
 
 
 def test_capture_disallow_change_variable():
-
-    # This tests that variables can be captured,
-    # that those captured variables can be modified
-    # and adhere to capture-by-value semantics,
-    # and that captures are not defined in
-    # an inner scope, but are defined at the
-    # function entry block, thus usable
-    # in other spots in the kernel.
-
+    
     n = 3
 
     @cudaq.kernel
     def kernel() -> int:
         if True:
             cudaq.dbg.ast.print_i64(n)
-            # Change n
+            # Change n, emits an error
             n = 4
-        # Return n
         return n
 
     with pytest.raises(RuntimeError) as e:


### PR DESCRIPTION
Throw a compile-time error if someone tries to assign to a variable captured from parent scope. 