### PR TITLE
Use a more meaningful template argument name.

### DIFF
--- a/runtime/cudaq/qis/managers/photonics/photonics_qis.h
+++ b/runtime/cudaq/qis/managers/photonics/photonics_qis.h
@@ -17,22 +17,22 @@
 namespace cudaq {
 /// @brief The `plus` gate
 // U|0> -> |1>, U|1> -> |2>, ..., and U|d> -> |0>
-template <std::size_t T>
-void plus(cudaq::qudit<T> &q) {
+template <std::size_t Levels>
+void plus(cudaq::qudit<Levels> &q) {
   cudaq::getExecutionManager()->apply("plusGate", {}, {},
                                       {{q.n_levels(), q.id()}});
 }
 
 /// @brief The `phase shift` gate
-template <std::size_t T>
-void phase_shift(cudaq::qudit<T> &q, const double &phi) {
+template <std::size_t Levels>
+void phase_shift(cudaq::qudit<Levels> &q, const double &phi) {
   cudaq::getExecutionManager()->apply("phaseShiftGate", {phi}, {},
                                       {{q.n_levels(), q.id()}});
 }
 
 /// @brief The `beam splitter` gate
-template <std::size_t T>
-void beam_splitter(cudaq::qudit<T> &q, cudaq::qudit<T> &r,
+template <std::size_t Levels>
+void beam_splitter(cudaq::qudit<Levels> &q, cudaq::qudit<Levels> &r,
                    const double &theta) {
   cudaq::getExecutionManager()->apply(
       "beamSplitterGate", {theta}, {},
@@ -40,14 +40,14 @@ void beam_splitter(cudaq::qudit<T> &q, cudaq::qudit<T> &r,
 }
 
 /// @brief Measure a qudit
-template <std::size_t T>
-int mz(cudaq::qudit<T> &q) {
+template <std::size_t Levels>
+int mz(cudaq::qudit<Levels> &q) {
   return cudaq::getExecutionManager()->measure({q.n_levels(), q.id()});
 }
 
 /// @brief Measure a vector of qudits
-template <std::size_t T>
-std::vector<int> mz(cudaq::qvector<T> &q) {
+template <std::size_t Levels>
+std::vector<int> mz(cudaq::qvector<Levels> &q) {
   std::vector<int> ret;
   for (auto &qq : q)
     ret.emplace_back(mz(qq));


### PR DESCRIPTION
`T` is often used for a type, but in this header it is used for the number of levels in a qudit.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
