### PR TITLE
Support using complex inside kernel functions

### DIFF
--- a/python/tests/kernel/test_kernel_complex.py
+++ b/python/tests/kernel/test_kernel_complex.py
@@ -1,0 +1,311 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import os, sys
+
+import pytest
+import numpy as np
+import math
+from typing import List
+
+import cudaq
+from cudaq import spin
+
+## [PYTHON_VERSION_FIX]
+skipIfPythonLessThan39 = pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="built-in collection types such as `list` not supported")
+
+def is_equal(expected, actual):
+    return np.isclose(expected, actual, atol=1e-6)
+
+def test_complex_params():
+    """Test that we can pass complex lists to kernel functions."""
+
+    # Pass a list of complex as a parameter
+    c = [.70710678 + 0j, 0., 0., 0.70710678]
+
+    @cudaq.kernel
+    def complex_vec_param(vec : list[complex], i: int) -> complex:
+        return vec[i]
+
+    # Returning complex is not supported yet
+    # for i in range(len(c)):
+    #    is_equal(c[i].real, complex_vec_param(c, i).real)
+    # for i in range(len(c)):
+    #    is_equal(c[i].imag, complex_vec_param(c, i).imag)
+
+    @cudaq.kernel
+    def complex_vec_param_real(vec : list[complex], i: int) -> float:
+        v = vec[i]
+        return v.real
+    # Fails due to https://github.com/NVIDIA/cuda-quantum/issues/1529
+    # for i in range(len(c)):
+    #    assert is_equal(c[i].real, complex_vec_param_real(c, i))
+
+    @cudaq.kernel
+    def complex_vec_param_real_temp(vec : list[complex]) -> float:
+        v = vec[1]
+        return v.real
+    assert is_equal(c[1], complex_vec_param_real_temp(c))
+
+    @cudaq.kernel
+    def complex_vec_param_imag(vec : list[complex], i: int) -> float:
+        v = vec[i]
+        return v.imag
+    # Fails due to https://github.com/NVIDIA/cuda-quantum/issues/1529
+    # for i in range(len(c)):
+    #    assert is_equal(c[i].imag, complex_vec_param_imag(c, i))
+
+    @cudaq.kernel
+    def complex_vec_param_imag_temp(vec : list[complex]) -> float:
+        v = vec[1]
+        return v.imag
+    assert is_equal(c[1], complex_vec_param_imag_temp(c))
+
+
+def test_complex_capture():
+    """Test that we can pass complex lists to kernel functions."""
+
+    # Capture a list of complex
+    c = [.70710678 + 0j, 0., 0., 0.70710678]
+
+    @cudaq.kernel
+    def complex_vec_capture_real(i: int) -> float:
+        v = c[i]
+        return v.real
+    for i in range(len(c)):
+        assert is_equal(c[i].real, complex_vec_capture_real(i))
+
+    @cudaq.kernel
+    def complex_vec_capture_imag(i: int) -> float:
+        v = c[i]
+        return v.imag
+    for i in range(len(c)):
+        assert is_equal(c[i].imag, complex_vec_capture_imag(i))
+
+def test_complex_definition():
+    """Test that we can define complex lists inside kernel functions."""
+
+    # Define a list of complex inside a kernel
+    c = [.70710678 + 0j, 0., 0., 0.70710678]
+
+    @cudaq.kernel
+    def complex_vec_definition_real(i:int) -> float:
+        v = [.70710678 + 0j, 0., 0., 0.70710678][i]
+        return v.real
+    for i in range(len(c)):
+        assert is_equal(c[i].real, complex_vec_definition_real(i))
+
+    @cudaq.kernel
+    def complex_vec_definition_imag(i:int) -> float:
+        v = [.70710678 + 0j, 0., 0., 0.70710678][i]
+        return v.imag
+    for i in range(len(c)):
+        assert is_equal(c[i].imag, complex_vec_definition_imag(i))
+
+def test_complex_definition_with_constructor():
+    """Test that we can define complex lists inside kernel functions."""
+
+    # Define a list of complex inside a kernel
+    c = [complex(.70710678, 0), 0., 0., 0.70710678]
+
+    @cudaq.kernel
+    def complex_vec_definition_real(i:int) -> float:
+        v = [complex(.70710678, 0.), 0., 0., 0.70710678][i]
+        return v.real
+    for i in range(len(c)):
+        assert is_equal(c[i].real, complex_vec_definition_real(i))
+
+    @cudaq.kernel
+    def complex_vec_definition_imag(i:int) -> float:
+        v = [complex(.70710678, 0.), 0., 0., 0.70710678][i]
+        return v.imag
+    for i in range(len(c)):
+        assert is_equal(c[i].imag, complex_vec_definition_imag(i))
+
+def test_complex_definition_with_constructor_named():
+    """Test that we can define complex lists inside kernel functions."""
+
+    # Define a list of complex inside a kernel
+    c = [complex(real=.70710678, imag=0), 0., 0., 0.70710678]
+
+    # Use float arguments to complex constructor
+    @cudaq.kernel
+    def complex_vec_definition_real(i:int) -> float:
+        v = [complex(real=.70710678, imag=0.), 0., 0., 0.70710678][i]
+        return v.real
+    for i in range(len(c)):
+        assert is_equal(c[i].real, complex_vec_definition_real(i))
+
+    @cudaq.kernel
+    def complex_vec_definition_imag(i:int) -> float:
+       v = [complex(real=.70710678, imag=0.), 0., 0., 0.70710678][i]
+       return v.imag
+    for i in range(len(c)):
+        assert is_equal(c[i].imag, complex_vec_definition_imag(i))
+
+    # Use int arguments to complex constructor
+    @cudaq.kernel
+    def complex_vec_definition_real_i(i:int) -> float:
+        v = [complex(real=.70710678, imag=0.), 0., 0., 0.70710678][i]
+        return v.real
+    for i in range(len(c)):
+        assert is_equal(c[i].real, complex_vec_definition_real_i(i))
+
+    @cudaq.kernel
+    def complex_vec_definition_imag_i(i:int) -> float:
+        v = [complex(real=.70710678, imag=0.), 0., 0., 0.70710678][i]
+        return v.imag
+    for i in range(len(c)):
+        assert is_equal(c[i].imag, complex_vec_definition_imag_i(i))
+
+    # Use int in list of complex
+    @cudaq.kernel
+    def complex_vec_definition_real_ii(i:int) -> float:
+        v = [complex(real=.70710678, imag=0.), 0., 0., 0.70710678][i]
+        return v.real
+    for i in range(len(c)):
+        assert is_equal(c[i].real, complex_vec_definition_real_ii(i))
+
+    @cudaq.kernel
+    def complex_vec_definition_imag_ii(i:int) -> float:
+        v = [complex(real=.70710678, imag=0.), 0., 0., 0.70710678][i]
+        return v.imag
+    for i in range(len(c)):
+        assert is_equal(c[i].imag, complex_vec_definition_imag_ii(i))
+
+def test_complex_use():
+    """Test that we can use complex numbers inside kernel functions."""
+
+    # Use a complex inside a kernel
+    @cudaq.kernel
+    def complex_use_real() -> float:
+        v =  complex.sin(0j)
+        return v.real
+    assert is_equal(0., complex_use_real())
+
+    # Use a complex inside np in a kernel
+    @cudaq.kernel
+    def complex_np_use_real() -> float:
+        v = np.sin(0j)
+        return v.real
+    assert is_equal(0., complex_np_use_real())
+
+
+# np.complex128
+
+def test_np_complex128_params():
+    """Test that we can pass complex lists to kernel functions."""
+
+    # Pass a list of complex as a parameter
+    c = [np.complex128(.70710678+0j),np.complex128(0.), np.complex128(0.), np.complex128(0.70710678)]
+
+    @cudaq.kernel
+    def complex_vec_param(vec : list[np.complex128], i: int) -> complex:
+        return vec[i]
+
+    # Returning complex is not supported yet
+    # for i in range(len(c)):
+    #    is_equal(c[i].real, complex_vec_param(c, i).real)
+    # for i in range(len(c)):
+    #    is_equal(c[i].imag, complex_vec_param(c, i).imag)
+
+    @cudaq.kernel
+    def complex_vec_param_real(vec : list[np.complex128], i: int) -> float:
+        v = vec[i]
+        return v.real
+    # Fails due to https://github.com/NVIDIA/cuda-quantum/issues/1529
+    # for i in range(len(c)):
+    #    assert is_equal(c[i].real, complex_vec_param_real(c, i))
+
+    @cudaq.kernel
+    def complex_vec_param_real_temp(vec : list[np.complex128]) -> float:
+        v = vec[1]
+        return v.real
+    assert is_equal(c[1], complex_vec_param_real_temp(c))
+
+    @cudaq.kernel
+    def complex_vec_param_imag(vec : list[np.complex128], i: int) -> float:
+        v = vec[i]
+        return v.imag
+    # Fails due to https://github.com/NVIDIA/cuda-quantum/issues/1529
+    # for i in range(len(c)):
+    #    assert is_equal(c[i].imag, complex_vec_param_imag(c, i))
+
+    @cudaq.kernel
+    def complex_vec_param_imag_temp(vec : list[np.complex128]) -> float:
+        v = vec[1]
+        return v.imag
+    assert is_equal(c[1], complex_vec_param_imag_temp(c))
+
+
+def test_np_complex128_capture():
+    """Test that we can pass complex lists to kernel functions."""
+
+    # Capture a list of complex
+    c = [np.complex128(.70710678 + 0j),np.complex128(0.), np.complex128(0.), np.complex128(0.70710678)]
+
+    @cudaq.kernel
+    def complex_vec_capture_real(i: int) -> float:
+        v = c[i]
+        return v.real
+    for i in range(len(c)):
+        assert is_equal(c[i].real, complex_vec_capture_real(i))
+
+    @cudaq.kernel
+    def complex_vec_capture_imag(i: int) -> float:
+        v = c[i]
+        return v.imag
+    for i in range(len(c)):
+        assert is_equal(c[i].imag, complex_vec_capture_imag(i))
+
+def test_np_complex128_definition():
+    """Test that we can define complex lists inside kernel functions."""
+
+    # Define a list of complex inside a kernel
+    c = [np.complex128(.70710678 + 0j),np.complex128(0.), np.complex128(0.), np.complex128(0.70710678)]
+
+    @cudaq.kernel
+    def complex_vec_definition_real(i:int) -> float:
+        v = [np.complex128(.70710678 + 0j),np.complex128(0.), np.complex128(0.), np.complex128(0.70710678)][i]
+        return v.real
+    for i in range(len(c)):
+        assert is_equal(c[i].real, complex_vec_definition_real(i))
+
+    @cudaq.kernel
+    def complex_vec_definition_imag(i:int) -> float:
+        v = [np.complex128(.70710678 + 0j),np.complex128(0.), np.complex128(0.), np.complex128(0.70710678)][i]
+        return v.imag
+    for i in range(len(c)):
+        assert is_equal(c[i].imag, complex_vec_definition_imag(i))
+
+def test_np_complex128_use():
+    """Test that we can use complex numbers inside kernel functions."""
+
+    # Use a complex inside a kernel
+    @cudaq.kernel
+    def complex_use_real() -> float:
+        v =  complex.sin(np.complex128(0. + 0j))
+        return v.real
+    assert is_equal(0., complex_use_real())
+
+    # Use a complex inside np in a kernel
+    @cudaq.kernel
+    def complex_np_use_real() -> float:
+        v = np.sin(np.complex128(0. + 0j))
+        return v.real
+    assert is_equal(0., complex_np_use_real())
+
+
+
+
+
+
+
+

--- a/python/tests/kernel/test_kernel_float.py
+++ b/python/tests/kernel/test_kernel_float.py
@@ -1,0 +1,87 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import os, sys
+
+import pytest
+import numpy as np
+import math
+from typing import List
+
+import cudaq
+from cudaq import spin
+
+## [PYTHON_VERSION_FIX]
+skipIfPythonLessThan39 = pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="built-in collection types such as `list` not supported")
+
+def test_float_params():
+    """Test that we can pass float lists to kernel functions."""
+
+    f = [0., 1., 1., 0.]
+
+    # Pass a list of float as a parameter
+    @cudaq.kernel
+    def float_vec_param(vec : list[float], i : int) -> float:
+        return vec[i]
+
+    # Fails due to https://github.com/NVIDIA/cuda-quantum/issues/1529
+    # for i in range(len(f)):
+    #    assert np.isclose(f[i], float_vec_param(f, i), atol=1e-6)
+    #
+    # Using below as a temporary replacement test until the issue is fixed
+    def float_vec_param_temp(vec : list[float]) -> float:
+        return vec[1]
+
+    assert np.isclose(f[1], float_vec_param_temp(f), atol=1e-6)
+
+def test_float_capture():
+    """Test that we can capture float lists inside kernel functions."""
+
+    f = [0., 1., 1., 0.]
+
+    # Capture a list of float
+    @cudaq.kernel
+    def float_vec_capture(i: int) -> float:
+        return f[i]
+
+    for i in range(len(f)):
+        assert np.isclose(f[i], float_vec_capture(i), atol=1e-6)
+
+
+def test_float_definition():
+    """Test that we can define float lists inside kernel functions."""
+
+    f = [0., 1., 1., 0.]
+
+    # Define a list of float inside a kernel
+    @cudaq.kernel
+    def float_vec_definition(i: int) -> float:
+        return [0., 1., 1., 0.][i]
+
+    for i in range(len(f)):
+        assert np.isclose(f[i], float_vec_definition(i), atol=1e-6)
+
+
+def test_float_use():
+    """Test that we can use floats inside kernel functions."""
+
+    # Use a float inside a kernel
+    @cudaq.kernel
+    def float_use() -> float:
+        return math.sin(0.)
+
+    assert np.isclose(0., float_use(), atol=1e-6)
+
+    # Use a float inside np in a kernel
+    @cudaq.kernel
+    def float_np_use() -> float:
+        return np.sin(0.)
+
+    assert np.isclose(0., float_np_use(), atol=1e-6)


### PR DESCRIPTION
### Description

Allow users to do following in kernel functions:

- pass complex numbers and lists as parameters
- capture complex numbers and lists
- define lists of complex numbers
- pass complex numbers to function calls
- allow using `complex`, `np.complex128` and `np.complex64`

- add tests for complex and float numbers and lists

Helps: https://github.com/NVIDIA/cuda-quantum/issues/1086

Closes: https://github.com/NVIDIA/cuda-quantum/issues/1548
Closes: https://github.com/NVIDIA/cuda-quantum/issues/1454



