### PR TITLE
Fix incorrect parameter copy when passing parameters to python kernel functions

### DIFF
--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -73,7 +73,7 @@ cudaq::cc::StructType factory::buildInvokeStructType(FunctionType funcTy) {
     eleTys.push_back(genBufferType</*isOutput=*/false>(inTy));
   for (auto outTy : funcTy.getResults())
     eleTys.push_back(genBufferType</*isOutput=*/true>(outTy));
-  return cudaq::cc::StructType::get(ctx, eleTys, true);
+  return cudaq::cc::StructType::get(ctx, eleTys /*packed=false*/);
 }
 
 Value factory::packIsArrayAndLengthArray(Location loc,

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -73,7 +73,7 @@ cudaq::cc::StructType factory::buildInvokeStructType(FunctionType funcTy) {
     eleTys.push_back(genBufferType</*isOutput=*/false>(inTy));
   for (auto outTy : funcTy.getResults())
     eleTys.push_back(genBufferType</*isOutput=*/true>(outTy));
-  return cudaq::cc::StructType::get(ctx, eleTys /*packed=false*/);
+  return cudaq::cc::StructType::get(ctx, eleTys, true);
 }
 
 Value factory::packIsArrayAndLengthArray(Location loc,

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -348,7 +348,6 @@ public:
     // Initialize the counter for extra size.
     Value zero = builder.create<arith::ConstantIntOp>(loc, 0, 64);
     Value extraBytes = zero;
-    Value returnOffset = zero;
 
     // Process all the arguments for the original call by looping over the
     // kernel's arguments.
@@ -427,16 +426,6 @@ public:
       }
       if (isa<cudaq::cc::PointerType>(currEleTy))
         continue;
-      
-      // Compute return offset
-      if (idx == kernelArgTypes.size() - 1) {
-        // Compute the struct size
-        auto nullSt = builder.create<cudaq::cc::CastOp>(loc, structPtrTy, zero);
-        auto computedOffset = builder.create<cudaq::cc::ComputePtrOp>(
-            loc, structPtrTy, nullSt, SmallVector<cudaq::cc::ComputePtrArg>{1});
-        Value returnOffset =
-            builder.create<cudaq::cc::CastOp>(loc, i64Ty, computedOffset);
-      }
 
       // cast to the struct element type, void* -> TYPE *
       argPtr = builder.create<cudaq::cc::CastOp>(
@@ -523,7 +512,6 @@ public:
       }
     }
     builder.create<cudaq::cc::StoreOp>(loc, buff, entry->getArgument(1));
-    builder.create<cudaq::cc::StoreOp>(loc, returnOffset, entry->getArgument(2));
     builder.create<func::ReturnOp>(loc, ValueRange{extendedStructSize});
     return argsCreatorFunc;
   }

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -48,7 +48,7 @@ using PyStateVectorStorage = std::map<std::string, PyStateVectorData>;
 static std::unique_ptr<PyStateVectorStorage> stateStorage =
     std::make_unique<PyStateVectorStorage>();
 
-std::tuple<ExecutionEngine *, void *, std::size_t>
+std::tuple<ExecutionEngine *, void *, std::size_t, std::size_t>
 jitAndCreateArgs(const std::string &name, MlirModule module,
                  cudaq::OpaqueArguments &runtimeArgs,
                  const std::vector<std::string> &names, Type returnType) {
@@ -172,6 +172,7 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
 
   void *rawArgs = nullptr;
   std::size_t size = 0;
+  std::size_t returnOffset = 0;
   if (runtimeArgs.size()) {
     auto expectedPtr = jit->lookup(name + ".argsCreator");
     if (!expectedPtr) {
@@ -179,18 +180,18 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
           "cudaq::builder failed to get argsCreator function.");
     }
     auto argsCreator =
-        reinterpret_cast<std::size_t (*)(void **, void **)>(*expectedPtr);
+        reinterpret_cast<std::size_t (*)(void **, void **, size_t*)>(*expectedPtr);
     rawArgs = nullptr;
-    size = argsCreator(runtimeArgs.data(), &rawArgs);
+    size = argsCreator(runtimeArgs.data(), &rawArgs, &returnOffset);
   }
-  return std::make_tuple(jit, rawArgs, size);
+  return std::make_tuple(jit, rawArgs, size, returnOffset);
 }
 
-std::tuple<void *, std::size_t>
+std::tuple<void *, std::size_t, std::size_t>
 pyAltLaunchKernelBase(const std::string &name, MlirModule module,
                       Type returnType, cudaq::OpaqueArguments &runtimeArgs,
                       const std::vector<std::string> &names) {
-  auto [jit, rawArgs, size] =
+  auto [jit, rawArgs, size, returnOffset] =
       jitAndCreateArgs(name, module, runtimeArgs, names, returnType);
 
   auto mod = unwrap(module);
@@ -249,12 +250,12 @@ pyAltLaunchKernelBase(const std::string &name, MlirModule module,
   if (platform.is_remote() || platform.is_emulated()) {
     auto *wrapper = new cudaq::ArgWrapper{mod, names, rawArgs};
     cudaq::altLaunchKernel(name.c_str(), thunk,
-                           reinterpret_cast<void *>(wrapper), size, 0);
+                           reinterpret_cast<void *>(wrapper), size, returnOffset);
     delete wrapper;
   } else
-    cudaq::altLaunchKernel(name.c_str(), thunk, rawArgs, size, 0);
+    cudaq::altLaunchKernel(name.c_str(), thunk, rawArgs, size, returnOffset);
 
-  return std::make_tuple(rawArgs, size);
+  return std::make_tuple(rawArgs, size, returnOffset);
 }
 
 void pyAltLaunchKernel(const std::string &name, MlirModule module,
@@ -270,34 +271,34 @@ py::object pyAltLaunchKernelR(const std::string &name, MlirModule module,
                               MlirType returnType,
                               cudaq::OpaqueArguments &runtimeArgs,
                               const std::vector<std::string> &names) {
-  auto [rawArgs, size] = pyAltLaunchKernelBase(name, module, unwrap(returnType),
+  auto [rawArgs, size, returnOffset] = pyAltLaunchKernelBase(name, module, unwrap(returnType),
                                                runtimeArgs, names);
   auto unwrapped = unwrap(returnType);
 
   // We first need to compute the offset for the return value.
   // We'll loop through all the arguments and increment the
   // offset for the argument type. Then we'll be at our return type location.
-  auto returnOffset = [&]() {
-    std::size_t offset = 0;
-    auto kernelFunc = getKernelFuncOp(module, name);
-    for (auto argType : kernelFunc.getArgumentTypes())
-      llvm::TypeSwitch<mlir::Type, void>(argType)
-          .Case([&](IntegerType ty) {
-            if (ty.getIntOrFloatBitWidth() == 1) {
-              offset += 1;
-              return;
-            }
+  // auto returnOffset = [&]() {
+  //   std::size_t offset = 0;
+  //   auto kernelFunc = getKernelFuncOp(module, name);
+  //   for (auto argType : kernelFunc.getArgumentTypes())
+  //     llvm::TypeSwitch<mlir::Type, void>(argType)
+  //         .Case([&](IntegerType ty) {
+  //           if (ty.getIntOrFloatBitWidth() == 1) {
+  //             offset += 1;
+  //             return;
+  //           }
 
-            offset += 8;
-            return;
-          })
-          .Case([&](cc::StdvecType ty) { offset += 8; })
-          .Case([&](Float64Type ty) { offset += 8; })
-          .Case([&](Float32Type ty) { offset += 4; })
-          .Default([](Type) {});
+  //           offset += 8;
+  //           return;
+  //         })
+  //         .Case([&](cc::StdvecType ty) { offset += 8; })
+  //         .Case([&](Float64Type ty) { offset += 8; })
+  //         .Case([&](Float32Type ty) { offset += 4; })
+  //         .Default([](Type) {});
 
-    return offset;
-  }();
+  //   return offset;
+  // }();
 
   // Extract the return value from the rawArgs pointer.
   return llvm::TypeSwitch<mlir::Type, py::object>(unwrapped)

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -180,9 +180,9 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
           "cudaq::builder failed to get argsCreator function.");
     }
     auto argsCreator =
-        reinterpret_cast<std::size_t (*)(void **, void **, size_t*)>(*expectedPtr);
+        reinterpret_cast<std::size_t (*)(void **, void **)>(*expectedPtr);
     rawArgs = nullptr;
-    size = argsCreator(runtimeArgs.data(), &rawArgs, &returnOffset);
+    size = argsCreator(runtimeArgs.data(), &rawArgs);
   }
   return std::make_tuple(jit, rawArgs, size, returnOffset);
 }

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -36,6 +36,7 @@ namespace py = pybind11;
 using namespace mlir;
 
 namespace cudaq {
+// TODO: unify with the definition in GenKernelExec.cpp
 static constexpr std::int32_t NoResultOffset =
     std::numeric_limits<std::int32_t>::max();
 static std::unique_ptr<JITExecutionCache> jitCache;

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -172,7 +172,6 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
 
   void *rawArgs = nullptr;
   std::size_t size = 0;
-  std::size_t returnOffset = 0;
   if (runtimeArgs.size()) {
     auto expectedPtr = jit->lookup(name + ".argsCreator");
     if (!expectedPtr) {
@@ -183,6 +182,18 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
         reinterpret_cast<std::size_t (*)(void **, void **)>(*expectedPtr);
     rawArgs = nullptr;
     size = argsCreator(runtimeArgs.data(), &rawArgs);
+  }
+
+  std::size_t returnOffset = 0;
+  if (runtimeArgs.size()) {
+    auto expectedPtr = jit->lookup(name + ".returnOffset");
+    if (!expectedPtr) {
+      throw std::runtime_error(
+          "cudaq::builder failed to get returnOffset function.");
+    }
+    auto returnOffsetCreator =
+        reinterpret_cast<std::size_t (*)()>(*expectedPtr);
+    returnOffset = returnOffsetCreator();
   }
   return std::make_tuple(jit, rawArgs, size, returnOffset);
 }
@@ -250,7 +261,8 @@ pyAltLaunchKernelBase(const std::string &name, MlirModule module,
   if (platform.is_remote() || platform.is_emulated()) {
     auto *wrapper = new cudaq::ArgWrapper{mod, names, rawArgs};
     cudaq::altLaunchKernel(name.c_str(), thunk,
-                           reinterpret_cast<void *>(wrapper), size, returnOffset);
+                           reinterpret_cast<void *>(wrapper), size,
+                           returnOffset);
     delete wrapper;
   } else
     cudaq::altLaunchKernel(name.c_str(), thunk, rawArgs, size, returnOffset);
@@ -262,7 +274,7 @@ void pyAltLaunchKernel(const std::string &name, MlirModule module,
                        cudaq::OpaqueArguments &runtimeArgs,
                        const std::vector<std::string> &names) {
   auto noneType = mlir::NoneType::get(unwrap(module).getContext());
-  auto [rawArgs, size] =
+  auto [rawArgs, size, returnOffset] =
       pyAltLaunchKernelBase(name, module, noneType, runtimeArgs, names);
   std::free(rawArgs);
 }
@@ -271,34 +283,9 @@ py::object pyAltLaunchKernelR(const std::string &name, MlirModule module,
                               MlirType returnType,
                               cudaq::OpaqueArguments &runtimeArgs,
                               const std::vector<std::string> &names) {
-  auto [rawArgs, size, returnOffset] = pyAltLaunchKernelBase(name, module, unwrap(returnType),
-                                               runtimeArgs, names);
+  auto [rawArgs, size, returnOffset] = pyAltLaunchKernelBase(
+      name, module, unwrap(returnType), runtimeArgs, names);
   auto unwrapped = unwrap(returnType);
-
-  // We first need to compute the offset for the return value.
-  // We'll loop through all the arguments and increment the
-  // offset for the argument type. Then we'll be at our return type location.
-  // auto returnOffset = [&]() {
-  //   std::size_t offset = 0;
-  //   auto kernelFunc = getKernelFuncOp(module, name);
-  //   for (auto argType : kernelFunc.getArgumentTypes())
-  //     llvm::TypeSwitch<mlir::Type, void>(argType)
-  //         .Case([&](IntegerType ty) {
-  //           if (ty.getIntOrFloatBitWidth() == 1) {
-  //             offset += 1;
-  //             return;
-  //           }
-
-  //           offset += 8;
-  //           return;
-  //         })
-  //         .Case([&](cc::StdvecType ty) { offset += 8; })
-  //         .Case([&](Float64Type ty) { offset += 8; })
-  //         .Case([&](Float32Type ty) { offset += 4; })
-  //         .Default([](Type) {});
-
-  //   return offset;
-  // }();
 
   // Extract the return value from the rawArgs pointer.
   return llvm::TypeSwitch<mlir::Type, py::object>(unwrapped)
@@ -337,7 +324,7 @@ MlirModule synthesizeKernel(const std::string &name, MlirModule module,
   ScopedTraceWithContext(cudaq::TIMING_JIT, "synthesizeKernel", name);
   auto noneType = mlir::NoneType::get(unwrap(module).getContext());
 
-  auto [jit, rawArgs, size] =
+  auto [jit, rawArgs, size, returnOffset] =
       jitAndCreateArgs(name, module, runtimeArgs, {}, noneType);
   auto cloned = unwrap(module).clone();
   auto context = cloned.getContext();
@@ -370,7 +357,7 @@ std::string getQIRLL(const std::string &name, MlirModule module,
   ScopedTraceWithContext(cudaq::TIMING_JIT, "getQIRLL", name);
   auto noneType = mlir::NoneType::get(unwrap(module).getContext());
 
-  auto [jit, rawArgs, size] =
+  auto [jit, rawArgs, size, returnOffset] =
       jitAndCreateArgs(name, module, runtimeArgs, {}, noneType);
   auto cloned = unwrap(module).clone();
   auto context = cloned.getContext();

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -201,7 +201,7 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
       returnOffset = 0;
     }
   }
-  return std::make_tuple(jit, rawArgs, size, returnOffset);
+  return {jit, rawArgs, size, returnOffset};
 }
 
 std::tuple<void *, std::size_t, std::int32_t>

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -1307,7 +1307,7 @@ def test_bad_return_int_bool_param():
     assert kernel(1, False) == 1
 
 
-def test_good_return_bool_bool_param():
+def test_return_bool_bool_param():
 
     @cudaq.kernel
     def kernel(b: bool, b2: bool) -> bool:
@@ -1316,10 +1316,26 @@ def test_good_return_bool_bool_param():
     assert kernel(True, False) == True
 
 
-def test_good_return_int_int_param():
+def test_return_int_int_param():
 
     @cudaq.kernel
     def kernel(b: int, b2: int) -> int:
         return b
 
     assert kernel(42, 53) == 42
+
+def test_return_no_param():
+
+    @cudaq.kernel
+    def kernel() -> int:
+        return 42
+
+    assert kernel() == 42
+
+def test_no_param_no_return():
+
+    @cudaq.kernel
+    def kernel():
+        return
+
+    kernel()

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -1001,14 +1001,12 @@ def test_draw_bug_1400():
         cx(q[0], q[1])
         mz(q)
 
-
     @cudaq.kernel
-    def kernel(angle:float):
+    def kernel(angle: float):
         q = cudaq.qubit()
         h(q)
         ry(angle, q)
-    
-    
+
     print(cudaq.draw(kernel, 0.59))
     print(cudaq.draw(kernel, 0.59))
     circuit = cudaq.draw(bell_pair)
@@ -1023,8 +1021,9 @@ q1 : ─────┤ x ├
 
 
 def test_with_docstring_2():
+
     @cudaq.kernel
-    def simple(n:int):
+    def simple(n: int):
         '''
         A docstring with triple single quote
         '''
@@ -1227,12 +1226,15 @@ def test_ctrl_wrong_dtype_1447():
 
 def test_math_module_pi_1448():
     import math
+
     @cudaq.kernel
     def test_kernel() -> float:
         theta = math.pi
         return theta
+
     test_kernel.compile()
     assert np.isclose(test_kernel(), math.pi, 1e-12)
+
 
 def test_len_qvector_1449():
 
@@ -1247,45 +1249,77 @@ def test_len_qvector_1449():
     test_kernel.compile()
     assert test_kernel(5) == 5
 
+
 def test_missing_paren_1450():
 
     @cudaq.kernel
     def test_kernel():
         state_reg = cudaq.qubit
         x(state_reg)
-    
+
     with pytest.raises(RuntimeError) as e:
         test_kernel.compile()
     assert 'invalid assignment detected.' in repr(e)
 
+
 def test_cast_error_1451():
+
     @cudaq.kernel
     def test_kernel(N: int):
         q = cudaq.qvector(N)
-        for i in range(0,N/2):
-            swap(q[i], q[N-i-1])
-    
+        for i in range(0, N / 2):
+            swap(q[i], q[N - i - 1])
+
     # Test is that this compiles
     test_kernel.compile()
 
 
 def test_bad_attr_call_error():
+
     @cudaq.kernel
     def test_state(N: int):
         q = cudaq.qvector(N)
         h(q[0])
         kernel.h(q[0])
-    
+
     with pytest.raises(RuntimeError) as e:
         test_state.compile()
     assert "Invalid function call - 'kernel' is unknown." in repr(e)
 
+
 def test_bad_return_value_with_stdvec_arg():
 
     @cudaq.kernel
-    def test_param(i: int, l : List[int]) -> int: 
+    def test_param(i: int, l: List[int]) -> int:
         return i
 
     l = [42]
     for i in range(4):
-        assert test_param(i,l) == i 
+        assert test_param(i, l) == i
+
+
+def test_bad_return_int_bool_param():
+
+    @cudaq.kernel(verbose=True)
+    def kernel(c: int, b: bool) -> int:
+        return c
+
+    assert kernel(1, False) == 1
+
+
+def test_good_return_bool_bool_param():
+
+    @cudaq.kernel(verbose=True)
+    def kernel(b: bool, b2: bool) -> bool:
+        return b
+
+    assert kernel(True, False) == True
+
+
+def test_good_return_int_int_param():
+
+    @cudaq.kernel(verbose=True)
+    def kernel(b: int, b2: int) -> int:
+        return b
+
+    assert kernel(42, 53) == 42

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -1300,7 +1300,7 @@ def test_bad_return_value_with_stdvec_arg():
 
 def test_bad_return_int_bool_param():
 
-    @cudaq.kernel(verbose=True)
+    @cudaq.kernel
     def kernel(c: int, b: bool) -> int:
         return c
 
@@ -1309,7 +1309,7 @@ def test_bad_return_int_bool_param():
 
 def test_good_return_bool_bool_param():
 
-    @cudaq.kernel(verbose=True)
+    @cudaq.kernel
     def kernel(b: bool, b2: bool) -> bool:
         return b
 
@@ -1318,7 +1318,7 @@ def test_good_return_bool_bool_param():
 
 def test_good_return_int_int_param():
 
-    @cudaq.kernel(verbose=True)
+    @cudaq.kernel
     def kernel(b: int, b2: int) -> int:
         return b
 


### PR DESCRIPTION
### Description

**Problem**
The structure we use for collecting arguments to pass to python is in non-packed form, but we rely on arguments to follow each other immediately (without alignment padding) when we try to find the return argument (last in that structure). This results in incorrect parameter passing to python when alignment padding is inserted (for example, in case of one bool and one int  argument).

**Solution**

Use `genReturnOffsetFunction` to create a `returnOffset` function and call it to compute the return offset for python kernels instead of performing incorrect manual calculations.

Closes: https://github.com/NVIDIA/cuda-quantum/issues/1580
