### PR TITLE
Rename --save-temps option to -save-temps.

### DIFF
--- a/docs/sphinx/using/extending/cudaq_ir.rst
+++ b/docs/sphinx/using/extending/cudaq_ir.rst
@@ -23,7 +23,7 @@ Let's see the output of :code:`nvq++` in verbose mode. Consider a simple code li
 
 .. code-block:: console 
 
-    $ nvq++ simple.cpp -v --save-temps
+    $ nvq++ simple.cpp -v -save-temps
     
     cudaq-quake --emit-llvm-file simple.cpp -o simple.qke
     cudaq-opt --pass-pipeline=builtin.module(canonicalize,lambda-lifting,canonicalize,apply-op-specialization,kernel-execution,indirect-to-direct-calls,inline,func.func(quake-add-metadata),device-code-loader{use-quake=1},expand-measurements,func.func(lower-to-cfg),canonicalize,cse) simple.qke -o simple.qke.LpsXpu
@@ -39,7 +39,7 @@ This workflow orchestration is represented in the figure below:
 .. image:: ../../_static/nvqpp_workflow.png
 
 We start by mapping CUDA-Q C++ kernel representations (structs, lambdas, and free functions) 
-to the Quake dialect. Since we added :code:`--save-temps`, 
+to the Quake dialect. Since we added :code:`-save-temps`, 
 we can look at the IR code that was produced. The base Quake file, :code:`simple.qke`, contains the following: 
 
 .. code-block:: console 

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -520,7 +520,7 @@ while [ $# -ne 0 ]; do
 		CUDAQ_OPT_EXTRA_PASSES=$(add_pass_to_pipeline "${CUDAQ_OPT_EXTRA_PASSES}" "$2") 
 		shift
 		;;
-	-save-temps)
+	-save-temps|--save-temps)
 		DELETE_TEMPS=false
 		;;
 	-h|--help)

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -221,7 +221,7 @@ function show_help {
 --opt-pass <pass name>
 	Append a pass to the pass pipeline by specifying its name in the pass pipeline syntax, e.g. <dialect>.<opname>(passname).
 
---save-temps
+-save-temps
 	Save temporary files.
 
 -o=<obj>
@@ -520,7 +520,7 @@ while [ $# -ne 0 ]; do
 		CUDAQ_OPT_EXTRA_PASSES=$(add_pass_to_pipeline "${CUDAQ_OPT_EXTRA_PASSES}" "$2") 
 		shift
 		;;
-	--save-temps)
+	-save-temps)
 		DELETE_TEMPS=false
 		;;
 	-h|--help)


### PR DESCRIPTION
Make the option match the clang++ option name. Having access to both just causes confusion and crashed the compiler.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
