### PR TITLE
Update mgpu commit hash for two bugfixes

### DIFF
--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: 34da02f5e29c25ef42d17cd77b0bb72e4a088c87
+nvidia-mgpu-commit: caf2c7c60a308f65da6d4593bf3f8f066636c2c5


### PR DESCRIPTION
1. Fix segfault during cudaq.draw()
2. Fix gate count telemetry to be consistent with other simulators