### PR TITLE
Fix wheel test Docker build failure (Fedora)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
     strategy:
       matrix:
         platform: [amd64, arm64]
-        python_version: ['3.8', '3.10']
+        python_version: ['3.8', '3.11']
       fail-fast: false
     uses: ./.github/workflows/python_wheels.yml
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
     strategy:
       matrix:
         platform: [amd64, arm64]
-        python_version: ['3.8', '3.11']
+        python_version: ['3.8', '3.10']
       fail-fast: false
     uses: ./.github/workflows/python_wheels.yml
     secrets:

--- a/docker/test/wheels/fedora.Dockerfile
+++ b/docker/test/wheels/fedora.Dockerfile
@@ -14,7 +14,11 @@ ARG pip_install_flags="--user"
 ARG preinstalled_modules="numpy pytest nvidia-cublas-cu11"
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN dnf install -y --nobest --setopt=install_weak_deps=False \
+
+# Some Python versions need the latest version of libexpat on Fedora, and the
+# base fedora:38 image doesn't have the latest version installed.
+RUN dnf update -y --nobest expat \
+    && dnf install -y --nobest --setopt=install_weak_deps=False \
         python$(echo $python_version | tr -d .) \
     && python${python_version} -m ensurepip --upgrade
 RUN if [ -n "$preinstalled_modules" ]; then \


### PR DESCRIPTION
## Summary 

The latest Deployment pipeline is failing due to python3.10-3.10.14-1.fc38 being released (bumped from python3.10-3.10.13-3.fc38.x86_64).

Example: https://github.com/NVIDIA/cuda-quantum/actions/runs/8571513425/job/23495607331

This change fixes the failure by making sure that the latest version of libexpat is installed for that wheel test. This is not a change to our release Docker images or our regular development Docker images.

## Details

The 3.10.14 release notes (https://www.python.org/downloads/release/python-31014/) say:
> [gh-115399](https://github.com/python/cpython/issues/115399) & [gh-115398](https://github.com/python/cpython/issues/115398): bundled libexpat was updated to 2.6.0 to address CVE-2023-52425, and control of the new reparse deferral functionality was exposed with new APIs

However, the `fedora:38` image only includes `2.5.0-2.fc38` by default, so remedy that here.