### PR TITLE
Config file update legacy nvidia targets

### DIFF
--- a/runtime/cudaq/platform/default/nvidia-fp64.yml
+++ b/runtime/cudaq/platform/default/nvidia-fp64.yml
@@ -12,6 +12,6 @@ warning: "This target is deprecating. Please use the 'nvidia' target with option
 gpu-requirements: true
 
 config:
-  nvqir-simulation-backend: custatevec-fp64
+  nvqir-simulation-backend: cusvsim-fp64, custatevec-fp64
   preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]
 

--- a/runtime/cudaq/platform/mqpu/nvidia-mqpu-fp64.yml
+++ b/runtime/cudaq/platform/mqpu/nvidia-mqpu-fp64.yml
@@ -12,7 +12,7 @@ warning: "This target is deprecating. Please use the 'nvidia' target with option
 gpu-requirements: true
 
 config:
-  nvqir-simulation-backend: custatevec-fp64
+  nvqir-simulation-backend: cusvsim-fp64, custatevec-fp64
   preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]
   platform-library: mqpu
 

--- a/runtime/cudaq/platform/mqpu/nvidia-mqpu.yml
+++ b/runtime/cudaq/platform/mqpu/nvidia-mqpu.yml
@@ -12,7 +12,7 @@ warning: "This target is deprecating. Please use the 'nvidia' target with option
 gpu-requirements: true
 
 config:
-  nvqir-simulation-backend: custatevec-fp32
+  nvqir-simulation-backend: cusvsim-fp32, custatevec-fp32
   preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP32"]
   platform-library: mqpu
 

--- a/targettests/TargetConfig/RegressionValidation/nvidia-fp64.config
+++ b/targettests/TargetConfig/RegressionValidation/nvidia-fp64.config
@@ -13,7 +13,7 @@ msg=""
 # CHECK-DAG: PREPROCESSOR_DEFINES="${PREPROCESSOR_DEFINES} -D CUDAQ_SIMULATION_SCALAR_FP64"
 gpu_found=$(query_gpu)
 if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ]; then
-# CHECK-DAG: NVQIR_SIMULATION_BACKEND="custatevec-fp64"
+# CHECK-DAG: NVQIR_SIMULATION_BACKEND="cu{{.*}}-fp64"
 else
 	msg="libnvqir-custatevec-fp64 is not installed, or there are no NVIDIA GPUs."
 fi

--- a/targettests/TargetConfig/RegressionValidation/nvidia-mqpu-fp64.config
+++ b/targettests/TargetConfig/RegressionValidation/nvidia-mqpu-fp64.config
@@ -12,7 +12,7 @@ msg=""
 
 gpu_found=$(query_gpu)
 if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp64.so" ]; then
-# CHECK-DAG:  NVQIR_SIMULATION_BACKEND="custatevec-fp64"
+# CHECK-DAG: NVQIR_SIMULATION_BACKEND="cu{{.*}}-fp64"
 else
 	msg="libnvqir-custatevec-fp64 is not installed, or there are no NVIDIA GPUs."
 fi

--- a/targettests/TargetConfig/RegressionValidation/nvidia-mqpu.config
+++ b/targettests/TargetConfig/RegressionValidation/nvidia-mqpu.config
@@ -11,7 +11,7 @@
 msg=""
 gpu_found=$(query_gpu)
 if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
-# CHECK-DAG:  NVQIR_SIMULATION_BACKEND="custatevec-fp32"
+# CHECK-DAG: NVQIR_SIMULATION_BACKEND="cu{{.*}}-fp32"
 else
 	msg="libnvqir-custatevec-fp32 is not installed, or there are no NVIDIA GPUs."
 fi

--- a/targettests/lit.cfg.py
+++ b/targettests/lit.cfg.py
@@ -27,7 +27,7 @@ config.name = 'CUDAQ-Target'
 # `testFormat`: The test format to use to interpret tests.
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
-config.suffixes = ['.cpp']
+config.suffixes = ['.cpp', '.config']
 
 # Exclude a list of directories from the test suite:
 #   - 'Inputs' contain auxiliary inputs for various tests.
@@ -41,6 +41,8 @@ config.substitutions.append(('%pluginext', config.llvm_plugin_ext))
 config.substitutions.append(('%llvmInclude', config.llvm_install + "/include"))
 config.substitutions.append(('%cudaq_lib_dir', config.cudaq_lib_dir))
 config.substitutions.append(('%cudaq_plugin_ext', config.cudaq_plugin_ext))
+config.substitutions.append(('%cudaq_target_dir', config.cudaq_target_dir))
+config.substitutions.append(('%cudaq_src_dir', config.cudaq_src_dir))
 
 llvm_config.use_default_substitutions()
 

--- a/targettests/lit.site.cfg.py.in
+++ b/targettests/lit.site.cfg.py.in
@@ -22,6 +22,7 @@ config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
 config.errc_messages = "@LLVM_LIT_ERRC_MESSAGES@"
 config.cudaq_obj_root = "@CUDAQ_BINARY_DIR@"
 config.cudaq_src_dir = "@CUDAQ_SOURCE_DIR@"
+config.cudaq_target_dir = "@CMAKE_BINARY_DIR@/targets"
 config.cudaq_tools_dir = lit_config.substitute("@CUDAQ_TOOLS_DIR@")
 config.cudaq_intrinsic_modules_dir = "@CUDAQ_INTRINSIC_MODULES_DIR@"
 config.cudaq_llvm_tools_dir = "@CMAKE_BINARY_DIR@/bin"

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -32,7 +32,7 @@ config.name = 'CUDAQ'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # A list of file extensions to treat as test files.
-config.suffixes = ['.cpp', '.ll', '.mlir', '.qke', '.config']
+config.suffixes = ['.cpp', '.ll', '.mlir', '.qke']
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 config.substitutions.append(('%llvmshlibdir', config.llvm_shlib_dir))


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- Enable the new custatevec-based simulators for all legacy targets (`nvidia-fp64`, `nvidia-mqpu`, and `nvidia-mqpu-fp32`) as the first option (to be taken if available).

- Update the config file regression checks.

- Fixed a fallout from https://github.com/NVIDIA/cuda-quantum/pull/1973, these `.config` files were not run in the new location unintentionally. 


