### PR TITLE
Use actual json string size to compare against NVCF message size limit

### DIFF
--- a/python/runtime/utils/PyRestRemoteClient.cpp
+++ b/python/runtime/utils/PyRestRemoteClient.cpp
@@ -405,7 +405,7 @@ public:
     });
 
     // Upload this request as an NVCF asset if needed.
-    if (request.code.size() > MAX_SIZE_BYTES) {
+    if (json(request).dump().size() > MAX_SIZE_BYTES) {
       assetId = uploadRequest(request);
       if (!assetId.has_value()) {
         if (optionalErrorMsg)

--- a/python/runtime/utils/PyRestRemoteClient.cpp
+++ b/python/runtime/utils/PyRestRemoteClient.cpp
@@ -405,7 +405,12 @@ public:
     });
 
     // Upload this request as an NVCF asset if needed.
-    if (json(request).dump().size() > MAX_SIZE_BYTES) {
+    // Note: The majority of the payload is the IR code. Hence, first checking
+    // if it exceed the size limit. Otherwise, if the code is small, make sure
+    // that the total payload doesn't exceed that limit as well by constructing
+    // a temporary JSON object of the full payload.
+    if (request.code.size() > MAX_SIZE_BYTES ||
+        json(request).dump().size() > MAX_SIZE_BYTES) {
       assetId = uploadRequest(request);
       if (!assetId.has_value()) {
         if (optionalErrorMsg)

--- a/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
+++ b/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
@@ -401,7 +401,7 @@ public:
     });
 
     // Upload this request as an NVCF asset if needed.
-    if (request.code.size() > MAX_SIZE_BYTES) {
+    if (json(request).dump().size() > MAX_SIZE_BYTES) {
       assetId = uploadRequest(request);
       if (!assetId.has_value()) {
         if (optionalErrorMsg)

--- a/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
+++ b/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteClient.cpp
@@ -401,7 +401,12 @@ public:
     });
 
     // Upload this request as an NVCF asset if needed.
-    if (json(request).dump().size() > MAX_SIZE_BYTES) {
+    // Note: The majority of the payload is the IR code. Hence, first checking
+    // if it exceed the size limit. Otherwise, if the code is small, make sure
+    // that the total payload doesn't exceed that limit as well by constructing
+    // a temporary JSON object of the full payload.
+    if (request.code.size() > MAX_SIZE_BYTES ||
+        json(request).dump().size() > MAX_SIZE_BYTES) {
       assetId = uploadRequest(request);
       if (!assetId.has_value()) {
         if (optionalErrorMsg)


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This PR fixes an oversight in checking whether we need to upload the request as an asset: need to use the full JSON string size rather than only the main IR payload.
