### PR TITLE
Optimize kernel mode for hybrid QNN test case

### DIFF
--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -140,8 +140,8 @@ class PyKernelDecorator(object):
                 # see if any of the variables we depend
                 # on have changed.
                 self.globalScopedVars = {
-                    k: v for k, v in dict(inspect.getmembers(s))
-                    ['f_locals'].items()
+                    k: v
+                    for k, v in dict(inspect.getmembers(s))['f_locals'].items()
                 }
                 if self.dependentCaptures != None:
                     for k, v in self.dependentCaptures.items():

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -133,13 +133,14 @@ class PyKernelDecorator(object):
         # variables from the parent frame that we captured
         # have not changed. If they have changed, we need to
         # recompile with the new values.
-        for i, s in enumerate(inspect.stack()):
-            if s.frame == self.parentFrame:
+        s = inspect.currentframe()
+        while s:
+            if s == self.parentFrame:
                 # We found the parent frame, now
                 # see if any of the variables we depend
                 # on have changed.
                 self.globalScopedVars = {
-                    k: v for k, v in dict(inspect.getmembers(s.frame))
+                    k: v for k, v in dict(inspect.getmembers(s))
                     ['f_locals'].items()
                 }
                 if self.dependentCaptures != None:
@@ -148,6 +149,8 @@ class PyKernelDecorator(object):
                             # Need to recompile
                             self.module = None
                             break
+                break
+            s = s.f_back
 
         if self.module != None:
             return


### PR DESCRIPTION
This PR optimizes for potential future modifications to `examples/python/tutorials/hybrid_qnns.ipynb`.

Enumerating and looping over all elements in `inspect.stack()` was incredibly slow when **running in a Jupyter notebook**. (Interestingly enough, the slowness was not apparent when running a Python script with the `python3` command.)

Here are some sample timings before the change:
```python
# Kernel mode
qubit_count = 1
@cudaq.kernel
def kernel():
    qubits = cudaq.qvector(qubit_count)
cudaq.sample(kernel)
%timeit cudaq.sample(kernel)
# 4.73 ms ± 156 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# Builder mode
qubit_count = 1
kernel = cudaq.make_kernel()
qubits = kernel.qalloc(qubit_count)
cudaq.sample(kernel)
%timeit cudaq.sample(kernel)
# 220 µs ± 26 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

And after the change:
```python
# Kernel mode
qubit_count = 1
@cudaq.kernel
def kernel():
    qubits = cudaq.qvector(qubit_count)
cudaq.sample(kernel)
%timeit cudaq.sample(kernel)
# 209 µs ± 6.2 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each) <------- large reduction compared to 4.73 ms

# Builder mode
qubit_count = 1
kernel = cudaq.make_kernel()
qubits = kernel.qalloc(qubit_count)
cudaq.sample(kernel)
%timeit cudaq.sample(kernel)
# 200 µs ± 16.3 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

This is a >20x speedup for this test case, which brings the kernel mode in line with the builder mode.