### PR TITLE
Adjust NVQC client logs to show queue position and dots by default

### DIFF
--- a/python/runtime/utils/PyRestRemoteClient.cpp
+++ b/python/runtime/utils/PyRestRemoteClient.cpp
@@ -423,38 +423,51 @@ public:
           m_restClient.post(nvcfInvocationUrl(), "", requestJson, jobHeader,
                             /*enableLogging=*/false, /*enableSsl=*/true);
       cudaq::debug("Response: {}", resultJs.dump());
+      bool needToPrintNewline = false;
       while (resultJs.contains("status") &&
              resultJs["status"] == "pending-evaluation") {
         const std::string reqId = resultJs["reqId"];
-        if (m_logLevel > LogLevel::Info) {
-          const int elapsedTimeSecs =
-              std::chrono::duration_cast<std::chrono::seconds>(
-                  std::chrono::system_clock::now() - requestStartTime)
-                  .count();
-          // Warns if the remaining time is less than this threshold.
-          constexpr int TIMEOUT_WARNING_SECS = 5 * 60; // 5 minutes.
-          const int remainingSecs =
-              m_availableFuncs[m_functionId].timeoutSecs - elapsedTimeSecs;
-          std::string additionalInfo;
-          if (remainingSecs < 0)
-            fmt::format_to(std::back_inserter(additionalInfo),
-                           ". Exceeded wall time limit ({} seconds), but time "
-                           "spent waiting in queue is not counted. Proceeding.",
-                           m_availableFuncs[m_functionId].timeoutSecs);
-          else if (remainingSecs < TIMEOUT_WARNING_SECS)
-            fmt::format_to(std::back_inserter(additionalInfo),
-                           ". Approaching the wall time limit ({} seconds). "
-                           "Remaining time: {} seconds.",
-                           m_availableFuncs[m_functionId].timeoutSecs,
-                           remainingSecs);
+        const int elapsedTimeSecs =
+            std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now() - requestStartTime)
+                .count();
+        // Warns if the remaining time is less than this threshold.
+        constexpr int TIMEOUT_WARNING_SECS = 5 * 60; // 5 minutes.
+        const int remainingSecs =
+            m_availableFuncs[m_functionId].timeoutSecs - elapsedTimeSecs;
+        std::string additionalInfo;
+        if (remainingSecs < 0)
+          fmt::format_to(std::back_inserter(additionalInfo),
+                         ". Exceeded wall time limit ({} seconds), but time "
+                         "spent waiting in queue is not counted. Proceeding.",
+                         m_availableFuncs[m_functionId].timeoutSecs);
+        else if (remainingSecs < TIMEOUT_WARNING_SECS)
+          fmt::format_to(std::back_inserter(additionalInfo),
+                         ". Approaching the wall time limit ({} seconds). "
+                         "Remaining time: {} seconds.",
+                         m_availableFuncs[m_functionId].timeoutSecs,
+                         remainingSecs);
+        // If NVQC log level is high enough or if we have additional info to
+        // print, then print the full message; else print a simple "."
+        if (m_logLevel > LogLevel::Info || !additionalInfo.empty()) {
+          if (needToPrintNewline)
+            std::cout << "\n";
+          needToPrintNewline = false;
           cudaq::log("Polling NVQC result data for Request Id {}{}", reqId,
                      additionalInfo);
+        } else if (m_logLevel > LogLevel::None) {
+          std::cout << ".";
+          std::cout.flush();
+          needToPrintNewline = true;
         }
         // Wait 1 sec then poll the result
         std::this_thread::sleep_for(std::chrono::seconds(1));
         resultJs = m_restClient.get(nvcfInvocationStatus(reqId), "", jobHeader,
                                     /*enableSsl=*/true);
       }
+
+      if (needToPrintNewline)
+        std::cout << "\n";
 
       if (!resultJs.contains("status") || resultJs["status"] != "fulfilled") {
         if (optionalErrorMsg)

--- a/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
+++ b/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
@@ -177,6 +177,26 @@ private:
     }
   }
 
+  // Fetch the queue position of the given request ID. If the job has already
+  // begun execution, it will return `std::nullopt`.
+  std::optional<std::size_t> getQueuePosition(const std::string &requestId) {
+    auto headers = getHeaders();
+    try {
+      auto queuePos =
+          m_restClient.get(fmt::format("https://{}/nvcf/queues/{}/position",
+                                       m_baseUrl, requestId),
+                           "", headers, /*enableSsl=*/true);
+      if (queuePos.contains("positionInQueue"))
+        return queuePos["positionInQueue"].get<std::size_t>();
+      // When the job enters execution, it returns "status": 400 and "title":
+      // "Bad Request", so translate that to `std::nullopt`.
+      return std::nullopt;
+    } catch (...) {
+      // Make this non-fatal. Returns null, i.e., unknown.
+      return std::nullopt;
+    }
+  }
+
 public:
   virtual void setConfig(
       const std::unordered_map<std::string, std::string> &configs) override {
@@ -402,23 +422,52 @@ public:
     try {
       // Making the request
       cudaq::debug("Sending NVQC request to {}", nvcfInvocationUrl());
-      if (m_logLevel > LogLevel::None) {
-        auto queueDepth = getQueueDepth(m_functionId, m_functionVersionId);
-        if (queueDepth.has_value() && queueDepth.value() > 0) {
-          cudaq::log(
-              "Number of jobs ahead of yours in the NVQC queue: {}. Your job "
-              "will start executing once it gets to the head of the queue.",
-              queueDepth.value());
-        }
-      }
+      auto lastQueuePos = std::numeric_limits<std::size_t>::max();
 
       if (m_logLevel > LogLevel::Info)
         cudaq::log("Posting NVQC request now");
-      const auto requestStartTime = std::chrono::system_clock::now();
       auto resultJs =
           m_restClient.post(nvcfInvocationUrl(), "", requestJson, jobHeader,
                             /*enableLogging=*/false, /*enableSsl=*/true);
       cudaq::debug("Response: {}", resultJs.dump());
+
+      // Call getQueuePosition() until we're at the front of the queue. If log
+      // level is "none", then skip all this because we don't need to show the
+      // status to the user, and we don't need to know the precise
+      // requestStartTime.
+      if (m_logLevel > LogLevel::None) {
+        if (resultJs.contains("status") &&
+            resultJs["status"] == "pending-evaluation") {
+          const std::string reqId = resultJs["reqId"];
+          auto queuePos = getQueuePosition(reqId);
+          while (queuePos.has_value() && queuePos.value() > 0) {
+            if (queuePos.value() != lastQueuePos) {
+              // Position in queue has changed.
+              if (lastQueuePos == std::numeric_limits<std::size_t>::max()) {
+                // If lastQueuePos hasn't been populated with a true value yet,
+                // it means we have not fetched the queue depth or displayed
+                // anything to the user yet.
+                cudaq::log("Number of jobs ahead of yours in the NVQC queue: "
+                           "{}. Your job will start executing once it gets to "
+                           "the head of the queue.",
+                           queuePos.value());
+              } else {
+                cudaq::log("Position in queue for request {} has changed from "
+                           "{} to {}",
+                           reqId, lastQueuePos, queuePos.value());
+              }
+              lastQueuePos = queuePos.value();
+            }
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            queuePos = getQueuePosition(reqId);
+          }
+        }
+        if (lastQueuePos != std::numeric_limits<std::size_t>::max())
+          cudaq::log("Your job is finished waiting in the queue and will now "
+                     "begin execution.");
+      }
+
+      const auto requestStartTime = std::chrono::system_clock::now();
       bool needToPrintNewline = false;
       while (resultJs.contains("status") &&
              resultJs["status"] == "pending-evaluation") {


### PR DESCRIPTION
This change is a follow-up to #1353.

* It displays a new dot (`.`) every 5-6 seconds while the job is in execution.
* If your job has to wait in a queue, it shows updates any time your position in the queue changes.

-------------------

Here is sample of what it looks like for a ~40 second job (using default log levels). The `.`'s come out every 5-6 seconds if the job is not completed within the first 5-6 seconds.
```bash
$ python3 ../docs/sphinx/examples/python/providers/nvqc_sample.py
[2024-03-08 16:17:42.239] Submitting jobs to NVQC service with 1 GPU(s). Max execution time: 3600 seconds (excluding queue wait time).
......

================ NVQC Device Info ================
GPU Device Name: "NVIDIA H100 80GB HBM3"
CUDA Driver Version / Runtime Version: 12.2 / 11.8
Total global memory (GB): 79.1
Memory Clock Rate (MHz): 2619.000
GPU Clock Rate (MHz): 1980.000
==================================================
{ 11111111111111111111111111111111111111111111111111:56 00000000000000000000000000000000000000000000000000:44 }
```
Here is what it would look like with `NVQC_LOG_LEVEL=trace`
```bash
$ NVQC_LOG_LEVEL=trace python3 ../docs/sphinx/examples/python/providers/nvqc_sample.py
[2024-03-08 16:19:52.244] Submitting jobs to NVQC service with 1 GPU(s). Max execution time: 3600 seconds (excluding queue wait time).
[2024-03-08 16:19:53.450] Posting NVQC request now
[2024-03-08 16:19:58.912] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed
[2024-03-08 16:20:05.329] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed
[2024-03-08 16:20:11.721] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed
[2024-03-08 16:20:18.128] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed
[2024-03-08 16:20:24.766] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed
[2024-03-08 16:20:31.124] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed

================ NVQC Device Info ================
GPU Device Name: "NVIDIA H100 80GB HBM3"
CUDA Driver Version / Runtime Version: 12.2 / 11.8
Total global memory (GB): 79.1
Memory Clock Rate (MHz): 2619.000
GPU Clock Rate (MHz): 1980.000
==================================================

===== NVQC Execution Timing ======
 - Pre-processing: 245 milliseconds 
 - Execution: 40039 milliseconds 
==================================
{ 11111111111111111111111111111111111111111111111111:48 00000000000000000000000000000000000000000000000000:52 }
```
Here is what it would look like with `NVQC_LOG_LEVEL=off`
```bash
$ NVQC_LOG_LEVEL=off python3 ../docs/sphinx/examples/python/providers/nvqc_sample.py
{ 11111111111111111111111111111111111111111111111111:48 00000000000000000000000000000000000000000000000000:52 }
```

----------------------

If you have a job that that approaches the timeout limit of 1 hour, it would (hypothetically) look like this:
```bash
$ python3 ../docs/sphinx/examples/python/providers/nvqc_sample.py
[2024-03-08 16:00:00.000] Submitting jobs to NVQC service with 1 GPU(s). Max execution time: 3600 seconds (excluding queue wait time).
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
[2024-03-08 16:55:00.000] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed. Approaching the wall time limit (3600 seconds). Remaining time: 300 seconds."
[2024-03-08 16:55:06.000] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed. Approaching the wall time limit (3600 seconds). Remaining time: 294 seconds."
[2024-03-08 16:55:12.000] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed. Approaching the wall time limit (3600 seconds). Remaining time: 288 seconds."
[2024-03-08 16:55:18.000] Polling NVQC result data for Request Id 96ca6032-e506-44c1-afb8-f225f07cf0ed. Approaching the wall time limit (3600 seconds). Remaining time: 282 seconds."
// and so on
```

--------------------

If your job has to wait in the queue, the log messages will look like this:
```bash
$ python3 ../docs/sphinx/examples/python/providers/nvqc_sample.py
[2024-03-08 20:45:31.360] Submitting jobs to NVQC service with 1 GPU(s). Max execution time: 3600 seconds (excluding queue wait time).
[2024-03-08 20:45:38.069] Number of jobs ahead of yours in the NVQC queue: 3. Your job will start executing once it gets to the head of the queue.
[2024-03-08 20:46:08.768] Position in queue for request 13f1e5eb-dbac-4683-a216-cbcb9065deae has changed from 3 to 2
[2024-03-08 20:46:43.221] Position in queue for request 13f1e5eb-dbac-4683-a216-cbcb9065deae has changed from 2 to 1
[2024-03-08 20:46:44.534] Your job is finished waiting in the queue and will now begin execution.
..........

================ NVQC Device Info ================
GPU Device Name: "NVIDIA H100 80GB HBM3"
CUDA Driver Version / Runtime Version: 12.2 / 11.8
Total global memory (GB): 79.1
Memory Clock Rate (MHz): 2619.000
GPU Clock Rate (MHz): 1980.000
==================================================
{ 11111111111111111111111111111111111111111111111111:56 00000000000000000000000000000000000000000000000000:44 }
```