### PR TITLE
Follow-up to #1363 - Fix test for Python 3.8 compatibility

### DIFF
--- a/python/tests/builder/test_SpinOperator.py
+++ b/python/tests/builder/test_SpinOperator.py
@@ -377,7 +377,7 @@ def test_spin_op_from_word():
 # 30 qubits
 def test_spin_op_serdes():
     for nq in range(1, 31):
-        for nt in range(1, nq):
+        for nt in range(1, nq + 1):
             h1 = cudaq.SpinOperator.random(qubit_count=nq, term_count=nt)
             h2 = h1.serialize()
             h3 = cudaq.SpinOperator(h2, nq)

--- a/python/tests/remote/test_remote_platform.py
+++ b/python/tests/remote/test_remote_platform.py
@@ -230,24 +230,19 @@ def test_seed():
 def test_additional_spin_ops():
 
     @cudaq.kernel
-    def ansatz(qubits: cudaq.qvector, thetas: list[float]):
+    def main_kernel():
+        qubits = cudaq.qvector(3)
         x(qubits[0])
         x.ctrl(qubits[1], qubits[0])
 
-    @cudaq.kernel
-    def main_kernel(thetas: list[float]):
-        qubits = cudaq.qvector(3)
-        ansatz(qubits, thetas)
-
-    thetas: list[float] = [0.0, 0.0]
     spin_ham = spin.z(0)
-    energy = cudaq.observe(main_kernel, spin_ham, thetas).expectation()
+    energy = cudaq.observe(main_kernel, spin_ham).expectation()
     assert assert_close(energy, -1)
     spin_ham = spin.z(0) - spin.z(1)
-    energy = cudaq.observe(main_kernel, spin_ham, thetas).expectation()
+    energy = cudaq.observe(main_kernel, spin_ham).expectation()
     assert assert_close(energy, -2)
     spin_ham = spin.z(0) + spin.z(1) + spin.z(2)
-    energy = cudaq.observe(main_kernel, spin_ham, thetas).expectation()
+    energy = cudaq.observe(main_kernel, spin_ham).expectation()
     assert assert_close(energy, 1)
 
 


### PR DESCRIPTION
Fix deployment failure with Python 3.8 (test only, not operational code): https://github.com/NVIDIA/cuda-quantum/actions/runs/8210300739/job/22457834545

(Python 3.8 doesn't have `list`; it's not truly needed for the new test, so simply eliminate it.)
