### PR TITLE
Set random seed in sampling for repeatability

### DIFF
--- a/unittests/integration/qubit_allocation.cpp
+++ b/unittests/integration/qubit_allocation.cpp
@@ -46,6 +46,7 @@ CUDAQ_TEST(AllocationTester, checkAllocationFromStateVecGeneral) {
   // Large number of shots
   constexpr int numShots = 1000000;
   const auto stateVec = randomState(numQubits);
+  cudaq::set_random_seed(13); // set for repeatability
   auto counts = cudaq::sample(numShots, test_state_vector_init{}, stateVec);
   counts.dump();
   for (const auto &[bitStrOrg, count] : counts) {
@@ -78,6 +79,7 @@ CUDAQ_TEST(AllocationTester, checkAllocationFromStateVecWithGate) {
   // Large number of shots
   constexpr int numShots = 1000000;
   const auto stateVec = randomState(numQubits);
+  cudaq::set_random_seed(13); // set for repeatability
   auto counts =
       cudaq::sample(numShots, test_state_vector_init_gate{}, stateVec);
   counts.dump();


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
These test cases use `cudaq::sample`, hence need random seed set for repeatability.