### PR TITLE
[NVQC] Add logging info for timeout 

### DIFF
--- a/python/runtime/utils/PyRestRemoteClient.cpp
+++ b/python/runtime/utils/PyRestRemoteClient.cpp
@@ -38,8 +38,15 @@ private:
   std::string m_functionId;
   // NVCF version Id of that function to use
   std::string m_functionVersionId;
-  // Available functions: function Id to number of GPUs mapping
-  using DeploymentInfo = std::unordered_map<std::string, std::size_t>;
+  // Information about function deployment from environment variable info.
+  struct FunctionEnvironments {
+    // These configs should be positive numbers.
+    int version;
+    int numGpus;
+    int timeoutSecs;
+  };
+  // Available functions: function Id to info mapping
+  using DeploymentInfo = std::unordered_map<std::string, FunctionEnvironments>;
   DeploymentInfo m_availableFuncs;
   const std::string CUDAQ_NCA_ID = cudaq::getNvqcNcaId();
   // Base URL for NVCF APIs
@@ -90,24 +97,27 @@ private:
           funcInfo["status"].get<std::string>() == "ACTIVE" &&
           funcInfo["name"].get<std::string>().starts_with(
               cudaqNvcfFuncNamePrefix)) {
-        const auto [numGpus, payLoadVersion] = [&]() -> std::pair<int, int> {
-          int version = -1; // Invalid
-          int gpuCounts = 1;
+        const auto containerEnvs = [&]() -> FunctionEnvironments {
+          FunctionEnvironments envs;
           if (funcInfo.contains("containerEnvironment")) {
             for (auto it : funcInfo["containerEnvironment"]) {
-              if (it["key"].get<std::string>() == "NUM_GPUS")
-                gpuCounts = std::stoi(it["value"].get<std::string>());
-              if (it["key"].get<std::string>() == "NVQC_REST_PAYLOAD_VERSION")
-                version = std::stoi(it["value"].get<std::string>());
+              const auto getEnvValueIfMatch =
+                  [](json &js, const std::string &envKey, int &varToSet) {
+                    if (js["key"].get<std::string>() == envKey)
+                      varToSet = std::stoi(js["value"].get<std::string>());
+                  };
+              getEnvValueIfMatch(it, "NUM_GPUS", envs.numGpus);
+              getEnvValueIfMatch(it, "NVQC_REST_PAYLOAD_VERSION", envs.version);
+              getEnvValueIfMatch(it, "WATCHDOG_TIMEOUT_SEC", envs.timeoutSecs);
             }
           }
 
-          return std::make_pair(gpuCounts, version);
+          return envs;
         }();
 
         // Only add functions that match client version.
-        if (payLoadVersion == version())
-          info[funcInfo["id"].get<std::string>()] = numGpus;
+        if (containerEnvs.version == version())
+          info[funcInfo["id"].get<std::string>()] = containerEnvs;
       }
     }
 
@@ -168,8 +178,8 @@ public:
     }
 
     m_availableFuncs = getAllAvailableDeployments();
-    for (const auto &[funcId, numGpus] : m_availableFuncs)
-      cudaq::info("Function Id {} has {} GPUs.", funcId, numGpus);
+    for (const auto &[funcId, info] : m_availableFuncs)
+      cudaq::info("Function Id {} has {} GPUs.", funcId, info.numGpus);
     {
       const auto funcIdIter = configs.find("function-id");
       if (funcIdIter != configs.end()) {
@@ -189,17 +199,18 @@ public:
         // Determine the function Id based on the number of GPUs
         const auto nGpusIter = configs.find("ngpus");
         // Default is 1 GPU if none specified
-        const std::size_t numGpusRequested =
+        const int numGpusRequested =
             (nGpusIter != configs.end()) ? std::stoi(nGpusIter->second) : 1;
         cudaq::info("Looking for an NVQC deployment that has {} GPUs.",
                     numGpusRequested);
-        for (const auto &[funcId, numGpus] : m_availableFuncs) {
-          if (numGpus == numGpusRequested) {
+        for (const auto &[funcId, info] : m_availableFuncs) {
+          if (info.numGpus == numGpusRequested) {
             m_functionId = funcId;
             if (m_logLevel > LogLevel::None) {
               // Print out the configuration
-              cudaq::log("Submitting jobs to NVQC service with {} GPU(s).",
-                         numGpus);
+              cudaq::log("Submitting jobs to NVQC service with {} GPU(s). Max "
+                         "wall time: {} seconds.",
+                         info.numGpus, info.timeoutSecs);
             }
             break;
           }
@@ -207,8 +218,8 @@ public:
         if (m_functionId.empty()) {
           // Make sure that we sort the GPU count list
           std::set<std::size_t> gpuCounts;
-          for (const auto &[funcId, numGpus] : m_availableFuncs) {
-            gpuCounts.emplace(numGpus);
+          for (const auto &[funcId, info] : m_availableFuncs) {
+            gpuCounts.emplace(info.numGpus);
           }
           std::stringstream ss;
           ss << "Unable to find NVQC deployment with " << numGpusRequested
@@ -289,13 +300,14 @@ public:
       // setting the backend to a single-GPU one. Only print once in case this
       // is a execution loop.
       static bool printOnce = false;
-      if (m_availableFuncs[m_functionId] > 1 &&
+      if (m_availableFuncs[m_functionId].numGpus > 1 &&
           std::find(MULTI_GPU_BACKENDS.begin(), MULTI_GPU_BACKENDS.end(),
                     backendSimName) == MULTI_GPU_BACKENDS.end() &&
           !printOnce) {
         std::cout << "The requested backend simulator (" << backendSimName
                   << ") is not capable of using all "
-                  << m_availableFuncs[m_functionId] << " GPUs requested.\n";
+                  << m_availableFuncs[m_functionId].numGpus
+                  << " GPUs requested.\n";
         std::cout << "Only one GPU will be used for simulation.\n";
         std::cout << "Please refer to CUDA Quantum documentation for a list of "
                      "multi-GPU capable simulator backends.\n";
@@ -371,6 +383,7 @@ public:
 
       if (m_logLevel > LogLevel::None)
         cudaq::log("Posting NVQC request now");
+      const auto requestStartTime = std::chrono::system_clock::now();
       auto resultJs =
           m_restClient.post(nvcfInvocationUrl(), "", requestJson, jobHeader,
                             /*enableLogging=*/false, /*enableSsl=*/true);
@@ -378,8 +391,21 @@ public:
       while (resultJs.contains("status") &&
              resultJs["status"] == "pending-evaluation") {
         const std::string reqId = resultJs["reqId"];
+        const int elapsedTimeSecs =
+            std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now() - requestStartTime)
+                .count();
         if (m_logLevel > LogLevel::None)
           cudaq::log("Polling NVQC result data for Request Id {}", reqId);
+        // Warns if the remaining time is less than this threshold.
+        constexpr int TIMEOUT_WARNING_SECS = 5 * 60; // 5 minutes.
+        const int remainingSecs = std::max(
+            m_availableFuncs[m_functionId].timeoutSecs - elapsedTimeSecs, 0);
+        if (remainingSecs < TIMEOUT_WARNING_SECS)
+          cudaq::log("Request Id {}: Approaching the wall time limit ({} "
+                     "seconds). Remaining time: {} seconds.",
+                     reqId, m_availableFuncs[m_functionId].timeoutSecs,
+                     remainingSecs);
         // Wait 1 sec then poll the result
         std::this_thread::sleep_for(std::chrono::seconds(1));
         resultJs = m_restClient.get(nvcfInvocationStatus(reqId), "", jobHeader,

--- a/python/runtime/utils/PyRestRemoteClient.cpp
+++ b/python/runtime/utils/PyRestRemoteClient.cpp
@@ -41,9 +41,9 @@ private:
   // Information about function deployment from environment variable info.
   struct FunctionEnvironments {
     // These configs should be positive numbers.
-    int version;
-    int numGpus;
-    int timeoutSecs;
+    int version{-1};
+    int numGpus{-1};
+    int timeoutSecs{-1};
   };
   // Available functions: function Id to info mapping
   using DeploymentInfo = std::unordered_map<std::string, FunctionEnvironments>;

--- a/python/runtime/utils/PyRestRemoteClient.cpp
+++ b/python/runtime/utils/PyRestRemoteClient.cpp
@@ -193,8 +193,10 @@ public:
       } else {
         // Output an error message if no deployments can be found.
         if (m_availableFuncs.empty())
-          throw std::runtime_error("Unable to find any ACTIVE NVQC "
-                                   "deployments. Please contact NVQC support.");
+          throw std::runtime_error(
+              "Unable to find any ACTIVE NVQC deployments. Please ensure that "
+              "the provided NVQC API key is authorized to invoke NVQC "
+              "functions; otherwise, please contact NVQC support.");
 
         // Determine the function Id based on the number of GPUs
         const auto nGpusIter = configs.find("ngpus");

--- a/python/runtime/utils/PyRestRemoteClient.cpp
+++ b/python/runtime/utils/PyRestRemoteClient.cpp
@@ -208,9 +208,10 @@ public:
             m_functionId = funcId;
             if (m_logLevel > LogLevel::None) {
               // Print out the configuration
-              cudaq::log("Submitting jobs to NVQC service with {} GPU(s). Max "
-                         "wall time: {} seconds.",
-                         info.numGpus, info.timeoutSecs);
+              cudaq::log(
+                  "Submitting jobs to NVQC service with {} GPU(s). Max "
+                  "execution time: {} seconds (excluding queue wait time).",
+                  info.numGpus, info.timeoutSecs);
             }
             break;
           }
@@ -391,21 +392,30 @@ public:
       while (resultJs.contains("status") &&
              resultJs["status"] == "pending-evaluation") {
         const std::string reqId = resultJs["reqId"];
-        const int elapsedTimeSecs =
-            std::chrono::duration_cast<std::chrono::seconds>(
-                std::chrono::system_clock::now() - requestStartTime)
-                .count();
-        if (m_logLevel > LogLevel::None)
-          cudaq::log("Polling NVQC result data for Request Id {}", reqId);
-        // Warns if the remaining time is less than this threshold.
-        constexpr int TIMEOUT_WARNING_SECS = 5 * 60; // 5 minutes.
-        const int remainingSecs = std::max(
-            m_availableFuncs[m_functionId].timeoutSecs - elapsedTimeSecs, 0);
-        if (remainingSecs < TIMEOUT_WARNING_SECS)
-          cudaq::log("Request Id {}: Approaching the wall time limit ({} "
-                     "seconds). Remaining time: {} seconds.",
-                     reqId, m_availableFuncs[m_functionId].timeoutSecs,
-                     remainingSecs);
+        if (m_logLevel > LogLevel::None) {
+          const int elapsedTimeSecs =
+              std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::system_clock::now() - requestStartTime)
+                  .count();
+          // Warns if the remaining time is less than this threshold.
+          constexpr int TIMEOUT_WARNING_SECS = 5 * 60; // 5 minutes.
+          const int remainingSecs =
+              m_availableFuncs[m_functionId].timeoutSecs - elapsedTimeSecs;
+          std::string additionalInfo;
+          if (remainingSecs < 0)
+            fmt::format_to(std::back_inserter(additionalInfo),
+                           ". Exceeded wall time limit ({} seconds), but time "
+                           "spent waiting in queue is not counted. Proceeding.",
+                           m_availableFuncs[m_functionId].timeoutSecs);
+          else if (remainingSecs < TIMEOUT_WARNING_SECS)
+            fmt::format_to(std::back_inserter(additionalInfo),
+                           ". Approaching the wall time limit ({} seconds). "
+                           "Remaining time: {} seconds.",
+                           m_availableFuncs[m_functionId].timeoutSecs,
+                           remainingSecs);
+          cudaq::log("Polling NVQC result data for Request Id {}{}", reqId,
+                     additionalInfo);
+        }
         // Wait 1 sec then poll the result
         std::this_thread::sleep_for(std::chrono::seconds(1));
         resultJs = m_restClient.get(nvcfInvocationStatus(reqId), "", jobHeader,

--- a/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
+++ b/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
@@ -38,9 +38,9 @@ private:
   // Information about function deployment from environment variable info.
   struct FunctionEnvironments {
     // These configs should be positive numbers.
-    int version;
-    int numGpus;
-    int timeoutSecs;
+    int version{-1};
+    int numGpus{-1};
+    int timeoutSecs{-1};
   };
   // Available functions: function Id to info mapping
   using DeploymentInfo = std::unordered_map<std::string, FunctionEnvironments>;

--- a/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
+++ b/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
@@ -190,8 +190,10 @@ public:
       } else {
         // Output an error message if no deployments can be found.
         if (m_availableFuncs.empty())
-          throw std::runtime_error("Unable to find any ACTIVE NVQC "
-                                   "deployments. Please contact NVQC support.");
+          throw std::runtime_error(
+              "Unable to find any ACTIVE NVQC deployments. Please ensure that "
+              "the provided NVQC API key is authorized to invoke NVQC "
+              "functions; otherwise, please contact NVQC support.");
 
         // Determine the function Id based on the number of GPUs
         const auto nGpusIter = configs.find("ngpus");


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- Retrieve timeout info from NVQC deployment (container environment variables).

- Log timeout limit alongside the NVQC info line.

- Warn users when timeout is approaching (less than 5 min remained).
