### PR TITLE
[test] Follow-up to #1969 - set random seed in return_values.cpp test

### DIFF
--- a/targettests/Remote-Sim/return_values.cpp
+++ b/targettests/Remote-Sim/return_values.cpp
@@ -84,6 +84,7 @@ struct returnInt {
 };
 
 int main() {
+  cudaq::set_random_seed(123);
   int n_iterations = 24;
   double mu = 0.7951, sigma = 0.6065;
   auto phase = rwpe{}(n_iterations, mu, sigma);
@@ -93,9 +94,9 @@ int main() {
   assert(returnTrue{}());
 
   assert(!returnFalse{}());
-  cudaq::set_random_seed(123);
   const int oneCount = returnInt{}(1000);
   std::cout << "One count = " << oneCount << "\n";
   // We expect ~ 50% one.
   assert(oneCount > 100);
+  return 0;
 }


### PR DESCRIPTION
The following CI jobs have been hanging on this test. I believe this change will help.

* https://github.com/NVIDIA/cuda-quantum/actions/runs/10101453154/job/27935618355
* https://github.com/NVIDIA/cuda-quantum/actions/runs/10098919554/job/27927334686
* https://github.com/NVIDIA/cuda-quantum/actions/runs/10097769956/job/27923837081
