### PR TITLE
[unittest] Remove std parallel execution policy.

### DIFF
--- a/unittests/integration/qubit_allocation.cpp
+++ b/unittests/integration/qubit_allocation.cpp
@@ -9,27 +9,23 @@
 #include "CUDAQTestUtils.h"
 #include <algorithm>
 #include <cudaq/algorithm.h>
-#include <execution>
 
 std::vector<cudaq::complex> randomState(int numQubits) {
   std::vector<cudaq::complex> stateVec(1ULL << numQubits);
-  std::generate(
-      std::execution::par_unseq, stateVec.begin(), stateVec.end(),
-      []() -> cudaq::complex {
-        thread_local std::default_random_engine
-            generator; // thread_local so we don't have to do any locking
-        thread_local std::normal_distribution<double> distribution(
-            0.0, 1.0); // mean = 0.0, stddev = 1.0
-        return cudaq::complex(distribution(generator), distribution(generator));
-      });
+  std::generate(stateVec.begin(), stateVec.end(), []() -> cudaq::complex {
+    thread_local std::default_random_engine
+        generator; // thread_local so we don't have to do any locking
+    thread_local std::normal_distribution<double> distribution(
+        0.0, 1.0); // mean = 0.0, stddev = 1.0
+    return cudaq::complex(distribution(generator), distribution(generator));
+  });
 
   const double norm =
       std::sqrt(std::accumulate(stateVec.begin(), stateVec.end(), 0.0,
                                 [](double accumulatedNorm, cudaq::complex val) {
                                   return accumulatedNorm + std::norm(val);
                                 }));
-  std::transform(std::execution::par_unseq, stateVec.begin(), stateVec.end(),
-                 stateVec.begin(),
+  std::transform(stateVec.begin(), stateVec.end(), stateVec.begin(),
                  [norm](std::complex<double> x) { return x / norm; });
   return stateVec;
 }


### PR DESCRIPTION
### Description

In `stdlib++` the use of parallel exection policy with standard algortihms requires the TBB. As we don't want to add another dependecy and our codebase already uses OpenMP, its better to either find a way of forcing `stdlib++` to use OpenMP backend or simply not use these policies.

Since this particular use of parallelism seems unnecessary (the size of the state vectors being generated are quite small), we opt to remove its use.

