### PR TITLE
Add support for vector<int64_t>, vector<int32_t>, and vector<float>

### DIFF
--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -40,8 +40,8 @@ using namespace mlir;
 /// BlockArgument with it.
 template <typename ConcreteType>
 void synthesizeRuntimeArgument(
-    OpBuilder &builder, BlockArgument &argument, void *args,
-    std::size_t &offset, std::size_t typeSize,
+    OpBuilder &builder, BlockArgument argument, void *args, std::size_t &offset,
+    std::size_t typeSize,
     std::function<Value(OpBuilder &, ConcreteType *)> &&opGenerator) {
 
   // Create an instance of the concrete type
@@ -54,9 +54,8 @@ void synthesizeRuntimeArgument(
   // Generate the MLIR Value (arith constant for example)
   auto runtimeArg = opGenerator(builder, &concrete);
 
-  // Most of the time, this arg will have an immediate
-  // stack allocation with memref, remove those load uses
-  // and replace with the concrete op.
+  // Most of the time, this arg will have an immediate stack allocation with
+  // memref, remove those load uses and replace with the concrete op.
   if (!argument.getUsers().empty()) {
     auto firstUse = *argument.user_begin();
     if (dyn_cast<cudaq::cc::StoreOp>(firstUse)) {
@@ -69,17 +68,33 @@ void synthesizeRuntimeArgument(
   argument.replaceAllUsesWith(runtimeArg);
 }
 
-static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
-                                              BlockArgument &argument,
-                                              std::vector<double> &vec) {
+template <typename T>
+Value makeIntegerElement(OpBuilder &builder, Location argLoc, T val,
+                         IntegerType eleTy) {
+  return builder.create<arith::ConstantIntOp>(argLoc, val, eleTy);
+}
+
+template <typename T>
+Value makeFloatElement(OpBuilder &builder, Location argLoc, T val,
+                       FloatType eleTy) {
+  return builder.create<arith::ConstantFloatOp>(argLoc, llvm::APFloat{val},
+                                                eleTy);
+}
+
+template <typename ELETY, typename T, typename ATTR, typename MAKER>
+LogicalResult synthesizeVectorArgument(OpBuilder &builder,
+                                       BlockArgument argument,
+                                       std::vector<T> &vec, ATTR arrayAttr,
+                                       MAKER makeElementValue) {
   auto *ctx = builder.getContext();
-  assert(isa<cudaq::cc::StdvecType>(argument.getType()));
-  auto eleTy = cast<cudaq::cc::StdvecType>(argument.getType()).getElementType();
-  auto arrayAttr = builder.getF64ArrayAttr(vec);
+  auto argTy = argument.getType();
+  assert(isa<cudaq::cc::StdvecType>(argTy));
+  auto strTy = cast<cudaq::cc::StdvecType>(argTy);
+  auto eleTy = cast<ELETY>(strTy.getElementType());
   builder.setInsertionPointToStart(argument.getOwner());
+  auto argLoc = argument.getLoc();
   auto conArray = builder.create<cudaq::cc::ConstantArrayOp>(
-      argument.getLoc(), cudaq::cc::ArrayType::get(ctx, eleTy, vec.size()),
-      arrayAttr);
+      argLoc, cudaq::cc::ArrayType::get(ctx, eleTy, vec.size()), arrayAttr);
   auto replaceLoads = [&](cudaq::cc::ComputePtrOp gepOp,
                           Value newVal) -> LogicalResult {
     for (auto *u : gepOp->getUsers()) {
@@ -87,20 +102,24 @@ static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
         loadOp.replaceAllUsesWith(newVal);
         continue;
       }
-      return gepOp.emitError("Unknown gep/load configuration for quake-synth.");
+      return gepOp.emitError("Unknown gep/load configuration for synthesis.");
     }
     return success();
   };
   for (auto *argUser : argument.getUsers()) {
+    if (auto stdvecSizeOp = dyn_cast<cudaq::cc::StdvecSizeOp>(argUser)) {
+      Value length = builder.create<arith::ConstantIntOp>(
+          argLoc, vec.size(), stdvecSizeOp.getType());
+      stdvecSizeOp.replaceAllUsesWith(length);
+      continue;
+    }
     if (auto stdvecDataOp = dyn_cast<cudaq::cc::StdvecDataOp>(argUser)) {
       for (auto *dataUser : stdvecDataOp->getUsers()) {
         // could be a load, or a getelementptr.
         // if load, the index is 0
         // if getelementptr, then we get the index there to use
         if (auto loadOp = dyn_cast<cudaq::cc::LoadOp>(dataUser)) {
-          llvm::APFloat f(vec[0]);
-          Value runtimeParam = builder.create<arith::ConstantFloatOp>(
-              argument.getLoc(), f, builder.getF64Type());
+          Value runtimeParam = makeElementValue(builder, argLoc, vec[0], eleTy);
           // Replace with the constant value
           loadOp.replaceAllUsesWith(runtimeParam);
           continue;
@@ -108,6 +127,7 @@ static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
         if (auto gepOp = dyn_cast<cudaq::cc::ComputePtrOp>(dataUser)) {
           auto index = gepOp.getRawConstantIndices()[0];
           if (index == cudaq::cc::ComputePtrOp::kDynamicIndex) {
+            OpBuilder::InsertionGuard guard(builder);
             builder.setInsertionPoint(gepOp);
             Value getEle = builder.create<cudaq::cc::GetConstantElementOp>(
                 gepOp.getLoc(), eleTy, conArray, gepOp.getDynamicIndices()[0]);
@@ -115,9 +135,8 @@ static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
               return failure();
             continue;
           }
-          llvm::APFloat f(vec[index]);
-          Value runtimeParam = builder.create<arith::ConstantFloatOp>(
-              argument.getLoc(), f, builder.getF64Type());
+          Value runtimeParam =
+              makeElementValue(builder, argLoc, vec[index], eleTy);
           if (failed(replaceLoads(gepOp, runtimeParam)))
             return failure();
         } else {
@@ -128,6 +147,38 @@ static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
     }
   }
   return success();
+}
+
+static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
+                                              BlockArgument argument,
+                                              std::vector<std::int32_t> &vec) {
+  auto arrayAttr = builder.getI32ArrayAttr(vec);
+  return synthesizeVectorArgument<IntegerType>(
+      builder, argument, vec, arrayAttr, makeIntegerElement<std::int32_t>);
+}
+
+static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
+                                              BlockArgument argument,
+                                              std::vector<std::int64_t> &vec) {
+  auto arrayAttr = builder.getI64ArrayAttr(vec);
+  return synthesizeVectorArgument<IntegerType>(
+      builder, argument, vec, arrayAttr, makeIntegerElement<std::int64_t>);
+}
+
+static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
+                                              BlockArgument argument,
+                                              std::vector<float> &vec) {
+  auto arrayAttr = builder.getF32ArrayAttr(vec);
+  return synthesizeVectorArgument<FloatType>(builder, argument, vec, arrayAttr,
+                                             makeFloatElement<float>);
+}
+
+static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
+                                              BlockArgument argument,
+                                              std::vector<double> &vec) {
+  auto arrayAttr = builder.getF64ArrayAttr(vec);
+  return synthesizeVectorArgument<FloatType>(builder, argument, vec, arrayAttr,
+                                             makeFloatElement<double>);
 }
 
 namespace {
@@ -150,130 +201,206 @@ public:
   void runOnOperation() override final {
     auto module = getModule();
     if (args == nullptr || kernelName.empty()) {
-      emitError(
-          module.getLoc(),
-          "Quake Synthesis requires runtime arguments and the kernel name.\n");
+      module.emitOpError("Synthesis requires a kernel and the values of the "
+                         "arguments passed when it is called.");
       signalPassFailure();
       return;
     }
 
-    for (auto &op : *module.getBody()) {
-      // Get the function we care about (the one with kernelName)
-      auto funcOp = dyn_cast<func::FuncOp>(op);
-      if (!funcOp)
-        continue;
+    auto kernelNameInQuake = cudaq::runtime::cudaqGenPrefixName + kernelName;
+    // Get the function we care about (the one with kernelName)
+    auto funcOp = module.lookupSymbol<func::FuncOp>(kernelNameInQuake);
+    if (!funcOp) {
+      module.emitOpError("The kernel '" + kernelName +
+                         "' was not found in the module.");
+      signalPassFailure();
+      return;
+    }
 
-      if (!funcOp.getName().startswith(cudaq::runtime::cudaqGenPrefixName +
-                                       kernelName))
-        continue;
+    // Create the builder and get the function arguments.
+    // We will remove these arguments and replace with constant ops
+    auto builder = OpBuilder::atBlockBegin(&funcOp.getBody().front());
+    auto arguments = funcOp.getArguments();
 
-      // Create the builder and get the function arguments.
-      // We will remove these arguments and replace with constant ops
-      auto builder = OpBuilder::atBlockBegin(&funcOp.getBody().front());
-      auto arguments = funcOp.getArguments();
+    // Keep track of the stdVec sizes.
+    std::vector<std::tuple<std::size_t, Type, std::uint64_t>> stdVecInfo;
 
-      // Keep track of the stdVec sizes.
-      std::vector<std::size_t> stdVecSizes;
+    // For each argument, get the type and synthesize
+    // the runtime constant value.
+    std::size_t offset = 0;
 
-      // For each argument, get the type and synthesize
-      // the runtime constant value.
-      std::size_t offset = 0;
-      for (auto &argument : arguments) {
-        // Get the argument type
-        auto type = argument.getType();
+    for (auto iter : llvm::enumerate(arguments)) {
+      auto argNum = iter.index();
+      auto argument = iter.value();
 
-        // Based on the type, we want to replace it
-        // with a concrete constant op.
-        if (type == builder.getIntegerType(1)) {
+      // Get the argument type
+      auto type = argument.getType();
+      auto loc = argument.getLoc();
+
+      // Based on the type, we want to replace it with a concrete constant op.
+      // Process scalar integral types.
+      if (auto ty = dyn_cast<IntegerType>(type)) {
+        switch (ty.getIntOrFloatBitWidth()) {
+        case 1:
           synthesizeRuntimeArgument<bool>(
               builder, argument, args, offset, sizeof(bool),
-              [](OpBuilder &builder, bool *concrete) {
-                return builder.create<arith::ConstantIntOp>(
-                    builder.getUnknownLoc(), *concrete, 1);
+              [=](OpBuilder &builder, bool *concrete) {
+                return builder.create<arith::ConstantIntOp>(loc, *concrete, 1);
               });
-        } else if (type == builder.getIntegerType(8)) {
+          break;
+        case 8:
           synthesizeRuntimeArgument<std::uint8_t>(
               builder, argument, args, offset, sizeof(std::uint8_t),
-              [](OpBuilder &builder, std::uint8_t *concrete) {
-                return builder.create<arith::ConstantIntOp>(
-                    builder.getUnknownLoc(), *concrete, 8);
+              [=](OpBuilder &builder, std::uint8_t *concrete) {
+                return builder.create<arith::ConstantIntOp>(loc, *concrete, 8);
               });
-        } else if (type == builder.getIntegerType(32)) {
+          break;
+        case 16:
+          synthesizeRuntimeArgument<std::int16_t>(
+              builder, argument, args, offset, sizeof(std::int16_t),
+              [=](OpBuilder &builder, std::int16_t *concrete) {
+                return builder.create<arith::ConstantIntOp>(loc, *concrete, 16);
+              });
+          break;
+        case 32:
           synthesizeRuntimeArgument<int>(
               builder, argument, args, offset, sizeof(int),
-              [](OpBuilder &builder, int *concrete) {
-                return builder.create<arith::ConstantIntOp>(
-                    builder.getUnknownLoc(), *concrete, 32);
+              [=](OpBuilder &builder, int *concrete) {
+                return builder.create<arith::ConstantIntOp>(loc, *concrete, 32);
               });
-        } else if (type == builder.getIntegerType(64)) {
+          break;
+        case 64:
           synthesizeRuntimeArgument<long>(
               builder, argument, args, offset, sizeof(long),
-              [](OpBuilder &builder, long *concrete) {
-                return builder.create<arith::ConstantIntOp>(
-                    builder.getUnknownLoc(), *concrete, 64);
+              [=](OpBuilder &builder, long *concrete) {
+                return builder.create<arith::ConstantIntOp>(loc, *concrete, 64);
               });
-        } else if (type == builder.getF32Type()) {
-          synthesizeRuntimeArgument<float>(
-              builder, argument, args, offset, type.getIntOrFloatBitWidth() / 8,
-              [](OpBuilder &builder, float *concrete) {
-                llvm::APFloat f(*concrete);
-                return builder.create<arith::ConstantFloatOp>(
-                    builder.getUnknownLoc(), f, builder.getF32Type());
-              });
-        } else if (type == builder.getF64Type()) {
-          synthesizeRuntimeArgument<double>(
-              builder, argument, args, offset, type.getIntOrFloatBitWidth() / 8,
-              [](OpBuilder &builder, double *concrete) {
-                llvm::APFloat f(*concrete);
-                return builder.create<arith::ConstantFloatOp>(
-                    builder.getUnknownLoc(), f, builder.getF64Type());
-              });
-        } else if (isa<cudaq::cc::StdvecType>(type)) {
-          std::size_t vectorSize = *(std::size_t *)(((char *)args) + offset);
-          vectorSize /= sizeof(double);
-          offset += sizeof(std::size_t);
-          stdVecSizes.push_back(vectorSize);
-        } else if (isa<cudaq::cc::StructType, cudaq::cc::CallableType>(type)) {
-          // The struct type ends up as a i64 in the thunk kernel
-          // args pointer, so just skip ahead.
-          offset += sizeof(std::size_t);
-        } else {
-          type.dump();
-          TODO("We cannot synthesize this type of argument yet.");
+          break;
+        default:
+          funcOp.emitOpError(
+              "argument was not synthesized, unhandled integer type");
+          break;
         }
+        continue;
       }
 
-      // For any `std::vector` arguments, we now know the sizes so let's replace
-      // the block arg with the actual vector element data.
-      double *ptr = (double *)(((char *)args) + offset);
-      for (std::size_t idx = 0; auto &stdVecSize : stdVecSizes) {
-        // FIXME: this only works with std::vector<double> for now.
-        std::vector<double> v(ptr, ptr + stdVecSize);
-        if (failed(synthesizeVectorArgument(builder, arguments[idx++], v))) {
-          funcOp.emitError("Quake Synthesis failed for stdvec type.");
-          signalPassFailure();
-        }
+      // Process scalar floating point types.
+      if (type == builder.getF32Type()) {
+        synthesizeRuntimeArgument<float>(
+            builder, argument, args, offset, type.getIntOrFloatBitWidth() / 8,
+            [=](OpBuilder &builder, float *concrete) {
+              llvm::APFloat f(*concrete);
+              return builder.create<arith::ConstantFloatOp>(
+                  loc, f, builder.getF32Type());
+            });
+        continue;
+      }
+      if (type == builder.getF64Type()) {
+        synthesizeRuntimeArgument<double>(
+            builder, argument, args, offset, type.getIntOrFloatBitWidth() / 8,
+            [=](OpBuilder &builder, double *concrete) {
+              llvm::APFloat f(*concrete);
+              return builder.create<arith::ConstantFloatOp>(
+                  loc, f, builder.getF64Type());
+            });
+        continue;
       }
 
-      // Clean up dead code.
-      {
-        IRRewriter rewriter(builder);
-        (void)simplifyRegions(rewriter, {funcOp.getBody()});
-      }
-
-      // Remove the old arguments.
-      auto numArgs = funcOp.getNumArguments();
-      BitVector argsToErase(numArgs);
-      for (std::size_t argIndex = 0; argIndex < numArgs; ++argIndex) {
-        argsToErase.set(argIndex);
-        if (!funcOp.getBody().front().getArgument(argIndex).getUses().empty()) {
-          funcOp.emitError("argument(s) still in use after synthesis.");
+      // If std::vector<arithmetic> type, add it to the list of vector info.
+      // These will be processed when we reach the buffer's appendix.
+      if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(type)) {
+        auto eleTy = vecTy.getElementType();
+        if (!isa<IntegerType, FloatType>(eleTy)) {
+          funcOp.emitOpError("synthesis: unsupported argument type");
           signalPassFailure();
           return;
         }
+        char *ptrToSizeInBuffer = static_cast<char *>(args) + offset;
+        auto sizeFromBuffer =
+            *reinterpret_cast<std::uint64_t *>(ptrToSizeInBuffer);
+        auto vectorSize = sizeFromBuffer / (eleTy.getIntOrFloatBitWidth() / 8);
+        offset += sizeof(std::uint64_t);
+        stdVecInfo.emplace_back(argNum, eleTy, vectorSize);
+        continue;
       }
-      funcOp.eraseArguments(argsToErase);
+
+      // The struct type ends up as a i64 in the thunk kernel args pointer, so
+      // just skip ahead. TODO: add support for struct types!
+      if (isa<cudaq::cc::StructType, cudaq::cc::CallableType>(type)) {
+        char *ptrToSizeInBuffer = static_cast<char *>(args) + offset;
+        auto rawSize = *reinterpret_cast<std::uint64_t *>(ptrToSizeInBuffer);
+        offset += sizeof(std::uint64_t);
+        stdVecInfo.emplace_back(argNum, Type{}, rawSize);
+        continue;
+      }
+      funcOp.emitOpError("We cannot synthesize argument(s) of this type.");
+      signalPassFailure();
+      return;
     }
+
+    // For any `std::vector` arguments, we now know the sizes so let's replace
+    // the block arg with the actual vector element data. First get the pointer
+    // to the start of the buffer's appendix.
+    char *bufferAppendix = static_cast<char *>(args) + offset;
+    for (auto [idx, eleTy, vecLength] : stdVecInfo) {
+      if (!eleTy) {
+        // FIXME: Skip struct values.
+        bufferAppendix += vecLength;
+        funcOp.emitOpError(
+            "argument to kernel may be a struct and was not synthesized");
+        continue;
+      }
+      auto doVector = [&]<typename T>(T) {
+        auto *ptr = reinterpret_cast<T *>(bufferAppendix);
+        std::vector<T> v(ptr, ptr + vecLength);
+        if (failed(synthesizeVectorArgument(builder, arguments[idx], v)))
+          funcOp.emitOpError("synthesis failed for vector<T>");
+        bufferAppendix += vecLength * sizeof(T);
+      };
+      if (auto ty = dyn_cast<IntegerType>(eleTy)) {
+        switch (ty.getIntOrFloatBitWidth()) {
+        case 32: {
+          doVector(std::int32_t{});
+        } break;
+        case 64: {
+          doVector(std::int64_t{});
+        } break;
+        default:
+          bufferAppendix += vecLength * (ty.getIntOrFloatBitWidth() / 8);
+          funcOp.emitOpError("synthesis failed for vector<integral-type>.");
+          break;
+        }
+        continue;
+      }
+      if (eleTy == builder.getF32Type()) {
+        doVector(float{});
+        continue;
+      }
+      if (eleTy == builder.getF64Type()) {
+        doVector(double{});
+        continue;
+      }
+    }
+
+    // Clean up dead code.
+    {
+      IRRewriter rewriter(builder);
+      [[maybe_unused]] auto unused =
+          simplifyRegions(rewriter, {funcOp.getBody()});
+    }
+
+    // Remove the old arguments.
+    auto numArgs = funcOp.getNumArguments();
+    BitVector argsToErase(numArgs);
+    for (std::size_t argIndex = 0; argIndex < numArgs; ++argIndex) {
+      argsToErase.set(argIndex);
+      if (!funcOp.getBody().front().getArgument(argIndex).getUses().empty()) {
+        funcOp.emitError("argument(s) still in use after synthesis.");
+        signalPassFailure();
+        return;
+      }
+    }
+    funcOp.eraseArguments(argsToErase);
   }
 };
 

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -754,9 +754,9 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
         std::string kernelName, std::vector<std::string> extraLibPaths) {
 
   // Start of by getting the current ModuleOp
-  auto block = builder.getBlock();
+  auto *block = builder.getBlock();
   auto *context = builder.getContext();
-  auto function = block->getParentOp();
+  auto *function = block->getParentOp();
   auto currentModule = function->getParentOfType<ModuleOp>();
 
   // Create a unique hash from that ModuleOp

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -302,14 +302,15 @@ struct ArgumentValidator<std::vector<T>> {
     auto &arg = args[argCounter];
     argCounter++;
 
-    // Validate the input vector<T> if possible
-    if (auto nRequiredElements = arg.getRequiredElements();
-        arg.canValidateNumElements())
-      if (input.size() != nRequiredElements)
-        throw std::runtime_error(
-            "Invalid vector<T> input. Number of elements provided != "
-            "number of elements required (" +
-            std::to_string(nRequiredElements) + " required).\n");
+    // Validate the input vector<T> if possible. If getRequiredElements()
+    // returns 0, any size vector is ok.
+    auto nRequiredElements = arg.getRequiredElements();
+    if (nRequiredElements && arg.canValidateNumElements() &&
+        input.size() < nRequiredElements)
+      throw std::runtime_error(
+          "Invalid vector<T> input. Number of elements provided (" +
+          std::to_string(input.size()) + ") != number of elements required (" +
+          std::to_string(nRequiredElements) + ").\n");
   }
 };
 

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -22,8 +22,8 @@
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 #include "mlir/Transforms/Passes.h"
-
 #include <gtest/gtest.h>
+#include <iostream>
 
 using namespace mlir;
 
@@ -118,7 +118,7 @@ TEST(QuakeSynthTests, checkSimpleIntegerInput) {
   auto qubits = kernel.qalloc(nQubits);
   kernel.h(qubits);
   kernel.mz(qubits);
-  printf("%s\n", kernel.to_quake().c_str());
+  std::cout << kernel.to_quake() << '\n';
 
   // Set the proper name for the kernel
   auto properName = cudaq::runtime::cudaqGenPrefixName + kernel.name();
@@ -127,7 +127,7 @@ TEST(QuakeSynthTests, checkSimpleIntegerInput) {
   auto counts = cudaq::sample(kernel, 5);
   EXPECT_EQ(counts.size(), 32);
 
-  // Map the kernel_builder to_quake output  to MLIR
+  // Map the kernel_builder to_quake output to MLIR
   auto context = cudaq::initializeMLIR();
   auto module = parseSourceString<ModuleOp>(kernel.to_quake(), context.get());
 
@@ -169,7 +169,7 @@ TEST(QuakeSynthTests, checkDoubleInput) {
   kernel.x<cudaq::ctrl>(q[0], q[1]);
   kernel.x<cudaq::ctrl>(q[1], q[0]);
 
-  printf("%s\n", kernel.to_quake().c_str());
+  std::cout << kernel.to_quake() << '\n';
 
   // Set the proper name for the kernel
   auto properName = cudaq::runtime::cudaqGenPrefixName + kernel.name();
@@ -212,7 +212,7 @@ TEST(QuakeSynthTests, checkDoubleInput) {
   EXPECT_NEAR(energy, -2.045375, 1e-3);
 }
 
-TEST(QuakeSynthTester, checkVector) {
+TEST(QuakeSynthTests, checkVectorOfDouble) {
   auto [kernel, thetas] = cudaq::make_kernel<std::vector<double>>();
   auto theta = thetas[0];
   auto phi = thetas[1];
@@ -226,7 +226,7 @@ TEST(QuakeSynthTester, checkVector) {
   kernel.x<cudaq::ctrl>(q[0], q[1]);
   kernel.x<cudaq::ctrl>(q[1], q[0]);
 
-  printf("%s\n", kernel.to_quake().c_str());
+  std::cout << kernel.to_quake() << '\n';
 
   // Set the proper name for the kernel
   auto properName = cudaq::runtime::cudaqGenPrefixName + kernel.name();
@@ -268,6 +268,60 @@ TEST(QuakeSynthTester, checkVector) {
   energy = observeJitCode(jit.get(), h3, kernel.name());
   // Should see the same thing as before.
   EXPECT_NEAR(energy, -2.045375, 1e-3);
+}
+
+TEST(QuakeSynthTests, checkVectorOfInt) {
+  auto [kernel, hiddenBits] = cudaq::make_kernel<std::vector<int>>();
+
+  auto q = kernel.qalloc(hiddenBits.size());
+  auto aq = kernel.qalloc();
+
+  kernel.h(aq);
+  kernel.z(aq);
+  kernel.h(q);
+  for (std::size_t i = 0; i < *q.constantSize(); ++i) {
+    kernel.c_if(hiddenBits[i], [&]() { kernel.x<cudaq::ctrl>(aq, q[i]); });
+  }
+  kernel.h(q);
+  kernel.mz(q);
+
+  // Dump the kernel to stdout.
+  std::cout << kernel.to_quake() << '\n';
+
+  // Set the proper name for the kernel
+  auto properName = cudaq::runtime::cudaqGenPrefixName + kernel.name();
+
+  // Should get a uniform distribution of all bit strings
+  std::vector<int> ghostBits = {0, 1, 1, 0, 0};
+  auto counts = cudaq::sample(kernel, ghostBits);
+  EXPECT_EQ(counts.size(), 1);
+
+  // Map the kernel_builder to_quake output to MLIR
+  auto context = cudaq::initializeMLIR();
+  auto module = parseSourceString<ModuleOp>(kernel.to_quake(), context.get());
+
+  // Create a struct defining the runtime args for the kernel
+  auto [args, offset] = cudaq::mapToRawArgs(kernel.name(), ghostBits);
+
+  // Run quake-synth
+  EXPECT_TRUE(succeeded(runQuakeSynth(kernel.name(), args, module)));
+
+  // Get the function, make sure that it has no arguments
+  auto func = module->lookupSymbol<func::FuncOp>(properName);
+  EXPECT_TRUE(func);
+  EXPECT_TRUE(func.getArguments().empty());
+
+  func.dump();
+
+  // Lower to LLVM and create the JIT execution engine
+  EXPECT_TRUE(succeeded(lowerToLLVMDialect(*module)));
+  auto jitOrError = ExecutionEngine::create(*module);
+  EXPECT_TRUE(!!jitOrError);
+  std::unique_ptr<ExecutionEngine> jit = std::move(jitOrError.get());
+
+  // Sample this new kernel processed with quake synth
+  auto countz = sampleJitCode(jit.get(), kernel.name());
+  EXPECT_EQ(countz.size(), 1);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
to the synthesizer.
Add test for vector<int64_t>.
Fix some bugs.
Implement folding of size() calls on vector inputs in synthesis. Allow vectors that are longer than what is required.

**Release**
These changes enable code that was failing on nvqc.