### PR TITLE
Allow inlined calls to cudaq-entrypoint funcs as long as not in a thunk

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Common/InlinerInterface.h
+++ b/include/cudaq/Optimizer/Dialect/Common/InlinerInterface.h
@@ -18,21 +18,21 @@ namespace cudaq {
 
 /// Generic opt-in with inlining any operation. Inlining kernels is important to
 /// build up larger functions to translate into quantum circuits.
-/// Do not allow kernel entry points to be inlined into their callers, typically
+/// Do not allow kernel entry points to be inlined into their callers while in
 /// the thunk function.
 struct EnableInlinerInterface : public mlir::DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
 
-  bool isLegalToInline(mlir::Region *, mlir::Region *src, bool,
+  bool isLegalToInline(mlir::Region *dest, mlir::Region *src, bool,
                        mlir::IRMapping &) const final {
-    if (auto func = src->getParentOfType<mlir::func::FuncOp>())
-      return !(func->hasAttr(cudaq::entryPointAttrName));
+    if (auto destFunc = dest->getParentOfType<mlir::func::FuncOp>())
+      if (destFunc.getName().ends_with(".thunk"))
+        if (auto srcFunc = src->getParentOfType<mlir::func::FuncOp>())
+          return !(srcFunc->hasAttr(cudaq::entryPointAttrName));
     return true;
   }
   bool isLegalToInline(mlir::Operation *op, mlir::Region *, bool,
                        mlir::IRMapping &) const final {
-    if (auto func = op->getParentOfType<mlir::func::FuncOp>())
-      return !(func->hasAttr(cudaq::entryPointAttrName));
     return true;
   }
   bool isLegalToInline(mlir::Operation *call, mlir::Operation *callable,

--- a/include/cudaq/Optimizer/Dialect/Common/InlinerInterface.h
+++ b/include/cudaq/Optimizer/Dialect/Common/InlinerInterface.h
@@ -31,8 +31,12 @@ struct EnableInlinerInterface : public mlir::DialectInlinerInterface {
           return !(srcFunc->hasAttr(cudaq::entryPointAttrName));
     return true;
   }
-  bool isLegalToInline(mlir::Operation *op, mlir::Region *, bool,
+  bool isLegalToInline(mlir::Operation *op, mlir::Region *dest, bool,
                        mlir::IRMapping &) const final {
+    if (auto destFunc = dest->getParentOfType<mlir::func::FuncOp>())
+      if (destFunc.getName().ends_with(".thunk"))
+        if (auto srcFunc = op->getParentOfType<mlir::func::FuncOp>())
+          return !(srcFunc->hasAttr(cudaq::entryPointAttrName));
     return true;
   }
   bool isLegalToInline(mlir::Operation *call, mlir::Operation *callable,

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -914,7 +914,7 @@ bool cudaq::EnableInlinerInterface::isLegalToInline(Operation *call,
   if (auto applyOp = dyn_cast<quake::ApplyOp>(call))
     if (applyOp.applyToVariant())
       return false;
-  return !(callable->hasAttr(cudaq::entryPointAttrName));
+  return true;
 }
 
 using EffectsVectorImpl =

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -914,6 +914,10 @@ bool cudaq::EnableInlinerInterface::isLegalToInline(Operation *call,
   if (auto applyOp = dyn_cast<quake::ApplyOp>(call))
     if (applyOp.applyToVariant())
       return false;
+  if (auto destFunc = call->getParentOfType<mlir::func::FuncOp>())
+    if (destFunc.getName().ends_with(".thunk"))
+      if (auto srcFunc = call->getParentOfType<mlir::func::FuncOp>())
+        return !(srcFunc->hasAttr(cudaq::entryPointAttrName));
   return true;
 }
 

--- a/targettests/Kernel/inline-qpu-func.cpp
+++ b/targettests/Kernel/inline-qpu-func.cpp
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ %cpp_std --enable-mlir %s -o %t && %t | FileCheck %s
+
+#include "cudaq.h"
+
+// This function has no cudaq::qubit's in the parameter list, so it will be
+// tagged as a possible cudaq-entrypoint kernel. Make sure we can still inline
+// it if called from another kernel.
+bool xor_result(const std::vector<cudaq::measure_result> &result_vec) __qpu__ {
+  bool result = false;
+  for (auto x : result_vec)
+    result ^= x;
+  return result;
+}
+
+bool kernel() __qpu__ {
+  cudaq::qvector q(7);
+  x(q);
+  std::vector<cudaq::measure_result> mz_res = mz(q);
+  bool res = xor_result(mz_res);
+  return res;
+}
+
+int main(int argc, char *argv[]) {
+  printf("Result: %d\n", static_cast<int>(kernel()));
+  return 0;
+}
+
+// CHECK: Result: 1


### PR DESCRIPTION
Fixes #1726 

The underlying problem is that `cudaq-entrypoint` attribute is applied to all `__qpu__` functions, but it is removed if there are any `cudaq::qubit` parameters. Downstream code was trying to prevent inlining of `cudaq-entrypoint` kernels for thunk functions, but it was preventing inlining of ALL `cudaq-entrypoint` kernels, which was a bit heavy handed.