### PR TITLE
Make nvqc_proxy.py multi-threaded

### DIFF
--- a/scripts/nvqc_proxy.py
+++ b/scripts/nvqc_proxy.py
@@ -25,6 +25,7 @@ QPUD_PORT = 3031  # see `docker/build/cudaq.nvqc.Dockerfile`
 class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     """Handle requests in a separate thread."""
 
+
 class Server(http.server.SimpleHTTPRequestHandler):
     protocol_version = 'HTTP/1.1'
     default_request_version = 'HTTP/1.1'

--- a/scripts/nvqc_proxy.py
+++ b/scripts/nvqc_proxy.py
@@ -22,6 +22,9 @@ PROXY_PORT = 3030
 QPUD_PORT = 3031  # see `docker/build/cudaq.nvqc.Dockerfile`
 
 
+class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    """Handle requests in a separate thread."""
+
 class Server(http.server.SimpleHTTPRequestHandler):
     protocol_version = 'HTTP/1.1'
     default_request_version = 'HTTP/1.1'
@@ -85,7 +88,7 @@ class Server(http.server.SimpleHTTPRequestHandler):
 
 
 Handler = Server
-with socketserver.TCPServer(("", PROXY_PORT), Handler) as httpd:
+with ThreadedHTTPServer(("", PROXY_PORT), Handler) as httpd:
     print("Serving at port", PROXY_PORT)
     print("Forward to port", QPUD_PORT)
     httpd.serve_forever()


### PR DESCRIPTION
The NVCF infrastructure team has requested that health endpoint requests (i.e. requests to our `/` endpoint) be served in a separate thread from the inference endpoint (i.e. `/job`) so that inference requests won't block health endpoint checks. This PR satisfies that request.

Regression testing was performed by pushing a new image with these changes into our NVCF organization.

In addition to asking the NVCF team to review their logs about health endpoint requests for these new deployments, I have performed the following stress tests:

1. Deploy multiple instances of our 1-GPU configuration and saturate it with multiple parallel requests.

```bash
$ bin/nvq++ --target nvqc ../examples/cpp/providers/nvqc_sample.cpp
$ for j in `seq 1 10`; do echo "*** j = $j ***"; for i in `seq 1 10`; do ./a.out & done; wait; done
```

2. Deploy a single instance of our 4-GPU configuration and saturate it with multiple parallel requests.

```bash
$ for i in `seq 1 10`; do python3 ../docs/sphinx/examples/python/providers/nvqc_mgpu.py --ngpus 4 & done; wait
```

3. Deploy a single instance of our 8-GPU configuration and saturate it with multiple parallel requests.

```bash
$ for i in `seq 1 10`; do python3 ../docs/sphinx/examples/python/providers/nvqc_mgpu.py --ngpus 8 & done; wait
```

4. Force the deployment to run with a reduced timeout (like 30 seconds), and then run the following:

```bash
$ bin/nvq++ --target nvqc ../examples/cpp/providers/nvqc_sample.cpp
$ python3 ../docs/sphinx/examples/python/providers/nvqc_sample.py
<Watch timeout because this test normally takes ~40 seconds, which is greater than the 30 second timeout>
$ ./a.out
<This succeeds, which proves it gracefully recovered from the timeout>
```
Note: I ran Test 4 on single-GPU configurations and multi-GPU configurations.