### PR TITLE
Demonstrate simple runnable example with dep-analysis pass

### DIFF
--- a/docs/sphinx/examples/cpp/basics/static_kernel_simple.cpp
+++ b/docs/sphinx/examples/cpp/basics/static_kernel_simple.cpp
@@ -1,0 +1,30 @@
+
+// Compile and run with:
+// ```
+// nvq++ --enable-mlir --opt-pass 'func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce' static_kernel_simple.cpp
+// ./a.out
+// ```
+
+#include <cudaq.h>
+
+template <std::size_t N>
+struct ghz {
+  double operator()() __qpu__ {
+    cudaq::qvector q(N);
+    h(q[0]);
+    x<cudaq::ctrl>(q[0], q[1]);
+    auto res = mz(q[1]);
+    double returnVal = 0.0;
+    if (res)
+      returnVal = 1.0;
+    return returnVal;
+  }
+};
+
+int main() {
+
+  double result = ghz<10>{}();
+  printf("Result = %f\n", result);
+
+  return 0;
+}

--- a/lib/Optimizer/Transforms/WiresToWiresets.cpp
+++ b/lib/Optimizer/Transforms/WiresToWiresets.cpp
@@ -98,9 +98,10 @@ struct AddWiresetPass
   void runOnOperation() override {
     ModuleOp mod = getOperation();
     OpBuilder builder(mod.getBodyRegion());
-    builder.create<quake::WireSetOp>(builder.getUnknownLoc(),
-                                     cudaq::opt::topologyAgnosticWiresetName,
-                                     INT_MAX, ElementsAttr{});
+    auto wireSetOp = builder.create<quake::WireSetOp>(
+        builder.getUnknownLoc(), cudaq::opt::topologyAgnosticWiresetName,
+        INT_MAX, ElementsAttr{});
+    wireSetOp.setPrivate();
   }
 };
 


### PR DESCRIPTION
This bypasses the REST platform in order to use kernel return values. In turn, all the passes are listed on the command line.

Also, update regtomem to be able comprehend wire sets.

The aforementioned example is purely a proof of concept right now. This should not be checked into any real branches yet.