### PR TITLE
[StateHandling] State data with value semantics via `state` acting as a thin pointer wrapper   

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -47,6 +47,8 @@ constexpr static const char QIRArrayQubitAllocateArrayWithStateFP64[] =
     "__quantum__rt__qubit_allocate_array_with_state_fp64";
 constexpr static const char QIRArrayQubitAllocateArrayWithStateFP32[] =
     "__quantum__rt__qubit_allocate_array_with_state_fp32";
+constexpr static const char QIRArrayQubitAllocateArrayWithStatePtr[] =
+    "__quantum__rt__qubit_allocate_array_with_state_ptr";
 constexpr static const char QIRQubitAllocate[] =
     "__quantum__rt__qubit_allocate";
 constexpr static const char QIRArrayQubitReleaseArray[] =

--- a/python/tests/kernel/test_kernel_complex.py
+++ b/python/tests/kernel/test_kernel_complex.py
@@ -22,7 +22,7 @@ skipIfPythonLessThan39 = pytest.mark.skipif(
 def is_close(expected, actual):
     return np.isclose(expected, actual, atol=1e-6)
 
-
+@skipIfPythonLessThan39
 def test_complex_params():
     """Test that we can pass complex lists to kernel functions."""
 
@@ -214,7 +214,7 @@ def test_complex_use():
 
 # np.complex128
 
-
+@skipIfPythonLessThan39
 def test_np_complex128_params():
     """Test that we can pass complex lists to kernel functions."""
 
@@ -376,7 +376,7 @@ def test_np_complex128_use():
 
 # Complex64
 
-
+@skipIfPythonLessThan39
 def test_np_complex64_params():
     """Test that we can pass complex lists to kernel functions."""
 

--- a/python/tests/kernel/test_kernel_complex.py
+++ b/python/tests/kernel/test_kernel_complex.py
@@ -16,11 +16,14 @@ import cudaq
 ## [PYTHON_VERSION_FIX]
 skipIfPythonLessThan39 = pytest.mark.skipif(
     sys.version_info < (3, 9),
-    reason="built-in collection types such as `list` not supported")
+    reason=
+    "built-in collection types such as `list` not supported or module 'ast' has no attribute 'unparse'"
+)
 
 
 def is_close(expected, actual):
     return np.isclose(expected, actual, atol=1e-6)
+
 
 @skipIfPythonLessThan39
 def test_complex_params():
@@ -214,6 +217,7 @@ def test_complex_use():
 
 # np.complex128
 
+
 @skipIfPythonLessThan39
 def test_np_complex128_params():
     """Test that we can pass complex lists to kernel functions."""
@@ -376,6 +380,7 @@ def test_np_complex128_use():
 
 # Complex64
 
+
 @skipIfPythonLessThan39
 def test_np_complex64_params():
     """Test that we can pass complex lists to kernel functions."""
@@ -443,6 +448,7 @@ def test_np_complex64_capture():
         assert is_close(c[i].imag, complex_vec_capture_imag(i))
 
 
+@skipIfPythonLessThan39
 def test_np_complex64_definition():
     """Test that we can define complex lists inside kernel functions."""
 

--- a/python/tests/kernel/test_kernel_float.py
+++ b/python/tests/kernel/test_kernel_float.py
@@ -22,7 +22,7 @@ skipIfPythonLessThan39 = pytest.mark.skipif(
 def is_close(expected, actual) -> bool:
     return np.isclose(expected, actual, atol=1e-6)
 
-
+@skipIfPythonLessThan39
 def test_float_params():
     """Test that we can pass float lists to kernel functions."""
 
@@ -78,7 +78,7 @@ def test_float_use():
 
 # np.float64
 
-
+@skipIfPythonLessThan39
 def test_float64_params():
     """Test that we can pass float lists to kernel functions."""
 
@@ -159,7 +159,7 @@ def test_float64_use():
 
 # np.float32
 
-
+@skipIfPythonLessThan39
 def test_float32_params():
     """Test that we can pass float lists to kernel functions."""
 

--- a/runtime/common/SimulationState.h
+++ b/runtime/common/SimulationState.h
@@ -22,7 +22,8 @@ class SimulationState;
 class TensorNetworkState {
 public:
   virtual ~TensorNetworkState() = default;
-  virtual std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() const = 0;
+  virtual std::unique_ptr<nvqir::TensorNetState>
+  reconstructBackendState() const = 0;
   virtual std::unique_ptr<cudaq::SimulationState> toSimulationState() const = 0;
 };
 

--- a/runtime/common/SimulationState.h
+++ b/runtime/common/SimulationState.h
@@ -22,9 +22,8 @@ class SimulationState;
 class TensorNetworkState {
 public:
   virtual ~TensorNetworkState() = default;
-
-  virtual std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() = 0;
-  virtual std::unique_ptr<cudaq::SimulationState> toSimulationState() = 0;
+  virtual std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() const = 0;
+  virtual std::unique_ptr<cudaq::SimulationState> toSimulationState() const = 0;
 };
 
 /// @brief state_data is a variant type

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -122,6 +122,14 @@ public:
   /// simulation state.
   virtual void initializeState(const std::vector<QuditInfo> &targets,
                                const SimulationState *state) = 0;
+
+  /// @brief Initialize the state of the given qudits to the provided
+  /// simulation state.
+  virtual void initializeState(const std::vector<QuditInfo> &targets,
+                               const SimulationState &state) {
+    initializeState(targets, &state);
+  }
+
   /// Apply the quantum instruction with the given name, on the provided target
   /// qudits. Supports input of control qudits and rotational parameters. Can
   /// also optionally take a spin_op as input to affect a general Pauli

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -17,6 +17,7 @@
 
 namespace cudaq {
 class ExecutionContext;
+class SimulationState;
 using SpinMeasureResult = std::pair<double, sample_result>;
 
 /// A QuditInfo is a type encoding the number of \a levels and the \a id of the
@@ -117,7 +118,10 @@ public:
   virtual void initializeState(const std::vector<QuditInfo> &targets,
                                const void *state,
                                simulation_precision precision) = 0;
-
+  /// @brief Initialize the state of the given qudits to the provided
+  /// simulation state.
+  virtual void initializeState(const std::vector<QuditInfo> &targets,
+                               const SimulationState *state) = 0;
   /// Apply the quantum instruction with the given name, on the provided target
   /// qudits. Supports input of control qudits and rotational parameters. Can
   /// also optionally take a spin_op as input to affect a general Pauli

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -86,6 +86,25 @@ protected:
     requestedAllocations.clear();
   }
 
+  void initializeState(const std::vector<cudaq::QuditInfo> &targets,
+                       const cudaq::SimulationState *state) override {
+    // Note: a void* ptr doesn't provide enough info to the simulators, hence
+    // need a dedicated code path.
+    // TODO: simplify/combine the two code paths (raw vector and state).
+    if (!requestedAllocations.empty() &&
+        targets.size() != requestedAllocations.size()) {
+      assert(targets.size() < requestedAllocations.size());
+      const auto numDefaultAllocs =
+          requestedAllocations.size() - targets.size();
+      simulator()->allocateQubits(numDefaultAllocs);
+      // The targets will be allocated in a specific state.
+      simulator()->allocateQubits(targets.size(), state);
+    } else {
+      simulator()->allocateQubits(requestedAllocations.size(), state);
+    }
+    requestedAllocations.clear();
+  }
+
   void deallocateQudit(const cudaq::QuditInfo &q) override {
 
     // Before trying to deallocate, make sure the qudit hasn't

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -61,6 +61,11 @@ protected:
     throw std::runtime_error("initializeState not implemented.");
   }
 
+  virtual void initializeState(const std::vector<QuditInfo> &targets,
+                               const SimulationState *state) override {
+    throw std::runtime_error("initializeState not implemented.");
+  }
+
   /// @brief Qudit deallocation method
   void deallocateQudit(const cudaq::QuditInfo &q) override {}
 

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -82,28 +82,23 @@ public:
   qvector() : qudits(1) {}
   /// @endcond
 
+  //===--------------------------------------------------------------------===//
+  // qvector with an initial state
+  //===--------------------------------------------------------------------===//
   /// @brief Construct a `qvector` from a pre-existing `state`.
   /// This `state` could be constructed with `state::from_data` or retrieved
   /// from an cudaq::get_state.
-  qvector(state state) : qudits(state.get_num_qubits()) {
+  explicit qvector(const state &state) : qudits(state.get_num_qubits()) {
     std::vector<QuditInfo> targets;
     for (auto &q : qudits)
       targets.emplace_back(QuditInfo{Levels, q.id()});
     // Note: the internal state data will be cloned by the simulator backend.
     getExecutionManager()->initializeState(targets, state.internal.get());
   }
-  //===--------------------------------------------------------------------===//
-  // qvector with an initial state
-  //===--------------------------------------------------------------------===//
-  // TODO: selectively enable these as needed. In this implementation, only
-  // using `state` by-value is needed (state is a thin wrapper around the
-  // SimulationState pointer).
-  //
-  // explicit qvector(const state *);
-  // explicit qvector(const state &)
-  // explicit qvector(state *);
-  // explicit qvector(state &);
-  // explicit qvector(state &&);
+  explicit qvector(const state *ptr) : qvector(*ptr){};
+  explicit qvector(state *ptr) : qvector(*ptr){};
+  explicit qvector(state &s) : qvector(const_cast<const state &>(s)){};
+  explicit qvector(state &&s) : qvector(s){};
 
   /// @brief `qvectors` cannot be copied
   qvector(qvector const &) = delete;

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -98,7 +98,7 @@ public:
   explicit qvector(const state *ptr) : qvector(*ptr){};
   explicit qvector(state *ptr) : qvector(*ptr){};
   explicit qvector(state &s) : qvector(const_cast<const state &>(s)){};
-  explicit qvector(state &&s) : qvector(s){};
+  explicit qvector(state &&s) : qvector(std::move(s)){};
 
   /// @brief `qvectors` cannot be copied
   qvector(qvector const &) = delete;

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -98,7 +98,7 @@ public:
   explicit qvector(const state *ptr) : qvector(*ptr){};
   explicit qvector(state *ptr) : qvector(*ptr){};
   explicit qvector(state &s) : qvector(const_cast<const state &>(s)){};
-  explicit qvector(state &&s) : qvector(std::move(s)){};
+  explicit qvector(state &&s) : qvector(s){};
 
   /// @brief `qvectors` cannot be copied
   qvector(qvector const &) = delete;

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -85,7 +85,7 @@ public:
   /// @brief Construct a `qvector` from a pre-existing `state`.
   /// This `state` could be constructed with `state::from_data` or retrieved
   /// from an cudaq::get_state.
-  explicit qvector(state state) : qudits(state.get_num_qubits()) {
+  qvector(state state) : qudits(state.get_num_qubits()) {
     std::vector<QuditInfo> targets;
     for (auto &q : qudits)
       targets.emplace_back(QuditInfo{Levels, q.id()});
@@ -95,12 +95,15 @@ public:
   //===--------------------------------------------------------------------===//
   // qvector with an initial state
   //===--------------------------------------------------------------------===//
-
-  explicit qvector(const state *);
-  explicit qvector(const state &);
-  explicit qvector(state *);
-  explicit qvector(state &);
-  explicit qvector(state &&);
+  // TODO: selectively enable these as needed. In this implementation, only
+  // using `state` by-value is needed (state is a thin wrapper around the
+  // SimulationState pointer).
+  //
+  // explicit qvector(const state *);
+  // explicit qvector(const state &)
+  // explicit qvector(state *);
+  // explicit qvector(state &);
+  // explicit qvector(state &&);
 
   /// @brief `qvectors` cannot be copied
   qvector(qvector const &) = delete;

--- a/runtime/cudaq/qis/state.cpp
+++ b/runtime/cudaq/qis/state.cpp
@@ -41,6 +41,8 @@ std::vector<SimulationState::Tensor> state::get_tensors() const {
 
 std::size_t state::get_num_tensors() const { return internal->getNumTensors(); }
 
+std::size_t state::get_num_qubits() const { return internal->getNumQubits(); }
+
 void state::dump() const { dump(std::cout); }
 void state::dump(std::ostream &os) const { internal->dump(os); }
 

--- a/runtime/cudaq/qis/state.h
+++ b/runtime/cudaq/qis/state.h
@@ -23,6 +23,8 @@ class state {
 private:
   /// @brief Reference to the simulation data
   std::shared_ptr<SimulationState> internal;
+  template <std::size_t Levels>
+  friend class qvector;
 
 public:
   /// @brief The constructor, takes the simulation data and owns it
@@ -49,6 +51,9 @@ public:
 
   /// @brief Return the number of tensors that represent this state.
   std::size_t get_num_tensors() const;
+
+  /// @brief Return the number of qubits.
+  std::size_t get_num_qubits() const;
 
   /// @brief Return the underlying floating point precision for this state.
   SimulationState::precision get_precision() const;

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -620,7 +620,10 @@ protected:
 
   /// @brief Add (appending) the given simulation state to the current simulator
   /// state.
-  virtual void addQubitsToState(const cudaq::SimulationState &state) = 0;
+  virtual void addQubitsToState(const cudaq::SimulationState &state) {
+    throw std::runtime_error("State initialization must be handled by "
+                             "subclasses, override addQubitsToState.");
+  }
 
   /// @brief Execute a sampling task with the current set of sample qubits.
   void flushAnySamplingTasks(bool force = false) {

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -193,6 +193,21 @@ Array *__quantum__rt__qubit_allocate_array_with_state_fp64(
   return vectorSizetToArray(qubitIdxs);
 }
 
+Array *__quantum__rt__qubit_allocate_array_with_state_ptr(
+    cudaq::SimulationState *state) {
+  if (!state)
+    throw std::invalid_argument("[NVQIR] Invalid simulation state encountered "
+                                "in qubit array allocation.");
+  ScopedTraceWithContext(
+      "NVQIR::__quantum__rt__qubit_allocate_array_with_state_ptr",
+      state->getNumQubits());
+
+  __quantum__rt__initialize(0, nullptr);
+  auto qubitIdxs = nvqir::getCircuitSimulatorInternal()->allocateQubits(
+      state->getNumQubits(), state);
+  return vectorSizetToArray(qubitIdxs);
+}
+
 Array *
 __quantum__rt__qubit_allocate_array_with_state_fp32(uint64_t size,
                                                     std::complex<float> *data) {

--- a/runtime/nvqir/custatevec/CuStateVecState.h
+++ b/runtime/nvqir/custatevec/CuStateVecState.h
@@ -291,6 +291,9 @@ public:
   /// @brief This state is GPU device data, always return true.
   bool isDeviceData() const override { return true; }
 
+  /// @brief Return the device pointer
+  const void *getDevicePointer() const { return devicePtr; }
+
   /// @brief Return the precision of the state data elements.
   precision getPrecision() const override {
     if constexpr (std::is_same_v<ScalarType, float>)

--- a/runtime/nvqir/cutensornet/mps_simulation_state.cpp
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.cpp
@@ -420,14 +420,14 @@ void MPSSimulationState::dump(std::ostream &os) const {
 }
 
 std::unique_ptr<nvqir::TensorNetState>
-MPSSimulationState::reconstructBackendState() {
+MPSSimulationState::reconstructBackendState() const {
   [[maybe_unused]] std::vector<MPSTensor> tensors;
   return nvqir::TensorNetState::createFromMpsTensors(
       m_mpsTensors, state->getInternalContext(), tensors);
 }
 
 std::unique_ptr<cudaq::SimulationState>
-MPSSimulationState::toSimulationState() {
+MPSSimulationState::toSimulationState() const {
   std::vector<MPSTensor> tensors;
   auto cloneState = nvqir::TensorNetState::createFromMpsTensors(
       m_mpsTensors, state->getInternalContext(), tensors);

--- a/runtime/nvqir/cutensornet/mps_simulation_state.h
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.h
@@ -68,8 +68,8 @@ public:
   // In this case (MPS), the initial state is set to the MPS tensor train, which
   // has been factorized when the previous get_state was called (to get a handle
   // to this MPSSimulationState).
-  std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() override;
-  std::unique_ptr<cudaq::SimulationState> toSimulationState() override;
+  std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() const override;
+  std::unique_ptr<cudaq::SimulationState> toSimulationState() const override;
 
 protected:
   void deallocate();

--- a/runtime/nvqir/cutensornet/mps_simulation_state.h
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.h
@@ -68,7 +68,8 @@ public:
   // In this case (MPS), the initial state is set to the MPS tensor train, which
   // has been factorized when the previous get_state was called (to get a handle
   // to this MPSSimulationState).
-  std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() const override;
+  std::unique_ptr<nvqir::TensorNetState>
+  reconstructBackendState() const override;
   std::unique_ptr<cudaq::SimulationState> toSimulationState() const override;
 
 protected:

--- a/runtime/nvqir/cutensornet/simulator_mps_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_mps_register.cpp
@@ -102,6 +102,11 @@ public:
     return numQubits;
   }
 
+  virtual void
+  addQubitsToState(const cudaq::SimulationState &in_state) override {
+    throw std::runtime_error("Not yet supported.");
+  }
+
   virtual std::string name() const override { return "tensornet-mps"; }
 
   CircuitSimulator *clone() override {

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -77,13 +77,13 @@ public:
   virtual void
   addQubitsToState(const cudaq::SimulationState &in_state) override {
     LOG_API_TIME();
-     const TensorNetSimulationState *const casted =
+    const TensorNetSimulationState *const casted =
         dynamic_cast<const TensorNetSimulationState *>(&in_state);
     if (!casted)
       throw std::invalid_argument(
           "[Tensornet simulator] Incompatible state input");
     if (!m_state) {
-       m_state = casted->reconstructBackendState();
+      m_state = casted->reconstructBackendState();
     } else {
       // Expand an existing state:
       //  (1) Create a blank tensor network with combined number of qubits

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -74,6 +74,44 @@ public:
     }
   }
 
+  virtual void
+  addQubitsToState(const cudaq::SimulationState &in_state) override {
+    LOG_API_TIME();
+     const TensorNetSimulationState *const casted =
+        dynamic_cast<const TensorNetSimulationState *>(&in_state);
+    if (!casted)
+      throw std::invalid_argument(
+          "[Tensornet simulator] Incompatible state input");
+    if (!m_state) {
+       m_state = casted->reconstructBackendState();
+    } else {
+      // Expand an existing state:
+      //  (1) Create a blank tensor network with combined number of qubits
+      //  (2) Add back the gate tensors of the original tensor network (first
+      // half of the register)
+      //  (3) Add gate tensors of the incoming init state
+      // after remapping the leg indices, i.e., shifting the leg id by the
+      // original size.
+      const auto currentSize = m_state->getNumQubits();
+      // Add qubits in zero state
+      m_state->addQubits(in_state.getNumQubits());
+      auto mapQubitIdxs = [currentSize](const std::vector<int32_t> &idxs) {
+        std::vector<int32_t> mapped(idxs);
+        for (auto &x : mapped)
+          x += currentSize;
+        return mapped;
+      };
+      for (auto &op : casted->getAppliedTensors()) {
+        if (op.isUnitary)
+          m_state->applyGate(mapQubitIdxs(op.qubitIds), op.deviceData,
+                             op.isAdjoint);
+        else
+          m_state->applyQubitProjector(op.deviceData,
+                                       mapQubitIdxs(op.qubitIds));
+      }
+    }
+  }
+
 private:
   friend nvqir::CircuitSimulator * ::getCircuitSimulator_tensornet();
   /// @brief Has cuTensorNet MPI been initialized?

--- a/runtime/nvqir/cutensornet/tn_simulation_state.cpp
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.cpp
@@ -192,12 +192,12 @@ void TensorNetSimulationState::dump(std::ostream &os) const {
 }
 
 std::unique_ptr<nvqir::TensorNetState>
-TensorNetSimulationState::reconstructBackendState() {
+TensorNetSimulationState::reconstructBackendState() const {
   return m_state->clone();
 }
 
 std::unique_ptr<cudaq::SimulationState>
-TensorNetSimulationState::toSimulationState() {
+TensorNetSimulationState::toSimulationState() const {
   return std::make_unique<TensorNetSimulationState>(
       m_state->clone(), m_state->getInternalContext());
 }

--- a/runtime/nvqir/cutensornet/tn_simulation_state.h
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.h
@@ -76,9 +76,15 @@ public:
   // the simulation. The resulting nvqir::TensorNetState should be able to be
   // fed to the appropriate tensor network based simulator to continue the
   // simulation.
-  std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() override;
+  std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() const override;
 
-  std::unique_ptr<cudaq::SimulationState> toSimulationState() override;
+  std::unique_ptr<cudaq::SimulationState> toSimulationState() const override;
+
+  /// @brief Return a reference to all the tensors that have been applied to the
+  /// state.
+  const std::vector<AppliedTensorOp> &getAppliedTensors() const {
+    return m_state->m_tensorOps;
+  }
 
 protected:
   std::unique_ptr<TensorNetState> m_state;

--- a/runtime/nvqir/cutensornet/tn_simulation_state.h
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.h
@@ -76,7 +76,8 @@ public:
   // the simulation. The resulting nvqir::TensorNetState should be able to be
   // fed to the appropriate tensor network based simulator to continue the
   // simulation.
-  std::unique_ptr<nvqir::TensorNetState> reconstructBackendState() const override;
+  std::unique_ptr<nvqir::TensorNetState>
+  reconstructBackendState() const override;
 
   std::unique_ptr<cudaq::SimulationState> toSimulationState() const override;
 

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -233,7 +233,6 @@ protected:
       state = casted->state;
     else
       state = qpp::kron(casted->state, state);
-    return;
   }
 
   /// @brief Reset the qubit state.

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -223,6 +223,19 @@ protected:
     return;
   }
 
+  void addQubitsToState(const cudaq::SimulationState &in_state) override {
+    const QppState *const casted = dynamic_cast<const QppState *>(&in_state);
+    if (!casted)
+      throw std::invalid_argument(
+          "[QppCircuitSimulator] Incompatible state input");
+
+    if (state.size() == 0)
+      state = casted->state;
+    else
+      state = qpp::kron(casted->state, state);
+    return;
+  }
+
   /// @brief Reset the qubit state.
   void deallocateStateImpl() override {
     StateType tmp;

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -229,7 +229,6 @@ protected:
 
     state =
         (state.size() == 0) ? casted->state : qpp::kron(casted->state, state);
-    
   }
 
   void setToZeroState() override {

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -220,6 +220,18 @@ protected:
     }
   }
 
+  void addQubitsToState(const cudaq::SimulationState &in_state) override {
+    const QppDmState *const casted =
+        dynamic_cast<const QppDmState *>(&in_state);
+    if (!casted)
+      throw std::invalid_argument(
+          "[QppNoiseCircuitSimulator] Incompatible state input");
+
+    state =
+        (state.size() == 0) ? casted->state : qpp::kron(casted->state, state);
+    return;
+  }
+  
   void setToZeroState() override {
     state = qpp::cmat::Zero(stateDimension, stateDimension);
     state(0, 0) = 1.0;

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -229,7 +229,7 @@ protected:
 
     state =
         (state.size() == 0) ? casted->state : qpp::kron(casted->state, state);
-    return;
+    
   }
 
   void setToZeroState() override {

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -231,7 +231,7 @@ protected:
         (state.size() == 0) ? casted->state : qpp::kron(casted->state, state);
     return;
   }
-  
+
   void setToZeroState() override {
     state = qpp::cmat::Zero(stateDimension, stateDimension);
     state(0, 0) = 1.0;

--- a/unittests/integration/qubit_allocation.cpp
+++ b/unittests/integration/qubit_allocation.cpp
@@ -111,8 +111,8 @@ CUDAQ_TEST(AllocationTester, checkDensityOrderingBug) {
 #endif
 
 struct test_allocation_from_state {
-  void operator()(cudaq::state &&state) __qpu__ {
-    cudaq::qvector q(std::move(state));
+  void operator()(cudaq::state state) __qpu__ {
+    cudaq::qvector q(state);
     mz(q);
   }
 };
@@ -123,8 +123,7 @@ CUDAQ_TEST(AllocationTester, checkAllocationFromRetrievedState) {
     h(q[0]);
     cx(q[0], q[1]);
   });
-  auto counts =
-      cudaq::sample(test_allocation_from_state{}, std::move(bellState));
+  auto counts = cudaq::sample(test_allocation_from_state{}, bellState);
   counts.dump();
   EXPECT_EQ(2, counts.size());
   int c = 0;

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -470,7 +470,6 @@ CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromStateVec) {
   __quantum__rt__finalize();
 }
 
-
 CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromRetrievedStateSimple) {
   // Library code...
   __quantum__rt__initialize(0, nullptr);
@@ -552,8 +551,7 @@ CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromRetrievedStateExpand) {
   cudaq::ExecutionContext sampleCtx("sample", shots);
   __quantum__rt__setExecutionContext(&sampleCtx);
   // Allocate some qubits in 0 state
-  auto *someQubits =
-      __quantum__rt__qubit_allocate_array(2);
+  auto *someQubits = __quantum__rt__qubit_allocate_array(2);
   // Allocate some more in a specific state
   auto *qubits =
       __quantum__rt__qubit_allocate_array_with_state_ptr(state.get());
@@ -569,6 +567,7 @@ CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromRetrievedStateExpand) {
   __quantum__qis__mz(q3);
   __quantum__qis__mz(q4);
   __quantum__rt__qubit_release_array(qubits);
+  __quantum__rt__qubit_release_array(someQubits);
   __quantum__rt__resetExecutionContext();
 
   cudaq::sample_result counts = sampleCtx.result;

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -71,6 +71,14 @@ void __quantum__qis__apply__general(Array *data, int64_t n_qubits, ...);
 
 // Qubit array allocation / deallocation
 Array *__quantum__rt__qubit_allocate_array(uint64_t idx);
+Array *
+__quantum__rt__qubit_allocate_array_with_state_fp64(uint64_t size,
+                                                    std::complex<double> *data);
+Array *
+__quantum__rt__qubit_allocate_array_with_state_fp32(uint64_t size,
+                                                    std::complex<float> *data);
+Array *__quantum__rt__qubit_allocate_array_with_state_ptr(
+    cudaq::SimulationState *state);
 void __quantum__rt__qubit_release_array(Array *q);
 void __quantum__rt__qubit_release(Qubit *q);
 Qubit *__quantum__rt__qubit_allocate();
@@ -420,4 +428,159 @@ CUDAQ_TEST(NVQIRTester, checkGates) {
     EXPECT_NEAR(0.0, m.imag(), 1e-12);
     std::cout << m.real() << ", " << m.imag() << "\n";
   }
+}
+
+CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromStateVec) {
+  // Library code...
+  __quantum__rt__initialize(0, nullptr);
+
+  const int shots = 1000;
+  cudaq::ExecutionContext ctx("sample", shots);
+  __quantum__rt__setExecutionContext(&ctx);
+
+  // Quantum Kernel Code at the QIR level
+  std::vector<cudaq::complex> bellState{M_SQRT1_2, 0.0, 0.0, M_SQRT1_2};
+  Array *qubits = [](auto &state) {
+    if constexpr (std::is_same_v<cudaq::complex, std::complex<double>>)
+      return __quantum__rt__qubit_allocate_array_with_state_fp64(2,
+                                                                 state.data());
+    else
+      return __quantum__rt__qubit_allocate_array_with_state_fp32(2,
+                                                                 state.data());
+  }(bellState);
+  Qubit *q1 = extract_qubit(qubits, 0);
+  Qubit *q2 = extract_qubit(qubits, 1);
+  __quantum__qis__mz(q1);
+  __quantum__qis__mz(q2);
+  __quantum__rt__qubit_release_array(qubits);
+
+  // Back to library code
+  __quantum__rt__resetExecutionContext();
+
+  cudaq::sample_result counts = ctx.result;
+  counts.dump();
+  int counter = 0;
+  for (auto &[bits, count] : counts) {
+    EXPECT_TRUE(bits == "00" || bits == "11");
+    counter += count;
+  }
+
+  EXPECT_EQ(shots, counter);
+
+  __quantum__rt__finalize();
+}
+
+
+CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromRetrievedStateSimple) {
+  // Library code...
+  __quantum__rt__initialize(0, nullptr);
+  cudaq::ExecutionContext ctx("extract-state");
+  {
+    __quantum__rt__setExecutionContext(&ctx);
+
+    // Quantum Kernel Code at the QIR level
+    auto qubits = __quantum__rt__qubit_allocate_array(2);
+    Qubit *q1 = *reinterpret_cast<Qubit **>(
+        __quantum__rt__array_get_element_ptr_1d(qubits, 0));
+    Qubit *q2 = *reinterpret_cast<Qubit **>(
+        __quantum__rt__array_get_element_ptr_1d(qubits, 1));
+
+    __quantum__qis__h(q1);
+    __quantum__qis__cnot(q1, q2);
+    __quantum__rt__qubit_release_array(qubits);
+    // Back to library code
+    __quantum__rt__resetExecutionContext();
+  }
+  // Get the state from the context since we're about change the context.
+  // Note: this is similar to passing the ctx.simulationState to the `state`
+  // result in a `get_state`.
+  std::unique_ptr<cudaq::SimulationState> state =
+      std::move(ctx.simulationState);
+  // Let's do some sampling
+  const int shots = 1000;
+  cudaq::ExecutionContext sampleCtx("sample", shots);
+  __quantum__rt__setExecutionContext(&sampleCtx);
+  auto *qubits =
+      __quantum__rt__qubit_allocate_array_with_state_ptr(state.get());
+  Qubit *q1 = extract_qubit(qubits, 0);
+  Qubit *q2 = extract_qubit(qubits, 1);
+  __quantum__qis__mz(q1);
+  __quantum__qis__mz(q2);
+  __quantum__rt__qubit_release_array(qubits);
+  __quantum__rt__resetExecutionContext();
+
+  cudaq::sample_result counts = sampleCtx.result;
+  counts.dump();
+  int counter = 0;
+  for (auto &[bits, count] : counts) {
+    EXPECT_TRUE(bits == "00" || bits == "11");
+    counter += count;
+  }
+
+  EXPECT_EQ(shots, counter);
+
+  __quantum__rt__finalize();
+}
+
+CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromRetrievedStateExpand) {
+  // Library code...
+  __quantum__rt__initialize(0, nullptr);
+  cudaq::ExecutionContext ctx("extract-state");
+  {
+    __quantum__rt__setExecutionContext(&ctx);
+
+    // Quantum Kernel Code at the QIR level
+    auto qubits = __quantum__rt__qubit_allocate_array(2);
+    Qubit *q1 = *reinterpret_cast<Qubit **>(
+        __quantum__rt__array_get_element_ptr_1d(qubits, 0));
+    Qubit *q2 = *reinterpret_cast<Qubit **>(
+        __quantum__rt__array_get_element_ptr_1d(qubits, 1));
+
+    __quantum__qis__h(q1);
+    __quantum__qis__cnot(q1, q2);
+    __quantum__rt__qubit_release_array(qubits);
+    // Back to library code
+    __quantum__rt__resetExecutionContext();
+  }
+  // Get the state from the context since we're about change the context.
+  // Note: this is similar to passing the ctx.simulationState to the `state`
+  // result in a `get_state`.
+  std::unique_ptr<cudaq::SimulationState> state =
+      std::move(ctx.simulationState);
+  // Let's do some sampling
+  const int shots = 1000;
+  cudaq::ExecutionContext sampleCtx("sample", shots);
+  __quantum__rt__setExecutionContext(&sampleCtx);
+  // Allocate some qubits in 0 state
+  auto *someQubits =
+      __quantum__rt__qubit_allocate_array(2);
+  // Allocate some more in a specific state
+  auto *qubits =
+      __quantum__rt__qubit_allocate_array_with_state_ptr(state.get());
+  Qubit *q1 = extract_qubit(someQubits, 0);
+  Qubit *q2 = extract_qubit(someQubits, 1);
+  Qubit *q3 = extract_qubit(qubits, 0);
+  Qubit *q4 = extract_qubit(qubits, 1);
+  // Spread the entanglement...
+  __quantum__qis__cnot(q3, q1);
+  __quantum__qis__cnot(q4, q2);
+  __quantum__qis__mz(q1);
+  __quantum__qis__mz(q2);
+  __quantum__qis__mz(q3);
+  __quantum__qis__mz(q4);
+  __quantum__rt__qubit_release_array(qubits);
+  __quantum__rt__resetExecutionContext();
+
+  cudaq::sample_result counts = sampleCtx.result;
+  counts.dump();
+  int counter = 0;
+  // We should have a bigger GHZ state: |0000> + |1111>
+  for (auto &[bits, count] : counts) {
+    EXPECT_TRUE(bits == "0000" || bits == "1111");
+    counter += count;
+  }
+
+  EXPECT_EQ(shots, counter);
+
+  __quantum__rt__finalize();
 }

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -72,7 +72,7 @@ void __quantum__qis__apply__general(Array *data, int64_t n_qubits, ...);
 // Qubit array allocation / deallocation
 Array *__quantum__rt__qubit_allocate_array(uint64_t idx);
 Array *
-__quantum__rt__qubit_allocate_array_with_state_fp64(uint64_t size,
+__quantum__rt__qubit_allocate_array_with_state_fp64(std::uint64_t size,
                                                     std::complex<double> *data);
 Array *
 __quantum__rt__qubit_allocate_array_with_state_fp32(uint64_t size,

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -127,7 +127,7 @@ public:
                                const cudaq::SimulationState *state) override {
     throw std::runtime_error("initializeState not implemented.");
   }
-  
+
   void resetQudit(const cudaq::QuditInfo &id) override {}
 };
 

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -122,6 +122,12 @@ public:
                        cudaq::simulation_precision precision) override {
     throw std::runtime_error("initializeState not implemented.");
   }
+
+  virtual void initializeState(const std::vector<cudaq::QuditInfo> &targets,
+                               const cudaq::SimulationState *state) override {
+    throw std::runtime_error("initializeState not implemented.");
+  }
+  
   void resetQudit(const cudaq::QuditInfo &id) override {}
 };
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This is an alternative approach to https://github.com/NVIDIA/cuda-quantum/pull/1542 whereby the user-facing `state` is a thin wrapper around the underlying `SimulationState` data (i.e., passing by reference or value doesn't really matter); plus sub-state allocation should force an implicit copy, and `qvector` initialization from existing state + subsequent `get_state` should also force a copy.

- Implementations for in-source simulator backends (except MPS) are provided. 

- Adding an NVQIR function prototype (along the existing allocation from vector QIR functions)

- Adding NVQIR tests.
