### PR TITLE
Fixes a bug with separate compilation.

### DIFF
--- a/docs/sphinx/using/extending/cudaq_ir.rst
+++ b/docs/sphinx/using/extending/cudaq_ir.rst
@@ -26,7 +26,7 @@ Let's see the output of :code:`nvq++` in verbose mode. Consider a simple code li
     $ nvq++ simple.cpp -v --save-temps
     
     cudaq-quake --emit-llvm-file simple.cpp -o simple.qke
-    cudaq-opt --pass-pipeline=builtin.module(canonicalize,lambda-lifting,canonicalize,apply-op-specialization,kernel-execution,inline{default-pipeline=func.func(indirect-to-direct-calls)},func.func(quake-add-metadata),device-code-loader{use-quake=1},expand-measurements,func.func(lower-to-cfg),canonicalize,cse) simple.qke -o simple.qke.LpsXpu
+    cudaq-opt --pass-pipeline=builtin.module(canonicalize,lambda-lifting,canonicalize,apply-op-specialization,kernel-execution,indirect-to-direct-calls,inline,func.func(quake-add-metadata),device-code-loader{use-quake=1},expand-measurements,func.func(lower-to-cfg),canonicalize,cse) simple.qke -o simple.qke.LpsXpu
     cudaq-translate --convert-to=qir simple.qke.LpsXpu -o simple.ll.p3De4L
     fixup-linkage.pl simple.qke simple.ll
     llc --relocation-model=pic --filetype=obj -O2 simple.ll.p3De4L -o simple.qke.o

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -266,6 +266,10 @@ mlir::Value createCast(mlir::OpBuilder &builder, mlir::Location loc,
 std::vector<std::complex<double>>
 readGlobalConstantArray(cudaq::cc::GlobalOp &global);
 
+std::pair<mlir::func::FuncOp, /*alreadyDefined=*/bool>
+getOrAddFunc(mlir::Location loc, mlir::StringRef funcName,
+             mlir::FunctionType funcTy, mlir::ModuleOp module);
+
 } // namespace factory
 
 std::size_t getDataSize(llvm::DataLayout &dataLayout, mlir::Type ty);

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -168,8 +168,7 @@ def ConstPropComplex : Pass<"const-prop-complex", "mlir::ModuleOp"> {
   }];
 }
 
-def ConvertToDirectCalls :
-    Pass<"indirect-to-direct-calls", "mlir::func::FuncOp"> {
+def ConvertToDirectCalls : Pass<"indirect-to-direct-calls", "mlir::ModuleOp"> {
   let summary = "Convert calls to direct calls to Quake routines.";
   let description = [{
     Rewrite the calls in the IR so that they point to the generated code and not

--- a/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -220,10 +220,10 @@ public:
     return result;
   }
 
-  bool VisitFunctionDecl(clang::FunctionDecl *func) {
+  bool VisitFunctionDecl(clang::FunctionDecl *x) {
     if (ignoreTemplate)
       return true;
-    func = func->getDefinition();
+    auto *func = x->getDefinition();
 
     if (func) {
       bool runChecks = false;
@@ -248,6 +248,9 @@ public:
         processQpu(cudaq::details::getTagNameOfFunctionDecl(func, mangler),
                    func);
       }
+    } else if (cudaq::ASTBridgeAction::ASTBridgeConsumer::isQuantum(x)) {
+      // Add declarations to support separate compilation.
+      processQpu(cudaq::details::getTagNameOfFunctionDecl(x, mangler), x);
     }
     return true;
   }
@@ -268,9 +271,9 @@ public:
     if (ignoreTemplate)
       return true;
     if (const auto *cxxMethodDecl = lambda->getCallOperator())
-      if (const auto *f = cxxMethodDecl->getAsFunction()->getDefinition();
-          f && cudaq::ASTBridgeAction::ASTBridgeConsumer::isQuantum(f))
-        processQpu(cudaq::details::getTagNameOfFunctionDecl(f, mangler), f);
+      if (const auto *f = cxxMethodDecl->getAsFunction()->getDefinition())
+        if (cudaq::ASTBridgeAction::ASTBridgeConsumer::isQuantum(f))
+          processQpu(cudaq::details::getTagNameOfFunctionDecl(f, mangler), f);
     return true;
   }
 

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -115,26 +115,10 @@ void QuakeBridgeVisitor::createEntryBlock(func::FuncOp func,
   addArgumentSymbols(entryBlock, x->parameters());
 }
 
-std::pair<func::FuncOp, /*alreadyDefined=*/bool>
+std::pair<func::FuncOp, bool>
 QuakeBridgeVisitor::getOrAddFunc(Location loc, StringRef funcName,
                                  FunctionType funcTy) {
-  auto func = module.lookupSymbol<func::FuncOp>(funcName);
-  if (func) {
-    if (!func.empty()) {
-      // Already lowered function func, skip it.
-      return {func, /*defined=*/true};
-    }
-    // Function was declared but not defined.
-    return {func, /*defined=*/false};
-  }
-  // Function not found, so add it to the module.
-  OpBuilder build(module.getBodyRegion());
-  OpBuilder::InsertionGuard guard(build);
-  build.setInsertionPointToEnd(module.getBody());
-  SmallVector<NamedAttribute> attrs;
-  func = build.create<func::FuncOp>(loc, funcName, funcTy, attrs);
-  func.setPrivate();
-  return {func, /*defined=*/false};
+  return cudaq::opt::factory::getOrAddFunc(loc, funcName, funcTy, module);
 }
 
 bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {

--- a/lib/Frontend/nvqpp/ConvertType.cpp
+++ b/lib/Frontend/nvqpp/ConvertType.cpp
@@ -507,7 +507,7 @@ bool QuakeBridgeVisitor::doSyntaxChecks(const clang::FunctionDecl *x) {
   auto astTy = x->getType();
   // Verify the argument and return types are valid for a kernel.
   auto *protoTy = dyn_cast<clang::FunctionProtoType>(astTy.getTypePtr());
-  auto syntaxError = [&]<unsigned N>(const char (&msg)[N]) -> bool {
+  auto syntaxError = [&]<unsigned N>(const char(&msg)[N]) -> bool {
     reportClangError(x, mangler, msg);
     [[maybe_unused]] auto ty = popType();
     LLVM_DEBUG(llvm::dbgs() << "invalid type: " << ty << '\n');

--- a/lib/Frontend/nvqpp/ConvertType.cpp
+++ b/lib/Frontend/nvqpp/ConvertType.cpp
@@ -507,14 +507,17 @@ bool QuakeBridgeVisitor::doSyntaxChecks(const clang::FunctionDecl *x) {
   auto astTy = x->getType();
   // Verify the argument and return types are valid for a kernel.
   auto *protoTy = dyn_cast<clang::FunctionProtoType>(astTy.getTypePtr());
-  if (!protoTy) {
-    reportClangError(x, mangler, "kernel must have a prototype");
+  auto syntaxError = [&]<unsigned N>(const char (&msg)[N]) -> bool {
+    reportClangError(x, mangler, msg);
+    [[maybe_unused]] auto ty = popType();
+    LLVM_DEBUG(llvm::dbgs() << "invalid type: " << ty << '\n');
     return false;
-  }
+  };
+  if (!protoTy)
+    return syntaxError("kernel must have a prototype");
   if (protoTy->getNumParams() != funcTy.getNumInputs()) {
     // The arity of the function doesn't match, so report an error.
-    reportClangError(x, mangler, "kernel has unexpected arguments");
-    return false;
+    return syntaxError("kernel has unexpected arguments");
   }
   for (auto [t, p] : llvm::zip(funcTy.getInputs(), x->parameters())) {
     // Structs, lambdas, functions are valid callable objects. Also pure
@@ -522,14 +525,12 @@ bool QuakeBridgeVisitor::doSyntaxChecks(const clang::FunctionDecl *x) {
     if (isKernelArgumentType(t) || isReferenceToCallableRecord(t, p) ||
         isReferenceToCudaqStateType(t))
       continue;
-    reportClangError(p, mangler, "kernel argument type not supported");
-    return false;
+    return syntaxError("kernel argument type not supported");
   }
   for (auto t : funcTy.getResults()) {
     if (isKernelResultType(t))
       continue;
-    reportClangError(x, mangler, "kernel result type not supported");
-    return false;
+    return syntaxError("kernel result type not supported");
   }
   return true;
 }

--- a/lib/Optimizer/Transforms/AggressiveEarlyInlining.cpp
+++ b/lib/Optimizer/Transforms/AggressiveEarlyInlining.cpp
@@ -67,10 +67,7 @@ public:
     auto *ctx = rewriter.getContext();
     auto loc = call.getLoc();
     auto funcTy = call.getCalleeType();
-    auto [fn, defn] =
-        cudaq::opt::factory::getOrAddFunc(loc, directName, funcTy, module);
-    if (!defn)
-      fn.setPrivate();
+    cudaq::opt::factory::getOrAddFunc(loc, directName, funcTy, module);
     rewriter.startRootUpdate(call);
     call.setCalleeAttr(SymbolRefAttr::get(ctx, directName));
     rewriter.finalizeRootUpdate(call);

--- a/lib/Optimizer/Transforms/AggressiveEarlyInlining.cpp
+++ b/lib/Optimizer/Transforms/AggressiveEarlyInlining.cpp
@@ -26,15 +26,15 @@ namespace cudaq::opt {
 
 using namespace mlir;
 
-static bool isIndirectFunc(llvm::StringRef funcName,
-                           llvm::StringMap<llvm::StringRef> indirectMap) {
+static bool isIndirectFunc(StringRef funcName,
+                           llvm::StringMap<StringRef> indirectMap) {
   return indirectMap.find(funcName) != indirectMap.end();
 }
 
 // Return the inverted mangled name map.
-static std::optional<llvm::StringMap<llvm::StringRef>>
+static std::optional<llvm::StringMap<StringRef>>
 getConversionMap(ModuleOp module) {
-  llvm::StringMap<llvm::StringRef> result;
+  llvm::StringMap<StringRef> result;
   if (auto mangledNameMap = module->getAttrOfType<DictionaryAttr>(
           cudaq::runtime::mangledNameMap)) {
     for (auto namedAttr : mangledNameMap) {
@@ -53,25 +53,34 @@ namespace {
 /// dialect calls and callables as well.]
 class RewriteCall : public OpRewritePattern<func::CallOp> {
 public:
-  RewriteCall(MLIRContext *ctx, llvm::StringMap<llvm::StringRef> &indirectMap)
-      : OpRewritePattern(ctx), indirectMap(indirectMap) {}
+  RewriteCall(MLIRContext *ctx, llvm::StringMap<StringRef> &indirectMap,
+              ModuleOp m)
+      : OpRewritePattern(ctx), indirectMap(indirectMap), module(m) {}
 
-  LogicalResult matchAndRewrite(func::CallOp op,
+  LogicalResult matchAndRewrite(func::CallOp call,
                                 PatternRewriter &rewriter) const override {
-    if (!isIndirectFunc(op.getCallee(), indirectMap))
+    if (!isIndirectFunc(call.getCallee(), indirectMap))
       return failure();
 
-    rewriter.startRootUpdate(op);
-    auto callee = op.getCallee();
-    llvm::StringRef directName = indirectMap[callee];
-    op.setCalleeAttr(SymbolRefAttr::get(op.getContext(), directName));
+    auto callee = call.getCallee();
+    StringRef directName = indirectMap[callee];
+    auto *ctx = rewriter.getContext();
+    auto loc = call.getLoc();
+    auto funcTy = call.getCalleeType();
+    auto [fn, defn] =
+        cudaq::opt::factory::getOrAddFunc(loc, directName, funcTy, module);
+    if (!defn)
+      fn.setPrivate();
+    rewriter.startRootUpdate(call);
+    call.setCalleeAttr(SymbolRefAttr::get(ctx, directName));
+    rewriter.finalizeRootUpdate(call);
     LLVM_DEBUG(llvm::dbgs() << "Rewriting " << directName << '\n');
-    rewriter.finalizeRootUpdate(op);
     return success();
   }
 
 private:
-  llvm::StringMap<llvm::StringRef> &indirectMap;
+  llvm::StringMap<StringRef> &indirectMap;
+  ModuleOp module;
 };
 
 /// Translate indirect calls to direct calls.
@@ -81,14 +90,13 @@ public:
   using ConvertToDirectCallsBase::ConvertToDirectCallsBase;
 
   void runOnOperation() override {
-    auto op = getOperation();
+    ModuleOp module = getOperation();
     auto *ctx = &getContext();
-    auto module = op->template getParentOfType<ModuleOp>();
     if (auto indirectMapOpt = getConversionMap(module)) {
-      LLVM_DEBUG(llvm::dbgs() << "Processing: " << op << '\n');
+      LLVM_DEBUG(llvm::dbgs() << "Processing: " << module << '\n');
       RewritePatternSet patterns(ctx);
-      patterns.insert<RewriteCall>(ctx, *indirectMapOpt);
-      if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns))))
+      patterns.insert<RewriteCall>(ctx, *indirectMapOpt, module);
+      if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns))))
         signalPassFailure();
     }
   }
@@ -136,7 +144,7 @@ static void defaultInlinerOptPipeline(OpPassManager &pm) {
 /// graph.
 void cudaq::opt::addAggressiveEarlyInlining(OpPassManager &pm) {
   llvm::StringMap<OpPassManager> opPipelines;
-  pm.addNestedPass<func::FuncOp>(cudaq::opt::createConvertToDirectCalls());
+  pm.addPass(cudaq::opt::createConvertToDirectCalls());
   pm.addPass(createInlinerPass(opPipelines, defaultInlinerOptPipeline));
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createCheckKernelCalls());
 }

--- a/lib/Optimizer/Transforms/GenDeviceCodeLoader.cpp
+++ b/lib/Optimizer/Transforms/GenDeviceCodeLoader.cpp
@@ -91,7 +91,7 @@ public:
         continue;
       if (!funcOp.getName().startswith(cudaq::runtime::cudaqGenPrefixName))
         continue;
-      if (funcOp->hasAttr(cudaq::generatorAnnotation))
+      if (funcOp->hasAttr(cudaq::generatorAnnotation) || funcOp.empty())
         continue;
       auto className =
           funcOp.getName().drop_front(cudaq::runtime::cudaqGenPrefixLength);

--- a/targettests/SeparateCompilation/pure_device.cpp
+++ b/targettests/SeparateCompilation/pure_device.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: if [ command -v split-file ]; then \
+// RUN: split-file %s %t && \
+// RUN: nvq++ %cpp_std --enable-mlir -c %t/pd_lib.cpp -o %t/pd_lib.o && \
+// RUN: nvq++ %cpp_std --enable-mlir -c %t/pd_main.cpp -o %t/pd_main.o && \
+// RUN: nvq++ %cpp_std --enable-mlir %t/pd_lib.o %t/pd_main.o -o %t/pd.a.out && \
+// RUN: %t/pd.a.out | FileCheck %s ; else \
+// RUN: echo "skipping" ; fi
+// clang-format on
+
+//--- pd_lib.h
+
+#pragma once
+
+#include "cudaq.h"
+
+// NB: The __qpu__ here on this declaration cannot be omitted!
+__qpu__ void callMe(cudaq::qvector<> &q, int i);
+
+//--- pd_lib.cpp
+
+#include "pd_lib.h"
+
+void send_bat_signal() { std::cout << "na na na na na ... BATMAN!\n"; }
+
+__qpu__ void callMe(cudaq::qvector<> &q, int i) {
+  ry(2.2, q[0]);
+  send_bat_signal();
+}
+
+//--- pd_main.cpp
+
+#include "pd_lib.h"
+
+__qpu__ void entry() {
+  cudaq::qvector q(2);
+  callMe(q, 5);
+}
+
+int main() { entry(); }
+
+// CHECK: na ... BATMAN!

--- a/test/AST-Quake/ctor-2.cpp
+++ b/test/AST-Quake/ctor-2.cpp
@@ -22,23 +22,37 @@ void S1::operator()(bool b) {
   cudaq::qubit q;
   S2 s2;
   s2(b);
+  x(q);
 }
 
 void S2::operator()(bool b) {
   cudaq::qubit q;
+  z(q);
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__S1(
-// CHECK-SAME:      %[[VAL_0:.*]]: i1{{.*}}) attributes
+// CHECK-SAME:      %[[VAL_0:.*]]: i1)
 // CHECK:           %[[VAL_1:.*]] = cc.alloca i1
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i1>
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.struct<"S2" {} [8,1]>
-// CHECK:           call @_ZN2S2C1Ev(%[[VAL_3]]) : (!cc.ptr<!cc.struct<"S2" {} [8,1]>>) -> () 
-// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_1]] : !cc.ptr<i1> 
-// CHECK:           call @_ZN2S2clEb(%[[VAL_5]]) : (i1) -> () 
-// CHECK:           return 
-// CHECK:         } 
+// CHECK:           call @_ZN2S2C1Ev(%[[VAL_3]]) : (!cc.ptr<!cc.struct<"S2" {} [8,1]>>) -> ()
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_1]] : !cc.ptr<i1>
+// CHECK:           call @_ZN2S2clEb(%[[VAL_4]]) : (i1) -> ()
+// CHECK:           quake.x %[[VAL_2]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__S2
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__S2(
+// CHECK-SAME:      %[[VAL_0:.*]]: i1)
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i1
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.z %[[VAL_2]] : (!quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
 
+// CHECK:         func.func private @_ZN2S2C1Ev(!cc.ptr<!cc.struct<"S2" {} [8,1]>>)
+// CHECK:         func.func private @_ZN2S2clEb(i1)
+
+// CHECK:         func.func @_ZN2S1clEb(

--- a/test/AST-error/quantum_struct_declarations.cpp
+++ b/test/AST-error/quantum_struct_declarations.cpp
@@ -16,6 +16,7 @@ struct error1 {
   cudaq::qvector<4> wrong;
 };
 
+// expected-error@+1 {{kernel argument type not supported}}
 __qpu__ void bug1(error1&);
 
 // expected-error@+1 {{quantum struct has invalid member type}}
@@ -23,6 +24,7 @@ struct error2 {
   cudaq::qubit cubit;
 };
 
+// expected-error@+1 {{kernel argument type not supported}}
 __qpu__ void bug2(error2&);
 
 // expected-error@+2 {{quantum struct has invalid member type}}
@@ -32,6 +34,7 @@ struct error3 {
   cudaq::qvector<2> sorry;
 };
 
+// expected-error@+1 {{kernel argument type not supported}}
 __qpu__ void bug3(error3&);
 
 __qpu__ void funny() {

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -707,7 +707,7 @@ if ${ENABLE_AGGRESSIVE_EARLY_INLINE}; then
 	if ${DO_LINK}; then
 		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "aggressive-early-inlining")
 	else
-		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(indirect-to-direct-calls),inline")
+		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "indirect-to-direct-calls,inline")
 	fi
 fi
 if ${ENABLE_DEVICE_CODE_LOADERS}; then


### PR DESCRIPTION
The bridge wasn't adding all possible `__qpu__` functions to the list, so the call converter wasn't converting a pure device kernel call on the device side. This change fixes that bug, updates the call converter to be able to add any missing declaration(s), and adds a regression test.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
