### PR TITLE
[core] Teach synthesis how to unpack a vector of complex values.

### DIFF
--- a/lib/Optimizer/CodeGen/ConvertToQIRProfile.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRProfile.cpp
@@ -88,6 +88,14 @@ struct FunctionProfileAnalysis {
   const FunctionAnalysisInfo &getAnalysisInfo() const { return infoMap; }
 
 private:
+  static bool isAllocateArray(StringRef f) {
+    return f == cudaq::opt::QIRArrayQubitAllocateArray ||
+           f == cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP64 ||
+           f == cudaq::opt::QIRArrayQubitAllocateArrayWithStateFP32 ||
+           f == cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex64 ||
+           f == cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex32;
+  }
+
   // Scan the body of a function for ops that will be used for profiling.
   void performAnalysis(Operation *operation) {
     auto funcOp = dyn_cast<LLVM::LLVMFuncOp>(operation);
@@ -109,7 +117,7 @@ private:
         }
       };
 
-      if (funcName.equals(cudaq::opt::QIRArrayQubitAllocateArray)) {
+      if (isAllocateArray(funcName)) {
         addAllocation([&]() { return getNumQubits(callOp); });
       } else if (funcName.equals(cudaq::opt::QIRQubitAllocate)) {
         addAllocation([]() { return 1; });

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -13,13 +13,17 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Target/LLVMIR/TypeToLLVM.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/RegionUtils.h"
+
+#define DEBUG_TYPE "quake-synthesizer"
 
 using namespace mlir;
 
@@ -79,6 +83,16 @@ Value makeFloatElement(OpBuilder &builder, Location argLoc, T val,
                        FloatType eleTy) {
   return builder.create<arith::ConstantFloatOp>(argLoc, llvm::APFloat{val},
                                                 eleTy);
+}
+
+template <typename T>
+Value makeComplexElement(OpBuilder &builder, Location argLoc,
+                         std::complex<T> val, ComplexType complexTy) {
+  auto eleTy = complexTy.getElementType();
+  auto realPart = builder.getFloatAttr(eleTy, llvm::APFloat{val.real()});
+  auto imagPart = builder.getFloatAttr(eleTy, llvm::APFloat{val.imag()});
+  auto complexVal = builder.getArrayAttr({realPart, imagPart});
+  return builder.create<complex::ConstantOp>(argLoc, eleTy, complexVal);
 }
 
 template <typename ELETY, typename T, typename ATTR, typename MAKER>
@@ -284,6 +298,32 @@ static LogicalResult synthesizeVectorArgument(OpBuilder &builder,
                                              makeFloatElement<double>);
 }
 
+static LogicalResult
+synthesizeVectorArgument(OpBuilder &builder, BlockArgument argument,
+                         std::vector<std::complex<float>> &vec) {
+  std::vector<float> vec2;
+  for (auto c : vec) {
+    vec2.push_back(c.real());
+    vec2.push_back(c.imag());
+  }
+  auto arrayAttr = builder.getF32ArrayAttr(vec2);
+  return synthesizeVectorArgument<ComplexType>(
+      builder, argument, vec, arrayAttr, makeComplexElement<float>);
+}
+
+static LogicalResult
+synthesizeVectorArgument(OpBuilder &builder, BlockArgument argument,
+                         std::vector<std::complex<double>> &vec) {
+  std::vector<double> vec2;
+  for (auto c : vec) {
+    vec2.push_back(c.real());
+    vec2.push_back(c.imag());
+  }
+  auto arrayAttr = builder.getF64ArrayAttr(vec2);
+  return synthesizeVectorArgument<ComplexType>(
+      builder, argument, vec, arrayAttr, makeComplexElement<double>);
+}
+
 namespace {
 class QuakeSynthesizer
     : public cudaq::opt::QuakeSynthesizeBase<QuakeSynthesizer> {
@@ -436,7 +476,7 @@ public:
       // These will be processed when we reach the buffer's appendix.
       if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(type)) {
         auto eleTy = vecTy.getElementType();
-        if (!isa<IntegerType, FloatType>(eleTy)) {
+        if (!isa<IntegerType, FloatType, ComplexType>(eleTy)) {
           funcOp.emitOpError("synthesis: unsupported argument type");
           signalPassFailure();
           return;
@@ -444,8 +484,13 @@ public:
         char *ptrToSizeInBuffer = static_cast<char *>(args) + offset;
         auto sizeFromBuffer =
             *reinterpret_cast<std::uint64_t *>(ptrToSizeInBuffer);
-        auto bytesInType =
-            cudaq::opt::convertBitsToBytes(eleTy.getIntOrFloatBitWidth());
+        unsigned bytesInType;
+        if (auto complexTy = dyn_cast<ComplexType>(eleTy))
+          bytesInType = cudaq::opt::convertBitsToBytes(
+              complexTy.getElementType().getIntOrFloatBitWidth() * 2);
+        else
+          bytesInType =
+              cudaq::opt::convertBitsToBytes(eleTy.getIntOrFloatBitWidth());
         assert(bytesInType > 0 && "element must have a size");
         auto vectorSize = sizeFromBuffer / bytesInType;
         stdVecInfo.emplace_back(argNum, eleTy, vectorSize);
@@ -525,6 +570,14 @@ public:
       }
       if (eleTy == builder.getF64Type()) {
         doVector(double{});
+        continue;
+      }
+      if (eleTy == ComplexType::get(builder.getF32Type())) {
+        doVector(std::complex<float>{});
+        continue;
+      }
+      if (eleTy == ComplexType::get(builder.getF64Type())) {
+        doVector(std::complex<double>{});
         continue;
       }
     }

--- a/runtime/common/JIT.cpp
+++ b/runtime/common/JIT.cpp
@@ -67,9 +67,9 @@ void invokeWrappedKernel(std::string_view irString,
     // Hence, fix the linkage.
     const auto fixUpLinkage = [](auto &func) {
       if (func.hasInternalLinkage()) {
-        llvm::dbgs() << "Change linkage type for symbol " << func.getName()
-                     << " internal to "
-                        "external linkage.";
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Change linkage type for symbol " << func.getName()
+                   << " internal to external linkage.");
         func.setLinkage(llvm::GlobalValue::LinkageTypes::ExternalLinkage);
       }
     };

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -494,7 +494,7 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder, QuakeValue &sizeOrVec) {
 
     auto ptrTy = cc::PointerType::get(stdvecTy.getElementType());
     Value initials = builder.create<cc::StdvecDataOp>(ptrTy, value);
-    builder.create<quake::InitializeStateOp>(veqTy, qubits, initials);
+    qubits = builder.create<quake::InitializeStateOp>(veqTy, qubits, initials);
     return QuakeValue(builder, qubits);
   }
 

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -361,6 +361,34 @@ TEST(QuakeSynthTests, checkCallable) {
   EXPECT_TRUE(func.getArguments().empty());
 }
 
+TEST(QuakeSynthTests, checkVectorOfComplex) {
+  auto [colonel, stateVec] =
+      cudaq::make_kernel<std::vector<std::complex<double>>>();
+  auto qubits = colonel.qalloc(stateVec);
+  colonel.h(qubits);
+  colonel.mz(qubits);
+  std::cout << colonel.to_quake() << '\n';
+
+  // Generate name of the kernel
+  auto colonelName = cudaq::runtime::cudaqGenPrefixName + colonel.name();
+  std::vector<std::complex<double>> initialState = {1.0, 2.0, 3.0, 4.0};
+
+  [[maybe_unused]] auto counts = cudaq::sample(colonel, initialState);
+  counts.dump();
+
+  auto context = cudaq::initializeMLIR();
+  auto module = parseSourceString<ModuleOp>(colonel.to_quake(), context.get());
+
+  auto [args, offset] = cudaq::mapToRawArgs(colonel.name(), initialState);
+
+  EXPECT_TRUE(succeeded(runQuakeSynth(colonel.name(), args, module)));
+
+  auto func = module->lookupSymbol<func::FuncOp>(colonelName);
+  EXPECT_TRUE(func);
+  EXPECT_TRUE(func.getArguments().empty());
+  func.dump();
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
This PR also addresses some issues in QIR codegen that were found doing ad hoc testing. It could be the case that trying to use QIR with state handling is not supposed to work at all, however. To wit, there are checks made the verify that the code conforms with the QIR specification and these *will* be violated when using qubit allocations with state. For example, the state is not a literal constant but rather a buffer of values. The buffer will be in memory, which is not a constant. The LLVM optimizer may chose LLVM instructions and intrinsics that QIR doesn't consider "legal" as well.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
