### PR TITLE
[rt] Rename getAvailableIndex function.

### DIFF
--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -95,8 +95,8 @@ protected:
 public:
   ExecutionManager() = default;
 
-  /// Return the next available qudit index
-  virtual std::size_t getAvailableIndex(std::size_t quditLevels = 2) = 0;
+  /// Allocates a qudit and returns its identifier (index).
+  virtual std::size_t allocateQudit(std::size_t quditLevels = 2) = 0;
 
   /// QuditInfo has been deallocated, return the qudit / id to the pool of
   /// qudits.

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -123,7 +123,7 @@ public:
     executionContext = nullptr;
   }
 
-  std::size_t getAvailableIndex(std::size_t quditLevels) override {
+  std::size_t allocateQudit(std::size_t quditLevels) override {
     auto new_id = getNextIndex();
     if (isInTracerMode())
       return new_id;

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -27,7 +27,7 @@ class qudit {
 
 public:
   /// Construct a qudit, will allocated a new unique index
-  qudit() : idx(getExecutionManager()->getAvailableIndex(n_levels())) {}
+  qudit() : idx(getExecutionManager()->allocateQudit(n_levels())) {}
 
   // Qudits cannot be copied
   qudit(const qudit &q) = delete;


### PR DESCRIPTION
### Description
The execution manager should not expose details of how qudit allocation is handle internally through its public API. User must only know that, when they ask for a qudit allocation, they get a qudit identifier back.

Users should not write code that rely on a qudit having a particular identifier---something that the current name might invite them to do.
