### PR TITLE
Pin ARM's `-march` flag for OpenMPI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,22 @@ jobs:
           echo "llvm_commit=$(git rev-parse @:./tpls/llvm)" >> $GITHUB_OUTPUT
           echo "pybind11_commit=$(git rev-parse @:./tpls/pybind11)" >> $GITHUB_OUTPUT
 
+##   DEBUG ####
+  openmpi:
+    name: Build Open MPI
+    strategy:
+      matrix:
+        platform: [arm64]
+      fail-fast: false
+    uses: ./.github/workflows/dev_environment.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_READONLY_TOKEN: ${{ secrets.DOCKERHUB_READONLY_TOKEN }}
+    with:
+      platforms: linux/${{ matrix.platform }}
+      dockerfile: build/devdeps.ompi.Dockerfile
+##   DEBUG #### 
+  
   devdeps:
     name: Load dependencies
     needs: metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: build/devdeps.ompi.Dockerfile
+          file: ./docker/build/devdeps.ompi.Dockerfile
           tags: debug-ompi-240509
           outputs: type=docker,dest=/tmp/ompi_image.tar
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,41 +72,6 @@ jobs:
           echo "llvm_commit=$(git rev-parse @:./tpls/llvm)" >> $GITHUB_OUTPUT
           echo "pybind11_commit=$(git rev-parse @:./tpls/pybind11)" >> $GITHUB_OUTPUT
 
-##   DEBUG ####
-  openmpi:
-    name: Build Open MPI
-    runs-on: linux-arm64-cpu8
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      
-      - name: Set up context for buildx
-        run: |
-          docker context create builder_context
-
-      - name: Set up buildx runner
-        uses: docker/setup-buildx-action@v3
-        with:
-          endpoint: builder_context
-      
-      - name: Build Open MPI image
-        id: docker_build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/build/devdeps.ompi.Dockerfile
-          tags: debug-ompi-240509
-          outputs: type=docker,dest=/tmp/ompi_image.tar
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ompi_240509
-          path: /tmp/ompi_image.tar
-          retention-days: 1
-          if-no-files-found: error
-##   DEBUG #### 
-  
   devdeps:
     name: Load dependencies
     needs: metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,17 +75,36 @@ jobs:
 ##   DEBUG ####
   openmpi:
     name: Build Open MPI
-    strategy:
-      matrix:
-        platform: [arm64]
-      fail-fast: false
-    uses: ./.github/workflows/dev_environment.yml
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_READONLY_TOKEN: ${{ secrets.DOCKERHUB_READONLY_TOKEN }}
-    with:
-      platforms: linux/${{ matrix.platform }}
-      dockerfile: build/devdeps.ompi.Dockerfile
+    runs-on: linux-arm64-cpu8
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up context for buildx
+        run: |
+          docker context create builder_context
+
+      - name: Set up buildx runner
+        uses: docker/setup-buildx-action@v3
+        with:
+          endpoint: builder_context
+      
+      - name: Build Open MPI image
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: build/devdeps.ompi.Dockerfile
+          tags: debug-ompi-240509
+          outputs: type=docker,dest=/tmp/ompi_image.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ompi_240509
+          path: /tmp/ompi_image.tar
+          retention-days: 1
+          if-no-files-found: error
 ##   DEBUG #### 
   
   devdeps:

--- a/docker/build/devdeps.ompi.Dockerfile
+++ b/docker/build/devdeps.ompi.Dockerfile
@@ -163,7 +163,3 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     && make -j$(nproc) && make -j$(nproc) install \
     && rm -rf /var/tmp/ompi \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
-
-# Debug
-RUN lscpu
-RUN objdump -S /usr/local/pmix/lib/libpmix.so.2 | grep stlur

--- a/docker/build/devdeps.ompi.Dockerfile
+++ b/docker/build/devdeps.ompi.Dockerfile
@@ -22,7 +22,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
 ENV CUDA_INSTALL_PREFIX=/usr/local/cuda-11.8
 ENV COMMON_COMPILER_FLAGS="-march=x86-64-v3 -mtune=generic -O2 -pipe"
-ENV COMMON_COMPILER_FLAGS_ARM="-march=native -mtune=generic -O2 -pipe"
+ENV COMMON_COMPILER_FLAGS_ARM="-march=armv8-a -mtune=generic -O2 -pipe"
 
 # 1 - Install basic tools needed for the builds
 
@@ -165,4 +165,5 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 # Debug
+RUN lscpu
 RUN objdump -S /usr/local/pmix/lib/libpmix.so.2 | grep stlur

--- a/docker/build/devdeps.ompi.Dockerfile
+++ b/docker/build/devdeps.ompi.Dockerfile
@@ -163,3 +163,6 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     && make -j$(nproc) && make -j$(nproc) install \
     && rm -rf /var/tmp/ompi \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+
+# Debug
+RUN objdump -S /usr/local/pmix/lib/libpmix.so.2 | grep stlur

--- a/docs/sphinx/using/install/data_center_install.rst
+++ b/docs/sphinx/using/install/data_center_install.rst
@@ -59,7 +59,7 @@ will be installed and used.
   or newer than the version on the build system. Our own builds
   use version 2.28.
 - CPU with either x86-64 (x86-64-v3 architecture and newer) or ARM64
-  (Armv8-A architecture and newer). Other architectures may work but are not tested and may require
+  (ARM v8-A architecture and newer). Other architectures may work but are not tested and may require
   adjustments to the build instructions.
 - Needed **only on the host** system: NVIDIA GPU with Volta, Turing, Ampere, Ada, or
   Hopper architecture and `Compute Capability

--- a/docs/sphinx/using/install/data_center_install.rst
+++ b/docs/sphinx/using/install/data_center_install.rst
@@ -59,7 +59,7 @@ will be installed and used.
   or newer than the version on the build system. Our own builds
   use version 2.28.
 - CPU with either x86-64 (x86-64-v3 architecture and newer) or ARM64
-  architecture. Other architectures may work but are not tested and may require
+  (Armv8-A architecture and newer). Other architectures may work but are not tested and may require
   adjustments to the build instructions.
 - Needed **only on the host** system: NVIDIA GPU with Volta, Turing, Ampere, Ada, or
   Hopper architecture and `Compute Capability

--- a/docs/sphinx/using/install/local_installation.rst
+++ b/docs/sphinx/using/install/local_installation.rst
@@ -802,7 +802,7 @@ Dependencies and Compatibility
 
 CUDA-Q can be used to compile and run quantum programs on a CPU-only system, but a GPU is highly recommended and necessary to use the GPU-based simulators, see also :doc:`../backends/simulators`.
 
-The supported CPUs include x86_64 (x86-64-v3 architecture and newer) and ARM64 architectures.
+The supported CPUs include x86_64 (x86-64-v3 architecture and newer) and ARM64 (Armv8-A architecture and newer).
 
 .. note:: 
 

--- a/docs/sphinx/using/install/local_installation.rst
+++ b/docs/sphinx/using/install/local_installation.rst
@@ -802,7 +802,7 @@ Dependencies and Compatibility
 
 CUDA-Q can be used to compile and run quantum programs on a CPU-only system, but a GPU is highly recommended and necessary to use the GPU-based simulators, see also :doc:`../backends/simulators`.
 
-The supported CPUs include x86_64 (x86-64-v3 architecture and newer) and ARM64 (Armv8-A architecture and newer).
+The supported CPUs include x86_64 (x86-64-v3 architecture and newer) and ARM64 (ARM v8-A architecture and newer).
 
 .. note:: 
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This PR pins the `-march=` compiler flag for OpenMPI build on ARM (similar to the approach taken for x86).
Currently, we're using `-march=native`, which is too broad, hence prone to runner's hardware update.

ARMv8.0-A was chosen as it's the first one in the v8 series (with 64-bit support).

### Issue & Root cause 

Illegal instruction exception when using cuda-q docker container on some specific ARM platforms, e.g., failed on ARM Neoverse-N1, passed on Grace Hopper.

The illegal instruction was ARM's `STLUR`, an ARMv8.4 instruction.

The CI runner, `linux-arm64-cpu8`, is an AWS's `m7g.2xlarge` instance, which has a Graviton3 (ARMv8.5) processor.

**Notes:**

- CUDA-Q's v0.6 image doesn't have `STLUR` in the OpenMPI's binary. We might have switched the runner hardware some time in between that release and now.
 
**Tested by:** 

Using a temp pipeline job (in https://github.com/NVIDIA/cuda-quantum/pull/1645/commits/2309b753db68712716185742535519397fe9c5f4, has been reverted) to build the OpenMPI image with the new flag and copy over the binary to verify the illegal instruction is now fixed (on an Neoverse-N1, ARMv8.2, machine) 