### PR TITLE
Fix #1886: refactoring of common code.

### DIFF
--- a/include/cudaq/Optimizer/Builder/Intrinsics.h
+++ b/include/cudaq/Optimizer/Builder/Intrinsics.h
@@ -60,7 +60,7 @@ public:
   using OpBuilder::OpBuilder;
 
   /// Create IRBuilder such that it has the same insertion point as \p builder.
-  IRBuilder(mlir::OpBuilder builder);
+  IRBuilder(const mlir::OpBuilder &builder);
 
   mlir::LLVM::ConstantOp genLlvmI32Constant(mlir::Location loc,
                                             std::int32_t val) {

--- a/include/cudaq/Optimizer/Builder/Intrinsics.h
+++ b/include/cudaq/Optimizer/Builder/Intrinsics.h
@@ -59,6 +59,9 @@ class IRBuilder : public mlir::OpBuilder {
 public:
   using OpBuilder::OpBuilder;
 
+  /// Create IRBuilder such that it has the same insertion point as \p builder.
+  IRBuilder(mlir::OpBuilder builder);
+
   mlir::LLVM::ConstantOp genLlvmI32Constant(mlir::Location loc,
                                             std::int32_t val) {
     return opt::factory::genLlvmI32Constant(loc, *this, val);
@@ -98,6 +101,10 @@ public:
                                     llvm::StringRef name);
 
   std::string hashStringByContent(llvm::StringRef sref);
+
+  /// Generates code that yields the size of any type that can be reified in
+  /// memory. Otherwise returns a `nullptr` Value.
+  mlir::Value getByteSizeOfType(mlir::Location loc, mlir::Type ty);
 
   static IRBuilder atBlockEnd(mlir::Block *block) {
     return IRBuilder(block, block->end(), nullptr);

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.h
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.h
@@ -47,6 +47,9 @@ public:
 using ComputePtrArg = InterleavedArgument;
 using ExtractValueArg = InterleavedArgument;
 
+mlir::Value getByteSizeOfType(mlir::OpBuilder &builder, mlir::Location loc,
+                              mlir::Type ty, bool useSizeOf);
+
 } // namespace cudaq::cc
 
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -11,7 +11,6 @@
 #include "cudaq/Optimizer/CodeGen/CudaqFunctionNames.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MD5.h"
 #include "mlir/Parser/Parser.h"

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -320,7 +320,8 @@ inline bool intrinsicTableIsSorted() {
 
 namespace cudaq {
 
-IRBuilder::IRBuilder(OpBuilder builder) : OpBuilder{builder.getContext()} {
+IRBuilder::IRBuilder(const OpBuilder &builder)
+    : OpBuilder{builder.getContext()} {
   // Sets the insertion point to be the same as \p builder. New operations will
   // be inserted immediately before this insertion point and the insertion
   // points will remain the identical, upto and unless one of the builders

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -1353,26 +1353,9 @@ public:
                                     rewriteEntryBlock->getArguments().front(),
                                     dataPtr, vecLen);
         } else {
-          Value tSize;
-          if (isa<IntegerType, FloatType>(eleTy)) {
-            auto size = (eleTy.getIntOrFloatBitWidth() + 7) / 8;
-            tSize = builder.create<arith::ConstantIntOp>(loc, size, 64);
-          } else if (auto complexTy = dyn_cast<ComplexType>(eleTy)) {
-            eleTy = complexTy.getElementType();
-            if (isa<IntegerType, FloatType>(eleTy)) {
-              auto size = ((eleTy.getIntOrFloatBitWidth() + 7) / 8) * 2;
-              tSize = builder.create<arith::ConstantIntOp>(loc, size, 64);
-            }
-          } else if (auto strTy = dyn_cast<cudaq::cc::StructType>(eleTy)) {
-            if (std::size_t bitWidth = strTy.getBitSize()) {
-              assert(bitWidth % 8 == 0 && "struct ought to be in bytes");
-              std::size_t byteWidth = bitWidth / 8;
-              tSize = builder.create<arith::ConstantIntOp>(loc, byteWidth, 64);
-            } else {
-              tSize = builder.create<cudaq::cc::SizeOfOp>(
-                  loc, builder.getI64Type(), strTy);
-            }
-          } else {
+          cudaq::IRBuilder irBuilder(builder);
+          Value tSize = irBuilder.getByteSizeOfType(loc, eleTy);
+          if (!tSize) {
             TODO_loc(loc, "unhandled vector element type");
             return;
           }


### PR DESCRIPTION
This refactors the common code that will generate expressions to determine the size of an object with a type that can be reified in memory statically. The code is moved to the IRBuilder and out from ConvertStmt and GenKernelExecution. (There may be other places that ought to use this new IRBuilder code.)

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
