### PR TITLE
Follow-up to #1914 - fix MPI shutdown problem

### DIFF
--- a/tools/cudaq-qpud/json_request_runner.py
+++ b/tools/cudaq-qpud/json_request_runner.py
@@ -163,11 +163,11 @@ if __name__ == "__main__":
             'errorMessage': error_message
         }
     finally:
-        if cudaq.mpi.is_initialized():
-            cudaq.mpi.finalize()
-
         # Only rank 0 prints the result
         if not (cudaq.mpi.is_initialized()) or (cudaq.mpi.rank() == 0):
             with open(jsonFile, 'w') as fp:
                 json.dump(result, fp)
                 fp.flush()
+
+        if cudaq.mpi.is_initialized():
+            cudaq.mpi.finalize()


### PR DESCRIPTION
Follow-up to #1914.

Fix the fact that `cudaq.mpi.rank()` was being called after `cudaq.mpi.finalize()`.

This issue was discovered during QA testing on multi-GPU systems for the release, but given our current plans, this probably does not have to be backported to 0.8.0 since we are probably not enabling this remote Python feature in 0.8.0.