### PR TITLE
python kernel builder qalloc support

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -6,7 +6,7 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-import sys, os
+import sys, os, numpy
 from ._packages import *
 from .kernel.kernel_decorator import kernel, PyKernelDecorator
 from .kernel.kernel_builder import make_kernel, QuakeValue, PyKernel
@@ -85,6 +85,26 @@ def synthesize(kernel, *args):
     return PyKernelDecorator(None,
                              module=cudaq_runtime.synthesize(kernel, *args),
                              kernelName=kernel.name)
+
+
+def simulation_dtype():
+    """
+    Return the data type for the current simulation backend, 
+    either `complex128` or `complex64`.
+    """
+    target = get_target()
+    precision = target.get_precision()
+    if precision == cudaq_runtime.SimulationPrecision.fp64:
+        return complex
+    return numpy.complex64
+
+
+def create_state(array_data):
+    """
+    Create a state array with the appropriate data type for the 
+    current simulation backend target. 
+    """
+    return numpy.array(array_data, dtype=simulation_dtype())
 
 
 def __clearKernelRegistries():

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -90,7 +90,7 @@ def synthesize(kernel, *args):
 def simulation_dtype():
     """
     Return the data type for the current simulation backend, 
-    either `complex128` or `complex64`.
+    either `numpy.complex128` or `numpy.complex64`.
     """
     target = get_target()
     precision = target.get_precision()

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -267,6 +267,7 @@ class PyKernel(object):
                     'bool': bool,
                     'float': float,
                     'complex': complex,
+                    'numpy.complex64': np.complex64,
                     'pauli_word': cudaq_runtime.pauli_word
                 }
                 # Infer the slice type
@@ -562,7 +563,6 @@ class PyKernel(object):
                 initializer = np.array(initializer, dtype=type(initializer[0]))
 
             if isinstance(initializer, np.ndarray):
-                hashValue = None
                 if len(initializer.shape) != 1:
                     raise RuntimeError(
                         "invalid initializer for qalloc (np.ndarray must be 1D, vector-like)"

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -553,7 +553,7 @@ class PyKernel(object):
             if isinstance(initializer, list):
                 initializer = np.array(initializer, dtype=type(initializer[0]))
 
-            if isinstance(initializer, (list, np.ndarray)):
+            if isinstance(initializer, np.ndarray):
                 hashValue = None
                 if len(initializer.shape) != 1:
                     raise RuntimeError(
@@ -604,8 +604,11 @@ class PyKernel(object):
                         func.ReturnOp([])
 
                 zero = self.getConstantInt(0)
-                veqTy = quake.VeqType.get(self.ctx, int(
-                    np.log2(size)))  # fixme check size
+                numQubits = np.log2(size)
+                if not numQubits.is_integer():
+                    raise RuntimeError("invalid input state size for qalloc (not a power of 2)")
+                # Fixme check state is normalized
+                veqTy = quake.VeqType.get(self.ctx, int(numQubits)) 
                 qubits = quake.AllocaOp(veqTy).result
                 address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),
                                          FlatSymbolRefAttr.get(globalName))

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -205,6 +205,7 @@ class PyKernel(object):
         cc.register_dialect(self.ctx)
         cudaq_runtime.registerLLVMDialectTranslation(self.ctx)
 
+        self.stateVectorStorage = {}
         self.metadata = {'conditionalOnMeasure': False}
         self.regCounter = 0
         self.loc = Location.unknown(context=self.ctx)
@@ -544,21 +545,56 @@ class PyKernel(object):
         ```
         """
         with self.insertPoint, self.loc:
-            # If no initializer, create a single qubit
-            if initializer == None:
-                qubitTy = quake.RefType.get(self.ctx)
-                return self.__createQuakeValue(quake.AllocaOp(qubitTy).result)
-
             # If the initializer is an integer, create `veq<N>`
             if isinstance(initializer, int):
                 veqTy = quake.VeqType.get(self.ctx, initializer)
                 return self.__createQuakeValue(quake.AllocaOp(veqTy).result)
 
-            if isinstance(initializer, np.ndarray):
-                if len(initializer.shape) != 1:
+            if isinstance(initializer, (list, np.ndarray)):
+                if hasattr(initializer, 'shape') and len(initializer.shape) != 1:
                     raise RuntimeError(
                         "invalid initializer for qalloc (np.ndarray must be 1D, vector-like)"
                     )
+                
+                def hashStateVector(state):
+                    seed = len(state)
+                    for el in state: 
+                        seed ^= hash(el.real) + hash(el.imag) + 0x9e3779b9 + (seed << 6) + (seed >> 2)
+                    return seed 
+                
+                hashValue = hashStateVector(initializer)
+                size = len(initializer)
+
+                # FIXME How to handle floating point precision here?
+                floatType = F64Type.get(self.ctx)
+                complexType = ComplexType.get(floatType)
+                ptrComplex = cc.PointerType.get(self.ctx, complexType)
+                i32Ty = self.getIntegerType(32)
+                globalTy = cc.StructType.get(self.ctx, [ptrComplex, i32Ty])
+                globalName = f'nvqpp.state.{hashValue}'
+                setStateName = f'nvqpp.set.state.{hashValue}'
+                with InsertionPoint.at_block_begin(self.module.body):
+                    cc.GlobalOp(TypeAttr.get(globalTy), globalName, external=True)
+                    setStateFunc = func.FuncOp(setStateName, FunctionType.get(inputs=[ptrComplex], results=[]), loc=self.loc)
+                    entry = setStateFunc.add_entry_block()
+                    kDynamicPtrIndex: int = -2147483648
+                    with InsertionPoint(entry):
+                        zero = self.getConstantInt(0)
+                        address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy), FlatSymbolRefAttr.get(globalName))
+                        ptr =  cc.ComputePtrOp(cc.PointerType.get(self.ctx, ptrComplex), address, [zero, zero], DenseI32ArrayAttr.get([kDynamicPtrIndex, kDynamicPtrIndex], context=self.ctx))
+                        cc.StoreOp(entry.arguments[0], ptr)
+                        func.ReturnOp([])
+                
+                zero = self.getConstantInt(0)
+                veqTy = quake.VeqType.get(self.ctx, int(np.log2(size))) # fixme check size
+                qubits = quake.AllocaOp(veqTy).result
+                address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy), FlatSymbolRefAttr.get(globalName))
+                ptr = cc.ComputePtrOp(cc.PointerType.get(self.ctx, ptrComplex), address, [zero, zero], DenseI32ArrayAttr.get([kDynamicPtrIndex, kDynamicPtrIndex], context=self.ctx))
+                loaded = cc.LoadOp(ptr)
+                qubits = quake.InitializeStateOp(qubits.type, qubits, loaded).result
+
+                self.stateVectorStorage[hashValue] = initializer
+                return self.__createQuakeValue(qubits)
 
             # If the initializer is a QuakeValue, see if it is
             # a integer or a `stdvec` type
@@ -584,6 +620,11 @@ class PyKernel(object):
                     quake.InitializeStateOp(veqTy, qubits, initials)
                     return self.__createQuakeValue(qubits)
 
+            # If no initializer, create a single qubit
+            if initializer == None:
+                qubitTy = quake.RefType.get(self.ctx)
+                return self.__createQuakeValue(quake.AllocaOp(qubitTy).result)
+            
             raise RuntimeError("invalid initializer argument for qalloc.")
 
     def __isPauliWordType(self, ty):
@@ -1214,6 +1255,10 @@ class PyKernel(object):
             else:
                 processedArgs.append(arg)
 
+        if len(self.stateVectorStorage):
+            cudaq_runtime.pyAltLaunchKernelWithStateData(self.name, self.module, *processedArgs, stateVectorStorage=self.stateVectorStorage)
+            return 
+        
         cudaq_runtime.pyAltLaunchKernel(self.name, self.module, *processedArgs)
 
 

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -637,7 +637,13 @@ class PyKernel(object):
                     raise RuntimeError(
                         "invalid input state size for qalloc (not a power of 2)"
                     )
-                # Fixme check state is normalized
+
+                # check state is normalized
+                norm = sum([np.conj(a) * a for a in initializer])
+                if np.abs(norm.imag) > 1e-4 or np.abs(1. - norm.real) > 1e-4:
+                    raise RuntimeError(
+                        "invalid input state for qalloc (not normalized)")
+
                 veqTy = quake.VeqType.get(self.ctx, int(numQubits))
                 qubits = quake.AllocaOp(veqTy).result
                 address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -209,8 +209,11 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
                     )
             return cc.StdvecType.get(ctx, mlirTypeFromPyType(float, ctx))
 
-        if isinstance(argInstance[0], complex):
+        if isinstance(argInstance[0], (complex, np.complex128)):
             return cc.StdvecType.get(ctx, mlirTypeFromPyType(complex, ctx))
+
+        if isinstance(argInstance[0], np.complex64):
+            return cc.StdvecType.get(ctx, ComplexType.get(F32Type.get(ctx)))
 
         if isinstance(argInstance[0], pauli_word):
             return cc.StdvecType.get(ctx, cc.CharspanType.get(ctx))

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -29,14 +29,23 @@
 #include "mlir/Target/LLVMIR/Export.h"
 
 #include <fmt/core.h>
-#include <pybind11/stl.h>
 #include <pybind11/numpy.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 using namespace mlir;
 
 namespace cudaq {
 static std::unique_ptr<JITExecutionCache> jitCache;
+
+struct PyStateVectorData {
+  void *data = nullptr;
+  simulation_precision precision = simulation_precision::fp32;
+};
+using PyStateVectorStorage = std::map<std::string, PyStateVectorData>;
+
+static std::unique_ptr<PyStateVectorStorage> stateStorage =
+    std::make_unique<PyStateVectorStorage>();
 
 std::tuple<ExecutionEngine *, void *, std::size_t>
 jitAndCreateArgs(const std::string &name, MlirModule module,
@@ -185,6 +194,26 @@ pyAltLaunchKernelBase(const std::string &name, MlirModule module,
   auto thunk = reinterpret_cast<void (*)(void *)>(*thunkPtr);
 
   std::string properName = name;
+
+  // If we have any state vector data, we need to extract the function pointer
+  // to set that data, and then set it.
+  for (auto &[stateHash, svdata] : *stateStorage) {
+    auto setStateFPtr = jit->lookup("nvqpp.set.state." + stateHash);
+    // Only operate if we have the data setter
+    if (!setStateFPtr)
+      continue;
+
+    if (svdata.precision == simulation_precision::fp64) {
+      auto setStateFunc =
+          reinterpret_cast<void (*)(std::complex<double> *)>(*setStateFPtr);
+      setStateFunc(reinterpret_cast<std::complex<double> *>(svdata.data));
+      continue;
+    }
+
+    auto setStateFunc =
+        reinterpret_cast<void (*)(std::complex<float> *)>(*setStateFPtr);
+    setStateFunc(reinterpret_cast<std::complex<float> *>(svdata.data));
+  }
 
   // Need to first invoke the init_func()
   auto kernelInitFunc = properName + ".init_func";
@@ -401,99 +430,15 @@ void bindAltLaunchKernel(py::module &mod) {
       },
       py::arg("kernel"), py::kw_only(), py::arg("profile") = "");
 
-  mod.def(
-      "pyAltLaunchKernelWithStateData",
-      [&](const std::string &kernelName, MlirModule module,
-          py::args runtimeArgs, py::dict &data) {
-        auto kernelFunc = getKernelFuncOp(module, kernelName);
+  py::enum_<simulation_precision>(mod, "SimulationPrecision")
+      .value("fp32", simulation_precision::fp32)
+      .value("fp64", simulation_precision::fp64);
 
-        cudaq::OpaqueArguments args;
-        cudaq::packArgs(args, runtimeArgs, kernelFunc, callableArgHandler);
-        auto noneType = mlir::NoneType::get(unwrap(module).getContext());
-        auto [jit, rawArgs, size] =
-            jitAndCreateArgs(kernelName, module, args, {}, noneType);
-
-        auto mod = unwrap(module);
-        auto thunkName = kernelName + ".thunk";
-        auto thunkPtr = jit->lookup(thunkName);
-        if (!thunkPtr)
-          throw std::runtime_error(
-              "cudaq::builder failed to get thunk function");
-
-        auto thunk = reinterpret_cast<void (*)(void *)>(*thunkPtr);
-
-        std::string properName = kernelName;
-
-        // If we have any state vector data, we need to extract the function
-        // pointer to set that data, and then set it.
-        for (auto &[stateHashK, svdata] : data) {
-          std::int64_t stateHash = stateHashK.cast<py::int_>();
-          auto svdataV  = svdata.cast<py::array>();
-          auto info = svdataV.request();
-          auto format = info.format;
-          void *ptr = nullptr;
-          simulation_precision precision = simulation_precision::fp32;
-          if (py::hasattr(svdataV, "shape")) {
-            // numpy array
-            if (py::format_descriptor<std::complex<double>>::format() == format)
-              precision = simulation_precision::fp64;
-
-            ptr = info.ptr;
-          } else
-            throw std::runtime_error("List input not supported yet.");
-
-          if (precision == simulation_precision::fp64)
-            throw std::runtime_error("FP32 not yet supported.");
-
-          auto setStateFPtr =
-              jit->lookup("nvqpp.set.state." + std::to_string(stateHash));
-          if (!setStateFPtr)
-            throw std::runtime_error(
-                "cudaq::builder failed to get set state function.");
-
-          if (precision == simulation_precision::fp64) {
-            auto setStateFunc =
-                reinterpret_cast<void (*)(std::complex<double> *)>(
-                    *setStateFPtr);
-            setStateFunc(reinterpret_cast<std::complex<double> *>(ptr));
-          } else {
-            auto setStateFunc =
-                reinterpret_cast<void (*)(std::complex<float> *)>(
-                    *setStateFPtr);
-            setStateFunc(reinterpret_cast<std::complex<float> *>(ptr));
-          }
-        }
-
-        // Need to first invoke the init_func()
-        auto kernelInitFunc = properName + ".init_func";
-        auto initFuncPtr = jit->lookup(kernelInitFunc);
-        if (!initFuncPtr) {
-          throw std::runtime_error(
-              "cudaq::builder failed to get kernelReg function.");
-        }
-        auto kernelInit = reinterpret_cast<void (*)()>(*initFuncPtr);
-        kernelInit();
-
-        // Need to first invoke the kernelRegFunc()
-        auto kernelRegFunc = properName + ".kernelRegFunc";
-        auto regFuncPtr = jit->lookup(kernelRegFunc);
-        if (!regFuncPtr) {
-          throw std::runtime_error(
-              "cudaq::builder failed to get kernelReg function.");
-        }
-        auto kernelReg = reinterpret_cast<void (*)()>(*regFuncPtr);
-        kernelReg();
-
-        auto &platform = cudaq::get_platform();
-        if (platform.is_remote() || platform.is_emulated()) {
-          auto *wrapper = new cudaq::ArgWrapper{mod, {}, rawArgs};
-          cudaq::altLaunchKernel(kernelName.c_str(), thunk,
-                                 reinterpret_cast<void *>(wrapper), size, 0);
-          delete wrapper;
-        } else
-          cudaq::altLaunchKernel(kernelName.c_str(), thunk, rawArgs, size, 0);
-      },
-      py::arg("kernelName"), py::arg("module"), py::kw_only(),
-      py::arg("stateVectorStorage"), "DOC STRING");
+  mod.def("storePointerToStateData",
+          [](const std::string &hash, py::buffer data,
+             simulation_precision precision) {
+            auto ptr = data.request().ptr;
+            stateStorage->insert({hash, PyStateVectorData{ptr, precision}});
+          });
 }
 } // namespace cudaq

--- a/python/runtime/cudaq/target/py_runtime_target.cpp
+++ b/python/runtime/cudaq/target/py_runtime_target.cpp
@@ -17,6 +17,10 @@ namespace cudaq {
 
 void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
 
+  py::enum_<simulation_precision>(mod, "SimulationPrecision")
+      .value("fp32", simulation_precision::fp32)
+      .value("fp64", simulation_precision::fp64);
+
   py::class_<cudaq::RuntimeTarget>(
       mod, "Target",
       "The `cudaq.Target` represents the underlying infrastructure that CUDA "
@@ -40,13 +44,17 @@ void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
       .def("is_emulated", &cudaq::RuntimeTarget::is_emulated,
            "Returns true if the emulation mode for the target has been "
            "activated.")
+      .def("get_precision", &cudaq::RuntimeTarget::get_precision, "")
       .def(
           "__str__",
           [](cudaq::RuntimeTarget &self) {
-            return fmt::format("Target {}\n\tsimulator={}\n\tplatform={}"
-                               "\n\tdescription={}\n",
-                               self.name, self.simulatorName, self.platformName,
-                               self.description);
+            return fmt::format(
+                "Target {}\n\tsimulator={}\n\tplatform={}"
+                "\n\tdescription={}\n\tprecision={}\n",
+                self.name, self.simulatorName, self.platformName,
+                self.description,
+                self.get_precision() == simulation_precision::fp32 ? "fp32"
+                                                                   : "fp64");
           },
           "Persist the information in this `cudaq.Target` to a string.");
 

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -976,7 +976,7 @@ def test_from_state():
     assert '11' in counts
     assert '00' in counts
 
-    state = cudaq.create_state(np.array([.70710678]*4))
+    state = cudaq.create_state(np.array([.5]*4))
     kernel2 = cudaq.make_kernel()
     qubits = kernel2.qalloc(state)
     counts = cudaq.sample(kernel2)

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -976,13 +976,15 @@ def test_from_state():
     assert '11' in counts
     assert '00' in counts
 
-    state = cudaq.create_state(np.array([.70710678, 0., 0., 0.70710678]))
+    state = cudaq.create_state(np.array([.70710678]*4))
     kernel2 = cudaq.make_kernel()
     qubits = kernel2.qalloc(state)
     counts = cudaq.sample(kernel2)
     print(counts)
     assert '11' in counts
     assert '00' in counts
+    assert '01' in counts
+    assert '10' in counts
 
     kernel, initState = cudaq.make_kernel(list[np.complex64])
     qubits = kernel.qalloc(initState)

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -934,6 +934,9 @@ def test_from_state():
         # Wrong precision for fp64 simulator
         qubits = kernel.qalloc(state)
 
+    with pytest.raises(RuntimeError) as e:
+        qubits = kernel.qalloc(np.array([1., 0., 0.], dtype=complex))
+
     cudaq.reset_target()
 
     # FIXME Handle FP32 simulation backend case.

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -884,7 +884,7 @@ def test_from_state():
     kernel, initState = cudaq.make_kernel(list[complex])
     qubits = kernel.qalloc(initState)
     
-    # Test float list
+    # Test float64 list, casts to complex
     state = [.70710678, 0., 0., 0.70710678]
     counts = cudaq.sample(kernel, state)
     print(counts)
@@ -904,9 +904,9 @@ def test_from_state():
     print(counts)
     assert '11' in counts
     assert '00' in counts
-    cudaq.reset_target()
 
-    state = np.array([.70710678, 0., 0., 0.70710678])
+    # Now test constant array data, not kernel input
+    state = np.array([.70710678, 0., 0., 0.70710678], dtype=complex)
     kernel = cudaq.make_kernel()
     qubits = kernel.qalloc(state)
     counts = cudaq.sample(kernel)
@@ -914,36 +914,29 @@ def test_from_state():
     assert '11' in counts
     assert '00' in counts
 
-    # state = np.asarray([.70710678, 0., 0., 0.70710678])
-    # kernel = cudaq.make_kernel()
-    # qubits = kernel.qalloc(state)
+    state = [.70710678+0j, 0., 0., 0.70710678]
+    kernel = cudaq.make_kernel()
+    qubits = kernel.qalloc(state)
+    counts = cudaq.sample(kernel)
+    print(counts)
+    assert '11' in counts
+    assert '00' in counts
+    
+    state = np.array([.70710678, 0., 0., 0.70710678])
+    kernel = cudaq.make_kernel()
+    with pytest.raises(RuntimeError) as e:
+        # float data and not complex data 
+        qubits = kernel.qalloc(state)
+    
+    state = np.array([.70710678, 0., 0., 0.70710678], dtype=np.complex64)
+    kernel = cudaq.make_kernel()
+    with pytest.raises(RuntimeError) as e:
+        # Wrong precision for fp64 simulator
+        qubits = kernel.qalloc(state)
 
-    # cudaq.from_state(kernel, qubits, state)
+    cudaq.reset_target()
 
-    # print(kernel)
-    # counts = cudaq.sample(kernel)
-    # print(counts)
-    # assert '11' in counts
-    # assert '00' in counts
-
-    # kernel = cudaq.from_state(state)
-    # counts = cudaq.sample(kernel)
-    # print(counts)
-    # assert '11' in counts
-    # assert '00' in counts
-
-    # hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
-    #     0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)
-    # state = np.asarray([0., .292786, .956178, 0.])
-    # kernel = cudaq.make_kernel()
-    # qubits = kernel.qalloc(2)
-    # cudaq.from_state(kernel, qubits, state)
-    # energy = cudaq.observe(kernel, hamiltonian).expectation()
-    # assert np.isclose(-1.748, energy, 1e-3)
-
-    # ss = cudaq.get_state(kernel)
-    # for i in range(4):
-    #     assert np.isclose(ss[i], state[i], 1e-3)
+    # FIXME Handle FP32 simulation backend case.
 
 
 @skipIfPythonLessThan39

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -906,6 +906,14 @@ def test_from_state():
     assert '00' in counts
     cudaq.reset_target()
 
+    state = np.array([.70710678, 0., 0., 0.70710678])
+    kernel = cudaq.make_kernel()
+    qubits = kernel.qalloc(state)
+    counts = cudaq.sample(kernel)
+    print(counts)
+    assert '11' in counts
+    assert '00' in counts
+
     # state = np.asarray([.70710678, 0., 0., 0.70710678])
     # kernel = cudaq.make_kernel()
     # qubits = kernel.qalloc(state)

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -984,6 +984,14 @@ def test_from_state():
     assert '11' in counts
     assert '00' in counts
 
+    kernel, initState = cudaq.make_kernel(list[np.complex64])
+    qubits = kernel.qalloc(initState)
+    state = cudaq.create_state([.70710678, 0., 0., 0.70710678])
+    counts = cudaq.sample(kernel, state)
+    print(counts)
+    assert '11' in counts
+    assert '00' in counts
+
 
 @skipIfPythonLessThan39
 def test_pauli_word_input():

--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "cudaq/host_config.h"
 #include <filesystem>
 #include <map>
 #include <string>
@@ -30,11 +31,13 @@ struct RuntimeTarget {
   std::string simulatorName;
   std::string platformName;
   std::string description;
+  simulation_precision precision;
 
   /// @brief Return the number of QPUs this target exposes.
   std::size_t num_qpus();
   bool is_remote();
   bool is_emulated();
+  simulation_precision get_precision();
 };
 
 /// @brief The LinkedLibraryHolder provides a mechanism for

--- a/python/utils/OpaqueArguments.h
+++ b/python/utils/OpaqueArguments.h
@@ -323,17 +323,31 @@ packArgs(OpaqueArguments &argData, py::args args,
                 return;
               })
               .Case([&](ComplexType type) {
-                genericVecAllocator.template operator()<std::complex<double>>(
-                    [](py::handle element) -> std::complex<double> {
-                      if (!py::hasattr(element, "real"))
-                        throw std::runtime_error(
-                            "invalid complex element type");
-                      if (!py::hasattr(element, "imag"))
-                        throw std::runtime_error(
-                            "invalid complex element type");
-                      return {PyFloat_AsDouble(element.attr("real").ptr()),
-                              PyFloat_AsDouble(element.attr("imag").ptr())};
-                    });
+                if (isa<Float64Type>(type.getElementType())) {
+                  genericVecAllocator.template operator()<std::complex<double>>(
+                      [](py::handle element) -> std::complex<double> {
+                        if (!py::hasattr(element, "real"))
+                          throw std::runtime_error(
+                              "invalid complex element type");
+                        if (!py::hasattr(element, "imag"))
+                          throw std::runtime_error(
+                              "invalid complex element type");
+                        return {PyFloat_AsDouble(element.attr("real").ptr()),
+                                PyFloat_AsDouble(element.attr("imag").ptr())};
+                      });
+                } else {
+                  genericVecAllocator.template operator()<std::complex<float>>(
+                      [](py::handle element) -> std::complex<float> {
+                        if (!py::hasattr(element, "real"))
+                          throw std::runtime_error(
+                              "invalid complex element type");
+                        if (!py::hasattr(element, "imag"))
+                          throw std::runtime_error(
+                              "invalid complex element type");
+                        return {element.attr("real").cast<float>(),
+                                element.attr("imag").cast<float>()};
+                      });
+                }
                 return;
               })
               .Default([](Type ty) {

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -42,10 +42,12 @@ public:
           "Invalid number of state vector elements for qudit allocation (" +
           std::to_string(state.size()) + ").");
 
-    auto norm = std::inner_product(
-        state.begin(), state.end(), state.begin(), simulation_scalar{0., 0.},
-        [](auto a, auto b) { return a + b; },
-        [](auto a, auto b) { return std::conj(a) * b; });
+    auto norm =
+        std::inner_product(
+            state.begin(), state.end(), state.begin(),
+            simulation_scalar{0., 0.}, [](auto a, auto b) { return a + b; },
+            [](auto a, auto b) { return std::conj(a) * b; })
+            .real();
     if (std::fabs(1.0 - norm) > 1e-4)
       throw std::runtime_error("Invalid vector norm for qudit allocation.");
 

--- a/test/AST-Quake/qalloc_initialization.cpp
+++ b/test/AST-Quake/qalloc_initialization.cpp
@@ -7,8 +7,8 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck %s
-// RUN: cudaq-quake %cpp_std %s | cudaq-opt | cudaq-translate --convert-to=qir | FileCheck --check-prefix=QIR %s
+// RUN: cudaq-quake -D CUDAQ_SIMULATION_SCALAR_FP64 %cpp_std %s | cudaq-opt | FileCheck %s
+// RUN: cudaq-quake -D CUDAQ_SIMULATION_SCALAR_FP64 %cpp_std %s | cudaq-opt | cudaq-translate --convert-to=qir | FileCheck --check-prefix=QIR %s
 // clang-format on
 
 // Test various flavors of qubits declared with initial state information.
@@ -279,7 +279,7 @@ __qpu__ bool Peppermint() {
 
 // clang-format off
 // QIR-LABEL: define { i1*, i64 } @__nvqpp__mlirgen__Vanilla() local_unnamed_addr {
-// QIR:         %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array_with_state(i64 2, i8* nonnull bitcast ([4 x double]* @__nvqpp__rodata_init_0 to i8*))
+// QIR:         %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 2, i8* nonnull bitcast ([4 x double]* @__nvqpp__rodata_init_0 to i8*))
 // QIR:         %[[VAL_2:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_1]]* %[[VAL_0]])
 // QIR:       }
 
@@ -298,7 +298,7 @@ __qpu__ bool Peppermint() {
 // QIR:         %[[VAL_6:.*]] = getelementptr inbounds [4 x { double, double }], [4 x { double, double }]* %[[VAL_0]], i64 0, i64 2, i32 1
 // QIR:         %[[VAL_7:.*]] = bitcast [4 x { double, double }]* %[[VAL_0]] to i8*
 // QIR:         call void @llvm.memset
-// QIR:         %[[VAL_8:.*]] = call %[[VAL_9:.*]]* @__quantum__rt__qubit_allocate_array_with_state(i64 2, i8* nonnull %[[VAL_7]])
+// QIR:         %[[VAL_8:.*]] = call %[[VAL_9:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 2, i8* nonnull %[[VAL_7]])
 // QIR:         %[[VAL_10:.*]] = call i64 @__quantum__rt__array_get_size_1d(%[[VAL_9]]* %[[VAL_8]])
 // QIR:       }
 
@@ -317,7 +317,7 @@ __qpu__ bool Peppermint() {
 // QIR:         %[[VAL_6:.*]] = getelementptr inbounds [4 x { double, double }], [4 x { double, double }]* %[[VAL_0]], i64 0, i64 2, i32 1
 // QIR:         %[[VAL_7:.*]] = bitcast [4 x { double, double }]* %[[VAL_0]] to i8*
 // QIR:         call void @llvm.memset
-// QIR:         %[[VAL_8:.*]] = call %[[VAL_9:.*]]* @__quantum__rt__qubit_allocate_array_with_state(i64 2, i8* nonnull %[[VAL_7]])
+// QIR:         %[[VAL_8:.*]] = call %[[VAL_9:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 2, i8* nonnull %[[VAL_7]])
 // QIR:         %[[VAL_10:.*]] = call i64 @__quantum__rt__array_get_size_1d(%[[VAL_9]]* %[[VAL_8]])
 // QIR:       }
 
@@ -362,7 +362,7 @@ __qpu__ bool Peppermint() {
 // QIR:         %[[VAL_26:.*]] = getelementptr inbounds [4 x { double, double }], [4 x { double, double }]* %[[VAL_16]], i64 0, i64 2, i32 1
 // QIR:         store double %[[VAL_25]], double* %[[VAL_26]], align 8
 // QIR:         %[[VAL_27:.*]] = bitcast [4 x { double, double }]* %[[VAL_16]] to i8*
-// QIR:         %[[VAL_28:.*]] = call %[[VAL_29:.*]]* @__quantum__rt__qubit_allocate_array_with_state(i64 2, i8* nonnull %[[VAL_27]])
+// QIR:         %[[VAL_28:.*]] = call %[[VAL_29:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 2, i8* nonnull %[[VAL_27]])
 // QIR:         %[[VAL_30:.*]] = call i64 @__quantum__rt__array_get_size_1d(%[[VAL_29]]* %[[VAL_28]])
 // QIR:       }
 
@@ -372,7 +372,7 @@ __qpu__ bool Peppermint() {
 // QIR: %[[VAL_1:.*]] = tail call i64 @llvm.cttz.i64(i64 %[[VAL_I]], i1 false)
 // QIR:         %[[VAL_2:.*]] = extractvalue { double*, i64 } %[[VAL_0]], 0
 // QIR:         %[[VAL_3:.*]] = bitcast double* %[[VAL_2]] to i8*
-// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state(i64 %[[VAL_1]], i8* %[[VAL_3]])
+// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 %[[VAL_1]], i8* %[[VAL_3]])
 // QIR:         %[[VAL_6:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_5]]* %[[VAL_4]])
 // QIR:       }
 
@@ -382,7 +382,7 @@ __qpu__ bool Peppermint() {
 // QIR: %[[VAL_1:.*]] = tail call i64 @llvm.cttz.i64(i64 %[[VAL_I]], i1 false)
 // QIR:         %[[VAL_2:.*]] = extractvalue { double*, i64 } %[[VAL_0]], 0
 // QIR:         %[[VAL_3:.*]] = bitcast double* %[[VAL_2]] to i8*
-// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state(i64 %[[VAL_1]], i8* %[[VAL_3]])
+// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 %[[VAL_1]], i8* %[[VAL_3]])
 // QIR:         %[[VAL_6:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_5]]* %[[VAL_4]])
 // QIR:       }
 
@@ -392,7 +392,7 @@ __qpu__ bool Peppermint() {
 // QIR: %[[VAL_1:.*]] = tail call i64 @llvm.cttz.i64(i64 %[[VAL_I]], i1 false)
 // QIR:         %[[VAL_2:.*]] = extractvalue { { double, double }*, i64 } %[[VAL_0]], 0
 // QIR:         %[[VAL_3:.*]] = bitcast { double, double }* %[[VAL_2]] to i8*
-// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state(i64 %[[VAL_1]], i8* %[[VAL_3]])
+// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 %[[VAL_1]], i8* %[[VAL_3]])
 // QIR:         %[[VAL_6:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_5]]* %[[VAL_4]])
 // QIR:       }
 
@@ -402,7 +402,7 @@ __qpu__ bool Peppermint() {
 // QIR: %[[VAL_1:.*]] = tail call i64 @llvm.cttz.i64(i64 %[[VAL_I]], i1 false)
 // QIR:         %[[VAL_2:.*]] = extractvalue { { double, double }*, i64 } %[[VAL_0]], 0
 // QIR:         %[[VAL_3:.*]] = bitcast { double, double }* %[[VAL_2]] to i8*
-// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state(i64 %[[VAL_1]], i8* %[[VAL_3]])
+// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 %[[VAL_1]], i8* %[[VAL_3]])
 // QIR:         %[[VAL_6:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_5]]* %[[VAL_4]])
 // QIR:       }
 


### PR DESCRIPTION
Implement `qalloc(state_vector)` support for the Python Kernel builder. 

Support patterns like 
```python
# Unknown state as function input 
kernel, initState = cudaq.make_kernel(list[complex])
qubits = kernel.qalloc(initState)
state = [.70710678, 0., 0., 0.70710678]
counts = cudaq.sample(kernel, state)

# Known state as qalloc input 
state = np.array([.70710678, 0., 0., 0.70710678], dtype=complex)
kernel = cudaq.make_kernel()
qubits = kernel.qalloc(state)
counts = cudaq.sample(kernel)
```

This requires a better handle at the Python level on the floating point precision of simulation state data. 
```python 
cudaq.set_target('nvidia-fp64')
state = np.array([.70710678, 0., 0., 0.70710678], dtype=complex)
kernel = cudaq.make_kernel()
# Works, Simulator is FP64 and so is state.dtype
qubits = kernel.qalloc(state)

# Raises an exception 
state = np.array([.70710678, 0., 0., 0.70710678], dtype=np.complex64)
kernel = cudaq.make_kernel()
# Fails, Simulator is FP64 and but state.dtype is FP32
qubits = kernel.qalloc(state)

# Provide convenience functions for user 
# code to work for any state vector target 
state = np.array([.70710678, 0., 0., 0.70710678],
                     dtype=cudaq.simulation_dtype()) # Note simulation_dtype() function
kernel = cudaq.make_kernel()
qubits = kernel.qalloc(state)
counts = cudaq.sample(kernel)

# Set the dtype automatically from any array data
state = cudaq.create_state([.70710678, 0., 0., 0.70710678])
kernel = cudaq.make_kernel()
qubits = kernel.qalloc(state)
counts = cudaq.sample(kernel)
```

Would be great to get reviewer thoughts on this approach to handling simulation data type mismatches.