### PR TITLE
Use `get_state.h` rather than the deprecated `state.h`

### DIFF
--- a/docs/sphinx/examples/cpp/providers/nvqc_state.cpp
+++ b/docs/sphinx/examples/cpp/providers/nvqc_state.cpp
@@ -7,7 +7,7 @@
 // variable. Please refer to the documentations for information about how to
 // attain NVQC API key.
 
-#include "cudaq/algorithms/state.h"
+#include "cudaq/algorithms/get_state.h"
 #include <cudaq.h>
 #include <iostream>
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

`state.h` is deprecated (pragma warning). We need to use `get_state.h` in the example.
Also, did a quick search to make sure we don't use this `algorithms/state.h` in any other places.