### PR TITLE
[pauli word] Rework the implementation from front to back.

### DIFF
--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -128,9 +128,13 @@ inline mlir::Type stateImplType(mlir::Type eleTy) {
   return cudaq::opt::factory::getPointerType(eleTy.getContext());
 }
 
-// Host side types for std::string and std::vector
+// Generate host side type for std::string. The result is the type of a block of
+// bytes and the length to allocate. This allows for the creation of code to
+// allocate a variable, stride across such a variable, etc. The ModuleOp must
+// contain the sizeof a pauli_word in its attributes.
+cudaq::cc::ArrayType genHostStringType(mlir::ModuleOp module);
 
-cudaq::cc::StructType stlStringType(mlir::MLIRContext *ctx);
+// Host side types for std::vector
 cudaq::cc::StructType stlVectorType(mlir::Type eleTy);
 
 //===----------------------------------------------------------------------===//
@@ -247,7 +251,7 @@ mlir::FunctionType toHostSideFuncType(mlir::FunctionType funcTy,
                                       bool addThisPtr, mlir::ModuleOp module);
 
 /// Convert device type, \p ty, to host side type.
-mlir::Type convertToHostSideType(mlir::Type ty);
+mlir::Type convertToHostSideType(mlir::Type ty, mlir::ModuleOp module);
 
 // Return `true` if the given type corresponds to a standard vector type
 // according to our convention.

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -246,6 +246,9 @@ bool hasSRet(mlir::func::FuncOp funcOp);
 mlir::FunctionType toHostSideFuncType(mlir::FunctionType funcTy,
                                       bool addThisPtr, mlir::ModuleOp module);
 
+/// Convert device type, \p ty, to host side type.
+mlir::Type convertToHostSideType(mlir::Type ty);
+
 // Return `true` if the given type corresponds to a standard vector type
 // according to our convention.
 // The convention is a `ptr<struct<ptr<T>, ptr<T>, ptr<T>>>`.

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -131,7 +131,7 @@ inline mlir::Type stateImplType(mlir::Type eleTy) {
 // Generate host side type for std::string. The result is the type of a block of
 // bytes and the length to allocate. This allows for the creation of code to
 // allocate a variable, stride across such a variable, etc. The ModuleOp must
-// contain the sizeof a pauli_word in its attributes.
+// contain the size of a pauli_word in its attributes.
 cudaq::cc::ArrayType genHostStringType(mlir::ModuleOp module);
 
 // Host side types for std::vector

--- a/include/cudaq/Optimizer/Builder/Intrinsics.h
+++ b/include/cudaq/Optimizer/Builder/Intrinsics.h
@@ -36,10 +36,15 @@ static constexpr const char getCudaqSizeFromTriple[] =
 // typically specialized to be bit packed).
 static constexpr const char stdvecBoolCtorFromInitList[] =
     "__nvqpp_initializer_list_to_vector_bool";
+
 // Convert a (likely packed) std::vector<bool> into a sequence of bytes, each
 // holding a boolean value.
 static constexpr const char stdvecBoolUnpackToInitList[] =
     "__nvqpp_vector_bool_to_initializer_list";
+
+// Free any temporary buffers used to hold std::vector<bool> data.
+static constexpr const char stdvecBoolFreeTemporaryLists[] =
+    "__nvqpp_vector_bool_free_temporary_initlists";
 
 // The internal data of the cudaq::state object must be `2**n` in length. This
 // function returns the value `n`.

--- a/include/cudaq/Optimizer/Builder/Runtime.h
+++ b/include/cudaq/Optimizer/Builder/Runtime.h
@@ -10,6 +10,16 @@
 
 #include "cudaq/Optimizer/Builder/Factory.h"
 
+//===----------------------------------------------------------------------===//
+//
+// Runtime helper functions are functions that will appear in the runtime
+// library (implementations are defined in either the headers or libraries in
+// the `runtime` directory). These helper functions may never be assumed to
+// appear on the device-side, so these helpers should only be used in host-side
+// code.
+//
+//===----------------------------------------------------------------------===//
+
 namespace cudaq::runtime {
 
 /// Prefix for all kernel entry functions.

--- a/include/cudaq/Optimizer/Builder/Runtime.h
+++ b/include/cudaq/Optimizer/Builder/Runtime.h
@@ -53,11 +53,14 @@ static constexpr const char cudaqAHSPrefixName[] =
     "__analog_hamiltonian_kernel__";
 
 // Host-side helper functions for working with `cudaq::pauli_word` or a
-// `std::string`.
+// `std::string`. These include both fully dynamic and binding time (library
+// build time) helper functions.
 static constexpr const char sizeofStringAttrName[] = "cc.sizeof_string";
 static constexpr const char getPauliWordSize[] =
     "_ZNK5cudaq10pauli_word11_nvqpp_sizeEv";
 static constexpr const char getPauliWordData[] =
     "_ZNK5cudaq10pauli_word11_nvqpp_dataEv";
+static constexpr const char bindingGetStringData[] = "__nvqpp_getStringData";
+static constexpr const char bindingGetStringSize[] = "__nvqpp_getStringSize";
 
 } // namespace cudaq::runtime

--- a/include/cudaq/Optimizer/Builder/Runtime.h
+++ b/include/cudaq/Optimizer/Builder/Runtime.h
@@ -52,4 +52,12 @@ static constexpr const char CudaqRegisterKernelName[] =
 static constexpr const char cudaqAHSPrefixName[] =
     "__analog_hamiltonian_kernel__";
 
+// Host-side helper functions for working with `cudaq::pauli_word` or a
+// `std::string`.
+static constexpr const char sizeofStringAttrName[] = "cc.sizeof_string";
+static constexpr const char getPauliWordSize[] =
+    "_ZNK5cudaq10pauli_word11_nvqpp_sizeEv";
+static constexpr const char getPauliWordData[] =
+    "_ZNK5cudaq10pauli_word11_nvqpp_dataEv";
+
 } // namespace cudaq::runtime

--- a/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -121,10 +121,10 @@ def cc_StructType : CCType<"Struct", "struct",
   let extraClassDeclaration = [{
     // O(1)
     bool isEmpty() const { return getMembers().empty(); }
-    
+
     // O(n)
     std::size_t getNumMembers() const { return getMembers().size(); }
-    
+
     Type getMember(unsigned position) { return getMembers()[position]; }
   }];
 }

--- a/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -119,7 +119,12 @@ def cc_StructType : CCType<"Struct", "struct",
   ];
 
   let extraClassDeclaration = [{
+    // O(1)
     bool isEmpty() const { return getMembers().empty(); }
+    
+    // O(n)
+    std::size_t getNumMembers() const { return getMembers().size(); }
+    
     Type getMember(unsigned position) { return getMembers()[position]; }
   }];
 }

--- a/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -331,7 +331,9 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *x) {
                                                 ValueRange{heapCopy, dynSize});
       };
       IRBuilder irb(builder);
-      Value tySize = irb.getByteSizeOfType(loc, eleTy);
+      Value tySize;
+      if (!cudaq::cc::isDynamicType(eleTy))
+        tySize = irb.getByteSizeOfType(loc, eleTy);
       if (!tySize) {
         TODO_x(toLocation(x), x, mangler, "unhandled vector element type");
         return false;

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
+#include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/CodeGen/QIRFunctionNames.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
@@ -305,12 +306,13 @@ cc::LoopOp factory::createMonotonicLoop(
   return loop;
 }
 
-cc::StructType factory::stlStringType(MLIRContext *ctx) {
+cc::ArrayType factory::genHostStringType(ModuleOp mod) {
+  auto *ctx = mod.getContext();
   auto i8Ty = IntegerType::get(ctx, 8);
-  auto ptrI8Ty = cc::PointerType::get(i8Ty);
-  auto i64Ty = IntegerType::get(ctx, 64);
-  auto padTy = cc::ArrayType::get(ctx, i8Ty, 16);
-  return cc::StructType::get(ctx, ArrayRef<Type>{ptrI8Ty, i64Ty, padTy});
+  auto sizeAttr = mod->getAttr(cudaq::runtime::sizeofStringAttrName);
+  assert(sizeAttr && "module must have cc.sizeof_string attribute");
+  auto size = cast<IntegerAttr>(sizeAttr).getInt();
+  return cc::ArrayType::get(ctx, i8Ty, size);
 }
 
 // FIXME: We should get the underlying structure of a std::vector from the
@@ -358,18 +360,19 @@ Type factory::getSRetElementType(FunctionType funcTy) {
   return funcTy.getResult(0);
 }
 
-Type factory::convertToHostSideType(Type ty) {
+Type factory::convertToHostSideType(Type ty, ModuleOp mod) {
   if (auto memrefTy = dyn_cast<cc::StdvecType>(ty))
-    return stlHostVectorType(convertToHostSideType(memrefTy.getElementType()));
+    return stlHostVectorType(
+        convertToHostSideType(memrefTy.getElementType(), mod));
   if (isa<cc::IndirectCallableType>(ty))
     return cc::PointerType::get(IntegerType::get(ty.getContext(), 8));
-  if (isa<cc::CharspanType>(ty))
-    return factory::stlStringType(ty.getContext());
+  if (auto csTy = dyn_cast<cc::CharspanType>(ty))
+    return genHostStringType(mod);
   auto *ctx = ty.getContext();
   if (auto structTy = dyn_cast<cc::StructType>(ty)) {
     SmallVector<Type> newMembers;
     for (auto mem : structTy.getMembers())
-      newMembers.push_back(convertToHostSideType(mem));
+      newMembers.push_back(convertToHostSideType(mem, mod));
     if (structTy.getName())
       return cc::StructType::get(ctx, structTy.getName(), newMembers,
                                  structTy.getBitSize(), structTy.getAlignment(),
@@ -589,7 +592,7 @@ FunctionType factory::toHostSideFuncType(FunctionType funcTy, bool addThisPtr,
       // returned via a sret argument in the first position. When this argument
       // is added, the this pointer becomes the second argument. Both are opaque
       // pointers at this point.
-      auto eleTy = convertToHostSideType(getSRetElementType(funcTy));
+      auto eleTy = convertToHostSideType(getSRetElementType(funcTy), module);
       inputTys.push_back(cc::PointerType::get(eleTy));
       hasSRet = true;
     } else {
@@ -605,7 +608,7 @@ FunctionType factory::toHostSideFuncType(FunctionType funcTy, bool addThisPtr,
 
   // Add all the explicit (not hidden) arguments after the hidden ones.
   for (auto kernelTy : funcTy.getInputs()) {
-    auto hostTy = convertToHostSideType(kernelTy);
+    auto hostTy = convertToHostSideType(kernelTy, module);
     if (auto strTy = dyn_cast<cc::StructType>(hostTy)) {
       // On x86_64 and aarch64, a struct that is smaller than 128 bits may be
       // passed in registers as separate arguments. See classifyArgumentType()
@@ -645,6 +648,9 @@ FunctionType factory::toHostSideFuncType(FunctionType funcTy, bool addThisPtr,
         }
       }
       // Pass a struct as a byval pointer.
+      hostTy = cc::PointerType::get(hostTy);
+    } else if (isa<cc::ArrayType>(hostTy)) {
+      // Pass a raw data block as a pointer. (It's a struct passed as a blob.)
       hostTy = cc::PointerType::get(hostTy);
     }
     inputTys.push_back(hostTy);

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -310,9 +310,11 @@ cc::ArrayType factory::genHostStringType(ModuleOp mod) {
   auto *ctx = mod.getContext();
   auto i8Ty = IntegerType::get(ctx, 8);
   auto sizeAttr = mod->getAttr(cudaq::runtime::sizeofStringAttrName);
-  assert(sizeAttr && "module must have cc.sizeof_string attribute");
-  auto size = cast<IntegerAttr>(sizeAttr).getInt();
-  return cc::ArrayType::get(ctx, i8Ty, size);
+  if (sizeAttr) {
+    auto size = cast<IntegerAttr>(sizeAttr).getInt();
+    return cc::ArrayType::get(ctx, i8Ty, size);
+  }
+  return cc::ArrayType::get(ctx, i8Ty, sizeof(std::string));
 }
 
 // FIXME: We should get the underlying structure of a std::vector from the

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -56,7 +56,8 @@ static constexpr IntrinsicCode intrinsicTable[] = {
      "func.func private @_ZNK5cudaq10pauli_word11_nvqpp_dataEv(%pw : "
      "!cc.ptr<i8>) -> !cc.ptr<i8>"},
     {cudaq::runtime::getPauliWordSize,
-     {cudaq::runtime::getPauliWordData},
+     {cudaq::runtime::getPauliWordData, cudaq::runtime::bindingGetStringData,
+      cudaq::runtime::bindingGetStringSize},
      "func.func private @_ZNK5cudaq10pauli_word11_nvqpp_sizeEv(%pw : "
      "!cc.ptr<i8>) -> i64"},
 
@@ -302,6 +303,15 @@ static constexpr IntrinsicCode intrinsicTable[] = {
      R"#(
   func.func private @__nvqpp_getStateVectorLength_fp64(%p : i64, %o : i64) -> i64
   )#"},
+
+    // Quasi-portable entry points for use with non-C++ front ends (Python).
+    {cudaq::runtime::bindingGetStringData,
+     {},
+     "func.func private @__nvqpp_getStringData(%p: !cc.ptr<i8>) -> "
+     "!cc.ptr<i8>"},
+    {cudaq::runtime::bindingGetStringSize,
+     {},
+     "func.func private @__nvqpp_getStringSize(%p: !cc.ptr<i8>) -> i64"},
 
     // __nvqpp_initializer_list_to_vector_bool
     {cudaq::stdvecBoolCtorFromInitList,

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -49,6 +49,17 @@ inline bool operator<(const IntrinsicCode &icode, const IntrinsicCode &jcode) {
 /// well as prototypes for LLVM intrinsics and C library calls that are used by
 /// the compiler. The table should be kept in sorted order.
 static constexpr IntrinsicCode intrinsicTable[] = {
+    // These following pauli_word helper functions are only available on the
+    // host-side. They ought not be called in kernel code.
+    {cudaq::runtime::getPauliWordData,
+     {},
+     "func.func private @_ZNK5cudaq10pauli_word11_nvqpp_dataEv(%pw : "
+     "!cc.ptr<i8>) -> !cc.ptr<i8>"},
+    {cudaq::runtime::getPauliWordSize,
+     {cudaq::runtime::getPauliWordData},
+     "func.func private @_ZNK5cudaq10pauli_word11_nvqpp_sizeEv(%pw : "
+     "!cc.ptr<i8>) -> i64"},
+
     // Initialize a (preallocated) buffer (the first parameter) with i64 values
     // on the semi-open range `[0..n)` where `n` is the second parameter.
     {cudaq::runtime::getLinkableKernelKey,

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -307,11 +307,17 @@ static constexpr IntrinsicCode intrinsicTable[] = {
     return %0 : !cc.ptr<i8>
   })#"},
 
+    // __nvqpp_vector_bool_free_temporary_lists
+    {cudaq::stdvecBoolFreeTemporaryLists,
+     {},
+     R"#(
+  func.func private @__nvqpp_vector_bool_free_temporary_initlists(!cc.ptr<i8>) -> ())#"},
+
     // __nvqpp_vector_bool_to_initializer_list
     {cudaq::stdvecBoolUnpackToInitList,
      {},
      R"#(
-  func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>) -> ())#"},
+  func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.array<i8 x 32>}>>, !cc.ptr<!cc.ptr<i8>>) -> ())#"},
 
     {"__nvqpp_zeroDynamicResult", {}, R"#(
   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -106,6 +106,10 @@ Value cudaq::cc::getByteSizeOfType(OpBuilder &builder, Location loc, Type ty,
         return builder.create<arith::MulIOp>(loc, builder.getI64Type(), v,
                                              scale);
       })
+      .Case([&](cudaq::cc::SpanLikeType) -> Value {
+        // Uniformly on the device size: {ptr, i64}
+        return createInt(16);
+      })
       .Default({});
 }
 

--- a/lib/Optimizer/Dialect/CC/CCTypes.cpp
+++ b/lib/Optimizer/Dialect/CC/CCTypes.cpp
@@ -158,7 +158,7 @@ Type cc::SpanLikeType::getElementType() const {
 }
 
 bool isDynamicType(Type ty) {
-  if (isa<StdvecType>(ty))
+  if (isa<SpanLikeType>(ty))
     return true;
   if (auto strTy = dyn_cast<StructType>(ty)) {
     for (auto memTy : strTy.getMembers())

--- a/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -362,6 +362,9 @@ struct ExpPauliDecomposition : public OpRewritePattern<quake::ExpPauliOp> {
               auto strAttr = cast<mlir::StringAttr>(attr.value());
               optPauliWordStr = strAttr.getValue();
             }
+          } else if (auto lit = addrOp.getDefiningOp<
+                                cudaq::cc::CreateStringLiteralOp>()) {
+            optPauliWordStr = lit.getStringLiteral();
           }
         }
       }
@@ -369,7 +372,7 @@ struct ExpPauliDecomposition : public OpRewritePattern<quake::ExpPauliOp> {
 
     // Assert that we have a constant known pauli word
     if (!optPauliWordStr.has_value())
-      return failure();
+      return expPauliOp.emitOpError("cannot determine pauli word string");
 
     auto pauliWordStr = optPauliWordStr.value();
 

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -351,8 +351,8 @@ convertAllStdVectorBool(Location loc, OpBuilder &builder, ModuleOp module,
     }();
     auto transEleTy = cast<cudaq::cc::StructType>(transientTy).getMember(0);
     auto dataTy = cast<cudaq::cc::PointerType>(transEleTy).getElementType();
-    auto sizeTransientTy = builder.create<cudaq::cc::SizeOfOp>(
-        loc, builder.getI64Type(), dataTy);
+    auto sizeTransientTy =
+        builder.create<cudaq::cc::SizeOfOp>(loc, builder.getI64Type(), dataTy);
     Value sizeInBytes =
         builder.create<arith::MulIOp>(loc, count, sizeTransientTy);
 

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -812,7 +812,7 @@ populateMessageBuffer(Location loc, OpBuilder &builder, Value msgBufferBase,
     if (isa<cudaq::cc::PointerType>(devArgTy))
       arg = builder.create<cudaq::cc::CastOp>(loc, memberTy, arg);
 
-    if (isa<cudaq::cc::StructType>(arg.getType()) &&
+    if (isa<cudaq::cc::StructType, cudaq::cc::ArrayType>(arg.getType()) &&
         (cudaq::cc::PointerType::get(arg.getType()) != slot.getType())) {
       slot = builder.create<cudaq::cc::CastOp>(
           loc, cudaq::cc::PointerType::get(arg.getType()), slot);

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -1167,7 +1167,7 @@ static std::pair<Value, Value> constructDynamicInputValue(Location loc,
 /// current level.
 static std::pair<Value, Value>
 processInputValue(Location loc, OpBuilder &builder, Value trailingData,
-                  Value ptrPackedStruct, Type inTy, std::int64_t off,
+                  Value ptrPackedStruct, Type inTy, std::int32_t off,
                   cudaq::cc::StructType packedStructTy) {
   auto packedPtr = builder.create<cudaq::cc::ComputePtrOp>(
       loc, cudaq::cc::PointerType::get(packedStructTy.getMember(off)),

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -122,8 +122,8 @@ synthesizeVectorArgument(OpBuilder &builder, ModuleOp module, unsigned &counter,
                          ATTR arrayAttr, MAKER makeElementValue) {
   auto *ctx = builder.getContext();
   auto argTy = argument.getType();
-  assert(isa<cudaq::cc::StdvecType>(argTy));
-  auto strTy = cast<cudaq::cc::StdvecType>(argTy);
+  assert(isa<cudaq::cc::SpanLikeType>(argTy));
+  auto strTy = cast<cudaq::cc::SpanLikeType>(argTy);
   auto eleTy = cast<ELETY>(strTy.getElementType());
   builder.setInsertionPointToStart(argument.getOwner());
   auto argLoc = argument.getLoc();
@@ -566,7 +566,7 @@ public:
 
       // If std::vector<arithmetic> type, add it to the list of vector info.
       // These will be processed when we reach the buffer's appendix.
-      if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(type)) {
+      if (auto vecTy = dyn_cast<cudaq::cc::SpanLikeType>(type)) {
         auto eleTy = vecTy.getElementType();
         if (!isa<IntegerType, FloatType, ComplexType, cudaq::cc::CharspanType>(
                 eleTy)) {

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -122,15 +122,9 @@ synthesizeVectorArgument(OpBuilder &builder, ModuleOp module, unsigned &counter,
                          ATTR arrayAttr, MAKER makeElementValue) {
   auto *ctx = builder.getContext();
   auto argTy = argument.getType();
-  assert(isa<cudaq::cc::StdvecType>(argTy) ||
-         isa<cudaq::cc::CharspanType>(argTy));
-  ELETY eleTy = [&]() -> ELETY {
-    if (auto strTy = dyn_cast<cudaq::cc::StdvecType>(argTy))
-      return cast<ELETY>(strTy.getElementType());
-    // Force cast this to ELETY. This will only happen for CharspanType.
-    return cast<ELETY>(cudaq::opt::factory::getCharType(ctx));
-  }();
-  auto strTy = cudaq::cc::StdvecType::get(ctx, eleTy);
+  assert(isa<cudaq::cc::StdvecType>(argTy));
+  auto strTy = cast<cudaq::cc::StdvecType>(argTy);
+  auto eleTy = cast<ELETY>(strTy.getElementType());
   builder.setInsertionPointToStart(argument.getOwner());
   auto argLoc = argument.getLoc();
   auto conArray = builder.create<cudaq::cc::ConstantArrayOp>(
@@ -618,19 +612,6 @@ public:
         auto rawSize =
             *reinterpret_cast<const std::uint64_t *>(ptrToSizeInBuffer);
         stdVecInfo.emplace_back(argNum, Type{}, rawSize);
-        continue;
-      }
-
-      if (auto charSpanTy = dyn_cast<cudaq::cc::CharspanType>(type)) {
-        const char *ptrToSizeInBuffer =
-            static_cast<const char *>(args) + offset;
-        auto sizeFromBuffer =
-            *reinterpret_cast<const std::uint64_t *>(ptrToSizeInBuffer);
-        std::size_t bytesInType = sizeof(char);
-        auto vectorSize = sizeFromBuffer / bytesInType;
-        stdVecInfo.emplace_back(
-            argNum, cudaq::opt::factory::getCharType(builder.getContext()),
-            vectorSize);
         continue;
       }
 

--- a/python/tests/kernel/test_observe_kernel.py
+++ b/python/tests/kernel/test_observe_kernel.py
@@ -302,8 +302,7 @@ def test_pack_args_pauli_list():
     def generateRandomPauliStrings(numQubits, numPaulis):
         s = ['X', 'Y', 'Z', 'I']
         return [
-            ''.join([random.choice(s)
-                     for i in range(numQubits)])
+            ''.join([random.choice(s) for i in range(numQubits)])
             for i in range(numPaulis)
         ]
 
@@ -336,7 +335,8 @@ def test_pack_args_pauli_list():
     ts = np.random.rand(len(pauliStings))
 
     exp_val1 = cudaq.observe_async(gqeCirc1, obs, numQubits, list(ts),
-                                   pauliStings[0]).get().expectation()
+                                   cudaq.pauli_word(
+                                       pauliStings[0])).get().expectation()
     print('observe_async exp_val1', exp_val1)
     exp_val2 = cudaq.observe_async(gqeCirc2, obs, numQubits, list(ts),
                                    pauliStings).get().expectation()

--- a/python/utils/OpaqueArguments.h
+++ b/python/utils/OpaqueArguments.h
@@ -101,7 +101,7 @@ inline py::args simplifiedValidateInputArguments(py::args &args) {
 
       arg = args[i].attr("tolist")();
     } else if (py::isinstance<py::str>(arg)) {
-      arg = cudaq::pauli_word(py::cast<std::string>(arg));
+      arg = py::cast<std::string>(arg);
     } else if (py::isinstance<py::list>(arg)) {
       py::list arg_list = py::cast<py::list>(arg);
       const bool all_strings = [&]() {
@@ -330,8 +330,7 @@ inline void packArgs(OpaqueArguments &argData, py::args args,
           addArgument(argData, arg.cast<long>());
         })
         .Case([&](cudaq::cc::CharspanType ty) {
-          addArgument(argData,
-                      cudaq::pauli_word(arg.cast<cudaq::pauli_word>().str()));
+          addArgument(argData, arg.cast<cudaq::pauli_word>().str());
         })
         .Case([&](cudaq::cc::PointerType ty) {
           if (isa<cudaq::cc::StateType>(ty.getElementType())) {
@@ -432,8 +431,7 @@ inline void packArgs(OpaqueArguments &argData, py::args args,
               .Case([&](cudaq::cc::CharspanType type) {
                 genericVecAllocator.template operator()<cudaq::pauli_word>(
                     [](py::handle element, int index, int elementIndex) {
-                      auto pw = element.cast<cudaq::pauli_word>();
-                      return cudaq::pauli_word(pw.str());
+                      return element.cast<cudaq::pauli_word>().str();
                     });
                 return;
               })

--- a/runtime/common/ArgumentConversion.cpp
+++ b/runtime/common/ArgumentConversion.cpp
@@ -77,14 +77,16 @@ static Value genConstant(OpBuilder &builder, FloatType fltTy, long double *v) {
 static Value genConstant(OpBuilder &builder, const std::string &v,
                          ModuleOp substMod) {
   auto loc = builder.getUnknownLoc();
-  cudaq::IRBuilder irBuilder(builder);
-  auto cString = irBuilder.genCStringLiteralAppendNul(loc, substMod, v);
-  auto addr = builder.create<cudaq::cc::AddressOfOp>(
-      loc, cudaq::cc::PointerType::get(cString.getType()), cString.getName());
-  auto i8PtrTy = cudaq::cc::PointerType::get(builder.getI8Type());
-  auto cast = builder.create<cudaq::cc::CastOp>(loc, i8PtrTy, addr);
+  auto *ctx = builder.getContext();
+  auto i8Ty = builder.getI8Type();
+  auto strLitTy = cudaq::cc::PointerType::get(
+      cudaq::cc::ArrayType::get(ctx, i8Ty, v.size() + 1));
+  auto strLit =
+      builder.create<cudaq::cc::CreateStringLiteralOp>(loc, strLitTy, v);
+  auto i8PtrTy = cudaq::cc::PointerType::get(i8Ty);
+  auto cast = builder.create<cudaq::cc::CastOp>(loc, i8PtrTy, strLit);
   auto size = builder.create<arith::ConstantIntOp>(loc, v.size(), 64);
-  auto chSpanTy = cudaq::cc::CharspanType::get(builder.getContext());
+  auto chSpanTy = cudaq::cc::CharspanType::get(ctx);
   return builder.create<cudaq::cc::StdvecInitOp>(loc, chSpanTy, cast, size);
 }
 
@@ -218,6 +220,21 @@ Value dispatchSubtype(OpBuilder &builder, Type ty, void *p, ModuleOp substMod,
       .Default({});
 }
 
+// Get the size of \p eleTy on the host side in bytes.
+static std::size_t getHostSideElementSize(Type eleTy,
+                                          llvm::DataLayout &layout) {
+  if (isa<cudaq::cc::StdvecType>(eleTy))
+    return sizeof(std::vector<int>);
+  if (isa<cudaq::cc::CharspanType>(eleTy)) {
+    // char span type is a std::string on host side.
+    return sizeof(std::string);
+  }
+  // Note: we want the size on the host side, but `getDataSize()` returns the
+  // size on the device side. This is ok for now since they are the same for
+  // most types and the special cases are handled above.
+  return cudaq::opt::getDataSize(layout, eleTy);
+}
+
 Value genConstant(OpBuilder &builder, cudaq::cc::StdvecType vecTy, void *p,
                   ModuleOp substMod, llvm::DataLayout &layout) {
   typedef const char *VectorType[3];
@@ -227,11 +244,7 @@ Value genConstant(OpBuilder &builder, cudaq::cc::StdvecType vecTy, void *p,
     return {};
   auto eleTy = vecTy.getElementType();
   auto elePtrTy = cudaq::cc::PointerType::get(eleTy);
-  auto eleSize = cudaq::opt::getDataSize(layout, eleTy);
-  if (isa<cudaq::cc::CharspanType>(eleTy)) {
-    // char span type (i.e. pauli word) is a `vector<char>`
-    eleSize = sizeof(VectorType);
-  }
+  auto eleSize = getHostSideElementSize(eleTy, layout);
 
   assert(eleSize && "element must have a size");
   auto loc = builder.getUnknownLoc();

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -470,20 +470,37 @@ void __nvqpp_initializer_list_to_vector_bool(std::vector<bool> &result,
 /// `std::vector<bool>` overload. The conversion turns the `std::vector<bool>`
 /// into a mock vector structure that looks like `std::vector<char>`. The
 /// calling routine must cleanup the buffer allocated by this code.
-void __nvqpp_vector_bool_to_initializer_list(void *outData,
-                                             const std::vector<bool> &inVec) {
+/// This helper routine may only be called on the host side.
+void __nvqpp_vector_bool_to_initializer_list(
+    void *outData, const std::vector<bool> &inVec,
+    std::vector<char *> **allocations) {
   // The MockVector must be allocated by the caller.
   struct MockVector {
     char *start;
     char *end;
+    char *end2;
   };
   MockVector *mockVec = reinterpret_cast<MockVector *>(outData);
   auto outSize = inVec.size();
   // The buffer allocated here must be freed by the caller.
-  mockVec->start = static_cast<char *>(malloc(outSize));
-  mockVec->end = mockVec->start + outSize;
+  if (!*allocations)
+    *allocations = new std::vector<char *>;
+  char *newData = static_cast<char *>(malloc(outSize));
+  (*allocations)->push_back(newData);
+  mockVec->start = newData;
+  mockVec->end2 = mockVec->end = newData + outSize;
   for (unsigned i = 0; i < outSize; ++i)
-    (mockVec->start)[i] = static_cast<char>(inVec[i]);
+    newData[i] = static_cast<char>(inVec[i]);
+}
+
+/// This helper routine deletes the vector that tracks all the temporaries that
+/// were created as well as the temporaries themselves.
+/// This routine may only be called on the host side.
+void __nvqpp_vector_bool_free_temporary_initlists(
+    std::vector<char *> *allocations) {
+  for (auto *p : *allocations)
+    free(p);
+  delete allocations;
 }
 }
 } // namespace cudaq::support

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -502,5 +502,12 @@ void __nvqpp_vector_bool_free_temporary_initlists(
     free(p);
   delete allocations;
 }
+
+/// Quasi-portable string helpers for Python (non-C++ frontends).  These library
+/// helper functions allow non-C++ front-ends to remain portable with the core
+/// layer. As these helpers ought to be built along with the bindings, there
+/// should not be a compatibility issue.
+const char *__nvqpp_getStringData(const std::string &s) { return s.data(); }
+std::uint64_t __nvqpp_getStringSize(const std::string &s) { return s.size(); }
 }
 } // namespace cudaq::support

--- a/runtime/cudaq/qis/pauli_word.h
+++ b/runtime/cudaq/qis/pauli_word.h
@@ -51,7 +51,7 @@ private:
     return term.size();
   }
 
-  std::string term; ///< Pauli words are string-like encodings.
+  std::string term; ///< Pauli words are string-like.
 };
 
 namespace details {

--- a/runtime/cudaq/qis/pauli_word.h
+++ b/runtime/cudaq/qis/pauli_word.h
@@ -8,20 +8,31 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 namespace cudaq {
-/// @brief The `pauli_word` is a thin wrapper on a
-/// Pauli tensor product string, e.g. `XXYZ` on 4
-// qubits.
+/// @brief The `pauli_word` is a thin wrapper on a Pauli tensor product string,
+/// e.g. `XXYZ` on 4 qubits.
 class pauli_word {
 private:
-  std::vector<char> term;
+  std::string term;
 
 public:
   pauli_word() = default;
-  pauli_word(const std::string t) : term(t.begin(), t.end()) {}
-  std::string str() const { return std::string(term.begin(), term.end()); }
-  const std::vector<char> &data() const { return term; }
+  pauli_word(std::string &&t) : term{std::move(t)} {}
+  pauli_word(const std::string &t) : term(t) {}
+  pauli_word(const char *const p) : term{p} {}
+  pauli_word &operator=(const std::string &t) {
+    term = t;
+    return *this;
+  }
+  pauli_word &operator=(const char *const p) {
+    term = p;
+    return *this;
+  }
+
+  std::string str() const { return term; }
+
+  // TODO: Obsolete? Used by KernelWrapper.h only.
+  const std::vector<char> data() const { return {term.begin(), term.end()}; }
 };
 } // namespace cudaq

--- a/runtime/cudaq/qis/pauli_word.h
+++ b/runtime/cudaq/qis/pauli_word.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <ctype.h>
 #include <string>
 

--- a/runtime/cudaq/qis/pauli_word.h
+++ b/runtime/cudaq/qis/pauli_word.h
@@ -5,28 +5,30 @@
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
+
 #pragma once
 
+#include <ctype.h>
 #include <string>
 
 namespace cudaq {
+
 /// @brief The `pauli_word` is a thin wrapper on a Pauli tensor product string,
 /// e.g. `XXYZ` on 4 qubits.
 class pauli_word {
-private:
-  std::string term;
-
 public:
   pauli_word() = default;
-  pauli_word(std::string &&t) : term{std::move(t)} {}
-  pauli_word(const std::string &t) : term(t) {}
-  pauli_word(const char *const p) : term{p} {}
+  pauli_word(std::string &&t) : term{std::move(t)} { to_upper_case(); }
+  pauli_word(const std::string &t) : term(t) { to_upper_case(); }
+  pauli_word(const char *const p) : term{p} { to_upper_case(); }
   pauli_word &operator=(const std::string &t) {
     term = t;
+    to_upper_case();
     return *this;
   }
   pauli_word &operator=(const char *const p) {
     term = p;
+    to_upper_case();
     return *this;
   }
 
@@ -34,5 +36,27 @@ public:
 
   // TODO: Obsolete? Used by KernelWrapper.h only.
   const std::vector<char> data() const { return {term.begin(), term.end()}; }
+
+private:
+  // Convert the string member to upper case at construction/assignment.
+  // TODO: This should probably verify the string contains only letters valid in
+  // this alphabet: I, X, Y, and Z.
+  void to_upper_case() {
+    std::transform(term.begin(), term.end(), term.begin(), ::toupper);
+  }
+
+  // These methods used by the compiler.
+  __attribute__((used)) const char *_nvqpp_data() const { return term.data(); }
+  __attribute__((used)) std::uint64_t _nvqpp_size() const {
+    return term.size();
+  }
+
+  std::string term; ///< Pauli words are string-like encodings.
 };
+
+namespace details {
+static_assert(sizeof(std::string) == sizeof(pauli_word));
+// This constant used by the compiler.
+static constexpr std::uint64_t _nvqpp_sizeof = sizeof(pauli_word);
+} // namespace details
 } // namespace cudaq

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -17,6 +17,7 @@
 #include "cudaq/qis/qreg.h"
 #include "cudaq/qis/qvector.h"
 #include "cudaq/spin_op.h"
+#include <algorithm>
 #include <cstring>
 #include <functional>
 

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -828,11 +828,13 @@ std::vector<measure_result> mz(qubit &q, Qs &&...qs) {
 }
 
 namespace support {
-// Helper to initialize a `vector<bool>` data structure.
+// Helpers to deal with the `vector<bool>` specialized template type.
 extern "C" {
 void __nvqpp_initializer_list_to_vector_bool(std::vector<bool> &, char *,
                                              std::size_t);
-void __nvqpp_vector_bool_to_initializer_list(void *, const std::vector<bool> &);
+void __nvqpp_vector_bool_to_initializer_list(void *, const std::vector<bool> &,
+                                             std::vector<char *> **);
+void __nvqpp_vector_bool_free_temporary_initlists(std::vector<char *> *);
 }
 } // namespace support
 

--- a/runtime/test/test_argument_conversion.cpp
+++ b/runtime/test/test_argument_conversion.cpp
@@ -202,12 +202,11 @@ void test_scalars(mlir::MLIRContext *ctx) {
 // CHECK:       Substitution module:
 
 // CHECK-LABEL:   cc.arg_subst[0] {
-// CHECK:           %[[VAL_0:.*]] = cc.address_of @cstr.58595A00 : !cc.ptr<!llvm.array<4 x i8>>
-// CHECK:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!llvm.array<4 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_0:.*]] = cc.string_literal "XYZ" : !cc.ptr<!cc.array<i8 x 4>>
+// CHECK:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_2:.*]] = arith.constant 3 : i64
 // CHECK:           %[[VAL_3:.*]] = cc.stdvec_init %[[VAL_1]], %[[VAL_2]] : (!cc.ptr<i8>, i64) -> !cc.charspan
 // CHECK:         }
-// CHECK-DAG:     llvm.mlir.global private constant @cstr.58595A00("XYZ\00") {addr_space = 0 : i32}
   // clang-format on
 }
 
@@ -250,14 +249,14 @@ void test_vectors(mlir::MLIRContext *ctx) {
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.array<!cc.charspan x 2>
-// CHECK:           %[[VAL_1:.*]] = cc.address_of @cstr.585800 : !cc.ptr<!llvm.array<3 x i8>>
-// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_1:.*]] = cc.string_literal "XX" : !cc.ptr<!cc.array<i8 x 3>>
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_2]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.charspan
 // CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
 // CHECK:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<!cc.charspan>
-// CHECK:           %[[VAL_6:.*]] = cc.address_of @cstr.585900 : !cc.ptr<!llvm.array<3 x i8>>
-// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_6:.*]] = cc.string_literal "XY" : !cc.ptr<!cc.array<i8 x 3>>
+// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_8:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_9:.*]] = cc.stdvec_init %[[VAL_7]], %[[VAL_8]] : (!cc.ptr<i8>, i64) -> !cc.charspan
 // CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
@@ -265,8 +264,6 @@ void test_vectors(mlir::MLIRContext *ctx) {
 // CHECK:           %[[VAL_11:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_12:.*]] = cc.stdvec_init %[[VAL_0]], %[[VAL_11]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>, i64) -> !cc.stdvec<!cc.charspan>
 // CHECK:         }
-// CHECK-DAG:     llvm.mlir.global private constant @cstr.585800("XX\00") {addr_space = 0 : i32}
-// CHECK-DAG:     llvm.mlir.global private constant @cstr.585900("XY\00") {addr_space = 0 : i32}
   // clang-format on
 }
 
@@ -502,14 +499,14 @@ void test_combinations(mlir::MLIRContext *ctx) {
 // CHECK-DAG:     func.func private @__nvqpp_cudaq_state_createFromData_fp64(!cc.ptr<i8>, i64) -> !cc.ptr<!cc.state>
 // CHECK-LABEL:   cc.arg_subst[2] {
 // CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.array<!cc.charspan x 2>
-// CHECK:           %[[VAL_1:.*]] = cc.address_of @cstr.585800 : !cc.ptr<!llvm.array<3 x i8>>
-// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_1:.*]] = cc.string_literal "XX" : !cc.ptr<!cc.array<i8 x 3>>
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_2]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.charspan
 // CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
 // CHECK:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<!cc.charspan>
-// CHECK:           %[[VAL_6:.*]] = cc.address_of @cstr.585900 : !cc.ptr<!llvm.array<3 x i8>>
-// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_6:.*]] = cc.string_literal "XY" : !cc.ptr<!cc.array<i8 x 3>>
+// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.ptr<i8>
 // CHECK:           %[[VAL_8:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_9:.*]] = cc.stdvec_init %[[VAL_7]], %[[VAL_8]] : (!cc.ptr<i8>, i64) -> !cc.charspan
 // CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
@@ -517,8 +514,6 @@ void test_combinations(mlir::MLIRContext *ctx) {
 // CHECK:           %[[VAL_11:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_12:.*]] = cc.stdvec_init %[[VAL_0]], %[[VAL_11]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>, i64) -> !cc.stdvec<!cc.charspan>
 // CHECK:         }
-// CHECK-DAG:     llvm.mlir.global private constant @cstr.585800("XX\00") {addr_space = 0 : i32}
-// CHECK-DAG:     llvm.mlir.global private constant @cstr.585900("XY\00") {addr_space = 0 : i32}
   // clang-format on
 }
 

--- a/targettests/Kernel/signature-0.cpp
+++ b/targettests/Kernel/signature-0.cpp
@@ -65,12 +65,9 @@ public:
   }
 };
 
-// FIXME: unhandled ctor call
-#define NYI /*__qpu__*/
-
 class Qernel7 {
 public:
-  std::vector<bool> operator()(std::vector<bool> v) NYI { return v; }
+  std::vector<bool> operator()(std::vector<bool> v) __qpu__ { return v; }
 };
 
 int main() {

--- a/targettests/Kernel/signature-4.cpp
+++ b/targettests/Kernel/signature-4.cpp
@@ -37,7 +37,7 @@ public:
 };
 
 struct QernelS1 {
-  S1 operator()(S1 s) __qpu__ {
+  S1 operator()(S1 s) NYI {
     if (s._1 == 4 && s._2 == 8.2)
       ok();
     else

--- a/targettests/Kernel/signature-4.cpp
+++ b/targettests/Kernel/signature-4.cpp
@@ -14,10 +14,8 @@
 
 // Tests that we can take a small struct, a struct with a vector member, a
 // vector of small structs, and a large struct as an argument and return the
-// same. Currently, DefaultQPU::launchKernel does not handle return values at
-// all.
+// same.
 
-// FIXME
 #define NYI /*__qpu__*/
 
 void ok() { std::cout << "ok\n"; }
@@ -39,7 +37,7 @@ public:
 };
 
 struct QernelS1 {
-  S1 operator()(S1 s) NYI {
+  S1 operator()(S1 s) __qpu__ {
     if (s._1 == 4 && s._2 == 8.2)
       ok();
     else
@@ -48,7 +46,6 @@ struct QernelS1 {
   }
 };
 
-// struct with vector member not yet supported
 struct S2 {
   int _1;
   std::vector<float> _2;
@@ -66,6 +63,7 @@ struct QernelS2a {
 };
 
 struct QernelS2 {
+  // kernel result type not supported (bridge)
   S2 operator()(S2 s) NYI {
     s._1++;
     s._2[0] = 0.0;
@@ -84,16 +82,14 @@ public:
   }
 };
 
-// ctor in return not supported
 struct QernelS3 {
-  std::vector<S1> operator()(std::vector<S1> s) NYI {
+  std::vector<S1> operator()(std::vector<S1> s) __qpu__ {
     s[0]._1++;
     s[0]._2 = 0.0;
     return s;
   }
 };
 
-// bug in bridge
 std::vector<S1> mock_ctor(const std::vector<S1> &v) { return v; }
 
 struct QernelS4 {

--- a/targettests/Kernel/signature-5.cpp
+++ b/targettests/Kernel/signature-5.cpp
@@ -15,7 +15,6 @@
 // Test kernels can take arguments of tuple or pair as well as return values of
 // same.
 
-// FIXME: tuple and pair are not handled.
 #define NYI /*__qpu__*/
 
 void ok() { std::cout << "ok\n"; }
@@ -24,7 +23,7 @@ void fail() { std::cout << "fail\n"; }
 using S1 = std::tuple<int, int, int>;
 
 struct QernelS1a {
-  void operator()(S1 s) NYI {
+  void operator()(S1 s) __qpu__ {
     if (std::get<0>(s) == 1 && std::get<1>(s) == 2 && std::get<2>(s) == 4)
       ok();
     else
@@ -38,10 +37,18 @@ struct QernelS1 {
   }
 };
 
+S1 qernel_s1b_helper(S1 s) {
+  return {std::get<2>(s) + 1, std::get<1>(s) + 1, std::get<0>(s) + 1};
+}
+
+struct QernelS1b {
+  S1 operator()(S1 s) NYI { return qernel_s1b_helper(s); }
+};
+
 using S2 = std::tuple<double, float, std::vector<int>>;
 
 struct QernelS2a {
-  void operator()(S2 s) NYI {
+  void operator()(S2 s) __qpu__ {
     if (std::get<0>(s) == 8.16 && std::get<1>(s) == 32.64f &&
         std::get<2>(s).size() == 2)
       ok();
@@ -88,6 +95,13 @@ int main() {
     ok();
   else
     fail();
+  std::cout << "QernelS1b ";
+  auto updated_s1b = QernelS1b{}(s1);
+  if (std::get<0>(updated_s1b) == 5 && std::get<1>(updated_s1b) == 3 &&
+      std::get<2>(updated_s1b) == 2)
+    ok();
+  else
+    fail();
 
   std::vector<int> v = {128, 256};
   S2 s2 = {8.16, 32.64f, v};
@@ -117,6 +131,7 @@ int main() {
 // clang-format off
 // CHECK-LABEL: QernelS1a ok
 // CHECK-NEXT: QernelS1 ok
+// CHECK-NEXT: QernelS1b ok
 // CHECK-NEXT: QernelS2a ok
 // CHECK-NEXT: QernelS2 ok
 // CHECK-NEXT: ok

--- a/targettests/Remote-Sim/pauli_word.cpp
+++ b/targettests/Remote-Sim/pauli_word.cpp
@@ -10,7 +10,6 @@
 
 // clang-format off
 // RUN: nvq++ %cpp_std --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
-// RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu --remote-mqpu-auto-launch 1 %s -o %t && %t
 // clang-format on
 
 #include "remote_test_assert.h"

--- a/targettests/SeparateCompilation/arith_spans.cpp
+++ b/targettests/SeparateCompilation/arith_spans.cpp
@@ -37,6 +37,19 @@ void dump_int_vector(std::span<int> x) {
   std::cout << '\n';
 }
 
+void dump_2d_int_vector(std::span<std::span<int>> x) {
+  std::cout << "integer matrix: {\n";
+  for (auto s : x) {
+    std::cout << "    ";
+    for (auto i : s)
+      std::cout << i << "  ";
+    std::cout << '\n';
+  }
+  std::cout << "}\n";
+}
+
+void dump_int_scalar(int x) { std::cout << "scalar integer: " << x << '\n'; }
+
 void dump_double_vector(std::span<double> x) {
   std::cout << "doubles: ";
   for (auto d : x)
@@ -53,8 +66,10 @@ void dump_double_vector(std::span<double> x) {
 // Fake host C++ signature that matches.
 extern "C" {
 void dump_int_vector(const std::vector<int> &pw);
+void dump_int_scalar(int v);
 void dump_bool_vector(const std::vector<bool> &pw);
 void dump_double_vector(const std::vector<double> &pw);
+void dump_2d_int_vector(const std::vector<std::vector<int>> &pw);
 }
 
 __qpu__ void kern1(std::vector<int> arg) { dump_int_vector(arg); }
@@ -129,6 +144,21 @@ __qpu__ void cern4(std::vector<BoolVectorPair> vivp) {
   }
 }
 
+struct Interesting {
+  std::vector<std::vector<std::vector<int>>> ragged3d;
+  int flags;
+  std::vector<double> angular;
+};
+
+__qpu__ void exciting(std::vector<Interesting> vi) {
+  for (unsigned i = 0; i < vi.size(); ++i) {
+    for (unsigned j = 0; j < vi[i].ragged3d.size(); ++j)
+      dump_2d_int_vector(vi[i].ragged3d[j]);
+    dump_int_scalar(vi[i].flags);
+    dump_double_vector(vi[i].angular);
+  }
+}
+
 int main() {
   std::vector<int> pw0 = {345, 1, 2};
   std::cout << "---\n";
@@ -149,7 +179,7 @@ int main() {
   IntVectorPair ivp4 = {{-4, -5, 6}, {-7, -8, -9, 88}};
   std::vector<IntVectorPair> vivp = {ivp, ivp2, ivp3, ivp4};
   std::cout << "---\n";
-  // kern4(vivp);
+  kern4(vivp);
 
   std::vector<double> dpw0 = {3.45, 1., 2.};
   std::cout << "---\n";
@@ -170,7 +200,7 @@ int main() {
   DoubleVectorPair dvp4 = {{-4., -5., 6.}, {-7., -8., -9., .88}};
   std::vector<DoubleVectorPair> vdvp = {dvp, dvp2, dvp3, dvp4};
   std::cout << "---\n";
-  // qern4(vdvp);
+  qern4(vdvp);
 
   std::vector<bool> bpw0 = {true, false};
   std::cout << "---\n";
@@ -192,7 +222,25 @@ int main() {
   BoolVectorPair bvp4 = {{true, false, false}, {false, true, false, true}};
   std::vector<BoolVectorPair> vbvp = {bvp, bvp2, bvp3, bvp4};
   std::cout << "---\n";
-  // cern4(vbvp);
+  cern4(vbvp);
+
+  std::vector<std::vector<int>> ix0 = {pw0, pw0};
+  std::vector<std::vector<int>> ix1 = {pw1, pw0};
+  std::vector<std::vector<int>> ix2 = {pw2, pw3, pw3};
+  std::vector<std::vector<int>> ix3 = {{404}, {101, 202}};
+  std::vector<std::vector<std::vector<int>>> i3d0 = {ix0, ix1};
+  std::vector<std::vector<std::vector<int>>> i3d1 = {ix1};
+  std::vector<std::vector<std::vector<int>>> i3d2 = {ix2, ix3};
+  std::vector<std::vector<std::vector<int>>> i3d3 = {ix3};
+  std::vector<std::vector<std::vector<int>>> i3d4 = {ix2, ix0, ix0};
+  Interesting in0 = {i3d0, 66, {2.0, 4.0}};
+  Interesting in1 = {i3d1, 123, {3.0, 6.0}};
+  Interesting in2 = {i3d2, 561, {4.0, 8.0}};
+  Interesting in3 = {i3d3, 72341, {5.0, 10.0}};
+  Interesting in4 = {i3d4, -2348, {12.0, 5280.1}};
+  std::vector<Interesting> ving = {in0, in1, in2, in3, in4};
+  std::cout << "===\n";
+  exciting(ving);
 
   return 0;
 }
@@ -201,29 +249,105 @@ int main() {
 // CHECK: integers: 345 1 2
 // CHECK: ---
 // CHECK: integers: 345 1 2
-// CHECK: integers: 92347 3 4
-// CHECK: integers: 2358 5 6
-// CHECK: integers: 45 7 18
+// CHECK-NEXT: integers: 92347 3 4
+// CHECK-NEXT: integers: 2358 5 6
+// CHECK-NEXT: integers: 45 7 18
 // CHECK: ---
 // CHECK: integers: 8 238 44
-// CHECK: integers: 0 -4 81 92745
+// CHECK-NEXT: integers: 0 -4 81 92745
+// CHECK: ---
+// CHECK: integers: 8 238 44
+// CHECK-NEXT: integers: 0 -4 81 92745
+// CHECK-NEXT: integers: 5 -87 43 1 76
+// CHECK-NEXT: integers: 0 0 2 1
+// CHECK-NEXT: integers: 1
+// CHECK-NEXT: integers: -2 3
+// CHECK-NEXT: integers: -4 -5 6
+// CHECK-NEXT: integers: -7 -8 -9 88
 // CHECK: ---
 // CHECK: doubles: 3.45 1 2
 // CHECK: ---
 // CHECK: doubles: 3.45 1 2
-// CHECK: doubles: 92.347 2.3 4
-// CHECK: doubles: 235.8 5.5 6.4
-// CHECK: doubles: 4.5 77.7 18.2
+// CHECK-NEXT: doubles: 92.347 2.3 4
+// CHECK-NEXT: doubles: 235.8 5.5 6.4
+// CHECK-NEXT: doubles: 4.5 77.7 18.2
 // CHECK: ---
 // CHECK: doubles: 8 2.38 4.4
-// CHECK: doubles: 0 -4.99 81.5 92.745
+// CHECK-NEXT: doubles: 0 -4.99 81.5 92.745
+// CHECK: ---
+// CHECK: doubles: 8 2.38 4.4
+// CHECK-NEXT: doubles: 0 -4.99 81.5 92.745
+// CHECK-NEXT: doubles: 5 -8.7 4.3 1 7.6
+// CHECK-NEXT: doubles: 0 0 2 1
+// CHECK-NEXT: doubles: 1
+// CHECK-NEXT: doubles: -2 3
+// CHECK-NEXT: doubles: -4 -5 6
+// CHECK-NEXT: doubles: -7 -8 -9 0.88
 // CHECK: ---
 // CHECK: booleans: 1 0
 // CHECK: ---
 // CHECK: booleans: 1 0
-// CHECK: booleans: 0 0 0
-// CHECK: booleans: 0 1 0 1
-// CHECK: booleans: 0 0 1 0 1
+// CHECK-NEXT: booleans: 0 0 0
+// CHECK-NEXT: booleans: 0 1 0 1
+// CHECK-NEXT: booleans: 0 0 1 0 1
 // CHECK: ---
 // CHECK: booleans: 0 0
-// CHECK: booleans: 0 1 1 0
+// CHECK-NEXT: booleans: 0 1 1 0
+// CHECK: ---
+// CHECK: booleans: 0 0
+// CHECK-NEXT: booleans: 0 1 1 0
+// CHECK-NEXT: booleans: 0 1 1 0 1 0
+// CHECK-NEXT: booleans: 0 1 1 0 0 0 1 0
+// CHECK-NEXT: booleans: 0
+// CHECK-NEXT: booleans: 1 1
+// CHECK-NEXT: booleans: 1 0 0
+// CHECK-NEXT: booleans: 0 1 0 1
+// CHECK: ===
+// CHECK: integer matrix: {
+// CHECK-NEXT:     345  1  2
+// CHECK-NEXT:     345  1  2
+// CHECK-NEXT: }
+// CHECK-NEXT: integer matrix: {
+// CHECK-NEXT:     92347  3  4
+// CHECK-NEXT:     345  1  2
+// CHECK-NEXT: }
+// CHECK-NEXT: scalar integer: 66
+// CHECK-NEXT: doubles: 2 4
+// CHECK-NEXT: integer matrix: {
+// CHECK-NEXT:     92347  3  4
+// CHECK-NEXT:     345  1  2
+// CHECK-NEXT: }
+// CHECK-NEXT: scalar integer: 123
+// CHECK-NEXT: doubles: 3 6
+// CHECK-NEXT: integer matrix: {
+// CHECK-NEXT:     2358  5  6
+// CHECK-NEXT:     45  7  18
+// CHECK-NEXT:     45  7  18
+// CHECK-NEXT: }
+// CHECK-NEXT: integer matrix: {
+// CHECK-NEXT:     404
+// CHECK-NEXT:     101  202
+// CHECK-NEXT: }
+// CHECK-NEXT: scalar integer: 561
+// CHECK-NEXT: doubles: 4 8
+// CHECK-NEXT: integer matrix: {
+// CHECK-NEXT:     404
+// CHECK-NEXT:     101  202
+// CHECK-NEXT: }
+// CHECK-NEXT: scalar integer: 72341
+// CHECK-NEXT: doubles: 5 10
+// CHECK-NEXT: integer matrix: {
+// CHECK-NEXT:     2358  5  6
+// CHECK-NEXT:     45  7  18
+// CHECK-NEXT:     45  7  18
+// CHECK-NEXT: }
+// CHECK-NEXT: integer matrix: {
+// CHECK-NEXT:     345  1  2
+// CHECK-NEXT:     345  1  2
+// CHECK-NEXT: }
+// CHECK-NEXT: integer matrix: {
+// CHECK-NEXT:     345  1  2
+// CHECK-NEXT:     345  1  2
+// CHECK-NEXT: }
+// CHECK-NEXT: scalar integer: -2348
+// CHECK-NEXT: doubles: 12 5280.1

--- a/targettests/SeparateCompilation/arith_spans.cpp
+++ b/targettests/SeparateCompilation/arith_spans.cpp
@@ -1,0 +1,229 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: if [ command -v split-file ]; then \
+// RUN: split-file %s %t && \
+// RUN: nvq++ %cpp_std --enable-mlir -c %t/span_dumps.cpp -o %t/span_dumps.o && \
+// RUN: nvq++ %cpp_std --enable-mlir -c %t/span_exercise.cpp -o %t/span_exercise.o && \
+// RUN: nvq++ %cpp_std --enable-mlir %t/span_dumps.o %t/span_exercise.o -o %t/spanaroo.out && \
+// RUN: %t/spanaroo.out | FileCheck %s ; else \
+// RUN: echo "skipping" ; fi
+// clang-format on
+
+//--- span_dumps.cpp
+
+#include <iostream>
+#include <span>
+#include <string>
+
+extern "C" {
+void dump_bool_vector(std::span<bool> x) {
+  std::cout << "booleans: ";
+  for (auto i : x)
+    std::cout << i << ' ';
+  std::cout << '\n';
+}
+
+void dump_int_vector(std::span<int> x) {
+  std::cout << "integers: ";
+  for (auto i : x)
+    std::cout << i << ' ';
+  std::cout << '\n';
+}
+
+void dump_double_vector(std::span<double> x) {
+  std::cout << "doubles: ";
+  for (auto d : x)
+    std::cout << d << ' ';
+  std::cout << '\n';
+}
+}
+
+//--- span_exercise.cpp
+
+#include <cudaq.h>
+#include <iostream>
+
+// Fake host C++ signature that matches.
+extern "C" {
+void dump_int_vector(const std::vector<int> &pw);
+void dump_bool_vector(const std::vector<bool> &pw);
+void dump_double_vector(const std::vector<double> &pw);
+}
+
+__qpu__ void kern1(std::vector<int> arg) { dump_int_vector(arg); }
+
+__qpu__ void kern2(std::vector<std::vector<int>> arg) {
+  for (unsigned i = 0; i < arg.size(); ++i)
+    dump_int_vector(arg[i]);
+}
+
+struct IntVectorPair {
+  std::vector<int> _0;
+  std::vector<int> _1;
+};
+
+__qpu__ void kern3(IntVectorPair ivp) {
+  dump_int_vector(ivp._0);
+  dump_int_vector(ivp._1);
+}
+
+__qpu__ void kern4(std::vector<IntVectorPair> vivp) {
+  for (unsigned i = 0; i < vivp.size(); ++i) {
+    dump_int_vector(vivp[i]._0);
+    dump_int_vector(vivp[i]._1);
+  }
+}
+
+__qpu__ void qern1(std::vector<double> arg) { dump_double_vector(arg); }
+
+__qpu__ void qern2(std::vector<std::vector<double>> arg) {
+  for (unsigned i = 0; i < arg.size(); ++i)
+    dump_double_vector(arg[i]);
+}
+
+struct DoubleVectorPair {
+  std::vector<double> _0;
+  std::vector<double> _1;
+};
+
+__qpu__ void qern3(DoubleVectorPair ivp) {
+  dump_double_vector(ivp._0);
+  dump_double_vector(ivp._1);
+}
+
+__qpu__ void qern4(std::vector<DoubleVectorPair> vivp) {
+  for (unsigned i = 0; i < vivp.size(); ++i) {
+    dump_double_vector(vivp[i]._0);
+    dump_double_vector(vivp[i]._1);
+  }
+}
+
+__qpu__ void cern1(std::vector<bool> arg) { dump_bool_vector(arg); }
+
+__qpu__ void cern2(std::vector<std::vector<bool>> arg) {
+  for (unsigned i = 0; i < arg.size(); ++i)
+    dump_bool_vector(arg[i]);
+}
+
+struct BoolVectorPair {
+  std::vector<bool> _0;
+  std::vector<bool> _1;
+};
+
+__qpu__ void cern3(BoolVectorPair ivp) {
+  dump_bool_vector(ivp._0);
+  dump_bool_vector(ivp._1);
+}
+
+__qpu__ void cern4(std::vector<BoolVectorPair> vivp) {
+  for (unsigned i = 0; i < vivp.size(); ++i) {
+    dump_bool_vector(vivp[i]._0);
+    dump_bool_vector(vivp[i]._1);
+  }
+}
+
+int main() {
+  std::vector<int> pw0 = {345, 1, 2};
+  std::cout << "---\n";
+  kern1(pw0);
+  std::vector<int> pw1 = {92347, 3, 4};
+  std::vector<int> pw2 = {2358, 5, 6};
+  std::vector<int> pw3 = {45, 7, 18};
+  std::vector<std::vector<int>> vpw{pw0, pw1, pw2, pw3};
+  std::cout << "---\n";
+  kern2(vpw);
+
+  IntVectorPair ivp = {{8, 238, 44}, {0, -4, 81, 92745}};
+  std::cout << "---\n";
+  kern3(ivp);
+
+  IntVectorPair ivp2 = {{5, -87, 43, 1, 76}, {0, 0, 2, 1}};
+  IntVectorPair ivp3 = {{1}, {-2, 3}};
+  IntVectorPair ivp4 = {{-4, -5, 6}, {-7, -8, -9, 88}};
+  std::vector<IntVectorPair> vivp = {ivp, ivp2, ivp3, ivp4};
+  std::cout << "---\n";
+  // kern4(vivp);
+
+  std::vector<double> dpw0 = {3.45, 1., 2.};
+  std::cout << "---\n";
+  qern1(dpw0);
+  std::vector<double> dpw1 = {92.347, 2.3, 4.};
+  std::vector<double> dpw2 = {235.8, 5.5, 6.4};
+  std::vector<double> dpw3 = {4.5, 77.7, 18.2};
+  std::vector<std::vector<double>> vdpw{dpw0, dpw1, dpw2, dpw3};
+  std::cout << "---\n";
+  qern2(vdpw);
+
+  DoubleVectorPair dvp = {{8., 2.38, 4.4}, {0., -4.99, 81.5, 92.745}};
+  std::cout << "---\n";
+  qern3(dvp);
+
+  DoubleVectorPair dvp2 = {{5., -8.7, 4.3, 1., 7.6}, {0., 0., 2., 1.}};
+  DoubleVectorPair dvp3 = {{1.}, {-2., 3.}};
+  DoubleVectorPair dvp4 = {{-4., -5., 6.}, {-7., -8., -9., .88}};
+  std::vector<DoubleVectorPair> vdvp = {dvp, dvp2, dvp3, dvp4};
+  std::cout << "---\n";
+  // qern4(vdvp);
+
+  std::vector<bool> bpw0 = {true, false};
+  std::cout << "---\n";
+  cern1(bpw0);
+  std::vector<bool> bpw1 = {false, false, false};
+  std::vector<bool> bpw2 = {false, true, false, true};
+  std::vector<bool> bpw3 = {false, false, true, false, true};
+  std::vector<std::vector<bool>> vbpw{bpw0, bpw1, bpw2, bpw3};
+  std::cout << "---\n";
+  cern2(vbpw);
+
+  BoolVectorPair bvp = {{false, false}, {false, true, true, false}};
+  std::cout << "---\n";
+  cern3(bvp);
+
+  BoolVectorPair bvp2 = {{false, true, true, false, true, false},
+                         {false, true, true, false, false, false, true, false}};
+  BoolVectorPair bvp3 = {{false}, {true, true}};
+  BoolVectorPair bvp4 = {{true, false, false}, {false, true, false, true}};
+  std::vector<BoolVectorPair> vbvp = {bvp, bvp2, bvp3, bvp4};
+  std::cout << "---\n";
+  // cern4(vbvp);
+
+  return 0;
+}
+
+// CHECK: ---
+// CHECK: integers: 345 1 2
+// CHECK: ---
+// CHECK: integers: 345 1 2
+// CHECK: integers: 92347 3 4
+// CHECK: integers: 2358 5 6
+// CHECK: integers: 45 7 18
+// CHECK: ---
+// CHECK: integers: 8 238 44
+// CHECK: integers: 0 -4 81 92745
+// CHECK: ---
+// CHECK: doubles: 3.45 1 2
+// CHECK: ---
+// CHECK: doubles: 3.45 1 2
+// CHECK: doubles: 92.347 2.3 4
+// CHECK: doubles: 235.8 5.5 6.4
+// CHECK: doubles: 4.5 77.7 18.2
+// CHECK: ---
+// CHECK: doubles: 8 2.38 4.4
+// CHECK: doubles: 0 -4.99 81.5 92.745
+// CHECK: ---
+// CHECK: booleans: 1 0
+// CHECK: ---
+// CHECK: booleans: 1 0
+// CHECK: booleans: 0 0 0
+// CHECK: booleans: 0 1 0 1
+// CHECK: booleans: 0 0 1 0 1
+// CHECK: ---
+// CHECK: booleans: 0 0
+// CHECK: booleans: 0 1 1 0

--- a/targettests/SeparateCompilation/pauli_words.cpp
+++ b/targettests/SeparateCompilation/pauli_words.cpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: if [ command -v split-file ]; then \
+// RUN: split-file %s %t && \
+// RUN: nvq++ %cpp_std --enable-mlir -c %t/pauli_word_display.cpp -o %t/pauli_word_display.o && \
+// RUN: nvq++ %cpp_std --enable-mlir -c %t/pauli_wordle.cpp -o %t/pauli_wordle.o && \
+// RUN: nvq++ %cpp_std --enable-mlir %t/pauli_word_display.o %t/pauli_wordle.o -o %t/pauli_wordle.out && \
+// RUN: %t/pauli_wordle.out | FileCheck %s ; else \
+// RUN: echo "skipping" ; fi
+// clang-format on
+
+//--- pauli_word_display.cpp
+
+#include <iostream>
+#include <span>
+#include <string>
+
+extern "C" {
+void display(std::span<char> x) {
+  std::string s{x.data(), x.size()};
+  std::cout << "pauli word: " << s << '\n';
+}
+}
+
+//--- pauli_wordle.cpp
+
+#include <cudaq.h>
+
+// Fake host C++ signature that matches. Since this is called on the device side
+// the pauli_word will have been converted to a span.
+extern "C" void display(const cudaq::pauli_word &pw);
+
+__qpu__ void kerny(std::vector<cudaq::pauli_word> arg) {
+  display(arg[0]);
+  display(arg[1]);
+  display(arg[2]);
+  display(arg[3]);
+}
+
+__qpu__ void kernub(cudaq::pauli_word arg) { display(arg); }
+
+int main() {
+  cudaq::pauli_word pw0 = "YYZ";
+  kernub(pw0);
+
+  cudaq::pauli_word pw1 = "ZIZ";
+  cudaq::pauli_word pw2 = "XXXY";
+  cudaq::pauli_word pw3 = "YIIII";
+  std::vector<cudaq::pauli_word> vpw{pw0, pw1, pw2, pw3};
+  kerny(vpw);
+  return 0;
+}
+
+// CHECK: pauli word: YYZ
+// CHECK: pauli word: YYZ
+// CHECK: pauli word: ZIZ
+// CHECK: pauli word: XXXY
+// CHECK: pauli word: YIIII

--- a/targettests/execution/exp_pauli.cpp
+++ b/targettests/execution/exp_pauli.cpp
@@ -8,17 +8,18 @@
 
 // clang-format off
 // Simulators
-// RUN: nvq++ %cpp_std --enable-mlir                                                    %s -o %t && %t | FileCheck %s
-// RUN: nvq++ %cpp_std --enable-mlir --target remote-mqpu          -fkernel-exec-kind=2 %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std --enable-mlir %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std -fkernel-exec-kind=2 --enable-mlir -target remote-mqpu %s -o %t && %t | FileCheck %s
 //
 // Quantum emulators
-// RUN: nvq++ %cpp_std --target quantinuum               --emulate -fkernel-exec-kind=2 %s -o %t && %t | FileCheck %s
-// RUN: nvq++ %cpp_std --target ionq                     --emulate -fkernel-exec-kind=2 %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std -fkernel-exec-kind=2 -target quantinuum --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std -fkernel-exec-kind=2 -target ionq       --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std -fkernel-exec-kind=2 -target oqc        --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std -fkernel-exec-kind=2 -target anyon      --emulate %s -o %t && %t | FileCheck %s
+
 // 2 different IQM machines for 2 different topologies
-// RUN: nvq++ %cpp_std --target iqm --iqm-machine Adonis --emulate -fkernel-exec-kind=2 %s -o %t && %t | FileCheck %s
-// RUN: nvq++ %cpp_std --target iqm --iqm-machine Apollo --emulate -fkernel-exec-kind=2 %s -o %t && %t | FileCheck %s
-// RUN: nvq++ %cpp_std --target oqc                      --emulate -fkernel-exec-kind=2 %s -o %t && %t | FileCheck %s
-// RUN: nvq++ %cpp_std --target anyon                    --emulate -fkernel-exec-kind=2 %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std -fkernel-exec-kind=2 -target iqm --iqm-machine Adonis --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std -fkernel-exec-kind=2 -target iqm --iqm-machine Apollo --emulate %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/test/AST-Quake/calling_convention-aarch64.cpp
+++ b/test/AST-Quake/calling_convention-aarch64.cpp
@@ -271,7 +271,7 @@ struct V3 {
 // CHECK-LABEL:  func.func @_ZN2V3clESt6vectorIlSaIlEES0_IbSaIbEE(
 // CHECK-SAME: %[[VAL_0:.*]]: !cc.ptr<i8>,
 // CHECK-SAME:     %[[VAL_1:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i64>, !cc.ptr<i64>, !cc.ptr<i64>}>>,
-// CHECK-SAME:     %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// CHECK-SAME:     %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.array<i8 x 32>}>>)
 // clang-format on
 
 //===----------------------------------------------------------------------===//

--- a/test/AST-Quake/calling_convention.cpp
+++ b/test/AST-Quake/calling_convention.cpp
@@ -278,9 +278,7 @@ struct V3 {
 // CHECK-SAME:     %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f32>, !cc.ptr<f32>, !cc.ptr<f32>}>>,
 // CHECK-SAME:     %[[VAL_3:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i16>, !cc.ptr<i16>, !cc.ptr<i16>}>>)
 // CHECK-LABEL:  func.func @_ZN2V3clESt6vectorIlSaIlEES0_IbSaIbEE(
-// CHECK-SAME: %[[VAL_0:.*]]: !cc.ptr<i8>,
-// CHECK-SAME:     %[[VAL_1:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i64>, !cc.ptr<i64>, !cc.ptr<i64>}>>,
-// CHECK-SAME:     %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// CHECK-SAME:     %[[VAL_0:.*]]: !cc.ptr<i8>, %[[VAL_1:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i64>, !cc.ptr<i64>, !cc.ptr<i64>}>>, %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.array<i8 x 32>}>>)
 // clang-format on
 
 //===----------------------------------------------------------------------===//

--- a/test/Quake/kernel_exec-1.qke
+++ b/test/Quake/kernel_exec-1.qke
@@ -6,14 +6,12 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --kernel-execution=codegen=1 %s | FileCheck %s
-// RUN: cudaq-opt --kernel-execution=codegen=2 %s | FileCheck --check-prefix=STREAM %s
-// RUN: cudaq-opt --kernel-execution %s | FileCheck --check-prefix=HYBRID %s
+// RUN: cudaq-opt -kernel-execution=codegen=1 %s | FileCheck --check-prefix=ALT %s
+// RUN: cudaq-opt -kernel-execution=codegen=2 %s | FileCheck --check-prefix=STREAMLINED %s
+// RUN: cudaq-opt -kernel-execution %s | FileCheck --check-prefix=HYBRID %s
 
 module attributes {quake.mangled_name_map = {
   __nvqpp__mlirgen__ghz = "_ZN3ghzclEi"}} {
-
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ghz(
 
   func.func @__nvqpp__mlirgen__ghz(%arg0: i32) -> f64 {
     %0 = cc.alloca i32
@@ -83,174 +81,369 @@ module attributes {quake.mangled_name_map = {
   }
 }
 
-// Check the generated code.
+// ALT-LABEL:   func.func @_ZN3ghzclEi(
+// ALT-SAME:                           %[[VAL_0:.*]]: !cc.ptr<i8>,
+// ALT-SAME:                           %[[VAL_1:.*]]: i32) -> f64 {
+// ALT:           %[[VAL_2:.*]] = cc.alloca i64
+// ALT:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
+// ALT:           %[[VAL_4:.*]] = cc.alloca i8{{\[}}%[[VAL_3]] : i64]
+// ALT:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// ALT:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i32>
+// ALT:           cc.store %[[VAL_1]], %[[VAL_6]] : !cc.ptr<i32>
+// ALT:           %[[VAL_7:.*]] = constant @ghz.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:           %[[VAL_8:.*]] = cc.func_ptr %[[VAL_7]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// ALT:           %[[VAL_9:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i8>
+// ALT:           %[[VAL_10:.*]] = cc.offsetof !cc.struct<{i32, f64}> [1] : i64
+// ALT:           %[[VAL_11:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
+// ALT:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
+// ALT:           %[[VAL_13:.*]] = call @altLaunchKernel(%[[VAL_12]], %[[VAL_8]], %[[VAL_9]], %[[VAL_3]], %[[VAL_10]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:           %[[VAL_14:.*]] = cc.extract_value %[[VAL_13]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// ALT:           %[[VAL_15:.*]] = cc.cast %[[VAL_14]] : (!cc.ptr<i8>) -> i64
+// ALT:           %[[VAL_16:.*]] = arith.constant 0 : i64
+// ALT:           %[[VAL_17:.*]] = arith.cmpi ne, %[[VAL_15]], %[[VAL_16]] : i64
+// ALT:           cf.cond_br %[[VAL_17]], ^bb1, ^bb2
+// ALT:         ^bb1:
+// ALT:           %[[VAL_18:.*]] = cc.cast %[[VAL_14]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// ALT:           %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_18]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// ALT:           cf.br ^bb3(%[[VAL_19]] : !cc.ptr<f64>)
+// ALT:         ^bb2:
+// ALT:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// ALT:           cf.br ^bb3(%[[VAL_20]] : !cc.ptr<f64>)
+// ALT:         ^bb3(%[[VAL_21:.*]]: !cc.ptr<f64>):
+// ALT:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// ALT:           %[[VAL_23:.*]] = cc.load %[[VAL_22]] : !cc.ptr<f64>
+// ALT:           return %[[VAL_23]] : f64
+// ALT:         }
+// ALT:         func.func private @altLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:         func.func private @cudaqRegisterArgsCreator(!cc.ptr<i8>, !cc.ptr<i8>)
+// ALT:         llvm.func @cudaqRegisterLambdaName(!llvm.ptr<i8>, !llvm.ptr<i8>) attributes {sym_visibility = "private"}
+// ALT:         func.func private @__cudaq_registerLinkableKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>)
+// ALT:         func.func private @__cudaq_getLinkableKernelKey(!cc.ptr<i8>) -> i64
+// ALT:         func.func private @cudaqRegisterKernelName(!cc.ptr<i8>)
+// ALT:         func.func private @malloc(i64) -> !cc.ptr<i8>
+// ALT:         func.func private @free(!cc.ptr<i8>)
+// ALT:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
+// ALT:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// ALT:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
 
-// CHECK-LABEL:   func.func @_ZN3ghzclEi(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<i8>, %[[VAL_1:.*]]: i32) -> f64 {
-// CHECK-DAG:       %[[VAL_2:.*]] = cc.undef !cc.struct<{i32, f64}>
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_1]], %[[VAL_2]][0] : (!cc.struct<{i32, f64}>, i32) -> !cc.struct<{i32, f64}>
-// CHECK:           %[[VAL_5:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
-// CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[VAL_3]] : i64
-// CHECK:           %[[VAL_7:.*]] = cc.alloca i8{{\[}}%[[VAL_6]] : i64]
-// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-// CHECK:           cc.store %[[VAL_4]], %[[VAL_8]] : !cc.ptr<!cc.struct<{i32, f64}>>
-// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>
-// CHECK:           %[[VAL_10:.*]] = constant @ghz.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_11:.*]] = cc.func_ptr %[[VAL_10]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_13:.*]] = cc.offsetof !cc.struct<{i32, f64}> [1] : i64
-// CHECK:           %[[VAL_14:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
-// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_14]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_16:.*]] = call @altLaunchKernel(%[[VAL_15]], %[[VAL_11]], %[[VAL_12]], %[[VAL_6]], %[[VAL_13]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_17:.*]] = cc.extract_value %[[VAL_16]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<i8>) -> i64
-// CHECK:           %[[VAL_19:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_20:.*]] = arith.cmpi ne, %[[VAL_18]], %[[VAL_19]] : i64
-// CHECK:           cf.cond_br %[[VAL_20]], ^bb1, ^bb2
-// CHECK:         ^bb1:
-// CHECK:           %[[VAL_21:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-// CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_21]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
-// CHECK:           cf.br ^bb3(%[[VAL_22]] : !cc.ptr<f64>)
-// CHECK:         ^bb2:
-// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_9]][0, 1] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>) -> !cc.ptr<f64>
-// CHECK:           cf.br ^bb3(%[[VAL_23]] : !cc.ptr<f64>)
-// CHECK:         ^bb3(%[[VAL_24:.*]]: !cc.ptr<f64>):
-// CHECK:           %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_9]][0, 1] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>) -> !cc.ptr<f64>
-// CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<f64>
-// CHECK:           return %[[VAL_26]] : f64
-// CHECK:         }
+// ALT-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// ALT:           %[[VAL_0:.*]] = arith.constant 0 : i64
+// ALT:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (i64) -> !cc.ptr<i8>
+// ALT:           %[[VAL_2:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:           %[[VAL_3:.*]] = cc.insert_value %[[VAL_1]], %[[VAL_2]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_0]], %[[VAL_3]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:           return %[[VAL_4]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:         }
 
-// CHECK:         func.func private @altLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:         func.func private @cudaqRegisterKernelName(!cc.ptr<i8>)
+// ALT-LABEL:   func.func private @__nvqpp_createDynamicResult(
+// ALT-SAME:                                                   %[[VAL_0:.*]]: !cc.ptr<i8>,
+// ALT-SAME:                                                   %[[VAL_1:.*]]: i64,
+// ALT-SAME:                                                   %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>,
+// ALT-SAME:                                                   %[[VAL_3:.*]]: i64) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// ALT:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+// ALT:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
+// ALT:           %[[VAL_6:.*]] = arith.addi %[[VAL_1]], %[[VAL_5]] : i64
+// ALT:           %[[VAL_7:.*]] = call @malloc(%[[VAL_6]]) : (i64) -> !cc.ptr<i8>
+// ALT:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// ALT:           %[[VAL_9:.*]] = arith.constant false
+// ALT:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_7]], %[[VAL_0]], %[[VAL_1]], %[[VAL_9]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// ALT:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+// ALT:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.ptr<i8>>
+// ALT:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_1]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// ALT:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_12]], %[[VAL_11]], %[[VAL_5]], %[[VAL_9]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// ALT:           %[[VAL_13:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:           %[[VAL_14:.*]] = cc.insert_value %[[VAL_7]], %[[VAL_13]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:           %[[VAL_15:.*]] = cc.insert_value %[[VAL_6]], %[[VAL_14]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// ALT:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.ptr<i8>>
+// ALT:           cc.store %[[VAL_12]], %[[VAL_17]] : !cc.ptr<!cc.ptr<i8>>
+// ALT:           return %[[VAL_15]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:         }
+// ALT:         llvm.mlir.global external constant @ghz.kernelName("ghz\00") {addr_space = 0 : i32}
 
-// CHECK:         llvm.mlir.global external constant @ghz.kernelName("ghz\00") {addr_space = 0 : i32}
+// ALT-LABEL:   func.func @ghz.returnOffset() -> i64 {
+// ALT:           %[[VAL_0:.*]] = cc.offsetof !cc.struct<{i32, f64}> [1] : i64
+// ALT:           return %[[VAL_0]] : i64
+// ALT:         }
 
-// CHECK-LABEL:   func.func @ghz.thunk(
-// CHECK-SAME:                         %[[VAL_0:.*]]: !cc.ptr<i8>,
-// CHECK-SAME:                         %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
-// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, f64}>>
-// CHECK:           %[[VAL_7:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
-// CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_20]][%[[VAL_7]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_9:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i32, f64}>) -> i32
-// CHECK:           %[[VAL_10:.*]] = call @__nvqpp__mlirgen__ghz(%[[VAL_9]]) : (i32) -> f64
-// CHECK:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
-// CHECK:           cc.store %[[VAL_10]], %[[VAL_11]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_12:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           return %[[VAL_12]] : !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:         }
+// ALT-LABEL:   func.func @ghz.thunk(
+// ALT-SAME:                         %[[VAL_0:.*]]: !cc.ptr<i8>,
+// ALT-SAME:                         %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// ALT:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// ALT:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, f64}>>
+// ALT:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
+// ALT:           %[[VAL_5:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// ALT:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// ALT:           %[[VAL_7:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i32, f64}>) -> i32
+// ALT:           %[[VAL_8:.*]] = call @__nvqpp__mlirgen__ghz(%[[VAL_7]]) : (i32) -> f64
+// ALT:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// ALT:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<f64>
+// ALT:           %[[VAL_10:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:           return %[[VAL_10]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// ALT:         }
 
-// CHECK-LABEL:   func.func @ghz.argsCreator(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
-// CHECK-SAME:      %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{i32, f64}>
-// CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.array<!cc.ptr<i8> x ?>>
-// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_14]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_8:.*]] = cc.insert_value %[[VAL_7]], %[[VAL_2]][0] : (!cc.struct<{i32, f64}>, i32) -> !cc.struct<{i32, f64}>
-// CHECK:           %[[VAL_11:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
-// CHECK:           %[[VAL_12:.*]] = call @malloc(%[[VAL_11]]) : (i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_12]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-// CHECK:           cc.store %[[VAL_8]], %[[VAL_13]] : !cc.ptr<!cc.struct<{i32, f64}>>
-// CHECK:           cc.store %[[VAL_12]], %[[VAL_1]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           return %[[VAL_11]] : i64
-// CHECK:         }
+// ALT-LABEL:   func.func @ghz.argsCreator(
+// ALT-SAME:                               %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
+// ALT-SAME:                               %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
+// ALT:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.array<!cc.ptr<i8> x ?>>
+// ALT:           %[[VAL_3:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
+// ALT:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<!cc.ptr<i8>>
+// ALT:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// ALT:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
+// ALT:           %[[VAL_7:.*]] = cc.alloca i64
+// ALT:           %[[VAL_8:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
+// ALT:           %[[VAL_9:.*]] = call @malloc(%[[VAL_8]]) : (i64) -> !cc.ptr<i8>
+// ALT:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// ALT:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][0] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i32>
+// ALT:           cc.store %[[VAL_6]], %[[VAL_11]] : !cc.ptr<i32>
+// ALT:           cc.store %[[VAL_9]], %[[VAL_1]] : !cc.ptr<!cc.ptr<i8>>
+// ALT:           return %[[VAL_8]] : i64
+// ALT:         }
 
-// CHECK-LABEL:   llvm.func @ghz.kernelRegFunc() {
-// CHECK:           %[[VAL_0:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
-// CHECK:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
-// CHECK:           func.call @cudaqRegisterKernelName(%[[VAL_1]]) : (!cc.ptr<i8>) -> ()
-// CHECK:           %[[VAL_2:.*]] = func.constant @ghz.argsCreator : (!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64
-// CHECK:           %[[VAL_3:.*]] = cc.func_ptr %[[VAL_2]] : ((!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64) -> !cc.ptr<i8>
-// CHECK:           func.call @cudaqRegisterArgsCreator(%[[VAL_1]], %[[VAL_3]]) : (!cc.ptr<i8>, !cc.ptr<i8>) -> ()
-// CHECK:           llvm.return
-// CHECK:         }
+// ALT-LABEL:   llvm.func @ghz.kernelRegFunc() {
+// ALT:           %[[VAL_0:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
+// ALT:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
+// ALT:           func.call @cudaqRegisterKernelName(%[[VAL_1]]) : (!cc.ptr<i8>) -> ()
+// ALT:           %[[VAL_2:.*]] = func.constant @ghz.argsCreator : (!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64
+// ALT:           %[[VAL_3:.*]] = cc.func_ptr %[[VAL_2]] : ((!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64) -> !cc.ptr<i8>
+// ALT:           func.call @cudaqRegisterArgsCreator(%[[VAL_1]], %[[VAL_3]]) : (!cc.ptr<i8>, !cc.ptr<i8>) -> ()
+// ALT:           llvm.return
+// ALT:         }
+// ALT:         llvm.mlir.global_ctors {ctors = [@ghz.kernelRegFunc], priorities = [17 : i32]}
+
+// STREAMLINED-LABEL:   func.func @_ZN3ghzclEi(
+// STREAMLINED-SAME:                           %[[VAL_0:.*]]: !cc.ptr<i8>,
+// STREAMLINED-SAME:                           %[[VAL_1:.*]]: i32) -> f64 {
+// STREAMLINED:           %[[VAL_2:.*]] = cc.alloca i64
+// STREAMLINED:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
+// STREAMLINED:           %[[VAL_4:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
+// STREAMLINED:           %[[VAL_5:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
+// STREAMLINED:           %[[VAL_6:.*]] = cc.sizeof !cc.array<!cc.ptr<i8> x 1> : i64
+// STREAMLINED:           %[[VAL_7:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// STREAMLINED:           %[[VAL_8:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// STREAMLINED:           cc.store %[[VAL_7]], %[[VAL_8]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// STREAMLINED:           %[[VAL_9:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
+// STREAMLINED:           %[[VAL_10:.*]] = arith.addi %[[VAL_9]], %[[VAL_6]] : i64
+// STREAMLINED:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
+// STREAMLINED:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_4]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// STREAMLINED:           cc.store %[[VAL_11]], %[[VAL_12]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// STREAMLINED:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_4]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// STREAMLINED:           cc.store %[[VAL_11]], %[[VAL_13]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// STREAMLINED:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// STREAMLINED:           %[[VAL_15:.*]] = cc.alloca i32
+// STREAMLINED:           cc.store %[[VAL_1]], %[[VAL_15]] : !cc.ptr<i32>
+// STREAMLINED:           %[[VAL_16:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
+// STREAMLINED:           cc.store %[[VAL_16]], %[[VAL_14]] : !cc.ptr<!cc.ptr<i8>>
+// STREAMLINED:           %[[VAL_17:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
+// STREAMLINED:           %[[VAL_18:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
+// STREAMLINED:           %[[VAL_19:.*]] = cc.cast %[[VAL_18]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
+// STREAMLINED:           call @streamlinedLaunchKernel(%[[VAL_19]], %[[VAL_17]]) : (!cc.ptr<i8>, !cc.ptr<i8>) -> ()
+// STREAMLINED:           %[[VAL_20:.*]] = cc.undef f64
+// STREAMLINED:           return %[[VAL_20]] : f64
+// STREAMLINED:         }
+// STREAMLINED:         func.func private @streamlinedLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>)
+// STREAMLINED:         func.func private @cudaqRegisterArgsCreator(!cc.ptr<i8>, !cc.ptr<i8>)
+// STREAMLINED:         llvm.func @cudaqRegisterLambdaName(!llvm.ptr<i8>, !llvm.ptr<i8>) attributes {sym_visibility = "private"}
+// STREAMLINED:         func.func private @__cudaq_registerLinkableKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>)
+// STREAMLINED:         func.func private @__cudaq_getLinkableKernelKey(!cc.ptr<i8>) -> i64
+// STREAMLINED:         func.func private @cudaqRegisterKernelName(!cc.ptr<i8>)
+// STREAMLINED:         func.func private @malloc(i64) -> !cc.ptr<i8>
+// STREAMLINED:         func.func private @free(!cc.ptr<i8>)
+// STREAMLINED:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
+// STREAMLINED:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// STREAMLINED:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
+
+// STREAMLINED-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// STREAMLINED:           %[[VAL_0:.*]] = arith.constant 0 : i64
+// STREAMLINED:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (i64) -> !cc.ptr<i8>
+// STREAMLINED:           %[[VAL_2:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// STREAMLINED:           %[[VAL_3:.*]] = cc.insert_value %[[VAL_1]], %[[VAL_2]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// STREAMLINED:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_0]], %[[VAL_3]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// STREAMLINED:           return %[[VAL_4]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// STREAMLINED:         }
+
+// STREAMLINED-LABEL:   func.func private @__nvqpp_createDynamicResult(
+// STREAMLINED-SAME:                                                   %[[VAL_0:.*]]: !cc.ptr<i8>,
+// STREAMLINED-SAME:                                                   %[[VAL_1:.*]]: i64,
+// STREAMLINED-SAME:                                                   %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>,
+// STREAMLINED-SAME:                                                   %[[VAL_3:.*]]: i64) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// STREAMLINED:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+// STREAMLINED:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
+// STREAMLINED:           %[[VAL_6:.*]] = arith.addi %[[VAL_1]], %[[VAL_5]] : i64
+// STREAMLINED:           %[[VAL_7:.*]] = call @malloc(%[[VAL_6]]) : (i64) -> !cc.ptr<i8>
+// STREAMLINED:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// STREAMLINED:           %[[VAL_9:.*]] = arith.constant false
+// STREAMLINED:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_7]], %[[VAL_0]], %[[VAL_1]], %[[VAL_9]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// STREAMLINED:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+// STREAMLINED:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.ptr<i8>>
+// STREAMLINED:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_1]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// STREAMLINED:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_12]], %[[VAL_11]], %[[VAL_5]], %[[VAL_9]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// STREAMLINED:           %[[VAL_13:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// STREAMLINED:           %[[VAL_14:.*]] = cc.insert_value %[[VAL_7]], %[[VAL_13]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// STREAMLINED:           %[[VAL_15:.*]] = cc.insert_value %[[VAL_6]], %[[VAL_14]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// STREAMLINED:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// STREAMLINED:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.ptr<i8>>
+// STREAMLINED:           cc.store %[[VAL_12]], %[[VAL_17]] : !cc.ptr<!cc.ptr<i8>>
+// STREAMLINED:           return %[[VAL_15]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// STREAMLINED:         }
+// STREAMLINED:         llvm.mlir.global external constant @ghz.kernelName("ghz\00") {addr_space = 0 : i32}
+
+// STREAMLINED-LABEL:   llvm.func @ghz.kernelRegFunc() {
+// STREAMLINED:           %[[VAL_0:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
+// STREAMLINED:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
+// STREAMLINED:           func.call @cudaqRegisterKernelName(%[[VAL_1]]) : (!cc.ptr<i8>) -> ()
+// STREAMLINED:           llvm.return
+// STREAMLINED:         }
+// STREAMLINED:         llvm.mlir.global_ctors {ctors = [@ghz.kernelRegFunc], priorities = [17 : i32]}
 
 
-// STREAM-LABEL:   func.func @_ZN3ghzclEi(
-// STREAM-SAME:      %[[VAL_0:.*]]: !cc.ptr<i8>, %[[VAL_1:.*]]: i32) -> f64 {
-// STREAM:           %[[VAL_2:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
-// STREAM:           %[[VAL_3:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
-// STREAM:           %[[VAL_4:.*]] = cc.sizeof !cc.array<!cc.ptr<i8> x 1> : i64
-// STREAM:           %[[VAL_5:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
-// STREAM:           %[[VAL_6:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// STREAM:           cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// STREAM:           %[[VAL_7:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
-// STREAM:           %[[VAL_8:.*]] = arith.addi %[[VAL_7]], %[[VAL_4]] : i64
-// STREAM:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
-// STREAM:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// STREAM:           cc.store %[[VAL_9]], %[[VAL_10]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// STREAM:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_2]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// STREAM:           cc.store %[[VAL_9]], %[[VAL_11]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// STREAM:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_3]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
-// STREAM:           %[[VAL_15:.*]] = cc.alloca i32
-// STREAM:           cc.store %[[VAL_1]], %[[VAL_15]] : !cc.ptr<i32>
-// STREAM:           %[[VAL_16:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
-// STREAM:           cc.store %[[VAL_16]], %[[VAL_14]] : !cc.ptr<!cc.ptr<i8>>
-// STREAM:           %[[VAL_19:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
-// STREAM:           %[[VAL_20:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
-// STREAM:           %[[VAL_21:.*]] = cc.cast %[[VAL_20]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
-// STREAM:           call @streamlinedLaunchKernel(%[[VAL_21]], %[[VAL_19]]) : (!cc.ptr<i8>, !cc.ptr<i8>) -> ()
-// STREAM:           %[[VAL_22:.*]] = cc.undef f64
-// STREAM:           return %[[VAL_22]] : f64
-// STREAM:         }
 
 // HYBRID-LABEL:   func.func @_ZN3ghzclEi(
-// HYBRID-SAME:      %[[VAL_0:.*]]: !cc.ptr<i8>, %[[VAL_1:.*]]: i32) -> f64 {
-// HYBRID:           %[[VAL_2:.*]] = cc.undef !cc.struct<{i32, f64}>
-// HYBRID:           %[[VAL_3:.*]] = arith.constant 0 : i64
-// HYBRID:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_1]], %[[VAL_2]][0] : (!cc.struct<{i32, f64}>, i32) -> !cc.struct<{i32, f64}>
-// HYBRID:           %[[VAL_5:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
-// HYBRID:           %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[VAL_3]] : i64
-// HYBRID:           %[[VAL_7:.*]] = cc.alloca i8{{\[}}%[[VAL_6]] : i64]
-// HYBRID:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-// HYBRID:           cc.store %[[VAL_4]], %[[VAL_8]] : !cc.ptr<!cc.struct<{i32, f64}>>
-// HYBRID:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>
-// HYBRID:           %[[VAL_10:.*]] = constant @ghz.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// HYBRID:           %[[VAL_11:.*]] = cc.func_ptr %[[VAL_10]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// HYBRID:           %[[VAL_12:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>) -> !cc.ptr<i8>
-// HYBRID:           %[[VAL_13:.*]] = cc.offsetof !cc.struct<{i32, f64}> [1] : i64
-// HYBRID:           %[[VAL_14:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
-// HYBRID:           %[[VAL_15:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
-// HYBRID:           %[[VAL_16:.*]] = cc.sizeof !cc.array<!cc.ptr<i8> x 1> : i64
-// HYBRID:           %[[VAL_17:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
-// HYBRID:           %[[VAL_18:.*]] = cc.cast %[[VAL_14]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// HYBRID:           cc.store %[[VAL_17]], %[[VAL_18]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// HYBRID:           %[[VAL_19:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
-// HYBRID:           %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_16]] : i64
-// HYBRID:           %[[VAL_21:.*]] = cc.cast %[[VAL_20]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
-// HYBRID:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_14]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// HYBRID:           cc.store %[[VAL_21]], %[[VAL_22]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// HYBRID:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_14]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// HYBRID:           cc.store %[[VAL_21]], %[[VAL_23]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// HYBRID:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_15]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
-// HYBRID:           %[[VAL_25:.*]] = cc.alloca i32
-// HYBRID:           cc.store %[[VAL_1]], %[[VAL_25]] : !cc.ptr<i32>
-// HYBRID:           %[[VAL_26:.*]] = cc.cast %[[VAL_25]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
-// HYBRID:           cc.store %[[VAL_26]], %[[VAL_24]] : !cc.ptr<!cc.ptr<i8>>
-// HYBRID:           %[[VAL_27:.*]] = cc.cast %[[VAL_14]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
-// HYBRID:           %[[VAL_28:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
-// HYBRID:           %[[VAL_29:.*]] = cc.cast %[[VAL_28]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
-// HYBRID:           %[[VAL_30:.*]] = call @hybridLaunchKernel(%[[VAL_29]], %[[VAL_11]], %[[VAL_12]], %[[VAL_6]], %[[VAL_13]], %[[VAL_27]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// HYBRID:           %[[VAL_31:.*]] = cc.extract_value %[[VAL_30]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// HYBRID:           %[[VAL_32:.*]] = cc.cast %[[VAL_31]] : (!cc.ptr<i8>) -> i64
-// HYBRID:           %[[VAL_33:.*]] = arith.constant 0 : i64
-// HYBRID:           %[[VAL_34:.*]] = arith.cmpi ne, %[[VAL_32]], %[[VAL_33]] : i64
-// HYBRID:           cf.cond_br %[[VAL_34]], ^bb1, ^bb2
+// HYBRID-SAME:                           %[[VAL_0:.*]]: !cc.ptr<i8>,
+// HYBRID-SAME:                           %[[VAL_1:.*]]: i32) -> f64 {
+// HYBRID:           %[[VAL_2:.*]] = cc.alloca i64
+// HYBRID:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
+// HYBRID:           %[[VAL_4:.*]] = cc.alloca i8{{\[}}%[[VAL_3]] : i64]
+// HYBRID:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// HYBRID:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i32>
+// HYBRID:           cc.store %[[VAL_1]], %[[VAL_6]] : !cc.ptr<i32>
+// HYBRID:           %[[VAL_7:.*]] = constant @ghz.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:           %[[VAL_8:.*]] = cc.func_ptr %[[VAL_7]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_9:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_10:.*]] = cc.offsetof !cc.struct<{i32, f64}> [1] : i64
+// HYBRID:           %[[VAL_11:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
+// HYBRID:           %[[VAL_12:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
+// HYBRID:           %[[VAL_13:.*]] = cc.sizeof !cc.array<!cc.ptr<i8> x 1> : i64
+// HYBRID:           %[[VAL_14:.*]] = cc.cast %[[VAL_12]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           %[[VAL_15:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// HYBRID:           cc.store %[[VAL_14]], %[[VAL_15]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// HYBRID:           %[[VAL_16:.*]] = cc.cast %[[VAL_12]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
+// HYBRID:           %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_13]] : i64
+// HYBRID:           %[[VAL_18:.*]] = cc.cast %[[VAL_17]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// HYBRID:           cc.store %[[VAL_18]], %[[VAL_19]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// HYBRID:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_11]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// HYBRID:           cc.store %[[VAL_18]], %[[VAL_20]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// HYBRID:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_12]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           %[[VAL_22:.*]] = cc.alloca i32
+// HYBRID:           cc.store %[[VAL_1]], %[[VAL_22]] : !cc.ptr<i32>
+// HYBRID:           %[[VAL_23:.*]] = cc.cast %[[VAL_22]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
+// HYBRID:           cc.store %[[VAL_23]], %[[VAL_21]] : !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           %[[VAL_24:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_25:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
+// HYBRID:           %[[VAL_26:.*]] = cc.cast %[[VAL_25]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_27:.*]] = call @hybridLaunchKernel(%[[VAL_26]], %[[VAL_8]], %[[VAL_9]], %[[VAL_3]], %[[VAL_10]], %[[VAL_24]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:           %[[VAL_28:.*]] = cc.extract_value %[[VAL_27]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_29:.*]] = cc.cast %[[VAL_28]] : (!cc.ptr<i8>) -> i64
+// HYBRID:           %[[VAL_30:.*]] = arith.constant 0 : i64
+// HYBRID:           %[[VAL_31:.*]] = arith.cmpi ne, %[[VAL_29]], %[[VAL_30]] : i64
+// HYBRID:           cf.cond_br %[[VAL_31]], ^bb1, ^bb2
 // HYBRID:         ^bb1:
-// HYBRID:           %[[VAL_35:.*]] = cc.cast %[[VAL_31]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-// HYBRID:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_35]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
-// HYBRID:           cf.br ^bb3(%[[VAL_36]] : !cc.ptr<f64>)
+// HYBRID:           %[[VAL_32:.*]] = cc.cast %[[VAL_28]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// HYBRID:           %[[VAL_33:.*]] = cc.compute_ptr %[[VAL_32]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// HYBRID:           cf.br ^bb3(%[[VAL_33]] : !cc.ptr<f64>)
 // HYBRID:         ^bb2:
-// HYBRID:           %[[VAL_37:.*]] = cc.compute_ptr %[[VAL_9]][0, 1] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>) -> !cc.ptr<f64>
-// HYBRID:           cf.br ^bb3(%[[VAL_37]] : !cc.ptr<f64>)
-// HYBRID:         ^bb3(%[[VAL_38:.*]]: !cc.ptr<f64>):
-// HYBRID:           %[[VAL_39:.*]] = cc.compute_ptr %[[VAL_9]][0, 1] : (!cc.ptr<!cc.array<!cc.struct<{i32, f64}> x ?>>) -> !cc.ptr<f64>
-// HYBRID:           %[[VAL_40:.*]] = cc.load %[[VAL_39]] : !cc.ptr<f64>
-// HYBRID:           return %[[VAL_40]] : f64
+// HYBRID:           %[[VAL_34:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// HYBRID:           cf.br ^bb3(%[[VAL_34]] : !cc.ptr<f64>)
+// HYBRID:         ^bb3(%[[VAL_35:.*]]: !cc.ptr<f64>):
+// HYBRID:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_5]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// HYBRID:           %[[VAL_37:.*]] = cc.load %[[VAL_36]] : !cc.ptr<f64>
+// HYBRID:           return %[[VAL_37]] : f64
 // HYBRID:         }
+// HYBRID:         func.func private @hybridLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:         func.func private @cudaqRegisterArgsCreator(!cc.ptr<i8>, !cc.ptr<i8>)
+// HYBRID:         llvm.func @cudaqRegisterLambdaName(!llvm.ptr<i8>, !llvm.ptr<i8>) attributes {sym_visibility = "private"}
+// HYBRID:         func.func private @__cudaq_registerLinkableKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>)
+// HYBRID:         func.func private @__cudaq_getLinkableKernelKey(!cc.ptr<i8>) -> i64
+// HYBRID:         func.func private @cudaqRegisterKernelName(!cc.ptr<i8>)
+// HYBRID:         func.func private @malloc(i64) -> !cc.ptr<i8>
+// HYBRID:         func.func private @free(!cc.ptr<i8>)
+// HYBRID:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
+// HYBRID:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// HYBRID:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
+
+// HYBRID-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// HYBRID:           %[[VAL_0:.*]] = arith.constant 0 : i64
+// HYBRID:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (i64) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_2:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:           %[[VAL_3:.*]] = cc.insert_value %[[VAL_1]], %[[VAL_2]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_0]], %[[VAL_3]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:           return %[[VAL_4]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:         }
+
+// HYBRID-LABEL:   func.func private @__nvqpp_createDynamicResult(
+// HYBRID-SAME:                                                   %[[VAL_0:.*]]: !cc.ptr<i8>,
+// HYBRID-SAME:                                                   %[[VAL_1:.*]]: i64,
+// HYBRID-SAME:                                                   %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>,
+// HYBRID-SAME:                                                   %[[VAL_3:.*]]: i64) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// HYBRID:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+// HYBRID:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
+// HYBRID:           %[[VAL_6:.*]] = arith.addi %[[VAL_1]], %[[VAL_5]] : i64
+// HYBRID:           %[[VAL_7:.*]] = call @malloc(%[[VAL_6]]) : (i64) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// HYBRID:           %[[VAL_9:.*]] = arith.constant false
+// HYBRID:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_7]], %[[VAL_0]], %[[VAL_1]], %[[VAL_9]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// HYBRID:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_1]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// HYBRID:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_12]], %[[VAL_11]], %[[VAL_5]], %[[VAL_9]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// HYBRID:           %[[VAL_13:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:           %[[VAL_14:.*]] = cc.insert_value %[[VAL_7]], %[[VAL_13]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:           %[[VAL_15:.*]] = cc.insert_value %[[VAL_6]], %[[VAL_14]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           cc.store %[[VAL_12]], %[[VAL_17]] : !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           return %[[VAL_15]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:         }
+// HYBRID:         llvm.mlir.global external constant @ghz.kernelName("ghz\00") {addr_space = 0 : i32}
+
+// HYBRID-LABEL:   func.func @ghz.returnOffset() -> i64 {
+// HYBRID:           %[[VAL_0:.*]] = cc.offsetof !cc.struct<{i32, f64}> [1] : i64
+// HYBRID:           return %[[VAL_0]] : i64
+// HYBRID:         }
+
+// HYBRID-LABEL:   func.func @ghz.thunk(
+// HYBRID-SAME:                         %[[VAL_0:.*]]: !cc.ptr<i8>,
+// HYBRID-SAME:                         %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// HYBRID:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// HYBRID:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, f64}>>
+// HYBRID:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
+// HYBRID:           %[[VAL_5:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// HYBRID:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_7:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i32, f64}>) -> i32
+// HYBRID:           %[[VAL_8:.*]] = call @__nvqpp__mlirgen__ghz(%[[VAL_7]]) : (i32) -> f64
+// HYBRID:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
+// HYBRID:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<f64>
+// HYBRID:           %[[VAL_10:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:           return %[[VAL_10]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// HYBRID:         }
+
+// HYBRID-LABEL:   func.func @ghz.argsCreator(
+// HYBRID-SAME:                               %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
+// HYBRID-SAME:                               %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
+// HYBRID:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.array<!cc.ptr<i8> x ?>>
+// HYBRID:           %[[VAL_3:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// HYBRID:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
+// HYBRID:           %[[VAL_7:.*]] = cc.alloca i64
+// HYBRID:           %[[VAL_8:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
+// HYBRID:           %[[VAL_9:.*]] = call @malloc(%[[VAL_8]]) : (i64) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
+// HYBRID:           %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][0] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i32>
+// HYBRID:           cc.store %[[VAL_6]], %[[VAL_11]] : !cc.ptr<i32>
+// HYBRID:           cc.store %[[VAL_9]], %[[VAL_1]] : !cc.ptr<!cc.ptr<i8>>
+// HYBRID:           return %[[VAL_8]] : i64
+// HYBRID:         }
+
+// HYBRID-LABEL:   llvm.func @ghz.kernelRegFunc() {
+// HYBRID:           %[[VAL_0:.*]] = llvm.mlir.addressof @ghz.kernelName : !llvm.ptr<array<4 x i8>>
+// HYBRID:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!llvm.ptr<array<4 x i8>>) -> !cc.ptr<i8>
+// HYBRID:           func.call @cudaqRegisterKernelName(%[[VAL_1]]) : (!cc.ptr<i8>) -> ()
+// HYBRID:           %[[VAL_2:.*]] = func.constant @ghz.argsCreator : (!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64
+// HYBRID:           %[[VAL_3:.*]] = cc.func_ptr %[[VAL_2]] : ((!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64) -> !cc.ptr<i8>
+// HYBRID:           func.call @cudaqRegisterArgsCreator(%[[VAL_1]], %[[VAL_3]]) : (!cc.ptr<i8>, !cc.ptr<i8>) -> ()
+// HYBRID:           llvm.return
+// HYBRID:         }
+// HYBRID:         llvm.mlir.global_ctors {ctors = [@ghz.kernelRegFunc], priorities = [17 : i32]}
+

--- a/test/Quake/kernel_exec-1.qke
+++ b/test/Quake/kernel_exec-1.qke
@@ -170,11 +170,11 @@ module attributes {quake.mangled_name_map = {
 // ALT-SAME:                         %[[VAL_0:.*]]: !cc.ptr<i8>,
 // ALT-SAME:                         %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
 // ALT:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-// ALT:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, f64}>>
-// ALT:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
-// ALT:           %[[VAL_5:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
-// ALT:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// ALT:           %[[VAL_7:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i32, f64}>) -> i32
+// ALT:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
+// ALT:           %[[VAL_4:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// ALT:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// ALT:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i32>
+// ALT:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
 // ALT:           %[[VAL_8:.*]] = call @__nvqpp__mlirgen__ghz(%[[VAL_7]]) : (i32) -> f64
 // ALT:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
 // ALT:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<f64>
@@ -403,14 +403,14 @@ module attributes {quake.mangled_name_map = {
 // HYBRID:         }
 
 // HYBRID-LABEL:   func.func @ghz.thunk(
-// HYBRID-SAME:                         %[[VAL_0:.*]]: !cc.ptr<i8>,
-// HYBRID-SAME:                         %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// HYBRID-SAME:        %[[VAL_0:.*]]: !cc.ptr<i8>,
+// HYBRID-SAME:        %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
 // HYBRID:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, f64}>>
-// HYBRID:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, f64}>>
-// HYBRID:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
-// HYBRID:           %[[VAL_5:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
-// HYBRID:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// HYBRID:           %[[VAL_7:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i32, f64}>) -> i32
+// HYBRID:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, f64}> : i64
+// HYBRID:           %[[VAL_4:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// HYBRID:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// HYBRID:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i32>
+// HYBRID:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
 // HYBRID:           %[[VAL_8:.*]] = call @__nvqpp__mlirgen__ghz(%[[VAL_7]]) : (i32) -> f64
 // HYBRID:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
 // HYBRID:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<f64>

--- a/test/Quake/kernel_exec-1.qke
+++ b/test/Quake/kernel_exec-1.qke
@@ -123,7 +123,7 @@ module attributes {quake.mangled_name_map = {
 // ALT:         func.func private @malloc(i64) -> !cc.ptr<i8>
 // ALT:         func.func private @free(!cc.ptr<i8>)
 // ALT:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
-// ALT:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// ALT:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.array<i8 x 32>}>>, !cc.ptr<!cc.ptr<i8>>)
 // ALT:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
 
 // ALT-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {
@@ -250,7 +250,7 @@ module attributes {quake.mangled_name_map = {
 // STREAMLINED:         func.func private @malloc(i64) -> !cc.ptr<i8>
 // STREAMLINED:         func.func private @free(!cc.ptr<i8>)
 // STREAMLINED:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
-// STREAMLINED:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// STREAMLINED:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.array<i8 x 32>}>>, !cc.ptr<!cc.ptr<i8>>)
 // STREAMLINED:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
 
 // STREAMLINED-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {
@@ -359,7 +359,7 @@ module attributes {quake.mangled_name_map = {
 // HYBRID:         func.func private @malloc(i64) -> !cc.ptr<i8>
 // HYBRID:         func.func private @free(!cc.ptr<i8>)
 // HYBRID:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
-// HYBRID:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// HYBRID:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.array<i8 x 32>}>>, !cc.ptr<!cc.ptr<i8>>)
 // HYBRID:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
 
 // HYBRID-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {

--- a/test/Quake/kernel_exec-2.qke
+++ b/test/Quake/kernel_exec-2.qke
@@ -131,7 +131,7 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 // CHECK:         func.func private @malloc(i64) -> !cc.ptr<i8>
 // CHECK:         func.func private @free(!cc.ptr<i8>)
 // CHECK:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
-// CHECK:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// CHECK:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.array<i8 x 32>}>>, !cc.ptr<!cc.ptr<i8>>)
 // CHECK:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
 
 // CHECK-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {

--- a/test/Quake/kernel_exec-2.qke
+++ b/test/Quake/kernel_exec-2.qke
@@ -172,24 +172,25 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @function_hawaiian.thunk(
-// CHECK-SAME:           %[[VAL_0:.*]]: !cc.ptr<i8>,
-// CHECK-SAME:           %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK-SAME:        %[[VAL_0:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:        %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
 // CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i1, i64}>>
-// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i1, i64}>>
-// CHECK:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i1, i64}> : i64
-// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_7:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i1, i64}>) -> i1
-// CHECK:           %[[VAL_8:.*]] = cc.extract_value %[[VAL_3]][1] : (!cc.struct<{i1, i64}>) -> i64
-// CHECK:           %[[VAL_9:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_10:.*]] = arith.divsi %[[VAL_8]], %[[VAL_9]] : i64
-// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_12:.*]] = cc.stdvec_init %[[VAL_11]], %[[VAL_10]] : (!cc.ptr<i32>, i64) -> !cc.stdvec<i32>
-// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]]{{\[}}%[[VAL_8]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           call @__nvqpp__mlirgen__function_hawaiian(%[[VAL_7]], %[[VAL_12]]) : (i1, !cc.stdvec<i32>) -> ()
-// CHECK:           %[[VAL_15:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           return %[[VAL_15]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i1, i64}> : i64
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.struct<{i1, i64}>>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i1, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_9:.*]] = cc.sizeof i32 : i64
+// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_8]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_11:.*]] = arith.divsi %[[VAL_10]], %[[VAL_9]] : i64
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_13:.*]] = cc.stdvec_init %[[VAL_12]], %[[VAL_11]] : (!cc.ptr<i32>, i64) -> !cc.stdvec<i32>
+// CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_14]]{{\[}}%[[VAL_10]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           call @__nvqpp__mlirgen__function_hawaiian(%[[VAL_7]], %[[VAL_13]]) : (i1, !cc.stdvec<i32>) -> ()
+// CHECK:           %[[VAL_16:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           return %[[VAL_16]] : !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @function_hawaiian.argsCreator(

--- a/test/Quake/kernel_exec-2.qke
+++ b/test/Quake/kernel_exec-2.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --kernel-execution=codegen=1 %s | FileCheck %s
+// RUN: cudaq-opt -kernel-execution %s | FileCheck %s
 
 module attributes {quake.mangled_name_map = {
 __nvqpp__mlirgen__function_hawaiian = "shirt",
@@ -36,120 +36,209 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
   }
 }
 
-// CHECK-LABEL:   func.func @shirt(
-// CHECK-SAME:      %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) {
-// CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{i1, i64}>
-// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_0]], %[[VAL_2]][0] : (!cc.struct<{i1, i64}>, i1) -> !cc.struct<{i1, i64}>
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_1]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_1]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_5]] : !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_6]] : !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i32>) -> i64
-// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<i32>) -> i64
-// CHECK:           %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
-// CHECK:           %[[VAL_12:.*]] = cc.insert_value %[[VAL_11]], %[[VAL_4]][1] : (!cc.struct<{i1, i64}>, i64) -> !cc.struct<{i1, i64}>
-// CHECK:           %[[VAL_13:.*]] = arith.addi %[[VAL_3]], %[[VAL_11]] : i64
-// CHECK:           %[[VAL_16:.*]] = cc.sizeof !cc.struct<{i1, i64}> : i64
-// CHECK:           %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_13]] : i64
-// CHECK:           %[[VAL_18:.*]] = cc.alloca i8[%[[VAL_17]] : i64]
-// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_18]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i1, i64}>>
-// CHECK:           cc.store %[[VAL_12]], %[[VAL_19]] : !cc.ptr<!cc.struct<{i1, i64}>>
-// CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_18]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.array<!cc.struct<{i1, i64}> x ?>>
-// CHECK:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_18]][%[[VAL_16]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_22:.*]] = cc.extract_value %[[VAL_12]][1] : (!cc.struct<{i1, i64}>) -> i64
-// CHECK:           %[[VAL_23:.*]] = arith.constant false
-// CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_1]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_25:.*]] = cc.load %[[VAL_24]] : !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_26:.*]] = cc.cast %[[VAL_25]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
-// CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_21]], %[[VAL_26]], %[[VAL_22]], %[[VAL_23]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
-// CHECK:           %[[VAL_90:.*]] = cc.cast %[[VAL_21]] :
-// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_90]][%[[VAL_22]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_29:.*]] = constant @function_hawaiian.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_31:.*]] = cc.func_ptr %[[VAL_29]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_32:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<!cc.array<!cc.struct<{i1, i64}> x ?>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_33:.*]] = arith.constant 2147483647 : i64
-// CHECK:           %[[VAL_28:.*]] = llvm.mlir.addressof @function_hawaiian.kernelName : !llvm.ptr<array<18 x i8>>
-// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_28]] : (!llvm.ptr<array<18 x i8>>) -> !cc.ptr<i8>
-// CHECK:           call @altLaunchKernel(%[[VAL_30]], %[[VAL_31]], %[[VAL_32]], %[[VAL_17]], %[[VAL_33]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_cargo(
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.stdvec<i32>,
+// CHECK-SAME:      %[[VAL_1:.*]]: !quake.ref) attributes {"cudaq-kernel", no_this} {
 // CHECK:           return
 // CHECK:         }
 
-// CHECK-DAG:     func.func private @altLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK-DAG:     func.func private @cudaqRegisterKernelName(!cc.ptr<i8>)
-// CHECK-DAG:     func.func private @cudaqRegisterArgsCreator(!cc.ptr<i8>, !cc.ptr<i8>)
-// CHECK-DAG:     func.func private @malloc(i64) -> !cc.ptr<i8>
-// CHECK-DAG:     func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
-// CHECK-DAG:     func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_hawaiian(
+// CHECK-SAME:      %[[VAL_0:.*]]: i1,
+// CHECK-SAME:      %[[VAL_1:.*]]: !cc.stdvec<i32>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
+// CHECK:           cc.if(%[[VAL_0]]) {
+// CHECK:             quake.x %[[VAL_4]] : (!quake.ref) -> ()
+// CHECK:           }
+// CHECK:           call @__nvqpp__mlirgen__function_cargo(%[[VAL_1]], %[[VAL_4]]) : (!cc.stdvec<i32>, !quake.ref) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @shirt(
+// CHECK-SAME:      %[[VAL_0:.*]]: i1,
+// CHECK-SAME:      %[[VAL_1:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) {
+// CHECK:           %[[VAL_2:.*]] = cc.alloca i64
+// CHECK:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i1, i64}> : i64
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_1]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_1]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_5]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<i32>) -> i64
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i32>) -> i64
+// CHECK:           %[[VAL_10:.*]] = arith.subi %[[VAL_8]], %[[VAL_9]] : i64
+// CHECK:           %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_3]] : i64
+// CHECK:           %[[VAL_12:.*]] = cc.alloca i8{{\[}}%[[VAL_11]] : i64]
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_12]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i1, i64}>>
+// CHECK:           %[[VAL_14:.*]] = cc.alloca !cc.ptr<i8>
+// CHECK:           %[[VAL_15:.*]] = cc.sizeof !cc.struct<{i1, i64}> : i64
+// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_12]]{{\[}}%[[VAL_15]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_17:.*]] = cc.compute_ptr %[[VAL_13]][0] : (!cc.ptr<!cc.struct<{i1, i64}>>) -> !cc.ptr<i1>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_17]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<!cc.struct<{i1, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_1]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_20:.*]] = cc.compute_ptr %[[VAL_1]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_19]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_22:.*]] = cc.load %[[VAL_20]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_23:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<i32>) -> i64
+// CHECK:           %[[VAL_24:.*]] = cc.cast %[[VAL_22]] : (!cc.ptr<i32>) -> i64
+// CHECK:           %[[VAL_25:.*]] = arith.subi %[[VAL_23]], %[[VAL_24]] : i64
+// CHECK:           cc.store %[[VAL_25]], %[[VAL_18]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_26:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_27:.*]] = cc.load %[[VAL_26]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_28:.*]] = arith.constant false
+// CHECK:           %[[VAL_29:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<i8>) -> !cc.ptr<i8>
+// CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_29]], %[[VAL_27]], %[[VAL_25]], %[[VAL_28]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_31:.*]] = cc.compute_ptr %[[VAL_30]]{{\[}}%[[VAL_25]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_32:.*]] = constant @function_hawaiian.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_33:.*]] = cc.func_ptr %[[VAL_32]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_34:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.struct<{i1, i64}>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_35:.*]] = arith.constant 2147483647 : i64
+// CHECK:           %[[VAL_36:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
+// CHECK:           %[[VAL_37:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 2>
+// CHECK:           %[[VAL_38:.*]] = cc.sizeof !cc.array<!cc.ptr<i8> x 2> : i64
+// CHECK:           %[[VAL_39:.*]] = cc.cast %[[VAL_37]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 2>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_40:.*]] = cc.cast %[[VAL_36]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_39]], %[[VAL_40]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_41:.*]] = cc.cast %[[VAL_37]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 2>>) -> i64
+// CHECK:           %[[VAL_42:.*]] = arith.addi %[[VAL_41]], %[[VAL_38]] : i64
+// CHECK:           %[[VAL_43:.*]] = cc.cast %[[VAL_42]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_44:.*]] = cc.compute_ptr %[[VAL_36]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_43]], %[[VAL_44]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_45:.*]] = cc.compute_ptr %[[VAL_36]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_43]], %[[VAL_45]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_46:.*]] = cc.compute_ptr %[[VAL_37]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 2>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_47:.*]] = cc.alloca i1
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_47]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_48:.*]] = cc.cast %[[VAL_47]] : (!cc.ptr<i1>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_48]], %[[VAL_46]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_49:.*]] = cc.compute_ptr %[[VAL_37]][1] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 2>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_50:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_50]], %[[VAL_49]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_51:.*]] = cc.cast %[[VAL_36]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_52:.*]] = llvm.mlir.addressof @function_hawaiian.kernelName : !llvm.ptr<array<18 x i8>>
+// CHECK:           %[[VAL_53:.*]] = cc.cast %[[VAL_52]] : (!llvm.ptr<array<18 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_54:.*]] = call @hybridLaunchKernel(%[[VAL_53]], %[[VAL_33]], %[[VAL_34]], %[[VAL_11]], %[[VAL_35]], %[[VAL_51]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           return
+// CHECK:         }
+// CHECK:         func.func private @hybridLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:         func.func private @cudaqRegisterArgsCreator(!cc.ptr<i8>, !cc.ptr<i8>)
+// CHECK:         llvm.func @cudaqRegisterLambdaName(!llvm.ptr<i8>, !llvm.ptr<i8>) attributes {sym_visibility = "private"}
+// CHECK:         func.func private @__cudaq_registerLinkableKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>)
+// CHECK:         func.func private @__cudaq_getLinkableKernelKey(!cc.ptr<i8>) -> i64
+// CHECK:         func.func private @cudaqRegisterKernelName(!cc.ptr<i8>)
+// CHECK:         func.func private @malloc(i64) -> !cc.ptr<i8>
+// CHECK:         func.func private @free(!cc.ptr<i8>)
+// CHECK:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
+// CHECK:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// CHECK:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
 
 // CHECK-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_3:.*]] = cc.insert_value %[[VAL_1]], %[[VAL_2]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_0]], %[[VAL_3]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           return %[[VAL_4]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:         }
 
 // CHECK-LABEL:   func.func private @__nvqpp_createDynamicResult(
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<i8>, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>, %[[VAL_3:.*]]: i64) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_1]], %[[VAL_5]] : i64
+// CHECK:           %[[VAL_7:.*]] = call @malloc(%[[VAL_6]]) : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_9:.*]] = arith.constant false
+// CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_7]], %[[VAL_0]], %[[VAL_1]], %[[VAL_9]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_1]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_12]], %[[VAL_11]], %[[VAL_5]], %[[VAL_9]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// CHECK:           %[[VAL_13:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_14:.*]] = cc.insert_value %[[VAL_7]], %[[VAL_13]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_15:.*]] = cc.insert_value %[[VAL_6]], %[[VAL_14]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_8]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           cc.store %[[VAL_12]], %[[VAL_17]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           return %[[VAL_15]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:         }
+// CHECK:         llvm.mlir.global external constant @function_hawaiian.kernelName("function_hawaiian\00") {addr_space = 0 : i32}
 
-// CHECK:         llvm.mlir.global external constant @function_hawaiian.kernelName("function
+// CHECK-LABEL:   func.func @function_hawaiian.returnOffset() -> i64 {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 2147483647 : i64
+// CHECK:           return %[[VAL_0]] : i64
+// CHECK:         }
 
 // CHECK-LABEL:   func.func @function_hawaiian.thunk(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<i8>, %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK-SAME:           %[[VAL_0:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:           %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
 // CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i1, i64}>>
 // CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i1, i64}>>
-// CHECK:           %[[VAL_7:.*]] = cc.sizeof !cc.struct<{i1, i64}> : i64
-// CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_20]][%[[VAL_7]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_9:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i1, i64}>) -> i1
-// CHECK:           %[[VAL_10:.*]] = cc.extract_value %[[VAL_3]][1] : (!cc.struct<{i1, i64}>) -> i64
-// CHECK:           %[[VAL_11:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_12:.*]] = arith.divsi %[[VAL_10]], %[[VAL_11]] : i64
-// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
-// CHECK:           %[[VAL_14:.*]] = cc.stdvec_init %[[VAL_13]], %[[VAL_12]] : (!cc.ptr<i32>, i64) -> !cc.stdvec<i32>
-// CHECK:           %[[VAL_90:.*]] = cc.cast %[[VAL_8]] :
-// CHECK:           %[[VAL_15:.*]] = cc.compute_ptr %[[VAL_90]][%[[VAL_10]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           call @__nvqpp__mlirgen__function_hawaiian(%[[VAL_9]], %[[VAL_14]]) : (i1, !cc.stdvec<i32>) -> ()
-// CHECK:           %[[VAL_16:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           return %[[VAL_16]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i1, i64}> : i64
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]]{{\[}}%[[VAL_4]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_7:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i1, i64}>) -> i1
+// CHECK:           %[[VAL_8:.*]] = cc.extract_value %[[VAL_3]][1] : (!cc.struct<{i1, i64}>) -> i64
+// CHECK:           %[[VAL_9:.*]] = arith.constant 4 : i64
+// CHECK:           %[[VAL_10:.*]] = arith.divsi %[[VAL_8]], %[[VAL_9]] : i64
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_12:.*]] = cc.stdvec_init %[[VAL_11]], %[[VAL_10]] : (!cc.ptr<i32>, i64) -> !cc.stdvec<i32>
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]]{{\[}}%[[VAL_8]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           call @__nvqpp__mlirgen__function_hawaiian(%[[VAL_7]], %[[VAL_12]]) : (i1, !cc.stdvec<i32>) -> ()
+// CHECK:           %[[VAL_15:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           return %[[VAL_15]] : !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @function_hawaiian.argsCreator(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>, %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{i1, i64}>
-// CHECK:           %[[VAL_90:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.ptr<i8>>) ->
-// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_90]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<i8>) -> !cc.ptr<i1>
-// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i1>
-// CHECK:           %[[VAL_8:.*]] = cc.insert_value %[[VAL_7]], %[[VAL_2]][0] : (!cc.struct<{i1, i64}>, i1) -> !cc.struct<{i1, i64}>
-// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_90]][1] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>
-// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_11]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK-SAME:              %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
+// CHECK-SAME:              %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.ptr<i8>>) -> !cc.ptr<!cc.array<!cc.ptr<i8> x ?>>
+// CHECK:           %[[VAL_3:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<i8>) -> !cc.ptr<i1>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>
+// CHECK:           %[[VAL_9:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_10:.*]] = cc.alloca i64
+// CHECK:           %[[VAL_11:.*]] = cc.sizeof !cc.struct<{i1, i64}> : i64
+// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_8]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_13:.*]] = cc.compute_ptr %[[VAL_8]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_14:.*]] = cc.load %[[VAL_12]] : !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_15:.*]] = cc.load %[[VAL_13]] : !cc.ptr<!cc.ptr<i32>>
 // CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_14]] : (!cc.ptr<i32>) -> i64
 // CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<i32>) -> i64
 // CHECK:           %[[VAL_18:.*]] = arith.subi %[[VAL_16]], %[[VAL_17]] : i64
-// CHECK:           %[[VAL_19:.*]] = cc.insert_value %[[VAL_18]], %[[VAL_8]][1] : (!cc.struct<{i1, i64}>, i64) -> !cc.struct<{i1, i64}>
-// CHECK:           %[[VAL_20:.*]] = arith.addi %[[VAL_3]], %[[VAL_18]] : i64
+// CHECK:           %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_11]] : i64
+// CHECK:           %[[VAL_20:.*]] = call @malloc(%[[VAL_19]]) : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_21:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i1, i64}>>
+// CHECK:           %[[VAL_22:.*]] = cc.alloca !cc.ptr<i8>
 // CHECK:           %[[VAL_23:.*]] = cc.sizeof !cc.struct<{i1, i64}> : i64
-// CHECK:           %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_20]] : i64
-// CHECK:           %[[VAL_25:.*]] = call @malloc(%[[VAL_24]]) : (i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_26:.*]] = cc.cast %[[VAL_25]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i1, i64}>>
-// CHECK:           cc.store %[[VAL_19]], %[[VAL_26]] : !cc.ptr<!cc.struct<{i1, i64}>>
-// CHECK:           %[[VAL_80:.*]] = cc.cast %[[VAL_25]] :
-// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_80]][%[[VAL_23]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_28:.*]] = cc.extract_value %[[VAL_19]][1] : (!cc.struct<{i1, i64}>) -> i64
-// CHECK:           %[[VAL_29:.*]] = cc.compute_ptr %[[VAL_90]][1] : (!cc.ptr<!cc.array<!cc.ptr<i8> x ?>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_30:.*]] = cc.load %[[VAL_29]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_31:.*]] = cc.cast %[[VAL_30]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>
-// CHECK:           %[[VAL_32:.*]] = arith.constant false
-// CHECK:           %[[VAL_33:.*]] = cc.compute_ptr %[[VAL_31]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_34:.*]] = cc.load %[[VAL_33]] : !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_35:.*]] = cc.cast %[[VAL_34]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
-// CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_27]], %[[VAL_35]], %[[VAL_28]], %[[VAL_32]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
-// CHECK:           %[[VAL_83:.*]] = cc.cast %[[VAL_27]] :
-// CHECK:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_83]][%[[VAL_28]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_25]], %[[VAL_1]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           return %[[VAL_24]] : i64
+// CHECK:           %[[VAL_24:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_24]]{{\[}}%[[VAL_23]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_26:.*]] = cc.compute_ptr %[[VAL_21]][0] : (!cc.ptr<!cc.struct<{i1, i64}>>) -> !cc.ptr<i1>
+// CHECK:           cc.store %[[VAL_9]], %[[VAL_26]] : !cc.ptr<i1>
+// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_21]][1] : (!cc.ptr<!cc.struct<{i1, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_8]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_29:.*]] = cc.compute_ptr %[[VAL_8]][0] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_30:.*]] = cc.load %[[VAL_28]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_31:.*]] = cc.load %[[VAL_29]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_32:.*]] = cc.cast %[[VAL_30]] : (!cc.ptr<i32>) -> i64
+// CHECK:           %[[VAL_33:.*]] = cc.cast %[[VAL_31]] : (!cc.ptr<i32>) -> i64
+// CHECK:           %[[VAL_34:.*]] = arith.subi %[[VAL_32]], %[[VAL_33]] : i64
+// CHECK:           cc.store %[[VAL_34]], %[[VAL_27]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_35:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_36:.*]] = cc.load %[[VAL_35]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_37:.*]] = arith.constant false
+// CHECK:           %[[VAL_38:.*]] = cc.cast %[[VAL_25]] : (!cc.ptr<i8>) -> !cc.ptr<i8>
+// CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_38]], %[[VAL_36]], %[[VAL_34]], %[[VAL_37]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// CHECK:           %[[VAL_39:.*]] = cc.cast %[[VAL_25]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_40:.*]] = cc.compute_ptr %[[VAL_39]]{{\[}}%[[VAL_34]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_20]], %[[VAL_1]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           return %[[VAL_19]] : i64
 // CHECK:         }
 
 // CHECK-LABEL:   llvm.func @function_hawaiian.kernelRegFunc() {
@@ -161,6 +250,5 @@ __nvqpp__mlirgen__function_cargo = "pants"}} {
 // CHECK:           func.call @cudaqRegisterArgsCreator(%[[VAL_1]], %[[VAL_3]]) : (!cc.ptr<i8>, !cc.ptr<i8>) -> ()
 // CHECK:           llvm.return
 // CHECK:         }
-
 // CHECK:         llvm.mlir.global_ctors {ctors = [@function_hawaiian.kernelRegFunc], priorities = [17 : i32]}
 

--- a/test/Quake/lambda_kernel_exec.qke
+++ b/test/Quake/lambda_kernel_exec.qke
@@ -15,7 +15,7 @@
 // CHECK: llvm.call @cudaqRegisterLambdaName(%[[VAL_1]], %{{.*}}) : (!llvm.ptr<i8>, !llvm.ptr<i8>) -> ()
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHaveMultiple = "_ZZ4mainENK3$_1clEv", __nvqpp__mlirgen__lambda.main.test = "_ZZ4mainENK3$_0clEv"}} {
-  func.func @__nvqpp__mlirgen__lambda.main.test() attributes {"cudaq-entrypoint"} {
+  func.func @__nvqpp__mlirgen__lambda.main.test() attributes {"cudaq-entrypoint", no_this} {
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
     %1 = quake.alloca !quake.veq<?>[%0 : i64]
@@ -54,7 +54,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__lambda.main.canHa
 // CHECK-NEXT: %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!llvm.ptr<array<10 x i8>>) -> !llvm.ptr<i8>
 // CHECK: llvm.call @cudaqRegisterLambdaName(%[[VAL_4]], %{{.*}}) : (!llvm.ptr<i8>, !llvm.ptr<i8>) -> ()
 
-  func.func @__nvqpp__mlirgen__lambda.main.canHaveMultiple() attributes {"cudaq-entrypoint"} {
+  func.func @__nvqpp__mlirgen__lambda.main.canHaveMultiple() attributes {"cudaq-entrypoint", no_this} {
     %c2_i32 = arith.constant 2 : i32
     %0 = arith.extsi %c2_i32 : i32 to i64
     %1 = quake.alloca !quake.veq<?>[%0 : i64]

--- a/test/Quake/return_vector.qke
+++ b/test/Quake/return_vector.qke
@@ -264,12 +264,12 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_0.thunk(
-// CHECK-SAME:                            %[[VAL_0:.*]]: !cc.ptr<i8>,
-// CHECK-SAME:                            %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK-SAME:        %[[VAL_0:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:        %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
 // CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
-// CHECK:           %[[VAL_5:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>) -> i32
+// CHECK:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = call @__nvqpp__mlirgen__test_0(%[[VAL_5]]) : (i32) -> !cc.stdvec<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.stdvec<i32>>
@@ -278,7 +278,7 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:         ^bb1:
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>
 // CHECK:           %[[VAL_10:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> [1] : i64
-// CHECK:           %[[VAL_11:.*]] = call @__nvqpp_createDynamicResult(%[[VAL_0]], %[[VAL_4]], %[[VAL_9]], %[[VAL_10]]) : (!cc.ptr<i8>, i64, !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_11:.*]] = call @__nvqpp_createDynamicResult(%[[VAL_0]], %[[VAL_3]], %[[VAL_9]], %[[VAL_10]]) : (!cc.ptr<i8>, i64, !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           return %[[VAL_11]] : !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:         ^bb2:
 // CHECK:           %[[VAL_12:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
@@ -319,12 +319,12 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_1.thunk(
-// CHECK-SAME:                            %[[VAL_0:.*]]: !cc.ptr<i8>,
-// CHECK-SAME:                            %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK-SAME:        %[[VAL_0:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:        %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
 // CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
-// CHECK:           %[[VAL_5:.*]] = cc.extract_value %[[VAL_3]][0] : (!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>) -> i32
+// CHECK:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_6:.*]] = call @__nvqpp__mlirgen__test_1(%[[VAL_5]]) : (i32) -> !cc.stdvec<f64>
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.stdvec<f64>>
@@ -333,7 +333,7 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:         ^bb1:
 // CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>
 // CHECK:           %[[VAL_10:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> [1] : i64
-// CHECK:           %[[VAL_11:.*]] = call @__nvqpp_createDynamicResult(%[[VAL_0]], %[[VAL_4]], %[[VAL_9]], %[[VAL_10]]) : (!cc.ptr<i8>, i64, !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_11:.*]] = call @__nvqpp_createDynamicResult(%[[VAL_0]], %[[VAL_3]], %[[VAL_9]], %[[VAL_10]]) : (!cc.ptr<i8>, i64, !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           return %[[VAL_11]] : !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:         ^bb2:
 // CHECK:           %[[VAL_12:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
@@ -341,8 +341,8 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_1.argsCreator(
-// CHECK-SAME:                                  %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
-// CHECK-SAME:                                  %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
+// CHECK-SAME:        %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
+// CHECK-SAME:        %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
 // CHECK:           %[[VAL_2:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.ptr<i8>>
 // CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>

--- a/test/Quake/return_vector.qke
+++ b/test/Quake/return_vector.qke
@@ -6,8 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --add-dealloc --kernel-execution=codegen=1 --canonicalize %s \
-// RUN: | FileCheck %s
+// RUN: cudaq-opt -add-dealloc -kernel-execution -canonicalize %s | FileCheck %s
 
 // NB: the mangled name map is required for the kernel-execution pass.
 module attributes{ quake.mangled_name_map = {
@@ -29,61 +28,81 @@ func.func @test_0(%0: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i3
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test_0(
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> !cc.stdvec<i32> {
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 8 : i64
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 256 : i64
-// CHECK:           %[[VAL_4:.*]] = call @malloc(%[[VAL_3]]) : (i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_init %[[VAL_4]], %[[VAL_2]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
-// CHECK:           return %[[VAL_5]] : !cc.stdvec<i32>
+// CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> !cc.stdvec<i32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 8 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 256 : i64
+// CHECK:           %[[VAL_3:.*]] = call @malloc(%[[VAL_2]]) : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_3]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<i32>
+// CHECK:           return %[[VAL_4]] : !cc.stdvec<i32>
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_0(
-// CHECK-SAME:          %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>> {llvm.sret = !cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>},
-// CHECK-SAME:          %[[VAL_1:.*]]: !cc.ptr<i8>, %[[VAL_2:.*]]: i32) {
+// CHECK-SAME:                      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>> {llvm.sret = !cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>},
+// CHECK-SAME:                      %[[VAL_1:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:                      %[[VAL_2:.*]]: i32) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_4:.*]] = constant @test_0.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_4:.*]] = arith.constant 8 : i64
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_6:.*]] = cc.undef !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>
-// CHECK:           %[[VAL_7:.*]] = cc.insert_value %[[VAL_2]], %[[VAL_6]][0] : (!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>, i32) -> !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>
+// CHECK:           %[[VAL_6:.*]] = constant @test_0.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_7:.*]] = cc.alloca i64
 // CHECK:           %[[VAL_8:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
 // CHECK:           %[[VAL_9:.*]] = cc.alloca i8{{\[}}%[[VAL_8]] : i64]
 // CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           cc.store %[[VAL_7]], %[[VAL_10]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           %[[VAL_11:.*]] = cc.func_ptr %[[VAL_4]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_13:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> [1] : i64
-// CHECK:           %[[VAL_14:.*]] = llvm.mlir.addressof @test_0.kernelName : !llvm.ptr<array<7 x i8>>
-// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_14]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_16:.*]] = call @altLaunchKernel(%[[VAL_15]], %[[VAL_11]], %[[VAL_12]], %[[VAL_8]], %[[VAL_13]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_17:.*]] = cc.extract_value %[[VAL_16]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<i8>) -> i64
-// CHECK:           %[[VAL_19:.*]] = arith.cmpi ne, %[[VAL_18]], %[[VAL_5]] : i64
-// CHECK:           cf.cond_br %[[VAL_19]], ^bb1, ^bb2
+// CHECK:           %[[VAL_11:.*]] = cc.alloca !cc.ptr<i8>
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_12]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_13:.*]] = cc.func_ptr %[[VAL_6]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_15:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> [1] : i64
+// CHECK:           %[[VAL_16:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
+// CHECK:           %[[VAL_17:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
+// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_18]], %[[VAL_19]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
+// CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_20]], %[[VAL_4]] : i64
+// CHECK:           %[[VAL_22:.*]] = cc.cast %[[VAL_21]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_16]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_22]], %[[VAL_23]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_16]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_22]], %[[VAL_24]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_26:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_26]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_27:.*]] = cc.cast %[[VAL_26]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_27]], %[[VAL_25]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_28:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_29:.*]] = llvm.mlir.addressof @test_0.kernelName : !llvm.ptr<array<7 x i8>>
+// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_29]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_31:.*]] = call @hybridLaunchKernel(%[[VAL_30]], %[[VAL_13]], %[[VAL_14]], %[[VAL_8]], %[[VAL_15]], %[[VAL_28]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_32:.*]] = cc.extract_value %[[VAL_31]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_33:.*]] = cc.cast %[[VAL_32]] : (!cc.ptr<i8>) -> i64
+// CHECK:           %[[VAL_34:.*]] = arith.cmpi ne, %[[VAL_33]], %[[VAL_5]] : i64
+// CHECK:           cf.cond_br %[[VAL_34]], ^bb1, ^bb2
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_20]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
-// CHECK:           cf.br ^bb3(%[[VAL_21]] : !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>)
+// CHECK:           %[[VAL_35:.*]] = cc.cast %[[VAL_32]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
+// CHECK:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_35]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
+// CHECK:           cf.br ^bb3(%[[VAL_36]] : !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>)
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_22:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_22]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
-// CHECK:           cf.br ^bb3(%[[VAL_23]] : !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>)
-// CHECK:         ^bb3(%[[VAL_24:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>):
-// CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_24]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_24]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<i64>
-// CHECK:           %[[VAL_28:.*]] = cc.load %[[VAL_27]] : !cc.ptr<i64>
-// CHECK:           %[[VAL_29:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
-// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_31:.*]] = cc.cast %[[VAL_26]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_31]], %[[VAL_30]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_32:.*]] = cc.compute_ptr %[[VAL_29]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_33:.*]] = arith.muli %[[VAL_28]], %[[VAL_3]] : i64
-// CHECK:           %[[VAL_34:.*]] = cc.cast %[[VAL_26]] : (!cc.ptr<i32>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_35:.*]] = cc.compute_ptr %[[VAL_34]]{{\[}}%[[VAL_33]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_35]], %[[VAL_32]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_29]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           cc.store %[[VAL_35]], %[[VAL_36]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           call @free(%[[VAL_17]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           %[[VAL_37:.*]] = cc.compute_ptr %[[VAL_10]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
+// CHECK:           cf.br ^bb3(%[[VAL_37]] : !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>)
+// CHECK:         ^bb3(%[[VAL_38:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>):
+// CHECK:           %[[VAL_39:.*]] = cc.cast %[[VAL_38]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_40:.*]] = cc.load %[[VAL_39]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_41:.*]] = cc.compute_ptr %[[VAL_38]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_42:.*]] = cc.load %[[VAL_41]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_43:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
+// CHECK:           %[[VAL_44:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_45:.*]] = cc.cast %[[VAL_40]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_45]], %[[VAL_44]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_46:.*]] = cc.compute_ptr %[[VAL_43]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_47:.*]] = arith.muli %[[VAL_42]], %[[VAL_3]] : i64
+// CHECK:           %[[VAL_48:.*]] = cc.cast %[[VAL_40]] : (!cc.ptr<i32>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_49:.*]] = cc.compute_ptr %[[VAL_48]]{{\[}}%[[VAL_47]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_49]], %[[VAL_46]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_50:.*]] = cc.compute_ptr %[[VAL_43]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           cc.store %[[VAL_49]], %[[VAL_50]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           call @free(%[[VAL_32]]) : (!cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -98,70 +117,139 @@ func.func @__nvqpp__mlirgen__test_1(%arg0: i32) -> !cc.stdvec<f64> {
 func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>> {llvm.sret = !cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>}, %1: !cc.ptr<i8>, %2: i32) {
   return
 }
+}
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test_1(
-// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> !cc.stdvec<f64> {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 9 : i64
-// CHECK:           %[[VAL_3:.*]] = arith.constant 520 : i64
-// CHECK:           %[[VAL_4:.*]] = call @malloc(%[[VAL_3]]) : (i64) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_5:.*]] = cc.stdvec_init %[[VAL_4]], %[[VAL_2]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<f64>
-// CHECK:           return
+// CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> !cc.stdvec<f64> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 9 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 520 : i64
+// CHECK:           %[[VAL_3:.*]] = call @malloc(%[[VAL_2]]) : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_3]], %[[VAL_1]] : (!cc.ptr<i8>, i64) -> !cc.stdvec<f64>
+// CHECK:           return %[[VAL_4]] : !cc.stdvec<f64>
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_1(
-// CHECK-SAME:           %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>> {llvm.sret = !cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>},
-// CHECK-SAME:           %[[VAL_1:.*]]: !cc.ptr<i8>, %[[VAL_2:.*]]: i32) {
+// CHECK-SAME:                      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>> {llvm.sret = !cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>},
+// CHECK-SAME:                      %[[VAL_1:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:                      %[[VAL_2:.*]]: i32) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 8 : i64
-// CHECK:           %[[VAL_4:.*]] = constant @test_1.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_6:.*]] = cc.undef !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>
-// CHECK:           %[[VAL_7:.*]] = cc.insert_value %[[VAL_2]], %[[VAL_6]][0] : (!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>, i32) -> !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>
-// CHECK:           %[[VAL_8:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
-// CHECK:           %[[VAL_9:.*]] = cc.alloca i8{{\[}}%[[VAL_8]] : i64]
-// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           cc.store %[[VAL_7]], %[[VAL_10]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           %[[VAL_11:.*]] = cc.func_ptr %[[VAL_4]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_13:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> [1] : i64
-// CHECK:           %[[VAL_14:.*]] = llvm.mlir.addressof @test_1.kernelName : !llvm.ptr<array<7 x i8>>
-// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_14]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_16:.*]] = call @altLaunchKernel(%[[VAL_15]], %[[VAL_11]], %[[VAL_12]], %[[VAL_8]], %[[VAL_13]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_17:.*]] = cc.extract_value %[[VAL_16]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<i8>) -> i64
-// CHECK:           %[[VAL_19:.*]] = arith.cmpi ne, %[[VAL_18]], %[[VAL_5]] : i64
-// CHECK:           cf.cond_br %[[VAL_19]], ^bb1, ^bb2
+// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_5:.*]] = constant @test_1.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_6:.*]] = cc.alloca i64
+// CHECK:           %[[VAL_7:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
+// CHECK:           %[[VAL_8:.*]] = cc.alloca i8{{\[}}%[[VAL_7]] : i64]
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
+// CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.ptr<i8>
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_11]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_12:.*]] = cc.func_ptr %[[VAL_5]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> [1] : i64
+// CHECK:           %[[VAL_15:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
+// CHECK:           %[[VAL_16:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
+// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_17]], %[[VAL_18]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
+// CHECK:           %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_3]] : i64
+// CHECK:           %[[VAL_21:.*]] = cc.cast %[[VAL_20]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_15]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_21]], %[[VAL_22]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_15]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_21]], %[[VAL_23]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_24:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_25:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_25]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_26:.*]] = cc.cast %[[VAL_25]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_26]], %[[VAL_24]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_27:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_28:.*]] = llvm.mlir.addressof @test_1.kernelName : !llvm.ptr<array<7 x i8>>
+// CHECK:           %[[VAL_29:.*]] = cc.cast %[[VAL_28]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_30:.*]] = call @hybridLaunchKernel(%[[VAL_29]], %[[VAL_12]], %[[VAL_13]], %[[VAL_7]], %[[VAL_14]], %[[VAL_27]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_31:.*]] = cc.extract_value %[[VAL_30]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_32:.*]] = cc.cast %[[VAL_31]] : (!cc.ptr<i8>) -> i64
+// CHECK:           %[[VAL_33:.*]] = arith.cmpi ne, %[[VAL_32]], %[[VAL_4]] : i64
+// CHECK:           cf.cond_br %[[VAL_33]], ^bb1, ^bb2
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           %[[VAL_21:.*]] = cc.compute_ptr %[[VAL_20]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
-// CHECK:           cf.br ^bb3(%[[VAL_21]] : !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>)
+// CHECK:           %[[VAL_34:.*]] = cc.cast %[[VAL_31]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
+// CHECK:           %[[VAL_35:.*]] = cc.compute_ptr %[[VAL_34]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
+// CHECK:           cf.br ^bb3(%[[VAL_35]] : !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>)
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_22:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_22]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
-// CHECK:           cf.br ^bb3(%[[VAL_23]] : !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>)
-// CHECK:         ^bb3(%[[VAL_24:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>):
-// CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_24]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.ptr<f64>>
-// CHECK:           %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<!cc.ptr<f64>>
-// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_24]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<i64>
-// CHECK:           %[[VAL_28:.*]] = cc.load %[[VAL_27]] : !cc.ptr<i64>
-// CHECK:           %[[VAL_29:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
-// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_31:.*]] = cc.cast %[[VAL_26]] : (!cc.ptr<f64>) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_31]], %[[VAL_30]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_32:.*]] = cc.compute_ptr %[[VAL_29]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_33:.*]] = arith.muli %[[VAL_28]], %[[VAL_3]] : i64
-// CHECK:           %[[VAL_34:.*]] = cc.cast %[[VAL_26]] : (!cc.ptr<f64>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_35:.*]] = cc.compute_ptr %[[VAL_34]]{{\[}}%[[VAL_33]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_35]], %[[VAL_32]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_29]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           cc.store %[[VAL_35]], %[[VAL_36]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           call @free(%[[VAL_17]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_9]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
+// CHECK:           cf.br ^bb3(%[[VAL_36]] : !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>)
+// CHECK:         ^bb3(%[[VAL_37:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>):
+// CHECK:           %[[VAL_38:.*]] = cc.cast %[[VAL_37]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.ptr<f64>>
+// CHECK:           %[[VAL_39:.*]] = cc.load %[[VAL_38]] : !cc.ptr<!cc.ptr<f64>>
+// CHECK:           %[[VAL_40:.*]] = cc.compute_ptr %[[VAL_37]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_41:.*]] = cc.load %[[VAL_40]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_42:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
+// CHECK:           %[[VAL_43:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_44:.*]] = cc.cast %[[VAL_39]] : (!cc.ptr<f64>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_44]], %[[VAL_43]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_45:.*]] = cc.compute_ptr %[[VAL_42]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_46:.*]] = arith.muli %[[VAL_41]], %[[VAL_3]] : i64
+// CHECK:           %[[VAL_47:.*]] = cc.cast %[[VAL_39]] : (!cc.ptr<f64>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_48:.*]] = cc.compute_ptr %[[VAL_47]]{{\[}}%[[VAL_46]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_48]], %[[VAL_45]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_49:.*]] = cc.compute_ptr %[[VAL_42]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           cc.store %[[VAL_48]], %[[VAL_49]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           call @free(%[[VAL_31]]) : (!cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }
+// CHECK:         func.func private @hybridLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:         func.func private @cudaqRegisterArgsCreator(!cc.ptr<i8>, !cc.ptr<i8>)
+// CHECK:         llvm.func @cudaqRegisterLambdaName(!llvm.ptr<i8>, !llvm.ptr<i8>) attributes {sym_visibility = "private"}
+// CHECK:         func.func private @__cudaq_registerLinkableKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>)
+// CHECK:         func.func private @__cudaq_getLinkableKernelKey(!cc.ptr<i8>) -> i64
+// CHECK:         func.func private @cudaqRegisterKernelName(!cc.ptr<i8>)
+// CHECK:         func.func private @free(!cc.ptr<i8>)
+// CHECK:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
+// CHECK:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// CHECK:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
 
-}
+// CHECK-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_2:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_3:.*]] = cc.insert_value %[[VAL_1]], %[[VAL_2]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_4:.*]] = cc.insert_value %[[VAL_0]], %[[VAL_3]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           return %[[VAL_4]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:         }
+
+// CHECK-LABEL:   func.func private @__nvqpp_createDynamicResult(
+// CHECK-SAME:                                                   %[[VAL_0:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:                                                   %[[VAL_1:.*]]: i64,
+// CHECK-SAME:                                                   %[[VAL_2:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>,
+// CHECK-SAME:                                                   %[[VAL_3:.*]]: i64) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK:           %[[VAL_4:.*]] = arith.constant false
+// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_7:.*]] = arith.addi %[[VAL_1]], %[[VAL_6]] : i64
+// CHECK:           %[[VAL_8:.*]] = call @malloc(%[[VAL_7]]) : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_8]], %[[VAL_0]], %[[VAL_1]], %[[VAL_4]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, i64}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_10]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_9]]{{\[}}%[[VAL_1]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_12]], %[[VAL_11]], %[[VAL_6]], %[[VAL_4]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// CHECK:           %[[VAL_13:.*]] = cc.undef !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_14:.*]] = cc.insert_value %[[VAL_8]], %[[VAL_13]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_15:.*]] = cc.insert_value %[[VAL_7]], %[[VAL_14]][1] : (!cc.struct<{!cc.ptr<i8>, i64}>, i64) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_9]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           cc.store %[[VAL_12]], %[[VAL_17]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           return %[[VAL_15]] : !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:         }
+// CHECK:         llvm.mlir.global external constant @test_0.kernelName("test_0\00") {addr_space = 0 : i32}
+
+// CHECK-LABEL:   func.func @test_0.returnOffset() -> i64 {
+// CHECK:           %[[VAL_0:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> [1] : i64
+// CHECK:           return %[[VAL_0]] : i64
+// CHECK:         }
 
 // CHECK-LABEL:   func.func @test_0.thunk(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<i8>, %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK-SAME:                            %[[VAL_0:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
 // CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
 // CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
 // CHECK:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
@@ -181,8 +269,42 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:           return %[[VAL_12]] : !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:         }
 
+// CHECK-LABEL:   func.func @test_0.argsCreator(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
+// CHECK-SAME:                                  %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
+// CHECK:           %[[VAL_2:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.alloca i64
+// CHECK:           %[[VAL_6:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
+// CHECK:           %[[VAL_7:.*]] = call @malloc(%[[VAL_6]]) : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_8:.*]] = cc.alloca !cc.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_4]], %[[VAL_9]] : !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_7]], %[[VAL_1]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           return %[[VAL_6]] : i64
+// CHECK:         }
+
+// CHECK-LABEL:   llvm.func @test_0.kernelRegFunc() {
+// CHECK:           %[[VAL_0:.*]] = func.constant @test_0.argsCreator : (!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.addressof @test_0.kernelName : !llvm.ptr<array<7 x i8>>
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
+// CHECK:           func.call @cudaqRegisterKernelName(%[[VAL_2]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           %[[VAL_3:.*]] = cc.func_ptr %[[VAL_0]] : ((!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64) -> !cc.ptr<i8>
+// CHECK:           func.call @cudaqRegisterArgsCreator(%[[VAL_2]], %[[VAL_3]]) : (!cc.ptr<i8>, !cc.ptr<i8>) -> ()
+// CHECK:           llvm.return
+// CHECK:         }
+// CHECK:         llvm.mlir.global_ctors {ctors = [@test_0.kernelRegFunc], priorities = [17 : i32]}
+// CHECK:         llvm.mlir.global external constant @test_1.kernelName("test_1\00") {addr_space = 0 : i32}
+
+// CHECK-LABEL:   func.func @test_1.returnOffset() -> i64 {
+// CHECK:           %[[VAL_0:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> [1] : i64
+// CHECK:           return %[[VAL_0]] : i64
+// CHECK:         }
+
 // CHECK-LABEL:   func.func @test_1.thunk(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<i8>, %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
+// CHECK-SAME:                            %[[VAL_0:.*]]: !cc.ptr<i8>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i1) -> !cc.struct<{!cc.ptr<i8>, i64}> {
 // CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
 // CHECK:           %[[VAL_3:.*]] = cc.load %[[VAL_2]] : !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
 // CHECK:           %[[VAL_4:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
@@ -201,3 +323,31 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:           %[[VAL_12:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:           return %[[VAL_12]] : !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:         }
+
+// CHECK-LABEL:   func.func @test_1.argsCreator(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: !cc.ptr<!cc.ptr<i8>>,
+// CHECK-SAME:                                  %[[VAL_1:.*]]: !cc.ptr<!cc.ptr<i8>>) -> i64 {
+// CHECK:           %[[VAL_2:.*]] = cc.load %[[VAL_0]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = cc.alloca i64
+// CHECK:           %[[VAL_6:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
+// CHECK:           %[[VAL_7:.*]] = call @malloc(%[[VAL_6]]) : (i64) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_8:.*]] = cc.alloca !cc.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_4]], %[[VAL_9]] : !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_7]], %[[VAL_1]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           return %[[VAL_6]] : i64
+// CHECK:         }
+
+// CHECK-LABEL:   llvm.func @test_1.kernelRegFunc() {
+// CHECK:           %[[VAL_0:.*]] = func.constant @test_1.argsCreator : (!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.addressof @test_1.kernelName : !llvm.ptr<array<7 x i8>>
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
+// CHECK:           func.call @cudaqRegisterKernelName(%[[VAL_2]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           %[[VAL_3:.*]] = cc.func_ptr %[[VAL_0]] : ((!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>) -> i64) -> !cc.ptr<i8>
+// CHECK:           func.call @cudaqRegisterArgsCreator(%[[VAL_2]], %[[VAL_3]]) : (!cc.ptr<i8>, !cc.ptr<i8>) -> ()
+// CHECK:           llvm.return
+// CHECK:         }
+// CHECK:         llvm.mlir.global_ctors {ctors = [@test_1.kernelRegFunc], priorities = [17 : i32]}
+

--- a/test/Quake/return_vector.qke
+++ b/test/Quake/return_vector.qke
@@ -28,7 +28,7 @@ func.func @test_0(%0: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i3
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test_0(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> !cc.stdvec<i32> {
+// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> !cc.stdvec<i32> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 8 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 256 : i64
 // CHECK:           %[[VAL_3:.*]] = call @malloc(%[[VAL_2]]) : (i64) -> !cc.ptr<i8>
@@ -37,72 +37,79 @@ func.func @test_0(%0: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i3
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_0(
-// CHECK-SAME:                      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>> {llvm.sret = !cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>},
-// CHECK-SAME:                      %[[VAL_1:.*]]: !cc.ptr<i8>,
-// CHECK-SAME:                      %[[VAL_2:.*]]: i32) {
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>> {llvm.sret = !cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>}, %[[VAL_1:.*]]: !cc.ptr<i8>, %[[VAL_2:.*]]: i32) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 4 : i64
 // CHECK:           %[[VAL_4:.*]] = arith.constant 8 : i64
-// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_6:.*]] = constant @test_0.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_7:.*]] = cc.alloca i64
-// CHECK:           %[[VAL_8:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
-// CHECK:           %[[VAL_9:.*]] = cc.alloca i8{{\[}}%[[VAL_8]] : i64]
-// CHECK:           %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           %[[VAL_11:.*]] = cc.alloca !cc.ptr<i8>
-// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i32>
-// CHECK:           cc.store %[[VAL_2]], %[[VAL_12]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_13:.*]] = cc.func_ptr %[[VAL_6]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_9]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_15:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> [1] : i64
-// CHECK:           %[[VAL_16:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
-// CHECK:           %[[VAL_17:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
-// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           cc.store %[[VAL_18]], %[[VAL_19]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           %[[VAL_20:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
-// CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_20]], %[[VAL_4]] : i64
-// CHECK:           %[[VAL_22:.*]] = cc.cast %[[VAL_21]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_16]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           cc.store %[[VAL_22]], %[[VAL_23]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_16]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           cc.store %[[VAL_22]], %[[VAL_24]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_17]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_26:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_2]], %[[VAL_26]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_27:.*]] = cc.cast %[[VAL_26]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_27]], %[[VAL_25]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_28:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_29:.*]] = llvm.mlir.addressof @test_0.kernelName : !llvm.ptr<array<7 x i8>>
-// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_29]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_31:.*]] = call @hybridLaunchKernel(%[[VAL_30]], %[[VAL_13]], %[[VAL_14]], %[[VAL_8]], %[[VAL_15]], %[[VAL_28]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_32:.*]] = cc.extract_value %[[VAL_31]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_33:.*]] = cc.cast %[[VAL_32]] : (!cc.ptr<i8>) -> i64
-// CHECK:           %[[VAL_34:.*]] = arith.cmpi ne, %[[VAL_33]], %[[VAL_5]] : i64
-// CHECK:           cf.cond_br %[[VAL_34]], ^bb1, ^bb2
+// CHECK:           %[[VAL_5:.*]] = constant @test_0.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_7:.*]] = cc.alloca !cc.ptr<i8>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_6]] : (i64) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_8]], %[[VAL_7]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_9:.*]] = cc.alloca i64
+// CHECK:           %[[VAL_10:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
+// CHECK:           %[[VAL_11:.*]] = cc.alloca i8{{\[}}%[[VAL_10]] : i64]
+// CHECK:           %[[VAL_12:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
+// CHECK:           %[[VAL_13:.*]] = cc.alloca !cc.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_14]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_15:.*]] = cc.load %[[VAL_7]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<i8>) -> i64
+// CHECK:           %[[VAL_17:.*]] = arith.cmpi ne, %[[VAL_16]], %[[VAL_6]] : i64
+// CHECK:           cc.if(%[[VAL_17]]) {
+// CHECK:             func.call @__nvqpp_vector_bool_free_temporary_initlists(%[[VAL_15]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           }
+// CHECK:           %[[VAL_18:.*]] = cc.func_ptr %[[VAL_5]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_11]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_20:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> [1] : i64
+// CHECK:           %[[VAL_21:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
+// CHECK:           %[[VAL_22:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
+// CHECK:           %[[VAL_23:.*]] = cc.cast %[[VAL_22]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_24:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_23]], %[[VAL_24]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_25:.*]] = cc.cast %[[VAL_22]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
+// CHECK:           %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_4]] : i64
+// CHECK:           %[[VAL_27:.*]] = cc.cast %[[VAL_26]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_21]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_27]], %[[VAL_28]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_29:.*]] = cc.compute_ptr %[[VAL_21]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_27]], %[[VAL_29]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_30:.*]] = cc.cast %[[VAL_22]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_31:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_31]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_32:.*]] = cc.cast %[[VAL_31]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_32]], %[[VAL_30]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_33:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_34:.*]] = llvm.mlir.addressof @test_0.kernelName : !llvm.ptr<array<7 x i8>>
+// CHECK:           %[[VAL_35:.*]] = cc.cast %[[VAL_34]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_36:.*]] = call @hybridLaunchKernel(%[[VAL_35]], %[[VAL_18]], %[[VAL_19]], %[[VAL_10]], %[[VAL_20]], %[[VAL_33]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_37:.*]] = cc.extract_value %[[VAL_36]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_38:.*]] = cc.cast %[[VAL_37]] : (!cc.ptr<i8>) -> i64
+// CHECK:           %[[VAL_39:.*]] = arith.cmpi ne, %[[VAL_38]], %[[VAL_6]] : i64
+// CHECK:           cf.cond_br %[[VAL_39]], ^bb1, ^bb2
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_35:.*]] = cc.cast %[[VAL_32]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
-// CHECK:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_35]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
-// CHECK:           cf.br ^bb3(%[[VAL_36]] : !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>)
+// CHECK:           %[[VAL_40:.*]] = cc.cast %[[VAL_37]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>
+// CHECK:           %[[VAL_41:.*]] = cc.compute_ptr %[[VAL_40]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
+// CHECK:           cf.br ^bb3(%[[VAL_41]] : !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>)
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_37:.*]] = cc.compute_ptr %[[VAL_10]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
-// CHECK:           cf.br ^bb3(%[[VAL_37]] : !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>)
-// CHECK:         ^bb3(%[[VAL_38:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>):
-// CHECK:           %[[VAL_39:.*]] = cc.cast %[[VAL_38]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_40:.*]] = cc.load %[[VAL_39]] : !cc.ptr<!cc.ptr<i32>>
-// CHECK:           %[[VAL_41:.*]] = cc.compute_ptr %[[VAL_38]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<i64>
-// CHECK:           %[[VAL_42:.*]] = cc.load %[[VAL_41]] : !cc.ptr<i64>
-// CHECK:           %[[VAL_43:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
-// CHECK:           %[[VAL_44:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_45:.*]] = cc.cast %[[VAL_40]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_45]], %[[VAL_44]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_46:.*]] = cc.compute_ptr %[[VAL_43]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_47:.*]] = arith.muli %[[VAL_42]], %[[VAL_3]] : i64
-// CHECK:           %[[VAL_48:.*]] = cc.cast %[[VAL_40]] : (!cc.ptr<i32>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_49:.*]] = cc.compute_ptr %[[VAL_48]]{{\[}}%[[VAL_47]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_49]], %[[VAL_46]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_50:.*]] = cc.compute_ptr %[[VAL_43]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           cc.store %[[VAL_49]], %[[VAL_50]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           call @free(%[[VAL_32]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           %[[VAL_42:.*]] = cc.compute_ptr %[[VAL_12]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
+// CHECK:           cf.br ^bb3(%[[VAL_42]] : !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>)
+// CHECK:         ^bb3(%[[VAL_43:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>):
+// CHECK:           %[[VAL_44:.*]] = cc.cast %[[VAL_43]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_45:.*]] = cc.load %[[VAL_44]] : !cc.ptr<!cc.ptr<i32>>
+// CHECK:           %[[VAL_46:.*]] = cc.compute_ptr %[[VAL_43]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_47:.*]] = cc.load %[[VAL_46]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_48:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
+// CHECK:           %[[VAL_49:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, !cc.ptr<i32>, !cc.ptr<i32>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_50:.*]] = cc.cast %[[VAL_45]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_50]], %[[VAL_49]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_51:.*]] = cc.compute_ptr %[[VAL_48]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_52:.*]] = arith.muli %[[VAL_47]], %[[VAL_3]] : i64
+// CHECK:           %[[VAL_53:.*]] = cc.cast %[[VAL_45]] : (!cc.ptr<i32>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_54:.*]] = cc.compute_ptr %[[VAL_53]]{{\[}}%[[VAL_52]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_54]], %[[VAL_51]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_55:.*]] = cc.compute_ptr %[[VAL_48]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           cc.store %[[VAL_54]], %[[VAL_55]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           call @free(%[[VAL_37]]) : (!cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -117,10 +124,9 @@ func.func @__nvqpp__mlirgen__test_1(%arg0: i32) -> !cc.stdvec<f64> {
 func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>> {llvm.sret = !cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>}, %1: !cc.ptr<i8>, %2: i32) {
   return
 }
-}
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__test_1(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> !cc.stdvec<f64> {
+// CHECK-SAME:      %[[VAL_0:.*]]: i32) -> !cc.stdvec<f64> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 9 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 520 : i64
 // CHECK:           %[[VAL_3:.*]] = call @malloc(%[[VAL_2]]) : (i64) -> !cc.ptr<i8>
@@ -129,73 +135,83 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:         }
 
 // CHECK-LABEL:   func.func @test_1(
-// CHECK-SAME:                      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>> {llvm.sret = !cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>},
-// CHECK-SAME:                      %[[VAL_1:.*]]: !cc.ptr<i8>,
-// CHECK-SAME:                      %[[VAL_2:.*]]: i32) {
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>> {llvm.sret = !cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>}, %[[VAL_1:.*]]: !cc.ptr<i8>, %[[VAL_2:.*]]: i32) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 8 : i64
-// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_5:.*]] = constant @test_1.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_6:.*]] = cc.alloca i64
-// CHECK:           %[[VAL_7:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
-// CHECK:           %[[VAL_8:.*]] = cc.alloca i8{{\[}}%[[VAL_7]] : i64]
-// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           %[[VAL_10:.*]] = cc.alloca !cc.ptr<i8>
-// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i32>
-// CHECK:           cc.store %[[VAL_2]], %[[VAL_11]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_12:.*]] = cc.func_ptr %[[VAL_5]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_14:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> [1] : i64
-// CHECK:           %[[VAL_15:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
-// CHECK:           %[[VAL_16:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
-// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           cc.store %[[VAL_17]], %[[VAL_18]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           %[[VAL_19:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
-// CHECK:           %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_3]] : i64
-// CHECK:           %[[VAL_21:.*]] = cc.cast %[[VAL_20]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_22:.*]] = cc.compute_ptr %[[VAL_15]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           cc.store %[[VAL_21]], %[[VAL_22]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_15]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           cc.store %[[VAL_21]], %[[VAL_23]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
-// CHECK:           %[[VAL_24:.*]] = cc.cast %[[VAL_16]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_25:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_2]], %[[VAL_25]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_26:.*]] = cc.cast %[[VAL_25]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_26]], %[[VAL_24]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_27:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_28:.*]] = llvm.mlir.addressof @test_1.kernelName : !llvm.ptr<array<7 x i8>>
-// CHECK:           %[[VAL_29:.*]] = cc.cast %[[VAL_28]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_30:.*]] = call @hybridLaunchKernel(%[[VAL_29]], %[[VAL_12]], %[[VAL_13]], %[[VAL_7]], %[[VAL_14]], %[[VAL_27]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
-// CHECK:           %[[VAL_31:.*]] = cc.extract_value %[[VAL_30]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_32:.*]] = cc.cast %[[VAL_31]] : (!cc.ptr<i8>) -> i64
-// CHECK:           %[[VAL_33:.*]] = arith.cmpi ne, %[[VAL_32]], %[[VAL_4]] : i64
-// CHECK:           cf.cond_br %[[VAL_33]], ^bb1, ^bb2
+// CHECK:           %[[VAL_4:.*]] = constant @test_1.thunk : (!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_6:.*]] = cc.alloca !cc.ptr<i8>
+// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_5]] : (i64) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_7]], %[[VAL_6]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_8:.*]] = cc.alloca i64
+// CHECK:           %[[VAL_9:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
+// CHECK:           %[[VAL_10:.*]] = cc.alloca i8{{\[}}%[[VAL_9]] : i64]
+// CHECK:           %[[VAL_11:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
+// CHECK:           %[[VAL_12:.*]] = cc.alloca !cc.ptr<i8>
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i32>
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_13]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_14:.*]] = cc.load %[[VAL_6]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_14]] : (!cc.ptr<i8>) -> i64
+// CHECK:           %[[VAL_16:.*]] = arith.cmpi ne, %[[VAL_15]], %[[VAL_5]] : i64
+// CHECK:           cc.if(%[[VAL_16]]) {
+// CHECK:             func.call @__nvqpp_vector_bool_free_temporary_initlists(%[[VAL_14]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           }
+// CHECK:           %[[VAL_17:.*]] = cc.func_ptr %[[VAL_4]] : ((!cc.ptr<i8>, i1) -> !cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_18:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_19:.*]] = cc.offsetof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> [1] : i64
+// CHECK:           %[[VAL_20:.*]] = cc.alloca !cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>
+// CHECK:           %[[VAL_21:.*]] = cc.alloca !cc.array<!cc.ptr<i8> x 1>
+// CHECK:           %[[VAL_22:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_23:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_22]], %[[VAL_23]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_24:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> i64
+// CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_3]] : i64
+// CHECK:           %[[VAL_26:.*]] = cc.cast %[[VAL_25]] : (i64) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_27:.*]] = cc.compute_ptr %[[VAL_20]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_26]], %[[VAL_27]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_20]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           cc.store %[[VAL_26]], %[[VAL_28]] : !cc.ptr<!cc.ptr<!cc.ptr<i8>>>
+// CHECK:           %[[VAL_29:.*]] = cc.cast %[[VAL_21]] : (!cc.ptr<!cc.array<!cc.ptr<i8> x 1>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_30:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_2]], %[[VAL_30]] : !cc.ptr<i32>
+// CHECK:           %[[VAL_31:.*]] = cc.cast %[[VAL_30]] : (!cc.ptr<i32>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_31]], %[[VAL_29]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_32:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<!cc.struct<{!cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>, !cc.ptr<!cc.ptr<i8>>}>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_33:.*]] = llvm.mlir.addressof @test_1.kernelName : !llvm.ptr<array<7 x i8>>
+// CHECK:           %[[VAL_34:.*]] = cc.cast %[[VAL_33]] : (!llvm.ptr<array<7 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_35:.*]] = call @hybridLaunchKernel(%[[VAL_34]], %[[VAL_17]], %[[VAL_18]], %[[VAL_9]], %[[VAL_19]], %[[VAL_32]]) : (!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
+// CHECK:           %[[VAL_36:.*]] = cc.extract_value %[[VAL_35]][0] : (!cc.struct<{!cc.ptr<i8>, i64}>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_37:.*]] = cc.cast %[[VAL_36]] : (!cc.ptr<i8>) -> i64
+// CHECK:           %[[VAL_38:.*]] = arith.cmpi ne, %[[VAL_37]], %[[VAL_5]] : i64
+// CHECK:           cf.cond_br %[[VAL_38]], ^bb1, ^bb2
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_34:.*]] = cc.cast %[[VAL_31]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
-// CHECK:           %[[VAL_35:.*]] = cc.compute_ptr %[[VAL_34]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
-// CHECK:           cf.br ^bb3(%[[VAL_35]] : !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>)
+// CHECK:           %[[VAL_39:.*]] = cc.cast %[[VAL_36]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>
+// CHECK:           %[[VAL_40:.*]] = cc.compute_ptr %[[VAL_39]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
+// CHECK:           cf.br ^bb3(%[[VAL_40]] : !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>)
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_36:.*]] = cc.compute_ptr %[[VAL_9]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
-// CHECK:           cf.br ^bb3(%[[VAL_36]] : !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>)
-// CHECK:         ^bb3(%[[VAL_37:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>):
-// CHECK:           %[[VAL_38:.*]] = cc.cast %[[VAL_37]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.ptr<f64>>
-// CHECK:           %[[VAL_39:.*]] = cc.load %[[VAL_38]] : !cc.ptr<!cc.ptr<f64>>
-// CHECK:           %[[VAL_40:.*]] = cc.compute_ptr %[[VAL_37]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<i64>
-// CHECK:           %[[VAL_41:.*]] = cc.load %[[VAL_40]] : !cc.ptr<i64>
-// CHECK:           %[[VAL_42:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
-// CHECK:           %[[VAL_43:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_44:.*]] = cc.cast %[[VAL_39]] : (!cc.ptr<f64>) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_44]], %[[VAL_43]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_45:.*]] = cc.compute_ptr %[[VAL_42]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_46:.*]] = arith.muli %[[VAL_41]], %[[VAL_3]] : i64
-// CHECK:           %[[VAL_47:.*]] = cc.cast %[[VAL_39]] : (!cc.ptr<f64>) -> !cc.ptr<!cc.array<i8 x ?>>
-// CHECK:           %[[VAL_48:.*]] = cc.compute_ptr %[[VAL_47]]{{\[}}%[[VAL_46]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
-// CHECK:           cc.store %[[VAL_48]], %[[VAL_45]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           %[[VAL_49:.*]] = cc.compute_ptr %[[VAL_42]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
-// CHECK:           cc.store %[[VAL_48]], %[[VAL_49]] : !cc.ptr<!cc.ptr<i8>>
-// CHECK:           call @free(%[[VAL_31]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           %[[VAL_41:.*]] = cc.compute_ptr %[[VAL_11]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
+// CHECK:           cf.br ^bb3(%[[VAL_41]] : !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>)
+// CHECK:         ^bb3(%[[VAL_42:.*]]: !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>):
+// CHECK:           %[[VAL_43:.*]] = cc.cast %[[VAL_42]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.ptr<f64>>
+// CHECK:           %[[VAL_44:.*]] = cc.load %[[VAL_43]] : !cc.ptr<!cc.ptr<f64>>
+// CHECK:           %[[VAL_45:.*]] = cc.compute_ptr %[[VAL_42]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_46:.*]] = cc.load %[[VAL_45]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_47:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>
+// CHECK:           %[[VAL_48:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f64>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_49:.*]] = cc.cast %[[VAL_44]] : (!cc.ptr<f64>) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_49]], %[[VAL_48]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_50:.*]] = cc.compute_ptr %[[VAL_47]][1] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_51:.*]] = arith.muli %[[VAL_46]], %[[VAL_3]] : i64
+// CHECK:           %[[VAL_52:.*]] = cc.cast %[[VAL_44]] : (!cc.ptr<f64>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_53:.*]] = cc.compute_ptr %[[VAL_52]]{{\[}}%[[VAL_51]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+// CHECK:           cc.store %[[VAL_53]], %[[VAL_50]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           %[[VAL_54:.*]] = cc.compute_ptr %[[VAL_47]][2] : (!cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>>) -> !cc.ptr<!cc.ptr<i8>>
+// CHECK:           cc.store %[[VAL_53]], %[[VAL_54]] : !cc.ptr<!cc.ptr<i8>>
+// CHECK:           call @free(%[[VAL_36]]) : (!cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }
+
+}
+
 // CHECK:         func.func private @hybridLaunchKernel(!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>, i64, i64, !cc.ptr<i8>) -> !cc.struct<{!cc.ptr<i8>, i64}>
 // CHECK:         func.func private @cudaqRegisterArgsCreator(!cc.ptr<i8>, !cc.ptr<i8>)
 // CHECK:         llvm.func @cudaqRegisterLambdaName(!llvm.ptr<i8>, !llvm.ptr<i8>) attributes {sym_visibility = "private"}
@@ -204,7 +220,7 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:         func.func private @cudaqRegisterKernelName(!cc.ptr<i8>)
 // CHECK:         func.func private @free(!cc.ptr<i8>)
 // CHECK:         func.func private @__nvqpp_initializer_list_to_vector_bool(!cc.ptr<none>, !cc.ptr<none>, i64)
-// CHECK:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>)
+// CHECK:         func.func private @__nvqpp_vector_bool_to_initializer_list(!cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.ptr<i1>, !cc.ptr<i1>}>>, !cc.ptr<!cc.struct<{!cc.ptr<i1>, !cc.array<i8 x 32>}>>, !cc.ptr<!cc.ptr<i8>>)
 // CHECK:         func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
 
 // CHECK-LABEL:   func.func private @__nvqpp_zeroDynamicResult() -> !cc.struct<{!cc.ptr<i8>, i64}> {

--- a/test/Translate/argument.qke
+++ b/test/Translate/argument.qke
@@ -297,12 +297,12 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 }
 
 // CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
-// CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
-// CHECK:         %[[VAL_3:.*]] = load i64, i64* %[[VAL_2]], align 4
-// CHECK:         %[[VAL_4:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
-// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_3]], 16
-// CHECK:         tail call void @anchor(i8* %[[VAL_4]], i64 %[[VAL_5]])
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK:         %[[VAL_2:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_0]] to i64*
+// CHECK:         %[[VAL_4:.*]] = load i64, i64* %[[VAL_3]], align 4
+// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_4]], 16
+// CHECK:         tail call void @anchor(i8* %[[VAL_2]], i64 %[[VAL_5]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
@@ -330,18 +330,18 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
-// CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
-// CHECK:         %[[VAL_3:.*]] = load i64, i64* %[[VAL_2]], align 4
-// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 8
-// CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_4]] to i64*
-// CHECK:         %[[VAL_6:.*]] = load i64, i64* %[[VAL_5]], align 4
-// CHECK:         %[[VAL_7:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
-// CHECK:         %[[VAL_8:.*]] = sdiv i64 %[[VAL_3]], 2
-// CHECK:         %[[VAL_9:.*]] = getelementptr i8, i8* %[[VAL_7]], i64 %[[VAL_3]]
-// CHECK:         %[[VAL_10:.*]] = sdiv i64 %[[VAL_6]], 4
-// CHECK:         tail call void @anchor(i8* %[[VAL_7]], i64 %[[VAL_8]])
-// CHECK:         tail call void @anchor(i8* %[[VAL_9]], i64 %[[VAL_10]])
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK:         %[[VAL_2:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
+// CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_0]] to i64*
+// CHECK:         %[[VAL_4:.*]] = load i64, i64* %[[VAL_3]], align 4
+// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_4]], 2
+// CHECK:         %[[VAL_6:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 %[[VAL_4]]
+// CHECK:         %[[VAL_7:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_8:.*]] = bitcast i8* %[[VAL_7]] to i64*
+// CHECK:         %[[VAL_9:.*]] = load i64, i64* %[[VAL_8]], align 4
+// CHECK:         %[[VAL_10:.*]] = sdiv i64 %[[VAL_9]], 4
+// CHECK:         tail call void @anchor(i8* %[[VAL_2]], i64 %[[VAL_5]])
+// CHECK:         tail call void @anchor(i8* %[[VAL_6]], i64 %[[VAL_10]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
@@ -391,12 +391,12 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_2.thunk(i8* 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
-// CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
-// CHECK:         %[[VAL_3:.*]] = load i64, i64* %[[VAL_2]], align 4
-// CHECK:         %[[VAL_4:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
-// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_3]], 16
-// CHECK:         tail call void @anchor(i8* %[[VAL_4]], i64 %[[VAL_5]])
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK:         %[[VAL_2:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_0]] to i64*
+// CHECK:         %[[VAL_4:.*]] = load i64, i64* %[[VAL_3]], align 4
+// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_4]], 16
+// CHECK:         tail call void @anchor(i8* %[[VAL_2]], i64 %[[VAL_5]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
@@ -424,18 +424,18 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_3.thunk(i8* 
-// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
-// CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
-// CHECK:         %[[VAL_3:.*]] = load i64, i64* %[[VAL_2]], align 4
-// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 8
-// CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_4]] to i64*
-// CHECK:         %[[VAL_6:.*]] = load i64, i64* %[[VAL_5]], align 4
-// CHECK:         %[[VAL_7:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
-// CHECK:         %[[VAL_8:.*]] = sdiv i64 %[[VAL_3]], 2
-// CHECK:         %[[VAL_9:.*]] = getelementptr i8, i8* %[[VAL_7]], i64 %[[VAL_3]]
-// CHECK:         %[[VAL_10:.*]] = sdiv i64 %[[VAL_6]], 4
-// CHECK:         tail call void @anchor(i8* %[[VAL_7]], i64 %[[VAL_8]])
-// CHECK:         tail call void @anchor(i8* %[[VAL_9]], i64 %[[VAL_10]])
+// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK:         %[[VAL_2:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
+// CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_0]] to i64*
+// CHECK:         %[[VAL_4:.*]] = load i64, i64* %[[VAL_3]], align 4
+// CHECK:         %[[VAL_5:.*]] = sdiv i64 %[[VAL_4]], 2
+// CHECK:         %[[VAL_6:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 %[[VAL_4]]
+// CHECK:         %[[VAL_7:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_8:.*]] = bitcast i8* %[[VAL_7]] to i64*
+// CHECK:         %[[VAL_9:.*]] = load i64, i64* %[[VAL_8]], align 4
+// CHECK:         %[[VAL_10:.*]] = sdiv i64 %[[VAL_9]], 4
+// CHECK:         tail call void @anchor(i8* %[[VAL_2]], i64 %[[VAL_5]])
+// CHECK:         tail call void @anchor(i8* %[[VAL_6]], i64 %[[VAL_10]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 

--- a/test/Translate/argument.qke
+++ b/test/Translate/argument.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --kernel-execution=codegen=1 --canonicalize %s | \
+// RUN: cudaq-opt -kernel-execution -canonicalize %s | \
 // RUN: cudaq-translate --convert-to=qir | FileCheck %s
 
 // NB: the mangled name map is required for the kernel-execution pass.
@@ -31,7 +31,7 @@ func.func @test_0(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_0({ { i32, double }*, i64 } 
-// CHECK-SAME:    %[[VAL_0:.*]]) {{.*}}{
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 0
 // CHECK:         %[[VAL_2:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 1
 // CHECK:         %[[VAL_3:.*]] = bitcast { i32, double }* %[[VAL_1]] to i8*
@@ -40,7 +40,7 @@ func.func @test_0(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_0(i8* nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], { { i32, double }*, { i32, double }*, { i32, double }* }* nocapture readonly %[[VAL_1:.*]]) {{.*}}{
+// CHECK-SAME:    %[[VAL_0:.*]], { { i32, double }*, { i32, double }*, { i32, double }* }* {{.*}}%[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 1
 // CHECK:         %[[VAL_3:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 0
 // CHECK:         %[[VAL_4:.*]] = load { i32, double }*, { i32, double }** %[[VAL_2]], align 8
@@ -50,12 +50,27 @@ func.func @test_0(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 // CHECK:         %[[VAL_8:.*]] = sub i64 %[[VAL_6]], %[[VAL_7]]
 // CHECK:         %[[VAL_9:.*]] = add i64 %[[VAL_8]], 8
 // CHECK:         %[[VAL_10:.*]] = alloca i8, i64 %[[VAL_9]], align 8
-// CHECK:         %[[VAL_11:.*]] = bitcast i8* %[[VAL_10]] to i64*
-// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_11]], align 8
-// CHECK:         %[[VAL_12:.*]] = getelementptr i8, i8* %[[VAL_10]], i64 8
+// CHECK:         %[[VAL_11:.*]] = getelementptr i8, i8* %[[VAL_10]], i64 8
+// CHECK:         %[[VAL_12:.*]] = bitcast i8* %[[VAL_10]] to i64*
+// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_12]], align 8
 // CHECK:         %[[VAL_13:.*]] = bitcast { i32, double }* %[[VAL_5]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_12]], i8* align 1 %[[VAL_13]], i64 %[[VAL_8]], i1 false)
-// CHECK:         call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_0.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_0.thunk to i8*), i8* nonnull %[[VAL_10]], i64 %[[VAL_9]], i64 2147483647)
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_11]], i8* align 1 %[[VAL_13]], i64 %[[VAL_8]], i1 false)
+// CHECK:         %[[VAL_14:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_15:.*]] = alloca [1 x i8*], align 8
+// CHECK:         %[[VAL_16:.*]] = getelementptr inbounds [1 x i8*], [1 x i8*]* %[[VAL_15]], i64 0, i64 0
+// CHECK:         %[[VAL_17:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_14]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_16]], i8*** %[[VAL_17]], align 8
+// CHECK:         %[[VAL_18:.*]] = ptrtoint [1 x i8*]* %[[VAL_15]] to i64
+// CHECK:         %[[VAL_19:.*]] = add i64 %[[VAL_18]], 8
+// CHECK:         %[[VAL_20:.*]] = inttoptr i64 %[[VAL_19]] to i8**
+// CHECK:         %[[VAL_21:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_14]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_20]], i8*** %[[VAL_21]], align 8
+// CHECK:         %[[VAL_22:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_14]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_20]], i8*** %[[VAL_22]], align 8
+// CHECK:         %[[VAL_23:.*]] = bitcast [1 x i8*]* %[[VAL_15]] to { { i32, double }*, { i32, double }*, { i32, double }* }**
+// CHECK:         store { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], { { i32, double }*, { i32, double }*, { i32, double }* }** %[[VAL_23]], align 8
+// CHECK:         %[[VAL_24:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_14]] to i8*
+// CHECK:         %[[VAL_25:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_0.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_0.thunk to i8*), i8* nonnull %[[VAL_10]], i64 %[[VAL_9]], i64 2147483647, i8* nonnull %[[VAL_24]])
 // CHECK:         ret void
 // CHECK:       }
 
@@ -78,7 +93,7 @@ func.func @test_1(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_1({ { i16*, i64 }, { float*, i64 } } 
-// CHECK-SAME:    %[[VAL_0:.*]]) {{.*}}{
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = extractvalue { { i16*, i64 }, { float*, i64 } } %[[VAL_0]], 0
 // CHECK:         %[[VAL_2:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 0
 // CHECK:         %[[VAL_3:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 1
@@ -93,7 +108,7 @@ func.func @test_1(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_1(i8* nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], { { i16*, i16*, i16* }, { float*, float*, float* } }* nocapture readonly %[[VAL_1:.*]]) {{.*}}{
+// CHECK-SAME:    %[[VAL_0:.*]], { { i16*, i16*, i16* }, { float*, float*, float* } }* {{.*}}%[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 1
 // CHECK:         %[[VAL_3:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 0
 // CHECK:         %[[VAL_4:.*]] = load i16*, i16** %[[VAL_2]], align 8
@@ -108,21 +123,36 @@ func.func @test_1(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_13:.*]] = ptrtoint float* %[[VAL_11]] to i64
 // CHECK:         %[[VAL_14:.*]] = ptrtoint float* %[[VAL_12]] to i64
 // CHECK:         %[[VAL_15:.*]] = sub i64 %[[VAL_13]], %[[VAL_14]]
-// CHECK:         %[[VAL_16:.*]] = add i64 %[[VAL_8]], 16
+// CHECK:         %[[VAL_16:.*]] = add i64 %[[VAL_8]], 32
 // CHECK:         %[[VAL_17:.*]] = add i64 %[[VAL_16]], %[[VAL_15]]
 // CHECK:         %[[VAL_18:.*]] = alloca i8, i64 %[[VAL_17]], align 8
-// CHECK:         %[[VAL_19:.*]] = bitcast i8* %[[VAL_18]] to i64*
-// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_19]], align 8
-// CHECK:         %[[VAL_20:.*]] = getelementptr inbounds i8, i8* %[[VAL_18]], i64 8
-// CHECK:         %[[VAL_21:.*]] = bitcast i8* %[[VAL_20]] to i64*
-// CHECK:         store i64 %[[VAL_15]], i64* %[[VAL_21]], align 8
-// CHECK:         %[[VAL_22:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 16
-// CHECK:         %[[VAL_23:.*]] = bitcast i16* %[[VAL_5]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_22]], i8* align 1 %[[VAL_23]], i64 %[[VAL_8]], i1 false)
-// CHECK:         %[[VAL_24:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 %[[VAL_8]]
+// CHECK:         %[[VAL_19:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 16
+// CHECK:         %[[VAL_20:.*]] = bitcast i8* %[[VAL_18]] to i64*
+// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_20]], align 8
+// CHECK:         %[[VAL_21:.*]] = bitcast i16* %[[VAL_5]] to i8*
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_19]], i8* align 1 %[[VAL_21]], i64 %[[VAL_8]], i1 false)
+// CHECK:         %[[VAL_22:.*]] = getelementptr i8, i8* %[[VAL_19]], i64 %[[VAL_8]]
+// CHECK:         %[[VAL_23:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 8
+// CHECK:         %[[VAL_24:.*]] = bitcast i8* %[[VAL_23]] to i64*
+// CHECK:         store i64 %[[VAL_15]], i64* %[[VAL_24]], align 8
 // CHECK:         %[[VAL_25:.*]] = bitcast float* %[[VAL_12]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_24]], i8* align 1 %[[VAL_25]], i64 %[[VAL_15]], i1 false)
-// CHECK:         call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_18]], i64 %[[VAL_17]], i64 2147483647)
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_22]], i8* align 1 %[[VAL_25]], i64 %[[VAL_15]], i1 false)
+// CHECK:         %[[VAL_26:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_27:.*]] = alloca [1 x i8*], align 8
+// CHECK:         %[[VAL_28:.*]] = getelementptr inbounds [1 x i8*], [1 x i8*]* %[[VAL_27]], i64 0, i64 0
+// CHECK:         %[[VAL_29:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_26]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_28]], i8*** %[[VAL_29]], align 8
+// CHECK:         %[[VAL_30:.*]] = ptrtoint [1 x i8*]* %[[VAL_27]] to i64
+// CHECK:         %[[VAL_31:.*]] = add i64 %[[VAL_30]], 8
+// CHECK:         %[[VAL_32:.*]] = inttoptr i64 %[[VAL_31]] to i8**
+// CHECK:         %[[VAL_33:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_26]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_32]], i8*** %[[VAL_33]], align 8
+// CHECK:         %[[VAL_34:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_26]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_32]], i8*** %[[VAL_34]], align 8
+// CHECK:         %[[VAL_35:.*]] = bitcast [1 x i8*]* %[[VAL_27]] to { { i16*, i16*, i16* }, { float*, float*, float* } }**
+// CHECK:         store { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], { { i16*, i16*, i16* }, { float*, float*, float* } }** %[[VAL_35]], align 8
+// CHECK:         %[[VAL_36:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_26]] to i8*
+// CHECK:         %[[VAL_37:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_18]], i64 %[[VAL_17]], i64 2147483647, i8* nonnull %[[VAL_36]])
 // CHECK:         ret void
 // CHECK:       }
 
@@ -139,7 +169,7 @@ func.func @test_2(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 }
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_2({ { i32, double }*, i64 } 
-// CHECK-SAME:    %[[VAL_0:.*]]) {{.*}}{
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 0
 // CHECK:         %[[VAL_2:.*]] = extractvalue { { i32, double }*, i64 } %[[VAL_0]], 1
 // CHECK:         %[[VAL_3:.*]] = bitcast { i32, double }* %[[VAL_1]] to i8*
@@ -148,7 +178,7 @@ func.func @test_2(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_2(i8* nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], { { i32, double }*, { i32, double }*, { i32, double }* }* nocapture readonly %[[VAL_1:.*]]) {{.*}}{
+// CHECK-SAME:    %[[VAL_0:.*]], { { i32, double }*, { i32, double }*, { i32, double }* }* {{.*}}%[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 1
 // CHECK:         %[[VAL_3:.*]] = getelementptr { { i32, double }*, { i32, double }*, { i32, double }* }, { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], i64 0, i32 0
 // CHECK:         %[[VAL_4:.*]] = load { i32, double }*, { i32, double }** %[[VAL_2]], align 8
@@ -158,12 +188,27 @@ func.func @test_2(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.ptr<!cc.struct<{i
 // CHECK:         %[[VAL_8:.*]] = sub i64 %[[VAL_6]], %[[VAL_7]]
 // CHECK:         %[[VAL_9:.*]] = add i64 %[[VAL_8]], 8
 // CHECK:         %[[VAL_10:.*]] = alloca i8, i64 %[[VAL_9]], align 8
-// CHECK:         %[[VAL_11:.*]] = bitcast i8* %[[VAL_10]] to i64*
-// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_11]], align 8
-// CHECK:         %[[VAL_12:.*]] = getelementptr i8, i8* %[[VAL_10]], i64 8
+// CHECK:         %[[VAL_11:.*]] = getelementptr i8, i8* %[[VAL_10]], i64 8
+// CHECK:         %[[VAL_12:.*]] = bitcast i8* %[[VAL_10]] to i64*
+// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_12]], align 8
 // CHECK:         %[[VAL_13:.*]] = bitcast { i32, double }* %[[VAL_5]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_12]], i8* align 1 %[[VAL_13]], i64 %[[VAL_8]], i1 false)
-// CHECK:         call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_2.thunk to i8*), i8* nonnull %[[VAL_10]], i64 %[[VAL_9]], i64 2147483647)
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_11]], i8* align 1 %[[VAL_13]], i64 %[[VAL_8]], i1 false)
+// CHECK:         %[[VAL_14:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_15:.*]] = alloca [1 x i8*], align 8
+// CHECK:         %[[VAL_16:.*]] = getelementptr inbounds [1 x i8*], [1 x i8*]* %[[VAL_15]], i64 0, i64 0
+// CHECK:         %[[VAL_17:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_14]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_16]], i8*** %[[VAL_17]], align 8
+// CHECK:         %[[VAL_18:.*]] = ptrtoint [1 x i8*]* %[[VAL_15]] to i64
+// CHECK:         %[[VAL_19:.*]] = add i64 %[[VAL_18]], 8
+// CHECK:         %[[VAL_20:.*]] = inttoptr i64 %[[VAL_19]] to i8**
+// CHECK:         %[[VAL_21:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_14]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_20]], i8*** %[[VAL_21]], align 8
+// CHECK:         %[[VAL_22:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_14]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_20]], i8*** %[[VAL_22]], align 8
+// CHECK:         %[[VAL_23:.*]] = bitcast [1 x i8*]* %[[VAL_15]] to { { i32, double }*, { i32, double }*, { i32, double }* }**
+// CHECK:         store { { i32, double }*, { i32, double }*, { i32, double }* }* %[[VAL_1]], { { i32, double }*, { i32, double }*, { i32, double }* }** %[[VAL_23]], align 8
+// CHECK:         %[[VAL_24:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_14]] to i8*
+// CHECK:         %[[VAL_25:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_2.thunk to i8*), i8* nonnull %[[VAL_10]], i64 %[[VAL_9]], i64 2147483647, i8* nonnull %[[VAL_24]])
 // CHECK:         ret void
 // CHECK:       }
 
@@ -184,10 +229,9 @@ func.func @__nvqpp__mlirgen__test_3(%arg0 : !cc.struct<{!cc.stdvec<i16>, !cc.std
 func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i16>, !cc.ptr<i16>, !cc.ptr<i16>}>, !cc.struct<{!cc.ptr<f32>, !cc.ptr<f32>, !cc.ptr<f32>}>}>>) {
   return
 }
-}
 
 // CHECK-LABEL: define void @__nvqpp__mlirgen__test_3({ { i16*, i64 }, { float*, i64 } } 
-// CHECK-SAME:    %[[VAL_0:.*]]) {{.*}}{
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = extractvalue { { i16*, i64 }, { float*, i64 } } %[[VAL_0]], 0
 // CHECK:         %[[VAL_2:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 0
 // CHECK:         %[[VAL_3:.*]] = extractvalue { i16*, i64 } %[[VAL_1]], 1
@@ -202,7 +246,7 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_3(i8* nocapture readnone 
-// CHECK-SAME:    %[[VAL_0:.*]], { { i16*, i16*, i16* }, { float*, float*, float* } }* nocapture readonly %[[VAL_1:.*]]) {{.*}}{
+// CHECK-SAME:    %[[VAL_0:.*]], { { i16*, i16*, i16* }, { float*, float*, float* } }* {{.*}}%[[VAL_1:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_2:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 1
 // CHECK:         %[[VAL_3:.*]] = getelementptr { { i16*, i16*, i16* }, { float*, float*, float* } }, { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], i64 0, i32 0, i32 0
 // CHECK:         %[[VAL_4:.*]] = load i16*, i16** %[[VAL_2]], align 8
@@ -217,27 +261,40 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_13:.*]] = ptrtoint float* %[[VAL_11]] to i64
 // CHECK:         %[[VAL_14:.*]] = ptrtoint float* %[[VAL_12]] to i64
 // CHECK:         %[[VAL_15:.*]] = sub i64 %[[VAL_13]], %[[VAL_14]]
-// CHECK:         %[[VAL_16:.*]] = add i64 %[[VAL_8]], 16
+// CHECK:         %[[VAL_16:.*]] = add i64 %[[VAL_8]], 32
 // CHECK:         %[[VAL_17:.*]] = add i64 %[[VAL_16]], %[[VAL_15]]
 // CHECK:         %[[VAL_18:.*]] = alloca i8, i64 %[[VAL_17]], align 8
-// CHECK:         %[[VAL_19:.*]] = bitcast i8* %[[VAL_18]] to i64*
-// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_19]], align 8
-// CHECK:         %[[VAL_20:.*]] = getelementptr inbounds i8, i8* %[[VAL_18]], i64 8
-// CHECK:         %[[VAL_21:.*]] = bitcast i8* %[[VAL_20]] to i64*
-// CHECK:         store i64 %[[VAL_15]], i64* %[[VAL_21]], align 8
-// CHECK:         %[[VAL_22:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 16
-// CHECK:         %[[VAL_23:.*]] = bitcast i16* %[[VAL_5]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_22]], i8* align 1 %[[VAL_23]], i64 %[[VAL_8]], i1 false)
-// CHECK:         %[[VAL_24:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 %[[VAL_8]]
+// CHECK:         %[[VAL_19:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 16
+// CHECK:         %[[VAL_20:.*]] = bitcast i8* %[[VAL_18]] to i64*
+// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_20]], align 8
+// CHECK:         %[[VAL_21:.*]] = bitcast i16* %[[VAL_5]] to i8*
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %[[VAL_19]], i8* align 1 %[[VAL_21]], i64 %[[VAL_8]], i1 false)
+// CHECK:         %[[VAL_22:.*]] = getelementptr i8, i8* %[[VAL_19]], i64 %[[VAL_8]]
+// CHECK:         %[[VAL_23:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 8
+// CHECK:         %[[VAL_24:.*]] = bitcast i8* %[[VAL_23]] to i64*
+// CHECK:         store i64 %[[VAL_15]], i64* %[[VAL_24]], align 8
 // CHECK:         %[[VAL_25:.*]] = bitcast float* %[[VAL_12]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_24]], i8* align 1 %[[VAL_25]], i64 %[[VAL_15]], i1 false)
-// CHECK:         call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_3.thunk to i8*), i8* nonnull %[[VAL_18]], i64 %[[VAL_17]], i64 2147483647)
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_22]], i8* align 1 %[[VAL_25]], i64 %[[VAL_15]], i1 false)
+// CHECK:         %[[VAL_26:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_27:.*]] = alloca [1 x i8*], align 8
+// CHECK:         %[[VAL_28:.*]] = getelementptr inbounds [1 x i8*], [1 x i8*]* %[[VAL_27]], i64 0, i64 0
+// CHECK:         %[[VAL_29:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_26]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_28]], i8*** %[[VAL_29]], align 8
+// CHECK:         %[[VAL_30:.*]] = ptrtoint [1 x i8*]* %[[VAL_27]] to i64
+// CHECK:         %[[VAL_31:.*]] = add i64 %[[VAL_30]], 8
+// CHECK:         %[[VAL_32:.*]] = inttoptr i64 %[[VAL_31]] to i8**
+// CHECK:         %[[VAL_33:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_26]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_32]], i8*** %[[VAL_33]], align 8
+// CHECK:         %[[VAL_34:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_26]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_32]], i8*** %[[VAL_34]], align 8
+// CHECK:         %[[VAL_35:.*]] = bitcast [1 x i8*]* %[[VAL_27]] to { { i16*, i16*, i16* }, { float*, float*, float* } }**
+// CHECK:         store { { i16*, i16*, i16* }, { float*, float*, float* } }* %[[VAL_1]], { { i16*, i16*, i16* }, { float*, float*, float* } }** %[[VAL_35]], align 8
+// CHECK:         %[[VAL_36:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_26]] to i8*
+// CHECK:         %[[VAL_37:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_3.thunk to i8*), i8* nonnull %[[VAL_18]], i64 %[[VAL_17]], i64 2147483647, i8* nonnull %[[VAL_36]])
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define i64 @test_0.returnOffset() {{.*}}{
-// CHECK:         ret i64 2147483647
-// CHECK:       }
+}
 
 // CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* 
 // CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
@@ -250,7 +307,7 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_0.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = load i8*, i8** %[[VAL_0]], align 8
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 8
 // CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to { i32, double }**
@@ -262,25 +319,14 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_10:.*]] = sub i64 %[[VAL_8]], %[[VAL_9]]
 // CHECK:         %[[VAL_11:.*]] = add i64 %[[VAL_10]], 8
 // CHECK:         %[[VAL_12:.*]] = tail call i8* @malloc(i64 %[[VAL_11]])
-// CHECK:         %[[VAL_13:.*]] = bitcast i8* %[[VAL_12]] to { i64 }*
-// CHECK:         %[[VAL_14:.*]] = getelementptr { i64 }, { i64 }* %[[VAL_13]], i64 0, i32 0
+// CHECK:         %[[VAL_13:.*]] = getelementptr i8, i8* %[[VAL_12]], i64 8
+// CHECK:         %[[VAL_14:.*]] = bitcast i8* %[[VAL_12]] to i64*
 // CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_14]], align 4
-// CHECK:         %[[VAL_15:.*]] = getelementptr i8, i8* %[[VAL_12]], i64 8
-// CHECK:         %[[VAL_16:.*]] = bitcast i8* %[[VAL_2]] to i8**
-// CHECK:         %[[VAL_17:.*]] = load i8*, i8** %[[VAL_16]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_15]], i8* align 1 %[[VAL_17]], i64 %[[VAL_10]], i1 false)
+// CHECK:         %[[VAL_15:.*]] = bitcast i8* %[[VAL_2]] to i8**
+// CHECK:         %[[VAL_16:.*]] = load i8*, i8** %[[VAL_15]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_13]], i8* align 1 %[[VAL_16]], i64 %[[VAL_10]], i1 false)
 // CHECK:         store i8* %[[VAL_12]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 %[[VAL_11]]
-// CHECK:       }
-
-// CHECK-LABEL: define void @test_0.kernelRegFunc() {
-// CHECK:         tail call void @cudaqRegisterKernelName(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_0.kernelName, i64 0, i64 0))
-// CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_0.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_0.argsCreator to i8*))
-// CHECK:         ret void
-// CHECK:       }
-
-// CHECK-LABEL: define i64 @test_1.returnOffset() {{.*}}{
-// CHECK:         ret i64 2147483647
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* 
@@ -300,7 +346,7 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_1.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = load i8*, i8** %[[VAL_0]], align 8
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 8
 // CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to i16**
@@ -318,36 +364,30 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_16:.*]] = load float*, float** %[[VAL_14]], align 8
 // CHECK:         %[[VAL_17:.*]] = ptrtoint float* %[[VAL_15]] to i64
 // CHECK:         %[[VAL_18:.*]] = ptrtoint float* %[[VAL_16]] to i64
-// CHECK:         %[[VAL_19:.*]] = sub i64 %[[VAL_17]], %[[VAL_18]]
-// CHECK:         %[[VAL_20:.*]] = add i64 %[[VAL_10]], 16
-// CHECK:         %[[VAL_21:.*]] = add i64 %[[VAL_20]], %[[VAL_19]]
+// CHECK:         %[[VAL_19:.*]] = add i64 %[[VAL_10]], 32
+// CHECK:         %[[VAL_20:.*]] = add i64 %[[VAL_19]], %[[VAL_17]]
+// CHECK:         %[[VAL_21:.*]] = sub i64 %[[VAL_20]], %[[VAL_18]]
 // CHECK:         %[[VAL_22:.*]] = tail call i8* @malloc(i64 %[[VAL_21]])
-// CHECK:         %[[VAL_23:.*]] = bitcast i8* %[[VAL_22]] to { { i64, i64 } }*
-// CHECK:         %[[VAL_24:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_23]], i64 0, i32 0, i32 0
-// CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_24]], align 4
-// CHECK:         %[[VAL_25:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_23]], i64 0, i32 0, i32 1
-// CHECK:         store i64 %[[VAL_19]], i64* %[[VAL_25]], align 4
-// CHECK:         %[[VAL_26:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 16
-// CHECK:         %[[VAL_27:.*]] = bitcast i8* %[[VAL_2]] to i8**
-// CHECK:         %[[VAL_28:.*]] = load i8*, i8** %[[VAL_27]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_26]], i8* align 1 %[[VAL_28]], i64 %[[VAL_10]], i1 false)
-// CHECK:         %[[VAL_29:.*]] = getelementptr i8, i8* %[[VAL_26]], i64 %[[VAL_10]]
-// CHECK:         %[[VAL_30:.*]] = bitcast i8* %[[VAL_13]] to i8**
-// CHECK:         %[[VAL_31:.*]] = load i8*, i8** %[[VAL_30]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_29]], i8* align 1 %[[VAL_31]], i64 %[[VAL_19]], i1 false)
+// CHECK:         %[[VAL_23:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 16
+// CHECK:         %[[VAL_24:.*]] = bitcast i8* %[[VAL_22]] to { i64, i64 }*
+// CHECK:         %[[VAL_25:.*]] = bitcast i8* %[[VAL_22]] to i64*
+// CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_25]], align 4
+// CHECK:         %[[VAL_26:.*]] = bitcast i8* %[[VAL_2]] to i8**
+// CHECK:         %[[VAL_27:.*]] = load i8*, i8** %[[VAL_26]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_23]], i8* align 1 %[[VAL_27]], i64 %[[VAL_10]], i1 false)
+// CHECK:         %[[VAL_28:.*]] = getelementptr i8, i8* %[[VAL_23]], i64 %[[VAL_10]]
+// CHECK:         %[[VAL_29:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_24]], i64 0, i32 1
+// CHECK:         %[[VAL_30:.*]] = load float*, float** %[[VAL_12]], align 8
+// CHECK:         %[[VAL_31:.*]] = load float*, float** %[[VAL_14]], align 8
+// CHECK:         %[[VAL_32:.*]] = ptrtoint float* %[[VAL_30]] to i64
+// CHECK:         %[[VAL_33:.*]] = ptrtoint float* %[[VAL_31]] to i64
+// CHECK:         %[[VAL_34:.*]] = sub i64 %[[VAL_32]], %[[VAL_33]]
+// CHECK:         store i64 %[[VAL_34]], i64* %[[VAL_29]], align 4
+// CHECK:         %[[VAL_35:.*]] = bitcast i8* %[[VAL_13]] to i8**
+// CHECK:         %[[VAL_36:.*]] = load i8*, i8** %[[VAL_35]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_28]], i8* align 1 %[[VAL_36]], i64 %[[VAL_34]], i1 false)
 // CHECK:         store i8* %[[VAL_22]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 %[[VAL_21]]
-// CHECK:       }
-
-// CHECK-LABEL: define void @test_1.kernelRegFunc() {
-// CHECK:         tail call void @cudaqRegisterKernelName(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0))
-// CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_1.argsCreator to i8*))
-// CHECK:         ret void
-// CHECK:       }
-// CHECK:       ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-
-// CHECK-LABEL: define i64 @test_2.returnOffset() {{.*}}{
-// CHECK:         ret i64 2147483647
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_2.thunk(i8* 
@@ -359,10 +399,9 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         tail call void @anchor(i8* %[[VAL_4]], i64 %[[VAL_5]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
-// CHECK:       ; Function Attrs: mustprogress nofree nounwind willreturn
 
 // CHECK-LABEL: define i64 @test_2.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = load i8*, i8** %[[VAL_0]], align 8
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 8
 // CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to { i32, double }**
@@ -374,25 +413,14 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_10:.*]] = sub i64 %[[VAL_8]], %[[VAL_9]]
 // CHECK:         %[[VAL_11:.*]] = add i64 %[[VAL_10]], 8
 // CHECK:         %[[VAL_12:.*]] = tail call i8* @malloc(i64 %[[VAL_11]])
-// CHECK:         %[[VAL_13:.*]] = bitcast i8* %[[VAL_12]] to { i64 }*
-// CHECK:         %[[VAL_14:.*]] = getelementptr { i64 }, { i64 }* %[[VAL_13]], i64 0, i32 0
+// CHECK:         %[[VAL_13:.*]] = getelementptr i8, i8* %[[VAL_12]], i64 8
+// CHECK:         %[[VAL_14:.*]] = bitcast i8* %[[VAL_12]] to i64*
 // CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_14]], align 4
-// CHECK:         %[[VAL_15:.*]] = getelementptr i8, i8* %[[VAL_12]], i64 8
-// CHECK:         %[[VAL_16:.*]] = bitcast i8* %[[VAL_2]] to i8**
-// CHECK:         %[[VAL_17:.*]] = load i8*, i8** %[[VAL_16]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_15]], i8* align 1 %[[VAL_17]], i64 %[[VAL_10]], i1 false)
+// CHECK:         %[[VAL_15:.*]] = bitcast i8* %[[VAL_2]] to i8**
+// CHECK:         %[[VAL_16:.*]] = load i8*, i8** %[[VAL_15]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_13]], i8* align 1 %[[VAL_16]], i64 %[[VAL_10]], i1 false)
 // CHECK:         store i8* %[[VAL_12]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 %[[VAL_11]]
-// CHECK:       }
-
-// CHECK-LABEL: define void @test_2.kernelRegFunc() {
-// CHECK:         tail call void @cudaqRegisterKernelName(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0))
-// CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_2.argsCreator to i8*))
-// CHECK:         ret void
-// CHECK:       }
-
-// CHECK-LABEL: define i64 @test_3.returnOffset() {{.*}}{
-// CHECK:         ret i64 2147483647
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_3.thunk(i8* 
@@ -412,7 +440,7 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_3.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:    %[[VAL_0:.*]], i8** nocapture writeonly %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = load i8*, i8** %[[VAL_0]], align 8
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_2]], i64 8
 // CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to i16**
@@ -430,23 +458,28 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         %[[VAL_16:.*]] = load float*, float** %[[VAL_14]], align 8
 // CHECK:         %[[VAL_17:.*]] = ptrtoint float* %[[VAL_15]] to i64
 // CHECK:         %[[VAL_18:.*]] = ptrtoint float* %[[VAL_16]] to i64
-// CHECK:         %[[VAL_19:.*]] = sub i64 %[[VAL_17]], %[[VAL_18]]
-// CHECK:         %[[VAL_20:.*]] = add i64 %[[VAL_10]], 16
-// CHECK:         %[[VAL_21:.*]] = add i64 %[[VAL_20]], %[[VAL_19]]
+// CHECK:         %[[VAL_19:.*]] = add i64 %[[VAL_10]], 32
+// CHECK:         %[[VAL_20:.*]] = add i64 %[[VAL_19]], %[[VAL_17]]
+// CHECK:         %[[VAL_21:.*]] = sub i64 %[[VAL_20]], %[[VAL_18]]
 // CHECK:         %[[VAL_22:.*]] = tail call i8* @malloc(i64 %[[VAL_21]])
-// CHECK:         %[[VAL_23:.*]] = bitcast i8* %[[VAL_22]] to { { i64, i64 } }*
-// CHECK:         %[[VAL_24:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_23]], i64 0, i32 0, i32 0
-// CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_24]], align 4
-// CHECK:         %[[VAL_25:.*]] = getelementptr inbounds { { i64, i64 } }, { { i64, i64 } }* %[[VAL_23]], i64 0, i32 0, i32 1
-// CHECK:         store i64 %[[VAL_19]], i64* %[[VAL_25]], align 4
-// CHECK:         %[[VAL_26:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 16
-// CHECK:         %[[VAL_27:.*]] = bitcast i8* %[[VAL_2]] to i8**
-// CHECK:         %[[VAL_28:.*]] = load i8*, i8** %[[VAL_27]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_26]], i8* align 1 %[[VAL_28]], i64 %[[VAL_10]], i1 false)
-// CHECK:         %[[VAL_29:.*]] = getelementptr i8, i8* %[[VAL_26]], i64 %[[VAL_10]]
-// CHECK:         %[[VAL_30:.*]] = bitcast i8* %[[VAL_13]] to i8**
-// CHECK:         %[[VAL_31:.*]] = load i8*, i8** %[[VAL_30]], align 8
-// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_29]], i8* align 1 %[[VAL_31]], i64 %[[VAL_19]], i1 false)
+// CHECK:         %[[VAL_23:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 16
+// CHECK:         %[[VAL_24:.*]] = bitcast i8* %[[VAL_22]] to { i64, i64 }*
+// CHECK:         %[[VAL_25:.*]] = bitcast i8* %[[VAL_22]] to i64*
+// CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_25]], align 4
+// CHECK:         %[[VAL_26:.*]] = bitcast i8* %[[VAL_2]] to i8**
+// CHECK:         %[[VAL_27:.*]] = load i8*, i8** %[[VAL_26]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_23]], i8* align 1 %[[VAL_27]], i64 %[[VAL_10]], i1 false)
+// CHECK:         %[[VAL_28:.*]] = getelementptr i8, i8* %[[VAL_23]], i64 %[[VAL_10]]
+// CHECK:         %[[VAL_29:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_24]], i64 0, i32 1
+// CHECK:         %[[VAL_30:.*]] = load float*, float** %[[VAL_12]], align 8
+// CHECK:         %[[VAL_31:.*]] = load float*, float** %[[VAL_14]], align 8
+// CHECK:         %[[VAL_32:.*]] = ptrtoint float* %[[VAL_30]] to i64
+// CHECK:         %[[VAL_33:.*]] = ptrtoint float* %[[VAL_31]] to i64
+// CHECK:         %[[VAL_34:.*]] = sub i64 %[[VAL_32]], %[[VAL_33]]
+// CHECK:         store i64 %[[VAL_34]], i64* %[[VAL_29]], align 4
+// CHECK:         %[[VAL_35:.*]] = bitcast i8* %[[VAL_13]] to i8**
+// CHECK:         %[[VAL_36:.*]] = load i8*, i8** %[[VAL_35]], align 8
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_28]], i8* align 1 %[[VAL_36]], i64 %[[VAL_34]], i1 false)
 // CHECK:         store i8* %[[VAL_22]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 %[[VAL_21]]
 // CHECK:       }
@@ -456,3 +489,4 @@ func.func @test_3(%0: !cc.ptr<i8>, %1: !cc.ptr<!cc.struct<{!cc.struct<{!cc.ptr<i
 // CHECK:         tail call void @cudaqRegisterArgsCreator(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast (i64 (i8**, i8**)* @test_3.argsCreator to i8*))
 // CHECK:         ret void
 // CHECK:       }
+

--- a/test/Translate/return_values.qke
+++ b/test/Translate/return_values.qke
@@ -208,7 +208,7 @@ func.func @test_1(%this: !cc.ptr<i8>) -> i16 {
 // CHECK:         store i8** %[[VAL_5]], i8*** %[[VAL_8]], align 8
 // CHECK:         %[[VAL_9:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_3]] to i8*
 // CHECK:         %[[VAL_10:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_4]], i64 2, i64 0, i8* nonnull %[[VAL_9]])
-// CHECK:         %[[VAL_11:.*]] = load i16, i16* %[[VAL_2]], align 2
+// CHECK:         %[[VAL_11:.*]] = load i16, i16* %[[VAL_2]]
 // CHECK:         ret i16 %[[VAL_11]]
 // CHECK:       }
 

--- a/test/Translate/return_values.qke
+++ b/test/Translate/return_values.qke
@@ -196,7 +196,7 @@ func.func @test_1(%this: !cc.ptr<i8>) -> i16 {
 // CHECK-LABEL: define i16 @test_1(i8* nocapture readnone 
 // CHECK-SAME:        %[[VAL_0:.*]]) local_unnamed_addr {
 // CHECK:         %[[VAL_1:.*]] = alloca [0 x i8*], align 8
-// CHECK:         %[[VAL_2:.*]] = alloca i16, align 2
+// CHECK:         %[[VAL_2:.*]] = alloca i16
 // CHECK:         %[[VAL_3:.*]] = alloca { i8**, i8**, i8** }, align 8
 // CHECK:         %[[VAL_4:.*]] = bitcast i16* %[[VAL_2]] to i8*
 // CHECK:         %[[VAL_5:.*]] = getelementptr inbounds [0 x i8*], [0 x i8*]* %[[VAL_1]], i64 0, i64 0

--- a/test/Translate/return_values.qke
+++ b/test/Translate/return_values.qke
@@ -6,7 +6,8 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --add-dealloc --kernel-execution=codegen=1 --canonicalize %s | cudaq-translate --convert-to=qir | FileCheck %s
+// RUN: cudaq-opt -add-dealloc -kernel-execution -canonicalize %s | \
+// RUN: cudaq-translate --convert-to=qir | FileCheck %s
 
 // NB: the mangled name map is required for the kernel-execution pass.
 // QIR codegen requires the target triple.
@@ -57,76 +58,94 @@ func.func @__nvqpp__mlirgen__test_0(%arg0: i32) -> !cc.stdvec<i1> {
 func.func @test_0(%1: !cc.ptr<!cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>> {llvm.sret = !cc.struct<{!cc.ptr<i8>, !cc.ptr<i8>, !cc.ptr<i8>}>}, %this: !cc.ptr<i8>, %2: i32) {
   return
 }
-
-// CHECK-LABEL: define { i1*, i64 } @__nvqpp__mlirgen__test_0(
-// CHECK-SAME:    i32 %[[VAL_1:.*]]) {{.*}}{
-// CHECK:         %[[VAL_2:.*]] = sext i32 %[[VAL_1]] to i64
-// CHECK:         %[[VAL_3:.*]] = tail call %[[VAL_4:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_2]])
-// CHECK:         %[[VAL_5:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_4]]* %[[VAL_3]])
-// CHECK:         %[[VAL_6:.*]] = icmp sgt i64 %[[VAL_5]], 0
-// CHECK:         br i1 %[[VAL_6]], label %[[VAL_7:.*]], label %[[VAL_8:.*]]
-// CHECK:       ._crit_edge.thread:                               ; preds = %[[VAL_9:.*]]
-// CHECK:         %[[VAL_10:.*]] = alloca i8, i64 %[[VAL_5]], align 1
-// CHECK:         br label %[[VAL_11:.*]]
-// CHECK:       .lr.ph:                                           ; preds = %[[VAL_9]], %[[VAL_7]]
-// CHECK:         %[[VAL_12:.*]] = phi i64 [ %[[VAL_13:.*]], %[[VAL_7]] ], [ 0, %[[VAL_9]] ]
-// CHECK:         %[[VAL_14:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_4]]* %[[VAL_3]], i64 %[[VAL_12]])
-// CHECK:         %[[VAL_15:.*]] = bitcast i8* %[[VAL_14]] to %[[VAL_16:.*]]**
-// CHECK:         %[[VAL_17:.*]] = load %[[VAL_16]]*, %[[VAL_16]]** %[[VAL_15]], align 8
-// CHECK:         tail call void @__quantum__qis__h(%[[VAL_16]]* %[[VAL_17]])
-// CHECK:         %[[VAL_13]] = add nuw nsw i64 %[[VAL_12]], 1
-// CHECK:         %[[VAL_18:.*]] = icmp eq i64 %[[VAL_13]], %[[VAL_5]]
-// CHECK:         br i1 %[[VAL_18]], label %[[VAL_19:.*]], label %[[VAL_7]]
-// CHECK:       ._crit_edge:                                      ; preds = %[[VAL_7]]
-// CHECK:         %[[VAL_20:.*]] = alloca i8, i64 %[[VAL_5]], align 1
-// CHECK:         br i1 %[[VAL_6]], label %[[VAL_21:.*]], label %[[VAL_11]]
-// CHECK:       .lr.ph4:                                          ; preds = %[[VAL_19]], %[[VAL_21]]
-// CHECK:         %[[VAL_22:.*]] = phi i64 [ %[[VAL_23:.*]], %[[VAL_21]] ], [ 0, %[[VAL_19]] ]
-// CHECK:         %[[VAL_24:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_4]]* %[[VAL_3]], i64 %[[VAL_22]])
-// CHECK:         %[[VAL_25:.*]] = bitcast i8* %[[VAL_24]] to %[[VAL_16]]**
-// CHECK:         %[[VAL_26:.*]] = load %[[VAL_16]]*, %[[VAL_16]]** %[[VAL_25]], align 8
-// CHECK:         %[[VAL_27:.*]] = tail call %[[VAL_28:.*]]* @__quantum__qis__mz(%[[VAL_16]]* %[[VAL_26]])
-// CHECK:         %[[VAL_29:.*]] = bitcast %[[VAL_28]]* %[[VAL_27]] to i1*
-// CHECK:         %[[VAL_30:.*]] = load i1, i1* %[[VAL_29]], align 1
-// CHECK:         %[[VAL_31:.*]] = getelementptr i8, i8* %[[VAL_20]], i64 %[[VAL_22]]
-// CHECK:         %[[VAL_32:.*]] = zext i1 %[[VAL_30]] to i8
-// CHECK:         store i8 %[[VAL_32]], i8* %[[VAL_31]], align 1
-// CHECK:         %[[VAL_23]] = add nuw nsw i64 %[[VAL_22]], 1
-// CHECK:         %[[VAL_33:.*]] = icmp eq i64 %[[VAL_23]], %[[VAL_5]]
-// CHECK:         br i1 %[[VAL_33]], label %[[VAL_11]], label %[[VAL_21]]
-// CHECK:       ._crit_edge5:                                     ; preds = %[[VAL_21]], %[[VAL_8]], %[[VAL_19]]
-// CHECK:         %[[VAL_34:.*]] = phi i8* [ %[[VAL_10]], %[[VAL_8]] ], [ %[[VAL_20]], %[[VAL_19]] ], [ %[[VAL_20]], %[[VAL_21]] ]
-// CHECK:         %[[VAL_35:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_34]], i64 %[[VAL_5]], i64 1)
-// CHECK:         %[[VAL_36:.*]] = bitcast i8* %[[VAL_35]] to i1*
-// CHECK:         %[[VAL_37:.*]] = insertvalue { i1*, i64 } undef, i1* %[[VAL_36]], 0
-// CHECK:         %[[VAL_38:.*]] = insertvalue { i1*, i64 } %[[VAL_37]], i64 %[[VAL_5]], 1
-// CHECK:         call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_3]])
-// CHECK:         ret { i1*, i64 } %[[VAL_38]]
+// CHECK-LABEL: define { i1*, i64 } @__nvqpp__mlirgen__test_0(i32 
+// CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_1:.*]] = sext i32 %[[VAL_0]] to i64
+// CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_1]])
+// CHECK:         %[[VAL_4:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_3]]* %[[VAL_2]])
+// CHECK:         %[[VAL_5:.*]] = icmp sgt i64 %[[VAL_4]], 0
+// CHECK:         br i1 %[[VAL_5]], label %[[VAL_6:.*]], label %[[VAL_7:.*]]
+// CHECK:       ._crit_edge.thread:                               ; preds = %[[VAL_8:.*]]
+// CHECK:         %[[VAL_9:.*]] = alloca i8, i64 %[[VAL_4]], align 1
+// CHECK:         br label %[[VAL_10:.*]]
+// CHECK:       .lr.ph:                                           ; preds = %[[VAL_8]], %[[VAL_6]]
+// CHECK:         %[[VAL_11:.*]] = phi i64 [ %[[VAL_12:.*]], %[[VAL_6]] ], [ 0, %[[VAL_8]] ]
+// CHECK:         %[[VAL_13:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_3]]* %[[VAL_2]], i64 %[[VAL_11]])
+// CHECK:         %[[VAL_14:.*]] = bitcast i8* %[[VAL_13]] to %[[VAL_15:.*]]**
+// CHECK:         %[[VAL_16:.*]] = load %[[VAL_15]]*, %[[VAL_15]]** %[[VAL_14]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_15]]* %[[VAL_16]])
+// CHECK:         %[[VAL_12]] = add nuw nsw i64 %[[VAL_11]], 1
+// CHECK:         %[[VAL_17:.*]] = icmp eq i64 %[[VAL_12]], %[[VAL_4]]
+// CHECK:         br i1 %[[VAL_17]], label %[[VAL_18:.*]], label %[[VAL_6]]
+// CHECK:       ._crit_edge:                                      ; preds = %[[VAL_6]]
+// CHECK:         %[[VAL_19:.*]] = alloca i8, i64 %[[VAL_4]], align 1
+// CHECK:         br i1 %[[VAL_5]], label %[[VAL_20:.*]], label %[[VAL_10]]
+// CHECK:       .lr.ph4:                                          ; preds = %[[VAL_18]], %[[VAL_20]]
+// CHECK:         %[[VAL_21:.*]] = phi i64 [ %[[VAL_22:.*]], %[[VAL_20]] ], [ 0, %[[VAL_18]] ]
+// CHECK:         %[[VAL_23:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_3]]* %[[VAL_2]], i64 %[[VAL_21]])
+// CHECK:         %[[VAL_24:.*]] = bitcast i8* %[[VAL_23]] to %[[VAL_15]]**
+// CHECK:         %[[VAL_25:.*]] = load %[[VAL_15]]*, %[[VAL_15]]** %[[VAL_24]], align 8
+// CHECK:         %[[VAL_26:.*]] = tail call %[[VAL_27:.*]]* @__quantum__qis__mz(%[[VAL_15]]* %[[VAL_25]])
+// CHECK:         %[[VAL_28:.*]] = bitcast %[[VAL_27]]* %[[VAL_26]] to i1*
+// CHECK:         %[[VAL_29:.*]] = load i1, i1* %[[VAL_28]], align 1
+// CHECK:         %[[VAL_30:.*]] = getelementptr i8, i8* %[[VAL_19]], i64 %[[VAL_21]]
+// CHECK:         %[[VAL_31:.*]] = zext i1 %[[VAL_29]] to i8
+// CHECK:         store i8 %[[VAL_31]], i8* %[[VAL_30]], align 1
+// CHECK:         %[[VAL_22]] = add nuw nsw i64 %[[VAL_21]], 1
+// CHECK:         %[[VAL_32:.*]] = icmp eq i64 %[[VAL_22]], %[[VAL_4]]
+// CHECK:         br i1 %[[VAL_32]], label %[[VAL_10]], label %[[VAL_20]]
+// CHECK:       ._crit_edge5:                                     ; preds = %[[VAL_20]], %[[VAL_7]], %[[VAL_18]]
+// CHECK:         %[[VAL_33:.*]] = phi i8* [ %[[VAL_9]], %[[VAL_7]] ], [ %[[VAL_19]], %[[VAL_18]] ], [ %[[VAL_19]], %[[VAL_20]] ]
+// CHECK:         %[[VAL_34:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_33]], i64 %[[VAL_4]], i64 1)
+// CHECK:         %[[VAL_35:.*]] = bitcast i8* %[[VAL_34]] to i1*
+// CHECK:         %[[VAL_36:.*]] = insertvalue { i1*, i64 } undef, i1* %[[VAL_35]], 0
+// CHECK:         %[[VAL_37:.*]] = insertvalue { i1*, i64 } %[[VAL_36]], i64 %[[VAL_4]], 1
+// CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
+// CHECK:         ret { i1*, i64 } %[[VAL_37]]
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_0({ i8*, i8*, i8* }* sret({ i8*, i8*, i8* }) 
-// CHECK-SAME:       %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]], i32 %[[VAL_2:.*]]) {{.*}}{
-// CHECK:         %[[VAL_3:.*]] = alloca { i32, { i1*, i64 } }, align 8
+// CHECK-SAME:                                                                 %[[VAL_0:.*]], i8* nocapture readnone
+// CHECK-SAME:                                                                 %[[VAL_1:.*]], i32
+// CHECK-SAME:                                                                 %[[VAL_2:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_3:.*]] = alloca { i32, { i1*, i64 } }, align 4
 // CHECK:         %[[VAL_4:.*]] = bitcast { i32, { i1*, i64 } }* %[[VAL_3]] to i8*
 // CHECK:         %[[VAL_5:.*]] = getelementptr inbounds { i32, { i1*, i64 } }, { i32, { i1*, i64 } }* %[[VAL_3]], i64 0, i32 0
-// CHECK:         store i32 %[[VAL_2]], i32* %[[VAL_5]], align 8
-// CHECK:         %[[VAL_6:.*]] = call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_0.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_0.thunk to i8*), i8* nonnull %[[VAL_4]], i64 24, i64 8)
-// CHECK:         %[[VAL_7:.*]] = extractvalue { i8*, i64 } %[[VAL_6]], 0
-// CHECK:         %[[VAL_8:.*]] = icmp eq i8* %[[VAL_7]], null
-// CHECK:         %[[VAL_9:.*]] = getelementptr i8, i8* %[[VAL_7]], i64 8
-// CHECK:         %[[VAL_10:.*]] = bitcast i8* %[[VAL_9]] to { i1*, i64 }*
-// CHECK:         %[[VAL_11:.*]] = getelementptr inbounds { i32, { i1*, i64 } }, { i32, { i1*, i64 } }* %[[VAL_3]], i64 0, i32 1
-// CHECK:         %[[VAL_12:.*]] = select i1 %[[VAL_8]], { i1*, i64 }* %[[VAL_11]], { i1*, i64 }* %[[VAL_10]]
-// CHECK:         %[[VAL_13:.*]] = bitcast { i1*, i64 }* %[[VAL_12]] to i8**
-// CHECK:         %[[VAL_14:.*]] = load i8*, i8** %[[VAL_13]], align 8
-// CHECK:         %[[VAL_15:.*]] = getelementptr inbounds { i32, { i1*, i64 } }, { i32, { i1*, i64 } }* %[[VAL_3]], i64 0, i32 1, i32 1
-// CHECK:         %[[VAL_16:.*]] = getelementptr i8, i8* %[[VAL_7]], i64 16
-// CHECK:         %[[VAL_17:.*]] = bitcast i8* %[[VAL_16]] to i64*
-// CHECK:         %[[VAL_18:.*]] = select i1 %[[VAL_8]], i64* %[[VAL_15]], i64* %[[VAL_17]]
-// CHECK:         %[[VAL_19:.*]] = load i64, i64* %[[VAL_18]], align 4
-// CHECK:         %[[VAL_20:.*]] = bitcast { i8*, i8*, i8* }* %[[VAL_0]] to i8*
-// CHECK:         call void @__nvqpp_initializer_list_to_vector_bool(i8* %[[VAL_20]], i8* %[[VAL_14]], i64 %[[VAL_19]])
-// CHECK:         call void @free(i8* %[[VAL_7]])
+// CHECK:         store i32 %[[VAL_2]], i32* %[[VAL_5]], align 4
+// CHECK:         %[[VAL_6:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_7:.*]] = alloca [1 x i8*], align 8
+// CHECK:         %[[VAL_8:.*]] = getelementptr inbounds [1 x i8*], [1 x i8*]* %[[VAL_7]], i64 0, i64 0
+// CHECK:         %[[VAL_9:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_6]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_8]], i8*** %[[VAL_9]], align 8
+// CHECK:         %[[VAL_10:.*]] = ptrtoint [1 x i8*]* %[[VAL_7]] to i64
+// CHECK:         %[[VAL_11:.*]] = add i64 %[[VAL_10]], 8
+// CHECK:         %[[VAL_12:.*]] = inttoptr i64 %[[VAL_11]] to i8**
+// CHECK:         %[[VAL_13:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_6]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_12]], i8*** %[[VAL_13]], align 8
+// CHECK:         %[[VAL_14:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_6]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_12]], i8*** %[[VAL_14]], align 8
+// CHECK:         %[[VAL_15:.*]] = alloca i32, align 4
+// CHECK:         store i32 %[[VAL_2]], i32* %[[VAL_15]], align 4
+// CHECK:         %[[VAL_16:.*]] = bitcast [1 x i8*]* %[[VAL_7]] to i32**
+// CHECK:         store i32* %[[VAL_15]], i32** %[[VAL_16]], align 8
+// CHECK:         %[[VAL_17:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_6]] to i8*
+// CHECK:         %[[VAL_18:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_0.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_0.thunk to i8*), i8* nonnull %[[VAL_4]], i64 24, i64 8, i8* nonnull %[[VAL_17]])
+// CHECK:         %[[VAL_19:.*]] = extractvalue { i8*, i64 } %[[VAL_18]], 0
+// CHECK:         %[[VAL_20:.*]] = icmp eq i8* %[[VAL_19]], null
+// CHECK:         %[[VAL_21:.*]] = getelementptr i8, i8* %[[VAL_19]], i64 8
+// CHECK:         %[[VAL_22:.*]] = bitcast i8* %[[VAL_21]] to { i1*, i64 }*
+// CHECK:         %[[VAL_23:.*]] = getelementptr inbounds { i32, { i1*, i64 } }, { i32, { i1*, i64 } }* %[[VAL_3]], i64 0, i32 1
+// CHECK:         %[[VAL_24:.*]] = select i1 %[[VAL_20]], { i1*, i64 }* %[[VAL_23]], { i1*, i64 }* %[[VAL_22]]
+// CHECK:         %[[VAL_25:.*]] = bitcast { i1*, i64 }* %[[VAL_24]] to i8**
+// CHECK:         %[[VAL_26:.*]] = load i8*, i8** %[[VAL_25]], align 8
+// CHECK:         %[[VAL_27:.*]] = getelementptr inbounds { i32, { i1*, i64 } }, { i32, { i1*, i64 } }* %[[VAL_3]], i64 0, i32 1, i32 1
+// CHECK:         %[[VAL_28:.*]] = getelementptr i8, i8* %[[VAL_19]], i64 16
+// CHECK:         %[[VAL_29:.*]] = bitcast i8* %[[VAL_28]] to i64*
+// CHECK:         %[[VAL_30:.*]] = select i1 %[[VAL_20]], i64* %[[VAL_27]], i64* %[[VAL_29]]
+// CHECK:         %[[VAL_31:.*]] = load i64, i64* %[[VAL_30]], align 4
+// CHECK:         %[[VAL_32:.*]] = bitcast { i8*, i8*, i8* }* %[[VAL_0]] to i8*
+// CHECK:         call void @__nvqpp_initializer_list_to_vector_bool(i8* %[[VAL_32]], i8* %[[VAL_26]], i64 %[[VAL_31]])
+// CHECK:         call void @free(i8* %[[VAL_19]])
 // CHECK:         ret void
 // CHECK:       }
 
@@ -152,35 +171,45 @@ func.func @test_1(%this: !cc.ptr<i8>) -> i16 {
   return %0 : i16
 }
 
-// CHECK-LABEL: define { i1, i1 } @__nvqpp__mlirgen__test_1()
-// CHECK:         %[[VAL_1:.*]] = tail call %[[VAL_2:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
-// CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 0)
-// CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to %[[VAL_5:.*]]**
-// CHECK:         %[[VAL_6:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_4]], align 8
-// CHECK:         %[[VAL_7:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 1)
-// CHECK:         %[[VAL_8:.*]] = bitcast i8* %[[VAL_7]] to %[[VAL_5]]**
-// CHECK:         %[[VAL_9:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_8]], align 8
-// CHECK:         tail call void @__quantum__qis__h(%[[VAL_5]]* %[[VAL_6]])
-// CHECK:         tail call void (i64, void (%[[VAL_2]]*, %[[VAL_5]]*)*, ...) @invokeWithControlQubits(i64 1, void (%[[VAL_2]]*, %[[VAL_5]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_5]]* %[[VAL_6]], %[[VAL_5]]* %[[VAL_9]])
-// CHECK:         %[[VAL_10:.*]] = tail call %[[VAL_11:.*]]* @__quantum__qis__mz(%[[VAL_5]]* %[[VAL_6]])
-// CHECK:         %[[VAL_12:.*]] = bitcast %Result* %[[VAL_10]] to i1*
-// CHECK:         %[[VAL_13:.*]] = load i1, i1* %[[VAL_12]], align 1
-// CHECK:         %[[VAL_14:.*]] = tail call %[[VAL_11]]* @__quantum__qis__mz(%[[VAL_5]]* %[[VAL_9]])
-// CHECK:         %[[VAL_15:.*]] = bitcast %Result* %[[VAL_14]] to i1*
-// CHECK:         %[[VAL_16:.*]] = load i1, i1* %[[VAL_15]], align 1
-// CHECK:         %[[VAL_20:.*]] = insertvalue { i1, i1 } undef, i1 %[[VAL_13]], 0
-// CHECK:         %[[VAL_19:.*]] = insertvalue { i1, i1 } %[[VAL_20]], i1 %[[VAL_16]], 1
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_2]]* %[[VAL_1]])
-// CHECK:         ret { i1, i1 } %[[VAL_19]]
+// CHECK-LABEL: define { i1, i1 } @__nvqpp__mlirgen__test_1() local_unnamed_addr {
+// CHECK:         %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
+// CHECK:         %[[VAL_2:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
+// CHECK:         %[[VAL_3:.*]] = bitcast i8* %[[VAL_2]] to %[[VAL_4:.*]]**
+// CHECK:         %[[VAL_5:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_3]], align 8
+// CHECK:         %[[VAL_6:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 1)
+// CHECK:         %[[VAL_7:.*]] = bitcast i8* %[[VAL_6]] to %[[VAL_4]]**
+// CHECK:         %[[VAL_8:.*]] = load %[[VAL_4]]*, %[[VAL_4]]** %[[VAL_7]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_4]]* %[[VAL_5]])
+// CHECK:         tail call void (i64, void (%[[VAL_1]]*, %[[VAL_4]]*)*, ...) @invokeWithControlQubits(i64 1, void (%[[VAL_1]]*, %[[VAL_4]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_4]]* %[[VAL_5]], %[[VAL_4]]* %[[VAL_8]])
+// CHECK:         %[[VAL_9:.*]] = tail call %[[VAL_10:.*]]* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_5]])
+// CHECK:         %[[VAL_11:.*]] = bitcast %[[VAL_10]]* %[[VAL_9]] to i1*
+// CHECK:         %[[VAL_12:.*]] = load i1, i1* %[[VAL_11]], align 1
+// CHECK:         %[[VAL_13:.*]] = tail call %[[VAL_10]]* @__quantum__qis__mz(%[[VAL_4]]* %[[VAL_8]])
+// CHECK:         %[[VAL_14:.*]] = bitcast %[[VAL_10]]* %[[VAL_13]] to i1*
+// CHECK:         %[[VAL_15:.*]] = load i1, i1* %[[VAL_14]], align 1
+// CHECK:         %[[VAL_16:.*]] = insertvalue { i1, i1 } undef, i1 %[[VAL_12]], 0
+// CHECK:         %[[VAL_17:.*]] = insertvalue { i1, i1 } %[[VAL_16]], i1 %[[VAL_15]], 1
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
+// CHECK:         ret { i1, i1 } %[[VAL_17]]
 // CHECK:       }
 
-// CHECK-LABEL: define i16 @test_1(i8* nocapture readnone
-// CHECK-SAME:    %[[VAL_0:.*]]) {{.*}}{
-// CHECK-NEXT:    %[[VAL_2:.*]] = alloca i16, align 8
-// CHECK:         %[[VAL_3:.*]] = bitcast i16* %[[VAL_2]] to i8*
-// CHECK:         call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_3]], i64 2, i64 0)
-// CHECK:         %[[VAL_4:.*]] = load i16, i16* %[[VAL_2]], align 8
-// CHECK:         ret i16 %[[VAL_4]]
+// CHECK-LABEL: define i16 @test_1(i8* nocapture readnone 
+// CHECK-SAME:        %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_1:.*]] = alloca [0 x i8*], align 8
+// CHECK:         %[[VAL_2:.*]] = alloca i16, align 2
+// CHECK:         %[[VAL_3:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_4:.*]] = bitcast i16* %[[VAL_2]] to i8*
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds [0 x i8*], [0 x i8*]* %[[VAL_1]], i64 0, i64 0
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_3]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_5]], i8*** %[[VAL_6]], align 8
+// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_3]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_5]], i8*** %[[VAL_7]], align 8
+// CHECK:         %[[VAL_8:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_3]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_5]], i8*** %[[VAL_8]], align 8
+// CHECK:         %[[VAL_9:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_3]] to i8*
+// CHECK:         %[[VAL_10:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_1.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_1.thunk to i8*), i8* nonnull %[[VAL_4]], i64 2, i64 0, i8* nonnull %[[VAL_9]])
+// CHECK:         %[[VAL_11:.*]] = load i16, i16* %[[VAL_2]], align 2
+// CHECK:         ret i16 %[[VAL_11]]
 // CHECK:       }
 
 // struct{i16, f32, f64, i64} -> sret ptr
@@ -201,19 +230,31 @@ func.func @test_2(%1: !cc.ptr<!cc.struct<{i16, f32, f64, i64}>> {llvm.sret = !cc
   return
 }
 
-// CHECK-LABEL: define { i16, float, double, i64 } @__nvqpp__mlirgen__test_2()
+// CHECK-LABEL: define { i16, float, double, i64 } @__nvqpp__mlirgen__test_2() local_unnamed_addr {{.*}} {
 // CHECK:         ret { i16, float, double, i64 } { i16 8, float 0x40159999A0000000, double 3.783000e+01, i64 1479 }
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_2({ i16, float, double, i64 }* nocapture writeonly sret({ i16, float, double, i64 }) 
-// CHECK-SAME:          %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) {{.*}}{
-// CHECK:         %[[VAL_2:.*]] = alloca { { i16, float, double, i64 } }, align 8
-// CHECK:         %[[VAL_3:.*]] = bitcast { { i16, float, double, i64 } }* %[[VAL_2]] to i8*
-// CHECK:         call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_2.thunk to i8*), i8* nonnull %[[VAL_3]], i64 24, i64 0)
-// CHECK:         %[[VAL_4:.*]] = bitcast { i16, float, double, i64 }* %[[VAL_0]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(24) %[[VAL_4]], i8* noundef nonnull align 8 dereferenceable(24) %[[VAL_3]], i64 24, i1 false)
+// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone
+// CHECK-SAME:      %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_2:.*]] = alloca [0 x i8*], align 8
+// CHECK:         %[[VAL_3:.*]] = alloca [24 x i8], align 1
+// CHECK:         %[[VAL_4:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds [24 x i8], [24 x i8]* %[[VAL_3]], i64 0, i64 0
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds [0 x i8*], [0 x i8*]* %[[VAL_2]], i64 0, i64 0
+// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_4]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_6]], i8*** %[[VAL_7]], align 8
+// CHECK:         %[[VAL_8:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_4]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_6]], i8*** %[[VAL_8]], align 8
+// CHECK:         %[[VAL_9:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_4]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_6]], i8*** %[[VAL_9]], align 8
+// CHECK:         %[[VAL_10:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_4]] to i8*
+// CHECK:         %[[VAL_11:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_2.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_2.thunk to i8*), i8* nonnull %[[VAL_5]], i64 24, i64 0, i8* nonnull %[[VAL_10]])
+// CHECK:         %[[VAL_12:.*]] = bitcast { i16, float, double, i64 }* %[[VAL_0]] to i8*
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(24) %[[VAL_12]], i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_5]], i64 24, i1 false)
 // CHECK:         ret void
 // CHECK:       }
+
 
 // array<T x n> -> sret ptr
 func.func @__nvqpp__mlirgen__test_3() -> !cc.array<i64 x 5> {
@@ -235,17 +276,28 @@ func.func @test_3(%1: !cc.ptr<!cc.array<i64 x 5>> {llvm.sret = !cc.array<i64 x 5
   return
 }
 
-// CHECK-LABEL: define [5 x i64] @__nvqpp__mlirgen__test_3(
+// CHECK-LABEL: define [5 x i64] @__nvqpp__mlirgen__test_3() local_unnamed_addr {{.*}} {
 // CHECK:         ret [5 x i64] [i64 5, i64 74, i64 299, i64 1659, i64 61234]
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_3([5 x i64]* nocapture writeonly sret([5 x i64]) 
-// CHECK-SAME:      %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) {{.*}}{
-// CHECK:         %[[VAL_2:.*]] = alloca { [5 x i64] }, align 8
-// CHECK:         %[[VAL_3:.*]] = bitcast { [5 x i64] }* %[[VAL_2]] to i8*
-// CHECK:         call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_3.thunk to i8*), i8* nonnull %[[VAL_3]], i64 40, i64 0)
-// CHECK:         %[[VAL_4:.*]] = bitcast [5 x i64]* %[[VAL_0]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(40) %[[VAL_4]], i8* noundef nonnull align 8 dereferenceable(40) %[[VAL_3]], i64 40, i1 false)
+// CHECK-SAME:                                                                     %[[VAL_0:.*]], i8* nocapture readnone
+// CHECK-SAME:                                                                     %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_2:.*]] = alloca [0 x i8*], align 8
+// CHECK:         %[[VAL_3:.*]] = alloca [40 x i8], align 1
+// CHECK:         %[[VAL_4:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds [40 x i8], [40 x i8]* %[[VAL_3]], i64 0, i64 0
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds [0 x i8*], [0 x i8*]* %[[VAL_2]], i64 0, i64 0
+// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_4]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_6]], i8*** %[[VAL_7]], align 8
+// CHECK:         %[[VAL_8:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_4]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_6]], i8*** %[[VAL_8]], align 8
+// CHECK:         %[[VAL_9:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_4]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_6]], i8*** %[[VAL_9]], align 8
+// CHECK:         %[[VAL_10:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_4]] to i8*
+// CHECK:         %[[VAL_11:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_3.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_3.thunk to i8*), i8* nonnull %[[VAL_5]], i64 40, i64 0, i8* nonnull %[[VAL_10]])
+// CHECK:         %[[VAL_12:.*]] = bitcast [5 x i64]* %[[VAL_0]] to i8*
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(40) %[[VAL_12]], i8* noundef nonnull align 1 dereferenceable(40) %[[VAL_5]], i64 40, i1 false)
 // CHECK:         ret void
 // CHECK:       }
 
@@ -260,17 +312,28 @@ func.func @test_4(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
   return
 }
 
-// CHECK-LABEL: define { i64, double } @__nvqpp__mlirgen__test_4() {{.*}}{
+// CHECK-LABEL: define { i64, double } @__nvqpp__mlirgen__test_4() local_unnamed_addr {{.*}} {
 // CHECK:         ret { i64, double } { i64 537892, double 0x40578DA858793DD9 }
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_4({ i64, double }* nocapture writeonly sret({ i64, double }) 
-// CHECK-SAME:     %[[VAL_0:.*]], i8* nocapture readnone %[[VAL_1:.*]]) {{.*}}{
-// CHECK:         %[[VAL_2:.*]] = alloca { i64, double }, align 8
-// CHECK:         %[[VAL_3:.*]] = bitcast { i64, double }* %[[VAL_2]] to i8*
-// CHECK:         call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_4.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_4.thunk to i8*), i8* nonnull %[[VAL_3]], i64 16, i64 0)
-// CHECK:         %[[VAL_4:.*]] = bitcast { i64, double }* %[[VAL_0]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(16) %[[VAL_4]], i8* noundef nonnull align 8 dereferenceable(16) %[[VAL_3]], i64 16, i1 false)
+// CHECK-SAME:     %[[VAL_0:.*]], i8* nocapture readnone
+// CHECK-SAME:     %[[VAL_1:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_2:.*]] = alloca [0 x i8*], align 8
+// CHECK:         %[[VAL_3:.*]] = alloca [16 x i8], align 1
+// CHECK:         %[[VAL_4:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds [16 x i8], [16 x i8]* %[[VAL_3]], i64 0, i64 0
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds [0 x i8*], [0 x i8*]* %[[VAL_2]], i64 0, i64 0
+// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_4]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_6]], i8*** %[[VAL_7]], align 8
+// CHECK:         %[[VAL_8:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_4]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_6]], i8*** %[[VAL_8]], align 8
+// CHECK:         %[[VAL_9:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_4]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_6]], i8*** %[[VAL_9]], align 8
+// CHECK:         %[[VAL_10:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_4]] to i8*
+// CHECK:         %[[VAL_11:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_4.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_4.thunk to i8*), i8* nonnull %[[VAL_5]], i64 16, i64 0, i8* nonnull %[[VAL_10]])
+// CHECK:         %[[VAL_12:.*]] = bitcast { i64, double }* %[[VAL_0]] to i8*
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(16) %[[VAL_12]], i8* noundef nonnull align 1 dereferenceable(16) %[[VAL_5]], i64 16, i1 false)
 // CHECK:         ret void
 // CHECK:       }
 
@@ -284,102 +347,114 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
   return
 }
 
-// CHECK-LABEL: define { i64, double } @__nvqpp__mlirgen__test_5() {{.*}}{
+// CHECK-LABEL: define { i64, double } @__nvqpp__mlirgen__test_5() local_unnamed_addr {{.*}} {
 // CHECK:         ret { i64, double } { i64 537892, double 0x40578DA858793DD9 }
 // CHECK:       }
 
 // CHECK-LABEL: define void @test_5({ i64, double }* nocapture writeonly sret({ i64, double }) 
-// CHECK-SAME:       %[[VAL_0:.*]]) {{.*}}{
-// CHECK:         %[[VAL_1:.*]] = alloca { i64, double }, align 8
-// CHECK:         %[[VAL_2:.*]] = bitcast { i64, double }* %[[VAL_1]] to i8*
-// CHECK:         call { i8*, i64 } @altLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_5.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_5.thunk to i8*), i8* nonnull %[[VAL_2]], i64 16, i64 0)
-// CHECK:         %[[VAL_3:.*]] = bitcast { i64, double }* %[[VAL_0]] to i8*
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(16) %[[VAL_3]], i8* noundef nonnull align 8 dereferenceable(16) %[[VAL_2]], i64 16, i1 false)
+// CHECK-SAME:                                                                                 %[[VAL_0:.*]]) local_unnamed_addr {
+// CHECK:         %[[VAL_1:.*]] = alloca [0 x i8*], align 8
+// CHECK:         %[[VAL_2:.*]] = alloca [16 x i8], align 1
+// CHECK:         %[[VAL_3:.*]] = alloca { i8**, i8**, i8** }, align 8
+// CHECK:         %[[VAL_4:.*]] = getelementptr inbounds [16 x i8], [16 x i8]* %[[VAL_2]], i64 0, i64 0
+// CHECK:         %[[VAL_5:.*]] = getelementptr inbounds [0 x i8*], [0 x i8*]* %[[VAL_1]], i64 0, i64 0
+// CHECK:         %[[VAL_6:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_3]], i64 0, i32 0
+// CHECK:         store i8** %[[VAL_5]], i8*** %[[VAL_6]], align 8
+// CHECK:         %[[VAL_7:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_3]], i64 0, i32 1
+// CHECK:         store i8** %[[VAL_5]], i8*** %[[VAL_7]], align 8
+// CHECK:         %[[VAL_8:.*]] = getelementptr inbounds { i8**, i8**, i8** }, { i8**, i8**, i8** }* %[[VAL_3]], i64 0, i32 2
+// CHECK:         store i8** %[[VAL_5]], i8*** %[[VAL_8]], align 8
+// CHECK:         %[[VAL_9:.*]] = bitcast { i8**, i8**, i8** }* %[[VAL_3]] to i8*
+// CHECK:         %[[VAL_10:.*]] = call { i8*, i64 } @hybridLaunchKernel(i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @test_5.kernelName, i64 0, i64 0), i8* nonnull bitcast ({ i8*, i64 } (i8*, i1)* @test_5.thunk to i8*), i8* nonnull %[[VAL_4]], i64 16, i64 0, i8* nonnull %[[VAL_9]])
+// CHECK:         %[[VAL_11:.*]] = bitcast { i64, double }* %[[VAL_0]] to i8*
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(16) %[[VAL_11]], i8* noundef nonnull align 1 dereferenceable(16) %[[VAL_4]], i64 16, i1 false)
 // CHECK:         ret void
 // CHECK:       }
 
 }
-
 //===----------------------------------------------------------------------===//
 
-// CHECK-LABEL: define i64 @test_0.returnOffset()
+// CHECK-LABEL: define i64 @test_0.returnOffset() local_unnamed_addr {{.*}} {
 // CHECK:         ret i64 8
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* nocapture 
-// CHECK-SAME:     %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
+// CHECK-SAME:    %[[VAL_0:.*]], i1
+// CHECK-SAME:    %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i32*
 // CHECK:         %[[VAL_3:.*]] = load i32, i32* %[[VAL_2]], align 4
-// CHECK:         %[[VAL_5:.*]] = sext i32 %[[VAL_3]] to i64
-// CHECK:         %[[VAL_6:.*]] = tail call %[[VAL_7:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_5]])
-// CHECK:         %[[VAL_8:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_7]]* %[[VAL_6]])
-// CHECK:         %[[VAL_9:.*]] = icmp sgt i64 %[[VAL_8]], 0
-// CHECK:         br i1 %[[VAL_9]], label %[[VAL_10:.*]], label %[[VAL_11:.*]]
-// CHECK:       ._crit_edge.thread:                               ; preds = %[[VAL_12:.*]]
-// CHECK:         %[[VAL_13:.*]] = alloca i8, i64 %[[VAL_8]], align 1
-// CHECK:         br label %[[VAL_14:.*]]
-// CHECK:       .lr.ph:                                           ; preds = %[[VAL_12]], %[[VAL_10]]
-// CHECK:         %[[VAL_15:.*]] = phi i64 [ %[[VAL_16:.*]], %[[VAL_10]] ], [ 0, %[[VAL_12]] ]
-// CHECK:         %[[VAL_17:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]]* %[[VAL_6]], i64 %[[VAL_15]])
-// CHECK:         %[[VAL_18:.*]] = bitcast i8* %[[VAL_17]] to %[[VAL_19:.*]]**
-// CHECK:         %[[VAL_20:.*]] = load %[[VAL_19]]*, %[[VAL_19]]** %[[VAL_18]], align 8
-// CHECK:         tail call void @__quantum__qis__h(%[[VAL_19]]* %[[VAL_20]])
-// CHECK:         %[[VAL_16]] = add nuw nsw i64 %[[VAL_15]], 1
-// CHECK:         %[[VAL_21:.*]] = icmp eq i64 %[[VAL_16]], %[[VAL_8]]
-// CHECK:         br i1 %[[VAL_21]], label %[[VAL_22:.*]], label %[[VAL_10]]
-// CHECK:       ._crit_edge:                                      ; preds = %[[VAL_10]]
-// CHECK:         %[[VAL_23:.*]] = alloca i8, i64 %[[VAL_8]], align 1
-// CHECK:         br i1 %[[VAL_9]], label %[[VAL_24:.*]], label %[[VAL_14]]
-// CHECK:       [[VAL_24]]:                                          ; preds = %[[VAL_22]], %[[VAL_24]]
-// CHECK:         %[[VAL_25:.*]] = phi i64 [ %[[VAL_26:.*]], %[[VAL_24]] ], [ 0, %[[VAL_22]] ]
-// CHECK:         %[[VAL_27:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_7]]* %[[VAL_6]], i64 %[[VAL_25]])
-// CHECK:         %[[VAL_28:.*]] = bitcast i8* %[[VAL_27]] to %[[VAL_19]]**
-// CHECK:         %[[VAL_29:.*]] = load %[[VAL_19]]*, %[[VAL_19]]** %[[VAL_28]], align 8
-// CHECK:         %[[VAL_30:.*]] = tail call %[[VAL_31:.*]]* @__quantum__qis__mz(%[[VAL_19]]* %[[VAL_29]])
-// CHECK:         %[[VAL_32:.*]] = bitcast %[[VAL_31]]* %[[VAL_30]] to i1*
-// CHECK:         %[[VAL_33:.*]] = load i1, i1* %[[VAL_32]], align 1
-// CHECK:         %[[VAL_34:.*]] = getelementptr i8, i8* %[[VAL_23]], i64 %[[VAL_25]]
-// CHECK:         %[[VAL_35:.*]] = zext i1 %[[VAL_33]] to i8
-// CHECK:         store i8 %[[VAL_35]], i8* %[[VAL_34]], align 1
-// CHECK:         %[[VAL_26]] = add nuw nsw i64 %[[VAL_25]], 1
-// CHECK:         %[[VAL_36:.*]] = icmp eq i64 %[[VAL_26]], %[[VAL_8]]
-// CHECK:         br i1 %[[VAL_36]], label %[[VAL_14]], label %[[VAL_24]]
-// CHECK:       [[VAL_14]]:                                     ; preds = %[[VAL_24]], %[[VAL_11]], %[[VAL_22]]
-// CHECK:         %[[VAL_37:.*]] = phi i8* [ %[[VAL_13]], %[[VAL_11]] ], [ %[[VAL_23]], %[[VAL_22]] ], [ %[[VAL_23]], %[[VAL_24]] ]
-// CHECK:         %[[VAL_38:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_37]], i64 %[[VAL_8]], i64 1)
-// CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_7]]* %[[VAL_6]])
-// CHECK:         %[[VAL_50:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
-// CHECK:         %[[VAL_51:.*]] = bitcast i8* %[[VAL_50]] to i8**
-// CHECK:         store i8* %[[VAL_38]], i8** %[[VAL_51]], align 8
-// CHECK:         %[[VAL_52:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
-// CHECK:         %[[VAL_53:.*]] = bitcast i8* %[[VAL_52]] to i64*
-// CHECK:         store i64 %[[VAL_8]], i64* %[[VAL_53]], align 8
+// CHECK:         %[[VAL_4:.*]] = sext i32 %[[VAL_3]] to i64
+// CHECK:         %[[VAL_5:.*]] = tail call %[[VAL_6:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_4]])
+// CHECK:         %[[VAL_7:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_6]]* %[[VAL_5]])
+// CHECK:         %[[VAL_8:.*]] = icmp sgt i64 %[[VAL_7]], 0
+// CHECK:         br i1 %[[VAL_8]], label %[[VAL_9:.*]], label %[[VAL_10:.*]]
+// CHECK:       ._crit_edge.thread:                               ; preds = %[[VAL_11:.*]]
+// CHECK:         %[[VAL_12:.*]] = alloca i8, i64 %[[VAL_7]], align 1
+// CHECK:         br label %[[VAL_13:.*]]
+// CHECK:       .lr.ph:                                           ; preds = %[[VAL_11]], %[[VAL_9]]
+// CHECK:         %[[VAL_14:.*]] = phi i64 [ %[[VAL_15:.*]], %[[VAL_9]] ], [ 0, %[[VAL_11]] ]
+// CHECK:         %[[VAL_16:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_5]], i64 %[[VAL_14]])
+// CHECK:         %[[VAL_17:.*]] = bitcast i8* %[[VAL_16]] to %[[VAL_18:.*]]**
+// CHECK:         %[[VAL_19:.*]] = load %[[VAL_18]]*, %[[VAL_18]]** %[[VAL_17]], align 8
+// CHECK:         tail call void @__quantum__qis__h(%[[VAL_18]]* %[[VAL_19]])
+// CHECK:         %[[VAL_15]] = add nuw nsw i64 %[[VAL_14]], 1
+// CHECK:         %[[VAL_20:.*]] = icmp eq i64 %[[VAL_15]], %[[VAL_7]]
+// CHECK:         br i1 %[[VAL_20]], label %[[VAL_21:.*]], label %[[VAL_9]]
+// CHECK:       ._crit_edge:                                      ; preds = %[[VAL_9]]
+// CHECK:         %[[VAL_22:.*]] = alloca i8, i64 %[[VAL_7]], align 1
+// CHECK:         br i1 %[[VAL_8]], label %[[VAL_23:.*]], label %[[VAL_13]]
+// CHECK:       .lr.ph6:                                          ; preds = %[[VAL_21]], %[[VAL_23]]
+// CHECK:         %[[VAL_24:.*]] = phi i64 [ %[[VAL_25:.*]], %[[VAL_23]] ], [ 0, %[[VAL_21]] ]
+// CHECK:         %[[VAL_26:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_5]], i64 %[[VAL_24]])
+// CHECK:         %[[VAL_27:.*]] = bitcast i8* %[[VAL_26]] to %[[VAL_18]]**
+// CHECK:         %[[VAL_28:.*]] = load %[[VAL_18]]*, %[[VAL_18]]** %[[VAL_27]], align 8
+// CHECK:         %[[VAL_29:.*]] = tail call %[[VAL_30:.*]]* @__quantum__qis__mz(%[[VAL_18]]* %[[VAL_28]])
+// CHECK:         %[[VAL_31:.*]] = bitcast %[[VAL_30]]* %[[VAL_29]] to i1*
+// CHECK:         %[[VAL_32:.*]] = load i1, i1* %[[VAL_31]], align 1
+// CHECK:         %[[VAL_33:.*]] = getelementptr i8, i8* %[[VAL_22]], i64 %[[VAL_24]]
+// CHECK:         %[[VAL_34:.*]] = zext i1 %[[VAL_32]] to i8
+// CHECK:         store i8 %[[VAL_34]], i8* %[[VAL_33]], align 1
+// CHECK:         %[[VAL_25]] = add nuw nsw i64 %[[VAL_24]], 1
+// CHECK:         %[[VAL_35:.*]] = icmp eq i64 %[[VAL_25]], %[[VAL_7]]
+// CHECK:         br i1 %[[VAL_35]], label %[[VAL_13]], label %[[VAL_23]]
+// CHECK:       ._crit_edge7:                                     ; preds = %[[VAL_23]], %[[VAL_10]], %[[VAL_21]]
+// CHECK:         %[[VAL_36:.*]] = phi i8* [ %[[VAL_12]], %[[VAL_10]] ], [ %[[VAL_22]], %[[VAL_21]] ], [ %[[VAL_22]], %[[VAL_23]] ]
+// CHECK:         %[[VAL_37:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_36]], i64 %[[VAL_7]], i64 1)
+// CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_5]])
+// CHECK:         %[[VAL_38:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_39:.*]] = bitcast i8* %[[VAL_38]] to i8**
+// CHECK:         store i8* %[[VAL_37]], i8** %[[VAL_39]], align 8
+// CHECK:         %[[VAL_40:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
+// CHECK:         %[[VAL_41:.*]] = bitcast i8* %[[VAL_40]] to i64*
+// CHECK:         store i64 %[[VAL_7]], i64* %[[VAL_41]], align 8
 // CHECK:         br i1 %[[VAL_1]], label %[[VAL_42:.*]], label %[[VAL_43:.*]]
-// CHECK:       [[VAL_43]]:                                       ; preds = %[[VAL_14]], %[[VAL_42]]
-// CHECK:         %[[VAL_44:.*]] = phi { i8*, i64 } [ %[[VAL_45:.*]], %[[VAL_42]] ], [ zeroinitializer, %[[VAL_14]] ]
+// CHECK:       common.ret:                                       ; preds = %[[VAL_13]], %[[VAL_42]]
+// CHECK:         %[[VAL_44:.*]] = phi { i8*, i64 } [ %[[VAL_45:.*]], %[[VAL_42]] ], [ zeroinitializer, %[[VAL_13]] ]
 // CHECK:         ret { i8*, i64 } %[[VAL_44]]
-// CHECK:       [[VAL_42]]:                                               ; preds = %[[VAL_14]]
-// CHECK:         %[[VAL_46:.*]] = add i64 %[[VAL_8]], 24
+// CHECK:       31:                                               ; preds = %[[VAL_13]]
+// CHECK:         %[[VAL_46:.*]] = add i64 %[[VAL_7]], 24
 // CHECK:         %[[VAL_47:.*]] = call i8* @malloc(i64 %[[VAL_46]])
 // CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_47]], i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_0]], i64 24, i1 false)
 // CHECK:         %[[VAL_48:.*]] = getelementptr i8, i8* %[[VAL_47]], i64 24
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_48]], i8* align 1 %[[VAL_38]], i64 %[[VAL_8]], i1 false)
+// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_48]], i8* align 1 %[[VAL_37]], i64 %[[VAL_7]], i1 false)
 // CHECK:         %[[VAL_49:.*]] = insertvalue { i8*, i64 } undef, i8* %[[VAL_47]], 0
 // CHECK:         %[[VAL_45]] = insertvalue { i8*, i64 } %[[VAL_49]], i64 %[[VAL_46]], 1
+// CHECK:         %[[VAL_50:.*]] = getelementptr i8, i8* %[[VAL_47]], i64 8
+// CHECK:         %[[VAL_51:.*]] = bitcast i8* %[[VAL_50]] to i8**
+// CHECK:         store i8* %[[VAL_48]], i8** %[[VAL_51]], align 8
 // CHECK:         br label %[[VAL_43]]
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_0.argsCreator(i8** nocapture readonly 
-// CHECK-SAME:        %[[VAL_0:.*]], i8** nocapture writeonly
-// CHECK-SAME:        %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                         %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:                                                         %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8** %[[VAL_0]] to i32**
 // CHECK:         %[[VAL_3:.*]] = load i32*, i32** %[[VAL_2]], align 8
 // CHECK:         %[[VAL_4:.*]] = load i32, i32* %[[VAL_3]], align 4
-// CHECK:         %[[VAL_5:.*]] = insertvalue { i32, { i1*, i64 } } undef, i32 %[[VAL_4]], 0
-// CHECK:         %[[VAL_6:.*]] = tail call dereferenceable_or_null(24) i8* @malloc(i64 24)
-// CHECK:         %[[VAL_7:.*]] = bitcast i8* %[[VAL_6]] to { i32, { i1*, i64 } }*
-// CHECK:         store { i32, { i1*, i64 } } %[[VAL_5]], { i32, { i1*, i64 } }* %[[VAL_7]], align 8
-// CHECK:         store i8* %[[VAL_6]], i8** %[[VAL_1]], align 8
+// CHECK:         %[[VAL_5:.*]] = tail call dereferenceable_or_null(24) i8* @malloc(i64 24)
+// CHECK:         %[[VAL_6:.*]] = bitcast i8* %[[VAL_5]] to i32*
+// CHECK:         store i32 %[[VAL_4]], i32* %[[VAL_6]], align 4
+// CHECK:         store i8* %[[VAL_5]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 24
 // CHECK:       }
 
@@ -389,13 +464,13 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define i64 @test_1.returnOffset()
+// CHECK-LABEL: define i64 @test_1.returnOffset() local_unnamed_addr {{.*}} {
 // CHECK:         ret i64 0
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* nocapture writeonly 
-// CHECK-SAME:      %[[VAL_0:.*]], i1
-// CHECK-SAME:      %[[VAL_1:.*]]) {
+// CHECK-SAME:                                                            %[[VAL_0:.*]], i1
+// CHECK-SAME:                                                            %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
 // CHECK:         %[[VAL_4:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_3]]* %[[VAL_2]], i64 0)
 // CHECK:         %[[VAL_5:.*]] = bitcast i8* %[[VAL_4]] to %[[VAL_6:.*]]**
@@ -421,8 +496,8 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_1.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:        %[[VAL_0:.*]], i8** nocapture writeonly
-// CHECK-SAME:        %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                         %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:                                                         %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(2) i8* @malloc(i64 2)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 2
@@ -434,21 +509,21 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define i64 @test_2.returnOffset()
+// CHECK-LABEL: define i64 @test_2.returnOffset() local_unnamed_addr {{.*}} {
 // CHECK:         ret i64 0
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_2.thunk(i8* nocapture writeonly 
-// CHECK-SAME:      %[[VAL_0:.*]], i1
-// CHECK-SAME:      %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                            %[[VAL_0:.*]], i1
+// CHECK-SAME:                                                            %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to { i16, float, double, i64 }*
 // CHECK:         store { i16, float, double, i64 } { i16 8, float 0x40159999A0000000, double 3.783000e+01, i64 1479 }, { i16, float, double, i64 }* %[[VAL_2]], align 8
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_2.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:         %[[VAL_0:.*]], i8** nocapture writeonly
-// CHECK-SAME:         %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                         %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:                                                         %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(24) i8* @malloc(i64 24)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 24
@@ -460,12 +535,13 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define i64 @test_3.returnOffset()
+// CHECK-LABEL: define i64 @test_3.returnOffset() local_unnamed_addr {{.*}} {
 // CHECK:         ret i64 0
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_3.thunk(i8* nocapture writeonly 
-// CHECK-SAME:          %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                            %[[VAL_0:.*]], i1
+// CHECK-SAME:                                                            %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 5, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 8
@@ -484,8 +560,8 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_3.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:       %[[VAL_0:.*]], i8** nocapture writeonly
-// CHECK-SAME:       %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                         %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:                                                         %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(40) i8* @malloc(i64 40)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 40
@@ -497,12 +573,13 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define i64 @test_4.returnOffset()
+// CHECK-LABEL: define i64 @test_4.returnOffset() local_unnamed_addr {{.*}} {
 // CHECK:         ret i64 0
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_4.thunk(i8* nocapture writeonly 
-// CHECK-SAME:        %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                            %[[VAL_0:.*]], i1
+// CHECK-SAME:                                                            %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
@@ -512,8 +589,8 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_4.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:         %[[VAL_0:.*]], i8** nocapture writeonly
-// CHECK-SAME:         %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                         %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:                                                         %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(16) i8* @malloc(i64 16)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 16
@@ -525,12 +602,13 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define i64 @test_5.returnOffset()
+// CHECK-LABEL: define i64 @test_5.returnOffset() local_unnamed_addr {{.*}} {
 // CHECK:         ret i64 0
 // CHECK:       }
 
 // CHECK-LABEL: define { i8*, i64 } @test_5.thunk(i8* nocapture writeonly 
-// CHECK-SAME:      %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                            %[[VAL_0:.*]], i1
+// CHECK-SAME:                                                            %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i64*
 // CHECK:         store i64 537892, i64* %[[VAL_2]], align 4
 // CHECK:         %[[VAL_3:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
@@ -540,8 +618,8 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_5.argsCreator(i8** nocapture readnone 
-// CHECK-SAME:      %[[VAL_0:.*]], i8** nocapture writeonly
-// CHECK-SAME:      %[[VAL_1:.*]]) #{{[0-9]+}} {
+// CHECK-SAME:                                                         %[[VAL_0:.*]], i8** nocapture writeonly
+// CHECK-SAME:                                                         %[[VAL_1:.*]]) {{.*}} {
 // CHECK:         %[[VAL_2:.*]] = tail call dereferenceable_or_null(16) i8* @malloc(i64 16)
 // CHECK:         store i8* %[[VAL_2]], i8** %[[VAL_1]], align 8
 // CHECK:         ret i64 16


### PR DESCRIPTION
This changes the pauli_word implementation to be compatible with std::string, use the core character literal support, which changes the code generation and provides a potential way to perform optimizations on quake.exp_pauli ops.

This PR also does a complete rewrite of the GKE code. The rewrite fuses the C++ host entry point argument processing with the .argsCreator support function. It removes several special cases that are no longer germane as the surface of supported C++ argument types has expanded quite a bit. It is fully backwards compatible with the old argument packing pointer-free format.  The .argsCreator function remains highly coupled with the Python implementation and launcher. C++ should use the streamlined launcher as it has greater flexibility.

Fixes tests and updates them to use the hybrid launcher where appropriate. Add new tests.

<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
