### PR TITLE
[stateHandling][RFC] Skeleton for chaining `get_state` -> `qvector` allocation

### DIFF
--- a/runtime/cudaq/algorithms/get_state.h
+++ b/runtime/cudaq/algorithms/get_state.h
@@ -59,7 +59,7 @@ state extractState(KernelFunctor &&kernel) {
   // pointer to the state type. The state will retain
   // value semantics, due to its tracking of this simulation
   // data as a shared_ptr.
-  return state(context.simulationState.release());
+  return state(std::move(context.simulationState));
 }
 
 template <typename KernelFunctor>
@@ -88,7 +88,7 @@ auto runGetStateAsync(KernelFunctor &&wrappedKernel,
         func();
         platform.reset_exec_ctx(qpu_id);
         // Extract state data
-        p.set_value(state(context.simulationState.release()));
+        p.set_value(state(std::move(context.simulationState)));
       });
 
   platform.enqueueAsyncTask(qpu_id, wrapped);

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -126,6 +126,12 @@ public:
   virtual void
   initializeState(const std::vector<QuditInfo> &targets,
                   std::unique_ptr<cudaq::SimulationState> &&initState) = 0;
+  virtual void
+  initializeState(const std::vector<QuditInfo> &targets,
+                  std::unique_ptr<cudaq::SimulationState> &initState) {}
+  virtual void
+  initializeState(const std::vector<QuditInfo> &targets,
+                  const std::unique_ptr<cudaq::SimulationState> &initState) {}
 
   /// Apply the quantum instruction with the given name, on the provided target
   /// qudits. Supports input of control qudits and rotational parameters. Can

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -123,8 +123,9 @@ public:
   /// state.
   /// Note: the state must be compatible with the current runtime simulator
   /// instance.
-  virtual void initializeState(const std::vector<QuditInfo> &targets,
-                               SimulationState *initState) = 0;
+  virtual void
+  initializeState(const std::vector<QuditInfo> &targets,
+                  std::unique_ptr<cudaq::SimulationState> &&initState) = 0;
 
   /// Apply the quantum instruction with the given name, on the provided target
   /// qudits. Supports input of control qudits and rotational parameters. Can

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -17,6 +17,7 @@
 
 namespace cudaq {
 class ExecutionContext;
+class SimulationState;
 using SpinMeasureResult = std::pair<double, sample_result>;
 
 /// A QuditInfo is a type encoding the number of \a levels and the \a id of the
@@ -117,6 +118,13 @@ public:
   virtual void initializeState(const std::vector<QuditInfo> &targets,
                                const void *state,
                                simulation_precision precision) = 0;
+
+  /// @brief Initialize the state of the given qudits to the provided
+  /// state.
+  /// Note: the state must be compatible with the current runtime simulator
+  /// instance.
+  virtual void initializeState(const std::vector<QuditInfo> &targets,
+                               SimulationState *initState) = 0;
 
   /// Apply the quantum instruction with the given name, on the provided target
   /// qudits. Supports input of control qudits and rotational parameters. Can

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -69,9 +69,10 @@ protected:
     requestedAllocations.clear();
   }
 
-  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
-                       cudaq::SimulationState *initState) override {
-    simulator()->allocateQubits(initState);
+  void initializeState(
+      const std::vector<cudaq::QuditInfo> &targets,
+      std::unique_ptr<cudaq::SimulationState> &&initState) override {
+    simulator()->allocateQubits(std::move(initState));
     requestedAllocations.clear();
   }
 

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -89,7 +89,26 @@ protected:
   void initializeState(
       const std::vector<cudaq::QuditInfo> &targets,
       std::unique_ptr<cudaq::SimulationState> &&initState) override {
-    simulator()->allocateQubits(std::move(initState));
+    simulator()->allocateQubits(
+        initState.release(),
+        nvqir::CircuitSimulator::AllocatorFlag::OwnershipTransfer);
+    requestedAllocations.clear();
+  }
+
+  void
+  initializeState(const std::vector<cudaq::QuditInfo> &targets,
+                  std::unique_ptr<cudaq::SimulationState> &initState) override {
+    simulator()->allocateQubits(
+        initState.get(), nvqir::CircuitSimulator::AllocatorFlag::Reference);
+    requestedAllocations.clear();
+  }
+
+  void initializeState(
+      const std::vector<cudaq::QuditInfo> &targets,
+      const std::unique_ptr<cudaq::SimulationState> &initState) override {
+    simulator()->allocateQubits(
+        initState.get(),
+        nvqir::CircuitSimulator::AllocatorFlag::ConstReference);
     requestedAllocations.clear();
   }
 

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -69,6 +69,12 @@ protected:
     requestedAllocations.clear();
   }
 
+  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
+                       cudaq::SimulationState *initState) override {
+    simulator()->allocateQubits(initState);
+    requestedAllocations.clear();
+  }
+
   void deallocateQudit(const cudaq::QuditInfo &q) override {
 
     // Before trying to deallocate, make sure the qudit hasn't

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -60,7 +60,10 @@ protected:
                        simulation_precision precision) override {
     throw std::runtime_error("initializeState not implemented.");
   }
-
+  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
+                       cudaq::SimulationState *initState) override {
+    throw std::runtime_error("initializeState not implemented.");
+  }
   /// @brief Qudit deallocation method
   void deallocateQudit(const cudaq::QuditInfo &q) override {}
 

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -60,8 +60,9 @@ protected:
                        simulation_precision precision) override {
     throw std::runtime_error("initializeState not implemented.");
   }
-  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
-                       cudaq::SimulationState *initState) override {
+  void initializeState(
+      const std::vector<cudaq::QuditInfo> &targets,
+      std::unique_ptr<cudaq::SimulationState> &&initState) override {
     throw std::runtime_error("initializeState not implemented.");
   }
   /// @brief Qudit deallocation method

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -10,6 +10,7 @@
 
 #include "cudaq/host_config.h"
 #include "cudaq/qis/qview.h"
+#include "cudaq/qis/state.h"
 
 namespace cudaq {
 
@@ -65,6 +66,19 @@ public:
       : qvector(std::vector<complex>{list.begin(), list.end()}) {}
   qvector(const std::initializer_list<complex> &list)
       : qvector(std::vector<complex>{list.begin(), list.end()}) {}
+
+  /// @brief Construct a `qvector` in a specific state.
+  // TODO: determine if we want to support state copying.
+  // On one hand, there could be a use case whereby the user want to keep the
+  // state intact. On the other hand, it's prone to excessive memory usage if
+  // not carefully managed.
+  qvector(const cudaq::state &initState) = delete;
+  qvector(cudaq::state &&initState) : qudits(initState.get_num_qubits()) {
+    std::vector<QuditInfo> targets;
+    for (auto &q : qudits)
+      targets.emplace_back(QuditInfo{Levels, q.id()});
+    getExecutionManager()->initializeState(targets, initState.release());
+  };
 
   /// @cond
   /// Nullary constructor

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -68,11 +68,21 @@ public:
       : qvector(std::vector<complex>{list.begin(), list.end()}) {}
 
   /// @brief Construct a `qvector` in a specific state.
-  // TODO: determine if we want to support state copying.
-  // On one hand, there could be a use case whereby the user want to keep the
-  // state intact. On the other hand, it's prone to excessive memory usage if
-  // not carefully managed.
-  qvector(const cudaq::state &initState) = delete;
+  qvector(const cudaq::state &initState) : qudits(initState.get_num_qubits()) {
+    std::vector<QuditInfo> targets;
+    for (auto &q : qudits)
+      targets.emplace_back(QuditInfo{Levels, q.id()});
+    getExecutionManager()->initializeState(targets, initState.get());
+  }
+  qvector(cudaq::state &initState) : qudits(initState.get_num_qubits()) {
+    std::vector<QuditInfo> targets;
+    for (auto &q : qudits)
+      targets.emplace_back(QuditInfo{Levels, q.id()});
+    getExecutionManager()->initializeState(targets, initState.get());
+  }
+  // qvector(cudaq::state initState) : qudits(initState.get_num_qubits()) {
+  //   // TODO
+  // }
   qvector(cudaq::state &&initState) : qudits(initState.get_num_qubits()) {
     std::vector<QuditInfo> targets;
     for (auto &q : qudits)

--- a/runtime/cudaq/qis/state.cpp
+++ b/runtime/cudaq/qis/state.cpp
@@ -24,7 +24,7 @@ state state::from_data(const state_data &data) {
     throw std::runtime_error(
         "[state::from_data] Could not find valid simulator backend.");
 
-  return state(simulator->createStateFromData(data).release());
+  return state(simulator->createStateFromData(data));
 }
 
 SimulationState::precision state::get_precision() const {
@@ -53,13 +53,6 @@ state::operator()(const std::initializer_list<std::size_t> &indices,
 }
 
 std::size_t state::get_num_qubits() const { return internal->getNumQubits(); }
-
-SimulationState *state::release() {
-  // TODO: make this safer: ideally making the `state` <-> `SimulationState` a
-  // 1:1 mapping.
-  SimulationState *ptr = internal.get();
-  return ptr;
-}
 
 std::complex<double> state::operator[](std::size_t idx) {
   std::size_t numQubits = internal->getNumQubits();
@@ -100,7 +93,7 @@ state::~state() {
   // Current use count is 1, so the
   // shared_ptr is about to go out of scope,
   // there are no users. Delete the state data.
-  if (internal.use_count() == 1)
+  if (internal)
     internal->destroyState();
 }
 

--- a/runtime/cudaq/qis/state.cpp
+++ b/runtime/cudaq/qis/state.cpp
@@ -52,6 +52,15 @@ state::operator()(const std::initializer_list<std::size_t> &indices,
   return (*internal)(tensorIdx, idxVec);
 }
 
+std::size_t state::get_num_qubits() const { return internal->getNumQubits(); }
+
+SimulationState *state::release() {
+  // TODO: make this safer: ideally making the `state` <-> `SimulationState` a
+  // 1:1 mapping.
+  SimulationState *ptr = internal.get();
+  return ptr;
+}
+
 std::complex<double> state::operator[](std::size_t idx) {
   std::size_t numQubits = internal->getNumQubits();
   if (!internal->isArrayLike()) {

--- a/runtime/cudaq/qis/state.h
+++ b/runtime/cudaq/qis/state.h
@@ -23,12 +23,20 @@ class state {
 
 private:
   /// @brief Reference to the simulation data
-  std::shared_ptr<SimulationState> internal;
+  std::unique_ptr<SimulationState> internal;
 
 public:
   /// @brief The constructor, takes the simulation data and owns it
-  state(SimulationState *ptrToOwn)
-      : internal(std::shared_ptr<SimulationState>(ptrToOwn)) {}
+  state(std::unique_ptr<SimulationState> &&ptrToOwn)
+      : internal(std::move(ptrToOwn)) {}
+
+  state(state &&s) : internal(std::move(s.internal)) {}
+  state &operator=(state &&other) {
+    internal.reset(other.internal.release());
+    return *this;
+  }
+
+  std::unique_ptr<SimulationState> release() { return std::move(internal); }
 
   /// @brief Convenience function for extracting from a known vector.
   std::complex<double> operator[](std::size_t idx);
@@ -42,9 +50,6 @@ public:
 
   /// @brief Return the number of qubits of this simulation state.
   std::size_t get_num_qubits() const;
-
-  /// Release the underlying state that this owns.
-  SimulationState *release();
 
   /// @brief Return the tensor at the given index for this state representation.
   /// For state-vector and density matrix simulation states, there is just one

--- a/runtime/cudaq/qis/state.h
+++ b/runtime/cudaq/qis/state.h
@@ -40,6 +40,12 @@ public:
   std::complex<double> operator()(const std::initializer_list<std::size_t> &,
                                   std::size_t tensorIdx = 0);
 
+  /// @brief Return the number of qubits of this simulation state.
+  std::size_t get_num_qubits() const;
+
+  /// Release the underlying state that this owns.
+  SimulationState *release();
+
   /// @brief Return the tensor at the given index for this state representation.
   /// For state-vector and density matrix simulation states, there is just one
   /// tensor with rank 1 or 2 respectively.

--- a/runtime/cudaq/qis/state.h
+++ b/runtime/cudaq/qis/state.h
@@ -37,6 +37,8 @@ public:
   }
 
   std::unique_ptr<SimulationState> release() { return std::move(internal); }
+  const std::unique_ptr<SimulationState> &get() const { return internal; }
+  std::unique_ptr<SimulationState> &get() { return internal; }
 
   /// @brief Convenience function for extracting from a known vector.
   std::complex<double> operator[](std::size_t idx);

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -203,6 +203,9 @@ public:
                  cudaq::simulation_precision precision =
                      cudaq::simulation_precision::fp32) = 0;
 
+  virtual std::vector<std::size_t>
+  allocateQubits(cudaq::SimulationState *initState) = 0;
+
   /// @brief Deallocate the qubit with give unique index
   virtual void deallocate(const std::size_t qubitIdx) = 0;
 
@@ -616,6 +619,8 @@ protected:
       addQubitToState();
   }
 
+  virtual void addQubitsToState(cudaq::SimulationState *initState) = 0;
+
   /// @brief Execute a sampling task with the current set of sample qubits.
   void flushAnySamplingTasks(bool force = false) {
     if (sampleQubits.empty())
@@ -827,6 +832,43 @@ public:
 
     // return the new qubit index
     return newIdx;
+  }
+
+  std::vector<std::size_t>
+  allocateQubits(cudaq::SimulationState *initState) override {
+    auto count = initState->getNumQubits();
+    std::vector<std::size_t> qubits;
+    for (std::size_t i = 0; i < count; i++)
+      qubits.emplace_back(tracker.getNextIndex());
+
+    if (isInBatchMode()) {
+      // Store the current number of qubits requested
+      batchModeCurrentNumQubits += count;
+
+      // We have an allocated state, it has been set to |0>,
+      // we want to reuse it as is. If the state needs to grow, then
+      // we will ask the subtype to add more qubits.
+      if (qubits.back() < nQubitsAllocated)
+        count = 0;
+      else
+        count = qubits.back() + 1 - nQubitsAllocated;
+    }
+
+    cudaq::info("Allocating {} new qubits.", count);
+
+    previousStateDimension = stateDimension;
+    nQubitsAllocated += count;
+    stateDimension = calculateStateDim(nQubitsAllocated);
+
+    // Tell the subtype to allocate more qubits
+    addQubitsToState(initState);
+
+    // May be that the state grows enough that we
+    // want to handle observation via sampling
+    if (executionContext)
+      executionContext->canHandleObserve = canHandleObserve();
+
+    return qubits;
   }
 
   /// @brief Allocate `count` qubits.

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -204,7 +204,7 @@ public:
                      cudaq::simulation_precision::fp32) = 0;
 
   virtual std::vector<std::size_t>
-  allocateQubits(cudaq::SimulationState *initState) = 0;
+  allocateQubits(std::unique_ptr<cudaq::SimulationState> &&initState) = 0;
 
   /// @brief Deallocate the qubit with give unique index
   virtual void deallocate(const std::size_t qubitIdx) = 0;
@@ -619,7 +619,8 @@ protected:
       addQubitToState();
   }
 
-  virtual void addQubitsToState(cudaq::SimulationState *initState) = 0;
+  virtual void
+  addQubitsToState(std::unique_ptr<cudaq::SimulationState> &&initState) = 0;
 
   /// @brief Execute a sampling task with the current set of sample qubits.
   void flushAnySamplingTasks(bool force = false) {
@@ -835,7 +836,7 @@ public:
   }
 
   std::vector<std::size_t>
-  allocateQubits(cudaq::SimulationState *initState) override {
+  allocateQubits(std::unique_ptr<cudaq::SimulationState> &&initState) override {
     auto count = initState->getNumQubits();
     std::vector<std::size_t> qubits;
     for (std::size_t i = 0; i < count; i++)
@@ -861,7 +862,7 @@ public:
     stateDimension = calculateStateDim(nQubitsAllocated);
 
     // Tell the subtype to allocate more qubits
-    addQubitsToState(initState);
+    addQubitsToState(std::move(initState));
 
     // May be that the state grows enough that we
     // want to handle observation via sampling

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -203,8 +203,9 @@ public:
                  cudaq::simulation_precision precision =
                      cudaq::simulation_precision::fp32) = 0;
 
+  enum class AllocatorFlag { OwnershipTransfer, Reference, ConstReference };
   virtual std::vector<std::size_t>
-  allocateQubits(std::unique_ptr<cudaq::SimulationState> &&initState) = 0;
+  allocateQubits(cudaq::SimulationState *initState, AllocatorFlag flag) = 0;
 
   /// @brief Deallocate the qubit with give unique index
   virtual void deallocate(const std::size_t qubitIdx) = 0;
@@ -619,8 +620,8 @@ protected:
       addQubitToState();
   }
 
-  virtual void
-  addQubitsToState(std::unique_ptr<cudaq::SimulationState> &&initState) = 0;
+  virtual void addQubitsToState(cudaq::SimulationState *initState,
+                                AllocatorFlag flag) = 0;
 
   /// @brief Execute a sampling task with the current set of sample qubits.
   void flushAnySamplingTasks(bool force = false) {
@@ -835,8 +836,8 @@ public:
     return newIdx;
   }
 
-  std::vector<std::size_t>
-  allocateQubits(std::unique_ptr<cudaq::SimulationState> &&initState) override {
+  std::vector<std::size_t> allocateQubits(cudaq::SimulationState *initState,
+                                          AllocatorFlag flag) override {
     auto count = initState->getNumQubits();
     std::vector<std::size_t> qubits;
     for (std::size_t i = 0; i < count; i++)
@@ -862,7 +863,7 @@ public:
     stateDimension = calculateStateDim(nQubitsAllocated);
 
     // Tell the subtype to allocate more qubits
-    addQubitsToState(std::move(initState));
+    addQubitsToState(initState, flag);
 
     // May be that the state grows enough that we
     // want to handle observation via sampling

--- a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
+++ b/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu
@@ -355,7 +355,6 @@ protected:
                    statePtr->getTensor().data))
       throw std::runtime_error("CusvState is on a different GPU device.");
     // Note: we assume the ownership of the initState pointer.
-    // TODO: look for a way to make this whole pointer passing safer.
     if (!deviceStateVector) {
       HANDLE_ERROR(custatevecCreate(&handle));
       deviceStateVector = statePtr->getTensor().data;

--- a/runtime/nvqir/custatevec/CuStateVecState.h
+++ b/runtime/nvqir/custatevec/CuStateVecState.h
@@ -89,20 +89,6 @@ private:
         cudaMemcpyDeviceToHost));
   }
 
-  /// @brief Return true if the given pointer is a GPU device pointer
-  bool isDevicePointer(void *ptr) const {
-    cudaPointerAttributes attributes;
-    HANDLE_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr));
-    return attributes.type > 1;
-  }
-
-  /// @brief Given a GPU device pointer, get the CUDA device it is on.
-  int deviceFromPointer(void *ptr) const {
-    cudaPointerAttributes attributes;
-    HANDLE_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr));
-    return attributes.device;
-  }
-
   /// @brief Check the input data pointer and if it is
   /// host data, copy it to the GPU.
   auto maybeCopyToDevice(std::size_t size, void *dataPtr) {
@@ -181,6 +167,20 @@ private:
   }
 
 public:
+  /// @brief Return true if the given pointer is a GPU device pointer
+  static bool isDevicePointer(void *ptr) {
+    cudaPointerAttributes attributes;
+    HANDLE_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr));
+    return attributes.type > 1;
+  }
+
+  /// @brief Given a GPU device pointer, get the CUDA device it is on.
+  static int deviceFromPointer(void *ptr) {
+    cudaPointerAttributes attributes;
+    HANDLE_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr));
+    return attributes.device;
+  }
+
   CusvState(std::size_t s, void *ptr) : size(s), devicePtr(ptr) {}
   CusvState(std::size_t s, void *ptr, bool owns)
       : size(s), devicePtr(ptr), ownsDevicePtr(owns) {}

--- a/runtime/nvqir/cutensornet/simulator_mps_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_mps_register.cpp
@@ -72,8 +72,8 @@ public:
     }
   }
 
-  void addQubitsToState(
-      std::unique_ptr<cudaq::SimulationState> &&initState) override {
+  void addQubitsToState(cudaq::SimulationState *initState,
+                        AllocatorFlag flag) override {
     throw std::runtime_error("addQubitsToState is not yet supported.");
   }
 

--- a/runtime/nvqir/cutensornet/simulator_mps_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_mps_register.cpp
@@ -72,7 +72,8 @@ public:
     }
   }
 
-  void addQubitsToState(cudaq::SimulationState *initState) override {
+  void addQubitsToState(
+      std::unique_ptr<cudaq::SimulationState> &&initState) override {
     throw std::runtime_error("addQubitsToState is not yet supported.");
   }
 

--- a/runtime/nvqir/cutensornet/simulator_mps_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_mps_register.cpp
@@ -72,6 +72,10 @@ public:
     }
   }
 
+  void addQubitsToState(cudaq::SimulationState *initState) override {
+    throw std::runtime_error("addQubitsToState is not yet supported.");
+  }
+
   virtual void prepareQubitTensorState() override {
     LOG_API_TIME();
     // Clean up previously factorized MPS tensors

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -51,9 +51,11 @@ public:
                                                       m_cutnHandle);
   }
 
-  void addQubitsToState(cudaq::SimulationState *initState) override {
+  void addQubitsToState(
+      std::unique_ptr<cudaq::SimulationState> &&initState) override {
     // Check if it is the state of this Simulator
-    auto *statePtr = dynamic_cast<TensorNetSimulationState *>(initState);
+    auto *statePtr =
+        dynamic_cast<TensorNetSimulationState *>(initState.release());
     if (!statePtr)
       throw std::runtime_error("Incompatible initial state provided.");
 
@@ -83,6 +85,8 @@ public:
           m_state->applyQubitProjector(op.deviceData,
                                        mapQubitIdxs(op.qubitIds));
       }
+      statePtr->destroyState();
+      delete statePtr;
     }
   }
 

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -69,8 +69,7 @@ public:
       // after remapping the leg indices, i.e., shifting the leg id by the
       // original size.
       const auto currentSize = m_state->getNumQubits();
-      // TODO: this depends on #1537 (implements addQubits);
-      // m_state->addQubits(statePtr->getNumQubits());
+      m_state->addQubits(statePtr->getNumQubits());
       auto mapQubitIdxs = [currentSize](const std::vector<int32_t> &idxs) {
         std::vector<int32_t> mapped(idxs);
         for (auto &x : mapped)

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -51,11 +51,10 @@ public:
                                                       m_cutnHandle);
   }
 
-  void addQubitsToState(
-      std::unique_ptr<cudaq::SimulationState> &&initState) override {
+  void addQubitsToState(cudaq::SimulationState *initState,
+                        AllocatorFlag flag) override {
     // Check if it is the state of this Simulator
-    auto *statePtr =
-        dynamic_cast<TensorNetSimulationState *>(initState.release());
+    auto *statePtr = dynamic_cast<TensorNetSimulationState *>(initState);
     if (!statePtr)
       throw std::runtime_error("Incompatible initial state provided.");
 

--- a/runtime/nvqir/cutensornet/tensornet_state.h
+++ b/runtime/nvqir/cutensornet/tensornet_state.h
@@ -145,6 +145,7 @@ public:
 
 private:
   friend class SimulatorMPS;
+  friend class SimulatorTensorNet;
   friend class TensorNetSimulationState;
   /// Internal method to contract the tensor network.
   /// Returns device memory pointer and size (number of elements).

--- a/runtime/nvqir/cutensornet/tn_simulation_state.h
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.h
@@ -80,6 +80,8 @@ public:
 
   std::unique_ptr<cudaq::SimulationState> toSimulationState() override;
 
+  friend class SimulatorTensorNet;
+
 protected:
   std::unique_ptr<TensorNetState> m_state;
   cutensornetHandle_t m_cutnHandle;

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -224,15 +224,19 @@ protected:
     return;
   }
 
-  void addQubitsToState(cudaq::SimulationState *initState) override {
+  void addQubitsToState(
+      std::unique_ptr<cudaq::SimulationState> &&initState) override {
     // Check if it is the state of this Simulator
-    QppState *statePtr = dynamic_cast<QppState *>(initState);
+    QppState *statePtr = dynamic_cast<QppState *>(initState.release());
     if (!statePtr)
       throw std::runtime_error("Incompatible initial state provided.");
-    if (state.size() == 0)
+    if (state.size() == 0) {
       state = std::move(statePtr->state);
-    else
+    } else {
       state = qpp::kron(statePtr->state, state);
+      statePtr->destroyState();
+      delete statePtr;
+    }
   }
 
   /// @brief Reset the qubit state.

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -223,10 +223,10 @@ protected:
     return;
   }
 
-  void addQubitsToState(
-      std::unique_ptr<cudaq::SimulationState> &&initState) override {
+  void addQubitsToState(cudaq::SimulationState *initState,
+                        AllocatorFlag flag) override {
     // Check if it is the state of this Simulator
-    QppState *statePtr = dynamic_cast<QppState *>(initState.release());
+    QppState *statePtr = dynamic_cast<QppState *>(initState);
     if (!statePtr)
       throw std::runtime_error("Incompatible initial state provided.");
     if (state.size() == 0) {

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -224,6 +224,17 @@ protected:
     return;
   }
 
+  void addQubitsToState(cudaq::SimulationState *initState) override {
+    // Check if it is the state of this Simulator
+    QppState *statePtr = dynamic_cast<QppState *>(initState);
+    if (!statePtr)
+      throw std::runtime_error("Incompatible initial state provided.");
+    if (state.size() == 0)
+      state = std::move(statePtr->state);
+    else
+      state = qpp::kron(statePtr->state, state);
+  }
+
   /// @brief Reset the qubit state.
   void deallocateStateImpl() override {
     StateType tmp;

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -220,10 +220,10 @@ protected:
     }
   }
 
-  void addQubitsToState(
-      std::unique_ptr<cudaq::SimulationState> &&initState) override {
+  void addQubitsToState(cudaq::SimulationState *initState,
+                        AllocatorFlag flag) override {
     // Check if it is the state of this Simulator
-    QppDmState *statePtr = dynamic_cast<QppDmState *>(initState.release());
+    QppDmState *statePtr = dynamic_cast<QppDmState *>(initState);
     if (!statePtr)
       throw std::runtime_error("Incompatible initial state provided.");
     if (state.size() == 0)

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -13,120 +13,6 @@
 using namespace cudaq;
 
 namespace {
-
-/// @brief QppDmState provides an implementation of `SimulationState` that
-/// encapsulates the state data for the Qpp Density Matrix Circuit Simulator.
-struct QppDmState : public cudaq::SimulationState {
-  /// @brief The state.
-  qpp::cmat state;
-
-  QppDmState(qpp::cmat &&data) : state(std::move(data)) {}
-  QppDmState(const std::vector<std::size_t> &shape,
-             const std::vector<std::complex<double>> &data) {
-    if (shape.size() != 2)
-      throw std::runtime_error(
-          "QppDmState must be created from data with 2D shape.");
-
-    state = Eigen::Map<qpp::ket>(
-        const_cast<std::complex<double> *>(data.data()), shape[0], shape[1]);
-  }
-  std::size_t getNumQubits() const override { return std::log2(state.rows()); }
-
-  std::complex<double> overlap(const cudaq::SimulationState &other) override {
-    if (other.getNumTensors() != 1 ||
-        (other.getTensor().extents != getTensor().extents))
-      throw std::runtime_error("[qpp-dm-state] overlap error - other state "
-                               "dimension not equal to this state dimension.");
-    // Create rho and sigma matrices
-    Eigen::MatrixXcd rho = Eigen::Map<Eigen::MatrixXcd>(
-        state.data(), getTensor().extents[0], getTensor().extents[1]);
-    Eigen::MatrixXcd sigma = Eigen::Map<Eigen::MatrixXcd>(
-        reinterpret_cast<std::complex<double> *>(other.getTensor().data),
-        other.getTensor().extents[0], other.getTensor().extents[1]);
-
-    // For qubit systems, F(rho,sigma) = tr(rho*sigma) + 2 *
-    // sqrt(det(rho)*det(sigma))
-    auto detprod = rho.determinant() * sigma.determinant();
-    return (rho * sigma).trace().real() + 2 * std::sqrt(detprod.real());
-  }
-
-  std::complex<double>
-  getAmplitude(const std::vector<int> &basisState) override {
-    if (getNumQubits() != basisState.size())
-      throw std::runtime_error(
-          fmt::format("[qpp-dm-state] getAmplitude with an invalid number "
-                      "of bits in the "
-                      "basis state: expected {}, provided {}.",
-                      getNumQubits(), basisState.size()));
-    if (std::any_of(basisState.begin(), basisState.end(),
-                    [](int x) { return x != 0 && x != 1; }))
-      throw std::runtime_error(
-          "[qpp-dm-state] getAmplitude with an invalid basis state: only "
-          "qubit state (0 or 1) is supported.");
-
-    // Convert the basis state to an index value
-    const std::size_t idx = std::accumulate(
-        std::make_reverse_iterator(basisState.end()),
-        std::make_reverse_iterator(basisState.begin()), 0ull,
-        [](std::size_t acc, int bit) { return (acc << 1) + bit; });
-    // Returns the diagonal element.
-    // Notes:
-    //  (1) This is considered a 'probability amplitude' in the (generally)
-    //  mixed state context represented by this density matrix.
-    //  (2) For pure states (i.e., Tr(rho^2) == 1), e.g., using the density
-    //  matrix simulator without noise,
-    // we can refactor the density matrix back to the state vector if needed.
-    // This is however not a common use case for the density matrix simulator.
-    return state(idx, idx);
-  }
-
-  Tensor getTensor(std::size_t tensorIdx = 0) const override {
-    if (tensorIdx != 0)
-      throw std::runtime_error("[qpp-dm-state] invalid tensor requested.");
-    return Tensor{
-        reinterpret_cast<void *>(
-            const_cast<std::complex<double> *>(state.data())),
-        std::vector<std::size_t>{static_cast<std::size_t>(state.rows()),
-                                 static_cast<std::size_t>(state.cols())},
-        getPrecision()};
-  }
-
-  // /// @brief Return all tensors that represent this state
-  std::vector<Tensor> getTensors() const override { return {getTensor()}; }
-
-  // /// @brief Return the number of tensors that represent this state.
-  std::size_t getNumTensors() const override { return 1; }
-
-  std::complex<double>
-  operator()(std::size_t tensorIdx,
-             const std::vector<std::size_t> &indices) override {
-    if (tensorIdx != 0)
-      throw std::runtime_error("[qpp-dm-state] invalid tensor requested.");
-    if (indices.size() != 2)
-      throw std::runtime_error("[qpp-dm-state] invalid element extraction.");
-
-    return state(indices[0], indices[1]);
-  }
-
-  std::unique_ptr<SimulationState>
-  createFromSizeAndPtr(std::size_t size, void *ptr, std::size_t) override {
-    return std::make_unique<QppDmState>(
-        Eigen::Map<qpp::cmat>(reinterpret_cast<std::complex<double> *>(ptr),
-                              std::sqrt(size), std::sqrt(size)));
-  }
-
-  void dump(std::ostream &os) const override { os << state << "\n"; }
-
-  precision getPrecision() const override {
-    return cudaq::SimulationState::precision::fp64;
-  }
-
-  void destroyState() override {
-    qpp::cmat k;
-    state = k;
-  }
-};
-
 /// @brief The QppNoiseCircuitSimulator further specializes the
 /// QppCircuitSimulator to use a density matrix representation of the state.
 /// This class directly enables a simple noise modeling capability for CUDA
@@ -166,7 +52,7 @@ protected:
 
     cudaq::info("Applying {} kraus channels to qubits {}", krausChannels.size(),
                 qubits);
-
+    auto &state = simState->state;
     for (auto &channel : krausChannels) {
       // Map our kraus ops to the qpp::cmat
       std::vector<qpp::cmat> K;
@@ -188,7 +74,7 @@ protected:
                         const void *stateDataIn = nullptr) override {
     if (qubitCount == 0)
       return;
-
+    auto &state = simState->state;
     if (state.size() == 0) {
       // If this is the first time, allocate the state
       if (!stateDataIn) {
@@ -220,22 +106,8 @@ protected:
     }
   }
 
-  void addQubitsToState(cudaq::SimulationState *initState,
-                        AllocatorFlag flag) override {
-    // Check if it is the state of this Simulator
-    QppDmState *statePtr = dynamic_cast<QppDmState *>(initState);
-    if (!statePtr)
-      throw std::runtime_error("Incompatible initial state provided.");
-    if (state.size() == 0)
-      state = std::move(statePtr->state);
-    else {
-      state = qpp::kron(statePtr->state, state);
-      statePtr->destroyState();
-      delete statePtr;
-    }
-  }
-
   void setToZeroState() override {
+    auto &state = simState->state;
     state = qpp::cmat::Zero(stateDimension, stateDimension);
     state(0, 0) = 1.0;
   }
@@ -244,11 +116,6 @@ public:
   QppNoiseCircuitSimulator() = default;
   virtual ~QppNoiseCircuitSimulator() = default;
   std::string name() const override { return "dm"; }
-
-  std::unique_ptr<cudaq::SimulationState> getSimulationState() override {
-    flushGateQueue();
-    return std::make_unique<QppDmState>(std::move(state));
-  }
 
   NVQIR_SIMULATOR_CLONE_IMPL(QppNoiseCircuitSimulator)
 };

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -204,6 +204,17 @@ protected:
     state = qpp::kron(zero_state, state);
   }
 
+  void addQubitsToState(cudaq::SimulationState *initState) override {
+    // Check if it is the state of this Simulator
+    QppDmState *statePtr = dynamic_cast<QppDmState *>(initState);
+    if (!statePtr)
+      throw std::runtime_error("Incompatible initial state provided.");
+    if (state.size() == 0)
+      state = std::move(statePtr->state);
+    else
+      state = qpp::kron(statePtr->state, state);
+  }
+
   void setToZeroState() override {
     state = qpp::cmat::Zero(stateDimension, stateDimension);
     state(0, 0) = 1.0;

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -204,15 +204,19 @@ protected:
     state = qpp::kron(zero_state, state);
   }
 
-  void addQubitsToState(cudaq::SimulationState *initState) override {
+  void addQubitsToState(
+      std::unique_ptr<cudaq::SimulationState> &&initState) override {
     // Check if it is the state of this Simulator
-    QppDmState *statePtr = dynamic_cast<QppDmState *>(initState);
+    QppDmState *statePtr = dynamic_cast<QppDmState *>(initState.release());
     if (!statePtr)
       throw std::runtime_error("Incompatible initial state provided.");
     if (state.size() == 0)
       state = std::move(statePtr->state);
-    else
+    else {
       state = qpp::kron(statePtr->state, state);
+      statePtr->destroyState();
+      delete statePtr;
+    }
   }
 
   void setToZeroState() override {

--- a/unittests/backends/qpp_observe/QPPObserveBackend.cpp
+++ b/unittests/backends/qpp_observe/QPPObserveBackend.cpp
@@ -28,7 +28,7 @@ public:
 
     auto nQ = op.num_qubits();
     double sum = 0.0;
-
+    auto &state = simState->state;
     // Want to loop over all terms in op and
     // compute E_i = coeff_i * < psi | Term | psi >
     // = coeff_i * sum_k <psi | Pauli_k psi>

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -122,8 +122,9 @@ public:
                        cudaq::simulation_precision precision) override {
     throw std::runtime_error("initializeState not implemented.");
   }
-  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
-                       cudaq::SimulationState *initState) override {
+  void initializeState(
+      const std::vector<cudaq::QuditInfo> &targets,
+      std::unique_ptr<cudaq::SimulationState> &&initState) override {
     throw std::runtime_error("initializeState not implemented.");
   }
   void resetQudit(const cudaq::QuditInfo &id) override {}

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -122,6 +122,10 @@ public:
                        cudaq::simulation_precision precision) override {
     throw std::runtime_error("initializeState not implemented.");
   }
+  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
+                       cudaq::SimulationState *initState) override {
+    throw std::runtime_error("initializeState not implemented.");
+  }
   void resetQudit(const cudaq::QuditInfo &id) override {}
 };
 


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- Allowing users to retrieve the state (`get_state`) then use that state to initialize a `qvector` later on. 

- Retaining the underlying memory as much as we can (e.g., unless we need to do a Kronecker product)

### Notes

This has some dependencies on https://github.com/NVIDIA/cuda-quantum/pull/1537: `simulator_tensornet_register.cpp` implementation is incomplete, pending for a rebase after merging 1537.  

MPS is not yet implemented, pending cuquantum v24.03 update.


