### PR TITLE
[test] Update integration_test.yml to enable remote Python execution on server

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -189,10 +189,18 @@ jobs:
         # When a new REST version is introduced, NVQC_REST_PAYLOAD_VERSION needs to be updated in lockstep with the new nightly CUDA Quantum image. 
         # Otherwise, deployment of the test function will fail.
         run: |
+          # We run with CUDAQ_SER_CODE_EXEC set. The final NVQC deployment may
+          # or may not have this set, but since we run the client with
+          # CUDAQ_CLIENT_REMOTE_CAPABILITY_OVERRIDE=1 (below), we need to run
+          # the CI with CUDAQ_SER_CODE_EXEC=1. If we ever remove
+          # CUDAQ_CLIENT_REMOTE_CAPABILITY_OVERRIDE=1 below, we can consider
+          # removing CUDAQ_SER_CODE_EXEC=1.
           create_function_result=$(ngc-cli/ngc cloud-function function create \
             --container-image nvcr.io/${{ env.NGC_QUANTUM_ORG }}/${{ env.NGC_QUANTUM_TEAM }}/cuda-quantum:nightly \
             --container-environment-variable NUM_GPUS:1 \
             --container-environment-variable NVQC_REST_PAYLOAD_VERSION:1.1 \
+            --container-environment-variable RUN_AS_NOBODY:1 \
+            --container-environment-variable CUDAQ_SER_CODE_EXEC:1 \
             --api-body-format CUSTOM \
             --inference-port 3030 \
             --health-uri / \


### PR DESCRIPTION
This will resolve the following two test failures seen in https://github.com/NVIDIA/cuda-quantum/actions/runs/10155426211:
* examples/python/advanced_vqe.py
* examples/python/qaoa_maxcut.py

Also add the `RUN_AS_NOBODY` environment variable since our standard deployment process will utilize that.