### PR TITLE
[stateHandling] Future proofing codegen dialect.

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/CodeGenOps.td
+++ b/include/cudaq/Optimizer/CodeGen/CodeGenOps.td
@@ -28,19 +28,22 @@ class CGQOp<string mnemonic, list<Trait> traits = []>
 def cgq_RAIIOp : CGQOp<"qmem_raii", [MemoryEffects<[MemAlloc, MemWrite]>]> {
   let summary = "Combine allocation and initialization of set of qubits.";
   let description = [{
-    Used only in QIR code generation.
+    Used only in QIR code generation. Fuse qubit allocation and initialization
+    semantics into a single macro op to facilitate lowering the pair to a
+    single QIR function call.
   }];
 
   let arguments = (ins
     cc_PointerType:$initState,
+    TypeAttr:$initElementType,
     TypeAttr:$allocType,
     Optional<AnySignlessIntegerOrIndex>:$allocSize
   );
   let results = (outs VeqType);
 
   let assemblyFormat = [{
-    $initState `(` $allocType ( `[` $allocSize^ `]` )? `)` `:`
-    functional-type(operands, results) attr-dict
+    $initState `from` $initElementType `onto` $allocType ( `[` $allocSize^ `]`
+      )? `:` functional-type(operands, results) attr-dict
   }];
 }
 

--- a/include/cudaq/Optimizer/CodeGen/Passes.h
+++ b/include/cudaq/Optimizer/CodeGen/Passes.h
@@ -23,8 +23,6 @@ class PassManager;
 } // namespace mlir
 
 namespace cudaq::opt {
-
-std::unique_ptr<mlir::Pass> createConvertToQIRPass();
 void registerConvertToQIRPass();
 
 /// Convert (generic) QIR to the profile-specific QIR for a specific target.

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -11,7 +11,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def QuakeToQIR : Pass<"quake-to-qir", "mlir::ModuleOp"> {
+def ConvertToQIR : Pass<"quake-to-qir", "mlir::ModuleOp"> {
   let summary = "Lower Quake to QIR.";
   let description = [{
     Converts Quake to QIR (as LLVM-IR). The add-dealloc pass should be run
@@ -22,7 +22,14 @@ def QuakeToQIR : Pass<"quake-to-qir", "mlir::ModuleOp"> {
   let dependentDialects = [
     "cudaq::codegen::CodeGenDialect", "mlir::LLVM::LLVMDialect"
   ];
-  let constructor = "cudaq::opt::createConvertToQIRPass()";
+}
+
+def LowerToCG : Pass<"lower-to-cg", "mlir::ModuleOp"> {
+  let summary = "Lower Quake to CG dialect.";
+  let description = [{
+    For testing purposes only.
+  }];
+  let dependentDialects = [ "cudaq::codegen::CodeGenDialect" ];
 }
 
 def QIRToQIRProfilePrep : Pass<"qir-profile-prep", "mlir::ModuleOp"> {

--- a/lib/Optimizer/CodeGen/ConvertToQIR.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIR.cpp
@@ -6,17 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#pragma GCC diagnostic ignored "-Wrestrict"
-#endif
-#include "PassDetails.h"
-#if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER))
-#pragma GCC diagnostic pop
-#endif
-
 #include "CodeGenOps.h"
+#include "PassDetails.h"
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/CodeGen/Peephole.h"
@@ -43,6 +34,12 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "convert-to-qir"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_CONVERTTOQIR
+#define GEN_PASS_DEF_LOWERTOCG
+#include "cudaq/Optimizer/CodeGen/Passes.h.inc"
+} // namespace cudaq::opt
 
 using namespace mlir;
 
@@ -141,30 +138,26 @@ public:
     // Inspect the element type of the complex data, need to
     // know if its f32 or f64
     StringRef functionName;
-    if (Type eleTy = dyn_cast<LLVM::LLVMPointerType>(ccState.getType())
-                         .getElementType()) {
-      if (auto elePtrTy = dyn_cast<LLVM::LLVMPointerType>(eleTy))
-        eleTy = elePtrTy.getElementType();
-      if (auto arrayTy = dyn_cast<LLVM::LLVMArrayType>(eleTy))
-        eleTy = arrayTy.getElementType();
-      bool fromComplex = false;
-      if (auto complexTy = dyn_cast<LLVM::LLVMStructType>(eleTy)) {
-        fromComplex = true;
-        eleTy = complexTy.getBody()[0];
-      }
-      if (eleTy == rewriter.getI8Type())
-        functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithCudaqStatePtr;
-      if (eleTy == rewriter.getF64Type())
-        functionName =
-            fromComplex
-                ? cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex64
-                : cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP64;
-      if (eleTy == rewriter.getF32Type())
-        functionName =
-            fromComplex
-                ? cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex32
-                : cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP32;
+    Type eleTy = raii.getInitElementType();
+    if (auto elePtrTy = dyn_cast<cudaq::cc::PointerType>(eleTy))
+      eleTy = elePtrTy.getElementType();
+    if (auto arrayTy = dyn_cast<cudaq::cc::ArrayType>(eleTy))
+      eleTy = arrayTy.getElementType();
+    bool fromComplex = false;
+    if (auto complexTy = dyn_cast<ComplexType>(eleTy)) {
+      fromComplex = true;
+      eleTy = complexTy.getElementType();
     }
+    if (isa<cudaq::cc::StateType>(eleTy))
+      functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithCudaqStatePtr;
+    if (eleTy == rewriter.getF64Type())
+      functionName =
+          fromComplex ? cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex64
+                      : cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP64;
+    if (eleTy == rewriter.getF32Type())
+      functionName =
+          fromComplex ? cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex32
+                      : cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP32;
     if (functionName.empty())
       return raii.emitOpError("invalid type on initialize state operation, "
                               "must be complex floating point.");
@@ -1852,32 +1845,45 @@ public:
     if (!alloc)
       return init.emitOpError("init_state must have alloca as input");
     rewriter.replaceOpWithNewOp<cudaq::codegen::RAIIOp>(
-        init, init.getType(), init.getState(), alloc.getType(),
-        alloc.getSize());
+        init, init.getType(), init.getState(),
+        cast<cudaq::cc::PointerType>(init.getState().getType())
+            .getElementType(),
+        alloc.getType(), alloc.getSize());
     rewriter.eraseOp(alloc);
     return success();
   }
 };
+} // namespace
+
+/// Greedy pass to match subgraphs in the IR and replace them with codegen
+/// ops. This step makes converting a DAG of nodes in the conversion step
+/// simpler.
+static LogicalResult fuseSubgraphPatterns(MLIRContext *ctx, ModuleOp module) {
+  RewritePatternSet patterns(ctx);
+  patterns.insert<CodeGenRAIIPattern>(ctx);
+  if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns))))
+    return failure();
+  return success();
+}
 
 //===----------------------------------------------------------------------===//
 // Code generation: converts the Quake IR to QIR.
 //===----------------------------------------------------------------------===//
 
+namespace {
 /// Convert Quake dialect to LLVM-IR and QIR.
-class QuakeToQIRRewrite : public cudaq::opt::QuakeToQIRBase<QuakeToQIRRewrite> {
+class ConvertToQIR : public cudaq::opt::impl::ConvertToQIRBase<ConvertToQIR> {
 public:
-  QuakeToQIRRewrite() = default;
+  using ConvertToQIRBase::ConvertToQIRBase;
 
   /// Measurement counter for unnamed measurements. Resets every module.
   unsigned measureCounter = 0;
-
-  ModuleOp getModule() { return getOperation(); }
 
   // This is an ad hox transformation to convert constant array values into a
   // buffer of constants.
   LogicalResult eraseConstantArrayOps() {
     bool ok = true;
-    getModule().walk([&](cudaq::cc::ConstantArrayOp carr) {
+    getOperation().walk([&](cudaq::cc::ConstantArrayOp carr) {
       // If there is a constant array, then we expect that it is involved in
       // a stdvec initializer expression. So look for the pattern and expand
       // the store into a series of scalar stores.
@@ -1932,26 +1938,16 @@ public:
     return ok ? success() : failure();
   }
 
-  /// Greedy pass to match subgraphs in the IR and replace them with codegen
-  /// ops. This step makes converting a DAG of nodes in the conversion step
-  /// simpler.
-  void fuseSubgraphPatterns() {
-    auto *ctx = &getContext();
-    RewritePatternSet patterns(ctx);
-    patterns.insert<CodeGenRAIIPattern>(ctx);
-    if (failed(applyPatternsAndFoldGreedily(getModule(), std::move(patterns))))
-      signalPassFailure();
-  }
-
   void runOnOperation() override final {
-    fuseSubgraphPatterns();
-
     auto *context = &getContext();
-
+    if (failed(fuseSubgraphPatterns(context, getOperation()))) {
+      signalPassFailure();
+      return;
+    }
     // Ad hoc deal with ConstantArrayOp transformation.
     // TODO: Merge this into the codegen dialect once that gets to main.
     if (failed(eraseConstantArrayOps())) {
-      getModule().emitOpError("unexpected constant arrays");
+      getOperation().emitOpError("unexpected constant arrays");
       signalPassFailure();
       return;
     }
@@ -2002,8 +1998,9 @@ public:
     target.addLegalDialect<LLVM::LLVMDialect>();
     target.addLegalOp<ModuleOp>();
 
-    if (failed(applyFullConversion(getModule(), target, std::move(patterns)))) {
-      LLVM_DEBUG(getModule().dump());
+    if (failed(
+            applyFullConversion(getOperation(), target, std::move(patterns)))) {
+      LLVM_DEBUG(getOperation().dump());
       signalPassFailure();
     }
   }
@@ -2059,6 +2056,14 @@ void cudaq::opt::initializeTypeConversions(LLVMTypeConverter &typeConverter) {
   });
 }
 
-std::unique_ptr<Pass> cudaq::opt::createConvertToQIRPass() {
-  return std::make_unique<QuakeToQIRRewrite>();
-}
+namespace {
+class LowerToCG : public cudaq::opt::impl::LowerToCGBase<LowerToCG> {
+public:
+  using LowerToCGBase::LowerToCGBase;
+
+  void runOnOperation() override {
+    if (failed(fuseSubgraphPatterns(&getContext(), getOperation())))
+      signalPassFailure();
+  }
+};
+} // namespace

--- a/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -36,7 +36,7 @@ void cudaq::opt::commonPipelineConvertToQIR(
   if (convertTo && convertTo->equals("qir-base"))
     pm.addNestedPass<func::FuncOp>(createDelayMeasurementsPass());
   pm.addPass(createConvertMathToFuncs());
-  pm.addPass(createConvertToQIRPass());
+  pm.addPass(createConvertToQIR());
 }
 
 void cudaq::opt::addPipelineTranslateToOpenQASM(PassManager &pm) {

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -983,7 +983,7 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
     optPM.addPass(cudaq::opt::createCombineQuantumAllocations());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
-  pm.addPass(cudaq::opt::createConvertToQIRPass());
+  pm.addPass(cudaq::opt::createConvertToQIR());
   pm.addPass(createCanonicalizerPass());
 
   if (failed(pm.run(module)))

--- a/test/Quake/codegen_dialect.qke
+++ b/test/Quake/codegen_dialect.qke
@@ -1,0 +1,118 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt -lower-to-cg %s | FileCheck %s
+
+func.func @test1(%arg : !cc.ptr<f64>) {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<f64>) -> !quake.veq<2>
+  return
+}
+
+func.func @test2(%arg : !cc.ptr<f32>) {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<f32>) -> !quake.veq<2>
+  return
+}
+
+func.func @test3(%arg : !cc.ptr<!cc.array<f64 x 4>>) {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<2>
+  return
+}
+
+func.func @test4(%arg : !cc.ptr<!cc.array<f32 x ?>>) {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<!cc.array<f32 x ?>>) -> !quake.veq<2>
+  return
+}
+
+// CHECK-LABEL:   func.func @test1(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !cc.ptr<f64>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from f64 onto !quake.veq<2> : (!cc.ptr<f64>) -> !quake.veq<2>
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @test2(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !cc.ptr<f32>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from f32 onto !quake.veq<2> : (!cc.ptr<f32>) -> !quake.veq<2>
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @test3(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !cc.ptr<!cc.array<f64 x 4>>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from !cc.array<f64 x 4> onto !quake.veq<2> : (!cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<2>
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @test4(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !cc.ptr<!cc.array<f32 x ?>>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from !cc.array<f32 x ?> onto !quake.veq<2> : (!cc.ptr<!cc.array<f32 x ?>>) -> !quake.veq<2>
+// CHECK:           return
+// CHECK:         }
+
+func.func @testc1(%arg : !cc.ptr<complex<f64>>) {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<complex<f64>>) -> !quake.veq<2>
+  return
+}
+
+func.func @testc2(%arg : !cc.ptr<complex<f32>>) {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<complex<f32>>) -> !quake.veq<2>
+  return
+}
+
+func.func @testc3(%arg : !cc.ptr<!cc.array<complex<f64> x ?>>) {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<!cc.array<complex<f64> x ?>>) -> !quake.veq<2>
+  return
+}
+
+func.func @testc4(%arg : !cc.ptr<!cc.array<complex<f32> x 4>>) {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<!cc.array<complex<f32> x 4>>) -> !quake.veq<2>
+  return
+}
+
+// CHECK-LABEL:   func.func @testc1(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !cc.ptr<complex<f64>>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from complex<f64> onto !quake.veq<2> : (!cc.ptr<complex<f64>>) -> !quake.veq<2>
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @testc2(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !cc.ptr<complex<f32>>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from complex<f32> onto !quake.veq<2> : (!cc.ptr<complex<f32>>) -> !quake.veq<2>
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @testc3(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !cc.ptr<!cc.array<complex<f64> x ?>>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from !cc.array<complex<f64> x ?> onto !quake.veq<2> : (!cc.ptr<!cc.array<complex<f64> x ?>>) -> !quake.veq<2>
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @testc4(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !cc.ptr<!cc.array<complex<f32> x 4>>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from !cc.array<complex<f32> x 4> onto !quake.veq<2> : (!cc.ptr<!cc.array<complex<f32> x 4>>) -> !quake.veq<2>
+// CHECK:           return
+// CHECK:         }
+
+func.func @teststate(%arg : !cc.ptr<!cc.state>) {
+  %0 = quake.alloca !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<!cc.state>) -> !quake.veq<2>
+  return
+}
+
+// CHECK-LABEL:   func.func @teststate(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !cc.ptr<!cc.state>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from !cc.state onto !quake.veq<2> : (!cc.ptr<!cc.state>) -> !quake.veq<2>
+// CHECK:           return
+// CHECK:         }
+

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -79,7 +79,7 @@ LogicalResult lowerToLLVMDialect(ModuleOp module) {
   optPM.addPass(cudaq::opt::createCombineQuantumAllocations());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
-  pm.addPass(cudaq::opt::createConvertToQIRPass());
+  pm.addPass(cudaq::opt::createConvertToQIR());
   return pm.run(module);
 }
 


### PR DESCRIPTION
Typed pointers have disappeared in the LLVM-IR dialect, so we needed a more coherent way of identifying the type of data passed to the initialization state. This change extends the op to keep track of the information so it isn't lost when lowering to opaque pointers.

Add a separate pass for testing and a regression test to make sure the RAII ops are being formed correctly.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
