### PR TITLE
Disable nightly tests for OQC due to maintenance

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -371,7 +371,11 @@ jobs:
         shell: bash
 
       - name: Submit to OQC Sandbox server
-        if: (success() || failure()) && (inputs.target == 'oqc' || github.event_name == 'schedule' || inputs.target == 'nightly')
+        # This step is currently bypassed during nightly runs due to
+        # maintenance. Restore the if check to the original value when
+        # maintenance is complete.
+        # if: (success() || failure()) && (inputs.target == 'oqc' || github.event_name == 'schedule' || inputs.target == 'nightly')
+        if: (success() || failure()) && (inputs.target == 'oqc')
         run: |
           echo "### Submit to OQC sandbox server" >> $GITHUB_STEP_SUMMARY
           export CUDAQ_LOG_LEVEL="info"


### PR DESCRIPTION
The nightly tests are failing, which is expected while OQC machines are down for maintenance. Disable the OQC tests so it is easier to tell if our [nightly tests](https://github.com/NVIDIA/cuda-quantum/actions/workflows/integration_tests.yml) for the other targets are in good shape.

The tests will be restored once the OQC machines are enabled again.