### PR TITLE
[stateHandling] Remove swap semantics optimization support.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -272,12 +272,16 @@ def cc_StateType : CCType<"State", "state"> {
     The CUDA-Q runtime will implement an ABI of intrinsic functions for the
     compiler generated code to interface with this information in a generic
     manner.
+
+    There are no legal operations in Quake/CC on a value of type `!cc.state`.
+    Only pointers to such values should exist in the IR for the purposes of
+    passing references to state objects to runtime functions at codegen.
   }];
   let genStorageClass = 0;
 }
 
-def AnyStateInitLike : TypeConstraint<Or<[cc_PointerType.predicate,
-        cc_StateType.predicate]>, "state initializer types">;
+def AnyStateInitLike : TypeConstraint<cc_PointerType.predicate,
+                         "state initializer types">;
 def AnyStateInitType : Type<AnyStateInitLike.predicate, "initial state type">;
 
 #endif // CUDAQ_DIALECT_CC_TYPES_TD

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -309,26 +309,13 @@ def quake_InitializeStateOp : QuakeOp<"init_state",
 
   let arguments = (ins
     VeqType:$targets,
-    AnyStateInitType:$state,
-    OptionalAttr<UnitAttr>:$move
+    AnyStateInitType:$state
   );
   let results = (outs VeqType);
   
   let assemblyFormat = [{
-    (`move` $move^)? $targets `,` $state `:`
-      functional-type(operands, results) attr-dict
+    $targets `,` $state `:` functional-type(operands, results) attr-dict
   }];
-
-  let builders = [
-    OpBuilder<(ins "mlir::Type":$vt, "mlir::Value":$t, "mlir::Value":$s), [{
-      return build($_builder, $_state, vt, t, s, mlir::UnitAttr{});
-    }]>,
-    OpBuilder<(ins "mlir::Type":$vt, "mlir::Value":$t, "mlir::Value":$s,
-               "bool":$m), [{
-      auto isMove = m ? mlir::UnitAttr::get(t.getContext()) : mlir::UnitAttr{};
-      return build($_builder, $_state, vt, t, s, isMove);
-    }]>
-  ];
 
   let hasVerifier = 1;
 }

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -159,7 +159,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   })#"},
 
     {cudaq::getNumQubitsFromCudaqState, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_numberOfQubits(%p : !cc.state) -> i64
+  func.func private @__nvqpp_cudaq_state_numberOfQubits(%p : !cc.ptr<!cc.state>) -> i64
   )#"},
 
     {"__nvqpp_getStateVectorData_fp32", {}, R"#(

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -495,6 +495,14 @@ LogicalResult quake::InitializeStateOp::verify() {
     if (!std::has_single_bit(veqTy.getSize()))
       return emitOpError("initialize state vector must be power of 2, but is " +
                          std::to_string(veqTy.getSize()) + " instead.");
+  auto ptrTy = cast<cudaq::cc::PointerType>(getState().getType());
+  Type ty = ptrTy.getElementType();
+  if (auto arrTy = dyn_cast<cudaq::cc::ArrayType>(ty)) {
+    if (!isa<FloatType, ComplexType>(arrTy.getElementType()))
+      return emitOpError("invalid data pointer type");
+  } else if (!isa<FloatType, ComplexType, cudaq::cc::StateType>(ty)) {
+    return emitOpError("invalid data pointer type");
+  }
   return success();
 }
 

--- a/runtime/cudaq/qis/qvector.h
+++ b/runtime/cudaq/qis/qvector.h
@@ -101,7 +101,6 @@ public:
   explicit qvector(const state *ptr) : qvector(*ptr){};
   explicit qvector(state *ptr) : qvector(*ptr){};
   explicit qvector(state &s) : qvector(const_cast<const state &>(s)){};
-  explicit qvector(state &&s) : qvector(s){};
 
   /// @brief `qvectors` cannot be copied
   qvector(qvector const &) = delete;

--- a/test/AST-Quake/qalloc_state.cpp
+++ b/test/AST-Quake/qalloc_state.cpp
@@ -20,10 +20,9 @@ struct Eins {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Eins(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK: %[[VAL_4:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.state>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
 
 struct Zwei {
@@ -36,10 +35,9 @@ struct Zwei {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Zwei(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.state>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
 
 struct Drei {
@@ -52,10 +50,9 @@ struct Drei {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Drei(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.state>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
 
 struct Vier {
@@ -68,27 +65,9 @@ struct Vier {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Vier(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.state>
-// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
 // CHECK:           %[[VAL_7:.*]] = quake.veq_size %[[VAL_6]] : (!quake.veq<?>) -> i64
 
-struct Fuenf {
-  std::vector<bool> operator()(cudaq::state &&state) __qpu__ {
-    cudaq::qvector v(std::move(state));
-    h(v);
-    return mz(v);
-  }
-};
-
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__Fuenf(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = call @".std::move"(%[[VAL_0]]) : (!cc.ptr<!cc.state>) -> !cc.ptr<!cc.state>
-// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<!cc.state>
-// CHECK:           %[[VAL_5:.*]] = call @__nvqpp_cudaq_state_numberOfQubits(%[[VAL_4]]) : (!cc.state) -> i64
-// CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_5]] : i64]
-// CHECK:           %[[VAL_7:.*]] = quake.init_state move %[[VAL_6]], %[[VAL_4]] : (!quake.veq<?>, !cc.state) -> !quake.veq<?>
-// CHECK:           %[[VAL_8:.*]] = quake.veq_size %[[VAL_7]] : (!quake.veq<?>) -> i64
-
-// CHECK: func.func private @__nvqpp_cudaq_state_numberOfQubits(!cc.state) -> i64
+// CHECK: func.func private @__nvqpp_cudaq_state_numberOfQubits(!cc.ptr<!cc.state>) -> i64


### PR DESCRIPTION
Follows the latest design change for ownership management of state objects. Remove the support for "move semantics" to allow the logical lifetime of a state object to escape into called functions and the swapping of any resources it may contain.
  - remove the move constructor from qvector
  - remove move attribute from init_state op
  - remove explicit test for move semantics
  - simplify the handling of init_state data: it has to be a pointer to a supported data type, floating-point, complex, or state.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
