### PR TITLE
Fix issues with `state.from_data` bindings

### DIFF
--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -311,7 +311,11 @@ void bindPyState(py::module &mod, LinkedLibraryHolder &holder) {
           "Return a state from matrix product state tensor data.")
       .def_static(
           "from_data",
-          [](const std::vector<py::object> &tensors) {
+          [](const py::list &tensors) {
+            // Note: we must use Python type (py::list) for proper overload
+            // resolution. The overload for py::object, intended for cupy arrays
+            // (implementing Python array interface), may be overshadowed by any
+            // std::vector overloads.
             cudaq::TensorStateData tensorData;
             for (auto &tensor : tensors) {
               // Make sure this is a CuPy array
@@ -347,7 +351,7 @@ void bindPyState(py::module &mod, LinkedLibraryHolder &holder) {
           "ndarray).")
       .def_static(
           "from_data",
-          [](py::object opaqueData) {
+          [&holder](py::object opaqueData) {
             // Make sure this is a CuPy array
             if (!py::hasattr(opaqueData, "data"))
               throw std::runtime_error(
@@ -380,6 +384,13 @@ void bindPyState(py::module &mod, LinkedLibraryHolder &holder) {
                 numElements *= el.cast<std::size_t>();
               return numElements;
             }();
+
+            // Check that the target is GPU-based, i.e., can handle device
+            // pointer.
+            if (!holder.getTarget().config.GpuRequired)
+              throw std::runtime_error(fmt::format(
+                  "Current target '{}' does not support CuPy arrays.",
+                  holder.getTarget().name));
 
             long ptr = data.attr("ptr").cast<long>();
             if (typeStr == "complex64")

--- a/python/tests/builder/test_cupy_integration.py
+++ b/python/tests/builder/test_cupy_integration.py
@@ -108,7 +108,8 @@ def test_cupy_to_state():
 
 
 def test_cupy_to_state_without_dtype():
-    cp_data = cp.array([.707107, 0, 0, .707107])
+    cudaq.set_target('nvidia-fp64')
+    cp_data = cp.array([.707107, 0j, 0, .707107])
     state_from_cupy = cudaq.State.from_data(cp_data)
     state_from_cupy.dump()
     kernel = cudaq.make_kernel()
@@ -119,6 +120,17 @@ def test_cupy_to_state_without_dtype():
     state = cudaq.get_state(kernel)
     result = state.overlap(state_from_cupy)
     assert np.isclose(result, 1.0, atol=1e-3)
+    cudaq.reset_target()
+
+
+@pytest.mark.parametrize("target", ["qpp-cpu", "density-matrix-cpu"])
+def test_cupy_to_state_cpu_sim(target):
+    cudaq.set_target(target)
+    cp_data = cp.array([.707107, 0, 0, .707107], dtype=cp.complex128)
+    # This should throw since these targets are CPU-based.
+    with pytest.raises(RuntimeError) as error:
+        state_from_cupy = cudaq.State.from_data(cp_data)
+    cudaq.reset_target()
 
 
 # leave for gdb debugging


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- The `std::vector<py::object>` overload overshadowed the `py::object` one as a cupy array object also implements Python array interface. Thus, it might be casted to a `std::vector<py::object>`. Fixed by using the Python type (`py::list`) instead.

- Add a check for cupy array input case: if the simulator is not GPU-based, throw an error. Previously, the pointer will be presented to the simulator anyhow, causing a segfault.
