### PR TITLE
[experimental/stateHandling] extend the semantics of quake.init_state

### DIFF
--- a/include/cudaq/Optimizer/Builder/Intrinsics.h
+++ b/include/cudaq/Optimizer/Builder/Intrinsics.h
@@ -34,13 +34,8 @@ static constexpr const char stdvecBoolCtorFromInitList[] =
 static constexpr const char stdvecBoolUnpackToInitList[] =
     "__nvqpp_vector_bool_to_initializer_list";
 
-// Returns the internal data of the cudaq::state object to a std::vector<double>
-// for use with InitializeStateOp.
-static constexpr const char getCudaqStateAsVector[] =
-    "__nvqpp_cudaq_state_vectorData";
-// The internal data, as returned by the `getCudaqStateAsVector` function, of
-// the cudaq::state object must be `2**n` in length. This function returns the
-// value `n`.
+// The internal data of the cudaq::state object must be `2**n` in length. This
+// function returns the value `n`.
 static constexpr const char getNumQubitsFromCudaqState[] =
     "__nvqpp_cudaq_state_numberOfQubits";
 

--- a/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -276,4 +276,8 @@ def cc_StateType : CCType<"State", "state"> {
   let genStorageClass = 0;
 }
 
+def AnyStateInitLike : TypeConstraint<Or<[cc_PointerType.predicate,
+        cc_StateType.predicate]>, "state initializer types">;
+def AnyStateInitType : Type<AnyStateInitLike.predicate, "initial state type">;
+
 #endif // CUDAQ_DIALECT_CC_TYPES_TD

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -295,8 +295,8 @@ def quake_ExtractRefOp : QuakeOp<"extract_ref", [Pure]> {
   }];
 }
 
-def quake_InitializeStateOp : QuakeOp<"init_state", [MemoryEffects<[MemAlloc,
-    MemWrite]>]> {
+def quake_InitializeStateOp : QuakeOp<"init_state",
+    [MemoryEffects<[MemAlloc, MemWrite]>]> {
   let summary = "Initialize the quantum state to a specific complex vector.";
   let description = [{
     Given a !cc.ptr pointing to a complex data array of size 2**N, where N is
@@ -309,13 +309,21 @@ def quake_InitializeStateOp : QuakeOp<"init_state", [MemoryEffects<[MemAlloc,
 
   let arguments = (ins
     VeqType:$targets,
-    AnyStateInitType:$state
+    AnyStateInitType:$state,
+    OptionalAttr<UnitAttr>:$move
   );
   let results = (outs VeqType);
-
+  
   let assemblyFormat = [{
-    $targets `,` $state `:` functional-type(operands, results) attr-dict
+    (`move` $move^)? $targets `,` $state `:`
+      functional-type(operands, results) attr-dict
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$vt, "mlir::Value":$t, "mlir::Value":$s), [{
+      return build($_builder, $_state, vt, t, s, mlir::UnitAttr{});
+    }]>
+  ];
 
   let hasVerifier = 1;
 }

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -309,7 +309,7 @@ def quake_InitializeStateOp : QuakeOp<"init_state", [MemoryEffects<[MemAlloc,
 
   let arguments = (ins
     VeqType:$targets,
-    cc_PointerType:$state
+    AnyStateInitType:$state
   );
   let results = (outs VeqType);
 

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -2462,8 +2462,6 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
           auto i64Ty = builder.getI64Type();
           auto numQubits = builder.create<func::CallOp>(
               loc, i64Ty, getNumQubitsFromCudaqState, ValueRange{state});
-          // FIXME: Do we need to consider f32?
-          auto stdvecTy = cc::PointerType::get(builder.getF64Type());
           auto veqTy = quake::VeqType::getUnsized(ctx);
           auto alloc = builder.create<quake::AllocaOp>(loc, veqTy,
                                                        numQubits.getResult(0));

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -2451,34 +2451,24 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
           IRBuilder irBuilder(builder.getContext());
           auto mod =
               builder.getBlock()->getParentOp()->getParentOfType<ModuleOp>();
-          auto result = irBuilder.loadIntrinsic(mod, getCudaqStateAsVector);
-          assert(succeeded(result) && "loading intrinsic should never fail");
-          result = irBuilder.loadIntrinsic(mod, getNumQubitsFromCudaqState);
+          auto result =
+              irBuilder.loadIntrinsic(mod, getNumQubitsFromCudaqState);
           assert(succeeded(result) && "loading intrinsic should never fail");
           Value state = initials;
-          if (!isa<cc::PointerType>(initials.getType())) {
-            // There must be a LoadOp in the middle. Eliminate it.
-            auto load = initials.getDefiningOp<cc::LoadOp>();
-            if (!load) {
-              reportClangError(
-                  x, mangler,
-                  "could not recover address of cudaq::state object");
-              return false;
-            }
-            state = load.getPtrvalue();
+          if (isa<cc::PointerType>(initials.getType())) {
+            // Add a LoadOp to eliminate the pointer dereference.
+            state = builder.create<cc::LoadOp>(loc, state);
           }
           auto i64Ty = builder.getI64Type();
           auto numQubits = builder.create<func::CallOp>(
               loc, i64Ty, getNumQubitsFromCudaqState, ValueRange{state});
           // FIXME: Do we need to consider f32?
           auto stdvecTy = cc::PointerType::get(builder.getF64Type());
-          auto dataVec = builder.create<func::CallOp>(
-              loc, stdvecTy, getCudaqStateAsVector, ValueRange{state});
           auto veqTy = quake::VeqType::getUnsized(ctx);
           auto alloc = builder.create<quake::AllocaOp>(loc, veqTy,
                                                        numQubits.getResult(0));
           return pushValue(builder.create<quake::InitializeStateOp>(
-              loc, veqTy, alloc, dataVec.getResult(0)));
+              loc, veqTy, alloc, state));
         }
         // Otherwise, it is the cudaq::qvector(std::vector<complex>) ctor.
         Value numQubits;

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -159,10 +159,10 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   })#"},
 
     {cudaq::getNumQubitsFromCudaqState, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_numberOfQubits(%p : !cc.ptr<!cc.state>) -> i64
+  func.func private @__nvqpp_cudaq_state_numberOfQubits(%p : !cc.state) -> i64
   )#"},
     {cudaq::getCudaqStateAsVector, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_vectorData(%p : !cc.ptr<!cc.state>) -> !cc.ptr<f64>
+  func.func private @__nvqpp_cudaq_state_vectorData(%p : !cc.state) -> !cc.ptr<f64>
   )#"},
 
     {"__nvqpp_getStateVectorData_fp32", {}, R"#(

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -161,9 +161,6 @@ static constexpr IntrinsicCode intrinsicTable[] = {
     {cudaq::getNumQubitsFromCudaqState, {}, R"#(
   func.func private @__nvqpp_cudaq_state_numberOfQubits(%p : !cc.state) -> i64
   )#"},
-    {cudaq::getCudaqStateAsVector, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_vectorData(%p : !cc.state) -> !cc.ptr<f64>
-  )#"},
 
     {"__nvqpp_getStateVectorData_fp32", {}, R"#(
   func.func private @__nvqpp_getStateVectorData_fp32(%p : i64, %o : i64) -> !cc.ptr<complex<f32>>

--- a/test/AST-Quake/qalloc_state.cpp
+++ b/test/AST-Quake/qalloc_state.cpp
@@ -20,10 +20,10 @@ struct Eins {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Eins(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
-// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<f64>) -> !quake.veq<?>
+// CHECK: %[[VAL_4:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
 
 struct Zwei {
@@ -36,10 +36,10 @@ struct Zwei {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Zwei(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
-// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<f64>) -> !quake.veq<?>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
 
 struct Drei {
@@ -52,10 +52,10 @@ struct Drei {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Drei(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
-// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<f64>) -> !quake.veq<?>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
 
 struct Vier {
@@ -68,10 +68,10 @@ struct Vier {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Vier(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
-// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_cudaq_state_vectorData(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.ptr<f64>) -> !quake.veq<?>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
 
 #if 0
@@ -85,5 +85,12 @@ struct Fuenf {
 };
 #endif
 
-// CHECK: func.func private @__nvqpp_cudaq_state_vectorData(!cc.ptr<!cc.state>) -> !cc.ptr<f64>
-// CHECK: func.func private @__nvqpp_cudaq_state_numberOfQubits(!cc.ptr<!cc.state>) -> i64
+// CHxCK-LABEL:   func.func @__nvqpp__mlirgen__Fuenf(
+// CHxCK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
+// CHxCK:           %[[VAL_4:.*]] = cc.load(%[[VAL_0]]) : (!cc.state) -> !cc.ptr<f64>
+// CHxCK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHxCK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
+// CHxCK:           %[[VAL_6:.*]] = quake.init_state move %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
+// CHxCK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
+
+// CHECK: func.func private @__nvqpp_cudaq_state_numberOfQubits(!cc.state) -> i64


### PR DESCRIPTION
Extend the init_state op to take !cc.state types.

This changes the semantics of init_state to be a family of initializations. It can use a vector of floats directly or a cudaq::state object. Additionally, it may use a runtime library call with move semantics if the initializer is a cudaq::state object.

Requires #1554 to be merged first.