### PR TITLE
Allocate temporaries in conversion to LLVM in entry block.

### DIFF
--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -159,6 +159,11 @@ inline mlir::Value createF64Constant(mlir::Location loc,
   return createFloatConstant(loc, builder, value, builder.getF64Type());
 }
 
+/// Create a temporary on the stack. The temporary is created such that it is
+/// \em{not} control dependent (other than on function entry).
+mlir::Value createLLVMTemporary(mlir::Location loc, mlir::OpBuilder &builder,
+                                mlir::Type type, std::size_t size = 1);
+
 //===----------------------------------------------------------------------===//
 
 inline mlir::Block *addEntryBlock(mlir::LLVM::GlobalOp initVar) {
@@ -172,7 +177,7 @@ inline mlir::Block *addEntryBlock(mlir::LLVM::GlobalOp initVar) {
 mlir::Value packIsArrayAndLengthArray(mlir::Location loc,
                                       mlir::ConversionPatternRewriter &rewriter,
                                       mlir::ModuleOp parentModule,
-                                      mlir::Value numOperands,
+                                      std::size_t numOperands,
                                       mlir::ValueRange operands);
 mlir::FlatSymbolRefAttr
 createLLVMFunctionSymbol(mlir::StringRef name, mlir::Type retType,

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -74,14 +74,14 @@ cudaq::cc::StructType factory::buildInvokeStructType(FunctionType funcTy) {
 Value factory::packIsArrayAndLengthArray(Location loc,
                                          ConversionPatternRewriter &rewriter,
                                          ModuleOp parentModule,
-                                         Value numOperands,
+                                         std::size_t numOperands,
                                          ValueRange operands) {
-  // Create an integer array where the kth element is N if the kth
-  // control operand is a veq<N>, and 0 otherwise.
+  // Create an integer array where the kth element is N if the kth control
+  // operand is a veq<N>, and 0 otherwise.
   auto i64Type = rewriter.getI64Type();
   auto context = rewriter.getContext();
-  Value isArrayAndLengthArr = rewriter.create<LLVM::AllocaOp>(
-      loc, LLVM::LLVMPointerType::get(i64Type), numOperands);
+  Value isArrayAndLengthArr = createLLVMTemporary(
+      loc, rewriter, LLVM::LLVMPointerType::get(i64Type), numOperands);
   auto intPtrTy = LLVM::LLVMPointerType::get(i64Type);
   Value zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
   auto getSizeSymbolRef = opt::factory::createLLVMFunctionSymbol(
@@ -197,6 +197,23 @@ cc::LoopOp factory::createInvariantLoop(
       });
   loop->setAttr("invariant", builder.getUnitAttr());
   return loop;
+}
+
+/// Create a temporary on the stack. The temporary is created such that it is
+/// \em{not} control dependent (other than on function entry).
+Value factory::createLLVMTemporary(Location loc, OpBuilder &builder, Type type,
+                                   std::size_t size) {
+  Operation *op = builder.getBlock()->getParentOp();
+  auto func = dyn_cast<LLVM::LLVMFuncOp>(op);
+  if (!func)
+    func = op->getParentOfType<LLVM::LLVMFuncOp>();
+  assert(func && "must be in a function");
+  auto *entryBlock = &func.getRegion().front();
+  assert(entryBlock && "function must have an entry block");
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(entryBlock);
+  Value one = genLlvmI64Constant(loc, builder, size);
+  return builder.create<LLVM::AllocaOp>(loc, type, ArrayRef<Value>{one});
 }
 
 // This builder will transform the monotonic loop into an invariant loop during

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -212,8 +212,8 @@ Value factory::createLLVMTemporary(Location loc, OpBuilder &builder, Type type,
   assert(entryBlock && "function must have an entry block");
   OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(entryBlock);
-  Value one = genLlvmI64Constant(loc, builder, size);
-  return builder.create<LLVM::AllocaOp>(loc, type, ArrayRef<Value>{one});
+  Value len = genLlvmI64Constant(loc, builder, size);
+  return builder.create<LLVM::AllocaOp>(loc, type, ArrayRef<Value>{len});
 }
 
 // This builder will transform the monotonic loop into an invariant loop during

--- a/lib/Optimizer/CodeGen/CCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/CCToLLVM.cpp
@@ -399,9 +399,8 @@ public:
                                                         op, offset);
         offsetVal++;
       }
-      Value one = cudaq::opt::factory::genLlvmI64Constant(loc, rewriter, 1);
       auto tuplePtrTy = cudaq::opt::factory::getPointerType(tupleTy);
-      tmp = rewriter.create<LLVM::AllocaOp>(loc, tuplePtrTy, one);
+      tmp = cudaq::opt::factory::createLLVMTemporary(loc, rewriter, tuplePtrTy);
       rewriter.create<LLVM::StoreOp>(loc, tupleVal, tmp);
     }
     Value tupleArg = rewriter.create<LLVM::UndefOp>(loc, tupleArgTy);
@@ -422,9 +421,9 @@ public:
                                                     trampoline, zeroA);
     auto castTmp =
         rewriter.create<LLVM::BitcastOp>(loc, tupleArgTy.getBody()[1], tmp);
-    auto oneA = DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{1});
-    rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(callable, tupleArgTy,
-                                                     tupleArg, castTmp, oneA);
+    rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(
+        callable, tupleArgTy, tupleArg, castTmp,
+        DenseI64ArrayAttr::get(ctx, ArrayRef<std::int64_t>{1}));
     return success();
   }
 };

--- a/test/Quake-QIR/basic.qke
+++ b/test/Quake-QIR/basic.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt %s --add-dealloc | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt -add-dealloc %s | cudaq-translate --convert-to=qir | FileCheck %s
 
 func.func @test_func(%p : i32) {
   %qv = quake.alloca !quake.veq<?>[%p : i32]
@@ -74,6 +74,7 @@ func.func @test_ctrl_swap_basic() {
 }
 
 // CHECK-LABEL: define void @test_ctrl_swap_basic() local_unnamed_addr {
+// CHECK:         %[[VAL_12:.*]] = alloca i64, align 8
 // CHECK:         %[[VAL_0:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 3)
 // CHECK:         %[[VAL_2:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 0)
 // CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %Qubit**
@@ -84,7 +85,6 @@ func.func @test_ctrl_swap_basic() {
 // CHECK:         %[[VAL_9:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 2)
 // CHECK:         %[[VAL_10:.*]] = bitcast i8* %[[VAL_9]] to %Qubit**
 // CHECK:         %[[VAL_11:.*]] = load %Qubit*, %Qubit** %[[VAL_10]], align 8
-// CHECK:         %[[VAL_12:.*]] = alloca i64, align 8
 // CHECK:         store i64 0, i64* %[[VAL_12]], align 8
 // CHECK:         call void (i64, i64*, i64, void (%Array*, %Qubit*, %Qubit*)*, ...) @invokeWithControlRegisterOrQubits(i64 1, i64* nonnull %[[VAL_12]], i64 2, void (%Array*, %Qubit*, %Qubit*)* nonnull @__quantum__qis__swap__ctl, %Qubit* %[[VAL_5]], %Qubit* %[[VAL_8]], %Qubit* %[[VAL_11]])
 // CHECK:         call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
@@ -103,6 +103,10 @@ func.func @test_ctrl_swap_complex() {
 }
 
 // CHECK-LABEL: define void @test_ctrl_swap_complex() local_unnamed_addr {
+// CHECK:     %[[VAL_17:.*]] = alloca [2 x i64], align 8
+// CHECK:     %[[VAL_13:.*]] = alloca [2 x i64], align 8
+// CHECK:     %[[VAL_14:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_13]], i64 0, i64 0
+// CHECK:     %[[VAL_18:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_17]], i64 0, i64 0
 // CHECK:         %[[VAL_0:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 7)
 // CHECK:         %[[VAL_2:.*]] = tail call %Array* @__quantum__rt__array_slice(%Array* %[[VAL_0]], i32 1, i64 0, i64 1, i64 3)
 // CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 4)
@@ -115,15 +119,11 @@ func.func @test_ctrl_swap_complex() {
 // CHECK:         %[[VAL_11:.*]] = bitcast i8* %[[VAL_10]] to %Qubit**
 // CHECK:         %[[VAL_12:.*]] = load %Qubit*, %Qubit** %[[VAL_11]], align 8
 // CHECK:         tail call void @__quantum__qis__swap__ctl(%Array* %[[VAL_2]], %Qubit* %[[VAL_6]], %Qubit* %[[VAL_9]])
-// CHECK:         %[[VAL_13:.*]] = alloca [2 x i64], align 8
-// CHECK:         %[[VAL_14:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_13]], i64 0, i64 0
 // CHECK:         store i64 0, i64* %[[VAL_14]], align 8
 // CHECK:         %[[VAL_15:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_13]], i64 0, i64 1
 // CHECK:         %[[VAL_16:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%Array* %[[VAL_2]])
 // CHECK:         store i64 %[[VAL_16]], i64* %[[VAL_15]], align 8
 // CHECK:         call void (i64, i64*, i64, void (%Array*, %Qubit*, %Qubit*)*, ...) @invokeWithControlRegisterOrQubits(i64 2, i64* nonnull %[[VAL_14]], i64 2, void (%Array*, %Qubit*, %Qubit*)* nonnull @__quantum__qis__swap__ctl, %Qubit* %[[VAL_6]], %Array* %[[VAL_2]], %Qubit* %[[VAL_9]], %Qubit* %[[VAL_12]])
-// CHECK:         %[[VAL_17:.*]] = alloca [2 x i64], align 8
-// CHECK:         %[[VAL_18:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_17]], i64 0, i64 0
 // CHECK:         %[[VAL_19:.*]] = call i64 @__quantum__rt__array_get_size_1d(%Array* %[[VAL_2]])
 // CHECK:         store i64 %[[VAL_19]], i64* %[[VAL_18]], align 8
 // CHECK:         %[[VAL_20:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_17]], i64 0, i64 1

--- a/test/Quake-QIR/exp_pauli-1.qke
+++ b/test/Quake-QIR/exp_pauli-1.qke
@@ -24,8 +24,8 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
   }
 }
 
-// CHECK:    %[[VAL_0:.*]] = tail call
-// CHECK:    %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 4)
+// CHECK:         %[[VAL_9:.*]] = alloca { i8*, i64 }, align 8
+// CHECK:    %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 4)
 // CHECK:         %[[VAL_2:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
 // CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %[[VAL_4:.*]]**
 // CHECK:         %[[VAL_5:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_3]], align 8
@@ -34,7 +34,6 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
 // CHECK:         %[[VAL_7:.*]] = bitcast i8* %[[VAL_6]] to %[[VAL_4]]**
 // CHECK:         %[[VAL_8:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_7]], align 8
 // CHECK:         tail call void @__quantum__qis__x(%[[VAL_4]]* %[[VAL_8]])
-// CHECK:         %[[VAL_9:.*]] = alloca { i8*, i64 }, align 8
 // CHECK:         %[[VAL_10:.*]] = getelementptr inbounds { i8*, i64 }, { i8*, i64 }* %[[VAL_9]], i64 0, i32 0
 // CHECK:         store i8* getelementptr inbounds ([5 x i8], [5 x i8]* @cstr.5858585900, i64 0, i64 0), i8** %[[VAL_10]], align 8
 // CHECK:         %[[VAL_11:.*]] = getelementptr inbounds { i8*, i64 }, { i8*, i64 }* %[[VAL_9]], i64 0, i32 1

--- a/test/Quake-QIR/exp_pauli-3.qke
+++ b/test/Quake-QIR/exp_pauli-3.qke
@@ -30,8 +30,8 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
   }
 }
 
-// CHECK:    %[[VAL_0:.*]] = tail call
-// CHECK:    %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 4)
+// CHECK:         %[[VAL_30:.*]] = alloca { i8*, i64 }, align 8
+// CHECK:    %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 4)
 // CHECK:         %[[VAL_2:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
 // CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %[[VAL_4:.*]]**
 // CHECK:         %[[VAL_5:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_3]], align 8
@@ -65,7 +65,6 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
 // CHECK:         %[[VAL_28:.*]] = bitcast i8* %[[VAL_27]] to i8**
 // CHECK:         store i8* %[[VAL_14]], i8** %[[VAL_28]], align 8
 // CHECK:         %[[VAL_29:.*]] = tail call %[[VAL_1]]* @__quantum__rt__array_concatenate(%[[VAL_1]]* %[[VAL_25]], %[[VAL_1]]* %[[VAL_26]])
-// CHECK:         %[[VAL_30:.*]] = alloca { i8*, i64 }, align 8
 // CHECK:         %[[VAL_31:.*]] = getelementptr inbounds { i8*, i64 }, { i8*, i64 }* %[[VAL_30]], i64 0, i32 0
 // CHECK:         store i8* getelementptr inbounds ([5 x i8], [5 x i8]* @cstr.5858585900, i64 0, i64 0), i8** %[[VAL_31]], align 8
 // CHECK:         %[[VAL_32:.*]] = getelementptr inbounds { i8*, i64 }, { i8*, i64 }* %[[VAL_30]], i64 0, i32 1

--- a/test/Quake-QIR/issue_1703.qke
+++ b/test/Quake-QIR/issue_1703.qke
@@ -1,0 +1,44 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --quake-to-qir %s | FileCheck %s
+
+module attributes {
+    quake.mangled_name_map = {
+      __nvqpp__mlirgen__kernel = "__nvqpp__mlirgen__kernel_PyKernelEntryPointRewrite"}} {
+
+  func.func @__nvqpp__mlirgen__kernel() attributes {"cudaq-entrypoint"} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant 1.000000e+00 : f64
+    %c262144_i64 = arith.constant 262144 : i64
+    %0 = quake.alloca !quake.veq<2>
+    cf.br ^bb1(%c0_i64 : i64)
+  ^bb1(%1: i64):  // 2 preds: ^bb0, ^bb2
+    %2 = arith.cmpi slt, %1, %c262144_i64 : i64
+    cf.cond_br %2, ^bb2(%1 : i64), ^bb3
+  ^bb2(%3: i64):  // pred: ^bb1
+    %4 = quake.extract_ref %0[0] : (!quake.veq<2>) -> !quake.ref
+    %5 = quake.extract_ref %0[1] : (!quake.veq<2>) -> !quake.ref
+    quake.r1 (%cst) [%4] %5 : (f64, !quake.ref, !quake.ref) -> ()
+    %6 = arith.addi %3, %c1_i64 : i64
+    cf.br ^bb1(%6 : i64)
+  ^bb3:  // pred: ^bb1
+    quake.dealloc %0 : !quake.veq<2>
+    return
+  }
+}
+
+// CHECK-LABEL:   llvm.func @__nvqpp__mlirgen__kernel() attributes {"cudaq-entrypoint"} {
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:           %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x i64 : (i64) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_6:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:           %[[VAL_7:.*]] = llvm.call @__quantum__rt__qubit_allocate_array(%[[VAL_6]]) : (i64) -> !llvm.ptr<struct<"Array", opaque>>
+// CHECK-NOT:       llvm.alloca
+// CHECK:           llvm.return
+// CHECK:         }

--- a/test/Quake-QIR/veq_or_qubit_control_args.qke
+++ b/test/Quake-QIR/veq_or_qubit_control_args.qke
@@ -27,8 +27,9 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__function_fancyCno
   }
 }
 
-// CHECK:         %[[VAL_0:.*]] = tail call
-// CHECK:         %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 3)
+// CHECK:         %[[VAL_15:.*]] = alloca [2 x i64], align 8
+// CHECK:         %[[VAL_16:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_15]], i64 0, i64 0
+// CHECK: %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 3)
 // CHECK:         %[[VAL_2:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
 // CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %[[VAL_4:.*]]**
 // CHECK:         %[[VAL_5:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_3]], align 8
@@ -44,8 +45,6 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__function_fancyCno
 // CHECK:         %[[VAL_13:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_12]], i64 0)
 // CHECK:         %[[VAL_14:.*]] = bitcast i8* %[[VAL_13]] to %[[VAL_4]]**
 // CHECK:         store %[[VAL_4]]* %[[VAL_5]], %[[VAL_4]]** %[[VAL_14]], align 8
-// CHECK:         %[[VAL_15:.*]] = alloca [2 x i64], align 8
-// CHECK:         %[[VAL_16:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_15]], i64 0, i64 0
 // CHECK:         %[[VAL_17:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_1]]* %[[VAL_12]])
 // CHECK:         store i64 %[[VAL_17]], i64* %[[VAL_16]], align 8
 // CHECK:         %[[VAL_18:.*]] = getelementptr inbounds [2 x i64], [2 x i64]* %[[VAL_15]], i64 0, i64 1


### PR DESCRIPTION
When a temporary has a constant size, it can be promoted to the entry block. This eliminates any control dependence that may creep in when the temporary, if added inline, may be in a block with control dependence. Leans into LLVM being able to do live range analysis and fuse/eliminate these allocations.

Add a new function in the factory to generate the pattern in LLVM-IR dialect.

Fixes #1703.  Adds regression test.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
