### PR TITLE
Fix issue with unknown base on attribute call (throw an error)

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -1631,8 +1631,8 @@ class PyASTBridge(ast.NodeVisitor):
                 if quake.VeqType.isinstance(var.type):
                     if node.func.attr == 'size':
                         # Handled already in the Attribute visit
-                        return 
-                    
+                        return
+
                     # `qreg` or `qview` method call
                     if node.func.attr == 'back':
                         qrSize = quake.VeqSizeOp(self.getIntegerType(),
@@ -1808,8 +1808,8 @@ class PyASTBridge(ast.NodeVisitor):
                     f'Unknown attribute on quantum operation {node.func.value.id} ({node.func.attr}). {maybeProposeOpAttrFix(node.func.value.id, node.func.attr)}'
                 )
 
-            self.emitFatalError(f"Invalid function call - '{node.func.value.id}' is unknown.")
-
+            self.emitFatalError(
+                f"Invalid function call - '{node.func.value.id}' is unknown.")
 
     def visit_ListComp(self, node):
         """

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -884,7 +884,7 @@ class PyASTBridge(ast.NodeVisitor):
             self.visit(node.value)
 
         if len(self.valueStack) == 0:
-            self.emitFatalError("invalid assignement detected.", node)
+            self.emitFatalError("invalid assignment detected.", node)
 
         varNames = []
         varValues = []

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -1629,6 +1629,10 @@ class PyASTBridge(ast.NodeVisitor):
                 # Method call on one of our variables
                 var = self.symbolTable[node.func.value.id]
                 if quake.VeqType.isinstance(var.type):
+                    if node.func.attr == 'size':
+                        # Handled already in the Attribute visit
+                        return 
+                    
                     # `qreg` or `qview` method call
                     if node.func.attr == 'back':
                         qrSize = quake.VeqSizeOp(self.getIntegerType(),
@@ -1803,6 +1807,9 @@ class PyASTBridge(ast.NodeVisitor):
                 self.emitFatalError(
                     f'Unknown attribute on quantum operation {node.func.value.id} ({node.func.attr}). {maybeProposeOpAttrFix(node.func.value.id, node.func.attr)}'
                 )
+
+            self.emitFatalError(f"Invalid function call - '{node.func.value.id}' is unknown.")
+
 
     def visit_ListComp(self, node):
         """

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -1256,7 +1256,7 @@ def test_missing_paren_1450():
     
     with pytest.raises(RuntimeError) as e:
         test_kernel.compile()
-    assert 'Invalid assignment detected.'
+    assert 'Invalid assignment detected.' in repr(e)
 
 def test_cast_error_1451():
     @cudaq.kernel
@@ -1267,3 +1267,15 @@ def test_cast_error_1451():
     
     # Test is that this compiles
     test_kernel.compile()
+
+
+def test_bad_attr_call_error():
+    @cudaq.kernel
+    def test_state(N: int):
+        q = cudaq.qvector(N)
+        h(q[0])
+        kernel.h(q[0])
+    
+    with pytest.raises(RuntimeError) as e:
+        test_state.compile()
+    assert "Invalid function call - 'kernel' is unknown." in repr(e)

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -1256,7 +1256,7 @@ def test_missing_paren_1450():
     
     with pytest.raises(RuntimeError) as e:
         test_kernel.compile()
-    assert 'Invalid assignment detected.' in repr(e)
+    assert 'invalid assignment detected.' in repr(e)
 
 def test_cast_error_1451():
     @cudaq.kernel


### PR DESCRIPTION
Fixes #1496 - issue with unknown attribute call expression 
```python 
import cudaq
@cudaq.kernel
def test_state(N: int):
    q = cudaq.qvector(N)
    h(q[0])
    kernel.h(q[0]) # user error
test_state.compile()
```