### PR TITLE
Follow-up to #1587 - fix NVQC deployment

### DIFF
--- a/docker/release/cudaq.nvqc.Dockerfile
+++ b/docker/release/cudaq.nvqc.Dockerfile
@@ -29,7 +29,7 @@ ADD scripts/nvqc_proxy.py /
 # to the RestRequest payload version with which `cudaq-qpud` in the deployment Docker image was compiled.
 # Failure to do so will result in early exits of the entry point command, thus deployment failure.
 RUN echo 'cat /opt/nvidia/cudaq/build_info.txt;' \
-    'EXPECTED_REST_PAYLOAD_VERSION="$(cudaq-qpud --type nvcf --schema-version | grep -o "CUDA Quantum REST API version: \S*" | cut -d ":" -f 2 | tr -d " ")" ;' \
+    'EXPECTED_REST_PAYLOAD_VERSION="$(cudaq-qpud --type nvcf --schema-version | grep -o "CUDA-Q REST API version: \S*" | cut -d ":" -f 2 | tr -d " ")" ;' \
     'if [[ "$NVQC_REST_PAYLOAD_VERSION" !=  "$EXPECTED_REST_PAYLOAD_VERSION" ]]; ' \
     '  then echo "Invalid Deployment: NVQC_REST_PAYLOAD_VERSION environment variable ($NVQC_REST_PAYLOAD_VERSION) does not match cudaq-qpud (expected $EXPECTED_REST_PAYLOAD_VERSION)." && exit 1; fi;' \
     'python3 /nvqc_proxy.py & ' \


### PR DESCRIPTION
The NVQC deployment is broken as a result of the recent rename. This fixes it.