### PR TITLE
[test] Limit the number of llvm-lit workers for target tests

### DIFF
--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -80,7 +80,7 @@ jobs:
           run: |
             cd $CUDAQ_REPO_ROOT
             python3 -m pip install iqm-client==16.1
-            ctest --output-on-failure --test-dir build -E ctest-nvqpp -E ctest-targettests
+            ctest --output-on-failure --test-dir build -E "ctest-nvqpp|ctest-targettests"
             ctest_status=$?
             /opt/llvm/bin/llvm-lit -v --param nvqpp_site_config=build/test/lit.site.cfg.py build/test
             lit_status=$?

--- a/targettests/CMakeLists.txt
+++ b/targettests/CMakeLists.txt
@@ -38,10 +38,15 @@ set(CUDAQ_TEST_DEPENDS
 add_custom_target(nvqpp-targettest-depends DEPENDS ${CUDAQ_TEST_DEPENDS})
 set_target_properties(nvqpp-targettest-depends PROPERTIES FOLDER "TargetTests")
 
+# Limit the number of llvm-lit worker threads because running too many of these
+# tests in parallel can consume all the GPU resources.
+set(LIT_ARGS "-j 8")
+
 add_lit_testsuite(check-targets "Running the end-to-end target tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   PARAMS ${CUDAQ_TEST_PARAMS}
   DEPENDS ${CUDAQ_TEST_DEPENDS}
+  ARGS ${LIT_ARGS}
 )
 set_target_properties(check-targets PROPERTIES FOLDER "TargetTests")
 
@@ -49,6 +54,7 @@ add_lit_testsuites(CUDAQ ${CMAKE_CURRENT_SOURCE_DIR}
   PARAMS ${CUDAQ_TEST_PARAMS}
   DEPENDS ${CUDAQ_TEST_DEPENDS}
   FOLDER "Tests/Subdirectories"
+  ARGS ${LIT_ARGS}
 )
 
 # Add nvqpp tests to the ctest suite


### PR DESCRIPTION
Running these tests on a machine with too many cores can exhaust the GPU resources, so provide a reasonable limit here.

Also fix the CI to use the correct `-E` syntax. You cannot daisy chain multiple `-E` options together for `ctest` because it will only honor the last one. Due to our incorrect usage, we have been running duplicate tests with `ctest-nvqpp` for a while, and this change will fix that.