### PR TITLE
Make sure that we register and load all dialects when using `PassManager` at runtime

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -52,6 +52,9 @@ std::unique_ptr<mlir::Pass> createRemoveMeasurementsPass();
 /// Register target pipelines.
 void registerTargetPipelines();
 
+/// Register CodeGenDialect with the provided DialectRegistry.
+void registerCodeGenDialect(mlir::DialectRegistry &registry);
+
 // declarative passes
 #define GEN_PASS_DECL
 #define GEN_PASS_REGISTRATION

--- a/lib/Optimizer/CodeGen/Passes.cpp
+++ b/lib/Optimizer/CodeGen/Passes.cpp
@@ -71,3 +71,7 @@ void cudaq::opt::registerTargetPipelines() {
                              "Convert kernels to IonQ gate set.",
                              addIonQPipeline);
 }
+
+void cudaq::opt::registerCodeGenDialect(DialectRegistry &registry) {
+  registry.insert<cudaq::codegen::CodeGenDialect>();
+}

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -17,7 +17,7 @@ from ..mlir.ir import *
 from ..mlir.passmanager import *
 from ..mlir.dialects import quake, cc
 from ..mlir.dialects import builtin, func, arith, math, complex
-from ..mlir._mlir_libs._quakeDialects import cudaq_runtime, load_intrinsic
+from ..mlir._mlir_libs._quakeDialects import cudaq_runtime, load_intrinsic, register_all_dialects
 
 # This file implements the CUDA Quantum Python AST to MLIR conversion.
 # It provides a `PyASTBridge` class that implements the `ast.NodeVisitor` type
@@ -115,6 +115,7 @@ class PyASTBridge(ast.NodeVisitor):
             self.loc = Location.unknown(context=self.ctx)
         else:
             self.ctx = Context()
+            register_all_dialects(self.ctx)
             quake.register_dialect(self.ctx)
             cc.register_dialect(self.ctx)
             cudaq_runtime.registerLLVMDialectTranslation(self.ctx)

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -23,7 +23,7 @@ from ..mlir.passmanager import *
 from ..mlir.execution_engine import *
 from ..mlir.dialects import quake, cc
 from ..mlir.dialects import builtin, func, arith
-from ..mlir._mlir_libs._quakeDialects import cudaq_runtime
+from ..mlir._mlir_libs._quakeDialects import cudaq_runtime, register_all_dialects
 
 
 ## [PYTHON_VERSION_FIX]
@@ -191,6 +191,7 @@ class PyKernel(object):
 
     def __init__(self, argTypeList):
         self.ctx = Context()
+        register_all_dialects(self.ctx)
         quake.register_dialect(self.ctx)
         cc.register_dialect(self.ctx)
         cudaq_runtime.registerLLVMDialectTranslation(self.ctx)

--- a/runtime/common/RuntimeMLIR.cpp
+++ b/runtime/common/RuntimeMLIR.cpp
@@ -87,9 +87,9 @@ std::unique_ptr<MLIRContext> initializeMLIR() {
   }
 
   DialectRegistry registry;
-  registry.insert<arith::ArithDialect, LLVM::LLVMDialect, math::MathDialect,
-                  memref::MemRefDialect, quake::QuakeDialect, cc::CCDialect,
-                  func::FuncDialect>();
+  registry.insert<quake::QuakeDialect, cc::CCDialect>();
+  cudaq::opt::registerCodeGenDialect(registry);
+  registerAllDialects(registry);
   auto context = std::make_unique<MLIRContext>(registry);
   context->loadAllAvailableDialects();
   registerLLVMDialectTranslation(*context);


### PR DESCRIPTION




<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

According to MLIR: "The process of loading a Dialect in the context is not thread-safe, which forces all involved Dialects to be loaded before the multi-threaded pass manager starts the execution."

This PR makes sure that we load all the dialects when MLIR is needed at runtime and, hence may be used in a multi-threading environment (async. execution).

In particular, add a method to register the internal CodeGenDialect, which is only used by our passes (not the frontend).

Make sure that we load all Dialects in C++ (CUDAQ `MLIRRuntime`) and Python (builder/decorator).

Tested by: running `python/tests/remote/test_remote_platform.py` 
