### PR TITLE
[core] Fix semantic problems with cc.compute_ptr

### DIFF
--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -249,6 +249,12 @@ bool isAArch64(mlir::ModuleOp);
 bool structUsesTwoArguments(mlir::Type ty);
 
 std::optional<std::int64_t> getIntIfConstant(mlir::Value value);
+
+/// Create a `cc.cast` operation, if it is needed.
+mlir::Value createCast(mlir::OpBuilder &builder, mlir::Location loc,
+                       mlir::Type toType, mlir::Value fromValue,
+                       bool signExtend = false, bool zeroExtend = false);
+
 } // namespace factory
 } // namespace opt
 } // namespace cudaq

--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -14,8 +14,13 @@ include "mlir/Pass/PassBase.td"
 def QuakeToCC : Pass<"quake-to-cc", "mlir::ModuleOp"> {
   let summary = "Lower Quake to CC.";
   let description = [{
-    Converts Quake to CC. The add-dealloc pass should be run before this pass
+    Converts Quake to CC. The `add-dealloc` pass should be run before this pass
     in order to properly generate deallocations for allocated qubits.
+
+    This is the second of 2 passes to lower quake code to cc code. The
+    `quake-to-cc-prep` pass must be run first. After these passes the code will
+    be in the CC dialect, with calls back to the runtime, specifically the
+    execution manager.
   }];
 
   let dependentDialects = [
@@ -26,7 +31,8 @@ def QuakeToCC : Pass<"quake-to-cc", "mlir::ModuleOp"> {
 def QuakeToCCPrep : Pass<"quake-to-cc-prep", "mlir::ModuleOp"> {
   let summary = "Prepare for lowering Quake to CC.";
   let description = [{
-    Do the preparation work on the module.
+    Do the preparation work on the module. This pass must be run before the
+    `quake-to-cc` pass is run.
   }];
 
   let dependentDialects = ["cudaq::cc::CCDialect"];
@@ -39,6 +45,10 @@ def CCToLLVM : Pass<"cc-to-llvm", "mlir::ModuleOp"> {
     This is the final step before generating LLVM code. It would typically be
     used after `-quake-to-cc` when a simulator is the target.
   }];
+
+  let dependentDialects = [
+    "cudaq::codegen::CodeGenDialect", "mlir::LLVM::LLVMDialect"
+  ];
 }
 
 def ConvertToQIR : Pass<"quake-to-qir", "mlir::ModuleOp"> {

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -1019,6 +1019,7 @@ def cc_ComputePtrOp : CCOp<"compute_ptr", [Pure]> {
 
   let hasFolder = 1;
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
 
   let builders = [
     OpBuilder<(ins "mlir::Type":$resultType, "mlir::Value":$basePtr,
@@ -1031,6 +1032,10 @@ def cc_ComputePtrOp : CCOp<"compute_ptr", [Pure]> {
   let extraClassDeclaration = [{
     static constexpr std::int32_t kDynamicIndex =
       std::numeric_limits<std::int32_t>::min();
+
+    static std::int32_t getDynamicIndexValue() { return kDynamicIndex; }
+
+    bool llvmNormalForm();
   }];
 }
 

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -547,4 +547,19 @@ bool factory::isStdVecArg(Type type) {
   return true;
 }
 
+Value factory::createCast(OpBuilder &builder, Location loc, Type toType,
+                          Value fromValue, bool signExtend, bool zeroExtend) {
+  if (signExtend && zeroExtend) {
+    emitError(loc, "cannot both sign and zero extend in a cast");
+    return fromValue;
+  }
+  if (fromValue.getType() == toType)
+    return fromValue;
+  auto unit = UnitAttr::get(builder.getContext());
+  UnitAttr none;
+  return builder.create<cudaq::cc::CastOp>(loc, toType, fromValue,
+                                           signExtend ? unit : none,
+                                           zeroExtend ? unit : none);
+}
+
 } // namespace cudaq::opt

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -149,7 +149,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
      {},
      R"#(
   func.func private @__nvqpp__cudaq_em_allocate_veq(%span : !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, %size : i64) {
-    %buffptr = cc.compute_ptr %span[0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+    %buffptr = cc.compute_ptr %span[0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
     %buffer = cc.load %buffptr : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
     %0 = arith.constant 0 : i64
     %1 = cc.loop while ((%arg0 = %0) -> (i64)) {
@@ -180,7 +180,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
      {cudaq::llvmMemCopyIntrinsic},
      R"#(
   func.func private @__nvqpp__cudaq_em_concatSpan(%dest : !cc.ptr<i64>, %from : !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, %length : i64) {
-    %ptrptr = cc.compute_ptr %from[0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+    %ptrptr = cc.compute_ptr %from[0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
     %src = cc.load %ptrptr : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
     %eight = arith.constant 8 : i64
     %len = arith.muli %length, %eight : i64
@@ -213,9 +213,9 @@ static constexpr IntrinsicCode intrinsicTable[] = {
      {},
      R"#(
   func.func private @__nvqpp__cudaq_em_writeToSpan(%span : !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, %ptr : !cc.ptr<!cc.array<i64 x ?>>, %size : i64) {
-    %buffptr = cc.compute_ptr %span[0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+    %buffptr = cc.compute_ptr %span[0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
     cc.store %ptr, %buffptr : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
-    %szptr = cc.compute_ptr %span[0, 1] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<i64>
+    %szptr = cc.compute_ptr %span[1] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<i64>
     cc.store %size, %szptr : !cc.ptr<i64>
     return
   })#"},
@@ -224,15 +224,16 @@ static constexpr IntrinsicCode intrinsicTable[] = {
      {cudaq::llvmMemCopyIntrinsic, "malloc"},
      R"#(
   func.func private @__nvqpp_createDynamicResult(%arg0: !cc.ptr<i8>, %arg1: i64, %arg2: !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.struct<{!cc.ptr<i8>, i64}> {
-    %0 = cc.compute_ptr %arg2[0, 1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+    %0 = cc.compute_ptr %arg2[1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
     %1 = cc.load %0 : !cc.ptr<i64>
     %2 = arith.addi %arg1, %1 : i64
     %3 = call @malloc(%2) : (i64) -> !cc.ptr<i8>
+    %10 = cc.cast %3 : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
     %false = arith.constant false
     call @llvm.memcpy.p0i8.p0i8.i64(%3, %arg0, %arg1, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
-    %4 = cc.compute_ptr %arg2[0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+    %4 = cc.compute_ptr %arg2[0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
     %5 = cc.load %4 : !cc.ptr<!cc.ptr<i8>>
-    %6 = cc.compute_ptr %3[%arg1] : (!cc.ptr<i8>, i64) -> !cc.ptr<i8>
+    %6 = cc.compute_ptr %10[%arg1] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
     call @llvm.memcpy.p0i8.p0i8.i64(%6, %5, %1, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
     %7 = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
     %8 = cc.insert_value %3, %7[0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>

--- a/lib/Optimizer/CodeGen/CCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/CCToLLVM.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/Optimizer/CodeGen/CCToLLVM.h"
+#include "CodeGenOps.h"
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
@@ -262,25 +263,38 @@ class ComputePtrOpPattern
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
-  // Convert each cc::ComputePtrOp to an LLVM::GEPOp.
   LogicalResult
-  matchAndRewrite(cudaq::cc::ComputePtrOp cp, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::cc::ComputePtrOp cpOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto operands = adaptor.getOperands();
-    bool dropFirst = false;
-    auto toTy = getTypeConverter()->convertType(cp.getType());
+    auto toTy = getTypeConverter()->convertType(cpOp.getType());
+    // The first operand is the base pointer.
     Value base = operands[0];
-    if (auto ptrTy = dyn_cast<LLVM::LLVMPointerType>(base.getType()))
-      if (auto arrTy = dyn_cast<LLVM::LLVMArrayType>(ptrTy.getElementType())) {
-        // Eliminate intermediate array type. Not needed in LLVM. (NB: for some
-        // element types, the executable will crash.)
-        auto ty = cudaq::opt::factory::getPointerType(arrTy.getElementType());
-        base = rewriter.create<LLVM::BitcastOp>(cp.getLoc(), ty, base);
-      }
-    auto gepOpnds = interleaveConstantsAndOperands(
-        operands.drop_front(),
-        cp.getRawConstantIndices().drop_front(dropFirst ? 1 : 0));
-    rewriter.replaceOpWithNewOp<LLVM::GEPOp>(cp, toTy, base, gepOpnds);
+    if (cpOp.llvmNormalForm()) {
+      // In this case, the `cc.compute_ptr` has already been converted such that
+      // it corresponds 1:1 with the C-like semantics of LLVM's getelementptr
+      // operation. Specifically, a pointer to a scalar type is overloaded to
+      // possibly be the same as a pointer to an array with unknown bound.
+      // All operands except the first are indices.
+      auto newOpnds = interleaveConstantsAndOperands(
+          operands.drop_front(), cpOp.getRawConstantIndices());
+      // Rewrite the ComputePtrOp as a LLVM::GEPOp.
+      rewriter.replaceOpWithNewOp<LLVM::GEPOp>(cpOp, toTy, base, newOpnds);
+    } else {
+      // If the `cc.compute_ptr` operation has a base argument that is not in
+      // LLVM normal form, we implicitly assume that pointer's element type
+      // should have been an `cc.array<T x ?>` instead of `T`. We therefore add
+      // an explicit `0` as the first index. This converts the strong semantics
+      // of `cc.compute_ptr` (which does not allow indexing out of bounds in
+      // objects) to the weaker semantics of C/LLVM, which do implicitly allow
+      // freely indexing out of bounds.
+      SmallVector<std::int32_t> constIndices = {0};
+      constIndices.append(cpOp.getRawConstantIndices().begin(),
+                          cpOp.getRawConstantIndices().end());
+      auto newOpnds =
+          interleaveConstantsAndOperands(operands.drop_front(), constIndices);
+      rewriter.replaceOpWithNewOp<LLVM::GEPOp>(cpOp, toTy, base, newOpnds);
+    }
     return success();
   }
 
@@ -463,7 +477,8 @@ public:
     // TODO: replace this with some target-specific memory layout computation
     // when we upgrade to a newer MLIR.
     auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
-    auto ptrTy = cudaq::cc::PointerType::get(inputTy);
+    auto ptrTy =
+        cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(inputTy));
     auto nullCast = rewriter.create<cudaq::cc::CastOp>(loc, ptrTy, zero);
     Value nextPtr = rewriter.create<cudaq::cc::ComputePtrOp>(
         loc, ptrTy, nullCast, ArrayRef<cudaq::cc::ComputePtrArg>{1});

--- a/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -22,6 +22,7 @@ add_cudaq_library(OptCodeGen
   Passes.cpp
   Pipelines.cpp
   QuakeToCC.cpp
+  QuakeToCodegen.cpp
   QuakeToLLVM.cpp
   RemoveMeasurements.cpp
   TranslateToIQMJson.cpp

--- a/lib/Optimizer/CodeGen/CodeGenOps.cpp
+++ b/lib/Optimizer/CodeGen/CodeGenOps.cpp
@@ -12,8 +12,6 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
 
-using namespace mlir;
-
 //===----------------------------------------------------------------------===//
 // Generated logic
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/CodeGen/ConvertCCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/ConvertCCToLLVM.cpp
@@ -6,6 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#include "CodeGenDialect.h"
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/CodeGen/CCToLLVM.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
@@ -53,7 +54,8 @@ void cudaq::opt::populateCCTypeConversions(LLVMTypeConverter *converter) {
       return factory::getPointerType(type.getContext());
     eleTy = converter->convertType(eleTy);
     if (auto arrTy = dyn_cast<cc::ArrayType>(eleTy)) {
-      // If array has a static size, it becomes an LLVMArrayType.
+      // If array has a static size, it becomes an LLVMArrayType. Otherwise, we
+      // end up here.
       assert(arrTy.isUnknownSize());
       return factory::getPointerType(
           converter->convertType(arrTy.getElementType()));

--- a/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *

--- a/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "QuakeToCodegen.h"
+#include "CodeGenOps.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+
+using namespace mlir;
+
+namespace {
+//===----------------------------------------------------------------------===//
+// Code generation: converts the Quake IR to Codegen IR.
+//===----------------------------------------------------------------------===//
+
+class CodeGenRAIIPattern : public OpRewritePattern<quake::InitializeStateOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(quake::InitializeStateOp init,
+                                PatternRewriter &rewriter) const override {
+    Value mem = init.getTargets();
+    auto alloc = mem.getDefiningOp<quake::AllocaOp>();
+    if (!alloc)
+      return init.emitOpError("init_state must have alloca as input");
+    rewriter.replaceOpWithNewOp<cudaq::codegen::RAIIOp>(
+        init, init.getType(), init.getState(),
+        cast<cudaq::cc::PointerType>(init.getState().getType())
+            .getElementType(),
+        alloc.getType(), alloc.getSize());
+    rewriter.eraseOp(alloc);
+    return success();
+  }
+};
+} // namespace
+
+void cudaq::codegen::populateQuakeToCodegenPatterns(
+    mlir::RewritePatternSet &patterns) {
+  auto *ctx = patterns.getContext();
+  patterns.insert<CodeGenRAIIPattern>(ctx);
+}

--- a/lib/Optimizer/CodeGen/QuakeToCodegen.h
+++ b/lib/Optimizer/CodeGen/QuakeToCodegen.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *

--- a/lib/Optimizer/CodeGen/QuakeToCodegen.h
+++ b/lib/Optimizer/CodeGen/QuakeToCodegen.h
@@ -8,17 +8,10 @@
 
 #pragma once
 
-#include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
-#include "cudaq/Optimizer/Dialect/Common/Traits.h"
-#include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/OpDefinition.h"
-#include "mlir/IR/OpImplementation.h"
+namespace mlir {
+class RewritePatternSet;
+}
 
-//===----------------------------------------------------------------------===//
-// Generated logic
-//===----------------------------------------------------------------------===//
-
-#define GET_OP_CLASSES
-#include "cudaq/Optimizer/CodeGen/CodeGenOps.h.inc"
+namespace cudaq::codegen {
+void populateQuakeToCodegenPatterns(mlir::RewritePatternSet &);
+}

--- a/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
@@ -82,8 +82,8 @@ public:
   }
 };
 
-// Lower quake.init_state to a QIR function to allocate the
-// qubits with the provided state vector.
+// Lower codegen.qmem_raii to a QIR function to allocate the qubits with the
+// provided state vector.
 class QmemRAIIOpRewrite
     : public ConvertOpToLLVMPattern<cudaq::codegen::RAIIOp> {
 public:

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -29,7 +29,7 @@ namespace cudaq::opt {
 #include "cudaq/Optimizer/Transforms/Passes.h.inc"
 } // namespace cudaq::opt
 
-#define DEBUG_TYPE "quake-kernel-exec"
+#define DEBUG_TYPE "kernel-execution"
 
 using namespace mlir;
 
@@ -103,7 +103,7 @@ public:
       // This is a string, so just read the length out.
       auto ptrI64Ty = cudaq::cc::PointerType::get(i64Ty);
       auto lenPtr = builder.create<cudaq::cc::ComputePtrOp>(
-          loc, ptrI64Ty, arg, SmallVector<cudaq::cc::ComputePtrArg>{0, 1});
+          loc, ptrI64Ty, arg, SmallVector<cudaq::cc::ComputePtrArg>{1});
       return builder.create<cudaq::cc::LoadOp>(loc, lenPtr);
     }
 
@@ -112,11 +112,11 @@ public:
 
     // Get the pointer to the pointer of the end of the array
     Value endPtr = builder.create<cudaq::cc::ComputePtrOp>(
-        loc, ptrTtype, arg, SmallVector<cudaq::cc::ComputePtrArg>{0, 1});
+        loc, ptrTtype, arg, SmallVector<cudaq::cc::ComputePtrArg>{1});
 
     // Get the pointer to the pointer of the beginning of the array
     Value beginPtr = builder.create<cudaq::cc::ComputePtrOp>(
-        loc, ptrTtype, arg, SmallVector<cudaq::cc::ComputePtrArg>{0, 0});
+        loc, ptrTtype, arg, SmallVector<cudaq::cc::ComputePtrArg>{0});
 
     // Load to a T*
     endPtr = builder.create<cudaq::cc::LoadOp>(loc, endPtr);
@@ -202,7 +202,7 @@ public:
           cast<cudaq::cc::StructType>(argTy.getElementType()).getMember(off);
       auto structMemPtrTy = cudaq::cc::PointerType::get(structMemTy);
       auto memPtrVal = builder.create<cudaq::cc::ComputePtrOp>(
-          loc, structMemPtrTy, arg, ArrayRef<cudaq::cc::ComputePtrArg>{0, off});
+          loc, structMemPtrTy, arg, ArrayRef<cudaq::cc::ComputePtrArg>{off});
       if (cudaq::cc::isDynamicType(memTy)) {
         if (auto sTy = dyn_cast<cudaq::cc::StructType>(memTy)) {
           auto gTy = cast<cudaq::cc::StructType>(structMemTy);
@@ -241,16 +241,20 @@ public:
         cast<cudaq::cc::PointerType>(hostArg.getType()).getElementType());
     auto beginPtr = builder.create<cudaq::cc::ComputePtrOp>(
         loc, cudaq::cc::PointerType::get(inStructTy.getMember(0)), hostArg,
-        SmallVector<cudaq::cc::ComputePtrArg>{0, 0});
+        SmallVector<cudaq::cc::ComputePtrArg>{0});
     auto fromBuff = builder.create<cudaq::cc::LoadOp>(loc, beginPtr);
-    auto vecFromBuff = builder.create<cudaq::cc::CastOp>(
-        loc, cudaq::cc::PointerType::get(builder.getI8Type()), fromBuff);
+    auto i8Ty = builder.getI8Type();
+    auto vecFromBuff = cudaq::opt::factory::createCast(
+        builder, loc, cudaq::cc::PointerType::get(i8Ty), fromBuff);
     builder.create<func::CallOp>(
         loc, std::nullopt, cudaq::llvmMemCopyIntrinsic,
         SmallVector<Value>{outputBuffer, vecFromBuff, bytes, notVolatile});
+    auto i8ArrTy = cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(i8Ty));
+    auto buf1 =
+        cudaq::opt::factory::createCast(builder, loc, i8ArrTy, outputBuffer);
     // Increment outputBuffer by size bytes.
     return builder.create<cudaq::cc::ComputePtrOp>(
-        loc, outputBuffer.getType(), outputBuffer, SmallVector<Value>{bytes});
+        loc, outputBuffer.getType(), buf1, SmallVector<Value>{bytes});
   }
 
   /// Given that \p arg is a SpanLikeType value, compute its extent size (the
@@ -282,7 +286,7 @@ public:
     auto resTy = cudaq::cc::PointerType::get(members[numKernelArgs]);
     auto gep = builder.create<cudaq::cc::ComputePtrOp>(
         loc, resTy, nullSt,
-        SmallVector<cudaq::cc::ComputePtrArg>{0, numKernelArgs});
+        SmallVector<cudaq::cc::ComputePtrArg>{numKernelArgs});
     return builder.create<cudaq::cc::CastOp>(loc, i64Ty, gep);
   }
 
@@ -328,7 +332,8 @@ public:
                                             FunctionType hostFuncTy,
                                             bool hasThisPtr) {
     auto *ctx = builder.getContext();
-    Type ptrI8Ty = cudaq::cc::PointerType::get(builder.getI8Type());
+    Type i8Ty = builder.getI8Type();
+    Type ptrI8Ty = cudaq::cc::PointerType::get(i8Ty);
     auto ptrPtrType = cudaq::cc::PointerType::get(ptrI8Ty);
     Type i64Ty = builder.getI64Type();
     auto structPtrTy = cudaq::cc::PointerType::get(msgStructTy);
@@ -353,7 +358,9 @@ public:
     Value stVal = builder.create<cudaq::cc::UndefOp>(loc, msgStructTy);
 
     // Get the variadic void* args
-    auto variadicArgs = entry->getArgument(0);
+    auto variadicArgs = builder.create<cudaq::cc::CastOp>(
+        loc, cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(ptrI8Ty)),
+        entry->getArgument(0));
 
     // Initialize the counter for extra size.
     Value zero = builder.create<arith::ConstantIntOp>(loc, 0, 64);
@@ -474,8 +481,11 @@ public:
     Value casted = builder.create<cudaq::cc::CastOp>(loc, structPtrTy, buff);
     builder.create<cudaq::cc::StoreOp>(loc, stVal, casted);
     if (hasTrailingData) {
+      auto arrTy = cudaq::cc::ArrayType::get(i8Ty);
+      auto ptrArrTy = cudaq::cc::PointerType::get(arrTy);
+      auto cast1 = builder.create<cudaq::cc::CastOp>(loc, ptrArrTy, buff);
       Value vecToBuffer = builder.create<cudaq::cc::ComputePtrOp>(
-          loc, ptrI8Ty, buff, SmallVector<Value>{structSize});
+          loc, ptrI8Ty, cast1, SmallVector<Value>{structSize});
       for (auto iter : llvm::enumerate(msgStructTy.getMembers())) {
         std::int32_t idx = iter.index();
         if (idx == static_cast<std::int32_t>(kernelArgTypes.size()))
@@ -501,7 +511,7 @@ public:
             auto arg = replacementArgs[idx];
             auto heapPtr = builder.create<cudaq::cc::ComputePtrOp>(
                 loc, cudaq::cc::PointerType::get(ptrI1Ty), arg,
-                ArrayRef<cudaq::cc::ComputePtrArg>{0, 0});
+                ArrayRef<cudaq::cc::ComputePtrArg>{0});
             auto loadHeapPtr = builder.create<cudaq::cc::LoadOp>(loc, heapPtr);
             auto i8Ty = builder.getI8Type();
             Value heapCast = builder.create<cudaq::cc::CastOp>(
@@ -563,7 +573,7 @@ public:
         for (int i = 0, end = funcOp.getNumResults(); i != end; ++i) {
           auto mem = builder.create<cudaq::cc::ComputePtrOp>(
               loc, cudaq::cc::PointerType::get(funcTy.getResult(i)), cast,
-              SmallVector<cudaq::cc::ComputePtrArg>{0, i});
+              SmallVector<cudaq::cc::ComputePtrArg>{i});
           builder.create<cudaq::cc::StoreOp>(loc, retOp.getOperands()[i], mem);
         }
       } else if (auto stdvecTy =
@@ -578,18 +588,21 @@ public:
               return builder.getI8Type();
           return stdvecTy.getElementType();
         }();
+        auto i8Ty = cudaq::cc::PointerType::get(builder.getI8Type());
         auto ptrTy = cudaq::cc::PointerType::get(eleTy);
         auto data = builder.create<cudaq::cc::StdvecDataOp>(loc, ptrTy, stdvec);
         auto mem0 = builder.create<cudaq::cc::ComputePtrOp>(
-            loc, cudaq::cc::PointerType::get(ptrTy), cast,
-            SmallVector<cudaq::cc::ComputePtrArg>{0, 0});
-        builder.create<cudaq::cc::StoreOp>(loc, data, mem0);
+            loc, cudaq::cc::PointerType::get(i8Ty), cast,
+            SmallVector<cudaq::cc::ComputePtrArg>{0});
+        auto mem1 = builder.create<cudaq::cc::CastOp>(
+            loc, cudaq::cc::PointerType::get(ptrTy), mem0);
+        builder.create<cudaq::cc::StoreOp>(loc, data, mem1);
         auto i64Ty = builder.getI64Type();
         auto size = builder.create<cudaq::cc::StdvecSizeOp>(loc, i64Ty, stdvec);
-        auto mem1 = builder.create<cudaq::cc::ComputePtrOp>(
+        auto mem2 = builder.create<cudaq::cc::ComputePtrOp>(
             loc, cudaq::cc::PointerType::get(i64Ty), cast,
-            SmallVector<cudaq::cc::ComputePtrArg>{0, 1});
-        builder.create<cudaq::cc::StoreOp>(loc, size, mem1);
+            SmallVector<cudaq::cc::ComputePtrArg>{1});
+        builder.create<cudaq::cc::StoreOp>(loc, size, mem2);
       } else {
         builder.create<cudaq::cc::StoreOp>(loc, retOp.getOperands()[0], cast);
       }
@@ -634,7 +647,10 @@ public:
     // Convert the pointer-free std::vector<T> to a span structure to be
     // passed. A span structure is a pointer and a size (in element
     // units). Note that this structure may be recursive.
-    auto ptrI8Ty = cudaq::cc::PointerType::get(builder.getI8Type());
+    auto i8Ty = builder.getI8Type();
+    auto arrI8Ty = cudaq::cc::ArrayType::get(i8Ty);
+    auto ptrI8Ty = cudaq::cc::PointerType::get(i8Ty);
+    auto bytesTy = cudaq::cc::PointerType::get(arrI8Ty);
     Type eleTy = stdvecTy.getElementType();
     auto innerStdvecTy = dyn_cast<cudaq::cc::SpanLikeType>(eleTy);
     std::size_t eleSize =
@@ -642,18 +658,11 @@ public:
     auto eleSizeVal = [&]() -> Value {
       if (eleSize)
         return builder.create<arith::ConstantIntOp>(loc, eleSize, 64);
-      // FIXME: should also handle ArrayType here.
-      assert(isa<cudaq::cc::StructType>(eleTy) && "handle non-StructType");
-      auto strTy = cast<cudaq::cc::StructType>(eleTy);
-      auto zero = builder.create<arith::ConstantIntOp>(loc, 0, 64);
-      auto arrTy = cudaq::cc::ArrayType::get(strTy);
-      auto ptrTy = cudaq::cc::PointerType::get(strTy);
-      auto ptrArrTy = cudaq::cc::PointerType::get(arrTy);
-      Value nullVal = builder.create<cudaq::cc::CastOp>(loc, ptrArrTy, zero);
-      Value sizePtr = builder.create<cudaq::cc::ComputePtrOp>(
-          loc, ptrTy, nullVal, SmallVector<cudaq::cc::ComputePtrArg>{0, 1});
+      assert(isa<cudaq::cc::StructType>(eleTy) ||
+             (isa<cudaq::cc::ArrayType>(eleTy) &&
+              !cast<cudaq::cc::ArrayType>(eleTy).isUnknownSize()));
       auto i64Ty = builder.getI64Type();
-      return builder.create<cudaq::cc::CastOp>(loc, i64Ty, sizePtr);
+      return builder.create<cudaq::cc::SizeOfOp>(loc, i64Ty, eleTy);
     }();
     auto vecLength = builder.create<arith::DivSIOp>(loc, vecSize, eleSizeVal);
     if (innerStdvecTy) {
@@ -665,11 +674,14 @@ public:
       auto vecTmp = builder.create<cudaq::cc::AllocaOp>(loc, eleTy, vecLength);
       auto currentEnd = builder.create<cudaq::cc::AllocaOp>(loc, ptrI8Ty);
       auto i64Ty = builder.getI64Type();
-      auto ptrI64Ty = cudaq::cc::PointerType::get(i64Ty);
+      auto arrI64Ty = cudaq::cc::ArrayType::get(i64Ty);
+      auto arrTy = cudaq::cc::PointerType::get(arrI64Ty);
       auto innerVec =
-          builder.create<cudaq::cc::CastOp>(loc, ptrI64Ty, trailingData);
+          builder.create<cudaq::cc::CastOp>(loc, arrTy, trailingData);
+      auto trailingBytes =
+          builder.create<cudaq::cc::CastOp>(loc, bytesTy, trailingData);
       trailingData = builder.create<cudaq::cc::ComputePtrOp>(
-          loc, ptrI8Ty, trailingData, vecSize);
+          loc, ptrI8Ty, trailingBytes, vecSize);
       builder.create<cudaq::cc::StoreOp>(loc, trailingData, currentEnd);
       // Loop over each subvector in the vector and recursively unpack it into
       // the vecTmp variable. Leaf vectors do not need a fresh variable. This
@@ -712,8 +724,10 @@ public:
         loc, cudaq::cc::PointerType::get(eleTy), trailingData);
     Value stdVecResult = builder.create<cudaq::cc::StdvecInitOp>(
         loc, stdvecTy, castData, vecLength);
-    trailingData = builder.create<cudaq::cc::ComputePtrOp>(
-        loc, ptrI8Ty, trailingData, vecSize);
+    auto arrTy = cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(i8Ty));
+    Value casted = builder.create<cudaq::cc::CastOp>(loc, arrTy, trailingData);
+    trailingData =
+        builder.create<cudaq::cc::ComputePtrOp>(loc, ptrI8Ty, casted, vecSize);
     return {stdVecResult, trailingData};
   }
 
@@ -821,7 +835,7 @@ public:
       auto eleTy = structTy.getMember(offset);
       auto mem = builder.create<cudaq::cc::ComputePtrOp>(
           loc, cudaq::cc::PointerType::get(eleTy), castOp,
-          SmallVector<cudaq::cc::ComputePtrArg>{0, offset});
+          SmallVector<cudaq::cc::ComputePtrArg>{offset});
       auto sretPtrTy = cudaq::cc::PointerType::get(
           cudaq::opt::factory::getSRetElementType(funcTy));
       auto sretMem = builder.create<cudaq::cc::CastOp>(loc, sretPtrTy, mem);
@@ -845,7 +859,7 @@ public:
       auto eleTy = structTy.getMember(offset);
       auto mem = builder.create<cudaq::cc::ComputePtrOp>(
           loc, cudaq::cc::PointerType::get(eleTy), castOp,
-          SmallVector<cudaq::cc::ComputePtrArg>{0, offset});
+          SmallVector<cudaq::cc::ComputePtrArg>{offset});
       builder.create<cudaq::cc::StoreOp>(loc, call.getResult(0), mem);
     }
 
@@ -867,7 +881,7 @@ public:
       int offset = funcTy.getNumInputs();
       auto gepRes = builder.create<cudaq::cc::ComputePtrOp>(
           loc, cudaq::cc::PointerType::get(structTy.getMember(offset)), castOp,
-          SmallVector<cudaq::cc::ComputePtrArg>{0, offset});
+          SmallVector<cudaq::cc::ComputePtrArg>{offset});
       auto gepRes2 = builder.create<cudaq::cc::CastOp>(
           loc, cudaq::cc::PointerType::get(thunkTy.getResults()[0]), gepRes);
       // createDynamicResult packs the input values and the dynamic results
@@ -915,7 +929,7 @@ public:
     auto castSret = builder.create<cudaq::cc::CastOp>(loc, stlVectorTy, sret);
     auto ptrPtrTy = cudaq::cc::PointerType::get(ptrTy);
     auto sret0 = builder.create<cudaq::cc::ComputePtrOp>(
-        loc, ptrPtrTy, castSret, SmallVector<cudaq::cc::ComputePtrArg>{0, 0});
+        loc, ptrPtrTy, castSret, SmallVector<cudaq::cc::ComputePtrArg>{0});
     Value vecPtr = builder.create<cudaq::cc::LoadOp>(loc, ptrTy, sret0);
     builder.create<func::CallOp>(loc, std::nullopt, "free", ValueRange{vecPtr});
     auto arrI8Ty = cudaq::cc::ArrayType::get(i8Ty);
@@ -923,14 +937,14 @@ public:
     auto buffPtr0 = builder.create<cudaq::cc::CastOp>(loc, ptrTy, data);
     builder.create<cudaq::cc::StoreOp>(loc, buffPtr0, sret0);
     auto sret1 = builder.create<cudaq::cc::ComputePtrOp>(
-        loc, ptrPtrTy, castSret, SmallVector<cudaq::cc::ComputePtrArg>{0, 1});
+        loc, ptrPtrTy, castSret, SmallVector<cudaq::cc::ComputePtrArg>{1});
     Value byteLen = builder.create<arith::MulIOp>(loc, tSize, vecSize);
     auto buffPtr = builder.create<cudaq::cc::CastOp>(loc, ptrArrTy, data);
     auto endPtr = builder.create<cudaq::cc::ComputePtrOp>(
-        loc, ptrTy, buffPtr, SmallVector<cudaq::cc::ComputePtrArg>{0, byteLen});
+        loc, ptrTy, buffPtr, SmallVector<cudaq::cc::ComputePtrArg>{byteLen});
     builder.create<cudaq::cc::StoreOp>(loc, endPtr, sret1);
     auto sret2 = builder.create<cudaq::cc::ComputePtrOp>(
-        loc, ptrPtrTy, castSret, SmallVector<cudaq::cc::ComputePtrArg>{0, 2});
+        loc, ptrPtrTy, castSret, SmallVector<cudaq::cc::ComputePtrArg>{2});
     builder.create<cudaq::cc::StoreOp>(loc, endPtr, sret2);
   }
 
@@ -965,7 +979,7 @@ public:
     auto inpStructTy = cast<cudaq::cc::StructType>(hostVecTy.getElementType());
     auto ptrTtype = cudaq::cc::PointerType::get(inpStructTy.getMember(0));
     auto beginPtr = builder.create<cudaq::cc::ComputePtrOp>(
-        loc, ptrTtype, hostArg, SmallVector<cudaq::cc::ComputePtrArg>{0, 0});
+        loc, ptrTtype, hostArg, SmallVector<cudaq::cc::ComputePtrArg>{0});
     auto ptrArrSTy = cudaq::opt::factory::getIndexedObjectType(inpStructTy);
     auto vecPtr = builder.create<cudaq::cc::CastOp>(
         loc, cudaq::cc::PointerType::get(ptrArrSTy), beginPtr);
@@ -982,24 +996,32 @@ public:
     auto vecLenIndex = builder.create<cudaq::cc::CastOp>(
         loc, builder.getI64Type(), vecLogicalLen,
         cudaq::cc::CastOpMode::Unsigned);
-    auto buffPtrTy = buffPtr.getType();
+    auto buffPtrTy = cast<cudaq::cc::PointerType>(buffPtr.getType());
     auto tmp = builder.create<cudaq::cc::AllocaOp>(loc, buffPtrTy);
+    auto buffArrTy = cudaq::cc::ArrayType::get(buffPtrTy.getElementType());
+    auto castPtr = builder.create<cudaq::cc::CastOp>(
+        loc, cudaq::cc::PointerType::get(buffArrTy), buffPtr);
     auto newEnd = builder.create<cudaq::cc::ComputePtrOp>(
-        loc, buffPtrTy, buffPtr, SmallVector<cudaq::cc::ComputePtrArg>{vecLen});
+        loc, buffPtrTy, castPtr, SmallVector<cudaq::cc::ComputePtrArg>{vecLen});
     builder.create<cudaq::cc::StoreOp>(loc, newEnd, tmp);
     auto i64Ty = builder.getI64Type();
+    auto arrI64Ty = cudaq::cc::ArrayType::get(i64Ty);
     auto ptrI64Ty = cudaq::cc::PointerType::get(i64Ty);
-    auto vecBasePtr = builder.create<cudaq::cc::CastOp>(loc, ptrI64Ty, buffPtr);
+    auto ptrArrTy = cudaq::cc::PointerType::get(arrI64Ty);
+    auto vecBasePtr = builder.create<cudaq::cc::CastOp>(loc, ptrArrTy, buffPtr);
     auto nestedArr = builder.create<cudaq::cc::CastOp>(loc, hostVecTy, nested);
+    auto hostArrVecTy = cudaq::cc::PointerType::get(
+        cudaq::cc::ArrayType::get(hostVecTy.getElementType()));
     cudaq::opt::factory::createInvariantLoop(
         builder, loc, vecLenIndex,
         [&](OpBuilder &builder, Location loc, Region &, Block &block) {
           Value i = block.getArgument(0);
           auto currBuffPtr = builder.create<cudaq::cc::ComputePtrOp>(
-              loc, ptrI64Ty, vecBasePtr,
-              SmallVector<cudaq::cc::ComputePtrArg>{i});
+              loc, ptrI64Ty, vecBasePtr, ArrayRef<cudaq::cc::ComputePtrArg>{i});
+          auto upCast =
+              builder.create<cudaq::cc::CastOp>(loc, hostArrVecTy, nestedArr);
           auto hostSubVec = builder.create<cudaq::cc::ComputePtrOp>(
-              loc, hostVecTy, nestedArr, i);
+              loc, hostVecTy, upCast, ArrayRef<cudaq::cc::ComputePtrArg>{i});
           Value buff = builder.create<cudaq::cc::LoadOp>(loc, tmp);
           // Compute and save the byte size.
           auto vecSz = computeHostVectorLengthInBytes(
@@ -1049,7 +1071,7 @@ public:
         auto size = builder.create<cudaq::cc::LoadOp>(loc, sizeAddr);
         auto vecAddr = builder.create<cudaq::cc::ComputePtrOp>(
             loc, ptrHostTy, hostArg,
-            ArrayRef<cudaq::cc::ComputePtrArg>{0, offset});
+            ArrayRef<cudaq::cc::ComputePtrArg>{offset});
         bufferAddendum = encodeVectorData(loc, builder, size, vecTy, vecAddr,
                                           bufferAddendum, ptrHostTy);
       } else if (auto strTy = dyn_cast<cudaq::cc::StructType>(memTy)) {
@@ -1058,7 +1080,7 @@ public:
           std::int32_t idx = iter.index();
           auto strAddr = builder.create<cudaq::cc::ComputePtrOp>(
               loc, ptrStrTy, bufferArg,
-              ArrayRef<cudaq::cc::ComputePtrArg>{0, idx});
+              ArrayRef<cudaq::cc::ComputePtrArg>{idx});
           bufferAddendum = encodeDynamicStructData(loc, builder, strTy, strAddr,
                                                    bufferArg, bufferAddendum);
         }
@@ -1169,8 +1191,9 @@ public:
           if (cudaq::opt::factory::isX86_64(module)) {
             builder.create<cudaq::cc::StoreOp>(loc, arg, cast);
             if (cudaq::opt::factory::structUsesTwoArguments(quakeTy)) {
+              auto arrTy = cudaq::cc::ArrayType::get(builder.getI8Type());
               auto cast = builder.create<cudaq::cc::CastOp>(
-                  loc, cudaq::cc::PointerType::get(builder.getI8Type()), tmp);
+                  loc, cudaq::cc::PointerType::get(arrTy), tmp);
               auto hiPtr = builder.create<cudaq::cc::ComputePtrOp>(
                   loc, cudaq::cc::PointerType::get(builder.getI8Type()), cast,
                   cudaq::cc::ComputePtrArg{8});
@@ -1269,7 +1292,7 @@ public:
             auto ptrI1Ty = cudaq::cc::PointerType::get(builder.getI1Type());
             auto heapPtr = builder.create<cudaq::cc::ComputePtrOp>(
                 loc, cudaq::cc::PointerType::get(ptrI1Ty), arg,
-                ArrayRef<cudaq::cc::ComputePtrArg>{0, 0});
+                ArrayRef<cudaq::cc::ComputePtrArg>{0});
             auto loadHeapPtr = builder.create<cudaq::cc::LoadOp>(loc, heapPtr);
             Value heapCast = builder.create<cudaq::cc::CastOp>(
                 loc, cudaq::cc::PointerType::get(i8Ty), loadHeapPtr);
@@ -1338,9 +1361,11 @@ public:
         }
         offset++;
       } else {
-        auto gep = builder.create<cudaq::cc::ComputePtrOp>(
-            loc, cudaq::cc::PointerType::get(res.value()), temp,
+        auto gep0 = builder.create<cudaq::cc::ComputePtrOp>(
+            loc, cudaq::cc::PointerType::get(structTy.getMember(off)), temp,
             SmallVector<cudaq::cc::ComputePtrArg>{0, off});
+        auto gep = cudaq::opt::factory::createCast(
+            builder, loc, cudaq::cc::PointerType::get(res.value()), gep0);
         Value loadVal = builder.create<cudaq::cc::LoadOp>(loc, gep);
         if (hiddenSRet) {
           auto sretPtr = [&]() -> Value {
@@ -1348,7 +1373,7 @@ public:
               return builder.create<cudaq::cc::ComputePtrOp>(
                   loc, cudaq::cc::PointerType::get(res.value()),
                   rewriteEntryBlock->getArguments().front(),
-                  SmallVector<cudaq::cc::ComputePtrArg>{0, off});
+                  SmallVector<cudaq::cc::ComputePtrArg>{off});
             return builder.create<cudaq::cc::CastOp>(
                 loc, cudaq::cc::PointerType::get(res.value()),
                 rewriteEntryBlock->getArguments().front());

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -154,7 +154,9 @@ synthesizeVectorArgument(OpBuilder &builder, ModuleOp module, unsigned &counter,
       buffer = builder.create<cudaq::cc::AllocaOp>(argLoc, arrTy);
       builder.create<cudaq::cc::StoreOp>(argLoc, conArray, buffer);
     }
-    Value res = builder.create<cudaq::cc::CastOp>(argLoc, ptrEleTy, buffer);
+    auto ptrArrEleTy =
+        cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(eleTy));
+    Value res = builder.create<cudaq::cc::CastOp>(argLoc, ptrArrEleTy, buffer);
     arrayInMemory = res;
     return res;
   };

--- a/python/cudaq/kernel/captured_data.py
+++ b/python/cudaq/kernel/captured_data.py
@@ -90,9 +90,8 @@ class CapturedDataStorage(object):
                 zero = self.getConstantInt(0)
                 address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),
                                          FlatSymbolRefAttr.get(globalName))
-                ptr = cc.ComputePtrOp(
-                    cc.PointerType.get(self.ctx, statePtrTy), address, [zero],
-                    DenseI32ArrayAttr.get([kDynamicPtrIndex], context=self.ctx))
+                ptr = cc.CastOp(cc.PointerType.get(self.ctx, statePtrTy),
+                                address)
 
                 cc.StoreOp(entry.arguments[0], ptr)
                 func.ReturnOp([])
@@ -108,9 +107,8 @@ class CapturedDataStorage(object):
         zero = self.getConstantInt(0)
         address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),
                                  FlatSymbolRefAttr.get(globalName)).result
-        ptr = cc.ComputePtrOp(
-            cc.PointerType.get(self.ctx, statePtrTy), address, [zero],
-            DenseI32ArrayAttr.get([kDynamicPtrIndex], context=self.ctx)).result
+        ptr = cc.CastOp(cc.PointerType.get(self.ctx, statePtrTy),
+                        address).result
         statePtr = cc.LoadOp(ptr).result
         return statePtr
 
@@ -143,11 +141,8 @@ class CapturedDataStorage(object):
                 zero = self.getConstantInt(0)
                 address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),
                                          FlatSymbolRefAttr.get(globalName))
-                ptr = cc.ComputePtrOp(
-                    cc.PointerType.get(self.ctx, ptrComplex), address,
-                    [zero, zero],
-                    DenseI32ArrayAttr.get([kDynamicPtrIndex, kDynamicPtrIndex],
-                                          context=self.ctx))
+                ptr = cc.CastOp(cc.PointerType.get(self.ctx, ptrComplex),
+                                address)
                 cc.StoreOp(entry.arguments[0], ptr)
                 func.ReturnOp([])
 
@@ -155,10 +150,7 @@ class CapturedDataStorage(object):
 
         address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),
                                  FlatSymbolRefAttr.get(globalName))
-        ptr = cc.ComputePtrOp(
-            cc.PointerType.get(self.ctx, ptrComplex), address, [zero, zero],
-            DenseI32ArrayAttr.get([kDynamicPtrIndex, kDynamicPtrIndex],
-                                  context=self.ctx))
+        ptr = cc.CastOp(cc.PointerType.get(self.ctx, ptrComplex), address)
 
         # Record the unique hash value
         if arrayId not in self.arrayIDs:

--- a/python/cudaq/kernel/quake_value.py
+++ b/python/cudaq/kernel/quake_value.py
@@ -334,8 +334,8 @@ class QuakeValue(object):
         with self.ctx, Location.unknown(), self.pyKernel.insertPoint:
             if cc.StdvecType.isinstance(self.mlirValue.type):
                 eleTy = cc.StdvecType.getElementType(self.mlirValue.type)
-                arrPtrTy = cc.PointerType.get(self.ctx,
-                                              cc.ArrayType.get(self.ctx, eleTy))
+                arrTy = cc.ArrayType.get(self.ctx, eleTy)
+                arrPtrTy = cc.PointerType.get(self.ctx, arrTy)
                 vecPtr = cc.StdvecDataOp(arrPtrTy, self.mlirValue).result
                 elePtrTy = cc.PointerType.get(self.ctx, eleTy)
                 eleAddr = None

--- a/python/tests/mlir/adjoint.py
+++ b/python/tests/mlir/adjoint.py
@@ -198,7 +198,7 @@ def test_kernel_adjoint_list_args():
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-# CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
+# CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return

--- a/python/tests/mlir/ast_elif.py
+++ b/python/tests/mlir/ast_elif.py
@@ -47,8 +47,8 @@ def test_elif():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_11:.*]]: i64):
 # CHECK:             %[[VAL_12:.*]] = cc.undef !cc.struct<{i64, f64}>
-# CHECK:             %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-# CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]]{{\[}}%[[VAL_11]]] : (!cc.ptr<f64>, i64) -> !cc.ptr<f64>
+# CHECK:             %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][%[[VAL_11]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 # CHECK:             %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<f64>
 # CHECK:             %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_11]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, f64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, f64}>>
 # CHECK:             %[[VAL_17:.*]] = cc.insert_value %[[VAL_11]], %[[VAL_12]][0] : (!cc.struct<{i64, f64}>, i64) -> !cc.struct<{i64, f64}>

--- a/python/tests/mlir/ast_for_stdvec.py
+++ b/python/tests/mlir/ast_for_stdvec.py
@@ -43,11 +43,11 @@ def test_elif():
 # CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_9:.*]]: i64):
-# CHECK:             %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-# CHECK:             %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]]{{\[}}%[[VAL_9]]] : (!cc.ptr<f64>, i64) -> !cc.ptr<f64>
+# CHECK:             %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:             %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][%[[VAL_9]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 # CHECK:             %[[VAL_12:.*]] = cc.load %[[VAL_11]] : !cc.ptr<f64>
 # CHECK:             %[[VAL_13:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
-# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_13]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:             %[[VAL_14:.*]] = quake.extract_ref %[[VAL_3]][%[[VAL_13]]] : (!quake.veq<4>, i64) -> !quake.ref
 # CHECK:             quake.ry (%[[VAL_12]]) %[[VAL_14]] : (f64, !quake.ref) -> ()
 # CHECK:             %[[VAL_15:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
 # CHECK:             %[[VAL_16:.*]] = arith.addi %[[VAL_15]], %[[VAL_1]] : i64

--- a/python/tests/mlir/ast_iterate_loop_init.py
+++ b/python/tests/mlir/ast_iterate_loop_init.py
@@ -40,7 +40,7 @@ def test_iterate_list_init():
 # CHECK:           cc.store %[[VAL_0]], %[[VAL_6]] : !cc.ptr<f64>
 # CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<4>
 # CHECK:           %[[VAL_8:.*]] = cc.alloca !cc.array<i64 x 4>
-# CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_8]][0] : (!cc.ptr<!cc.array<i64 x 4>>) -> !cc.ptr<i64>
+# CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i64 x 4>>) -> !cc.ptr<i64>
 # CHECK:           cc.store %[[VAL_4]], %[[VAL_9]] : !cc.ptr<i64>
 # CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_8]][1] : (!cc.ptr<!cc.array<i64 x 4>>) -> !cc.ptr<i64>
 # CHECK:           cc.store %[[VAL_3]], %[[VAL_10]] : !cc.ptr<i64>
@@ -53,8 +53,7 @@ def test_iterate_list_init():
 # CHECK:             cc.condition %[[VAL_15]](%[[VAL_14]] : i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_16:.*]]: i64):
-# CHECK:             %[[VAL_17:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i64 x 4>>) -> !cc.ptr<i64>
-# CHECK:             %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_17]]{{\[}}%[[VAL_16]]] : (!cc.ptr<i64>, i64) -> !cc.ptr<i64>
+# CHECK:             %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_8]][%[[VAL_16]]] : (!cc.ptr<!cc.array<i64 x 4>>, i64) -> !cc.ptr<i64>
 # CHECK:             %[[VAL_19:.*]] = cc.load %[[VAL_18]] : !cc.ptr<i64>
 # CHECK:             %[[VAL_20:.*]] = cc.load %[[VAL_6]] : !cc.ptr<f64>
 # CHECK:             %[[VAL_21:.*]] = arith.sitofp %[[VAL_19]] : i64 to f64

--- a/python/tests/mlir/ast_list_init.py
+++ b/python/tests/mlir/ast_list_init.py
@@ -30,17 +30,17 @@ def test_list_init():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel() attributes {"cudaq-entrypoint"} {
-# CHECK-DAG:           %[[VAL_0:.*]] = arith.constant 1 : i64
-# CHECK-DAG:           %[[VAL_1:.*]] = arith.constant 0 : i64
-# CHECK-DAG:           %[[VAL_2:.*]] = arith.constant 4 : i64
-# CHECK-DAG:           %[[VAL_3:.*]] = arith.constant 4.000000e+00 : f64
-# CHECK-DAG:           %[[VAL_4:.*]] = arith.constant 3.000000e+00 : f64
-# CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 2.000000e+00 : f64
-# CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 1.000000e+00 : f64
-# CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<6>
-# CHECK:           %[[VAL_8:.*]] = cc.alloca !cc.array<f64 x 4>
-# CHECK:           %[[VAL_81:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<!cc.array<f64 x ?>>
-# CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_8]][0] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+# CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 1 : i64
+# CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0 : i64
+# CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 4 : i64
+# CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 4.000000e+00 : f64
+# CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 3.000000e+00 : f64
+# CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 2.000000e+00 : f64
+# CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 1.000000e+00 : f64
+# CHECK-DAG:       %[[VAL_7:.*]] = quake.alloca !quake.veq<6>
+# CHECK-DAG:       %[[VAL_8:.*]] = cc.alloca !cc.array<f64 x 4>
+# CHECK:           %[[VAL_91:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
 # CHECK:           cc.store %[[VAL_6]], %[[VAL_9]] : !cc.ptr<f64>
 # CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_8]][1] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
 # CHECK:           cc.store %[[VAL_5]], %[[VAL_10]] : !cc.ptr<f64>
@@ -48,22 +48,22 @@ def test_list_init():
 # CHECK:           cc.store %[[VAL_4]], %[[VAL_11]] : !cc.ptr<f64>
 # CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_8]][3] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
 # CHECK:           cc.store %[[VAL_3]], %[[VAL_12]] : !cc.ptr<f64>
-# CHECK:           %[[VAL_13:.*]] = cc.stdvec_init %[[VAL_81]], %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.stdvec<f64>
+# CHECK:           %[[VAL_13:.*]] = cc.stdvec_init %[[VAL_91]], %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.stdvec<f64>
 # CHECK:           %[[VAL_14:.*]] = cc.alloca !cc.stdvec<f64>
 # CHECK:           cc.store %[[VAL_13]], %[[VAL_14]] : !cc.ptr<!cc.stdvec<f64>>
 # CHECK:           %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.stdvec<f64>>
 # CHECK:           %[[VAL_16:.*]] = cc.stdvec_size %[[VAL_15]] : (!cc.stdvec<f64>) -> i64
-# CHECK:           %[[VAL_17:.*]] = cc.alloca !cc.struct<{i64, f64}>{{\[}}%[[VAL_16]] : i64]
+# CHECK:           %[[VAL_17:.*]] = cc.alloca !cc.struct<{i64, f64}>[%[[VAL_16]] : i64]
 # CHECK:           %[[VAL_18:.*]] = cc.loop while ((%[[VAL_19:.*]] = %[[VAL_1]]) -> (i64)) {
 # CHECK:             %[[VAL_20:.*]] = arith.cmpi slt, %[[VAL_19]], %[[VAL_16]] : i64
 # CHECK:             cc.condition %[[VAL_20]](%[[VAL_19]] : i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_21:.*]]: i64):
 # CHECK:             %[[VAL_22:.*]] = cc.undef !cc.struct<{i64, f64}>
-# CHECK:             %[[VAL_23:.*]] = cc.stdvec_data %[[VAL_15]] : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-# CHECK:             %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_23]]{{\[}}%[[VAL_21]]] : (!cc.ptr<f64>, i64) -> !cc.ptr<f64>
+# CHECK:             %[[VAL_23:.*]] = cc.stdvec_data %[[VAL_15]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:             %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_23]][%[[VAL_21]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 # CHECK:             %[[VAL_25:.*]] = cc.load %[[VAL_24]] : !cc.ptr<f64>
-# CHECK:             %[[VAL_26:.*]] = cc.compute_ptr %[[VAL_17]]{{\[}}%[[VAL_21]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, f64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, f64}>>
+# CHECK:             %[[VAL_26:.*]] = cc.compute_ptr %[[VAL_17]][%[[VAL_21]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, f64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, f64}>>
 # CHECK:             %[[VAL_27:.*]] = cc.insert_value %[[VAL_21]], %[[VAL_22]][0] : (!cc.struct<{i64, f64}>, i64) -> !cc.struct<{i64, f64}>
 # CHECK:             %[[VAL_28:.*]] = cc.insert_value %[[VAL_25]], %[[VAL_27]][1] : (!cc.struct<{i64, f64}>, f64) -> !cc.struct<{i64, f64}>
 # CHECK:             cc.store %[[VAL_28]], %[[VAL_26]] : !cc.ptr<!cc.struct<{i64, f64}>>

--- a/python/tests/mlir/ast_list_int.py
+++ b/python/tests/mlir/ast_list_int.py
@@ -46,8 +46,8 @@ def test_list_int():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_11:.*]]: i64):
 # CHECK:             %[[VAL_12:.*]] = cc.undef !cc.struct<{i64, i64}>
-# CHECK:             %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<i64>) -> !cc.ptr<i64>
-# CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]]{{\[}}%[[VAL_11]]] : (!cc.ptr<i64>, i64) -> !cc.ptr<i64>
+# CHECK:             %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+# CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][%[[VAL_11]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
 # CHECK:             %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<i64>
 # CHECK:             %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_11]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, i64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, i64}>>
 # CHECK:             %[[VAL_17:.*]] = cc.insert_value %[[VAL_11]], %[[VAL_12]][0] : (!cc.struct<{i64, i64}>, i64) -> !cc.struct<{i64, i64}>

--- a/python/tests/mlir/ast_qreg_slice.py
+++ b/python/tests/mlir/ast_qreg_slice.py
@@ -79,7 +79,7 @@ def test_slice():
 # CHECK:           quake.z %[[VAL_16]] : (!quake.ref) -> ()
 # CHECK:           %[[VAL_17:.*]] = cc.alloca !cc.array<i64 x 5>
 # CHECK:           %[[VAL_172:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<!cc.array<i64 x ?>>
-# CHECK:           %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_17]][0] : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<i64>
+# CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<i64>
 # CHECK:           cc.store %[[VAL_3]], %[[VAL_18]] : !cc.ptr<i64>
 # CHECK:           %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_17]][1] : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<i64>
 # CHECK:           cc.store %[[VAL_2]], %[[VAL_19]] : !cc.ptr<i64>
@@ -93,8 +93,8 @@ def test_slice():
 # CHECK:           %[[VAL_24:.*]] = cc.alloca !cc.stdvec<i64>
 # CHECK:           cc.store %[[VAL_23]], %[[VAL_24]] : !cc.ptr<!cc.stdvec<i64>>
 # CHECK:           %[[VAL_25:.*]] = cc.load %[[VAL_24]] : !cc.ptr<!cc.stdvec<i64>>
-# CHECK:           %[[VAL_26:.*]] = cc.stdvec_data %[[VAL_25]] : (!cc.stdvec<i64>) -> !cc.ptr<i64>
-# CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_26]][2] : (!cc.ptr<i64>) -> !cc.ptr<i64>
+# CHECK:           %[[VAL_26:.*]] = cc.stdvec_data %[[VAL_25]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+# CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_26]][2] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
 # CHECK:           %[[VAL_28:.*]] = cc.stdvec_init %[[VAL_27]], %[[VAL_2]] : (!cc.ptr<i64>, i64) -> !cc.stdvec<i64>
 # CHECK:           %[[VAL_29:.*]] = cc.alloca !cc.stdvec<i64>
 # CHECK:           cc.store %[[VAL_28]], %[[VAL_29]] : !cc.ptr<!cc.stdvec<i64>>
@@ -107,8 +107,8 @@ def test_slice():
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_36:.*]]: i64):
 # CHECK:             %[[VAL_37:.*]] = cc.undef !cc.struct<{i64, i64}>
-# CHECK:             %[[VAL_38:.*]] = cc.stdvec_data %[[VAL_30]] : (!cc.stdvec<i64>) -> !cc.ptr<i64>
-# CHECK:             %[[VAL_39:.*]] = cc.compute_ptr %[[VAL_38]]{{\[}}%[[VAL_36]]] : (!cc.ptr<i64>, i64) -> !cc.ptr<i64>
+# CHECK:             %[[VAL_38:.*]] = cc.stdvec_data %[[VAL_30]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+# CHECK:             %[[VAL_39:.*]] = cc.compute_ptr %[[VAL_38]][%[[VAL_36]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
 # CHECK:             %[[VAL_40:.*]] = cc.load %[[VAL_39]] : !cc.ptr<i64>
 # CHECK:             %[[VAL_41:.*]] = cc.compute_ptr %[[VAL_32]]{{\[}}%[[VAL_36]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, i64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, i64}>>
 # CHECK:             %[[VAL_42:.*]] = cc.insert_value %[[VAL_36]], %[[VAL_37]][0] : (!cc.struct<{i64, i64}>, i64) -> !cc.struct<{i64, i64}>

--- a/python/tests/mlir/call.py
+++ b/python/tests/mlir/call.py
@@ -193,7 +193,7 @@ def test_kernel_apply_call_list_args():
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-# CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
+# CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64,
 # CHECK:           return

--- a/python/tests/mlir/control.py
+++ b/python/tests/mlir/control.py
@@ -216,7 +216,7 @@ def test_kernel_control_list_args(qubit_count):
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-# CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
+# CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return
@@ -233,7 +233,7 @@ def test_kernel_control_list_args(qubit_count):
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) {
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_2:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-# CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
+# CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_4]] : !cc.ptr<f64>
 # CHECK:           quake.rx (%[[VAL_3]]) %[[VAL_1]] : (f64, !quake.ref) -> ()
 # CHECK:           return

--- a/python/tests/mlir/ctrl_gates.py
+++ b/python/tests/mlir/ctrl_gates.py
@@ -93,7 +93,7 @@ def test_kernel_ctrl_rotation():
 # CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           %[[VAL_8:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-# CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_8]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
+# CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 # CHECK:           quake.r1 (%[[VAL_10]]) {{\[}}%[[VAL_6]]] %[[VAL_7]] : (f64, !quake.ref, !quake.ref) -> ()
 # CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_8]][1] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
@@ -253,12 +253,12 @@ def test_kernel_rotation_ctrl_register():
 # CHECK:           quake.ry (%[[VAL_3]]) {{\[}}%[[VAL_8]]] %[[VAL_10]] : (f64, !quake.veq<3>, !quake.ref) -> ()
 # CHECK:           quake.rz (%[[VAL_2]]) {{\[}}%[[VAL_8]]] %[[VAL_11]] : (f64, !quake.veq<3>, !quake.ref) -> ()
 # CHECK:           %[[VAL_19:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-# CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_19]][0] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
+# CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_19]] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_20]] : !cc.ptr<f64>
-# CHECK:           quake.r1 (%[[VAL_21]]) {{\[}}%[[VAL_8]]] %[[VAL_10]] : (f64, !quake.veq<3>, !quake.ref) -> ()
+# CHECK:           quake.r1 (%[[VAL_21]]) [%[[VAL_8]]] %[[VAL_10]] : (f64, !quake.veq<3>, !quake.ref) -> ()
 # CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_19]][1] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_23:.*]] = cc.load %[[VAL_22]] : !cc.ptr<f64>
-# CHECK:           quake.rx (%[[VAL_23]]) {{\[}}%[[VAL_8]]] %[[VAL_11]] : (f64, !quake.veq<3>, !quake.ref) -> ()
+# CHECK:           quake.rx (%[[VAL_23]]) [%[[VAL_8]]] %[[VAL_11]] : (f64, !quake.veq<3>, !quake.ref) -> ()
 # CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_19]][2] : (!cc.ptr<!cc.array<f64 x ?>>) -> !cc.ptr<f64>
 # CHECK:           %[[VAL_25:.*]] = cc.load %[[VAL_24]] : !cc.ptr<f64>
 # CHECK:           quake.ry (%[[VAL_25]]) {{\[}}%[[VAL_8]]] %[[VAL_10]] : (f64, !quake.veq<3>, !quake.ref) -> ()

--- a/targettests/execution/qir_cond_for_loop-4.cpp
+++ b/targettests/execution/qir_cond_for_loop-4.cpp
@@ -9,9 +9,6 @@
 // clang-format off
 // RUN: nvq++ %cpp_std --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ -std=c++17 --enable-mlir %s -o %t
-// XFAIL: *
-// ^^^^^ This probably needs an issue posted. It's not setting qubitMeasurementFeedback.
-//       It passes on H1-1E but not --emulate
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/qir_cond_for_loop-5.cpp
+++ b/targettests/execution/qir_cond_for_loop-5.cpp
@@ -9,9 +9,6 @@
 // clang-format off
 // RUN: nvq++ %cpp_std --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ -std=c++17 --enable-mlir %s -o %t
-// XFAIL: *
-// ^^^^^ This probably needs an issue posted. It's not setting qubitMeasurementFeedback.
-//       It passes on H1-1E but not --emulate
 // clang-format on
 
 #include <cudaq.h>

--- a/test/AST-Quake/array.cpp
+++ b/test/AST-Quake/array.cpp
@@ -57,14 +57,14 @@ struct S {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 8 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.constant 10 : i32
 // CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.array<i32 x 3>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][0] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_3]][2] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.alloca !cc.struct<"T" {} [8,1]>
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_3]][0] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_9:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:           call @__nvqpp__mlirgen__T(%[[VAL_9]]) : (i32) -> ()
 // CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.struct<"T" {} [8,1]>
@@ -92,14 +92,14 @@ struct S1 {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 8 : i32
 // CHECK:           %[[VAL_2:.*]] = arith.constant 10 : i32
 // CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.array<i32 x 3>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][0] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_3]][2] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.alloca !cc.struct<"T" {} [8,1]>
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_3]][0] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_9:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i32>
 // CHECK:           call @__nvqpp__mlirgen__T(%[[VAL_9]]) : (i32) -> ()
 // CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.struct<"T" {} [8,1]>

--- a/test/AST-Quake/auto_kernel-1.cpp
+++ b/test/AST-Quake/auto_kernel-1.cpp
@@ -28,7 +28,7 @@ struct ak1 {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           %[[VAL_7:.*]] = quake.discriminate %[[VAL_3]] : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_7]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_7]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i1 x ?>>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i1>
 // CHECK:           return %[[VAL_6]] : i1

--- a/test/AST-Quake/initialization_list.cpp
+++ b/test/AST-Quake/initialization_list.cpp
@@ -33,7 +33,7 @@ __qpu__ void g() {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 5.000000e+00 : f64
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<1>
 // CHECK:           %[[VAL_5:.*]] = cc.alloca !cc.array<f64 x 4>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_7]] : !cc.ptr<f64>

--- a/test/AST-Quake/loop_unroll-1.cpp
+++ b/test/AST-Quake/loop_unroll-1.cpp
@@ -23,16 +23,18 @@ struct C {
 // CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
 // CHECK-DAG:       %[[VAL_10:.*]] = quake.alloca !quake.ref
 // CHECK-DAG:       %[[VAL_11:.*]] = quake.mz %[[VAL_10]] name "singleQubit" : (!quake.ref) -> !quake.measure
-// CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.array<i1 x 2>
+// CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.array<i8 x 2>
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           %[[VAL_6:.*]] = quake.mz %[[VAL_5]] name "myRegister%0" : (!quake.ref) -> !quake.measure
-// CHECK:           %[[VAL_10:.*]] = quake.discriminate %[[VAL_6]] :
-// CHECK:           cc.store %[[VAL_10]], %{{.*}} : !cc.ptr<i1>
+// CHECK:           %[[VAL_10:.*]] = quake.discriminate %[[VAL_6]] : {{.*}} -> i1
+// CHECK:           %[[VAL_14:.*]] = cc.cast unsigned %[[VAL_10]]
+// CHECK:           cc.store %[[VAL_14]], %{{.*}} : !cc.ptr<i8>
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           %[[VAL_8:.*]] = quake.mz %[[VAL_7]] name "myRegister%1" : (!quake.ref) -> !quake.measure
 // CHECK:           %[[VAL_11:.*]] = quake.discriminate %[[VAL_8]] :
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<i1 x 2>>) -> !cc.ptr<i1>
-// CHECK:           cc.store %[[VAL_11]], %[[VAL_9]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<i8 x 2>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_13:.*]] = cc.cast unsigned %[[VAL_11]]
+// CHECK:           cc.store %[[VAL_13]], %[[VAL_9]] : !cc.ptr<i8>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/measure_bell.cpp
+++ b/test/AST-Quake/measure_bell.cpp
@@ -55,13 +55,13 @@ struct bell {
 // CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:               %[[VAL_12:.*]] = quake.discriminate %[[VAL_112]] :
-// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
-// CHECK:               %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
+// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+// CHECK:               %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<i1 x ?>>) -> !cc.ptr<i1>
 // CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<i1>
 // CHECK:               %[[VAL_16:.*]] = cc.alloca i1
 // CHECK:               cc.store %[[VAL_15]], %[[VAL_16]] : !cc.ptr<i1>
 // CHECK:               %[[VAL_17:.*]] = cc.load %[[VAL_16]] : !cc.ptr<i1>
-// CHECK:               %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<i1>) -> !cc.ptr<i1>
+// CHECK:               %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<!cc.array<i1 x ?>>) -> !cc.ptr<i1>
 // CHECK:               %[[VAL_19:.*]] = cc.load %[[VAL_18]] : !cc.ptr<i1>
 // CHECK:               %[[VAL_20:.*]] = arith.cmpi eq, %[[VAL_17]], %[[VAL_19]] : i1
 // CHECK:               cc.if(%[[VAL_20]]) {
@@ -120,9 +120,9 @@ struct libertybell {
 // CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:               %[[VAL_12:.*]] = quake.discriminate %[[VAL_112]] :
-// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
-// CHECK:               %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
-// CHECK-DAG:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<i1>) -> !cc.ptr<i1>
+// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+// CHECK:               %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<i1 x ?>>) -> !cc.ptr<i1>
+// CHECK-DAG:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<!cc.array<i1 x ?>>) -> !cc.ptr<i1>
 // CHECK-DAG:           %[[VAL_16:.*]] = cc.load %[[VAL_15]] : !cc.ptr<i1>
 // CHECK-DAG:           %[[VAL_17:.*]] = cc.load %[[VAL_14]] : !cc.ptr<i1>
 // CHECK:               %[[VAL_18:.*]] = arith.cmpi eq, %[[VAL_17]], %[[VAL_16]] : i1
@@ -184,9 +184,9 @@ struct tinkerbell {
 // CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:               %[[VAL_12:.*]] = quake.discriminate %[[VAL_112]] :
-// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
-// CHECK:               %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
-// CHECK-DAG:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<i1>) -> !cc.ptr<i1>
+// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+// CHECK:               %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<i1 x ?>>) -> !cc.ptr<i1>
+// CHECK-DAG:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<!cc.array<i1 x ?>>) -> !cc.ptr<i1>
 // CHECK-DAG:           %[[VAL_16:.*]] = cc.load %[[VAL_15]] : !cc.ptr<i1>
 // CHECK-DAG:           %[[VAL_17:.*]] = cc.load %[[VAL_14]] : !cc.ptr<i1>
 // CHECK:               %[[VAL_18:.*]] = arith.cmpi eq, %[[VAL_17]], %[[VAL_16]] : i1

--- a/test/AST-Quake/qalloc_initialization.cpp
+++ b/test/AST-Quake/qalloc_initialization.cpp
@@ -53,7 +53,7 @@ struct Cherry {
 // CHECK:           %[[VAL_9:.*]] = complex.create %[[VAL_6]], %[[VAL_5]] : complex<f64>
 // CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.array<complex<f64> x 4>
 // CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_10]]
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][0] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_7]], %[[VAL_11]] : !cc.ptr<complex<f64>>
 // CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_10]][1] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_12]] : !cc.ptr<complex<f64>>
@@ -86,7 +86,7 @@ struct MooseTracks {
 // CHECK:           %[[VAL_9:.*]] = complex.create %[[VAL_6]], %[[VAL_5]] : complex<f64>
 // CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.array<complex<f64> x 4>
 // CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_10]]
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][0] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_7]], %[[VAL_11]] : !cc.ptr<complex<f64>>
 // CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_10]][1] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_12]] : !cc.ptr<complex<f64>>
@@ -130,7 +130,7 @@ struct RockyRoad {
 // CHECK:           %[[VAL_17:.*]] = call @_ZStplIdESt7complexIT_ERKS1_RKS2_(%[[VAL_14]], %[[VAL_16]]) : (!cc.ptr<f64>, !cc.ptr<complex<f64>>) -> complex<f64>
 // CHECK:           %[[VAL_18:.*]] = cc.alloca !cc.array<complex<f64> x 4>
 // CHECK:           %[[VAL_24:.*]] = cc.cast %[[VAL_18]]
-// CHECK:           %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_18]][0] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
+// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_18]] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_12]], %[[VAL_19]] : !cc.ptr<complex<f64>>
 // CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_18]][1] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_13]], %[[VAL_20]] : !cc.ptr<complex<f64>>
@@ -229,7 +229,7 @@ __qpu__ auto Strawberry() {
 // CHECK:           %[[VAL_3:.*]] = complex.create %[[VAL_0]], %[[VAL_1]] : complex<f64>
 // CHECK:           %[[VAL_4:.*]] = cc.alloca !cc.array<complex<f64> x 2>
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_4]]
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<!cc.array<complex<f64> x 2>>) -> !cc.ptr<complex<f64>>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<complex<f64> x 2>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_5]] : !cc.ptr<complex<f64>>
 // CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<complex<f64> x 2>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_6]] : !cc.ptr<complex<f64>>
@@ -263,7 +263,7 @@ __qpu__ bool Peppermint() {
 // CHECK:           %[[VAL_3:.*]] = complex.create %[[VAL_0]], %[[VAL_1]] : complex<f64>
 // CHECK:           %[[VAL_4:.*]] = cc.alloca !cc.array<complex<f64> x 2>
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_4]] :
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<!cc.array<complex<f64> x 2>>) -> !cc.ptr<complex<f64>>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<complex<f64> x 2>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_5]] : !cc.ptr<complex<f64>>
 // CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<complex<f64> x 2>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_6]] : !cc.ptr<complex<f64>>

--- a/test/AST-Quake/reverse.cpp
+++ b/test/AST-Quake/reverse.cpp
@@ -27,8 +27,8 @@ __qpu__ int std_reverse_std_vector_int() {
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 8 : i64
 // CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca !cc.array<i32 x 10>
-// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x 10>>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_6]][10] : (!cc.ptr<i32>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] :
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_5]][10] : (!cc.ptr<!cc.array<i32 x 10>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i32>) -> i64
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<i32>) -> i64
 // CHECK:           %[[VAL_10:.*]] = arith.subi %[[VAL_8]], %[[VAL_9]] : i64
@@ -89,8 +89,8 @@ __qpu__ double std_reverse_std_vector_double() {
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 16 : i64
 // CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca !cc.array<f64 x 7>
-// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<f64 x 7>>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_6]][7] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] :
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_5]][7] : (!cc.ptr<!cc.array<f64 x 7>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<f64>) -> i64
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<f64>) -> i64
 // CHECK:           %[[VAL_10:.*]] = arith.subi %[[VAL_8]], %[[VAL_9]] : i64

--- a/test/AST-Quake/struct-1.cpp
+++ b/test/AST-Quake/struct-1.cpp
@@ -41,11 +41,11 @@ struct S0 {
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>) -> !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
 // CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>
-// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_1]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_1]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_1]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_1]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_8:.*]] = call @_Z16help_me_help_youv() : () -> !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
@@ -68,21 +68,21 @@ struct S1 {
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant true
 // CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_6]], %[[VAL_8]], %[[VAL_10]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_11:.*]] = cc.alloca !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][0, 0] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_12]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_11]][0, 1] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_13]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_11]][0, 2] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_11]][2] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_14]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_11]][0, 3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_11]][3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_15]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>
 // CHECK:           return %[[VAL_16]] : !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
@@ -104,21 +104,21 @@ struct S2 {
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant true
 // CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_6]], %[[VAL_8]], %[[VAL_10]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_11:.*]] = cc.alloca !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][0, 0] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_12]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_11]][0, 1] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_13]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_11]][0, 2] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_11]][2] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_14]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_11]][0, 3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_11]][3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_15]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>
 // CHECK:           return %[[VAL_16]] : !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
@@ -140,21 +140,21 @@ struct S3 {
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant false
 // CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_6]], %[[VAL_8]], %[[VAL_10]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_11:.*]] = cc.alloca !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][0, 0] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_12]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_11]][0, 1] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_13]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_11]][0, 2] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_11]][2] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_14]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_11]][0, 3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_11]][3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_15]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>
 // CHECK:           return %[[VAL_16]] : !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
@@ -176,17 +176,17 @@ struct S4 {
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 47 : i32
 // CHECK-DAG:       %[[VAL_2:.*]] = cc.alloca !cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_2]] : !cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>
-// CHECK:           %[[VAL_3:.*]] = cc.compute_ptr %[[VAL_2]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_2]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_2]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_2]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_4]], %[[VAL_6]], %[[VAL_8]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_9:.*]] = call @_Z16help_me_help_youv() : () -> !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
 // CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
 // CHECK:           cc.store %[[VAL_9]], %[[VAL_10]] : !cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][0, 3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_11]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>
 // CHECK:           return %[[VAL_12]] : !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
@@ -213,34 +213,34 @@ struct S5 {
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_4]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_6]], %[[VAL_8]], %[[VAL_10]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_11:.*]] = cc.alloca !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
 // CHECK:           call @_ZN11ResultThingC1Ev(%[[VAL_11]]) : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> ()
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][0, 0] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
-// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_4]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_14:.*]] = cc.load %[[VAL_13]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_15:.*]] = arith.cmpi sgt, %[[VAL_14]], %[[VAL_3]] : i32
 // CHECK:           cc.store %[[VAL_15]], %[[VAL_12]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_11]][0, 1] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
-// CHECK:           %[[VAL_17:.*]] = cc.compute_ptr %[[VAL_4]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_17:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_18:.*]] = cc.load %[[VAL_17]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_19:.*]] = arith.cmpi sgt, %[[VAL_18]], %[[VAL_2]] : i32
 // CHECK:           cc.store %[[VAL_19]], %[[VAL_16]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_11]][0, 2] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
-// CHECK:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_4]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_11]][2] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_4]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_22:.*]] = cc.load %[[VAL_21]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_23:.*]] = arith.cmpf one, %[[VAL_22]], %[[VAL_1]] : f64
 // CHECK:           cc.store %[[VAL_23]], %[[VAL_20]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_11]][0, 3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_4]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_11]][3] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_4]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_28:.*]] = cc.load %[[VAL_27]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_29:.*]] = arith.subi %[[VAL_26]], %[[VAL_28]] : i32
 // CHECK:           cc.store %[[VAL_29]], %[[VAL_24]] : !cc.ptr<i32>
@@ -275,35 +275,35 @@ struct S6 {
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 2 : i32
 // CHECK-DAG:       %[[VAL_3:.*]] = cc.alloca !cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_3]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_3]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_3]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_9:.*]] = cc.load %[[VAL_8]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_5]], %[[VAL_7]], %[[VAL_9]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.struct<{i1, i32, i16, i32} [128,4]>
 // CHECK:           call @_ZN2S61TC1Ev(%[[VAL_10]]) : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> ()
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][0, 0] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i1>
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_3]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_13:.*]] = cc.load %[[VAL_12]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_14:.*]] = arith.cmpi sgt, %[[VAL_13]], %[[VAL_2]] : i32
 // CHECK:           cc.store %[[VAL_14]], %[[VAL_11]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_10]][0, 2] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i16>
-// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_3]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_10]][2] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i16>
+// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_17:.*]] = cc.load %[[VAL_16]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_18:.*]] = arith.cmpi sgt, %[[VAL_17]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_19:.*]] = arith.extui %[[VAL_18]] : i1 to i16
 // CHECK:           cc.store %[[VAL_19]], %[[VAL_15]] : !cc.ptr<i16>
-// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_10]][0, 3] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_3]][0, 2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_10]][3] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_3]][2] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_22:.*]] = cc.load %[[VAL_21]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_23:.*]] = arith.fptosi %[[VAL_22]] : f64 to i32
 // CHECK:           cc.store %[[VAL_23]], %[[VAL_20]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_10]][0, 1] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_3]][0, 0] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_10]][1] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_3]][0, 1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_28:.*]] = cc.load %[[VAL_27]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_29:.*]] = arith.subi %[[VAL_26]], %[[VAL_28]] : i32
 // CHECK:           cc.store %[[VAL_29]], %[[VAL_24]] : !cc.ptr<i32>

--- a/test/AST-Quake/struct-2.cpp
+++ b/test/AST-Quake/struct-2.cpp
@@ -27,14 +27,13 @@ struct Qernel0 {
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<"ProductOfVector" {!cc.stdvec<i32>, !cc.stdvec<f64>} [384,8]>)
 // CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<"ProductOfVector" {!cc.stdvec<i32>, !cc.stdvec<f64>} [384,8]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<"ProductOfVector" {!cc.stdvec<i32>, !cc.stdvec<f64>} [384,8]>>
-// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][0, 0] : (!cc.ptr<!cc.struct<"ProductOfVector" {!cc.stdvec<i32>, !cc.stdvec<f64>} [384,8]>>) -> !cc.ptr<!cc.stdvec<i32>>
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.struct<"ProductOfVector" {!cc.stdvec<i32>, !cc.stdvec<f64>} [384,8]>>) -> !cc.ptr<!cc.stdvec<i32>>
 // CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.stdvec<i32>>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i32>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<i32>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i32 x ?>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.alloca i32
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_7]][0] : (!cc.ptr<i32>) -> !cc.ptr<i32>
-// CHECK:           cc.store %[[VAL_6]], %[[VAL_8]] : !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_6]], %[[VAL_7]] : !cc.ptr<i32>
 // CHECK:           return
 // CHECK:         }
 
@@ -65,12 +64,10 @@ struct Qernel1 {
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<"ProductOfPis" {!cc.struct<"Pi0" {i32, f32} [64,4]>, !cc.struct<"Pi1" {i8, f64} [128,8]>} [192,8]>)
 // CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<"ProductOfPis" {!cc.struct<"Pi0" {i32, f32} [64,4]>, !cc.struct<"Pi1" {i8, f64} [128,8]>} [192,8]>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<"ProductOfPis" {!cc.struct<"Pi0" {i32, f32} [64,4]>, !cc.struct<"Pi1" {i8, f64} [128,8]>} [192,8]>>
-// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][0, 1] : (!cc.ptr<!cc.struct<"ProductOfPis" {!cc.struct<"Pi0" {i32, f32} [64,4]>, !cc.struct<"Pi1" {i8, f64} [128,8]>} [192,8]>>) -> !cc.ptr<!cc.struct<"Pi1" {i8, f64} [128,8]>>
-// CHECK:           %[[VAL_3:.*]] = cc.compute_ptr %[[VAL_2]][0, 0] : (!cc.ptr<!cc.struct<"Pi1" {i8, f64} [128,8]>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i8>
+// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][1, 0] : (!cc.ptr<!cc.struct<"ProductOfPis" {!cc.struct<"Pi0" {i32, f32} [64,4]>, !cc.struct<"Pi1" {i8, f64} [128,8]>} [192,8]>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i8>
 // CHECK:           %[[VAL_5:.*]] = cc.alloca i8
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<i8>) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_4]], %[[VAL_6]] : !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<i8>
 // CHECK:           return
 // CHECK:         }
 
@@ -91,13 +88,11 @@ struct Qernel2 {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Qernel2(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<!cc.struct<"Product" {i16, f32} [64,4]>>)
-// CHECK:           %[[VAL_1:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.struct<"Product" {i16, f32} [64,4]>>) -> !cc.ptr<!cc.struct<"Product" {i16, f32} [64,4]>>
-// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][0] : (!cc.ptr<!cc.struct<"Product" {i16, f32} [64,4]>>) -> !cc.ptr<!cc.struct<"Product" {i16, f32} [64,4]>>
-// CHECK:           %[[VAL_3:.*]] = cc.compute_ptr %[[VAL_2]][0, 0] : (!cc.ptr<!cc.struct<"Product" {i16, f32} [64,4]>>) -> !cc.ptr<i16>
-// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i16>
+// CHECK:           %[[VAL_1:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.struct<"Product" {i16, f32} [64,4]>>) -> !cc.ptr<!cc.array<!cc.struct<"Product" {i16, f32} [64,4]> x ?>>
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.struct<"Product" {i16, f32} [64,4]> x ?>>) -> !cc.ptr<i16>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i16>
 // CHECK:           %[[VAL_5:.*]] = cc.alloca i16
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<i16>) -> !cc.ptr<i16>
-// CHECK:           cc.store %[[VAL_4]], %[[VAL_6]] : !cc.ptr<i16>
+// CHECK:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<i16>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/tuple-0.cpp
+++ b/test/AST-Quake/tuple-0.cpp
@@ -61,7 +61,7 @@ struct ArithmeticTupleQernelWithUse {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<{i32, f64, i16, i64}>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<!cc.struct<{i32, f64, i16, i64}>>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][0, 0] : (!cc.ptr<!cc.struct<{i32, f64, i16, i64}>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.struct<{i32, f64, i16, i64}>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_6]] : i64]
@@ -99,7 +99,7 @@ struct ArithmeticTupleQernelWithUse0 {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<{i32, f64, i16, i64}>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<!cc.struct<{i32, f64, i16, i64}>>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][0, 0] : (!cc.ptr<!cc.struct<{i32, f64, i16, i64}>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.struct<{i32, f64, i16, i64}>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_6]] : i64]
@@ -134,7 +134,7 @@ struct ArithmeticPairQernelWithUse {
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<{f32, i32}>)
 // CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<{f32, i32}>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<{f32, i32}>>
-// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][0, 1] : (!cc.ptr<!cc.struct<{f32, i32}>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][1] : (!cc.ptr<!cc.struct<{f32, i32}>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_4:.*]] = arith.extsi %[[VAL_3]] : i32 to i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_4]] : i64]

--- a/test/AST-Quake/vector_bool.cpp
+++ b/test/AST-Quake/vector_bool.cpp
@@ -25,8 +25,8 @@ struct t1 {
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_1]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 // CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_12]] :
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<i1>) -> !cc.ptr<i1>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][0] : (!cc.ptr<i1>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i1 x ?>>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i1>
 // CHECK:           return %[[VAL_5]] : i1
 // CHECK:         }

--- a/test/AST-Quake/vector_ctor_initlist.cpp
+++ b/test/AST-Quake/vector_ctor_initlist.cpp
@@ -26,22 +26,19 @@ __qpu__ void testDouble() {
 // CHECK-DAG:           %[[VAL_2:.*]] = arith.constant 1.5707963267948966 : f64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_4:.*]] = cc.alloca !cc.array<f64 x 3>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_5]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_6]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_4]][2] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_7]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_8]][0] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 // CHECK:           quake.ry (%[[VAL_10]]) %[[VAL_3]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_13:.*]] = cc.load %[[VAL_12]] : !cc.ptr<f64>
 // CHECK:           quake.ry (%[[VAL_13]]) %[[VAL_3]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_14]][2] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_4]][2] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_15]] : !cc.ptr<f64>
 // CHECK:           quake.ry (%[[VAL_16]]) %[[VAL_3]] : (f64, !quake.ref) -> ()
 // CHECK:           return

--- a/test/AST-Quake/vector_ctor_initlist_int.cpp
+++ b/test/AST-Quake/vector_ctor_initlist_int.cpp
@@ -28,26 +28,23 @@ __qpu__ void testInt() {
 // CHECK-DAG:           %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<3>
 // CHECK:           %[[VAL_5:.*]] = cc.alloca !cc.array<i32 x 3>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_6]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_7]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_5]][2] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_8]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_9]][0] : (!cc.ptr<i32>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_12:.*]] = arith.extsi %[[VAL_11]] : i32 to i64
 // CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_12]]] : (!quake.veq<3>, i64) -> !quake.ref
 // CHECK:           quake.ry (%[[VAL_0]]) %[[VAL_13]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_14]][1] : (!cc.ptr<i32>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_15]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_17:.*]] = arith.extsi %[[VAL_16]] : i32 to i64
 // CHECK:           %[[VAL_18:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_17]]] : (!quake.veq<3>, i64) -> !quake.ref
 // CHECK:           quake.ry (%[[VAL_0]]) %[[VAL_18]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_19]][2] : (!cc.ptr<i32>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_5]][2] : (!cc.ptr<!cc.array<i32 x 3>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_20]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_22:.*]] = arith.extsi %[[VAL_21]] : i32 to i64
 // CHECK:           %[[VAL_23:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_22]]] : (!quake.veq<3>, i64) -> !quake.ref

--- a/test/AST-Quake/vector_ctor_sized.cpp
+++ b/test/AST-Quake/vector_ctor_sized.cpp
@@ -28,18 +28,14 @@ __qpu__ void test() {
 // CHECK-DAG:           %[[VAL_1:.*]] = arith.constant 1.5707963267948966 : f64
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.array<f64 x 2>
-// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_5]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_6]][1] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_7]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_8]][0] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 // CHECK:           quake.ry (%[[VAL_10]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<f64>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_13:.*]] = cc.load %[[VAL_12]] : !cc.ptr<f64>
 // CHECK:           quake.ry (%[[VAL_13]]) %[[VAL_2]] : (f64, !quake.ref) -> ()
 // CHECK:           return

--- a/test/AST-Quake/vector_front_back.cpp
+++ b/test/AST-Quake/vector_front_back.cpp
@@ -24,7 +24,7 @@ __qpu__ void testFrontFloat() {
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.array<f32 x 4>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_5]] : !cc.ptr<f32>
 // CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_6]] : !cc.ptr<f32>
@@ -50,7 +50,7 @@ __qpu__ void testFrontBool() {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant true
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant false
 // CHECK-DAG:       %[[VAL_2:.*]] = cc.alloca !cc.array<i1 x 4>
-// CHECK:           %[[VAL_3:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_3]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<i1>
@@ -77,7 +77,7 @@ __qpu__ void testBackFloat() {
 // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       %[[VAL_6:.*]] = cc.alloca !cc.array<f32 x 4>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_6]][0] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
+// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_7]] : !cc.ptr<f32>
 // CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_6]][1] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_8]] : !cc.ptr<f32>
@@ -85,8 +85,7 @@ __qpu__ void testBackFloat() {
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_9]] : !cc.ptr<f32>
 // CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_6]][3] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_10]] : !cc.ptr<f32>
-// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
-// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_12]][3] : (!cc.ptr<f32>) -> !cc.ptr<f32>
+// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_6]][3] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
 // CHECK:           %[[VAL_16:.*]] = cc.load %[[VAL_15]] : !cc.ptr<f32>
 // CHECK:           %[[VAL_17:.*]] = cc.alloca f32
 // CHECK:           cc.store %[[VAL_16]], %[[VAL_17]] : !cc.ptr<f32>
@@ -103,7 +102,7 @@ __qpu__ void testBackBool() {
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant true
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant false
 // CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.array<i1 x 4>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]][0] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_5]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_6]] : !cc.ptr<i1>
@@ -111,8 +110,7 @@ __qpu__ void testBackBool() {
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_7]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_4]][3] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_8]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
-// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_10]][3] : (!cc.ptr<i1>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_4]][3] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_14:.*]] = cc.load %[[VAL_13]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_15:.*]] = cc.alloca i1
 // CHECK:           cc.store %[[VAL_14]], %[[VAL_15]] : !cc.ptr<i1>

--- a/test/AST-Quake/vector_vector.cpp
+++ b/test/AST-Quake/vector_vector.cpp
@@ -45,8 +45,8 @@ struct VectorVectorReader {
 // CHECK:             } do {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_9:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]]{{\[}}%[[VAL_9]]] : (!cc.ptr<!cc.stdvec<f64>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
+// CHECK:                 %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
+// CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][%[[VAL_9]]] : (!cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_12:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_1]], %[[VAL_12]] : !cc.ptr<i64>
@@ -62,8 +62,8 @@ struct VectorVectorReader {
 // CHECK:                   } do {
 // CHECK:                     %[[VAL_19:.*]] = cc.load %[[VAL_12]] : !cc.ptr<i64>
 // CHECK:                     %[[VAL_20:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                     %[[VAL_21:.*]] = cc.stdvec_data %[[VAL_20]] : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-// CHECK:                     %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]]{{\[}}%[[VAL_19]]] : (!cc.ptr<f64>, i64) -> !cc.ptr<f64>
+// CHECK:                     %[[VAL_21:.*]] = cc.stdvec_data %[[VAL_20]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:                     %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][%[[VAL_19]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:                     %[[VAL_23:.*]] = cc.load %[[VAL_22]] : !cc.ptr<f64>
 // CHECK:                     func.call @_Z12do_somethingd(%[[VAL_23]]) : (f64) -> ()
 // CHECK:                     cc.continue
@@ -117,8 +117,8 @@ struct TripleVectorReader {
 // CHECK:             } do {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_9:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<!cc.stdvec<f64>>>) -> !cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>
-// CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]]{{\[}}%[[VAL_9]]] : (!cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>, i64) -> !cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>
+// CHECK:                 %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<!cc.stdvec<f64>>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.stdvec<f64>> x ?>>
+// CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][%[[VAL_9]]] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.stdvec<f64>> x ?>>, i64) -> !cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_12:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_1]], %[[VAL_12]] : !cc.ptr<i64>
@@ -135,8 +135,8 @@ struct TripleVectorReader {
 // CHECK:                     cc.scope {
 // CHECK:                       %[[VAL_19:.*]] = cc.load %[[VAL_12]] : !cc.ptr<i64>
 // CHECK:                       %[[VAL_20:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>
-// CHECK:                       %[[VAL_21:.*]] = cc.stdvec_data %[[VAL_20]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                       %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]]{{\[}}%[[VAL_19]]] : (!cc.ptr<!cc.stdvec<f64>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
+// CHECK:                       %[[VAL_21:.*]] = cc.stdvec_data %[[VAL_20]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
+// CHECK:                       %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][%[[VAL_19]]] : (!cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
 // CHECK:                       cc.scope {
 // CHECK:                         %[[VAL_23:.*]] = cc.alloca i64
 // CHECK:                         cc.store %[[VAL_1]], %[[VAL_23]] : !cc.ptr<i64>
@@ -152,8 +152,8 @@ struct TripleVectorReader {
 // CHECK:                         } do {
 // CHECK:                           %[[VAL_30:.*]] = cc.load %[[VAL_23]] : !cc.ptr<i64>
 // CHECK:                           %[[VAL_31:.*]] = cc.load %[[VAL_22]] : !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                           %[[VAL_32:.*]] = cc.stdvec_data %[[VAL_31]] : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-// CHECK:                           %[[VAL_33:.*]] = cc.compute_ptr %[[VAL_32]]{{\[}}%[[VAL_30]]] : (!cc.ptr<f64>, i64) -> !cc.ptr<f64>
+// CHECK:                           %[[VAL_32:.*]] = cc.stdvec_data %[[VAL_31]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:                           %[[VAL_33:.*]] = cc.compute_ptr %[[VAL_32]][%[[VAL_30]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:                           %[[VAL_34:.*]] = cc.load %[[VAL_33]] : !cc.ptr<f64>
 // CHECK:                           func.call @_Z12do_somethingd(%[[VAL_34]]) : (f64) -> ()
 // CHECK:                           cc.continue
@@ -213,8 +213,8 @@ struct VectorVectorWriter {
 // CHECK:             } do {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_10:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_11:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.stdvec<i32>>
-// CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]]{{\[}}%[[VAL_10]]] : (!cc.ptr<!cc.stdvec<i32>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
+// CHECK:                 %[[VAL_11:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>
+// CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][%[[VAL_10]]] : (!cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_13:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_1]], %[[VAL_13]] : !cc.ptr<i64>
@@ -230,8 +230,8 @@ struct VectorVectorWriter {
 // CHECK:                   } do {
 // CHECK:                     %[[VAL_20:.*]] = cc.load %[[VAL_13]] : !cc.ptr<i64>
 // CHECK:                     %[[VAL_21:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.stdvec<i32>>
-// CHECK:                     %[[VAL_22:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i32>) -> !cc.ptr<i32>
-// CHECK:                     %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_22]]{{\[}}%[[VAL_20]]] : (!cc.ptr<i32>, i64) -> !cc.ptr<i32>
+// CHECK:                     %[[VAL_22:.*]] = cc.stdvec_data %[[VAL_21]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:                     %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_22]][%[[VAL_20]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
 // CHECK:                     cc.store %[[VAL_3]], %[[VAL_23]] : !cc.ptr<i32>
 // CHECK:                     cc.continue
 // CHECK:                   } step {
@@ -283,11 +283,11 @@ struct VectorVectorBilingual {
 // CHECK:             } do {
 // CHECK:               cc.scope {
 // CHECK:                 %[[VAL_10:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_11:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.stdvec<i32>>
-// CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]]{{\[}}%[[VAL_10]]] : (!cc.ptr<!cc.stdvec<i32>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
+// CHECK:                 %[[VAL_11:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>
+// CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][%[[VAL_10]]] : (!cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
 // CHECK:                 %[[VAL_13:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
-// CHECK:                 %[[VAL_14:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                 %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_14]]{{\[}}%[[VAL_13]]] : (!cc.ptr<!cc.stdvec<f64>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
+// CHECK:                 %[[VAL_14:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
+// CHECK:                 %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_14]][%[[VAL_13]]] : (!cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_16:.*]] = cc.alloca i64
 // CHECK:                   cc.store %[[VAL_2]], %[[VAL_16]] : !cc.ptr<i64>
@@ -303,12 +303,12 @@ struct VectorVectorBilingual {
 // CHECK:                   } do {
 // CHECK:                     %[[VAL_23:.*]] = cc.load %[[VAL_16]] : !cc.ptr<i64>
 // CHECK:                     %[[VAL_24:.*]] = cc.load %[[VAL_15]] : !cc.ptr<!cc.stdvec<f64>>
-// CHECK:                     %[[VAL_25:.*]] = cc.stdvec_data %[[VAL_24]] : (!cc.stdvec<f64>) -> !cc.ptr<f64>
-// CHECK:                     %[[VAL_26:.*]] = cc.compute_ptr %[[VAL_25]]{{\[}}%[[VAL_23]]] : (!cc.ptr<f64>, i64) -> !cc.ptr<f64>
+// CHECK:                     %[[VAL_25:.*]] = cc.stdvec_data %[[VAL_24]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+// CHECK:                     %[[VAL_26:.*]] = cc.compute_ptr %[[VAL_25]][%[[VAL_23]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
 // CHECK:                     %[[VAL_27:.*]] = cc.load %[[VAL_16]] : !cc.ptr<i64>
 // CHECK:                     %[[VAL_28:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.stdvec<i32>>
-// CHECK:                     %[[VAL_29:.*]] = cc.stdvec_data %[[VAL_28]] : (!cc.stdvec<i32>) -> !cc.ptr<i32>
-// CHECK:                     %[[VAL_30:.*]] = cc.compute_ptr %[[VAL_29]]{{\[}}%[[VAL_27]]] : (!cc.ptr<i32>, i64) -> !cc.ptr<i32>
+// CHECK:                     %[[VAL_29:.*]] = cc.stdvec_data %[[VAL_28]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:                     %[[VAL_30:.*]] = cc.compute_ptr %[[VAL_29]][%[[VAL_27]]] : (!cc.ptr<!cc.array<i32 x ?>>, i64) -> !cc.ptr<i32>
 // CHECK:                     %[[VAL_31:.*]] = cc.load %[[VAL_30]] : !cc.ptr<i32>
 // CHECK:                     %[[VAL_32:.*]] = arith.sitofp %[[VAL_31]] : i32 to f64
 // CHECK:                     cc.store %[[VAL_32]], %[[VAL_26]] : !cc.ptr<f64>

--- a/test/AST-Quake/veq_size_init_state.cpp
+++ b/test/AST-Quake/veq_size_init_state.cpp
@@ -27,7 +27,7 @@ struct kernel {
 // CHECK:           %[[VAL_4:.*]] = complex.create %[[VAL_1]], %[[VAL_1]] : complex<f64>
 // CHECK:           %[[VAL_5:.*]] = complex.create %[[VAL_1]], %[[VAL_1]] : complex<f64>
 // CHECK:           %[[VAL_6:.*]] = cc.alloca !cc.array<complex<f64> x 4>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_6]][0] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
+// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_7]] : !cc.ptr<complex<f64>>
 // CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_6]][1] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
 // CHECK:           cc.store %[[VAL_3]], %[[VAL_8]] : !cc.ptr<complex<f64>>

--- a/test/Quake-QIR/argument.qke
+++ b/test/Quake-QIR/argument.qke
@@ -31,7 +31,7 @@ func.func @test_0(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_0({ { i32, double }*, i64 } 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK-SAME:         %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 0
 // CHECK:         %[[VAL_2:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 1
 // CHECK:         %[[VAL_3:.*]] = bitcast { i32, double }* %[[VAL_1]] to i8*
@@ -40,7 +40,8 @@ func.func @test_0(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_0(i8* nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], { { i32, double }*, { i32, double }*, { i32, double }* }* nocapture readonly %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK-SAME:         %[[VAL_0:.*]], { { i32, double }*, { i32, double }*, { i32, double }* }* nocapture readonly
+// CHECK-SAME:         %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 1
 // CHECK:         %[[VAL_3:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 0
 // CHECK:         %[[VAL_4:.*]] = load { i32, double }*, { i32, double }** %[[VAL_2]], align 8
@@ -61,14 +62,14 @@ func.func @test_0(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 
 func.func @__nvqpp__mlirgen__test_1(%arg0 : !cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) {
   %0 = cc.extract_value %arg0[0] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<i16>
-  %1 = cc.stdvec_data %0 : (!cc.stdvec<i16>) -> !cc.ptr<i16>
+  %1 = cc.stdvec_data %0 : (!cc.stdvec<i16>) -> !cc.ptr<!cc.array<i16 x ?>>
   %2 = cc.stdvec_size %0 : (!cc.stdvec<i16>) -> i64
-  %3 = cc.cast %1 : (!cc.ptr<i16>) -> !cc.ptr<none>
+  %3 = cc.cast %1 : (!cc.ptr<!cc.array<i16 x ?>>) -> !cc.ptr<none>
   call @anchor(%3, %2) : (!cc.ptr<none>, i64) -> ()
   %4 = cc.extract_value %arg0[1] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<f32>
-  %5 = cc.stdvec_data %4 : (!cc.stdvec<f32>) -> !cc.ptr<f32>
+  %5 = cc.stdvec_data %4 : (!cc.stdvec<f32>) -> !cc.ptr<!cc.array<f32 x ?>>
   %6 = cc.stdvec_size %4 : (!cc.stdvec<f32>) -> i64
-  %7 = cc.cast %5 : (!cc.ptr<f32>) -> !cc.ptr<none>
+  %7 = cc.cast %5 : (!cc.ptr<!cc.array<f32 x ?>>) -> !cc.ptr<none>
   call @anchor(%7, %6) : (!cc.ptr<none>, i64) -> ()
   return
 }
@@ -78,7 +79,7 @@ func.func @test_1(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_1({ { i16*, i64 }, { float*, i64 } } 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK-SAME:         %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = extractvalue { { i16*, i64 }, { float*, i64 } } %[[VAL_0]], 0
 // CHECK:         %[[VAL_2:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 0
 // CHECK:         %[[VAL_3:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 1
@@ -93,110 +94,8 @@ func.func @test_1(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_1(i8* nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], { { i16*, i16*, i16* }, { float*, float*, float* } }* nocapture readonly %[[VAL_1:.*]]) local_unnamed_addr {
-// CHECK:         %[[VAL_2:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 1
-// CHECK:         %[[VAL_3:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 0
-// CHECK:         %[[VAL_4:.*]] = load i16*, i16** %[[VAL_2]], align 8
-// CHECK:         %[[VAL_5:.*]] = load i16*, i16** %[[VAL_3]], align 8
-// CHECK:         %[[VAL_6:.*]] = ptrtoint i16* %[[VAL_4]] to i64
-// CHECK:         %[[VAL_7:.*]] = ptrtoint i16* %[[VAL_5]] to i64
-// CHECK:         %[[VAL_8:.*]] = sub i64 %[[VAL_6]], %[[VAL_7]]
-// CHECK:         %[[VAL_9:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 1, i32 1
-// CHECK:         %[[VAL_10:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 1, i32 0
-// CHECK:         %[[VAL_11:.*]] = load float*, float** %[[VAL_9]], align 8
-// CHECK:         %[[VAL_12:.*]] = load float*, float** %[[VAL_10]], align 8
-// CHECK:         %[[VAL_13:.*]] = ptrtoint float* %[[VAL_11]] to i64
-// CHECK:         %[[VAL_14:.*]] = ptrtoint float* %[[VAL_12]] to i64
-// CHECK:         %[[VAL_15:.*]] = sub i64 %[[VAL_13]], %[[VAL_14]]
-// CHECK:         %[[VAL_16:.*]] = add i64 %[[VAL_8]], 16
-// CHECK:         %[[VAL_17:.*]] = add i64 %[[VAL_16]], %[[VAL_15]]
-// CHECK:         %[[VAL_18:.*]] = alloca i8, i64 %[[VAL_17]], align 8
-// CHECK:         %[[VAL_19:.*]] = bitcast i8* %[[VAL_18]] to i64*
-// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_19]], align 8
-// CHECK:         %[[VAL_20:.*]] = getelementptr inbounds i8, i8* %[[VAL_18]], i64 8
-// CHECK:         %[[VAL_21:.*]] = bitcast i8* %[[VAL_20]] to i64*
-// CHECK:         store i64 %[[VAL_15]], i64* %[[VAL_21]], align 8
-// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_18]], i64 %[[VAL_17]], i64 2147483647)
-// CHECK:         ret void
-// CHECK:       }
-
-func.func @__nvqpp__mlirgen__test_2(%arg0: !cc.stdvec<!cc.struct<{i32, f64}>>) {
-  %0 = cc.stdvec_data %arg0 : (!cc.stdvec<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-  %1 = cc.stdvec_size %arg0 : (!cc.stdvec<!cc.struct<{i32, f64}>>) -> i64
-  %2 = cc.cast %0 : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<none>
-  call @anchor(%2, %1) : (!cc.ptr<none>, i64) -> ()
-  return
-}
-
-func.func @test_2(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i32, f64}>>, !cc.ptr<!cc.struct<{i32, f64}>>, !cc.ptr<!cc.struct<{i32, f64}>>}>>) {
-  return
-}
-
-// CHECK-LABEL: define void @__nvqpp__mlirgen__test_2({ { i32, double }*, i64 } 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
-// CHECK:         %[[VAL_1:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 0
-// CHECK:         %[[VAL_2:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 1
-// CHECK:         %[[VAL_3:.*]] = bitcast { i32, double }* %[[VAL_1]] to i8*
-// CHECK:         tail call void @anchor(i8* %[[VAL_3]], i64 %[[VAL_2]])
-// CHECK:         ret void
-// CHECK:       }
-
-// CHECK-LABEL: define void @test_2(i8* nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], { { i32, double }*, { i32, double }*, { i32, double }* }* nocapture readonly %[[VAL_1:.*]]) local_unnamed_addr {
-// CHECK:         %[[VAL_2:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 1
-// CHECK:         %[[VAL_3:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 0
-// CHECK:         %[[VAL_4:.*]] = load { i32, double }*, { i32, double }** %[[VAL_2]], align 8
-// CHECK:         %[[VAL_5:.*]] = load { i32, double }*, { i32, double }** %[[VAL_3]], align 8
-// CHECK:         %[[VAL_6:.*]] = ptrtoint { i32, double }* %[[VAL_4]] to i64
-// CHECK:         %[[VAL_7:.*]] = ptrtoint { i32, double }* %[[VAL_5]] to i64
-// CHECK:         %[[VAL_8:.*]] = sub i64 %[[VAL_6]], %[[VAL_7]]
-// CHECK:         %[[VAL_9:.*]] = add i64 %[[VAL_8]], 8
-// CHECK:         %[[VAL_10:.*]] = alloca i8, i64 %[[VAL_9]], align 8
-// CHECK:         %[[VAL_11:.*]] = bitcast i8* %[[VAL_10]] to i64*
-// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_11]], align 8
-// CHECK:         %[[VAL_12:.*]] = getelementptr i8, i8* %[[VAL_10]], i64 8
-// CHECK:         %[[VAL_13:.*]] = bitcast { i32, double }* %[[VAL_5]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_12]], i8* align 1 %[[VAL_13]], i64 %[[VAL_8]], i1 false)
-// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_2.thunk to i8*), i8* nonnull %[[VAL_10]], i64 %[[VAL_9]], i64 2147483647)
-// CHECK:         ret void
-// CHECK:       }
-
-
-func.func @__nvqpp__mlirgen__test_3(%arg0 : !cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) {
-  %0 = cc.extract_value %arg0[0] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<i16>
-  %1 = cc.stdvec_data %0 : (!cc.stdvec<i16>) -> !cc.ptr<i16>
-  %2 = cc.stdvec_size %0 : (!cc.stdvec<i16>) -> i64
-  %3 = cc.cast %1 : (!cc.ptr<i16>) -> !cc.ptr<none>
-  call @anchor(%3, %2) : (!cc.ptr<none>, i64) -> ()
-  %5 = cc.extract_value %arg0[1] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<f32>
-  %6 = cc.stdvec_data %5 : (!cc.stdvec<f32>) -> !cc.ptr<f32>
-  %7 = cc.stdvec_size %5 : (!cc.stdvec<f32>) -> i64
-  %8 = cc.cast %6 : (!cc.ptr<f32>) -> !cc.ptr<none>
-  call @anchor(%8, %7) : (!cc.ptr<none>, i64) -> ()
-  return
-}
-
-func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i16>, !cc.ptr<i16>, !cc.ptr<i16>}>, !cc.struct<{!cc.ptr<f32>, !cc.ptr<f32>, !cc.ptr<f32>}>}>>) {
-  return
-}
-
-// CHECK-LABEL: define void @__nvqpp__mlirgen__test_3({ { i16*, i64 }, { float*, i64 } } 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
-// CHECK:         %[[VAL_1:.*]] = extractvalue { { i16*, i64 }, { float*, i64 } } %[[VAL_0]], 0
-// CHECK:         %[[VAL_2:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 0
-// CHECK:         %[[VAL_3:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 1
-// CHECK:         %[[VAL_4:.*]] = bitcast i16* %[[VAL_2]] to i8*
-// CHECK:         tail call void @anchor(i8* %[[VAL_4]], i64 %[[VAL_3]])
-// CHECK:         %[[VAL_5:.*]] = extractvalue { { i16*, i64 }, { float*, i64 } } %[[VAL_0]], 1
-// CHECK:         %[[VAL_6:.*]] = extractvalue { float*, i64 } %[[VAL_5]], 0
-// CHECK:         %[[VAL_7:.*]] = extractvalue { float*, i64 } %[[VAL_5]], 1
-// CHECK:         %[[VAL_8:.*]] = bitcast float* %[[VAL_6]] to i8*
-// CHECK:         tail call void @anchor(i8* %[[VAL_8]], i64 %[[VAL_7]])
-// CHECK:         ret void
-// CHECK:       }
-
-// CHECK-LABEL: define void @test_3(i8* nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], { { i16*, i16*, i16* }, { float*, float*, float* } }* nocapture readonly %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK-SAME:         %[[VAL_0:.*]], { { i16*, i16*, i16* }, { float*, float*, float* } }* nocapture readonly
+// CHECK-SAME:         %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 1
 // CHECK:         %[[VAL_3:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 0
 // CHECK:         %[[VAL_4:.*]] = load i16*, i16** %[[VAL_2]], align 8
@@ -222,7 +121,118 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_22:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 16
 // CHECK:         %[[VAL_23:.*]] = bitcast i16* %[[VAL_5]] to i8*
 // CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_22]], i8* align 1 %[[VAL_23]], i64 %[[VAL_8]], i1 false)
-// CHECK:         %[[VAL_24:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 %[[VAL_16]]
+// CHECK:         %[[VAL_24:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 %[[VAL_8]]
+// CHECK:         %[[VAL_25:.*]] = bitcast float* %[[VAL_12]] to i8*
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_24]], i8* align 1 %[[VAL_25]], i64 %[[VAL_15]], i1 false)
+// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_18]], i64 %[[VAL_17]], i64 2147483647)
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @__nvqpp__mlirgen__test_2(%arg0: !cc.stdvec<!cc.struct<{i32, f64}>>) {
+  %0 = cc.stdvec_data %arg0 : (!cc.stdvec<!cc.struct<{i32, f64}>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+  %1 = cc.stdvec_size %arg0 : (!cc.stdvec<!cc.struct<{i32, f64}>>) -> i64
+  %2 = cc.cast %0 : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<none>
+  call @anchor(%2, %1) : (!cc.ptr<none>, i64) -> ()
+  return
+}
+
+func.func @test_2(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i32, f64}>>, !cc.ptr<!cc.struct<{i32, f64}>>, !cc.ptr<!cc.struct<{i32, f64}>>}>>) {
+  return
+}
+
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_2({ { i32, double }*, i64 } 
+// CHECK-SAME:         %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_1:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 0
+// CHECK:         %[[VAL_2:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 1
+// CHECK:         %[[VAL_3:.*]] = bitcast { i32, double }* %[[VAL_1]] to i8*
+// CHECK:         tail call void @anchor(i8* %[[VAL_3]], i64 %[[VAL_2]])
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_2(i8* nocapture readnone 
+// CHECK-SAME:         %[[VAL_0:.*]], { { i32, double }*, { i32, double }*, { i32, double }* }* nocapture readonly
+// CHECK-SAME:         %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_2:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 1
+// CHECK:         %[[VAL_3:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 0
+// CHECK:         %[[VAL_4:.*]] = load { i32, double }*, { i32, double }** %[[VAL_2]], align 8
+// CHECK:         %[[VAL_5:.*]] = load { i32, double }*, { i32, double }** %[[VAL_3]], align 8
+// CHECK:         %[[VAL_6:.*]] = ptrtoint { i32, double }* %[[VAL_4]] to i64
+// CHECK:         %[[VAL_7:.*]] = ptrtoint { i32, double }* %[[VAL_5]] to i64
+// CHECK:         %[[VAL_8:.*]] = sub i64 %[[VAL_6]], %[[VAL_7]]
+// CHECK:         %[[VAL_9:.*]] = add i64 %[[VAL_8]], 8
+// CHECK:         %[[VAL_10:.*]] = alloca i8, i64 %[[VAL_9]], align 8
+// CHECK:         %[[VAL_11:.*]] = bitcast i8* %[[VAL_10]] to i64*
+// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_11]], align 8
+// CHECK:         %[[VAL_12:.*]] = getelementptr i8, i8* %[[VAL_10]], i64 8
+// CHECK:         %[[VAL_13:.*]] = bitcast { i32, double }* %[[VAL_5]] to i8*
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_12]], i8* align 1 %[[VAL_13]], i64 %[[VAL_8]], i1 false)
+// CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_2.thunk to i8*), i8* nonnull %[[VAL_10]], i64 %[[VAL_9]], i64 2147483647)
+// CHECK:         ret void
+// CHECK:       }
+
+func.func @__nvqpp__mlirgen__test_3(%arg0 : !cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) {
+  %0 = cc.extract_value %arg0[0] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<i16>
+  %1 = cc.stdvec_data %0 : (!cc.stdvec<i16>) -> !cc.ptr<i16>
+  %2 = cc.stdvec_size %0 : (!cc.stdvec<i16>) -> i64
+  %3 = cc.cast %1 : (!cc.ptr<i16>) -> !cc.ptr<none>
+  call @anchor(%3, %2) : (!cc.ptr<none>, i64) -> ()
+  %5 = cc.extract_value %arg0[1] : (!cc.struct<{!cc.stdvec<i16>, !cc.stdvec<f32>}>) -> !cc.stdvec<f32>
+  %6 = cc.stdvec_data %5 : (!cc.stdvec<f32>) -> !cc.ptr<f32>
+  %7 = cc.stdvec_size %5 : (!cc.stdvec<f32>) -> i64
+  %8 = cc.cast %6 : (!cc.ptr<f32>) -> !cc.ptr<none>
+  call @anchor(%8, %7) : (!cc.ptr<none>, i64) -> ()
+  return
+}
+
+func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i16>, !cc.ptr<i16>, !cc.ptr<i16>}>, !cc.struct<{!cc.ptr<f32>, !cc.ptr<f32>, !cc.ptr<f32>}>}>>) {
+  return
+}
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__test_3({ { i16*, i64 }, { float*, i64 } }
+// CHECK-SAME:          %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_1:.*]] = extractvalue { { i16*, i64 }, { float*, i64 } } %[[VAL_0]], 0
+// CHECK:         %[[VAL_2:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 0
+// CHECK:         %[[VAL_3:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 1
+// CHECK:         %[[VAL_4:.*]] = bitcast i16* %[[VAL_2]] to i8*
+// CHECK:         tail call void @anchor(i8* %[[VAL_4]], i64 %[[VAL_3]])
+// CHECK:         %[[VAL_5:.*]] = extractvalue { { i16*, i64 }, { float*, i64 } } %[[VAL_0]], 1
+// CHECK:         %[[VAL_6:.*]] = extractvalue { float*, i64 } %[[VAL_5]], 0
+// CHECK:         %[[VAL_7:.*]] = extractvalue { float*, i64 } %[[VAL_5]], 1
+// CHECK:         %[[VAL_8:.*]] = bitcast float* %[[VAL_6]] to i8*
+// CHECK:         tail call void @anchor(i8* %[[VAL_8]], i64 %[[VAL_7]])
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define void @test_3(i8* nocapture readnone 
+// CHECK-SAME:          %[[VAL_0:.*]], { { i16*, i16*, i16* }, { float*, float*, float* } }* nocapture readonly
+// CHECK-SAME:          %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_2:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 1
+// CHECK:         %[[VAL_3:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 0
+// CHECK:         %[[VAL_4:.*]] = load i16*, i16** %[[VAL_2]], align 8
+// CHECK:         %[[VAL_5:.*]] = load i16*, i16** %[[VAL_3]], align 8
+// CHECK:         %[[VAL_6:.*]] = ptrtoint i16* %[[VAL_4]] to i64
+// CHECK:         %[[VAL_7:.*]] = ptrtoint i16* %[[VAL_5]] to i64
+// CHECK:         %[[VAL_8:.*]] = sub i64 %[[VAL_6]], %[[VAL_7]]
+// CHECK:         %[[VAL_9:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 1, i32 1
+// CHECK:         %[[VAL_10:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 1, i32 0
+// CHECK:         %[[VAL_11:.*]] = load float*, float** %[[VAL_9]], align 8
+// CHECK:         %[[VAL_12:.*]] = load float*, float** %[[VAL_10]], align 8
+// CHECK:         %[[VAL_13:.*]] = ptrtoint float* %[[VAL_11]] to i64
+// CHECK:         %[[VAL_14:.*]] = ptrtoint float* %[[VAL_12]] to i64
+// CHECK:         %[[VAL_15:.*]] = sub i64 %[[VAL_13]], %[[VAL_14]]
+// CHECK:         %[[VAL_16:.*]] = add i64 %[[VAL_8]], 16
+// CHECK:         %[[VAL_17:.*]] = add i64 %[[VAL_16]], %[[VAL_15]]
+// CHECK:         %[[VAL_18:.*]] = alloca i8, i64 %[[VAL_17]], align 8
+// CHECK:         %[[VAL_19:.*]] = bitcast i8* %[[VAL_18]] to i64*
+// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_19]], align 8
+// CHECK:         %[[VAL_20:.*]] = getelementptr inbounds i8, i8* %[[VAL_18]], i64 8
+// CHECK:         %[[VAL_21:.*]] = bitcast i8* %[[VAL_20]] to i64*
+// CHECK:         store i64 %[[VAL_15]], i64* %[[VAL_21]], align 8
+// CHECK:         %[[VAL_22:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 16
+// CHECK:         %[[VAL_23:.*]] = bitcast i16* %[[VAL_5]] to i8*
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_22]], i8* align 1 %[[VAL_23]], i64 %[[VAL_8]], i1 false)
+// CHECK:         %[[VAL_24:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 %[[VAL_8]]
 // CHECK:         %[[VAL_25:.*]] = bitcast float* %[[VAL_12]] to i8*
 // CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_24]], i8* align 1 %[[VAL_25]], i64 %[[VAL_15]], i1 false)
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_3.thunk to i8*), i8* nonnull %[[VAL_18]], i64 %[[VAL_17]], i64 2147483647)
@@ -231,22 +241,27 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 
 }
 
+// CHECK-LABEL: define i64 @test_0.returnOffset()
+// CHECK:         ret i64 2147483647
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         %[[VAL_3:.*]] = load i64, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_4:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
-// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_3]], 8
+// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_3]], 16
 // CHECK:         tail call void @anchor(i8* %[[VAL_4]], i64 %[[VAL_5]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_0.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
-// CHECK:         %[[VAL_2:.*]] = bitcast i8** %[[VAL_0]] to { { i32, double }*, { i32, double }*, { i32, double }* }**
-// CHECK:         %[[VAL_3:.*]] = load { { i32, double }*, { i32, double }*, { i32, double }* }*, { { i32, double }*, { i32, double }*, { i32, double }* }** %[[VAL_2]], align 8
-// CHECK:         %[[VAL_4:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_3]], i64 0, i32 1
-// CHECK:         %[[VAL_5:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_3]], i64 0, i32 0
+// CHECK-SAME:      %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:      %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK:         %[[VAL_2:.*]] = load i8*, i8** %[[VAL_0]], align 8
+// CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 8
+// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to { i32, double }**
+// CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_2]] to { i32, double }**
 // CHECK:         %[[VAL_6:.*]] = load { i32, double }*, { i32, double }** %[[VAL_4]], align 8
 // CHECK:         %[[VAL_7:.*]] = load { i32, double }*, { i32, double }** %[[VAL_5]], align 8
 // CHECK:         %[[VAL_8:.*]] = ptrtoint { i32, double }* %[[VAL_6]] to i64
@@ -258,7 +273,7 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_14:.*]] = getelementptr { i64 }, { i64 }* %[[VAL_13]], i64 0, i32 0
 // CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_14]], align 4
 // CHECK:         %[[VAL_15:.*]] = getelementptr i8, i8* %[[VAL_12]], i64 8
-// CHECK:         %[[VAL_16:.*]] = bitcast { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_3]] to i8**
+// CHECK:         %[[VAL_16:.*]] = bitcast i8* %[[VAL_2]] to i8**
 // CHECK:         %[[VAL_17:.*]] = load i8*, i8** %[[VAL_16]], align 8
 // CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_15]], i8* align 1 %[[VAL_17]], i64 %[[VAL_10]], i1 false)
 // CHECK:         store i8* %[[VAL_12]], i8** %[[VAL_1]], align 8
@@ -271,8 +286,12 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         ret void
 // CHECK:       }
 
+// CHECK-LABEL: define i64 @test_1.returnOffset()
+// CHECK:         ret i64 2147483647
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK-SAME:       %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         %[[VAL_3:.*]] = load i64, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_4:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 8
@@ -280,50 +299,52 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_6:.*]] = load i64, i64* %[[VAL_5]], align 4
 // CHECK:         %[[VAL_7:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
 // CHECK:         %[[VAL_8:.*]] = sdiv i64 %[[VAL_3]], 2
-// CHECK:         %[[VAL_9:.*]] = add i64 %[[VAL_3]], 16
-// CHECK:         %[[VAL_10:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 %[[VAL_9]]
-// CHECK:         %[[VAL_11:.*]] = sdiv i64 %[[VAL_6]], 4
+// CHECK:         %[[VAL_9:.*]] = getelementptr i8, i8* %[[VAL_7]], i64 %[[VAL_3]]
+// CHECK:         %[[VAL_10:.*]] = sdiv i64 %[[VAL_6]], 4
 // CHECK:         tail call void @anchor(i8* %[[VAL_7]], i64 %[[VAL_8]])
-// CHECK:         tail call void @anchor(i8* %[[VAL_10]], i64 %[[VAL_11]])
+// CHECK:         tail call void @anchor(i8* %[[VAL_9]], i64 %[[VAL_10]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_1.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]*}} {
-// CHECK:         %[[VAL_2:.*]] = bitcast i8** %[[VAL_0]] to { { i16*, i16*, i16* }, { float*, float*, float* } }**
-// CHECK:         %[[VAL_3:.*]] = load { { i16*, i16*, i16* }, { float*, float*, float* } }*, { { i16*, i16*, i16* }, { float*, float*, float* } }** %[[VAL_2]], align 8
-// CHECK:         %[[VAL_4:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]], i64 0, i32 0, i32 1
-// CHECK:         %[[VAL_5:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]], i64 0, i32 0, i32 0
+// CHECK-SAME:        %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:        %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK:         %[[VAL_2:.*]] = load i8*, i8** %[[VAL_0]], align 8
+// CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 8
+// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to i16**
+// CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_2]] to i16**
 // CHECK:         %[[VAL_6:.*]] = load i16*, i16** %[[VAL_4]], align 8
 // CHECK:         %[[VAL_7:.*]] = load i16*, i16** %[[VAL_5]], align 8
 // CHECK:         %[[VAL_8:.*]] = ptrtoint i16* %[[VAL_6]] to i64
 // CHECK:         %[[VAL_9:.*]] = ptrtoint i16* %[[VAL_7]] to i64
 // CHECK:         %[[VAL_10:.*]] = sub i64 %[[VAL_8]], %[[VAL_9]]
-// CHECK:         %[[VAL_11:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]], i64 0, i32 1, i32 1
-// CHECK:         %[[VAL_12:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]], i64 0, i32 1, i32 0
-// CHECK:         %[[VAL_13:.*]] = load float*, float** %[[VAL_11]], align 8
-// CHECK:         %[[VAL_14:.*]] = load float*, float** %[[VAL_12]], align 8
-// CHECK:         %[[VAL_15:.*]] = ptrtoint float* %[[VAL_13]] to i64
-// CHECK:         %[[VAL_16:.*]] = ptrtoint float* %[[VAL_14]] to i64
-// CHECK:         %[[VAL_17:.*]] = sub i64 %[[VAL_15]], %[[VAL_16]]
-// CHECK:         %[[VAL_18:.*]] = add i64 %[[VAL_10]], 16
-// CHECK:         %[[VAL_19:.*]] = add i64 %[[VAL_18]], %[[VAL_17]]
-// CHECK:         %[[VAL_20:.*]] = tail call i8* @malloc(i64 %[[VAL_19]])
-// CHECK:         %[[VAL_21:.*]] = bitcast i8* %[[VAL_20]] to { { i64, i64 } }*
-// CHECK:         %[[VAL_22:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_21]], i64 0, i32 0, i32 0
-// CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_22]], align 4
-// CHECK:         %[[VAL_23:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_21]], i64 0, i32 0, i32 1
-// CHECK:         store i64 %[[VAL_17]], i64* %[[VAL_23]], align 4
-// CHECK:         %[[VAL_24:.*]] = getelementptr i8, i8* %[[VAL_20]], i64 16
-// CHECK:         %[[VAL_25:.*]] = bitcast { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]] to i8**
-// CHECK:         %[[VAL_26:.*]] = load i8*, i8** %[[VAL_25]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_24]], i8* align 1 %[[VAL_26]], i64 %[[VAL_10]], i1 false)
-// CHECK:         %[[VAL_27:.*]] = getelementptr i8, i8* %[[VAL_20]], i64 %[[VAL_18]]
-// CHECK:         %[[VAL_28:.*]] = bitcast float** %[[VAL_12]] to i8**
-// CHECK:         %[[VAL_29:.*]] = load i8*, i8** %[[VAL_28]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_27]], i8* align 1 %[[VAL_29]], i64 %[[VAL_17]], i1 false)
-// CHECK:         store i8* %[[VAL_20]], i8** %[[VAL_1]], align 8
-// CHECK:         ret i64 %[[VAL_19]]
+// CHECK:         %[[VAL_11:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 32
+// CHECK:         %[[VAL_12:.*]] = bitcast i8* %[[VAL_11]] to float**
+// CHECK:         %[[VAL_13:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 24
+// CHECK:         %[[VAL_14:.*]] = bitcast i8* %[[VAL_13]] to float**
+// CHECK:         %[[VAL_15:.*]] = load float*, float** %[[VAL_12]], align 8
+// CHECK:         %[[VAL_16:.*]] = load float*, float** %[[VAL_14]], align 8
+// CHECK:         %[[VAL_17:.*]] = ptrtoint float* %[[VAL_15]] to i64
+// CHECK:         %[[VAL_18:.*]] = ptrtoint float* %[[VAL_16]] to i64
+// CHECK:         %[[VAL_19:.*]] = sub i64 %[[VAL_17]], %[[VAL_18]]
+// CHECK:         %[[VAL_20:.*]] = add i64 %[[VAL_10]], 16
+// CHECK:         %[[VAL_21:.*]] = add i64 %[[VAL_20]], %[[VAL_19]]
+// CHECK:         %[[VAL_22:.*]] = tail call i8* @malloc(i64 %[[VAL_21]])
+// CHECK:         %[[VAL_23:.*]] = bitcast i8* %[[VAL_22]] to { { i64, i64 } }*
+// CHECK:         %[[VAL_24:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_23]], i64 0, i32 0, i32 0
+// CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_24]], align 4
+// CHECK:         %[[VAL_25:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_23]], i64 0, i32 0, i32 1
+// CHECK:         store i64 %[[VAL_19]], i64* %[[VAL_25]], align 4
+// CHECK:         %[[VAL_26:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 16
+// CHECK:         %[[VAL_27:.*]] = bitcast i8* %[[VAL_2]] to i8**
+// CHECK:         %[[VAL_28:.*]] = load i8*, i8** %[[VAL_27]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_26]], i8* align 1 %[[VAL_28]], i64 %[[VAL_10]], i1 false)
+// CHECK:         %[[VAL_29:.*]] = getelementptr i8, i8* %[[VAL_26]], i64 %[[VAL_10]]
+// CHECK:         %[[VAL_30:.*]] = bitcast i8* %[[VAL_13]] to i8**
+// CHECK:         %[[VAL_31:.*]] = load i8*, i8** %[[VAL_30]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_29]], i8* align 1 %[[VAL_31]], i64 %[[VAL_19]], i1 false)
+// CHECK:         store i8* %[[VAL_22]], i8** %[[VAL_1]], align 8
+// CHECK:         ret i64 %[[VAL_21]]
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_1.kernelRegFunc() {
@@ -332,22 +353,27 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         ret void
 // CHECK:       }
 
+// CHECK-LABEL: define i64 @test_2.returnOffset()
+// CHECK:         ret i64 2147483647
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_2.thunk(i8* 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK-SAME:        %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         %[[VAL_3:.*]] = load i64, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_4:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
-// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_3]], 8
+// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_3]], 16
 // CHECK:         tail call void @anchor(i8* %[[VAL_4]], i64 %[[VAL_5]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_2.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]*}} {
-// CHECK:         %[[VAL_2:.*]] = bitcast i8** %[[VAL_0]] to { { i32, double }*, { i32, double }*, { i32, double }* }**
-// CHECK:         %[[VAL_3:.*]] = load { { i32, double }*, { i32, double }*, { i32, double }* }*, { { i32, double }*, { i32, double }*, { i32, double }* }** %[[VAL_2]], align 8
-// CHECK:         %[[VAL_4:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_3]], i64 0, i32 1
-// CHECK:         %[[VAL_5:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_3]], i64 0, i32 0
+// CHECK-SAME:          %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:          %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK:         %[[VAL_2:.*]] = load i8*, i8** %[[VAL_0]], align 8
+// CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 8
+// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to { i32, double }**
+// CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_2]] to { i32, double }**
 // CHECK:         %[[VAL_6:.*]] = load { i32, double }*, { i32, double }** %[[VAL_4]], align 8
 // CHECK:         %[[VAL_7:.*]] = load { i32, double }*, { i32, double }** %[[VAL_5]], align 8
 // CHECK:         %[[VAL_8:.*]] = ptrtoint { i32, double }* %[[VAL_6]] to i64
@@ -359,7 +385,7 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_14:.*]] = getelementptr { i64 }, { i64 }* %[[VAL_13]], i64 0, i32 0
 // CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_14]], align 4
 // CHECK:         %[[VAL_15:.*]] = getelementptr i8, i8* %[[VAL_12]], i64 8
-// CHECK:         %[[VAL_16:.*]] = bitcast { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_3]] to i8**
+// CHECK:         %[[VAL_16:.*]] = bitcast i8* %[[VAL_2]] to i8**
 // CHECK:         %[[VAL_17:.*]] = load i8*, i8** %[[VAL_16]], align 8
 // CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_15]], i8* align 1 %[[VAL_17]], i64 %[[VAL_10]], i1 false)
 // CHECK:         store i8* %[[VAL_12]], i8** %[[VAL_1]], align 8
@@ -372,8 +398,12 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         ret void
 // CHECK:       }
 
+// CHECK-LABEL: define i64 @test_3.returnOffset()
+// CHECK:         ret i64 2147483647
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_3.thunk(i8* 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK-SAME:        %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         %[[VAL_3:.*]] = load i64, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_4:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 8
@@ -381,50 +411,52 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_6:.*]] = load i64, i64* %[[VAL_5]], align 4
 // CHECK:         %[[VAL_7:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
 // CHECK:         %[[VAL_8:.*]] = sdiv i64 %[[VAL_3]], 2
-// CHECK:         %[[VAL_9:.*]] = add i64 %[[VAL_3]], 16
-// CHECK:         %[[VAL_10:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 %[[VAL_9]]
-// CHECK:         %[[VAL_11:.*]] = sdiv i64 %[[VAL_6]], 4
+// CHECK:         %[[VAL_9:.*]] = getelementptr i8, i8* %[[VAL_7]], i64 %[[VAL_3]]
+// CHECK:         %[[VAL_10:.*]] = sdiv i64 %[[VAL_6]], 4
 // CHECK:         tail call void @anchor(i8* %[[VAL_7]], i64 %[[VAL_8]])
-// CHECK:         tail call void @anchor(i8* %[[VAL_10]], i64 %[[VAL_11]])
+// CHECK:         tail call void @anchor(i8* %[[VAL_9]], i64 %[[VAL_10]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_3.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]*}} {
-// CHECK:         %[[VAL_2:.*]] = bitcast i8** %[[VAL_0]] to { { i16*, i16*, i16* }, { float*, float*, float* } }**
-// CHECK:         %[[VAL_3:.*]] = load { { i16*, i16*, i16* }, { float*, float*, float* } }*, { { i16*, i16*, i16* }, { float*, float*, float* } }** %[[VAL_2]], align 8
-// CHECK:         %[[VAL_4:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]], i64 0, i32 0, i32 1
-// CHECK:         %[[VAL_5:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]], i64 0, i32 0, i32 0
+// CHECK-SAME:        %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:        %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK:         %[[VAL_2:.*]] = load i8*, i8** %[[VAL_0]], align 8
+// CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 8
+// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to i16**
+// CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_2]] to i16**
 // CHECK:         %[[VAL_6:.*]] = load i16*, i16** %[[VAL_4]], align 8
 // CHECK:         %[[VAL_7:.*]] = load i16*, i16** %[[VAL_5]], align 8
 // CHECK:         %[[VAL_8:.*]] = ptrtoint i16* %[[VAL_6]] to i64
 // CHECK:         %[[VAL_9:.*]] = ptrtoint i16* %[[VAL_7]] to i64
 // CHECK:         %[[VAL_10:.*]] = sub i64 %[[VAL_8]], %[[VAL_9]]
-// CHECK:         %[[VAL_11:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]], i64 0, i32 1, i32 1
-// CHECK:         %[[VAL_12:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]], i64 0, i32 1, i32 0
-// CHECK:         %[[VAL_13:.*]] = load float*, float** %[[VAL_11]], align 8
-// CHECK:         %[[VAL_14:.*]] = load float*, float** %[[VAL_12]], align 8
-// CHECK:         %[[VAL_15:.*]] = ptrtoint float* %[[VAL_13]] to i64
-// CHECK:         %[[VAL_16:.*]] = ptrtoint float* %[[VAL_14]] to i64
-// CHECK:         %[[VAL_17:.*]] = sub i64 %[[VAL_15]], %[[VAL_16]]
-// CHECK:         %[[VAL_18:.*]] = add i64 %[[VAL_10]], 16
-// CHECK:         %[[VAL_19:.*]] = add i64 %[[VAL_18]], %[[VAL_17]]
-// CHECK:         %[[VAL_20:.*]] = tail call i8* @malloc(i64 %[[VAL_19]])
-// CHECK:         %[[VAL_21:.*]] = bitcast i8* %[[VAL_20]] to { { i64, i64 } }*
-// CHECK:         %[[VAL_22:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_21]], i64 0, i32 0, i32 0
-// CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_22]], align 4
-// CHECK:         %[[VAL_23:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_21]], i64 0, i32 0, i32 1
-// CHECK:         store i64 %[[VAL_17]], i64* %[[VAL_23]], align 4
-// CHECK:         %[[VAL_24:.*]] = getelementptr i8, i8* %[[VAL_20]], i64 16
-// CHECK:         %[[VAL_25:.*]] = bitcast { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_3]] to i8**
-// CHECK:         %[[VAL_26:.*]] = load i8*, i8** %[[VAL_25]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_24]], i8* align 1 %[[VAL_26]], i64 %[[VAL_10]], i1 false)
-// CHECK:         %[[VAL_27:.*]] = getelementptr i8, i8* %[[VAL_20]], i64 %[[VAL_18]]
-// CHECK:         %[[VAL_28:.*]] = bitcast float** %[[VAL_12]] to i8**
-// CHECK:         %[[VAL_29:.*]] = load i8*, i8** %[[VAL_28]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_27]], i8* align 1 %[[VAL_29]], i64 %[[VAL_17]], i1 false)
-// CHECK:         store i8* %[[VAL_20]], i8** %[[VAL_1]], align 8
-// CHECK:         ret i64 %[[VAL_19]]
+// CHECK:         %[[VAL_11:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 32
+// CHECK:         %[[VAL_12:.*]] = bitcast i8* %[[VAL_11]] to float**
+// CHECK:         %[[VAL_13:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 24
+// CHECK:         %[[VAL_14:.*]] = bitcast i8* %[[VAL_13]] to float**
+// CHECK:         %[[VAL_15:.*]] = load float*, float** %[[VAL_12]], align 8
+// CHECK:         %[[VAL_16:.*]] = load float*, float** %[[VAL_14]], align 8
+// CHECK:         %[[VAL_17:.*]] = ptrtoint float* %[[VAL_15]] to i64
+// CHECK:         %[[VAL_18:.*]] = ptrtoint float* %[[VAL_16]] to i64
+// CHECK:         %[[VAL_19:.*]] = sub i64 %[[VAL_17]], %[[VAL_18]]
+// CHECK:         %[[VAL_20:.*]] = add i64 %[[VAL_10]], 16
+// CHECK:         %[[VAL_21:.*]] = add i64 %[[VAL_20]], %[[VAL_19]]
+// CHECK:         %[[VAL_22:.*]] = tail call i8* @malloc(i64 %[[VAL_21]])
+// CHECK:         %[[VAL_23:.*]] = bitcast i8* %[[VAL_22]] to { { i64, i64 } }*
+// CHECK:         %[[VAL_24:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_23]], i64 0, i32 0, i32 0
+// CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_24]], align 4
+// CHECK:         %[[VAL_25:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_23]], i64 0, i32 0, i32 1
+// CHECK:         store i64 %[[VAL_19]], i64* %[[VAL_25]], align 4
+// CHECK:         %[[VAL_26:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 16
+// CHECK:         %[[VAL_27:.*]] = bitcast i8* %[[VAL_2]] to i8**
+// CHECK:         %[[VAL_28:.*]] = load i8*, i8** %[[VAL_27]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_26]], i8* align 1 %[[VAL_28]], i64 %[[VAL_10]], i1 false)
+// CHECK:         %[[VAL_29:.*]] = getelementptr i8, i8* %[[VAL_26]], i64 %[[VAL_10]]
+// CHECK:         %[[VAL_30:.*]] = bitcast i8* %[[VAL_13]] to i8**
+// CHECK:         %[[VAL_31:.*]] = load i8*, i8** %[[VAL_30]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_29]], i8* align 1 %[[VAL_31]], i64 %[[VAL_19]], i1 false)
+// CHECK:         store i8* %[[VAL_22]], i8** %[[VAL_1]], align 8
+// CHECK:         ret i64 %[[VAL_21]]
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_3.kernelRegFunc() {
@@ -432,4 +464,3 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_3.argsCreator to i8*))
 // CHECK:         ret void
 // CHECK:       }
-

--- a/test/Quake-QIR/return_values.qke
+++ b/test/Quake-QIR/return_values.qke
@@ -57,18 +57,16 @@ func.func @test_0(%1: !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_0({ i8*, i64 }* nocapture writeonly sret({ i8*, i64 }) 
-// CHECK-SAME:    %[[VAL_0:.*]], i32 %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK-SAME:           %[[VAL_0:.*]], i32 %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = sext i32 %[[VAL_1]] to i64
 // CHECK:         %[[VAL_3:.*]] = tail call %[[VAL_4:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_2]])
 // CHECK:         %[[VAL_5:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_4]]* %[[VAL_3]])
 // CHECK:         %[[VAL_6:.*]] = icmp sgt i64 %[[VAL_5]], 0
 // CHECK:         br i1 %[[VAL_6]], label %[[VAL_7:.*]], label %[[VAL_8:.*]]
-// CHECK:       [[VAL_8]]:
-// CHECK-SAME:  preds = %[[VAL_9:.*]]
-// CHECK:         %[[VAL_10:.*]] = alloca i1, i64 %[[VAL_5]], align 1
+// CHECK:       ._crit_edge.thread:                               ; preds = %[[VAL_9:.*]]
+// CHECK:         %[[VAL_10:.*]] = alloca i8, i64 %[[VAL_5]], align 1
 // CHECK:         br label %[[VAL_11:.*]]
-// CHECK:       [[VAL_7]]:
-// CHECK-SAME:  preds = %[[VAL_9]], %[[VAL_7]]
+// CHECK:       .lr.ph:                                           ; preds = %[[VAL_9]], %[[VAL_7]]
 // CHECK:         %[[VAL_12:.*]] = phi i64 [ %[[VAL_13:.*]], %[[VAL_7]] ], [ 0, %[[VAL_9]] ]
 // CHECK:         %[[VAL_14:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_4]]* %[[VAL_3]], i64 %[[VAL_12]])
 // CHECK:         %[[VAL_15:.*]] = bitcast i8* %[[VAL_14]] to %[[VAL_16:.*]]**
@@ -77,12 +75,10 @@ func.func @test_0(%1: !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}
 // CHECK:         %[[VAL_13]] = add nuw nsw i64 %[[VAL_12]], 1
 // CHECK:         %[[VAL_18:.*]] = icmp eq i64 %[[VAL_13]], %[[VAL_5]]
 // CHECK:         br i1 %[[VAL_18]], label %[[VAL_19:.*]], label %[[VAL_7]]
-// CHECK:       [[VAL_19]]:
-// CHECK-SAME:  preds = %[[VAL_7]]
-// CHECK:         %[[VAL_20:.*]] = alloca i1, i64 %[[VAL_5]], align 1
+// CHECK:       ._crit_edge:                                      ; preds = %[[VAL_7]]
+// CHECK:         %[[VAL_20:.*]] = alloca i8, i64 %[[VAL_5]], align 1
 // CHECK:         br i1 %[[VAL_6]], label %[[VAL_21:.*]], label %[[VAL_11]]
-// CHECK:       [[VAL_21]]:
-// CHECK-SAME:  preds = %[[VAL_19]], %[[VAL_21]]
+// CHECK:       .lr.ph4:                                          ; preds = %[[VAL_19]], %[[VAL_21]]
 // CHECK:         %[[VAL_22:.*]] = phi i64 [ %[[VAL_23:.*]], %[[VAL_21]] ], [ 0, %[[VAL_19]] ]
 // CHECK:         %[[VAL_24:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_4]]* %[[VAL_3]], i64 %[[VAL_22]])
 // CHECK:         %[[VAL_25:.*]] = bitcast i8* %[[VAL_24]] to %[[VAL_16]]**
@@ -90,18 +86,17 @@ func.func @test_0(%1: !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}
 // CHECK:         %[[VAL_27:.*]] = tail call %[[VAL_28:.*]]* @__quantum__qis__mz(%[[VAL_16]]* %[[VAL_26]])
 // CHECK:         %[[VAL_29:.*]] = bitcast %[[VAL_28]]* %[[VAL_27]] to i1*
 // CHECK:         %[[VAL_30:.*]] = load i1, i1* %[[VAL_29]], align 1
-// CHECK:         %[[VAL_31:.*]] = getelementptr i1, i1* %[[VAL_20]], i64 %[[VAL_22]]
-// CHECK:         store i1 %[[VAL_30]], i1* %[[VAL_31]], align 1
+// CHECK:         %[[VAL_31:.*]] = getelementptr i8, i8* %[[VAL_20]], i64 %[[VAL_22]]
+// CHECK:         %[[VAL_32:.*]] = zext i1 %[[VAL_30]] to i8
+// CHECK:         store i8 %[[VAL_32]], i8* %[[VAL_31]], align 1
 // CHECK:         %[[VAL_23]] = add nuw nsw i64 %[[VAL_22]], 1
-// CHECK:         %[[VAL_32:.*]] = icmp eq i64 %[[VAL_23]], %[[VAL_5]]
-// CHECK:         br i1 %[[VAL_32]], label %[[VAL_11]], label %[[VAL_21]]
-// CHECK:       [[VAL_11]]:
-// CHECK-SAME:  preds = %[[VAL_21]], %[[VAL_8]], %[[VAL_19]]
-// CHECK:         %[[VAL_33:.*]] = phi i1* [ %[[VAL_10]], %[[VAL_8]] ], [ %[[VAL_20]], %[[VAL_19]] ], [ %[[VAL_20]], %[[VAL_21]] ]
-// CHECK:         %[[VAL_34:.*]] = bitcast i1* %[[VAL_33]] to i8*
+// CHECK:         %[[VAL_33:.*]] = icmp eq i64 %[[VAL_23]], %[[VAL_5]]
+// CHECK:         br i1 %[[VAL_33]], label %[[VAL_11]], label %[[VAL_21]]
+// CHECK:       ._crit_edge5:                                     ; preds = %[[VAL_21]], %[[VAL_8]], %[[VAL_19]]
+// CHECK:         %[[VAL_34:.*]] = phi i8* [ %[[VAL_10]], %[[VAL_8]] ], [ %[[VAL_20]], %[[VAL_19]] ], [ %[[VAL_20]], %[[VAL_21]] ]
 // CHECK:         %[[VAL_35:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_34]], i64 %[[VAL_5]], i64 1)
 // CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_4]]* %[[VAL_3]])
-// CHECK:         %[[VAL_36:.*]] = getelementptr { i8*, i64 }, { i8*, i64 }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         %[[VAL_36:.*]] = getelementptr inbounds { i8*, i64 }, { i8*, i64 }* %[[VAL_0]], i64 0, i32 0
 // CHECK:         store i8* %[[VAL_35]], i8** %[[VAL_36]], align 8
 // CHECK:         %[[VAL_37:.*]] = getelementptr { i8*, i64 }, { i8*, i64 }* %[[VAL_0]], i64 0, i32 1
 // CHECK:         store i64 %[[VAL_5]], i64* %[[VAL_37]], align 8
@@ -109,7 +104,7 @@ func.func @test_0(%1: !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_0({ i8*, i8*, i8* }* sret({ i8*, i8*, i8* }) 
-// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]], i32 %[[VAL_2:.*]]) local_unnamed_addr {
+// CHECK-SAME:       %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]], i32 %[[VAL_2:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_3:.*]] = alloca { i32, { i1*, i64 } }, align 8
 // CHECK:         %[[VAL_4:.*]] = bitcast { i32, { i1*, i64 } }* %[[VAL_3]] to i8*
 // CHECK:         %[[VAL_5:.*]] = getelementptr inbounds { i32, { i1*, i64 } }, { i32, { i1*, i64 } }* %[[VAL_3]], i64 0, i32 0
@@ -146,7 +141,7 @@ func.func @test_1(%1: !cc.ptr<!cc.struct<{i1, i1}>> {llvm.sret = !cc.struct<{i1,
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_1({ i1, i1 }* nocapture writeonly sret({ i1, i1 }) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK-SAME:       %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = tail call %[[VAL_2:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
 // CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 0)
 // CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to %[[VAL_5:.*]]**
@@ -171,7 +166,8 @@ func.func @test_1(%1: !cc.ptr<!cc.struct<{i1, i1}>> {llvm.sret = !cc.struct<{i1,
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_1({ i1, i1 }* nocapture writeonly sret({ i1, i1 }) 
-// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone
+// CHECK-SAME:      %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = alloca [2 x i8], align 8
 // CHECK:         %[[VAL_3:.*]] = getelementptr inbounds [2 x i8], [2 x i8]* %[[VAL_2]], i64 0, i64 0
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_3]], i64 2, i64 0)
@@ -186,6 +182,7 @@ func.func @test_1(%1: !cc.ptr<!cc.struct<{i1, i1}>> {llvm.sret = !cc.struct<{i1,
 // CHECK:         store i1 %[[VAL_8]], i1* %[[VAL_10]], align 1
 // CHECK:         ret void
 // CHECK:       }
+
 
 func.func @__nvqpp__mlirgen__test_2() -> !cc.struct<{i16, f32, f64, i64}> {
   %rv = cc.undef !cc.struct<{i16, f32, f64, i64}>
@@ -205,13 +202,14 @@ func.func @test_2(%1: !cc.ptr<!cc.struct<{i16, f32, f64, i64}>> {llvm.sret = !cc
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 }) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
+// CHECK-SAME:        %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
 // CHECK:         store { i16, float, double, i64 } { i16 8, float 0x40159999A0000000, double 3.783000e+01, i64 1479 }, { i16, float, double, i64 }* %[[VAL_0]], align 8
 // CHECK:         ret void
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 }) 
-// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK-SAME:          %[[VAL_0:.*]], i8* nocapture readnone
+// CHECK-SAME:          %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = alloca { { i16, float, double, i64 } }, align 8
 // CHECK:         %[[VAL_3:.*]] = bitcast { { i16, float, double, i64 } }* %[[VAL_2]] to i8*
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_2.thunk to i8*), i8* nonnull %[[VAL_3]], i64 24, i64 0)
@@ -251,7 +249,7 @@ func.func @test_3(%1: !cc.ptr<!cc.array<i64 x 5>> {llvm.sret = !cc.array<i64 x 5
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_3([5 x i64]* nocapture writeonly sret([5 x i64]) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
+// CHECK-SAME:        %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
 // CHECK:         %[[VAL_1:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 0
 // CHECK:         store i64 5, i64* %[[VAL_1]], align 8
 // CHECK:         %[[VAL_2:.*]] = getelementptr inbounds [5 x i64], [5 x i64]* %[[VAL_0]], i64 0, i64 1
@@ -266,7 +264,8 @@ func.func @test_3(%1: !cc.ptr<!cc.array<i64 x 5>> {llvm.sret = !cc.array<i64 x 5
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_3([5 x i64]* nocapture writeonly sret([5 x i64]) 
-// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone
+// CHECK-SAME:      %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = alloca { [5 x i64] }, align 8
 // CHECK:         %[[VAL_3:.*]] = bitcast { [5 x i64] }* %[[VAL_2]] to i8*
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_3.thunk to i8*), i8* nonnull %[[VAL_3]], i64 40, i64 0)
@@ -304,8 +303,8 @@ func.func @test_4(%1: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_4({ i64, double }* nocapture writeonly sret({ i64, double }) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
-// CHECK:         %[[VAL_1:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
+// CHECK-SAME:     %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
+// CHECK:         %[[VAL_1:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
 // CHECK:         store i64 537892, i64* %[[VAL_1]], align 8
 // CHECK:         %[[VAL_2:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
 // CHECK:         store double 0x40578DA858793DD9, double* %[[VAL_2]], align 8
@@ -313,13 +312,14 @@ func.func @test_4(%1: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_4({ i64, double }* nocapture writeonly sret({ i64, double }) 
-// CHECK-SAME:    %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK-SAME:     %[[VAL_0:.*]], i8* nocapture readnone
+// CHECK-SAME:     %[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = alloca { i64, double }, align 8
 // CHECK:         %[[VAL_3:.*]] = bitcast { i64, double }* %[[VAL_2]] to i8*
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_4.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_4.thunk to i8*), i8* nonnull %[[VAL_3]], i64 16, i64 0)
 // CHECK:         %[[VAL_4:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_2]], i64 0, i32 0
 // CHECK:         %[[VAL_5:.*]] = load i64, i64* %[[VAL_4]], align 8
-// CHECK:         %[[VAL_6:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
 // CHECK:         store i64 %[[VAL_5]], i64* %[[VAL_6]], align 8
 // CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_2]], i64 0, i32 1
 // CHECK:         %[[VAL_8:.*]] = load double, double* %[[VAL_7]], align 8
@@ -339,8 +339,8 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_5({ i64, double }* nocapture writeonly sret({ i64, double }) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
-// CHECK:         %[[VAL_1:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
+// CHECK-SAME:       %[[VAL_0:.*]]) local_unnamed_addr #{{[0-9]+}} {
+// CHECK:         %[[VAL_1:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
 // CHECK:         store i64 537892, i64* %[[VAL_1]], align 8
 // CHECK:         %[[VAL_2:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 1
 // CHECK:         store double 0x40578DA858793DD9, double* %[[VAL_2]], align 8
@@ -348,13 +348,13 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_5({ i64, double }* nocapture writeonly sret({ i64, double }) 
-// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK-SAME:       %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = alloca { i64, double }, align 8
 // CHECK:         %[[VAL_2:.*]] = bitcast { i64, double }* %[[VAL_1]] to i8*
 // CHECK:         call void @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_5.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_5.thunk to i8*), i8* nonnull %[[VAL_2]], i64 16, i64 0)
 // CHECK:         %[[VAL_3:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_1]], i64 0, i32 0
 // CHECK:         %[[VAL_4:.*]] = load i64, i64* %[[VAL_3]], align 8
-// CHECK:         %[[VAL_5:.*]] = getelementptr { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_0]], i64 0, i32 0
 // CHECK:         store i64 %[[VAL_4]], i64* %[[VAL_5]], align 8
 // CHECK:         %[[VAL_6:.*]] = getelementptr inbounds { i64, double }, { i64, double }* %[[VAL_1]], i64 0, i32 1
 // CHECK:         %[[VAL_7:.*]] = load double, double* %[[VAL_6]], align 8
@@ -365,8 +365,14 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 
 }
 
+
+
+// CHECK-LABEL: define i64 @test_0.returnOffset()
+// CHECK:         ret i64 8
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* nocapture 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK-SAME:     %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i32*
 // CHECK:         %[[VAL_3:.*]] = load i32, i32* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_4:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
@@ -375,12 +381,10 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         %[[VAL_8:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_7]]* %[[VAL_6]])
 // CHECK:         %[[VAL_9:.*]] = icmp sgt i64 %[[VAL_8]], 0
 // CHECK:         br i1 %[[VAL_9]], label %[[VAL_10:.*]], label %[[VAL_11:.*]]
-// CHECK:       [[VAL_11]]:
-// CHECK-SAME:  preds = %[[VAL_12:.*]]
-// CHECK:         %[[VAL_13:.*]] = alloca i1, i64 %[[VAL_8]], align 1
+// CHECK:       ._crit_edge.thread:                               ; preds = %[[VAL_12:.*]]
+// CHECK:         %[[VAL_13:.*]] = alloca i8, i64 %[[VAL_8]], align 1
 // CHECK:         br label %[[VAL_14:.*]]
-// CHECK:       [[VAL_10]]:
-// CHECK-SAME:  preds = %[[VAL_12]], %[[VAL_10]]
+// CHECK:       .lr.ph:                                           ; preds = %[[VAL_12]], %[[VAL_10]]
 // CHECK:         %[[VAL_15:.*]] = phi i64 [ %[[VAL_16:.*]], %[[VAL_10]] ], [ 0, %[[VAL_12]] ]
 // CHECK:         %[[VAL_17:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]]* %[[VAL_6]], i64 %[[VAL_15]])
 // CHECK:         %[[VAL_18:.*]] = bitcast i8* %[[VAL_17]] to %[[VAL_19:.*]]**
@@ -389,12 +393,10 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         %[[VAL_16]] = add nuw nsw i64 %[[VAL_15]], 1
 // CHECK:         %[[VAL_21:.*]] = icmp eq i64 %[[VAL_16]], %[[VAL_8]]
 // CHECK:         br i1 %[[VAL_21]], label %[[VAL_22:.*]], label %[[VAL_10]]
-// CHECK:       [[VAL_22]]:
-// CHECK-SAME:  preds = %[[VAL_10]]
-// CHECK:         %[[VAL_23:.*]] = alloca i1, i64 %[[VAL_8]], align 1
+// CHECK:       ._crit_edge:                                      ; preds = %[[VAL_10]]
+// CHECK:         %[[VAL_23:.*]] = alloca i8, i64 %[[VAL_8]], align 1
 // CHECK:         br i1 %[[VAL_9]], label %[[VAL_24:.*]], label %[[VAL_14]]
-// CHECK:       [[VAL_24]]:
-// CHECK-SAME:  preds = %[[VAL_22]], %[[VAL_24]]
+// CHECK:       .lr.ph4:                                          ; preds = %[[VAL_22]], %[[VAL_24]]
 // CHECK:         %[[VAL_25:.*]] = phi i64 [ %[[VAL_26:.*]], %[[VAL_24]] ], [ 0, %[[VAL_22]] ]
 // CHECK:         %[[VAL_27:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]]* %[[VAL_6]], i64 %[[VAL_25]])
 // CHECK:         %[[VAL_28:.*]] = bitcast i8* %[[VAL_27]] to %[[VAL_19]]**
@@ -402,15 +404,14 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         %[[VAL_30:.*]] = tail call %[[VAL_31:.*]]* @__quantum__qis__mz(%[[VAL_19]]* %[[VAL_29]])
 // CHECK:         %[[VAL_32:.*]] = bitcast %[[VAL_31]]* %[[VAL_30]] to i1*
 // CHECK:         %[[VAL_33:.*]] = load i1, i1* %[[VAL_32]], align 1
-// CHECK:         %[[VAL_34:.*]] = getelementptr i1, i1* %[[VAL_23]], i64 %[[VAL_25]]
-// CHECK:         store i1 %[[VAL_33]], i1* %[[VAL_34]], align 1
+// CHECK:         %[[VAL_34:.*]] = getelementptr i8, i8* %[[VAL_23]], i64 %[[VAL_25]]
+// CHECK:         %[[VAL_35:.*]] = zext i1 %[[VAL_33]] to i8
+// CHECK:         store i8 %[[VAL_35]], i8* %[[VAL_34]], align 1
 // CHECK:         %[[VAL_26]] = add nuw nsw i64 %[[VAL_25]], 1
-// CHECK:         %[[VAL_35:.*]] = icmp eq i64 %[[VAL_26]], %[[VAL_8]]
-// CHECK:         br i1 %[[VAL_35]], label %[[VAL_14]], label %[[VAL_24]]
-// CHECK:       [[VAL_14]]:
-// CHECK-SAME:  preds = %[[VAL_24]], %[[VAL_11]], %[[VAL_22]]
-// CHECK:         %[[VAL_36:.*]] = phi i1* [ %[[VAL_13]], %[[VAL_11]] ], [ %[[VAL_23]], %[[VAL_22]] ], [ %[[VAL_23]], %[[VAL_24]] ]
-// CHECK:         %[[VAL_37:.*]] = bitcast i1* %[[VAL_36]] to i8*
+// CHECK:         %[[VAL_36:.*]] = icmp eq i64 %[[VAL_26]], %[[VAL_8]]
+// CHECK:         br i1 %[[VAL_36]], label %[[VAL_14]], label %[[VAL_24]]
+// CHECK:       ._crit_edge5:                                     ; preds = %[[VAL_24]], %[[VAL_11]], %[[VAL_22]]
+// CHECK:         %[[VAL_37:.*]] = phi i8* [ %[[VAL_13]], %[[VAL_11]] ], [ %[[VAL_23]], %[[VAL_22]] ], [ %[[VAL_23]], %[[VAL_24]] ]
 // CHECK:         %[[VAL_38:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_37]], i64 %[[VAL_8]], i64 1)
 // CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_7]]* %[[VAL_6]])
 // CHECK:         %[[VAL_39:.*]] = bitcast i8* %[[VAL_4]] to i8**
@@ -419,10 +420,10 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         %[[VAL_41:.*]] = bitcast i8* %[[VAL_40]] to i64*
 // CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_41]], align 4
 // CHECK:         br i1 %[[VAL_1]], label %[[VAL_42:.*]], label %[[VAL_43:.*]]
-// CHECK:       {{.*}}:
+// CHECK:       common.ret:                                       ; preds = %[[VAL_14]], %[[VAL_42]]
 // CHECK:         %[[VAL_44:.*]] = phi { i8*, i64 } [ %[[VAL_45:.*]], %[[VAL_42]] ], [ zeroinitializer, %[[VAL_14]] ]
 // CHECK:         ret { i8*, i64 } %[[VAL_44]]
-// CHECK:       {{.*}}:
+// CHECK:       32:                                               ; preds = %[[VAL_14]]
 // CHECK:         %[[VAL_46:.*]] = add i64 %[[VAL_8]], 24
 // CHECK:         %[[VAL_47:.*]] = call i8* @malloc(i64 %[[VAL_46]])
 // CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_47]], i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_0]], i64 24, i1 false)
@@ -434,7 +435,8 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_0.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:        %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:        %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8** %[[VAL_0]] to i32**
 // CHECK:         %[[VAL_3:.*]] = load i32*, i32** %[[VAL_2]], align 8
 // CHECK:         %[[VAL_4:.*]] = load i32, i32* %[[VAL_3]], align 4
@@ -452,8 +454,13 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         ret void
 // CHECK:       }
 
+// CHECK-LABEL: define i64 @test_1.returnOffset()
+// CHECK:         ret i64 0
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* nocapture writeonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK-SAME:      %[[VAL_0:.*]], i1
+// CHECK-SAME:      %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
 // CHECK:         %[[VAL_4:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_3]]* %[[VAL_2]], i64 0)
 // CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_4]] to %[[VAL_6:.*]]**
@@ -479,7 +486,8 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_1.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:        %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:        %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(2) i8* @malloc(i64 2)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 2
@@ -491,15 +499,21 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         ret void
 // CHECK:       }
 
+// CHECK-LABEL: define i64 @test_2.returnOffset()
+// CHECK:         ret i64 0
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_2.thunk(i8* nocapture writeonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:      %[[VAL_0:.*]], i1
+// CHECK-SAME:      %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to { i16, float, double, i64 }*
 // CHECK:         store { i16, float, double, i64 } { i16 8, float 0x40159999A0000000, double 3.783000e+01, i64 1479 }, { i16, float, double, i64 }* %[[VAL_2]], align 8
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_2.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:         %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:         %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(24) i8* @malloc(i64 24)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 24
@@ -511,8 +525,12 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         ret void
 // CHECK:       }
 
+// CHECK-LABEL: define i64 @test_3.returnOffset()
+// CHECK:         ret i64 0
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_3.thunk(i8* nocapture writeonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:          %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 5, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 8
@@ -531,7 +549,8 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_3.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:       %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:       %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(40) i8* @malloc(i64 40)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 40
@@ -543,8 +562,12 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         ret void
 // CHECK:       }
 
+// CHECK-LABEL: define i64 @test_4.returnOffset()
+// CHECK:         ret i64 0
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_4.thunk(i8* nocapture writeonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:        %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
@@ -554,7 +577,8 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_4.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:         %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:         %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(16) i8* @malloc(i64 16)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 16
@@ -566,8 +590,12 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         ret void
 // CHECK:       }
 
+// CHECK-LABEL: define i64 @test_5.returnOffset()
+// CHECK:         ret i64 0
+// CHECK:       }
+
 // CHECK-LABEL: define { i8*, i64 } @test_5.thunk(i8* nocapture writeonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
@@ -577,7 +605,8 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_5.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:      %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:      %[[VAL_1:.*]]) #{{[0-9]+}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(16) i8* @malloc(i64 16)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 16
@@ -588,4 +617,3 @@ func.func @test_5(%0: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct<{i
 // CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_5.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_5.argsCreator to i8*))
 // CHECK:         ret void
 // CHECK:       }
-

--- a/test/Quake/canonical-3.qke
+++ b/test/Quake/canonical-3.qke
@@ -59,7 +59,7 @@ func.func @__nvqpp__mlirgen__super() attributes {"cudaq-entrypoint", "cudaq-kern
 // CHECK:           %[[VAL_5:.*]] = cc.alloca !cc.array<i1 x 4>
 // CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<4>) -> !quake.ref
 // CHECK:           %[[VAL_7:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> !quake.measure
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_107:.*]] = quake.discriminate %[[VAL_7]] :
 // CHECK:           cc.store %[[VAL_107]], %[[VAL_8]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<4>) -> !quake.ref

--- a/test/Quake/cc_execution_manager.qke
+++ b/test/Quake/cc_execution_manager.qke
@@ -60,21 +60,22 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i64 x 3>>) -> !cc.ptr<!cc.array<i64 x ?>>
 // CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_9]], %[[VAL_11]], %[[VAL_5]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
 // CHECK:           call @__nvqpp__cudaq_em_allocate_veq(%[[VAL_9]], %[[VAL_5]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, i64) -> ()
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_9]][0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
 // CHECK:           %[[VAL_13:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
-// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.array<i64 x ?>>
 // CHECK:           %[[VAL_15:.*]] = cc.alloca !cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>
-// CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_15]], %[[VAL_14]], %[[VAL_3]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
-// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_9]][0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+// CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_15]], %[[VAL_13]], %[[VAL_3]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
+// CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
 // CHECK:           %[[VAL_17:.*]] = cc.load %[[VAL_16]] : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
-// CHECK:           %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_17]][1] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_17]][1] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_19:.*]] = cc.alloca !cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>
-// CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_19]], %[[VAL_18]], %[[VAL_3]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
-// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_9]][0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+// CHECK:           %[[VAL_81:.*]] = cc.cast %[[VAL_18]] :
+// CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_19]], %[[VAL_81]], %[[VAL_3]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
+// CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
 // CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_20]] : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
-// CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][2] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][2] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_23:.*]] = cc.alloca !cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>
-// CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_23]], %[[VAL_22]], %[[VAL_3]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
+// CHECK:           %[[VAL_82:.*]] = cc.cast %[[VAL_22]] :
+// CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_23]], %[[VAL_82]], %[[VAL_3]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
 // CHECK:           %[[VAL_24:.*]] = cc.address_of @cstr.6800 : !cc.ptr<!llvm.array<2 x i8>>
 // CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_24]] : (!cc.ptr<!llvm.array<2 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_26:.*]] = cc.cast %[[VAL_4]] : (i64) -> !cc.ptr<!cc.array<f64 x ?>>
@@ -111,11 +112,11 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_50:.*]] = arith.addi %[[VAL_47]], %[[VAL_49]] : i64
 // CHECK:           %[[VAL_51:.*]] = cc.alloca i64{{\[}}%[[VAL_50]] : i64]
 // CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_45]], %[[VAL_51]], %[[VAL_50]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
-// CHECK:           %[[VAL_52:.*]] = cc.compute_ptr %[[VAL_51]][0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_52:.*]] = cc.cast %[[VAL_51]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_53:.*]] = cc.compute_ptr %[[VAL_23]][1] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_54:.*]] = cc.load %[[VAL_53]] : !cc.ptr<i64>
 // CHECK:           call @__nvqpp__cudaq_em_concatSpan(%[[VAL_52]], %[[VAL_23]], %[[VAL_54]]) : (!cc.ptr<i64>, !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, i64) -> ()
-// CHECK:           %[[VAL_55:.*]] = cc.compute_ptr %[[VAL_51]]{{\[}}%[[VAL_54]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_55:.*]] = cc.compute_ptr %[[VAL_51]][%[[VAL_54]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_56:.*]] = cc.compute_ptr %[[VAL_15]][1] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_57:.*]] = cc.load %[[VAL_56]] : !cc.ptr<i64>
 // CHECK:           call @__nvqpp__cudaq_em_concatSpan(%[[VAL_55]], %[[VAL_15]], %[[VAL_57]]) : (!cc.ptr<i64>, !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, i64) -> ()
@@ -145,14 +146,14 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_74:.*]] = cc.cast %[[VAL_73]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_75:.*]] = cc.alloca !cc.array<f64 x 1>
 // CHECK:           %[[VAL_76:.*]] = cc.cast %[[VAL_75]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_77:.*]] = cc.compute_ptr %[[VAL_75]][0] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_77:.*]] = cc.cast %[[VAL_75]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_77]] : !cc.ptr<f64>
 // CHECK:           call @__nvqpp__cudaq_em_apply(%[[VAL_74]], %[[VAL_3]], %[[VAL_76]], %[[VAL_15]], %[[VAL_19]], %[[VAL_1]]) : (!cc.ptr<i8>, i64, !cc.ptr<!cc.array<f64 x ?>>, !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, i1) -> ()
 // CHECK:           %[[VAL_78:.*]] = cc.address_of @cstr.7068617365645F727800 : !cc.ptr<!llvm.array<10 x i8>>
 // CHECK:           %[[VAL_79:.*]] = cc.cast %[[VAL_78]] : (!cc.ptr<!llvm.array<10 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_80:.*]] = cc.alloca !cc.array<f64 x 2>
 // CHECK:           %[[VAL_81:.*]] = cc.cast %[[VAL_80]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_82:.*]] = cc.compute_ptr %[[VAL_80]][0] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_82:.*]] = cc.cast %[[VAL_80]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_82]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_83:.*]] = cc.compute_ptr %[[VAL_80]][1] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_7]], %[[VAL_83]] : !cc.ptr<f64>
@@ -164,7 +165,7 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_87:.*]] = cc.cast %[[VAL_86]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_88:.*]] = cc.alloca !cc.array<f64 x 1>
 // CHECK:           %[[VAL_89:.*]] = cc.cast %[[VAL_88]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_90:.*]] = cc.compute_ptr %[[VAL_88]][0] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_90:.*]] = cc.cast %[[VAL_88]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_7]], %[[VAL_90]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_91:.*]] = cc.alloca !cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>
 // CHECK:           %[[VAL_92:.*]] = cc.cast %[[VAL_4]] : (i64) -> !cc.ptr<!cc.array<i64 x ?>>
@@ -174,14 +175,14 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_94:.*]] = cc.alloca !cc.array<i64 x 1>
 // CHECK:           %[[VAL_95:.*]] = cc.cast %[[VAL_94]] : (!cc.ptr<!cc.array<i64 x 1>>) -> !cc.ptr<!cc.array<i64 x ?>>
 // CHECK:           %[[VAL_96:.*]] = call @__nvqpp__cudaq_em_allocate() : () -> i64
-// CHECK:           %[[VAL_97:.*]] = cc.compute_ptr %[[VAL_94]][0] : (!cc.ptr<!cc.array<i64 x 1>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_97:.*]] = cc.cast %[[VAL_94]] : (!cc.ptr<!cc.array<i64 x 1>>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[VAL_96]], %[[VAL_97]] : !cc.ptr<i64>
 // CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_93]], %[[VAL_95]], %[[VAL_3]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
 // CHECK:           %[[VAL_98:.*]] = cc.address_of @cstr.727800 : !cc.ptr<!llvm.array<3 x i8>>
 // CHECK:           %[[VAL_99:.*]] = cc.cast %[[VAL_98]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_100:.*]] = cc.alloca !cc.array<f64 x 1>
 // CHECK:           %[[VAL_101:.*]] = cc.cast %[[VAL_100]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_102:.*]] = cc.compute_ptr %[[VAL_100]][0] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_102:.*]] = cc.cast %[[VAL_100]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_7]], %[[VAL_102]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_103:.*]] = cc.alloca !cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>
 // CHECK:           %[[VAL_104:.*]] = cc.cast %[[VAL_4]] : (i64) -> !cc.ptr<!cc.array<i64 x ?>>
@@ -199,7 +200,7 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_111:.*]] = cc.cast %[[VAL_110]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_112:.*]] = cc.alloca !cc.array<f64 x 1>
 // CHECK:           %[[VAL_113:.*]] = cc.cast %[[VAL_112]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_114:.*]] = cc.compute_ptr %[[VAL_112]][0] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_114:.*]] = cc.cast %[[VAL_112]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_114]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_115:.*]] = cc.alloca !cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>
 // CHECK:           %[[VAL_116:.*]] = cc.cast %[[VAL_4]] : (i64) -> !cc.ptr<!cc.array<i64 x ?>>
@@ -209,7 +210,7 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_118:.*]] = cc.cast %[[VAL_117]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_119:.*]] = cc.alloca !cc.array<f64 x 1>
 // CHECK:           %[[VAL_120:.*]] = cc.cast %[[VAL_119]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_121:.*]] = cc.compute_ptr %[[VAL_119]][0] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_121:.*]] = cc.cast %[[VAL_119]] : (!cc.ptr<!cc.array<f64 x 1>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_7]], %[[VAL_121]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_122:.*]] = cc.alloca !cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>
 // CHECK:           %[[VAL_123:.*]] = cc.cast %[[VAL_4]] : (i64) -> !cc.ptr<!cc.array<i64 x ?>>
@@ -219,7 +220,7 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_125:.*]] = cc.cast %[[VAL_124]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_126:.*]] = cc.alloca !cc.array<f64 x 2>
 // CHECK:           %[[VAL_127:.*]] = cc.cast %[[VAL_126]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_128:.*]] = cc.compute_ptr %[[VAL_126]][0] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_128:.*]] = cc.cast %[[VAL_126]] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_7]], %[[VAL_128]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_129:.*]] = cc.compute_ptr %[[VAL_126]][1] : (!cc.ptr<!cc.array<f64 x 2>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_129]] : !cc.ptr<f64>
@@ -231,7 +232,7 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_133:.*]] = cc.cast %[[VAL_132]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_134:.*]] = cc.alloca !cc.array<f64 x 3>
 // CHECK:           %[[VAL_135:.*]] = cc.cast %[[VAL_134]] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<!cc.array<f64 x ?>>
-// CHECK:           %[[VAL_136:.*]] = cc.compute_ptr %[[VAL_134]][0] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_136:.*]] = cc.cast %[[VAL_134]] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_7]], %[[VAL_136]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_137:.*]] = cc.compute_ptr %[[VAL_134]][1] : (!cc.ptr<!cc.array<f64 x 3>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_137]] : !cc.ptr<f64>
@@ -255,11 +256,11 @@ func.func @tocc.test() {
 // CHECK:           %[[VAL_151:.*]] = arith.addi %[[VAL_148]], %[[VAL_150]] : i64
 // CHECK:           %[[VAL_152:.*]] = cc.alloca i64{{\[}}%[[VAL_151]] : i64]
 // CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_146]], %[[VAL_152]], %[[VAL_151]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
-// CHECK:           %[[VAL_153:.*]] = cc.compute_ptr %[[VAL_152]][0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_153:.*]] = cc.cast %[[VAL_152]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_154:.*]] = cc.compute_ptr %[[VAL_15]][1] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_155:.*]] = cc.load %[[VAL_154]] : !cc.ptr<i64>
 // CHECK:           call @__nvqpp__cudaq_em_concatSpan(%[[VAL_153]], %[[VAL_15]], %[[VAL_155]]) : (!cc.ptr<i64>, !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, i64) -> ()
-// CHECK:           %[[VAL_156:.*]] = cc.compute_ptr %[[VAL_152]]{{\[}}%[[VAL_155]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_156:.*]] = cc.compute_ptr %[[VAL_152]][%[[VAL_155]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_157:.*]] = cc.compute_ptr %[[VAL_23]][1] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_158:.*]] = cc.load %[[VAL_157]] : !cc.ptr<i64>
 // CHECK:           call @__nvqpp__cudaq_em_concatSpan(%[[VAL_156]], %[[VAL_23]], %[[VAL_158]]) : (!cc.ptr<i64>, !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, i64) -> ()
@@ -303,7 +304,7 @@ func.func @tocc.test() {
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, %[[VAL_1:.*]]: i64) {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_0]][0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
 // CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
 // CHECK:           %[[VAL_4:.*]] = cc.loop while ((%[[VAL_5:.*]] = %[[VAL_3]]) -> (i64)) {
 // CHECK:             %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_1]] : i64
@@ -328,7 +329,7 @@ func.func @tocc.test() {
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<i64>, %[[VAL_1:.*]]: !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, %[[VAL_2:.*]]: i64) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant false
 // CHECK:           %[[VAL_4:.*]] = arith.constant 8 : i64
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_1]][0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
 // CHECK:           %[[VAL_7:.*]] = arith.muli %[[VAL_2]], %[[VAL_4]] : i64
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i64>) -> !cc.ptr<i8>
@@ -342,9 +343,9 @@ func.func @tocc.test() {
 
 // CHECK-LABEL:   func.func private @__nvqpp__cudaq_em_writeToSpan(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, %[[VAL_1:.*]]: !cc.ptr<!cc.array<i64 x ?>>, %[[VAL_2:.*]]: i64) {
-// CHECK:           %[[VAL_3:.*]] = cc.compute_ptr %[[VAL_0]][0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+// CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_3]] : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_0]][0, 1] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_4]] : !cc.ptr<i64>
 // CHECK:           return
 // CHECK:         }
@@ -385,18 +386,18 @@ func.func @tocc.test() {
 // LLVM:           %[[VAL_11:.*]] = llvm.mlir.constant(1 : i32) : i32
 // LLVM:           %[[VAL_12:.*]] = llvm.alloca %[[VAL_11]] x !llvm.struct<(ptr<i64>, i64)> : (i32) -> !llvm.ptr<struct<(ptr<i64>, i64)>>
 // LLVM:           %[[VAL_13:.*]] = llvm.mlir.constant(1 : i64) : i64
-// LLVM:           llvm.call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_12]], %[[VAL_10]], %[[VAL_13]]) : (!llvm.ptr<struct<(ptr<i64>, i64)>>, !llvm.ptr<i64>, i64) -> ()
+// LLVM:           llvm.call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_12]], %{{.*}}, %[[VAL_13]]) : (!llvm.ptr<struct<(ptr<i64>, i64)>>, !llvm.ptr<i64>, i64) -> ()
 // LLVM:           %[[VAL_14:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<ptr<i64>>
 // LLVM:           %[[VAL_15:.*]] = llvm.getelementptr %[[VAL_14]][1] : (!llvm.ptr<i64>) -> !llvm.ptr<i64>
 // LLVM:           %[[VAL_16:.*]] = llvm.mlir.constant(1 : i32) : i32
 // LLVM:           %[[VAL_17:.*]] = llvm.alloca %[[VAL_16]] x !llvm.struct<(ptr<i64>, i64)> : (i32) -> !llvm.ptr<struct<(ptr<i64>, i64)>>
-// LLVM:           llvm.call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_17]], %[[VAL_15]], %[[VAL_13]]) : (!llvm.ptr<struct<(ptr<i64>, i64)>>, !llvm.ptr<i64>, i64) -> ()
+// LLVM:           llvm.call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_17]], %{{.*}}, %[[VAL_13]]) : (!llvm.ptr<struct<(ptr<i64>, i64)>>, !llvm.ptr<i64>, i64) -> ()
 // LLVM:           %[[VAL_18:.*]] = llvm.mlir.constant(2 : i64) : i64
 // LLVM:           %[[VAL_19:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<ptr<i64>>
 // LLVM:           %[[VAL_20:.*]] = llvm.getelementptr %[[VAL_19]][2] : (!llvm.ptr<i64>) -> !llvm.ptr<i64>
 // LLVM:           %[[VAL_21:.*]] = llvm.mlir.constant(1 : i32) : i32
 // LLVM:           %[[VAL_22:.*]] = llvm.alloca %[[VAL_21]] x !llvm.struct<(ptr<i64>, i64)> : (i32) -> !llvm.ptr<struct<(ptr<i64>, i64)>>
-// LLVM:           llvm.call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_22]], %[[VAL_20]], %[[VAL_13]]) : (!llvm.ptr<struct<(ptr<i64>, i64)>>, !llvm.ptr<i64>, i64) -> ()
+// LLVM:           llvm.call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_22]], %{{.*}}, %[[VAL_13]]) : (!llvm.ptr<struct<(ptr<i64>, i64)>>, !llvm.ptr<i64>, i64) -> ()
 // LLVM:           %[[VAL_23:.*]] = llvm.mlir.addressof @cstr.6800 : !llvm.ptr<array<2 x i8>>
 // LLVM:           %[[VAL_24:.*]] = llvm.bitcast %[[VAL_23]] : !llvm.ptr<array<2 x i8>> to !llvm.ptr<i8>
 // LLVM:           %[[VAL_25:.*]] = llvm.inttoptr %[[VAL_7]] : i64 to !llvm.ptr<f64>
@@ -423,10 +424,10 @@ func.func @tocc.test() {
 // LLVM:           %[[VAL_39:.*]] = llvm.bitcast %[[VAL_38]] : !llvm.ptr<array<2 x i8>> to !llvm.ptr<i8>
 // LLVM:           %[[VAL_40:.*]] = llvm.mlir.constant(1 : i32) : i32
 // LLVM:           %[[VAL_41:.*]] = llvm.alloca %[[VAL_40]] x !llvm.struct<(ptr<i64>, i64)> : (i32) -> !llvm.ptr<struct<(ptr<i64>, i64)>>
-// LLVM:           %[[VAL_42:.*]] = llvm.getelementptr %[[VAL_22]][1] : (!llvm.ptr<struct<(ptr<i64>, i64)>>) -> !llvm.ptr<i64>
+// LLVM:           %[[VAL_42:.*]] = llvm.getelementptr %[[VAL_22]][0, 1] : (!llvm.ptr<struct<(ptr<i64>, i64)>>) -> !llvm.ptr<i64>
 // LLVM:           %[[VAL_43:.*]] = llvm.load %[[VAL_42]] : !llvm.ptr<i64>
 // LLVM:           %[[VAL_44:.*]] = llvm.add %[[VAL_7]], %[[VAL_43]]  : i64
-// LLVM:           %[[VAL_45:.*]] = llvm.getelementptr %[[VAL_12]][1] : (!llvm.ptr<struct<(ptr<i64>, i64)>>) -> !llvm.ptr<i64>
+// LLVM:           %[[VAL_45:.*]] = llvm.getelementptr %[[VAL_12]][0, 1] : (!llvm.ptr<struct<(ptr<i64>, i64)>>) -> !llvm.ptr<i64>
 // LLVM:           %[[VAL_46:.*]] = llvm.load %[[VAL_45]] : !llvm.ptr<i64>
 // LLVM:           %[[VAL_47:.*]] = llvm.add %[[VAL_44]], %[[VAL_46]]  : i64
 // LLVM:           %[[VAL_48:.*]] = llvm.alloca %[[VAL_47]] x i64 : (i64) -> !llvm.ptr<i64>

--- a/test/Quake/compute_ptr.qke
+++ b/test/Quake/compute_ptr.qke
@@ -14,7 +14,7 @@ func.func @e() -> !cc.ptr<f64> {
   %1 = arith.addi %z, %0 : i32
   %2 = arith.addi %1, %0 : i32
   %3 = cc.alloca !cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>
-  %4 = cc.compute_ptr %3[%1, %2] : (!cc.ptr<!cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>>, i32, i32) -> !cc.ptr<f64>
+  %4 = cc.compute_ptr %3[1, %2] : (!cc.ptr<!cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>>, i32) -> !cc.ptr<f64>
   return %4 : !cc.ptr<f64>
 }
 
@@ -24,7 +24,7 @@ func.func @r(%arg0: i64) -> !cc.ptr<f64> {
   %1 = arith.addi %z, %0 : i32
   %2 = arith.addi %1, %0 : i32
   %3 = cc.alloca !cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>
-  %4 = cc.compute_ptr %3[%1, %arg0] : (!cc.ptr<!cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>>, i32, i64) -> !cc.ptr<f64>
+  %4 = cc.compute_ptr %3[1, %arg0] : (!cc.ptr<!cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>>, i64) -> !cc.ptr<f64>
   return %4 : !cc.ptr<f64>
 }
 
@@ -35,7 +35,7 @@ func.func @r(%arg0: i64) -> !cc.ptr<f64> {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @r(
-// CHECK-SAME:                 %[[VAL_0:.*]]: i64) -> !cc.ptr<f64> {
+// CHECK-SAME:      %[[VAL_0:.*]]: i64) -> !cc.ptr<f64> {
 // CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>
 // CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_1]][1, %[[VAL_0]]] : (!cc.ptr<!cc.struct<{!cc.array<i64 x 4>, !cc.array<f64 x 4>}>>, i64) -> !cc.ptr<f64>
 // CHECK:           return %[[VAL_2]] : !cc.ptr<f64>

--- a/test/Quake/kernel_exec-1.qke
+++ b/test/Quake/kernel_exec-1.qke
@@ -100,7 +100,7 @@ module attributes {quake.mangled_name_map = {
 // CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_12]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_15:.*]] = cc.func_ptr %[[VAL_13]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_17:.*]] = cc.compute_ptr %[[VAL_5]][0, 1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_17:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
 // CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<f64>) -> i64
 // CHECK:           call @altLaunchKernel(%[[VAL_14]], %[[VAL_15]], %[[VAL_16]], %[[VAL_8]], %[[VAL_18]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> ()
 // CHECK:           %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_11]][0, 1] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>) -> !cc.ptr<f64>
@@ -123,7 +123,7 @@ module attributes {quake.mangled_name_map = {
 // CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_20]][%[[VAL_7]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_9:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i32, f64}>) -> i32
 // CHECK:           %[[VAL_10:.*]] = call @__nvqpp__mlirgen__ghz(%[[VAL_9]]) : (i32) -> f64
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_2]][0, 1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
 // CHECK:           cc.store %[[VAL_10]], %[[VAL_11]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_12:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           return %[[VAL_12]] : !cc.struct<{!cc.ptr<i8>, i64}>
@@ -133,8 +133,9 @@ module attributes {quake.mangled_name_map = {
 // CHECK-SAME:                               %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
 // CHECK-SAME:                               %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
 // CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{i32, f64}>
+// CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.array<!cc.ptr<i8> x ?>>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_14]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>

--- a/test/Quake/kernel_exec-2.qke
+++ b/test/Quake/kernel_exec-2.qke
@@ -41,8 +41,8 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 // CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{i1, i64}>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_0]], %[[VAL_2]][0] : (!cc.struct<{i1, i64}>, i1) -> !cc.struct<{i1, i64}>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_1]][0, 1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_1]][0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_1]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_1]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_5]] : !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_6]] : !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i32>) -> i64
@@ -56,14 +56,15 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 // CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_18]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i1, i64}>>
 // CHECK:           cc.store %[[VAL_12]], %[[VAL_19]] : !cc.ptr<!cc.struct<{i1, i64}>>
 // CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_18]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.array<!cc.struct<{i1, i64}> x ?>>
-// CHECK:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_18]]{{\[}}%[[VAL_16]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_18]][%[[VAL_16]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_22:.*]] = cc.extract_value %[[VAL_12]][1] : (!cc.struct<{i1, i64}>) -> i64
 // CHECK:           %[[VAL_23:.*]] = arith.constant false
-// CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_1]][0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_1]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_25:.*]] = cc.load %[[VAL_24]] : !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_26:.*]] = cc.cast %[[VAL_25]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
 // CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_21]], %[[VAL_26]], %[[VAL_22]], %[[VAL_23]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
-// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_21]][%[[VAL_22]]] : (!cc.ptr<i8>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_90:.*]] = cc.cast %[[VAL_21]] :
+// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_90]][%[[VAL_22]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_28:.*]] = llvm.mlir.addressof @function_hawaiian.kernelName : !llvm.ptr<array<18 x i8>>
 // CHECK:           %[[VAL_29:.*]] = constant @function_hawaiian.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_28]] : (!llvm.ptr<array<18 x i8>>) -> !cc.ptr<i8>
@@ -100,7 +101,8 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 // CHECK:           %[[VAL_12:.*]] = arith.divsi %[[VAL_10]], %[[VAL_11]] : i64
 // CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_14:.*]] = cc.stdvec_init %[[VAL_13]], %[[VAL_12]] : (!cc.ptr<i32>, i64) -> !cc.stdvec<i32>
-// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_8]][%[[VAL_10]]] : (!cc.ptr<i8>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_90:.*]] = cc.cast %[[VAL_8]] :
+// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_90]][%[[VAL_10]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:           call @__nvqpp__mlirgen__function_hawaiian(%[[VAL_9]], %[[VAL_14]]) : (i1, !cc.stdvec<i32>) -> ()
 // CHECK:           %[[VAL_16:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           return %[[VAL_16]] : !cc.struct<{!cc.ptr<i8>, i64}>
@@ -109,17 +111,18 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 // CHECK-LABEL:   func.func @function_hawaiian.argsCreator(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>, %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
 // CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{i1, i64}>
+// CHECK:           %[[VAL_90:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.ptr<i8>>) ->
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_90]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<i8>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_8:.*]] = cc.insert_value %[[VAL_7]], %[[VAL_2]][0] : (!cc.struct<{i1, i64}>, i1) -> !cc.struct<{i1, i64}>
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_90]][1] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][0, 1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_11]][0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_11]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_14:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_15:.*]] = cc.load %[[VAL_13]] : !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_14]] : (!cc.ptr<i32>) -> i64
@@ -132,17 +135,19 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 // CHECK:           %[[VAL_25:.*]] = call @malloc(%[[VAL_24]]) : (i64) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_26:.*]] = cc.cast %[[VAL_25]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i1, i64}>>
 // CHECK:           cc.store %[[VAL_19]], %[[VAL_26]] : !cc.ptr<!cc.struct<{i1, i64}>>
-// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_25]][%[[VAL_23]]] : (!cc.ptr<i8>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_80:.*]] = cc.cast %[[VAL_25]] :
+// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_80]][%[[VAL_23]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_28:.*]] = cc.extract_value %[[VAL_19]][1] : (!cc.struct<{i1, i64}>) -> i64
-// CHECK:           %[[VAL_29:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_29:.*]] = cc.compute_ptr %[[VAL_90]][1] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_30:.*]] = cc.load %[[VAL_29]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_31:.*]] = cc.cast %[[VAL_30]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>
 // CHECK:           %[[VAL_32:.*]] = arith.constant false
-// CHECK:           %[[VAL_33:.*]] = cc.compute_ptr %[[VAL_31]][0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_33:.*]] = cc.compute_ptr %[[VAL_31]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_34:.*]] = cc.load %[[VAL_33]] : !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_35:.*]] = cc.cast %[[VAL_34]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
 // CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_27]], %[[VAL_35]], %[[VAL_28]], %[[VAL_32]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
-// CHECK:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_27]][%[[VAL_28]]] : (!cc.ptr<i8>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_83:.*]] = cc.cast %[[VAL_27]] :
+// CHECK:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_83]][%[[VAL_28]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:           cc.store %[[VAL_25]], %[[VAL_1]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           return %[[VAL_24]] : i64
 // CHECK:         }

--- a/test/Quake/quake_to_cc.qke
+++ b/test/Quake/quake_to_cc.qke
@@ -19,6 +19,7 @@ func.func @test1(%arg1: i32) {
   quake.dealloc %5 : !quake.veq<?>
   return
 }
+
 // CHECK-LABEL:   func.func @test1(
 // CHECK-SAME:        %[[VAL_0:.*]]: i32) {
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant false
@@ -32,11 +33,10 @@ func.func @test1(%arg1: i32) {
 // CHECK:           %[[VAL_8:.*]] = cc.alloca i64{{\[}}%[[VAL_6]] : i64]
 // CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_7]], %[[VAL_8]], %[[VAL_6]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
 // CHECK:           call @__nvqpp__cudaq_em_allocate_veq(%[[VAL_7]], %[[VAL_6]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, i64) -> ()
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_7]][0, 0] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>) -> !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<!cc.ptr<!cc.array<i64 x ?>>>
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.array<i64 x ?>>
 // CHECK:           %[[VAL_12:.*]] = cc.alloca !cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>
-// CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_12]], %[[VAL_11]], %[[VAL_2]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
+// CHECK:           call @__nvqpp__cudaq_em_writeToSpan(%[[VAL_12]], %[[VAL_10]], %[[VAL_2]]) : (!cc.ptr<!cc.struct<".qubit_span" {!cc.ptr<!cc.array<i64 x ?>>, i64}>>, !cc.ptr<!cc.array<i64 x ?>>, i64) -> ()
 // CHECK:           %[[VAL_13:.*]] = cc.address_of @cstr.7800 : !cc.ptr<!llvm.array<2 x i8>>
 // CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!llvm.array<2 x i8>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_3]] : (i64) -> !cc.ptr<!cc.array<f64 x ?>>

--- a/test/Quake/return_vector.qke
+++ b/test/Quake/return_vector.qke
@@ -30,53 +30,55 @@ func.func @test_0(%0: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i3
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test_0(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>> {llvm.sret = !cc.struct<{!cc.ptr<i8>, i64}>}, %[[VAL_1:.*]]: i32) {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 8 : i64
-// CHECK:           %[[VAL_3:.*]] = arith.constant 256 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 8 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 256 : i64
 // CHECK:           %[[VAL_4:.*]] = call @malloc(%[[VAL_3]]) : (i64) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_0]][0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_0]][0, 1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           cc.store %[[VAL_5]], %[[VAL_9]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_7]] : !cc.ptr<i64>
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_0(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>> {llvm.sret = !cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>}, %[[VAL_1:.*]]: !cc.ptr<i8>, %[[VAL_2:.*]]: i32) {
+// CHECK-SAME:          %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>> {llvm.sret = !cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>},
+// CHECK-SAME:          %[[VAL_1:.*]]: !cc.ptr<i8>, %[[VAL_2:.*]]: i32) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 4 : i64
 // CHECK:           %[[VAL_4:.*]] = constant @test_0.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_6:.*]] = cc.undef !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>
 // CHECK:           %[[VAL_7:.*]] = cc.insert_value %[[VAL_2]], %[[VAL_6]][0] : (!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>, i32) -> !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_5]] : (i64) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           %[[VAL_10:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
-// CHECK:           %[[VAL_11:.*]] = cc.alloca i8{{\[}}%[[VAL_10]] : i64]
-// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           cc.store %[[VAL_7]], %[[VAL_12]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.array<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> x ?>>
-// CHECK:           %[[VAL_14:.*]] = llvm.mlir.addressof @test_0.kernelName : !llvm.ptr<array<7 x i8>>
-// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_14]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_16:.*]] = cc.func_ptr %[[VAL_4]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_8]][0, 1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
-// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_18]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> i64
-// CHECK:           call @altLaunchKernel(%[[VAL_15]], %[[VAL_16]], %[[VAL_17]], %[[VAL_10]], %[[VAL_19]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> ()
-// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_13]][0, 1, 0] : (!cc.ptr<!cc.array<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> x ?>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_20]] : !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_13]][0, 1, 1] : (!cc.ptr<!cc.array<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> x ?>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_9:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
+// CHECK:           %[[VAL_10:.*]] = cc.alloca i8{{\[}}%[[VAL_9]] : i64]
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
+// CHECK:           cc.store %[[VAL_7]], %[[VAL_11]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
+// CHECK:           %[[VAL_12:.*]] = llvm.mlir.addressof @test_0.kernelName : !llvm.ptr<array<7 x i8>>
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_12]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = cc.func_ptr %[[VAL_4]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_8]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
+// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> i64
+// CHECK:           call @altLaunchKernel(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_9]], %[[VAL_17]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> ()
+// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
+// CHECK:           %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_18]][1, 0] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_20:.*]] = cc.load %[[VAL_19]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_21:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
+// CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][1, 1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_23:.*]] = cc.load %[[VAL_22]] : !cc.ptr<i64>
 // CHECK:           %[[VAL_24:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
-// CHECK:           %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_24]][0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           call @free(%[[VAL_26]]) : (!cc.ptr<i8>) -> ()
-// CHECK:           %[[VAL_27:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_27:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
 // CHECK:           cc.store %[[VAL_27]], %[[VAL_25]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_24]][0, 1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_24]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_29:.*]] = arith.muli %[[VAL_23]], %[[VAL_3]] : i64
-// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<i32>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_31:.*]] = cc.compute_ptr %[[VAL_30]][0, %[[VAL_29]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<i32>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_31:.*]] = cc.compute_ptr %[[VAL_30]]{{\[}}%[[VAL_29]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:           cc.store %[[VAL_31]], %[[VAL_28]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_32:.*]] = cc.compute_ptr %[[VAL_24]][0, 2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_32:.*]] = cc.compute_ptr %[[VAL_24]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           cc.store %[[VAL_31]], %[[VAL_32]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           return
 // CHECK:         }
@@ -99,48 +101,51 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:           %[[VAL_3:.*]] = arith.constant 520 : i64
 // CHECK:           %[[VAL_4:.*]] = call @malloc(%[[VAL_3]]) : (i64) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<i8>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_0]][0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<f64>>
-// CHECK:           cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<!cc.ptr<f64>>
-// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_0]][0, 1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<f64>>
+// CHECK:           cc.store %[[VAL_5]], %[[VAL_8]] : !cc.ptr<!cc.ptr<f64>>
+// CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
 // CHECK:           cc.store %[[VAL_2]], %[[VAL_7]] : !cc.ptr<i64>
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_1(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>> {llvm.sret = !cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>}, %[[VAL_1:.*]]: !cc.ptr<i8>, %[[VAL_2:.*]]: i32) {
+// CHECK-SAME:           %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>> {llvm.sret = !cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>},
+// CHECK-SAME:           %[[VAL_1:.*]]: !cc.ptr<i8>, %[[VAL_2:.*]]: i32) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 8 : i64
 // CHECK:           %[[VAL_4:.*]] = constant @test_1.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_6:.*]] = cc.undef !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>
 // CHECK:           %[[VAL_7:.*]] = cc.insert_value %[[VAL_2]], %[[VAL_6]][0] : (!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>, i32) -> !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>
-// CHECK:           %[[VAL_10:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
-// CHECK:           %[[VAL_11:.*]] = cc.alloca i8{{\[}}%[[VAL_10]] : i64]
-// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           cc.store %[[VAL_7]], %[[VAL_12]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.array<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> x ?>>
-// CHECK:           %[[VAL_14:.*]] = llvm.mlir.addressof @test_1.kernelName : !llvm.ptr<array<7 x i8>>
-// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_14]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_16:.*]] = cc.func_ptr %[[VAL_4]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_8]][0, 1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
-// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_18]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> i64
-// CHECK:           call @altLaunchKernel(%[[VAL_15]], %[[VAL_16]], %[[VAL_17]], %[[VAL_10]], %[[VAL_19]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> ()
-// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_13]][0, 1, 0] : (!cc.ptr<!cc.array<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> x ?>>) -> !cc.ptr<!cc.ptr<f64>>
-// CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_20]] : !cc.ptr<!cc.ptr<f64>>
-// CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_13]][0, 1, 1] : (!cc.ptr<!cc.array<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> x ?>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_5]] : (i64) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
+// CHECK:           %[[VAL_9:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
+// CHECK:           %[[VAL_10:.*]] = cc.alloca i8{{\[}}%[[VAL_9]] : i64]
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
+// CHECK:           cc.store %[[VAL_7]], %[[VAL_11]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
+// CHECK:           %[[VAL_12:.*]] = llvm.mlir.addressof @test_1.kernelName : !llvm.ptr<array<7 x i8>>
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_12]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = cc.func_ptr %[[VAL_4]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_8]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
+// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> i64
+// CHECK:           call @altLaunchKernel(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_9]], %[[VAL_17]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> ()
+// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
+// CHECK:           %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_18]][1, 0] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.ptr<f64>>
+// CHECK:           %[[VAL_20:.*]] = cc.load %[[VAL_19]] : !cc.ptr<!cc.ptr<f64>>
+// CHECK:           %[[VAL_21:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
+// CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][1, 1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_23:.*]] = cc.load %[[VAL_22]] : !cc.ptr<i64>
 // CHECK:           %[[VAL_24:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
-// CHECK:           %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_24]][0, 0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           call @free(%[[VAL_26]]) : (!cc.ptr<i8>) -> ()
-// CHECK:           %[[VAL_27:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<f64>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_27:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<f64>) -> !cc.ptr<i8>
 // CHECK:           cc.store %[[VAL_27]], %[[VAL_25]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_24]][0, 1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_24]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_29:.*]] = arith.muli %[[VAL_23]], %[[VAL_3]] : i64
-// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<f64>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_31:.*]] = cc.compute_ptr %[[VAL_30]][0, %[[VAL_29]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<f64>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_31:.*]] = cc.compute_ptr %[[VAL_30]]{{\[}}%[[VAL_29]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // CHECK:           cc.store %[[VAL_31]], %[[VAL_28]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_32:.*]] = cc.compute_ptr %[[VAL_24]][0, 2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_32:.*]] = cc.compute_ptr %[[VAL_24]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
 // CHECK:           cc.store %[[VAL_31]], %[[VAL_32]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           return
 // CHECK:         }
@@ -152,13 +157,13 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
 // CHECK:           %[[VAL_7:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_3]][0, 1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
+// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>
 // CHECK:           %[[VAL_10:.*]] = cc.extract_value %[[VAL_4]][0] : (!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>) -> i32
 // CHECK:           call @__nvqpp__mlirgen__test_0(%[[VAL_9]], %[[VAL_10]]) : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>, i32) -> ()
 // CHECK:           cf.cond_br %[[VAL_1]], ^bb1, ^bb2
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_3]][0, 1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>
+// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>
 // CHECK:           %[[VAL_13:.*]] = call @__nvqpp_createDynamicResult(%[[VAL_0]], %[[VAL_7]], %[[VAL_12]]) : (!cc.ptr<i8>, i64, !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           return %[[VAL_13]] : !cc.struct<{!cc.ptr<i8>, i64}>
@@ -172,13 +177,13 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
 // CHECK:           %[[VAL_7:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_3]][0, 1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
+// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>
 // CHECK:           %[[VAL_10:.*]] = cc.extract_value %[[VAL_4]][0] : (!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>) -> i32
 // CHECK:           call @__nvqpp__mlirgen__test_1(%[[VAL_9]], %[[VAL_10]]) : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>, i32) -> ()
 // CHECK:           cf.cond_br %[[VAL_1]], ^bb1, ^bb2
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_3]][0, 1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
+// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_3]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>
 // CHECK:           %[[VAL_13:.*]] = call @__nvqpp_createDynamicResult(%[[VAL_0]], %[[VAL_7]], %[[VAL_12]]) : (!cc.ptr<i8>, i64, !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           return %[[VAL_13]] : !cc.struct<{!cc.ptr<i8>, i64}>


### PR DESCRIPTION
The CC dialect has a strong semantics on sequence types. Unlike C (and LLVM), a pointer to a scalar type is not conflated with a pointer to an array of scalars. The types are explicitly distinct.

As a consequence, the following has no semantics:

```mlir
  %1 = ... : !cc.ptr<i32>
  %2 = cc.compute_ptr %1[5] : (!cc.ptr<i32>) -> !cc.ptr<i32>
```

This construct violates the semantics of cc.compute_ptr and will now fail to pass the verifier. The correct way to do this is:

```mlir
  %1 = ... : !cc.ptr<!cc.array<i32 x ?>>
  %2 = cc.compute_ptr %1[5] : (!cc.ptr<!cc.array<i32 x ?>>) -> !cc.ptr<i32>
```

These patches add the checks and fix all the places where the semantics were being violated.

As a consequence, it will be easier to reason about cc.compute_ptr, to debug issues, and to write code that uses cc.compute_ptr.

Reimplement the quake add metadata pass so that it isn't doing ad hoc pattern matching and is prone to failure when small changes to the IR happen. (Is there an issue for this?)

Add more canonicalizations for cc.compute_ptr.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
