### PR TITLE
[Kernel Launch] Remote state to use new launch mode

### DIFF
--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -65,6 +65,7 @@ class PyRemoteSimulationState : public RemoteSimulationState {
   // Holder of args data for clean-up.
   cudaq::OpaqueArguments *argsData;
   mlir::ModuleOp kernelMod;
+
 public:
   PyRemoteSimulationState(const std::string &in_kernelName,
                           cudaq::ArgWrapper args,

--- a/python/runtime/utils/PyRemoteSimulatorQPU.cpp
+++ b/python/runtime/utils/PyRemoteSimulatorQPU.cpp
@@ -74,6 +74,41 @@ static void _launchKernel(cudaq::ExecutionContext *executionContextPtr,
     throw std::runtime_error("Failed to launch kernel. Error: " + errorMsg);
 }
 
+static void
+_launchKernelStreamline(cudaq::ExecutionContext *executionContextPtr,
+                        std::unique_ptr<cudaq::RemoteRuntimeClient> &m_client,
+                        const std::string &m_simName, const std::string &name,
+                        const std::vector<void *> &rawArgs) {
+  if (rawArgs.empty())
+    throw std::runtime_error(
+        "Streamlined kernel launch: arguments cannot "
+        "be empty. The first argument should be a pointer to the MLIR "
+        "ModuleOp.");
+
+  auto *moduleOpPtr = reinterpret_cast<mlir::ModuleOp *>(rawArgs[0]);
+  auto m_module = *moduleOpPtr;
+  auto *mlirContext = m_module->getContext();
+
+  // Default context for a 'fire-and-ignore' kernel launch; i.e., no context
+  // was set before launching the kernel. Use a static variable per thread to
+  // set up a single-shot execution context for this case.
+  static thread_local cudaq::ExecutionContext defaultContext("sample",
+                                                             /*shots=*/1);
+  cudaq::ExecutionContext &executionContext =
+      executionContextPtr ? *executionContextPtr : defaultContext;
+  std::string errorMsg;
+  auto actualArgs = rawArgs;
+  // Remove the first argument (the MLIR ModuleOp) from the list of arguments.
+  actualArgs.erase(actualArgs.begin());
+
+  const bool requestOkay = m_client->sendRequest(
+      *mlirContext, executionContext, /*serializedCodeContext=*/nullptr,
+      /*vqe_gradient=*/nullptr, /*vqe_optimizer=*/nullptr, /*vqe_n_params=*/0,
+      m_simName, name, nullptr, nullptr, 0, &errorMsg, &actualArgs);
+  if (!requestOkay)
+    throw std::runtime_error("Failed to launch kernel. Error: " + errorMsg);
+}
+
 // Remote QPU: delegating the execution to a remotely-hosted server, which can
 // reinstate the execution context and JIT-invoke the kernel.
 class PyRemoteSimulatorQPU : public cudaq::BaseRemoteSimulatorQPU {
@@ -106,37 +141,12 @@ public:
 
   void launchKernel(const std::string &name,
                     const std::vector<void *> &rawArgs) override {
-    cudaq::info("PyRemoteSimulatorQPU: Launch kernel named '{}' remote QPU {} "
+    cudaq::info("PyRemoteSimulatorQPU: Streamline launch kernel named '{}' "
+                "remote QPU {} "
                 "(simulator = {})",
                 name, qpu_id, m_simName);
-    if (rawArgs.empty())
-      throw std::runtime_error(
-          "[PyRemoteSimulatorQPU] Streamlined kernel launch: arguments cannot "
-          "be empty. The first argument should be a pointer to the MLIR "
-          "ModuleOp.");
-
-    auto *moduleOpPtr = reinterpret_cast<mlir::ModuleOp *>(rawArgs[0]);
-    auto m_module = *moduleOpPtr;
-    auto *mlirContext = m_module->getContext();
-
-    // Default context for a 'fire-and-ignore' kernel launch; i.e., no context
-    // was set before launching the kernel. Use a static variable per thread to
-    // set up a single-shot execution context for this case.
-    static thread_local cudaq::ExecutionContext defaultContext("sample",
-                                                               /*shots=*/1);
-    auto *executionContextPtr = getExecutionContextForMyThread();
-    cudaq::ExecutionContext &executionContext =
-        executionContextPtr ? *executionContextPtr : defaultContext;
-    std::string errorMsg;
-    auto actualArgs = rawArgs;
-    actualArgs.erase(actualArgs.begin());
-
-    const bool requestOkay = m_client->sendRequest(
-        *mlirContext, executionContext, /*serializedCodeContext=*/nullptr,
-        /*vqe_gradient=*/nullptr, /*vqe_optimizer=*/nullptr, /*vqe_n_params=*/0,
-        m_simName, name, nullptr, nullptr, 0, &errorMsg, &actualArgs);
-    if (!requestOkay)
-      throw std::runtime_error("Failed to launch kernel. Error: " + errorMsg);
+    ::_launchKernelStreamline(getExecutionContextForMyThread(), m_client,
+                              m_simName, name, rawArgs);
   }
 
   PyRemoteSimulatorQPU(PyRemoteSimulatorQPU &&) = delete;
@@ -173,6 +183,16 @@ public:
                 name, qpu_id, m_simName);
     ::_launchKernel(getExecutionContextForMyThread(), m_client, m_simName, name,
                     kernelFunc, args, voidStarSize, resultOffset);
+  }
+
+  void launchKernel(const std::string &name,
+                    const std::vector<void *> &rawArgs) override {
+    cudaq::info("PyNvcfSimulatorQPU: Streamline launch kernel named '{}' "
+                "remote QPU {} "
+                "(simulator = {})",
+                name, qpu_id, m_simName);
+    ::_launchKernelStreamline(getExecutionContextForMyThread(), m_client,
+                              m_simName, name, rawArgs);
   }
 
   PyNvcfSimulatorQPU(PyNvcfSimulatorQPU &&) = delete;

--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -327,18 +327,18 @@ public:
       if (!castedState1 || !castedState2)
         throw std::runtime_error(
             "Invalid execution context: input states are not compatible");
-      auto [kernelName1, args1, argsSize1] = castedState1->getKernelInfo();
-      auto [kernelName2, args2, argsSize2] = castedState2->getKernelInfo();
+      auto [kernelName1, args1] = castedState1->getKernelInfo();
+      auto [kernelName2, args2] = castedState2->getKernelInfo();
       cudaq::IRPayLoad stateIrPayload1, stateIrPayload2;
 
       stateIrPayload1.entryPoint = kernelName1;
       stateIrPayload1.ir =
-          constructKernelPayload(mlirContext, kernelName1, nullptr, args1,
-                                 argsSize1, /*startingArgIdx=*/0, nullptr);
+          constructKernelPayload(mlirContext, kernelName1, nullptr, nullptr, 0,
+                                 /*startingArgIdx=*/0, &args1);
       stateIrPayload2.entryPoint = kernelName2;
       stateIrPayload2.ir =
-          constructKernelPayload(mlirContext, kernelName2, nullptr, args2,
-                                 argsSize2, /*startingArgIdx=*/0, nullptr);
+          constructKernelPayload(mlirContext, kernelName2, nullptr, nullptr, 0,
+                                 /*startingArgIdx=*/0, &args2);
       // First kernel of the overlap calculation
       request.code = stateIrPayload1.ir;
       request.entryPoint = stateIrPayload1.entryPoint;

--- a/runtime/cudaq/qis/remote_state.cpp
+++ b/runtime/cudaq/qis/remote_state.cpp
@@ -128,7 +128,8 @@ void RemoteSimulationState::toHost(std::complex<float> *clientAllocatedData,
   }
 }
 
-std::pair<std::string, std::vector<void *>> RemoteSimulationState::getKernelInfo() const {
+std::pair<std::string, std::vector<void *>>
+RemoteSimulationState::getKernelInfo() const {
   return std::make_pair(kernelName, args);
 }
 

--- a/runtime/cudaq/qis/remote_state.h
+++ b/runtime/cudaq/qis/remote_state.h
@@ -27,12 +27,34 @@ protected:
   // to be mutable) or overlap calculation with another remote state (combining
   // the IR of both states for remote evaluation)
   mutable std::unique_ptr<cudaq::SimulationState> state;
-  mutable std::vector<char> argsBuffer;
   // Cache log messages from the remote execution.
   // Mutable to support lazy execution during `const` API calls.
   mutable std::string platformExecutionLog;
+  using ArgDeleter = std::function<void(void *)>;
+  /// @brief  Vector of arguments
+  // Note: we create a copy of all arguments except pointers.
+  std::vector<void *> args;
+  /// @brief Deletion functions for the arguments.
+  std::vector<std::function<void(void *)>> deleters;
 
 public:
+  template <typename T>
+  void addArgument(const T &arg) {
+    if constexpr (std::is_pointer<std::decay_t<T>>::value) {
+      args.push_back(const_cast<void *>(static_cast<const void *>(arg)));
+      deleters.push_back([](void *ptr) {});
+    } else if constexpr (std::is_copy_constructible<std::decay_t<T>>::value) {
+      auto *ptr = new std::decay_t<T>(arg);
+      args.push_back(ptr);
+      deleters.push_back(
+          [](void *ptr) { delete static_cast<std::decay_t<T> *>(ptr); });
+    } else {
+      throw std::invalid_argument(
+          "Unsupported argument type: only pointers and "
+          "copy-constructible types are supported.");
+    }
+  }
+
   /// @brief Constructor
   template <typename QuantumKernel, typename... Args>
   RemoteSimulationState(QuantumKernel &&kernel, Args &&...args) {
@@ -43,16 +65,15 @@ public:
     } else {
       kernelName = cudaq::getKernelName(kernel);
     }
-
-    argsBuffer = cudaq::serializeArgs(std::forward<Args>(args)...);
+    (addArgument(args), ...);
   }
   RemoteSimulationState() = default;
   virtual ~RemoteSimulationState();
   /// @brief Triggers remote execution to resolve the state data.
   virtual void execute() const;
 
-  /// @brief Helper to retrieve (kernel name, `args` pointer and `args` size)
-  virtual std::tuple<std::string, void *, std::size_t> getKernelInfo() const;
+  /// @brief Helper to retrieve (kernel name, `args` pointers)
+  virtual std::pair<std::string, std::vector<void *>> getKernelInfo() const;
 
   /// @brief Return the number of qubits this state represents.
   std::size_t getNumQubits() const override;

--- a/targettests/Remote-Sim/state_overlap.cpp
+++ b/targettests/Remote-Sim/state_overlap.cpp
@@ -17,26 +17,26 @@
 #include <cudaq.h>
 
 struct bellCircuit {
-  void operator()() __qpu__ {
-    cudaq::qvector qubits(2);
+  void operator()(int N) __qpu__ {
+    cudaq::qvector qubits(N);
     h(qubits[0]);
-    cx(qubits[0], qubits[1]);
+    for (int i = 0; i < N - 1; ++i)
+      cx(qubits[i], qubits[i + 1]);
   }
 };
 
 struct noOpCircuit {
-  void operator()() __qpu__ {
-    cudaq::qvector qubits(2);
-    h(qubits[0]);
-    cx(qubits[0], qubits[1]);
-    cx(qubits[0], qubits[1]);
-    h(qubits[0]);
+  void operator()(int N) __qpu__ {
+    cudaq::qvector qubits(N);
+    h(qubits);
+    h(qubits);
   }
 };
 
 int main() {
-  auto state1 = cudaq::get_state(bellCircuit{});
-  auto state2 = cudaq::get_state(noOpCircuit{});
+  constexpr int N = 2;
+  auto state1 = cudaq::get_state(bellCircuit{}, 2);
+  auto state2 = cudaq::get_state(noOpCircuit{}, 2);
   const auto overlap = state1.overlap(state2);
   REMOTE_TEST_ASSERT(std::abs(M_SQRT1_2 - overlap) < 1e-3);
   return 0;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- Use the new `vector<void*>` arguments for streamline launch in `remote_state`.

- For Python, previously, we pack `void*` into an `ArgWrapper*` primarily to send on the `mlir::ModuleOp`. In the new streamline launch approach, use the first element in `vector<void*>` to store `mlir::ModuleOp*`, i.e., the rest will be actual arguments.