### PR TITLE
[C++ bridge] Add lowering for vector<complex<REAL>> and

### DIFF
--- a/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -341,7 +341,7 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *x) {
           TODO_x(toLocation(x), x, mangler, "unhandled complex element type");
           return false;
         }
-        std::size_t byteWidth = (eleTy.getIntOrFloatBitWidth() + 3) / 4;
+        std::size_t byteWidth = ((eleTy.getIntOrFloatBitWidth() + 7) / 8) * 2;
         result = createVectorInit(
             builder.create<arith::ConstantIntOp>(loc, byteWidth, 64));
       } else if (auto strTy = dyn_cast<cc::StructType>(eleTy)) {

--- a/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -291,8 +291,8 @@ bool QuakeBridgeVisitor::TraverseSwitchStmt(clang::SwitchStmt *x,
   return false;
 }
 
-bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *stmt) {
-  auto loc = toLocation(stmt->getSourceRange());
+bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *x) {
+  auto loc = toLocation(x->getSourceRange());
   bool isFuncScope = [&]() {
     if (auto *block = builder.getBlock())
       if (auto *region = block->getParent())
@@ -300,8 +300,8 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *stmt) {
           return isa<func::FuncOp, cc::CreateLambdaOp>(op);
     return false;
   }();
-  LLVM_DEBUG(llvm::dbgs() << "%% "; stmt->dump());
-  if (stmt->getRetValue()) {
+  LLVM_DEBUG(llvm::dbgs() << "%% "; x->dump());
+  if (x->getRetValue()) {
     auto result = popValue();
     auto resTy = result.getType();
     if (isa<cc::PointerType>(resTy)) {
@@ -317,19 +317,47 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *stmt) {
       if (failed(irBuilder.loadIntrinsic(module, "__nvqpp_vectorCopyCtor")))
         module.emitError("failed to load intrinsic");
       auto eleTy = vecTy.getElementType();
-      auto ptrTy = cudaq::cc::PointerType::get(builder.getI8Type());
-      Value resBuff = builder.create<cc::StdvecDataOp>(loc, ptrTy, result);
-      std::size_t byteWidth = (eleTy.getIntOrFloatBitWidth() + 7) / 8;
-      Value dynSize =
-          builder.create<cc::StdvecSizeOp>(loc, builder.getI64Type(), result);
-      auto eleSize = builder.create<arith::ConstantIntOp>(loc, byteWidth, 64);
-      Value heapCopy =
-          builder
-              .create<func::CallOp>(loc, ptrTy, "__nvqpp_vectorCopyCtor",
-                                    ValueRange{resBuff, dynSize, eleSize})
-              .getResult(0);
-      result = builder.create<cc::StdvecInitOp>(loc, resTy,
+      auto createVectorInit = [&](Value eleSize) {
+        auto ptrTy = cudaq::cc::PointerType::get(builder.getI8Type());
+        Value resBuff = builder.create<cc::StdvecDataOp>(loc, ptrTy, result);
+        Value dynSize =
+            builder.create<cc::StdvecSizeOp>(loc, builder.getI64Type(), result);
+        Value heapCopy =
+            builder
+                .create<func::CallOp>(loc, ptrTy, "__nvqpp_vectorCopyCtor",
+                                      ValueRange{resBuff, dynSize, eleSize})
+                .getResult(0);
+        return builder.create<cc::StdvecInitOp>(loc, resTy,
                                                 ValueRange{heapCopy, dynSize});
+      };
+
+      if (isa<IntegerType, FloatType>(eleTy)) {
+        std::size_t byteWidth = (eleTy.getIntOrFloatBitWidth() + 7) / 8;
+        result = createVectorInit(
+            builder.create<arith::ConstantIntOp>(loc, byteWidth, 64));
+      } else if (auto complexTy = dyn_cast<ComplexType>(eleTy)) {
+        eleTy = complexTy.getElementType();
+        if (!isa<IntegerType, FloatType>(eleTy)) {
+          TODO_x(toLocation(x), x, mangler, "unhandled complex element type");
+          return false;
+        }
+        std::size_t byteWidth = (eleTy.getIntOrFloatBitWidth() + 3) / 4;
+        result = createVectorInit(
+            builder.create<arith::ConstantIntOp>(loc, byteWidth, 64));
+      } else if (auto strTy = dyn_cast<cc::StructType>(eleTy)) {
+        if (std::size_t bitWidth = strTy.getBitSize()) {
+          assert(bitWidth % 8 == 0 && "struct ought to be in bytes");
+          std::size_t byteWidth = bitWidth / 8;
+          result = createVectorInit(
+              builder.create<arith::ConstantIntOp>(loc, byteWidth, 64));
+        } else {
+          TODO_x(toLocation(x), x, mangler, "unhandled struct type");
+          return false;
+        }
+      } else {
+        TODO_x(toLocation(x), x, mangler, "unhandled vector element type");
+        return false;
+      }
     }
     if (isFuncScope)
       builder.create<cc::ReturnOp>(loc, result);

--- a/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -351,8 +351,8 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *x) {
           result = createVectorInit(
               builder.create<arith::ConstantIntOp>(loc, byteWidth, 64));
         } else {
-          TODO_x(toLocation(x), x, mangler, "unhandled struct type");
-          return false;
+          result = createVectorInit(
+              builder.create<cc::SizeOfOp>(loc, builder.getI64Type(), strTy));
         }
       } else {
         TODO_x(toLocation(x), x, mangler, "unhandled vector element type");


### PR DESCRIPTION
for vector<struct{...}> when the struct size is recorded from the AST.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
