### PR TITLE
Re-enable skipped tests and update script usage comment.

### DIFF
--- a/python/tests/kernel/test_sample_kernel.py
+++ b/python/tests/kernel/test_sample_kernel.py
@@ -42,10 +42,6 @@ def test_simple_sampling_ghz():
     assert '0' * 10 in counts and '1' * 10 in counts
 
 
-## [NOTE] With pybind11 v2.11.0+, the use of 'front', e.g. 'qubits.front(qubits.size() - 1)'
-## results in following error : 'RuntimeError: return_value_policy = move, but type
-## cudaq::qview<2ul> is neither movable nor copyable!'
-## https://github.com/NVIDIA/cuda-quantum/issues/1046
 def test_simple_sampling_qpe():
     """Test that we can build up a set of kernels, compose them, and sample."""
 

--- a/python/tests/mlir/ast_elif.py
+++ b/python/tests/mlir/ast_elif.py
@@ -28,9 +28,7 @@ def test_elif():
                 rx(theta, q[i % 4])
 
     print(cost)
-    ## [SKIP_TEST] : Following gives as error on 'python/cudaq/kernel/utils.py:176: ValueError'
-    ## ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
-    # cost(np.asarray([1., 2., 3., 4., 5., 6.]))
+    cost(np.asarray([1., 2., 3., 4., 5., 6.]))
     cost([1., 2., 3., 4., 5., 6.])
 
 

--- a/python/tests/mlir/ast_for_stdvec.py
+++ b/python/tests/mlir/ast_for_stdvec.py
@@ -27,9 +27,7 @@ def test_elif():
             i += 1
 
     print(cost)
-    ## [SKIP_TEST] : Following gives as error on 'python/cudaq/kernel/utils.py:176: ValueError'
-    ## ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
-    # cost(np.asarray([1., 2., 3., 4.]))
+    cost(np.asarray([1., 2., 3., 4.]))
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__cost(

--- a/scripts/build_cudaq.sh
+++ b/scripts/build_cudaq.sh
@@ -11,7 +11,7 @@
 # Usage:
 # bash scripts/build_cudaq.sh
 # -or-
-# bash scripts/build_cudaq.sh -c DEBUG
+# bash scripts/build_cudaq.sh -c Debug
 # -or-
 # LLVM_INSTALL_PREFIX=/path/to/dir bash scripts/build_cudaq.sh
 # -or-

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -17,7 +17,7 @@
 # Usage:
 # bash scripts/build_llvm.sh
 # -or-
-# bash scripts/build_llvm.sh -c DEBUG
+# bash scripts/build_llvm.sh -c Debug
 # -or-
 # LLVM_INSTALL_PREFIX=/installation/path/ bash scripts/build_llvm.sh
 


### PR DESCRIPTION
### Description
* (Re-)Enable 'pycudaq-mlir' tests which have been fixed by PR# https://github.com/NVIDIA/cuda-quantum/pull/1406(https://github.com/NVIDIA/cuda-quantum/pull/1406)
* Update comment in scripts to reflect allowed build type ('Debug', not 'DEBUG')
  - Using 'DEBUG' results in error `Invalid build type` 
* Removed the comment about issue# https://github.com/NVIDIA/cuda-quantum/issues/1046
