### PR TITLE
Allow to define publishing assets as repo variable, disable codeql for C++, and fix issue in nightly workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -5,7 +5,7 @@ labels: [triage]
 body:
   - type: markdown
     attributes:
-      value: Thank you for helping us improve CUDA Quantum.
+      value: Thank you for helping us improve CUDA-Q.
 
   - type: checkboxes
     attributes:
@@ -60,7 +60,7 @@ body:
     attributes:
       label: Environment
       description: |
-        For the CUDA Quantum version, please give the actual version number
+        For the CUDA-Q version, please give the actual version number
         (_e.g._ 0.3.0) if you are using a release version, or the first 7-8
         characters of the commit hash if you have built from source. If you are
         using the python interface _and_ have not built it from source, you can
@@ -69,7 +69,7 @@ body:
         is relevant to the list.
       # Keep the trailing spaces on the following lines
       value: |
-        - **CUDA Quantum version**: 
+        - **CUDA-Q version**: 
         - **Python version**: 
         - **C++ compiler**: 
         - **Operating system**: 

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -5,7 +5,7 @@ labels: [enhancement]
 body:
   - type: markdown
     attributes:
-      value: Thank you for helping us improve CUDA Quantum.
+      value: Thank you for helping us improve CUDA-Q.
 
   - type: checkboxes
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-Thanks for helping us improve CUDA Quantum!
+Thanks for helping us improve CUDA-Q!
 
 ⚠️ The pull request title should be concise and understandable for all.
 ⚠️ If your pull request fixes an open issue, please link to the issue.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,7 @@ jobs:
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: 'ubuntu-latest'
     permissions:
+      packages: read # required to fetch internal or private CodeQL packs
       security-events: write
       # read permissions below are only required for workflows in private repositories
       actions: read
@@ -47,10 +48,11 @@ jobs:
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
         # For analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
-        - language: c-cpp
-          build-mode: none # Consider setting this to manual and providing a build command to get more accurate scanning
         - language: python
-          build-mode: none
+          build-mode: none # Consider setting this to manual and providing a build command to get more accurate scanning
+        # FIXME: enable code scanning for C++
+        # - language: c-cpp
+        #   build-mode: manual # Consider setting this to manual and providing a build command to get more accurate scanning
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -796,7 +796,7 @@ jobs:
           python_version=${{ inputs.python_version || env.python_version }}
           workflow_id=${{ inputs.workflow_id }}
           # Helper to get the *valid* Publishing run Id for a commit hash
-          # Notes: runs that have 'CUDA Quantum Python wheels' jobs skipped are not considered.
+          # Notes: runs that have 'CUDA-Q Python wheels' jobs skipped are not considered.
           function get_publishing_run_id {
             # Find all Publishing runs, we'll look into its jobs' status later
             if [[ -z "$1" ]]; then
@@ -805,9 +805,9 @@ jobs:
               publishing_run_ids=$(gh run list --commit $1 --workflow Publishing --json databaseId --jq .[].databaseId)
             fi
             for run_id in $publishing_run_ids ; do
-                # Look into its jobs: if "CUDA Quantum Python wheels" matrix build was performed,
-                # then we have multiple jobs, like "CUDA Quantum Python wheels (python_arm64....")
-                cuda_wheel_build_jobs=$(gh run view $run_id --jq '.jobs.[] | select(.name | startswith("CUDA Quantum Python wheels (python_")).name' --json jobs)
+                # Look into its jobs: if "CUDA-Q Python wheels" matrix build was performed,
+                # then we have multiple jobs, like "CUDA-Q Python wheels (python_arm64....")
+                cuda_wheel_build_jobs=$(gh run view $run_id --jq '.jobs.[] | select(.name | startswith("CUDA-Q Python wheels (python_")).name' --json jobs)
                 if [ ! -z "$cuda_wheel_build_jobs" ]; then
                   # This is a valid run that produces wheel artifacts
                   echo $run_id

--- a/.github/workflows/nvqc_regression_tests.yml
+++ b/.github/workflows/nvqc_regression_tests.yml
@@ -262,7 +262,7 @@ jobs:
           python_version=${{ inputs.python_version || env.python_version }}
           workflow_id=${{ inputs.workflow_id }}
           # Helper to get the *valid* Publishing run Id for a commit hash
-          # Notes: runs that have 'CUDA Quantum Python wheels' jobs skipped are not considered.
+          # Notes: runs that have 'CUDA-Q Python wheels' jobs skipped are not considered.
           function get_publishing_run_id {
             # Find all Publishing runs, we'll look into its jobs' status later
             if [[ -z "$1" ]]; then
@@ -271,9 +271,9 @@ jobs:
               publishing_run_ids=$(gh run -R NVIDIA/cuda-quantum list --commit $1 --workflow Publishing --json databaseId --jq .[].databaseId)
             fi
             for run_id in $publishing_run_ids ; do
-                # Look into its jobs: if "CUDA Quantum Python wheels" matrix build was performed,
-                # then we have multiple jobs, like "CUDA Quantum Python wheels (python_arm64....")
-                cuda_wheel_build_jobs=$(gh run -R NVIDIA/cuda-quantum view $run_id --jq '.jobs.[] | select(.name | startswith("CUDA Quantum Python wheels (python_")).name' --json jobs)
+                # Look into its jobs: if "CUDA-Q Python wheels" matrix build was performed,
+                # then we have multiple jobs, like "CUDA-Q Python wheels (python_arm64....")
+                cuda_wheel_build_jobs=$(gh run -R NVIDIA/cuda-quantum view $run_id --jq '.jobs.[] | select(.name | startswith("CUDA-Q Python wheels (python_")).name' --json jobs)
                 if [ ! -z "$cuda_wheel_build_jobs" ]; then
                   # This is a valid run that produces wheel artifacts
                   echo $run_id

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -163,13 +163,14 @@ jobs:
           # Using the image sha as the file name and the docker image name
           # as the folder is convenient for the GitLab CI.
 
-          if ${{ inputs.manual_assets_creation == '' }}; then 
+          publishing_assets=${{ inputs.manual_assets_creation || vars.publishing_assets || '' }}
+          if [ -z "${publishing_assets}" ]; then 
             git config --global user.name "cuda-quantum-bot"
             git config --global user.email "cuda-quantum-bot@users.noreply.github.com"
             current_branch=$(git rev-parse --abbrev-ref HEAD)
           else
-            gh release download ${{ inputs.manual_assets_creation }} -R ${{ vars.assets_repo || github.repository }}
-            unzip -d /tmp/ ${{ inputs.manual_assets_creation }}.zip && rm -rf ${{ inputs.manual_assets_creation }}.zip
+            gh release download ${publishing_assets} -R ${{ vars.assets_repo || github.repository }}
+            unzip -d /tmp/ ${publishing_assets}.zip && rm -rf ${publishing_assets}.zip
           fi
 
           function create_assets {
@@ -190,7 +191,7 @@ jobs:
             echo "release-id: $release_id" >> "$1.txt"
             echo "artifacts-url: $artifacts_url" >> "$1.txt"
 
-            if ${{ inputs.manual_assets_creation == '' }}; then 
+            if [ -z "${publishing_assets}" ]; then 
               echo "Pushing $1 to $staging_branch"
               mkdir -p "$staging_folder" && mv -v "$1.txt" "$staging_folder/$file_id"
               git add "$staging_folder" && git commit -m "$image_hash"
@@ -217,7 +218,7 @@ jobs:
               fi              
               
               assets_folder=$(echo $release_id | cut -d _ -f2-)
-              upload=`find /tmp/${{ inputs.manual_assets_creation }}/$assets_folder -name '*.zip'`
+              upload=`find /tmp/${publishing_assets}/$assets_folder -name '*.zip'`
               echo "Uploading assets $upload $1.txt..."
               echo $upload | xargs gh release upload $release_id -R ${{ vars.assets_repo || github.repository }} --clobber "$1.txt"
             fi
@@ -249,7 +250,7 @@ jobs:
 
       # We can delete staging branch now after the expected draft releases have been created.
       - name: Clean up
-        if: steps.assets_creation.outcome != 'skipped' && inputs.manual_assets_creation == ''
+        if: steps.assets_creation.outcome != 'skipped' && inputs.manual_assets_creation == '' && vars.publishing_assets == ''
         run: |
           # Clean up the staging branch that was used to trigger the GitLab pipeline.
           git config --global user.name "cuda-quantum-bot"

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -2,7 +2,7 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: NVIDIA Corporation & Affiliates
-    software-name: CUDA Quantum
+    software-name: CUDA-Q
 
     content: |
       Copyright (c) 2023 - 2024 NVIDIA Corporation & Affiliates.


### PR DESCRIPTION
This will allow to configure the repo such that all publishing runs bypass rebuilding these assets. 