### PR TITLE
[tools] Fix segfault in `cudaq-translate` when `emit-llvm=0`

### DIFF
--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -142,9 +142,8 @@ int main(int argc, char **argv) {
   std::error_code ec;
   llvm::ToolOutputFile out(outputFilename, ec, llvm::sys::fs::OF_None);
   checkErrorCode(ec);
-  llvm::function_ref<void()> targetAction = [&]() {
-    out.os() << *module << '\n';
-  };
+  auto printModuleAction = [&]() { out.os() << *module << '\n'; };
+  llvm::function_ref<void()> targetAction = printModuleAction;
   bool targetUsesLlvm = emitLLVM;
   auto *modOp = module->getOperation();
   auto modLoc = module->getLoc();


### PR DESCRIPTION
This patch fixes a segmentation fault in `cudaq-translate` when `--emit-llvm` is false. The issue occurs because the initialization lambda has non-trivial storage, and `llvm::function_ref` only holds a reference to a function, trashing the lambda after initialization.

