### PR TITLE
Update `mgpu` commit SHA

### DIFF
--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: 191b415f12e6d636e4ab81094ce6619a774910dd
+nvidia-mgpu-commit: 59b8ed189989d6d2d944e41d8fbc5881b289c83c

--- a/.github/workflows/config/md_link_check_config.json
+++ b/.github/workflows/config/md_link_check_config.json
@@ -13,7 +13,7 @@
     ],
     "ignorePatterns": [
       {
-        "pattern": "^https://www.gnu.org/prep/standards/standards.html"
+        "pattern": "^https://www.gnu.org/"
       },
       {
         "pattern": "^https://epubs.siam.org/doi/10.1137/S0097539796300921"

--- a/.github/workflows/config/md_link_check_config.json
+++ b/.github/workflows/config/md_link_check_config.json
@@ -16,6 +16,9 @@
         "pattern": "^https://www.gnu.org/"
       },
       {
+        "pattern": "^https://gcc.gnu.org/"
+      },
+      {
         "pattern": "^https://epubs.siam.org/doi/10.1137/S0097539796300921"
       },
       {


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Changes (compared to the previous sha):

- Minor code refactor.

- Fixed a bug in the `nvidia-mgpu` config: `CUDAQ_SIMULATION_SCALAR_FPXX` preprocessor define was not set. Hence, it does not report the proper precision in Python runtime target info (parsed from this config).

- Expose the `nvidia-mgpu-fp32` target. The Python config parser only supports simple config (e.g., switching simulator plugin based on extra arguments needs more investigation).