### PR TITLE
Merge main and CI fixes

### DIFF
--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -53,7 +53,25 @@ Common
 
 .. doxygenclass:: cudaq::SimulationState
 
+.. doxygenstruct:: cudaq::SimulationState::Tensor
+    :members:
+
+.. doxygenenum:: cudaq::SimulationState::precision
+
+.. doxygenenum:: cudaq::simulation_precision
+
+.. doxygentypedef:: cudaq::tensor
+
+.. doxygentypedef:: cudaq::state_data
+
 .. doxygenclass:: cudaq::CusvState
+
+.. doxygenclass:: cudaq::TensorNetworkState
+
+.. doxygenclass:: nvqir::MPSSimulationState
+
+.. doxygenclass:: nvqir::TensorNetSimulationState
+
 
 .. doxygenclass:: cudaq::registry::RegisteredType
     :members:

--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -92,6 +92,8 @@ Data Types
 .. autoclass:: cudaq::State
     :members:
 
+.. autoclass:: cudaq::Tensor
+
 .. autoclass:: cudaq::QuakeValue
 
     .. automethod:: __add__

--- a/docs/sphinx/releases.rst
+++ b/docs/sphinx/releases.rst
@@ -19,7 +19,7 @@ Check out our `documentation <https://nvidia.github.io/cuda-quantum/latest/using
 to get started with the new Python syntax support we have added, and `follow our blog <https://developer.nvidia.com/cuda-q>`__
 to learn more about the new setup and its performance benefits.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/>`__
 - `C++ installer <https://github.com/NVIDIA/cuda-quantum/releases>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.7.0>`__
@@ -40,7 +40,7 @@ The binaries are built against the `GNU C library <https://www.gnu.org/software/
 version 2.28.
 We've added a detailed :doc:`Building from Source <using/install/data_center_install>` guide to build these binaries for older `glibc` versions.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.6.0>`__
 - `C++ installer <https://github.com/NVIDIA/cuda-quantum/releases/0.6.0>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.6.0>`__
@@ -57,7 +57,7 @@ The 0.5.0 release furthermore improves the tensor network simulation tools and a
 Additionally, we are now publishing images for experimental features, which currently includes improved Python language support.
 Please take a look at :doc:`using/install/install` for more information about how to obtain them.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.5.0>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.5.0>`__
 - `Examples <https://github.com/NVIDIA/cuda-quantum/tree/releases/v0.5.0/docs/sphinx/examples>`__
@@ -68,7 +68,7 @@ The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/r
 
 The 0.4.1 release adds support for ARM processors in the form of multi-platform Docker images and `aarch64` Python wheels. Additionally, all GPU-based backends are now included in the Python wheels as well as in the Docker image.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.4.1>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.4.1>`__
 - `Examples <https://github.com/NVIDIA/cuda-quantum/tree/releases/v0.4.1/docs/sphinx/examples>`__
@@ -83,7 +83,7 @@ The 0.4.0 release adds support for quantum kernel execution on Quantinuum and Io
 The 0.4.0 PyPI release does not yet include all of the GPU-based backends.
 The fully featured version is available as a Docker image for `linux/amd64` platforms.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.4.0>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.4.0>`__
 - `Examples <https://github.com/NVIDIA/cuda-quantum/tree/0.4.0/docs/sphinx/examples>`__
@@ -94,6 +94,6 @@ The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/r
 
 The 0.3.0 release of CUDA Quantum is available as a Docker image for `linux/amd64` platforms.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.3.0>`__
 - `Examples <https://github.com/NVIDIA/cuda-quantum/tree/0.3.0/docs/sphinx/examples>`__

--- a/docs/sphinx/using/install/local_installation.rst
+++ b/docs/sphinx/using/install/local_installation.rst
@@ -34,7 +34,7 @@ If you do not have the necessary administrator permissions to install software o
 take a look at the section below on how to use `Singularity`_ instead.
 
 Docker images for all CUDA Quantum releases are available on the `NGC Container Registry`_.
-In addition to publishing `stable releases <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__, 
+In addition to publishing `stable releases <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__, 
 we also publish Docker images whenever we update certain branches on our `GitHub repository <https://github.com/NVIDIA/cuda-quantum>`_.
 These images are published in our `nightly channel on NGC <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nightly/containers/cuda-quantum/tags>`__.
 To download the latest version on the main branch of our GitHub repository, for example, use the command
@@ -43,7 +43,7 @@ To download the latest version on the main branch of our GitHub repository, for 
 
     docker pull nvcr.io/nvidia/nightly/cuda-quantum:latest
 
-.. _NGC Container Registry: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum
+.. _NGC Container Registry: https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum
 
 Early prototypes for features we are considering can be tried out by using the image tags starting 
 with `experimental`. The `README` in the `/home/cudaq` folder in the container gives more details 
@@ -129,7 +129,7 @@ Once you have singularity installed, create a file `cuda-quantum.def` with the f
         bash
 
 Replace the image name and/or tag in the `From` line, if necessary, with the one you want to use;
-In addition to publishing `stable releases <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__, 
+In addition to publishing `stable releases <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__, 
 we also publish Docker images whenever we update certain branches on our `GitHub repository <https://github.com/NVIDIA/cuda-quantum>`_.
 These images are published in our `nightly channel on NGC <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nightly/containers/cuda-quantum/tags>`__.
 Early prototypes for features we are considering can be tried out by using the image tags starting 

--- a/docs/sphinx/using/quick_start.rst
+++ b/docs/sphinx/using/quick_start.rst
@@ -14,7 +14,7 @@ programming in Python and in C++.
 
 This Quick Start page guides you through installing CUDA Quantum and running your first program.
 If you have already installed and configured CUDA Quantum, or if you are using our 
-`Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum>`_, you can move directly to our
+`Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum>`_, you can move directly to our
 :doc:`Basics Section <basics/basics>`. More information about working with containers and Docker alternatives can be 
 found in our complete :doc:`Installation Guide <install/install>`.
 

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -29,6 +29,8 @@ Pauli = cudaq_runtime.Pauli
 Kernel = PyKernel
 Target = cudaq_runtime.Target
 State = cudaq_runtime.State
+Tensor = cudaq_runtime.Tensor
+SimulationPrecision = cudaq_runtime.SimulationPrecision
 pauli_word = cudaq_runtime.pauli_word
 
 # to be deprecated

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -877,10 +877,11 @@ def test_recursive_calls():
 
     print(kernel3)
 
-  
+
 skipIfNvidiaFP64NotInstalled = pytest.mark.skipif(
-  not cudaq.has_target('nvidia-fp64'),
-  reason='Could not find nvidia-fp64 in installation')
+    not (cudaq.num_available_gpus() > 0 and cudaq.has_target('nvidia-fp64')),
+    reason='Could not find nvidia-fp64 in installation')
+
 
 @skipIfNvidiaFP64NotInstalled
 def test_from_state0():
@@ -944,10 +945,12 @@ def test_from_state0():
 
     cudaq.reset_target()
 
+
 skipIfNvidiaNotInstalled = pytest.mark.skipif(
-  not cudaq.has_target('nvidia'),
-  reason='Could not find nvidia in installation')
-  
+    not (cudaq.num_available_gpus() > 0 and cudaq.has_target('nvidia')),
+    reason='Could not find nvidia in installation')
+
+
 @skipIfNvidiaNotInstalled
 def test_from_state1():
     cudaq.set_target('nvidia')
@@ -986,7 +989,7 @@ def test_from_state1():
     assert '11' in counts
     assert '00' in counts
 
-    state = cudaq.create_state(np.array([.5]*4))
+    state = cudaq.create_state(np.array([.5] * 4))
     kernel2 = cudaq.make_kernel()
     qubits = kernel2.qalloc(state)
     counts = cudaq.sample(kernel2)

--- a/python/tests/kernel/test_state_kernel.py
+++ b/python/tests/kernel/test_state_kernel.py
@@ -20,12 +20,17 @@ skipIfPythonLessThan39 = pytest.mark.skipif(
     reason="built-in collection types such as `list` not supported")
 
 
+skipIfNoGQPU = pytest.mark.skipif(
+    not cudaq.has_target('nvidia'),
+    reason="nvidia-mqpu backend not available")
+
 @pytest.fixture(autouse=True)
 def do_something():
     yield
     cudaq.__clearKernelRegistries()
 
 
+@skipIfNoGQPU
 def test_state_vector_simple():
     """
     A simple end-to-end test of the state class on a state vector

--- a/python/tests/kernel/test_state_kernel.py
+++ b/python/tests/kernel/test_state_kernel.py
@@ -19,10 +19,10 @@ skipIfPythonLessThan39 = pytest.mark.skipif(
     sys.version_info < (3, 9),
     reason="built-in collection types such as `list` not supported")
 
-
 skipIfNoGQPU = pytest.mark.skipif(
-    not cudaq.has_target('nvidia'),
-    reason="nvidia-mqpu backend not available")
+    not (cudaq.num_available_gpus() > 0 and cudaq.has_target('nvidia')),
+    reason="nvidia backend not available")
+
 
 @pytest.fixture(autouse=True)
 def do_something():
@@ -38,6 +38,7 @@ def test_state_vector_simple():
     its member functions.
     """
     cudaq.set_target('nvidia-fp64')
+
     @cudaq.kernel
     def bell():
         qubits = cudaq.qvector(2)
@@ -47,10 +48,11 @@ def test_state_vector_simple():
     # Get the quantum state, which should be a vector.
     got_state = cudaq.get_state(bell)
 
-    want_state = cudaq.State.from_data(np.array([1. / np.sqrt(2.), 0., 0., 1. / np.sqrt(2.)],
-                          dtype=np.complex128))
-    
-    assert len(want_state) == 4 
+    want_state = cudaq.State.from_data(
+        np.array([1. / np.sqrt(2.), 0., 0., 1. / np.sqrt(2.)],
+                 dtype=np.complex128))
+
+    assert len(want_state) == 4
 
     # Check the indexing operators on the State class
     # while also checking their values

--- a/runtime/common/SimulationState.h
+++ b/runtime/common/SimulationState.h
@@ -23,6 +23,7 @@ class TensorNetworkState {
 public:
   virtual std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() = 0;
   virtual std::unique_ptr<cudaq::SimulationState> toSimulationState() = 0;
+  virtual ~TensorNetworkState() {}
 };
 
 /// @brief state_data is a variant type

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -18,7 +18,6 @@
 namespace cudaq {
 class ExecutionContext;
 using SpinMeasureResult = std::pair<double, sample_result>;
-using complex = std::complex<double>;
 
 /// A QuditInfo is a type encoding the number of \a levels and the \a id of the
 /// qudit to the ExecutionManager.

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -97,8 +97,8 @@ protected:
 public:
   ExecutionManager() = default;
 
-  /// Return the next available qudit index
-  virtual std::size_t getAvailableIndex(std::size_t quditLevels = 2) = 0;
+  /// Allocates a qudit and returns its identifier (index).
+  virtual std::size_t allocateQudit(std::size_t quditLevels = 2) = 0;
 
   /// QuditInfo has been deallocated, return the qudit / id to the pool of
   /// qudits.

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -18,6 +18,7 @@
 namespace cudaq {
 class ExecutionContext;
 using SpinMeasureResult = std::pair<double, sample_result>;
+using complex = std::complex<double>;
 
 /// A QuditInfo is a type encoding the number of \a levels and the \a id of the
 /// qudit to the ExecutionManager.

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -123,7 +123,7 @@ public:
     executionContext = nullptr;
   }
 
-  std::size_t getAvailableIndex(std::size_t quditLevels) override {
+  std::size_t allocateQudit(std::size_t quditLevels) override {
     auto new_id = getNextIndex();
     if (isInTracerMode())
       return new_id;

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -10,7 +10,15 @@
 
 #include "execution_manager.h"
 
+using namespace std::complex_literals;
+
 namespace cudaq {
+using complex = std::complex<double>;
+
+namespace ket {
+inline static const std::vector<complex> zero{1. + 0i, 0. + 0i};
+inline static const std::vector<complex> one{0. + 0i, 1. + 0i};
+} // namespace ket
 
 /// The qudit models a general d-level quantum system.
 /// This type is templated on the number of levels d.

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -35,7 +35,7 @@ class qudit {
 
 public:
   /// Construct a qudit, will allocated a new unique index
-  qudit() : idx(getExecutionManager()->getAvailableIndex(n_levels())) {}
+  qudit() : idx(getExecutionManager()->allocateQudit(n_levels())) {}
   qudit(const std::vector<simulation_scalar> &state) : qudit() {
     if (state.size() != Levels)
       throw std::runtime_error(

--- a/runtime/cudaq/qis/qudit.h
+++ b/runtime/cudaq/qis/qudit.h
@@ -10,15 +10,7 @@
 
 #include "execution_manager.h"
 
-using namespace std::complex_literals;
-
 namespace cudaq {
-using complex = std::complex<double>;
-
-namespace ket {
-inline static const std::vector<complex> zero{1. + 0i, 0. + 0i};
-inline static const std::vector<complex> one{0. + 0i, 1. + 0i};
-} // namespace ket
 
 /// The qudit models a general d-level quantum system.
 /// This type is templated on the number of levels d.

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <qpp.h>
 #include <set>
+#include <span>
 
 using namespace cudaq;
 
@@ -42,9 +43,14 @@ struct QppState : public cudaq::SimulationState {
         (other.getTensor().extents != getTensor().extents))
       throw std::runtime_error("[qpp-state] overlap error - other state "
                                "dimension not equal to this state dimension.");
-    return state.transpose().dot(Eigen::Map<qpp::ket>(
+    std::span<std::complex<double>> otherState(
         reinterpret_cast<std::complex<double> *>(other.getTensor().data),
-        other.getTensor().extents[0]));
+        other.getTensor().extents[0]);
+    return std::inner_product(
+               state.begin(), state.end(), otherState.begin(),
+               simulation_scalar{0., 0.}, [](auto a, auto b) { return a + b; },
+               [](auto a, auto b) { return std::abs(a * std::conj(b)); })
+        .real();
   }
 
   std::complex<double>

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -300,7 +300,7 @@ if (CUDAQ_ENABLE_PYTHON)
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
     target_link_options(test_domains PRIVATE -Wl,--no-as-needed)
   endif()
-  target_compile_definitions(test_domains PRIVATE -DNVQIR_BACKEND_NAME=qpp)
+  target_compile_definitions(test_domains PRIVATE -DNVQIR_BACKEND_NAME=qpp -DCUDAQ_SIMULATION_SCALAR_FP64)
   target_include_directories(test_domains PRIVATE .)
   set_property(TARGET test_domains PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python")
   target_link_libraries(test_domains

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -307,7 +307,7 @@ if (CUDAQ_ENABLE_PYTHON)
     PRIVATE 
     cudaq
     cudaq-platform-default
-    nvqir nvqir-custatevec-fp32
+    nvqir nvqir-qpp
     cudaq-spin
     cudaq-chemistry
     cudaq-pyscf

--- a/unittests/domains/ChemistryTester.cpp
+++ b/unittests/domains/ChemistryTester.cpp
@@ -131,7 +131,7 @@ CUDAQ_TEST(H2MoleculeTester, checkUCCSD) {
     auto eigenVectors = matrix.eigenvectors();
 
     // Map it to a cudaq::state
-    std::vector<std::complex<float>> expectedData(eigenVectors.rows());
+    std::vector<cudaq::simulation_scalar> expectedData(eigenVectors.rows());
     for (std::size_t i = 0; i < eigenVectors.rows(); i++)
       expectedData[i] = eigenVectors(i, 0);
     auto groundState = cudaq::get_state(ansatz, std::get<1>(res));

--- a/unittests/integration/get_state_tester.cpp
+++ b/unittests/integration/get_state_tester.cpp
@@ -51,10 +51,14 @@ CUDAQ_TEST(GetStateTester, checkSimple) {
     x(q);
     x(q);
   };
-
   // Check <00|Bell> = 1/sqrt(2)
+#ifdef CUDAQ_BACKEND_DM
+  EXPECT_NEAR(state.overlap(cudaq::get_state(kernelNoop)).real(), (1. / 2.),
+              1e-3);
+#else
   EXPECT_NEAR(state.overlap(cudaq::get_state(kernelNoop)).real(),
               1. / std::sqrt(2.), 1e-3);
+#endif
 
   auto kernelX = []() __qpu__ {
     cudaq::qubit q, r;
@@ -63,8 +67,12 @@ CUDAQ_TEST(GetStateTester, checkSimple) {
   };
 
   // Check <11|Bell> = 1/sqrt(2)
+#ifdef CUDAQ_BACKEND_DM
+  EXPECT_NEAR(state.overlap(cudaq::get_state(kernelX)).real(), 1. / 2., 1e-3);
+#else
   EXPECT_NEAR(state.overlap(cudaq::get_state(kernelX)).real(),
               1. / std::sqrt(2.), 1e-3);
+#endif
 
   // Check endianess of basis state
   auto kernel1 = []() __qpu__ {


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

'Mostly' fixed the CI for `experimental/stateHandling` branch:

- Merge `main` (to fix the link check)

- Fixed issue with GPU detection (check both target name and GPU count)

- Fixed Qpp overlap calculation (to be the same as custatevec)

- Fixed overlap check value for DM simulator.

- Fixes for docs build (partially, see below for the remaining)

### Remaining items

- [ ] Python docs build failure 

```
/workspaces/cuda-quantum/docs/docstring of cudaq.mlir._mlir_libs._quakeDialects.cudaq_runtime.PyCapsule.get_precision:1: WARNING: duplicate object description of cudaq.Target.get_precision, other instance in api/languages/python_api, use :noindex: for one of them
docstring of cudaq.mlir._mlir_libs._quakeDialects.cudaq_runtime.Target:1: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/workspaces/cuda-quantum/docs/docstring of cudaq.mlir._mlir_libs._quakeDialects.cudaq_runtime.PyCapsule.get_precision:1: WARNING: py:class reference target not found: cudaq.mlir._mlir_libs._quakeDialects.cudaq_runtime.SimulationPrecision
```

- [ ] `CUDAQ :: AST-Quake/vector.cpp` test failure but **only** for `Create CUDA Quantum installer` pipelines. It passed in the regular `Build and test pipelines`. 