### PR TITLE
[experimental/stateHandling] Add rvalue reference to bridge.

### DIFF
--- a/include/cudaq/Frontend/nvqpp/AttributeNames.h
+++ b/include/cudaq/Frontend/nvqpp/AttributeNames.h
@@ -11,9 +11,9 @@
 namespace cudaq {
 
 /// Name of the attribute attached to entry point functions.
-static constexpr char entryPointAttrName[] = "cudaq-entrypoint";
+static constexpr const char entryPointAttrName[] = "cudaq-entrypoint";
 
 /// Name of the attribute attached to cudaq kernels.
-static constexpr char kernelAttrName[] = "cudaq-kernel";
+static constexpr const char kernelAttrName[] = "cudaq-kernel";
 
 } // namespace cudaq

--- a/include/cudaq/Optimizer/Builder/Intrinsics.h
+++ b/include/cudaq/Optimizer/Builder/Intrinsics.h
@@ -12,6 +12,10 @@
 
 namespace cudaq {
 
+/// This is the name of a dummy builtin to identify a std::move() call. These
+/// calls will be erased before code gen.
+static constexpr const char stdMoveBuiltin[] = ".std::move";
+
 static constexpr const char llvmMemCopyIntrinsic[] =
     "llvm.memcpy.p0i8.p0i8.i64";
 

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -61,7 +61,8 @@ def QIRToQIRProfileFunc : Pass<"quake-to-qir-func",
                             "mlir::LLVM::LLVMFuncOp"> {
   let summary = "Analyze kernels and add attributes and record calls.";
   let description = [{
-    This is a (function) subpass of the pipeline to convert to specific QIR Profile.
+    This is a (function) subpass of the pipeline to convert to specific QIR
+    Profile.
 
     Each function with a body is analyzed for qubit allocations and qubit
     measurements. Attributes for the total count of qubits are added to the

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -322,6 +322,11 @@ def quake_InitializeStateOp : QuakeOp<"init_state",
   let builders = [
     OpBuilder<(ins "mlir::Type":$vt, "mlir::Value":$t, "mlir::Value":$s), [{
       return build($_builder, $_state, vt, t, s, mlir::UnitAttr{});
+    }]>,
+    OpBuilder<(ins "mlir::Type":$vt, "mlir::Value":$t, "mlir::Value":$s,
+               "bool":$m), [{
+      auto isMove = m ? mlir::UnitAttr::get(t.getContext()) : mlir::UnitAttr{};
+      return build($_builder, $_state, vt, t, s, isMove);
     }]>
   ];
 

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -164,6 +164,14 @@ def DecompositionPass: Pass<"decomposition", "mlir::ModuleOp"> {
   ];
 }
 
+def EraseNopCalls : Pass<"erase-nop-calls", "mlir::func::FuncOp"> {
+  let summary = "Erase calls to any builtin intrinsics that are NOPs.";
+  let description = [{
+    The code may contain marker function calls that do not generate any actual
+    code. These calls are NOPs that will be erased by this pass.
+  }];
+}
+
 def ExpandMeasurements : Pass<"expand-measurements"> {
   let summary = "Expand multi-ref measurements to series on single refs.";
   let description = [{

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -356,17 +356,17 @@ bool QuakeBridgeVisitor::TraverseFunctionDecl(clang::FunctionDecl *x) {
   if (!TraverseDeclarationNameInfo(x->getNameInfo()))
     return false;
 
-  // If we're an explicit template specialization, iterate over the
-  // template args that were explicitly specified.  If we were doing
-  // this in typing order, we'd do it between the return type and
-  // the function args, but both are handled by the FunctionTypeLoc
-  // above, so we have to choose one side.  I've decided to do before.
+  // If we're an explicit template specialization, iterate over the template
+  // args that were explicitly specified.  If we were doing this in typing
+  // order, we'd do it between the return type and the function args, but both
+  // are handled by the FunctionTypeLoc above, so we have to choose one side.
+  // I've decided to do before.
   if (const auto *FTSI = x->getTemplateSpecializationInfo()) {
     if (FTSI->getTemplateSpecializationKind() != clang::TSK_Undeclared &&
         FTSI->getTemplateSpecializationKind() !=
             clang::TSK_ImplicitInstantiation) {
-      // A specialization might not have explicit template arguments if it
-      // has a templated return type and concrete arguments.
+      // A specialization might not have explicit template arguments if it has a
+      // templated return type and concrete arguments.
       if (const auto *tali = FTSI->TemplateArgumentsAsWritten) {
         auto *tal = tali->getTemplateArgs();
         for (unsigned i = 0; i != tali->NumTemplateArgs; ++i)
@@ -483,6 +483,10 @@ bool QuakeBridgeVisitor::VisitFunctionDecl(clang::FunctionDecl *x) {
   auto kernName = [&]() {
     if (isKernelEntryPoint(x))
       return generateCudaqKernelName(x);
+    // create a special name for 'std::move()' so we can erase it.
+    if (isInNamespace(x, "std") && x->getIdentifier() &&
+        x->getName().equals("move"))
+      return std::string(".std::move");
     return cxxMangledDeclName(x);
   }();
   auto kernSym = SymbolRefAttr::get(builder.getContext(), kernName);

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/Frontend/nvqpp/ASTBridge.h"
+#include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Todo.h"
@@ -486,7 +487,7 @@ bool QuakeBridgeVisitor::VisitFunctionDecl(clang::FunctionDecl *x) {
     // create a special name for 'std::move()' so we can erase it.
     if (isInNamespace(x, "std") && x->getIdentifier() &&
         x->getName().equals("move"))
-      return std::string(".std::move");
+      return std::string(cudaq::stdMoveBuiltin);
     return cxxMangledDeclName(x);
   }();
   auto kernSym = SymbolRefAttr::get(builder.getContext(), kernName);

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -1717,24 +1717,6 @@ public:
   }
 };
 
-// Erase the std::move() call here.
-// TODO: move to a special quake "canonicalize" pass?
-class EraseStdMovePattern : public OpRewritePattern<func::CallOp> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(func::CallOp call,
-                                PatternRewriter &rewriter) const override {
-    auto callee = call.getCallee();
-    if (callee.equals(cudaq::stdMoveBuiltin)) {
-      rewriter.replaceOp(call, call.getOperands());
-      rewriter.eraseOp(call);
-      return success();
-    }
-    return failure();
-  }
-};
-
 //===----------------------------------------------------------------------===//
 // Code generation: converts the Quake IR to QIR.
 //===----------------------------------------------------------------------===//
@@ -1814,7 +1796,7 @@ public:
   void fuseSubgraphPatterns() {
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
-    patterns.insert<CodeGenRAIIPattern, EraseStdMovePattern>(ctx);
+    patterns.insert<CodeGenRAIIPattern>(ctx);
     if (failed(applyPatternsAndFoldGreedily(getModule(), std::move(patterns))))
       signalPassFailure();
   }

--- a/lib/Optimizer/CodeGen/LowerToQIR.cpp
+++ b/lib/Optimizer/CodeGen/LowerToQIR.cpp
@@ -1717,6 +1717,24 @@ public:
   }
 };
 
+// Erase the std::move() call here.
+// TODO: move to a special quake "canonicalize" pass?
+class EraseStdMovePattern : public OpRewritePattern<func::CallOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(func::CallOp call,
+                                PatternRewriter &rewriter) const override {
+    auto callee = call.getCallee();
+    if (callee.equals(cudaq::stdMoveBuiltin)) {
+      rewriter.replaceOp(call, call.getOperands());
+      rewriter.eraseOp(call);
+      return success();
+    }
+    return failure();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Code generation: converts the Quake IR to QIR.
 //===----------------------------------------------------------------------===//
@@ -1796,7 +1814,7 @@ public:
   void fuseSubgraphPatterns() {
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
-    patterns.insert<CodeGenRAIIPattern>(ctx);
+    patterns.insert<CodeGenRAIIPattern, EraseStdMovePattern>(ctx);
     if (failed(applyPatternsAndFoldGreedily(getModule(), std::move(patterns))))
       signalPassFailure();
   }

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_cudaq_library(OptTransforms
   Decomposition.cpp
   DecompositionPatterns.cpp
   DelayMeasurements.cpp
+  EraseNopCalls.cpp
   ExpandMeasurements.cpp
   FactorQuantumAlloc.cpp
   GenKernelExecution.cpp

--- a/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -10,7 +10,6 @@
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
-#include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 

--- a/lib/Optimizer/Transforms/EraseNopCalls.cpp
+++ b/lib/Optimizer/Transforms/EraseNopCalls.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Builder/Intrinsics.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_ERASENOPCALLS
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "erase-nop-calls"
+
+using namespace mlir;
+
+namespace {
+// Erase the std::move() call here.
+class EraseStdMovePattern : public OpRewritePattern<func::CallOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(func::CallOp call,
+                                PatternRewriter &rewriter) const override {
+    auto callee = call.getCallee();
+    if (callee.equals(cudaq::stdMoveBuiltin)) {
+      rewriter.replaceOp(call, call.getOperands());
+      rewriter.eraseOp(call);
+      return success();
+    }
+    return failure();
+  }
+};
+
+class EraseNopCallsPass
+    : public cudaq::opt::impl::EraseNopCallsBase<EraseNopCallsPass> {
+public:
+  using EraseNopCallsBase::EraseNopCallsBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    LLVM_DEBUG(llvm::dbgs() << "Function before erasure:\n" << func << "\n\n");
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<EraseStdMovePattern>(ctx);
+    if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns))))
+      signalPassFailure();
+    LLVM_DEBUG(llvm::dbgs() << "Function after erasure:\n" << func << "\n\n");
+  }
+};
+} // namespace

--- a/lib/Optimizer/Transforms/FactorQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/FactorQuantumAlloc.cpp
@@ -9,8 +9,6 @@
 #include "PassDetails.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
-#include "cudaq/Todo.h"
-#include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
 

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -81,8 +81,15 @@ public:
   qvector() : qudits(1) {}
   /// @endcond
 
+  //===--------------------------------------------------------------------===//
+  // qvector with an initial state
+  //===--------------------------------------------------------------------===//
+
   explicit qvector(const state *);
   explicit qvector(const state &);
+  explicit qvector(state *);
+  explicit qvector(state &);
+  explicit qvector(state &&);
 
   /// @brief `qvectors` cannot be copied
   qvector(qvector const &) = delete;

--- a/test/AST-Quake/qalloc_state.cpp
+++ b/test/AST-Quake/qalloc_state.cpp
@@ -74,8 +74,6 @@ struct Vier {
 // CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
 
-#if 0
-// rvalue reference isn't supported yet.
 struct Fuenf {
   std::vector<bool> operator()(cudaq::state &&state) __qpu__ {
     cudaq::qvector v(std::move(state));
@@ -83,14 +81,14 @@ struct Fuenf {
     return mz(v);
   }
 };
-#endif
 
-// CHxCK-LABEL:   func.func @__nvqpp__mlirgen__Fuenf(
-// CHxCK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHxCK:           %[[VAL_4:.*]] = cc.load(%[[VAL_0]]) : (!cc.state) -> !cc.ptr<f64>
-// CHxCK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
-// CHxCK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHxCK:           %[[VAL_6:.*]] = quake.init_state move %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
-// CHxCK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__Fuenf(
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = call @".std::move"(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_5:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_5]] : i64]
+// CHECK:           %[[VAL_7:.*]] = quake.init_state move %[[VAL_6]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
+// CHECK:           %[[VAL_8:.*]] = quake.veq_size %[[VAL_7]] : (!quake.veq<?>) -> i64
 
 // CHECK: func.func private @__nvqpp_cudaq_state_numberOfQubits(!cc.state) -> i64


### PR DESCRIPTION
This is intended to lower the rvalue reference to a cudaq::state to the newly extended quake.init_state operation, which now supports lowering of move semantics.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
