### PR TITLE
[core] Merge the get_const_element and extract_value operations.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.h
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.h
@@ -22,24 +22,31 @@
 #include "mlir/Interfaces/LoopLikeInterface.h"
 
 namespace cudaq::cc {
-constexpr int kComputePtrConstantBitWidth = 29;
-using ComputePtrConstantIndex =
-    llvm::PointerEmbeddedInt<std::int32_t, kComputePtrConstantBitWidth>;
+constexpr int kInterleavedArgumentConstantBitWidth = 29;
+using InterleavedArgumentConstantIndex =
+    llvm::PointerEmbeddedInt<std::int32_t,
+                             kInterleavedArgumentConstantBitWidth>;
 
 enum class CastOpMode { Signed, Unsigned };
 
 // Allow a mix of values and constants to be passed as arguments to
 // ComputePtrOp's builder.
-class ComputePtrArg
-    : public llvm::PointerUnion<mlir::Value, ComputePtrConstantIndex> {
-  using BaseT = llvm::PointerUnion<mlir::Value, ComputePtrConstantIndex>;
+class InterleavedArgument
+    : public llvm::PointerUnion<mlir::Value, InterleavedArgumentConstantIndex> {
+
+  using BaseT =
+      llvm::PointerUnion<mlir::Value, InterleavedArgumentConstantIndex>;
 
 public:
-  ComputePtrArg(std::int32_t integer) : BaseT(integer) {}
-  ComputePtrArg(mlir::Value value) : BaseT(value) {}
+  InterleavedArgument(std::int32_t integer) : BaseT(integer) {}
+  InterleavedArgument(mlir::Value value) : BaseT(value) {}
 
   using BaseT::operator=;
 };
+
+using ComputePtrArg = InterleavedArgument;
+using ExtractValueArg = InterleavedArgument;
+
 } // namespace cudaq::cc
 
 //===----------------------------------------------------------------------===//
@@ -53,6 +60,9 @@ namespace cudaq::cc {
 
 template <typename A>
 using ComputePtrIndicesAdaptor = mlir::LLVM::GEPIndicesAdaptor<A>;
+
+template <typename A>
+using ExtractValueIndicesAdaptor = mlir::LLVM::GEPIndicesAdaptor<A>;
 
 class RegionBuilderGuard : mlir::OpBuilder::InsertionGuard {
   using Base = mlir::OpBuilder::InsertionGuard;

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -934,22 +934,44 @@ def cc_ExtractValueOp : CCOp<"extract_value", [Pure]> {
   }];
 
   let arguments = (ins
-    AnyAggregateType:$container,
-    DenseI64ArrayAttr:$position
+    AnyAggregateType:$aggregate,
+    Variadic<AnyInteger>:$dynamicIndices,
+    DenseI32ArrayAttr:$rawConstantIndices
   );
   let results = (outs AnyType);
 
   let assemblyFormat = [{
-    $container `` $position `:` functional-type(operands, results) attr-dict
+    $aggregate `[` custom<ExtractValueIndices>($dynamicIndices,
+      $rawConstantIndices) `]` `:` functional-type(operands, results) attr-dict
   }];
+
+  let hasFolder = 1;
+  let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 
   let builders = [
     OpBuilder<(ins "mlir::Type":$resultType, "mlir::Value":$aggregate,
-               "std::int64_t":$index), [{
-      return build($_builder, $_state, resultType, aggregate,
-                   mlir::ArrayRef<std::int64_t>{index});
-    }]>
+               "mlir::ValueRange":$indices,
+               CArg<"mlir::ArrayRef<mlir::NamedAttribute>", "{}">:$attrs)>,
+    OpBuilder<(ins "mlir::Type":$resultType, "mlir::Value":$aggregate,
+               "mlir::ArrayRef<cudaq::cc::ExtractValueArg>":$indices,
+               CArg<"mlir::ArrayRef<mlir::NamedAttribute>", "{}">:$attrs)>,
+    OpBuilder<(ins "mlir::Type":$resultType, "mlir::Value":$aggregate,
+               "std::int32_t":$index,
+               CArg<"mlir::ArrayRef<mlir::NamedAttribute>", "{}">:$attrs)>,
+    OpBuilder<(ins "mlir::Type":$resultType, "mlir::Value":$aggregate,
+               "mlir::Value":$index,
+               CArg<"mlir::ArrayRef<mlir::NamedAttribute>", "{}">:$attrs)>
   ];
+
+  let extraClassDeclaration = [{
+    static constexpr std::int32_t kDynamicIndex =
+      std::numeric_limits<std::int32_t>::min();
+
+    static std::int32_t getDynamicIndexValue() { return kDynamicIndex; }
+
+    bool indicesAreConstant() { return getDynamicIndices().empty(); }
+  }];
 }
 
 def cc_InsertValueOp : CCOp<"insert_value", [Pure]> {
@@ -1084,37 +1106,6 @@ def cc_ConstantArrayOp : CCOp<"const_array", [Pure]> {
   let results = (outs cc_ArrayType:$arrayType);
   let assemblyFormat = [{
     $constantValues `:` qualified(type($arrayType)) attr-dict
-  }];
-}
-
-def cc_GetConstantElementOp : CCOp<"get_const_element", [Pure]> {
-  let summary = "Get a constant value from a constant array.";
-  let description = [{
-    A GetConstantElementOp is used to extract a constant value from an aggregate
-    of type !cc.array<T,n>. The aggregate must be built by a `cc.const_array`
-    operation. The offset of the element must be between 0 and the length of the
-    array minus 1 (inclusive). Any other value has undefined behavior. If the
-    offset is a constant, this operation can be folded into a scalar constant
-    (or a cc.undef operation).
-
-    Example:
-
-    ```mlir
-      %arrCon = cc.get_const_element %4[%5] : (!cc.array<f64 x 2>, i32) -> f64
-    ```
-  }];
-
-  let arguments = (ins
-    cc_ArrayType:$constantArray,
-    AnySignlessInteger:$offset
-  );
-  let results = (outs AnyType);
-
-  let hasFolder = 1;
-  //let hasVerifier = 1; // FIXME: output type must match incoming const array
-
-  let assemblyFormat = [{
-    $constantArray `,` $offset `:` functional-type(operands, results) attr-dict
   }];
 }
 

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -228,6 +228,52 @@ void cudaq::cc::CastOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 }
 
 //===----------------------------------------------------------------------===//
+// Support for operations with interleaved indices.
+//===----------------------------------------------------------------------===//
+
+template <typename A>
+ParseResult parseInterleavedIndices(
+    OpAsmParser &parser,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &indices,
+    DenseI32ArrayAttr &rawConstantIndices) {
+  SmallVector<std::int32_t> constantIndices;
+
+  auto idxParser = [&]() -> ParseResult {
+    std::int32_t constantIndex;
+    OptionalParseResult parsedInteger =
+        parser.parseOptionalInteger(constantIndex);
+    if (parsedInteger.has_value()) {
+      if (failed(parsedInteger.value()))
+        return failure();
+      constantIndices.push_back(constantIndex);
+      return success();
+    }
+
+    constantIndices.push_back(A::kDynamicIndex);
+    return parser.parseOperand(indices.emplace_back());
+  };
+  if (parser.parseCommaSeparatedList(idxParser))
+    return failure();
+
+  rawConstantIndices =
+      DenseI32ArrayAttr::get(parser.getContext(), constantIndices);
+  return success();
+}
+
+template <typename Adaptor, typename B>
+void printInterleavedIndices(OpAsmPrinter &printer, B computePtrOp,
+                             OperandRange indices,
+                             DenseI32ArrayAttr rawConstantIndices) {
+  llvm::interleaveComma(Adaptor{rawConstantIndices, indices}, printer,
+                        [&](PointerUnion<IntegerAttr, Value> cst) {
+                          if (Value val = cst.dyn_cast<Value>())
+                            printer.printOperand(val);
+                          else
+                            printer << cst.get<IntegerAttr>().getInt();
+                        });
+}
+
+//===----------------------------------------------------------------------===//
 // ComputePtrOp
 //===----------------------------------------------------------------------===//
 
@@ -237,13 +283,12 @@ LogicalResult cudaq::cc::ComputePtrOp::verify() {
   auto resultTy = cast<cc::PointerType>(getResult().getType());
   for (std::int32_t i : getRawConstantIndices()) {
     if (auto arrTy = dyn_cast<cc::ArrayType>(eleTy)) {
-      if (i != kDynamicIndex && !arrTy.isUnknownSize())
-        if (i > arrTy.getSize()) {
-          // Note: allow indexing of last element + 1 so we can compute a
-          // pointer to `end()` of a stdvec buffer. Consider adding a flag
-          // to cc.compute_ptr explicitly for this or using casts.
-          return emitOpError("array cannot index out of bounds elements");
-        }
+      if (i != kDynamicIndex && !arrTy.isUnknownSize() && i > arrTy.getSize()) {
+        // Note: allow indexing of last element + 1 so we can compute a
+        // pointer to `end()` of a stdvec buffer. Consider adding a flag
+        // to cc.compute_ptr explicitly for this or using casts.
+        return emitOpError("array cannot index out of bounds elements");
+      }
       eleTy = arrTy.getElementType();
     } else if (auto strTy = dyn_cast<cc::StructType>(eleTy)) {
       if (i == kDynamicIndex)
@@ -276,42 +321,16 @@ static ParseResult
 parseComputePtrIndices(OpAsmParser &parser,
                        SmallVectorImpl<OpAsmParser::UnresolvedOperand> &indices,
                        DenseI32ArrayAttr &rawConstantIndices) {
-  SmallVector<int32_t> constantIndices;
-
-  auto idxParser = [&]() -> ParseResult {
-    int32_t constantIndex;
-    OptionalParseResult parsedInteger =
-        parser.parseOptionalInteger(constantIndex);
-    if (parsedInteger.has_value()) {
-      if (failed(parsedInteger.value()))
-        return failure();
-      constantIndices.push_back(constantIndex);
-      return success();
-    }
-
-    constantIndices.push_back(LLVM::GEPOp::kDynamicIndex);
-    return parser.parseOperand(indices.emplace_back());
-  };
-  if (parser.parseCommaSeparatedList(idxParser))
-    return failure();
-
-  rawConstantIndices =
-      DenseI32ArrayAttr::get(parser.getContext(), constantIndices);
-  return success();
+  return parseInterleavedIndices<cudaq::cc::ComputePtrOp>(parser, indices,
+                                                          rawConstantIndices);
 }
 
 static void printComputePtrIndices(OpAsmPrinter &printer,
                                    cudaq::cc::ComputePtrOp computePtrOp,
                                    OperandRange indices,
                                    DenseI32ArrayAttr rawConstantIndices) {
-  llvm::interleaveComma(cudaq::cc::ComputePtrIndicesAdaptor<OperandRange>(
-                            rawConstantIndices, indices),
-                        printer, [&](PointerUnion<IntegerAttr, Value> cst) {
-                          if (Value val = cst.dyn_cast<Value>())
-                            printer.printOperand(val);
-                          else
-                            printer << cst.get<IntegerAttr>().getInt();
-                        });
+  printInterleavedIndices<cudaq::cc::ComputePtrIndicesAdaptor<OperandRange>>(
+      printer, computePtrOp, indices, rawConstantIndices);
 }
 
 void cudaq::cc::ComputePtrOp::build(OpBuilder &builder, OperationState &result,
@@ -322,17 +341,17 @@ void cudaq::cc::ComputePtrOp::build(OpBuilder &builder, OperationState &result,
         SmallVector<ComputePtrArg>(indices), attrs);
 }
 
-static void
-destructureIndices(Type currType, ArrayRef<cudaq::cc::ComputePtrArg> indices,
-                   SmallVectorImpl<std::int32_t> &rawConstantIndices,
-                   SmallVectorImpl<Value> &dynamicIndices) {
-  for (const cudaq::cc::ComputePtrArg &iter : indices) {
-    if (Value val = iter.dyn_cast<Value>()) {
-      rawConstantIndices.push_back(cudaq::cc::ComputePtrOp::kDynamicIndex);
+template <typename A, typename B>
+void destructureIndices(Type currType, ArrayRef<B> indices,
+                        SmallVectorImpl<std::int32_t> &rawConstantIndices,
+                        SmallVectorImpl<Value> &dynamicIndices) {
+  for (const B &iter : indices) {
+    if (Value val = iter.template dyn_cast<Value>()) {
+      rawConstantIndices.push_back(A::kDynamicIndex);
       dynamicIndices.push_back(val);
     } else {
       rawConstantIndices.push_back(
-          iter.get<cudaq::cc::ComputePtrConstantIndex>());
+          iter.template get<cudaq::cc::InterleavedArgumentConstantIndex>());
     }
 
     currType =
@@ -341,7 +360,7 @@ destructureIndices(Type currType, ArrayRef<cudaq::cc::ComputePtrArg> indices,
               return containerType.getElementType();
             })
             .Case([&](cudaq::cc::StructType structType) -> Type {
-              int64_t memberIndex = rawConstantIndices.back();
+              auto memberIndex = rawConstantIndices.back();
               if (memberIndex >= 0 && static_cast<std::size_t>(memberIndex) <
                                           structType.getMembers().size())
                 return structType.getMembers()[memberIndex];
@@ -355,10 +374,11 @@ void cudaq::cc::ComputePtrOp::build(OpBuilder &builder, OperationState &result,
                                     Type resultType, Value basePtr,
                                     ArrayRef<ComputePtrArg> cpArgs,
                                     ArrayRef<NamedAttribute> attrs) {
-  SmallVector<int32_t> rawConstantIndices;
+  SmallVector<std::int32_t> rawConstantIndices;
   SmallVector<Value> dynamicIndices;
   Type elementType = cast<cc::PointerType>(basePtr.getType()).getElementType();
-  destructureIndices(elementType, cpArgs, rawConstantIndices, dynamicIndices);
+  destructureIndices<cudaq::cc::ComputePtrOp>(
+      elementType, cpArgs, rawConstantIndices, dynamicIndices);
 
   result.addTypes(resultType);
   result.addAttributes(attrs);
@@ -536,44 +556,192 @@ void cudaq::cc::ComputePtrOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
-// GetConstantElementOp
+// ExtractValueOp
 //===----------------------------------------------------------------------===//
 
-// If this operation has a constant offset, then the value can be looked up in
-// the constant array and used as a scalar value directly.
-OpFoldResult cudaq::cc::GetConstantElementOp::fold(FoldAdaptor adaptor) {
-  auto params = adaptor.getOperands();
-  if (params.size() < 2)
-    return nullptr;
-  auto intAttr = dyn_cast_or_null<IntegerAttr>(params[1]);
-  if (!intAttr)
-    return nullptr;
-  auto offset = intAttr.getInt();
-  auto conArr = getConstantArray().getDefiningOp<ConstantArrayOp>();
-  if (!conArr)
-    return nullptr;
-  cc::ArrayType arrTy = conArr.getType();
-  if (arrTy.isUnknownSize())
-    return nullptr;
-  auto eleTy = arrTy.getElementType();
-  auto arrSize = arrTy.getSize();
-  OpBuilder builder(getContext());
-  builder.setInsertionPoint(getOperation());
-  auto loc = getLoc();
-  if (offset < arrSize) {
-    if (auto fltTy = dyn_cast<FloatType>(eleTy)) {
-      auto floatConstVal =
-          cast<FloatAttr>(conArr.getConstantValues()[offset]).getValue();
-      return builder.create<arith::ConstantFloatOp>(loc, floatConstVal, fltTy)
-          .getResult();
-    }
-    auto intConstVal =
-        cast<IntegerAttr>(conArr.getConstantValues()[offset]).getInt();
-    auto intTy = cast<IntegerType>(eleTy);
-    return builder.create<arith::ConstantIntOp>(loc, intConstVal, intTy)
-        .getResult();
+// Recursively determine if \p ty1 and \p ty2 are compatible. Ordinarily we can
+// use type equality, but for StructType we may have a named and unnamed struct
+// that are equivalent structurally.
+static bool isCompatible(Type ty1, Type ty2) {
+  if (ty1 == ty2)
+    return true;
+  auto sty1 = dyn_cast<cudaq::cc::StructType>(ty1);
+  auto sty2 = dyn_cast<cudaq::cc::StructType>(ty2);
+  if (sty1 && sty2) {
+    if (sty1.getMembers().size() != sty2.getMembers().size() ||
+        sty1.getPacked() != sty2.getPacked())
+      return false;
+    for (auto [a, b] : llvm::zip(sty1.getMembers(), sty2.getMembers()))
+      if (!isCompatible(a, b))
+        return false;
+    return true;
   }
-  return builder.create<cc::PoisonOp>(loc, eleTy).getResult();
+  return false;
+}
+
+LogicalResult cudaq::cc::ExtractValueOp::verify() {
+  Type eleTy = getAggregate().getType();
+  auto resultTy = getResult().getType();
+  for (std::int32_t i : getRawConstantIndices()) {
+    if (auto arrTy = dyn_cast<cc::ArrayType>(eleTy)) {
+      if (arrTy.isUnknownSize())
+        return emitOpError("array must have constant size");
+      if (i != kDynamicIndex && i >= arrTy.getSize())
+        return emitOpError("array cannot index out of bounds elements");
+      eleTy = arrTy.getElementType();
+    } else if (auto strTy = dyn_cast<cc::StructType>(eleTy)) {
+      if (i == kDynamicIndex)
+        return emitOpError("struct cannot have non-constant index");
+      if (static_cast<std::size_t>(i) >= strTy.getMembers().size())
+        return emitOpError("struct cannot index out of bounds members");
+      eleTy = strTy.getMember(i);
+    } else {
+      return emitOpError("too many indices (" +
+                         std::to_string(getRawConstantIndices().size()) +
+                         ") for the source pointer");
+    }
+  }
+  if (!isCompatible(eleTy, resultTy))
+    return emitOpError("result type does not match input");
+  return success();
+}
+
+OpFoldResult cudaq::cc::ExtractValueOp::fold(FoldAdaptor adaptor) {
+  if (indicesAreConstant())
+    return nullptr;
+
+  // Params is a list of possible substitutions (Attributes) the length of the
+  // SSA arguments. Skip the first one, which is the base pointer argument.
+  auto paramIter = adaptor.getOperands().begin();
+  ++paramIter;
+
+  auto dynamicIndexIter = getDynamicIndices().begin();
+  SmallVector<std::int32_t> newConstantIndices;
+  SmallVector<Value> newIndices;
+  bool changed = false;
+
+  // Build lists of raw constants and SSA values with the SSA values that have
+  // substituions omitted and properly interleaved in as constants in the first
+  // list.
+  for (auto index : getRawConstantIndices()) {
+    if (index != kDynamicIndex) {
+      newConstantIndices.push_back(index);
+      continue;
+    }
+    if (auto newVal = dyn_cast_if_present<IntegerAttr>(*paramIter)) {
+      newConstantIndices.push_back(newVal.getInt());
+      changed = true;
+    } else {
+      newConstantIndices.push_back(kDynamicIndex);
+      newIndices.push_back(*dynamicIndexIter);
+    }
+    ++dynamicIndexIter;
+    ++paramIter;
+  }
+
+  // If any new constants were found, update the cc.compute_ptr in place, adding
+  // the new constants and dropping any unneeded SSA arguments on the floor.
+  if (changed) {
+    assert(newConstantIndices.size() == getRawConstantIndices().size());
+    assert(newIndices.size() < getDynamicIndices().size());
+    getDynamicIndicesMutable().assign(newIndices);
+    setRawConstantIndices(newConstantIndices);
+    return Value{*this};
+  }
+  return nullptr;
+}
+
+static ParseResult parseExtractValueIndices(
+    OpAsmParser &parser,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &indices,
+    DenseI32ArrayAttr &rawConstantIndices) {
+  return parseInterleavedIndices<cudaq::cc::ExtractValueOp>(parser, indices,
+                                                            rawConstantIndices);
+}
+
+static void printExtractValueIndices(OpAsmPrinter &printer,
+                                     cudaq::cc::ExtractValueOp extractValueOp,
+                                     OperandRange indices,
+                                     DenseI32ArrayAttr rawConstantIndices) {
+  printInterleavedIndices<cudaq::cc::ExtractValueIndicesAdaptor<OperandRange>>(
+      printer, extractValueOp, indices, rawConstantIndices);
+}
+
+void cudaq::cc::ExtractValueOp::build(OpBuilder &builder,
+                                      OperationState &result, Type resultType,
+                                      Value aggregate,
+                                      ArrayRef<ExtractValueArg> indices,
+                                      ArrayRef<NamedAttribute> attrs) {
+  SmallVector<std::int32_t> rawConstantIndices;
+  SmallVector<Value> dynamicIndices;
+  Type elementType = aggregate.getType();
+  destructureIndices<cudaq::cc::ExtractValueOp>(
+      elementType, indices, rawConstantIndices, dynamicIndices);
+
+  result.addTypes(resultType);
+  result.addAttributes(attrs);
+  result.addAttribute(getRawConstantIndicesAttrName(result.name),
+                      builder.getDenseI32ArrayAttr(rawConstantIndices));
+  result.addOperands(aggregate);
+  result.addOperands(dynamicIndices);
+}
+void cudaq::cc::ExtractValueOp::build(OpBuilder &builder,
+                                      OperationState &result, Type resultType,
+                                      Value aggregate, ValueRange indices,
+                                      ArrayRef<NamedAttribute> attrs) {
+  SmallVector<ExtractValueArg> args{indices.begin(), indices.end()};
+  build(builder, result, resultType, aggregate, args, attrs);
+}
+void cudaq::cc::ExtractValueOp::build(OpBuilder &builder,
+                                      OperationState &result, Type resultType,
+                                      Value aggregate, std::int32_t index,
+                                      ArrayRef<NamedAttribute> attrs) {
+  build(builder, result, resultType, aggregate,
+        ArrayRef<ExtractValueArg>{index}, attrs);
+}
+void cudaq::cc::ExtractValueOp::build(OpBuilder &builder,
+                                      OperationState &result, Type resultType,
+                                      Value aggregate, Value index,
+                                      ArrayRef<NamedAttribute> attrs) {
+  build(builder, result, resultType, aggregate, ValueRange{index}, attrs);
+}
+
+namespace {
+struct FuseWithConstantArray
+    : public OpRewritePattern<cudaq::cc::ExtractValueOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::cc::ExtractValueOp extval,
+                                PatternRewriter &rewriter) const override {
+    if (auto conarr =
+            extval.getAggregate().getDefiningOp<cudaq::cc::ConstantArrayOp>())
+      if (extval.indicesAreConstant() &&
+          extval.getRawConstantIndices().size() == 1) {
+        if (auto intTy = dyn_cast<IntegerType>(extval.getType())) {
+          std::int32_t i = extval.getRawConstantIndices()[0];
+          auto cval = cast<IntegerAttr>(conarr.getConstantValues()[i]).getInt();
+          rewriter.replaceOpWithNewOp<arith::ConstantIntOp>(extval, cval,
+                                                            intTy);
+
+          return success();
+        }
+        if (auto fltTy = dyn_cast<FloatType>(extval.getType())) {
+          std::int32_t i = extval.getRawConstantIndices()[0];
+          auto cval = cast<FloatAttr>(conarr.getConstantValues()[i]).getValue();
+          rewriter.replaceOpWithNewOp<arith::ConstantFloatOp>(extval, cval,
+                                                              fltTy);
+
+          return success();
+        }
+      }
+    return success();
+  }
+};
+} // namespace
+
+void cudaq::cc::ExtractValueOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<FuseWithConstantArray>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -211,7 +211,7 @@ synthesizeVectorArgument(OpBuilder &builder, ModuleOp module, unsigned &counter,
           if (index == cudaq::cc::ComputePtrOp::kDynamicIndex) {
             OpBuilder::InsertionGuard guard(builder);
             builder.setInsertionPoint(elePtrOp);
-            Value getEle = builder.create<cudaq::cc::GetConstantElementOp>(
+            Value getEle = builder.create<cudaq::cc::ExtractValueOp>(
                 elePtrOp.getLoc(), eleTy, conArray,
                 elePtrOp.getDynamicIndices()[0]);
             if (failed(replaceLoads(elePtrOp, getEle))) {

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2826,8 +2826,8 @@ class PyASTBridge(ast.NodeVisitor):
                     for i, ty in enumerate(types):
                         ret.append(
                             cc.ExtractValueOp(
-                                ty, loaded,
-                                DenseI64ArrayAttr.get([i],
+                                ty, loaded, [],
+                                DenseI32ArrayAttr.get([i],
                                                       context=self.ctx)).result)
                     return ret
 

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -474,8 +474,8 @@ MlirModule synthesizeKernel(const std::string &name, MlirModule module,
   registerLLVMDialectTranslation(*context);
 
   PassManager pm(context);
-  pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createQuakeSynthesizer(name, rawArgs));
+  pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createExpandMeasurementsPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createClassicalMemToReg());
   pm.addPass(createCanonicalizerPass());

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #pragma once
+
 #include "common/ExecutionContext.h"
 #include "common/Executor.h"
 #include "common/FmtCore.h"
@@ -41,6 +42,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-translate/Translation.h"
+#include "mlir/Transforms/Passes.h"
 #include <fstream>
 #include <iostream>
 #include <netinet/in.h>
@@ -402,6 +404,7 @@ public:
       cudaq::info("Run Quake Synth.\n");
       mlir::PassManager pm(&context);
       pm.addPass(cudaq::opt::createQuakeSynthesizer(kernelName, updatedArgs));
+      pm.addPass(mlir::createCanonicalizerPass());
       if (disableMLIRthreading || enablePrintMLIREachPass)
         moduleOp.getContext()->disableMultithreading();
       if (enablePrintMLIREachPass)

--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -154,6 +154,7 @@ public:
         cudaq::info("Run Quake Synth.\n");
         mlir::PassManager pm(&mlirContext);
         pm.addPass(cudaq::opt::createQuakeSynthesizer(name, args));
+        pm.addPass(mlir::createCanonicalizerPass());
         if (failed(pm.run(moduleOp)))
           throw std::runtime_error("Could not successfully apply quake-synth.");
       }

--- a/test/Quake-QIR/const_array.qke
+++ b/test/Quake-QIR/const_array.qke
@@ -12,7 +12,7 @@ func.func private @g(%0 : !cc.stdvec<i32>)
 func.func @f() {
   %0 = cc.const_array [0, 1, 0] : !cc.array<i32 x 3>
   %1 = arith.constant 1 : i32
-  %2 = cc.get_const_element %0, %1 : (!cc.array<i32 x 3>, i32) -> i32
+  %2 = cc.extract_value %0[%1] : (!cc.array<i32 x 3>, i32) -> i32
   %3 = cc.alloca !cc.array<i32 x 3>
   cc.store %0, %3 : !cc.ptr<!cc.array<i32 x 3>>
   %4 = arith.constant 3 : i64

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -680,7 +680,7 @@ func.func @cc_struct() {
 // CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_7]][1, 4, 3] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_7]][1, %[[VAL_4]], 1] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>, i32) -> !cc.ptr<i16>
 // CHECK:           %[[VAL_10:.*]] = cc.const_array [1.000000e+00, 2.000000e+00] : !cc.array<f32 x 2>
-// CHECK:           %[[VAL_11:.*]] = cc.get_const_element %[[VAL_10]], %[[VAL_4]] : (!cc.array<f32 x 2>, i32) -> f32
+// CHECK:           %[[VAL_11:.*]] = cc.extract_value %[[VAL_10]][%[[VAL_4]]] : (!cc.array<f32 x 2>, i32) -> f32
 // CHECK:   %[[VAL_12:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i32
 // CHECK:   %[[VAL_13:.*]] = cc.sizeof !cc.struct<{f64, f32}> : i64
 // CHECK:           return
@@ -698,7 +698,7 @@ func.func @cc_indexing(%arg0 : !cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f
   %p = cc.compute_ptr %ss[1, 4, 3] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>) -> !cc.ptr<i64>
   %q = cc.compute_ptr %ss[1, %one, 1] : (!cc.ptr<!cc.struct<{i32, !cc.array<!cc.struct<{i8, i16, f32, i64}> x 100>}>>, i32) -> !cc.ptr<i16>
   %arr = cc.const_array [1.0, 2.0] : !cc.array<f32 x 2>
-  %ele = cc.get_const_element %arr, %one : (!cc.array<f32 x 2>, i32) -> f32
+  %ele = cc.extract_value %arr[%one] : (!cc.array<f32 x 2>, i32) -> f32
   %size1 = cc.sizeof !cc.struct<{i32, f64}> : i32
   %size2 = cc.sizeof !cc.struct<{f64, f32}> : i64
   return

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -52,8 +52,8 @@ std::pair<void *, std::size_t> mapToRawArgs(const std::string &kernelName,
 LogicalResult runQuakeSynth(std::string_view kernelName, void *rawArgs,
                             OwningOpRef<mlir::ModuleOp> &module) {
   PassManager pm(module->getContext());
-  pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createQuakeSynthesizer(kernelName, rawArgs));
+  pm.addPass(createCanonicalizerPass());
   pm.addPass(cudaq::opt::createExpandMeasurementsPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createClassicalMemToReg());
   pm.addPass(createCanonicalizerPass());


### PR DESCRIPTION
These are semantically the same operation. The distinction was a
manifestation of how LLVM works rather than what the operation did.

While we're here, add semantics verification tests. Also split apart the
get_const_element fold operation from a canonicalization. Make sure we
run canonicalization *after* parameter synthesis. Update affected tests.

Depends on merge of #1853 