### PR TITLE
[kernel_builder] Use quake.reset with a veq argument.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -186,6 +186,9 @@ def ExpandMeasurements : Pass<"expand-measurements"> {
     The target may only support measuring a single qubit however. This pass
     expands these ops in list format into a series of measurements (including
     loops) on individual qubits and into a single `std::vector<bool>` result.
+
+    The `reset` op can also take a veq argument and this pass will also expand
+    that to a series of `reset` operations on single qubits.
   }];
 
   let dependentDialects = ["cudaq::cc::CCDialect", "mlir::LLVM::LLVMDialect"];

--- a/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
@@ -386,11 +386,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto parentModule = instOp->getParentOfType<ModuleOp>();
     auto context = parentModule->getContext();
-    std::string qirQisPrefix{cudaq::opt::QIRQISPrefix};
     std::string instName = instOp->getName().stripDialect().str();
 
     // Get the reset QIR function name
-    auto qirFunctionName = qirQisPrefix + instName;
+    auto qirFunctionName = cudaq::opt::QIRQISPrefix + instName;
 
     // Create the qubit pointer type
     auto qirQubitPointerType = cudaq::opt::getQubitType(context);

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -792,30 +792,7 @@ QuakeValue mz(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQvec,
 }
 
 void reset(ImplicitLocOpBuilder &builder, const QuakeValue &qubitOrQvec) {
-  auto value = qubitOrQvec.getValue();
-  if (isa<quake::RefType>(value.getType())) {
-    builder.create<quake::ResetOp>(TypeRange{}, value);
-    return;
-  }
-
-  if (isa<quake::VeqType>(value.getType())) {
-    auto target = value;
-    Value rank = builder.create<quake::VeqSizeOp>(builder.getI64Type(), target);
-    auto bodyBuilder = [&](OpBuilder &builder, Location loc, Region &,
-                           Block &block) {
-      Value ref = builder.create<quake::ExtractRefOp>(loc, target,
-                                                      block.getArgument(0));
-      builder.create<quake::ResetOp>(loc, TypeRange{}, ref);
-    };
-    cudaq::opt::factory::createInvariantLoop(builder, builder.getUnknownLoc(),
-                                             rank, bodyBuilder);
-    return;
-  }
-
-  llvm::errs() << "Invalid type:\n";
-  value.getType().dump();
-  llvm::errs() << '\n';
-  throw std::runtime_error("Invalid type passed to reset().");
+  builder.create<quake::ResetOp>(TypeRange{}, qubitOrQvec.getValue());
 }
 
 void swap(ImplicitLocOpBuilder &builder, const std::vector<QuakeValue> &ctrls,


### PR DESCRIPTION
Simplify the kernel_builder to use both qubit and veq forms of the reset op. Add a pattern to expand measurements that also expands resets.

~Requires #1910 to be merged first.~
