### PR TITLE
[C++ bridge] Add support for move constructor of std::vector.

### DIFF
--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -2838,8 +2838,12 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
       if (ctor->isDefaultConstructor())
         reportClangError(ctor, mangler,
                          "Default std::vector<T> constructor within quantum "
-                         "kernel is not allowed "
-                         "(cannot resize the vector).");
+                         "kernel is not allowed (cannot resize the vector).");
+
+      if (ctor->isMoveConstructor()) {
+        // Just use the !cc.stdvec<T> value at TOS.
+        return true;
+      }
     }
   }
 

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -1811,7 +1811,6 @@ public:
       });
       for (auto *op : deadCalls)
         op->erase();
-      module.dump();
 
       LLVM_DEBUG(llvm::dbgs() << "final module:\n" << module << '\n');
     }

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -608,6 +608,8 @@ public:
       op->erase();
     for (std::size_t i = 0, end = funcOp.getNumResults(); i != end; ++i)
       funcOp.eraseResult(0);
+    modifiedDevKernels.insert(
+        std::pair<StringRef, Type>{funcOp.getName(), newFuncTy.getInput(0)});
   }
 
   /// In the thunk, we need to unpack any `std::vector` objects encoded in the
@@ -1776,11 +1778,47 @@ public:
       // kernel as having been processed.
       cudaq::opt::factory::createGlobalCtorCall(
           module, FlatSymbolRefAttr::get(ctx, initFun.getName()));
-      LLVM_DEBUG(llvm::dbgs() << module << '\n');
+
+      SmallVector<Operation *> deadCalls;
+      module.walk([&](func::CallOp call) {
+        if (!call.getResults().empty()) {
+          auto callee = call.getCallee();
+          auto iter = modifiedDevKernels.find(callee);
+          if (iter != modifiedDevKernels.end()) {
+            OpBuilder builder(call);
+            Type ty = call.getResult(0).getType();
+            auto loc = call.getLoc();
+            auto strTy = cast<cudaq::cc::StructType>(
+                cast<cudaq::cc::PointerType>(iter->second).getElementType());
+            auto buff = builder.create<cudaq::cc::AllocaOp>(loc, strTy);
+            SmallVector<Value> args = {buff};
+            args.append(call.getOperands().begin(), call.getOperands().end());
+            builder.create<func::CallOp>(loc, TypeRange{}, callee, args);
+            auto buffPtrPtr = builder.create<cudaq::cc::ComputePtrOp>(
+                loc, cudaq::cc::PointerType::get(strTy.getMember(0)), buff,
+                ArrayRef<cudaq::cc::ComputePtrArg>{0});
+            auto buffPtr = builder.create<cudaq::cc::LoadOp>(loc, buffPtrPtr);
+            auto buffSizePtr = builder.create<cudaq::cc::ComputePtrOp>(
+                loc, cudaq::cc::PointerType::get(strTy.getMember(1)), buff,
+                ArrayRef<cudaq::cc::ComputePtrArg>{1});
+            auto buffSize = builder.create<cudaq::cc::LoadOp>(loc, buffSizePtr);
+            auto sv = builder.create<cudaq::cc::StdvecInitOp>(loc, ty, buffPtr,
+                                                              buffSize);
+            call.getResult(0).replaceAllUsesWith(sv);
+            deadCalls.push_back(call);
+          }
+        }
+      });
+      for (auto *op : deadCalls)
+        op->erase();
+      module.dump();
+
+      LLVM_DEBUG(llvm::dbgs() << "final module:\n" << module << '\n');
     }
     out.keep();
   }
 
   const DataLayout *dataLayout = nullptr;
+  DenseMap<StringRef, Type> modifiedDevKernels;
 };
 } // namespace

--- a/python/tests/mlir/adjoint.py
+++ b/python/tests/mlir/adjoint.py
@@ -275,6 +275,7 @@ def test_sample_adjoint_qreg():
     print(kernel)
 
 
+# CHECK-LABEL: test_sample_adjoint_qreg
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: i64) attributes {"cudaq-entrypoint"} {
 # CHECK-DAG:           %[[VAL_1:.*]] = arith.constant 1 : i64

--- a/python/tests/mlir/conditional.py
+++ b/python/tests/mlir/conditional.py
@@ -113,6 +113,7 @@ def test_kernel_conditional_with_sample():
     print(kernel)
 
 
+# CHECK-LABEL: test_kernel_conditional_with_sample
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
@@ -155,6 +156,7 @@ def test_cif_extract_ref_bug():
     print(kernel)
 
 
+# CHECK-LABEL: test_cif_extract_ref_bug
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<2>) -> !quake.ref

--- a/python/tests/mlir/control.py
+++ b/python/tests/mlir/control.py
@@ -331,6 +331,7 @@ def test_sample_control_qreg_args():
     print(kernel)
 
 
+# CHECK-LABEL: test_sample_control_qreg_args
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
 # CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.ref
@@ -387,6 +388,7 @@ def test_sample_apply_call_control():
     print(kernel)
 
 
+# CHECK-LABEL: test_sample_apply_call_control
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref

--- a/python/tests/mlir/ctrl_gates.py
+++ b/python/tests/mlir/ctrl_gates.py
@@ -82,6 +82,7 @@ def test_kernel_ctrl_rotation():
     print(kernel)
 
 
+# CHECK-LABEL: test_kernel_ctrl_rotation
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint"} {
 # CHECK-DAG:           %[[VAL_1:.*]] = arith.constant 3.000000e+00 : f64
@@ -137,6 +138,7 @@ def test_kernel_multi_ctrl():
     print(kernel)
 
 
+# CHECK-LABEL: test_kernel_multi_ctrl
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
 # CHECK:           %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<3>) -> !quake.ref
@@ -175,6 +177,7 @@ def test_kernel_ctrl_register():
     print(kernel)
 
 
+# CHECK-LABEL: test_kernel_ctrl_register
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
 # CHECK-DAG:       %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
 # CHECK-DAG:       %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
@@ -221,6 +224,7 @@ def test_kernel_rotation_ctrl_register():
     print(kernel)
 
 
+# CHECK-LABEL: test_kernel_rotation_ctrl_register
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<f64>) attributes {"cudaq-entrypoint"} {
 # CHECK-DAG:           %[[VAL_1:.*]] = arith.constant 3 : i64
@@ -286,6 +290,7 @@ def test_ctrl_swap():
     print(kernel)
 
 
+# CHECK-LABEL: test_ctrl_swap
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
 # CHECK-DAG:       %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK-DAG:       %[[VAL_1:.*]] = quake.alloca !quake.ref

--- a/python/tests/mlir/one_qubit.py
+++ b/python/tests/mlir/one_qubit.py
@@ -81,6 +81,7 @@ def test_kernel_param_1q():
     print(kernel)
 
 
+# CHECK-LABEL: test_kernel_param_1q
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(
 # CHECK-SAME:                                                                   %[[VAL_0:.*]]: f64) attributes {"cudaq-entrypoint"} {
 # CHECK:           %0 = quake.alloca !quake.veq<1>

--- a/targettests/execution/cudaq_observe.cpp
+++ b/targettests/execution/cudaq_observe.cpp
@@ -8,7 +8,6 @@
 
 // REQUIRES: c++20
 // clang-format off
-// RUN: nvq++ --target anyon                    --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target ionq                     --emulate %s -o %t && %t | FileCheck %s
 // 2 different IQM machines for 2 different topologies
 // RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %t && %t | FileCheck %s

--- a/test/AST-Quake/vector_bool.cpp
+++ b/test/AST-Quake/vector_bool.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: cudaq-quake %cpp_std %s | FileCheck %s
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck %s
 
 // Simple test using a std::vector<bool> operator.
 
@@ -20,6 +20,7 @@ struct t1 {
   }
 };
 
+// clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__t1(
 // CHECK-SAME:        %[[VAL_0:.*]]: !cc.stdvec<f64>{{.*}}) -> i1 attributes
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
@@ -31,4 +32,47 @@ struct t1 {
 // CHECK:           return %[[VAL_5]] : i1
 // CHECK:         }
 // CHECK-NOT:     func.func private @_ZNKSt14_Bit_referencecvbEv() -> i1
+// clang-format on
 
+struct VectorBoolReturn {
+   std::vector<bool> operator()() __qpu__ {
+    cudaq::qvector q(4);
+    return mz(q);
+  }
+};
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorBoolReturn() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_6:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_4]], %[[VAL_5]], %[[VAL_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_7:.*]] = cc.stdvec_init %[[VAL_6]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
+// CHECK:           return %[[VAL_7]] : !cc.stdvec<i1>
+// CHECK:         }
+// clang-format on
+
+struct VectorBoolResult {
+   std::vector<bool> operator()() __qpu__ {
+    cudaq::qvector q(4);
+    std::vector<bool> vec = mz(q);
+    return vec;
+  }
+};
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorBoolResult() -> !cc.stdvec<i1> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "vec" : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
+// CHECK:           %[[VAL_3:.*]] = quake.discriminate %[[VAL_2]] : (!cc.stdvec<!quake.measure>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_4:.*]] = cc.stdvec_data %[[VAL_3]] : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_3]] : (!cc.stdvec<i1>) -> i64
+// CHECK:           %[[VAL_6:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_4]], %[[VAL_5]], %[[VAL_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_7:.*]] = cc.stdvec_init %[[VAL_6]], %[[VAL_5]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
+// CHECK:           return %[[VAL_7]] : !cc.stdvec<i1>
+// CHECK:         }
+// clang-format on

--- a/test/AST-Quake/vector_int-0.cpp
+++ b/test/AST-Quake/vector_int-0.cpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck %s
+
+#include <cudaq.h>
+
+struct VectorIntReturn {
+  std::vector<int> operator()() __qpu__ { return {142, 243}; }
+};
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorIntReturn() -> !cc.stdvec<i32> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 4 : i64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 142 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 243 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = cc.alloca !cc.array<i32 x 2>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_6]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_8:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_7]], %[[VAL_3]], %[[VAL_0]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = cc.stdvec_init %[[VAL_8]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
+// CHECK:           return %[[VAL_9]] : !cc.stdvec<i32>
+// CHECK:         }
+// clang-format on
+
+struct VectorIntResult {
+  std::vector<int> operator()() __qpu__ {
+    std::vector<int> result(2);
+    result[0] = 42;
+    return result;
+  }
+};
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorIntResult() -> !cc.stdvec<i32> attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 4 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 42 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = cc.alloca !cc.array<i32 x 2>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_4]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_6:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_5]], %[[VAL_0]], %[[VAL_1]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_7:.*]] = cc.stdvec_init %[[VAL_6]], %[[VAL_0]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
+// CHECK:           return %[[VAL_7]] : !cc.stdvec<i32>
+// CHECK:         }
+// clang-format on

--- a/test/AST-Quake/vector_int-1.cpp
+++ b/test/AST-Quake/vector_int-1.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt -kernel-execution | FileCheck %s
+
+#include <cudaq.h>
+
+__qpu__ std::vector<int> doubleDeckerBus() {
+  std::vector<int> ii(2);
+  ii[0] = 2;
+  return ii;
+}
+
+__qpu__ void touringLondon() {
+  auto ii = doubleDeckerBus();
+  cudaq::qvector q(ii[0]);
+  return;
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_doubleDeckerBus._Z15doubleDeckerBusv(
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>> {llvm.sret = !cc.struct<{!cc.ptr<i8>, i64}>}) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 2 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 4 : i64
+// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i32
+// CHECK:           %[[VAL_4:.*]] = cc.alloca !cc.array<i32 x 2>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_3]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i32 x 2>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_7:.*]] = call @__nvqpp_vectorCopyCtor(%[[VAL_6]], %[[VAL_1]], %[[VAL_2]]) : (!cc.ptr<i8>, i64, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_8:.*]] = cc.stdvec_init %[[VAL_7]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>
+// CHECK:           %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_8]] : (!cc.stdvec<i32>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_9]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           cc.store %[[VAL_10]], %[[VAL_12]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_13:.*]] = cc.stdvec_size %[[VAL_8]] : (!cc.stdvec<i32>) -> i64
+// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_9]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           cc.store %[[VAL_13]], %[[VAL_14]] : !cc.ptr<i64>
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_touringLondon._Z13touringLondonv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           call @__nvqpp__mlirgen__function_doubleDeckerBus._Z15doubleDeckerBusv(%[[VAL_0]]) : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> ()
+// CHECK:           %[[VAL_1:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_1]], %[[VAL_3]] : (!cc.ptr<!cc.ptr<i8>>, i64) -> !cc.stdvec<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.stdvec_data %[[VAL_4]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
+// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x ?>>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_8:.*]] = cc.cast signed %[[VAL_7]] : (i32) -> i64
+// CHECK:           %[[VAL_9:.*]] = quake.alloca !quake.veq<?>{{\[}}%[[VAL_8]] : i64]
+// CHECK:           return
+// CHECK:         }

--- a/test/AST-Quake/vector_int-1.cpp
+++ b/test/AST-Quake/vector_int-1.cpp
@@ -47,10 +47,11 @@ __qpu__ void touringLondon() {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_touringLondon._Z13touringLondonv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           call @__nvqpp__mlirgen__function_doubleDeckerBus._Z15doubleDeckerBusv(%[[VAL_0]]) : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> ()
-// CHECK:           %[[VAL_1:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_1:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
 // CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<i64>
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_1]], %[[VAL_3]] : (!cc.ptr<!cc.ptr<i8>>, i64) -> !cc.stdvec<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_1]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.stdvec_data %[[VAL_4]] : (!cc.stdvec<i32>) -> !cc.ptr<!cc.array<i32 x ?>>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<i32 x ?>>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>

--- a/test/AST-error/vector.cpp
+++ b/test/AST-error/vector.cpp
@@ -22,7 +22,6 @@ struct VectorVectorReturner {
       for (std::size_t j = 0, M = v.size(); j < M; ++j)
         r[j] = v[j];
     }
-    // expected-error@+1{{C++ constructor (non-default)}}
     return result;
   }
 };


### PR DESCRIPTION
Allow the use of the move constructor so that cases such as

	std::vector<int> vectorValue(N);
	...
	return vectorValue;

will compile and simple vectors of arithmetic types may be used.  Note that this requires the CUDA-Q runtime to actually return these values to the caller rather than dropping them on the floor after a launched kernel has deactivated.  That is not always the case, however, since some launchers do not expect any return value(s).

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
