### PR TITLE
Add nvidia-mqpu as a valid multi-GPU backend for NVQC

### DIFF
--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -681,8 +681,8 @@ public:
               const std::string &backendSimName, const std::string &kernelName,
               void (*kernelFunc)(void *), void *kernelArgs,
               std::uint64_t argsSize, std::string *optionalErrorMsg) override {
-    static const std::vector<std::string> MULTI_GPU_BACKENDS = {"tensornet",
-                                                                "nvidia-mgpu"};
+    static const std::vector<std::string> MULTI_GPU_BACKENDS = {
+        "tensornet", "nvidia-mgpu", "nvidia-mqpu"};
     {
       // Print out a message if users request a multi-GPU deployment while
       // setting the backend to a single-GPU one. Only print once in case this


### PR DESCRIPTION
Without this change, some uses of `backend='nvidia-mqpu'` for `nvqc` would cause a false warning message:

```
The requested backend simulator (nvidia-mqpu) is not capable of using all 4 GPUs requested.
Only one GPU will be used for simulation.
```

This change fixes that by adding it to an internal list of multi-GPU backends.