### PR TITLE
Update the terminology used in the names of type testing functions.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -38,7 +38,7 @@ inline bool isQuantumReferenceType(mlir::Type ty) {
   return mlir::isa<quake::RefType, quake::VeqType>(ty);
 }
 
-/// A quake value type is a linear type.
+/// A quake wire type is a linear type.
 inline bool isLinearType(mlir::Type ty) {
   return mlir::isa<quake::WireType>(ty);
 }

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -22,7 +22,7 @@
 
 namespace quake {
 /// \returns true if \p `ty` is a quantum value or reference.
-inline bool isaQuantumType(mlir::Type ty) {
+inline bool isQuantumType(mlir::Type ty) {
   // NB: this intentionally excludes MeasureType.
   return mlir::isa<quake::RefType, quake::VeqType, quake::WireType,
                    quake::ControlType>(ty);
@@ -31,12 +31,20 @@ inline bool isaQuantumType(mlir::Type ty) {
 /// \returns true if \p `ty` is a Quake type.
 inline bool isQuakeType(mlir::Type ty) {
   // This should correspond to the registered types in QuakeTypes.cpp.
-  return isaQuantumType(ty) || mlir::isa<quake::MeasureType>(ty);
+  return isQuantumType(ty) || mlir::isa<quake::MeasureType>(ty);
+}
+
+inline bool isQuantumReferenceType(mlir::Type ty) {
+  return mlir::isa<quake::RefType, quake::VeqType>(ty);
 }
 
 /// A quake value type is a linear type.
 inline bool isLinearType(mlir::Type ty) {
   return mlir::isa<quake::WireType>(ty);
+}
+
+inline bool isQuantumValueType(mlir::Type ty) {
+   return isLinearType(ty) || mlir::isa<quake::ControlType>(ty);
 }
 
 } // namespace quake

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -44,7 +44,7 @@ inline bool isLinearType(mlir::Type ty) {
 }
 
 inline bool isQuantumValueType(mlir::Type ty) {
-   return isLinearType(ty) || mlir::isa<quake::ControlType>(ty);
+  return isLinearType(ty) || mlir::isa<quake::ControlType>(ty);
 }
 
 } // namespace quake

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -1356,10 +1356,10 @@ public:
   /// must be called via other quantum code.
   bool hasLegalType(FunctionType funTy) {
     for (auto ty : funTy.getInputs())
-      if (quake::isaQuantumType(ty))
+      if (quake::isQuantumType(ty))
         return false;
     for (auto ty : funTy.getResults())
-      if (quake::isaQuantumType(ty))
+      if (quake::isQuantumType(ty))
         return false;
     return true;
   }

--- a/lib/Optimizer/Transforms/Mapping.cpp
+++ b/lib/Optimizer/Transforms/Mapping.cpp
@@ -570,7 +570,7 @@ struct Mapper : public cudaq::opt::impl::MappingPassBase<Mapper> {
         sources.push_back(qop);
       } else if (quake::isSupportedMappingOperation(&op)) {
         // Make sure the operation is using value semantics.
-        if (!quake::isValueSSAForm(&op)) {
+        if (!quake::isLinearValueForm(&op)) {
           llvm::errs() << "This is not SSA form: " << op << '\n';
           llvm::errs() << "isa<quake::NullWireOp>() = "
                        << isa<quake::NullWireOp>(&op) << '\n';

--- a/lib/Optimizer/Transforms/RegToMem.cpp
+++ b/lib/Optimizer/Transforms/RegToMem.cpp
@@ -109,7 +109,7 @@ private:
   }
 
   void insertToEqClass(Value v) {
-    if (quake::isValueSSAForm(v))
+    if (quake::isLinearValueForm(v))
       eqClasses.insert(toOpaque(v));
     insertBlockArgumentToEqClass(v);
   }
@@ -123,7 +123,7 @@ private:
   }
 
   void insertToEqClass(Value v, Value u) {
-    if (quake::isValueSSAForm(v) || isUnwrapRef(v))
+    if (quake::isLinearValueForm(v) || isUnwrapRef(v))
       eqClasses.unionSets(toOpaque(v), toOpaque(u));
     insertBlockArgumentToEqClass(v);
   }


### PR DESCRIPTION
We were using the terminology "value-SSA" and "reference-SSA" from classical computing in some of the old code to distinguish between quantum values that are referred to by value and by reference. The value/reference model is clearly appropriate, but the SSA isn't quite correct, pedantically speaking.

Unlike SSA, in quantum computation a value has a linear quantum type. It must be used exactly once. This follows from the inability to "make a copy" of a quantum state. SSA values, on the other hand, cannot be redefined but one can make as many copies of them as one wants.

While tweaking this terminology (hopefully to make it easier on the reader), these changes tighten some of the IR checks. One can now test if an Operation is purely in linear-value or reference form (or neither).

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
