### PR TITLE
Prevent usage of cmake 3.29.0 in Python wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -33,7 +33,7 @@ Releases = "https://nvidia.github.io/cuda-quantum/latest/releases.html"
 chemistry = [ "scipy==1.10.1", "openfermionpyscf==0.5" ]
 
 [build-system]
-requires = ["scikit-build-core", "cmake>=3.26"]
+requires = ["scikit-build-core", "cmake>=3.26,<3.29"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
Our Python wheel builds seem to be broken (e.g. [this example](https://github.com/NVIDIA/cuda-quantum/actions/runs/8434834595/job/23101378620)), and it seems to be related to the recent release of [CMake 3.29](https://github.com/Kitware/CMake/releases/tag/v3.29.0).

This is a quick fix to get our wheels building again, but we should additionally try to figure out why the build process doesn't work with the new version and fix that separately.