### PR TITLE
Fix the comment in intro.py example #1497

### DIFF
--- a/docs/sphinx/examples/python/intro.py
+++ b/docs/sphinx/examples/python/intro.py
@@ -8,8 +8,7 @@ def kernel():
     '''
     This is our first CUDA Quantum kernel.
     '''
-    # Next, we can allocate qubits to the kernel via `qalloc(qubit_count)`.
-    # An empty call to `qalloc` will return a single qubit.
+    # Allocates qubit to |0> state
     qubit = cudaq.qubit()
 
     # Now we can begin adding instructions to apply to this qubit!

--- a/docs/sphinx/examples/python/intro.py
+++ b/docs/sphinx/examples/python/intro.py
@@ -8,7 +8,7 @@ def kernel():
     '''
     This is our first CUDA Quantum kernel.
     '''
-    # Allocates qubit to |0> state
+    # Next, we can allocate a single qubit to the kernel via `qubit()`.
     qubit = cudaq.qubit()
 
     # Now we can begin adding instructions to apply to this qubit!


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Fixed the comment in intro.py example, 
[Issue #1497](https://github.com/NVIDIA/cuda-quantum/issues/1497)

```# Next, we can allocate qubits to the kernel via `qalloc(qubit_count)`.```
```# An empty call to `qalloc` will return a single qubit.```
```qubit = cudaq.qubit()```

To

 ```# Allocates qubit to |0> state```
  ```qubit = cudaq.qubit()```

Fixes #1497 