### PR TITLE
Reduce NVQC server log file clutter

### DIFF
--- a/scripts/nvqc_proxy.py
+++ b/scripts/nvqc_proxy.py
@@ -30,6 +30,24 @@ class Server(http.server.SimpleHTTPRequestHandler):
     protocol_version = 'HTTP/1.1'
     default_request_version = 'HTTP/1.1'
 
+    # Override this function because we seem to be getting a lot of
+    # ConnectionResetError exceptions in the health monitoring endpoint,
+    # producing lots of ugly stack traces in the logs. Hopefully this will
+    # reduce them.
+    def handle_one_request(self):
+        try:
+            super().handle_one_request()
+        except ConnectionResetError as e:
+            if self.path != '/':
+                print(f"Connection was reset by peer: {e}")
+        except Exception as e:
+            print(f"Unhandled exception: {e}")
+
+    def log_message(self, format, *args):
+        # Don't log the health endpoint queries
+        if len(args) > 0 and args[0] != "GET / HTTP/1.1":
+            super().log_message(format, *args)
+
     def do_GET(self):
         # Allow the proxy to automatically handle the health endpoint. The proxy
         # will exit if the application's /job endpoint is down.


### PR DESCRIPTION
Our NVQC logs have too much clutter originating from the utils container talking to the health endpoint, which we don't have any control over. Use this change to help reduce log clutter on the health endpoint.