### PR TITLE
Fixes for backward compatibility with NVQC

### DIFF
--- a/runtime/common/JsonConvert.h
+++ b/runtime/common/JsonConvert.h
@@ -151,18 +151,23 @@ inline void from_json(const json &j, ExecutionContext &context) {
     j["simulationData"]["dim"].get_to(stateDim);
     j["simulationData"]["data"].get_to(stateData);
 
-    // Create the simulation specific SimulationState
-    auto *simulator = cudaq::get_simulator();
-    if (simulator->isSinglePrecision()) {
-      // If the host (local) simulator is single-precision, convert the type
-      // before loading the state vector.
-      std::vector<std::complex<float>> converted(stateData.begin(),
-                                                 stateData.end());
-      context.simulationState = simulator->createStateFromData(
-          std::make_pair(converted.data(), stateDim[0]));
-    } else {
-      context.simulationState = simulator->createStateFromData(
-          std::make_pair(stateData.data(), stateDim[0]));
+    // Note: before `SimulationState` was added, `simulationData` contains a
+    // flat pair of dimensions and data, whereby an empty dimension array
+    // represents no state data in the context.
+    if (!stateDim.empty()) {
+      // Create the simulation specific SimulationState
+      auto *simulator = cudaq::get_simulator();
+      if (simulator->isSinglePrecision()) {
+        // If the host (local) simulator is single-precision, convert the type
+        // before loading the state vector.
+        std::vector<std::complex<float>> converted(stateData.begin(),
+                                                   stateData.end());
+        context.simulationState = simulator->createStateFromData(
+            std::make_pair(converted.data(), stateDim[0]));
+      } else {
+        context.simulationState = simulator->createStateFromData(
+            std::make_pair(stateData.data(), stateDim[0]));
+      }
     }
   }
 


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

The `ExecutionContext::simulationData` (pre-state handling) type change from `std::tuple<std::vector<std::size_t>, std::vector<std::complex<double>>>` to `std::unique_ptr<SimulationState>` needs to be handle properly during JSON serialization.

In particular, an old/existing server instance adds `simulationData` with empty dim when no state data is available rather than non-data as we switch to the `unique_ptr` data type. 

### Tested by

- Manually run the `nvqc_integration_docker_test` of `nvqc_regression_tests.yml` with the locally-build cuda-q client against the prod nvqc service. 

Notes: 

- Will monitor wheel check post-merge.

- The docker test does include Python examples.
