### PR TITLE
Support results polling interval override for RemoteRESTQPUs

### DIFF
--- a/runtime/common/Future.cpp
+++ b/runtime/common/Future.cpp
@@ -34,7 +34,8 @@ sample_result future::get() {
     cudaq::info("Future got job retrieval path as {}.", jobGetPath);
     auto resultResponse = client.get(jobGetPath, "", headers);
     while (!serverHelper->jobIsDone(resultResponse)) {
-      std::this_thread::sleep_for(std::chrono::microseconds(100));
+      auto polling_interval = serverHelper->nextResultPolingInterval(resultResponse);
+      std::this_thread::sleep_for(polling_interval);
       resultResponse = client.get(jobGetPath, "", headers);
     }
     auto c = serverHelper->processResults(resultResponse, id.first);

--- a/runtime/common/Future.cpp
+++ b/runtime/common/Future.cpp
@@ -34,7 +34,8 @@ sample_result future::get() {
     cudaq::info("Future got job retrieval path as {}.", jobGetPath);
     auto resultResponse = client.get(jobGetPath, "", headers);
     while (!serverHelper->jobIsDone(resultResponse)) {
-      auto polling_interval = serverHelper->nextResultPolingInterval(resultResponse);
+      auto polling_interval =
+          serverHelper->nextResultPolingInterval(resultResponse);
       std::this_thread::sleep_for(polling_interval);
       resultResponse = client.get(jobGetPath, "", headers);
     }

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -114,6 +114,12 @@ public:
   /// from the full server response message.
   virtual std::string constructGetJobPath(ServerMessage &postResponse) = 0;
 
+  /// @brief Get the jobs results polling interval.
+  /// @return
+  virtual std::chrono::microseconds nextResultPolingInterval(ServerMessage &postResponse) {
+    return std::chrono::microseconds(100);
+  }
+
   /// @brief Return true if the job is done.
   virtual bool jobIsDone(ServerMessage &getJobResponse) = 0;
 

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -116,7 +116,8 @@ public:
 
   /// @brief Get the jobs results polling interval.
   /// @return
-  virtual std::chrono::microseconds nextResultPolingInterval(ServerMessage &postResponse) {
+  virtual std::chrono::microseconds
+  nextResultPolingInterval(ServerMessage &postResponse) {
     return std::chrono::microseconds(100);
   }
 

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
@@ -156,6 +156,9 @@ public:
   std::string constructGetJobPath(ServerMessage &postResponse) override;
   std::string constructGetJobPath(std::string &jobId) override;
 
+  /// @brief Return next results polling interval
+  std::chrono::microseconds nextResultPolingInterval(ServerMessage &postResponse) override;
+
   /// @brief Return true if the job is done
   bool jobIsDone(ServerMessage &getJobResponse) override;
 
@@ -203,6 +206,10 @@ std::string IQMServerHelper::constructGetJobPath(ServerMessage &postResponse) {
 std::string IQMServerHelper::constructGetJobPath(std::string &jobId) {
   return iqmServerUrl + "jobs/" + jobId + "/counts";
 }
+
+std::chrono::microseconds IQMServerHelper::nextResultPolingInterval(ServerMessage &postResponse) {
+  return std::chrono::seconds(1); // jobs never take less than few seconds
+};
 
 bool IQMServerHelper::jobIsDone(ServerMessage &getJobResponse) {
   cudaq::debug("getJobResponse: {}", getJobResponse.dump());

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
@@ -157,7 +157,8 @@ public:
   std::string constructGetJobPath(std::string &jobId) override;
 
   /// @brief Return next results polling interval
-  std::chrono::microseconds nextResultPolingInterval(ServerMessage &postResponse) override;
+  std::chrono::microseconds
+  nextResultPolingInterval(ServerMessage &postResponse) override;
 
   /// @brief Return true if the job is done
   bool jobIsDone(ServerMessage &getJobResponse) override;
@@ -207,7 +208,8 @@ std::string IQMServerHelper::constructGetJobPath(std::string &jobId) {
   return iqmServerUrl + "jobs/" + jobId + "/counts";
 }
 
-std::chrono::microseconds IQMServerHelper::nextResultPolingInterval(ServerMessage &postResponse) {
+std::chrono::microseconds
+IQMServerHelper::nextResultPolingInterval(ServerMessage &postResponse) {
   return std::chrono::seconds(1); // jobs never take less than few seconds
 };
 


### PR DESCRIPTION
CUDA Quantum runtime polls for a `RemoteRESTQPU` results quite aggressively, 100 microseconds is the hardcoded value. While this is ok for a QPU HTTP API located in the local network, when executing CUDA Quantum programs against a QPU HTTP API located in a cloud, it is very likely to hit a rate-limiter of sorts, like, for example, in case of IQM Resonance.