### PR TITLE
[Core] Remove the use of IndexType

### DIFF
--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -167,11 +167,11 @@ cc::LoopOp factory::createInvariantLoop(
     OpBuilder &builder, Location loc, Value totalIterations,
     llvm::function_ref<void(OpBuilder &, Location, Region &, Block &)>
         bodyBuilder) {
-  Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Type indexTy = builder.getIndexType();
+  Value zero = builder.create<arith::ConstantIntOp>(loc, 0, 64);
+  Value one = builder.create<arith::ConstantIntOp>(loc, 1, 64);
+  Type i64Ty = builder.getI64Type();
   SmallVector<Value> inputs = {zero};
-  SmallVector<Type> resultTys = {indexTy};
+  SmallVector<Type> resultTys = {i64Ty};
   auto loop = builder.create<cc::LoopOp>(
       loc, resultTys, inputs, /*postCondition=*/false,
       [&](OpBuilder &builder, Location loc, Region &region) {
@@ -364,7 +364,7 @@ bool factory::structUsesTwoArguments(mlir::Type ty) {
 static bool onlyArithmeticMembers(cc::StructType structTy) {
   for (auto t : structTy.getMembers()) {
     // FIXME: check complex type
-    if (isa<IntegerType, FloatType, IndexType>(t))
+    if (isa<IntegerType, FloatType>(t))
       continue;
     return false;
   }

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -252,14 +252,8 @@ public:
       idx_operand = adaptor.getOperands()[1];
 
       if (idx_operand.getType().isIntOrFloat() &&
-          idx_operand.getType().cast<IntegerType>().getWidth() < 64) {
+          idx_operand.getType().cast<IntegerType>().getWidth() < 64)
         idx_operand = rewriter.create<LLVM::ZExtOp>(loc, i64Ty, idx_operand);
-      }
-      if (idx_operand.getType().isa<IndexType>()) {
-        idx_operand =
-            rewriter.create<arith::IndexCastOp>(loc, i64Ty, idx_operand)
-                .getResult();
-      }
     }
 
     auto get_qbit_qir_call = rewriter.create<LLVM::CallOp>(
@@ -301,8 +295,6 @@ public:
       if (v.getType().isa<IntegerType>() &&
           v.getType().cast<IntegerType>().getWidth() < 64)
         return rewriter.create<LLVM::ZExtOp>(loc, i64Ty, v);
-      if (v.getType().isa<IndexType>())
-        return rewriter.create<arith::IndexCastOp>(loc, i64Ty, v);
       return v;
     };
     lowArg = extend(lowArg);

--- a/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -25,8 +25,8 @@ using namespace mlir;
 
 static Value createCast(PatternRewriter &rewriter, Location loc, Value inVal) {
   auto i64Ty = rewriter.getI64Type();
-  if (inVal.getType() == rewriter.getIndexType())
-    return rewriter.create<arith::IndexCastOp>(loc, i64Ty, inVal);
+  assert(inVal.getType() != rewriter.getIndexType() &&
+         "use of index type is deprecated");
   return rewriter.create<cudaq::cc::CastOp>(loc, i64Ty, inVal,
                                             cudaq::cc::CastOpMode::Unsigned);
 }

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -158,13 +158,13 @@ public:
       auto topLevelCount =
           convertLengthBytesToLengthI64(loc, builder, topLevelSize);
       // Now walk the vectors recursively.
-      auto topLevelIndex = builder.create<arith::IndexCastOp>(
-          loc, builder.getIndexType(), topLevelCount);
+      auto topLevelIndex = builder.create<cudaq::cc::CastOp>(
+          loc, builder.getI64Type(), topLevelCount,
+          cudaq::cc::CastOpMode::Unsigned);
       cudaq::opt::factory::createInvariantLoop(
           builder, loc, topLevelIndex,
           [&](OpBuilder &builder, Location loc, Region &, Block &block) {
-            Value i = builder.create<arith::IndexCastOp>(
-                loc, builder.getI64Type(), block.getArgument(0));
+            Value i = block.getArgument(0);
             auto sub = builder.create<cudaq::cc::ComputePtrOp>(loc, hostVecTy,
                                                                nested, i);
             auto p =
@@ -627,13 +627,13 @@ public:
       // the vecTmp variable. Leaf vectors do not need a fresh variable. This
       // effectively translates all the size/offset information for all the
       // subvectors into temps.
-      Value vecLengthIndex = builder.create<arith::IndexCastOp>(
-          loc, builder.getIndexType(), vecLength);
+      Value vecLengthIndex = builder.create<cudaq::cc::CastOp>(
+          loc, builder.getI64Type(), vecLength,
+          cudaq::cc::CastOpMode::Unsigned);
       cudaq::opt::factory::createInvariantLoop(
           builder, loc, vecLengthIndex,
           [&](OpBuilder &builder, Location loc, Region &, Block &block) {
-            Value i = builder.create<arith::IndexCastOp>(loc, i64Ty,
-                                                         block.getArgument(0));
+            Value i = block.getArgument(0);
             auto innerPtr = builder.create<cudaq::cc::ComputePtrOp>(
                 loc, cudaq::cc::PointerType::get(i64Ty), innerVec,
                 SmallVector<cudaq::cc::ComputePtrArg>{i});
@@ -937,8 +937,9 @@ public:
                                                  stdvecTy, hostVecTy);
     auto nested = fetchHostVectorFront(loc, builder, hostArg, hostVecTy);
     auto vecLogicalLen = convertLengthBytesToLengthI64(loc, builder, vecLen);
-    auto vecLenIndex = builder.create<arith::IndexCastOp>(
-        loc, builder.getIndexType(), vecLogicalLen);
+    auto vecLenIndex = builder.create<cudaq::cc::CastOp>(
+        loc, builder.getI64Type(), vecLogicalLen,
+        cudaq::cc::CastOpMode::Unsigned);
     auto buffPtrTy = buffPtr.getType();
     auto tmp = builder.create<cudaq::cc::AllocaOp>(loc, buffPtrTy);
     auto newEnd = builder.create<cudaq::cc::ComputePtrOp>(
@@ -951,8 +952,7 @@ public:
     cudaq::opt::factory::createInvariantLoop(
         builder, loc, vecLenIndex,
         [&](OpBuilder &builder, Location loc, Region &, Block &block) {
-          Value i = builder.create<arith::IndexCastOp>(
-              loc, builder.getI64Type(), block.getArgument(0));
+          Value i = block.getArgument(0);
           auto currBuffPtr = builder.create<cudaq::cc::ComputePtrOp>(
               loc, ptrI64Ty, vecBasePtr,
               SmallVector<cudaq::cc::ComputePtrArg>{i});

--- a/lib/Optimizer/Transforms/LoopNormalize.cpp
+++ b/lib/Optimizer/Transforms/LoopNormalize.cpp
@@ -59,8 +59,6 @@ public:
     auto ty = c.initialValue.getType();
     rewriter.startRootUpdate(loop);
     auto createConstantOp = [&](std::int64_t val) -> Value {
-      if (ty == rewriter.getIndexType())
-        return rewriter.create<arith::ConstantIndexOp>(loc, val);
       return rewriter.create<arith::ConstantIntOp>(loc, val, ty);
     };
     auto zero = createConstantOp(0);

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -158,10 +158,6 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
     return QuakeValue(opBuilder, extractedQubit);
   }
 
-  if (indexVar.getType().isa<IndexType>())
-    indexVar =
-        opBuilder.create<arith::IndexCastOp>(opBuilder.getI64Type(), indexVar);
-
   // We are unable to check that the number of elements have
   // been passed in correctly.
   canValidateVectorNumElements = false;
@@ -340,14 +336,10 @@ QuakeValue QuakeValue::operator+(const double constValue) {
 QuakeValue QuakeValue::operator+(const int constValue) {
   auto v = value->asMLIR();
   if (!v.getType().isIntOrIndex())
-    throw std::runtime_error("Can only add int/index QuakeValues.");
+    throw std::runtime_error("Can only add integral QuakeValues.");
 
-  Value constant;
-  if (isa<IndexType>(v.getType())) {
-    constant = opBuilder.create<arith::ConstantIndexOp>(constValue);
-  } else {
-    constant = opBuilder.create<arith::ConstantIntOp>(constValue, v.getType());
-  }
+  Value constant =
+      opBuilder.create<arith::ConstantIntOp>(constValue, v.getType());
   Value added = opBuilder.create<arith::AddIOp>(v.getType(), constant, v);
   return QuakeValue(opBuilder, added);
 }
@@ -382,12 +374,8 @@ QuakeValue QuakeValue::operator-(const int constValue) {
   if (!v.getType().isIntOrIndex())
     throw std::runtime_error("Can only subtract double/float QuakeValues.");
 
-  Value constant;
-  if (isa<IndexType>(v.getType())) {
-    constant = opBuilder.create<arith::ConstantIndexOp>(constValue);
-  } else {
-    constant = opBuilder.create<arith::ConstantIntOp>(constValue, v.getType());
-  }
+  Value constant =
+      opBuilder.create<arith::ConstantIntOp>(constValue, v.getType());
 
   Value subtracted = opBuilder.create<arith::SubIOp>(v.getType(), v, constant);
   return QuakeValue(opBuilder, subtracted);

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -90,8 +90,6 @@ struct run_circuit {
 // ADJOINT-LABEL:   func.func private @__nvqpp__mlirgen__statePrep_A.adj(
 // ADJOINT-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: f64) {
 // ADJOINT-DAG:       %[[VAL_2:.*]] = arith.constant 2.000000e+00 : f64
-// ADJOINT-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
-// ADJOINT-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
 // ADJOINT-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i64
 // ADJOINT-DAG:       %[[VAL_6:.*]] = arith.constant 0 : i64
 // ADJOINT-DAG:       %[[VAL_7:.*]] = arith.constant 1 : i32
@@ -102,7 +100,6 @@ struct run_circuit {
 // ADJOINT:           %[[VAL_12:.*]] = arith.subi %[[VAL_11]], %[[VAL_5]] : i64
 // ADJOINT:           %[[VAL_13:.*]] = quake.subveq %[[VAL_0]], %[[VAL_6]], %[[VAL_12]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
 // ADJOINT:           %[[VAL_14:.*]] = quake.veq_size %[[VAL_13]] : (!quake.veq<?>) -> i64
-// ADJOINT:           %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i64 to index
 // ADJOINT:           %[[VAL_16:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
 // ADJOINT:           %[[VAL_18:.*]] = math.fpowi %[[VAL_2]], %[[VAL_16]] : f64, i32
 // ADJOINT:           %[[VAL_19:.*]] = arith.divf %[[VAL_1]], %[[VAL_18]] : f64
@@ -151,34 +148,34 @@ struct run_circuit {
 // ADJOINT:           }
 // ADJOINT:           %[[VAL_67:.*]] = arith.negf %[[VAL_19]] : f64
 // ADJOINT:           quake.ry (%[[VAL_67]]) %[[VAL_22]] : (f64, !quake.ref) -> ()
-// ADJOINT:           %[[VAL_68:.*]] = arith.constant 0 : index
-// ADJOINT:           %[[VAL_69:.*]] = arith.constant 1 : index
-// ADJOINT:           %[[VAL_70:.*]] = arith.cmpi slt, %[[VAL_3]], %[[VAL_68]] : index
-// ADJOINT:           %[[VAL_71:.*]] = arith.constant -1 : index
-// ADJOINT:           %[[VAL_72:.*]] = arith.select %[[VAL_70]], %[[VAL_69]], %[[VAL_71]] : index
-// ADJOINT:           %[[VAL_73:.*]] = arith.addi %[[VAL_15]], %[[VAL_72]] : index
-// ADJOINT:           %[[VAL_74:.*]] = arith.addi %[[VAL_73]], %[[VAL_3]] : index
-// ADJOINT:           %[[VAL_75:.*]] = arith.cmpi sgt, %[[VAL_74]], %[[VAL_68]] : index
-// ADJOINT:           %[[VAL_76:.*]] = arith.select %[[VAL_75]], %[[VAL_74]], %[[VAL_68]] : index
-// ADJOINT:           %[[VAL_77:.*]] = arith.subi %[[VAL_76]], %[[VAL_69]] : index
-// ADJOINT:           %[[VAL_78:.*]] = arith.addi %[[VAL_4]], %[[VAL_77]] : index
-// ADJOINT:           %[[VAL_79:.*]] = arith.constant 0 : index
-// ADJOINT:           %[[VAL_80:.*]]:2 = cc.loop while ((%[[VAL_81:.*]] = %[[VAL_78]], %[[VAL_82:.*]] = %[[VAL_76]]) -> (index, index)) {
-// ADJOINT:             %[[VAL_83:.*]] = arith.cmpi slt, %[[VAL_81]], %[[VAL_15]] : index
-// ADJOINT:             %[[VAL_84:.*]] = arith.cmpi sgt, %[[VAL_82]], %[[VAL_79]] : index
-// ADJOINT:             cc.condition %[[VAL_84]](%[[VAL_81]], %[[VAL_82]] : index, index)
+// ADJOINT:           %[[VAL_68:.*]] = arith.constant 0 : i64
+// ADJOINT:           %[[VAL_69:.*]] = arith.constant 1 : i64
+// ADJOINT:           %[[VAL_70:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_68]] : i64
+// ADJOINT:           %[[VAL_71:.*]] = arith.constant -1 : i64
+// ADJOINT:           %[[VAL_72:.*]] = arith.select %[[VAL_70]], %[[VAL_69]], %[[VAL_71]] : i64
+// ADJOINT:           %[[VAL_73:.*]] = arith.addi %[[VAL_14]], %[[VAL_72]] : i64
+// ADJOINT:           %[[VAL_74:.*]] = arith.addi %[[VAL_73]], %[[VAL_5]] : i64
+// ADJOINT:           %[[VAL_75:.*]] = arith.cmpi sgt, %[[VAL_74]], %[[VAL_68]] : i64
+// ADJOINT:           %[[VAL_76:.*]] = arith.select %[[VAL_75]], %[[VAL_74]], %[[VAL_68]] : i64
+// ADJOINT:           %[[VAL_77:.*]] = arith.subi %[[VAL_76]], %[[VAL_69]] : i64
+// ADJOINT:           %[[VAL_78:.*]] = arith.addi %[[VAL_6]], %[[VAL_77]] : i64
+// ADJOINT:           %[[VAL_79:.*]] = arith.constant 0 : i64
+// ADJOINT:           %[[VAL_80:.*]]:2 = cc.loop while ((%[[VAL_81:.*]] = %[[VAL_78]], %[[VAL_82:.*]] = %[[VAL_76]]) -> (i64, i64)) {
+// ADJOINT:             %[[VAL_83:.*]] = arith.cmpi slt, %[[VAL_81]], %[[VAL_14]] : i64
+// ADJOINT:             %[[VAL_84:.*]] = arith.cmpi sgt, %[[VAL_82]], %[[VAL_79]] : i64
+// ADJOINT:             cc.condition %[[VAL_84]](%[[VAL_81]], %[[VAL_82]] : i64, i64)
 // ADJOINT:           } do {
-// ADJOINT:           ^bb0(%[[VAL_85:.*]]: index, %[[VAL_86:.*]]: index):
-// ADJOINT:             %[[VAL_87:.*]] = quake.extract_ref %[[VAL_13]]{{\[}}%[[VAL_85]]] : (!quake.veq<?>, index) -> !quake.ref
+// ADJOINT:           ^bb0(%[[VAL_85:.*]]: i64, %[[VAL_86:.*]]: i64):
+// ADJOINT:             %[[VAL_87:.*]] = quake.extract_ref %[[VAL_13]]{{\[}}%[[VAL_85]]] : (!quake.veq<?>, i64) -> !quake.ref
 // ADJOINT:             quake.h %[[VAL_87]] : (!quake.ref) -> ()
-// ADJOINT:             cc.continue %[[VAL_85]], %[[VAL_86]] : index, index
+// ADJOINT:             cc.continue %[[VAL_85]], %[[VAL_86]] : i64, i64
 // ADJOINT:           } step {
-// ADJOINT:           ^bb0(%[[VAL_88:.*]]: index, %[[VAL_89:.*]]: index):
-// ADJOINT:             %[[VAL_90:.*]] = arith.addi %[[VAL_88]], %[[VAL_3]] : index
-// ADJOINT:             %[[VAL_91:.*]] = arith.subi %[[VAL_88]], %[[VAL_3]] : index
-// ADJOINT:             %[[VAL_92:.*]] = arith.constant 1 : index
-// ADJOINT:             %[[VAL_93:.*]] = arith.subi %[[VAL_89]], %[[VAL_92]] : index
-// ADJOINT:             cc.continue %[[VAL_91]], %[[VAL_93]] : index, index
+// ADJOINT:           ^bb0(%[[VAL_88:.*]]: i64, %[[VAL_89:.*]]: i64):
+// ADJOINT:             %[[VAL_90:.*]] = arith.addi %[[VAL_88]], %[[VAL_5]] : i64
+// ADJOINT:             %[[VAL_91:.*]] = arith.subi %[[VAL_88]], %[[VAL_5]] : i64
+// ADJOINT:             %[[VAL_92:.*]] = arith.constant 1 : i64
+// ADJOINT:             %[[VAL_93:.*]] = arith.subi %[[VAL_89]], %[[VAL_92]] : i64
+// ADJOINT:             cc.continue %[[VAL_91]], %[[VAL_93]] : i64, i64
 // ADJOINT:           }
 // ADJOINT:           return
 // ADJOINT:         }

--- a/test/AST-Quake/array.cpp
+++ b/test/AST-Quake/array.cpp
@@ -19,27 +19,26 @@ struct T {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__T(
 // CHECK-SAME:         %[[VAL_0:.*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_3:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = arith.extsi %[[VAL_4]] : i32 to i64
 // CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_5]] : i64]
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
-// CHECK:           %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : i64 to index
-// CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_8]] : index
-// CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : index)
+// CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_7]] : i64
+// CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_12:.*]]: index):
-// CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_6]]{{\[}}%[[VAL_12]]] : (!quake.veq<?>, index) -> !quake.ref
+// CHECK:           ^bb0(%[[VAL_12:.*]]: i64):
+// CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_6]]{{\[}}%[[VAL_12]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             quake.x %[[VAL_13]] : (!quake.ref) -> ()
-// CHECK:             cc.continue %[[VAL_12]] : index
+// CHECK:             cc.continue %[[VAL_12]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_14:.*]]: index):
-// CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_1]] : index
-// CHECK:             cc.continue %[[VAL_15]] : index
+// CHECK:           ^bb0(%[[VAL_14:.*]]: i64):
+// CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_15]] : i64
 // CHECK:           } {invariant}
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/control_flow.cpp
+++ b/test/AST-Quake/control_flow.cpp
@@ -43,9 +43,9 @@ struct C {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__C()
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
@@ -82,18 +82,18 @@ struct C {
 // CHECK:               cc.continue
 // CHECK:             ^bb4:
 // CHECK:               func.call @_Z2g3v() : () -> ()
-// CHECK:               %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:                 %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : index
-// CHECK:                 cc.condition %[[VAL_21]](%[[VAL_20]] : index)
+// CHECK:               %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:                 %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : i64
+// CHECK:                 cc.condition %[[VAL_21]](%[[VAL_20]] : i64)
 // CHECK:               } do {
-// CHECK:               ^bb0(%[[VAL_22:.*]]: index):
-// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]]{{\[}}%[[VAL_22]]] : (!quake.veq<2>, index) -> !quake.ref
+// CHECK:               ^bb0(%[[VAL_22:.*]]: i64):
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]]{{\[}}%[[VAL_22]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:                 quake.z %[[VAL_23]] : (!quake.ref) -> ()
-// CHECK:                 cc.continue %[[VAL_22]] : index
+// CHECK:                 cc.continue %[[VAL_22]] : i64
 // CHECK:               } step {
-// CHECK:               ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:                 %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : index
-// CHECK:                 cc.continue %[[VAL_25]] : index
+// CHECK:               ^bb0(%[[VAL_24:.*]]: i64):
+// CHECK:                 %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : i64
+// CHECK:                 cc.continue %[[VAL_25]] : i64
 // CHECK:               } {invariant}
 // CHECK:               cc.continue
 // CHECK:             } step {
@@ -132,9 +132,9 @@ struct D {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__D() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
@@ -171,18 +171,18 @@ struct D {
 // CHECK:               cc.break
 // CHECK:             ^bb4:
 // CHECK:               func.call @_Z2g3v() : () -> ()
-// CHECK:               %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:                 %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : index
-// CHECK:                 cc.condition %[[VAL_21]](%[[VAL_20]] : index)
+// CHECK:               %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:                 %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : i64
+// CHECK:                 cc.condition %[[VAL_21]](%[[VAL_20]] : i64)
 // CHECK:               } do {
-// CHECK:               ^bb0(%[[VAL_22:.*]]: index):
-// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]]{{\[}}%[[VAL_22]]] : (!quake.veq<2>, index) -> !quake.ref
+// CHECK:               ^bb0(%[[VAL_22:.*]]: i64):
+// CHECK:                 %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]]{{\[}}%[[VAL_22]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:                 quake.z %[[VAL_23]] : (!quake.ref) -> ()
-// CHECK:                 cc.continue %[[VAL_22]] : index
+// CHECK:                 cc.continue %[[VAL_22]] : i64
 // CHECK:               } step {
-// CHECK:               ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:                 %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : index
-// CHECK:                 cc.continue %[[VAL_25]] : index
+// CHECK:               ^bb0(%[[VAL_24:.*]]: i64):
+// CHECK:                 %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : i64
+// CHECK:                 cc.continue %[[VAL_25]] : i64
 // CHECK:               } {invariant}
 // CHECK:               cc.continue
 // CHECK:             } step {
@@ -221,9 +221,9 @@ struct E {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__E() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
@@ -261,18 +261,18 @@ struct E {
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb6:
 // CHECK:           call @_Z2g3v() : () -> ()
-// CHECK:           %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:             %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : index
-// CHECK:             cc.condition %[[VAL_21]](%[[VAL_20]] : index)
+// CHECK:           %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : i64
+// CHECK:             cc.condition %[[VAL_21]](%[[VAL_20]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_22:.*]]: index):
-// CHECK:             %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]][%[[VAL_22]]] : (!quake.veq<2>, index) -> !quake.ref
+// CHECK:           ^bb0(%[[VAL_22:.*]]: i64):
+// CHECK:             %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]][%[[VAL_22]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.z %[[VAL_23]] : (!quake.ref) -> ()
-// CHECK:             cc.continue %[[VAL_22]] : index
+// CHECK:             cc.continue %[[VAL_22]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : index
-// CHECK:             cc.continue %[[VAL_25]] : index
+// CHECK:           ^bb0(%[[VAL_24:.*]]: i64):
+// CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_25]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : i32
@@ -309,9 +309,9 @@ struct F {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__F() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : index
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 10 : i32
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
@@ -349,18 +349,18 @@ struct F {
 // CHECK:           return
 // CHECK:         ^bb6:
 // CHECK:           call @_Z2g3v() : () -> ()
-// CHECK:           %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:             %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : index
-// CHECK:             cc.condition %[[VAL_21]](%[[VAL_20]] : index)
+// CHECK:           %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_0]] : i64
+// CHECK:             cc.condition %[[VAL_21]](%[[VAL_20]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_22:.*]]: index):
-// CHECK:             %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]][%[[VAL_22]]] : (!quake.veq<2>, index) -> !quake.ref
+// CHECK:           ^bb0(%[[VAL_22:.*]]: i64):
+// CHECK:             %[[VAL_23:.*]] = quake.extract_ref %[[VAL_6]][%[[VAL_22]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:             quake.z %[[VAL_23]] : (!quake.ref) -> ()
-// CHECK:             cc.continue %[[VAL_22]] : index
+// CHECK:             cc.continue %[[VAL_22]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_24:.*]]: index):
-// CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : index
-// CHECK:             cc.continue %[[VAL_25]] : index
+// CHECK:           ^bb0(%[[VAL_24:.*]]: i64):
+// CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_25]] : i64
 // CHECK:           } {invariant}
 // CHECK:           cf.br ^bb7
 // CHECK:         ^bb7:

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -209,44 +209,42 @@ int main() {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__tgate(
 // CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_3:.*]] = quake.veq_size %[[VAL_0]] : (!quake.veq<?>) -> i64
-// CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
-// CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
-// CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
+// CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_3]] : i64
+// CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, index) -> !quake.ref
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i64):
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             quake.t %[[VAL_9]] : (!quake.ref) -> ()
-// CHECK:             cc.continue %[[VAL_8]] : index
+// CHECK:             cc.continue %[[VAL_8]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_10:.*]]: index):
-// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_1]] : index
-// CHECK:             cc.continue %[[VAL_11]] : index
+// CHECK:           ^bb0(%[[VAL_10:.*]]: i64):
+// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_11]] : i64
 // CHECK:           } {invariant}
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Z4mainE3$_0(
 // CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<?>) attributes {"cudaq-kernel"} {
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_3:.*]] = quake.veq_size %[[VAL_0]] : (!quake.veq<?>) -> i64
-// CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
-// CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : index
-// CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : index)
+// CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_3]] : i64
+// CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_8:.*]]: index):
-// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, index) -> !quake.ref
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i64):
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             quake.x %[[VAL_9]] : (!quake.ref) -> ()
-// CHECK:             cc.continue %[[VAL_8]] : index
+// CHECK:             cc.continue %[[VAL_8]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_10:.*]]: index):
-// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_1]] : index
-// CHECK:             cc.continue %[[VAL_11]] : index
+// CHECK:           ^bb0(%[[VAL_10:.*]]: i64):
+// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_11]] : i64
 // CHECK:           } {invariant}
 // CHECK:           return
 // CHECK:         }
@@ -255,10 +253,8 @@ int main() {
 // CHECK-SAME:      (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: !cc.callable<(!quake.veq<?>) -> ()>, %[[VAL_3:.*]]: !cc.struct<"tgate" {} [8,1]>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_8:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_9:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_10:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_11:.*]] = cc.alloca i32
@@ -270,29 +266,28 @@ int main() {
 // CHECK:           %[[VAL_16:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_15]] : i64]
 // CHECK:           %[[VAL_17:.*]] = cc.load %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_18:.*]] = arith.extsi %[[VAL_17]] : i32 to i64
-// CHECK:           %[[VAL_19:.*]] = arith.subi %[[VAL_18]], %[[VAL_8]] : i64
-// CHECK:           %[[VAL_20:.*]] = quake.subveq %[[VAL_16]], %[[VAL_9]], %[[VAL_19]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+// CHECK:           %[[VAL_19:.*]] = arith.subi %[[VAL_18]], %[[VAL_6]] : i64
+// CHECK:           %[[VAL_20:.*]] = quake.subveq %[[VAL_16]], %[[VAL_7]], %[[VAL_19]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
 // CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_11]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_22:.*]] = arith.extsi %[[VAL_21]] : i32 to i64
 // CHECK:           %[[VAL_23:.*]] = quake.veq_size %[[VAL_16]] : (!quake.veq<?>) -> i64
-// CHECK:           %[[VAL_24:.*]] = arith.subi %[[VAL_23]], %[[VAL_8]] : i64
+// CHECK:           %[[VAL_24:.*]] = arith.subi %[[VAL_23]], %[[VAL_6]] : i64
 // CHECK:           %[[VAL_25:.*]] = arith.subi %[[VAL_23]], %[[VAL_22]] : i64
 // CHECK:           %[[VAL_26:.*]] = quake.subveq %[[VAL_16]], %[[VAL_25]], %[[VAL_24]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
 // CHECK:           call @__nvqpp__mlirgen__Z4mainE3$_0(%[[VAL_26]]) : (!quake.veq<?>) -> ()
 // CHECK:           %[[VAL_27:.*]] = quake.veq_size %[[VAL_20]] : (!quake.veq<?>) -> i64
-// CHECK:           %[[VAL_28:.*]] = arith.index_cast %[[VAL_27]] : i64 to index
-// CHECK:           %[[VAL_29:.*]] = cc.loop while ((%[[VAL_30:.*]] = %[[VAL_7]]) -> (index)) {
-// CHECK:             %[[VAL_31:.*]] = arith.cmpi slt, %[[VAL_30]], %[[VAL_28]] : index
-// CHECK:             cc.condition %[[VAL_31]](%[[VAL_30]] : index)
+// CHECK:           %[[VAL_29:.*]] = cc.loop while ((%[[VAL_30:.*]] = %[[VAL_7]]) -> (i64)) {
+// CHECK:             %[[VAL_31:.*]] = arith.cmpi slt, %[[VAL_30]], %[[VAL_27]] : i64
+// CHECK:             cc.condition %[[VAL_31]](%[[VAL_30]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_32:.*]]: index):
-// CHECK:             %[[VAL_33:.*]] = quake.extract_ref %[[VAL_20]]{{\[}}%[[VAL_32]]] : (!quake.veq<?>, index) -> !quake.ref
+// CHECK:           ^bb0(%[[VAL_32:.*]]: i64):
+// CHECK:             %[[VAL_33:.*]] = quake.extract_ref %[[VAL_20]]{{\[}}%[[VAL_32]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             quake.h %[[VAL_33]] : (!quake.ref) -> ()
-// CHECK:             cc.continue %[[VAL_32]] : index
+// CHECK:             cc.continue %[[VAL_32]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_34:.*]]: index):
-// CHECK:             %[[VAL_35:.*]] = arith.addi %[[VAL_34]], %[[VAL_6]] : index
-// CHECK:             cc.continue %[[VAL_35]] : index
+// CHECK:           ^bb0(%[[VAL_34:.*]]: i64):
+// CHECK:             %[[VAL_35:.*]] = arith.addi %[[VAL_34]], %[[VAL_6]] : i64
+// CHECK:             cc.continue %[[VAL_35]] : i64
 // CHECK:           } {invariant}
 // CHECK:           cc.scope {
 // CHECK:             %[[VAL_36:.*]] = cc.alloca i32
@@ -312,7 +307,7 @@ int main() {
 // CHECK:                     %[[VAL_42:.*]] = arith.extsi %[[VAL_41]] : i32 to i64
 // CHECK:                     %[[VAL_43:.*]] = cc.load %[[VAL_36]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_44:.*]] = arith.extsi %[[VAL_43]] : i32 to i64
-// CHECK:                     %[[VAL_45:.*]] = arith.shli %[[VAL_8]], %[[VAL_44]] : i64
+// CHECK:                     %[[VAL_45:.*]] = arith.shli %[[VAL_6]], %[[VAL_44]] : i64
 // CHECK:                     %[[VAL_46:.*]] = arith.cmpi ult, %[[VAL_42]], %[[VAL_45]] : i64
 // CHECK:                     cc.condition %[[VAL_46]]
 // CHECK:                   } do {

--- a/test/AST-Quake/ranged_for.cpp
+++ b/test/AST-Quake/ranged_for.cpp
@@ -34,31 +34,29 @@ struct Colonel {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Colonel(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes
-// CHECK-DAG:        %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:        %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_6:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
 // CHECK:           %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_8:.*]] = arith.index_cast %[[VAL_6]] : i64 to index
-// CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_8]] : index
-// CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : index)
+// CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i64
+// CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_12:.*]]: index):
-// CHECK:             %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
-// CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
+// CHECK:           ^bb0(%[[VAL_12:.*]]: i64):
+// CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_12]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK-DAG:         %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<f64>
 // CHECK-DAG:         %[[VAL_16:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:             %[[VAL_17:.*]] = arith.addf %[[VAL_16]], %[[VAL_15]] : f64
 // CHECK:             cc.store %[[VAL_17]], %[[VAL_5]] : !cc.ptr<f64>
-// CHECK:             cc.continue %[[VAL_12]] : index
+// CHECK:             cc.continue %[[VAL_12]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_18:.*]]: index):
-// CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_1]] : index
-// CHECK:             cc.continue %[[VAL_19]] : index
+// CHECK:           ^bb0(%[[VAL_18:.*]]: i64):
+// CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_19]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_20:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           quake.rx (%[[VAL_20]]) %[[VAL_4]] : (f64, !quake.ref) -> ()
@@ -89,31 +87,29 @@ struct Lt_Colonel {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Lt_Colonel(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_6:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
 // CHECK:           %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_8:.*]] = arith.index_cast %[[VAL_6]] : i64 to index
-// CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_8]] : index
-// CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : index)
+// CHECK:           %[[VAL_9:.*]] = cc.loop while ((%[[VAL_10:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_6]] : i64
+// CHECK:             cc.condition %[[VAL_11]](%[[VAL_10]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_12:.*]]: index):
-// CHECK:             %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
-// CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
+// CHECK:           ^bb0(%[[VAL_12:.*]]: i64):
+// CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_12]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK-DAG:         %[[VAL_15:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
 // CHECK-DAG:         %[[VAL_16:.*]] = cc.load %[[VAL_14]] : !cc.ptr<f64>
 // CHECK:             %[[VAL_17:.*]] = arith.addf %[[VAL_15]], %[[VAL_16]] : f64
 // CHECK:             cc.store %[[VAL_17]], %[[VAL_5]] : !cc.ptr<f64>
-// CHECK:             cc.continue %[[VAL_12]] : index
+// CHECK:             cc.continue %[[VAL_12]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_18:.*]]: index):
-// CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_1]] : index
-// CHECK:             cc.continue %[[VAL_19]] : index
+// CHECK:           ^bb0(%[[VAL_18:.*]]: i64):
+// CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_19]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_20:.*]] = cc.load %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           quake.rx (%[[VAL_20]]) %[[VAL_4]] : (f64, !quake.ref) -> ()
@@ -158,42 +154,38 @@ struct Qernel {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Qernel(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1.000000e+03 : f64
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-DAG:       %[[VAL_5:.*]] = quake.alloca !quake.ref
 // CHECK-DAG:       %[[VAL_6:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_4]], %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_7:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
 // CHECK:           %[[VAL_8:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_9:.*]] = arith.index_cast %[[VAL_7]] : i64 to index
-// CHECK:           %[[VAL_10:.*]] = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_3]]) -> (index)) {
-// CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_9]] : index
-// CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : index)
+// CHECK:           %[[VAL_10:.*]] = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_3]]) -> (i64)) {
+// CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_7]] : i64
+// CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_13:.*]]: index):
-// CHECK:             %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : index to i64
-// CHECK:             %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_14]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
+// CHECK:           ^bb0(%[[VAL_13:.*]]: i64):
+// CHECK:             %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:             %[[VAL_16:.*]] = cc.load %[[VAL_15]] : !cc.ptr<f64>
 // CHECK:             %[[VAL_17:.*]] = func.call @sqrt(%[[VAL_16]]) : (f64) -> f64
 // CHECK:             cc.store %[[VAL_17]], %[[VAL_15]] : !cc.ptr<f64>
-// CHECK:             cc.continue %[[VAL_13]] : index
+// CHECK:             cc.continue %[[VAL_13]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_18:.*]]: index):
-// CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_2]] : index
-// CHECK:             cc.continue %[[VAL_19]] : index
+// CHECK:           ^bb0(%[[VAL_18:.*]]: i64):
+// CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_2]] : i64
+// CHECK:             cc.continue %[[VAL_19]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_20:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
 // CHECK:           %[[VAL_21:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_22:.*]] = arith.index_cast %[[VAL_20]] : i64 to index
-// CHECK:           %[[VAL_23:.*]] = cc.loop while ((%[[VAL_24:.*]] = %[[VAL_3]]) -> (index)) {
-// CHECK:             %[[VAL_25:.*]] = arith.cmpi slt, %[[VAL_24]], %[[VAL_22]] : index
-// CHECK:             cc.condition %[[VAL_25]](%[[VAL_24]] : index)
+// CHECK:           %[[VAL_23:.*]] = cc.loop while ((%[[VAL_24:.*]] = %[[VAL_3]]) -> (i64)) {
+// CHECK:             %[[VAL_25:.*]] = arith.cmpi slt, %[[VAL_24]], %[[VAL_20]] : i64
+// CHECK:             cc.condition %[[VAL_25]](%[[VAL_24]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_26:.*]]: index):
-// CHECK:             %[[VAL_27:.*]] = arith.index_cast %[[VAL_26]] : index to i64
+// CHECK:           ^bb0(%[[VAL_26:.*]]: i64):
 // CHECK:             cc.scope {
-// CHECK:               %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_21]]{{\[}}%[[VAL_27]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
+// CHECK:               %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_21]]{{\[}}%[[VAL_26]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:               %[[VAL_29:.*]] = cc.alloca f64
 // CHECK:               %[[VAL_30:.*]] = cc.load %[[VAL_28]] : !cc.ptr<f64>
 // CHECK:               cc.store %[[VAL_30]], %[[VAL_29]] : !cc.ptr<f64>
@@ -205,11 +197,11 @@ struct Qernel {
 // CHECK:               %[[VAL_35:.*]] = arith.addf %[[VAL_34]], %[[VAL_1]] : f64
 // CHECK:               cc.store %[[VAL_35]], %[[VAL_29]] : !cc.ptr<f64>
 // CHECK:             }
-// CHECK:             cc.continue %[[VAL_26]] : index
+// CHECK:             cc.continue %[[VAL_26]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_36:.*]]: index):
-// CHECK:             %[[VAL_37:.*]] = arith.addi %[[VAL_36]], %[[VAL_2]] : index
-// CHECK:             cc.continue %[[VAL_37]] : index
+// CHECK:           ^bb0(%[[VAL_36:.*]]: i64):
+// CHECK:             %[[VAL_37:.*]] = arith.addi %[[VAL_36]], %[[VAL_2]] : i64
+// CHECK:             cc.continue %[[VAL_37]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_38:.*]] = cc.load %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           quake.rx (%[[VAL_38]]) %[[VAL_5]] : (f64, !quake.ref) -> ()
@@ -236,32 +228,28 @@ struct Nesting {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Nesting(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.stdvec<f64>, %[[VAL_1:.*]]: !cc.stdvec<f32>) attributes
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-DAG:       %[[VAL_5:.*]] = quake.alloca !quake.ref
 // CHECK-DAG:       %[[VAL_6:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_4]], %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_7:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
 // CHECK:           %[[VAL_8:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_9:.*]] = arith.index_cast %[[VAL_7]] : i64 to index
-// CHECK:           %[[VAL_10:.*]] = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_3]]) -> (index)) {
-// CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_9]] : index
-// CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : index)
+// CHECK:           %[[VAL_10:.*]] = cc.loop while ((%[[VAL_11:.*]] = %[[VAL_3]]) -> (i64)) {
+// CHECK:             %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]], %[[VAL_7]] : i64
+// CHECK:             cc.condition %[[VAL_12]](%[[VAL_11]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_13:.*]]: index):
-// CHECK:             %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : index to i64
-// CHECK:             %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_14]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
+// CHECK:           ^bb0(%[[VAL_13:.*]]: i64):
+// CHECK:             %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:             %[[VAL_16:.*]] = cc.stdvec_size %[[VAL_1]] : (!cc.stdvec<f32>) -> i64
 // CHECK:             %[[VAL_17:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
-// CHECK:             %[[VAL_18:.*]] = arith.index_cast %[[VAL_16]] : i64 to index
-// CHECK:             %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_3]]) -> (index)) {
-// CHECK:               %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_18]] : index
-// CHECK:               cc.condition %[[VAL_21]](%[[VAL_20]] : index)
+// CHECK:             %[[VAL_19:.*]] = cc.loop while ((%[[VAL_20:.*]] = %[[VAL_3]]) -> (i64)) {
+// CHECK:               %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]], %[[VAL_16]] : i64
+// CHECK:               cc.condition %[[VAL_21]](%[[VAL_20]] : i64)
 // CHECK:             } do {
-// CHECK:             ^bb0(%[[VAL_22:.*]]: index):
-// CHECK:               %[[VAL_23:.*]] = arith.index_cast %[[VAL_22]] : index to i64
-// CHECK:               %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_17]]{{\[}}%[[VAL_23]]] : (!cc.ptr<!cc.array<f32 x ?>>, i64) -> !cc.ptr<f32>
+// CHECK:             ^bb0(%[[VAL_22:.*]]: i64):
+// CHECK:               %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_17]]{{\[}}%[[VAL_22]]] : (!cc.ptr<!cc.array<f32 x ?>>, i64) -> !cc.ptr<f32>
 // CHECK-DAG:           %[[VAL_25:.*]] = cc.load %[[VAL_15]] : !cc.ptr<f64>
 // CHECK-DAG:           %[[VAL_26:.*]] = cc.load %[[VAL_24]] : !cc.ptr<f32>
 // CHECK:               %[[VAL_27:.*]] = arith.extf %[[VAL_26]] : f32 to f64
@@ -269,17 +257,17 @@ struct Nesting {
 // CHECK:               %[[VAL_29:.*]] = cc.load %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:               %[[VAL_30:.*]] = arith.addf %[[VAL_29]], %[[VAL_28]] : f64
 // CHECK:               cc.store %[[VAL_30]], %[[VAL_6]] : !cc.ptr<f64>
-// CHECK:               cc.continue %[[VAL_22]] : index
+// CHECK:               cc.continue %[[VAL_22]] : i64
 // CHECK:             } step {
-// CHECK:             ^bb0(%[[VAL_31:.*]]: index):
-// CHECK:               %[[VAL_32:.*]] = arith.addi %[[VAL_31]], %[[VAL_2]] : index
-// CHECK:               cc.continue %[[VAL_32]] : index
+// CHECK:             ^bb0(%[[VAL_31:.*]]: i64):
+// CHECK:               %[[VAL_32:.*]] = arith.addi %[[VAL_31]], %[[VAL_2]] : i64
+// CHECK:               cc.continue %[[VAL_32]] : i64
 // CHECK:             } {invariant}
-// CHECK:             cc.continue %[[VAL_13]] : index
+// CHECK:             cc.continue %[[VAL_13]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_33:.*]]: index):
-// CHECK:             %[[VAL_34:.*]] = arith.addi %[[VAL_33]], %[[VAL_2]] : index
-// CHECK:             cc.continue %[[VAL_34]] : index
+// CHECK:           ^bb0(%[[VAL_33:.*]]: i64):
+// CHECK:             %[[VAL_34:.*]] = arith.addi %[[VAL_33]], %[[VAL_2]] : i64
+// CHECK:             cc.continue %[[VAL_34]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_35:.*]] = cc.load %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           quake.rx (%[[VAL_35]]) %[[VAL_5]] : (f64, !quake.ref) -> ()
@@ -299,25 +287,23 @@ struct FreeRange {
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__FreeRange(
 // CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: i32) attributes
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca i32
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.cast unsigned %[[VAL_5]] : (i32) -> i64
-// CHECK:           %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : i64 to index
-// CHECK:           %[[VAL_8:.*]] = cc.loop while ((%[[VAL_9:.*]] = %[[VAL_3]]) -> (index)) {
-// CHECK:             %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_7]] : index
-// CHECK:             cc.condition %[[VAL_10]](%[[VAL_9]] : index)
+// CHECK:           %[[VAL_8:.*]] = cc.loop while ((%[[VAL_9:.*]] = %[[VAL_3]]) -> (i64)) {
+// CHECK:             %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_6]] : i64
+// CHECK:             cc.condition %[[VAL_10]](%[[VAL_9]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_11:.*]]: index):
-// CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i64
-// CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_12]]] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:           ^bb0(%[[VAL_11:.*]]: i64):
+// CHECK:             %[[VAL_13:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_11]]] : (!quake.veq<?>, i64) -> !quake.ref
 // CHECK:             quake.h %[[VAL_13]] : (!quake.ref) -> ()
-// CHECK:             cc.continue %[[VAL_11]] : index
+// CHECK:             cc.continue %[[VAL_11]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_14:.*]]: index):
-// CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_2]] : index
-// CHECK:             cc.continue %[[VAL_15]] : index
+// CHECK:           ^bb0(%[[VAL_14:.*]]: i64):
+// CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_2]] : i64
+// CHECK:             cc.continue %[[VAL_15]] : i64
 // CHECK:           } {invariant}
 // clang-format on

--- a/test/AST-Quake/ranged_for_qreg.cpp
+++ b/test/AST-Quake/ranged_for_qreg.cpp
@@ -19,28 +19,27 @@ __qpu__ void range_qubit() {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_range_qubit
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 10 : index
-// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 10 : i64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.veq<10>
-// CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (index)) {
-// CHECK:             %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_0]] : index
-// CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : index)
+// CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_0]] : i64
+// CHECK:             cc.condition %[[VAL_6]](%[[VAL_5]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_7:.*]]: index):
-// CHECK:             %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
-// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_8]]] : (!quake.veq<10>, i64) -> !quake.ref
+// CHECK:           ^bb0(%[[VAL_7:.*]]: i64):
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_7]]] : (!quake.veq<10>, i64) -> !quake.ref
 // CHECK:             cc.scope {
 // CHECK:               %[[VAL_110:.*]] = quake.mx %[[VAL_9]] : (!quake.ref) -> !quake.measure
 // CHECK:               %[[VAL_10:.*]] = quake.discriminate %[[VAL_110]] :
 // CHECK:               %[[VAL_11:.*]] = cc.alloca i1
 // CHECK:               cc.store %[[VAL_10]], %[[VAL_11]] : !cc.ptr<i1>
 // CHECK:             }
-// CHECK:             cc.continue %[[VAL_7]] : index
+// CHECK:             cc.continue %[[VAL_7]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_12:.*]]: index):
-// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : index
-// CHECK:             cc.continue %[[VAL_13]] : index
+// CHECK:           ^bb0(%[[VAL_12:.*]]: i64):
+// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_13]] : i64
 // CHECK:           } {invariant}
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/reverse.cpp
+++ b/test/AST-Quake/reverse.cpp
@@ -22,10 +22,9 @@ __qpu__ int std_reverse_std_vector_int() {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_std_reverse_std_vector_int
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 10 : index
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 10 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 8 : i64
 // CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca !cc.array<i32 x 10>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x 10>>) -> !cc.ptr<i32>
@@ -35,45 +34,42 @@ __qpu__ int std_reverse_std_vector_int() {
 // CHECK:           %[[VAL_10:.*]] = arith.subi %[[VAL_8]], %[[VAL_9]] : i64
 // CHECK:           %[[VAL_11:.*]] = arith.divsi %[[VAL_10]], %[[VAL_4]] : i64
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
-// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_11]] : i64 to index
-// CHECK:           %[[VAL_14:.*]] = cc.loop while ((%[[VAL_15:.*]] = %[[VAL_3]]) -> (index)) {
-// CHECK:             %[[VAL_16:.*]] = arith.cmpi slt, %[[VAL_15]], %[[VAL_13]] : index
-// CHECK:             cc.condition %[[VAL_16]](%[[VAL_15]] : index)
+// CHECK:           %[[VAL_14:.*]] = cc.loop while ((%[[VAL_15:.*]] = %[[VAL_3]]) -> (i64)) {
+// CHECK:             %[[VAL_16:.*]] = arith.cmpi slt, %[[VAL_15]], %[[VAL_11]] : i64
+// CHECK:             cc.condition %[[VAL_16]](%[[VAL_15]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_17:.*]]: index):
-// CHECK:             %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : index to i64
-// CHECK:             %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_12]]{{\[}}%[[VAL_18]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
+// CHECK:           ^bb0(%[[VAL_17:.*]]: i64):
+// CHECK:             %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_12]][%[[VAL_17]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
 // CHECK:             %[[VAL_20:.*]] = arith.subi %[[VAL_11]], %[[VAL_1]] : i64
-// CHECK:             %[[VAL_21:.*]] = arith.subi %[[VAL_20]], %[[VAL_18]] : i64
-// CHECK:             %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_12]]{{\[}}%[[VAL_21]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
+// CHECK:             %[[VAL_21:.*]] = arith.subi %[[VAL_20]], %[[VAL_17]] : i64
+// CHECK:             %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_12]][%[[VAL_21]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
 // CHECK:             %[[VAL_23:.*]] = cc.load %[[VAL_19]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_24:.*]] = cc.load %[[VAL_22]] : !cc.ptr<i32>
 // CHECK:             cc.store %[[VAL_23]], %[[VAL_22]] : !cc.ptr<i32>
 // CHECK:             cc.store %[[VAL_24]], %[[VAL_19]] : !cc.ptr<i32>
-// CHECK:             cc.continue %[[VAL_17]] : index
+// CHECK:             cc.continue %[[VAL_17]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_25:.*]]: index):
-// CHECK:             %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_2]] : index
-// CHECK:             cc.continue %[[VAL_26]] : index
+// CHECK:           ^bb0(%[[VAL_25:.*]]: i64):
+// CHECK:             %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_26]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_27:.*]] = cc.alloca i32
 // CHECK:           %[[VAL_28:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x 10>>) -> !cc.ptr<!cc.array<i32 x ?>>
-// CHECK:           %[[VAL_29:.*]] = cc.loop while ((%[[VAL_30:.*]] = %[[VAL_3]]) -> (index)) {
-// CHECK:             %[[VAL_31:.*]] = arith.cmpi slt, %[[VAL_30]], %[[VAL_0]] : index
-// CHECK:             cc.condition %[[VAL_31]](%[[VAL_30]] : index)
+// CHECK:           %[[VAL_29:.*]] = cc.loop while ((%[[VAL_30:.*]] = %[[VAL_3]]) -> (i64)) {
+// CHECK:             %[[VAL_31:.*]] = arith.cmpi slt, %[[VAL_30]], %[[VAL_0]] : i64
+// CHECK:             cc.condition %[[VAL_31]](%[[VAL_30]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_32:.*]]: index):
-// CHECK:             %[[VAL_33:.*]] = arith.index_cast %[[VAL_32]] : index to i64
-// CHECK:             %[[VAL_34:.*]] = cc.compute_ptr %[[VAL_28]]{{\[}}%[[VAL_33]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
+// CHECK:           ^bb0(%[[VAL_32:.*]]: i64):
+// CHECK:             %[[VAL_34:.*]] = cc.compute_ptr %[[VAL_28]][%[[VAL_32]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
 // CHECK:             %[[VAL_35:.*]] = cc.load %[[VAL_34]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_36:.*]] = cc.load %[[VAL_27]] : !cc.ptr<i32>
 // CHECK:             %[[VAL_37:.*]] = arith.addi %[[VAL_36]], %[[VAL_35]] : i32
 // CHECK:             cc.store %[[VAL_37]], %[[VAL_27]] : !cc.ptr<i32>
-// CHECK:             cc.continue %[[VAL_32]] : index
+// CHECK:             cc.continue %[[VAL_32]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_38:.*]]: index):
-// CHECK:             %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_2]] : index
-// CHECK:             cc.continue %[[VAL_39]] : index
+// CHECK:           ^bb0(%[[VAL_38:.*]]: i64):
+// CHECK:             %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_39]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_40:.*]] = cc.load %[[VAL_27]] : !cc.ptr<i32>
 // CHECK:           return %[[VAL_40]] : i32
@@ -90,10 +86,9 @@ __qpu__ double std_reverse_std_vector_double() {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_std_reverse_std_vector_double
-// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 7 : index
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 7 : i64
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 16 : i64
 // CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca !cc.array<f64 x 7>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<f64 x 7>>) -> !cc.ptr<f64>
@@ -103,45 +98,42 @@ __qpu__ double std_reverse_std_vector_double() {
 // CHECK:           %[[VAL_10:.*]] = arith.subi %[[VAL_8]], %[[VAL_9]] : i64
 // CHECK:           %[[VAL_11:.*]] = arith.divsi %[[VAL_10]], %[[VAL_4]] : i64
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_11]] : i64 to index
-// CHECK:           %[[VAL_14:.*]] = cc.loop while ((%[[VAL_15:.*]] = %[[VAL_3]]) -> (index)) {
-// CHECK:             %[[VAL_16:.*]] = arith.cmpi slt, %[[VAL_15]], %[[VAL_13]] : index
-// CHECK:             cc.condition %[[VAL_16]](%[[VAL_15]] : index)
+// CHECK:           %[[VAL_14:.*]] = cc.loop while ((%[[VAL_15:.*]] = %[[VAL_3]]) -> (i64)) {
+// CHECK:             %[[VAL_16:.*]] = arith.cmpi slt, %[[VAL_15]], %[[VAL_11]] : i64
+// CHECK:             cc.condition %[[VAL_16]](%[[VAL_15]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_17:.*]]: index):
-// CHECK:             %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : index to i64
-// CHECK:             %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_12]]{{\[}}%[[VAL_18]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
+// CHECK:           ^bb0(%[[VAL_17:.*]]: i64):
+// CHECK:             %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_12]][%[[VAL_17]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:             %[[VAL_20:.*]] = arith.subi %[[VAL_11]], %[[VAL_1]] : i64
-// CHECK:             %[[VAL_21:.*]] = arith.subi %[[VAL_20]], %[[VAL_18]] : i64
-// CHECK:             %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_12]]{{\[}}%[[VAL_21]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
+// CHECK:             %[[VAL_21:.*]] = arith.subi %[[VAL_20]], %[[VAL_17]] : i64
+// CHECK:             %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_12]][%[[VAL_21]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:             %[[VAL_23:.*]] = cc.load %[[VAL_19]] : !cc.ptr<f64>
 // CHECK:             %[[VAL_24:.*]] = cc.load %[[VAL_22]] : !cc.ptr<f64>
 // CHECK:             cc.store %[[VAL_23]], %[[VAL_22]] : !cc.ptr<f64>
 // CHECK:             cc.store %[[VAL_24]], %[[VAL_19]] : !cc.ptr<f64>
-// CHECK:             cc.continue %[[VAL_17]] : index
+// CHECK:             cc.continue %[[VAL_17]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_25:.*]]: index):
-// CHECK:             %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_2]] : index
-// CHECK:             cc.continue %[[VAL_26]] : index
+// CHECK:           ^bb0(%[[VAL_25:.*]]: i64):
+// CHECK:             %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_26]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_27:.*]] = cc.alloca f64
 // CHECK:           %[[VAL_28:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<f64 x 7>>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_29:.*]] = cc.loop while ((%[[VAL_30:.*]] = %[[VAL_3]]) -> (index)) {
-// CHECK:             %[[VAL_31:.*]] = arith.cmpi slt, %[[VAL_30]], %[[VAL_0]] : index
-// CHECK:             cc.condition %[[VAL_31]](%[[VAL_30]] : index)
+// CHECK:           %[[VAL_29:.*]] = cc.loop while ((%[[VAL_30:.*]] = %[[VAL_3]]) -> (i64)) {
+// CHECK:             %[[VAL_31:.*]] = arith.cmpi slt, %[[VAL_30]], %[[VAL_0]] : i64
+// CHECK:             cc.condition %[[VAL_31]](%[[VAL_30]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_32:.*]]: index):
-// CHECK:             %[[VAL_33:.*]] = arith.index_cast %[[VAL_32]] : index to i64
-// CHECK:             %[[VAL_34:.*]] = cc.compute_ptr %[[VAL_28]]{{\[}}%[[VAL_33]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
+// CHECK:           ^bb0(%[[VAL_32:.*]]: i64):
+// CHECK:             %[[VAL_34:.*]] = cc.compute_ptr %[[VAL_28]][%[[VAL_32]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:             %[[VAL_35:.*]] = cc.load %[[VAL_34]] : !cc.ptr<f64>
 // CHECK:             %[[VAL_36:.*]] = cc.load %[[VAL_27]] : !cc.ptr<f64>
 // CHECK:             %[[VAL_37:.*]] = arith.addf %[[VAL_36]], %[[VAL_35]] : f64
 // CHECK:             cc.store %[[VAL_37]], %[[VAL_27]] : !cc.ptr<f64>
-// CHECK:             cc.continue %[[VAL_32]] : index
+// CHECK:             cc.continue %[[VAL_32]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_38:.*]]: index):
-// CHECK:             %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_2]] : index
-// CHECK:             cc.continue %[[VAL_39]] : index
+// CHECK:           ^bb0(%[[VAL_38:.*]]: i64):
+// CHECK:             %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_39]] : i64
 // CHECK:           } {invariant}
 // CHECK:           %[[VAL_40:.*]] = cc.load %[[VAL_27]] : !cc.ptr<f64>
 // CHECK:           return %[[VAL_40]] : f64

--- a/test/Quake-QIR/return_values.qke
+++ b/test/Quake-QIR/return_values.qke
@@ -22,27 +22,26 @@ func.func private @__nvqpp_vectorCopyCtor(%arg0: !cc.ptr<i8> , %arg1: i64 , %arg
 
 func.func @__nvqpp__mlirgen__test_0(%arg0: i32) -> !cc.stdvec<i1> {
   %c1_i64 = arith.constant 1 : i64
-  %c1 = arith.constant 1 : index
-  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : i64
+  %c0 = arith.constant 0 : i64
   %0 = cc.alloca i32
   cc.store %arg0, %0 : !cc.ptr<i32>
   %1 = cc.load %0 : !cc.ptr<i32>
   %2 = arith.extsi %1 : i32 to i64
   %3 = quake.alloca !quake.veq<?>[%2 : i64]
   %4 = quake.veq_size %3 : (!quake.veq<?>) -> i64
-  %5 = arith.index_cast %4 : i64 to index
-  %6 = cc.loop while ((%arg1 = %c0) -> (index)) {
-    %12 = arith.cmpi slt, %arg1, %5 : index
-    cc.condition %12(%arg1 : index)
+  %6 = cc.loop while ((%arg1 = %c0) -> (i64)) {
+    %12 = arith.cmpi slt, %arg1, %4 : i64
+    cc.condition %12(%arg1 : i64)
   } do {
-  ^bb0(%arg1: index):
-    %12 = quake.extract_ref %3[%arg1] : (!quake.veq<?>, index) -> !quake.ref
+  ^bb0(%arg1: i64):
+    %12 = quake.extract_ref %3[%arg1] : (!quake.veq<?>, i64) -> !quake.ref
     quake.h %12 : (!quake.ref) -> ()
-    cc.continue %arg1 : index
+    cc.continue %arg1 : i64
   } step {
-  ^bb0(%arg1: index):
-    %12 = arith.addi %arg1, %c1 : index
-    cc.continue %12 : index
+  ^bb0(%arg1: i64):
+    %12 = arith.addi %arg1, %c1 : i64
+    cc.continue %12 : i64
   } {invariant}
   %measOut = quake.mz %3 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
   %7 = quake.discriminate %measOut : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
@@ -57,52 +56,59 @@ func.func @test_0(%1: !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}
   return
 }
 
-// CHECK-LABEL: define void @__nvqpp__mlirgen__test_0({ i8*, i64 }* nocapture writeonly sret({ i8*, i64 })
-// CHECK-SAME:      %[[VAL_0:.*]], i32 %[[VAL_1:.*]])
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_0({ i8*, i64 }* nocapture writeonly sret({ i8*, i64 }) 
+// CHECK-SAME:    %[[VAL_0:.*]], i32 %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = sext i32 %[[VAL_1]] to i64
 // CHECK:         %[[VAL_3:.*]] = tail call %[[VAL_4:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_2]])
 // CHECK:         %[[VAL_5:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_4]]* %[[VAL_3]])
 // CHECK:         %[[VAL_6:.*]] = icmp sgt i64 %[[VAL_5]], 0
 // CHECK:         br i1 %[[VAL_6]], label %[[VAL_7:.*]], label %[[VAL_8:.*]]
-// CHECK:       .{{.*}}:                                           ; preds = %[[VAL_9:.*]], %[[VAL_7]]
-// CHECK:         %[[VAL_10:.*]] = phi i64 [ %[[VAL_11:.*]], %[[VAL_7]] ], [ 0, %[[VAL_9]] ]
-// CHECK:         %[[VAL_12:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_4]]* %[[VAL_3]], i64 %[[VAL_10]])
-// CHECK:         %[[VAL_13:.*]] = bitcast i8* %[[VAL_12]] to %[[VAL_14:.*]]**
-// CHECK:         %[[VAL_15:.*]] = load %[[VAL_14]]*, %[[VAL_14]]** %[[VAL_13]], align 8
-// CHECK:         tail call void @__quantum__qis__h(%[[VAL_14]]* %[[VAL_15]])
-// CHECK:         %[[VAL_11]] = add nuw nsw i64 %[[VAL_10]], 1
-// CHECK:         %[[VAL_16:.*]] = icmp eq i64 %[[VAL_11]], %[[VAL_5]]
-// CHECK:         br i1 %[[VAL_16]], label %[[VAL_8]], label %[[VAL_7]]
-// CHECK:       .{{.*}}:                                      ; preds = %[[VAL_7]], %[[VAL_9]]
-// CHECK:         %[[VAL_17:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_4]]* %[[VAL_3]])
-// CHECK:         %[[VAL_18:.*]] = alloca i1, i64 %[[VAL_17]], align 1
-// CHECK:         %[[VAL_19:.*]] = icmp sgt i64 %[[VAL_17]], 0
-// CHECK:         br i1 %[[VAL_19]], label %[[VAL_20:.*]], label %[[VAL_21:.*]]
-// CHECK:       .{{.*}}:                                          ; preds = %[[VAL_8]], %[[VAL_20]]
-// CHECK:         %[[VAL_22:.*]] = phi i64 [ %[[VAL_23:.*]], %[[VAL_20]] ], [ 0, %[[VAL_8]] ]
+// CHECK:       [[VAL_8]]:
+// CHECK-SAME:  preds = %[[VAL_9:.*]]
+// CHECK:         %[[VAL_10:.*]] = alloca i1, i64 %[[VAL_5]], align 1
+// CHECK:         br label %[[VAL_11:.*]]
+// CHECK:       [[VAL_7]]:
+// CHECK-SAME:  preds = %[[VAL_9]], %[[VAL_7]]
+// CHECK:         %[[VAL_12:.*]] = phi i64 [ %[[VAL_13:.*]], %[[VAL_7]] ], [ 0, %[[VAL_9]] ]
+// CHECK:         %[[VAL_14:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_4]]* %[[VAL_3]], i64 %[[VAL_12]])
+// CHECK:         %[[VAL_15:.*]] = bitcast i8* %[[VAL_14]] to %[[VAL_16:.*]]**
+// CHECK:         %[[VAL_17:.*]] = load %[[VAL_16]]*, %[[VAL_16]]** %[[VAL_15]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_16]]* %[[VAL_17]])
+// CHECK:         %[[VAL_13]] = add nuw nsw i64 %[[VAL_12]], 1
+// CHECK:         %[[VAL_18:.*]] = icmp eq i64 %[[VAL_13]], %[[VAL_5]]
+// CHECK:         br i1 %[[VAL_18]], label %[[VAL_19:.*]], label %[[VAL_7]]
+// CHECK:       [[VAL_19]]:
+// CHECK-SAME:  preds = %[[VAL_7]]
+// CHECK:         %[[VAL_20:.*]] = alloca i1, i64 %[[VAL_5]], align 1
+// CHECK:         br i1 %[[VAL_6]], label %[[VAL_21:.*]], label %[[VAL_11]]
+// CHECK:       [[VAL_21]]:
+// CHECK-SAME:  preds = %[[VAL_19]], %[[VAL_21]]
+// CHECK:         %[[VAL_22:.*]] = phi i64 [ %[[VAL_23:.*]], %[[VAL_21]] ], [ 0, %[[VAL_19]] ]
 // CHECK:         %[[VAL_24:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_4]]* %[[VAL_3]], i64 %[[VAL_22]])
-// CHECK:         %[[VAL_25:.*]] = bitcast i8* %[[VAL_24]] to %[[VAL_14]]**
-// CHECK:         %[[VAL_26:.*]] = load %[[VAL_14]]*, %[[VAL_14]]** %[[VAL_25]], align 8
-// CHECK:         %[[VAL_27:.*]] = tail call %[[VAL_28:.*]]* @__quantum__qis__mz(%[[VAL_14]]* %[[VAL_26]])
+// CHECK:         %[[VAL_25:.*]] = bitcast i8* %[[VAL_24]] to %[[VAL_16]]**
+// CHECK:         %[[VAL_26:.*]] = load %[[VAL_16]]*, %[[VAL_16]]** %[[VAL_25]], align 8
+// CHECK:         %[[VAL_27:.*]] = tail call %[[VAL_28:.*]]* @__quantum__qis__mz(%[[VAL_16]]* %[[VAL_26]])
 // CHECK:         %[[VAL_29:.*]] = bitcast %[[VAL_28]]* %[[VAL_27]] to i1*
 // CHECK:         %[[VAL_30:.*]] = load i1, i1* %[[VAL_29]], align 1
-// CHECK:         %[[VAL_31:.*]] = getelementptr i1, i1* %[[VAL_18]], i64 %[[VAL_22]]
+// CHECK:         %[[VAL_31:.*]] = getelementptr i1, i1* %[[VAL_20]], i64 %[[VAL_22]]
 // CHECK:         store i1 %[[VAL_30]], i1* %[[VAL_31]], align 1
 // CHECK:         %[[VAL_23]] = add nuw nsw i64 %[[VAL_22]], 1
-// CHECK:         %[[VAL_32:.*]] = icmp eq i64 %[[VAL_23]], %[[VAL_17]]
-// CHECK:         br i1 %[[VAL_32]], label %[[VAL_21]], label %[[VAL_20]]
-// CHECK:       .{{.*}}:                                     ; preds = %[[VAL_20]], %[[VAL_8]]
-// CHECK:         %[[VAL_33:.*]] = bitcast i1* %[[VAL_18]] to i8*
-// CHECK:         %[[VAL_34:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_33]], i64 %[[VAL_17]], i64 1)
+// CHECK:         %[[VAL_32:.*]] = icmp eq i64 %[[VAL_23]], %[[VAL_5]]
+// CHECK:         br i1 %[[VAL_32]], label %[[VAL_11]], label %[[VAL_21]]
+// CHECK:       [[VAL_11]]:
+// CHECK-SAME:  preds = %[[VAL_21]], %[[VAL_8]], %[[VAL_19]]
+// CHECK:         %[[VAL_33:.*]] = phi i1* [ %[[VAL_10]], %[[VAL_8]] ], [ %[[VAL_20]], %[[VAL_19]] ], [ %[[VAL_20]], %[[VAL_21]] ]
+// CHECK:         %[[VAL_34:.*]] = bitcast i1* %[[VAL_33]] to i8*
+// CHECK:         %[[VAL_35:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_34]], i64 %[[VAL_5]], i64 1)
 // CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_4]]* %[[VAL_3]])
-// CHECK:         %[[VAL_35:.*]] = getelementptr { i8*, i64 }, { i8*, i64 }* %[[VAL_0]], i64 0, i32 0
-// CHECK:         store i8* %[[VAL_34]], i8** %[[VAL_35]], align 8
-// CHECK:         %[[VAL_36:.*]] = getelementptr { i8*, i64 }, { i8*, i64 }* %[[VAL_0]], i64 0, i32 1
-// CHECK:         store i64 %[[VAL_17]], i64* %[[VAL_36]], align 8
+// CHECK:         %[[VAL_36:.*]] = getelementptr { i8*, i64 }, { i8*, i64 }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i8* %[[VAL_35]], i8** %[[VAL_36]], align 8
+// CHECK:         %[[VAL_37:.*]] = getelementptr { i8*, i64 }, { i8*, i64 }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store i64 %[[VAL_5]], i64* %[[VAL_37]], align 8
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define void @test_0({ i8*, i8*, i8* }* sret({ i8*, i8*, i8* })
+// CHECK-LABEL: define void @test_0({ i8*, i8*, i8* }* sret({ i8*, i8*, i8* }) 
 // CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]], i32 %[[VAL_2:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_3:.*]] = alloca { i32, { i1*, i64 } }, align 8
 // CHECK:         %[[VAL_4:.*]] = bitcast { i32, { i1*, i64 } }* %[[VAL_3]] to i8*
@@ -139,8 +145,8 @@ func.func @test_1(%1: !cc.ptr<!cc.struct<{i1, i1}>> {llvm.sret = !cc.struct<{i1,
   return
 }
 
-// CHECK-LABEL: define void @__nvqpp__mlirgen__test_1({ i1, i1 }* nocapture writeonly sret({ i1, i1 })
-// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_1({ i1, i1 }* nocapture writeonly sret({ i1, i1 }) 
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = tail call %[[VAL_2:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
 // CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 0)
 // CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to %[[VAL_5:.*]]**
@@ -164,8 +170,8 @@ func.func @test_1(%1: !cc.ptr<!cc.struct<{i1, i1}>> {llvm.sret = !cc.struct<{i1,
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define void @test_1({ i1, i1 }* nocapture writeonly sret({ i1, i1 })
-// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]])
+// CHECK-LABEL: define void @test_1({ i1, i1 }* nocapture writeonly sret({ i1, i1 }) 
+// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = alloca [2 x i8], align 8
 // CHECK:         %[[VAL_3:.*]] = getelementptr inbounds [2 x i8], [2 x i8]* %[[VAL_2]], i64 0, i64 0
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_3]], i64 2, i64 0)
@@ -198,14 +204,14 @@ func.func @test_2(%1: !cc.ptr<!cc.struct<{i16, f32, f64, i64}>> {llvm.sret = !cc
   return
 }
 
-// CHECK-LABEL: define void @__nvqpp__mlirgen__test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 })
-// CHECK-SAME:      %[[VAL_0:.*]])
-// CHECK:         store { i16, float, double, i64 } { i16 8, float {{.*}}, double 3{{.*}}, i64 1479 }, { i16, float, double, i64 }* %[[VAL_0]], align 8
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 }) 
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #1 {
+// CHECK:         store { i16, float, double, i64 } { i16 8, float 0x40159999A0000000, double 3.783000e+01, i64 1479 }, { i16, float, double, i64 }* %[[VAL_0]], align 8
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define void @test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 })
-// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]])
+// CHECK-LABEL: define void @test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 }) 
+// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = alloca { { i16, float, double, i64 } }, align 8
 // CHECK:         %[[VAL_3:.*]] = bitcast { { i16, float, double, i64 } }* %[[VAL_2]] to i8*
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_2.thunk to i8*), i8* nonnull %[[VAL_3]], i64 24, i64 0)
@@ -244,8 +250,8 @@ func.func @test_3(%1: !cc.ptr<!cc.array<i64 x 5>> {llvm.sret = !cc.array<i64 x 5
   return
 }
 
-// CHECK-LABEL: define void @__nvqpp__mlirgen__test_3([5 x i64]* nocapture writeonly sret([5 x i64])
-// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_3([5 x i64]* nocapture writeonly sret([5 x i64]) 
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #1 {
 // CHECK:         %[[VAL_1:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 0
 // CHECK:         store i64 5, i64* %[[VAL_1]], align 8
 // CHECK:         %[[VAL_2:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 1
@@ -259,8 +265,8 @@ func.func @test_3(%1: !cc.ptr<!cc.array<i64 x 5>> {llvm.sret = !cc.array<i64 x 5
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define void @test_3([5 x i64]* nocapture writeonly sret([5 x i64])
-// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]])
+// CHECK-LABEL: define void @test_3([5 x i64]* nocapture writeonly sret([5 x i64]) 
+// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = alloca { [5 x i64] }, align 8
 // CHECK:         %[[VAL_3:.*]] = bitcast { [5 x i64] }* %[[VAL_2]] to i8*
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_3.thunk to i8*), i8* nonnull %[[VAL_3]], i64 40, i64 0)
@@ -297,17 +303,17 @@ func.func @test_4(%1: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
   return
 }
 
-// CHECK-LABEL: define void @__nvqpp__mlirgen__test_4({ i64, double }* nocapture writeonly sret({ i64, double })
-// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_4({ i64, double }* nocapture writeonly sret({ i64, double }) 
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #1 {
 // CHECK:         %[[VAL_1:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
 // CHECK:         store i64 537892, i64* %[[VAL_1]], align 8
 // CHECK:         %[[VAL_2:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
-// CHECK:         store double {{.*}}, double* %[[VAL_2]], align 8
+// CHECK:         store double 0x40578DA858793DD9, double* %[[VAL_2]], align 8
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define void @test_4({ i64, double }* nocapture writeonly sret({ i64, double })
-// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]])
+// CHECK-LABEL: define void @test_4({ i64, double }* nocapture writeonly sret({ i64, double }) 
+// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = alloca { i64, double }, align 8
 // CHECK:         %[[VAL_3:.*]] = bitcast { i64, double }* %[[VAL_2]] to i8*
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_4.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_4.thunk to i8*), i8* nonnull %[[VAL_3]], i64 16, i64 0)
@@ -332,35 +338,35 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
   return
 }
 
-// CHECK-LABEL: define void @__nvqpp__mlirgen__test_5({ i64, double }* nocapture writeonly sret({ i64, double })
-// CHECK-SAME:      %[[VAL_0:.*]])
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_5({ i64, double }* nocapture writeonly sret({ i64, double }) 
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #1 {
 // CHECK:         %[[VAL_1:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
 // CHECK:         store i64 537892, i64* %[[VAL_1]], align 8
 // CHECK:         %[[VAL_2:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
-// CHECK:         store double {{.*}}, double* %[[VAL_2]], align 8
+// CHECK:         store double 0x40578DA858793DD9, double* %[[VAL_2]], align 8
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define void @test_5({ i64, double }* nocapture writeonly sret({ i64, double })
-// CHECK-SAME:      %[[VAL_0:.*]])
-// CHECK:         %[[VAL_2:.*]] = alloca { i64, double }, align 8
-// CHECK:         %[[VAL_3:.*]] = bitcast { i64, double }* %[[VAL_2]] to i8*
-// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_5.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_5.thunk to i8*), i8* nonnull %[[VAL_3]], i64 16, i64 0)
-// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_2]], i64 0, i32 0
-// CHECK:         %[[VAL_5:.*]] = load i64, i64* %[[VAL_4]], align 8
-// CHECK:         %[[VAL_6:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
-// CHECK:         store i64 %[[VAL_5]], i64* %[[VAL_6]], align 8
-// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_2]], i64 0, i32 1
-// CHECK:         %[[VAL_8:.*]] = load double, double* %[[VAL_7]], align 8
-// CHECK:         %[[VAL_9:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
-// CHECK:         store double %[[VAL_8]], double* %[[VAL_9]], align 8
+// CHECK-LABEL: define void @test_5({ i64, double }* nocapture writeonly sret({ i64, double }) 
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_1:.*]] = alloca { i64, double }, align 8
+// CHECK:         %[[VAL_2:.*]] = bitcast { i64, double }* %[[VAL_1]] to i8*
+// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_5.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_5.thunk to i8*), i8* nonnull %[[VAL_2]], i64 16, i64 0)
+// CHECK:         %[[VAL_3:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_1]], i64 0, i32 0
+// CHECK:         %[[VAL_4:.*]] = load i64, i64* %[[VAL_3]], align 8
+// CHECK:         %[[VAL_5:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         store i64 %[[VAL_4]], i64* %[[VAL_5]], align 8
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_1]], i64 0, i32 1
+// CHECK:         %[[VAL_7:.*]] = load double, double* %[[VAL_6]], align 8
+// CHECK:         %[[VAL_8:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
+// CHECK:         store double %[[VAL_7]], double* %[[VAL_8]], align 8
 // CHECK:         ret void
 // CHECK:       }
 
 }
 
-// CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* nocapture
-// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* nocapture 
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i32*
 // CHECK:         %[[VAL_3:.*]] = load i32, i32* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_4:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
@@ -369,59 +375,85 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         %[[VAL_8:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_7]]* %[[VAL_6]])
 // CHECK:         %[[VAL_9:.*]] = icmp sgt i64 %[[VAL_8]], 0
 // CHECK:         br i1 %[[VAL_9]], label %[[VAL_10:.*]], label %[[VAL_11:.*]]
-// CHECK:       .{{.*}}:                                           ; preds = %[[VAL_12:.*]], %[[VAL_10]]
-// CHECK:         %[[VAL_13:.*]] = phi i64 [ %[[VAL_14:.*]], %[[VAL_10]] ], [ 0, %[[VAL_12]] ]
-// CHECK:         %[[VAL_15:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]]* %[[VAL_6]], i64 %[[VAL_13]])
-// CHECK:         %[[VAL_16:.*]] = bitcast i8* %[[VAL_15]] to %[[VAL_17:.*]]**
-// CHECK:         %[[VAL_18:.*]] = load %[[VAL_17]]*, %[[VAL_17]]** %[[VAL_16]], align 8
-// CHECK:         tail call void @__quantum__qis__h(%[[VAL_17]]* %[[VAL_18]])
-// CHECK:         %[[VAL_14]] = add nuw nsw i64 %[[VAL_13]], 1
-// CHECK:         %[[VAL_19:.*]] = icmp eq i64 %[[VAL_14]], %[[VAL_8]]
-// CHECK:         br i1 %[[VAL_19]], label %[[VAL_11]], label %[[VAL_10]]
-// CHECK:       .{{.*}}:                                      ; preds = %[[VAL_10]], %[[VAL_12]]
-// CHECK:         %[[VAL_20:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_7]]* %[[VAL_6]])
-// CHECK:         %[[VAL_21:.*]] = alloca i1, i64 %[[VAL_20]], align 1
-// CHECK:         %[[VAL_22:.*]] = icmp sgt i64 %[[VAL_20]], 0
-// CHECK:         br i1 %[[VAL_22]], label %[[VAL_23:.*]], label %[[VAL_24:.*]]
-// CHECK:       .{{.*}}:                                          ; preds = %[[VAL_11]], %[[VAL_23]]
-// CHECK:         %[[VAL_25:.*]] = phi i64 [ %[[VAL_26:.*]], %[[VAL_23]] ], [ 0, %[[VAL_11]] ]
+// CHECK:       [[VAL_11]]:
+// CHECK-SAME:  preds = %[[VAL_12:.*]]
+// CHECK:         %[[VAL_13:.*]] = alloca i1, i64 %[[VAL_8]], align 1
+// CHECK:         br label %[[VAL_14:.*]]
+// CHECK:       [[VAL_10]]:
+// CHECK-SAME:  preds = %[[VAL_12]], %[[VAL_10]]
+// CHECK:         %[[VAL_15:.*]] = phi i64 [ %[[VAL_16:.*]], %[[VAL_10]] ], [ 0, %[[VAL_12]] ]
+// CHECK:         %[[VAL_17:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]]* %[[VAL_6]], i64 %[[VAL_15]])
+// CHECK:         %[[VAL_18:.*]] = bitcast i8* %[[VAL_17]] to %[[VAL_19:.*]]**
+// CHECK:         %[[VAL_20:.*]] = load %[[VAL_19]]*, %[[VAL_19]]** %[[VAL_18]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_19]]* %[[VAL_20]])
+// CHECK:         %[[VAL_16]] = add nuw nsw i64 %[[VAL_15]], 1
+// CHECK:         %[[VAL_21:.*]] = icmp eq i64 %[[VAL_16]], %[[VAL_8]]
+// CHECK:         br i1 %[[VAL_21]], label %[[VAL_22:.*]], label %[[VAL_10]]
+// CHECK:       [[VAL_22]]:
+// CHECK-SAME:  preds = %[[VAL_10]]
+// CHECK:         %[[VAL_23:.*]] = alloca i1, i64 %[[VAL_8]], align 1
+// CHECK:         br i1 %[[VAL_9]], label %[[VAL_24:.*]], label %[[VAL_14]]
+// CHECK:       [[VAL_24]]:
+// CHECK-SAME:  preds = %[[VAL_22]], %[[VAL_24]]
+// CHECK:         %[[VAL_25:.*]] = phi i64 [ %[[VAL_26:.*]], %[[VAL_24]] ], [ 0, %[[VAL_22]] ]
 // CHECK:         %[[VAL_27:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]]* %[[VAL_6]], i64 %[[VAL_25]])
-// CHECK:         %[[VAL_28:.*]] = bitcast i8* %[[VAL_27]] to %[[VAL_17]]**
-// CHECK:         %[[VAL_29:.*]] = load %[[VAL_17]]*, %[[VAL_17]]** %[[VAL_28]], align 8
-// CHECK:         %[[VAL_30:.*]] = tail call %[[VAL_31:.*]]* @__quantum__qis__mz(%[[VAL_17]]* %[[VAL_29]])
+// CHECK:         %[[VAL_28:.*]] = bitcast i8* %[[VAL_27]] to %[[VAL_19]]**
+// CHECK:         %[[VAL_29:.*]] = load %[[VAL_19]]*, %[[VAL_19]]** %[[VAL_28]], align 8
+// CHECK:         %[[VAL_30:.*]] = tail call %[[VAL_31:.*]]* @__quantum__qis__mz(%[[VAL_19]]* %[[VAL_29]])
 // CHECK:         %[[VAL_32:.*]] = bitcast %[[VAL_31]]* %[[VAL_30]] to i1*
 // CHECK:         %[[VAL_33:.*]] = load i1, i1* %[[VAL_32]], align 1
-// CHECK:         %[[VAL_34:.*]] = getelementptr i1, i1* %[[VAL_21]], i64 %[[VAL_25]]
+// CHECK:         %[[VAL_34:.*]] = getelementptr i1, i1* %[[VAL_23]], i64 %[[VAL_25]]
 // CHECK:         store i1 %[[VAL_33]], i1* %[[VAL_34]], align 1
 // CHECK:         %[[VAL_26]] = add nuw nsw i64 %[[VAL_25]], 1
-// CHECK:         %[[VAL_35:.*]] = icmp eq i64 %[[VAL_26]], %[[VAL_20]]
-// CHECK:         br i1 %[[VAL_35]], label %[[VAL_24]], label %[[VAL_23]]
-// CHECK:       .{{.*}}:                                     ; preds = %[[VAL_23]], %[[VAL_11]]
-// CHECK:         %[[VAL_36:.*]] = bitcast i1* %[[VAL_21]] to i8*
-// CHECK:         %[[VAL_37:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_36]], i64 %[[VAL_20]], i64 1)
+// CHECK:         %[[VAL_35:.*]] = icmp eq i64 %[[VAL_26]], %[[VAL_8]]
+// CHECK:         br i1 %[[VAL_35]], label %[[VAL_14]], label %[[VAL_24]]
+// CHECK:       [[VAL_14]]:
+// CHECK-SAME:  preds = %[[VAL_24]], %[[VAL_11]], %[[VAL_22]]
+// CHECK:         %[[VAL_36:.*]] = phi i1* [ %[[VAL_13]], %[[VAL_11]] ], [ %[[VAL_23]], %[[VAL_22]] ], [ %[[VAL_23]], %[[VAL_24]] ]
+// CHECK:         %[[VAL_37:.*]] = bitcast i1* %[[VAL_36]] to i8*
+// CHECK:         %[[VAL_38:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_37]], i64 %[[VAL_8]], i64 1)
 // CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_7]]* %[[VAL_6]])
-// CHECK:         %[[VAL_38:.*]] = bitcast i8* %[[VAL_4]] to i8**
-// CHECK:         store i8* %[[VAL_37]], i8** %[[VAL_38]], align 8
-// CHECK:         %[[VAL_39:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
-// CHECK:         %[[VAL_40:.*]] = bitcast i8* %[[VAL_39]] to i64*
-// CHECK:         store i64 %[[VAL_20]], i64* %[[VAL_40]], align 4
-// CHECK:         br i1 %[[VAL_1]], label %[[VAL_41:.*]], label %[[VAL_42:.*]]
-// CHECK:       :                                       ; preds = %[[VAL_24]], %[[VAL_41]]
-// CHECK:         %[[VAL_43:.*]] = phi { i8*, i64 } [ %[[VAL_44:.*]], %[[VAL_41]] ], [ zeroinitializer, %[[VAL_24]] ]
-// CHECK:         ret { i8*, i64 } %[[VAL_43]]
-// CHECK:       32:                                               ; preds = %[[VAL_24]]
-// CHECK:         %[[VAL_45:.*]] = add i64 %[[VAL_20]], 24
-// CHECK:         %[[VAL_46:.*]] = call i8* @malloc(i64 %[[VAL_45]])
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_46]], i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_0]], i64 24, i1 false)
-// CHECK:         %[[VAL_47:.*]] = getelementptr i8, i8* %[[VAL_46]], i64 24
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_47]], i8* align 1 %[[VAL_37]], i64 %[[VAL_20]], i1 false)
-// CHECK:         %[[VAL_48:.*]] = insertvalue { i8*, i64 } undef, i8* %[[VAL_46]], 0
-// CHECK:         %[[VAL_44]] = insertvalue { i8*, i64 } %[[VAL_48]], i64 %[[VAL_45]], 1
-// CHECK:         br label %[[VAL_42]]
+// CHECK:         %[[VAL_39:.*]] = bitcast i8* %[[VAL_4]] to i8**
+// CHECK:         store i8* %[[VAL_38]], i8** %[[VAL_39]], align 8
+// CHECK:         %[[VAL_40:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
+// CHECK:         %[[VAL_41:.*]] = bitcast i8* %[[VAL_40]] to i64*
+// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_41]], align 4
+// CHECK:         br i1 %[[VAL_1]], label %[[VAL_42:.*]], label %[[VAL_43:.*]]
+// CHECK:       {{.*}}:
+// CHECK:         %[[VAL_44:.*]] = phi { i8*, i64 } [ %[[VAL_45:.*]], %[[VAL_42]] ], [ zeroinitializer, %[[VAL_14]] ]
+// CHECK:         ret { i8*, i64 } %[[VAL_44]]
+// CHECK:       {{.*}}:
+// CHECK:         %[[VAL_46:.*]] = add i64 %[[VAL_8]], 24
+// CHECK:         %[[VAL_47:.*]] = call i8* @malloc(i64 %[[VAL_46]])
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_47]], i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_0]], i64 24, i1 false)
+// CHECK:         %[[VAL_48:.*]] = getelementptr i8, i8* %[[VAL_47]], i64 24
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_48]], i8* align 1 %[[VAL_38]], i64 %[[VAL_8]], i1 false)
+// CHECK:         %[[VAL_49:.*]] = insertvalue { i8*, i64 } undef, i8* %[[VAL_47]], 0
+// CHECK:         %[[VAL_45]] = insertvalue { i8*, i64 } %[[VAL_49]], i64 %[[VAL_46]], 1
+// CHECK:         br label %[[VAL_43]]
 // CHECK:       }
 
-// CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* nocapture writeonly
-// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK-LABEL: define i64 @test_0.argsCreator(i8** nocapture readonly 
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #3 {
+// CHECK:         %[[VAL_2:.*]] = bitcast i8** %[[VAL_0]] to i32**
+// CHECK:         %[[VAL_3:.*]] = load i32*, i32** %[[VAL_2]], align 8
+// CHECK:         %[[VAL_4:.*]] = load i32, i32* %[[VAL_3]], align 4
+// CHECK:         %[[VAL_5:.*]] = insertvalue { i32, { i1*, i64 } } undef, i32 %[[VAL_4]], 0
+// CHECK:         %[[VAL_6:.*]] = tail call dereferenceable_or_null(24) i8* @malloc(i64 24)
+// CHECK:         %[[VAL_7:.*]] = bitcast i8* %[[VAL_6]] to { i32, { i1*, i64 } }*
+// CHECK:         store { i32, { i1*, i64 } } %[[VAL_5]], { i32, { i1*, i64 } }* %[[VAL_7]], align 8
+// CHECK:         store i8* %[[VAL_6]], i8** %[[VAL_1]], align 8
+// CHECK:         ret i64 24
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_0.kernelRegFunc() {
+// CHECK:         tail call void @cudaqRegisterKernelName(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_0.kernelName, i64 0, i64 0))
+// CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_0.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_0.argsCreator to i8*))
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* nocapture writeonly 
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
 // CHECK:         %[[VAL_4:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_3]]* %[[VAL_2]], i64 0)
 // CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_4]] to %[[VAL_6:.*]]**
@@ -446,15 +478,41 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
-// CHECK-LABEL: define { i8*, i64 } @test_2.thunk(i8* nocapture writeonly
-// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]])
+// CHECK-LABEL: define i64 @test_1.argsCreator(i8** nocapture readnone 
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(2) i8* @malloc(i64 2)
+// CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
+// CHECK:         ret i64 2
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_1.kernelRegFunc() {
+// CHECK:         tail call void @cudaqRegisterKernelName(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0))
+// CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_1.argsCreator to i8*))
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_2.thunk(i8* nocapture writeonly 
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to { i16, float, double, i64 }*
-// CHECK:         store { i16, float, double, i64 } { i16 8, float {{.*}}, double 3{{.*}}, i64 1479 }, { i16, float, double, i64 }* %[[VAL_2]], align 8
+// CHECK:         store { i16, float, double, i64 } { i16 8, float 0x40159999A0000000, double 3.783000e+01, i64 1479 }, { i16, float, double, i64 }* %[[VAL_2]], align 8
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
-// CHECK-LABEL: define { i8*, i64 } @test_3.thunk(i8* nocapture writeonly
-// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]])
+// CHECK-LABEL: define i64 @test_2.argsCreator(i8** nocapture readnone 
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(24) i8* @malloc(i64 24)
+// CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
+// CHECK:         ret i64 24
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_2.kernelRegFunc() {
+// CHECK:         tail call void @cudaqRegisterKernelName(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0))
+// CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_2.argsCreator to i8*))
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_3.thunk(i8* nocapture writeonly 
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 5, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 8
@@ -472,22 +530,62 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
-// CHECK-LABEL: define { i8*, i64 } @test_4.thunk(i8* nocapture writeonly
-// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
+// CHECK-LABEL: define i64 @test_3.argsCreator(i8** nocapture readnone 
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(40) i8* @malloc(i64 40)
+// CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
+// CHECK:         ret i64 40
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_3.kernelRegFunc() {
+// CHECK:         tail call void @cudaqRegisterKernelName(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0))
+// CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_3.argsCreator to i8*))
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_4.thunk(i8* nocapture writeonly 
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
 // CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to double*
-// CHECK:         store double {{.*}}, double* %[[VAL_4]], align 8
+// CHECK:         store double 0x40578DA858793DD9, double* %[[VAL_4]], align 8
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
-// CHECK-LABEL: define { i8*, i64 } @test_5.thunk(i8* nocapture writeonly
-// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
+// CHECK-LABEL: define i64 @test_4.argsCreator(i8** nocapture readnone 
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(16) i8* @malloc(i64 16)
+// CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
+// CHECK:         ret i64 16
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_4.kernelRegFunc() {
+// CHECK:         tail call void @cudaqRegisterKernelName(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_4.kernelName, i64 0, i64 0))
+// CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_4.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_4.argsCreator to i8*))
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @test_5.thunk(i8* nocapture writeonly 
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
 // CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to double*
-// CHECK:         store double {{.*}}, double* %[[VAL_4]], align 8
+// CHECK:         store double 0x40578DA858793DD9, double* %[[VAL_4]], align 8
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
+
+// CHECK-LABEL: define i64 @test_5.argsCreator(i8** nocapture readnone 
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(16) i8* @malloc(i64 16)
+// CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
+// CHECK:         ret i64 16
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_5.kernelRegFunc() {
+// CHECK:         tail call void @cudaqRegisterKernelName(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_5.kernelName, i64 0, i64 0))
+// CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_5.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_5.argsCreator to i8*))
+// CHECK:         ret void
+// CHECK:       }
+


### PR DESCRIPTION
Fix #925

Remove the last few traces of the mlir::IndexType from the compiler and update the tests accordingly.
