### PR TITLE
Fix Publishing validation failures

### DIFF
--- a/docs/sphinx/examples/cpp/basics/bernstein_vazirani.cpp
+++ b/docs/sphinx/examples/cpp/basics/bernstein_vazirani.cpp
@@ -16,7 +16,7 @@
 
 std::vector<int> random_bitstring(int qubit_count) {
   std::vector<int> vector_of_bits;
-  for (auto i = 0; i <= qubit_count; i++) {
+  for (auto i = 0; i < qubit_count; i++) {
     // Populate our vector of bits with random binary
     // values (base 2).
     vector_of_bits.push_back(rand() % 2);
@@ -26,7 +26,7 @@ std::vector<int> random_bitstring(int qubit_count) {
 
 __qpu__ void oracle(cudaq::qview<> qvector, cudaq::qubit &auxillary_qubit,
                     std::vector<int> &hidden_bitstring) {
-  for (auto i = 0; i <= hidden_bitstring.size(); i++) {
+  for (auto i = 0; i < hidden_bitstring.size(); i++) {
     if (hidden_bitstring[i] == 1)
       // Apply a `cx` gate with the current qubit as
       // the control and the auxillary qubit as the target.
@@ -60,6 +60,7 @@ __qpu__ void bernstein_vazirani(std::vector<int> &hidden_bitstring) {
 }
 
 int main() {
+  // Note: this algorithm will require an additional ancillary qubit.
   auto qubit_count = 5; // set to around 30 qubits for `nvidia` target
 
   // Generate a bitstring to encode and recover with our algorithm.


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

There are failures in Publishing validation, e.g., https://github.com/NVIDIA/cuda-quantum/actions/runs/8443846828

```
 loc(callsite("bernstein_vazirani.cpp":33:22 at "bernstein_vazirani.cpp":52:3)): error: 'quake.extract_ref' op invalid index [6] because >= size [6]
```

This only showed up in the `remote-mqpu` (probably hardware emulation too) since we performed argument synthesis and loop unrolling => the pass manager can detect indexing issues.

This PR fixes the example.


Tested by: running locally

```
nvq++ --enable-mlir --target remote-mqpu  /home/cuda-quantum/examples/cpp/basics/bernstein_vazirani.cpp && ./a.out 
nvq++ --target quantinuum --emulate /home/cuda-quantum/examples/cpp/basics/bernstein_vazirani.cpp && ./a.out
```

Both produced correct results (`Encoded bitstring` == `Measured bitstring`)
 
