### PR TITLE
[NFC] Code cleanup

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -227,7 +227,7 @@ def cc_LoopOp : CCOp<"loop",
         mlir::Location, mlir::Region &)>;
 
     bool hasArguments() { return getOperands().size(); }
-    constexpr static llvm::StringRef postCondAttrName() {
+    static constexpr llvm::StringRef postCondAttrName() {
       return llvm::StringLiteral("post_condition");
     }
     bool isPostConditional() {

--- a/python/runtime/cudaq/domains/plugins/PySCFDriver.cpp
+++ b/python/runtime/cudaq/domains/plugins/PySCFDriver.cpp
@@ -49,10 +49,10 @@ spin_op fromOpenFermionQubitOperator(const py::object &op) {
 class PySCFPackageDriver : public MoleculePackageDriver {
 protected:
   /// @brief The name of the chemistry python module.
-  constexpr static const char ChemistryModuleName[] = "cudaq.domains.chemistry";
+  static constexpr const char ChemistryModuleName[] = "cudaq.domains.chemistry";
 
   /// @brief The name of the function we'll use to drive PySCF.
-  constexpr static const char CreatorFunctionName[] =
+  static constexpr const char CreatorFunctionName[] =
       "__internal_cpp_create_molecular_hamiltonian";
 
 public:

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -25,10 +25,10 @@ void __nvqir__setCircuitSimulator(nvqir::CircuitSimulator *);
 namespace cudaq {
 void setQuantumPlatformInternal(quantum_platform *p);
 
-constexpr static const char PLATFORM_LIBRARY[] = "PLATFORM_LIBRARY=";
-constexpr static const char NVQIR_SIMULATION_BACKEND[] =
+static constexpr const char PLATFORM_LIBRARY[] = "PLATFORM_LIBRARY=";
+static constexpr const char NVQIR_SIMULATION_BACKEND[] =
     "NVQIR_SIMULATION_BACKEND=";
-constexpr static const char TARGET_DESCRIPTION[] = "TARGET_DESCRIPTION=";
+static constexpr const char TARGET_DESCRIPTION[] = "TARGET_DESCRIPTION=";
 
 /// @brief A utility function to check availability of Nvidia GPUs and return
 /// their count

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -394,7 +394,7 @@ protected:
   /// @brief Environment variable name that allows a programmer to
   /// specify how expectation values should be computed. This
   /// defaults to true.
-  constexpr static const char observeSamplingEnvVar[] =
+  static constexpr const char observeSamplingEnvVar[] =
       "CUDAQ_OBSERVE_FROM_SAMPLING";
 
   /// @brief A GateApplicationTask consists of a

--- a/tools/cudaq-quake/cudaq-quake.cpp
+++ b/tools/cudaq-quake/cudaq-quake.cpp
@@ -39,8 +39,8 @@
 
 using namespace llvm;
 
-constexpr static const char toolName[] = "cudaq-quake";
-constexpr static const char mangledKernelNameMapAttrName[] =
+static constexpr const char toolName[] = "cudaq-quake";
+static constexpr const char mangledKernelNameMapAttrName[] =
     "quake.mangled_name_map";
 
 //===----------------------------------------------------------------------===//

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -73,9 +73,9 @@ static llvm::cl::opt<bool> emitLLVM(
                    "translation will terminate with the selected dialect."),
     llvm::cl::init(true));
 
-constexpr static char BOLD[] = "\033[1m";
-constexpr static char RED[] = "\033[91m";
-constexpr static char CLEAR[] = "\033[0m";
+static constexpr const char BOLD[] = "\033[1m";
+static constexpr const char RED[] = "\033[91m";
+static constexpr const char CLEAR[] = "\033[0m";
 
 using namespace mlir;
 

--- a/tools/nvqpp/backendConfig.cpp
+++ b/tools/nvqpp/backendConfig.cpp
@@ -9,10 +9,15 @@
 /// This file is meant to be used by the nvq++ driver script, the
 /// NVQPP_TARGET_BACKEND_CONFIG string must be replaced (e.g. with sed)
 /// with the actual target backend string.
+
+// TODO: Replace this file with a compiler generated constant string and cleanup
+// the driver.
 namespace cudaq {
 void set_target_backend(const char *);
 }
-constexpr static const char ____targetBackend[] = NVQPP_TARGET_BACKEND_CONFIG;
+
+static constexpr const char targetBackendName[] = NVQPP_TARGET_BACKEND_CONFIG;
+
 __attribute__((constructor)) void setTargetBackend() {
-  cudaq::set_target_backend(____targetBackend);
+  cudaq::set_target_backend(targetBackendName);
 }


### PR DESCRIPTION
- Add a note that the backendConfig.cpp file and it's content can be done more cleanly by generating the string in the compiler when we deprecate support for library mode and server-side execution.
- Tweak a few definitions to be in "storage-class specifiers type name = init;" order for regularity.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
