### PR TITLE
NVQC: Auto-select NCA ID based on API key

### DIFF
--- a/runtime/common/NvqcConfig.h
+++ b/runtime/common/NvqcConfig.h
@@ -10,13 +10,21 @@
 #include <stdlib.h>
 #include <string>
 namespace cudaq {
+
+static constexpr const char *NVQC_NCA_ID_ENV_VAR = "NVQC_NCA_ID";
+static constexpr const char *DEV_NVQC_NCA_ID =
+    "mZraB3k06kOd8aPhD6MVXJwBVZ67aXDLsfmDo4MYXDs";
+static constexpr const char *PROD_NVQC_NCA_ID =
+    "audj0Ow_82RT0BbiewKaIryIdZWiSrOqiiDSaA8w7a8";
+
+inline bool isNvqcNcaIdOverridden() {
+  return std::getenv(NVQC_NCA_ID_ENV_VAR) != nullptr;
+}
+
 inline std::string getNvqcNcaId() {
-  // Default NVQC NVIDIA Cloud Account (NCA) Id
-  static constexpr const char *NVQC_NCA_ID =
-      "audj0Ow_82RT0BbiewKaIryIdZWiSrOqiiDSaA8w7a8";
   // Allows runtime override by environment variable.
-  if (auto ncaIdVar = std::getenv("NVQC_NCA_ID"))
+  if (auto ncaIdVar = std::getenv(NVQC_NCA_ID_ENV_VAR))
     return std::string(ncaIdVar);
-  return NVQC_NCA_ID;
+  return PROD_NVQC_NCA_ID;
 }
 } // namespace cudaq


### PR DESCRIPTION
This change is intended to have no effect on production usage of NVQC while making it simpler for developers to use the dev organization. (I.e. the `NVQC_NCA_ID` environment shouldn't be needed for most use cases anymore.)