### PR TITLE
Remove the redundant header from optimizer file 

### DIFF
--- a/runtime/cudaq/algorithms/optimizer.h
+++ b/runtime/cudaq/algorithms/optimizer.h
@@ -10,8 +10,6 @@
 
 #include <functional>
 
-#include "cudaq/utils/cudaq_utils.h"
-
 namespace cudaq {
 
 /// Typedef modeling the result of an optimization strategy,


### PR DESCRIPTION
This allows the optimizer logic to be reused within the CUDA-Q source tree.

(No side effect observed on tests / application / user code)
