### PR TITLE
Runtime error if kernel arguments missing / incorrect when invoking   'draw'

### DIFF
--- a/python/runtime/cudaq/algorithms/py_draw.cpp
+++ b/python/runtime/cudaq/algorithms/py_draw.cpp
@@ -21,6 +21,9 @@ void pyAltLaunchKernel(const std::string &, MlirModule, OpaqueArguments &,
 /// @brief Run `cudaq::get_state` on the provided kernel and spin operator.
 std::string pyDraw(py::object &kernel, py::args args) {
 
+  if (py::len(kernel.attr("arguments")) != args.size())
+    throw std::runtime_error("Invalid number of arguments passed to draw.");
+
   if (py::hasattr(kernel, "compile"))
     kernel.attr("compile")();
 

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -649,7 +649,7 @@ def test_capture_vars():
 
 
 def test_capture_disallow_change_variable():
-    
+
     n = 3
 
     @cudaq.kernel
@@ -888,3 +888,15 @@ q3 : ┤ h ├──────────────────────
 '''
 
     assert circuit == expected_str
+
+
+def test_draw_fail():
+
+    @cudaq.kernel
+    def kernel(argument: float):
+        q = cudaq.qvector(2)
+        h(q[0])
+        ry(argument, q[1])
+
+    with pytest.raises(RuntimeError) as error:
+        print(cudaq.draw(kernel))


### PR DESCRIPTION
Description:
> We should throw a better error in cudaq.draw() if someone forgets to pass along the kernel arguments. Right now, it just returns a segfault without explanation.
