### PR TITLE
Excluding building_kernels from NVQC integration test

### DIFF
--- a/.github/workflows/nvqc_regression_tests.yml
+++ b/.github/workflows/nvqc_regression_tests.yml
@@ -202,7 +202,8 @@ jobs:
 
           # Test NVQC Python examples + Python MLIR execution tests (not IR tests)
           python3 -m pip install pytest
-          for ex in `find examples/python python/tests/mlir/target -name '*.py'`; do
+          # Disabling building_kernels as the state is not yet supported on NVQC
+          for ex in `find examples/python python/tests/mlir/target -name '*.py' ! -name '*building_kernels*'`; do
             filename=$(basename -- "$ex")
             filename="${filename%.*}"
             echo "Testing $filename:"


### PR DESCRIPTION
Excluding building_kernels from NVQC integration test

This will fix the NVQC integration test below
https://github.com/NVIDIA/cuda-quantum/actions/runs/11789940366/job/32839604580#step:4:1667