### PR TITLE
Fix the Json conversion for custatevec-fp32 state data

### DIFF
--- a/runtime/nvqir/custatevec/CuStateVecState.h
+++ b/runtime/nvqir/custatevec/CuStateVecState.h
@@ -345,8 +345,8 @@ public:
               std::size_t numElements) const override {
     // Must have the correct precision
     if constexpr (std::is_same_v<ScalarType, float>)
-      throw std::runtime_error("simulation precision is FP32 but overlap "
-                               "requested with FP64 state data.");
+      throw std::runtime_error("simulation precision is FP32 but toHost "
+                               "requested with FP64 host buffer.");
 
     // Must have the correct number of elements.
     if (numElements != size)
@@ -363,8 +363,8 @@ public:
               std::size_t numElements) const override {
     // Must have the correct precision
     if constexpr (std::is_same_v<ScalarType, double>)
-      throw std::runtime_error("simulation precision is FP32 but overlap "
-                               "requested with FP64 state data.");
+      throw std::runtime_error("simulation precision is FP64 but toHost "
+                               "requested with FP32 host buffer.");
 
     // Must have the correct number of elements.
     if (numElements != size)


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Fixing nightly integration failure: "Server error: simulation precision is FP32 but overlap requested with FP64 state data."

We need to use the proper `toHost` call since implicit conversion is disabled.

Also, fix the error messages.
