### PR TITLE
Follow-up to #1901 - fix shots-based VQE handling on server

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -511,6 +511,11 @@ jobs:
           export NVQC_API_KEY="${{ secrets.NVQC_SERVICE_KEY }}"
           export NVQC_FUNCTION_ID="$NVQC_FUNCTION_ID"
           export NVQC_FUNCTION_VERSION_ID="${{ needs.deploy_nvqc_test_function.outputs.nvqc_function_version_id }}"
+          # When overriding the NVQC_FUNCTION_ID to a function that doesn't
+          # follow the production naming convenvtions, we need to set the
+          # following environment variable to tell the client that the server
+          # has all the remote capabilities.
+          export CUDAQ_CLIENT_REMOTE_CAPABILITY_OVERRIDE=1
           set +e # Allow script to keep going through errors
           test_err_sum=0
           # Test all NVQPP execution tests

--- a/targettests/Remote-Sim/vqe_h2.cpp
+++ b/targettests/Remote-Sim/vqe_h2.cpp
@@ -142,10 +142,16 @@ int main() {
     cudaq::optimizers::cobyla optimizer;
     optimizer.initial_parameters = init_params;
     optimizer.max_eval = 100;
+    cudaq::set_random_seed(13);
     auto [opt_val, opt_params] = cudaq::vqe(
         /*shots=*/1000, ansatz, H, optimizer, n_params, n_qubits, n_layers);
     printf("Optimal value = %.16lf\n", opt_val);
-    REMOTE_TEST_ASSERT(std::abs(opt_val - -1.0769400650758392) < 1e-3);
+
+    // Increase the error tolerance for the shots-based test because this test
+    // needs to sometimes run against a server without the remote VQE
+    // capability, so the handling of RNG seeds for back-and-forth iterations of
+    // observe's behave slightly differently than a fully remote VQE.
+    REMOTE_TEST_ASSERT(std::abs(opt_val - -1.0906868832471321) < 0.015);
   }
   return 0;
 }


### PR DESCRIPTION
This has 3 separate-but-related changes:

1. Update the NVQC server code (and `remote-mqpu` server code) to honor the number of shots in the request from the client when doing VQE optimizations.
2. Updated the targettests/Remote-Sim/vqe_h2.cpp test to set a random number seed and widen the tolerance of the assertion. This is required due to the variety of different ways the test can be executed (qpp-cpu, nvidia, new-nvqc, old-nvqc, and remote-mqpu).
3. Update the nightly integration test to set `CUDAQ_CLIENT_REMOTE_CAPABILITY_OVERRIDE=1` because the existing name of our deployed test doesn't follow any specific naming conventions that allow the client to infer anything about the server-side capabilities. The environment variable should only be set in integration_tests.yml when we are testing the current version of the server; it should remain unset for nvqc_regression_tests.yml where we are using the production NVQC servers.