### PR TITLE
[cmake] Fix downstream cmake

### DIFF
--- a/cmake/Modules/CMakeLists.txt
+++ b/cmake/Modules/CMakeLists.txt
@@ -6,9 +6,22 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-file(GLOB CONFIG_FILES CUDAQ*Config.cmake)
-file (GLOB LANG_FILES CMake*)
-install(FILES NVQIRConfig.cmake DESTINATION lib/cmake/nvqir)
+set(CONFIG_FILES
+  CUDAQCommonConfig.cmake
+  CUDAQEmDefaultConfig.cmake
+  CUDAQNloptConfig.cmake
+  CUDAQSpinConfig.cmake
+  CUDAQConfig.cmake
+  CUDAQEnsmallenConfig.cmake
+  CUDAQPlatformDefaultConfig.cmake
+)
+set(LANG_FILES
+  CMakeCUDAQCompiler.cmake.in
+  CMakeCUDAQInformation.cmake
+  CMakeDetermineCUDAQCompiler.cmake
+  CMakeTestCUDAQCompiler.cmake
+)
+
 install(FILES ${CONFIG_FILES} DESTINATION lib/cmake/cudaq)
 install(FILES ${LANG_FILES} DESTINATION lib/cmake/cudaq)
-install(FILES CUDAQConfig.cmake DESTINATION lib/cmake/cudaq)
+install(FILES NVQIRConfig.cmake DESTINATION lib/cmake/nvqir)

--- a/cmake/Modules/NVQIRConfig.cmake
+++ b/cmake/Modules/NVQIRConfig.cmake
@@ -10,13 +10,10 @@ get_filename_component(NVQIR_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(CMakeFindDependencyMacro)
 
 get_filename_component(PARENT_DIRECTORY ${NVQIR_CMAKE_DIR} DIRECTORY)
-set (CUDAQCommon_DIR "${PARENT_DIRECTORY}/cudaq")
-set (CUDAQSpin_DIR "${PARENT_DIRECTORY}/cudaq")
-set(fmt_DIR "${PARENT_DIRECTORY}/fmt")
 
-find_dependency(CUDAQSpin REQUIRED)
-find_dependency(CUDAQCommon REQUIRED)
-find_dependency(fmt REQUIRED)
+find_dependency(CUDAQSpin REQUIRED HINTS "${PARENT_DIRECTORY}/cudaq")
+find_dependency(CUDAQCommon REQUIRED HINTS "${PARENT_DIRECTORY}/cudaq")
+find_dependency(fmt REQUIRED HINTS "${PARENT_DIRECTORY}/cudaq")
 
 if(NOT TARGET nvqir::nvqir)
     include("${NVQIR_CMAKE_DIR}/NVQIRTargets.cmake")


### PR DESCRIPTION
### Description
CUDAQ is hardcoded to install itself on `lib/`, while not all of our dependencies will do the same. For example, `fmt` installs itself on `CMAKE_INSTALL_LIBDIR`, which might be `lib` or `lib64/` depending on the system. Thus, when trying to create a downstream project that depends on CUDAQ cmake integration, the hardcoded paths set on our downstream cmake files might fail to find required dependencies. 

For example, trying to build a downstream project using:
```sh
cmake .. -G ninja -DCUDAQ_DIR=~/.cudaq/lib/cmake/cudaq
```

Might fail because it cannot find the required `fmt` lib. This partially fixes that by setting our hardcoded paths as HINTS in `find_dependency`. Now, user will be able to use:
```sh
cmake .. -G ninja -DCUDAQ_DIR=~/.cudaq/lib/cmake/cudaq -DFMT_DIR=~/.cudaq/lib64/cmake/fmt
```
to circumvent the issue.

Ideally, we should change CUDAQ to also rely on `CMAKE_INSTALL_LIBDIR`---thus playing nice with the user's system.
