### PR TITLE
[Bug-fix] Support use of `control` and `adjoint` variants of a kernel

### DIFF
--- a/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -68,8 +68,14 @@ private:
       ApplyVariants variant;
       auto callee = lookupCallee(apply);
       auto iter = infoMap.find(callee);
-      if (iter != infoMap.end())
+      if (iter != infoMap.end()) {
         variant = iter->second;
+        /// NOTE: As per the `DenseMap` API  in
+        /// llvm/include/llvm/ADT/DenseMap.h, an `insert` operation doesn't
+        /// update the value if key is already in the map. Hence, remove it and
+        /// insert a new entry with updated key.
+        infoMap.erase(iter);
+      }
       if (apply.getIsAdj() && !apply.getControls().empty())
         variant.needsAdjointControlVariant = true;
       else if (apply.getIsAdj())

--- a/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -68,21 +68,18 @@ private:
       ApplyVariants variant;
       auto callee = lookupCallee(apply);
       auto iter = infoMap.find(callee);
-      if (iter != infoMap.end()) {
+      if (iter != infoMap.end())
         variant = iter->second;
-        /// NOTE: As per the `DenseMap` API  in
-        /// llvm/include/llvm/ADT/DenseMap.h, an `insert` operation doesn't
-        /// update the value if key is already in the map. Hence, remove it and
-        /// insert a new entry with updated key.
-        infoMap.erase(iter);
-      }
       if (apply.getIsAdj() && !apply.getControls().empty())
         variant.needsAdjointControlVariant = true;
       else if (apply.getIsAdj())
         variant.needsAdjointVariant = true;
       else if (!apply.getControls().empty())
         variant.needsControlVariant = true;
-      infoMap.insert(std::make_pair(callee.getOperation(), variant));
+      if (iter != infoMap.end())
+        infoMap[callee.getOperation()] = variant;
+      else
+        infoMap.insert(std::make_pair(callee.getOperation(), variant));
     });
 
     // Propagate the transitive closure over the call tree.

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -1578,26 +1578,30 @@ def test_subtract():
 
     cudaq.sample(bug_subtract)
 
+
 def test_capture_opaque_kernel():
 
     def retFunc():
+
         @cudaq.kernel
-        def bell(i : int):
+        def bell(i: int):
             q = cudaq.qvector(i)
             h(q[0])
             x.ctrl(q[0], q[1])
-        
-        return bell 
+
+        return bell
 
     def retFunc2():
+
         @cudaq.kernel
         def super():
             q = cudaq.qubit()
             h(q)
-        
-        return super 
+
+        return super
 
     b = retFunc()
+
     @cudaq.kernel
     def k():
         b(2)
@@ -1605,6 +1609,7 @@ def test_capture_opaque_kernel():
     print(k)
 
     b = retFunc2()
+
     @cudaq.kernel
     def kd():
         b()
@@ -1612,11 +1617,11 @@ def test_capture_opaque_kernel():
     print(kd)
 
     counts = cudaq.sample(k)
-    assert len(counts) == 2 and '00' in counts and '11' in counts 
-    
+    assert len(counts) == 2 and '00' in counts and '11' in counts
+
     counts = cudaq.sample(kd)
-    assert len(counts) == 2 and '0' in counts and '1' in counts 
-    
+    assert len(counts) == 2 and '0' in counts and '1' in counts
+
 
 @skipIfPythonLessThan39
 def test_issue_9():
@@ -1669,6 +1674,27 @@ def test_issue_1641():
         print(invalid_ctrl)
     assert 'controlled operation requested without any control argument(s)' in repr(
         error)
+
+
+def test_control_then_adjoint():
+
+    @cudaq.kernel
+    def my_func(q: cudaq.qubit, theta: float):
+        ry(theta, q)
+        rz(theta, q)
+
+    @cudaq.kernel
+    def kernel(theta: float):
+        ancilla = cudaq.qubit()
+        q = cudaq.qubit()
+
+        h(ancilla)
+        cudaq.control(my_func, ancilla, q, theta)
+        cudaq.adjoint(my_func, q, theta)
+
+    theta = 1.5
+    # test here is that this compiles and runs
+    cudaq.sample(kernel, theta).dump()
 
 
 # leave for gdb debugging

--- a/test/Quake/control_and_adjoint.qke
+++ b/test/Quake/control_and_adjoint.qke
@@ -1,0 +1,88 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --apply-op-specialization --canonicalize %s | FileCheck %s
+
+module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel = "__nvqpp__mlirgen__kernel_PyKernelEntryPointRewrite"}} {
+  func.func @__nvqpp__mlirgen__my_func(%arg0: !quake.ref, %arg1: f64) {
+    %0 = cc.alloca f64
+    cc.store %arg1, %0 : !cc.ptr<f64>
+    %1 = cc.load %0 : !cc.ptr<f64>
+    quake.ry (%1) %arg0 : (f64, !quake.ref) -> ()
+    %2 = cc.load %0 : !cc.ptr<f64>
+    quake.rz (%2) %arg0 : (f64, !quake.ref) -> ()
+    return
+  }
+  func.func @__nvqpp__mlirgen__kernel(%arg0: f64) attributes {"cudaq-entrypoint"} {
+    %0 = cc.alloca f64
+    cc.store %arg0, %0 : !cc.ptr<f64>
+    %1 = quake.alloca !quake.ref
+    %2 = quake.alloca !quake.ref
+    quake.h %1 : (!quake.ref) -> ()
+    %3 = cc.load %0 : !cc.ptr<f64>
+    quake.apply @__nvqpp__mlirgen__my_func [%1] %2, %3 : (!quake.ref, !quake.ref, f64) -> ()
+    %4 = cc.load %0 : !cc.ptr<f64>
+    quake.apply<adj> @__nvqpp__mlirgen__my_func %2, %4 : (!quake.ref, f64) -> ()
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func private @__nvqpp__mlirgen__my_func.adj(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: !quake.ref,
+// CHECK-SAME:                                                     %[[VAL_1:.*]]: f64) {
+// CHECK:           %[[VAL_2:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_5:.*]] = arith.negf %[[VAL_4]] : f64
+// CHECK:           quake.rz (%[[VAL_5]]) %[[VAL_0]] : (f64, !quake.ref) -> ()
+// CHECK:           %[[VAL_6:.*]] = arith.negf %[[VAL_3]] : f64
+// CHECK:           quake.ry (%[[VAL_6]]) %[[VAL_0]] : (f64, !quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func private @__nvqpp__mlirgen__my_func.ctrl(
+// CHECK-SAME:                                                      %[[VAL_0:.*]]: !quake.veq<?>,
+// CHECK-SAME:                                                      %[[VAL_1:.*]]: !quake.ref,
+// CHECK-SAME:                                                      %[[VAL_2:.*]]: f64) {
+// CHECK:           %[[VAL_3:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_3]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<f64>
+// CHECK:           quake.ry (%[[VAL_4]]) {{\[}}%[[VAL_0]]] %[[VAL_1]] : (f64, !quake.veq<?>, !quake.ref) -> ()
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_3]] : !cc.ptr<f64>
+// CHECK:           quake.rz (%[[VAL_5]]) {{\[}}%[[VAL_0]]] %[[VAL_1]] : (f64, !quake.veq<?>, !quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__my_func(
+// CHECK-SAME:                                         %[[VAL_0:.*]]: !quake.ref,
+// CHECK-SAME:                                         %[[VAL_1:.*]]: f64) {
+// CHECK:           %[[VAL_2:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:           quake.ry (%[[VAL_3]]) %[[VAL_0]] : (f64, !quake.ref) -> ()
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:           quake.rz (%[[VAL_4]]) %[[VAL_0]] : (f64, !quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: f64) attributes {"cudaq-entrypoint"} {
+// CHECK:           %[[VAL_1:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.h %[[VAL_2]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_1]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_5:.*]] = quake.concat %[[VAL_2]] : (!quake.ref) -> !quake.veq<1>
+// CHECK:           %[[VAL_6:.*]] = quake.relax_size %[[VAL_5]] : (!quake.veq<1>) -> !quake.veq<?>
+// CHECK:           call @__nvqpp__mlirgen__my_func.ctrl(%[[VAL_6]], %[[VAL_3]], %[[VAL_4]]) : (!quake.veq<?>, !quake.ref, f64) -> ()
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_1]] : !cc.ptr<f64>
+// CHECK:           call @__nvqpp__mlirgen__my_func.adj(%[[VAL_3]], %[[VAL_7]]) : (!quake.ref, f64) -> ()
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
* Handle case where both `control` and `adjoint` variants of a kernel are used.

* Fixes one of the issues captured in issue #1871

