### PR TITLE
Make Python support `--target=<target>` option (with `=`)

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -129,6 +129,14 @@ from .dbg import ast
 
 initKwargs = {}
 
+# Look for --target=<target> options
+for p in sys.argv:
+    split_params = p.split('=')
+    if len(split_params) == 2:
+        if split_params[0] in ['-target', '--target']:
+            initKwargs['target'] = split_params[1]
+
+# Look for --target <target> (with a space)
 if '-target' in sys.argv:
     initKwargs['target'] = sys.argv[sys.argv.index('-target') + 1]
 if '--target' in sys.argv:

--- a/python/tests/mlir/target/callable_kernel_arg.py
+++ b/python/tests/mlir/target/callable_kernel_arg.py
@@ -9,6 +9,9 @@
 # RUN: PYTHONPATH=../../.. python3 %s 
 # RUN: PYTHONPATH=../../.. python3 %s --target quantinuum --emulate 
 
+# Perform a single test with --target=<target>
+# RUN: PYTHONPATH=../../.. python3 %s --target=quantinuum --emulate 
+
 import cudaq
 from typing import Callable
 


### PR DESCRIPTION
Resolves #1745 

This makes it similar to the `nvq++` driver script so there isn't a discrepancy anymore.