### PR TITLE
[core] Add dynamic tuple layout handling.

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -151,12 +151,14 @@ public:
       llvm::ArrayRef<clang::Decl *> reachableFuncs,
       MangledKernelNamesMap &namesMap, clang::CompilerInstance &ci,
       clang::ItaniumMangleContext *mangler,
-      std::unordered_map<std::string, std::string> &customOperations)
+      std::unordered_map<std::string, std::string> &customOperations,
+      bool tuplesAreReversed)
       : astContext(astCtx), mlirContext(mlirCtx), builder(bldr), module(module),
         symbolTable(symTab), functionsToEmit(funcsToEmit),
         reachableFunctions(reachableFuncs), namesMap(namesMap),
         compilerInstance(ci), mangler(mangler),
-        customOperationNames(customOperations) {}
+        customOperationNames(customOperations),
+        tuplesAreReversed(tuplesAreReversed) {}
 
   /// `nvq++` renames quantum kernels to differentiate them from classical C++
   /// code. This renaming is done on function names. \p tag makes it easier
@@ -618,6 +620,7 @@ private:
   llvm::DenseMap<clang::RecordType *, mlir::Type> records;
 
   // State Flags
+  const bool tuplesAreReversed : 1;
   bool skipCompoundScope : 1 = false;
   bool isEntry : 1 = false;
   /// If there is a catastrophic error in the bridge (there is no rational way
@@ -687,6 +690,8 @@ public:
 
     // Keep track of user custom operation names.
     std::unordered_map<std::string, std::string> customOperationNames;
+
+    bool tuplesAreReversed = false;
 
     /// Add a placeholder definition to the module in \p visitor for the
     /// function, \p funcDecl. This is used for adding the host-side function

--- a/include/cudaq/Optimizer/Builder/Runtime.h
+++ b/include/cudaq/Optimizer/Builder/Runtime.h
@@ -27,4 +27,6 @@ static constexpr const char launchKernelStreamlinedFuncName[] =
     "streamlinedLaunchKernel";
 static constexpr const char launchKernelHybridFuncName[] = "hybridLaunchKernel";
 
+static constexpr const char mangledNameMap[] = "quake.mangled_name_map";
+
 } // namespace cudaq::runtime

--- a/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -301,10 +301,8 @@ public:
   }
 
   bool isTupleReverseVar(clang::VarDecl *decl) {
-    if (cudaq::isInNamespace(decl, "cudaq")) {
-      auto name = decl->getName();
-      return name == "TupleIsReverse";
-    }
+    if (cudaq::isInNamespace(decl, "cudaq"))
+      return decl->getName().equals("TupleIsReverse");
     return false;
   }
 

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -265,6 +265,8 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
           return false;
         members.push_back(popType());
       }
+      if (tuplesAreReversed)
+        std::reverse(members.begin(), members.end());
       return pushType(cc::StructType::get(ctx, members));
     }
     if (ignoredClass(x))

--- a/lib/Optimizer/Transforms/AggressiveEarlyInlining.cpp
+++ b/lib/Optimizer/Transforms/AggressiveEarlyInlining.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/IR/Diagnostics.h"
@@ -34,8 +35,8 @@ static bool isIndirectFunc(llvm::StringRef funcName,
 static std::optional<llvm::StringMap<llvm::StringRef>>
 getConversionMap(ModuleOp module) {
   llvm::StringMap<llvm::StringRef> result;
-  if (auto mangledNameMap =
-          module->getAttrOfType<DictionaryAttr>("quake.mangled_name_map")) {
+  if (auto mangledNameMap = module->getAttrOfType<DictionaryAttr>(
+          cudaq::runtime::mangledNameMap)) {
     for (auto namedAttr : mangledNameMap) {
       auto key = namedAttr.getName();
       auto val = namedAttr.getValue().cast<StringAttr>().getValue();

--- a/runtime/common/ArgumentConversion.cpp
+++ b/runtime/common/ArgumentConversion.cpp
@@ -97,8 +97,6 @@ static Value genConstant(OpBuilder &, cudaq::cc::StdvecType, void *,
                          ModuleOp substMod, llvm::DataLayout &);
 static Value genConstant(OpBuilder &, cudaq::cc::StructType, void *,
                          ModuleOp substMod, llvm::DataLayout &);
-static Value genConstant(OpBuilder &, TupleType, void *, ModuleOp substMod,
-                         llvm::DataLayout &);
 static Value genConstant(OpBuilder &, cudaq::cc::ArrayType, void *,
                          ModuleOp substMod, llvm::DataLayout &);
 
@@ -159,35 +157,7 @@ Value dispatchSubtype(OpBuilder &builder, Type ty, void *p, ModuleOp substMod,
       .Case([&](cudaq::cc::ArrayType ty) {
         return genConstant(builder, ty, p, substMod, layout);
       })
-      .Case([&](TupleType ty) {
-        return genConstant(builder, ty, p, substMod, layout);
-      })
       .Default({});
-}
-
-// Clang++ lays std::tuples out in reverse order.
-Value genConstant(OpBuilder &builder, TupleType tupTy, void *p,
-                  ModuleOp substMod, llvm::DataLayout &layout) {
-  if (tupTy.getTypes().empty())
-    return {};
-  SmallVector<Type> members;
-  for (auto ty : llvm::reverse(tupTy.getTypes()))
-    members.emplace_back(ty);
-  auto *ctx = builder.getContext();
-  auto strTy = cudaq::cc::StructType::get(ctx, members);
-  // FIXME: read out in reverse order, but build in forward order.
-  auto revCon = genConstant(builder, strTy, p, substMod, layout);
-  auto fwdTy = cudaq::cc::StructType::get(ctx, tupTy.getTypes());
-  auto loc = builder.getUnknownLoc();
-  Value aggie = builder.create<cudaq::cc::UndefOp>(loc, fwdTy);
-  auto n = fwdTy.getMembers().size();
-  for (auto iter : llvm::enumerate(fwdTy.getMembers())) {
-    auto i = iter.index();
-    Value v = builder.create<cudaq::cc::ExtractValueOp>(loc, iter.value(),
-                                                        revCon, n - i - 1);
-    aggie = builder.create<cudaq::cc::InsertValueOp>(loc, fwdTy, aggie, v, i);
-  }
-  return aggie;
 }
 
 Value genConstant(OpBuilder &builder, cudaq::cc::StdvecType vecTy, void *p,
@@ -352,9 +322,6 @@ void cudaq::opt::ArgumentConverter::gen(const std::vector<void *> &arguments) {
               return buildSubst(ty, argPtr, substModule, dataLayout);
             })
             .Case([&](cc::ArrayType ty) {
-              return buildSubst(ty, argPtr, substModule, dataLayout);
-            })
-            .Case([&](TupleType ty) {
               return buildSubst(ty, argPtr, substModule, dataLayout);
             })
             .Default({});

--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -22,7 +22,7 @@ constexpr bool isTupleRecursivelyDefined() {
   std::tuple<double, int, char> t;
   return static_cast<void *>(&std::get<double>(t)) != static_cast<void *>(&t);
 }
-static bool TupleIsReverse = isTupleRecursivelyDefined();
+[[maybe_unused]] static bool TupleIsReverse = isTupleRecursivelyDefined();
 } // namespace details
 
 namespace __internal__ {

--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -12,9 +12,19 @@
 #include "cudaq/host_config.h"
 #include "cudaq/qis/qubit_qis.h"
 #include <string>
+#include <tuple>
 #include <type_traits>
 
 namespace cudaq {
+namespace details {
+// Test std::tuple layout.
+constexpr bool isTupleRecursivelyDefined() {
+  std::tuple<double, int, char> t;
+  return static_cast<void *>(&std::get<double>(t)) != static_cast<void *>(&t);
+}
+static bool TupleIsReverse = isTupleRecursivelyDefined();
+} // namespace details
+
 namespace __internal__ {
 std::string demangle_kernel(const char *);
 bool isLibraryMode(const std::string &);

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -941,7 +941,7 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
   names.emplace_back(mlir::StringAttr::get(ctx, kernelName),
                      mlir::StringAttr::get(ctx, "BuilderKernel.EntryPoint"));
   auto mapAttr = mlir::DictionaryAttr::get(ctx, names);
-  module->setAttr("quake.mangled_name_map", mapAttr);
+  module->setAttr(cudaq::runtime::mangledNameMap, mapAttr);
 
   // Tag as an entrypoint if it is one
   tagEntryPoint(builder, module, StringRef{});

--- a/targettests/Kernel/signature-2.cpp
+++ b/targettests/Kernel/signature-2.cpp
@@ -126,6 +126,18 @@ struct SV {
   }
 };
 
+void show5(long john) { std::cout << john << ' '; }
+void show6(char actor) { std::cout << actor << '\n'; }
+
+struct T {
+  void operator()(std::tuple<int, long, double, char> tup) __qpu__ {
+    show3(std::get<0>(tup));
+    show5(std::get<1>(tup));
+    show4(std::get<double>(tup));
+    show6(std::get<3>(tup));
+  }
+};
+
 int main() {
   VectorOfStruct vsData = {{1, 1.0f, 95.0}, {2, 18.4f, 86.945}};
   VS{}(vsData);
@@ -136,6 +148,9 @@ int main() {
   StructOfVector svData = {{1, 10, 3, 100}, {1.2, 2.4, 4.8}};
   SV{}(svData);
 
+  std::tuple<int, long, double, char> t1{234, 89238, 3.14, 'Z'};
+  T{}(t1);
+
   return 0;
 }
 
@@ -144,3 +159,4 @@ int main() {
 // CHECK: A { 737 87.250 }; B { 0.750 639 }
 // CHECK: 1 10 3 100
 // CHECK: 1.200 2.400 4.800
+// CHECK: 234 89238 3.140 Z

--- a/test/AST-Quake/tuple-0.cpp
+++ b/test/AST-Quake/tuple-0.cpp
@@ -19,9 +19,9 @@ struct ArithmeticTupleQernel {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ArithmeticTupleQernel(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<{i32, f64, i16, i64}>)
-// CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<{i32, f64, i16, i64}>
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<{i32, f64, i16, i64}>>
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<{[[TUP:.*, .*, .*, .*]]}>)
+// CHECK:           %[[VAL_1:.*]] = cc.alloca !cc.struct<{[[TUP]]}>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<!cc.struct<{[[TUP]]}>>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<1>
 // CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_2]] : (!quake.veq<1>) -> !cc.stdvec<!quake.measure>
 // CHECK:           return
@@ -56,12 +56,12 @@ struct ArithmeticTupleQernelWithUse {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ArithmeticTupleQernelWithUse(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<{i32, f64, i16, i64}>)
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<{[[TUP]]}>)
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<{i32, f64, i16, i64}>
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<!cc.struct<{i32, f64, i16, i64}>>
-// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.struct<{i32, f64, i16, i64}>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<{[[TUP]]}>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<!cc.struct<{[[TUP]]}>>
+// CHECK:           %[[VAL_4:.*]] = cc.c{{.*}} %[[VAL_3]]{{.*}} : (!cc.ptr<!cc.struct<{[[TUP]]}>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.cast signed %[[VAL_5]] : (i32) -> i64
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<?>[%[[VAL_6]] : i64]
@@ -94,12 +94,12 @@ struct ArithmeticTupleQernelWithUse0 {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__ArithmeticTupleQernelWithUse0(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<{i32, f64, i16, i64}>)
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.struct<{[[TUP]]}>)
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<{i32, f64, i16, i64}>
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<!cc.struct<{i32, f64, i16, i64}>>
-// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.struct<{i32, f64, i16, i64}>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<{[[TUP]]}>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<!cc.struct<{[[TUP]]}>>
+// CHECK:           %[[VAL_4:.*]] = cc.c{{.*}} %[[VAL_3]]{{.*}} : (!cc.ptr<!cc.struct<{[[TUP]]}>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = cc.cast signed %[[VAL_5]] : (i32) -> i64
 // CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<?>[%[[VAL_6]] : i64]

--- a/test/AST-Quake/tuple-1.cpp
+++ b/test/AST-Quake/tuple-1.cpp
@@ -75,18 +75,18 @@ int main2() {
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_prepQubit2
-// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.struct<{i1, f32, i32}>, %[[VAL_1:.*]]: !quake.ref)
-// CHECK:           %[[VAL_2:.*]] = cc.alloca !cc.struct<{i1, f32, i32}>
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_2]] : !cc.ptr<!cc.struct<{i1, f32, i32}>>
+// CHECK-SAME:        (%[[VAL_0:.*]]: !cc.struct<{[[TUP:.*, .*, .*]]}>, %[[VAL_1:.*]]: !quake.ref)
+// CHECK:           %[[VAL_2:.*]] = cc.alloca !cc.struct<{[[TUP]]}>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_2]] : !cc.ptr<!cc.struct<{[[TUP]]}>>
 // CHECK:           return
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_RzArcTan22
-// CHECK-SAME:        (%[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: !cc.struct<{i1, f32, i32}>) attributes
+// CHECK-SAME:        (%[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: !cc.struct<{[[TUP]]}>) attributes
 // CHECK:           %[[VAL_2:.*]] = cc.alloca i1
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_2]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<{i1, f32, i32}>
-// CHECK:           cc.store %[[VAL_1]], %[[VAL_3]] : !cc.ptr<!cc.struct<{i1, f32, i32}>>
+// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<{[[TUP]]}>
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_3]] : !cc.ptr<!cc.struct<{[[TUP]]}>>
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.ref
@@ -94,10 +94,10 @@ int main2() {
 // CHECK:           cc.if(%[[VAL_7]]) {
 // CHECK:             quake.x %[[VAL_6]] : (!quake.ref) -> ()
 // CHECK:           }
-// CHECK:           %[[VAL_8:.*]] = cc.alloca !cc.struct<{i1, f32, i32}>
-// CHECK:           %[[VAL_9:.*]] = cc.load %[[VAL_3]] : !cc.ptr<!cc.struct<{i1, f32, i32}>>
-// CHECK:           cc.store %[[VAL_9]], %[[VAL_8]] : !cc.ptr<!cc.struct<{i1, f32, i32}>>
-// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_8]] : !cc.ptr<!cc.struct<{i1, f32, i32}>>
-// CHECK:           call @__nvqpp__mlirgen__function_prepQubit2{{.*}}(%[[VAL_10]], %[[VAL_6]]) : (!cc.struct<{i1, f32, i32}>, !quake.ref) -> ()
+// CHECK:           %[[VAL_8:.*]] = cc.alloca !cc.struct<{[[TUP]]}>
+// CHECK:           %[[VAL_9:.*]] = cc.load %[[VAL_3]] : !cc.ptr<!cc.struct<{[[TUP]]}>>
+// CHECK:           cc.store %[[VAL_9]], %[[VAL_8]] : !cc.ptr<!cc.struct<{[[TUP]]}>>
+// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_8]] : !cc.ptr<!cc.struct<{[[TUP]]}>>
+// CHECK:           call @__nvqpp__mlirgen__function_prepQubit2{{.*}}(%[[VAL_10]], %[[VAL_6]]) : (!cc.struct<{[[TUP]]}>, !quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/tools/cudaq-quake/cudaq-quake.cpp
+++ b/tools/cudaq-quake/cudaq-quake.cpp
@@ -13,6 +13,7 @@
 /// salient part of this tool.)
 
 #include "cudaq/Frontend/nvqpp/ASTBridge.h"
+#include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/Support/Verifier.h"
@@ -35,13 +36,10 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include <filesystem>
-#include <sstream>
 
 using namespace llvm;
 
 static constexpr const char toolName[] = "cudaq-quake";
-static constexpr const char mangledKernelNameMapAttrName[] =
-    "quake.mangled_name_map";
 
 //===----------------------------------------------------------------------===//
 // Command line options.
@@ -470,7 +468,7 @@ int main(int argc, char **argv) {
         names.emplace_back(mlir::StringAttr::get(&context, key),
                            mlir::StringAttr::get(&context, value));
       auto mapAttr = mlir::DictionaryAttr::get(&context, names);
-      moduleOp->setAttr(mangledKernelNameMapAttrName, mapAttr);
+      moduleOp->setAttr(cudaq::runtime::mangledNameMap, mapAttr);
     }
 
     // Running the verifier to make it easier to track down errors.


### PR DESCRIPTION
A std::tuple can be laid out in memory either like a struct or like the reverse of a struct. We need to be able to detect which one of these schemes is being used and it depends on the C++ headers being used. (libstdc++ is reversed, while libc++ is like a struct.)

Update tests.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
