### PR TITLE
Remove the TODO_loc on functions in the cudaq namespace

### DIFF
--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -169,8 +169,6 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
       auto fnTy = cast<FunctionType>(popType());
       return pushType(cc::IndirectCallableType::get(fnTy));
     }
-    auto loc = toLocation(x);
-    TODO_loc(loc, "unhandled type, " + name + ", in cudaq namespace");
   }
   if (isInNamespace(x, "std")) {
     if (name.equals("vector")) {

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -2049,8 +2049,6 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
                                        ValueRange{buffer, start, stop, step});
       return pushValue(call.getResult(0));
     }
-
-    TODO_loc(loc, "unknown function, " + funcName + ", in cudaq namespace");
   } // end in cudaq namespace
 
   if (isInNamespace(func, "std")) {

--- a/test/AST-Quake/kernels_in_cudaq_ns.cpp
+++ b/test/AST-Quake/kernels_in_cudaq_ns.cpp
@@ -7,34 +7,33 @@
  ******************************************************************************/
 
 // REQUIRES: c++20
-// RUN: cudaq-quake %s | FileCheck %s
+// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
 
 #include "cudaq.h"
 
 namespace cudaq {
 __qpu__ void callMe(int i) {}
-
 __qpu__ void kernel() { cudaq::callMe(5); }
 } // namespace cudaq
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_callMe._ZN5cudaq6callMeEi(
-// CHECK-SAME:                                                                    %[[VAL_0:.*]]: i32 loc("/cuda-quantum/runtime/cudaq/qis/qubit_qis.h":23:17)) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-// CHECK:           %[[VAL_1:.*]] = cc.alloca i32 loc(#[[?]])
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32> loc(#[[?]])
-// CHECK:           return loc(#[[$ATTR_0]])
-// CHECK:         } loc(#[[$ATTR_0]])
+// CHECK-SAME:                                                                    %[[VAL_0:.*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32>
+// CHECK:           return
+// CHECK:         }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_kernel._ZN5cudaq6kernelEv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-// CHECK:           %[[VAL_0:.*]] = arith.constant 5 : i32 loc(#[[?]])
-// CHECK:           call @__nvqpp__mlirgen__function_callMe._ZN5cudaq6callMeEi(%[[VAL_0]]) : (i32) -> () loc(#[[?]])
-// CHECK:           return loc(#[[$ATTR_0]])
-// CHECK:         } loc(#[[$ATTR_0]])
+// CHECK:           %[[VAL_0:.*]] = arith.constant 5 : i32
+// CHECK:           call @__nvqpp__mlirgen__function_callMe._ZN5cudaq6callMeEi(%[[VAL_0]]) : (i32) -> ()
+// CHECK:           return
+// CHECK:         }
 
 // CHECK-LABEL:   func.func @_ZN5cudaq6callMeEi(
-// CHECK-SAME:                                  %[[VAL_0:.*]]: i32 loc("/cuda-quantum/runtime/cudaq/qis/qubit_qis.h":23:17)) attributes {no_this} {
-// CHECK:           return loc(#[[$ATTR_0]])
-// CHECK:         } loc(#[[$ATTR_0]])
+// CHECK-SAME:                                  %[[VAL_0:.*]]: i32) attributes {no_this} {
+// CHECK:           return
+// CHECK:         }
 
 // CHECK-LABEL:   func.func @_ZN5cudaq6kernelEv() attributes {no_this} {
-// CHECK:           return loc(#[[$ATTR_0]])
-// CHECK:         } loc(#[[$ATTR_0]]
+// CHECK:           return
+// CHECK:         }

--- a/test/AST-Quake/kernels_in_cudaq_ns.cpp
+++ b/test/AST-Quake/kernels_in_cudaq_ns.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// REQUIRES: c++20
+// RUN: cudaq-quake %s | FileCheck %s
+
+#include "cudaq.h"
+
+namespace cudaq {
+__qpu__ void callMe(int i) {}
+
+__qpu__ void kernel() { cudaq::callMe(5); }
+} // namespace cudaq
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_callMe._ZN5cudaq6callMeEi(
+// CHECK-SAME:                                                                    %[[VAL_0:.*]]: i32 loc("/cuda-quantum/runtime/cudaq/qis/qubit_qis.h":23:17)) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_1:.*]] = cc.alloca i32 loc(#[[?]])
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_1]] : !cc.ptr<i32> loc(#[[?]])
+// CHECK:           return loc(#[[$ATTR_0]])
+// CHECK:         } loc(#[[$ATTR_0]])
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_kernel._ZN5cudaq6kernelEv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 5 : i32 loc(#[[?]])
+// CHECK:           call @__nvqpp__mlirgen__function_callMe._ZN5cudaq6callMeEi(%[[VAL_0]]) : (i32) -> () loc(#[[?]])
+// CHECK:           return loc(#[[$ATTR_0]])
+// CHECK:         } loc(#[[$ATTR_0]])
+
+// CHECK-LABEL:   func.func @_ZN5cudaq6callMeEi(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: i32 loc("/cuda-quantum/runtime/cudaq/qis/qubit_qis.h":23:17)) attributes {no_this} {
+// CHECK:           return loc(#[[$ATTR_0]])
+// CHECK:         } loc(#[[$ATTR_0]])
+
+// CHECK-LABEL:   func.func @_ZN5cudaq6kernelEv() attributes {no_this} {
+// CHECK:           return loc(#[[$ATTR_0]])
+// CHECK:         } loc(#[[$ATTR_0]]


### PR DESCRIPTION
Allow libraries to expose kernel code in cudaq namespace
