### PR TITLE
Fix mismatches between input state and simulation engine precision.

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -16,57 +16,61 @@
 namespace cudaq::opt {
 
 /// QIS Function name strings
-constexpr static const char QIRQISPrefix[] = "__quantum__qis__";
-constexpr static const char QIRMeasureBody[] = "__quantum__qis__mz__body";
-constexpr static const char QIRMeasure[] = "__quantum__qis__mz";
-constexpr static const char QIRMeasureToRegister[] =
+static constexpr const char QIRQISPrefix[] = "__quantum__qis__";
+static constexpr const char QIRMeasureBody[] = "__quantum__qis__mz__body";
+static constexpr const char QIRMeasure[] = "__quantum__qis__mz";
+static constexpr const char QIRMeasureToRegister[] =
     "__quantum__qis__mz__to__register";
 
-constexpr static const char QIRCnot[] = "__quantum__qis__cnot";
-constexpr static const char QIRCphase[] = "__quantum__qis__cphase";
-constexpr static const char QIRReadResultBody[] =
+static constexpr const char QIRCnot[] = "__quantum__qis__cnot";
+static constexpr const char QIRCphase[] = "__quantum__qis__cphase";
+static constexpr const char QIRReadResultBody[] =
     "__quantum__qis__read_result__body";
 
-constexpr static const char NVQIRInvokeWithControlBits[] =
+static constexpr const char NVQIRInvokeWithControlBits[] =
     "invokeWithControlQubits";
-constexpr static const char NVQIRInvokeRotationWithControlBits[] =
+static constexpr const char NVQIRInvokeRotationWithControlBits[] =
     "invokeRotationWithControlQubits";
-constexpr static const char NVQIRInvokeU3RotationWithControlBits[] =
+static constexpr const char NVQIRInvokeU3RotationWithControlBits[] =
     "invokeU3RotationWithControlQubits";
-constexpr static const char NVQIRInvokeWithControlRegisterOrBits[] =
+static constexpr const char NVQIRInvokeWithControlRegisterOrBits[] =
     "invokeWithControlRegisterOrQubits";
-constexpr static const char NVQIRPackSingleQubitInArray[] =
+static constexpr const char NVQIRPackSingleQubitInArray[] =
     "packSingleQubitInArray";
-constexpr static const char NVQIRReleasePackedQubitArray[] =
+static constexpr const char NVQIRReleasePackedQubitArray[] =
     "releasePackedQubitArray";
 
 /// QIR Array function name strings
-constexpr static const char QIRArrayGetElementPtr1d[] =
+static constexpr const char QIRArrayGetElementPtr1d[] =
     "__quantum__rt__array_get_element_ptr_1d";
-constexpr static const char QIRArrayQubitAllocateArray[] =
+static constexpr const char QIRArrayQubitAllocateArray[] =
     "__quantum__rt__qubit_allocate_array";
-constexpr static const char QIRArrayQubitAllocateArrayWithStateFP64[] =
+static constexpr const char QIRArrayQubitAllocateArrayWithStateFP64[] =
     "__quantum__rt__qubit_allocate_array_with_state_fp64";
-constexpr static const char QIRArrayQubitAllocateArrayWithStateFP32[] =
+static constexpr const char QIRArrayQubitAllocateArrayWithStateFP32[] =
     "__quantum__rt__qubit_allocate_array_with_state_fp32";
-constexpr static const char QIRArrayQubitAllocateArrayWithStatePtr[] =
+static constexpr const char QIRArrayQubitAllocateArrayWithStateComplex64[] =
+    "__quantum__rt__qubit_allocate_array_with_state_complex64";
+static constexpr const char QIRArrayQubitAllocateArrayWithStateComplex32[] =
+    "__quantum__rt__qubit_allocate_array_with_state_complex32";
+static constexpr const char QIRArrayQubitAllocateArrayWithStatePtr[] =
     "__quantum__rt__qubit_allocate_array_with_state_ptr";
-constexpr static const char QIRQubitAllocate[] =
+static constexpr const char QIRQubitAllocate[] =
     "__quantum__rt__qubit_allocate";
-constexpr static const char QIRArrayQubitReleaseArray[] =
+static constexpr const char QIRArrayQubitReleaseArray[] =
     "__quantum__rt__qubit_release_array";
-constexpr static const char QIRArrayQubitReleaseQubit[] =
+static constexpr const char QIRArrayQubitReleaseQubit[] =
     "__quantum__rt__qubit_release";
-constexpr static const char QIRArraySlice[] = "__quantum__rt__array_slice";
-constexpr static const char QIRArrayGetSize[] =
+static constexpr const char QIRArraySlice[] = "__quantum__rt__array_slice";
+static constexpr const char QIRArrayGetSize[] =
     "__quantum__rt__array_get_size_1d";
-constexpr static const char QIRArrayConcatArray[] =
+static constexpr const char QIRArrayConcatArray[] =
     "__quantum__rt__array_concatenate";
-constexpr static const char QIRArrayCreateArray[] =
+static constexpr const char QIRArrayCreateArray[] =
     "__quantum__rt__array_create_1d";
 
 /// QIR Base/Adaptive Profile record output function names
-constexpr static const char QIRRecordOutput[] =
+static constexpr const char QIRRecordOutput[] =
     "__quantum__rt__result_record_output";
 
 inline mlir::Type getQuantumTypeByName(mlir::StringRef type,

--- a/lib/Optimizer/CodeGen/ConvertToQIR.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIR.cpp
@@ -145,12 +145,21 @@ public:
                          .getElementType()) {
       if (auto arrayTy = dyn_cast<LLVM::LLVMArrayType>(eleTy))
         eleTy = arrayTy.getElementType();
-      if (auto complexTy = dyn_cast<LLVM::LLVMStructType>(eleTy))
+      bool fromComplex = false;
+      if (auto complexTy = dyn_cast<LLVM::LLVMStructType>(eleTy)) {
+        fromComplex = true;
         eleTy = complexTy.getBody()[0];
+      }
       if (eleTy == rewriter.getF64Type())
-        functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP64;
+        functionName =
+            fromComplex
+                ? cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex64
+                : cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP64;
       if (eleTy == rewriter.getF32Type())
-        functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP32;
+        functionName =
+            fromComplex
+                ? cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex32
+                : cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP32;
     }
     if (functionName.empty())
       return raii.emitOpError("invalid type on initialize state operation, "

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -779,7 +779,7 @@ protected:
   }
 
   bool isSinglePrecision() const override {
-    return std::is_same_v<std::remove_cvref<ScalarType>, float>;
+    return std::is_same_v<ScalarType, float>;
   }
 
 public:

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -345,6 +345,10 @@ public:
 
   /// @brief Return a thread_local pointer to this CircuitSimulator
   virtual CircuitSimulator *clone() = 0;
+
+  /// Determine the (preferred) precision of the simulator.
+  virtual bool isSinglePrecision() const = 0;
+  bool isDoublePrecision() const { return !isSinglePrecision(); }
 };
 
 /// @brief The CircuitSimulatorBase is the type that is meant to
@@ -772,6 +776,10 @@ protected:
     }
 
     return defaultConfig;
+  }
+
+  bool isSinglePrecision() const override {
+    return std::is_same_v<std::remove_cvref<ScalarType>, float>;
   }
 
 public:

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -199,6 +199,7 @@ Array *__quantum__rt__qubit_allocate_array_with_state_complex64(
   }
   // Input was complex<double> but we prefer complex<float>. Make a copy,
   // truncating the values.
+  cudaq::info("copying {} complex values from double to float.", size);
   auto convertData = std::make_unique<std::complex<float>[]>(size);
   for (uint64_t i = 0; i < size; ++i)
     convertData[i] = std::complex<float>{static_cast<float>(data[i].real()),
@@ -212,6 +213,7 @@ Array *__quantum__rt__qubit_allocate_array_with_state_fp64(uint64_t size,
                                                            double *data) {
   ScopedTraceWithContext("NVQIR::qubit_allocate_array_with_data_fp64", size);
   if (nvqir::getCircuitSimulatorInternal()->isDoublePrecision()) {
+    cudaq::info("copying {} double values to complex<double>.", size);
     auto convertData = std::make_unique<std::complex<double>[]>(size);
     for (uint64_t i = 0; i < size; ++i)
       convertData[i] = std::complex<double>{data[i], 0.0};
@@ -220,6 +222,7 @@ Array *__quantum__rt__qubit_allocate_array_with_state_fp64(uint64_t size,
   }
   // Input was double but we prefer complex<float>. Make a copy, truncating the
   // values.
+  cudaq::info("copying {} double values to complex<float>.", size);
   auto convertData = std::make_unique<std::complex<float>[]>(size);
   for (uint64_t i = 0; i < size; ++i)
     convertData[i] = std::complex<float>{static_cast<float>(data[i]), 0.0f};
@@ -254,6 +257,7 @@ Array *__quantum__rt__qubit_allocate_array_with_state_complex32(
   }
   // Input was complex<float> but we prefer complex<double>. Make a copy,
   // extending the values.
+  cudaq::info("copying {} complex values from float to double.", size);
   auto convertData = std::make_unique<std::complex<double>[]>(size);
   for (uint64_t i = 0; i < size; ++i)
     convertData[i] = std::complex<double>{static_cast<double>(data[i].real()),
@@ -267,6 +271,7 @@ Array *__quantum__rt__qubit_allocate_array_with_state_fp32(uint64_t size,
                                                            float *data) {
   ScopedTraceWithContext("NVQIR::qubit_allocate_array_with_data_fp32", size);
   if (nvqir::getCircuitSimulatorInternal()->isSinglePrecision()) {
+    cudaq::info("copying {} float values to complex<float>.", size);
     auto convertData = std::make_unique<std::complex<float>[]>(size);
     for (uint64_t i = 0; i < size; ++i)
       convertData[i] = std::complex<float>{data[i], 0.0};
@@ -275,6 +280,7 @@ Array *__quantum__rt__qubit_allocate_array_with_state_fp32(uint64_t size,
   }
   // Input was float but we prefer complex<double>. Make a copy, extending the
   // values.
+  cudaq::info("copying {} float values to complex<double>.", size);
   auto convertData = std::make_unique<std::complex<double>[]>(size);
   for (uint64_t i = 0; i < size; ++i)
     convertData[i] = std::complex<double>{static_cast<double>(data[i]), 0.0};

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -184,13 +184,47 @@ Array *__quantum__rt__qubit_allocate_array(uint64_t size) {
   return vectorSizetToArray(qubitIdxs);
 }
 
-Array *__quantum__rt__qubit_allocate_array_with_state_fp64(
+Array *__quantum__rt__qubit_allocate_array_with_state_complex32(
+    uint64_t size, std::complex<float> *data);
+
+Array *__quantum__rt__qubit_allocate_array_with_state_complex64(
     uint64_t size, std::complex<double> *data) {
-  ScopedTraceWithContext("NVQIR::qubit_allocate_array_with_data_fp64", size);
+  ScopedTraceWithContext("NVQIR::qubit_allocate_array_with_data_complex64",
+                         size);
   __quantum__rt__initialize(0, nullptr);
+  if (nvqir::getCircuitSimulatorInternal()->isDoublePrecision()) {
+    auto qubitIdxs = nvqir::getCircuitSimulatorInternal()->allocateQubits(
+        size, data, cudaq::simulation_precision::fp64);
+    return vectorSizetToArray(qubitIdxs);
+  }
+  // Input was complex<double> but we prefer complex<float>. Make a copy,
+  // truncating the values.
+  auto convertData = std::make_unique<std::complex<float>[]>(size);
+  for (uint64_t i = 0; i < size; ++i)
+    convertData[i] = std::complex<float>{static_cast<float>(data[i].real()),
+                                         static_cast<float>(data[i].imag())};
   auto qubitIdxs = nvqir::getCircuitSimulatorInternal()->allocateQubits(
-      size, data, cudaq::simulation_precision::fp64);
+      size, convertData.get(), cudaq::simulation_precision::fp32);
   return vectorSizetToArray(qubitIdxs);
+}
+
+Array *__quantum__rt__qubit_allocate_array_with_state_fp64(uint64_t size,
+                                                           double *data) {
+  ScopedTraceWithContext("NVQIR::qubit_allocate_array_with_data_fp64", size);
+  if (nvqir::getCircuitSimulatorInternal()->isDoublePrecision()) {
+    auto convertData = std::make_unique<std::complex<double>[]>(size);
+    for (uint64_t i = 0; i < size; ++i)
+      convertData[i] = std::complex<double>{data[i], 0.0};
+    return __quantum__rt__qubit_allocate_array_with_state_complex64(
+        size, convertData.get());
+  }
+  // Input was double but we prefer complex<float>. Make a copy, truncating the
+  // values.
+  auto convertData = std::make_unique<std::complex<float>[]>(size);
+  for (uint64_t i = 0; i < size; ++i)
+    convertData[i] = std::complex<float>{static_cast<float>(data[i]), 0.0f};
+  return __quantum__rt__qubit_allocate_array_with_state_complex32(
+      size, convertData.get());
 }
 
 Array *__quantum__rt__qubit_allocate_array_with_state_ptr(
@@ -208,14 +242,44 @@ Array *__quantum__rt__qubit_allocate_array_with_state_ptr(
   return vectorSizetToArray(qubitIdxs);
 }
 
-Array *
-__quantum__rt__qubit_allocate_array_with_state_fp32(uint64_t size,
-                                                    std::complex<float> *data) {
-  ScopedTraceWithContext("NVQIR::qubit_allocate_array_with_data_fp32", size);
+Array *__quantum__rt__qubit_allocate_array_with_state_complex32(
+    uint64_t size, std::complex<float> *data) {
+  ScopedTraceWithContext("NVQIR::qubit_allocate_array_with_data_complex32",
+                         size);
   __quantum__rt__initialize(0, nullptr);
+  if (nvqir::getCircuitSimulatorInternal()->isSinglePrecision()) {
+    auto qubitIdxs = nvqir::getCircuitSimulatorInternal()->allocateQubits(
+        size, data, cudaq::simulation_precision::fp32);
+    return vectorSizetToArray(qubitIdxs);
+  }
+  // Input was complex<float> but we prefer complex<double>. Make a copy,
+  // extending the values.
+  auto convertData = std::make_unique<std::complex<double>[]>(size);
+  for (uint64_t i = 0; i < size; ++i)
+    convertData[i] = std::complex<double>{static_cast<double>(data[i].real()),
+                                          static_cast<double>(data[i].imag())};
   auto qubitIdxs = nvqir::getCircuitSimulatorInternal()->allocateQubits(
-      size, data, cudaq::simulation_precision::fp32);
+      size, convertData.get(), cudaq::simulation_precision::fp64);
   return vectorSizetToArray(qubitIdxs);
+}
+
+Array *__quantum__rt__qubit_allocate_array_with_state_fp32(uint64_t size,
+                                                           float *data) {
+  ScopedTraceWithContext("NVQIR::qubit_allocate_array_with_data_fp32", size);
+  if (nvqir::getCircuitSimulatorInternal()->isSinglePrecision()) {
+    auto convertData = std::make_unique<std::complex<float>[]>(size);
+    for (uint64_t i = 0; i < size; ++i)
+      convertData[i] = std::complex<float>{data[i], 0.0};
+    return __quantum__rt__qubit_allocate_array_with_state_complex32(
+        size, convertData.get());
+  }
+  // Input was float but we prefer complex<double>. Make a copy, extending the
+  // values.
+  auto convertData = std::make_unique<std::complex<double>[]>(size);
+  for (uint64_t i = 0; i < size; ++i)
+    convertData[i] = std::complex<double>{static_cast<double>(data[i]), 0.0};
+  return __quantum__rt__qubit_allocate_array_with_state_complex64(
+      size, convertData.get());
 }
 
 /// @brief Once done, release the QIR qubit array

--- a/targettests/execution/qvector_mismatch.cpp
+++ b/targettests/execution/qvector_mismatch.cpp
@@ -23,5 +23,4 @@ int main() {
   return 0;
 }
 
-// CHECK: { 11:{{[0-9]+}} 00:{{[0-9]+}} }
-// CHECK: size 2
+// CHECK: size {{[0-9]+}}

--- a/targettests/execution/qvector_mismatch.cpp
+++ b/targettests/execution/qvector_mismatch.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ %cpp_std --enable-mlir %s -o %t && %t | FileCheck %s
+
+#include <cudaq.h>
+
+__qpu__ void test(std::vector<double> inState) {
+  cudaq::qvector q = inState;
+}
+
+int main() {
+  std::vector<double> vec{M_SQRT1_2, 0., 0., M_SQRT1_2};
+  auto counts = cudaq::sample(test, vec);
+  counts.dump();
+
+  printf("size %zu\n", counts.size());
+  return 0;
+}
+
+// CHECK: { 11:{{[0-9]+}} 00:{{[0-9]+}} }
+// CHECK: size 2

--- a/test/AST-Quake/qalloc_initialization.cpp
+++ b/test/AST-Quake/qalloc_initialization.cpp
@@ -298,7 +298,7 @@ __qpu__ bool Peppermint() {
 // QIR:         %[[VAL_6:.*]] = getelementptr inbounds [4 x { double, double }], [4 x { double, double }]* %[[VAL_0]], i64 0, i64 2, i32 1
 // QIR:         %[[VAL_7:.*]] = bitcast [4 x { double, double }]* %[[VAL_0]] to i8*
 // QIR:         call void @llvm.memset
-// QIR:         %[[VAL_8:.*]] = call %[[VAL_9:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 2, i8* nonnull %[[VAL_7]])
+// QIR:         %[[VAL_8:.*]] = call %[[VAL_9:.*]]* @__quantum__rt__qubit_allocate_array_with_state_complex64(i64 2, i8* nonnull %[[VAL_7]])
 // QIR:         %[[VAL_10:.*]] = call i64 @__quantum__rt__array_get_size_1d(%[[VAL_9]]* %[[VAL_8]])
 // QIR:       }
 
@@ -317,7 +317,7 @@ __qpu__ bool Peppermint() {
 // QIR:         %[[VAL_6:.*]] = getelementptr inbounds [4 x { double, double }], [4 x { double, double }]* %[[VAL_0]], i64 0, i64 2, i32 1
 // QIR:         %[[VAL_7:.*]] = bitcast [4 x { double, double }]* %[[VAL_0]] to i8*
 // QIR:         call void @llvm.memset
-// QIR:         %[[VAL_8:.*]] = call %[[VAL_9:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 2, i8* nonnull %[[VAL_7]])
+// QIR:         %[[VAL_8:.*]] = call %[[VAL_9:.*]]* @__quantum__rt__qubit_allocate_array_with_state_complex64(i64 2, i8* nonnull %[[VAL_7]])
 // QIR:         %[[VAL_10:.*]] = call i64 @__quantum__rt__array_get_size_1d(%[[VAL_9]]* %[[VAL_8]])
 // QIR:       }
 
@@ -362,7 +362,7 @@ __qpu__ bool Peppermint() {
 // QIR:         %[[VAL_26:.*]] = getelementptr inbounds [4 x { double, double }], [4 x { double, double }]* %[[VAL_16]], i64 0, i64 2, i32 1
 // QIR:         store double %[[VAL_25]], double* %[[VAL_26]], align 8
 // QIR:         %[[VAL_27:.*]] = bitcast [4 x { double, double }]* %[[VAL_16]] to i8*
-// QIR:         %[[VAL_28:.*]] = call %[[VAL_29:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 2, i8* nonnull %[[VAL_27]])
+// QIR:         %[[VAL_28:.*]] = call %[[VAL_29:.*]]* @__quantum__rt__qubit_allocate_array_with_state_complex64(i64 2, i8* nonnull %[[VAL_27]])
 // QIR:         %[[VAL_30:.*]] = call i64 @__quantum__rt__array_get_size_1d(%[[VAL_29]]* %[[VAL_28]])
 // QIR:       }
 
@@ -392,7 +392,7 @@ __qpu__ bool Peppermint() {
 // QIR: %[[VAL_1:.*]] = tail call i64 @llvm.cttz.i64(i64 %[[VAL_I]], i1 false)
 // QIR:         %[[VAL_2:.*]] = extractvalue { { double, double }*, i64 } %[[VAL_0]], 0
 // QIR:         %[[VAL_3:.*]] = bitcast { double, double }* %[[VAL_2]] to i8*
-// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 %[[VAL_1]], i8* %[[VAL_3]])
+// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state_complex64(i64 %[[VAL_1]], i8* %[[VAL_3]])
 // QIR:         %[[VAL_6:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_5]]* %[[VAL_4]])
 // QIR:       }
 
@@ -402,7 +402,7 @@ __qpu__ bool Peppermint() {
 // QIR: %[[VAL_1:.*]] = tail call i64 @llvm.cttz.i64(i64 %[[VAL_I]], i1 false)
 // QIR:         %[[VAL_2:.*]] = extractvalue { { double, double }*, i64 } %[[VAL_0]], 0
 // QIR:         %[[VAL_3:.*]] = bitcast { double, double }* %[[VAL_2]] to i8*
-// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state_fp64(i64 %[[VAL_1]], i8* %[[VAL_3]])
+// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]* @__quantum__rt__qubit_allocate_array_with_state_complex64(i64 %[[VAL_1]], i8* %[[VAL_3]])
 // QIR:         %[[VAL_6:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_5]]* %[[VAL_4]])
 // QIR:       }
 


### PR DESCRIPTION
It may be the case that the state vector data is in a precision that does not match that of the simulator. The runtime library knows precisely what simulator has been selected and can therefore convert the state vector to the expected format at runtime. This conversion may be *expensive* if the state vector is quite long. As a result, the runtime may want to emit a warning when a conversion path is taken.

The following conversions happen at runtime with this change:
```
  vector<float> -> vector<complex<float>>
  vector<float> -> vector<complex<double>>
  vector<double> -> vector<complex<float>>
  vector<double> -> vector<complex<double>>
  vector<complex<float>> -> vector<complex<double>>
  vector<complex<double>> -> vector<complex<float>>
```
If the input is `vector<complex<float>>` or `vector<complex<double>>` and the simulator's precision is a precise match, no conversions or runtime overhead is incurred.

Fix #1670

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
