### PR TITLE
Skip state_overlap test for nightly NVQC test

### DIFF
--- a/.github/workflows/nvqc_regression_tests.yml
+++ b/.github/workflows/nvqc_regression_tests.yml
@@ -124,7 +124,7 @@ jobs:
           # Test all remote-sim tests
           for filename in `find targettests/Remote-Sim -name '*.cpp'`; do
             # unsupport_args is a compile error test
-            if [[ "$filename" != *"unsupport_args"* ]]; then
+            if [[ "$filename" != *"unsupport_args"* ]] && [[ "$filename" != *"state_overlap"* ]]; then
               echo "$filename"
               nvqc_config=""
               # Look for a --remote-mqpu-auto-launch to determine the number of QPUs


### PR DESCRIPTION
This test is regularly failing because the deployed NVQC server does not support this yet. Skip it so that the test can pass (and it will be easier to identify test failures).

For an example failure, see: https://github.com/NVIDIA/cuda-quantum/actions/runs/9672862176