### PR TITLE
Follow-up to #1824 - update validate_wheel.sh

### DIFF
--- a/scripts/validate_wheel.sh
+++ b/scripts/validate_wheel.sh
@@ -99,7 +99,7 @@ done
 
 # Run core tests
 echo "Running core tests."
-python3 -m pip install pytest numpy
+python3 -m pip install pytest numpy psutil
 python3 -m pytest -v "$root_folder/tests" \
     --ignore "$root_folder/tests/backends" \
     --ignore "$root_folder/tests/parallel" \


### PR DESCRIPTION
This resolves the Publishing failure seen in last night's run: https://github.com/NVIDIA/cuda-quantum/actions/runs/9674889993/job/26693187678.

`psutil` is a package needed by some of our tests so, like `numpy`, simply `pip install` it will doing validation.