### PR TITLE
Work on `qalloc` with input = raw vectors

### DIFF
--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -65,7 +65,23 @@ protected:
                        cudaq::simulation_precision precision) override {
     // Here we have qubits in requestedAllocations
     // want to allocate and set state
-    simulator()->allocateQubits(requestedAllocations.size(), state, precision);
+    // There could be previous 'default' allocations whereby we just cached them
+    // in requestedAllocations.
+    // These default allocations need to be dispatched separately.
+    // FIXME: this assumes no qubit reuse, aka the qubits in targets are the
+    // last ones to be allocated. This is consistent with the Kronecker product
+    // assumption in CircuitSimulator.
+    if (targets.size() != requestedAllocations.size()) {
+      assert(targets.size() < requestedAllocations.size());
+      const auto numDefaultAllocs =
+          requestedAllocations.size() - targets.size();
+      simulator()->allocateQubits(numDefaultAllocs);
+      // The targets will be allocated in a specific state.
+      simulator()->allocateQubits(targets.size(), state, precision);
+    } else {
+      simulator()->allocateQubits(requestedAllocations.size(), state,
+                                  precision);
+    }
     requestedAllocations.clear();
   }
 

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -51,6 +51,29 @@ public:
                                                       m_cutnHandle);
   }
 
+  void addQubitsToState(std::size_t numQubits, const void *ptr) override {
+    LOG_API_TIME();
+    if (!m_state) {
+      if (!ptr) {
+        m_state = std::make_unique<TensorNetState>(numQubits, m_cutnHandle);
+      } else {
+        auto *casted =
+            reinterpret_cast<std::complex<double> *>(const_cast<void *>(ptr));
+        std::span<std::complex<double>> stateVec(casted, 1ULL << numQubits);
+        m_state = TensorNetState::createFromStateVector(stateVec, m_cutnHandle);
+      }
+    } else {
+      if (!ptr) {
+        m_state->addQubits(numQubits);
+      } else {
+        auto *casted =
+            reinterpret_cast<std::complex<double> *>(const_cast<void *>(ptr));
+        std::span<std::complex<double>> stateVec(casted, 1ULL << numQubits);
+        m_state->addQubits(stateVec);
+      }
+    }
+  }
+
 private:
   friend nvqir::CircuitSimulator * ::getCircuitSimulator_tensornet();
   /// @brief Has cuTensorNet MPI been initialized?

--- a/runtime/nvqir/cutensornet/tensornet_state.h
+++ b/runtime/nvqir/cutensornet/tensornet_state.h
@@ -7,13 +7,13 @@
  ******************************************************************************/
 
 #pragma once
+#include "common/EigenDense.h"
+#include "common/SimulationState.h"
 #include "cutensornet.h"
 #include "tensornet_utils.h"
 #include "timing_utils.h"
+#include <span>
 #include <unordered_map>
-
-#include "common/EigenDense.h"
-#include "common/SimulationState.h"
 
 namespace nvqir {
 /// This is used to track whether the tensor state is default initialized vs
@@ -79,7 +79,7 @@ public:
   // is required if users have a state vector that they want to initialize the
   // tensor network simulator with.
   static std::unique_ptr<TensorNetState>
-  createFromStateVector(const std::vector<std::complex<double>> &stateVec,
+  createFromStateVector(std::span<std::complex<double>> stateVec,
                         cutensornetHandle_t handle);
 
   /// @brief Apply a unitary gate
@@ -93,6 +93,14 @@ public:
   /// @param proj_d Projector matrix (expected a 2x2 matrix in column major)
   /// @param qubitIdx Qubit operand
   void applyQubitProjector(void *proj_d, const std::vector<int32_t> &qubitIdx);
+
+  /// @brief Add a number of qubits to the state.
+  /// The qubits will be initialized to zero.
+  void addQubits(std::size_t numQubits);
+
+  /// @brief Add a number of qubits in a specific superposition to the current
+  /// state. The size of the wave function determines the number of qubits.
+  void addQubits(std::span<std::complex<double>> stateVec);
 
   /// @brief Accessor to the cuTensorNet handle (context).
   cutensornetHandle_t getInternalContext() { return m_cutnHandle; }

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -185,9 +185,9 @@ protected:
 
   /// @brief Override the default sized allocation of qubits
   /// here to be a bit more efficient than the default implementation
-  void addQubitsToState(std::size_t count,
+  void addQubitsToState(std::size_t qubitCount,
                         const void *stateDataIn = nullptr) override {
-    if (count == 0)
+    if (qubitCount == 0)
       return;
 
     auto *stateData = reinterpret_cast<std::complex<double> *>(
@@ -202,16 +202,15 @@ protected:
         state = qpp::ket::Map(stateData, stateDimension);
       return;
     }
-
     // If we are resizing an existing, allocate
     // a zero state on a n qubit, and Kron-prod
     // that with the existing state.
     if (stateData == nullptr) {
-      qpp::ket zero_state = qpp::ket::Zero((1UL << count));
+      qpp::ket zero_state = qpp::ket::Zero((1UL << qubitCount));
       zero_state(0) = 1.0;
       state = qpp::kron(zero_state, state);
     } else {
-      qpp::ket initState = qpp::ket::Map(stateData, count);
+      qpp::ket initState = qpp::ket::Map(stateData, (1UL << qubitCount));
       state = qpp::kron(initState, state);
     }
     return;

--- a/unittests/integration/qubit_allocation.cpp
+++ b/unittests/integration/qubit_allocation.cpp
@@ -36,6 +36,25 @@ struct test_resizing {
   }
 };
 
+struct test_bell_init {
+  void operator()() __qpu__ {
+    // Start with an initial allocation of 2 qubits in a specific state.
+    cudaq::qvector q({M_SQRT1_2, 0.0, 0.0, M_SQRT1_2});
+    mz(q);
+  }
+};
+
+struct test_state_expand_init {
+  void operator()() __qpu__ {
+    cudaq::qvector q(2);
+    x(q);
+    // Add 2 more qubits in Bell state
+    cudaq::qvector q1({M_SQRT1_2, 0.0, 0.0, M_SQRT1_2});
+    mz(q);
+    mz(q1);
+  }
+};
+
 CUDAQ_TEST(AllocationTester, checkSimple) {
   test_allocation{}();
 
@@ -49,6 +68,26 @@ CUDAQ_TEST(AllocationTester, checkSimple) {
   EXPECT_EQ(c, 1000);
 }
 
+CUDAQ_TEST(AllocationTester, checkSetState) {
+  auto counts = cudaq::sample(test_bell_init{});
+  EXPECT_EQ(2, counts.size());
+  int c = 0;
+  for (auto &[bits, count] : counts) {
+    c += count;
+    EXPECT_TRUE(bits == "00" || bits == "11");
+  }
+}
+
+CUDAQ_TEST(AllocationTester, checkSetStateExpandRegister) {
+  auto counts = cudaq::sample(test_state_expand_init{});
+  EXPECT_EQ(2, counts.size());
+  counts.dump();
+  int c = 0;
+  for (auto &[bits, count] : counts) {
+    c += count;
+    EXPECT_TRUE(bits == "1100" || bits == "1111");
+  }
+}
 
 #ifdef CUDAQ_BACKEND_DM
 // Tests for a previous bug in the density simulator, where


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- Implementation

 - [x] tensornet
 - [x] dm
 - [ ] mps
 - [x] qpp (minor fix) 

- Fix an issue whereby there are default `qvector` declarations (no state init) before a `qvector` declaration with initial vector. We need to dispatch those alloc calls to the simulator separately.

- Add tests
