### PR TITLE
[core] Add -lift-array-value pass

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -1020,10 +1020,10 @@ def cc_ComputePtrOp : CCOp<"compute_ptr", [Pure]> {
     Example:
 
     ```mlir
-      %p = cc.compute_ptr %struct, 1 : (!cc.ptr<!cc.struct<{i32, f32}>>) ->
-                                       !cc.ptr<f32>
-      %q = cc.compute_ptr %array, %i : (!cc.ptr<!cc.array<i32 x 100>>, i64) ->
-                                       !cc.ptr<i32>
+      %p = cc.compute_ptr %struct[1] : (!cc.ptr<!cc.struct<{i32, f32}>>) ->
+                                        !cc.ptr<f32>
+      %q = cc.compute_ptr %array[%i] : (!cc.ptr<!cc.array<i32 x 100>>, i64) ->
+                                        !cc.ptr<i32>
     ```
   }];
 
@@ -1058,6 +1058,8 @@ def cc_ComputePtrOp : CCOp<"compute_ptr", [Pure]> {
     static std::int32_t getDynamicIndexValue() { return kDynamicIndex; }
 
     bool llvmNormalForm();
+
+    std::optional<std::int32_t> getConstantIndex(std::size_t arg);
   }];
 }
 

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -251,6 +251,46 @@ def LambdaLifting : Pass<"lambda-lifting", "mlir::ModuleOp"> {
   let constructor = "cudaq::opt::createLambdaLiftingPass()";
 }
 
+def LiftArrayAlloc : Pass<"lift-to-array-value", "mlir::func::FuncOp"> {
+  let summary = "Convert constant arrays built on the stack to array values";
+  let description = [{
+    The bridge or other passes may generate inline code to build an array of
+    arithmetic types. This construction can involve quite a few CC dialect
+    operations and can "hide" what is really being done in the volume of that
+    code. This pass folds and lifts those memory operations into a constant
+    array value operation.
+
+    Example:
+    ```mlir
+      %cst = arith.constant 5.000000e+00 : f64
+      %cst_0 = arith.constant 6.000000e+00 : f64
+      %cst_1 = arith.constant 7.000000e+00 : f64
+      %cst_2 = arith.constant 8.000000e+00 : f64
+      %0 = cc.alloca !cc.array<f64 x 4>
+      %1 = cc.compute_ptr %0[0] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+      cc.store %cst, %1 : !cc.ptr<f64>
+      %2 = cc.compute_ptr %0[1] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+      cc.store %cst_0, %2 : !cc.ptr<f64>
+      %3 = cc.compute_ptr %0[2] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+      cc.store %cst_1, %3 : !cc.ptr<f64>
+      %4 = cc.compute_ptr %0[3] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+      cc.store %cst_2, %4 : !cc.ptr<f64>
+    ```
+
+    would be converted to
+
+    ```mlir
+      %0 = cc.const_array [5.0, 6.0, 7.0, 8.0] : !cc.array<f64 x 4>
+    ```
+
+    This converts a value in memory SSA form to an SSA value, so additional
+    uses must also be considered. For example, if the array is subsequently
+    updated or escapes the function, it cannot be replaced by a value. If
+    it is elements are accessed in a read-only way, it is a legal transform
+    and will enable further constant folding in other passes.
+  }];
+}
+
 def LinearCtrlRelations : Pass<"linear-ctrl-form", "mlir::func::FuncOp"> {
   let summary = "Removes control type values between quantum ops.";
   let description = [{

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -251,7 +251,7 @@ def LambdaLifting : Pass<"lambda-lifting", "mlir::ModuleOp"> {
   let constructor = "cudaq::opt::createLambdaLiftingPass()";
 }
 
-def LiftArrayAlloc : Pass<"lift-to-array-value", "mlir::func::FuncOp"> {
+def LiftArrayAlloc : Pass<"lift-array-value", "mlir::func::FuncOp"> {
   let summary = "Convert constant arrays built on the stack to array values";
   let description = [{
     The bridge or other passes may generate inline code to build an array of
@@ -289,6 +289,8 @@ def LiftArrayAlloc : Pass<"lift-to-array-value", "mlir::func::FuncOp"> {
     it is elements are accessed in a read-only way, it is a legal transform
     and will enable further constant folding in other passes.
   }];
+
+  let dependentDialects = ["mlir::complex::ComplexDialect"];
 }
 
 def LinearCtrlRelations : Pass<"linear-ctrl-form", "mlir::func::FuncOp"> {

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -251,7 +251,7 @@ def LambdaLifting : Pass<"lambda-lifting", "mlir::ModuleOp"> {
   let constructor = "cudaq::opt::createLambdaLiftingPass()";
 }
 
-def LiftArrayAlloc : Pass<"lift-array-value", "mlir::func::FuncOp"> {
+def LiftArrayAlloc : Pass<"lift-array-value", "mlir::ModuleOp"> {
   let summary = "Convert constant arrays built on the stack to array values";
   let description = [{
     The bridge or other passes may generate inline code to build an array of

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -555,6 +555,16 @@ void cudaq::cc::ComputePtrOp::getCanonicalizationPatterns(
   patterns.add<FuseAddressArithmetic>(context);
 }
 
+std::optional<std::int32_t>
+cudaq::cc::ComputePtrOp::getConstantIndex(std::size_t arg) {
+  if (arg >= getRawConstantIndices().size())
+    return {};
+  std::int32_t result = getRawConstantIndices()[arg];
+  if (result == getDynamicIndexValue())
+    return {};
+  return {result};
+}
+
 //===----------------------------------------------------------------------===//
 // ExtractValueOp
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_cudaq_library(OptTransforms
   GenKernelExecution.cpp
   GenDeviceCodeLoader.cpp
   LambdaLifting.cpp
+  LiftArrayAlloc.cpp
   LinearCtrlRelations.cpp
   LoopAnalysis.cpp
   LoopNormalize.cpp

--- a/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
+++ b/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
@@ -1,0 +1,208 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_LIFTARRAYALLOC
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "lift-array-alloc"
+
+using namespace mlir;
+
+// Determine if \p alloc is a legit candidate for promotion to a constant array
+// value.
+static bool isGoodCandidate(cudaq::cc::AllocaOp alloc,
+                            SmallVectorImpl<Operation *> &scoreboard) {
+  LLVM_DEBUG(llvm::dbgs() << "checking candidate\n");
+  if (alloc.getSeqSize())
+    return false;
+  auto arrTy = dyn_cast<cudaq::cc::ArrayType>(alloc.getElementType());
+  if (!arrTy || arrTy.isUnknownSize())
+    return false;
+  auto arrEleTy = arrTy.getElementType();
+  if (!isa<IntegerType, FloatType, ComplexType>(arrEleTy))
+    return false;
+
+  // There must be at least `size` uses to initialize the entire array.
+  auto size = arrTy.getSize();
+  if (std::distance(alloc->getUses().begin(), alloc->getUses().end()) < size)
+    return false;
+
+  // Keep a scoreboard for every element in the array. Every element *must* be
+  // stored to with a constant exactly one time.
+  scoreboard.resize(size);
+  for (int i = 0; i < size; i++)
+    scoreboard[i] = nullptr;
+
+  auto getWriteOp = [](auto op) -> Operation * {
+    Operation *theStore = nullptr;
+    for (auto &use : op->getUses()) {
+      Operation *u = use.getOwner();
+      if (!u)
+        return nullptr;
+      if (auto store = dyn_cast<cudaq::cc::StoreOp>(u)) {
+        if (op.getOperation() == store.getPtrvalue().getDefiningOp() &&
+            isa_and_present<arith::ConstantOp, complex::ConstantOp>(
+                store.getValue().getDefiningOp())) {
+          if (theStore) {
+            LLVM_DEBUG(llvm::dbgs()
+                       << "more than 1 store to element of array\n");
+            return nullptr;
+          }
+          theStore = u;
+        }
+        continue;
+      }
+      if (!isa<cudaq::cc::LoadOp, quake::InitializeStateOp>(u))
+        return nullptr;
+    }
+    return theStore;
+  };
+
+  auto ptrArrEleTy = cudaq::cc::PointerType::get(arrTy.getElementType());
+  for (auto &use : alloc->getUses()) {
+    // All uses *must* be a degenerate cc.cast, cc.compute_ptr, or
+    // cc.init_state.
+    auto *op = use.getOwner();
+    if (!op) {
+      LLVM_DEBUG(llvm::dbgs() << "use was not an op\n");
+      return false;
+    }
+    if (auto cptr = dyn_cast<cudaq::cc::ComputePtrOp>(op)) {
+      if (auto index = cptr.getConstantIndex(0)) {
+        if (auto w = getWriteOp(cptr)) {
+          if (!scoreboard[*index]) {
+            scoreboard[*index] = w;
+          } else {
+            return false;
+          }
+        }
+      }
+    } else if (auto cast = dyn_cast<cudaq::cc::CastOp>(op)) {
+      if (cast.getType() == ptrArrEleTy) {
+        if (auto w = getWriteOp(cast)) {
+          if (!scoreboard[0]) {
+            scoreboard[0] = w;
+          } else {
+            return false;
+          }
+        }
+      } else {
+        LLVM_DEBUG(llvm::dbgs() << "unexpected cast\n");
+        return false;
+      }
+    } else {
+      LLVM_DEBUG(llvm::dbgs() << "unexpected use: " << *op << '\n');
+      return false;
+    }
+  }
+
+  bool ok = std::all_of(scoreboard.begin(), scoreboard.end(),
+                        [](bool b) { return b; });
+  LLVM_DEBUG(llvm::dbgs() << "all elements of array are set: " << ok << '\n');
+  return ok;
+}
+
+namespace {
+class AllocaPattern : public OpRewritePattern<cudaq::cc::AllocaOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cudaq::cc::AllocaOp alloc,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<Operation *> stores;
+    if (!isGoodCandidate(alloc, stores))
+      return failure();
+
+    auto arrTy = cast<cudaq::cc::ArrayType>(alloc.getElementType());
+    SmallVector<Attribute> values;
+    // Every element of `stores` must be a cc::StoreOp with a ConstantOp as the
+    // value argument. Build the array attr to attach to a cc.const_array.
+    for (auto *op : stores) {
+      auto store = cast<cudaq::cc::StoreOp>(op);
+      auto *valOp = store.getValue().getDefiningOp();
+      if (auto con = dyn_cast<arith::ConstantOp>(valOp))
+        values.push_back(con.getValueAttr());
+      else if (auto con = dyn_cast<complex::ConstantOp>(valOp))
+        values.push_back(con.getValueAttr());
+      else
+        return alloc.emitOpError("could not fold");
+    }
+
+    // Create the cc.const_array.
+    auto valuesAttr = rewriter.getArrayAttr(values);
+    auto conArr = rewriter.create<cudaq::cc::ConstantArrayOp>(
+        alloc.getLoc(), arrTy, valuesAttr);
+    auto eleTy = arrTy.getElementType();
+
+    // Rewalk all the uses of alloc, u, which must be cc.cast or cc.compute_ptr.
+    // For each,u, remove a store and replace a load with a cc.extract_value.
+    for (auto &use : alloc->getUses()) {
+      auto *user = use.getOwner();
+      std::int32_t offset = 0;
+      if (auto cptr = dyn_cast<cudaq::cc::ComputePtrOp>(user))
+        offset = cptr.getRawConstantIndices()[0];
+      for (auto &useuse : user->getUses()) {
+        auto *useuser = useuse.getOwner();
+        if (auto ist = dyn_cast<quake::InitializeStateOp>(useuser)) {
+          LLVM_DEBUG(llvm::dbgs() << "replaced init_state\n");
+          rewriter.replaceOpWithNewOp<quake::InitializeStateOp>(
+              ist, ist.getType(), ist.getTargets(), conArr);
+          continue;
+        }
+        if (auto load = dyn_cast<cudaq::cc::LoadOp>(useuser)) {
+          LLVM_DEBUG(llvm::dbgs() << "replaced load\n");
+          rewriter.replaceOpWithNewOp<cudaq::cc::ExtractValueOp>(
+              load, eleTy, conArr,
+              ArrayRef<cudaq::cc::ExtractValueArg>{offset});
+          continue;
+        }
+        assert(isa<cudaq::cc::StoreOp>(useuser));
+        rewriter.eraseOp(useuser);
+      }
+      rewriter.eraseOp(user);
+    }
+
+    rewriter.eraseOp(alloc);
+    return success();
+  }
+};
+
+class LiftArrayAllocPass
+    : public cudaq::opt::impl::LiftArrayAllocBase<LiftArrayAllocPass> {
+public:
+  using LiftArrayAllocBase::LiftArrayAllocBase;
+
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+    auto func = getOperation();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<AllocaPattern>(ctx);
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "Before lifting constant array: " << func << '\n');
+
+    if (failed(applyPatternsAndFoldGreedily(func.getOperation(),
+                                            std::move(patterns))))
+      signalPassFailure();
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "After lifting constant array: " << func << '\n');
+  }
+};
+} // namespace

--- a/lib/Optimizer/Transforms/PassDetails.h
+++ b/lib/Optimizer/Transforms/PassDetails.h
@@ -12,6 +12,7 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/test/Quake/lift_array.qke
+++ b/test/Quake/lift_array.qke
@@ -71,7 +71,7 @@ func.func @test2() -> !quake.veq<2> {
 // CHECK:           return %[[VAL_2]] : !quake.veq<2>
 // CHECK:         }
 
-// CHECK:         cc.global constant @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v.rodata_{{[0-9]+}} (dense<[(0.70710678118654757,0.000000e+00), (0.70710678118654757,0.000000e+00), (0.70710678118654757,0.000000e+00), (-0.70710678118654757,0.000000e+00)]> : tensor<4xcomplex<f64>>) : !cc.array<complex<f64> x 4>
+// CHECK-DAG:         cc.global constant @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v.rodata_{{[0-9]+}} (dense<[(0.70710678118654757,0.000000e+00), (0.70710678118654757,0.000000e+00), (0.70710678118654757,0.000000e+00), (-0.70710678118654757,0.000000e+00)]> : tensor<4xcomplex<f64>>) : !cc.array<complex<f64> x 4>
 
-// CHECK:         cc.global constant @test2.rodata_{{[0-9]+}} ([1.000000e+00, 2.000000e+00, 6.000000e+00, 9.000000e+00]) : !cc.array<f64 x 4>
+// CHECK-DAG:         cc.global constant @test2.rodata_{{[0-9]+}} ([1.000000e+00, 2.000000e+00, 6.000000e+00, 9.000000e+00]) : !cc.array<f64 x 4>
 

--- a/test/Quake/lift_array.qke
+++ b/test/Quake/lift_array.qke
@@ -1,0 +1,77 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt -lift-array-value %s | FileCheck %s
+
+func.func private @__nvqpp_vectorCopyCtor(%0: !cc.ptr<i8>, %1: i64, %2: i64) -> !cc.ptr<i8>
+
+func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.stdvec<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+  %cst = arith.constant -0.70710678118654757 : f64
+  %c16_i64 = arith.constant 16 : i64
+  %c4_i64 = arith.constant 4 : i64
+  %cst_0 = arith.constant 0.70710678118654757 : f64
+  %cst_1 = arith.constant 0.000000e+00 : f64
+  %0 = complex.create %cst_0, %cst_1 : complex<f64>
+  %1 = complex.create %cst_0, %cst_1 : complex<f64>
+  %2 = complex.create %cst_0, %cst_1 : complex<f64>
+  %3 = complex.create %cst, %cst_1 : complex<f64>
+  %4 = cc.alloca !cc.array<complex<f64> x 4>
+  %5 = cc.cast %4 : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
+  cc.store %0, %5 : !cc.ptr<complex<f64>>
+  %6 = cc.compute_ptr %4[1] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
+  cc.store %1, %6 : !cc.ptr<complex<f64>>
+  %7 = cc.compute_ptr %4[2] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
+  cc.store %2, %7 : !cc.ptr<complex<f64>>
+  %8 = cc.compute_ptr %4[3] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<complex<f64>>
+  cc.store %3, %8 : !cc.ptr<complex<f64>>
+  %9 = cc.cast %4 : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<i8>
+  %10 = call @__nvqpp_vectorCopyCtor(%9, %c4_i64, %c16_i64) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+  %11 = cc.stdvec_init %10, %c4_i64 : (!cc.ptr<i8>, i64) -> !cc.stdvec<complex<f64>>
+  return %11 : !cc.stdvec<complex<f64>>
+}
+  
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v() -> !cc.stdvec<complex<f64>> attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 16 : i64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 4 : i64
+// CHECK:           %[[VAL_2:.*]] = cc.address_of @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v.rodata_{{[0-9]+}} : !cc.ptr<!cc.array<complex<f64> x 4>>
+// CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<complex<f64> x 4>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_3]], %[[VAL_1]], %[[VAL_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = cc.stdvec_init %[[VAL_4]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<complex<f64>>
+// CHECK:           return %[[VAL_5]] : !cc.stdvec<complex<f64>>
+// CHECK:         }
+
+func.func @test2() -> !quake.veq<2> {
+  %0 = cc.alloca !cc.array<f64 x 4>
+  %1 = cc.compute_ptr %0[0] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+  %2 = arith.constant 1.0 : f64
+  cc.store %2, %1 : !cc.ptr<f64>
+  %3 = cc.compute_ptr %0[1] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+  %4 = arith.constant 2.0 : f64
+  cc.store %4, %3 : !cc.ptr<f64>
+  %5 = cc.compute_ptr %0[2] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+  %6 = arith.constant 6.0 : f64
+  cc.store %6, %5 : !cc.ptr<f64>
+  %7 = cc.compute_ptr %0[3] : (!cc.ptr<!cc.array<f64 x 4>>) -> !cc.ptr<f64>
+  %8 = arith.constant 9.0 : f64
+  cc.store %8, %7 : !cc.ptr<f64>
+  %9 = quake.alloca !quake.veq<2>
+  %10 = quake.init_state %9, %0 : (!quake.veq<2>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<2>
+  return %10 : !quake.veq<2>
+}
+
+// CHECK-LABEL:   func.func @test2() -> !quake.veq<2> {
+// CHECK:           %[[VAL_0:.*]] = cc.address_of @test2.rodata_{{[0-9]+}} : !cc.ptr<!cc.array<f64 x 4>>
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_2:.*]] = quake.init_state %[[VAL_1]], %[[VAL_0]] : (!quake.veq<2>, !cc.ptr<!cc.array<f64 x 4>>) -> !quake.veq<2>
+// CHECK:           return %[[VAL_2]] : !quake.veq<2>
+// CHECK:         }
+
+// CHECK:         cc.global constant @__nvqpp__mlirgen__function_custom_h_generator_1._Z20custom_h_generator_1v.rodata_{{[0-9]+}} (dense<[(0.70710678118654757,0.000000e+00), (0.70710678118654757,0.000000e+00), (0.70710678118654757,0.000000e+00), (-0.70710678118654757,0.000000e+00)]> : tensor<4xcomplex<f64>>) : !cc.array<complex<f64> x 4>
+
+// CHECK:         cc.global constant @test2.rodata_{{[0-9]+}} ([1.000000e+00, 2.000000e+00, 6.000000e+00, 9.000000e+00]) : !cc.array<f64 x 4>
+


### PR DESCRIPTION
This pass will promote an array constructed inline on the stack to a cc.const_array op.

TODO: when the array is used by quake.init_state, the verifier will fail. Nothing in the code base is built to accept an array *value* as an input to quake.init_state's second argument.

~Builds on #1862~

This pass will be useful to both the unitary custom op and state handling projects. 