### PR TITLE
[driver] Add a new option, change names of flag options.

### DIFF
--- a/targettests/Remote-Sim/args_synthesis.cpp
+++ b/targettests/Remote-Sim/args_synthesis.cpp
@@ -9,7 +9,7 @@
 // REQUIRES: remote-sim
 // clang-format off
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
-// RUN: nvq++ %cpp_std --enable-mlir --no-aggressive-early-inline --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
+// RUN: nvq++ %cpp_std --enable-mlir -fno-aggressive-early-inline --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
 // This is a comprehensive set of tests for kernel argument synthesis for remote

--- a/targettests/Remote-Sim/no_inline.cpp
+++ b/targettests/Remote-Sim/no_inline.cpp
@@ -11,7 +11,7 @@
 // REQUIRES: remote-sim
 
 // clang-format off
-// RUN: nvq++ %cpp_std --enable-mlir --no-aggressive-early-inline --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
+// RUN: nvq++ %cpp_std --enable-mlir -fno-aggressive-early-inline --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/gen_device_code.cpp
+++ b/targettests/execution/gen_device_code.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ %cpp_std %s --enable-mlir --no-aggressive-early-inline -o %t && %t | \
+// RUN: nvq++ %cpp_std %s --enable-mlir -fno-aggressive-early-inline -o %t && %t | \
 // RUN: FileCheck %s
 
 #include <cudaq.h>

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -43,6 +43,59 @@ function add_pass_to_pipeline {
 	fi
 }
 
+# Function that groups and handles all of our -f* and -fno-* flags.
+function f_option_handling {
+	case $1 in
+	-fno-device-code-loading)
+		ENABLE_DEVICE_CODE_LOADERS=false
+		;;
+	-fdevice-code-loading)
+		ENABLE_DEVICE_CODE_LOADERS=true
+		;;
+	-fno-unwind-lowering)
+		ENABLE_UNWIND_LOWERING=false
+		;;
+	-funwind-lowering)
+		ENABLE_UNWIND_LOWERING=true
+		;;
+	-fno-kernel-execution)
+		ENABLE_KERNEL_EXECUTION=false
+		;;
+	-fkernel-execution)
+		ENABLE_KERNEL_EXECUTION=true
+		;;
+	-fno-aggressive-early-inline)
+		ENABLE_AGGRESSIVE_EARLY_INLINE=false
+		;;
+	-faggressive-early-inline)
+		ENABLE_AGGRESSIVE_EARLY_INLINE=true
+		;;
+	-fno-apply-specialization)
+		ENABLE_APPLY_SPECIALIZATION=false
+		;;
+	-fapply-specialization)
+		ENABLE_APPLY_SPECIALIZATION=true
+		;;
+	-fno-lambda-lifting)
+		ENABLE_LAMBDA_LIFTING=false
+		;;
+	-flambda-lifting)
+		ENABLE_LAMBDA_LIFTING=true
+		;;
+	-fno-lower-to-cfg)
+		ENABLE_LOWER_TO_CFG=false
+		;;
+	-flower-to-cfg)
+		ENABLE_LOWER_TO_CFG=true
+		;;
+	*)
+		# Pass any unrecognized options on to the clang++ tool.
+		ARGS="${ARGS} $1"
+		CUDAQ_QUAKE_ARGS="${CUDAQ_QUAKE_ARGS} --Xcudaq $1"
+		;;
+	esac
+}
+
 function list_targets {
 	ls -I *.cpp -1 ${install_dir}/targets/ | grep ".config$" | sed -e 's/\.config$//'
 	exit 0
@@ -122,22 +175,22 @@ function show_help {
 --mapping-file <path/to/file>
 	Use the specified topology file during mapping (if mapping is needed).
 
---[no-]device-code-loading
+-f[no-]device-code-loading
 	Enable/disable device code loading pass.
 
---[no-]unwind-lowering
+-f[no-]unwind-lowering
 	Enable/disable unwind lowering pass.
 
---[no-]kernel-execution
+-f[no-]kernel-execution
 	Enable/disable kernel execution pass.
 
---[no-]aggressive-early-inline
+-f[no-]aggressive-early-inline
 	Enable/disable early inlining pass.
 
---[no-]apply-specialization
+-f[no-]apply-specialization
 	Enable/disable specialization of quake.apply ops.
 
---[no-]lambda-lifting
+-f[no-]lambda-lifting
 	Enable/disable lambda lifting pass.
 
 --opt-plugin <dynamic library file>
@@ -404,6 +457,10 @@ while [ $# -ne 0 ]; do
 		MAPPING_FILE="base64_"$(echo -n $2 | base64 --wrap=0)
 		shift
 		;;
+	--codegen-assembly-spec)
+		LLVM_QUANTUM_TARGET="$2"
+		shift
+		;;
 	--list-targets)
 		LIST_TARGETS=true
 		;;
@@ -442,41 +499,8 @@ while [ $# -ne 0 ]; do
 	--clang-verbose | -clang-verbose)
 		CLANG_VERBOSE="-v"
 		;;
-	--no-device-code-loading)
-		ENABLE_DEVICE_CODE_LOADERS=false
-		;;
-	--device-code-loading)
-		ENABLE_DEVICE_CODE_LOADERS=true
-		;;
-	--no-unwind-lowering)
-		ENABLE_UNWIND_LOWERING=false
-		;;
-	--unwind-lowering)
-		ENABLE_UNWIND_LOWERING=true
-		;;
-	--no-kernel-execution)
-		ENABLE_KERNEL_EXECUTION=false
-		;;
-	--kernel-execution)
-		ENABLE_KERNEL_EXECUTION=true
-		;;
-	--no-aggressive-early-inline)
-		ENABLE_AGGRESSIVE_EARLY_INLINE=false
-		;;
-	--aggressive-early-inline)
-		ENABLE_AGGRESSIVE_EARLY_INLINE=true
-		;;
-	--no-apply-specialization)
-		ENABLE_APPLY_SPECIALIZATION=false
-		;;
-	--apply-specialization)
-		ENABLE_APPLY_SPECIALIZATION=true
-		;;
-	--no-lambda-lifting)
-		ENABLE_LAMBDA_LIFTING=false
-		;;
-	--lambda-lifting)
-		ENABLE_LAMBDA_LIFTING=true
+	-f*)
+		f_option_handling "$1"
 		;;
 	--opt-plugin)
 		CUDAQ_OPT_ARGS="${CUDAQ_OPT_ARGS} --load-cudaq-plugin $2"


### PR DESCRIPTION
Add a new option to be able to select the "assembly" specification to emit code for (e.g. "qir", "qir-adaptive", ...) and rename all the pass flag options to conform with the `-f*` and `-fno*` style seen in clang++, etc.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
