### PR TITLE
Change the test port for `anyon` target 

### DIFF
--- a/unittests/backends/anyon/AnyonStartServerAndTest.sh.in
+++ b/unittests/backends/anyon/AnyonStartServerAndTest.sh.in
@@ -14,7 +14,7 @@
 # import socket
 # try:
 #     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-#     s.connect(("host.docker.internal", 5000))
+#     s.connect(("host.docker.internal", 62446))
 #     s.close()
 # except Exception:
 #     exit(1)
@@ -27,7 +27,7 @@ checkServerConnection() {
 import socket
 try:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect(("localhost", 5000))
+    s.connect(("localhost", 62446))
     s.close()
 except Exception:
     exit(1)

--- a/unittests/backends/anyon/AnyonTester.cpp
+++ b/unittests/backends/anyon/AnyonTester.cpp
@@ -15,7 +15,7 @@
 
 // port number and localhost connect to mock_qpu backend server within the
 // container (mock_qpu/anyon).
-std::string mockPort = "5000";
+std::string mockPort = "62446";
 std::string machine = "telegraph-8q";
 std::string backendStringTemplate =
     "anyon;emulate;false;url;http://localhost:{};credentials;{};machine;{}";

--- a/utils/mock_qpu/anyon/__init__.py
+++ b/utils/mock_qpu/anyon/__init__.py
@@ -146,4 +146,4 @@ def startServer(port):
 
 if __name__ == '__main__':
     print("Server Starting")
-    startServer(5000)
+    startServer(62446)


### PR DESCRIPTION
Changed from '5000' to '62446' to match other targets' ports.
