### PR TITLE
Use a single scratchpad for all tensornet operations

### DIFF
--- a/runtime/nvqir/cutensornet/mps_simulation_state.h
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.h
@@ -32,6 +32,7 @@ class MPSSimulationState : public cudaq::SimulationState {
 public:
   MPSSimulationState(std::unique_ptr<TensorNetState> inState,
                      const std::vector<MPSTensor> &mpsTensors,
+                     ScratchDeviceMem &inScratchPad,
                      cutensornetHandle_t cutnHandle);
 
   MPSSimulationState(const MPSSimulationState &) = delete;
@@ -78,6 +79,7 @@ public:
   /// Util method to create an MPS state from an input state vector.
   // For example, state vector from the user's input.
   static MpsStateData createFromStateVec(cutensornetHandle_t cutnHandle,
+                                         ScratchDeviceMem &inScratchPad,
                                          std::size_t size,
                                          std::complex<double> *data,
                                          int bondDim);
@@ -95,7 +97,7 @@ protected:
   cutensornetHandle_t m_cutnHandle;
   std::unique_ptr<TensorNetState> state;
   std::vector<MPSTensor> m_mpsTensors;
-  ScratchDeviceMem m_scratchPad;
+  ScratchDeviceMem &scratchPad;
   // Max number of qubits whereby the tensor network state should be contracted
   // and cached into a state vector.
   // This speeds up sequential state amplitude accessors for small states.

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
@@ -287,7 +287,8 @@ void SimulatorTensorNetBase::setToZeroState() {
   const auto numQubits = m_state->getNumQubits();
   m_state.reset();
   // Re-create a zero state of the same size
-  m_state = std::make_unique<TensorNetState>(numQubits, m_cutnHandle);
+  m_state =
+      std::make_unique<TensorNetState>(numQubits, scratchPad, m_cutnHandle);
 }
 
 void SimulatorTensorNetBase::swap(const std::vector<std::size_t> &ctrlBits,

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.h
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.h
@@ -90,6 +90,7 @@ protected:
   cutensornetHandle_t m_cutnHandle;
   std::unique_ptr<TensorNetState> m_state;
   std::unordered_map<std::string, void *> m_gateDeviceMemCache;
+  ScratchDeviceMem scratchPad;
 };
 
 } // end namespace nvqir

--- a/runtime/nvqir/cutensornet/simulator_mps_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_mps_register.cpp
@@ -45,7 +45,7 @@ public:
           "[SimulatorMPS simulator] Incompatible state input");
     if (!m_state) {
       m_state = TensorNetState::createFromMpsTensors(casted->getMpsTensors(),
-                                                     m_cutnHandle);
+                                                     scratchPad, m_cutnHandle);
     } else {
       // Expand an existing state: Append MPS tensors
       // Factor the existing state
@@ -72,7 +72,8 @@ public:
                                      tensorSizeBytes, cudaMemcpyDefault));
         tensors.emplace_back(MPSTensor(mpsTensor, extents));
       }
-      m_state = TensorNetState::createFromMpsTensors(tensors, m_cutnHandle);
+      m_state = TensorNetState::createFromMpsTensors(tensors, scratchPad,
+                                                     m_cutnHandle);
     }
   }
 
@@ -159,10 +160,11 @@ public:
     LOG_API_TIME();
     if (!m_state) {
       if (!ptr) {
-        m_state = std::make_unique<TensorNetState>(numQubits, m_cutnHandle);
+        m_state = std::make_unique<TensorNetState>(numQubits, scratchPad,
+                                                   m_cutnHandle);
       } else {
         auto [state, mpsTensors] = MPSSimulationState::createFromStateVec(
-            m_cutnHandle, 1ULL << numQubits,
+            m_cutnHandle, scratchPad, 1ULL << numQubits,
             reinterpret_cast<std::complex<double> *>(const_cast<void *>(ptr)),
             m_settings.maxBond);
         m_state = std::move(state);
@@ -188,11 +190,12 @@ public:
                                        cudaMemcpyHostToDevice));
           tensors.emplace_back(MPSTensor(mpsTensor, extents));
         }
-        m_state = TensorNetState::createFromMpsTensors(tensors, m_cutnHandle);
+        m_state = TensorNetState::createFromMpsTensors(tensors, scratchPad,
+                                                       m_cutnHandle);
       } else {
         // Non-zero state needs to be factorized and appended.
         auto [state, mpsTensors] = MPSSimulationState::createFromStateVec(
-            m_cutnHandle, 1ULL << numQubits,
+            m_cutnHandle, scratchPad, 1ULL << numQubits,
             reinterpret_cast<std::complex<double> *>(const_cast<void *>(ptr)),
             m_settings.maxBond);
         auto tensors = m_state->factorizeMPS(
@@ -206,7 +209,8 @@ public:
         mpsTensors.front().extents = extents;
         // Combine the list
         tensors.insert(tensors.end(), mpsTensors.begin(), mpsTensors.end());
-        m_state = TensorNetState::createFromMpsTensors(tensors, m_cutnHandle);
+        m_state = TensorNetState::createFromMpsTensors(tensors, scratchPad,
+                                                       m_cutnHandle);
       }
     }
   }
@@ -215,14 +219,15 @@ public:
     LOG_API_TIME();
 
     if (!m_state || m_state->getNumQubits() == 0)
-      return std::make_unique<MPSSimulationState>(
-          std::move(m_state), std::vector<MPSTensor>{}, m_cutnHandle);
+      return std::make_unique<MPSSimulationState>(std::move(m_state),
+                                                  std::vector<MPSTensor>{},
+                                                  scratchPad, m_cutnHandle);
 
     if (m_state->getNumQubits() > 1) {
       std::vector<MPSTensor> tensors = m_state->factorizeMPS(
           m_settings.maxBond, m_settings.absCutoff, m_settings.relCutoff);
       return std::make_unique<MPSSimulationState>(std::move(m_state), tensors,
-                                                  m_cutnHandle);
+                                                  scratchPad, m_cutnHandle);
     }
 
     auto [d_tensor, numElements] = m_state->contractStateVectorInternal({});
@@ -232,7 +237,8 @@ public:
     stateTensor.extents = {static_cast<int64_t>(numElements)};
 
     return std::make_unique<MPSSimulationState>(
-        std::move(m_state), std::vector<MPSTensor>{stateTensor}, m_cutnHandle);
+        std::move(m_state), std::vector<MPSTensor>{stateTensor}, scratchPad,
+        m_cutnHandle);
   }
 
   virtual ~SimulatorMPS() noexcept {

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -48,19 +48,21 @@ public:
   std::unique_ptr<cudaq::SimulationState> getSimulationState() override {
     LOG_API_TIME();
     return std::make_unique<TensorNetSimulationState>(std::move(m_state),
-                                                      m_cutnHandle);
+                                                      scratchPad, m_cutnHandle);
   }
 
   void addQubitsToState(std::size_t numQubits, const void *ptr) override {
     LOG_API_TIME();
     if (!m_state) {
       if (!ptr) {
-        m_state = std::make_unique<TensorNetState>(numQubits, m_cutnHandle);
+        m_state = std::make_unique<TensorNetState>(numQubits, scratchPad,
+                                                   m_cutnHandle);
       } else {
         auto *casted =
             reinterpret_cast<std::complex<double> *>(const_cast<void *>(ptr));
         std::span<std::complex<double>> stateVec(casted, 1ULL << numQubits);
-        m_state = TensorNetState::createFromStateVector(stateVec, m_cutnHandle);
+        m_state = TensorNetState::createFromStateVector(stateVec, scratchPad,
+                                                        m_cutnHandle);
       }
     } else {
       if (!ptr) {
@@ -83,8 +85,9 @@ public:
       throw std::invalid_argument(
           "[Tensornet simulator] Incompatible state input");
     if (!m_state) {
-      m_state = TensorNetState::createFromOpTensors(
-          in_state.getNumQubits(), casted->getAppliedTensors(), m_cutnHandle);
+      m_state = TensorNetState::createFromOpTensors(in_state.getNumQubits(),
+                                                    casted->getAppliedTensors(),
+                                                    scratchPad, m_cutnHandle);
     } else {
       // Expand an existing state:
       //  (1) Create a blank tensor network with combined number of qubits

--- a/runtime/nvqir/cutensornet/tensornet_state.cpp
+++ b/runtime/nvqir/cutensornet/tensornet_state.cpp
@@ -14,8 +14,9 @@
 namespace nvqir {
 
 TensorNetState::TensorNetState(std::size_t numQubits,
+                               ScratchDeviceMem &inScratchPad,
                                cutensornetHandle_t handle)
-    : m_numQubits(numQubits), m_cutnHandle(handle) {
+    : m_numQubits(numQubits), m_cutnHandle(handle), scratchPad(inScratchPad) {
   const std::vector<int64_t> qubitDims(m_numQubits, 2);
   HANDLE_CUTN_ERROR(cutensornetCreateState(
       m_cutnHandle, CUTENSORNET_STATE_PURITY_PURE, m_numQubits,
@@ -23,8 +24,9 @@ TensorNetState::TensorNetState(std::size_t numQubits,
 }
 
 TensorNetState::TensorNetState(const std::vector<int> &basisState,
+                               ScratchDeviceMem &inScratchPad,
                                cutensornetHandle_t handle)
-    : TensorNetState(basisState.size(), handle) {
+    : TensorNetState(basisState.size(), inScratchPad, handle) {
   constexpr std::complex<double> h_xGate[4] = {0.0, 1.0, 1.0, 0.0};
   constexpr auto sizeBytes = 4 * sizeof(std::complex<double>);
   void *d_gate{nullptr};
@@ -41,7 +43,8 @@ TensorNetState::TensorNetState(const std::vector<int> &basisState,
 }
 
 std::unique_ptr<TensorNetState> TensorNetState::clone() const {
-  return createFromOpTensors(m_numQubits, m_tensorOps, m_cutnHandle);
+  return createFromOpTensors(m_numQubits, m_tensorOps, scratchPad,
+                             m_cutnHandle);
 }
 
 void TensorNetState::applyGate(const std::vector<int32_t> &controlQubits,
@@ -147,7 +150,6 @@ TensorNetState::sample(const std::vector<int32_t> &measuredBitIds,
                                              measuredBitIds.size(),
                                              measuredBitIds.data(), &sampler));
 
-  ScratchDeviceMem scratchPad;
   // Configure the quantum circuit sampler
   constexpr int32_t numHyperSamples =
       8; // desired number of hyper samples used in the tensor network
@@ -231,9 +233,11 @@ std::pair<void *, std::size_t> TensorNetState::contractStateVectorInternal(
   LOG_API_TIME();
   void *d_sv{nullptr};
   const uint64_t svDim = 1ull << (m_numQubits - projectedModes.size());
-  HANDLE_CUDA_ERROR(cudaMalloc(&d_sv, svDim * sizeof(std::complex<double>)));
-  ScratchDeviceMem scratchPad;
-
+  {
+    ScopedTraceWithContext("TensorNetState::contractStateVectorInternal "
+                           "State vector allocation");
+    HANDLE_CUDA_ERROR(cudaMalloc(&d_sv, svDim * sizeof(std::complex<double>)));
+  }
   // Create the quantum state amplitudes accessor
   cutensornetStateAccessor_t accessor;
   HANDLE_CUTN_ERROR(cutensornetCreateAccessor(
@@ -250,9 +254,12 @@ std::pair<void *, std::size_t> TensorNetState::contractStateVectorInternal(
   cutensornetWorkspaceDescriptor_t workDesc;
   HANDLE_CUTN_ERROR(
       cutensornetCreateWorkspaceDescriptor(m_cutnHandle, &workDesc));
-  HANDLE_CUTN_ERROR(cutensornetAccessorPrepare(
-      m_cutnHandle, accessor, scratchPad.scratchSize, workDesc, 0));
-
+  {
+    ScopedTraceWithContext("TensorNetState::contractStateVectorInternal::"
+                           "cutensornetAccessorPrepare");
+    HANDLE_CUTN_ERROR(cutensornetAccessorPrepare(
+        m_cutnHandle, accessor, scratchPad.scratchSize, workDesc, 0));
+  }
   // Attach the workspace buffer
   int64_t worksize = 0;
   HANDLE_CUTN_ERROR(cutensornetWorkspaceGetMemorySize(
@@ -279,11 +286,13 @@ std::pair<void *, std::size_t> TensorNetState::contractStateVectorInternal(
       in_projectedModeValues.empty()
           ? std::vector<int64_t>(projectedModes.size(), 0)
           : in_projectedModeValues;
-
-  HANDLE_CUTN_ERROR(cutensornetAccessorCompute(
-      m_cutnHandle, accessor, projectedModeValues.data(), workDesc, d_sv,
-      static_cast<void *>(&stateNorm), 0));
-
+  {
+    ScopedTraceWithContext("TensorNetState::contractStateVectorInternal::"
+                           "cutensornetAccessorCompute");
+    HANDLE_CUTN_ERROR(cutensornetAccessorCompute(
+        m_cutnHandle, accessor, projectedModeValues.data(), workDesc, d_sv,
+        static_cast<void *>(&stateNorm), 0));
+  }
   // Free resources
   HANDLE_CUTN_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
   HANDLE_CUTN_ERROR(cutensornetDestroyAccessor(accessor));
@@ -320,7 +329,6 @@ TensorNetState::computeRDM(const std::vector<int32_t> &qubits) {
   const uint64_t rdmSize = 1ull << (2 * qubits.size());
   const uint64_t rdmSizeBytes = rdmSize * sizeof(std::complex<double>);
   HANDLE_CUDA_ERROR(cudaMalloc(&d_rdm, rdmSizeBytes));
-  ScratchDeviceMem scratchPad;
 
   cutensornetStateMarginal_t marginal;
   HANDLE_CUTN_ERROR(cutensornetCreateMarginal(
@@ -435,7 +443,6 @@ TensorNetState::factorizeMPS(int64_t maxExtent, double absCutoff,
 
   // Prepare the MPS computation and attach workspace
   cutensornetWorkspaceDescriptor_t workDesc;
-  ScratchDeviceMem scratchPad;
 
   HANDLE_CUTN_ERROR(
       cutensornetCreateWorkspaceDescriptor(m_cutnHandle, &workDesc));
@@ -501,7 +508,6 @@ std::complex<double> TensorNetState::computeExpVal(
 
   // Step 3: Prepare
   cutensornetWorkspaceDescriptor_t workDesc;
-  ScratchDeviceMem scratchPad;
   HANDLE_CUTN_ERROR(
       cutensornetCreateWorkspaceDescriptor(m_cutnHandle, &workDesc));
   {
@@ -543,10 +549,12 @@ std::complex<double> TensorNetState::computeExpVal(
 }
 
 std::unique_ptr<TensorNetState> TensorNetState::createFromMpsTensors(
-    const std::vector<MPSTensor> &in_mpsTensors, cutensornetHandle_t handle) {
+    const std::vector<MPSTensor> &in_mpsTensors, ScratchDeviceMem &inScratchPad,
+    cutensornetHandle_t handle) {
   if (in_mpsTensors.empty())
     throw std::invalid_argument("Empty MPS tensor list");
-  auto state = std::make_unique<TensorNetState>(in_mpsTensors.size(), handle);
+  auto state = std::make_unique<TensorNetState>(in_mpsTensors.size(),
+                                                inScratchPad, handle);
   std::vector<const int64_t *> extents;
   std::vector<void *> tensorData;
   for (const auto &tensor : in_mpsTensors) {
@@ -563,8 +571,9 @@ std::unique_ptr<TensorNetState> TensorNetState::createFromMpsTensors(
 /// operators.
 std::unique_ptr<TensorNetState> TensorNetState::createFromOpTensors(
     std::size_t numQubits, const std::vector<AppliedTensorOp> &opTensors,
-    cutensornetHandle_t handle) {
-  auto state = std::make_unique<TensorNetState>(numQubits, handle);
+    ScratchDeviceMem &inScratchPad, cutensornetHandle_t handle) {
+  auto state =
+      std::make_unique<TensorNetState>(numQubits, inScratchPad, handle);
   for (const auto &op : opTensors)
     if (op.isUnitary)
       state->applyGate(op.controlQubitIds, op.targetQubitIds, op.deviceData,
@@ -591,9 +600,11 @@ TensorNetState::reverseQubitOrder(std::span<std::complex<double>> stateVec) {
 
 std::unique_ptr<TensorNetState>
 TensorNetState::createFromStateVector(std::span<std::complex<double>> stateVec,
+                                      ScratchDeviceMem &inScratchPad,
                                       cutensornetHandle_t handle) {
   const std::size_t numQubits = std::log2(stateVec.size());
-  auto state = std::make_unique<TensorNetState>(numQubits, handle);
+  auto state =
+      std::make_unique<TensorNetState>(numQubits, inScratchPad, handle);
 
   // Support initializing the tensor network in a specific state vector state.
   // Note: this is not intended for large state vector but for relatively small

--- a/runtime/nvqir/cutensornet/tensornet_state.h
+++ b/runtime/nvqir/cutensornet/tensornet_state.h
@@ -51,28 +51,30 @@ protected:
   std::vector<void *> m_tempDevicePtrs;
   // Tensor ops that have been applied to the state.
   std::vector<AppliedTensorOp> m_tensorOps;
+  ScratchDeviceMem &scratchPad;
 
 public:
   /// @brief Constructor
-  TensorNetState(std::size_t numQubits, cutensornetHandle_t handle);
+  TensorNetState(std::size_t numQubits, ScratchDeviceMem &inScratchPad,
+                 cutensornetHandle_t handle);
 
   /// @brief Constructor (specific basis state)
   TensorNetState(const std::vector<int> &basisState,
-                 cutensornetHandle_t handle);
+                 ScratchDeviceMem &inScratchPad, cutensornetHandle_t handle);
 
   std::unique_ptr<TensorNetState> clone() const;
 
   /// Reconstruct/initialize a state from MPS tensors
   static std::unique_ptr<TensorNetState>
   createFromMpsTensors(const std::vector<MPSTensor> &mpsTensors,
+                       ScratchDeviceMem &inScratchPad,
                        cutensornetHandle_t handle);
 
   /// Reconstruct/initialize a tensor network state from a list of tensor
   /// operators.
-  static std::unique_ptr<TensorNetState>
-  createFromOpTensors(std::size_t numQubits,
-                      const std::vector<AppliedTensorOp> &opTensors,
-                      cutensornetHandle_t handle);
+  static std::unique_ptr<TensorNetState> createFromOpTensors(
+      std::size_t numQubits, const std::vector<AppliedTensorOp> &opTensors,
+      ScratchDeviceMem &inScratchPad, cutensornetHandle_t handle);
 
   // Create a tensor network state from the input state vector.
   // Note: this is not the most efficient mode of initialization. However, this
@@ -80,6 +82,7 @@ public:
   // tensor network simulator with.
   static std::unique_ptr<TensorNetState>
   createFromStateVector(std::span<std::complex<double>> stateVec,
+                        ScratchDeviceMem &inScratchPad,
                         cutensornetHandle_t handle);
 
   /// @brief Apply a unitary gate

--- a/runtime/nvqir/cutensornet/tn_simulation_state.h
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.h
@@ -22,6 +22,7 @@ class TensorNetSimulationState : public cudaq::SimulationState {
 
 public:
   TensorNetSimulationState(std::unique_ptr<TensorNetState> inState,
+                           ScratchDeviceMem &inScratchPad,
                            cutensornetHandle_t cutnHandle);
 
   TensorNetSimulationState(const TensorNetSimulationState &) = delete;
@@ -70,8 +71,8 @@ public:
 
 protected:
   std::unique_ptr<TensorNetState> m_state;
+  ScratchDeviceMem &scratchPad;
   cutensornetHandle_t m_cutnHandle;
-  ScratchDeviceMem m_scratchPad;
   // Max number of qubits whereby the tensor network state should be contracted
   // and cached into a state vector.
   // This speeds up sequential state amplitude accessors for small states.


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Scratchpad (to use with tensornet 'compute' API) is created a single time, attached to the simulator class.
All other sub-classes (`state`-like objects) just keep a reference to this scratch pad.


**Rationale**:
We observed some performance degradation running these compute API (e.g., state/observe, etc.) in a loop. Theoretically, the performance should be better since the system is warmed up. 
The root cause is this scratch pad dealloc-realloc operations.

