### PR TITLE
Fix bug - enable list[T] argument specification with kernel builder

### DIFF
--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -7,8 +7,11 @@
 # ============================================================================ #
 
 from functools import partialmethod
+from pydoc import locate
 import random
+import re
 import string
+import typing
 from .quake_value import QuakeValue
 from .kernel_decorator import PyKernelDecorator
 from .utils import mlirTypeFromPyType, nvqppPrefix, emitFatalError, mlirTypeToPyType
@@ -215,7 +218,9 @@ class PyKernel(object):
 
         with self.ctx, InsertionPoint(self.module.body), self.loc:
             self.mlirArgTypes = [
-                mlirTypeFromPyType(argType, self.ctx) for argType in argTypeList
+                mlirTypeFromPyType(argType[0], self.ctx, argInstance=argType[1])
+                for argType in
+                [self.__processArgType(ty) for ty in argTypeList]
             ]
 
             self.funcOp = func.FuncOp(self.funcName, (self.mlirArgTypes, []),
@@ -230,6 +235,21 @@ class PyKernel(object):
                 func.ReturnOp([])
 
             self.insertPoint = InsertionPoint.at_block_begin(e)
+
+    def __processArgType(self, ty):
+        """
+        Process input argument type. Specifically, try to infer the 
+        element type for a list, e.g. list[float]. 
+        """
+        if typing.get_origin(ty) == list or isinstance(ty(), list):
+            if '[' in str(ty) and ']' in str(ty):
+                # Infer the slice type
+                result = re.search('ist\[(.*)\]', str(ty))
+                eleTyName = result.group(1)
+                if eleTyName != None and locate(eleTyName) != None:
+                    return list, [locate(eleTyName)()]
+                emitFatalError(f'Invalid type for kernel builder {ty}')
+        return ty, None, None
 
     def getIntegerAttr(self, type, value):
         """

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -241,15 +241,17 @@ class PyKernel(object):
         Process input argument type. Specifically, try to infer the 
         element type for a list, e.g. list[float]. 
         """
+        if ty in [cudaq_runtime.qvector, cudaq_runtime.qubit]:
+            return ty, None
         if typing.get_origin(ty) == list or isinstance(ty(), list):
             if '[' in str(ty) and ']' in str(ty):
                 # Infer the slice type
-                result = re.search('ist\[(.*)\]', str(ty))
+                result = re.search(r'ist\[(.*)\]', str(ty))
                 eleTyName = result.group(1)
                 if eleTyName != None and locate(eleTyName) != None:
                     return list, [locate(eleTyName)()]
                 emitFatalError(f'Invalid type for kernel builder {ty}')
-        return ty, None, None
+        return ty, None
 
     def getIntegerAttr(self, type, value):
         """

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -7,7 +7,6 @@
 # ============================================================================ #
 
 from functools import partialmethod
-from pydoc import locate
 import random
 import re
 import string
@@ -245,12 +244,13 @@ class PyKernel(object):
             return ty, None
         if typing.get_origin(ty) == list or isinstance(ty(), list):
             if '[' in str(ty) and ']' in str(ty):
+                allowedTypeMap = {'int':int, 'bool':bool, 'float':float}
                 # Infer the slice type
                 result = re.search(r'ist\[(.*)\]', str(ty))
                 eleTyName = result.group(1)
-                pyType = locate(eleTyName)
-                if eleTyName != None and pyType != None:
-                    return list, [pyType()]
+                pyType = allowedTypeMap[eleTyName]
+                if eleTyName != None and eleTyName in allowedTypeMap:
+                    return list, [allowedTypeMap[eleTyName]()]
                 emitFatalError(f'Invalid type for kernel builder {ty}')
         return ty, None
 

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -244,7 +244,7 @@ class PyKernel(object):
             return ty, None
         if typing.get_origin(ty) == list or isinstance(ty(), list):
             if '[' in str(ty) and ']' in str(ty):
-                allowedTypeMap = {'int':int, 'bool':bool, 'float':float}
+                allowedTypeMap = {'int': int, 'bool': bool, 'float': float}
                 # Infer the slice type
                 result = re.search(r'ist\[(.*)\]', str(ty))
                 eleTyName = result.group(1)

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -248,8 +248,9 @@ class PyKernel(object):
                 # Infer the slice type
                 result = re.search(r'ist\[(.*)\]', str(ty))
                 eleTyName = result.group(1)
-                if eleTyName != None and locate(eleTyName) != None:
-                    return list, [locate(eleTyName)()]
+                pyType = locate(eleTyName)
+                if eleTyName != None and pyType != None:
+                    return list, [pyType()]
                 emitFatalError(f'Invalid type for kernel builder {ty}')
         return ty, None
 

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -173,7 +173,7 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
         return ComplexType.get(mlirTypeFromPyType(float, ctx))
 
     if argType in [list, np.ndarray, List]:
-        if 'argInstance' not in kwargs:
+        if 'argInstance' not in kwargs or kwargs['argInstance'] == None:
             return cc.StdvecType.get(ctx, mlirTypeFromPyType(float, ctx))
 
         argInstance = kwargs['argInstance']

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -177,17 +177,22 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
             return cc.StdvecType.get(ctx, mlirTypeFromPyType(float, ctx))
 
         argInstance = kwargs['argInstance']
-        argTypeToCompareTo = kwargs['argTypeToCompareTo']
+        argTypeToCompareTo = kwargs[
+            'argTypeToCompareTo'] if 'argTypeToCompareTo' in kwargs else None
+
+        if isinstance(argInstance[0], bool):
+            return cc.StdvecType.get(ctx, mlirTypeFromPyType(bool, ctx))
 
         if isinstance(argInstance[0], int):
             return cc.StdvecType.get(ctx, mlirTypeFromPyType(int, ctx))
         if isinstance(argInstance[0], float):
-            # check if we are comparing to a complex...
-            eleTy = cc.StdvecType.getElementType(argTypeToCompareTo)
-            if ComplexType.isinstance(eleTy):
-                emitFatalError(
-                    "Invalid runtime argument to kernel. list[complex] required, but list[float] provided."
-                )
+            if argTypeToCompareTo != None:
+                # check if we are comparing to a complex...
+                eleTy = cc.StdvecType.getElementType(argTypeToCompareTo)
+                if ComplexType.isinstance(eleTy):
+                    emitFatalError(
+                        "Invalid runtime argument to kernel. list[complex] required, but list[float] provided."
+                    )
             return cc.StdvecType.get(ctx, mlirTypeFromPyType(float, ctx))
         if isinstance(argInstance[0], complex):
             return cc.StdvecType.get(ctx, mlirTypeFromPyType(complex, ctx))

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -1195,6 +1195,12 @@ q3 : ┤ h ├──────────────────────
     assert circuit == expected_str
 
 
+def test_list_subscript():
+    kernelAndArgs = cudaq.make_kernel(bool, list[bool], List[int], list[float])
+    print(kernelAndArgs[0])
+    assert len(kernelAndArgs) == 5 and len(kernelAndArgs[0].arguments) == 4
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)


### PR DESCRIPTION
We now require argument annotations with the Python language kernels, and lists must have element type specified (e.g. `list[float]` instead of just `list`). 

Users likely will try to specify list element types with the kernel builder as well, but this currently emits an error 
```python
import cudaq 
kernel, thetas = cudaq.make_kernel(list[float])
print(kernel)
```
```bash
RuntimeError: error: Can not handle conversion of python type list[float] to MLIR type.

Offending code:
  File "/workspaces/cuda-quantum/builds/gcc-12-debug/test.py", line 3, in <module>
    kernel, thetas = cudaq.make_kernel(list[float])
```

This PR fixes this by enabling element type inference for kernel builder list arguments. 