### PR TITLE
Add inlining pass before synthesis for the remote client

### DIFF
--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -173,6 +173,8 @@ public:
       if (args) {
         cudaq::info("Run Quake Synth.\n");
         PassManager pm(&mlirContext);
+        // Synthesis requires that calls be inlined.
+        cudaq::opt::addAggressiveEarlyInlining(pm);
         pm.addPass(cudaq::opt::createQuakeSynthesizer(name, args));
         if (failed(pm.run(moduleOp)))
           throw std::runtime_error("Could not successfully apply quake-synth.");


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->


According to https://github.com/NVIDIA/cuda-quantum/pull/1347/commits/0a0582bde569c06256569a17123266cb0ce0a693, we need to make sure function calls are inlined before synthesis. Hence, adding it to the remote client pass.

Also, adding a test case in the new Python MLIR, adapting from @marwafar's example.