### PR TITLE
[experimental/StateHandling] add new state type

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -779,10 +779,6 @@ inline bool isCharPointerType(mlir::Type t) {
   return false;
 }
 
-inline bool isCudaqStateType(mlir::Type t) {
-  if (auto strTy = dyn_cast<cc::StructType>(t))
-    return strTy.getName().getValue().equals("cudaq.state");
-  return false;
-}
+inline bool isCudaqStateType(mlir::Type t) { return isa<cc::StateType>(t); }
 
 } // namespace cudaq

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -20,6 +20,7 @@ namespace cudaq {
 namespace cc {
 class LoopOp;
 class PointerType;
+class StateType;
 class StructType;
 } // namespace cc
 
@@ -71,7 +72,7 @@ inline mlir::Type getPointerType(mlir::Type ty) {
 }
 
 /// Get the Quake type translation of a `cudaq::state` type.
-cc::StructType getCudaqStateType(mlir::MLIRContext *ctx);
+cc::StateType getCudaqStateType(mlir::MLIRContext *ctx);
 
 cudaq::cc::PointerType getIndexedObjectType(mlir::Type eleTy);
 

--- a/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -195,7 +195,7 @@ def cc_CallableType : CCType<"Callable", "callable"> {
 }
 
 //===----------------------------------------------------------------------===//
-// StdVectorType
+// StdVectorType - implemented as a span
 //===----------------------------------------------------------------------===//
 
 def cc_StdVectorType : CCType<"Stdvec", "stdvec", [],
@@ -227,6 +227,10 @@ def cc_StdVectorType : CCType<"Stdvec", "stdvec", [],
   ];
 }
 
+//===----------------------------------------------------------------------===//
+// CharSpanType - implemented as a span
+//===----------------------------------------------------------------------===//
+
 def cc_CharSpanType
     : CCType<"Charspan", "charspan", [], "cudaq::cc::SpanLikeType"> {
   let summary = "Proxy for a span over a std::string in cc";
@@ -253,5 +257,23 @@ def cc_CharSpanType
 
 def IsSpanLikePred : CPred<"$_self.isa<cudaq::cc::SpanLikeType>()">;
 def SpanningType : Type<IsSpanLikePred, "dynamic length type">;
+
+//===----------------------------------------------------------------------===//
+// StateType
+//===----------------------------------------------------------------------===//
+
+def cc_StateType : CCType<"State", "state"> {
+  let summary = "Proxy for the cudaq::state class.";
+  let description = [{
+    The cudaq::state class is an abstraction for any data that may be used to
+    describe the initial state of a set of qubits. It would typically be used
+    in a simulation environment.
+
+    The CUDA-Q runtime will implement an ABI of intrinsic functions for the
+    compiler generated code to interface with this information in a generic
+    manner.
+  }];
+  let genStorageClass = 0;
+}
 
 #endif // CUDAQ_DIALECT_CC_TYPES_TD

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -27,6 +27,7 @@ class QuakeType<string name, string typeMnemonic, list<Trait> traits = [],
 //===----------------------------------------------------------------------===//
 
 def WireType : QuakeType<"Wire", "wire"> {
+  let summary = "A quantum value. Wires are a linear type.";
   let description = [{
     A `wire` is a primitive quantum "SSA-value" that differs from a traditional
     SSA-value in that it can and will be modified when used in any target
@@ -65,6 +66,7 @@ def WireType : QuakeType<"Wire", "wire"> {
 //===----------------------------------------------------------------------===//
 
 def ControlType : QuakeType<"Control", "control"> {
+  let summary = "A quantum control value.";
   let description = [{
     A value having type `control` is quite similar to a value of type `wire`.
     The distinction is that a value of type `control` must be used in a control

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -17,8 +17,8 @@ using namespace mlir;
 
 namespace cudaq::opt {
 
-cc::StructType factory::getCudaqStateType(MLIRContext *ctx) {
-  return cc::StructType::get(ctx, "cudaq.state");
+cc::StateType factory::getCudaqStateType(MLIRContext *ctx) {
+  return cc::StateType::get(ctx);
 }
 
 bool factory::isX86_64(ModuleOp module) {

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -159,10 +159,10 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   })#"},
 
     {cudaq::getNumQubitsFromCudaqState, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_numberOfQubits(%p : !cc.ptr<!cc.struct<"cudaq.state">>) -> i64
+  func.func private @__nvqpp_cudaq_state_numberOfQubits(%p : !cc.ptr<!cc.state>) -> i64
   )#"},
     {cudaq::getCudaqStateAsVector, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_vectorData(%p : !cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.ptr<f64>
+  func.func private @__nvqpp_cudaq_state_vectorData(%p : !cc.ptr<!cc.state>) -> !cc.ptr<f64>
   )#"},
 
     {"__nvqpp_getStateVectorData_fp32", {}, R"#(

--- a/lib/Optimizer/Dialect/CC/CCTypes.cpp
+++ b/lib/Optimizer/Dialect/CC/CCTypes.cpp
@@ -178,7 +178,7 @@ CallableType CallableType::getNoSignature(MLIRContext *ctx) {
 
 void CCDialect::registerTypes() {
   addTypes<ArrayType, CallableType, CharspanType, PointerType, StdvecType,
-           StructType>();
+           StateType, StructType>();
 }
 
 } // namespace cudaq::cc

--- a/test/AST-Quake/qalloc_state.cpp
+++ b/test/AST-Quake/qalloc_state.cpp
@@ -19,9 +19,9 @@ struct Eins {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Eins(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.struct<"cudaq.state">>) -> i64
-// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.ptr<f64>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
+// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<f64>) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
@@ -35,9 +35,9 @@ struct Zwei {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Zwei(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.struct<"cudaq.state">>) -> i64
-// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.ptr<f64>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
+// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<f64>) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
@@ -51,9 +51,9 @@ struct Drei {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Drei(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.struct<"cudaq.state">>) -> i64
-// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.ptr<f64>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
+// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<f64>) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
@@ -67,9 +67,9 @@ struct Vier {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Vier(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.struct<"cudaq.state">>) -> i64
-// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.ptr<f64>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
+// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_3]] : i64]
 // CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<f64>) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
@@ -85,5 +85,5 @@ struct Fuenf {
 };
 #endif
 
-// CHECK: func.func private @__nvqpp_cudaq_state_vectorData(!cc.ptr<!cc.struct<"cudaq.state">>) -> !cc.ptr<f64>
-// CHECK: func.func private @__nvqpp_cudaq_state_numberOfQubits(!cc.ptr<!cc.struct<"cudaq.state">>) -> i64
+// CHECK: func.func private @__nvqpp_cudaq_state_vectorData(!cc.ptr<!cc.state>) -> !cc.ptr<f64>
+// CHECK: func.func private @__nvqpp_cudaq_state_numberOfQubits(!cc.ptr<!cc.state>) -> i64


### PR DESCRIPTION
Add a cc.state type to the CC dialect.
Replace !cc.struct<"cudaq.state"> with !cc.state.
Requires #1534 to be merged first.