### PR TITLE
Fixes for https://github.com/NVIDIA/cuda-quantum/issues/1618

### DIFF
--- a/python/cudaq/kernel/analysis.py
+++ b/python/cudaq/kernel/analysis.py
@@ -38,24 +38,45 @@ class MidCircuitMeasurementAnalyzer(ast.NodeVisitor):
         ]:
             self.measureResultsVars.append(target.id)
 
+    # Get the variable name from a variable node.
+    # Returns an empty string if not something we know how to get a variable name from.
+    def getVariableName(self, node):
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Subscript):
+            return self.getVariableName(node.value)
+        return ''
+
     def visit_If(self, node):
         condition = node.test
         # catch `if mz(q)`
         if self.isMeasureCallOp(condition):
             self.hasMidCircuitMeasures = True
             return
-
-        # Catch if val, where `val = mz(q)`
-        if 'id' in condition.__dict__ and condition.id in self.measureResultsVars:
+        # Catch `if val`, where `val = mz(q)` or `if var[k]`, where `var = mz(qvec)`
+        if self.getVariableName(condition) in self.measureResultsVars:
             self.hasMidCircuitMeasures = True
-        # Catch `if UnaryOp mz(q)`
+        elif isinstance(condition, ast.Compare):
+            # Compare: look at left expression.
+            # Handle: `if var == True/False` and `if var[k] == True/False:`
+            if self.getVariableName(condition.left) in self.measureResultsVars:
+                self.hasMidCircuitMeasures = True
+            elif self.isMeasureCallOp(condition.left):
+                # Handle: `if mz(q) == True/False`
+                self.hasMidCircuitMeasures = True
+        # Catch `if UnaryOp mz(q)` or `if UnaryOp var` (var = mz(q))
         elif isinstance(condition, ast.UnaryOp):
-            self.hasMidCircuitMeasures = self.isMeasureCallOp(condition.operand)
-        # Catch `if something BoolOp mz(q)`
+            self.hasMidCircuitMeasures = self.isMeasureCallOp(
+                condition.operand) or (self.getVariableName(condition.operand)
+                                       in self.measureResultsVars)
+        # Catch `if something BoolOp mz(q)` or `something BoolOp var` (var = mz(q))
         elif isinstance(condition,
                         ast.BoolOp) and 'values' in condition.__dict__:
             for node in condition.__dict__['values']:
                 if self.isMeasureCallOp(node):
+                    self.hasMidCircuitMeasures = True
+                    break
+                elif self.getVariableName(node) in self.measureResultsVars:
                     self.hasMidCircuitMeasures = True
                     break
 

--- a/python/cudaq/kernel/analysis.py
+++ b/python/cudaq/kernel/analysis.py
@@ -64,12 +64,12 @@ class MidCircuitMeasurementAnalyzer(ast.NodeVisitor):
             elif self.isMeasureCallOp(condition.left):
                 # Handle: `if mz(q) == True/False`
                 self.hasMidCircuitMeasures = True
-        # Catch `if UnaryOp mz(q)` or `if UnaryOp var` (var = mz(q))
+        # Catch `if UnaryOp mz(q)` or `if UnaryOp var` (`var = mz(q)`)
         elif isinstance(condition, ast.UnaryOp):
             self.hasMidCircuitMeasures = self.isMeasureCallOp(
                 condition.operand) or (self.getVariableName(condition.operand)
                                        in self.measureResultsVars)
-        # Catch `if something BoolOp mz(q)` or `something BoolOp var` (var = mz(q))
+        # Catch `if something BoolOp mz(q)` or `something BoolOp var` (`var = mz(q)`)
         elif isinstance(condition,
                         ast.BoolOp) and 'values' in condition.__dict__:
             for node in condition.__dict__['values']:

--- a/python/tests/mlir/ast_conditionals.py
+++ b/python/tests/mlir/ast_conditionals.py
@@ -1,0 +1,156 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# RUN: PYTHONPATH=../../ pytest -rP  %s | FileCheck %s
+
+import os
+
+import pytest
+import numpy as np
+
+import cudaq
+
+
+# Check that the `qubitMeasurementFeedback` metadata is properly set.
+def test_conditional_on_vars():
+
+    @cudaq.kernel
+    def test1():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        bit = mz(ancilla[0])
+        if bit:
+            x(data[0])
+        mz(data)
+
+    print(test1)
+
+    # CHECK-LABEL:   func.func @__nvqpp__mlirgen__test1() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+    @cudaq.kernel
+    def test2():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        bit = mz(ancilla[0])
+        if bit == False:
+            x(data[0])
+        mz(data)
+
+    print(test2)
+
+    # CHECK-LABEL:   func.func @__nvqpp__mlirgen__test2() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+    @cudaq.kernel
+    def test3():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        bits = mz(ancilla)
+        if bits[0]:
+            x(data[0])
+        mz(data)
+
+    print(test3)
+
+    # CHECK-LABEL:   func.func @__nvqpp__mlirgen__test3() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+    @cudaq.kernel
+    def test4():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        bits = mz(ancilla)
+        if bits[0] != True:
+            x(data[0])
+        mz(data)
+
+    print(test4)
+
+    # CHECK-LABEL:   func.func @__nvqpp__mlirgen__test4() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+    @cudaq.kernel
+    def test5():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        bits = mz(ancilla)
+        if not bits[0]:
+            x(data[0])
+        mz(data)
+
+    print(test5)
+
+    # CHECK-LABEL:   func.func @__nvqpp__mlirgen__test5() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+    @cudaq.kernel
+    def test6():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        bits = mz(ancilla)
+        if bits[0] and bits[1]:
+            x(data[0])
+        mz(data)
+
+    print(test6)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__test6() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+
+def test_conditional_on_measure():
+
+    @cudaq.kernel
+    def test7():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        if mz(ancilla[0]):
+            x(data[0])
+        mz(data)
+
+    print(test7)
+
+    # CHECK-LABEL:   func.func @__nvqpp__mlirgen__test7() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+    @cudaq.kernel
+    def test8():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        if mz(ancilla[0]) == False:
+            x(data[0])
+        mz(data)
+
+    print(test8)
+
+    # CHECK-LABEL:   func.func @__nvqpp__mlirgen__test8() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+    @cudaq.kernel
+    def test9():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        if not mz(ancilla[0]):
+            x(data[0])
+        mz(data)
+
+    print(test9)
+
+    # CHECK-LABEL:   func.func @__nvqpp__mlirgen__test9() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+    @cudaq.kernel
+    def test10():
+        data = cudaq.qvector(2)
+        ancilla = cudaq.qvector(2)
+        if mz(ancilla[0]) or mz(ancilla[1]):
+            x(data[0])
+        mz(data)
+
+    print(test10)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__test10() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
+
+# leave for gdb debugging
+if __name__ == "__main__":
+    loc = os.path.abspath(__file__)
+    pytest.main([loc, "-rP"])

--- a/python/tests/mlir/target/conditional_sample.py
+++ b/python/tests/mlir/target/conditional_sample.py
@@ -6,10 +6,11 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-# RUN: PYTHONPATH=../../.. python3 %s 
-# RUN: PYTHONPATH=../../.. python3 %s --target quantinuum --emulate 
+# RUN: PYTHONPATH=../../.. python3 %s
+# RUN: PYTHONPATH=../../.. python3 %s --target quantinuum --emulate
 
 import cudaq
+
 
 @cudaq.kernel
 def kernel():
@@ -25,8 +26,9 @@ def kernel():
         x(q[2])
     if b0:
         z(q[2])
-    
+
     mz(q[2])
+
 
 counts = cudaq.sample(kernel, shots_count=100)
 counts.dump()
@@ -35,3 +37,73 @@ resultsOnZero.dump()
 
 nOnes = resultsOnZero.count('1')
 assert nOnes == 100
+
+
+@cudaq.kernel
+def kernel1():
+    data = cudaq.qvector(2)
+    aux = cudaq.qvector(2)
+    bits = mz(aux)
+    # Nothing occurs since aux == |00>
+    if bits[0]:
+        x(data[0])
+
+    mz(data)
+
+
+counts = cudaq.sample(kernel1, shots_count=100)
+counts.dump()
+assert counts.get_register_counts("__global__")["00"] == 100
+
+
+@cudaq.kernel
+def kernel2():
+    data = cudaq.qvector(2)
+    aux = cudaq.qvector(2)
+    bits = mz(aux)
+    # Nothing occurs since aux == |00>
+    # Write the condition a bit differently
+    if bits[0] == True:
+        x(data[0])
+
+    mz(data)
+
+
+counts = cudaq.sample(kernel2, shots_count=100)
+counts.dump()
+assert counts.get_register_counts("__global__")["00"] == 100
+
+
+@cudaq.kernel
+def kernel3():
+    data = cudaq.qvector(2)
+    aux = cudaq.qvector(2)
+    bits = mz(aux)
+    # Now, this should has some effects
+    if not bits[0]:
+        x(data[0])
+
+    mz(data)
+
+
+counts = cudaq.sample(kernel3, shots_count=100)
+counts.dump()
+assert counts.get_register_counts("__global__")["10"] == 100
+
+
+@cudaq.kernel
+def kernel4(checkVal: bool):
+    data = cudaq.qvector(2)
+    aux = cudaq.qubit()
+    bit = mz(aux)
+    if bit != checkVal:
+        x(data[0])
+    mz(data)
+
+
+counts = cudaq.sample(kernel4, True, shots_count=100)
+counts.dump()
+assert counts.get_register_counts("__global__")["10"] == 100
+counts = cudaq.sample(kernel4, False, shots_count=100)
+counts.dump()
+assert counts.get_register_counts("__global__")["00"] == 100


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

The current Python `MidCircuitMeasurementAnalyzer` visitor only supports certain expressions, e.g., `if val` but not `if val == boolVar`, where `val = mz(q)`.

Hence, it may mis-identify some kernels as non-measurement feedback, i.e., not setting `qubitMeasurementFeedback=true`, causing wrong sampling mode being used.

This PR:

- Add more handling cases: variable name or variable subscript; `CompareOp`; handle variables in `BoolOp` and `UnaryOp`.

- Add IR checks and target tests.

Note: this is not an exhaustive handling of all possible scenarios.



Resolves https://github.com/NVIDIA/cuda-quantum/issues/1618