### PR TITLE
Fix #1384 - synthesis of vectors with small integers.

### DIFF
--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -483,6 +483,9 @@ public:
       };
       if (auto ty = dyn_cast<IntegerType>(eleTy)) {
         switch (ty.getIntOrFloatBitWidth()) {
+        case 1:
+          doVector(false);
+          break;
         case 8:
           doVector(std::int8_t{});
           break;


### PR DESCRIPTION
The constant array op is using at ArrayAttr, which does not naturally support integral sizes less than i32. This patch upcasts the short values to i32 to get around the issue. Another approach would be to have the constant array op take a DenseArrayAttr, which does support the shorter integral types. Might need a custom parser/pretty printer if we go that route?

Fix #1384 