### PR TITLE
Fix spin-op deserialization bug when there is exactly 1 term

### DIFF
--- a/python/tests/builder/test_SpinOperator.py
+++ b/python/tests/builder/test_SpinOperator.py
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -371,6 +371,17 @@ def test_spin_op_from_word():
     want_spin_op = spin.x(0) * spin.y(1) * spin.z(2)
     got_spin_op = cudaq.SpinOperator.from_word("XYZ")
     assert got_spin_op == want_spin_op
+
+
+# Test serialization and deserialization for all term/qubit combinations up to
+# 30 qubits
+def test_spin_op_serdes():
+    for nq in range(1, 31):
+        for nt in range(1, nq):
+            h1 = cudaq.SpinOperator.random(qubit_count=nq, term_count=nt)
+            h2 = h1.serialize()
+            h3 = cudaq.SpinOperator(h2, nq)
+            assert (h1 == h3)
 
 
 # leave for gdb debugging

--- a/python/tests/remote/test_remote_platform.py
+++ b/python/tests/remote/test_remote_platform.py
@@ -15,6 +15,10 @@ from cudaq import spin
 num_qpus = 3
 
 
+def assert_close(want, got, tolerance=1.e-5) -> bool:
+    return abs(want - got) < tolerance
+
+
 @pytest.fixture(scope="session", autouse=True)
 def startUpMockServer():
     cudaq.set_target("remote-mqpu", auto_launch=str(num_qpus))
@@ -221,6 +225,30 @@ def test_seed():
         # Rerun sampling
         count = cudaq.sample(kernel)
         assert (count["0"] == zero_counts[i])
+
+
+def test_additional_spin_ops():
+
+    @cudaq.kernel
+    def ansatz(qubits: cudaq.qvector, thetas: list[float]):
+        x(qubits[0])
+        x.ctrl(qubits[1], qubits[0])
+
+    @cudaq.kernel
+    def main_kernel(thetas: list[float]):
+        qubits = cudaq.qvector(3)
+        ansatz(qubits, thetas)
+
+    thetas: list[float] = [0.0, 0.0]
+    spin_ham = spin.z(0)
+    energy = cudaq.observe(main_kernel, spin_ham, thetas).expectation()
+    assert assert_close(energy, -1)
+    spin_ham = spin.z(0) - spin.z(1)
+    energy = cudaq.observe(main_kernel, spin_ham, thetas).expectation()
+    assert assert_close(energy, -2)
+    spin_ham = spin.z(0) + spin.z(1) + spin.z(2)
+    energy = cudaq.observe(main_kernel, spin_ham, thetas).expectation()
+    assert assert_close(energy, 1)
 
 
 # leave for gdb debugging

--- a/python/tests/remote/test_remote_platform.py
+++ b/python/tests/remote/test_remote_platform.py
@@ -7,6 +7,7 @@
 # ============================================================================ #
 import pytest
 import os, math
+import numpy as np
 
 import cudaq
 from cudaq import spin
@@ -97,6 +98,23 @@ def test_observe():
     kernel.cx(qreg[1], qreg[0])
 
     check_observe(kernel)
+
+
+# Make sure spin_op serializes and deserializes correctly
+def test_single_term_spin_op():
+    h = spin.z(0)
+    n_samples = 3
+    n_qubits = 5
+    n_parameters = n_qubits
+    parameters = np.random.default_rng(13).uniform(low=0,
+                                                   high=1,
+                                                   size=(n_samples,
+                                                         n_parameters))
+    kernel, params = cudaq.make_kernel(list)
+    qubits = kernel.qalloc(n_qubits)
+    for i in range(n_qubits):
+        kernel.rx(params[i], qubits[i])
+    cudaq.observe(kernel, h, parameters)
 
 
 def test_observe_kernel():

--- a/runtime/cudaq/spin/spin_op.cpp
+++ b/runtime/cudaq/spin/spin_op.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -554,7 +554,7 @@ void spin_op::dump() const {
 
 spin_op::spin_op(std::vector<double> &input_vec, std::size_t nQubits) {
   auto n_terms = (int)input_vec.back();
-  if (nQubits != ((input_vec.size() - 2 * n_terms) / n_terms))
+  if (nQubits != (((input_vec.size() - 1) - 2 * n_terms) / n_terms))
     throw std::runtime_error("Invalid data representation for construction "
                              "spin_op. Number of data elements is incorrect.");
 
@@ -652,7 +652,7 @@ spin_op binary_spin_op_reader::read(const std::string &data_filename) {
   std::vector<double> input_vec(size / sizeof(double));
   input.read((char *)&input_vec[0], size);
   auto n_terms = (int)input_vec.back();
-  auto nQubits = (input_vec.size() - 2 * n_terms) / n_terms;
+  auto nQubits = (input_vec.size() - 1 - 2 * n_terms) / n_terms;
   spin_op s(input_vec, nQubits);
   return s;
 }


### PR DESCRIPTION
This fixes a bug in formulas used when deserializing a spin op from a vector. The new test in the PR fails without the code change and passes with the accompanying code change.

I confirmed that this error was only happening when there was exactly 1 term in the spin op.