### PR TITLE
[runtime] Fix bug with function declarations being dropped on the floor

### DIFF
--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -154,11 +154,13 @@ public:
       auto moduleOp = builder.create<mlir::ModuleOp>();
       moduleOp->setAttrs((*module)->getAttrDictionary());
       for (auto &op : *module) {
-        auto funcOp = dyn_cast<mlir::func::FuncOp>(op);
-        // Add quantum kernels defined in the module.
-        if (funcOp && (funcOp->hasAttr(cudaq::kernelAttrName) ||
-                       funcOp.getName().startswith("__nvqpp__mlirgen__")))
-          moduleOp.push_back(funcOp.clone());
+        if (auto funcOp = dyn_cast<mlir::func::FuncOp>(op)) {
+          // Add quantum kernels defined in the module.
+          if (funcOp->hasAttr(cudaq::kernelAttrName) ||
+              funcOp.getName().startswith("__nvqpp__mlirgen__") ||
+              funcOp.getBody().empty())
+            moduleOp.push_back(funcOp.clone());
+        }
       }
 
       if (args) {


### PR DESCRIPTION
This small change copies function declarations from the "old" module to the new module to fix correctness issues. This will never be a problem if the old module is well formed. Dropping them on the floor is a bug because there may be calls to these functions in the selected kernel, and those calls will fail to verify after the declarations are dropped.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
