### PR TITLE
Improved type handling for OpaqueArguments::packArgs

### DIFF
--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -188,7 +188,6 @@ class PyKernelDecorator(object):
         # validate the argument types
         processedArgs = []
         callableNames = []
-        isEmptyListAndElementType = [None]*len(args)
         for i, arg in enumerate(args):
             if isinstance(arg, PyKernelDecorator):
                 arg.compile()

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -188,6 +188,7 @@ class PyKernelDecorator(object):
         # validate the argument types
         processedArgs = []
         callableNames = []
+        isEmptyListAndElementType = [None]*len(args)
         for i, arg in enumerate(args):
             if isinstance(arg, PyKernelDecorator):
                 arg.compile()
@@ -216,6 +217,7 @@ class PyKernelDecorator(object):
                             argEleTy):
                         processedArgs.append([float(i) for i in arg])
                         mlirType = self.argTypes[i]
+                        continue
 
             if not cc.CallableType.isinstance(
                     mlirType) and mlirType != self.argTypes[i]:

--- a/python/runtime/cudaq/algorithms/py_draw.cpp
+++ b/python/runtime/cudaq/algorithms/py_draw.cpp
@@ -30,7 +30,7 @@ std::string pyDraw(py::object &kernel, py::args args) {
   auto kernelName = kernel.attr("name").cast<std::string>();
   auto kernelMod = kernel.attr("module").cast<MlirModule>();
   args = simplifiedValidateInputArguments(args);
-  auto *argData = toOpaqueArgs(args);
+  auto *argData = toOpaqueArgs(args, kernelMod, kernelName);
 
   return details::extractTrace([&]() mutable {
     pyAltLaunchKernel(kernelName, kernelMod, *argData, {});

--- a/python/runtime/cudaq/algorithms/py_observe_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe_async.cpp
@@ -111,7 +111,6 @@ observe_result pyObservePar(const PyParType &type, py::object &kernel,
     kernel.attr("compile")();
 
   // Ensure the user input is correct.
-  // auto validatedArgs = validateInputArguments(kernel, args);
   auto &platform = cudaq::get_platform();
   if (!platform.supports_task_distribution())
     throw std::runtime_error(

--- a/python/runtime/cudaq/algorithms/py_observe_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe_async.cpp
@@ -83,13 +83,14 @@ async_observe_result pyObserveAsync(py::object &kernel, spin_op &spin_operator,
 
   auto &platform = cudaq::get_platform();
   auto kernelName = kernel.attr("name").cast<std::string>();
+  auto kernelMod = kernel.attr("module").cast<MlirModule>();
+  auto kernelFunc = getKernelFuncOp(kernelMod, kernelName);
 
   // The provided kernel is a builder or MLIR kernel
   auto *argData = new cudaq::OpaqueArguments();
   args = simplifiedValidateInputArguments(args);
-  cudaq::packArgs(*argData, args,
+  cudaq::packArgs(*argData, args, kernelFunc,
                   [](OpaqueArguments &, py::object &) { return false; });
-  auto kernelMod = kernel.attr("module").cast<MlirModule>();
 
   // Launch the asynchronous execution.
   py::gil_scoped_release release;

--- a/python/runtime/cudaq/algorithms/py_vqe.cpp
+++ b/python/runtime/cudaq/algorithms/py_vqe.cpp
@@ -59,14 +59,14 @@ bool isArgumentStdVec(MlirModule &module, const std::string &kernelName,
 observe_result pyObserve(py::object &kernel, spin_op &spin_operator,
                          py::args args, const int shots,
                          bool argMapperProvided = false) {
-  auto kernelName = kernel.attr("name").cast<std::string>();
-  auto &platform = cudaq::get_platform();
-  args = simplifiedValidateInputArguments(args);
-  auto *argData = toOpaqueArgs(args);
   if (py::hasattr(kernel, "compile"))
     kernel.attr("compile")();
-
+  auto kernelName = kernel.attr("name").cast<std::string>();
   auto kernelMod = kernel.attr("module").cast<MlirModule>();
+  auto &platform = cudaq::get_platform();
+  args = simplifiedValidateInputArguments(args);
+  auto *argData = toOpaqueArgs(args, kernelMod, kernelName);
+
   auto numKernelArgs = getNumArguments(kernelMod, kernelName);
   if (numKernelArgs == 0)
     throw std::runtime_error(

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -375,8 +375,9 @@ void bindAltLaunchKernel(py::module &mod) {
         auto name = kernel.attr("name").cast<std::string>();
         auto kernelFuncOp = getKernelFuncOp(module, name);
         cudaq::OpaqueArguments args;
-        cudaq::packArgs(args, runtimeArgs, kernelFuncOp,
-                        [](OpaqueArguments &, py::object &) { return false; });
+        cudaq::packArgs(
+            args, runtimeArgs, kernelFuncOp,
+            [](OpaqueArguments &, py::object &) { return false; }, false);
         return getQIRLL(name, module, args, profile);
       },
       py::arg("kernel"), py::kw_only(), py::arg("profile") = "");

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -108,26 +108,40 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
   // We need to append the return type to the OpaqueArguments here
   // so that we get a spot in the `rawArgs` memory for the
   // altLaunchKernel function to dump the result
-  if (!isa<NoneType>(returnType)) {
-    if (returnType.isInteger(64)) {
-      py::args returnVal = py::make_tuple(py::int_(0));
-      packArgs(runtimeArgs, returnVal);
-    } else if (returnType.isInteger(1)) {
-      py::args returnVal = py::make_tuple(py::bool_(0));
-      packArgs(runtimeArgs, returnVal);
-    } else if (isa<FloatType>(returnType)) {
-      py::args returnVal = py::make_tuple(py::float_(0.0));
-      packArgs(runtimeArgs, returnVal);
-    } else {
-      std::string msg;
-      {
-        llvm::raw_string_ostream os(msg);
-        returnType.print(os);
-      }
-      throw std::runtime_error(
-          "Unsupported CUDA Quantum kernel return type - " + msg + ".\n");
-    }
-  }
+  if (!isa<NoneType>(returnType))
+    TypeSwitch<Type, void>(returnType)
+        .Case([&](IntegerType type) {
+          if (type.getIntOrFloatBitWidth() == 1) {
+            bool *ourAllocatedArg = new bool();
+            *ourAllocatedArg = 0;
+            runtimeArgs.emplace_back(ourAllocatedArg, [](void *ptr) {
+              delete static_cast<bool *>(ptr);
+            });
+            return;
+          }
+
+          long *ourAllocatedArg = new long();
+          *ourAllocatedArg = 0;
+          runtimeArgs.emplace_back(ourAllocatedArg, [](void *ptr) {
+            delete static_cast<long *>(ptr);
+          });
+        })
+        .Case([&](Float64Type type) {
+          double *ourAllocatedArg = new double();
+          *ourAllocatedArg = 0.;
+          runtimeArgs.emplace_back(ourAllocatedArg, [](void *ptr) {
+            delete static_cast<double *>(ptr);
+          });
+        })
+        .Default([](Type ty) {
+          std::string msg;
+          {
+            llvm::raw_string_ostream os(msg);
+            ty.print(os);
+          }
+          throw std::runtime_error(
+              "Unsupported CUDA Quantum kernel return type - " + msg + ".\n");
+        });
 
   void *rawArgs = nullptr;
   std::size_t size = 0;
@@ -345,8 +359,10 @@ void bindAltLaunchKernel(py::module &mod) {
   mod.def("synthesize", [](py::object kernel, py::args runtimeArgs) {
     MlirModule module = kernel.attr("module").cast<MlirModule>();
     auto name = kernel.attr("name").cast<std::string>();
+    auto kernelFuncOp = getKernelFuncOp(module, name);
     cudaq::OpaqueArguments args;
-    cudaq::packArgs(args, runtimeArgs);
+    cudaq::packArgs(args, runtimeArgs, kernelFuncOp,
+                    [](OpaqueArguments &, py::object &) { return false; });
     return synthesizeKernel(name, module, args);
   });
 
@@ -357,8 +373,10 @@ void bindAltLaunchKernel(py::module &mod) {
           kernel.attr("compile")();
         MlirModule module = kernel.attr("module").cast<MlirModule>();
         auto name = kernel.attr("name").cast<std::string>();
+        auto kernelFuncOp = getKernelFuncOp(module, name);
         cudaq::OpaqueArguments args;
-        cudaq::packArgs(args, runtimeArgs);
+        cudaq::packArgs(args, runtimeArgs, kernelFuncOp,
+                        [](OpaqueArguments &, py::object &) { return false; });
         return getQIRLL(name, module, args, profile);
       },
       py::arg("kernel"), py::kw_only(), py::arg("profile") = "");

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -368,16 +368,12 @@ void bindAltLaunchKernel(py::module &mod) {
 
   mod.def(
       "get_qir",
-      [](py::object kernel, py::args runtimeArgs, std::string profile) {
+      [](py::object kernel, std::string profile) {
         if (py::hasattr(kernel, "compile"))
           kernel.attr("compile")();
         MlirModule module = kernel.attr("module").cast<MlirModule>();
         auto name = kernel.attr("name").cast<std::string>();
-        auto kernelFuncOp = getKernelFuncOp(module, name);
         cudaq::OpaqueArguments args;
-        cudaq::packArgs(
-            args, runtimeArgs, kernelFuncOp,
-            [](OpaqueArguments &, py::object &) { return false; }, false);
         return getQIRLL(name, module, args, profile);
       },
       py::arg("kernel"), py::kw_only(), py::arg("profile") = "");

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -319,8 +319,10 @@ void bindAltLaunchKernel(py::module &mod) {
       "pyAltLaunchKernel",
       [&](const std::string &kernelName, MlirModule module,
           py::args runtimeArgs, std::vector<std::string> callable_names) {
+        auto kernelFunc = getKernelFuncOp(module, kernelName);
+
         cudaq::OpaqueArguments args;
-        cudaq::packArgs(args, runtimeArgs, callableArgHandler);
+        cudaq::packArgs(args, runtimeArgs, kernelFunc, callableArgHandler);
         pyAltLaunchKernel(kernelName, module, args, callable_names);
       },
       py::arg("kernelName"), py::arg("module"), py::kw_only(),
@@ -329,8 +331,10 @@ void bindAltLaunchKernel(py::module &mod) {
       "pyAltLaunchKernelR",
       [&](const std::string &kernelName, MlirModule module, MlirType returnType,
           py::args runtimeArgs, std::vector<std::string> callable_names) {
+        auto kernelFunc = getKernelFuncOp(module, kernelName);
+
         cudaq::OpaqueArguments args;
-        cudaq::packArgs(args, runtimeArgs, callableArgHandler);
+        cudaq::packArgs(args, runtimeArgs, kernelFunc, callableArgHandler);
         return pyAltLaunchKernelR(kernelName, module, returnType, args,
                                   callable_names);
       },

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -201,9 +201,9 @@ def test_pauli_word_input():
         1, 3, 3, -0.0454063, -0, 15
     ]
     h = cudaq.SpinOperator(h2_data, 4)
-    
+
     @cudaq.kernel
-    def kernel(theta : float, var : cudaq.pauli_word):
+    def kernel(theta: float, var: cudaq.pauli_word):
         q = cudaq.qvector(4)
         x(q[0])
         x(q[1])
@@ -215,17 +215,18 @@ def test_pauli_word_input():
     want_exp = cudaq.observe(kernel, h, .11, 'XXXY').expectation()
     assert np.isclose(want_exp, -1.13, atol=1e-2)
 
-    want_exp = cudaq.observe(kernel, h, .11, cudaq.pauli_word('XXXY')).expectation()
+    want_exp = cudaq.observe(kernel, h, .11,
+                             cudaq.pauli_word('XXXY')).expectation()
     assert np.isclose(want_exp, -1.13, atol=1e-2)
-    
+
     @cudaq.kernel
-    def test(theta : float, paulis: list[cudaq.pauli_word]):
+    def test(theta: float, paulis: list[cudaq.pauli_word]):
         q = cudaq.qvector(4)
         x(q[0])
         x(q[1])
         for p in paulis:
             exp_pauli(theta, q, p)
-    
+
     print(test)
     want_exp = cudaq.observe(test, h, .11, ['XXXY']).expectation()
     assert np.isclose(want_exp, -1.13, atol=1e-2)
@@ -853,19 +854,20 @@ def test_invalid_cudaq_type():
 
 @skipIfPythonLessThan39
 def test_bool_list_elements():
+
     @cudaq.kernel
-    def kernel(var : list[bool]):
+    def kernel(var: list[bool]):
         q = cudaq.qubit()
         x(q)
         if var[0]:
             x(q)
-        
+
     counts = cudaq.sample(kernel, [False], shots_count=100)
     assert '1' in counts and len(counts) == 1
-    
+
     counts = cudaq.sample(kernel, [True], shots_count=100)
     assert '0' in counts and len(counts) == 1
-    
+
 
 def test_list_float_pass_list_int():
 
@@ -916,12 +918,15 @@ def test_aug_assign_add():
 
 @skipIfPythonLessThan39
 def test_empty_lists():
+
     @cudaq.kernel
-    def empty(var : list[cudaq.pauli_word], varvar : list[float], varvarvar :list[bool]):
+    def empty(var: list[cudaq.pauli_word], varvar: list[float],
+              varvarvar: list[bool]):
         q = cudaq.qvector(2)
         x(q[0])
 
     empty([], [], [])
+
 
 def test_no_valueerror_np_array():
 

--- a/python/utils/OpaqueArguments.h
+++ b/python/utils/OpaqueArguments.h
@@ -13,6 +13,7 @@
 #include "cudaq/builder/kernel_builder.h"
 #include "cudaq/qis/pauli_word.h"
 
+#include "llvm/ADT/TypeSwitch.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 
@@ -25,6 +26,7 @@
 
 namespace py = pybind11;
 using namespace std::chrono_literals;
+using namespace mlir;
 
 namespace cudaq {
 
@@ -161,96 +163,7 @@ inline py::args simplifiedValidateInputArguments(py::args &args) {
   return processed;
 }
 
-/// @brief For general function broadcasting over many argument
-/// sets, this function will create those argument sets from
-/// the input `args`.
-inline std::vector<py::args> createArgumentSet(py::args &args) {
-  // we accept float, int, list so we will check here for
-  // list[float], list[int], list[list], or ndarray for any,
-  // where the ndarray could be 2D (list[list])
-
-  // First we need to get the size of the arg set.
-  std::size_t nArgSets = py::len(args[0]);
-
-  // Now I want to build up vector<tuple (arg0, arg1, ...)>
-  std::vector<py::args> argSet;
-  for (std::size_t j = 0; j < nArgSets; j++) {
-    py::args currentArgs = py::tuple(args.size());
-
-    for (std::size_t i = 0; i < args.size(); ++i) {
-      auto arg = args[i];
-
-      if (py::isinstance<py::list>(arg)) {
-        auto list = arg.cast<py::list>();
-        if (list.size() != nArgSets)
-          throw std::runtime_error(
-              "Invalid argument to sample/observe broadcast, must be a list of "
-              "argument instances.");
-        currentArgs[i] = list[j];
-      }
-
-      // This is not a list, but see if we can get it as one
-      if (py::hasattr(args[i], "tolist")) {
-        // This is a valid ndarray if it has tolist and shape
-        if (!py::hasattr(args[i], "shape"))
-          throw std::runtime_error(
-              "Invalid input argument type, could not get shape of array.");
-
-        // This is an ndarray with tolist() and shape attributes
-        // get the shape and check its size
-        auto shape = args[i].attr("shape").cast<py::tuple>();
-        if (shape.size() > 2)
-          throw std::runtime_error(
-              "Invalid kernel arg for sample_n / observe_n, shape.size() > 2");
-
-        // Can handle 1d array and 2d matrix of data
-        if (shape.size() == 2) {
-          auto list =
-              arg.attr("__getitem__")(j).attr("tolist")().cast<py::list>();
-          currentArgs[i] = list;
-        } else {
-          auto list = arg.attr("tolist")().cast<py::list>();
-          currentArgs[i] = list[j];
-        }
-      }
-    }
-
-    argSet.push_back(currentArgs);
-  }
-
-  return argSet;
-}
-
-/// @brief Convert `py::args` to an OpaqueArguments instance
-inline void packArgs(OpaqueArguments &argData, py::args args) {
-  for (auto &arg : args) {
-    if (py::isinstance<py::float_>(arg)) {
-      double *ourAllocatedArg = new double();
-      *ourAllocatedArg = PyFloat_AsDouble(arg.ptr());
-      argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-        delete static_cast<double *>(ptr);
-      });
-    } else if (py::isinstance<py::int_>(arg)) {
-      long *ourAllocatedArg = new long();
-      *ourAllocatedArg = PyLong_AsLong(arg.ptr());
-      argData.emplace_back(ourAllocatedArg,
-                           [](void *ptr) { delete static_cast<long *>(ptr); });
-    } else if (py::isinstance<py::list>(arg)) {
-      auto casted = py::cast<py::list>(arg);
-      std::vector<double> *ourAllocatedArg =
-          new std::vector<double>(casted.size());
-      for (std::size_t counter = 0; auto el : casted) {
-        (*ourAllocatedArg)[counter++] = PyFloat_AsDouble(el.ptr());
-      }
-      argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-        delete static_cast<std::vector<double> *>(ptr);
-      });
-    } else
-      throw std::runtime_error("Could not pack argument: " +
-                               py::str(args).cast<std::string>());
-  }
-}
-
+/// @brief Search the given Module for the function with provided name.
 inline mlir::func::FuncOp getKernelFuncOp(MlirModule module,
                                           const std::string &kernelName) {
   using namespace mlir;
@@ -284,135 +197,162 @@ packArgs(OpaqueArguments &argData, py::args args,
 
   for (std::size_t i = 0; i < args.size(); i++) {
     py::object arg = args[i];
-    if (py::isinstance<py::float_>(arg)) {
-      double *ourAllocatedArg = new double();
-      *ourAllocatedArg = PyFloat_AsDouble(arg.ptr());
-      argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-        delete static_cast<double *>(ptr);
-      });
-      continue;
-    }
-
-    if (py::isinstance<py::int_>(arg)) {
-      long *ourAllocatedArg = new long();
-      *ourAllocatedArg = PyLong_AsLong(arg.ptr());
-      argData.emplace_back(ourAllocatedArg,
-                           [](void *ptr) { delete static_cast<long *>(ptr); });
-      continue;
-    }
-
-    if (py::isinstance<cudaq::pauli_word>(arg)) {
-      cudaq::pauli_word *ourAllocatedArg =
-          new cudaq::pauli_word(arg.cast<cudaq::pauli_word>().str());
-      argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-        delete static_cast<cudaq::pauli_word *>(ptr);
-      });
-      continue;
-    }
-
-    if (py::isinstance<py::list>(arg)) {
-      auto casted = py::cast<py::list>(arg);
-      if (casted.empty()) {
-        auto mlirArgITy = kernelFuncOp.getArgument(i).getType();
-        auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(mlirArgITy);
-        if (!stdvecTy)
-          throw std::runtime_error(
-              "Runtime argument is a list but corresponding kernel argument "
-              "type is not a list.");
-
-        auto eleTy = stdvecTy.getElementType();
-        // Handle boolean different since C++ library implementation
-        // for vectors of bool is different than other types.
-        if (eleTy.isInteger(1)) {
-          std::vector<bool> *ourAllocatedArg = new std::vector<bool>();
+    auto kernelArgTy = kernelFuncOp.getArgument(i).getType();
+    llvm::TypeSwitch<mlir::Type, void>(kernelArgTy)
+        .Case([&](mlir::Float64Type ty) {
+          if (!py::isinstance<py::float_>(arg))
+            throw std::runtime_error("kernel argument type is `float` but "
+                                     "argument provided is not (argument " +
+                                     std::to_string(i) + ", value=" +
+                                     py::str(arg).cast<std::string>() + ").");
+          double *ourAllocatedArg = new double();
+          *ourAllocatedArg = PyFloat_AsDouble(arg.ptr());
           argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-            delete static_cast<std::vector<bool> *>(ptr);
+            delete static_cast<double *>(ptr);
           });
-          continue;
-        }
+        })
+        .Case([&](mlir::IntegerType ty) {
+          if (ty.getIntOrFloatBitWidth() == 1) {
+            if (!py::isinstance<py::bool_>(arg))
+              throw std::runtime_error("kernel argument type is `bool` but "
+                                       "argument provided is not (argument " +
+                                       std::to_string(i) + ", value=" +
+                                       py::str(arg).cast<std::string>() + ").");
+            bool *ourAllocatedArg = new bool();
+            *ourAllocatedArg = arg.ptr() == (PyObject *)&_Py_TrueStruct;
+            argData.emplace_back(ourAllocatedArg, [](void *ptr) {
+              delete static_cast<bool *>(ptr);
+            });
+            return;
+          }
 
-        // If its empty, just put any vector on the `argData`,
-        // it won't matter since it is empty and all
-        // vectors have the same memory footprint (span-like).
-        std::vector<std::size_t> *ourAllocatedArg =
-            new std::vector<std::size_t>();
-        argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-          delete static_cast<std::vector<std::size_t> *>(ptr);
-        });
-        continue;
-      }
+          if (!py::isinstance<py::int_>(arg))
+            throw std::runtime_error("kernel argument type is `int` but "
+                                     "argument provided is not (argument " +
+                                     std::to_string(i) + ", value=" +
+                                     py::str(arg).cast<std::string>() + ").");
 
-      // Get the first element in the list
-      auto firstElement = casted[0];
+          long *ourAllocatedArg = new long();
+          *ourAllocatedArg = PyLong_AsLong(arg.ptr());
+          argData.emplace_back(ourAllocatedArg, [](void *ptr) {
+            delete static_cast<long *>(ptr);
+          });
+        })
+        .Case([&](cudaq::cc::CharspanType ty) {
+          // pauli word
+          cudaq::pauli_word *ourAllocatedArg =
+              new cudaq::pauli_word(arg.cast<cudaq::pauli_word>().str());
+          argData.emplace_back(ourAllocatedArg, [](void *ptr) {
+            delete static_cast<cudaq::pauli_word *>(ptr);
+          });
+        })
+        .Case([&](cudaq::cc::StdvecType ty) {
+          if (!py::isinstance<py::list>(arg))
+            throw std::runtime_error("kernel argument type is `list` but "
+                                     "argument provided is not (argument " +
+                                     std::to_string(i) + ", value=" +
+                                     py::str(arg).cast<std::string>() + ").");
+          auto casted = py::cast<py::list>(arg);
+          auto eleTy = ty.getElementType();
+          if (casted.empty()) {
+            // Handle boolean different since C++ library implementation
+            // for vectors of bool is different than other types.
+            if (eleTy.isInteger(1)) {
+              std::vector<bool> *ourAllocatedArg = new std::vector<bool>();
+              argData.emplace_back(ourAllocatedArg, [](void *ptr) {
+                delete static_cast<std::vector<bool> *>(ptr);
+              });
+              return;
+            }
 
-      // Handle `list[pauli_word]`
-      if (py::isinstance<cudaq::pauli_word>(firstElement)) {
-        std::vector<cudaq::pauli_word> *ourAllocatedArg =
-            new std::vector<cudaq::pauli_word>(casted.size());
-        for (std::size_t counter = 0; auto el : casted) {
-          auto pw = el.cast<cudaq::pauli_word>();
-          (*ourAllocatedArg)[counter++] = cudaq::pauli_word(pw.str());
-        }
-        argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-          delete static_cast<std::vector<cudaq::pauli_word> *>(ptr);
-        });
-        continue;
-      }
+            // If its empty, just put any vector on the `argData`,
+            // it won't matter since it is empty and all
+            // vectors have the same memory footprint (span-like).
+            std::vector<std::size_t> *ourAllocatedArg =
+                new std::vector<std::size_t>();
+            argData.emplace_back(ourAllocatedArg, [](void *ptr) {
+              delete static_cast<std::vector<std::size_t> *>(ptr);
+            });
+            return;
+          }
 
-      if (py::isinstance<py::bool_>(firstElement)) {
-        std::vector<bool> *ourAllocatedArg =
-            new std::vector<bool>(casted.size());
-        for (std::size_t counter = 0; auto el : casted) {
-          (*ourAllocatedArg)[counter++] =
-              el.ptr() == (PyObject *)&_Py_TrueStruct;
-        }
-        argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-          delete static_cast<std::vector<bool> *>(ptr);
-        });
-        continue;
-      }
+          // Define a generic vector allocator as a
+          // templated lambda so we can capture argData and casted.
+          auto genericVecAllocator = [&]<typename VecTy>(auto &&converter) {
+            std::vector<VecTy> *ourAllocatedArg =
+                new std::vector<VecTy>(casted.size());
+            for (std::size_t counter = 0; auto el : casted) {
+              (*ourAllocatedArg)[counter++] = converter(el);
+            }
+            argData.emplace_back(ourAllocatedArg, [](void *ptr) {
+              delete static_cast<std::vector<VecTy> *>(ptr);
+            });
+          };
 
-      if (py::isinstance<py::int_>(firstElement)) {
-        std::vector<std::size_t> *ourAllocatedArg =
-            new std::vector<std::size_t>(casted.size());
-        for (std::size_t counter = 0; auto el : casted) {
-          (*ourAllocatedArg)[counter++] = PyLong_AsLong(el.ptr());
-        }
-        argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-          delete static_cast<std::vector<std::size_t> *>(ptr);
-        });
-      } else if (py::hasattr(firstElement, "real") &&
-                 py::hasattr(firstElement, "imag") &&
-                 !py::isinstance<py::float_>(firstElement)) {
-        // Trying to catch elements of type complex
-        std::vector<std::complex<double>> *ourAllocatedArg =
-            new std::vector<std::complex<double>>(casted.size());
-        for (std::size_t counter = 0; auto el : casted) {
-          (*ourAllocatedArg)[counter++] = {
-              PyFloat_AsDouble(el.attr("real").ptr()),
-              PyFloat_AsDouble(el.attr("imag").ptr())};
-        }
-        argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-          delete static_cast<std::vector<std::complex<double>> *>(ptr);
-        });
-      } else {
-        std::vector<double> *ourAllocatedArg =
-            new std::vector<double>(casted.size());
-        for (std::size_t counter = 0; auto el : casted) {
-          (*ourAllocatedArg)[counter++] = PyFloat_AsDouble(el.ptr());
-        }
-        argData.emplace_back(ourAllocatedArg, [](void *ptr) {
-          delete static_cast<std::vector<double> *>(ptr);
-        });
-      }
-      continue;
-    }
+          // Switch on the vector element type
+          TypeSwitch<Type, void>(eleTy)
+              .Case([&](IntegerType type) {
+                // Handle vec<bool> and vec<int>
+                if (type.getIntOrFloatBitWidth() == 1) {
+                  genericVecAllocator.template operator()<bool>(
+                      [](py::handle element) {
+                        return element.ptr() == (PyObject *)&_Py_TrueStruct;
+                      });
+                  return;
+                }
 
-    // Unhandled, see if someone else knows how to handle it
-    auto worked = backupHandler(argData, arg);
-    if (!worked)
-      throw std::runtime_error("Could not pack argument: " +
-                               py::str(args).cast<std::string>());
+                genericVecAllocator.template operator()<std::size_t>(
+                    [](py::handle element) -> std::size_t {
+                      return PyLong_AsLong(element.ptr());
+                    });
+                return;
+              })
+              .Case([&](Float64Type type) {
+                genericVecAllocator.template operator()<double>(
+                    [](py::handle element) {
+                      return PyFloat_AsDouble(element.ptr());
+                    });
+                return;
+              })
+              .Case([&](cudaq::cc::CharspanType type) {
+                genericVecAllocator.template operator()<cudaq::pauli_word>(
+                    [](py::handle element) {
+                      auto pw = element.cast<cudaq::pauli_word>();
+                      return cudaq::pauli_word(pw.str());
+                    });
+                return;
+              })
+              .Case([&](ComplexType type) {
+                genericVecAllocator.template operator()<std::complex<double>>(
+                    [](py::handle element) -> std::complex<double> {
+                      if (!py::hasattr(element, "real"))
+                        throw std::runtime_error(
+                            "invalid complex element type");
+                      if (!py::hasattr(element, "imag"))
+                        throw std::runtime_error(
+                            "invalid complex element type");
+                      return {PyFloat_AsDouble(element.attr("real").ptr()),
+                              PyFloat_AsDouble(element.attr("imag").ptr())};
+                    });
+                return;
+              })
+              .Default([](Type ty) {
+                std::string msg;
+                {
+                  llvm::raw_string_ostream os(msg);
+                  ty.print(os);
+                }
+                throw std::runtime_error("invalid list element type (" + msg +
+                                         ").");
+              });
+        })
+        .Default([&](Type) {
+          // See if we have a backup type handler.
+          auto worked = backupHandler(argData, arg);
+          if (!worked)
+            throw std::runtime_error("Could not pack argument: " +
+                                     py::str(args).cast<std::string>());
+        });
   }
 }
 

--- a/python/utils/OpaqueArguments.h
+++ b/python/utils/OpaqueArguments.h
@@ -184,17 +184,16 @@ inline mlir::func::FuncOp getKernelFuncOp(MlirModule module,
   return kernelFunc;
 }
 
-inline void packArgs(OpaqueArguments &argData, py::args args,
-                     mlir::func::FuncOp kernelFuncOp,
-                     const std::function<bool(OpaqueArguments &argData,
-                                              py::object &arg)> &backupHandler,
-                     bool checkNumArgs = false) {
-  if (checkNumArgs)
-    if (kernelFuncOp.getNumArguments() != args.size())
-      throw std::runtime_error("Invalid runtime arguments - kernel expected " +
-                               std::to_string(kernelFuncOp.getNumArguments()) +
-                               " but was provided " +
-                               std::to_string(args.size()) + " arguments.");
+inline void
+packArgs(OpaqueArguments &argData, py::args args,
+         mlir::func::FuncOp kernelFuncOp,
+         const std::function<bool(OpaqueArguments &argData, py::object &arg)>
+             &backupHandler) {
+  if (kernelFuncOp.getNumArguments() != args.size())
+    throw std::runtime_error("Invalid runtime arguments - kernel expected " +
+                             std::to_string(kernelFuncOp.getNumArguments()) +
+                             " but was provided " +
+                             std::to_string(args.size()) + " arguments.");
 
   for (std::size_t i = 0; i < args.size(); i++) {
     py::object arg = args[i];

--- a/python/utils/OpaqueArguments.h
+++ b/python/utils/OpaqueArguments.h
@@ -184,16 +184,17 @@ inline mlir::func::FuncOp getKernelFuncOp(MlirModule module,
   return kernelFunc;
 }
 
-inline void
-packArgs(OpaqueArguments &argData, py::args args,
-         mlir::func::FuncOp kernelFuncOp,
-         const std::function<bool(OpaqueArguments &argData, py::object &arg)>
-             &backupHandler) {
-  if (kernelFuncOp.getNumArguments() != args.size())
-    throw std::runtime_error("Invalid runtime arguments - kernel expected " +
-                             std::to_string(kernelFuncOp.getNumArguments()) +
-                             " but was provided " +
-                             std::to_string(args.size()) + " arguments.");
+inline void packArgs(OpaqueArguments &argData, py::args args,
+                     mlir::func::FuncOp kernelFuncOp,
+                     const std::function<bool(OpaqueArguments &argData,
+                                              py::object &arg)> &backupHandler,
+                     bool checkNumArgs = false) {
+  if (checkNumArgs)
+    if (kernelFuncOp.getNumArguments() != args.size())
+      throw std::runtime_error("Invalid runtime arguments - kernel expected " +
+                               std::to_string(kernelFuncOp.getNumArguments()) +
+                               " but was provided " +
+                               std::to_string(args.size()) + " arguments.");
 
   for (std::size_t i = 0; i < args.size(); i++) {
     py::object arg = args[i];


### PR DESCRIPTION
Inject the kernel `FuncOp` when packing input runtime arguments into the opaque arg used by `altLaunchKernel`. This provides better handling of runtime argument types via the LLVM TypeSwitch utility.

Without this we should experience issues with regards to processing empty lists passed as runtime arguments. Currently we can only know that the argument is a `list` and infer the element type by checking the type of the list's first element, which does not exist if the list is empty. This PR brings the kernel argument signature to this processing step, and so we can check / process the args knowing the required argument type.
