### PR TITLE
Make assign-wire-indices skip functions with calls

### DIFF
--- a/lib/Optimizer/Transforms/WiresToWiresets.cpp
+++ b/lib/Optimizer/Transforms/WiresToWiresets.cpp
@@ -8,6 +8,7 @@
 
 #include "cudaq/Frontend/nvqpp/AttributeNames.h"
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
+#include "cudaq/Optimizer/Dialect/Characteristics.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
@@ -73,6 +74,13 @@ struct AssignWireIndicesPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
+
+    // TODO: someday we may want to allow calls to non-quantum functions
+    if (cudaq::opt::hasCallOp(func)) {
+      func.emitRemark(
+          "AssignWireIndicesPass function has calls, pass will not be run.");
+      return;
+    }
 
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);

--- a/lib/Optimizer/Transforms/WiresToWiresets.cpp
+++ b/lib/Optimizer/Transforms/WiresToWiresets.cpp
@@ -84,7 +84,7 @@ struct AssignWireIndicesPass
 
     // Only run on the entrypoint, the expectation is that inlining has been
     // done already, so there should only be one kernel remaining.
-    if (!func->hasAttr("cudaq-entrypoint"))
+    if (!func->hasAttr(cudaq::entryPointAttrName))
       return;
 
     auto *ctx = &getContext();

--- a/lib/Optimizer/Transforms/WiresToWiresets.cpp
+++ b/lib/Optimizer/Transforms/WiresToWiresets.cpp
@@ -82,6 +82,11 @@ struct AssignWireIndicesPass
       return;
     }
 
+    // Only run on the entrypoint, the expectation is that inlining has been
+    // done already, so there should only be one kernel remaining.
+    if (!func->hasAttr("cudaq-entrypoint"))
+      return;
+
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     unsigned x = 0;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
Multiple functions that allocate qubits will cause `assign-wire-indices` to produce duplicate `borrow_wire` ops (i.e., two `borrow_wire` ops with the same index). This change ensures that `assign-wire-indices` refuses to run on kernels with multiple functions to ensure that each `borrow_wire` is unique.
