### PR TITLE
[ci] Whitelist microsoft and visualstudio.

### DIFF
--- a/.github/workflows/config/md_link_check_config.json
+++ b/.github/workflows/config/md_link_check_config.json
@@ -22,6 +22,12 @@
         "pattern": "^https://vscode.dev/"
       },
       {
+        "pattern": "microsoft.com/"
+      },
+      {
+        "pattern": "visualstudio.com/"
+      },
+      {
         "pattern": "openapi.html"
       }
     ]


### PR DESCRIPTION
These servers go up and down enough to cause the CI to fail frequently enough to cause a lot of lost productivity. Just whitelist the domain to keep the CI from failing.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
