### PR TITLE
Update the `cuTensor` version and fix state retrieval logic for `tensornet`

### DIFF
--- a/runtime/cudaq/qis/state.cpp
+++ b/runtime/cudaq/qis/state.cpp
@@ -62,7 +62,9 @@ std::complex<double> state::operator[](std::size_t idx) const {
     // network state.
     std::vector<int> basisState(numQubits, 0);
     // Are we dealing with qudits or qubits?
-    if (std::log2(numElements) / numQubits > 1) {
+    /// NOTE: Following check makes assumption that only qubit simulation uses
+    /// GPU(s)
+    if (!internal->isDeviceData() && std::log2(numElements) / numQubits > 1) {
       for (std::size_t i = 0; i < numQubits; ++i) {
         basisState[i] = 1; // TODO: This is a placeholder. We need to figure out
                            // how to handle qudits.

--- a/scripts/configure_build.sh
+++ b/scripts/configure_build.sh
@@ -79,7 +79,7 @@ if [ "$1" == "install-cutensor" ]; then
     CUDA_ARCH_FOLDER=$([ "$(uname -m)" == "aarch64" ] && echo sbsa || echo x86_64)
 
 # [>cuTensorInstall]
-    CUTENSOR_VERSION=2.0.1.2
+    CUTENSOR_VERSION=2.0.2.5
     CUTENSOR_DOWNLOAD_URL=https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor
 
     cutensor_archive=libcutensor-linux-${CUDA_ARCH_FOLDER}-${CUTENSOR_VERSION}-archive.tar.xz


### PR DESCRIPTION
* cuTensor version upgraded to 2.0.2.5
* Bug-fix for issue introduced in PR #2289

Tested in local dev environment. 
```
100% tests passed, 0 tests failed out of 709

Label Time Summary:
gpu_required    = 348.95 sec*proc (374 tests)
```
