### PR TITLE
Fix #1957: accept pauli_word as an argument.

### DIFF
--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1442,6 +1442,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           // Load the char span, which is a char*
           auto span = builder.create<cc::LoadOp>(loc, v);
           processedArgs.push_back(span);
+        } else if (isa<cudaq::cc::CharspanType>(v.getType())) {
+          processedArgs.push_back(v);
         } else {
           reportClangError(x, mangler, "could not determine string argument");
         }

--- a/test/AST-Quake/pauli_word.cpp
+++ b/test/AST-Quake/pauli_word.cpp
@@ -16,10 +16,12 @@ __qpu__ void pauli_word_vec(std::vector<cudaq::pauli_word> words,
   exp_pauli(theta, v, words[0]);
 }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_pauli_word_vec._Z14pauli_word_vecSt6vectorIN5cudaq10pauli_wordESaIS1_EEd(
+// clang-format off
+// CHECK-LABEL:   func.func
+// @__nvqpp__mlirgen__function_pauli_word_vec._Z14pauli_word_vecSt6vectorIN5cudaq10pauli_wordESaIS1_EEd(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<!cc.charspan>,
-// CHECK-SAME:      %[[VAL_1:.*]]: f64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-// CHECK:           %[[VAL_2:.*]] = cc.alloca f64
+// CHECK-SAME:      %[[VAL_1:.*]]: f64) attributes {"cudaq-entrypoint",
+// "cudaq-kernel", no_this} { CHECK:           %[[VAL_2:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
@@ -29,3 +31,22 @@ __qpu__ void pauli_word_vec(std::vector<cudaq::pauli_word> words,
 // CHECK:           quake.exp_pauli %[[VAL_4]], %[[VAL_3]], %[[VAL_7]] : (f64, !quake.veq<4>, !cc.charspan) -> ()
 // CHECK:           return
 // CHECK:         }
+// clang-format on
+
+__qpu__ void pauli_word(cudaq::pauli_word wordle, double theta) {
+  cudaq::qvector v(4);
+  exp_pauli(theta, v, wordle);
+}
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_pauli_word._Z10pauli_wordN5cudaq10pauli_wordEd(
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.charspan,
+// CHECK-SAME:      %[[VAL_1:.*]]: f64) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_2:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:           quake.exp_pauli %[[VAL_4]], %[[VAL_3]], %[[VAL_0]] : (f64, !quake.veq<4>, !cc.charspan) -> ()
+// CHECK:           return
+// CHECK:         }
+// clang-format on


### PR DESCRIPTION
This fixes passing a cudaq::pauli_word as an argument. (This is only a front-end change.)

Requires #1966 to be merged first.
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
