### PR TITLE
Fix #1383: bridge not lowering to correct IR

### DIFF
--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1952,6 +1952,8 @@ bool QuakeBridgeVisitor::WalkUpFromCXXOperatorCallExpr(
 bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
     clang::CXXOperatorCallExpr *x) {
   auto loc = toLocation(x->getSourceRange());
+
+  // Helper to replace the operator[] function name with the value, v.
   auto replaceTOSValue = [&](Value v) {
     [[maybe_unused]] auto funcVal = popValue();
     assert(funcVal.getDefiningOp<func::ConstantOp>());

--- a/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -444,6 +444,19 @@ bool QuakeBridgeVisitor::TraverseIfStmt(clang::IfStmt *x,
     // If there is no initialization expression, skip creating an `if` scope.
     if (!TraverseStmt(cond))
       return false;
+
+    // For something like an `operator[]` the TOS value (likely) is a
+    // pointer to the indexed element in a vector. Since there may not be a cast
+    // node in the AST to make that a RHS value, we must explicitly check here
+    // and add the required a load and cast.
+    if (auto ptrTy = dyn_cast<cc::PointerType>(peekValue().getType())) {
+      Value v = popValue();
+      pushValue(builder.create<cc::LoadOp>(loc, v));
+      if (ptrTy != builder.getI1Type()) {
+        reportClangError(x, mangler,
+                         "expression in condition not yet supported");
+      }
+    }
     if (x->getElse())
       builder.create<cc::IfOp>(loc, TypeRange{}, popValue(),
                                stmtBuilder(x->getThen()),


### PR DESCRIPTION
The operator[] returns a reference, but the AST doesn't have a cast node. So the value appearing in the conditional is not loaded. This adds an explicit check and an error message if the load is returning an unexpected value.

Fix #1383.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
