### PR TITLE
Fix issue #1367

### DIFF
--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -75,7 +75,7 @@ mlir::Type genArgumentBufferType(mlir::Type ty);
 /// ```c++
 /// i32_t operator() (i16_t, std::vector<double>, double);
 /// ```
-/// will generate the llvm struct
+/// will generate the LLVM struct
 /// ```llvm
 /// { i16, i64, double, i32 }
 /// ```

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -64,6 +64,25 @@ inline mlir::Type getPointerType(mlir::Type ty) {
 
 cudaq::cc::PointerType getIndexedObjectType(mlir::Type eleTy);
 
+mlir::Type genArgumentBufferType(mlir::Type ty);
+
+/// Build an LLVM struct type with all the arguments and then all the results.
+/// If the type is a std::vector, then add an i64 to the struct for the
+/// length. The actual data values will be appended to the end of the
+/// dynamically sized struct.
+///
+/// A kernel signature of
+/// ```c++
+/// i32_t operator() (i16_t, std::vector<double>, double);
+/// ```
+/// will generate the llvm struct
+/// ```llvm
+/// { i16, i64, double, i32 }
+/// ```
+/// where the values of the vector argument are pass-by-value and appended to
+/// the end of the struct as a sequence of \i n double values.
+cudaq::cc::StructType buildInvokeStructType(mlir::FunctionType funcTy);
+
 /// Return the LLVM-IR dialect type: `[length x i8]`.
 inline mlir::Type getStringType(mlir::MLIRContext *ctx, std::size_t length) {
   return mlir::LLVM::LLVMArrayType::get(mlir::IntegerType::get(ctx, 8), length);

--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -11,6 +11,8 @@
 /// This file provides some common QIR function name string s
 /// for use throughout our MLIR lowering infrastructure.
 
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+
 namespace cudaq::opt {
 
 /// QIS Function name strings
@@ -82,5 +84,7 @@ inline mlir::Type getResultType(mlir::MLIRContext *context) {
 inline mlir::Type getCharPointerType(mlir::MLIRContext *context) {
   return mlir::LLVM::LLVMPointerType::get(mlir::IntegerType::get(context, 8));
 }
+
+void initializeTypeConversions(mlir::LLVMTypeConverter &typeConverter);
 
 } // namespace cudaq::opt

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -61,21 +61,6 @@ Type factory::genArgumentBufferType(Type ty) {
   return genBufferType</*isOutput=*/false>(ty);
 }
 
-/// Build an LLVM struct type with all the arguments and then all the results.
-/// If the type is a std::vector, then add an i64 to the struct for the
-/// length. The actual data values will be appended to the end of the
-/// dynamically sized struct.
-///
-/// A kernel signature of
-/// ```c++
-/// i32_t operator() (i16_t, std::vector<double>, double);
-/// ```
-/// will generate the llvm struct
-/// ```llvm
-/// { i16, i64, double, i32 }
-/// ```
-/// where the values of the vector argument are pass-by-value and appended to
-/// the end of the struct as a sequence of \i n double values.
 cudaq::cc::StructType factory::buildInvokeStructType(FunctionType funcTy) {
   auto *ctx = funcTy.getContext();
   SmallVector<Type> eleTys;
@@ -86,8 +71,6 @@ cudaq::cc::StructType factory::buildInvokeStructType(FunctionType funcTy) {
   return cudaq::cc::StructType::get(ctx, eleTys /*packed=false*/);
 }
 
-/// Return an i64 array where the kth element is N if the kth
-/// operand is veq<N> and 0 otherwise (e.g. is a ref).
 Value factory::packIsArrayAndLengthArray(Location loc,
                                          ConversionPatternRewriter &rewriter,
                                          ModuleOp parentModule,

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -1591,7 +1591,7 @@ public:
 
     LLVMConversionTarget target{*context};
     LLVMTypeConverter typeConverter(&getContext());
-    initializeTypeConversions(typeConverter);
+    cudaq::opt::initializeTypeConversions(typeConverter);
     RewritePatternSet patterns(context);
 
     populateComplexToLibmConversionPatterns(patterns, 1);
@@ -1636,55 +1636,52 @@ public:
     if (failed(applyFullConversion(getModule(), target, std::move(patterns))))
       signalPassFailure();
   }
-
-  void initializeTypeConversions(LLVMTypeConverter &typeConverter) {
-    typeConverter.addConversion([](quake::VeqType type) {
-      return cudaq::opt::getArrayType(type.getContext());
-    });
-    typeConverter.addConversion([](quake::RefType type) {
-      return cudaq::opt::getQubitType(type.getContext());
-    });
-    typeConverter.addConversion([](cudaq::cc::CallableType type) {
-      return lambdaAsPairOfPointers(type.getContext());
-    });
-    typeConverter.addConversion([&typeConverter](cudaq::cc::StdvecType type) {
-      auto eleTy = typeConverter.convertType(type.getElementType());
-      return cudaq::opt::factory::stdVectorImplType(eleTy);
-    });
-    typeConverter.addConversion([](quake::MeasureType type) {
-      return IntegerType::get(type.getContext(), 1);
-    });
-    typeConverter.addConversion([&typeConverter](cudaq::cc::PointerType type) {
-      auto eleTy = type.getElementType();
-      if (isa<NoneType>(eleTy))
-        return cudaq::opt::factory::getPointerType(type.getContext());
-      eleTy = typeConverter.convertType(eleTy);
-      if (auto arrTy = dyn_cast<cudaq::cc::ArrayType>(eleTy)) {
-        // If array has a static size, it becomes an LLVMArrayType.
-        assert(arrTy.isUnknownSize());
-        return cudaq::opt::factory::getPointerType(
-            typeConverter.convertType(arrTy.getElementType()));
-      }
-      return cudaq::opt::factory::getPointerType(eleTy);
-    });
-    typeConverter.addConversion(
-        [&typeConverter](cudaq::cc::ArrayType type) -> Type {
-          auto eleTy = typeConverter.convertType(type.getElementType());
-          if (type.isUnknownSize())
-            return type;
-          return LLVM::LLVMArrayType::get(eleTy, type.getSize());
-        });
-    typeConverter.addConversion(
-        [&typeConverter](cudaq::cc::StructType type) -> Type {
-          SmallVector<Type> members;
-          for (auto t : type.getMembers())
-            members.push_back(typeConverter.convertType(t));
-          return LLVM::LLVMStructType::getLiteral(type.getContext(), members);
-        });
-  }
 };
 
 } // namespace
+
+void cudaq::opt::initializeTypeConversions(LLVMTypeConverter &typeConverter) {
+  typeConverter.addConversion(
+      [](quake::VeqType type) { return getArrayType(type.getContext()); });
+  typeConverter.addConversion(
+      [](quake::RefType type) { return getQubitType(type.getContext()); });
+  typeConverter.addConversion([](cc::CallableType type) {
+    return lambdaAsPairOfPointers(type.getContext());
+  });
+  typeConverter.addConversion([&typeConverter](cc::StdvecType type) {
+    auto eleTy = typeConverter.convertType(type.getElementType());
+    return factory::stdVectorImplType(eleTy);
+  });
+  typeConverter.addConversion([](quake::MeasureType type) {
+    return IntegerType::get(type.getContext(), 1);
+  });
+  typeConverter.addConversion([&typeConverter](cc::PointerType type) {
+    auto eleTy = type.getElementType();
+    if (isa<NoneType>(eleTy))
+      return factory::getPointerType(type.getContext());
+    eleTy = typeConverter.convertType(eleTy);
+    if (auto arrTy = dyn_cast<cc::ArrayType>(eleTy)) {
+      // If array has a static size, it becomes an LLVMArrayType.
+      assert(arrTy.isUnknownSize());
+      return factory::getPointerType(
+          typeConverter.convertType(arrTy.getElementType()));
+    }
+    return factory::getPointerType(eleTy);
+  });
+  typeConverter.addConversion([&typeConverter](cc::ArrayType type) -> Type {
+    auto eleTy = typeConverter.convertType(type.getElementType());
+    if (type.isUnknownSize())
+      return type;
+    return LLVM::LLVMArrayType::get(eleTy, type.getSize());
+  });
+  typeConverter.addConversion([&typeConverter](cc::StructType type) -> Type {
+    SmallVector<Type> members;
+    for (auto t : type.getMembers())
+      members.push_back(typeConverter.convertType(t));
+    return LLVM::LLVMStructType::getLiteral(type.getContext(), members,
+                                            type.getPacked());
+  });
+}
 
 std::unique_ptr<Pass> cudaq::opt::createConvertToQIRPass() {
   return std::make_unique<QuakeToQIRRewrite>();

--- a/lib/Optimizer/Transforms/GenDeviceCodeLoader.cpp
+++ b/lib/Optimizer/Transforms/GenDeviceCodeLoader.cpp
@@ -83,7 +83,7 @@ public:
         OpPrintingFlags opf;
         opf.enableDebugInfo(/*enable=*/true,
                             /*pretty=*/false);
-        strOut << "module { ";
+        strOut << "module attributes " << module->getAttrDictionary() << " { ";
         funcOp.print(strOut, opf);
         strOut << '\n';
 

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -378,6 +378,7 @@ public:
       func->setAttr(cudaq::entryPointAttrName, builder.getUnitAttr());
     auto moduleOp = builder.create<ModuleOp>();
     moduleOp.push_back(func.clone());
+    moduleOp->setAttrs(m_module->getAttrDictionary());
 
     // Lambda to apply a specific pipeline to the given ModuleOp
     auto runPassPipeline = [&](const std::string &pipeline,

--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -162,6 +162,7 @@ public:
       if (!func->hasAttr(cudaq::entryPointAttrName))
         func->setAttr(cudaq::entryPointAttrName, builder.getUnitAttr());
       auto moduleOp = builder.create<ModuleOp>();
+      moduleOp->setAttrs(module->getAttrDictionary());
       for (auto &op : *module) {
         auto funcOp = dyn_cast<func::FuncOp>(op);
         // Add quantum kernels defined in the module.

--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -162,7 +162,7 @@ public:
       if (!func->hasAttr(cudaq::entryPointAttrName))
         func->setAttr(cudaq::entryPointAttrName, builder.getUnitAttr());
       auto moduleOp = builder.create<ModuleOp>();
-      moduleOp->setAttrs(module->getAttrDictionary());
+      moduleOp->setAttrs((*module)->getAttrDictionary());
       for (auto &op : *module) {
         auto funcOp = dyn_cast<func::FuncOp>(op);
         // Add quantum kernels defined in the module.

--- a/targettests/execution/device_code_loaded.cpp
+++ b/targettests/execution/device_code_loaded.cpp
@@ -14,7 +14,7 @@
 #include <cudaq.h>
 
 // CHECK: { [[B0:.*]]:[[C0:.*]] [[B1:.*]]:[[C1:.*]] }
-// CHECK-NEXT: module { func.func @__nvqpp__mlirgen__ghz{{.*}}(%arg0: i32{{.*}}) attributes {
+// CHECK-NEXT: module {{.*}} func.func @__nvqpp__mlirgen__ghz{{.*}}(%arg0: i32{{.*}}) attributes {
 
 // Define a quantum kernel
 struct ghz {

--- a/targettests/execution/lambda_introspection.cpp
+++ b/targettests/execution/lambda_introspection.cpp
@@ -57,7 +57,7 @@ int main() {
   return 0;
 }
 
-// CHECK: 2: module { func.func @__nvqpp__mlirgen__Z4mainE3$_0() attributes {
-// CHECK: 3: module { func.func @__nvqpp__mlirgen__Z4mainE3$_1() attributes {
-// CHECK: 4: module { func.func @__nvqpp__mlirgen__ghz{{.*}}() attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
-// CHECK: 5: module { func.func @__nvqpp__mlirgen__Z8functionvE3$_0() attributes {
+// CHECK: 2: module {{.*}} func.func @__nvqpp__mlirgen__Z4mainE3$_0() attributes {
+// CHECK: 3: module {{.*}} func.func @__nvqpp__mlirgen__Z4mainE3$_1() attributes {
+// CHECK: 4: module {{.*}} func.func @__nvqpp__mlirgen__ghz{{.*}}() attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
+// CHECK: 5: module {{.*}} func.func @__nvqpp__mlirgen__Z8functionvE3$_0() attributes {

--- a/targettests/execution/template_introspection.cpp
+++ b/targettests/execution/template_introspection.cpp
@@ -20,8 +20,8 @@ struct ghz {
   }
 };
 
-// CHECK: 1: module { func.func @__nvqpp__mlirgen__ghzILm3EE() attributes
-// CHECK: 2: module { func.func @__nvqpp__mlirgen__ghzILm4EE() attributes
+// CHECK: 1: module {{.*}} func.func @__nvqpp__mlirgen__ghzILm3EE() attributes
+// CHECK: 2: module {{.*}} func.func @__nvqpp__mlirgen__ghzILm4EE() attributes
 
 int main() {
   printf("1: %s", cudaq::get_quake(ghz<3>{}).c_str());


### PR DESCRIPTION
Need to use LLVM's understanding of how the struct of arguments is laid out in memory in order to recover the values that the synthesizer will use to instantiate a circuit from a kernel.

Fix #1367 