### PR TITLE
Update the qubit mapping pass to use wire sets

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -81,7 +81,7 @@ inline std::unique_ptr<mlir::Pass> createQuantumMemToReg() {
   return createMemToReg(m2rOpt);
 }
 
-/// Prefix of `quake.wire_set` generated for each function prior to mapping
-static constexpr const char topologyAgnosticWireSetPrefix[] = "wires_";
+/// Name of `quake.wire_set` generated prior to mapping
+static constexpr const char topologyAgnosticWiresetName[] = "wires";
 
 } // namespace cudaq::opt

--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -29,6 +29,7 @@ void addAggressiveEarlyInlining(mlir::OpPassManager &pm);
 void registerAggressiveEarlyInlining();
 
 void registerUnrollingPipeline();
+void registerMappingPipeline();
 
 std::unique_ptr<mlir::Pass> createApplyOpSpecializationPass();
 std::unique_ptr<mlir::Pass>

--- a/include/cudaq/Optimizer/Transforms/Passes.h
+++ b/include/cudaq/Optimizer/Transforms/Passes.h
@@ -80,7 +80,7 @@ inline std::unique_ptr<mlir::Pass> createQuantumMemToReg() {
   return createMemToReg(m2rOpt);
 }
 
-/// Name of `quake.wire_set` generated prior to mapping
-static constexpr const char topologyAgnosticWiresetName[] = "wires";
+/// Prefix of `quake.wire_set` generated for each function prior to mapping
+static constexpr const char topologyAgnosticWireSetPrefix[] = "wires_";
 
 } // namespace cudaq::opt

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -583,9 +583,9 @@ def MappingFunc: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
     performs mapping of the qubits by inserting the necessary swap operations
     into the Quake IR.
 
-    Note 1: this pass requires strictly value semantics for any quantum
-    operations. It will throw an error if any memory reference semantics are
-    present on quantum operations.
+    Note 1: this pass requires strictly value semantics (in the form of wire
+    sets) for any quantum operations. It will throw an error if any memory
+    reference semantics are present on quantum operations.
 
     Note 2: this pass can introduce ancilla qubits.
 

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -12,10 +12,10 @@
 include "mlir/Pass/PassBase.td"
 
 def AddWireset : Pass<"add-wireset", "mlir::ModuleOp"> {
-  let summary = "Adds topology-less `quake.wire_set`s to the module.";
+  let summary = "Adds a topology-less `quake.wire_set` to the module.";
   let description = [{
-    Adds `quake.wire_set` operations without any topological information to the
-    ModuleOp (one for each function).
+    Adds a `quake.wire_set` operation without any topological information to the
+    ModuleOp.
   }];
 }
 

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -576,7 +576,7 @@ def LowerToCFG : Pass<"lower-to-cfg", "mlir::func::FuncOp"> {
   let constructor = "cudaq::opt::createLowerToCFGPass()";
 }
 
-def MappingPass: Pass<"qubit-mapping", "mlir::func::FuncOp"> {
+def MappingPass: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
   let summary = "Perform qubit mapping to account for connectivity constraints";
   let description = [{
     Some backends cannot support any-to-any multi-qubit operations, so this pass
@@ -595,15 +595,26 @@ def MappingPass: Pass<"qubit-mapping", "mlir::func::FuncOp"> {
   }];
 
   let options = [
-    Option<"device", "device", "std::string", /*default=*/"\"-\"",
-      "Device topology: path(N), ring(N), star(N), star(N,c), grid(w,h), file(/path/to/file), bypass">,
-    Option<"debug", "debug", "bool", /*default=*/"false", "Enable debug for qubit-mapping pass algorithm">,
     Option<"extendedLayerSize", "extendedLayerSize", "unsigned", /*default=*/"20", "Extended layer size">,
     Option<"extendedLayerWeight", "extendedLayerWeight", "float", /*default=*/"0.5", "Extended layer weight">,
     Option<"decayDelta", "decayDelta", "float", /*default=*/"0.5", "Decay delta">,
     Option<"roundsDecayReset", "roundsDecayReset", "unsigned", /*default=*/"5", "Number of rounds before decay is reset">
   ];
 }
+
+def MappingPrep: Pass<"qubit-mapping-prep", "mlir::ModuleOp"> {
+  let summary = "Prepare module for qubit mapping.";
+  let description = [{
+    Insert the required topology-aware `quake.wire_set` operation that
+    corresponds to the requested device.
+  }];
+
+  let options = [
+    Option<"device", "device", "std::string", /*default=*/"\"-\"",
+      "Device topology: path(N), ring(N), star(N), star(N,c), grid(w,h), file(/path/to/file), bypass">,
+  ];
+}
+
 
 def MemToReg : Pass<"memtoreg", "mlir::func::FuncOp"> {
   let summary = "Converts memory-SSA to register-SSA form.";

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -576,7 +576,7 @@ def LowerToCFG : Pass<"lower-to-cfg", "mlir::func::FuncOp"> {
   let constructor = "cudaq::opt::createLowerToCFGPass()";
 }
 
-def MappingPass: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
+def MappingFunc: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
   let summary = "Perform qubit mapping to account for connectivity constraints";
   let description = [{
     Some backends cannot support any-to-any multi-qubit operations, so this pass

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -12,10 +12,10 @@
 include "mlir/Pass/PassBase.td"
 
 def AddWireset : Pass<"add-wireset", "mlir::ModuleOp"> {
-  let summary = "Adds a topology-less `quake.wire_set` to the module.";
+  let summary = "Adds topology-less `quake.wire_set`s to the module.";
   let description = [{
-    Adds a `quake.wire_set` operation without any topological information to the
-    ModuleOp.
+    Adds `quake.wire_set` operations without any topological information to the
+    ModuleOp (one for each function).
   }];
 }
 

--- a/include/cudaq/Support/Device.h
+++ b/include/cudaq/Support/Device.h
@@ -105,7 +105,8 @@ public:
     Device device;
     device.topology.createNode();
     for (unsigned i = 0u; i < numQubits; ++i) {
-      device.topology.createNode();
+      if (i < numQubits - 1)
+        device.topology.createNode();
       device.topology.addEdge(Qubit(i), Qubit((i + 1) % numQubits));
     }
     device.computeAllPairShortestPaths();
@@ -160,6 +161,50 @@ public:
           device.topology.addEdge(q0, Qubit(base + width));
       }
     }
+    device.computeAllPairShortestPaths();
+    return device;
+  }
+
+  /// Create a device from a `mlir::SparseElementsAttr`, which might come from
+  /// the adjacency attribute of a `WireSetOp`.
+  static Device attr(const mlir::SparseElementsAttr &attr) {
+    Device device;
+    auto tensorType = attr.getType().dyn_cast<mlir::RankedTensorType>();
+    if (!tensorType || tensorType.getRank() != 2 ||
+        tensorType.getShape()[0] != tensorType.getShape()[1] ||
+        !tensorType.getElementType().isInteger(1)) {
+      llvm::errs() << "Attribute is not an NxN tensor of i1\n";
+      return device;
+    }
+
+    // Create nodes
+    auto numQubits = tensorType.getShape()[0];
+    for (decltype(numQubits) i = 0; i < numQubits; i++)
+      device.topology.createNode();
+
+    // Now create the edges
+    auto indices = attr.getIndices();
+    auto values = attr.getValues();
+
+    // Ensure indices and values match the number of non-zero elements
+    if (indices.size() != 2 * values.size()) {
+      llvm::errs() << "Mismatch between indices size (" << indices.size()
+                   << ") and values size (" << values.size() << ")\n";
+      return device;
+    }
+
+    // Traverse the sparse elements
+    auto indicesIt = indices.value_begin<mlir::APInt>();
+    auto valuesIt = values.value_begin<mlir::APInt>();
+
+    for (std::int64_t i = 0, e = indices.getNumElements() / 2; i < e; i++) {
+      auto row = (*(indicesIt++)).getSExtValue();
+      auto col = (*(indicesIt++)).getSExtValue();
+      bool value = (*(valuesIt++)).getBoolValue();
+      if (value)
+        device.topology.addEdge(Qubit(row), Qubit(col), /*undirected=*/false);
+    }
+
     device.computeAllPairShortestPaths();
     return device;
   }

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -81,7 +81,7 @@ LogicalResult quake::verifyWireArityAndCoarity(Operation *op) {
 }
 
 bool quake::isSupportedMappingOperation(Operation *op) {
-  return isa<OperatorInterface, MeasurementInterface, SinkOp>(op);
+  return isa<OperatorInterface, MeasurementInterface, SinkOp, ReturnWireOp>(op);
 }
 
 ValueRange quake::getQuantumTypesFromRange(ValueRange range) {
@@ -824,7 +824,7 @@ ParseResult quake::WireSetOp::parse(OpAsmParser &parser,
     if (parser.parseAttribute(sparseEle, getAdjacencyAttrName(result.name),
                               result.attributes))
       return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDictWithKeyword(result.attributes))
     return failure();
   return success();
 }

--- a/lib/Optimizer/Transforms/Mapping.cpp
+++ b/lib/Optimizer/Transforms/Mapping.cpp
@@ -659,8 +659,8 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
     Block &block = *blocks.begin();
 
     Device d;
-    if (auto adj = dyn_cast_or_null<SparseElementsAttr>(
-            wireSetOp.getAdjacencyAttr()))
+    if (auto adj =
+            dyn_cast_or_null<SparseElementsAttr>(wireSetOp.getAdjacencyAttr()))
       d = Device::attr(adj);
 
     if (d.getNumQubits() == 0) {

--- a/lib/Optimizer/Transforms/Mapping.cpp
+++ b/lib/Optimizer/Transforms/Mapping.cpp
@@ -16,7 +16,6 @@
 #include "llvm/Support/ScopedPrinter.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/TopologicalSortUtils.h"
-#include <mutex>
 
 #define DEBUG_TYPE "quantum-mapper"
 
@@ -895,9 +894,7 @@ struct MappingPipelineOptions
     : public PassPipelineOptions<MappingPipelineOptions> {
 
 #define DECLARE_SUB_OPTION(_PARENT_STRUCT, _FIELD)                             \
-  PassOptions::Option<decltype(_PARENT_STRUCT::_FIELD)> _FIELD {               \
-    *this, #_FIELD                                                             \
-  }
+  PassOptions::Option<decltype(_PARENT_STRUCT::_FIELD)> _FIELD{*this, #_FIELD}
   DECLARE_SUB_OPTION(MappingPrepOptions, device);
   DECLARE_SUB_OPTION(MappingFuncOptions, extendedLayerSize);
   DECLARE_SUB_OPTION(MappingFuncOptions, extendedLayerWeight);

--- a/lib/Optimizer/Transforms/Mapping.cpp
+++ b/lib/Optimizer/Transforms/Mapping.cpp
@@ -687,6 +687,16 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
         finalQubitWire[id] = qop.getResult();
         sources[id] = qop;
         lastSource = &op;
+      } else if (dyn_cast<quake::NullWireOp>(op)) {
+        op.emitOpError(
+            "the mapper requires borrow operations and prohibits null wires");
+        signalPassFailure();
+        return;
+      } else if (dyn_cast<quake::AllocaOp>(op)) {
+        op.emitOpError("the mapper requires borrow operations and prohibits "
+                       "reference semantics");
+        signalPassFailure();
+        return;
       } else if (quake::isSupportedMappingOperation(&op)) {
         // Make sure the operation is using value semantics.
         if (!quake::isLinearValueForm(&op)) {

--- a/lib/Optimizer/Transforms/WiresToWiresets.cpp
+++ b/lib/Optimizer/Transforms/WiresToWiresets.cpp
@@ -98,9 +98,10 @@ struct AddWiresetPass
   void runOnOperation() override {
     ModuleOp mod = getOperation();
     OpBuilder builder(mod.getBodyRegion());
-    builder.create<quake::WireSetOp>(builder.getUnknownLoc(),
-                                     cudaq::opt::topologyAgnosticWiresetName,
-                                     INT_MAX, ElementsAttr{});
+    auto wireSetOp = builder.create<quake::WireSetOp>(
+        builder.getUnknownLoc(), cudaq::opt::topologyAgnosticWiresetName,
+        INT_MAX, ElementsAttr{});
+    wireSetOp.setPrivate();
   }
 };
 

--- a/lib/Optimizer/Transforms/WiresToWiresets.cpp
+++ b/lib/Optimizer/Transforms/WiresToWiresets.cpp
@@ -77,10 +77,8 @@ struct AssignWireIndicesPass
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     unsigned x = 0;
-    std::string wireSetName =
-        cudaq::opt::topologyAgnosticWireSetPrefix + func.getName().str();
-
-    patterns.insert<NullWirePat>(ctx, &x, wireSetName);
+    patterns.insert<NullWirePat>(ctx, &x,
+                                 cudaq::opt::topologyAgnosticWiresetName);
     patterns.insert<SinkOpPat>(ctx);
     ConversionTarget target(*ctx);
     target.addLegalDialect<quake::QuakeDialect>();
@@ -100,15 +98,9 @@ struct AddWiresetPass
   void runOnOperation() override {
     ModuleOp mod = getOperation();
     OpBuilder builder(mod.getBodyRegion());
-    mod.walk([&](func::FuncOp func) {
-      std::string wireSetName =
-          cudaq::opt::topologyAgnosticWireSetPrefix + func.getName().str();
-      if (!mod.lookupSymbol<quake::WireSetOp>(wireSetName)) {
-        auto wireSetOp = builder.create<quake::WireSetOp>(
-            builder.getUnknownLoc(), wireSetName, INT_MAX, ElementsAttr{});
-        wireSetOp.setPrivate();
-      }
-    });
+    builder.create<quake::WireSetOp>(builder.getUnknownLoc(),
+                                     cudaq::opt::topologyAgnosticWiresetName,
+                                     INT_MAX, ElementsAttr{});
   }
 };
 

--- a/python/runtime/mlir/py_register_dialects.cpp
+++ b/python/runtime/mlir/py_register_dialects.cpp
@@ -48,6 +48,7 @@ void registerQuakeDialectAndTypes(py::module &m) {
           cudaq::opt::registerAggressiveEarlyInlining();
           cudaq::opt::registerUnrollingPipeline();
           cudaq::opt::registerTargetPipelines();
+          cudaq::opt::registerMappingPipeline();
           registered = true;
         }
       },

--- a/runtime/common/RuntimeMLIR.cpp
+++ b/runtime/common/RuntimeMLIR.cpp
@@ -83,6 +83,7 @@ std::unique_ptr<MLIRContext> initializeMLIR() {
     registerToIQMJsonTranslation();
     cudaq::opt::registerUnrollingPipeline();
     cudaq::opt::registerTargetPipelines();
+    cudaq::opt::registerMappingPipeline();
     mlirLLVMInitialized = true;
   }
 

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
@@ -16,7 +16,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices,qubit-mapping{device=file(%QPU_ARCH%)},delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
+  platform-lowering-config: "const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
   # Tell the rest-qpu that we are generating IQM JSON.
   codegen-emission: iqm
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
@@ -16,7 +16,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg,qubit-mapping{device=file(%QPU_ARCH%)},delay-measurements,regtomem),iqm-gate-set-mapping"
+  platform-lowering-config: "const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices,qubit-mapping{device=file(%QPU_ARCH%)},delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
   # Tell the rest-qpu that we are generating IQM JSON.
   codegen-emission: iqm
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
@@ -16,7 +16,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices,qubit-mapping{device=file(%QPU_ARCH%)},regtomem),symbol-dce"
+  platform-lowering-config: "const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qir-base
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
@@ -16,7 +16,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg,qubit-mapping{device=file(%QPU_ARCH%)},regtomem)"
+  platform-lowering-config: "const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices,qubit-mapping{device=file(%QPU_ARCH%)},regtomem),symbol-dce"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qir-base
   # Library mode is only for simulators, physical backends must turn this off

--- a/targettests/TargetConfig/RegressionValidation/iqm.config
+++ b/targettests/TargetConfig/RegressionValidation/iqm.config
@@ -20,7 +20,7 @@
 # Define the lowering pipeline, here we lower to Base QIR
 # Note: the runtime will dynamically substitute %QPU_ARCH% based on
 # qpu-architecture
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices,qubit-mapping{device=file(%QPU_ARCH%)},delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating IQM JSON.
 # CHECK-DAG: CODEGEN_EMISSION=iqm

--- a/targettests/TargetConfig/RegressionValidation/iqm.config
+++ b/targettests/TargetConfig/RegressionValidation/iqm.config
@@ -20,7 +20,7 @@
 # Define the lowering pipeline, here we lower to Base QIR
 # Note: the runtime will dynamically substitute %QPU_ARCH% based on
 # qpu-architecture
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg,qubit-mapping{device=file(%QPU_ARCH%)},delay-measurements,regtomem),iqm-gate-set-mapping"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices,qubit-mapping{device=file(%QPU_ARCH%)},delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating IQM JSON.
 # CHECK-DAG: CODEGEN_EMISSION=iqm

--- a/targettests/TargetConfig/RegressionValidation/oqc.config
+++ b/targettests/TargetConfig/RegressionValidation/oqc.config
@@ -20,7 +20,7 @@
 # Define the lowering pipeline. Lucy has an 8-qubit ring topology, so mapping
 # uses ring(8).
 # Toshiko uses a Kagome lattice with 2-3 connectivity per qubit
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg,qubit-mapping{device=file(%QPU_ARCH%)},regtomem)"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices,qubit-mapping{device=file(%QPU_ARCH%)},regtomem),symbol-dce"
 
 
 # Tell the rest-qpu that we are generating QIR.

--- a/targettests/TargetConfig/RegressionValidation/oqc.config
+++ b/targettests/TargetConfig/RegressionValidation/oqc.config
@@ -20,7 +20,7 @@
 # Define the lowering pipeline. Lucy has an 8-qubit ring topology, so mapping
 # uses ring(8).
 # Toshiko uses a Kagome lattice with 2-3 connectivity per qubit
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices,qubit-mapping{device=file(%QPU_ARCH%)},regtomem),symbol-dce"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="const-prop-complex,canonicalize,cse,lift-array-value,state-prep,expand-measurements,unrolling-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
 
 
 # Tell the rest-qpu that we are generating QIR.

--- a/targettests/execution/mapping_test-1-cpp17.cpp
+++ b/targettests/execution/mapping_test-1-cpp17.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // REQUIRES: c++17
-// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t |& FileCheck %s
+// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s && FileCheck --check-prefix=QUAKE %s < %t.txt
 // RUN: mkdir -p %t.dir && cp "%iqm_test_src_dir/Adonis.txt" "%t.dir/Adonis Variant.txt" && nvq++ %cpp_std %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%t.dir/Adonis Variant.txt" --emulate && %t
 // RUN: nvq++ %cpp_std --enable-mlir %s -o %t
 // RUN: rm -rf %t.txt %t.dir
@@ -37,5 +37,17 @@ int main() {
   return 0;
 }
 
-// CHECK: { 101:1000 }
-// CHECK: most_probable "101"
+// QUAKE-LABEL: tail call void @__quantum__qis__x__body(%Qubit* null)
+// QUAKE:       tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
+// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
+// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
+// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// QUAKE:       ret void
+
+// CHECK-LABEL: most_probable "101"

--- a/targettests/execution/mapping_test-1-cpp17.cpp
+++ b/targettests/execution/mapping_test-1-cpp17.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // REQUIRES: c++17
-// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s && FileCheck --check-prefix=QUAKE %s < %t.txt
+// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t |& FileCheck %s
 // RUN: mkdir -p %t.dir && cp "%iqm_test_src_dir/Adonis.txt" "%t.dir/Adonis Variant.txt" && nvq++ %cpp_std %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%t.dir/Adonis Variant.txt" --emulate && %t
 // RUN: nvq++ %cpp_std --enable-mlir %s -o %t
 // RUN: rm -rf %t.txt %t.dir
@@ -37,17 +37,5 @@ int main() {
   return 0;
 }
 
-// QUAKE-LABEL: tail call void @__quantum__qis__x__body(%Qubit* null)
-// QUAKE:       tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:       tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
-// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
-// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
-// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
-// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// QUAKE:       ret void
-
-// CHECK-LABEL: most_probable "101"
+// CHECK: { 101:1000 }
+// CHECK: most_probable "101"

--- a/targettests/execution/mapping_test-1.cpp
+++ b/targettests/execution/mapping_test-1.cpp
@@ -8,7 +8,7 @@
 
 // REQUIRES: c++20
 // clang-format off
-// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t |& FileCheck %s
+// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s &&  FileCheck --check-prefix=QUAKE %s < %t.txt
 // RUN: mkdir -p %t.dir && cp "%iqm_test_src_dir/Adonis.txt" "%t.dir/Adonis Variant.txt" && nvq++ %cpp_std %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%t.dir/Adonis Variant.txt" --emulate && %t
 // clang-format on
 // RUN: nvq++ %cpp_std --enable-mlir %s -o %t
@@ -39,5 +39,17 @@ int main() {
   return 0;
 }
 
-// CHECK: { 101:1000 }
-// CHECK: most_probable "101"
+// QUAKE-LABEL: tail call void @__quantum__qis__x__body(%Qubit* null)
+// QUAKE:       tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
+// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
+// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
+// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
+// QUAKE:       ret void
+
+// CHECK-LABEL: most_probable "101"

--- a/targettests/execution/mapping_test-1.cpp
+++ b/targettests/execution/mapping_test-1.cpp
@@ -8,8 +8,9 @@
 
 // REQUIRES: c++20
 // clang-format off
-// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s &&  FileCheck --check-prefix=QUAKE %s < %t.txt
+// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t |& FileCheck %s
 // RUN: mkdir -p %t.dir && cp "%iqm_test_src_dir/Adonis.txt" "%t.dir/Adonis Variant.txt" && nvq++ %cpp_std %s -o %t --target iqm --iqm-machine Adonis --mapping-file "%t.dir/Adonis Variant.txt" --emulate && %t
+// clang-format on
 // RUN: nvq++ %cpp_std --enable-mlir %s -o %t
 // RUN: rm -rf %t.txt %t.dir
 
@@ -38,17 +39,5 @@ int main() {
   return 0;
 }
 
-// QUAKE-LABEL: tail call void @__quantum__qis__x__body(%Qubit* null)
-// QUAKE:       tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:       tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
-// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
-// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
-// QUAKE:       tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
-// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// QUAKE:       tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.{{.*}}, i64 0, i64 0))
-// QUAKE:       ret void
-
-// CHECK-LABEL: most_probable "101"
+// CHECK: { 101:1000 }
+// CHECK: most_probable "101"

--- a/targettests/execution/mapping_test-2-cpp17.cpp
+++ b/targettests/execution/mapping_test-2-cpp17.cpp
@@ -8,7 +8,7 @@
 
 // REQUIRES: c++17
 // clang-format off
-// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s && FileCheck --check-prefix=QUAKE %s < %t.txt
+// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s --check-prefix=STDOUT && FileCheck %s < %t.txt
 // clang-format on
 
 #include <cudaq.h>
@@ -34,20 +34,20 @@ int main() {
   return 0;
 }
 
-// QUAKE:         tail call void @__quantum__qis__x__body(%Qubit* null)
-// QUAKE:         tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:         tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:         tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:         tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
-// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
-// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
-// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
-// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253000, i64 0, i64 0))
-// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253100, i64 0, i64 0))
-// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253200, i64 0, i64 0))
-// QUAKE:         ret void
-// CHECK-DAG: __global__ : { 101:1000 }
-// CHECK-DAG: result%0 : { 1:1000 }
-// CHECK-DAG: result%1 : { 0:1000 }
-// CHECK-DAG: result%2 : { 1:1000 }
-// CHECK-DAG: most_probable "101"
+// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* null)
+// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// CHECK:         tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
+// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
+// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
+// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253000, i64 0, i64 0))
+// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253100, i64 0, i64 0))
+// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253200, i64 0, i64 0))
+// CHECK:         ret void
+// STDOUT-DAG: __global__ : { 101:1000 }
+// STDOUT-DAG: result%0 : { 1:1000 }
+// STDOUT-DAG: result%1 : { 0:1000 }
+// STDOUT-DAG: result%2 : { 1:1000 }
+// STDOUT-DAG: most_probable "101"

--- a/targettests/execution/mapping_test-2-cpp17.cpp
+++ b/targettests/execution/mapping_test-2-cpp17.cpp
@@ -8,7 +8,7 @@
 
 // REQUIRES: c++17
 // clang-format off
-// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t |& FileCheck %s
+// RUN: nvq++ %cpp_std %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s && FileCheck --check-prefix=QUAKE %s < %t.txt
 // clang-format on
 
 #include <cudaq.h>
@@ -34,6 +34,18 @@ int main() {
   return 0;
 }
 
+// QUAKE:         tail call void @__quantum__qis__x__body(%Qubit* null)
+// QUAKE:         tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:         tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:         tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:         tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
+// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
+// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
+// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253000, i64 0, i64 0))
+// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253100, i64 0, i64 0))
+// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253200, i64 0, i64 0))
+// QUAKE:         ret void
 // CHECK-DAG: __global__ : { 101:1000 }
 // CHECK-DAG: result%0 : { 1:1000 }
 // CHECK-DAG: result%1 : { 0:1000 }

--- a/targettests/execution/mapping_test-2-cpp17.cpp
+++ b/targettests/execution/mapping_test-2-cpp17.cpp
@@ -34,16 +34,8 @@ int main() {
   return 0;
 }
 
-// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* null)
-// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
-// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
-// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
-// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253000, i64 0, i64 0))
-// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253100, i64 0, i64 0))
-// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253200, i64 0, i64 0))
-// CHECK:         ret void
-// CHECK:         most_probable "101"
+// CHECK-DAG: __global__ : { 101:1000 }
+// CHECK-DAG: result%0 : { 1:1000 }
+// CHECK-DAG: result%1 : { 0:1000 }
+// CHECK-DAG: result%2 : { 1:1000 }
+// CHECK-DAG: most_probable "101"

--- a/targettests/execution/mapping_test-2.cpp
+++ b/targettests/execution/mapping_test-2.cpp
@@ -8,7 +8,7 @@
 
 // REQUIRES: c++20
 // clang-format off
-// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t |& FileCheck %s
+// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s &&  FileCheck --check-prefix=QUAKE %s < %t.txt
 // clang-format on
 
 #include <cudaq.h>
@@ -34,6 +34,18 @@ int main() {
   return 0;
 }
 
+// QUAKE:         tail call void @__quantum__qis__x__body(%Qubit* null)
+// QUAKE:         tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:         tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:         tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// QUAKE:         tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
+// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
+// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
+// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253000, i64 0, i64 0))
+// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253100, i64 0, i64 0))
+// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253200, i64 0, i64 0))
+// QUAKE:         ret void
 // CHECK-DAG: __global__ : { 101:1000 }
 // CHECK-DAG: result%0 : { 1:1000 }
 // CHECK-DAG: result%1 : { 0:1000 }

--- a/targettests/execution/mapping_test-2.cpp
+++ b/targettests/execution/mapping_test-2.cpp
@@ -8,7 +8,7 @@
 
 // REQUIRES: c++20
 // clang-format off
-// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s &&  FileCheck --check-prefix=QUAKE %s < %t.txt
+// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck --check-prefix=STDOUT %s && FileCheck %s < %t.txt
 // clang-format on
 
 #include <cudaq.h>
@@ -34,20 +34,20 @@ int main() {
   return 0;
 }
 
-// QUAKE:         tail call void @__quantum__qis__x__body(%Qubit* null)
-// QUAKE:         tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:         tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:         tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// QUAKE:         tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
-// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
-// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
-// QUAKE:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
-// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253000, i64 0, i64 0))
-// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253100, i64 0, i64 0))
-// QUAKE:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253200, i64 0, i64 0))
-// QUAKE:         ret void
-// CHECK-DAG: __global__ : { 101:1000 }
-// CHECK-DAG: result%0 : { 1:1000 }
-// CHECK-DAG: result%1 : { 0:1000 }
-// CHECK-DAG: result%2 : { 1:1000 }
-// CHECK-DAG: most_probable "101"
+// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* null)
+// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// CHECK:         tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
+// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
+// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
+// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253000, i64 0, i64 0))
+// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253100, i64 0, i64 0))
+// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253200, i64 0, i64 0))
+// CHECK:         ret void
+// STDOUT-DAG: __global__ : { 101:1000 }
+// STDOUT-DAG: result%0 : { 1:1000 }
+// STDOUT-DAG: result%1 : { 0:1000 }
+// STDOUT-DAG: result%2 : { 1:1000 }
+// STDOUT-DAG: most_probable "101"

--- a/targettests/execution/mapping_test-2.cpp
+++ b/targettests/execution/mapping_test-2.cpp
@@ -34,16 +34,8 @@ int main() {
   return 0;
 }
 
-// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* null)
-// CHECK:         tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__swap__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
-// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* writeonly null)
-// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull writeonly inttoptr (i64 1 to %Result*))
-// CHECK:         tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull writeonly inttoptr (i64 2 to %Result*))
-// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253000, i64 0, i64 0))
-// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253100, i64 0, i64 0))
-// CHECK:         tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 2 to %Result*), i8* nonnull getelementptr inbounds ([9 x i8], [9 x i8]* @cstr.726573756C74253200, i64 0, i64 0))
-// CHECK:         ret void
-// CHECK:         most_probable "101"
+// CHECK-DAG: __global__ : { 101:1000 }
+// CHECK-DAG: result%0 : { 1:1000 }
+// CHECK-DAG: result%1 : { 0:1000 }
+// CHECK-DAG: result%2 : { 1:1000 }
+// CHECK-DAG: most_probable "101"

--- a/targettests/execution/qspan_slices.cpp
+++ b/targettests/execution/qspan_slices.cpp
@@ -49,5 +49,5 @@ int main() {
 
 // For this test, we should see the mapping pass run, but there should be no
 // mapping_v2p attribute applied anywhere thereafter.
-// DISABLE: IR Dump Before MappingPass
+// DISABLE: IR Dump Before MappingFunc
 // DISABLE-NOT: mapping_v2p

--- a/test/Quake/wires_to_wireset.qke
+++ b/test/Quake/wires_to_wireset.qke
@@ -8,13 +8,6 @@
 
 // RUN: cudaq-opt --add-wireset --assign-wire-indices %s | FileCheck %s
 
-func.func @anotherFunc() {
-  %0 = quake.null_wire
-  %measOut, %wires = quake.mz %0 : (!quake.wire) -> (!quake.measure, !quake.wire)
-  quake.sink %wires : !quake.wire
-  return
-}
-
 func.func @__nvqpp__mlirgen__run_test() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %0 = quake.null_wire
   %1 = quake.h %0 : (!quake.wire) -> !quake.wire
@@ -27,33 +20,23 @@ func.func @__nvqpp__mlirgen__run_test() attributes {"cudaq-entrypoint", "cudaq-k
     quake.sink %wires_1 : !quake.wire
   } else {
   }
-  call @anotherFunc() : () -> ()
   quake.sink %wires : !quake.wire
   return
 }
 
-// CHECK-LABEL:   quake.wire_set @wires_anotherFunc[2147483647] attributes {sym_visibility = "private"}
-// CHECK:         quake.wire_set @wires___nvqpp__mlirgen__run_test[2147483647] attributes {sym_visibility = "private"}
-
-// CHECK-LABEL:   func.func @anotherFunc() {
-// CHECK:           %[[VAL_0:.*]] = quake.borrow_wire @wires_anotherFunc[0] : !quake.wire
-// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = quake.mz %[[VAL_0]] : (!quake.wire) -> (!quake.measure, !quake.wire)
-// CHECK:           quake.return_wire %[[VAL_2]] : !quake.wire
-// CHECK:           return
-// CHECK:         }
+// CHECK-LABEL:   quake.wire_set @wires[2147483647]
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__run_test() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_0:.*]] = quake.borrow_wire @wires___nvqpp__mlirgen__run_test[0] : !quake.wire
+// CHECK:           %[[VAL_0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
 // CHECK:           %[[VAL_1:.*]] = quake.h %[[VAL_0]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_4:.*]] = quake.discriminate %[[VAL_2]] : (!quake.measure) -> i1
 // CHECK:           cc.if(%[[VAL_4]]) {
-// CHECK:             %[[VAL_5:.*]] = quake.borrow_wire @wires___nvqpp__mlirgen__run_test[1] : !quake.wire
+// CHECK:             %[[VAL_5:.*]] = quake.borrow_wire @wires[1] : !quake.wire
 // CHECK:             %[[VAL_6:.*]] = quake.h %[[VAL_5]] : (!quake.wire) -> !quake.wire
 // CHECK:             %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:             quake.return_wire %[[VAL_8]] : !quake.wire
 // CHECK:           }
-// CHECK:           call @anotherFunc() : () -> ()
 // CHECK:           quake.return_wire %[[VAL_3]] : !quake.wire
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/wires_to_wireset.qke
+++ b/test/Quake/wires_to_wireset.qke
@@ -8,6 +8,13 @@
 
 // RUN: cudaq-opt --add-wireset --assign-wire-indices %s | FileCheck %s
 
+func.func @anotherFunc() {
+  %0 = quake.null_wire
+  %measOut, %wires = quake.mz %0 : (!quake.wire) -> (!quake.measure, !quake.wire)
+  quake.sink %wires : !quake.wire
+  return
+}
+
 func.func @__nvqpp__mlirgen__run_test() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
   %0 = quake.null_wire
   %1 = quake.h %0 : (!quake.wire) -> !quake.wire
@@ -20,23 +27,33 @@ func.func @__nvqpp__mlirgen__run_test() attributes {"cudaq-entrypoint", "cudaq-k
     quake.sink %wires_1 : !quake.wire
   } else {
   }
+  call @anotherFunc() : () -> ()
   quake.sink %wires : !quake.wire
   return
 }
 
-// CHECK-LABEL:   quake.wire_set @wires[2147483647]
+// CHECK-LABEL:   quake.wire_set @wires_anotherFunc[2147483647] attributes {sym_visibility = "private"}
+// CHECK:         quake.wire_set @wires___nvqpp__mlirgen__run_test[2147483647] attributes {sym_visibility = "private"}
+
+// CHECK-LABEL:   func.func @anotherFunc() {
+// CHECK:           %[[VAL_0:.*]] = quake.borrow_wire @wires_anotherFunc[0] : !quake.wire
+// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = quake.mz %[[VAL_0]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:           quake.return_wire %[[VAL_2]] : !quake.wire
+// CHECK:           return
+// CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__run_test() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_0:.*]] = quake.borrow_wire @wires[0] : !quake.wire
+// CHECK:           %[[VAL_0:.*]] = quake.borrow_wire @wires___nvqpp__mlirgen__run_test[0] : !quake.wire
 // CHECK:           %[[VAL_1:.*]] = quake.h %[[VAL_0]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = quake.mz %[[VAL_1]] : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_4:.*]] = quake.discriminate %[[VAL_2]] : (!quake.measure) -> i1
 // CHECK:           cc.if(%[[VAL_4]]) {
-// CHECK:             %[[VAL_5:.*]] = quake.borrow_wire @wires[1] : !quake.wire
+// CHECK:             %[[VAL_5:.*]] = quake.borrow_wire @wires___nvqpp__mlirgen__run_test[1] : !quake.wire
 // CHECK:             %[[VAL_6:.*]] = quake.h %[[VAL_5]] : (!quake.wire) -> !quake.wire
 // CHECK:             %[[VAL_7:.*]], %[[VAL_8:.*]] = quake.mz %[[VAL_6]] : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:             quake.return_wire %[[VAL_8]] : !quake.wire
 // CHECK:           }
+// CHECK:           call @anotherFunc() : () -> ()
 // CHECK:           quake.return_wire %[[VAL_3]] : !quake.wire
 // CHECK:           return
 // CHECK:         }

--- a/test/Transforms/mapping_errors.qke
+++ b/test/Transforms/mapping_errors.qke
@@ -1,0 +1,64 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --qubit-mapping=device=path\(3\) %s -split-input-file -verify-diagnostics
+
+// expected-error @+1 {{no borrow_wire ops found in test_00}}
+func.func @test_00() {
+  %0 = quake.null_wire
+  %1 = quake.null_wire
+  %2 = quake.null_wire
+  %3:2 = quake.x [%1] %0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %4:2 = quake.x [%3#0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %5:2 = quake.x [%4#1] %3#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.sink %4#0 : !quake.wire
+  quake.sink %5#0 : !quake.wire
+  quake.sink %5#1 : !quake.wire
+  return
+}
+
+// -----
+
+quake.wire_set @wires_01[10]
+
+func.func @test_01() {
+  %0 = quake.borrow_wire @wires_01[0] : !quake.wire
+  // expected-error @+1 {{the mapper requires borrow operations and prohibits null wires}}
+  %1 = quake.null_wire
+  %2 = quake.null_wire
+  %3:2 = quake.x [%1] %0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %4:2 = quake.x [%3#0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  %5:2 = quake.x [%4#1] %3#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+  quake.sink %4#0 : !quake.wire
+  quake.sink %5#0 : !quake.wire
+  quake.return_wire %5#1 : !quake.wire
+  return
+}
+
+// -----
+
+quake.wire_set @wires_02[10]
+
+func.func @test_02() {
+  %0 = quake.borrow_wire @wires_02[0] : !quake.wire
+  // expected-error @+1 {{the mapper requires borrow operations and prohibits reference semantics}}
+  %1 = quake.alloca !quake.ref
+  %2 = quake.alloca !quake.ref
+  %3 = quake.alloca !quake.ref
+  quake.return_wire %0 : !quake.wire
+  return
+}
+
+// -----
+
+quake.wire_set @wires_03[10]
+
+// expected-error @+1 {{no borrow_wire ops found in test_03}}
+func.func @test_03() {
+  return
+}

--- a/test/Transforms/mapping_non_unitaries.qke
+++ b/test/Transforms/mapping_non_unitaries.qke
@@ -6,7 +6,6 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --qubit-mapping=device=path %s | CircuitCheck --up-to-mapping %s
 // RUN: cudaq-opt --qubit-mapping=device=path\(5\) %s | CircuitCheck --up-to-mapping %s
 // RUN: cudaq-opt --qubit-mapping=device=ring\(5\) %s | CircuitCheck --up-to-mapping %s
 // RUN: cudaq-opt --qubit-mapping=device=star\(5,2\) %s | CircuitCheck --up-to-mapping %s
@@ -14,7 +13,6 @@
 // RUN: cudaq-opt --qubit-mapping=device=grid\(3,3\) %s | CircuitCheck --up-to-mapping %s
 // RUN: cudaq-opt --qubit-mapping=device=grid\(1,5\) %s | CircuitCheck --up-to-mapping %s
 // RUN: cudaq-opt --qubit-mapping=device=grid\(5,1\) %s | CircuitCheck --up-to-mapping %s
-// RUN: cudaq-opt --qubit-mapping=device=path %s | FileCheck %s
 // RUN: cudaq-opt --qubit-mapping=device=path\(5\) %s | FileCheck %s
 // RUN: cudaq-opt --qubit-mapping=device=ring\(5\) %s | FileCheck %s
 // RUN: cudaq-opt --qubit-mapping=device=star\(5,2\) %s | FileCheck --check-prefix=STAR52 %s
@@ -23,32 +21,34 @@
 // RUN: cudaq-opt --qubit-mapping=device=grid\(1,5\) %s | FileCheck %s
 // RUN: cudaq-opt --qubit-mapping=device=grid\(5,1\) %s | FileCheck %s
 
+quake.wire_set @wires[2147483647]
+
 func.func @test_measurement() {
-  %0 = quake.null_wire
-  %1 = quake.null_wire
-  %2 = quake.null_wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
+  %1 = quake.borrow_wire @wires[1] : !quake.wire
+  %2 = quake.borrow_wire @wires[2] : !quake.wire
   %3:2 = quake.x [%1] %0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %4:2 = quake.x [%3#0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %5:2 = quake.x [%4#1] %3#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %bits, %wires:3 = quake.mz %5#1, %4#0, %5#0 name "result": (!quake.wire, !quake.wire, !quake.wire) -> (!cc.stdvec<!quake.measure>, !quake.wire, !quake.wire, !quake.wire)
-  quake.sink %wires#0 : !quake.wire
-  quake.sink %wires#1 : !quake.wire
-  quake.sink %wires#2 : !quake.wire
+  quake.return_wire %wires#0 : !quake.wire
+  quake.return_wire %wires#1 : !quake.wire
+  quake.return_wire %wires#2 : !quake.wire
   return
 }
 
 // CHECK-LABEL:   func.func @test_measurement() attributes {mapping_reorder_idx = [0, 2, 1], mapping_v2p = [0, 2, 1]} {
-// CHECK:           %[[VAL_0:.*]] = quake.null_wire
-// CHECK:           %[[VAL_1:.*]] = quake.null_wire
-// CHECK:           %[[VAL_2:.*]] = quake.null_wire
+// CHECK:           %[[VAL_0:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_1:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_2:.*]] = quake.borrow_wire @mapped_wireset
 // CHECK:           %[[VAL_3:.*]]:2 = quake.x {{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_4:.*]]:2 = quake.x {{\[}}%[[VAL_3]]#0] %[[VAL_2]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_5:.*]]:2 = quake.swap %[[VAL_4]]#1, %[[VAL_4]]#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_6:.*]]:2 = quake.x {{\[}}%[[VAL_5]]#1] %[[VAL_3]]#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]]:3 = quake.mz %[[VAL_6]]#1, %[[VAL_5]]#0, %[[VAL_6]]#0 name "result" : (!quake.wire, !quake.wire, !quake.wire) -> (!cc.stdvec<!quake.measure>, !quake.wire, !quake.wire, !quake.wire)
-// CHECK-DAG:       quake.sink %[[VAL_8]]#0 : !quake.wire
-// CHECK-DAG:       quake.sink %[[VAL_8]]#1 : !quake.wire
-// CHECK-DAG:       quake.sink %[[VAL_8]]#2 : !quake.wire
+// CHECK-DAG:       quake.return_wire %[[VAL_8]]#0 : !quake.wire
+// CHECK-DAG:       quake.return_wire %[[VAL_8]]#1 : !quake.wire
+// CHECK-DAG:       quake.return_wire %[[VAL_8]]#2 : !quake.wire
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Transforms/mapping_phased_rx.qke
+++ b/test/Transforms/mapping_phased_rx.qke
@@ -9,12 +9,13 @@
 // RUN: cudaq-opt '--qubit-mapping=device=star(5,2)' %s | FileCheck %s
 
 module {
+  quake.wire_set @wires[2147483647]
   func.func @__nvqpp__mlirgen__ghzILm2EE() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %cst = arith.constant 1.5707963267948966 : f64
     %cst_0 = arith.constant 3.1415926535897931 : f64
     %cst_1 = arith.constant 0.000000e+00 : f64
-    %0 = quake.null_wire
-    %1 = quake.null_wire
+    %0 = quake.borrow_wire @wires[0] : !quake.wire
+    %1 = quake.borrow_wire @wires[1] : !quake.wire
     %2 = quake.phased_rx (%cst, %cst) %0 : (f64, f64, !quake.wire) -> !quake.wire
     %3 = quake.phased_rx (%cst_0, %cst_1) %2 : (f64, f64, !quake.wire) -> !quake.wire
     %4 = quake.phased_rx (%cst, %cst) %1 : (f64, f64, !quake.wire) -> !quake.wire
@@ -23,8 +24,8 @@ module {
     %7 = quake.phased_rx (%cst, %cst) %6#1 : (f64, f64, !quake.wire) -> !quake.wire
     %8 = quake.phased_rx (%cst_0, %cst_1) %7 : (f64, f64, !quake.wire) -> !quake.wire
     %bits, %wires = quake.mz %6#0 name "result": (!quake.wire) -> (!quake.measure, !quake.wire)
-    quake.sink %wires : !quake.wire
-    quake.sink %8 : !quake.wire
+    quake.return_wire %wires : !quake.wire
+    quake.return_wire %8 : !quake.wire
     return
   }
 }
@@ -33,9 +34,9 @@ module {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1.5707963267948966 : f64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 3.1415926535897931 : f64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_3:.*]] = quake.null_wire
-// CHECK:           %[[VAL_4:.*]] = quake.null_wire
-// CHECK:           %[[VAL_5:.*]] = quake.null_wire
+// CHECK:           %[[VAL_3:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_4:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_5:.*]] = quake.borrow_wire @mapped_wireset
 // CHECK:           %[[VAL_6:.*]] = quake.phased_rx (%[[VAL_0]], %[[VAL_0]]) %[[VAL_3]] : (f64, f64, !quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_7:.*]] = quake.phased_rx (%[[VAL_1]], %[[VAL_2]]) %[[VAL_6]] : (f64, f64, !quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_8:.*]] = quake.phased_rx (%[[VAL_0]], %[[VAL_0]]) %[[VAL_4]] : (f64, f64, !quake.wire) -> !quake.wire
@@ -45,8 +46,8 @@ module {
 // CHECK:           %[[VAL_12:.*]] = quake.phased_rx (%[[VAL_0]], %[[VAL_0]]) %[[VAL_11]]#1 : (f64, f64, !quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_13:.*]] = quake.phased_rx (%[[VAL_1]], %[[VAL_2]]) %[[VAL_12]] : (f64, f64, !quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = quake.mz %[[VAL_11]]#0 name "result" : (!quake.wire) -> (!quake.measure, !quake.wire)
-// CHECK:           quake.sink %[[VAL_10]]#0 : !quake.wire
-// CHECK:           quake.sink %[[VAL_13]] : !quake.wire
-// CHECK:           quake.sink %[[VAL_15]] : !quake.wire
+// CHECK:           quake.return_wire %[[VAL_10]]#0 : !quake.wire
+// CHECK:           quake.return_wire %[[VAL_13]] : !quake.wire
+// CHECK:           quake.return_wire %[[VAL_15]] : !quake.wire
 // CHECK:           return
 // CHECK:         }

--- a/test/Transforms/mapping_qspan.qke
+++ b/test/Transforms/mapping_qspan.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --qubit-mapping=device=path --delay-measurements %s | FileCheck %s
+// RUN: cudaq-opt --qubit-mapping=device=path\(5\) --delay-measurements %s | FileCheck %s
 // RUN: cudaq-opt --qubit-mapping=device=ring\(5\) --delay-measurements %s | FileCheck --check-prefix RING %s
 // RUN: cudaq-opt --qubit-mapping=device=grid\(3,3\) --delay-measurements %s | FileCheck --check-prefix GRID %s
 // RUN: cudaq-opt --qubit-mapping=device=star\(5\) --delay-measurements %s | FileCheck --check-prefix STAR50 %s
@@ -14,12 +14,13 @@
 // RUN: cudaq-opt --qubit-mapping=device=star\(5,2\) --delay-measurements %s | FileCheck --check-prefix STAR52 %s
 
 module {
+  quake.wire_set @wires[2147483647]
   func.func @__nvqpp__mlirgen__function_foo._Z3foov() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-    %0 = quake.null_wire
-    %1 = quake.null_wire
-    %2 = quake.null_wire
-    %3 = quake.null_wire
-    %4 = quake.null_wire
+    %0 = quake.borrow_wire @wires[0] : !quake.wire
+    %1 = quake.borrow_wire @wires[1] : !quake.wire
+    %2 = quake.borrow_wire @wires[2] : !quake.wire
+    %3 = quake.borrow_wire @wires[3] : !quake.wire
+    %4 = quake.borrow_wire @wires[4] : !quake.wire
     %5 = quake.x %1 : (!quake.wire) -> !quake.wire
     %6 = quake.x %2 : (!quake.wire) -> !quake.wire
     %7 = quake.x %3 : (!quake.wire) -> !quake.wire
@@ -86,21 +87,21 @@ module {
     %bits_4 = quake.discriminate %bit_4 : (!quake.measure) -> i1
     %58 = cc.compute_ptr %54[3] : (!cc.ptr<!cc.array<i1 x 4>>) -> !cc.ptr<i1>
     cc.store %bits_4, %58 : !cc.ptr<i1>
-    quake.sink %53 : !quake.wire
-    quake.sink %wires : !quake.wire
-    quake.sink %wires_1 : !quake.wire
-    quake.sink %wires_3 : !quake.wire
-    quake.sink %wires_5 : !quake.wire
+    quake.return_wire %53 : !quake.wire
+    quake.return_wire %wires : !quake.wire
+    quake.return_wire %wires_1 : !quake.wire
+    quake.return_wire %wires_3 : !quake.wire
+    quake.return_wire %wires_5 : !quake.wire
     return
   }
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_foo._Z3foov() attributes {"cudaq-entrypoint", "cudaq-kernel", mapping_reorder_idx = [1, 0, 2, 3], mapping_v2p = [2, 1, 0, 3, 4], no_this} {
-// CHECK:           %[[VAL_0:.*]] = quake.null_wire
-// CHECK:           %[[VAL_1:.*]] = quake.null_wire
-// CHECK:           %[[VAL_2:.*]] = quake.null_wire
-// CHECK:           %[[VAL_3:.*]] = quake.null_wire
-// CHECK:           %[[VAL_4:.*]] = quake.null_wire
+// CHECK:           %[[VAL_0:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_1:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_2:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_3:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_4:.*]] = quake.borrow_wire @mapped_wireset
 // CHECK:           %[[VAL_5:.*]] = quake.x %[[VAL_1]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_6:.*]] = quake.x %[[VAL_2]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_7:.*]] = quake.x %[[VAL_3]] : (!quake.wire) -> !quake.wire
@@ -162,23 +163,23 @@ module {
 // CHECK:           %[[VAL_63:.*]] = quake.t %[[VAL_62]]#1 : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_64:.*]] = quake.t %[[VAL_62]]#0 : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_65:.*]] = quake.h %[[VAL_59]] : (!quake.wire) -> !quake.wire
-// CHECK:           quake.sink %[[VAL_65]] : !quake.wire
+// CHECK:           quake.return_wire %[[VAL_65]] : !quake.wire
 // CHECK:           %[[VAL_66:.*]], %[[VAL_67:.*]] = quake.mz %[[VAL_64]] name "result%[[VAL_0]]" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_68:.*]] = quake.discriminate %[[VAL_66]] : (!quake.measure) -> i1
 // CHECK:           cc.store %[[VAL_68]], %[[VAL_12]] : !cc.ptr<i1>
-// CHECK:           quake.sink %[[VAL_67]] : !quake.wire
+// CHECK:           quake.return_wire %[[VAL_67]] : !quake.wire
 // CHECK:           %[[VAL_69:.*]], %[[VAL_70:.*]] = quake.mz %[[VAL_63]] name "result%[[VAL_1]]" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_71:.*]] = quake.discriminate %[[VAL_69]] : (!quake.measure) -> i1
 // CHECK:           cc.store %[[VAL_71]], %[[VAL_13]] : !cc.ptr<i1>
-// CHECK:           quake.sink %[[VAL_70]] : !quake.wire
+// CHECK:           quake.return_wire %[[VAL_70]] : !quake.wire
 // CHECK:           %[[VAL_72:.*]], %[[VAL_73:.*]] = quake.mz %[[VAL_47]] name "result%[[VAL_2]]" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_74:.*]] = quake.discriminate %[[VAL_72]] : (!quake.measure) -> i1
 // CHECK:           cc.store %[[VAL_74]], %[[VAL_14]] : !cc.ptr<i1>
-// CHECK:           quake.sink %[[VAL_73]] : !quake.wire
+// CHECK:           quake.return_wire %[[VAL_73]] : !quake.wire
 // CHECK:           %[[VAL_75:.*]], %[[VAL_76:.*]] = quake.mz %[[VAL_42]]#0 name "result%[[VAL_3]]" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_77:.*]] = quake.discriminate %[[VAL_75]] : (!quake.measure) -> i1
 // CHECK:           cc.store %[[VAL_77]], %[[VAL_15]] : !cc.ptr<i1>
-// CHECK:           quake.sink %[[VAL_76]] : !quake.wire
+// CHECK:           quake.return_wire %[[VAL_76]] : !quake.wire
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Transforms/mapping_unitaries.qke
+++ b/test/Transforms/mapping_unitaries.qke
@@ -6,26 +6,28 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --qubit-mapping=device=path %s | CircuitCheck --up-to-mapping %s
+// RUN: cudaq-opt --qubit-mapping=device=path\(10\) %s | CircuitCheck --up-to-mapping %s
+
+quake.wire_set @wires[2147483647]
 
 func.func @test_00() {
-  %0 = quake.null_wire
-  %1 = quake.null_wire
-  %2 = quake.null_wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
+  %1 = quake.borrow_wire @wires[1] : !quake.wire
+  %2 = quake.borrow_wire @wires[2] : !quake.wire
   %3:2 = quake.x [%1] %0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %4:2 = quake.x [%3#0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %5:2 = quake.x [%4#1] %3#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %4#0 : !quake.wire
-  quake.sink %5#0 : !quake.wire
-  quake.sink %5#1 : !quake.wire
+  quake.return_wire %4#0 : !quake.wire
+  quake.return_wire %5#0 : !quake.wire
+  quake.return_wire %5#1 : !quake.wire
   return
 }
 
 func.func @test_01() {
-  %0 = quake.null_wire
-  %1 = quake.null_wire
-  %2 = quake.null_wire
-  %3 = quake.null_wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
+  %1 = quake.borrow_wire @wires[1] : !quake.wire
+  %2 = quake.borrow_wire @wires[2] : !quake.wire
+  %3 = quake.borrow_wire @wires[3] : !quake.wire
   %4:2 = quake.x [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %5:2 = quake.x [%4#1] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %6:2 = quake.x [%5#0] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
@@ -35,42 +37,42 @@ func.func @test_01() {
   %10:2 = quake.x [%9#0] %7#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %11:2 = quake.x [%9#1] %10#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %12:2 = quake.x [%8#0] %10#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %12#0 : !quake.wire
+  quake.return_wire %12#0 : !quake.wire
   %13:2 = quake.x [%11#1] %11#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %14:2 = quake.x [%12#1] %13#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %15:2 = quake.x [%13#1] %14#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %14#0 : !quake.wire
-  quake.sink %15#0 : !quake.wire
-  quake.sink %15#1 : !quake.wire
+  quake.return_wire %14#0 : !quake.wire
+  quake.return_wire %15#0 : !quake.wire
+  quake.return_wire %15#1 : !quake.wire
   return
 }
 
 func.func @test_02() {
-  %0 = quake.null_wire
-  %1 = quake.null_wire
-  %2 = quake.null_wire
-  %3 = quake.null_wire
-  %5 = quake.null_wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
+  %1 = quake.borrow_wire @wires[1] : !quake.wire
+  %2 = quake.borrow_wire @wires[2] : !quake.wire
+  %3 = quake.borrow_wire @wires[3] : !quake.wire
+  %5 = quake.borrow_wire @wires[4] : !quake.wire
   %6:2 = quake.x [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %7:2 = quake.x [%6#1] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %8:2 = quake.x [%7#0] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %9:2 = quake.x [%7#1] %5 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %10:2 = quake.x [%6#0] %8#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %10#0 : !quake.wire
+  quake.return_wire %10#0 : !quake.wire
   %11:2 = quake.x [%10#1] %9#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %11#1 : !quake.wire
+  quake.return_wire %11#1 : !quake.wire
   %12:2 = quake.x [%11#0] %8#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %9#1 : !quake.wire
-  quake.sink %12#0 : !quake.wire
-  quake.sink %12#1 : !quake.wire
+  quake.return_wire %9#1 : !quake.wire
+  quake.return_wire %12#0 : !quake.wire
+  quake.return_wire %12#1 : !quake.wire
   return
 }
 
 func.func @test_03() {
-  %0 = quake.null_wire
-  %1 = quake.null_wire
-  %2 = quake.null_wire
-  %3 = quake.null_wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
+  %1 = quake.borrow_wire @wires[1] : !quake.wire
+  %2 = quake.borrow_wire @wires[2] : !quake.wire
+  %3 = quake.borrow_wire @wires[3] : !quake.wire
   %4:2 = quake.x [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %5:2 = quake.x [%4#1] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %6:2 = quake.x [%5#0] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
@@ -86,24 +88,24 @@ func.func @test_03() {
   %16:2 = quake.x [%15#1] %15#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %17:2 = quake.x [%16#0] %14#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %18:2 = quake.x [%17#0] %12#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %16#1 : !quake.wire
-  quake.sink %17#1 : !quake.wire
-  quake.sink %18#0 : !quake.wire
-  quake.sink %18#1 : !quake.wire
+  quake.return_wire %16#1 : !quake.wire
+  quake.return_wire %17#1 : !quake.wire
+  quake.return_wire %18#0 : !quake.wire
+  quake.return_wire %18#1 : !quake.wire
   return
 }
 
 func.func @test_04() {
-  %0 = quake.null_wire
-  %1 = quake.null_wire
-  %2 = quake.null_wire
-  %3 = quake.null_wire
-  %4 = quake.null_wire
-  %5 = quake.null_wire
-  %6 = quake.null_wire
-  %7 = quake.null_wire
-  %8 = quake.null_wire
-  %9 = quake.null_wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
+  %1 = quake.borrow_wire @wires[1] : !quake.wire
+  %2 = quake.borrow_wire @wires[2] : !quake.wire
+  %3 = quake.borrow_wire @wires[3] : !quake.wire
+  %4 = quake.borrow_wire @wires[4] : !quake.wire
+  %5 = quake.borrow_wire @wires[5] : !quake.wire
+  %6 = quake.borrow_wire @wires[6] : !quake.wire
+  %7 = quake.borrow_wire @wires[7] : !quake.wire
+  %8 = quake.borrow_wire @wires[8] : !quake.wire
+  %9 = quake.borrow_wire @wires[9] : !quake.wire
   %10:2 = quake.x [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %11:2 = quake.x [%10#1] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %12:2 = quake.x [%11#0] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
@@ -118,97 +120,97 @@ func.func @test_04() {
   %21:2 = quake.x [%10#0] %19#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %22:2 = quake.x [%21#1] %20#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %23:2 = quake.x [%22#0] %19#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %14#0 : !quake.wire
-  quake.sink %16#0 : !quake.wire
-  quake.sink %17#1 : !quake.wire
-  quake.sink %18#0 : !quake.wire
-  quake.sink %18#1 : !quake.wire
-  quake.sink %20#1 : !quake.wire
-  quake.sink %21#0 : !quake.wire
-  quake.sink %22#1 : !quake.wire
-  quake.sink %23#0 : !quake.wire
-  quake.sink %23#1 : !quake.wire
+  quake.return_wire %14#0 : !quake.wire
+  quake.return_wire %16#0 : !quake.wire
+  quake.return_wire %17#1 : !quake.wire
+  quake.return_wire %18#0 : !quake.wire
+  quake.return_wire %18#1 : !quake.wire
+  quake.return_wire %20#1 : !quake.wire
+  quake.return_wire %21#0 : !quake.wire
+  quake.return_wire %22#1 : !quake.wire
+  quake.return_wire %23#0 : !quake.wire
+  quake.return_wire %23#1 : !quake.wire
   return
 }
 
 func.func @test_05() {
-  %0 = quake.null_wire
-  %1 = quake.null_wire
-  %2 = quake.null_wire
-  %3 = quake.null_wire
-  %4 = quake.null_wire
-  %5 = quake.null_wire
-  %6 = quake.null_wire
-  %7 = quake.null_wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
+  %1 = quake.borrow_wire @wires[1] : !quake.wire
+  %2 = quake.borrow_wire @wires[2] : !quake.wire
+  %3 = quake.borrow_wire @wires[3] : !quake.wire
+  %4 = quake.borrow_wire @wires[4] : !quake.wire
+  %5 = quake.borrow_wire @wires[5] : !quake.wire
+  %6 = quake.borrow_wire @wires[6] : !quake.wire
+  %7 = quake.borrow_wire @wires[7] : !quake.wire
   %8:2 = quake.x [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %9:2 = quake.x [%8#1] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %10:2 = quake.x [%9#0] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %11:2 = quake.x [%4] %5 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %12:2 = quake.x [%11#1] %6 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %13:2 = quake.x [%12#0] %7 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %8#0 : !quake.wire
-  quake.sink %9#1 : !quake.wire
-  quake.sink %10#0 : !quake.wire
-  quake.sink %10#1 : !quake.wire
-  quake.sink %11#0 : !quake.wire
-  quake.sink %12#1 : !quake.wire
-  quake.sink %13#0 : !quake.wire
-  quake.sink %13#1 : !quake.wire
+  quake.return_wire %8#0 : !quake.wire
+  quake.return_wire %9#1 : !quake.wire
+  quake.return_wire %10#0 : !quake.wire
+  quake.return_wire %10#1 : !quake.wire
+  quake.return_wire %11#0 : !quake.wire
+  quake.return_wire %12#1 : !quake.wire
+  quake.return_wire %13#0 : !quake.wire
+  quake.return_wire %13#1 : !quake.wire
   return
 }
 
 func.func @test_06() {
-  %0 = quake.null_wire
-  %1 = quake.null_wire
-  %2 = quake.null_wire
-  %3 = quake.null_wire
-  %4 = quake.null_wire
-  %5 = quake.null_wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
+  %1 = quake.borrow_wire @wires[1] : !quake.wire
+  %2 = quake.borrow_wire @wires[2] : !quake.wire
+  %3 = quake.borrow_wire @wires[3] : !quake.wire
+  %4 = quake.borrow_wire @wires[4] : !quake.wire
+  %5 = quake.borrow_wire @wires[5] : !quake.wire
   %6:2 = quake.x [%0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %7:2 = quake.x [%6#1] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %8:2 = quake.x [%6#0] %4 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %9:2 = quake.x [%3] %8#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %10:2 = quake.x [%9#1] %5 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %7#0 : !quake.wire
-  quake.sink %7#1 : !quake.wire
-  quake.sink %8#1 : !quake.wire
-  quake.sink %9#0 : !quake.wire
-  quake.sink %10#0 : !quake.wire
-  quake.sink %10#1 : !quake.wire
+  quake.return_wire %7#0 : !quake.wire
+  quake.return_wire %7#1 : !quake.wire
+  quake.return_wire %8#1 : !quake.wire
+  quake.return_wire %9#0 : !quake.wire
+  quake.return_wire %10#0 : !quake.wire
+  quake.return_wire %10#1 : !quake.wire
   return
 }
 
 func.func @test_07() {
-  %0 = quake.null_wire
-  %1 = quake.null_wire
-  %2 = quake.null_wire
-  %3 = quake.null_wire
-  %4 = quake.null_wire
-  %5 = quake.null_wire  
-  quake.sink %5 : !quake.wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
+  %1 = quake.borrow_wire @wires[1] : !quake.wire
+  %2 = quake.borrow_wire @wires[2] : !quake.wire
+  %3 = quake.borrow_wire @wires[3] : !quake.wire
+  %4 = quake.borrow_wire @wires[4] : !quake.wire
+  %5 = quake.borrow_wire @wires[5] : !quake.wire  
+  quake.return_wire %5 : !quake.wire
   %6:2 = quake.x [%0] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %7:2 = quake.x [%6#1] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %8:2 = quake.x [%7#1] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %9:2 = quake.x [%8#1] %4 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %10:2 = quake.x [%6#0] %9#1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %7#0 : !quake.wire
-  quake.sink %8#0 : !quake.wire
-  quake.sink %9#0 : !quake.wire
-  quake.sink %10#0 : !quake.wire
-  quake.sink %10#1 : !quake.wire
+  quake.return_wire %7#0 : !quake.wire
+  quake.return_wire %8#0 : !quake.wire
+  quake.return_wire %9#0 : !quake.wire
+  quake.return_wire %10#0 : !quake.wire
+  quake.return_wire %10#1 : !quake.wire
   return
 }
 
 func.func @test_08() {
-  %0 = quake.null_wire
+  %0 = quake.borrow_wire @wires[0] : !quake.wire
   %1 = quake.h %0 : (!quake.wire) -> !quake.wire
-  %2 = quake.null_wire
-  %3 = quake.null_wire
+  %2 = quake.borrow_wire @wires[1] : !quake.wire
+  %3 = quake.borrow_wire @wires[2] : !quake.wire
   %4:2 = quake.x [%1] %3 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
   %5:2 = quake.x [%4#0] %2 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
-  quake.sink %4#1 : !quake.wire
-  quake.sink %5#0 : !quake.wire
-  quake.sink %5#1 : !quake.wire
+  quake.return_wire %4#1 : !quake.wire
+  quake.return_wire %5#0 : !quake.wire
+  quake.return_wire %5#1 : !quake.wire
   return
 }
 

--- a/test/Transforms/mapping_with_meas-1.qke
+++ b/test/Transforms/mapping_with_meas-1.qke
@@ -6,12 +6,13 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --qubit-mapping=device=path %s | FileCheck %s
+// RUN: cudaq-opt --qubit-mapping=device=path\(3\) %s | FileCheck %s
 module {
+  quake.wire_set @wires[2147483647]
   func.func @__nvqpp__mlirgen__function_foo._Z3foov() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-    %0 = quake.null_wire
-    %1 = quake.null_wire
-    %2 = quake.null_wire
+    %0 = quake.borrow_wire @wires[0] : !quake.wire
+    %1 = quake.borrow_wire @wires[1] : !quake.wire
+    %2 = quake.borrow_wire @wires[2] : !quake.wire
     %3 = quake.x %0 : (!quake.wire) -> !quake.wire
     %4 = quake.x %1 : (!quake.wire) -> !quake.wire
     %5:2 = quake.x [%3] %4 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
@@ -19,17 +20,17 @@ module {
     %bits, %wires = quake.mz %6#0 name "q0result" : (!quake.wire) -> (!quake.measure, !quake.wire)
     %bits_0, %wires_1 = quake.mz %5#1 name "q1result" : (!quake.wire) -> (!quake.measure, !quake.wire)
     %bits_2, %wires_3 = quake.mz %6#1 name "q2result" : (!quake.wire) -> (!quake.measure, !quake.wire)
-    quake.sink %wires : !quake.wire
-    quake.sink %wires_1 : !quake.wire
-    quake.sink %wires_3 : !quake.wire
+    quake.return_wire %wires : !quake.wire
+    quake.return_wire %wires_1 : !quake.wire
+    quake.return_wire %wires_3 : !quake.wire
     return
   }
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_foo._Z3foov() attributes {"cudaq-entrypoint", "cudaq-kernel", mapping_reorder_idx = [1, 0, 2], mapping_v2p = [1, 0, 2], no_this} {
-// CHECK:           %[[VAL_0:.*]] = quake.null_wire
-// CHECK:           %[[VAL_1:.*]] = quake.null_wire
-// CHECK:           %[[VAL_2:.*]] = quake.null_wire
+// CHECK:           %[[VAL_0:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_1:.*]] = quake.borrow_wire @mapped_wireset
+// CHECK:           %[[VAL_2:.*]] = quake.borrow_wire @mapped_wireset
 // CHECK:           %[[VAL_3:.*]] = quake.x %[[VAL_0]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_4:.*]] = quake.x %[[VAL_1]] : (!quake.wire) -> !quake.wire
 // CHECK:           %[[VAL_5:.*]]:2 = quake.x {{\[}}%[[VAL_3]]] %[[VAL_4]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
@@ -38,8 +39,8 @@ module {
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = quake.mz %[[VAL_7]]#0 name "q0result" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = quake.mz %[[VAL_6]]#0 name "q1result" : (!quake.wire) -> (!quake.measure, !quake.wire)
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = quake.mz %[[VAL_7]]#1 name "q2result" : (!quake.wire) -> (!quake.measure, !quake.wire)
-// CHECK-DAG:       quake.sink %[[VAL_9]] : !quake.wire
-// CHECK-DAG:       quake.sink %[[VAL_11]] : !quake.wire
-// CHECK-DAG:       quake.sink %[[VAL_13]] : !quake.wire
+// CHECK-DAG:       quake.return_wire %[[VAL_9]] : !quake.wire
+// CHECK-DAG:       quake.return_wire %[[VAL_11]] : !quake.wire
+// CHECK-DAG:       quake.return_wire %[[VAL_13]] : !quake.wire
 // CHECK:           return
 // CHECK:         }

--- a/tools/cudaq-opt/cudaq-opt.cpp
+++ b/tools/cudaq-opt/cudaq-opt.cpp
@@ -62,6 +62,7 @@ int main(int argc, char **argv) {
   cudaq::opt::registerUnrollingPipeline();
   cudaq::opt::registerToExecutionManagerCCPipeline();
   cudaq::opt::registerTargetPipelines();
+  cudaq::opt::registerMappingPipeline();
 
   // See if we have been asked to load a pass plugin,
   // if so load it.

--- a/utils/CircuitCheck/UnitaryBuilder.cpp
+++ b/utils/CircuitCheck/UnitaryBuilder.cpp
@@ -29,6 +29,8 @@ LogicalResult UnitaryBuilder::build(func::FuncOp func) {
   auto result = func.walk([&](Operation *op) {
     if (auto nullWireOp = dyn_cast<quake::NullWireOp>(op))
       return allocateQubits(nullWireOp.getResult());
+    if (auto borrowOp = dyn_cast<quake::BorrowWireOp>(op))
+      return allocateQubits(borrowOp.getResult());
     if (auto allocOp = dyn_cast<quake::AllocaOp>(op))
       return allocateQubits(allocOp.getResult());
     if (auto extractOp = dyn_cast<quake::ExtractRefOp>(op))


### PR DESCRIPTION
This PR contains a collection of changes that were originally developed on the `features/qubit-mgmt` branch, but they have been isolated such that they can be merged into `main`, independent of that feature branch. The changes have not been previously reviewed, so they need to be reviewed just like normal in this PR.

* ~~Make the `add-wireset` pass add one `quake.wire_set` per function. The problem with the old approach of one per module is shown in a newly added test case (`test/Quake/wires_to_wireset.qke`). (The problem was that nested functions could borrow the same wire twice, which is not a good idea.) I backed these changes out.~~ Edit: Adam is going to make a separate PR to resolve the issue.
* Make the `qubit-mapping` pass operate on wires from a wire set rather than unnumbered null wires. This is the main point of the PR. This makes the qubit IDs used in the pass explicit rather than implicit. (However, the IDs are still dropped on the floor if the IR goes through the `regtomem` pass, which it does for now; this is no worse than it was before.)
* The `qubit-mapping` pass now manipulates the top level module by adding a `mapped_wireset` symbol in accordance with the user-provided device topology. Hence, the pass was split into a "prep" pass (to operate on the module) and a "func" pass (to operate on each function).
* Update `regtomem` to understand wire sets.
* Update CircuitCheck to understand wire sets to enable the existing mapping tests to continue working.
* Fix a bug in the `quake::WireSetOp::parse` function. The bug only occurred when it was parsing an op with that was set to private.