### PR TITLE
[experimental/stateHandling] Update to use cudaq::complex throughout 

### DIFF
--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -53,7 +53,24 @@ Common
 
 .. doxygenclass:: cudaq::SimulationState
 
+.. doxygenstruct:: cudaq::SimulationState::Tensor
+    :members:
+
+.. doxygenenum:: cudaq::SimulationState::precision
+
+.. doxygenenum:: cudaq::simulation_precision
+
+.. doxygentypedef:: cudaq::tensor
+
+.. doxygentypedef:: cudaq::state_data
+
 .. doxygenclass:: cudaq::CusvState
+
+.. doxygenclass:: cudaq::TensorNetworkState
+
+.. doxygenclass:: nvqir::MPSSimulationState
+
+.. doxygenclass:: nvqir::TensorNetSimulationState
 
 .. doxygenclass:: cudaq::registry::RegisteredType
     :members:

--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -91,7 +91,6 @@ Common
 
 Noise Modeling 
 ================
-.. doxygentypedef:: cudaq::complex
 
 .. doxygenstruct:: cudaq::kraus_op
     :members:
@@ -180,6 +179,10 @@ Platform
 
 Utilities
 =========
+
+.. doxygentypedef:: cudaq::complex
+
+.. doxygentypedef:: cudaq::real 
 
 .. doxygenfunction:: cudaq::range(std::size_t)
     

--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -86,6 +86,9 @@ Backend Configuration
 Data Types
 =============================
 
+.. autoclass:: cudaq::SimulationPrecision
+    :members:
+    
 .. autoclass:: cudaq::Target
     :members:
 

--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -92,6 +92,8 @@ Data Types
 .. autoclass:: cudaq::State
     :members:
 
+.. autoclass:: cudaq::Tensor
+
 .. autoclass:: cudaq::QuakeValue
 
     .. automethod:: __add__

--- a/docs/sphinx/examples/cpp/other/builder/builder.cpp
+++ b/docs/sphinx/examples/cpp/other/builder/builder.cpp
@@ -130,7 +130,7 @@ int main() {
     // In this example, we create a kernel template `sim_kernel` that captures
     // the variable `init_state` by reference.
     auto sim_builder = cudaq::make_kernel();
-    std::vector<cudaq::simulation_scalar> init_state;
+    std::vector<cudaq::complex> init_state;
     auto q = sim_builder.qalloc(init_state);
     // Build the quantum circuit template here.
     sim_builder.mz(q);

--- a/docs/sphinx/releases.rst
+++ b/docs/sphinx/releases.rst
@@ -19,7 +19,7 @@ Check out our `documentation <https://nvidia.github.io/cuda-quantum/latest/using
 to get started with the new Python syntax support we have added, and `follow our blog <https://developer.nvidia.com/cuda-q>`__
 to learn more about the new setup and its performance benefits.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/>`__
 - `C++ installer <https://github.com/NVIDIA/cuda-quantum/releases>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.7.0>`__
@@ -40,7 +40,7 @@ The binaries are built against the `GNU C library <https://www.gnu.org/software/
 version 2.28.
 We've added a detailed :doc:`Building from Source <using/install/data_center_install>` guide to build these binaries for older `glibc` versions.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.6.0>`__
 - `C++ installer <https://github.com/NVIDIA/cuda-quantum/releases/0.6.0>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.6.0>`__
@@ -57,7 +57,7 @@ The 0.5.0 release furthermore improves the tensor network simulation tools and a
 Additionally, we are now publishing images for experimental features, which currently includes improved Python language support.
 Please take a look at :doc:`using/install/install` for more information about how to obtain them.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.5.0>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.5.0>`__
 - `Examples <https://github.com/NVIDIA/cuda-quantum/tree/releases/v0.5.0/docs/sphinx/examples>`__
@@ -68,7 +68,7 @@ The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/r
 
 The 0.4.1 release adds support for ARM processors in the form of multi-platform Docker images and `aarch64` Python wheels. Additionally, all GPU-based backends are now included in the Python wheels as well as in the Docker image.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.4.1>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.4.1>`__
 - `Examples <https://github.com/NVIDIA/cuda-quantum/tree/releases/v0.4.1/docs/sphinx/examples>`__
@@ -83,7 +83,7 @@ The 0.4.0 release adds support for quantum kernel execution on Quantinuum and Io
 The 0.4.0 PyPI release does not yet include all of the GPU-based backends.
 The fully featured version is available as a Docker image for `linux/amd64` platforms.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.4.0>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.4.0>`__
 - `Examples <https://github.com/NVIDIA/cuda-quantum/tree/0.4.0/docs/sphinx/examples>`__
@@ -94,6 +94,6 @@ The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/r
 
 The 0.3.0 release of CUDA Quantum is available as a Docker image for `linux/amd64` platforms.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.3.0>`__
 - `Examples <https://github.com/NVIDIA/cuda-quantum/tree/0.3.0/docs/sphinx/examples>`__

--- a/docs/sphinx/using/install/local_installation.rst
+++ b/docs/sphinx/using/install/local_installation.rst
@@ -34,7 +34,7 @@ If you do not have the necessary administrator permissions to install software o
 take a look at the section below on how to use `Singularity`_ instead.
 
 Docker images for all CUDA Quantum releases are available on the `NGC Container Registry`_.
-In addition to publishing `stable releases <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__, 
+In addition to publishing `stable releases <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__, 
 we also publish Docker images whenever we update certain branches on our `GitHub repository <https://github.com/NVIDIA/cuda-quantum>`_.
 These images are published in our `nightly channel on NGC <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nightly/containers/cuda-quantum/tags>`__.
 To download the latest version on the main branch of our GitHub repository, for example, use the command
@@ -43,7 +43,7 @@ To download the latest version on the main branch of our GitHub repository, for 
 
     docker pull nvcr.io/nvidia/nightly/cuda-quantum:latest
 
-.. _NGC Container Registry: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum
+.. _NGC Container Registry: https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum
 
 Early prototypes for features we are considering can be tried out by using the image tags starting 
 with `experimental`. The `README` in the `/home/cudaq` folder in the container gives more details 
@@ -129,7 +129,7 @@ Once you have singularity installed, create a file `cuda-quantum.def` with the f
         bash
 
 Replace the image name and/or tag in the `From` line, if necessary, with the one you want to use;
-In addition to publishing `stable releases <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__, 
+In addition to publishing `stable releases <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__, 
 we also publish Docker images whenever we update certain branches on our `GitHub repository <https://github.com/NVIDIA/cuda-quantum>`_.
 These images are published in our `nightly channel on NGC <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nightly/containers/cuda-quantum/tags>`__.
 Early prototypes for features we are considering can be tried out by using the image tags starting 

--- a/docs/sphinx/using/quick_start.rst
+++ b/docs/sphinx/using/quick_start.rst
@@ -14,7 +14,7 @@ programming in Python and in C++.
 
 This Quick Start page guides you through installing CUDA Quantum and running your first program.
 If you have already installed and configured CUDA Quantum, or if you are using our 
-`Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum>`_, you can move directly to our
+`Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum>`_, you can move directly to our
 :doc:`Basics Section <basics/basics>`. More information about working with containers and Docker alternatives can be 
 found in our complete :doc:`Installation Guide <install/install>`.
 

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -30,6 +30,8 @@ Kernel = PyKernel
 Target = cudaq_runtime.Target
 State = cudaq_runtime.State
 pauli_word = cudaq_runtime.pauli_word
+Tensor = cudaq_runtime.Tensor
+SimulationPrecision = cudaq_runtime.SimulationPrecision
 
 # to be deprecated
 qreg = cudaq_runtime.qvector

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -88,7 +88,7 @@ def synthesize(kernel, *args):
                              kernelName=kernel.name)
 
 
-def simulation_dtype():
+def complex():
     """
     Return the data type for the current simulation backend, 
     either `numpy.complex128` or `numpy.complex64`.
@@ -100,12 +100,12 @@ def simulation_dtype():
     return numpy.complex64
 
 
-def create_state(array_data):
+def amplitudes(array_data):
     """
     Create a state array with the appropriate data type for the 
     current simulation backend target. 
     """
-    return numpy.array(array_data, dtype=simulation_dtype())
+    return numpy.array(array_data, dtype=complex())
 
 
 def __clearKernelRegistries():

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -45,7 +45,10 @@ state pyGetState(py::object kernel, py::args args) {
 /// @brief Bind the get_state cudaq function
 void bindPyState(py::module &mod) {
 
-  py::class_<SimulationState::Tensor>(mod, "Tensor")
+  py::class_<SimulationState::Tensor>(
+      mod, "Tensor",
+      "The `Tensor` describes a pointer to simulation data as well as the rank "
+      "and extents for that tensorial data it represents.")
       .def("data",
            [](SimulationState::Tensor &tensor) {
              return reinterpret_cast<intptr_t>(tensor.data);

--- a/python/runtime/cudaq/domains/plugins/PySCFDriver.cpp
+++ b/python/runtime/cudaq/domains/plugins/PySCFDriver.cpp
@@ -6,8 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "LinkedLibraryHolder.h"
 #include "cudaq/domains/chemistry/MoleculePackageDriver.h"
+#include "cudaq/target_control.h"
 #include <pybind11/embed.h>
 
 namespace py = pybind11;
@@ -76,13 +76,13 @@ public:
     }
 
     // We don't want to modify the platform, indicate so
-    cudaq::LinkedLibraryHolder::disallowTargetModification = true;
+    cudaq::__internal__::disableTargetModification();
 
     // Import the cudaq python chemistry module
     auto cudaqModule = py::module_::import(ChemistryModuleName);
 
     // Reset it
-    cudaq::LinkedLibraryHolder::disallowTargetModification = false;
+    cudaq::__internal__::enableTargetModification();
 
     // Setup the active space if requested.
     py::object nElectrons = py::none();

--- a/python/runtime/cudaq/target/py_runtime_target.cpp
+++ b/python/runtime/cudaq/target/py_runtime_target.cpp
@@ -17,7 +17,9 @@ namespace cudaq {
 
 void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
 
-  py::enum_<simulation_precision>(mod, "SimulationPrecision")
+  py::enum_<simulation_precision>(
+      mod, "SimulationPrecision",
+      "Enumeration describing the precision of the underyling simulation.")
       .value("fp32", simulation_precision::fp32)
       .value("fp64", simulation_precision::fp64);
 
@@ -44,7 +46,8 @@ void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
       .def("is_emulated", &cudaq::RuntimeTarget::is_emulated,
            "Returns true if the emulation mode for the target has been "
            "activated.")
-      .def("get_precision", &cudaq::RuntimeTarget::get_precision, "")
+      .def("get_precision", &cudaq::RuntimeTarget::get_precision,
+           "Return the simulation precision for the current target.")
       .def(
           "__str__",
           [](cudaq::RuntimeTarget &self) {

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -968,9 +968,9 @@ def test_from_state1():
     cudaq.reset_target()
 
     # Regardless of the target precision, use
-    # cudaq.simulation_dtype() or cudaq.create_state()
+    # cudaq.complex() or cudaq.amplitudes()
     state = np.array([.70710678, 0., 0., 0.70710678],
-                     dtype=cudaq.simulation_dtype())
+                     dtype=cudaq.complex()) 
     kernel2 = cudaq.make_kernel()
     qubits = kernel2.qalloc(state)
     counts = cudaq.sample(kernel2)
@@ -978,7 +978,7 @@ def test_from_state1():
     assert '11' in counts
     assert '00' in counts
 
-    state = cudaq.create_state([.70710678, 0., 0., 0.70710678])
+    state = cudaq.amplitudes([.70710678, 0., 0., 0.70710678])
     kernel2 = cudaq.make_kernel()
     qubits = kernel2.qalloc(state)
     counts = cudaq.sample(kernel2)
@@ -986,7 +986,7 @@ def test_from_state1():
     assert '11' in counts
     assert '00' in counts
 
-    state = cudaq.create_state(np.array([.5]*4))
+    state = cudaq.amplitudes(np.array([.5]*4))
     kernel2 = cudaq.make_kernel()
     qubits = kernel2.qalloc(state)
     counts = cudaq.sample(kernel2)
@@ -998,7 +998,7 @@ def test_from_state1():
 
     kernel, initState = cudaq.make_kernel(list[np.complex64])
     qubits = kernel.qalloc(initState)
-    state = cudaq.create_state([.70710678, 0., 0., 0.70710678])
+    state = cudaq.amplitudes([.70710678, 0., 0., 0.70710678])
     counts = cudaq.sample(kernel, state)
     print(counts)
     assert '11' in counts

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -879,7 +879,7 @@ def test_recursive_calls():
 
   
 skipIfNvidiaFP64NotInstalled = pytest.mark.skipif(
-  not cudaq.has_target('nvidia-fp64'),
+  not (cudaq.num_available_gpus() > 0 and cudaq.has_target('nvidia-fp64')),
   reason='Could not find nvidia-fp64 in installation')
 
 @skipIfNvidiaFP64NotInstalled
@@ -945,7 +945,7 @@ def test_from_state0():
     cudaq.reset_target()
 
 skipIfNvidiaNotInstalled = pytest.mark.skipif(
-  not cudaq.has_target('nvidia'),
+  not (cudaq.num_available_gpus() > 0 and cudaq.has_target('nvidia')),
   reason='Could not find nvidia in installation')
   
 @skipIfNvidiaNotInstalled

--- a/python/tests/kernel/test_state_kernel.py
+++ b/python/tests/kernel/test_state_kernel.py
@@ -20,12 +20,17 @@ skipIfPythonLessThan39 = pytest.mark.skipif(
     reason="built-in collection types such as `list` not supported")
 
 
+skipIfNoGQPU = pytest.mark.skipif(
+    not cudaq.has_target('nvidia'),
+    reason="nvidia-mqpu backend not available")
+
 @pytest.fixture(autouse=True)
 def do_something():
     yield
     cudaq.__clearKernelRegistries()
 
 
+@skipIfNoGQPU
 def test_state_vector_simple():
     """
     A simple end-to-end test of the state class on a state vector

--- a/python/tests/kernel/test_state_kernel.py
+++ b/python/tests/kernel/test_state_kernel.py
@@ -21,7 +21,7 @@ skipIfPythonLessThan39 = pytest.mark.skipif(
 
 
 skipIfNoGQPU = pytest.mark.skipif(
-    not cudaq.has_target('nvidia'),
+    not (cudaq.num_available_gpus() > 0 and cudaq.has_target('nvidia')),
     reason="nvidia-mqpu backend not available")
 
 @pytest.fixture(autouse=True)

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -11,6 +11,7 @@
 #include "common/Logger.h"
 #include "common/PluginUtils.h"
 #include "cudaq/platform.h"
+#include "cudaq/target_control.h"
 #include "nvqir/CircuitSimulator.h"
 #include <fstream>
 #include <regex>
@@ -156,6 +157,9 @@ void findAvailableTargets(
 LinkedLibraryHolder::LinkedLibraryHolder() {
   cudaq::info("Init infrastructure for pythonic builder.");
 
+  if (!cudaq::__internal__::canModifyTarget())
+    return;
+
   cudaq::__internal__::CUDAQLibraryData data;
 #if defined(__APPLE__) && defined(__MACH__)
   libSuffix = "dylib";
@@ -300,9 +304,6 @@ LinkedLibraryHolder::LinkedLibraryHolder() {
   // argument or set_target() API
   currentTarget = defaultTarget;
 
-  if (disallowTargetModification)
-    return;
-
   // We'll always start off with the default target
   resetTarget();
 }
@@ -367,7 +368,7 @@ void LinkedLibraryHolder::setTarget(
     std::map<std::string, std::string> extraConfig) {
   // Do not set the default target if the disallow
   // flag has been set.
-  if (disallowTargetModification)
+  if (!cudaq::__internal__::canModifyTarget())
     return;
 
   auto iter = targets.find(targetName);

--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -44,12 +44,6 @@ struct RuntimeTarget {
 /// dynamically loading and storing the required plugin libraries
 /// for the CUDA Quantum runtime within the Python runtime.
 class LinkedLibraryHolder {
-public:
-  /// @brief Global boolean that disables target modification.
-  /// This will turn off (bypass) target modification in the LinkedLibraryHolder
-  /// instance used by Python bindings.
-  static inline bool disallowTargetModification = false;
-
 protected:
   // Store the library suffix
   std::string libSuffix = "";

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -12,39 +12,31 @@
 
 namespace cudaq {
 
-kraus_op &kraus_op::operator=(const kraus_op &other) {
-  data = other.data;
-  return *this;
+template <typename ScalarType>
+bool isIdentity(const Eigen::MatrixX<ScalarType> &mat,
+                double threshold = 1e-9) {
+  Eigen::MatrixX<ScalarType> idMat =
+      Eigen::MatrixX<ScalarType>::Identity(mat.rows(), mat.cols());
+  return mat.isApprox(
+      Eigen::MatrixX<ScalarType>::Identity(mat.rows(), mat.cols()), threshold);
 }
 
-kraus_op kraus_op::adjoint() {
-  Eigen::Map<Eigen::MatrixXcd> map(data.data(), nRows, nCols);
-  Eigen::MatrixXcd adj = map.adjoint();
-  std::vector<complex> vec(adj.data(), adj.data() + adj.rows() * adj.cols());
-  return kraus_op(vec);
-}
-
-bool isIdentity(const Eigen::MatrixXcd &mat, double threshold = 1e-9) {
-  Eigen::MatrixXcd idMat = Eigen::MatrixXcd::Identity(mat.rows(), mat.cols());
-  return mat.isApprox(Eigen::MatrixXcd::Identity(mat.rows(), mat.cols()),
-                      threshold);
-}
-
-bool validateCPTP(const std::vector<Eigen::MatrixXcd> &mats,
+template <typename ScalarType>
+bool validateCPTP(const std::vector<Eigen::MatrixX<ScalarType>> &mats,
                   double threshold = 1e-9) {
   if (mats.empty()) {
     return true;
   }
 
-  Eigen::MatrixXcd cptp =
-      Eigen::MatrixXcd::Zero(mats[0].rows(), mats[0].cols());
+  Eigen::MatrixX<ScalarType> cptp =
+      Eigen::MatrixX<ScalarType>::Zero(mats[0].rows(), mats[0].cols());
   for (const auto &mat : mats) {
     cptp = cptp + mat.adjoint() * mat;
   }
   return isIdentity(cptp, threshold);
 }
 
-void kraus_channel::validateCompleteness() {
+void validateCompletenessRelation_fp32(const std::vector<kraus_op> &ops) {
   // First check that all the kraus_ops have the same size.
   auto size = ops[0].nRows;
   for (std::size_t i = 1; i < ops.size(); ++i)
@@ -52,9 +44,33 @@ void kraus_channel::validateCompleteness() {
       throw std::runtime_error(
           "Kraus ops passed to this channel do not all have the same size.");
 
-  std::vector<Eigen::MatrixXcd> matrices;
+  std::vector<Eigen::MatrixX<std::complex<float>>> matrices;
   for (auto &op : ops) {
-    Eigen::Map<Eigen::MatrixXcd> map(op.data.data(), op.nRows, op.nCols);
+    auto *nonConstPtr = const_cast<complex *>(op.data.data());
+    Eigen::Map<Eigen::MatrixX<std::complex<float>>> map(
+        reinterpret_cast<std::complex<float> *>(nonConstPtr), op.nRows,
+        op.nCols);
+    matrices.push_back(map);
+  }
+  if (!validateCPTP(matrices, 1e-4))
+    throw std::runtime_error(
+        "Provided kraus_ops are not completely positive and trace preserving.");
+}
+
+void validateCompletenessRelation_fp64(const std::vector<kraus_op> &ops) {
+  // First check that all the kraus_ops have the same size.
+  auto size = ops[0].nRows;
+  for (std::size_t i = 1; i < ops.size(); ++i)
+    if (ops[i].nRows != size)
+      throw std::runtime_error(
+          "Kraus ops passed to this channel do not all have the same size.");
+
+  std::vector<Eigen::MatrixX<std::complex<double>>> matrices;
+  for (auto &op : ops) {
+    auto *nonConstPtr = const_cast<complex *>(op.data.data());
+    Eigen::Map<Eigen::MatrixX<std::complex<double>>> map(
+        reinterpret_cast<std::complex<double> *>(nonConstPtr), op.nRows,
+        op.nCols);
     matrices.push_back(map);
   }
   if (!validateCPTP(matrices))
@@ -62,9 +78,7 @@ void kraus_channel::validateCompleteness() {
         "Provided kraus_ops are not completely positive and trace preserving.");
 }
 
-kraus_channel::kraus_channel( // std::vector<std::size_t> &qbits,
-    std::vector<kraus_op> &_ops)
-    : ops(_ops) {
+kraus_channel::kraus_channel(std::vector<kraus_op> &_ops) : ops(_ops) {
   validateCompleteness();
 }
 
@@ -79,7 +93,6 @@ std::size_t kraus_channel::dimension() const { return ops[0].nRows; }
 kraus_op &kraus_channel::operator[](const std::size_t idx) { return ops[idx]; }
 
 kraus_channel &kraus_channel::operator=(const kraus_channel &other) {
-  // qubits = other.qubits;
   ops = other.ops;
   return *this;
 }
@@ -136,36 +149,4 @@ noise_model::get_channels(const std::string &quantumOp,
   return iter->second;
 }
 
-depolarization_channel::depolarization_channel(const double p)
-    : kraus_channel() {
-  std::vector<complex> k0v{std::sqrt(1 - p), 0, 0, std::sqrt(1 - p)},
-      k1v{0, std::sqrt(p / 3.), std::sqrt(p / 3.), 0},
-      k2v{0, cudaq::complex{0, -1. * std::sqrt(p / 3.)},
-          cudaq::complex{0, std::sqrt(p / 3.)}, 0},
-      k3v{std::sqrt(p / 3.), 0, 0, -1. * std::sqrt(p / 3.)};
-  ops = {k0v, k1v, k2v, k3v};
-  validateCompleteness();
-}
-
-amplitude_damping_channel::amplitude_damping_channel(const double p)
-    : kraus_channel() {
-  std::vector<complex> k0v{1, 0, 0, std::sqrt(1 - p)},
-      k1v{0, 0, std::sqrt(p), 0};
-  ops = {k0v, k1v};
-  validateCompleteness();
-}
-
-bit_flip_channel::bit_flip_channel(const double p) : kraus_channel() {
-  std::vector<complex> k0v{std::sqrt(1 - p), 0, 0, std::sqrt(1 - p)},
-      k1v{0, std::sqrt(p), std::sqrt(p), 0};
-  ops = {k0v, k1v};
-  validateCompleteness();
-}
-
-phase_flip_channel::phase_flip_channel(const double p) : kraus_channel() {
-  std::vector<complex> k0v{std::sqrt(1 - p), 0, 0, std::sqrt(1 - p)},
-      k1v{std::sqrt(p), 0, 0, -1. * std::sqrt(p)};
-  ops = {k0v, k1v};
-  validateCompleteness();
-}
 } // namespace cudaq

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -73,9 +73,9 @@ struct kraus_op {
   kraus_op adjoint() const {
     std::size_t N = data.size();
     std::vector<cudaq::complex> newData(N);
-    for (std::size_t i = 0; i < N; i++)
-      for (std::size_t j = 0; j < N; j++)
-        newData[j * N + i] = std::conj(data[i * N + j]);
+    for (std::size_t i = 0; i < nRows; i++)
+      for (std::size_t j = 0; j < nCols; j++)
+        newData[i * nRows + j] = std::conj(data[j * nCols + i]);
     return kraus_op(newData);
   }
 };

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -8,14 +8,15 @@
 
 #pragma once
 
+#include "cudaq/host_config.h"
+
 #include <array>
 #include <complex>
+#include <math.h>
 #include <unordered_map>
 #include <vector>
 
 namespace cudaq {
-
-using complex = std::complex<double>;
 
 /// @brief A kraus_op represents a single Kraus operation,
 /// described as a complex matrix of specific size. The matrix
@@ -24,7 +25,7 @@ struct kraus_op {
 
   /// @brief Matrix data, represented as a 1d flattened
   // row major matrix.
-  std::vector<std::complex<double>> data;
+  std::vector<cudaq::complex> data;
 
   /// @brief The number of rows in the matrix
   std::size_t nRows = 0;
@@ -37,7 +38,7 @@ struct kraus_op {
   kraus_op(const kraus_op &) = default;
 
   /// @brief Constructor, initialize from vector data
-  kraus_op(std::vector<complex> d) : data(d) {
+  kraus_op(std::vector<cudaq::complex> d) : data(d) {
     auto nElements = d.size();
     auto sqrtNEl = std::sqrt(nElements);
     if (sqrtNEl * sqrtNEl != nElements)
@@ -63,11 +64,24 @@ struct kraus_op {
   }
 
   /// @brief Set this kraus_op equal to the other
-  kraus_op &operator=(const kraus_op &other);
+  kraus_op &operator=(const kraus_op &other) {
+    data = other.data;
+    return *this;
+  }
 
   /// @brief Return the adjoint of this kraus_op
-  kraus_op adjoint();
+  kraus_op adjoint() const {
+    std::size_t N = data.size();
+    std::vector<cudaq::complex> newData(N);
+    for (std::size_t i = 0; i < N; i++)
+      for (std::size_t j = 0; j < N; j++)
+        newData[j * N + i] = std::conj(data[i * N + j]);
+    return kraus_op(newData);
+  }
 };
+
+void validateCompletenessRelation_fp32(const std::vector<kraus_op> &ops);
+void validateCompletenessRelation_fp64(const std::vector<kraus_op> &ops);
 
 /// @brief A kraus_channel represents a quantum noise channel
 /// on specific qubits. The action of the noise channel is
@@ -83,7 +97,13 @@ protected:
   std::vector<kraus_op> ops;
 
   /// @brief Validate that Sum K_i^† K_i = I
-  void validateCompleteness();
+  void validateCompleteness() {
+    if constexpr (std::is_same_v<cudaq::complex::value_type, float>) {
+      validateCompletenessRelation_fp32(ops);
+      return;
+    }
+    validateCompletenessRelation_fp64(ops);
+  }
 
 public:
   ~kraus_channel() = default;
@@ -220,7 +240,20 @@ public:
 /// a single-qubit depolarization error channel.
 class depolarization_channel : public kraus_channel {
 public:
-  depolarization_channel(const double probability);
+  depolarization_channel(const real probability) : kraus_channel() {
+    auto three = static_cast<real>(3.);
+    auto negOne = static_cast<real>(-1.);
+    std::vector<cudaq::complex> k0v{std::sqrt(1 - probability), 0, 0,
+                                    std::sqrt(1 - probability)},
+        k1v{0, std::sqrt(probability / three), std::sqrt(probability / three),
+            0},
+        k2v{0, cudaq::complex{0, negOne * std::sqrt(probability / three)},
+            cudaq::complex{0, std::sqrt(probability / three)}, 0},
+        k3v{std::sqrt(probability / three), 0, 0,
+            negOne * std::sqrt(probability / three)};
+    ops = {k0v, k1v, k2v, k3v};
+    validateCompleteness();
+  }
 };
 
 /// @brief amplitude_damping_channel is a kraus_channel that
@@ -228,7 +261,12 @@ public:
 /// a single-qubit amplitude damping error channel.
 class amplitude_damping_channel : public kraus_channel {
 public:
-  amplitude_damping_channel(const double probability);
+  amplitude_damping_channel(const real probability) : kraus_channel() {
+    std::vector<cudaq::complex> k0v{1, 0, 0, std::sqrt(1 - probability)},
+        k1v{0, 0, std::sqrt(probability), 0};
+    ops = {k0v, k1v};
+    validateCompleteness();
+  }
 };
 
 /// @brief bit_flip_channel is a kraus_channel that
@@ -236,7 +274,13 @@ public:
 /// a single-qubit bit flipping error channel.
 class bit_flip_channel : public kraus_channel {
 public:
-  bit_flip_channel(const double probability);
+  bit_flip_channel(const real probability) : kraus_channel() {
+    std::vector<cudaq::complex> k0v{std::sqrt(1 - probability), 0, 0,
+                                    std::sqrt(1 - probability)},
+        k1v{0, std::sqrt(probability), std::sqrt(probability), 0};
+    ops = {k0v, k1v};
+    validateCompleteness();
+  }
 };
 
 /// @brief phase_flip_channel is a kraus_channel that
@@ -244,6 +288,13 @@ public:
 /// a single-qubit phase flip error channel.
 class phase_flip_channel : public kraus_channel {
 public:
-  phase_flip_channel(const double probability);
+  phase_flip_channel(const real probability) : kraus_channel() {
+    auto negOne = static_cast<real>(-1.);
+    std::vector<cudaq::complex> k0v{std::sqrt(1 - probability), 0, 0,
+                                    std::sqrt(1 - probability)},
+        k1v{std::sqrt(probability), 0, 0, negOne * std::sqrt(probability)};
+    ops = {k0v, k1v};
+    validateCompleteness();
+  }
 };
 } // namespace cudaq

--- a/runtime/common/SimulationState.h
+++ b/runtime/common/SimulationState.h
@@ -23,6 +23,7 @@ class TensorNetworkState {
 public:
   virtual std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() = 0;
   virtual std::unique_ptr<cudaq::SimulationState> toSimulationState() = 0;
+  virtual ~TensorNetworkState() {}
 };
 
 /// @brief state_data is a variant type

--- a/runtime/cudaq/CMakeLists.txt
+++ b/runtime/cudaq/CMakeLists.txt
@@ -15,6 +15,7 @@ set(INTERFACE_POSITION_INDEPENDENT_CODE ON)
 # Create the CUDA Quantum Library
 add_library(${LIBRARY_NAME} 
          SHARED cudaq.cpp 
+                target_control.cpp
                 algorithms/draw.cpp
                 qis/state.cpp
                 platform/quantum_platform.cpp 

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -69,8 +69,7 @@ concept KernelBuilderArgTypeIsValid =
           Args, float, double, std::size_t, int, std::vector<int>,             \
           std::vector<float>, std::vector<std::size_t>, std::vector<double>,   \
           std::vector<std::complex<float>>, std::vector<std::complex<double>>, \
-          std::vector<cudaq::simulation_scalar>, cudaq::qubit,                 \
-          cudaq::qvector<>> &&                                                 \
+          std::vector<cudaq::complex>, cudaq::qubit, cudaq::qvector<>> &&      \
       ...)
 #else
 // Not C++ 2020: stub these out.

--- a/runtime/cudaq/host_config.h
+++ b/runtime/cudaq/host_config.h
@@ -23,14 +23,14 @@ enum class simulation_precision { fp32, fp64 };
     defined(CUDAQ_SIMULATION_SCALAR_FP32)
 #error "Simulation precision cannot be both double and float"
 #elif defined(CUDAQ_SIMULATION_SCALAR_FP32)
-using simulation_scalar = std::complex<float>;
+using real = float;
 #elif defined(CUDAQ_SIMULATION_SCALAR_FP64)
-using simulation_scalar = std::complex<double>;
+using real = double;
 #else
 // If neither precision is specified, assume double.
-// Do NOT add the warning though as this fires hundreds of times during a build.
-// #pragma message("Simulation precision is unspecified, assuming double")
-using simulation_scalar = std::complex<double>;
+using real = double;
 #endif
+
+using complex = std::complex<real>;
 
 } // namespace cudaq

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -18,7 +18,6 @@
 namespace cudaq {
 class ExecutionContext;
 using SpinMeasureResult = std::pair<double, sample_result>;
-using complex = std::complex<double>;
 
 /// A QuditInfo is a type encoding the number of \a levels and the \a id of the
 /// qudit to the ExecutionManager.

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -418,7 +418,7 @@ void oneQubitSingleParameterApply(ScalarAngle angle, QubitArgs &...args) {
 
   // We just want to apply the same gate to all qubits provided
   for (auto &targetId : targets)
-    getExecutionManager()->apply(gateName, std::vector<ScalarAngle>{angle}, {},
+    getExecutionManager()->apply(gateName, std::vector<double>{angle}, {},
                                  {targetId});
 }
 

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -36,7 +36,7 @@ class qudit {
 public:
   /// Construct a qudit, will allocated a new unique index
   qudit() : idx(getExecutionManager()->getAvailableIndex(n_levels())) {}
-  qudit(const std::vector<simulation_scalar> &state) : qudit() {
+  qudit(const std::vector<complex> &state) : qudit() {
     if (state.size() != Levels)
       throw std::runtime_error(
           "Invalid number of state vector elements for qudit allocation (" +
@@ -45,14 +45,14 @@ public:
     auto norm =
         std::inner_product(
             state.begin(), state.end(), state.begin(),
-            simulation_scalar{0., 0.}, [](auto a, auto b) { return a + b; },
+            complex{0., 0.}, [](auto a, auto b) { return a + b; },
             [](auto a, auto b) { return std::conj(a) * b; })
             .real();
     if (std::fabs(1.0 - norm) > 1e-4)
       throw std::runtime_error("Invalid vector norm for qudit allocation.");
 
     // Perform the initialization
-    auto precision = std::is_same_v<simulation_scalar::value_type, float>
+    auto precision = std::is_same_v<complex::value_type, float>
                          ? simulation_precision::fp32
                          : simulation_precision::fp64;
     getExecutionManager()->initializeState({QuditInfo(n_levels(), idx)},

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -42,12 +42,11 @@ public:
           "Invalid number of state vector elements for qudit allocation (" +
           std::to_string(state.size()) + ").");
 
-    auto norm =
-        std::inner_product(
-            state.begin(), state.end(), state.begin(),
-            complex{0., 0.}, [](auto a, auto b) { return a + b; },
-            [](auto a, auto b) { return std::conj(a) * b; })
-            .real();
+    auto norm = std::inner_product(
+                    state.begin(), state.end(), state.begin(), complex{0., 0.},
+                    [](auto a, auto b) { return a + b; },
+                    [](auto a, auto b) { return std::conj(a) * b; })
+                    .real();
     if (std::fabs(1.0 - norm) > 1e-4)
       throw std::runtime_error("Invalid vector norm for qudit allocation.");
 

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -10,15 +10,7 @@
 
 #include "execution_manager.h"
 
-using namespace std::complex_literals;
-
 namespace cudaq {
-using complex = std::complex<double>;
-
-namespace ket {
-inline static const std::vector<complex> zero{1. + 0i, 0. + 0i};
-inline static const std::vector<complex> one{0. + 0i, 1. + 0i};
-} // namespace ket
 
 /// The qudit models a general d-level quantum system.
 /// This type is templated on the number of levels d.

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -40,12 +40,11 @@ public:
             "elements must be power of 2.");
     }
 
-    auto norm =
-        std::inner_product(
-            vector.begin(), vector.end(), vector.begin(),
-            complex{0., 0.}, [](auto a, auto b) { return a + b; },
-            [](auto a, auto b) { return std::conj(a) * b; })
-            .real();
+    auto norm = std::inner_product(
+                    vector.begin(), vector.end(), vector.begin(),
+                    complex{0., 0.}, [](auto a, auto b) { return a + b; },
+                    [](auto a, auto b) { return std::conj(a) * b; })
+                    .real();
     if (std::fabs(1.0 - norm) > 1e-4)
       throw std::runtime_error("Invalid vector norm for qudit allocation.");
 

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -30,7 +30,7 @@ public:
   /// @brief Construct a `qvector` with `size` qudits in the |0> state.
   qvector(std::size_t size) : qudits(size) {}
 
-  qvector(const std::vector<simulation_scalar> &vector)
+  qvector(const std::vector<complex> &vector)
       : qudits(std::log2(vector.size())) {
     if (Levels == 2) {
       auto numElements = std::log2(vector.size());
@@ -43,7 +43,7 @@ public:
     auto norm =
         std::inner_product(
             vector.begin(), vector.end(), vector.begin(),
-            simulation_scalar{0., 0.}, [](auto a, auto b) { return a + b; },
+            complex{0., 0.}, [](auto a, auto b) { return a + b; },
             [](auto a, auto b) { return std::conj(a) * b; })
             .real();
     if (std::fabs(1.0 - norm) > 1e-4)
@@ -53,19 +53,19 @@ public:
     for (auto &q : qudits)
       targets.emplace_back(QuditInfo{Levels, q.id()});
 
-    auto precision = std::is_same_v<simulation_scalar::value_type, float>
+    auto precision = std::is_same_v<complex::value_type, float>
                          ? simulation_precision::fp32
                          : simulation_precision::fp64;
     getExecutionManager()->initializeState(targets, vector.data(), precision);
   }
 
-  // FIXME do we need float versions?
+  // // FIXME do we need float versions?
   qvector(const std::vector<double> &vector)
-      : qvector(std::vector<simulation_scalar>{vector.begin(), vector.end()}) {}
+      : qvector(std::vector<complex>{vector.begin(), vector.end()}) {}
   qvector(const std::initializer_list<double> &list)
-      : qvector(std::vector<simulation_scalar>{list.begin(), list.end()}) {}
+      : qvector(std::vector<complex>{list.begin(), list.end()}) {}
   qvector(const std::initializer_list<complex> &list)
-      : qvector(std::vector<simulation_scalar>{list.begin(), list.end()}) {}
+      : qvector(std::vector<complex>{list.begin(), list.end()}) {}
 
   /// @cond
   /// Nullary constructor

--- a/runtime/cudaq/target_control.cpp
+++ b/runtime/cudaq/target_control.cpp
@@ -1,0 +1,15 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#include "target_control.h"
+
+namespace cudaq::__internal__ {
+static bool targetModificationKillSwitch = false;
+void enableTargetModification() { targetModificationKillSwitch = true; }
+void disableTargetModification() { targetModificationKillSwitch = false; }
+bool canModifyTarget() { return targetModificationKillSwitch; }
+} // namespace cudaq::__internal__

--- a/runtime/cudaq/target_control.cpp
+++ b/runtime/cudaq/target_control.cpp
@@ -8,8 +8,8 @@
 #include "target_control.h"
 
 namespace cudaq::__internal__ {
-static bool targetModificationKillSwitch = false;
-void enableTargetModification() { targetModificationKillSwitch = true; }
-void disableTargetModification() { targetModificationKillSwitch = false; }
-bool canModifyTarget() { return targetModificationKillSwitch; }
+static bool m_CanModifyTarget = true;
+void enableTargetModification() { m_CanModifyTarget = true; }
+void disableTargetModification() { m_CanModifyTarget = false; }
+bool canModifyTarget() { return m_CanModifyTarget; }
 } // namespace cudaq::__internal__

--- a/runtime/cudaq/target_control.h
+++ b/runtime/cudaq/target_control.h
@@ -1,0 +1,25 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+namespace cudaq::__internal__ {
+
+/// @brief Provide an API call that enables
+/// target modification at runtime (primarily used by
+/// runtime execution environments, like Python).
+void enableTargetModification();
+
+/// @brief Provide an API call that disables
+/// target modification at runtime (primarily used by
+/// runtime execution environments, like Python).
+void disableTargetModification();
+
+/// @brief Provide an API call that returns
+/// true if the target is modifiable at runtime.
+bool canModifyTarget();
+} // namespace cudaq::__internal__

--- a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
+++ b/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
@@ -335,7 +335,7 @@ protected:
         reinterpret_cast<CudaDataType *>(otherState),
         reinterpret_cast<CudaDataType *>(newDeviceStateVector));
     HANDLE_CUDA_ERROR(cudaGetLastError());
-
+    
     // Free the old vectors we don't need anymore.
     HANDLE_CUDA_ERROR(cudaFree(deviceStateVector));
     HANDLE_CUDA_ERROR(cudaFree(otherState));

--- a/targettests/execution/from_state.cpp
+++ b/targettests/execution/from_state.cpp
@@ -11,14 +11,14 @@
 
 #include <cudaq.h>
 
-__qpu__ void test(std::vector<cudaq::simulation_scalar> inState) {
+__qpu__ void test(std::vector<cudaq::complex> inState) {
   cudaq::qvector q = inState;
 }
 
 // CHECK: size 2
 
 int main() {
-  std::vector<cudaq::simulation_scalar> vec{M_SQRT1_2, 0., 0., M_SQRT1_2};
+  std::vector<cudaq::complex> vec{M_SQRT1_2, 0., 0., M_SQRT1_2};
   auto counts = cudaq::sample(test, vec);
   counts.dump();
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -300,7 +300,7 @@ if (CUDAQ_ENABLE_PYTHON)
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
     target_link_options(test_domains PRIVATE -Wl,--no-as-needed)
   endif()
-  target_compile_definitions(test_domains PRIVATE -DNVQIR_BACKEND_NAME=qpp)
+  target_compile_definitions(test_domains PRIVATE -DNVQIR_BACKEND_NAME=qpp -DCUDAQ_SIMULATION_SCALAR_FP64)
   target_include_directories(test_domains PRIVATE .)
   set_property(TARGET test_domains PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python")
   target_link_libraries(test_domains

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -307,7 +307,7 @@ if (CUDAQ_ENABLE_PYTHON)
     PRIVATE 
     cudaq
     cudaq-platform-default
-    nvqir nvqir-custatevec-fp32
+    nvqir nvqir-qpp
     cudaq-spin
     cudaq-chemistry
     cudaq-pyscf

--- a/unittests/domains/ChemistryTester.cpp
+++ b/unittests/domains/ChemistryTester.cpp
@@ -131,7 +131,7 @@ CUDAQ_TEST(H2MoleculeTester, checkUCCSD) {
     auto eigenVectors = matrix.eigenvectors();
 
     // Map it to a cudaq::state
-    std::vector<std::complex<float>> expectedData(eigenVectors.rows());
+    std::vector<cudaq::complex> expectedData(eigenVectors.rows());
     for (std::size_t i = 0; i < eigenVectors.rows(); i++)
       expectedData[i] = eigenVectors(i, 0);
     auto groundState = cudaq::get_state(ansatz, std::get<1>(res));

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -1206,7 +1206,7 @@ CUDAQ_TEST(BuilderTester, checkControlledRotations) {
 #if !defined(CUDAQ_BACKEND_DM) && !defined(CUDAQ_BACKEND_TENSORNET)
 
 TEST(BuilderTester, checkFromStateVector) {
-  std::vector<cudaq::simulation_scalar> vec{M_SQRT1_2, 0., 0., M_SQRT1_2};
+  std::vector<cudaq::complex> vec{M_SQRT1_2, 0., 0., M_SQRT1_2};
   {
     auto kernel = cudaq::make_kernel();
     auto qubits = kernel.qalloc(vec);
@@ -1224,7 +1224,7 @@ TEST(BuilderTester, checkFromStateVector) {
 
   {
     auto [kernel, initState] =
-        cudaq::make_kernel<std::vector<cudaq::simulation_scalar>>();
+        cudaq::make_kernel<std::vector<cudaq::complex>>();
     auto qubits = kernel.qalloc(initState);
     std::cout << kernel << "\n";
     auto counts = cudaq::sample(kernel, vec);
@@ -1240,9 +1240,9 @@ TEST(BuilderTester, checkFromStateVector) {
 
   {
     // 2 qubit 11 state
-    std::vector<cudaq::simulation_scalar> vec{0., 0., 0., 1.};
+    std::vector<cudaq::complex> vec{0., 0., 0., 1.};
     auto [kernel, initState] =
-        cudaq::make_kernel<std::vector<cudaq::simulation_scalar>>();
+        cudaq::make_kernel<std::vector<cudaq::complex>>();
     auto qubits = kernel.qalloc(initState);
     // induce the need for a kron prod between
     // [0,0,0,1] and [1, 0, 0, 0]
@@ -1256,9 +1256,9 @@ TEST(BuilderTester, checkFromStateVector) {
 
   {
     // 2 qubit 11 state
-    std::vector<cudaq::simulation_scalar> vec{0., 0., 0., 1.};
+    std::vector<cudaq::complex> vec{0., 0., 0., 1.};
     auto [kernel, initState] =
-        cudaq::make_kernel<std::vector<cudaq::simulation_scalar>>();
+        cudaq::make_kernel<std::vector<cudaq::complex>>();
     auto qubits = kernel.qalloc(initState);
     // induce the need for a kron prod between
     // [0,0,0,1] and [1, 0]

--- a/unittests/integration/get_state_tester.cpp
+++ b/unittests/integration/get_state_tester.cpp
@@ -52,9 +52,14 @@ CUDAQ_TEST(GetStateTester, checkSimple) {
     x(q);
   };
 
-  // Check <00|Bell> = 1/sqrt(2)
+// Check <00|Bell> = 1/sqrt(2)
+#ifdef CUDAQ_BACKEND_DM
+  EXPECT_NEAR(state.overlap(cudaq::get_state(kernelNoop)).real(), (1. / 2.),
+              1e-3);
+#else
   EXPECT_NEAR(state.overlap(cudaq::get_state(kernelNoop)).real(),
               1. / std::sqrt(2.), 1e-3);
+#endif
 
   auto kernelX = []() __qpu__ {
     cudaq::qubit q, r;
@@ -62,9 +67,13 @@ CUDAQ_TEST(GetStateTester, checkSimple) {
     x(r);
   };
 
-  // Check <11|Bell> = 1/sqrt(2)
+// Check <11|Bell> = 1/sqrt(2)
+#ifdef CUDAQ_BACKEND_DM
+  EXPECT_NEAR(state.overlap(cudaq::get_state(kernelX)).real(), 1. / 2., 1e-3);
+#else
   EXPECT_NEAR(state.overlap(cudaq::get_state(kernelX)).real(),
               1. / std::sqrt(2.), 1e-3);
+#endif
 
   // Check endianess of basis state
   auto kernel1 = []() __qpu__ {

--- a/unittests/integration/qubit_allocation.cpp
+++ b/unittests/integration/qubit_allocation.cpp
@@ -49,7 +49,6 @@ CUDAQ_TEST(AllocationTester, checkSimple) {
   EXPECT_EQ(c, 1000);
 }
 
-
 #ifdef CUDAQ_BACKEND_DM
 // Tests for a previous bug in the density simulator, where
 // the qubit ordering flipped after resizing the density matrix


### PR DESCRIPTION
Per the language specification meeting - prefer `cudaq::complex` over `cudaq::simulation_scalar`, and introduce `cudaq::real`. 

Refactor `NoiseModel` to adhere to the simulation scalar type. 

Address #1539 
