### PR TITLE
Remove exact version specifier in Python install instructions

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -45,7 +45,7 @@ Quantum with all its dependencies:
 [//]: # (Begin conda install)
 
 ```console
-    conda create -y -n cuda-quantum python==3.10 pip
+    conda create -y -n cuda-quantum python=3.10 pip
     conda install -y -n cuda-quantum -c "nvidia/label/cuda-11.8.0" cuda
     conda install -y -n cuda-quantum -c conda-forge mpi4py openmpi cxx-compiler cuquantum
     conda env config vars set -n cuda-quantum LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CONDA_PREFIX/envs/cuda-quantum/lib"


### PR DESCRIPTION
Anaconda doesn't have linux-aarch64 packages for Python 3.8.0 and 3.9.0, so without this change, these instructions will fail on ARM. However, when switching to a single "=", conda will allow the user to specify a version up to the number of digits provided, and then use the latest version available after that. For example, if the user provides "3.8", then conda will choose "3.8.18", which is the largest patch version matching "3.8".