### PR TITLE
Update decomposition patterns for value semantics

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -852,7 +852,7 @@ class QuakeOperator<string mnemonic, list<Trait> traits = [],
                    "mlir::ValueRange":$controls,
                    "mlir::ValueRange":$targets,
                    "mlir::DenseBoolArrayAttr":$negates), [{
-      return build($_builder, $_state, mlir::TypeRange{}, is_adj, parameters,
+      return build($_builder, $_state, static_cast<bool>(is_adj), parameters,
                    controls, targets, negates);
     }]>,
     OpBuilder<(ins "bool":$is_adj,
@@ -860,7 +860,17 @@ class QuakeOperator<string mnemonic, list<Trait> traits = [],
                    "mlir::ValueRange":$controls,
                    "mlir::ValueRange":$targets,
                    "mlir::DenseBoolArrayAttr":$negates), [{
-      return build($_builder, $_state, mlir::TypeRange{}, is_adj, parameters,
+      // For each wire in the controls and targets, return an output wire
+      auto wireTy = WireType::get($_builder.getContext());
+      std::size_t numControlWires = 
+          std::count_if(controls.begin(), controls.end(),
+                [wireTy](const Value &v) { return v.getType() == wireTy; });
+      std::size_t numTargetWires = 
+          std::count_if(targets.begin(), targets.end(),
+                [wireTy](const Value &v) { return v.getType() == wireTy; });
+      auto numWireOperands = numControlWires + numTargetWires;
+      mlir::SmallVector<mlir::Type> resultTypes(numWireOperands, wireTy);
+      return build($_builder, $_state, resultTypes, is_adj, parameters,
                    controls, targets, negates);
     }]>,
     OpBuilder<(ins "bool":$is_adj,

--- a/test/Transforms/DecompositionPatterns/CCXToCCZ.qke
+++ b/test/Transforms/DecompositionPatterns/CCXToCCZ.qke
@@ -8,7 +8,7 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CCXToCCZ})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CCXToCCZ})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CCXToCCZ})' %s | FileCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness
@@ -16,7 +16,7 @@
 
 // CHECK-LABEL: func.func @qref_control
 func.func @qref_control(%c0: !quake.ref, %c1: !quake.ref, %t: !quake.ref) {
-  // CHECK-NEXT: quake.h
+  // CHECK:      quake.h
   // CHECK-NEXT: quake.z
   // CHECK-NEXT: quake.h
   quake.x [%c0, %c1] %t : (!quake.ref, !quake.ref, !quake.ref) -> ()
@@ -25,7 +25,7 @@ func.func @qref_control(%c0: !quake.ref, %c1: !quake.ref, %t: !quake.ref) {
 
 // CHECK-LABEL: func.func @qvec_control
 func.func @qvec_control(%c: !quake.veq<2>, %t: !quake.ref) {
-  // CHECK-NEXT: quake.h
+  // CHECK:      quake.h
   // CHECK-NEXT: quake.z
   // CHECK-NEXT: quake.h
   quake.x [%c] %t : (!quake.veq<2>, !quake.ref) -> ()
@@ -34,7 +34,7 @@ func.func @qvec_control(%c: !quake.veq<2>, %t: !quake.ref) {
 
 // CHECK-LABEL: func.func @qvec_control_2
 func.func @qvec_control_2(%c0: !quake.veq<1>, %c1: !quake.veq<1>, %t: !quake.ref) {
-  // CHECK-NEXT: quake.h
+  // CHECK:      quake.h
   // CHECK-NEXT: quake.z
   // CHECK-NEXT: quake.h
   quake.x [%c0, %c1] %t : (!quake.veq<1>, !quake.veq<1>, !quake.ref) -> ()
@@ -43,7 +43,7 @@ func.func @qvec_control_2(%c0: !quake.veq<1>, %c1: !quake.veq<1>, %t: !quake.ref
 
 // CHECK-LABEL: func.func @mixed_control
 func.func @mixed_control(%c0: !quake.ref, %c1: !quake.veq<1>, %t: !quake.ref) {
-  // CHECK-NEXT: quake.h
+  // CHECK:      quake.h
   // CHECK-NEXT: quake.z
   // CHECK-NEXT: quake.h
   quake.x [%c0, %c1] %t : (!quake.ref, !quake.veq<1>, !quake.ref) -> ()

--- a/test/Transforms/DecompositionPatterns/CCZToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CCZToCX.qke
@@ -8,7 +8,7 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CCZToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CCZToCX})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CCZToCX})' %s | FileCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness

--- a/test/Transforms/DecompositionPatterns/CHToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CHToCX.qke
@@ -8,7 +8,7 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CHToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CHToCX})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=CHToCX})' %s | FileCheck --check-prefix=VALUE %s
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.
@@ -19,3 +19,20 @@ func.func @test(%control: !quake.ref, %target: !quake.ref) {
   quake.h [%control] %target : (!quake.ref, !quake.ref) -> ()
   return
 }
+
+// VALUE-LABEL:   func.func @test(
+// VALUE-SAME:                    %[[VAL_0:.*]]: !quake.ref,
+// VALUE-SAME:                    %[[VAL_1:.*]]: !quake.ref) {
+// VALUE:           %[[VAL_2:.*]] = quake.unwrap %[[VAL_1]] : (!quake.ref) -> !quake.wire
+// VALUE:           %[[VAL_3:.*]] = quake.unwrap %[[VAL_0]] : (!quake.ref) -> !quake.wire
+// VALUE:           %[[VAL_4:.*]] = quake.s %[[VAL_2]] : (!quake.wire) -> !quake.wire
+// VALUE:           %[[VAL_5:.*]] = quake.h %[[VAL_4]] : (!quake.wire) -> !quake.wire
+// VALUE:           %[[VAL_6:.*]] = quake.t %[[VAL_5]] : (!quake.wire) -> !quake.wire
+// VALUE:           %[[VAL_7:.*]]:2 = quake.x {{\[}}%[[VAL_3]]] %[[VAL_6]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// VALUE:           %[[VAL_8:.*]] = quake.t<adj> %[[VAL_7]]#1 : (!quake.wire) -> !quake.wire
+// VALUE:           %[[VAL_9:.*]] = quake.h %[[VAL_8]] : (!quake.wire) -> !quake.wire
+// VALUE:           %[[VAL_10:.*]] = quake.s<adj> %[[VAL_9]] : (!quake.wire) -> !quake.wire
+// VALUE:           quake.wrap %[[VAL_7]]#0 to %[[VAL_0]] : !quake.wire, !quake.ref
+// VALUE:           quake.wrap %[[VAL_10]] to %[[VAL_1]] : !quake.wire, !quake.ref
+// VALUE:           return
+// VALUE:         }

--- a/test/Transforms/DecompositionPatterns/CR1ToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CR1ToCX.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CR1ToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CR1ToCX})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CR1ToCX})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CR1ToCX})' %s | CircuitCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness

--- a/test/Transforms/DecompositionPatterns/CRxToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CRxToCX.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CRxToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CRxToCX})' %s | CircuitCheck %s --up-to-global-phase
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CRxToCX})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CRxToCX})' %s | CircuitCheck %s --up-to-global-phase
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness

--- a/test/Transforms/DecompositionPatterns/CRyToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CRyToCX.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CRyToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CRyToCX})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CRyToCX})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CRyToCX})' %s | CircuitCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness

--- a/test/Transforms/DecompositionPatterns/CRzToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CRzToCX.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CRzToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CRzToCX})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CRzToCX})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CRzToCX})' %s | CircuitCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness

--- a/test/Transforms/DecompositionPatterns/CXToCZ.qke
+++ b/test/Transforms/DecompositionPatterns/CXToCZ.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CXToCZ})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CXToCZ})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CXToCZ})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CXToCZ})' %s | CircuitCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness
@@ -16,7 +17,7 @@
 
 // CHECK-LABEL: func.func @qref_control
 func.func @qref_control(%c: !quake.ref, %t: !quake.ref) {
-  // CHECK-NEXT: quake.h
+  // CHECK:      quake.h
   // CHECK-NEXT: quake.z
   // CHECK-NEXT: quake.h
   quake.x [%c] %t : (!quake.ref, !quake.ref) -> ()
@@ -25,7 +26,7 @@ func.func @qref_control(%c: !quake.ref, %t: !quake.ref) {
 
 // CHECK-LABEL: func.func @qvec_control
 func.func @qvec_control(%c: !quake.veq<1>, %t: !quake.ref) {
-  // CHECK-NEXT: quake.h
+  // CHECK:      quake.h
   // CHECK-NEXT: quake.z
   // CHECK-NEXT: quake.h
   quake.x [%c] %t : (!quake.veq<1>, !quake.ref) -> ()

--- a/test/Transforms/DecompositionPatterns/CZToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CZToCX.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CZToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CZToCX})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CZToCX})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CZToCX})' %s | CircuitCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness
@@ -16,7 +17,7 @@
 
 // CHECK-LABEL: func.func @qref_control
 func.func @qref_control(%c: !quake.ref, %t: !quake.ref) {
-  // CHECK-NEXT: quake.h
+  // CHECK:      quake.h
   // CHECK-NEXT: quake.x
   // CHECK-NEXT: quake.h
   quake.z [%c] %t : (!quake.ref, !quake.ref) -> ()
@@ -25,7 +26,7 @@ func.func @qref_control(%c: !quake.ref, %t: !quake.ref) {
 
 // CHECK-LABEL: func.func @qvec_control
 func.func @qvec_control(%c: !quake.veq<1>, %t: !quake.ref) {
-  // CHECK-NEXT: quake.h
+  // CHECK:      quake.h
   // CHECK-NEXT: quake.x
   // CHECK-NEXT: quake.h
   quake.z [%c] %t : (!quake.veq<1>, !quake.ref) -> ()

--- a/test/Transforms/DecompositionPatterns/HToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/HToPhasedRx.qke
@@ -8,6 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=HToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=HToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=HToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=HToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
 
 
 // The FileCheck part of this test only cares about the sequence of operations.

--- a/test/Transforms/DecompositionPatterns/R1ToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/R1ToPhasedRx.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=R1ToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=R1ToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=R1ToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=R1ToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/test/Transforms/DecompositionPatterns/RxToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/RxToPhasedRx.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=RxToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=RxToPhasedRx})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=RxToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=RxToPhasedRx})' %s | CircuitCheck %s
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/test/Transforms/DecompositionPatterns/RyToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/RyToPhasedRx.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=RyToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=RyToPhasedRx})' %s | CircuitCheck %s
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=RyToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=RyToPhasedRx})' %s | CircuitCheck %s
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/test/Transforms/DecompositionPatterns/RzToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/RzToPhasedRx.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=RzToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=RzToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=RzToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=RzToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/test/Transforms/DecompositionPatterns/SToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/SToPhasedRx.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=SToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=SToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=SToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=SToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/test/Transforms/DecompositionPatterns/SwapToCX.qke
+++ b/test/Transforms/DecompositionPatterns/SwapToCX.qke
@@ -1,0 +1,39 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=SwapToCX})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=SwapToCX})' %s | CircuitCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=SwapToCX})' %s | FileCheck --check-prefix=VALUE %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=SwapToCX})' %s | CircuitCheck %s
+
+func.func @test(%qa: !quake.ref, %qb : !quake.ref) {
+  quake.swap %qa, %qb : (!quake.ref, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !quake.ref,
+// CHECK-SAME:                    %[[VAL_1:.*]]: !quake.ref) {
+// CHECK:           quake.x {{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.x {{\[}}%[[VAL_0]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.x {{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// VALUE-LABEL:   func.func @test(
+// VALUE-SAME:                    %[[VAL_0:.*]]: !quake.ref,
+// VALUE-SAME:                    %[[VAL_1:.*]]: !quake.ref) {
+// VALUE:           %[[VAL_2:.*]] = quake.unwrap %[[VAL_1]] : (!quake.ref) -> !quake.wire
+// VALUE:           %[[VAL_3:.*]] = quake.unwrap %[[VAL_0]] : (!quake.ref) -> !quake.wire
+// VALUE:           %[[VAL_4:.*]]:2 = quake.x {{\[}}%[[VAL_2]]] %[[VAL_3]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// VALUE:           %[[VAL_5:.*]]:2 = quake.x {{\[}}%[[VAL_4]]#1] %[[VAL_4]]#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// VALUE:           %[[VAL_6:.*]]:2 = quake.x {{\[}}%[[VAL_5]]#1] %[[VAL_5]]#0 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// VALUE:           quake.wrap %[[VAL_6]]#1 to %[[VAL_0]] : !quake.wire, !quake.ref
+// VALUE:           quake.wrap %[[VAL_6]]#0 to %[[VAL_1]] : !quake.wire, !quake.ref
+// VALUE:           return
+// VALUE:         }

--- a/test/Transforms/DecompositionPatterns/TToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/TToPhasedRx.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=TToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=TToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=TToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=TToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/test/Transforms/DecompositionPatterns/U3ToRotations.qke
+++ b/test/Transforms/DecompositionPatterns/U3ToRotations.qke
@@ -8,6 +8,8 @@
 
 // RUN: cudaq-opt --decomposition=enable-patterns=U3ToRotations %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=U3ToRotations})' %s | CircuitCheck %s --up-to-global-phase
+// RUN: cudaq-opt --memtoreg --decomposition=enable-patterns=U3ToRotations %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=U3ToRotations})' %s | CircuitCheck %s --up-to-global-phase
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/test/Transforms/DecompositionPatterns/XToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/XToPhasedRx.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=XToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=XToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=XToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=XToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/test/Transforms/DecompositionPatterns/YToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/YToPhasedRx.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=YToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=YToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=YToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=YToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/test/Transforms/DecompositionPatterns/ZToPhasedRx.qke
+++ b/test/Transforms/DecompositionPatterns/ZToPhasedRx.qke
@@ -8,7 +8,8 @@
 
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=ZToPhasedRx})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=ZToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
-
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=ZToPhasedRx})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(memtoreg),decomposition{enable-patterns=ZToPhasedRx})' %s | CircuitCheck %s --up-to-global-phase
 
 // The FileCheck part of this test only cares about the sequence of operations.
 // Correcteness is checked by CircuitCheck.

--- a/utils/CircuitCheck/UnitaryBuilder.cpp
+++ b/utils/CircuitCheck/UnitaryBuilder.cpp
@@ -35,6 +35,8 @@ LogicalResult UnitaryBuilder::build(func::FuncOp func) {
       return allocateQubits(allocOp.getResult());
     if (auto extractOp = dyn_cast<quake::ExtractRefOp>(op))
       return visitExtractOp(extractOp);
+    if (auto unwrapOp = dyn_cast<quake::UnwrapOp>(op))
+      return visitUnwrapOp(unwrapOp);
     if (auto optor = dyn_cast<quake::OperatorInterface>(op)) {
       optor.getOperatorMatrix(matrix);
       // If the operator couldn't produce a matrix, stop the walk.
@@ -98,6 +100,13 @@ WalkResult UnitaryBuilder::visitExtractOp(quake::ExtractRefOp op) {
   }
   auto [entry, _] = qubitMap.try_emplace(op.getResult());
   entry->second.push_back(qubits[index]);
+  return WalkResult::advance();
+}
+
+WalkResult UnitaryBuilder::visitUnwrapOp(quake::UnwrapOp op) {
+  ArrayRef<unsigned> qubits = qubitMap[op.getOperand()];
+  auto [entry, _] = qubitMap.try_emplace(op.getResult());
+  entry->second.push_back(qubits.front());
   return WalkResult::advance();
 }
 

--- a/utils/CircuitCheck/UnitaryBuilder.h
+++ b/utils/CircuitCheck/UnitaryBuilder.h
@@ -36,6 +36,8 @@ private:
 
   mlir::WalkResult visitExtractOp(quake::ExtractRefOp op);
 
+  mlir::WalkResult visitUnwrapOp(quake::UnwrapOp op);
+
   mlir::WalkResult allocateQubits(mlir::Value value);
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
* Update QuakeOperator builders to automatically return wires when appropriate.
* Create helpers to allow common "create" functions for both reference semantics and value semantics.
* Update UnitaryBuilder to understand unwraps.
* Update decomposition pattern tests to additionally test value semantics.