### PR TITLE
Decomposition updates for `quake.control` types

### DIFF
--- a/test/Transforms/DecompositionPatterns/CCZToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CCZToCX.qke
@@ -9,6 +9,7 @@
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CCZToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CCZToCX})' %s | CircuitCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CCZToCX})' %s | FileCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg,pruned-ctrl-form),decomposition{enable-patterns=CCZToCX})' %s | FileCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness

--- a/test/Transforms/DecompositionPatterns/CR1ToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CR1ToCX.qke
@@ -10,6 +10,7 @@
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CR1ToCX})' %s | CircuitCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CR1ToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CR1ToCX})' %s | CircuitCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg,pruned-ctrl-form),decomposition{enable-patterns=CR1ToCX})' %s | FileCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness

--- a/test/Transforms/DecompositionPatterns/CXToCZ.qke
+++ b/test/Transforms/DecompositionPatterns/CXToCZ.qke
@@ -10,6 +10,7 @@
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CXToCZ})' %s | CircuitCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CXToCZ})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CXToCZ})' %s | CircuitCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg,pruned-ctrl-form),decomposition{enable-patterns=CXToCZ})' %s | FileCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness

--- a/test/Transforms/DecompositionPatterns/CZToCX.qke
+++ b/test/Transforms/DecompositionPatterns/CZToCX.qke
@@ -10,6 +10,7 @@
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CZToCX})' %s | CircuitCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CZToCX})' %s | FileCheck %s
 // RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg),decomposition{enable-patterns=CZToCX})' %s | CircuitCheck %s
+// RUN: cudaq-opt -pass-pipeline='builtin.module(func.func(expand-control-veqs,memtoreg,pruned-ctrl-form),decomposition{enable-patterns=CZToCX})' %s | FileCheck %s
 
 // Test the decomposition pattern with different control types. The FileCheck
 // part of this test only cares about the sequence of operations. Correcteness


### PR DESCRIPTION
This is a follow-up to #2145 to handle decompositions with more scenarios with `quake.control` types.

The only scenarios remaining after this PR are threading modified controls through to arbitrary locations. That will need to handle CFG and structured control flow (with arbitrary nesting levels), so I decided to mark that as `TODO` for now since there is currently no pressing need for that. (The current PR will gracefully not perform transformations if it encounters those more complicated scenarios.)