### PR TITLE
Add `get_state_async` examples to the `mqpu` platform docs

### DIFF
--- a/docs/sphinx/using/backends/platform.rst
+++ b/docs/sphinx/using/backends/platform.rst
@@ -49,7 +49,8 @@ Here is a simple example demonstrating its usage.
         ./a.out
 
 CUDA-Q exposes asynchronous versions of the default :code:`cudaq` algorithmic
-primitive functions like :code:`sample` and :code:`observe` (e.g., :code:`sample_async` function in the above code snippets).
+primitive functions like :code:`sample`, :code:`observe`, and :code:`get_state` 
+(e.g., :code:`sample_async` function in the above code snippets).
 
 Depending on the number of GPUs available on the system, the :code:`nvidia` multi-QPU platform will create the same number of virtual QPU instances.
 For example, on a system with 4 GPUs, the above code will distribute the four sampling tasks among those :code:`GPUEmulatedQPU` instances.
@@ -69,6 +70,30 @@ The results might look like the following 4 different random samplings:
   By default, the :code:`nvidia` multi-QPU platform will utilize all available GPUs (number of QPUs instances is equal to the number of GPUs).
   To specify the number QPUs to be instantiated, one can set the :code:`CUDAQ_MQPU_NGPUS` environment variable.
   For example, use :code:`export CUDAQ_MQPU_NGPUS=2` to specify that only 2 QPUs (GPUs) are needed.
+
+Since the underlying :code:`GPUEmulatedQPU` is a simulator backend, we can also retrieve the state vector from each
+QPU via the :code:`cudaq::get_state_async` (C++) or :code:`cudaq.get_state_async` (Python) as shown in the bellow code snippets.
+
+.. tab:: Python
+
+    .. literalinclude:: ../../snippets/python/using/cudaq/platform/get_state_async.py
+        :language: python
+        :start-after: [Begin Documentation]
+
+.. tab:: C++
+
+    .. literalinclude:: ../../snippets/cpp/using/cudaq/platform/get_state_async.cpp
+        :language: cpp
+        :start-after: [Begin Documentation]
+        :end-before: [End Documentation]
+
+
+    One can specify the target multi-QPU architecture with the :code:`--target` flag:
+    
+    .. code-block:: console
+
+        nvq++ get_state_async.cpp --target nvidia --target-option mqpu
+        ./a.out
 
 .. deprecated:: 0.8
     The :code:`nvidia-mqpu` and :code:`nvidia-mqpu-fp64` targets, which are equivalent to the multi-QPU options `mgpu,fp32` and `mgpu,fp64`, respectively, of the :code:`nvidia` target, are deprecated and will be removed in a future release.


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

We've had these two `get_state_async` (py and cpp) examples added and tested for some time.
However, they were not included in the docs. Hence, this PR fixes that.

**Note**: the [linked issue](https://github.com/NVIDIA/cuda-quantum/issues/775) also mentioned layout/format/etc. since it's from a long time ago when we didn't use tabs throughout the docs to show C++ and Python examples. Since then, they have all been reorganized. 


Resolved https://github.com/NVIDIA/cuda-quantum/issues/775
