### PR TITLE
[test] Add missing test for #1557:

### DIFF
--- a/test/Quake-QIR/emit-mlir.qke
+++ b/test/Quake-QIR/emit-mlir.qke
@@ -1,0 +1,27 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-translate --convert-to=qir --emit-llvm=false %s | FileCheck %s
+
+// CHECK-LABEL: llvm.func @test_func(
+// CHECK-SAME:   %[[ARG_0:.*]]: i32) {
+// CHECK:        %[[VAL_0:.*]] = llvm.zext %[[ARG_0]] : i32 to i64
+// CHECK:        %[[VAL_1:.*]] = llvm.call @__quantum__rt__qubit_allocate_array(%[[VAL_0]]) : (i64) -> ![[ARRAY_TYPE:.*]]
+// CHECK:        %[[VAL_2:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:        %[[VAL_3:.*]] = llvm.call @__quantum__rt__qubit_allocate_array(%[[VAL_2]]) : (i64) -> ![[ARRAY_TYPE]]
+// CHECK-DAG:    llvm.call @__quantum__rt__qubit_release_array(%[[VAL_1]]) : (![[ARRAY_TYPE]]) -> ()
+// CHECK-DAG:    llvm.call @__quantum__rt__qubit_release_array(%[[VAL_3]]) : (![[ARRAY_TYPE]]) -> ()
+// CHECK:        llvm.return
+// CHECK:       }
+
+func.func @test_func(%p : i32) {
+  %qv = quake.alloca !quake.veq<?>[%p : i32]
+  %t = arith.constant 2 : i32
+  %v = quake.alloca !quake.veq<?>[%t : i32]
+  return
+}


### PR DESCRIPTION
This patch adds a test for the change introduced in #1557.
This test verifies that `cudaq-translate --emit-llvm=false` works as intended and produces MLIR instead of LLVM IR.

