### PR TITLE
Add JSON serializers/deserializers for optimizers and gradients

### DIFF
--- a/runtime/common/JsonConvert.h
+++ b/runtime/common/JsonConvert.h
@@ -290,40 +290,42 @@ inline void from_json(const nlohmann::json &j,
 inline std::unique_ptr<cudaq::optimizer>
 make_optimizer_from_json(const nlohmann::json &j,
                          const OptimizerEnum optimizer_type) {
-  if (optimizer_type == OptimizerEnum::COBYLA) {
+  switch (optimizer_type) {
+  case OptimizerEnum::COBYLA: {
     auto ret_ptr = std::make_unique<cudaq::optimizers::cobyla>();
-    from_json(j, dynamic_cast<cudaq::optimizers::base_nlopt &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
   }
-  if (optimizer_type == OptimizerEnum::NELDERMEAD) {
+  case OptimizerEnum::NELDERMEAD: {
     auto ret_ptr = std::make_unique<cudaq::optimizers::neldermead>();
-    from_json(j, dynamic_cast<cudaq::optimizers::base_nlopt &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
   }
-  if (optimizer_type == OptimizerEnum::LBFGS) {
+  case OptimizerEnum::LBFGS: {
     auto ret_ptr = std::make_unique<cudaq::optimizers::lbfgs>();
-    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
   }
-  if (optimizer_type == OptimizerEnum::SPSA) {
+  case OptimizerEnum::SPSA: {
     auto ret_ptr = std::make_unique<cudaq::optimizers::spsa>();
-    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
   }
-  if (optimizer_type == OptimizerEnum::ADAM) {
+  case OptimizerEnum::ADAM: {
     auto ret_ptr = std::make_unique<cudaq::optimizers::adam>();
-    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
   }
-  if (optimizer_type == OptimizerEnum::GRAD_DESC) {
+  case OptimizerEnum::GRAD_DESC: {
     auto ret_ptr = std::make_unique<cudaq::optimizers::gradient_descent>();
-    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
   }
-  if (optimizer_type == OptimizerEnum::SGD) {
+  case OptimizerEnum::SGD: {
     auto ret_ptr = std::make_unique<cudaq::optimizers::sgd>();
-    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
+  }
   }
   // This shouldn't happen, but gracefully handle it if it does.
   return std::make_unique<cudaq::optimizers::cobyla>();
@@ -371,22 +373,22 @@ inline void to_json(json &j, const cudaq::gradient &p) {
 inline std::unique_ptr<cudaq::gradient>
 make_gradient_from_json(const nlohmann::json &j,
                         const GradientEnum gradient_type) {
-  if (gradient_type == GradientEnum::CENTRAL_DIFF) {
+  switch (gradient_type) {
+  case GradientEnum::CENTRAL_DIFF: {
     auto ret_ptr = std::make_unique<cudaq::gradients::central_difference>();
-    from_json(j,
-              dynamic_cast<cudaq::gradients::central_difference &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
   }
-  if (gradient_type == GradientEnum::FORWARD_DIFF) {
+  case GradientEnum::FORWARD_DIFF: {
     auto ret_ptr = std::make_unique<cudaq::gradients::forward_difference>();
-    from_json(j,
-              dynamic_cast<cudaq::gradients::forward_difference &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
   }
-  if (gradient_type == GradientEnum::PARAMETER_SHIFT) {
+  case GradientEnum::PARAMETER_SHIFT: {
     auto ret_ptr = std::make_unique<cudaq::gradients::parameter_shift>();
-    from_json(j, dynamic_cast<cudaq::gradients::parameter_shift &>(*ret_ptr));
+    from_json(j, *ret_ptr);
     return ret_ptr;
+  }
   }
   // This shouldn't happen, but handle it gracefully if it does.
   return std::make_unique<cudaq::gradients::central_difference>();

--- a/runtime/common/JsonConvert.h
+++ b/runtime/common/JsonConvert.h
@@ -11,6 +11,8 @@
 #include "common/ExecutionContext.h"
 #include "common/FmtCore.h"
 #include "cudaq/Support/Version.h"
+#include "cudaq/gradients.h"
+#include "cudaq/optimizers.h"
 #include "cudaq/simulators.h"
 #include "nlohmann/json.hpp"
 /*! \file
@@ -32,6 +34,23 @@ void from_json(const json &j, std::complex<T> &p) {
   p.imag(j.at(1));
 }
 } // namespace std
+
+// Macros to help reduce redundant field typing for optional fields
+#define TO_JSON_OPT_HELPER(field)                                              \
+  do {                                                                         \
+    if (p.field)                                                               \
+      j[#field] = *p.field;                                                    \
+  } while (0)
+
+#define FROM_JSON_OPT_HELPER(field)                                            \
+  do {                                                                         \
+    if (j.contains(#field))                                                    \
+      p.field = j[#field];                                                     \
+  } while (0)
+
+// Macros to help reduce redundant field typing for non-optional fields
+#define TO_JSON_HELPER(field) j[#field] = p.field
+#define FROM_JSON_HELPER(field) j[#field].get_to(p.field)
 
 namespace cudaq {
 
@@ -178,10 +197,236 @@ inline void from_json(const json &j, ExecutionContext &context) {
 // Enum data to denote the payload format.
 enum class CodeFormat { MLIR, LLVM };
 
-NLOHMANN_JSON_SERIALIZE_ENUM(CodeFormat, {
-                                             {CodeFormat::MLIR, "MLIR"},
-                                             {CodeFormat::LLVM, "LLVM"},
-                                         });
+#define JSON_ENUM(enum_class, val)                                             \
+  { enum_class::val, #val }
+
+NLOHMANN_JSON_SERIALIZE_ENUM(CodeFormat, {JSON_ENUM(CodeFormat, MLIR),
+                                          JSON_ENUM(CodeFormat, LLVM)});
+
+// ----- cudaq::optimizer serialization/deserialization support below
+
+// Enum data for the OptimizerEnum.
+enum class OptimizerEnum {
+  COBYLA,
+  NELDERMEAD,
+  LBFGS,
+  SPSA,
+  ADAM,
+  GRAD_DESC,
+  SGD
+};
+
+NLOHMANN_JSON_SERIALIZE_ENUM(
+    OptimizerEnum,
+    {JSON_ENUM(OptimizerEnum, COBYLA), JSON_ENUM(OptimizerEnum, NELDERMEAD),
+     JSON_ENUM(OptimizerEnum, LBFGS), JSON_ENUM(OptimizerEnum, SPSA),
+     JSON_ENUM(OptimizerEnum, ADAM), JSON_ENUM(OptimizerEnum, GRAD_DESC),
+     JSON_ENUM(OptimizerEnum, SGD)});
+
+inline OptimizerEnum get_optimizer_type(const cudaq::optimizer &p) {
+  if (dynamic_cast<const cudaq::optimizers::cobyla *>(&p))
+    return OptimizerEnum::COBYLA;
+  if (dynamic_cast<const cudaq::optimizers::neldermead *>(&p))
+    return OptimizerEnum::NELDERMEAD;
+  if (dynamic_cast<const cudaq::optimizers::lbfgs *>(&p))
+    return OptimizerEnum::LBFGS;
+  if (dynamic_cast<const cudaq::optimizers::spsa *>(&p))
+    return OptimizerEnum::SPSA;
+  if (dynamic_cast<const cudaq::optimizers::adam *>(&p))
+    return OptimizerEnum::ADAM;
+  if (dynamic_cast<const cudaq::optimizers::gradient_descent *>(&p))
+    return OptimizerEnum::GRAD_DESC;
+  if (dynamic_cast<const cudaq::optimizers::sgd *>(&p))
+    return OptimizerEnum::SGD;
+  // This shouldn't happen, but gracefully handle it if it does.
+  return OptimizerEnum::COBYLA;
+}
+
+inline void to_json(json &j, const cudaq::optimizers::BaseEnsmallen &p) {
+  TO_JSON_OPT_HELPER(max_eval);
+  TO_JSON_OPT_HELPER(initial_parameters);
+  TO_JSON_OPT_HELPER(lower_bounds);
+  TO_JSON_OPT_HELPER(upper_bounds);
+  TO_JSON_OPT_HELPER(f_tol);
+  TO_JSON_OPT_HELPER(step_size);
+}
+
+inline void to_json(json &j, const cudaq::optimizers::base_nlopt &p) {
+  TO_JSON_OPT_HELPER(max_eval);
+  TO_JSON_OPT_HELPER(initial_parameters);
+  TO_JSON_OPT_HELPER(lower_bounds);
+  TO_JSON_OPT_HELPER(upper_bounds);
+  TO_JSON_OPT_HELPER(f_tol);
+}
+
+inline void to_json(json &j, const cudaq::optimizer &p) {
+  if (auto *base_ensmallen =
+          dynamic_cast<const cudaq::optimizers::BaseEnsmallen *>(&p))
+    j = json(*base_ensmallen);
+  else if (auto *base_nlopt =
+               dynamic_cast<const cudaq::optimizers::base_nlopt *>(&p))
+    j = json(*base_nlopt);
+}
+
+inline void from_json(const nlohmann::json &j,
+                      cudaq::optimizers::BaseEnsmallen &p) {
+  FROM_JSON_OPT_HELPER(max_eval);
+  FROM_JSON_OPT_HELPER(initial_parameters);
+  FROM_JSON_OPT_HELPER(lower_bounds);
+  FROM_JSON_OPT_HELPER(upper_bounds);
+  FROM_JSON_OPT_HELPER(f_tol);
+  FROM_JSON_OPT_HELPER(step_size);
+}
+
+inline void from_json(const nlohmann::json &j,
+                      cudaq::optimizers::base_nlopt &p) {
+  FROM_JSON_OPT_HELPER(max_eval);
+  FROM_JSON_OPT_HELPER(initial_parameters);
+  FROM_JSON_OPT_HELPER(lower_bounds);
+  FROM_JSON_OPT_HELPER(upper_bounds);
+  FROM_JSON_OPT_HELPER(f_tol);
+}
+
+inline std::unique_ptr<cudaq::optimizer>
+make_optimizer_from_json(const nlohmann::json &j,
+                         const OptimizerEnum optimizer_type) {
+  if (optimizer_type == OptimizerEnum::COBYLA) {
+    auto ret_ptr = std::make_unique<cudaq::optimizers::cobyla>();
+    from_json(j, dynamic_cast<cudaq::optimizers::base_nlopt &>(*ret_ptr));
+    return ret_ptr;
+  }
+  if (optimizer_type == OptimizerEnum::NELDERMEAD) {
+    auto ret_ptr = std::make_unique<cudaq::optimizers::neldermead>();
+    from_json(j, dynamic_cast<cudaq::optimizers::base_nlopt &>(*ret_ptr));
+    return ret_ptr;
+  }
+  if (optimizer_type == OptimizerEnum::LBFGS) {
+    auto ret_ptr = std::make_unique<cudaq::optimizers::lbfgs>();
+    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    return ret_ptr;
+  }
+  if (optimizer_type == OptimizerEnum::SPSA) {
+    auto ret_ptr = std::make_unique<cudaq::optimizers::spsa>();
+    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    return ret_ptr;
+  }
+  if (optimizer_type == OptimizerEnum::ADAM) {
+    auto ret_ptr = std::make_unique<cudaq::optimizers::adam>();
+    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    return ret_ptr;
+  }
+  if (optimizer_type == OptimizerEnum::GRAD_DESC) {
+    auto ret_ptr = std::make_unique<cudaq::optimizers::gradient_descent>();
+    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    return ret_ptr;
+  }
+  if (optimizer_type == OptimizerEnum::SGD) {
+    auto ret_ptr = std::make_unique<cudaq::optimizers::sgd>();
+    from_json(j, dynamic_cast<cudaq::optimizers::BaseEnsmallen &>(*ret_ptr));
+    return ret_ptr;
+  }
+  // This shouldn't happen, but gracefully handle it if it does.
+  return std::make_unique<cudaq::optimizers::cobyla>();
+}
+
+// ----- cudaq::gradient serialization/deserialization support below
+
+enum class GradientEnum { CENTRAL_DIFF, FORWARD_DIFF, PARAMETER_SHIFT };
+NLOHMANN_JSON_SERIALIZE_ENUM(GradientEnum,
+                             {JSON_ENUM(GradientEnum, CENTRAL_DIFF),
+                              JSON_ENUM(GradientEnum, FORWARD_DIFF),
+                              JSON_ENUM(GradientEnum, PARAMETER_SHIFT)});
+
+inline GradientEnum get_gradient_type(const cudaq::gradient &p) {
+  if (dynamic_cast<const cudaq::gradients::central_difference *>(&p))
+    return GradientEnum::CENTRAL_DIFF;
+  if (dynamic_cast<const cudaq::gradients::forward_difference *>(&p))
+    return GradientEnum::FORWARD_DIFF;
+  if (dynamic_cast<const cudaq::gradients::parameter_shift *>(&p))
+    return GradientEnum::PARAMETER_SHIFT;
+  // This shouldn't happen, but handle it gracefully if it does.
+  return GradientEnum::CENTRAL_DIFF;
+}
+
+// These do not attempt to serialize or deserialize the quantum kernel
+// (ansatz_functor). That is intentional because those will be handled via the
+// RestRequest.code.
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(cudaq::gradients::central_difference, step);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(cudaq::gradients::forward_difference, step);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(cudaq::gradients::parameter_shift,
+                                   shiftScalar);
+
+inline void to_json(json &j, const cudaq::gradient &p) {
+  if (auto *central_difference =
+          dynamic_cast<const cudaq::gradients::central_difference *>(&p))
+    j = json(*central_difference);
+  else if (auto *forward_difference =
+               dynamic_cast<const cudaq::gradients::forward_difference *>(&p))
+    j = json(*forward_difference);
+  else if (auto *parameter_shift =
+               dynamic_cast<const cudaq::gradients::parameter_shift *>(&p))
+    j = json(*parameter_shift);
+}
+
+inline std::unique_ptr<cudaq::gradient>
+make_gradient_from_json(const nlohmann::json &j,
+                        const GradientEnum gradient_type) {
+  if (gradient_type == GradientEnum::CENTRAL_DIFF) {
+    auto ret_ptr = std::make_unique<cudaq::gradients::central_difference>();
+    from_json(j,
+              dynamic_cast<cudaq::gradients::central_difference &>(*ret_ptr));
+    return ret_ptr;
+  }
+  if (gradient_type == GradientEnum::FORWARD_DIFF) {
+    auto ret_ptr = std::make_unique<cudaq::gradients::forward_difference>();
+    from_json(j,
+              dynamic_cast<cudaq::gradients::forward_difference &>(*ret_ptr));
+    return ret_ptr;
+  }
+  if (gradient_type == GradientEnum::PARAMETER_SHIFT) {
+    auto ret_ptr = std::make_unique<cudaq::gradients::parameter_shift>();
+    from_json(j, dynamic_cast<cudaq::gradients::parameter_shift &>(*ret_ptr));
+    return ret_ptr;
+  }
+  // This shouldn't happen, but handle it gracefully if it does.
+  return std::make_unique<cudaq::gradients::central_difference>();
+}
+
+// ----- Optional optimizer serialization/deserialization support below
+
+struct RestRequestOptFields {
+  std::optional<std::size_t> optimizer_n_params;
+  std::optional<OptimizerEnum> optimizer_type;
+  std::optional<GradientEnum> gradient_type;
+
+  // Used on the server
+  std::unique_ptr<cudaq::optimizer> optimizer;
+  std::unique_ptr<cudaq::gradient> gradient;
+
+  // Used on the client
+  cudaq::optimizer *optimizer_ptr = nullptr;
+  cudaq::gradient *gradient_ptr = nullptr;
+};
+
+void to_json(json &j, const RestRequestOptFields &p) {
+  if (p.optimizer_ptr)
+    j["optimizer"] = *p.optimizer_ptr;
+  if (p.gradient_ptr)
+    j["gradient"] = *p.gradient_ptr;
+  TO_JSON_OPT_HELPER(optimizer_n_params);
+  TO_JSON_OPT_HELPER(optimizer_type);
+  TO_JSON_OPT_HELPER(gradient_type);
+}
+
+void from_json(const json &j, RestRequestOptFields &p) {
+  FROM_JSON_OPT_HELPER(optimizer_n_params);
+  FROM_JSON_OPT_HELPER(optimizer_type);
+  if (p.optimizer_type)
+    p.optimizer = make_optimizer_from_json(j["optimizer"], *p.optimizer_type);
+  FROM_JSON_OPT_HELPER(gradient_type);
+  if (p.gradient_type)
+    p.gradient = make_gradient_from_json(j["gradient"], *p.gradient_type);
+}
 
 // Payload from client to server for a kernel execution.
 class RestRequest {
@@ -241,6 +486,8 @@ public:
   CodeFormat format;
   // Simulation random seed.
   std::size_t seed;
+  // Optional optimizer fields
+  std::optional<RestRequestOptFields> opt;
   // List of MLIR passes to be applied on the code before execution.
   std::vector<std::string> passes;
   // Serialized kernel arguments.
@@ -250,9 +497,33 @@ public:
   // Version of the runtime client submitting the request.
   std::string clientVersion;
 
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(RestRequest, version, entryPoint, simulator,
-                                 executionContext, code, args, format, seed,
-                                 passes, clientVersion);
+  friend void to_json(json &j, const RestRequest &p) {
+    TO_JSON_HELPER(version);
+    TO_JSON_HELPER(entryPoint);
+    TO_JSON_HELPER(simulator);
+    TO_JSON_HELPER(executionContext);
+    TO_JSON_HELPER(code);
+    TO_JSON_HELPER(args);
+    TO_JSON_HELPER(format);
+    TO_JSON_OPT_HELPER(opt);
+    TO_JSON_HELPER(seed);
+    TO_JSON_HELPER(passes);
+    TO_JSON_HELPER(clientVersion);
+  }
+
+  friend void from_json(const json &j, RestRequest &p) {
+    FROM_JSON_HELPER(version);
+    FROM_JSON_HELPER(entryPoint);
+    FROM_JSON_HELPER(simulator);
+    FROM_JSON_HELPER(executionContext);
+    FROM_JSON_HELPER(code);
+    FROM_JSON_HELPER(args);
+    FROM_JSON_HELPER(format);
+    FROM_JSON_OPT_HELPER(opt);
+    FROM_JSON_HELPER(seed);
+    FROM_JSON_HELPER(passes);
+    FROM_JSON_HELPER(clientVersion);
+  }
 };
 
 /// NVCF function version status

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -247,6 +247,7 @@ target_link_libraries(test_utils
   cudaq
   cudaq-platform-default
   cudaq-em-photonics
+  nvqir
   nvqir-qpp fmt::fmt-header-only
   gtest_main)
 gtest_discover_tests(test_utils)

--- a/unittests/utils/UtilsTester.cpp
+++ b/unittests/utils/UtilsTester.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "common/FmtCore.h"
+#include "common/JsonConvert.h"
 #include "cudaq/utils/cudaq_utils.h"
 
 TEST(UtilsTester, checkRange) {
@@ -46,5 +47,164 @@ TEST(UtilsTester, checkRange) {
     EXPECT_EQ(10, v.size());
     std::vector<std::size_t> expected{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     EXPECT_EQ(expected, v);
+  }
+}
+
+TEST(UtilsTester, JsonSerDesOptimizer) {
+  {
+    cudaq::optimizers::cobyla test_opt;
+    test_opt.f_tol = 0.01;
+    test_opt.lower_bounds = {0.02, 0.03};
+    json j(test_opt);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(), "{\"f_tol\":0.01,\"lower_bounds\":[0.02,0.03]}");
+    EXPECT_EQ(json(cudaq::get_optimizer_type(test_opt)).dump(), "\"COBYLA\"");
+
+    auto test_opt_round_trip =
+        make_optimizer_from_json(j, cudaq::get_optimizer_type(test_opt));
+    json j2(*test_opt_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
+  }
+
+  {
+    cudaq::optimizers::neldermead test_opt;
+    test_opt.f_tol = 0.01;
+    test_opt.upper_bounds = {0.02, 0.03};
+    json j(test_opt);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(), "{\"f_tol\":0.01,\"upper_bounds\":[0.02,0.03]}");
+    EXPECT_EQ(json(cudaq::get_optimizer_type(test_opt)).dump(),
+              "\"NELDERMEAD\"");
+
+    auto test_opt_round_trip =
+        make_optimizer_from_json(j, cudaq::get_optimizer_type(test_opt));
+    json j2(*test_opt_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
+  }
+
+  {
+    cudaq::optimizers::lbfgs test_opt;
+    test_opt.step_size = 0.99;
+    test_opt.initial_parameters = {0.04, -0.05};
+    json j(test_opt);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(),
+              "{\"initial_parameters\":[0.04,-0.05],\"step_size\":0.99}");
+    EXPECT_EQ(json(cudaq::get_optimizer_type(test_opt)).dump(), "\"LBFGS\"");
+
+    auto test_opt_round_trip =
+        make_optimizer_from_json(j, cudaq::get_optimizer_type(test_opt));
+    json j2(*test_opt_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
+  }
+
+  {
+    cudaq::optimizers::spsa test_opt;
+    test_opt.step_size = 0.99;
+    test_opt.initial_parameters = {0.04, -0.05};
+    json j(test_opt);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(),
+              "{\"initial_parameters\":[0.04,-0.05],\"step_size\":0.99}");
+    EXPECT_EQ(json(cudaq::get_optimizer_type(test_opt)).dump(), "\"SPSA\"");
+
+    auto test_opt_round_trip =
+        make_optimizer_from_json(j, cudaq::get_optimizer_type(test_opt));
+    json j2(*test_opt_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
+  }
+
+  {
+    cudaq::optimizers::adam test_opt;
+    test_opt.step_size = 0.99;
+    test_opt.initial_parameters = {0.04, -0.05};
+    json j(test_opt);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(),
+              "{\"initial_parameters\":[0.04,-0.05],\"step_size\":0.99}");
+    EXPECT_EQ(json(cudaq::get_optimizer_type(test_opt)).dump(), "\"ADAM\"");
+
+    auto test_opt_round_trip =
+        make_optimizer_from_json(j, cudaq::get_optimizer_type(test_opt));
+    json j2(*test_opt_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
+  }
+
+  {
+    cudaq::optimizers::gradient_descent test_opt;
+    test_opt.step_size = 0.99;
+    test_opt.initial_parameters = {0.04, -0.05};
+    json j(test_opt);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(),
+              "{\"initial_parameters\":[0.04,-0.05],\"step_size\":0.99}");
+    EXPECT_EQ(json(cudaq::get_optimizer_type(test_opt)).dump(),
+              "\"GRAD_DESC\"");
+
+    auto test_opt_round_trip =
+        make_optimizer_from_json(j, cudaq::get_optimizer_type(test_opt));
+    json j2(*test_opt_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
+  }
+
+  {
+    cudaq::optimizers::sgd test_opt;
+    test_opt.step_size = 0.99;
+    test_opt.initial_parameters = {0.04, -0.05};
+    json j(test_opt);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(),
+              "{\"initial_parameters\":[0.04,-0.05],\"step_size\":0.99}");
+    EXPECT_EQ(json(cudaq::get_optimizer_type(test_opt)).dump(), "\"SGD\"");
+
+    auto test_opt_round_trip =
+        make_optimizer_from_json(j, cudaq::get_optimizer_type(test_opt));
+    json j2(*test_opt_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
+  }
+}
+
+TEST(UtilsTester, JsonSerDesGradient) {
+  {
+    cudaq::gradients::central_difference grad;
+    grad.step = 0.01;
+    json j(grad);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(), "{\"step\":0.01}");
+    EXPECT_EQ(json(cudaq::get_gradient_type(grad)).dump(), "\"CENTRAL_DIFF\"");
+
+    auto test_grad_round_trip =
+        make_gradient_from_json(j, cudaq::get_gradient_type(grad));
+    json j2(*test_grad_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
+  }
+
+  {
+    cudaq::gradients::forward_difference grad;
+    grad.step = 0.02;
+    json j(grad);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(), "{\"step\":0.02}");
+    EXPECT_EQ(json(cudaq::get_gradient_type(grad)).dump(), "\"FORWARD_DIFF\"");
+
+    auto test_grad_round_trip =
+        make_gradient_from_json(j, cudaq::get_gradient_type(grad));
+    json j2(*test_grad_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
+  }
+
+  {
+    cudaq::gradients::parameter_shift grad;
+    grad.shiftScalar = 0.03;
+    json j(grad);
+    std::cout << j.dump() << '\n';
+    EXPECT_EQ(j.dump(), "{\"shiftScalar\":0.03}");
+    EXPECT_EQ(json(cudaq::get_gradient_type(grad)).dump(),
+              "\"PARAMETER_SHIFT\"");
+
+    auto test_grad_round_trip =
+        make_gradient_from_json(j, cudaq::get_gradient_type(grad));
+    json j2(*test_grad_round_trip);
+    EXPECT_EQ(j.dump(), j2.dump());
   }
 }


### PR DESCRIPTION
## Description

`cudaq::optimizer` and `cudaq::gradient` are abstract virtual classes, so they need special handling for JSON serialization and deserialization. This PR adds that support.

These changes should be backwards compatible with the existing NVQC deployment as long as the new `std::optional<RestRequestOptFields> opt` field in the `RestRequest` is not populated. (And it is indeed not populated in any of our current code.)

This is all in support of remote VQE/optimizer execution on NVQC.