### PR TITLE
ensure quantum_lib is built after nvq++ components are built

### DIFF
--- a/python/tests/interop/quantum_lib/CMakeLists.txt
+++ b/python/tests/interop/quantum_lib/CMakeLists.txt
@@ -11,3 +11,4 @@ set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> -fPIC --enable-mlir --disable
 
 # FIXME Error with SHARED, it pulls in all the mlir libraries anyway
 add_library(quantum_lib OBJECT quantum_lib.cpp)
+add_dependencies(quantum_lib nvq++ cudaq-opt cudaq-quake cudaq-translate)


### PR DESCRIPTION
A bad rebase removed the add_dependency line for the quantum_lib test library. Add that back here. 