### PR TITLE
Only check links in files that changed for any given PR

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -162,6 +162,11 @@ jobs:
           echo "llvm_commit=$(git rev-parse @:./tpls/llvm)" >> $GITHUB_OUTPUT
           echo "pybind11_commit=$(git rev-parse @:./tpls/pybind11)" >> $GITHUB_OUTPUT
 
+  repo_checks:
+    name: Repo checks
+    if: github.event_name != 'workflow_run' || needs.metadata.outputs.pull_request_number != ''
+    uses: ./.github/workflows/repo_checks.yml
+
   devdeps:
     name: Build dev dependencies
     needs: metadata

--- a/.github/workflows/repo_checks.yml
+++ b/.github/workflows/repo_checks.yml
@@ -23,7 +23,7 @@ jobs:
         id: convert
         run: |
           pip install "rst-to-myst[sphinx]==0.4.0"
-          echo "is_pr=$([[ ${{ github.event_name }} == 'pull_request' ]] && echo 'yes' || echo 'no')"
+          echo "is_pr=$([[ '${{ github.event_name }}'' == 'pull_request' ]] && echo 'yes' || echo 'no')" >> $GITHUB_OUTPUT
           if ${{ github.event_name == 'pull_request' }}; then
             # Call rst2myst an appropriate files modified in this PR.
             diff_base=${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/repo_checks.yml
+++ b/.github/workflows/repo_checks.yml
@@ -1,6 +1,7 @@
 on:
   workflow_dispatch:
   pull_request:
+  workflow_call:
 
 name: "Basic content checks"
 
@@ -17,15 +18,27 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Convert reStructuredText files to Markdown
+        id: convert
         run: |
           pip install "rst-to-myst[sphinx]==0.4.0"
-          find docs/sphinx/ -type f -name "*.rst" -print0 | xargs -0 rst2myst convert --raise-on-warning
+          echo "is_pr=$([[ ${{ github.event_name }} == 'pull_request' ]] && echo 'yes' || echo 'no')"
+          if ${{ github.event_name == 'pull_request' }}; then
+            # Call rst2myst an appropriate files modified in this PR.
+            diff_base=${{ github.event.pull_request.base.sha }}
+            git rev-list HEAD..$diff_base # fails the step if something went wrong
+            git diff --diff-filter=d --name-only $diff_base -- docs/sphinx | tr '\n' '\0' | xargs -0 rst2myst convert --raise-on-warning
+          else
+            # Call rst2myst an all files.
+            find docs/sphinx/ -type f -name "*.rst" -print0 | xargs -0 rst2myst convert --raise-on-warning
+          fi
 
       - name: Check links in Markdown files
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: "yes"
           config-file: ".github/workflows/config/md_link_check_config.json"        
+          check-modified-files-only: "${{ steps.convert.outputs.is_pr }}"
+          base-branch: "main"
 
   license_headers:
     name: Check license headers

--- a/.github/workflows/repo_checks.yml
+++ b/.github/workflows/repo_checks.yml
@@ -25,7 +25,8 @@ jobs:
           if ${{ github.event_name == 'pull_request' }}; then
             # Call rst2myst an appropriate files modified in this PR.
             diff_base=${{ github.event.pull_request.base.sha }}
-            git rev-list HEAD..$diff_base # fails the step if something went wrong
+            echo "## Changed docs/sphinx files" >> $GITHUB_STEP_SUMMARY
+            git diff --diff-filter=d --name-only $diff_base -- docs/sphinx >> $GITHUB_STEP_SUMMARY
             git diff --diff-filter=d --name-only $diff_base -- docs/sphinx | tr '\n' '\0' | xargs -0 rst2myst convert --raise-on-warning
           else
             # Call rst2myst an all files.

--- a/.github/workflows/repo_checks.yml
+++ b/.github/workflows/repo_checks.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ (github.event_name == 'pull_request' && '0') || '1' }}
 
       - name: Convert reStructuredText files to Markdown
         id: convert

--- a/.github/workflows/repo_checks.yml
+++ b/.github/workflows/repo_checks.yml
@@ -23,7 +23,7 @@ jobs:
         id: convert
         run: |
           pip install "rst-to-myst[sphinx]==0.4.0"
-          echo "is_pr=$([[ '${{ github.event_name }}'' == 'pull_request' ]] && echo 'yes' || echo 'no')" >> $GITHUB_OUTPUT
+          echo "is_pr=$([[ '${{ github.event_name }}' == 'pull_request' ]] && echo 'yes' || echo 'no')" >> $GITHUB_OUTPUT
           if ${{ github.event_name == 'pull_request' }}; then
             # Call rst2myst an appropriate files modified in this PR.
             diff_base=${{ github.event.pull_request.base.sha }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ src="https://github.com/NVIDIA/cuda-quantum/actions/workflows/publishing.yml/bad
 />
 
 <img align="left"
-src="https://github.com/NVIDIA-DOESNOTEXIST/cuda-quantum/actions/workflows/documentation.yml/badge.svg?branch=main"
+src="https://github.com/NVIDIA/cuda-quantum/actions/workflows/documentation.yml/badge.svg?branch=main"
 /> <br/>
 
 <a href="https://zenodo.org/badge/latestdoi/614026597"><img align="left"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ src="https://github.com/NVIDIA/cuda-quantum/actions/workflows/publishing.yml/bad
 />
 
 <img align="left"
-src="https://github.com/NVIDIA/cuda-quantum/actions/workflows/documentation.yml/badge.svg?branch=main"
+src="https://github.com/NVIDIA-DOESNOTEXIST/cuda-quantum/actions/workflows/documentation.yml/badge.svg?branch=main"
 /> <br/>
 
 <a href="https://zenodo.org/badge/latestdoi/614026597"><img align="left"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ packages][github_packages] deployed on the GitHub Container Registry. For more
 information about building CUDA-Q from source, see [these
 instructions](./Building.md).
 
-[cuda_quantum_docs]: https://nvidia.github.io/cuda-quantumANOTHERBROKENLINK/latest
+[cuda_quantum_docs]: https://nvidia.github.io/cuda-quantum/latest
 [official_install]: https://nvidia.github.io/cuda-quantum/latest/using/quick_start.html#install-cuda-q
 [github_packages]:
     https://github.com/orgs/NVIDIA/packages?repo_name=cuda-quantum

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ packages][github_packages] deployed on the GitHub Container Registry. For more
 information about building CUDA-Q from source, see [these
 instructions](./Building.md).
 
-[cuda_quantum_docs]: https://nvidia.github.io/cuda-quantum/latest
+[cuda_quantum_docs]: https://nvidia.github.io/cuda-quantumANOTHERBROKENLINK/latest
 [official_install]: https://nvidia.github.io/cuda-quantum/latest/using/quick_start.html#install-cuda-q
 [github_packages]:
     https://github.com/orgs/NVIDIA/packages?repo_name=cuda-quantum

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -21,7 +21,7 @@ You are browsing the documentation for |version| version of CUDA-Q. You can find
       Basics <using/basics/basics.rst>
       Examples <using/examples/examples.rst>
       Applications <using/tutorials.rst>
-      Backends <using/backends/backends.rst>
+      Backends <using/backends/backendsbroken.rst>
       Installation <using/install/install.rst>
       Integration <using/integration/integration.rst>
       Extending <using/extending/extending.rst>

--- a/docs/sphinx/releases.rst
+++ b/docs/sphinx/releases.rst
@@ -8,7 +8,7 @@ The latest version of CUDA-Q is on the main branch of our `GitHub repository <ht
 
 - `Docker image (nightly builds) <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nightly/containers/cuda-quantum>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/latest>`__
-- `Examples <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examples>`__
+- `Examples <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examplesBROKENLINK>`__
 
 **0.8.0**
 


### PR DESCRIPTION
We're getting too many sporadic link check failures for link checks that haven't actually changed and aren't permanently down. Update the workflow to only check the links in the files that have changed in any given PR.