### PR TITLE
Fix issue with `spin_op` result retrieval

### DIFF
--- a/runtime/common/ObserveResult.h
+++ b/runtime/common/ObserveResult.h
@@ -80,7 +80,7 @@ public:
     // Expand the string representation of the term to match the number of
     // qubits of the overall spin_op this result represents by appending
     // identity ops.
-    if (!data.has_expectation(termStr) && termStr.size() < numQubits)
+    if (!data.has_expectation(termStr))
       for (std::size_t i = termStr.size(); i < numQubits; i++)
         termStr += "I";
     return data.expectation(termStr);

--- a/runtime/common/ObserveResult.h
+++ b/runtime/common/ObserveResult.h
@@ -77,8 +77,11 @@ public:
     // on more than 1 qubit can be <ZIII...III>
     auto numQubits = spinOp.num_qubits();
     auto termStr = term.to_string(false);
-    if (!data.has_expectation(termStr) && termStr.size() == 1 && numQubits > 1)
-      for (std::size_t i = 1; i < numQubits; i++)
+    // Expand the string representation of the term to match the number of
+    // qubits of the overall spin_op this result represents by appending
+    // identity ops.
+    if (!data.has_expectation(termStr) && termStr.size() < numQubits)
+      for (std::size_t i = termStr.size(); i < numQubits; i++)
         termStr += "I";
     return data.expectation(termStr);
   }


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

We have the logic to expand the term strings (used as index keys) for result look-up but it was limited to single-qubit cases (e.g., only expanding Z0 but not Z1 to the target number of qubits).

This caused the issue reported in #1396 whereby the second `spin_op` in that list is Z1. It wasn't expanded properly, hence reported as a zero result.

This PR fixed the issue and added a test based on the bug report.

Resolved #1396 
 
