### PR TITLE
Update `tensornet` backend/state implementation post merge

### DIFF
--- a/docker/release/cudaq.wheel.Dockerfile
+++ b/docker/release/cudaq.wheel.Dockerfile
@@ -38,7 +38,7 @@ RUN echo "Building wheel for python${python_version}." \
     && export CUDAQ_EXTERNAL_NVQIR_SIMS=$(bash scripts/find_wheel_assets.sh assets) \
     && export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/assets" \
     && $python -m pip install --no-cache-dir \
-        auditwheel cuquantum-cu11==24.03.0 cutensor-cu11==2.0.1 \
+        auditwheel cuquantum-cu11==24.03.0.post1 cutensor-cu11==2.0.1 \
     && cuquantum_location=`$python -m pip show cuquantum-cu11 | grep -e 'Location: .*$'` \
     && export CUQUANTUM_INSTALL_PREFIX="${cuquantum_location#Location: }/cuquantum" \
     && cutensor_location=`$python -m pip show cutensor-cu11 | grep -e 'Location: .*$'` \

--- a/runtime/nvqir/cutensornet/mps_simulation_state.cpp
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.cpp
@@ -18,16 +18,14 @@ int deviceFromPointer(void *ptr) {
   return attributes.device;
 }
 std::size_t MPSSimulationState::getNumQubits() const {
-  return state->getNumQubits() - m_auxTensorIds.size();
+  return state->getNumQubits();
 }
 
-MPSSimulationState::MPSSimulationState(
-    std::unique_ptr<TensorNetState> inState,
-    const std::vector<MPSTensor> &mpsTensors,
-    const std::vector<std::size_t> &auxTensorIds,
-    cutensornetHandle_t cutnHandle)
+MPSSimulationState::MPSSimulationState(std::unique_ptr<TensorNetState> inState,
+                                       const std::vector<MPSTensor> &mpsTensors,
+                                       cutensornetHandle_t cutnHandle)
     : m_cutnHandle(cutnHandle), state(std::move(inState)),
-      m_mpsTensors(mpsTensors), m_auxTensorIds(auxTensorIds) {}
+      m_mpsTensors(mpsTensors) {}
 
 MPSSimulationState::~MPSSimulationState() { deallocate(); }
 
@@ -235,12 +233,7 @@ MPSSimulationState::getAmplitude(const std::vector<int> &basisState) {
         "[tensornet-state] getAmplitude with an invalid basis state: only "
         "qubit state (0 or 1) is supported.");
   if (getNumQubits() > 1) {
-    auto extendedBasisState = basisState;
-    for (std::size_t i = 0; i < m_auxTensorIds.size(); ++i)
-      extendedBasisState.emplace_back(0);
-
-    TensorNetState basisTensorNetState(extendedBasisState,
-                                       state->getInternalContext());
+    TensorNetState basisTensorNetState(basisState, state->getInternalContext());
     // Note: this is a basis state, hence bond dim == 1
     std::vector<MPSTensor> basisStateTensors =
         basisTensorNetState.factorizeMPS(1, std::numeric_limits<double>::min(),
@@ -433,7 +426,7 @@ MPSSimulationState::toSimulationState() const {
       m_mpsTensors, state->getInternalContext(), tensors);
 
   return std::make_unique<MPSSimulationState>(std::move(cloneState), tensors,
-                                              m_auxTensorIds, m_cutnHandle);
+                                              m_cutnHandle);
 }
 
 static Eigen::MatrixXcd reshapeStateVec(const Eigen::VectorXcd &stateVec) {
@@ -474,8 +467,7 @@ MPSSimulationState::createFromSizeAndPtr(std::size_t size, void *ptr,
     stateTensor.extents = std::vector<int64_t>{2};
 
     return std::make_unique<MPSSimulationState>(
-        std::move(state), std::vector<MPSTensor>{stateTensor},
-        std::vector<std::size_t>{}, m_cutnHandle);
+        std::move(state), std::vector<MPSTensor>{stateTensor}, m_cutnHandle);
   }
 
   // Recursively factor the state vector from left to right.
@@ -525,7 +517,7 @@ MPSSimulationState::createFromSizeAndPtr(std::size_t size, void *ptr,
   stateTensor.extents = std::vector<int64_t>{numSingularValues.back(), 2};
   mpsTensors.emplace_back(stateTensor);
   assert(mpsTensors.size() == numQubits);
-  return std::make_unique<MPSSimulationState>(
-      std::move(state), mpsTensors, std::vector<std::size_t>{}, m_cutnHandle);
+  return std::make_unique<MPSSimulationState>(std::move(state), mpsTensors,
+                                              m_cutnHandle);
 }
 } // namespace nvqir

--- a/runtime/nvqir/cutensornet/mps_simulation_state.h
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.h
@@ -24,7 +24,6 @@ class MPSSimulationState : public cudaq::SimulationState,
 public:
   MPSSimulationState(std::unique_ptr<TensorNetState> inState,
                      const std::vector<MPSTensor> &mpsTensors,
-                     const std::vector<std::size_t> &auxTensorIds,
                      cutensornetHandle_t cutnHandle);
 
   MPSSimulationState(const MPSSimulationState &) = delete;
@@ -83,7 +82,6 @@ protected:
   std::unique_ptr<TensorNetState> state;
   std::vector<MPSTensor> m_mpsTensors;
   ScratchDeviceMem m_scratchPad;
-  std::vector<std::size_t> m_auxTensorIds;
 };
 
 } // namespace nvqir

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.h
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.h
@@ -61,6 +61,11 @@ public:
   /// Clone API
   virtual nvqir::CircuitSimulator *clone() override;
 
+  virtual std::unique_ptr<cudaq::SimulationState>
+  getSimulationState() override {
+    throw std::runtime_error("[tensornet] getSimulationState not implemented");
+    return nullptr;
+  }
   /// Swap gate implementation
   // Note: cutensornetStateApplyControlledTensorOperator can only handle
   // single-target.

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -103,11 +103,12 @@ public:
       };
       for (auto &op : casted->getAppliedTensors()) {
         if (op.isUnitary)
-          m_state->applyGate(mapQubitIdxs(op.qubitIds), op.deviceData,
+          m_state->applyGate(mapQubitIdxs(op.controlQubitIds),
+                             mapQubitIdxs(op.targetQubitIds), op.deviceData,
                              op.isAdjoint);
         else
           m_state->applyQubitProjector(op.deviceData,
-                                       mapQubitIdxs(op.qubitIds));
+                                       mapQubitIdxs(op.targetQubitIds));
       }
     }
   }

--- a/runtime/nvqir/cutensornet/tensornet_state.cpp
+++ b/runtime/nvqir/cutensornet/tensornet_state.cpp
@@ -21,6 +21,28 @@ TensorNetState::TensorNetState(std::size_t numQubits,
       qubitDims.data(), CUDA_C_64F, &m_quantumState));
 }
 
+TensorNetState::TensorNetState(const std::vector<int> &basisState,
+                               cutensornetHandle_t handle)
+    : TensorNetState(basisState.size(), handle) {
+  constexpr std::complex<double> h_xGate[4] = {0.0, 1.0, 1.0, 0.0};
+  constexpr auto sizeBytes = 4 * sizeof(std::complex<double>);
+  void *d_gate{nullptr};
+  HANDLE_CUDA_ERROR(cudaMalloc(&d_gate, sizeBytes));
+  HANDLE_CUDA_ERROR(
+      cudaMemcpy(d_gate, h_xGate, sizeBytes, cudaMemcpyHostToDevice));
+  m_tempDevicePtrs.emplace_back(d_gate);
+  for (int32_t qId = 0; const auto &bit : basisState) {
+    if (bit == 1) {
+      applyGate({}, {qId}, d_gate);
+    }
+    ++qId;
+  }
+}
+
+std::unique_ptr<TensorNetState> TensorNetState::clone() const {
+  return createFromOpTensors(m_numQubits, m_tensorOps, m_cutnHandle);
+}
+
 void TensorNetState::applyGate(const std::vector<int32_t> &controlQubits,
                                const std::vector<int32_t> &targetQubits,
                                void *gateDeviceMem, bool adjoint) {
@@ -39,13 +61,79 @@ void TensorNetState::applyGate(const std::vector<int32_t> &controlQubits,
         /*immutable*/ 1,
         /*adjoint*/ static_cast<int32_t>(adjoint), /*unitary*/ 1, &m_tensorId));
   }
+  m_tensorOps.emplace_back(AppliedTensorOp{gateDeviceMem, targetQubits,
+                                           controlQubits, adjoint, true});
 }
 
-void TensorNetState::applyQubitProjector(void *proj_d, int32_t qubitIdx) {
+void TensorNetState::applyQubitProjector(void *proj_d,
+                                         const std::vector<int32_t> &qubitIdx) {
   HANDLE_CUTN_ERROR(cutensornetStateApplyTensorOperator(
-      m_cutnHandle, m_quantumState, 1, &qubitIdx, proj_d, nullptr,
+      m_cutnHandle, m_quantumState, qubitIdx.size(), qubitIdx.data(), proj_d,
+      nullptr,
       /*immutable*/ 1,
       /*adjoint*/ 0, /*unitary*/ 0, &m_tensorId));
+  m_tensorOps.emplace_back(AppliedTensorOp{proj_d, qubitIdx, {}, false, false});
+}
+
+void TensorNetState::addQubits(std::size_t numQubits) {
+  // Destroy the current quantum circuit state
+  HANDLE_CUTN_ERROR(cutensornetDestroyState(m_quantumState));
+  m_numQubits += numQubits;
+  const std::vector<int64_t> qubitDims(m_numQubits, 2);
+  HANDLE_CUTN_ERROR(cutensornetCreateState(
+      m_cutnHandle, CUTENSORNET_STATE_PURITY_PURE, m_numQubits,
+      qubitDims.data(), CUDA_C_64F, &m_quantumState));
+  // Append any previously-applied gate tensors.
+  // These tensors will only be appending to those existing qubit wires, i.e.,
+  // the new wires are all empty (zero state).
+  int64_t tensorId = 0;
+  for (auto &op : m_tensorOps)
+    if (op.controlQubitIds.empty()) {
+      HANDLE_CUTN_ERROR(cutensornetStateApplyTensorOperator(
+          m_cutnHandle, m_quantumState, op.targetQubitIds.size(),
+          op.targetQubitIds.data(), op.deviceData, nullptr, /*immutable*/ 1,
+          /*adjoint*/ static_cast<int32_t>(op.isAdjoint),
+          /*unitary*/ static_cast<int32_t>(op.isUnitary), &tensorId));
+    } else {
+      HANDLE_CUTN_ERROR(cutensornetStateApplyControlledTensorOperator(
+          m_cutnHandle, m_quantumState,
+          /*numControlModes=*/op.controlQubitIds.size(),
+          /*stateControlModes=*/op.controlQubitIds.data(),
+          /*stateControlValues=*/nullptr,
+          /*numTargetModes*/ op.targetQubitIds.size(),
+          /*stateTargetModes*/ op.targetQubitIds.data(), op.deviceData, nullptr,
+          /*immutable*/ 1,
+          /*adjoint*/ static_cast<int32_t>(op.isAdjoint),
+          /*unitary*/ static_cast<int32_t>(op.isUnitary), &m_tensorId));
+    }
+}
+
+void TensorNetState::addQubits(std::span<std::complex<double>> stateVec) {
+  const std::size_t numQubits = std::log2(stateVec.size());
+  auto ket =
+      Eigen::Map<const Eigen::VectorXcd>(stateVec.data(), stateVec.size());
+  Eigen::VectorXcd initState = Eigen::VectorXcd::Zero(stateVec.size());
+  initState(0) = std::complex<double>{1.0, 0.0};
+  Eigen::MatrixXcd stateVecProj = ket * initState.transpose();
+  assert(static_cast<std::size_t>(stateVecProj.size()) ==
+         stateVec.size() * stateVec.size());
+  stateVecProj.transposeInPlace();
+  void *d_proj{nullptr};
+  HANDLE_CUDA_ERROR(
+      cudaMalloc(&d_proj, stateVecProj.size() * sizeof(std::complex<double>)));
+  HANDLE_CUDA_ERROR(
+      cudaMemcpy(d_proj, stateVecProj.data(),
+                 stateVecProj.size() * sizeof(std::complex<double>),
+                 cudaMemcpyHostToDevice));
+
+  std::vector<int32_t> qubitIdx(numQubits);
+  std::iota(qubitIdx.begin(), qubitIdx.end(), m_numQubits);
+  // Add qubits in zero state
+  addQubits(numQubits);
+
+  // Project the state of those new qubits to the input state.
+  applyQubitProjector(d_proj, qubitIdx);
+  m_tempDevicePtrs.emplace_back(d_proj);
 }
 
 std::unordered_map<std::string, size_t>
@@ -470,9 +558,10 @@ std::unique_ptr<TensorNetState> TensorNetState::createFromOpTensors(
   auto state = std::make_unique<TensorNetState>(numQubits, handle);
   for (const auto &op : opTensors)
     if (op.isUnitary)
-      state->applyGate(op.qubitIds, op.deviceData, op.isAdjoint);
+      state->applyGate(op.controlQubitIds, op.targetQubitIds, op.deviceData,
+                       op.isAdjoint);
     else
-      state->applyQubitProjector(op.deviceData, op.qubitIds);
+      state->applyQubitProjector(op.deviceData, op.targetQubitIds);
 
   return state;
 }

--- a/runtime/nvqir/cutensornet/tensornet_state.h
+++ b/runtime/nvqir/cutensornet/tensornet_state.h
@@ -31,7 +31,8 @@ struct MPSTensor {
 /// Track gate tensors that were appended to the tensor network.
 struct AppliedTensorOp {
   void *deviceData = nullptr;
-  std::vector<int32_t> qubitIds;
+  std::vector<int32_t> targetQubitIds;
+  std::vector<int32_t> controlQubitIds;
   bool isAdjoint;
   bool isUnitary;
 };


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Some non-trivial changes to the tensornet backend and state implementations required after merging from `main`.

In particular, the introduction of `cutensornetStateApplyControlledTensorOperator` in the latest cuquantum (pulled in from main) requires some code changes to the state implementation.
