### PR TITLE
[pauli_word] Update the C++ host type for pauli_word class.

### DIFF
--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -359,8 +359,13 @@ static Type convertToHostSideType(Type ty) {
   if (auto memrefTy = dyn_cast<cc::StdvecType>(ty))
     return convertToHostSideType(
         factory::stlVectorType(memrefTy.getElementType()));
-  if (auto memrefTy = dyn_cast<cc::CharspanType>(ty))
-    return convertToHostSideType(factory::stlStringType(memrefTy.getContext()));
+  if (auto memrefTy = dyn_cast<cc::CharspanType>(ty)) {
+    // `pauli_word` is an object with a std::vector in the header files at
+    // present. This data type *must* be updated if it becomes a std::string
+    // once again.
+    return convertToHostSideType(
+        factory::stlVectorType(IntegerType::get(ty.getContext(), 8)));
+  }
   auto *ctx = ty.getContext();
   if (auto structTy = dyn_cast<cc::StructType>(ty)) {
     SmallVector<Type> newMembers;


### PR DESCRIPTION
The pauli_word used to be a std::string, but it was morphed to be a std::vector and the type signatures were not updated. This resulted in the host side function trying to pack the wrong datatype into the comm buffer and crashing with a SIGSEGV.

Related: #1957 

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
