### PR TITLE
[docs] Remove tensornet-mps limitation that is no longer accurate

### DIFF
--- a/docs/sphinx/using/backends/simulators.rst
+++ b/docs/sphinx/using/backends/simulators.rst
@@ -258,10 +258,6 @@ Matrix product state
 The :code:`tensornet-mps` backend is based on the matrix product state (MPS) representation of the state vector/wave function, exploiting the sparsity in the tensor network via tensor decomposition techniques such as QR and SVD. As such, this backend is an approximate simulator, whereby the number of singular values may be truncated to keep the MPS size tractable. 
 The :code:`tensornet-mps` backend only supports single-GPU simulation. Its approximate nature allows the :code:`tensornet-mps` backend to handle a large number of qubits for certain classes of quantum circuits on a relatively small memory footprint.
 
-.. warning:: 
-
-  The :code:`tensornet-mps` cannot handle quantum gates acting on more than two qubit operands. It will throw an error when this constraint is not satisfied.
-
 To execute a program on the :code:`tensornet-mps` target, use the following commands:
 
 .. tab:: Python


### PR DESCRIPTION
This warning is no longer accurate since #1420 was merged.