### PR TITLE
[Core] Add poison op and fold optimization

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -658,6 +658,17 @@ def cc_UnwindReturnOp : CCOp<"unwind_return", [
 // Memory operations and initializations.
 //===----------------------------------------------------------------------===//
 
+def cc_PoisonOp : CCOp<"poison", [Pure]> {
+  let summary = "Explicit poison value";
+  let description = [{
+    A PoisonOp is used to create an LLVM poison value. A poison value occurs
+    in CC when the IR violates its own semantics, such as accessing the 10th
+    element of a constant array which only has 3 elements.
+  }];
+  let results = (outs AnyType:$inputType);
+  let assemblyFormat = "type($inputType) attr-dict";
+}
+
 def cc_UndefOp : CCOp<"undef", [Pure]> {
   let summary = "Explicit undefined value.";
   let description = [{
@@ -671,9 +682,7 @@ def cc_UndefOp : CCOp<"undef", [Pure]> {
     ```
   }];
   let results = (outs AnyType:$inputType);
-  let assemblyFormat = [{
-    type($inputType) attr-dict
-  }];
+  let assemblyFormat = "type($inputType) attr-dict";
 }
 
 def cc_AllocaOp : CCOp<"alloca", [

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -1428,6 +1428,20 @@ public:
   }
 };
 
+class PoisonOpPattern : public ConvertOpToLLVMPattern<cudaq::cc::PoisonOp> {
+public:
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(cudaq::cc::PoisonOp poison, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resTy = getTypeConverter()->convertType(poison.getType());
+    // FIXME: This should use PoisonOp, obviously, when we upgrade MLIR.
+    rewriter.replaceOpWithNewOp<LLVM::UndefOp>(poison, resTy);
+    return success();
+  }
+};
+
 class UndefOpPattern : public ConvertOpToLLVMPattern<cudaq::cc::UndefOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -1624,7 +1638,7 @@ public:
         OneTargetOneParamRewrite<quake::RyOp>,
         OneTargetOneParamRewrite<quake::RzOp>,
         OneTargetTwoParamRewrite<quake::U2Op>,
-        OneTargetTwoParamRewrite<quake::U3Op>, ResetRewrite,
+        OneTargetTwoParamRewrite<quake::U3Op>, PoisonOpPattern, ResetRewrite,
         StdvecDataOpPattern, StdvecInitOpPattern, StdvecSizeOpPattern,
         StoreOpPattern, SubveqOpRewrite, TwoTargetRewrite<quake::SwapOp>,
         UndefOpPattern>(typeConverter);


### PR DESCRIPTION
We can't use it yet since we're lagging LLVM, but this greases the skids to make folding of invalid constant array accesses to poison values.
