### PR TITLE
Enable quantum struct member types in kernel code 

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -585,6 +585,10 @@ private:
                                                    mlir::StringRef funcName,
                                                    mlir::FunctionType funcTy);
 
+  /// Return true if the input type is a CC StructType and
+  /// contains any quantum members.
+  bool isQuantumStructType(mlir::Type ty);
+
   /// Stack of Values built by the visitor. (right-to-left ordering)
   mlir::SmallVector<mlir::Value> valueStack;
   clang::ASTContext *astContext;

--- a/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -50,8 +50,9 @@ listReachableFunctions(clang::CallGraphNode *cgn) {
   return result;
 }
 
-// Does `ty` refer to a Quake quantum type? This also checks custom recursive
-// types. It does not check builtin recursive types; e.g., `!llvm.ptr<T>`.
+// Does `ty` refer to a Quake quantum type? This also checks CC Dialect
+// recursive types. It does not check builtin recursive types; e.g.,
+// `!llvm.ptr<T>`.
 static bool isQubitType(Type ty) {
   if (isa<quake::RefType, quake::VeqType>(ty))
     return true;
@@ -360,6 +361,18 @@ private:
 
 #ifndef NDEBUG
 namespace cudaq::details {
+bool QuakeBridgeVisitor::isQuantumStructType(Type ty) {
+  auto structTy = dyn_cast<cc::StructType>(ty);
+  if (!structTy)
+    return false;
+
+  for (auto member : structTy.getMembers())
+    if (quake::isQuantumType(member))
+      return true;
+
+  return false;
+}
+
 bool QuakeBridgeVisitor::pushValue(Value v) {
   LLVM_DEBUG(llvm::dbgs() << std::string(valueStack.size(), ' ')
                           << "+push value: ";

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -93,7 +93,8 @@ void QuakeBridgeVisitor::addArgumentSymbols(
       auto parmTy = entryBlock->getArgument(index).getType();
       if (isa<FunctionType, cc::CallableType, cc::PointerType, cc::SpanLikeType,
               LLVM::LLVMStructType, quake::ControlType, quake::RefType,
-              quake::VeqType, quake::WireType>(parmTy)) {
+              quake::VeqType, quake::WireType>(parmTy) ||
+          isQuantumStructType(parmTy)) {
         symbolTable.insert(name, entryBlock->getArgument(index));
       } else {
         auto stackSlot = builder.create<cc::AllocaOp>(loc, parmTy);
@@ -792,6 +793,12 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
 
   // Initialization expression resulted in a value. Create a variable and save
   // that value to the variable's memory address.
+
+  // Don't allocate memory for a quantum or value-semantic struct.
+  if (auto insertValOp = initValue.getDefiningOp<cc::InsertValueOp>()) {
+    symbolTable.insert(x->getName(), initValue);
+    return pushValue(initValue);
+  }
   Value alloca = builder.create<cc::AllocaOp>(loc, type);
   builder.create<cc::StoreOp>(loc, initValue, alloca);
   symbolTable.insert(x->getName(), alloca);

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -791,14 +791,14 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     return pushValue(cast);
   }
 
-  // Initialization expression resulted in a value. Create a variable and save
-  // that value to the variable's memory address.
-
   // Don't allocate memory for a quantum or value-semantic struct.
   if (auto insertValOp = initValue.getDefiningOp<cc::InsertValueOp>()) {
     symbolTable.insert(x->getName(), initValue);
     return pushValue(initValue);
   }
+
+  // Initialization expression resulted in a value. Create a variable and save
+  // that value to the variable's memory address.
   Value alloca = builder.create<cc::AllocaOp>(loc, type);
   builder.create<cc::StoreOp>(loc, initValue, alloca);
   symbolTable.insert(x->getName(), alloca);

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -2208,6 +2208,9 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
         return replaceTOSValue(address_qubit);
       }
 
+      // We have a quantum value that is not in the symbol table.
+      // Here we will just extract the qubit. This is likely
+      // coming from a quantum struct member.
       auto address_qubit =
           builder.create<quake::ExtractRefOp>(loc, qreg_var, idx_var);
       return replaceTOSValue(address_qubit);

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -970,11 +970,64 @@ struct FuseWithConstantArray
     return success();
   }
 };
+
+struct FoldQuantumStructMember
+    : public OpRewritePattern<cudaq::cc::ExtractValueOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  // Replace
+  //
+  // %6 = cc.extract_value %5[2]:(!cc.struct<{..., !veq<?>}>) -> !veq<?>
+  //
+  // in code like
+  //
+  // %0 = quake.alloca !quake.veq<4>
+  // %1 = quake.relax_size %0 : (!quake.veq<4>) -> !quake.veq<?>
+  // ...
+  // %5 = cc.insert_value %1, %4[2] : (cc.struct..., !veq<?>) -> cc.struct...
+  // %6 = cc.extract_value %5[2]:(!cc.struct<{..., !veq<?>}>) -> !veq<?>
+  //
+  // with
+  //
+  // %0 = quake.alloca !quake.veq<4>
+
+  LogicalResult matchAndRewrite(cudaq::cc::ExtractValueOp evOp,
+                                PatternRewriter &rewriter) const override {
+    using namespace cudaq;
+
+    // Only operate on quantum extractions.
+    if (!quake::isQuantumType(evOp.getResult().getType()))
+      return failure();
+
+    auto base = evOp.getAggregate();
+    auto idx = evOp.getRawConstantIndices()[0];
+
+    Value originalVeq;
+    cc::InsertValueOp ivOp = base.getDefiningOp<cc::InsertValueOp>();
+    while (ivOp) {
+      if (idx == ivOp.getPosition()[0]) {
+        originalVeq = ivOp.getValue();
+        break;
+      }
+      ivOp = ivOp.getContainer().getDefiningOp<cc::InsertValueOp>();
+    }
+
+    if (!ivOp)
+      return failure();
+
+    if (auto relaxSizeOp = originalVeq.getDefiningOp<quake::RelaxSizeOp>())
+      originalVeq = relaxSizeOp.getInputVec();
+
+    rewriter.replaceOp(evOp, originalVeq);
+    return success();
+  }
+};
+
 } // namespace
 
 void cudaq::cc::ExtractValueOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add<FuseWithConstantArray>(context);
+  patterns.add<FoldQuantumStructMember, FuseWithConstantArray>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -1480,9 +1480,15 @@ public:
   /// device kernel) cannot be called directly from C++ (classical) code. It
   /// must be called via other quantum code.
   bool hasLegalType(FunctionType funTy) {
-    for (auto ty : funTy.getInputs())
+    for (auto ty : funTy.getInputs()) {
       if (quake::isQuantumType(ty))
         return false;
+
+      if (auto structTy = dyn_cast<cudaq::cc::StructType>(ty))
+        for (auto memberTy : structTy.getMembers())
+          if (quake::isQuantumType(memberTy))
+            return false;
+    }
     for (auto ty : funTy.getResults())
       if (quake::isQuantumType(ty))
         return false;

--- a/targettests/execution/quantum_struct_exec.cpp
+++ b/targettests/execution/quantum_struct_exec.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ %cpp_std --enable-mlir %s -o %t && %t | FileCheck %s
+
+#include "cudaq.h"
+
+struct test {
+  int i;
+  double d;
+  cudaq::qview<> q;
+};
+
+__qpu__ void hello(cudaq::qubit &q) { h(q); }
+
+__qpu__ void kernel(test t) {
+  h(t.q);
+  for (int i = 0; i < t.i; i++)
+    hello(t.q[i]);
+}
+
+__qpu__ void entry(int i) {
+  cudaq::qvector q(i);
+  test tt{i, 2.2, q};
+  kernel(tt);
+}
+
+int main() {
+  auto counts = cudaq::sample(entry, 4);
+  assert(counts.size() == 1);
+  assert(counts.begin()->first == "0000");
+}

--- a/test/AST-Quake/quantum_struct.cpp
+++ b/test/AST-Quake/quantum_struct.cpp
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck %s
+
+#include "cudaq.h"
+
+struct test {
+  int i;
+  double d;
+  cudaq::qview<> q;
+};
+
+__qpu__ void hello(cudaq::qubit &q) { h(q); }
+
+__qpu__ void kernel(test t) {
+  h(t.q);
+  hello(t.q[0]);
+}
+
+__qpu__ void entry(int i) {
+  cudaq::qvector q(i);
+  test tt{1, 2.2, q};
+  kernel(tt);
+}
+
+int main() { cudaq::sample(entry, 4); }
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_hello._Z5helloRN5cudaq5quditILm2EEE(
+// CHECK-SAME:                                                                              %[[VAL_0:.*]]: !quake.ref) attributes {"cudaq-kernel", no_this} {
+// CHECK:           quake.h %[[VAL_0]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_kernel._Z6kernel4test(
+// CHECK-SAME:                                                                %[[VAL_0:.*]]: !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>) attributes {"cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][2] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<!quake.veq<?>>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!quake.veq<?>>
+// CHECK:           %[[VAL_6:.*]] = quake.veq_size %[[VAL_5]] : (!quake.veq<?>) -> i64
+// CHECK:           %[[VAL_7:.*]] = cc.loop while ((%[[VAL_8:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_6]] : i64
+// CHECK:             cc.condition %[[VAL_9]](%[[VAL_8]] : i64)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_10:.*]]: i64):
+// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_10]]] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:             quake.h %[[VAL_11]] : (!quake.ref) -> ()
+// CHECK:             cc.continue %[[VAL_10]] : i64
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_12:.*]]: i64):
+// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_13]] : i64
+// CHECK:           } {invariant}
+// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_3]][2] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<!quake.veq<?>>
+// CHECK:           %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!quake.veq<?>>
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_15]][0] : (!quake.veq<?>) -> !quake.ref
+// CHECK:           call @__nvqpp__mlirgen__function_hello._Z5helloRN5cudaq5quditILm2EEE(%[[VAL_16]]) : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_entry._Z5entryi(
+// CHECK-SAME:                                                          %[[VAL_0:.*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 2.200000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_3:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.cast signed %[[VAL_4]] : (i32) -> i64
+// CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_5]] : i64]
+// CHECK:           %[[VAL_7:.*]] = cc.alloca !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_8]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_7]][1] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<f64>
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_9]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_7]][2] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<!quake.veq<?>>
+// CHECK:           cc.store %[[VAL_6]], %[[VAL_10]] : !cc.ptr<!quake.veq<?>>
+// CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_7]] : !cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>
+// CHECK:           call @__nvqpp__mlirgen__function_kernel._Z6kernel4test(%[[VAL_11]]) : (!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z5entryi(
+// CHECK-SAME:                         %[[VAL_0:.*]]: i32) attributes {no_this} {
+// CHECK:           return
+// CHECK:         }

--- a/test/AST-Quake/quantum_struct.cpp
+++ b/test/AST-Quake/quantum_struct.cpp
@@ -41,28 +41,24 @@ int main() { cudaq::sample(entry, 4); }
 // CHECK-SAME:                                                                %[[VAL_0:.*]]: !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>) attributes {"cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_3]][2] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<!quake.veq<?>>
-// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!quake.veq<?>>
-// CHECK:           %[[VAL_6:.*]] = quake.veq_size %[[VAL_5]] : (!quake.veq<?>) -> i64
-// CHECK:           %[[VAL_7:.*]] = cc.loop while ((%[[VAL_8:.*]] = %[[VAL_2]]) -> (i64)) {
-// CHECK:             %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_6]] : i64
-// CHECK:             cc.condition %[[VAL_9]](%[[VAL_8]] : i64)
+// CHECK:           %[[VAL_3:.*]] = cc.extract_value %[[VAL_0]][2] : (!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>) -> !quake.veq<?>
+// CHECK:           %[[VAL_4:.*]] = quake.veq_size %[[VAL_3]] : (!quake.veq<?>) -> i64
+// CHECK:           %[[VAL_5:.*]] = cc.loop while ((%[[VAL_6:.*]] = %[[VAL_2]]) -> (i64)) {
+// CHECK:             %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_6]], %[[VAL_4]] : i64
+// CHECK:             cc.condition %[[VAL_7]](%[[VAL_6]] : i64)
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_10:.*]]: i64):
-// CHECK:             %[[VAL_11:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_10]]] : (!quake.veq<?>, i64) -> !quake.ref
-// CHECK:             quake.h %[[VAL_11]] : (!quake.ref) -> ()
-// CHECK:             cc.continue %[[VAL_10]] : i64
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i64):
+// CHECK:             %[[VAL_9:.*]] = quake.extract_ref %[[VAL_3]]{{\[}}%[[VAL_8]]] : (!quake.veq<?>, i64) -> !quake.ref
+// CHECK:             quake.h %[[VAL_9]] : (!quake.ref) -> ()
+// CHECK:             cc.continue %[[VAL_8]] : i64
 // CHECK:           } step {
-// CHECK:           ^bb0(%[[VAL_12:.*]]: i64):
-// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : i64
-// CHECK:             cc.continue %[[VAL_13]] : i64
+// CHECK:           ^bb0(%[[VAL_10:.*]]: i64):
+// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_1]] : i64
+// CHECK:             cc.continue %[[VAL_11]] : i64
 // CHECK:           } {invariant}
-// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_3]][2] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<!quake.veq<?>>
-// CHECK:           %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!quake.veq<?>>
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_15]][0] : (!quake.veq<?>) -> !quake.ref
-// CHECK:           call @__nvqpp__mlirgen__function_hello._Z5helloRN5cudaq5quditILm2EEE(%[[VAL_16]]) : (!quake.ref) -> ()
+// CHECK:           %[[VAL_12:.*]] = cc.extract_value %[[VAL_0]][2] : (!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>) -> !quake.veq<?>
+// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_12]][0] : (!quake.veq<?>) -> !quake.ref
+// CHECK:           call @__nvqpp__mlirgen__function_hello._Z5helloRN5cudaq5quditILm2EEE(%[[VAL_13]]) : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -75,15 +71,11 @@ int main() { cudaq::sample(entry, 4); }
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.cast signed %[[VAL_4]] : (i32) -> i64
 // CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_5]] : i64]
-// CHECK:           %[[VAL_7:.*]] = cc.alloca !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>
-// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<i32>
-// CHECK:           cc.store %[[VAL_2]], %[[VAL_8]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_7]][1] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<f64>
-// CHECK:           cc.store %[[VAL_1]], %[[VAL_9]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_7]][2] : (!cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>) -> !cc.ptr<!quake.veq<?>>
-// CHECK:           cc.store %[[VAL_6]], %[[VAL_10]] : !cc.ptr<!quake.veq<?>>
-// CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_7]] : !cc.ptr<!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>>
-// CHECK:           call @__nvqpp__mlirgen__function_kernel._Z6kernel4test(%[[VAL_11]]) : (!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>) -> ()
+// CHECK:           %[[VAL_7:.*]] = cc.undef !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>
+// CHECK:           %[[VAL_8:.*]] = cc.insert_value %[[VAL_2]], %[[VAL_7]][0] : (!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>, i32) -> !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>
+// CHECK:           %[[VAL_9:.*]] = cc.insert_value %[[VAL_1]], %[[VAL_8]][1] : (!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>, f64) -> !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>
+// CHECK:           %[[VAL_10:.*]] = cc.insert_value %[[VAL_6]], %[[VAL_9]][2] : (!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>, !quake.veq<?>) -> !cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>
+// CHECK:           call @__nvqpp__mlirgen__function_kernel._Z6kernel4test(%[[VAL_10]]) : (!cc.struct<"test" {i32, f64, !quake.veq<?>} [256,8]>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/quantum_struct_unroll.cpp
+++ b/test/AST-Quake/quantum_struct_unroll.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt --unrolling-pipeline | FileCheck %s
+
+#include "cudaq.h"
+
+struct test {
+  int i;
+  double d;
+  cudaq::qview<> q;
+};
+
+__qpu__ void entry() {
+  cudaq::qvector q(4);
+  test tt{4, 2.2, q};
+  h(tt.q);
+}
+
+int main() { cudaq::sample(entry); }
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_entry._Z5entryv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<4>) -> !quake.ref
+// CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<4>) -> !quake.ref
+// CHECK:           quake.h %[[VAL_2]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_0]][2] : (!quake.veq<4>) -> !quake.ref
+// CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_0]][3] : (!quake.veq<4>) -> !quake.ref
+// CHECK:           quake.h %[[VAL_4]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/AST-Quake/struct-1.cpp
+++ b/test/AST-Quake/struct-1.cpp
@@ -221,6 +221,7 @@ struct S5 {
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_6]], %[[VAL_8]], %[[VAL_10]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_11:.*]] = cc.alloca !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
+// CHECK:           call @_ZN11ResultThingC1Ev(%[[VAL_11]]) : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> ()
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_14:.*]] = cc.load %[[VAL_13]] : !cc.ptr<i32>
@@ -282,6 +283,7 @@ struct S6 {
 // CHECK:           %[[VAL_9:.*]] = cc.load %[[VAL_8]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_5]], %[[VAL_7]], %[[VAL_9]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.struct<{i1, i32, i16, i32} [128,4]>
+// CHECK:           call @_ZN2S61TC1Ev(%[[VAL_10]]) : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> ()
 // CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_13:.*]] = cc.load %[[VAL_12]] : !cc.ptr<i32>
@@ -309,4 +311,3 @@ struct S6 {
 // CHECK:           return %[[VAL_30]] : !cc.struct<{i1, i32, i16, i32} [128,4]>
 // CHECK:         }
 // clang-format on
-

--- a/test/AST-Quake/struct-1.cpp
+++ b/test/AST-Quake/struct-1.cpp
@@ -221,7 +221,6 @@ struct S5 {
 // CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_6]], %[[VAL_8]], %[[VAL_10]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_11:.*]] = cc.alloca !cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>
-// CHECK:           call @_ZN11ResultThingC1Ev(%[[VAL_11]]) : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> ()
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<"ResultThing" {i1, i1, i1, i32} [64,4]>>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_14:.*]] = cc.load %[[VAL_13]] : !cc.ptr<i32>
@@ -283,7 +282,6 @@ struct S6 {
 // CHECK:           %[[VAL_9:.*]] = cc.load %[[VAL_8]] : !cc.ptr<f64>
 // CHECK:           call @_Z15debug_the_thingiid(%[[VAL_5]], %[[VAL_7]], %[[VAL_9]]) : (i32, i32, f64) -> ()
 // CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.struct<{i1, i32, i16, i32} [128,4]>
-// CHECK:           call @_ZN2S61TC1Ev(%[[VAL_10]]) : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> ()
 // CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.struct<{i1, i32, i16, i32} [128,4]>>) -> !cc.ptr<i1>
 // CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.struct<"ArgumentThing" {i32, i32, f64} [128,8]>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_13:.*]] = cc.load %[[VAL_12]] : !cc.ptr<i32>


### PR DESCRIPTION
Enable expressions in C++ like this 
```cpp
struct MyStructWithQuantumType {
  int i;
  double d;
  cudaq::qview<> q;
};

__qpu__ void applyHadamardOnQubit(cudaq::qubit &q) { h(q); }

__qpu__ void pureDeviceKernelTakesQuantumStruct(MyStructWithQuantumType t) {
  h(t.q);
  for (int i = 0; i < t.i; i++)
    applyHadamardOnQubit(t.q[i]);
}

__qpu__ void entryPoint(int i) {
  cudaq::qvector q(i);
  MyStructWithQuantumType t{i, 2.2, q};
  pureDeviceKernelTakesQuantumStruct(t);
}
```