### PR TITLE
Bump mgpu gitlab commit

### DIFF
--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: b63a90466dc49d7c0c950984d3a882097b7db870
+nvidia-mgpu-commit: 5ecebd6b7642e8526baf5930634f2f854aef9ea7


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA Quantum!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Bump mgpu commit to include a fix for `getNumElements` when host-device migration is used (mgpu MR!32).

The base implementation of `getNumElements` iterates over tensors, which is not supported for host-device migration (throwing an error). Hence, adding a direct `getNumElements` implementation.

This issue was exposed by a recent change in https://github.com/NVIDIA/cuda-quantum/pull/2289, which calls `getNumElements` as part of state data indexing. The bug and fix can be checked by the existing mgpu unit tests.