### PR TITLE
[0.7.1] Reverts some support for Pauli word operations from kernels.

### DIFF
--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -175,8 +175,6 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
     TODO_loc(loc, "unhandled type, " + name + ", in cudaq namespace");
   }
   if (isInNamespace(x, "std")) {
-    if (name.equals("basic_string"))
-      return pushType(cc::CharspanType::get(ctx));
     if (name.equals("vector")) {
       auto *cts = cast<clang::ClassTemplateSpecializationDecl>(x);
       // Traverse template argument 0 to get the vector's element type.

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1160,21 +1160,11 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
     return pushValue(builder.create<math::PowFOp>(loc, base, power));
   }
 
-  if (isInClassInNamespace(func, "basic_string", "std")) {
-    if (funcName.equals("data") || funcName.equals("c_str")) {
-      FunctionType funcTy = cast<FunctionType>(popType());
-      return pushValue(builder.create<cc::StdvecDataOp>(
-          loc, funcTy.getResult(0), popValue()));
-    }
-    // fall through and use std::vector for other member functions.
-  }
-
   // Dealing with our std::vector as a view data structures. If we have some θ
   // with the type `std::vector<double/float/int>`, and in the kernel, θ.size()
   // is called, we need to convert that to loading the size field of the pair.
   // For θ.empty(), the size is loaded and compared to zero.
-  if (isInClassInNamespace(func, "vector", "std") ||
-      isInClassInNamespace(func, "basic_string", "std")) {
+  if (isInClassInNamespace(func, "vector", "std")) {
     // Get the size of the std::vector.
     auto svec = popValue();
     if (isa<cc::PointerType>(svec.getType()))

--- a/lib/Frontend/nvqpp/ConvertType.cpp
+++ b/lib/Frontend/nvqpp/ConvertType.cpp
@@ -133,16 +133,12 @@ static bool isKernelResultType(Type t) {
          isStaticArithmeticProductType(t);
 }
 
-/// Is \p t a std::string type?
-static bool isStringType(Type t) { return isa<cudaq::cc::CharspanType>(t); }
-
 /// Return true if and only if \p t is a (simple) arithmetic type, an possibly
 /// dynamic type composed of arithmetic types, a quantum type, a callable
 /// (function), or a string.
 static bool isKernelArgumentType(Type t) {
   return isArithmeticType(t) || isComposedArithmeticType(t) ||
          isQuantumType(t) || isKernelCallable(t) || isFunctionCallable(t) ||
-         isStringType(t) ||
          // TODO: move from pointers to a builtin string type.
          cudaq::isCharPointerType(t);
 }

--- a/test/AST-Quake/string-0.cpp
+++ b/test/AST-Quake/string-0.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 // RUN: cudaq-quake %cpp_std %s | FileCheck %s
+// XFAIL: *
 
 // Test that a std::string argument can be passed to a kernel.
 

--- a/test/AST-Quake/string-1.cpp
+++ b/test/AST-Quake/string-1.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 // RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck %s
+// XFAIL: *
 
 #include <cudaq.h>
 #include <string>


### PR DESCRIPTION
This patch reverts some of the core support intended for Pauli words. Revert this PR when the Pauli word work is picked up again.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
