### PR TITLE
Update remote-mqpu tests to cleanly abort during assertion checks

### DIFF
--- a/targettests/Remote-Sim/args_parsing.cpp
+++ b/targettests/Remote-Sim/args_parsing.cpp
@@ -12,6 +12,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 struct hGateTest {
@@ -27,7 +28,7 @@ int main() {
   // H == Rx(pi)Ry(pi/2) (up to a global phase)
   auto counts = cudaq::sample(hGateTest{}, std::vector<double>{M_PI_2, M_PI});
   counts.dump();
-  assert(counts.size() == 1);
-  assert(counts.begin()->first == "0");
+  REMOTE_TEST_ASSERT(counts.size() == 1);
+  REMOTE_TEST_ASSERT(counts.begin()->first == "0");
   return 0;
 }

--- a/targettests/Remote-Sim/free_func-cpp17.cpp
+++ b/targettests/Remote-Sim/free_func-cpp17.cpp
@@ -14,6 +14,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 void ghz(std::size_t N) __qpu__ {
@@ -35,13 +36,13 @@ void ansatz(double theta) __qpu__ {
 int main() {
   auto counts = cudaq::sample(ghz, 10);
   counts.dump();
-  assert(counts.size() == 2);
+  REMOTE_TEST_ASSERT(counts.size() == 2);
   using namespace cudaq::spin;
   cudaq::spin_op h = 5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) +
                      .21829 * z(0) - 6.125 * z(1);
 
   double energy = cudaq::observe(ansatz, h, .59);
   printf("Energy is %lf\n", energy);
-  assert(std::abs(energy + 1.748794) < 1e-3);
+  REMOTE_TEST_ASSERT(std::abs(energy + 1.748794) < 1e-3);
   return 0;
 }

--- a/targettests/Remote-Sim/free_func.cpp
+++ b/targettests/Remote-Sim/free_func.cpp
@@ -14,6 +14,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 void ghz(std::size_t N) __qpu__ {
@@ -35,13 +36,13 @@ void ansatz(double theta) __qpu__ {
 int main() {
   auto counts = cudaq::sample(ghz, 10);
   counts.dump();
-  assert(counts.size() == 2);
+  REMOTE_TEST_ASSERT(counts.size() == 2);
   using namespace cudaq::spin;
   cudaq::spin_op h = 5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) +
                      .21829 * z(0) - 6.125 * z(1);
 
   double energy = cudaq::observe(ansatz, h, .59);
   printf("Energy is %lf\n", energy);
-  assert(std::abs(energy + 1.748794) < 1e-3);
+  REMOTE_TEST_ASSERT(std::abs(energy + 1.748794) < 1e-3);
   return 0;
 }

--- a/targettests/Remote-Sim/get_state.cpp
+++ b/targettests/Remote-Sim/get_state.cpp
@@ -13,6 +13,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 int main() {
@@ -22,10 +23,10 @@ int main() {
     kernel.h(q[0]);
     kernel.x<cudaq::ctrl>(q[0], q[1]);
     auto state = cudaq::get_state(kernel);
-    assert(std::abs(M_SQRT1_2 - state[0].real()) < 1e-3);
-    assert(std::abs(state[1].real()) < 1e-3);
-    assert(std::abs(state[2].real()) < 1e-3);
-    assert(std::abs(M_SQRT1_2 - state[3].real()) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(M_SQRT1_2 - state[0].real()) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(state[1].real()) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(state[2].real()) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(M_SQRT1_2 - state[3].real()) < 1e-3);
   }
 // Skipped test due to a stability issue. See:
 // https://github.com/NVIDIA/cuda-quantum/issues/1087
@@ -34,7 +35,7 @@ int main() {
     auto &platform = cudaq::get_platform();
 
     auto num_qpus = platform.num_qpus();
-    assert(num_qpus == 4);
+    REMOTE_TEST_ASSERT(num_qpus == 4);
     std::vector<cudaq::async_state_result> stateFutures;
     auto [kernel, num_qubits] = cudaq::make_kernel<int>();
     auto q = kernel.qalloc(num_qubits);
@@ -47,9 +48,9 @@ int main() {
     }
     for (std::size_t i = 0; i < num_qpus; ++i) {
       auto state = stateFutures[i].get();
-      assert(state.get_shape()[0] == (1ULL << (i + 1)));
-      assert(std::abs(M_SQRT1_2 - state[0].real()) < 1e-3);
-      assert(std::abs(M_SQRT1_2 - state[(1ULL << (i + 1)) - 1].real()) < 1e-3);
+      REMOTE_TEST_ASSERT(state.get_shape()[0] == (1ULL << (i + 1)));
+      REMOTE_TEST_ASSERT(std::abs(M_SQRT1_2 - state[0].real()) < 1e-3);
+      REMOTE_TEST_ASSERT(std::abs(M_SQRT1_2 - state[(1ULL << (i + 1)) - 1].real()) < 1e-3);
     }
   }
 #endif

--- a/targettests/Remote-Sim/kernel_builder.cpp
+++ b/targettests/Remote-Sim/kernel_builder.cpp
@@ -13,6 +13,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 int main() {
@@ -35,7 +36,7 @@ int main() {
     // parameters for the kernel
     double energy = cudaq::observe(ansatz, h, .59);
     printf("Energy is %lf\n", energy);
-    assert(std::abs(energy + 1.748794) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(energy + 1.748794) < 1e-3);
   }
   {
     auto [ansatz, thetas] = cudaq::make_kernel<std::vector<double>>();
@@ -49,7 +50,7 @@ int main() {
     ansatz.x<cudaq::ctrl>(q[1], q[0]);
     double energy = cudaq::observe(ansatz, h, std::vector<double>{.59});
     printf("Energy is %lf\n", energy);
-    assert(std::abs(energy + 1.748794) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(energy + 1.748794) < 1e-3);
   }
 
   {

--- a/targettests/Remote-Sim/nested_vectors.cpp
+++ b/targettests/Remote-Sim/nested_vectors.cpp
@@ -11,6 +11,7 @@
 // RUN: nvq++ %cpp_std --target remote-mqpu %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 struct hGateTest {
@@ -27,7 +28,7 @@ int main() {
   auto counts = cudaq::sample(
       hGateTest{}, std::vector<std::vector<double>>{{M_PI_2}, {M_PI}});
   counts.dump();
-  assert(counts.size() == 1);
-  assert(counts.begin()->first == "0");
+  REMOTE_TEST_ASSERT(counts.size() == 1);
+  REMOTE_TEST_ASSERT(counts.begin()->first == "0");
   return 0;
 }

--- a/targettests/Remote-Sim/no_inline.cpp
+++ b/targettests/Remote-Sim/no_inline.cpp
@@ -14,6 +14,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir -fno-aggressive-early-inline --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 #include <iostream>
 
@@ -38,6 +39,6 @@ struct foo {
 int main() {
   auto result = cudaq::sample(1000, foo{}, baz{}, /*qreg size*/ 1);
   std::cout << result.most_probable() << '\n';
-  assert("1" == result.most_probable());
+  REMOTE_TEST_ASSERT("1" == result.most_probable());
   return 0;
 }

--- a/targettests/Remote-Sim/observe-cpp17.cpp
+++ b/targettests/Remote-Sim/observe-cpp17.cpp
@@ -14,6 +14,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 #include <cudaq/algorithm.h>
 #include <cudaq/builder.h>
@@ -37,7 +38,7 @@ int main() {
     // Simple `cudaq::observe` test
     double energy = cudaq::observe(ansatz{}, h, .59);
     printf("Energy is %lf\n", energy);
-    assert(std::abs(energy + 1.748794) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(energy + 1.748794) < 1e-3);
   }
   {
     // Full VQE test with gradients
@@ -56,7 +57,7 @@ int main() {
           return e;
         });
     printf("Optimal value = %.16lf\n", opt_val);
-    assert(std::abs(opt_val + 1.748794) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(opt_val + 1.748794) < 1e-3);
   }
   return 0;
 }

--- a/targettests/Remote-Sim/observe.cpp
+++ b/targettests/Remote-Sim/observe.cpp
@@ -14,6 +14,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 #include <cudaq/algorithm.h>
 #include <cudaq/builder.h>
@@ -37,7 +38,7 @@ int main() {
     // Simple `cudaq::observe` test
     double energy = cudaq::observe(ansatz{}, h, .59);
     printf("Energy is %lf\n", energy);
-    assert(std::abs(energy + 1.748794) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(energy + 1.748794) < 1e-3);
   }
   {
     // Full VQE test with gradients
@@ -56,7 +57,7 @@ int main() {
           return e;
         });
     printf("Optimal value = %.16lf\n", opt_val);
-    assert(std::abs(opt_val + 1.748794) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(opt_val + 1.748794) < 1e-3);
   }
   return 0;
 }

--- a/targettests/Remote-Sim/observe_async-cpp17.cpp
+++ b/targettests/Remote-Sim/observe_async-cpp17.cpp
@@ -14,6 +14,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 3 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 struct ansatz {
@@ -43,13 +44,13 @@ int main() {
       (2 * shift);
   printf("Energy is %lf\n", energy);
   printf("Gradient is %lf\n", gradient);
-  assert(std::abs(energy + 1.748794) < 1e-3);
+  REMOTE_TEST_ASSERT(std::abs(energy + 1.748794) < 1e-3);
   // Shots-based observe async. API
   cudaq::set_random_seed(13);
   auto energyFutureShots =
       cudaq::observe_async(/*shots=*/8192, /*qpu_id=*/0, ansatz{}, h, .59);
   const auto energyShots = energyFutureShots.get().expectation();
   printf("Energy (shots) is %lf\n", energyShots);
-  assert(std::abs(energyShots + 1.748794) < 0.1);
+  REMOTE_TEST_ASSERT(std::abs(energyShots + 1.748794) < 0.1);
   return 0;
 }

--- a/targettests/Remote-Sim/observe_async.cpp
+++ b/targettests/Remote-Sim/observe_async.cpp
@@ -14,6 +14,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 3 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 struct ansatz {
@@ -43,13 +44,13 @@ int main() {
       (2 * shift);
   printf("Energy is %lf\n", energy);
   printf("Gradient is %lf\n", gradient);
-  assert(std::abs(energy + 1.748794) < 1e-3);
+  REMOTE_TEST_ASSERT(std::abs(energy + 1.748794) < 1e-3);
   // Shots-based observe async. API
   cudaq::set_random_seed(13);
   auto energyFutureShots =
       cudaq::observe_async(/*shots=*/8192, /*qpu_id=*/0, ansatz{}, h, .59);
   const auto energyShots = energyFutureShots.get().expectation();
   printf("Energy (shots) is %lf\n", energyShots);
-  assert(std::abs(energyShots + 1.748794) < 0.1);
+  REMOTE_TEST_ASSERT(std::abs(energyShots + 1.748794) < 0.1);
   return 0;
 }

--- a/targettests/Remote-Sim/pauli_word.cpp
+++ b/targettests/Remote-Sim/pauli_word.cpp
@@ -13,6 +13,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 #include <cudaq/algorithm.h>
 #include <iostream>
@@ -54,7 +55,7 @@ int main() {
         cudaq::observe(kernelSingle{}, h, cudaq::pauli_word{"XXXY"}, 0.11);
     std::cout << "e = " << e << "\n";
     constexpr double expectedVal = -1.13;
-    assert(std::abs(e - expectedVal) < 0.1);
+    REMOTE_TEST_ASSERT(std::abs(e - expectedVal) < 0.1);
   }
   {
     // Vector of three terms (same values)
@@ -62,7 +63,7 @@ int main() {
     const double e = cudaq::observe(kernelVector{}, h, paulis, 0.11);
     std::cout << "e = " << e << "\n";
     constexpr double expectedVal = -1.13;
-    assert(std::abs(e - expectedVal) < 0.1);
+    REMOTE_TEST_ASSERT(std::abs(e - expectedVal) < 0.1);
   }
   return 0;
 }

--- a/targettests/Remote-Sim/remote_test_assert.h
+++ b/targettests/Remote-Sim/remote_test_assert.h
@@ -1,0 +1,19 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// llvm-lit tests for remote-mqpu tend to hang rather than abort if they hit an
+// assertion error using the regular `assert()` call. Use this instead to
+// cleanly exit/abort from your main function while printing an error message
+// about where the error occurred.
+#define REMOTE_TEST_ASSERT(x)                                                  \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      printf("Assertion failure in %s:%d\nExiting\n", __FILE__, __LINE__);     \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)

--- a/targettests/Remote-Sim/remote_test_assert.h
+++ b/targettests/Remote-Sim/remote_test_assert.h
@@ -16,6 +16,9 @@
 // E.g., https://man7.org/linux/man-pages/man3/abort.3.html says:
 // "As with other cases of abnormal termination the functions registered with
 // atexit(3) and on_exit(3) are not called."
+
+// Use this macro instead to cleanly exit/abort from your main function while
+// printing an error message about where the error occurred.
 #define REMOTE_TEST_ASSERT(x)                                                  \
   do {                                                                         \
     if (!(x)) {                                                                \

--- a/targettests/Remote-Sim/remote_test_assert.h
+++ b/targettests/Remote-Sim/remote_test_assert.h
@@ -6,10 +6,16 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// llvm-lit tests for remote-mqpu tend to hang rather than abort if they hit an
-// assertion error using the regular `assert()` call. Use this instead to
-// cleanly exit/abort from your main function while printing an error message
-// about where the error occurred.
+// llvm-lit tests for remote-mqpu hang rather than abort if they hit an
+// assertion error using the regular `assert()` call. The reason is that the
+// AutoLaunchRestServerProcess destructor is not called when the assertion
+// fails, so the `cudaq-qpud` process stays running in the background, and the
+// llvm-lit wrapper thinks the test has not completed, so it just hangs waiting
+// for completion.
+// Note: this is similar to what would happen if abort() were called.
+// E.g., https://man7.org/linux/man-pages/man3/abort.3.html says:
+// "As with other cases of abnormal termination the functions registered with
+// atexit(3) and on_exit(3) are not called."
 #define REMOTE_TEST_ASSERT(x)                                                  \
   do {                                                                         \
     if (!(x)) {                                                                \

--- a/targettests/Remote-Sim/return_values.cpp
+++ b/targettests/Remote-Sim/return_values.cpp
@@ -13,6 +13,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 #include <iostream>
 
@@ -89,14 +90,14 @@ int main() {
   double mu = 0.7951, sigma = 0.6065;
   auto phase = rwpe{}(n_iterations, mu, sigma);
 
-  assert(std::abs(phase - 0.49) < 0.05);
+  REMOTE_TEST_ASSERT(std::abs(phase - 0.49) < 0.05);
 
-  assert(returnTrue{}());
+  REMOTE_TEST_ASSERT(returnTrue{}());
 
-  assert(!returnFalse{}());
+  REMOTE_TEST_ASSERT(!returnFalse{}());
   const int oneCount = returnInt{}(1000);
   std::cout << "One count = " << oneCount << "\n";
   // We expect ~ 50% one.
-  assert(oneCount > 100);
+  REMOTE_TEST_ASSERT(oneCount > 100);
   return 0;
 }

--- a/targettests/Remote-Sim/sample-cpp17.cpp
+++ b/targettests/Remote-Sim/sample-cpp17.cpp
@@ -14,6 +14,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 template <std::size_t N>
@@ -33,7 +34,7 @@ int main() {
     auto kernel = ghz<10>{};
     auto counts = cudaq::sample(kernel);
     counts.dump();
-    assert(counts.size() == 2);
+    REMOTE_TEST_ASSERT(counts.size() == 2);
   }
   {
     // Kernels as lambda functions
@@ -47,7 +48,7 @@ int main() {
     };
     auto counts = cudaq::sample(ghz, 3);
     counts.dump();
-    assert(counts.size() == 2);
+    REMOTE_TEST_ASSERT(counts.size() == 2);
   }
   return 0;
 }

--- a/targettests/Remote-Sim/sample.cpp
+++ b/targettests/Remote-Sim/sample.cpp
@@ -14,6 +14,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 template <std::size_t N>
@@ -33,7 +34,7 @@ int main() {
     auto kernel = ghz<10>{};
     auto counts = cudaq::sample(kernel);
     counts.dump();
-    assert(counts.size() == 2);
+    REMOTE_TEST_ASSERT(counts.size() == 2);
   }
   {
     // Kernels as lambda functions
@@ -47,7 +48,7 @@ int main() {
     };
     auto counts = cudaq::sample(ghz, 3);
     counts.dump();
-    assert(counts.size() == 2);
+    REMOTE_TEST_ASSERT(counts.size() == 2);
   }
   return 0;
 }

--- a/targettests/Remote-Sim/sample_async.cpp
+++ b/targettests/Remote-Sim/sample_async.cpp
@@ -13,6 +13,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 4 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 struct simpleX {
@@ -27,7 +28,7 @@ int main() {
   auto &platform = cudaq::get_platform();
   auto num_qpus = platform.num_qpus();
   printf("Number of QPUs: %zu\n", num_qpus);
-  assert(num_qpus == 4);
+  REMOTE_TEST_ASSERT(num_qpus == 4);
   std::vector<cudaq::async_sample_result> countFutures;
   // sample_async API with default shots
   for (std::size_t i = 0; i < num_qpus; i++) {
@@ -45,8 +46,8 @@ int main() {
          {countFutures[i].get(), countFuturesWithShots[i].get()}) {
       counts.dump();
       const std::string expectedBitStr(i + 1, '1');
-      assert(counts.size() == 1);
-      assert(counts.begin()->first == expectedBitStr);
+      REMOTE_TEST_ASSERT(counts.size() == 1);
+      REMOTE_TEST_ASSERT(counts.begin()->first == expectedBitStr);
     }
   }
   return 0;

--- a/targettests/Remote-Sim/state_amplitude.cpp
+++ b/targettests/Remote-Sim/state_amplitude.cpp
@@ -13,6 +13,7 @@
 // RUN: nvq++ %cpp_std --target remote-mqpu %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 struct cat_state {
@@ -30,9 +31,9 @@ int main() {
   const std::vector<int> basisStateAll1(numQubits, 1);
   auto state = cudaq::get_state(cat_state{}, numQubits);
   const auto amplitudes = state.amplitudes({basisStateAll0, basisStateAll1});
-  assert(amplitudes.size() == 2);
-  assert(std::abs(M_SQRT1_2 - amplitudes[0]) < 1e-3);
-  assert(std::abs(M_SQRT1_2 - amplitudes[1]) < 1e-3);
+  REMOTE_TEST_ASSERT(amplitudes.size() == 2);
+  REMOTE_TEST_ASSERT(std::abs(M_SQRT1_2 - amplitudes[0]) < 1e-3);
+  REMOTE_TEST_ASSERT(std::abs(M_SQRT1_2 - amplitudes[1]) < 1e-3);
 
   return 0;
 }

--- a/targettests/Remote-Sim/state_overlap.cpp
+++ b/targettests/Remote-Sim/state_overlap.cpp
@@ -13,6 +13,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 
 struct bellCircuit {
@@ -37,6 +38,6 @@ int main() {
   auto state1 = cudaq::get_state(bellCircuit{});
   auto state2 = cudaq::get_state(noOpCircuit{});
   const auto overlap = state1.overlap(state2);
-  assert(std::abs(M_SQRT1_2 - overlap) < 1e-3);
+  REMOTE_TEST_ASSERT(std::abs(M_SQRT1_2 - overlap) < 1e-3);
   return 0;
 }

--- a/targettests/Remote-Sim/unsupport_args.cpp
+++ b/targettests/Remote-Sim/unsupport_args.cpp
@@ -70,4 +70,5 @@ int main() {
     // CHECK NEXT: rewrite the entry  point kernel or use MLIR mode.
     counts.dump();
   }
+  return 0;
 }

--- a/targettests/Remote-Sim/vqe_h2.cpp
+++ b/targettests/Remote-Sim/vqe_h2.cpp
@@ -12,6 +12,7 @@
 // RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
+#include "remote_test_assert.h"
 #include <cudaq.h>
 #include <cudaq/algorithm.h>
 #include <cudaq/builder.h>
@@ -124,7 +125,7 @@ int main() {
     auto [opt_val, opt_params] = cudaq::vqe(ansatz, gradient, H, optimizer,
                                             n_params, n_qubits, n_layers);
     printf("Optimal value = %.16lf\n", opt_val);
-    assert(std::abs(opt_val - -1.1164613629294273) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(opt_val - -1.1164613629294273) < 1e-3);
   }
   // Run VQE with cobyla
   {
@@ -134,7 +135,7 @@ int main() {
     auto [opt_val, opt_params] =
         cudaq::vqe(ansatz, H, optimizer, n_params, n_qubits, n_layers);
     printf("Optimal value = %.16lf\n", opt_val);
-    assert(std::abs(opt_val - -1.0769400650758392) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(opt_val - -1.0769400650758392) < 1e-3);
   }
   // Run VQE with cobyla with fixed number of shots
   {
@@ -144,6 +145,7 @@ int main() {
     auto [opt_val, opt_params] = cudaq::vqe(
         /*shots=*/1000, ansatz, H, optimizer, n_params, n_qubits, n_layers);
     printf("Optimal value = %.16lf\n", opt_val);
-    assert(std::abs(opt_val - -1.0769400650758392) < 1e-3);
+    REMOTE_TEST_ASSERT(std::abs(opt_val - -1.0769400650758392) < 1e-3);
   }
+  return 0;
 }


### PR DESCRIPTION
Update `targettests/Remote-Sim/*.cpp` to use a new macro instead of `assert()` because the standard `assert()` calls are causing hangs during test failures rather than cleanly aborting with an error message. I manually tested this change by modifying one of the assertion checks to intentionally fail while running `llvm-lit`, and it failed as desired now.