### PR TITLE
[Core] Completes making quantum values a linear type.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCInterfaces.h
+++ b/include/cudaq/Optimizer/Dialect/CC/CCInterfaces.h
@@ -11,3 +11,23 @@
 #include "cudaq/Optimizer/Dialect/Common/InlinerInterface.h"
 
 using CCInlinerInterface = cudaq::EnableInlinerInterface;
+
+namespace cudaq::cc {
+
+mlir::LogicalResult verifyConvergentLinearTypesInRegions(mlir::Operation *op);
+
+template <typename ConcreteType>
+class LinearTypeArgsTrait
+    : public mlir::OpTrait::TraitBase<ConcreteType, LinearTypeArgsTrait> {
+public:
+  static mlir::LogicalResult verifyRegionTrait(mlir::Operation *op) {
+    return verifyConvergentLinearTypesInRegions(op);
+  }
+};
+} // namespace cudaq::cc
+
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
+
+#include "cudaq/Optimizer/Dialect/CC/CCInterfaces.h.inc"

--- a/include/cudaq/Optimizer/Dialect/CC/CCInterfaces.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCInterfaces.td
@@ -1,0 +1,18 @@
+/********************************************************** -*- tablegen -*- ***
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifndef CUDAQ_OPTIMIZER_DIALECT_CC_IR_INTERFACES
+#define CUDAQ_OPTIMIZER_DIALECT_CC_IR_INTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def LinearTypeArgsTrait : NativeOpTrait<"LinearTypeArgsTrait"> {
+  let cppNamespace = "::cudaq::cc";
+}
+
+#endif // CUDAQ_OPTIMIZER_DIALECT_CC_IR_INTERFACES

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.h
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "cudaq/Optimizer/Dialect/CC/CCInterfaces.h"
 #include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
 #include "cudaq/Optimizer/Dialect/Common/Traits.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -12,7 +12,9 @@
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "cudaq/Optimizer/Dialect/Common/Traits.td"
 include "cudaq/Optimizer/Dialect/CC/CCDialect.td"
+include "cudaq/Optimizer/Dialect/CC/CCInterfaces.td"
 include "cudaq/Optimizer/Dialect/CC/CCTypes.td"
+include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.td"
 
 def AnyPointerType : Type<CPred<"$_self.isa<mlir::LLVM::LLVMPointerType,"
                           "cudaq::cc::PointerType>()">, "any pointer type">;
@@ -340,7 +342,7 @@ def cc_IfOp : CCOp<"if",
     [DeclareOpInterfaceMethods<RegionBranchOpInterface,
                                ["getNumRegionInvocations",
                                 "getRegionInvocationBounds"]>,
-     RecursiveMemoryEffects, NoRegionArguments]> {
+     RecursiveMemoryEffects, LinearTypeArgsTrait]> {
   let summary = "if-then-else operation";
   let description = [{
     An IfOp is a C-like if statement that supports single-entry, multiple-exit
@@ -368,9 +370,15 @@ def cc_IfOp : CCOp<"if",
     ```
   }];
 
-  let arguments = (ins I1:$condition);
+  let arguments = (ins
+    I1:$condition,
+    Variadic<AnyQLinearType>:$linearArgs
+  );
   let results = (outs Variadic<AnyType>:$results);
-  let regions = (region AnyRegion:$thenRegion, AnyRegion:$elseRegion);
+  let regions = (region
+    AnyRegion:$thenRegion,
+    AnyRegion:$elseRegion
+  );
 
   let builders = [
     OpBuilder<(ins "mlir::TypeRange":$resultTypes, "mlir::Value":$cond,
@@ -388,6 +396,23 @@ def cc_IfOp : CCOp<"if",
         mlir::Location, mlir::Region &)>;
 
     bool hasResults() { return getResults().size(); }
+
+    // A cc.if must have a valid then region.
+    bool hasThen() { return !getThenRegion().empty(); }
+    mlir::Block *getThenEntryBlock() { return &getThenRegion().front(); }
+    mlir::Block::BlockArgListType getThenEntryArguments() {
+      return getThenEntryBlock()->getArguments();
+    }
+
+    bool hasElse() { return !getElseRegion().empty(); }
+    mlir::Block *getElseEntryBlock() {
+      return hasElse() ? &getElseRegion().front() :
+        static_cast<mlir::Block*>(nullptr);
+    }
+    mlir::Block::BlockArgListType getElseEntryArguments() {
+      return hasElse() ? getElseEntryBlock()->getArguments() :
+        mlir::Block::BlockArgListType{};
+    }
   }];
 }
 

--- a/include/cudaq/Optimizer/Dialect/CC/CMakeLists.txt
+++ b/include/cudaq/Optimizer/Dialect/CC/CMakeLists.txt
@@ -7,4 +7,5 @@
 # ============================================================================ #
 
 add_cudaq_dialect(CC cc)
+add_cudaq_interface(CCInterfaces)
 add_cudaq_dialect_doc(CCDialect cc)

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeInterfaces.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeInterfaces.td
@@ -6,8 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#ifndef CUDAQ_OPTIMIZER_DIALECT_QUAKE_IR_QUAKE_INTERFACES
-#define CUDAQ_OPTIMIZER_DIALECT_QUAKE_IR_QUAKE_INTERFACES
+#ifndef CUDAQ_OPTIMIZER_DIALECT_QUAKE_IR_INTERFACES
+#define CUDAQ_OPTIMIZER_DIALECT_QUAKE_IR_INTERFACES
 
 include "mlir/IR/OpBase.td"
 
@@ -133,4 +133,4 @@ def MeasurementInterface : OpInterface<"MeasurementInterface"> {
   ];
 }
 
-#endif // CUDAQ_OPTIMIZER_DIALECT_QUAKE_IR_QUAKE_INTERFACES
+#endif // CUDAQ_OPTIMIZER_DIALECT_QUAKE_IR_INTERFACES

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -24,13 +24,19 @@ namespace quake {
 /// \returns true if \p `ty` is a quantum value or reference.
 inline bool isaQuantumType(mlir::Type ty) {
   // NB: this intentionally excludes MeasureType.
-  return llvm::isa<quake::RefType, quake::VeqType, quake::WireType,
+  return mlir::isa<quake::RefType, quake::VeqType, quake::WireType,
                    quake::ControlType>(ty);
 }
 
 /// \returns true if \p `ty` is a Quake type.
 inline bool isQuakeType(mlir::Type ty) {
   // This should correspond to the registered types in QuakeTypes.cpp.
-  return isaQuantumType(ty) || llvm::isa<quake::MeasureType>(ty);
+  return isaQuantumType(ty) || mlir::isa<quake::MeasureType>(ty);
 }
+
+/// A quake value type is a linear type.
+inline bool isLinearType(mlir::Type ty) {
+  return mlir::isa<quake::WireType>(ty);
+}
+
 } // namespace quake

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -192,6 +192,7 @@ def AnyRefType : Type<AnyRefTypeLike.predicate, "quantum reference type">;
 def AnyQValueTypeLike : TypeConstraint<Or<[WireType.predicate,
         ControlType.predicate]>, "quake quantum value types">;
 def AnyQValueType : Type<AnyQValueTypeLike.predicate, "quantum value type">;
+def AnyQLinearType : Type<WireType.predicate, "linear quantum value type">;
 
 def IsStdvecTypePred : CPred<"$_self.isa<::cudaq::cc::StdvecType>()">;
 

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -17,6 +17,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
+#include <unordered_set>
 
 using namespace mlir;
 
@@ -33,31 +34,19 @@ static bool isQuakeOperation(Operation *op) {
   return false;
 }
 
-// If a wire value is used more than once but in distinct blocks, assume that
-// the uses are dynamically mutually exclusive. This is an approximation and not
-// sufficient to prove the value has a linear type.
-// TODO: implement an analysis that proves the control-flow to the blocks is
-// mutually exclusive (a then and an else block, for example).
-inline static bool allUsesInDistinctBlocks(Operation *defOp, Value v) {
-  SmallPtrSet<Block *, 4> blockSet;
-  for (Operation *u : v.getUsers()) {
-    // If `u` is not in quake, then it is not a quantum operation. Skip it.
-    if (!isQuakeOperation(u))
-      continue;
-    Block *b = u->getBlock();
-    if (blockSet.count(b))
-      return false;
-    blockSet.insert(b);
-  }
-  return true;
-}
-
 static LogicalResult verifyWireResultsAreLinear(Operation *op) {
   for (Value v : op->getOpResults())
     if (isa<quake::WireType>(v.getType())) {
       // Terminators can forward wire values, but they are not quantum
       // operations.
-      if (v.hasOneUse() || allUsesInDistinctBlocks(op, v))
+      if (v.hasOneUse() || v.use_empty())
+        continue;
+      // Allow a single cf.cond_br to use the value twice, once for each arm.
+      std::unordered_set<Operation *> uniqs;
+      for (auto *op : v.getUsers())
+        uniqs.insert(op);
+      if (uniqs.size() == 1 &&
+          (*uniqs.begin())->hasTrait<OpTrait::IsTerminator>())
         continue;
       return op->emitOpError(
           "wires are a linear type and must have exactly one use");

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2630,7 +2630,7 @@ class PyASTBridge(ast.NodeVisitor):
                                     1 if shortCircuitWhenTrue else 0), lhs,
                 zero).result
 
-            ifOp = cc.IfOp([cond.type], cond)
+            ifOp = cc.IfOp([cond.type], cond, [])
             thenBlock = Block.create_at_start(ifOp.thenRegion, [])
             with InsertionPoint(thenBlock):
                 if isinstance(node.op, ast.And):
@@ -2822,7 +2822,7 @@ class PyASTBridge(ast.NodeVisitor):
             condition = arith.CmpIOp(condPred, condition,
                                      self.getConstantInt(0)).result
 
-        ifOp = cc.IfOp([], condition)
+        ifOp = cc.IfOp([], condition, [])
         thenBlock = Block.create_at_start(ifOp.thenRegion, [])
         with InsertionPoint(thenBlock):
             self.symbolTable.pushScope()

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -1035,7 +1035,7 @@ class PyKernel(object):
                 conditional = arith.CmpIOp(condPred, condition,
                                            self.getConstantInt(0)).result
 
-            ifOp = cc.IfOp([], conditional)
+            ifOp = cc.IfOp([], conditional, [])
             thenBlock = Block.create_at_start(ifOp.thenRegion, [])
             with InsertionPoint(thenBlock):
                 tmpIp = self.insertPoint

--- a/test/Quake/memtoreg-2.qke
+++ b/test/Quake/memtoreg-2.qke
@@ -26,14 +26,16 @@ func.func @classical_if01(%c1: i1) {
 // CHECK-SAME:                              %[[VAL_0:.*]]: i1) {
 // CHECK:           %[[VAL_1:.*]] = quake.null_wire
 // CHECK:           %[[VAL_2:.*]] = quake.null_wire
-// CHECK:           %[[VAL_3:.*]]:2 = cc.if(%[[VAL_0]]) -> (!quake.wire, !quake.wire) {
-// CHECK:             %[[VAL_4:.*]]:2 = quake.x [%[[VAL_1]]] %[[VAL_2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:             cc.continue %[[VAL_4]]#0, %[[VAL_4]]#1 : !quake.wire, !quake.wire
+// CHECK:           %[[VAL_3:.*]]:2 = cc.if(%[[VAL_0]]) ((%[[VAL_4:.*]] = %[[VAL_1]], %[[VAL_5:.*]] = %[[VAL_2]])) -> (!quake.wire, !quake.wire) {
+// CHECK:             %[[VAL_6:.*]]:2 = quake.x [%[[VAL_4]]] %[[VAL_5]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[VAL_6]]#0, %[[VAL_6]]#1 : !quake.wire, !quake.wire
 // CHECK:           } else {
-// CHECK:             %[[VAL_5:.*]]:2 = quake.y [%[[VAL_1]]] %[[VAL_2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:             cc.continue %[[VAL_5]]#0, %[[VAL_5]]#1 : !quake.wire, !quake.wire
+// CHECK:             %[[VAL_7:.*]]:2 = quake.y [%[[VAL_8:.*]]] %[[VAL_9:.*]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[VAL_7]]#0, %[[VAL_7]]#1 : !quake.wire, !quake.wire
 // CHECK:           }
-// CHECK:           %[[VAL_6:.*]]:2 = quake.z [%[[VAL_3]]#0] %[[VAL_3]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_10:.*]]:2 = quake.z [%[[VAL_11:.*]]#0] %[[VAL_11]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           quake.sink %[[VAL_10]]#0 : !quake.wire
+// CHECK:           quake.sink %[[VAL_10]]#1 : !quake.wire
 // CHECK:           return
 // CHECK:         }
 
@@ -55,14 +57,16 @@ func.func @classical_if02(%c1: i1) {
 // CHECK-SAME:                              %[[VAL_0:.*]]: i1) {
 // CHECK:           %[[VAL_1:.*]] = quake.null_wire
 // CHECK:           %[[VAL_2:.*]] = quake.null_wire
-// CHECK:           %[[VAL_3:.*]]:2 = cc.if(%[[VAL_0]]) -> (!quake.wire, !quake.wire) {
-// CHECK:             %[[VAL_4:.*]]:2 = quake.x [%[[VAL_1]]] %[[VAL_2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:             cc.continue %[[VAL_4]]#0, %[[VAL_4]]#1 : !quake.wire, !quake.wire
+// CHECK:           %[[VAL_3:.*]]:2 = cc.if(%[[VAL_0]]) ((%[[VAL_4:.*]] = %[[VAL_1]], %[[VAL_5:.*]] = %[[VAL_2]])) -> (!quake.wire, !quake.wire) {
+// CHECK:             %[[VAL_6:.*]]:2 = quake.x [%[[VAL_4]]] %[[VAL_5]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[VAL_6]]#0, %[[VAL_6]]#1 : !quake.wire, !quake.wire
 // CHECK:           } else {
-// CHECK:             %[[VAL_5:.*]]:2 = quake.y [%[[VAL_2]]] %[[VAL_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:             cc.continue %[[VAL_5]]#1, %[[VAL_5]]#0 : !quake.wire, !quake.wire
+// CHECK:             %[[VAL_7:.*]]:2 = quake.y [%[[VAL_8:.*]]] %[[VAL_9:.*]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[VAL_7]]#1, %[[VAL_7]]#0 : !quake.wire, !quake.wire
 // CHECK:           }
-// CHECK:           %[[VAL_6:.*]]:2 = quake.z [%[[VAL_3]]#0] %[[VAL_3]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_10:.*]]:2 = quake.z [%[[VAL_11:.*]]#0] %[[VAL_11]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           quake.sink %[[VAL_10]]#0 : !quake.wire
+// CHECK:           quake.sink %[[VAL_10]]#1 : !quake.wire
 // CHECK:           return
 // CHECK:         }
 
@@ -82,13 +86,15 @@ func.func @classical_if03(%c1: i1) {
 // CHECK-SAME:                              %[[VAL_0:.*]]: i1) {
 // CHECK:           %[[VAL_1:.*]] = quake.null_wire
 // CHECK:           %[[VAL_2:.*]] = quake.null_wire
-// CHECK:           %[[VAL_3:.*]]:2 = cc.if(%[[VAL_0]]) -> (!quake.wire, !quake.wire) {
-// CHECK:             %[[VAL_4:.*]]:2 = quake.x [%[[VAL_1]]] %[[VAL_2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:             cc.continue %[[VAL_4]]#0, %[[VAL_4]]#1 : !quake.wire, !quake.wire
+// CHECK:           %[[VAL_3:.*]]:2 = cc.if(%[[VAL_0]]) ((%[[VAL_4:.*]] = %[[VAL_1]], %[[VAL_5:.*]] = %[[VAL_2]])) -> (!quake.wire, !quake.wire) {
+// CHECK:             %[[VAL_6:.*]]:2 = quake.x [%[[VAL_4]]] %[[VAL_5]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[VAL_6]]#0, %[[VAL_6]]#1 : !quake.wire, !quake.wire
 // CHECK:           } else {
-// CHECK:             cc.continue %[[VAL_1]], %[[VAL_2]] : !quake.wire, !quake.wire
+// CHECK:             cc.continue %[[VAL_4]], %[[VAL_5]] : !quake.wire, !quake.wire
 // CHECK:           }
-// CHECK:           %[[VAL_5:.*]]:2 = quake.y [%[[VAL_3]]#0] %[[VAL_3]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_9:.*]]:2 = quake.y [%[[VAL_10:.*]]#0] %[[VAL_10]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           quake.sink %[[VAL_9]]#0 : !quake.wire
+// CHECK:           quake.sink %[[VAL_9]]#1 : !quake.wire
 // CHECK:           return
 // CHECK:         }
 
@@ -111,27 +117,27 @@ func.func @classical_if04(%c1: i1, %c2: i1) {
 }
 
 // CHECK-LABEL:   func.func @classical_if04(
-// CHECK-SAME:        %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1) {
+// CHECK-SAME:      %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1) {
 // CHECK:           %[[VAL_2:.*]] = quake.null_wire
 // CHECK:           %[[VAL_3:.*]] = quake.null_wire
 // CHECK:           %[[VAL_4:.*]] = quake.null_wire
-// CHECK:           %[[VAL_5:.*]]:3 = cc.if(%[[VAL_0]]) -> (!quake.wire, !quake.wire, !quake.wire) {
-// CHECK:             %[[VAL_6:.*]]:2 = quake.h [%[[VAL_2]]] %[[VAL_3]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:             %[[VAL_7:.*]]:2 = cc.if(%[[VAL_1]]) -> (!quake.wire, !quake.wire) {
-// CHECK:               %[[VAL_8:.*]]:2 = quake.x [%[[VAL_6]]#0] %[[VAL_4]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:               cc.continue %[[VAL_8]]#0, %[[VAL_8]]#1 : !quake.wire, !quake.wire
+// CHECK:           %[[VAL_5:.*]]:3 = cc.if(%[[VAL_0]]) ((%[[VAL_6:.*]] = %[[VAL_2]], %[[VAL_7:.*]] = %[[VAL_3]], %[[VAL_8:.*]] = %[[VAL_4]])) -> (!quake.wire, !quake.wire, !quake.wire) {
+// CHECK:             %[[VAL_9:.*]]:2 = quake.h [%[[VAL_6]]] %[[VAL_7]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[VAL_10:.*]]:2 = cc.if(%[[VAL_1]]) ((%[[VAL_11:.*]] = %[[VAL_9]]#0, %[[VAL_12:.*]] = %[[VAL_8]])) -> (!quake.wire, !quake.wire) {
+// CHECK:               %[[VAL_13:.*]]:2 = quake.x [%[[VAL_11]]] %[[VAL_12]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:               cc.continue %[[VAL_13]]#0, %[[VAL_13]]#1 : !quake.wire, !quake.wire
 // CHECK:             } else {
-// CHECK:               cc.continue %[[VAL_6]]#0, %[[VAL_4]] : !quake.wire, !quake.wire
+// CHECK:               cc.continue %[[VAL_11]], %[[VAL_12]] : !quake.wire, !quake.wire
 // CHECK:             }
-// CHECK:             cc.continue %[[VAL_7]]#0, %[[VAL_6]]#1, %[[VAL_7]]#1 : !quake.wire, !quake.wire, !quake.wire
+// CHECK:             cc.continue %[[VAL_10]]#0, %[[VAL_9]]#1, %[[VAL_10]]#1 : !quake.wire, !quake.wire, !quake.wire
 // CHECK:           } else {
-// CHECK:             cc.continue %[[VAL_2]], %[[VAL_3]], %[[VAL_4]] : !quake.wire, !quake.wire, !quake.wire
+// CHECK:             cc.continue %[[VAL_6]], %[[VAL_7]], %[[VAL_19:.*]] : !quake.wire, !quake.wire, !quake.wire
 // CHECK:           }
-// CHECK:           %[[VAL_10:.*]]:2 = quake.y [%[[VAL_5]]#0] %[[VAL_5]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           %[[VAL_12:.*]]:2 = quake.z [%[[VAL_10]]#0] %[[VAL_5]]#2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:           quake.sink %[[VAL_12]]#0
-// CHECK:           quake.sink %[[VAL_10]]#1
-// CHECK:           quake.sink %[[VAL_12]]#1
+// CHECK:           %[[VAL_20:.*]]:2 = quake.y [%[[VAL_21:.*]]#0] %[[VAL_21]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           %[[VAL_22:.*]]:2 = quake.z [%[[VAL_20]]#0] %[[VAL_21]]#2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:           quake.sink %[[VAL_22]]#0 : !quake.wire
+// CHECK:           quake.sink %[[VAL_20]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_22]]#1 : !quake.wire
 // CHECK:           return
 // CHECK:         }
 
@@ -149,19 +155,21 @@ func.func @classical_if05(%q0: !quake.ref, %c1: i1) {
 }
 
 // CHECK-LABEL:   func.func @classical_if05(
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.ref, %[[VAL_1:.*]]: i1) {
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.ref, %[[VAL_1:.*]]: i1) {
 // CHECK:           %[[VAL_2:.*]] = quake.unwrap %[[VAL_0]] : (!quake.ref) -> !quake.wire
-// CHECK:           %[[VAL_6:.*]] = cc.if(%[[VAL_1]]) -> !quake.wire {
-// CHECK:             %[[VAL_7:.*]] = cc.scope -> (!quake.wire) {
-// CHECK:               %[[VAL_3:.*]] = quake.null_wire
-// CHECK:               %[[VAL_4:.*]]:2 = quake.x [%[[VAL_2]]] %[[VAL_3]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-// CHECK:               quake.sink
-// CHECK:               cc.continue %[[VAL_4]]#0
+// CHECK:           %[[VAL_3:.*]] = cc.if(%[[VAL_1]]) ((%[[VAL_4:.*]] = %[[VAL_2]])) -> !quake.wire {
+// CHECK:             %[[VAL_5:.*]] = cc.scope -> (!quake.wire) {
+// CHECK:               %[[VAL_6:.*]] = quake.null_wire
+// CHECK:               %[[VAL_7:.*]]:2 = quake.x [%[[VAL_4]]] %[[VAL_6]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:               quake.sink %[[VAL_7]]#1 : !quake.wire
+// CHECK:               cc.continue %[[VAL_7]]#0 : !quake.wire
 // CHECK:             }
+// CHECK:             cc.continue %[[VAL_5]] : !quake.wire
 // CHECK:           } else {
+// CHECK:             cc.continue %[[VAL_4]] : !quake.wire
 // CHECK:           }
-// CHECK:           %[[VAL_5:.*]] = quake.y %[[VAL_6]] : (!quake.wire) -> !quake.wire
-// CHECK:           quake.wrap %[[VAL_5]] to %[[VAL_0]] : !quake.wire, !quake.ref
+// CHECK:           %[[VAL_10:.*]] = quake.y %[[VAL_3]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[VAL_10]] to %[[VAL_0]] : !quake.wire, !quake.ref
 // CHECK:           return
 // CHECK:         }
 
@@ -179,19 +187,21 @@ func.func @classical_if06(%veq : !quake.veq<2>, %c1: i1) {
 }
 
 // CHECK-LABEL:   func.func @classical_if06(
-// CHECK-SAME:        %[[VAL_0:.*]]: !quake.veq<2>, %[[VAL_1:.*]]: i1) {
+// CHECK-SAME:      %[[VAL_0:.*]]: !quake.veq<2>, %[[VAL_1:.*]]: i1) {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_2]]] : (!quake.veq<2>, i32) -> !quake.ref
 // CHECK:           %[[VAL_4:.*]] = quake.unwrap %[[VAL_3]] : (!quake.ref) -> !quake.wire
 // CHECK:           %[[VAL_5:.*]] = quake.x %[[VAL_4]] : (!quake.wire) -> !quake.wire
+// CHECK:           quake.wrap %[[VAL_5]] to %[[VAL_3]] : !quake.wire, !quake.ref
 // CHECK:           cc.if(%[[VAL_1]]) {
 // CHECK:             %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK:             %[[VAL_7:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_6]]] : (!quake.veq<2>, i32) -> !quake.ref
 // CHECK:             %[[VAL_8:.*]] = quake.unwrap %[[VAL_7]] : (!quake.ref) -> !quake.wire
 // CHECK:             %[[VAL_9:.*]] = quake.y %[[VAL_8]] : (!quake.wire) -> !quake.wire
+// CHECK:             quake.wrap %[[VAL_9]] to %[[VAL_7]] : !quake.wire, !quake.ref
 // CHECK:           } else {
 // CHECK:           }
-// CHECK:           quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -699,3 +699,34 @@ func.func @cc_indexing(%arg0 : !cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f
   %ele = cc.get_const_element %arr, %one : (!cc.array<f32 x 2>, i32) -> f32
   return
 }
+
+func.func @ssi_if(%arg0: i1) {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2:2 = cc.if (%arg0) ((%arg1 = %0, %arg2 = %1)) -> (!quake.wire, !quake.wire) {
+    %3:2 = quake.x [%arg1] %arg2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    cc.continue %3#0, %3#1 : !quake.wire, !quake.wire
+  } else {
+    %4:2 = quake.x [%arg1] %arg2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    cc.continue %4#0, %4#1 : !quake.wire, !quake.wire
+  }
+  quake.sink %2#1 : !quake.wire
+  quake.sink %2#0 : !quake.wire
+  return
+}
+
+// CHECK-LABEL:   func.func @ssi_if(
+// CHECK-SAME:      %[[VAL_0:.*]]: i1) {
+// CHECK:           %[[VAL_1:.*]] = quake.null_wire
+// CHECK:           %[[VAL_2:.*]] = quake.null_wire
+// CHECK:           %[[VAL_3:.*]]:2 = cc.if(%[[VAL_0]]) ((%[[VAL_4:.*]] = %[[VAL_1]], %[[VAL_5:.*]] = %[[VAL_2]])) -> (!quake.wire, !quake.wire) {
+// CHECK:             %[[VAL_6:.*]]:2 = quake.x [%[[VAL_4]]] %[[VAL_5]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[VAL_6]]#0, %[[VAL_6]]#1 : !quake.wire, !quake.wire
+// CHECK:           } else {
+// CHECK:             %[[VAL_7:.*]]:2 = quake.x [%[[VAL_8:.*]]] %[[VAL_9:.*]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             cc.continue %[[VAL_7]]#0, %[[VAL_7]]#1 : !quake.wire, !quake.wire
+// CHECK:           }
+// CHECK:           quake.sink %[[VAL_10:.*]]#1 : !quake.wire
+// CHECK:           quake.sink %[[VAL_10]]#0 : !quake.wire
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
A quantum type (!quake.wire) is a linear type. While this constraint was widely enforced previously, it was exempted when the linear value reached a control-flow conditional. This patch closes that loophole.

- Add a new Linear type trait to be used with high-level conditionals that are conceptually conditional control-flow. (cc.if)
- Modify cc.if to use the linear type trait. Implement parser and pretty printer, to support the sigma arguments on the blocks.
- Add roundtrip test.
- Fix check lines in existing tests.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
