### PR TITLE
enable downstream libraries to turn off direct cudaq-mlir-runtime linking with nvq++

### DIFF
--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -705,7 +705,7 @@ template <
         std::remove_reference_t<std::remove_cv_t<QubitRange>>, cudaq::qubit>>>
 #endif
 void exp_pauli(double theta, QubitRange &&qubits,
-               cudaq::pauli_word &pauliWord) {
+               const cudaq::pauli_word &pauliWord) {
   exp_pauli(theta, qubits, pauliWord.str().c_str());
 }
 

--- a/targettests/TargetConfig/check_disable_mlir_links.cpp
+++ b/targettests/TargetConfig/check_disable_mlir_links.cpp
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// REQUIRES: c++20
+// RUN: nvq++ --disable-mlir-links %s -o %s.x && ! ldd %s.x | grep -q libcudaq-mlir-runtime.so 
+
+#include "cudaq.h"
+
+__qpu__ void bell() {
+  cudaq::qubit q, r;
+  h(q);
+  x<cudaq::ctrl>(q, r);
+}
+
+int main() {
+  auto counts = cudaq::sample(bell);
+  counts.dump();
+  return 0;
+}

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -155,6 +155,9 @@ function show_help {
 --execution-manager=<mgr> | -em=<mgr> | -execution-manager=<mgr>
 	Set the execution manager to <mgr>.
 
+--disable-mlir-links
+    Disable linking to cudaq-mlir-runtime and cudaq-builder. 
+
 --target=<target> | -target=<target>
 	Set the Target name to <target>.
 
@@ -297,7 +300,7 @@ LIBRARY_MODE_EXECUTION_MANAGER="default"
 PLATFORM_LIBRARY="default"
 LLVM_QUANTUM_TARGET="qir"
 LINKDIRS="-L${install_dir}/lib -L${install_dir}/lib/plugins @CUDAQ_CXX_NVQPP_LINK_STR@"
-LINKLIBS="-lcudaq -lcudaq-common -lcudaq-mlir-runtime -lcudaq-builder -lcudaq-ensmallen -lcudaq-nlopt -lcudaq-spin"
+LINKLIBS="-lcudaq -lcudaq-common -lcudaq-ensmallen -lcudaq-nlopt -lcudaq-spin"
 
 # Add any plugin libraries to the link stage
 CUDAQ_PLUGIN_DIR=${install_dir}/lib/plugins
@@ -333,6 +336,7 @@ ENABLE_AGGRESSIVE_EARLY_INLINE=true
 ENABLE_LOWER_TO_CFG=true
 ENABLE_APPLY_SPECIALIZATION=true
 ENABLE_LAMBDA_LIFTING=true
+ENABLE_MLIR_LIB_LINKING=true
 DELETE_TEMPS=true
 TARGET_CONFIG=
 EMIT_QIR=false
@@ -447,6 +451,9 @@ while [ $# -ne 0 ]; do
 		;;
 	--emulate | -emulate)
 		CUDAQ_EMULATE_REMOTE=true
+		;;
+	--disable-mlir-links | -disable-mlir-links)
+	    ENABLE_MLIR_LIB_LINKING=false 
 		;;
 	# This is intentionally not included in the "show_help" documentation
 	# because it may change in the future.
@@ -649,6 +656,11 @@ fi
 
 # Configure the NVQIR link line if this is in refactored mode
 NVQIR_LIBS="${NVQIR_LIBS}${NVQIR_SIMULATION_BACKEND}"
+
+# Add the MLIR-related libraries if requested. 
+if ${ENABLE_MLIR_LIB_LINKING}; then 
+    LINKLIBS="${LINKLIBS} -lcudaq-mlir-runtime -lcudaq-builder"
+fi
 
 # Set the execution manager and the platform
 LINKLIBS="${LINKLIBS} -lcudaq-em-${LIBRARY_MODE_EXECUTION_MANAGER}"


### PR DESCRIPTION
When compiling quantum device code for libraries, it is beneficial for one to be able to avoid direct linking to libcudaq-mlir-runtime and libcudaq-builder. If removing these links is not possible, and one tries to expose compiled device code to Python, they will hit the LLVM static initialization errors due to LLVM/MLIR being provided twice (once in the python cudaq module, and then again from the device library). 

This PR enables one to turn off those links with a compiler flag. This PR also fixes one of the exp_pauli signatures (add const to the pauli_word argument) to fix downstream compilation issues. 