### PR TITLE
[llvm] Fix region simplification bug

### DIFF
--- a/docker/build/devdeps.Dockerfile
+++ b/docker/build/devdeps.Dockerfile
@@ -52,6 +52,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends git \
 ADD ./tpls/customizations/llvm/llvm_pr71968_mod.diff /
 RUN cd /llvm-project && git apply /llvm_pr71968_mod.diff && rm /llvm_pr71968_mod.diff
 
+# Apply customization for https://github.com/NVIDIA/cuda-quantum/issues/1799
+ADD ./tpls/customizations/llvm/fix_region_simplification.diff /
+RUN cd /llvm-project && git apply /fix_region_simplification.diff && rm /fix_region_simplification.diff
+
 # Build the the LLVM libraries and compiler toolchain needed to build CUDA-Q;
 # The safest option to avoid any compatibility issues is to build an application using these libraries 
 # with the same compiler toolchain that the libraries were compiled with.

--- a/tpls/customizations/llvm/fix_region_simplification.diff
+++ b/tpls/customizations/llvm/fix_region_simplification.diff
@@ -1,0 +1,20 @@
+diff --git a/mlir/lib/Transforms/Utils/RegionUtils.cpp b/mlir/lib/Transforms/Utils/RegionUtils.cpp
+index 996588243..63ab385be 100644
+--- a/mlir/lib/Transforms/Utils/RegionUtils.cpp
++++ b/mlir/lib/Transforms/Utils/RegionUtils.cpp
+@@ -679,6 +679,15 @@ static LogicalResult mergeIdenticalBlocks(RewriterBase &rewriter,
+       if (hasNonEmptyRegion)
+         continue;
+
++      // Don't allow merging if this block's arguments are used outside of the
++      // original block.
++      bool argHasExternalUsers = llvm::any_of(
++          block->getArguments(), [block](mlir::BlockArgument &arg) {
++            return arg.isUsedOutsideOfBlock(block);
++          });
++      if (argHasExternalUsers)
++        continue;
++
+       // Try to add this block to an existing cluster.
+       bool addedToCluster = false;
+       for (auto &cluster : clusters)


### PR DESCRIPTION
Fixes #1799 

This fixes the underlying MLIR bug by applying a patch to our version of LLVM. The problem is that it was merging regions despite their block arguments being used differently downstream. It should not do that, so this patch fixes that.

We will work on getting it merged upstream in the coming weeks.