### PR TITLE
[QuakeSynth] Fix bug in pointer-free size calculation.

### DIFF
--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -573,8 +573,11 @@ public:
         auto sizeFromBuffer =
             *reinterpret_cast<const std::uint64_t *>(ptrToSizeInBuffer);
         auto bytesInType = [&eleTy]() -> unsigned {
-          if (isa<cudaq::cc::CharspanType>(eleTy))
-            return 16 /*bytes: sizeof(ptr) + sizeof(i64)*/;
+          if (isa<cudaq::cc::CharspanType>(eleTy)) {
+            /* A charspan is a struct{ ptr, i64 }, which is just an i64 in
+             * pointer-free encoding. */
+            return sizeof(std::int64_t);
+          }
           if (auto complexTy = dyn_cast<ComplexType>(eleTy))
             return 2 * cudaq::opt::convertBitsToBytes(
                            complexTy.getElementType().getIntOrFloatBitWidth());


### PR DESCRIPTION
When computing the size in pointer-free format, pointers have 0 size.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
