### PR TITLE
Fix custom operations on remote-mqpu (library mode)

### DIFF
--- a/runtime/common/JIT.cpp
+++ b/runtime/common/JIT.cpp
@@ -31,11 +31,10 @@
 #define DEBUG_TYPE "cudaq-qpud"
 
 namespace cudaq {
-
-void invokeWrappedKernel(std::string_view irString,
-                         const std::string &entryPointFn, void *args,
-                         std::uint64_t argsSize, std::size_t numTimes,
-                         std::function<void(std::size_t)> postExecCallback) {
+std::unique_ptr<llvm::orc::LLJIT>
+invokeWrappedKernel(std::string_view irString, const std::string &entryPointFn,
+                    void *args, std::uint64_t argsSize, std::size_t numTimes,
+                    std::function<void(std::size_t)> postExecCallback) {
 
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext);
   // Parse bitcode
@@ -144,5 +143,7 @@ void invokeWrappedKernel(std::string_view irString,
       postExecCallback(i);
     }
   }
+
+  return jit;
 }
 } // namespace cudaq

--- a/runtime/common/JIT.h
+++ b/runtime/common/JIT.h
@@ -7,8 +7,10 @@
  ******************************************************************************/
 #pragma once
 
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace cudaq {
@@ -20,8 +22,9 @@ namespace cudaq {
 // Optionally, the JIT'ed kernel can be executed a number of
 // times along with a post-execution callback. For example, sample a dynamic
 // kernel.
-void invokeWrappedKernel(
-    std::string_view llvmIr, const std::string &kernelName, void *args,
-    std::uint64_t argsSize, std::size_t numTimes = 1,
-    std::function<void(std::size_t)> postExecCallback = {});
+std::unique_ptr<llvm::orc::LLJIT>
+invokeWrappedKernel(std::string_view llvmIr, const std::string &kernelName,
+                    void *args, std::uint64_t argsSize,
+                    std::size_t numTimes = 1,
+                    std::function<void(std::size_t)> postExecCallback = {});
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteServer.cpp
+++ b/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteServer.cpp
@@ -76,6 +76,14 @@ T getValueOrThrow(llvm::Expected<T> valOrErr,
   }
 }
 
+// Clear any registered operations in the ExecutionManager and then destroy the
+// JIT. This needs to be called when the registered operations may contain
+// pointers into the code objects inside the JIT.
+void clearRegOpsAndDestroyJIT(std::unique_ptr<llvm::orc::LLJIT> &jit) {
+  cudaq::getExecutionManager()->clearRegisteredOperations();
+  jit.release();
+}
+
 class RemoteRestRuntimeServer : public cudaq::RemoteRuntimeServer {
   int m_port = -1;
   std::unique_ptr<cudaq::RestServer> m_server;
@@ -270,14 +278,19 @@ public:
       cudaq::set_random_seed(seed);
     auto &platform = cudaq::get_platform();
     auto &requestInfo = m_codeTransform[reqId];
+
+    // The lifetime of this pointer should be just as long as `platform` because
+    // any calls to `platform` functions could invoke code that relies on the
+    // JIT being present.
+    std::unique_ptr<llvm::orc::LLJIT> llvmJit;
     if (requestInfo.format == cudaq::CodeFormat::LLVM) {
       if (io_context.name == "sample") {
         // In library mode (LLVM), check to see if we have mid-circuit measures
         // by tracing the kernel function.
         cudaq::ExecutionContext context("tracer");
         platform.set_exec_ctx(&context);
-        cudaq::invokeWrappedKernel(ir, std::string(kernelName), kernelArgs,
-                                   argsSize);
+        llvmJit = cudaq::invokeWrappedKernel(ir, std::string(kernelName),
+                                             kernelArgs, argsSize);
         platform.reset_exec_ctx();
         // In trace mode, if we have a measure result
         // that is passed to an if statement, then
@@ -291,32 +304,40 @@ public:
           // Need to run simulation shot-by-shot
           cudaq::sample_result counts;
           platform.set_exec_ctx(&io_context);
+          // Since registered operations may contain pointers to classes defined
+          // in an LLVM JIT, we must clear them before any prior LLVM JIT gets
+          // deleted.
+          clearRegOpsAndDestroyJIT(llvmJit);
           // If it has conditionals, loop over individual circuit executions
-          cudaq::invokeWrappedKernel(ir, std::string(kernelName), kernelArgs,
-                                     argsSize, io_context.shots,
-                                     [&](std::size_t i) {
-                                       // Reset the context and get the single
-                                       // measure result, add it to the
-                                       // sample_result and clear the context
-                                       // result
-                                       platform.reset_exec_ctx();
-                                       counts += io_context.result;
-                                       io_context.result.clear();
-                                       if (i != (io_context.shots - 1))
-                                         platform.set_exec_ctx(&io_context);
-                                     });
+          llvmJit = cudaq::invokeWrappedKernel(
+              ir, std::string(kernelName), kernelArgs, argsSize,
+              io_context.shots, [&](std::size_t i) {
+                // Reset the context and get the single
+                // measure result, add it to the
+                // sample_result and clear the context
+                // result
+                platform.reset_exec_ctx();
+                counts += io_context.result;
+                io_context.result.clear();
+                if (i != (io_context.shots - 1))
+                  platform.set_exec_ctx(&io_context);
+              });
           io_context.result = counts;
           platform.set_exec_ctx(&io_context);
         } else {
           // If no conditionals, nothing special to do for library mode
           platform.set_exec_ctx(&io_context);
-          cudaq::invokeWrappedKernel(ir, std::string(kernelName), kernelArgs,
-                                     argsSize);
+          // Since registered operations may contain pointers to classes defined
+          // in an LLVM JIT, we must clear them before any prior LLVM JIT gets
+          // deleted.
+          clearRegOpsAndDestroyJIT(llvmJit);
+          llvmJit = cudaq::invokeWrappedKernel(ir, std::string(kernelName),
+                                               kernelArgs, argsSize);
         }
       } else {
         platform.set_exec_ctx(&io_context);
-        cudaq::invokeWrappedKernel(ir, std::string(kernelName), kernelArgs,
-                                   argsSize);
+        llvmJit = cudaq::invokeWrappedKernel(ir, std::string(kernelName),
+                                             kernelArgs, argsSize);
       }
     } else {
       platform.set_exec_ctx(&io_context);
@@ -345,6 +366,10 @@ public:
       }
     }
     platform.reset_exec_ctx();
+    // Clear the registered operations before the `llvmJit` goes out of scope
+    // so that destruction of registered operations doesn't cause segfaults
+    // during shutdown.
+    clearRegOpsAndDestroyJIT(llvmJit);
     simulationEnd = std::chrono::high_resolution_clock::now();
   }
 

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -186,6 +186,9 @@ public:
     registeredOperations.insert({name, std::make_unique<T>()});
   }
 
+  /// Clear the registered operations
+  virtual void clearRegisteredOperations() { registeredOperations.clear(); }
+
   virtual ~ExecutionManager() = default;
 };
 

--- a/targettests/Remote-Sim/custom_operation.cpp
+++ b/targettests/Remote-Sim/custom_operation.cpp
@@ -8,11 +8,9 @@
 
 // REQUIRES: remote-sim
 // clang-format off
+// RUN: nvq++ %cpp_std --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t 
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
-
-/// NOTE: Library mode not yet supported
-// nvq++ %cpp_std --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t 
 
 #include <cudaq.h>
 


### PR DESCRIPTION
Fixes #1922 

The problem was that the LLVM JIT objects were being destroyed right at the end of `invokeWrappedKernel()`, and the ExecutionManager's `registeredOperations` contained there were dangling pointers into object code created during that JIT (specifically the vtables for the custom operations' structs). The fix is to make the lifetime of the LLVM JIT last longer than it previously did.

Also, we have to provide a mechanism to clear the registered operations so that shutdown of `cudaq-qpud` doesn't attempt to call destructors in object code that was created during a JIT (again, vtables).
