### PR TITLE
Minor updates for downstream projects. 

### DIFF
--- a/cmake/Modules/CMakeLists.txt
+++ b/cmake/Modules/CMakeLists.txt
@@ -22,6 +22,20 @@ set(LANG_FILES
   CMakeTestCUDAQCompiler.cmake
 )
 
+execute_process(
+  COMMAND git rev-parse HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tpls/fmt
+  OUTPUT_VARIABLE CUDAQ_FMTLIB_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Configure the file
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/NVQIRConfig.cmake.in
+  ${CMAKE_BINARY_DIR}/cmake/Modules/NVQIRConfig.cmake
+  @ONLY
+)
+
 install(FILES ${CONFIG_FILES} DESTINATION lib/cmake/cudaq)
 install(FILES ${LANG_FILES} DESTINATION lib/cmake/cudaq)
-install(FILES NVQIRConfig.cmake DESTINATION lib/cmake/nvqir)
+install(FILES ${CMAKE_BINARY_DIR}/cmake/Modules/NVQIRConfig.cmake DESTINATION lib/cmake/nvqir)

--- a/cmake/Modules/CUDAQConfig.cmake
+++ b/cmake/Modules/CUDAQConfig.cmake
@@ -52,3 +52,9 @@ add_library(cudaq::cudaq-builder SHARED IMPORTED)
 set_target_properties(cudaq::cudaq-builder PROPERTIES
   IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libcudaq-builder${CMAKE_SHARED_LIBRARY_SUFFIX}"
   IMPORTED_SONAME "libcudaq-builder${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+
+add_library(cudaq::cudaq-nvidia-target SHARED IMPORTED)
+set_target_properties(cudaq::cudaq-nvidia-target PROPERTIES
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/cmake/Modules/CUDAQConfig.cmake
+++ b/cmake/Modules/CUDAQConfig.cmake
@@ -45,23 +45,68 @@ if (NOT CUDAQ_LIBRARY_MODE)
 endif() 
 
 # ---- TARGET EXPORTS ----
+# Prefer cusvsim libraries if they are present
+set (__base_nvtarget_name "custatevec") 
+find_library(CUDAQ_CUSVSIM_PATH NAMES cusvsim-fp32 HINTS ${CUDAQ_LIBRARY_DIR})
+if (CUDAQ_CUSVSIM_PATH)
+  set(__base_nvtarget_name "cusvsim")
+endif() 
+
+# NVIDIA Target
 add_library(cudaq::cudaq-nvidia-target SHARED IMPORTED)
 set_target_properties(cudaq::cudaq-nvidia-target PROPERTIES
-  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
-  IMPORTED_SONAME "libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-${__base_nvtarget_name}-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-${__base_nvtarget_name}-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
   IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
 
+# NVIDIA FP64 Target
 add_library(cudaq::cudaq-nvidia-fp64-target SHARED IMPORTED)
 set_target_properties(cudaq::cudaq-nvidia-fp64-target PROPERTIES
-  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-custatevec-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
-  IMPORTED_SONAME "libnvqir-custatevec-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-${__base_nvtarget_name}-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-${__base_nvtarget_name}-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
   IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
 
+# NVIDIA MGPU Target
+add_library(cudaq::cudaq-nvidia-mgpu-target SHARED IMPORTED)
+set_target_properties(cudaq::cudaq-nvidia-mgpu-target PROPERTIES
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-mgpu-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-mgpu-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
+
+# NVIDIA MGPU-FP64 Target
+add_library(cudaq::cudaq-nvidia-mgpu-fp64-target SHARED IMPORTED)
+set_target_properties(cudaq::cudaq-nvidia-mgpu-fp64-target PROPERTIES
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-mgpu-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-mgpu-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
+
+# NVIDIA MQPU Target
+add_library(cudaq::cudaq-nvidia-mqpu-target SHARED IMPORTED)
+set_target_properties(cudaq::cudaq-nvidia-mqpu-target PROPERTIES
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-${__base_nvtarget_name}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-${__base_nvtarget_name}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-mqpu;cudaq::cudaq-em-default")
+
+# NVIDIA MQPU FP64 Target
+add_library(cudaq::cudaq-nvidia-mqpu-fp64-target SHARED IMPORTED)
+set_target_properties(cudaq::cudaq-nvidia-mqpu-fp64-target PROPERTIES
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-${__base_nvtarget_name}-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-${__base_nvtarget_name}-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-mqpu;cudaq::cudaq-em-default")
+
+# QPP CPU Target
 add_library(cudaq::cudaq-qpp-cpu-target SHARED IMPORTED)
 set_target_properties(cudaq::cudaq-qpp-cpu-target PROPERTIES
   IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-qpp${CMAKE_SHARED_LIBRARY_SUFFIX}"
   IMPORTED_SONAME "libnvqir-qpp${CMAKE_SHARED_LIBRARY_SUFFIX}"
   IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
+
+# QPP CPU DensityMatrix Target
+add_library(cudaq::cudaq-qpp-density-matrix-cpu-target SHARED IMPORTED)
+  set_target_properties(cudaq::cudaq-qpp-density-matrix-cpu-target PROPERTIES
+    IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-dm${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    IMPORTED_SONAME "libnvqir-dm${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
 # -------------------------
 
 if(NOT TARGET cudaq::cudaq)

--- a/cmake/Modules/CUDAQConfig.cmake
+++ b/cmake/Modules/CUDAQConfig.cmake
@@ -78,7 +78,5 @@ set_target_properties(cudaq::cudaq-builder PROPERTIES
   IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libcudaq-builder${CMAKE_SHARED_LIBRARY_SUFFIX}"
   IMPORTED_SONAME "libcudaq-builder${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
-target_link_libraries(cudaq::cudaq INTERFACE cudaq::cudaq-builder)
-
 set(CUDAQ_TARGET "nvidia" CACHE STRING "The CUDA Quantum target to compile for and execute on. Defaults to `nvidia`")
 cudaq_set_target(${CUDAQ_TARGET})

--- a/cmake/Modules/CUDAQConfig.cmake
+++ b/cmake/Modules/CUDAQConfig.cmake
@@ -44,17 +44,41 @@ if (NOT CUDAQ_LIBRARY_MODE)
   enable_language(CUDAQ)
 endif() 
 
+# ---- TARGET EXPORTS ----
+add_library(cudaq::cudaq-nvidia-target SHARED IMPORTED)
+set_target_properties(cudaq::cudaq-nvidia-target PROPERTIES
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
+
+add_library(cudaq::cudaq-nvidia-fp64-target SHARED IMPORTED)
+set_target_properties(cudaq::cudaq-nvidia-fp64-target PROPERTIES
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-custatevec-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-custatevec-fp64${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
+
+add_library(cudaq::cudaq-qpp-cpu-target SHARED IMPORTED)
+set_target_properties(cudaq::cudaq-qpp-cpu-target PROPERTIES
+  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-qpp${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_SONAME "libnvqir-qpp${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
+# -------------------------
+
 if(NOT TARGET cudaq::cudaq)
     include("${CUDAQ_CMAKE_DIR}/CUDAQTargets.cmake")
 endif()
+
+function(cudaq_set_target TARGETNAME)
+  message(STATUS "CUDA Quantum Target = ${TARGETNAME}")
+  target_link_libraries(cudaq::cudaq INTERFACE cudaq::cudaq-${TARGETNAME}-target)
+endfunction()
 
 add_library(cudaq::cudaq-builder SHARED IMPORTED)
 set_target_properties(cudaq::cudaq-builder PROPERTIES
   IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libcudaq-builder${CMAKE_SHARED_LIBRARY_SUFFIX}"
   IMPORTED_SONAME "libcudaq-builder${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
+target_link_libraries(cudaq::cudaq INTERFACE cudaq::cudaq-builder)
 
-add_library(cudaq::cudaq-nvidia-target SHARED IMPORTED)
-set_target_properties(cudaq::cudaq-nvidia-target PROPERTIES
-  IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}"
-  IMPORTED_SONAME "libnvqir-custatevec-fp32${CMAKE_SHARED_LIBRARY_SUFFIX}")
+set(CUDAQ_TARGET "nvidia" CACHE STRING "The CUDA Quantum target to compile for and execute on. Defaults to `nvidia`")
+cudaq_set_target(${CUDAQ_TARGET})

--- a/cmake/Modules/CUDAQConfig.cmake
+++ b/cmake/Modules/CUDAQConfig.cmake
@@ -78,5 +78,45 @@ set_target_properties(cudaq::cudaq-builder PROPERTIES
   IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/libcudaq-builder${CMAKE_SHARED_LIBRARY_SUFFIX}"
   IMPORTED_SONAME "libcudaq-builder${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
-set(CUDAQ_TARGET "nvidia" CACHE STRING "The CUDA Quantum target to compile for and execute on. Defaults to `nvidia`")
+# Check for the presence of NVIDIA GPUs, if none
+# are found set the default target to qpp-cpu
+set(__tmp_cudaq_target "qpp-cpu")
+include(CheckLanguage)
+check_language(CUDA)
+if(CMAKE_CUDA_COMPILER)
+  enable_language(CUDA)
+  message(STATUS "CUDA compiler found: ${CMAKE_CUDA_COMPILER}")
+  set(CUDA_TEST_SOURCE "
+    #include <cuda_runtime.h>
+    #include <stdio.h>
+    int main() {
+      int deviceCount;
+      cudaError_t error = cudaGetDeviceCount(&deviceCount);
+      if (error != cudaSuccess) {
+        printf(\"cudaGetDeviceCount returned error %d: %s\\n\", error, cudaGetErrorString(error));
+        return 1;
+      }
+      printf(\"%d\", deviceCount);
+      return 0;
+    }
+  ")
+
+  set(CUDA_TEST_FILE "${CMAKE_BINARY_DIR}/platform/cuda_test.cu")
+  file(WRITE "${CUDA_TEST_FILE}" "${CUDA_TEST_SOURCE}")
+
+  try_run(RUN_RESULT COMPILE_RESULT
+    "${CMAKE_BINARY_DIR}" "${CUDA_TEST_FILE}"
+    CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
+    LINK_LIBRARIES ${CMAKE_CUDA_RUNTIME_LIBRARY}
+    RUN_OUTPUT_VARIABLE GPU_COUNT
+  )
+
+  if(COMPILE_RESULT AND RUN_RESULT EQUAL 0)
+    # We have NVIDIA GPUs, set the NVIDIA target as the default
+    message(STATUS "Number of NVIDIA GPUs detected: ${GPU_COUNT}")
+    set(__tmp_cudaq_target "nvidia")
+  endif()
+endif() 
+
+set(CUDAQ_TARGET ${__tmp_cudaq_target} CACHE STRING "The CUDA Quantum target to compile for and execute on. Defaults to `${__tmp_cudaq_target}`")
 cudaq_set_target(${CUDAQ_TARGET})

--- a/cmake/Modules/NVQIRConfig.cmake
+++ b/cmake/Modules/NVQIRConfig.cmake
@@ -13,7 +13,15 @@ get_filename_component(PARENT_DIRECTORY ${NVQIR_CMAKE_DIR} DIRECTORY)
 
 find_dependency(CUDAQSpin REQUIRED HINTS "${PARENT_DIRECTORY}/cudaq")
 find_dependency(CUDAQCommon REQUIRED HINTS "${PARENT_DIRECTORY}/cudaq")
-find_dependency(fmt REQUIRED HINTS "${PARENT_DIRECTORY}/cudaq")
+find_package(fmt QUIET)
+if (NOT fmt_FOUND)
+  include(FetchContent)
+  FetchContent_Declare(
+    fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt
+    GIT_TAG        e69e5f977d458f2650bb346dadf2ad30c5320281) # 10.2.1
+  FetchContent_MakeAvailable(fmt)
+endif()
 
 if(NOT TARGET nvqir::nvqir)
     include("${NVQIR_CMAKE_DIR}/NVQIRTargets.cmake")

--- a/cmake/Modules/NVQIRConfig.cmake.in
+++ b/cmake/Modules/NVQIRConfig.cmake.in
@@ -19,7 +19,7 @@ if (NOT fmt_FOUND)
   FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt
-    GIT_TAG        e69e5f977d458f2650bb346dadf2ad30c5320281) # 10.2.1
+    GIT_TAG        @CUDAQ_FMTLIB_HASH@) 
   FetchContent_MakeAvailable(fmt)
 endif()
 

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -1357,10 +1357,11 @@ class PyASTBridge(ast.NodeVisitor):
                                                                  name]
                 fType = otherKernel.type
                 if len(fType.inputs) != len(node.args):
+                    funcName = node.func.id if hasattr(node.func,
+                                                       'id') else node.func.attr
                     self.emitFatalError(
-                        "invalid number of arguments passed to callable {} ({} vs required {})"
-                        .format(node.func.id, len(node.args),
-                                len(fType.inputs)), node)
+                        f"invalid number of arguments passed to callable {funcName} ({len(node.args)} vs required {len(fType.inputs)})",
+                        node)
 
                 [self.visit(arg) for arg in node.args]
                 values = [self.popValue() for _ in node.args]

--- a/python/runtime/common/py_SampleResult.cpp
+++ b/python/runtime/common/py_SampleResult.cpp
@@ -42,6 +42,8 @@ Attributes:
           "dump", [](sample_result &self) { self.dump(); },
           "Print a string of the raw measurement counts data to the "
           "terminal.\n")
+      .def("serialize", &sample_result::serialize, "")
+      .def("deserialize", &sample_result::deserialize, "")
       .def(
           "__str__",
           [](sample_result &self) {

--- a/python/runtime/common/py_SampleResult.cpp
+++ b/python/runtime/common/py_SampleResult.cpp
@@ -42,8 +42,11 @@ Attributes:
           "dump", [](sample_result &self) { self.dump(); },
           "Print a string of the raw measurement counts data to the "
           "terminal.\n")
-      .def("serialize", &sample_result::serialize, "")
-      .def("deserialize", &sample_result::deserialize, "")
+      .def("serialize", &sample_result::serialize,
+           "Serialize this SampleResult to a vector of integer encoding.")
+      .def("deserialize", &sample_result::deserialize,
+           "Deserialize this SampleResult from an existing vector of integers "
+           "adhering to the implicit encoding.")
       .def(
           "__str__",
           [](sample_result &self) {

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -1177,7 +1177,8 @@ public:
                                controls, {}, targets) +
                       " = {}",
                   matrix);
-    enqueueGate("custom", actual, controls, targets, {});
+    enqueueGate(customName.empty() ? "unknown op" : customName.data(), actual,
+                controls, targets, {});
   }
 
   template <typename QuantumOperation>


### PR DESCRIPTION
* Create imported CMake targets for cudaq targets.
* Enable downstream CMake to set the target. 
* Fix bug where fmtlib not found for downstream project import NVQIR config.
* Fix issue printing out call error in python bridge.
* Add serialize / deserialize to sample result in python bindings.
* carry the custom operator name through to the GateApplicationTask. 