### PR TITLE
Fix a bug in `sample.h` affecting `sample_async` in library mode

### DIFF
--- a/runtime/cudaq/algorithms/sample.h
+++ b/runtime/cudaq/algorithms/sample.h
@@ -67,7 +67,7 @@ runSampling(KernelFunctor &&wrappedKernel, quantum_platform &platform,
     auto &platform = get_platform();
     platform.set_exec_ctx(&context, qpu_id);
     wrappedKernel();
-    platform.reset_exec_ctx();
+    platform.reset_exec_ctx(qpu_id);
     // In trace mode, if we have a measure result
     // that is passed to an if statement, then
     // we'll have collected registernames


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

In library mode, we need to run a tracing pass before actual execution. 
With multi-qpu, we `set_exec_ctx` on specific QPU id but didn't reset the context on that particular qpu id (fall back to reset QPU 0 context all the time).

Resolves #1374 
