### PR TITLE
Allow controlled Z gates for profile-specific QIR

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Peephole.h
+++ b/include/cudaq/Optimizer/CodeGen/Peephole.h
@@ -31,6 +31,17 @@ inline bool callToInvokeWithXCtrlOneTarget(mlir::StringRef callee,
   return false;
 }
 
+inline bool callToInvokeWithZCtrlOneTarget(mlir::StringRef callee,
+                                           mlir::ValueRange args) {
+  if ((args.size() == 4) && (callee == cudaq::opt::NVQIRInvokeWithControlBits))
+    if (auto addrOf = dyn_cast_or_null<mlir::LLVM::AddressOfOp>(
+            args[1].getDefiningOp())) {
+      return addrOf.getGlobalName().startswith(
+          std::string(cudaq::opt::QIRQISPrefix) + "z__ctl");
+    }
+  return false;
+}
+
 inline bool isIntToPtrOp(mlir::Value operand) {
   return dyn_cast_or_null<mlir::LLVM::IntToPtrOp>(operand.getDefiningOp());
 }

--- a/include/cudaq/Optimizer/CodeGen/Peephole.td
+++ b/include/cudaq/Optimizer/CodeGen/Peephole.td
@@ -33,6 +33,23 @@ def XCtrlOneTargetToCNot : Pat<
     (LLVM_CallOp $callee, $args, $_, $_), (CreateCallCnot $args),
     [(InvokeOnXWithOneControl $callee, $args)]>;
 
+def InvokeOnZWithOneControl : Constraint<CPred<
+    "$0 && callToInvokeWithZCtrlOneTarget($0.getValue(), $1)">>;
+
+def CreateCallCZ : NativeCodeCall<
+    "[&]() -> std::size_t {"
+    "  $_builder.create<mlir::LLVM::CallOp>($_loc,"
+    "    mlir::TypeRange{}, cudaq::opt::QIRCZ, $0.drop_front(2));"
+    "  return 0; }()">;
+
+// %1 = address_of @__quantum__qis__z__ctl
+// %2 = call @invokewithControlBits %1, %ctrl, %targ
+// ─────────────────────────────────────────────────
+// %2 = call __quantum__qis__cz %ctrl, %targ
+def ZCtrlOneTargetToCZ : Pat<
+    (LLVM_CallOp $callee, $args, $_, $_), (CreateCallCZ $args),
+    [(InvokeOnZWithOneControl $callee, $args)]>;
+
 //===----------------------------------------------------------------------===//
 
 def NeedsRenaming : Constraint<CPred<"$0 && needsToBeRenamed($0.getValue())">>;

--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -24,6 +24,7 @@ static constexpr const char QIRMeasureToRegister[] =
 
 static constexpr const char QIRCnot[] = "__quantum__qis__cnot";
 static constexpr const char QIRCphase[] = "__quantum__qis__cphase";
+static constexpr const char QIRCZ[] = "__quantum__qis__cz";
 static constexpr const char QIRReadResultBody[] =
     "__quantum__qis__read_result__body";
 

--- a/lib/Optimizer/CodeGen/ConvertToQIRProfile.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRProfile.cpp
@@ -457,10 +457,11 @@ struct QIRToQIRProfileQIRPass
     RewritePatternSet patterns(context);
     // Note: LoadMeasureResult is not compliant with the Base Profile, so don't
     // add it here unless we're specifically doing the Adaptive Profile.
-    patterns.insert<AddrOfCisToBase, ArrayGetElementPtrConv, CallAlloc,
-                    CalleeConv, EraseArrayAlloc, EraseArrayRelease,
-                    EraseDeadArrayGEP, MeasureCallConv,
-                    MeasureToRegisterCallConv, XCtrlOneTargetToCNot>(context);
+    patterns
+        .insert<AddrOfCisToBase, ArrayGetElementPtrConv, CallAlloc, CalleeConv,
+                EraseArrayAlloc, EraseArrayRelease, EraseDeadArrayGEP,
+                MeasureCallConv, MeasureToRegisterCallConv,
+                XCtrlOneTargetToCNot, ZCtrlOneTargetToCZ>(context);
     if (convertTo.getValue() == "qir-adaptive")
       patterns.insert<LoadMeasureResult>(context);
     if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns))))
@@ -503,6 +504,11 @@ struct QIRProfilePreparationPass
     // Add cnot declaration as it may be referenced after peepholes run.
     cudaq::opt::factory::createLLVMFunctionSymbol(
         cudaq::opt::QIRCnot, LLVM::LLVMVoidType::get(ctx),
+        {cudaq::opt::getQubitType(ctx), cudaq::opt::getQubitType(ctx)}, module);
+
+    // Add cz declaration as it may be referenced after peepholes run.
+    cudaq::opt::factory::createLLVMFunctionSymbol(
+        cudaq::opt::QIRCZ, LLVM::LLVMVoidType::get(ctx),
         {cudaq::opt::getQubitType(ctx), cudaq::opt::getQubitType(ctx)}, module);
 
     // Add measure_body as it has a different signature than measure.

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -542,6 +542,14 @@ void __quantum__qis__cnot__body(Qubit *q, Qubit *r) {
   nvqir::getCircuitSimulatorInternal()->x(controls, rI);
 }
 
+void __quantum__qis__cz__body(Qubit *q, Qubit *r) {
+  auto qI = qubitToSizeT(q);
+  auto rI = qubitToSizeT(r);
+  ScopedTraceWithContext("NVQIR::cz", qI, rI);
+  std::vector<std::size_t> controls{qI};
+  nvqir::getCircuitSimulatorInternal()->z(controls, rI);
+}
+
 void __quantum__qis__reset(Qubit *q) {
   auto qI = qubitToSizeT(q);
   ScopedTraceWithContext("NVQIR::reset", qI);

--- a/targettests/execution/qspan_slices.cpp
+++ b/targettests/execution/qspan_slices.cpp
@@ -8,11 +8,12 @@
 
 // REQUIRES: c++20
 // clang-format off
-// RUN: nvq++ --target anyon                    --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target ionq                     --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target iqm --iqm-machine Adonis --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target oqc                      --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target quantinuum               --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target anyon                              --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target anyon --anyon-machine berkeley-25q --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target ionq                               --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target iqm --iqm-machine Adonis           --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target oqc                                --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target quantinuum                         --emulate %s -o %t && %t | FileCheck %s
 // Tests for --disable-qubit-mapping:
 // RUN: nvq++ -v %s -o %t --target oqc --emulate --disable-qubit-mapping && CUDAQ_MLIR_PRINT_EACH_PASS=1 %t |& FileCheck --check-prefix=DISABLE %s
 // RUN: nvq++ -v %s -o %t --target iqm --iqm-machine Adonis --emulate --disable-qubit-mapping && CUDAQ_MLIR_PRINT_EACH_PASS=1 %t |& FileCheck --check-prefix=DISABLE %s


### PR DESCRIPTION
The `anyon-pgate-set-mapping` pass (used by the `berkeley-25q` machine from the Anyon target) uses the `z(1)` gate as the primary two-qubit gate. No other QIR-based hardware backend was using this gate as the primary two-qubit gate, so it was the first one to encounter this gap in the QIR implementation. This PR fixes the shortcoming and adds a test to prove that it works.