### PR TITLE
[Core] Add a function to determine the offset of the return value in the

### DIFF
--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -287,7 +287,7 @@ public:
         return builder.create<arith::ConstantIntOp>(loc, NoResultOffset, 64);
       auto ptrTy = cudaq::cc::PointerType::get(msgStructTy);
       auto members = msgStructTy.getMembers();
-      auto numKernelArgs = devKernelTy.getNumInputs();
+      std::int32_t numKernelArgs = devKernelTy.getNumInputs();
       auto zero = builder.create<arith::ConstantIntOp>(loc, 0, 64);
       auto basePtr = builder.create<cudaq::cc::CastOp>(loc, ptrTy, zero);
       auto off = builder.create<cudaq::cc::ComputePtrOp>(

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -268,6 +268,36 @@ public:
     return {stVal, extraBytes};
   }
 
+  /// Create a function that determines the return value offset in the message
+  /// buffer.
+  void genReturnOffsetFunction(Location loc, OpBuilder &builder,
+                               FunctionType devKernelTy,
+                               cudaq::cc::StructType msgStructTy,
+                               const std::string &classNameStr) {
+    auto *ctx = builder.getContext();
+    auto i64Ty = builder.getI64Type();
+    auto funcTy = FunctionType::get(ctx, {}, {i64Ty});
+    auto returnOffsetFunc = builder.create<func::FuncOp>(
+        loc, classNameStr + ".returnOffset", funcTy);
+    OpBuilder::InsertionGuard guard(builder);
+    auto *entry = returnOffsetFunc.addEntryBlock();
+    builder.setInsertionPointToStart(entry);
+    auto result = [&]() -> Value {
+      if (devKernelTy.getNumResults() == 0)
+        return builder.create<arith::ConstantIntOp>(loc, NoResultOffset, 64);
+      auto ptrTy = cudaq::cc::PointerType::get(msgStructTy);
+      auto members = msgStructTy.getMembers();
+      auto numKernelArgs = devKernelTy.getNumInputs();
+      auto zero = builder.create<arith::ConstantIntOp>(loc, 0, 64);
+      auto basePtr = builder.create<cudaq::cc::CastOp>(loc, ptrTy, zero);
+      auto off = builder.create<cudaq::cc::ComputePtrOp>(
+          loc, cudaq::cc::PointerType::get(members[numKernelArgs]), basePtr,
+          ArrayRef<cudaq::cc::ComputePtrArg>{0, numKernelArgs});
+      return builder.create<cudaq::cc::CastOp>(loc, i64Ty, off);
+    }();
+    builder.create<func::ReturnOp>(loc, result);
+  }
+
   /// Creates a function that can take a block of pointers to argument values
   /// and using the compiler's knowledge of a kernel encodes those argument
   /// values into a message buffer. The message buffer is a pointer-free block
@@ -1449,6 +1479,9 @@ public:
         hostFuncTy =
             cudaq::opt::factory::toHostSideFuncType(funcTy, hasThisPtr, module);
       }
+
+      // Generate the function that computes the return offset.
+      genReturnOffsetFunction(loc, builder, funcTy, structTy, classNameStr);
 
       // Generate thunk, `<kernel>.thunk`, to call back to the MLIR code.
       auto thunk = genThunkFunction(loc, builder, classNameStr, structTy,

--- a/test/Quake-QIR/argument.qke
+++ b/test/Quake-QIR/argument.qke
@@ -242,7 +242,7 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_0.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #2 {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8** %[[VAL_0]] to { { i32, double }*, { i32, double }*, { i32, double }* }**
 // CHECK:         %[[VAL_3:.*]] = load { { i32, double }*, { i32, double }*, { i32, double }* }*, { { i32, double }*, { i32, double }*, { i32, double }* }** %[[VAL_2]], align 8
 // CHECK:         %[[VAL_4:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_3]], i64 0, i32 1

--- a/test/Quake-QIR/return_values.qke
+++ b/test/Quake-QIR/return_values.qke
@@ -205,7 +205,7 @@ func.func @test_2(%1: !cc.ptr<!cc.struct<{i16, f32, f64, i64}>> {llvm.sret = !cc
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 }) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #1 {
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
 // CHECK:         store { i16, float, double, i64 } { i16 8, float 0x40159999A0000000, double 3.783000e+01, i64 1479 }, { i16, float, double, i64 }* %[[VAL_0]], align 8
 // CHECK:         ret void
 // CHECK:       }
@@ -251,7 +251,7 @@ func.func @test_3(%1: !cc.ptr<!cc.array<i64 x 5>> {llvm.sret = !cc.array<i64 x 5
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_3([5 x i64]* nocapture writeonly sret([5 x i64]) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #1 {
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
 // CHECK:         %[[VAL_1:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 0
 // CHECK:         store i64 5, i64* %[[VAL_1]], align 8
 // CHECK:         %[[VAL_2:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 1
@@ -304,7 +304,7 @@ func.func @test_4(%1: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_4({ i64, double }* nocapture writeonly sret({ i64, double }) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #1 {
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
 // CHECK:         %[[VAL_1:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
 // CHECK:         store i64 537892, i64* %[[VAL_1]], align 8
 // CHECK:         %[[VAL_2:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
@@ -339,7 +339,7 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_5({ i64, double }* nocapture writeonly sret({ i64, double }) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #1 {
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
 // CHECK:         %[[VAL_1:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
 // CHECK:         store i64 537892, i64* %[[VAL_1]], align 8
 // CHECK:         %[[VAL_2:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
@@ -434,7 +434,7 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_0.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #3 {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8** %[[VAL_0]] to i32**
 // CHECK:         %[[VAL_3:.*]] = load i32*, i32** %[[VAL_2]], align 8
 // CHECK:         %[[VAL_4:.*]] = load i32, i32* %[[VAL_3]], align 4
@@ -479,7 +479,7 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_1.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(2) i8* @malloc(i64 2)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 2
@@ -492,14 +492,14 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_2.thunk(i8* nocapture writeonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to { i16, float, double, i64 }*
 // CHECK:         store { i16, float, double, i64 } { i16 8, float 0x40159999A0000000, double 3.783000e+01, i64 1479 }, { i16, float, double, i64 }* %[[VAL_2]], align 8
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_2.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(24) i8* @malloc(i64 24)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 24
@@ -512,7 +512,7 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_3.thunk(i8* nocapture writeonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 5, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 8
@@ -531,7 +531,7 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_3.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(40) i8* @malloc(i64 40)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 40
@@ -544,7 +544,7 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_4.thunk(i8* nocapture writeonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
@@ -554,7 +554,7 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_4.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(16) i8* @malloc(i64 16)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 16
@@ -567,7 +567,7 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_5.thunk(i8* nocapture writeonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #1 {
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
@@ -577,7 +577,7 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_5.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #4 {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(16) i8* @malloc(i64 16)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 16


### PR DESCRIPTION
buffer when calling altLaunchKernel().

- update tests

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
