### PR TITLE
Allow env var override for remote-mqpu capabilities

### DIFF
--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -57,10 +57,9 @@ public:
   // Conditional feedback is handled by the server side.
   virtual bool supportsConditionalFeedback() override { return true; }
 
-  // By default, the remote capabilities are all enabled. Subtypes may override
-  // this.
+  // Get the capabilities from the client.
   virtual RemoteCapabilities getRemoteCapabilities() const override {
-    return RemoteCapabilities(/*initValues=*/true);
+    return m_client->getRemoteCapabilities();
   }
 
   virtual void setTargetBackend(const std::string &backend) override {

--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -431,9 +431,12 @@ public:
   }
 
   // The remote-mqpu backend (this class) returns true for all remote
-  // capabilities.
+  // capabilities unless overridden by environment variable.
   virtual RemoteCapabilities getRemoteCapabilities() const override {
-    return RemoteCapabilities(/*initValues=*/true);
+    // Default to all true, but allow the user to override to all false.
+    if (getEnvBool("CUDAQ_CLIENT_REMOTE_CAPABILITY_OVERRIDE", true))
+      return RemoteCapabilities(/*initValues=*/true);
+    return RemoteCapabilities(/*initValues=*/false);
   }
 };
 
@@ -859,15 +862,9 @@ public:
   // The NVCF version of this function needs to dynamically determine the remote
   // capabilities based on the servers currently deployed.
   virtual RemoteCapabilities getRemoteCapabilities() const override {
-    // If an environment variable override is activated, then enable all remote
-    // capabilities.
-    if (auto *envVal = std::getenv("CUDAQ_CLIENT_REMOTE_CAPABILITY_OVERRIDE")) {
-      std::string tmp(envVal);
-      std::transform(tmp.begin(), tmp.end(), tmp.begin(),
-                     [](unsigned char c) { return std::tolower(c); });
-      if (tmp == "1" || tmp == "on" || tmp == "true" || tmp == "yes")
-        return RemoteCapabilities(/*initValues=*/true);
-    }
+    // Allow the user to override to all true.
+    if (getEnvBool("CUDAQ_CLIENT_REMOTE_CAPABILITY_OVERRIDE", false))
+      return RemoteCapabilities(/*initValues=*/true);
     // Else determine capabilities based on server deployment info.
     RemoteCapabilities capabilities(/*initValues=*/false);
     if (!m_availableFuncs.contains(m_functionId)) {


### PR DESCRIPTION
This is a minor change to allow developers to override the client's knowledge of remote-mqpu server capabilities similar to how we could already override the client's knowledge of NVQC server capabilities.

It also updates the code to use the new common `getEnvBool` function in both places.