### PR TITLE
Refactoring measurecounts

### DIFF
--- a/runtime/common/MeasureCounts.cpp
+++ b/runtime/common/MeasureCounts.cpp
@@ -149,9 +149,12 @@ void sample_result::deserialize(std::vector<std::size_t> &data) {
     deserializeCounts(data, stride, localCounts);
 
     sampleResults.insert({name, ExecutionResult{localCounts, name}});
-    totalShots = std::accumulate(
-        localCounts.begin(), localCounts.end(), 0,
-        [](std::size_t sum, const auto &pair) { return sum + pair.second; });
+
+    if (stride >= data.size()) {
+      totalShots = std::accumulate(
+          localCounts.begin(), localCounts.end(), 0,
+          [](std::size_t sum, const auto &pair) { return sum + pair.second; });
+    }
   }
 }
 


### PR DESCRIPTION
# Refactoring MeasureCounts for efficiency

1. Moved similar code for ExecutionResult and sample_result deserialization in a separate deserialize method as per @schweitzpgi's suggestion
2. Used emplace instead of insert to avoid copies
3. Directly constructed a string into a vector instead of using for loops, which involves repeatedly concatenating strings
4. Used move utility to allow the transferring of resources from one object to another efficiently

# Test result

100% tests passed, 0 tests failed out of 564

Label Time Summary:
gpu_required    = 133.59 sec*proc (312 tests)

Total Test time (real) = 302.33 sec

The following tests did not run:
        515 - iqm-tests (Skipped)