### PR TITLE
[refactoring] [C++] Clean-up for "generator" functions

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -718,6 +718,10 @@ public:
 
     // Return true if this FunctionDecl is a quantum kernel.
     static bool isQuantum(const clang::FunctionDecl *decl);
+
+    // Return true if this FunctionDecl is a generator function for custom
+    // operation
+    static bool isCustomOpGenerator(const clang::FunctionDecl *decl);
   };
 
 protected:

--- a/include/cudaq/Frontend/nvqpp/AttributeNames.h
+++ b/include/cudaq/Frontend/nvqpp/AttributeNames.h
@@ -10,10 +10,18 @@
 
 namespace cudaq {
 
+/// Name of the annotation attribute attached to CUDA-Q kernels
+static constexpr const char kernelAnnotation[] = "quantum";
+
 /// Name of the attribute attached to entry point functions.
 static constexpr const char entryPointAttrName[] = "cudaq-entrypoint";
 
-/// Name of the attribute attached to cudaq kernels.
+/// Name of the attribute attached to CUDA-Q kernels.
 static constexpr const char kernelAttrName[] = "cudaq-kernel";
+
+/// Name of the annotation attribute attached to unitary generator function for
+/// user-defined custom operations
+static constexpr const char generatorAnnotation[] =
+    "user_custom_quantum_operation";
 
 } // namespace cudaq

--- a/lib/Optimizer/Transforms/GenDeviceCodeLoader.cpp
+++ b/lib/Optimizer/Transforms/GenDeviceCodeLoader.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Frontend/nvqpp/AttributeNames.h"
 #include "cudaq/Optimizer/Builder/Factory.h"
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
@@ -117,6 +118,8 @@ public:
       // FIXME: May not be a FuncOp in the future.
       if (auto funcOp = dyn_cast<func::FuncOp>(op)) {
         if (!funcOp.getName().startswith(cudaq::runtime::cudaqGenPrefixName))
+          continue;
+        if (funcOp->hasAttr(cudaq::generatorAnnotation))
           continue;
         auto className =
             funcOp.getName().drop_front(cudaq::runtime::cudaqGenPrefixLength);

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Frontend/nvqpp/AttributeNames.h"
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
@@ -1483,6 +1484,8 @@ public:
     LLVM_DEBUG(llvm::dbgs()
                << workList.size() << " kernel entry functions to process\n");
     for (auto funcOp : workList) {
+      if (funcOp->hasAttr(cudaq::generatorAnnotation))
+        continue;
       auto loc = funcOp.getLoc();
       [[maybe_unused]] auto className =
           funcOp.getName().drop_front(cudaq::runtime::cudaqGenPrefixLength);


### PR DESCRIPTION
### Description
* Address the comment captured in issue #1918 
 -- don't treat custom operation generator functions exactly like kernels.
 * They are still processed similar to kernels but aren't entry-point kernels and skipped by kernel execution, and device code loader passes.
