### PR TITLE
[core] Add to the factory's IRBuilder the creating of vector<complex>

### DIFF
--- a/include/cudaq/Optimizer/Builder/Intrinsics.h
+++ b/include/cudaq/Optimizer/Builder/Intrinsics.h
@@ -11,6 +11,9 @@
 #include "cudaq/Optimizer/Builder/Factory.h"
 
 namespace cudaq {
+namespace cc {
+class GlobalOp;
+}
 
 /// This is the name of a dummy builtin to identify a std::move() call. These
 /// calls will be erased before code gen.
@@ -78,6 +81,15 @@ public:
     buffer += '\0';
     return genCStringLiteral(loc, module, buffer);
   }
+
+  cc::GlobalOp
+  genVectorOfComplexConstant(mlir::Location loc, mlir::ModuleOp module,
+                             mlir::StringRef name,
+                             const std::vector<std::complex<double>> &values);
+  cc::GlobalOp
+  genVectorOfComplexConstant(mlir::Location loc, mlir::ModuleOp module,
+                             mlir::StringRef name,
+                             const std::vector<std::complex<float>> &values);
 
   /// Load an intrinsic into \p module. The intrinsic to load has name \p name.
   /// This will automatically load any intrinsics that \p name depends upon.


### PR DESCRIPTION
These changes add a pair of methods to correctly build a GlobalOp that corresponds with a `vector<complex<REAL>>` constant block. Using these functions will generate a GlobalOp which has the attributes that MLIR will lower to LLVM correctly (and without crashing).

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
