### PR TITLE
Follow-up to #1477 - fix multi-gpu observe() calls

### DIFF
--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: 492b8bf4a4017e221dc7b989e899dfee7c8a2c44
+nvidia-mgpu-commit: e5dd5dce35ab4dfc85831851db7a56afc0f7685e


### PR DESCRIPTION
CircuitSimulator does not call `canHandleObserve()` right before `observe` calls, so the `nvidia-mgpu` simulator was returning incorrect values to `canHandleObserve()` at the times they were being called. This PR fixes that...or, more specifically, it updates the GitLab commit to include the fix from GitLab.