### PR TITLE
[core] Modify quake.subveq such that it folds constant arguments.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/Canonical.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/Canonical.h
@@ -1,0 +1,125 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace quake::canonical {
+
+inline mlir::Value createCast(mlir::PatternRewriter &rewriter,
+                              mlir::Location loc, mlir::Value inVal) {
+  auto i64Ty = rewriter.getI64Type();
+  assert(inVal.getType() != rewriter.getIndexType() &&
+         "use of index type is deprecated");
+  return rewriter.create<cudaq::cc::CastOp>(loc, i64Ty, inVal,
+                                            cudaq::cc::CastOpMode::Unsigned);
+}
+
+class ExtractRefFromSubVeqPattern
+    : public mlir::OpRewritePattern<ExtractRefOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  // Replace a pattern such as:
+  // ```
+  //   %1 = ... : !quake.veq<4>
+  //   %2 = quake.subveq %1, %c2, %c3 : (!quake.veq<4>, i32, i32) ->
+  //        !quake.veq<2>
+  //   %3 = quake.extract_ref %2[0] : (!quake.veq<2>) -> !quake.ref
+  // ```
+  // with:
+  // ```
+  //   %1 = ... : !quake.veq<4>
+  //   %3 = quake.extract_ref %1[2] : (!uwake.veq<4>) -> !quake.ref
+  // ```
+  mlir::LogicalResult
+  matchAndRewrite(ExtractRefOp extract,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto subveq = extract.getVeq().getDefiningOp<SubVeqOp>();
+    if (!subveq)
+      return mlir::failure();
+    // Let the combining of back-to-back subveq ops happen first.
+    if (isa<SubVeqOp>(subveq.getVeq().getDefiningOp()))
+      return mlir::failure();
+
+    mlir::Value offset;
+    auto loc = extract.getLoc();
+    auto low = [&]() -> mlir::Value {
+      if (subveq.hasConstantLowerBound())
+        return rewriter.create<mlir::arith::ConstantIntOp>(
+            loc, subveq.getConstantLowerBound(), 64);
+      return subveq.getLower();
+    }();
+    if (extract.hasConstantIndex()) {
+      mlir::Value cv = rewriter.create<mlir::arith::ConstantIntOp>(
+          loc, extract.getConstantIndex(), low.getType());
+      offset = rewriter.create<mlir::arith::AddIOp>(loc, cv, low);
+    } else {
+      auto cast1 = createCast(rewriter, loc, extract.getIndex());
+      auto cast2 = createCast(rewriter, loc, low);
+      offset = rewriter.create<mlir::arith::AddIOp>(loc, cast1, cast2);
+    }
+    rewriter.replaceOpWithNewOp<ExtractRefOp>(extract, subveq.getVeq(), offset);
+    return mlir::success();
+  }
+};
+
+// Combine back-to-back quake.subveq operations.
+//
+// %10 = quake.subveq %4, 1, 6 : (!quake.veq<?>) -> !quake.veq<7>
+// %11 = quake.subveq %10, 0, 2 : (!quake.veq<7>) -> !quake.veq<3>
+// ───────────────────────────────────────────────────────────────
+// %11 = quake.subveq %4, 1, 3 : (!quake.veq<?>) -> !quake.veq<3>
+class CombineSubVeqsPattern : public mlir::OpRewritePattern<SubVeqOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(SubVeqOp subveq,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto prior = subveq.getVeq().getDefiningOp<SubVeqOp>();
+    if (!prior)
+      return mlir::failure();
+
+    auto loc = subveq.getLoc();
+
+    // Lambda to create a Value for the lower bound of `s`.
+    auto lofunc = [&](SubVeqOp s) -> mlir::Value {
+      if (s.hasConstantLowerBound())
+        return rewriter.create<mlir::arith::ConstantIntOp>(
+            loc, s.getConstantLowerBound(), 64);
+      return s.getLower();
+    };
+    auto priorlo = lofunc(prior);
+    auto svlo = lofunc(subveq);
+
+    // Lambda for creating the upper bound Value.
+    auto svup = [&]() -> mlir::Value {
+      if (subveq.hasConstantUpperBound())
+        return rewriter.create<mlir::arith::ConstantIntOp>(
+            loc, subveq.getConstantUpperBound(), 64);
+      return subveq.getUpper();
+    }();
+    auto cast1 = createCast(rewriter, loc, priorlo);
+    auto cast2 = createCast(rewriter, loc, svlo);
+    auto cast3 = createCast(rewriter, loc, svup);
+    mlir::Value sum1 = rewriter.create<mlir::arith::AddIOp>(loc, cast1, cast2);
+    mlir::Value sum2 = rewriter.create<mlir::arith::AddIOp>(loc, cast1, cast3);
+    auto veqTy = subveq.getType();
+    rewriter.replaceOpWithNewOp<SubVeqOp>(subveq, veqTy, prior.getVeq(), sum1,
+                                          sum2);
+    return mlir::success();
+  }
+};
+
+} // namespace quake::canonical

--- a/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/Canonical.td
@@ -64,28 +64,4 @@ def FuseConstantToExtractRefPattern : Pat<
       (createExtractRefOp $veq, $index),
       [(SizeIsPresentPred $index)]>;
 
-def createSizedSubVeqOp : NativeCodeCall<
-      "quake::createSizedSubVeqOp($_builder, $_loc, $0, $1, $2, $3)">;
-
-def ArgIsConstantPred : Constraint<CPred<
-      "dyn_cast_or_null<mlir::arith::ConstantOp>($0.getDefiningOp())">>;
-
-def IsUnknownVec : Constraint<CPred<
-      "dyn_cast_or_null<mlir::arith::ConstantOp>($0.getDefiningOp())">>;
-
-// %1 = constant 4 : i64
-// %2 = constant 10 : i64
-// %3 = quake.subveq (%0 : !quake.ref<12>, %1 : i64, %2 : i64) : !quake.ref<?>
-// ─────────────────────────────────────────────────────────────────────────────
-// %1 = constant 4 : i64
-// %2 = constant 10 : i64
-// %new3 = quake.subveq (%0 : !quake.ref<12>, %1 : i64, %2 : i64) :
-//     !quake.ref<7>
-// %3 = quake.relax_size %new3 : (!quake.ref<7>) -> !quake.ref<?>
-def FuseConstantToSubveqPattern : Pat<
-      (quake_SubVeqOp:$subveq $v, $lo, $hi),
-      (createSizedSubVeqOp $subveq, $v, $lo, $hi),
-      [(UnknownSizePred $subveq), (ArgIsConstantPred $lo),
-       (ArgIsConstantPred $hi)]>;
-
 #endif

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
@@ -30,11 +30,6 @@ mlir::Value createConstantAlloca(mlir::PatternRewriter &builder,
                                  mlir::Location loc, mlir::OpResult result,
                                  mlir::ValueRange args);
 
-mlir::Value createSizedSubVeqOp(mlir::PatternRewriter &builder,
-                                mlir::Location loc, mlir::OpResult result,
-                                mlir::Value inVec, mlir::Value lo,
-                                mlir::Value hi);
-
 void getResetEffectsImpl(
     mlir::SmallVectorImpl<
         mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -273,7 +273,7 @@ def quake_RelaxSizeOp : QuakeOp<"relax_size", [Pure]> {
   let hasCanonicalizer = 1;
 }
 
-def quake_SubVeqOp : QuakeOp<"subveq", [Pure]> {
+def quake_SubVeqOp : QuakeOp<"subveq", [AttrSizedOperandSegments, Pure]> {
   let summary = "Extract a subvector from a veq reference value.";
   let description = [{
     The `subveq` operation returns a subvector of references, type
@@ -298,16 +298,42 @@ def quake_SubVeqOp : QuakeOp<"subveq", [Pure]> {
 
   let arguments = (ins
     VeqType:$veq,
-    AnySignlessIntegerOrIndex:$low,
-    AnySignlessIntegerOrIndex:$high
+    Optional<AnySignlessIntegerOrIndex>:$lower,
+    Optional<AnySignlessIntegerOrIndex>:$upper,
+    I64Attr:$rawLower,
+    I64Attr:$rawUpper
   );
   let results = (outs VeqType:$qsub);
 
   let assemblyFormat = [{
-    operands attr-dict `:` functional-type(operands, results)
+    $veq `,` custom<RawIndex>($lower, $rawLower) `,` custom<RawIndex>($upper,
+      $rawUpper) `:` functional-type(operands, results) attr-dict
   }];
 
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$veqTy, "mlir::Value":$input,
+                   "mlir::Value":$lower, "mlir::Value":$upper), [{
+      return build($_builder, $_state, veqTy, input, lower, upper,
+        quake::SubVeqOp::kDynamicIndex, quake::SubVeqOp::kDynamicIndex);
+    }]>,
+    OpBuilder<(ins "mlir::Type":$veqTy, "mlir::Value":$input,
+                   "std::int64_t":$lower, "std::int64_t":$upper), [{
+      return build($_builder, $_state, veqTy, input, {}, {}, lower, upper);
+    }]>
+  ];
+  
+  let extraClassDeclaration = [{
+    static constexpr std::size_t kDynamicIndex =
+      std::numeric_limits<std::size_t>::max();
+
+    bool hasConstantLowerBound() { return getRawLower() != kDynamicIndex; }
+    bool hasConstantUpperBound() { return getRawUpper() != kDynamicIndex; }
+    std::size_t getConstantLowerBound() { return getRawLower(); }
+    std::size_t getConstantUpperBound() { return getRawUpper(); }
+  }];
 }
 
 def quake_VeqSizeOp : QuakeOp<"veq_size", [Pure]> {
@@ -1298,11 +1324,12 @@ def ZOp : OneTargetOp<"z", [Hermitian]> {
   }];
 }
 
-def CustomUnitarySymbolOp : QuakeOperator<"custom_op", [], (ins SymbolRefAttr:$generator)> {
+def CustomUnitarySymbolOp :
+    QuakeOperator<"custom_op", [], (ins SymbolRefAttr:$generator)> {
   let summary = "Custom unitary operation.";
   let description = [{
-    Custom unitary operation leveraging a `SymbolRefAttr` describing the unitary 
-    data generator function. 
+    Custom unitary operation leveraging a `SymbolRefAttr` describing the
+    unitary data generator function. 
   }];
 
   let builders = [
@@ -1349,13 +1376,16 @@ def CustomUnitarySymbolOp : QuakeOperator<"custom_op", [], (ins SymbolRefAttr:$g
     OpBuilder<(ins "mlir::SymbolRefAttr":$generator,
                    "mlir::ValueRange":$controls,
                    "mlir::ValueRange":$targets), [{
-      return build($_builder, $_state, generator,  /*is_adj=*/false, controls, targets);
+      return build($_builder, $_state, generator,  /*is_adj=*/false, controls,
+                   targets);
     }]>,
     OpBuilder<(ins "mlir::SymbolRefAttr":$generator, "bool":$is_adj,
                    "mlir::ValueRange":$targets), [{
-      return build($_builder, $_state, generator, is_adj, mlir::ValueRange{}, targets);
+      return build($_builder, $_state, generator, is_adj, mlir::ValueRange{},
+                   targets);
     }]>,
-    OpBuilder<(ins "mlir::SymbolRefAttr":$generator, "mlir::ValueRange":$targets), [{
+    OpBuilder<(ins "mlir::SymbolRefAttr":$generator,
+                   "mlir::ValueRange":$targets), [{
       return build($_builder, $_state, generator, /*is_adj=*/false, targets);
     }]>
   ];

--- a/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
@@ -393,8 +393,18 @@ public:
         rtSubveqFuncName, arrayTy, {arrayTy, i32Ty, i64Ty, i64Ty, i64Ty},
         parentModule);
 
-    Value lowArg = adaptor.getOperands()[1];
-    Value highArg = adaptor.getOperands()[2];
+    auto lowArg = [&]() -> Value {
+      if (!adaptor.getLower())
+        return rewriter.create<arith::ConstantIntOp>(loc, adaptor.getRawLower(),
+                                                     64);
+      return adaptor.getLower();
+    }();
+    auto highArg = [&]() -> Value {
+      if (!adaptor.getUpper())
+        return rewriter.create<arith::ConstantIntOp>(loc, adaptor.getRawUpper(),
+                                                     64);
+      return adaptor.getUpper();
+    }();
     auto extend = [&](Value &v) -> Value {
       if (v.getType().isa<IntegerType>() &&
           v.getType().cast<IntegerType>().getWidth() < 64)

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "cudaq/Optimizer/Builder/Factory.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
@@ -411,9 +412,10 @@ parseRawIndex(OpAsmParser &parser,
   return success();
 }
 
-static void printRawIndex(OpAsmPrinter &printer, quake::ExtractRefOp refOp,
-                          Value index, IntegerAttr rawIndex) {
-  if (rawIndex.getValue() == quake::ExtractRefOp::kDynamicIndex)
+template <typename OP>
+void printRawIndex(OpAsmPrinter &printer, OP refOp, Value index,
+                   IntegerAttr rawIndex) {
+  if (rawIndex.getValue() == OP::kDynamicIndex)
     printer.printOperand(index);
   else
     printer << rawIndex.getValue();
@@ -686,70 +688,131 @@ void quake::RelaxSizeOp::getCanonicalizationPatterns(
 // SubVeqOp
 //===----------------------------------------------------------------------===//
 
+LogicalResult quake::SubVeqOp::verify() {
+  if ((hasConstantLowerBound() && getRawLower() == kDynamicIndex) ||
+      (!hasConstantLowerBound() && getRawLower() != kDynamicIndex))
+    return emitOpError("invalid lower bound specified");
+  if ((hasConstantUpperBound() && getRawUpper() == kDynamicIndex) ||
+      (!hasConstantUpperBound() && getRawUpper() != kDynamicIndex))
+    return emitOpError("invalid upper bound specified");
+  if (hasConstantLowerBound() && hasConstantUpperBound()) {
+    if (getRawLower() > getRawUpper())
+      return emitOpError("invalid subrange specified");
+    if (auto veqTy = dyn_cast<quake::VeqType>(getVeq().getType()))
+      if (veqTy.hasSpecifiedSize())
+        if (getRawLower() >= veqTy.getSize() ||
+            getRawUpper() >= veqTy.getSize())
+          return emitOpError(
+              "subveq range does not fully intersect the input veq");
+    if (auto veqTy = dyn_cast<quake::VeqType>(getResult().getType()))
+      if (veqTy.hasSpecifiedSize())
+        if (veqTy.getSize() != getRawUpper() - getRawLower() + 1)
+          return emitOpError("incorrect size for result veq type");
+  }
+  return success();
+}
+
 namespace {
+// %3 = quake.subveq %0, 4, 10 : (!quake.veq<12>, i64, i64) -> !quake.veq<?>
+// ─────────────────────────────────────────────────────────────────────────────
+// %new3 = quake.subveq %0, 4, 10 : (!quake.veq<12>, i64, i64) -> !quake.veq<7>
+// %3 = quake.relax_size %new3 : (!quake.veq<7>) -> !quake.veq<?>
+struct FixUnspecifiedSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(quake::SubVeqOp subveq,
+                                PatternRewriter &rewriter) const override {
+    auto veqTy = dyn_cast<quake::VeqType>(subveq.getType());
+    if (veqTy && veqTy.hasSpecifiedSize())
+      return failure();
+    if (!(subveq.hasConstantLowerBound() && subveq.hasConstantUpperBound()))
+      return failure();
+    auto *ctx = rewriter.getContext();
+    std::size_t size =
+        subveq.getConstantUpperBound() - subveq.getConstantLowerBound() + 1u;
+    auto szVecTy = quake::VeqType::get(ctx, size);
+    auto loc = subveq.getLoc();
+    auto subv = rewriter.create<quake::SubVeqOp>(
+        loc, szVecTy, subveq.getVeq(), subveq.getLower(), subveq.getUpper(),
+        subveq.getRawLower(), subveq.getRawUpper());
+    rewriter.replaceOpWithNewOp<quake::RelaxSizeOp>(subveq, veqTy, subv);
+    return success();
+  }
+};
+
+// %1 = constant 4 : i64
+// %2 = constant 10 : i64
+// %3 = quake.subveq %0, %1, %2 : (!quake.veq<12>, i64, i64) -> !quake.veq<?>
+// ─────────────────────────────────────────────────────────────────────────────
+// %3 = quake.subveq %0, 4, 10 : (!quake.veq<12>, i64, i64) -> !quake.veq<7>
+struct FuseConstantToSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(quake::SubVeqOp subveq,
+                                PatternRewriter &rewriter) const override {
+    if (subveq.hasConstantLowerBound() && subveq.hasConstantUpperBound())
+      return failure();
+    bool regen = false;
+    std::int64_t lo = subveq.getConstantLowerBound();
+    Value loVal = subveq.getLower();
+    if (!subveq.hasConstantLowerBound())
+      if (auto olo = cudaq::opt::factory::getIntIfConstant(subveq.getLower())) {
+        regen = true;
+        loVal = nullptr;
+        lo = *olo;
+      }
+
+    std::int64_t hi = subveq.getConstantUpperBound();
+    Value hiVal = subveq.getUpper();
+    if (!subveq.hasConstantUpperBound())
+      if (auto ohi = cudaq::opt::factory::getIntIfConstant(subveq.getUpper())) {
+        regen = true;
+        hiVal = nullptr;
+        hi = *ohi;
+      }
+
+    if (!regen)
+      return failure();
+    rewriter.replaceOpWithNewOp<quake::SubVeqOp>(
+        subveq, subveq.getType(), subveq.getVeq(), loVal, hiVal, lo, hi);
+    return success();
+  }
+};
+
+// Replace subveq operations that extract the entire original register with the
+// original register.
 struct RemoveSubVeqNoOpPattern : public OpRewritePattern<quake::SubVeqOp> {
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(quake::SubVeqOp subVeqOp,
                                 PatternRewriter &rewriter) const override {
-    // Replace subveq operations that extract the entire original register
-    // with the original register.
     auto origVeq = subVeqOp.getVeq();
-    auto low = subVeqOp.getLow();
-    auto high = subVeqOp.getHigh();
-
-    // The start of the subveq must be known
-    auto arithLow = low.getDefiningOp<arith::ConstantIntOp>();
-    if (!arithLow)
-      return failure();
-
-    // The end of the subveq must be known
-    auto arithHigh = high.getDefiningOp<arith::ConstantIntOp>();
-    if (!arithHigh)
-      return failure();
-
     // The original veq size must be known
     auto veqType = dyn_cast<quake::VeqType>(origVeq.getType());
     if (!veqType.hasSpecifiedSize())
       return failure();
+    if (!(subVeqOp.hasConstantLowerBound() && subVeqOp.hasConstantUpperBound()))
+      return failure();
 
-    // If the subveq is the whole register, than the
-    // start value must be 0
-    if (arithLow.value() != 0)
+    // If the subveq is the whole register, than the start value must be 0.
+    if (subVeqOp.getConstantLowerBound() != 0)
       return failure();
 
     // If the sizes are equal, then replace
-    if (static_cast<int64_t>(veqType.getSize()) == arithHigh.value() + 1) {
-      // this subveq is the whole original register, hence a no-op
-      rewriter.replaceOp(subVeqOp, origVeq);
-      return success();
-    }
+    if (veqType.getSize() != subVeqOp.getConstantUpperBound() + 1)
+      return failure();
 
-    // All else fail
-    return failure();
+    // this subveq is the whole original register, hence a no-op
+    rewriter.replaceOp(subVeqOp, origVeq);
+    return success();
   }
 };
 } // namespace
 
-Value quake::createSizedSubVeqOp(PatternRewriter &builder, Location loc,
-                                 OpResult result, Value inVec, Value lo,
-                                 Value hi) {
-  auto vecTy = result.getType().cast<quake::VeqType>();
-  auto *ctx = builder.getContext();
-  auto getVal = [&](Value v) {
-    auto vCon = cast<arith::ConstantOp>(v.getDefiningOp());
-    return static_cast<std::size_t>(
-        vCon.getValue().cast<IntegerAttr>().getInt());
-  };
-  std::size_t size = getVal(hi) - getVal(lo) + 1u;
-  auto szVecTy = quake::VeqType::get(ctx, size);
-  auto subveq = builder.create<quake::SubVeqOp>(loc, szVecTy, inVec, lo, hi);
-  return builder.create<quake::RelaxSizeOp>(loc, vecTy, subveq);
-}
-
 void quake::SubVeqOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                                   MLIRContext *context) {
-  patterns.add<FuseConstantToSubveqPattern, RemoveSubVeqNoOpPattern>(context);
+  patterns.add<FixUnspecifiedSubveqPattern, FuseConstantToSubveqPattern,
+               RemoveSubVeqNoOpPattern>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -8,6 +8,7 @@
 
 #include "PassDetails.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Dialect/Quake/Canonical.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -21,14 +22,6 @@ namespace cudaq::opt {
 #define DEBUG_TYPE "combine-quantum-alloc"
 
 using namespace mlir;
-
-static Value createCast(PatternRewriter &rewriter, Location loc, Value inVal) {
-  auto i64Ty = rewriter.getI64Type();
-  assert(inVal.getType() != rewriter.getIndexType() &&
-         "use of index type is deprecated");
-  return rewriter.create<cudaq::cc::CastOp>(loc, i64Ty, inVal,
-                                            cudaq::cc::CastOpMode::Unsigned);
-}
 
 namespace {
 struct Analysis {
@@ -83,69 +76,6 @@ public:
   Analysis &analysis;
 };
 
-class ExtractPat : public OpRewritePattern<quake::ExtractRefOp> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  // Replace a pattern such as:
-  // ```
-  //   %1 = ... : !quake.veq<4>
-  //   %2 = quake.subveq %1, %c2, %c3 : (!quake.veq<4>, i32, i32) ->
-  //        !quake.veq<2>
-  //   %3 = quake.extract_ref %2[0] : (!quake.veq<2>) -> !quake.ref
-  // ```
-  // with:
-  // ```
-  //   %1 = ... : !quake.veq<4>
-  //   %3 = quake.extract_ref %1[2] : (!uwake.veq<4>) -> !quake.ref
-  // ```
-  LogicalResult matchAndRewrite(quake::ExtractRefOp extract,
-                                PatternRewriter &rewriter) const override {
-    auto subveq = extract.getVeq().getDefiningOp<quake::SubVeqOp>();
-    if (!subveq || isa<quake::SubVeqOp>(subveq.getVeq().getDefiningOp()))
-      return failure();
-
-    Value offset;
-    auto loc = extract.getLoc();
-    Value low = subveq.getLow();
-    if (extract.hasConstantIndex()) {
-      Value cv = rewriter.create<arith::ConstantIntOp>(
-          loc, extract.getConstantIndex(), low.getType());
-      offset = rewriter.create<arith::AddIOp>(loc, cv, low);
-    } else {
-      Value cast1 = createCast(rewriter, loc, extract.getIndex());
-      Value cast2 = createCast(rewriter, loc, low);
-      offset = rewriter.create<arith::AddIOp>(loc, cast1, cast2);
-    }
-    rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(extract, subveq.getVeq(),
-                                                     offset);
-    return success();
-  }
-};
-
-class SubVeqPat : public OpRewritePattern<quake::SubVeqOp> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(quake::SubVeqOp subveq,
-                                PatternRewriter &rewriter) const override {
-    auto prior = subveq.getVeq().getDefiningOp<quake::SubVeqOp>();
-    if (!prior)
-      return failure();
-
-    auto loc = subveq.getLoc();
-    Value cast1 = createCast(rewriter, loc, prior.getLow());
-    Value cast2 = createCast(rewriter, loc, subveq.getLow());
-    Value cast3 = createCast(rewriter, loc, subveq.getHigh());
-    Value sum1 = rewriter.create<arith::AddIOp>(loc, cast1, cast2);
-    Value sum2 = rewriter.create<arith::AddIOp>(loc, cast1, cast3);
-    auto veqTy = subveq.getType();
-    rewriter.replaceOpWithNewOp<quake::SubVeqOp>(subveq, veqTy, prior.getVeq(),
-                                                 sum1, sum2);
-    return success();
-  }
-};
-
 class CombineQuantumAllocationsPass
     : public cudaq::opt::impl::CombineQuantumAllocationsBase<
           CombineQuantumAllocationsPass> {
@@ -194,7 +124,8 @@ public:
     {
       RewritePatternSet patterns(ctx);
       patterns.insert<AllocaPat>(ctx, analysis);
-      patterns.insert<ExtractPat, SubVeqPat>(ctx);
+      patterns.insert<quake::canonical::ExtractRefFromSubVeqPattern,
+                      quake::canonical::CombineSubVeqsPattern>(ctx);
       if (failed(applyPatternsAndFoldGreedily(func.getOperation(),
                                               std::move(patterns)))) {
         func.emitOpError("combining alloca, subveq, and extract ops failed");

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2395,9 +2395,14 @@ class PyASTBridge(ast.NodeVisitor):
                         if len(node.args):
                             # extract the `subveq`
                             startOff = arith.SubIOp(qrSize, self.popValue())
+                            dyna = IntegerAttr.get(self.getIntegerType(), -1)
                             self.pushValue(
-                                quake.SubVeqOp(self.getVeqType(), var, startOff,
-                                               endOff).result)
+                                quake.SubVeqOp(self.getVeqType(),
+                                               var,
+                                               dyna,
+                                               dyna,
+                                               lower=startOff,
+                                               upper=endOff).result)
                         else:
                             # extract the qubit...
                             self.pushValue(
@@ -2413,9 +2418,14 @@ class PyASTBridge(ast.NodeVisitor):
                             qrSize = self.popValue()
                             one = self.getConstantInt(1)
                             offset = arith.SubIOp(qrSize, one)
+                            dyna = IntegerAttr.get(self.getIntegerType(), -1)
                             self.pushValue(
-                                quake.SubVeqOp(self.getVeqType(), var, zero,
-                                               offset).result)
+                                quake.SubVeqOp(self.getVeqType(),
+                                               var,
+                                               dyna,
+                                               dyna,
+                                               lower=zero,
+                                               upper=offset).result)
                         else:
                             # extract the qubit...
                             self.pushValue(
@@ -2990,9 +3000,14 @@ class PyASTBridge(ast.NodeVisitor):
             if quake.VeqType.isinstance(var.type):
                 # Upper bound is exclusive
                 upperVal = arith.SubIOp(upperVal, self.getConstantInt(1)).result
+                dyna = IntegerAttr.get(self.getIntegerType(), -1)
                 self.pushValue(
-                    quake.SubVeqOp(self.getVeqType(), var, lowerVal,
-                                   upperVal).result)
+                    quake.SubVeqOp(self.getVeqType(),
+                                   var,
+                                   dyna,
+                                   dyna,
+                                   lower=lowerVal,
+                                   upper=upperVal).result)
             elif cc.StdvecType.isinstance(var.type):
                 eleTy = cc.StdvecType.getElementType(var.type)
                 ptrTy = cc.PointerType.get(self.ctx, eleTy)

--- a/python/tests/mlir/ast_compute_action.py
+++ b/python/tests/mlir/ast_compute_action.py
@@ -34,7 +34,7 @@ def test_control_kernel():
 # CHECK-DAG:           %[[VAL_3:.*]] = arith.constant 1 : i64
 # CHECK:           %[[VAL_4:.*]] = quake.veq_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 # CHECK:           %[[VAL_5:.*]] = arith.subi %[[VAL_4]], %[[VAL_1]] : i64
-# CHECK:           %[[VAL_6:.*]] = quake.subveq %[[VAL_0]], %[[VAL_2]], %[[VAL_5]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+# CHECK:           %[[VAL_6:.*]] = quake.subveq %[[VAL_0]], 0, %[[VAL_5]] : (!quake.veq<?>, i64) -> !quake.veq<?>
 # CHECK:           %[[VAL_7:.*]] = arith.subi %[[VAL_4]], %[[VAL_3]] : i64
 # CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_7]]] : (!quake.veq<?>, i64) -> !quake.ref
 # CHECK:           %[[VAL_9:.*]] = cc.create_lambda {

--- a/python/tests/mlir/ast_lambda_tuple_stmts.py
+++ b/python/tests/mlir/ast_lambda_tuple_stmts.py
@@ -30,7 +30,7 @@ def test_control_kernel():
 # CHECK-DAG:           %[[VAL_3:.*]] = arith.constant 1 : i64
 # CHECK:           %[[VAL_4:.*]] = quake.veq_size %[[VAL_0]] : (!quake.veq<?>) -> i64
 # CHECK:           %[[VAL_5:.*]] = arith.subi %[[VAL_4]], %[[VAL_1]] : i64
-# CHECK:           %[[VAL_6:.*]] = quake.subveq %[[VAL_0]], %[[VAL_2]], %[[VAL_5]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+# CHECK:           %[[VAL_6:.*]] = quake.subveq %[[VAL_0]], 0, %[[VAL_5]] : (!quake.veq<?>, i64) -> !quake.veq<?>
 # CHECK:           %[[VAL_7:.*]] = arith.subi %[[VAL_4]], %[[VAL_3]] : i64
 # CHECK:           %[[VAL_8:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_7]]] : (!quake.veq<?>, i64) -> !quake.ref
 # CHECK:           %[[VAL_9:.*]] = cc.create_lambda {

--- a/python/tests/mlir/ast_qreg_slice.py
+++ b/python/tests/mlir/ast_qreg_slice.py
@@ -59,17 +59,17 @@ def test_slice():
 # CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 5 : i64
 # CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 0 : i64
 # CHECK:           %[[VAL_7:.*]] = quake.alloca !quake.veq<4>
-# CHECK:           %[[VAL_8:.*]] = quake.subveq %[[VAL_7]], %[[VAL_2]], %[[VAL_0]] : (!quake.veq<4>, i64, i64) -> !quake.veq<2>
+# CHECK:           %[[VAL_8:.*]] = quake.subveq %[[VAL_7]], 2, 3 : (!quake.veq<4>) -> !quake.veq<2>
 # CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_9]] : (!quake.ref) -> ()
 # CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_10]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_11:.*]] = quake.subveq %[[VAL_7]], %[[VAL_6]], %[[VAL_3]] : (!quake.veq<4>, i64, i64) -> !quake.veq<2>
+# CHECK:           %[[VAL_11:.*]] = quake.subveq %[[VAL_7]], 0, 1 : (!quake.veq<4>) -> !quake.veq<2>
 # CHECK:           %[[VAL_12:.*]] = quake.extract_ref %[[VAL_11]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.y %[[VAL_12]] : (!quake.ref) -> ()
 # CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_11]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.y %[[VAL_13]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_14:.*]] = quake.subveq %[[VAL_7]], %[[VAL_3]], %[[VAL_2]] : (!quake.veq<4>, i64, i64) -> !quake.veq<2>
+# CHECK:           %[[VAL_14:.*]] = quake.subveq %[[VAL_7]], 1, 2 : (!quake.veq<4>) -> !quake.veq<2>
 # CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_14]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.z %[[VAL_15]] : (!quake.ref) -> ()
 # CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_14]][1] : (!quake.veq<2>) -> !quake.ref

--- a/python/tests/mlir/ghz.py
+++ b/python/tests/mlir/ghz.py
@@ -75,7 +75,7 @@ def test_ghz():
 # CHECK:           quake.h %[[VAL_7]] : (!quake.ref) -> ()
 # CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
 # CHECK:           %[[VAL_9:.*]] = arith.subi %[[VAL_8]], %[[VAL_1]] : i64
-# CHECK:           %[[VAL_10:.*]] = quake.subveq %[[VAL_6]], %[[VAL_3]], %[[VAL_9]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+# CHECK:           %[[VAL_10:.*]] = quake.subveq %[[VAL_6]], 0, %[[VAL_9]] : (!quake.veq<?>, i64) -> !quake.veq<?>
 # CHECK:           %[[VAL_11:.*]] = quake.veq_size %[[VAL_10]] : (!quake.veq<?>) -> i64
 # CHECK:           %[[VAL_12:.*]] = cc.alloca !cc.struct<{i64, !quake.ref}>{{\[}}%[[VAL_11]] : i64]
 # CHECK:           %[[VAL_13:.*]] = cc.loop while ((%[[VAL_14:.*]] = %[[VAL_3]]) -> (i64)) {

--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -99,7 +99,7 @@ struct run_circuit {
 // ADJOINT:           %[[VAL_10:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
 // ADJOINT:           %[[VAL_11:.*]] = cc.cast signed %[[VAL_10]] : (i32) -> i64
 // ADJOINT:           %[[VAL_12:.*]] = arith.subi %[[VAL_11]], %[[VAL_5]] : i64
-// ADJOINT:           %[[VAL_13:.*]] = quake.subveq %[[VAL_0]], %[[VAL_6]], %[[VAL_12]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+// ADJOINT:           %[[VAL_13:.*]] = quake.subveq %[[VAL_0]], 0, %[[VAL_12]] : (!quake.veq<?>, i64) -> !quake.veq<?>
 // ADJOINT:           %[[VAL_14:.*]] = quake.veq_size %[[VAL_13]] : (!quake.veq<?>) -> i64
 // ADJOINT:           %[[VAL_16:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
 // ADJOINT:           %[[VAL_18:.*]] = math.fpowi %[[VAL_2]], %[[VAL_16]] : f64, i32

--- a/test/AST-Quake/custom_operations.cpp
+++ b/test/AST-Quake/custom_operations.cpp
@@ -80,11 +80,10 @@ __qpu__ void kernel_4() {
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_kernel_4._Z8kernel_4v() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_1:.*]] = arith.constant 2 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<4>
-// CHECK:           %[[VAL_5:.*]] = quake.subveq %[[VAL_4]], %[[VAL_3]], %[[VAL_1]] : (!quake.veq<4>, i64, i64) -> !quake.veq<3>
+// CHECK:           %[[VAL_5:.*]] = quake.subveq %[[VAL_4]], 0, 2 : (!quake.veq<4>) -> !quake.veq<3>
 // CHECK:           %[[VAL_6:.*]] = cc.loop while ((%[[VAL_7:.*]] = %[[VAL_3]]) -> (i64)) {
 // CHECK:             %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_0]] : i64
 // CHECK:             cc.condition %[[VAL_8]](%[[VAL_7]] : i64)

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -268,7 +268,7 @@ int main() {
 // CHECK:           %[[VAL_17:.*]] = cc.load %[[VAL_10]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_18:.*]] = cc.cast signed %[[VAL_17]] : (i32) -> i64
 // CHECK:           %[[VAL_19:.*]] = arith.subi %[[VAL_18]], %[[VAL_6]] : i64
-// CHECK:           %[[VAL_20:.*]] = quake.subveq %[[VAL_16]], %[[VAL_7]], %[[VAL_19]] : (!quake.veq<?>, i64, i64) -> !quake.veq<?>
+// CHECK:           %[[VAL_20:.*]] = quake.subveq %[[VAL_16]], 0, %[[VAL_19]] : (!quake.veq<?>, i64) -> !quake.veq<?>
 // CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_11]] : !cc.ptr<i32>
 // CHECK:           %[[VAL_22:.*]] = cc.cast signed %[[VAL_21]] : (i32) -> i64
 // CHECK:           %[[VAL_23:.*]] = quake.veq_size %[[VAL_16]] : (!quake.veq<?>) -> i64

--- a/test/Quake/canonical-1.qke
+++ b/test/Quake/canonical-1.qke
@@ -47,10 +47,8 @@ func.func @test3() {
 }
 
 // CHECK-LABEL:   func.func @test3() {
-// CHECK:           %[[VAL_1:.*]] = arith.constant 7 : i64
-// CHECK:           %[[VAL_2:.*]] = arith.constant 4 : i64
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<10>
-// CHECK:           %[[VAL_4:.*]] = quake.subveq %[[VAL_3]], %[[VAL_2]], %[[VAL_1]] : (!quake.veq<10>, i64, i64) -> !quake.veq<4>
+// CHECK:           %[[VAL_4:.*]] = quake.subveq %[[VAL_3]], 4, 7 : (!quake.veq<10>) -> !quake.veq<4>
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_4]][2] : (!quake.veq<4>) -> !quake.ref
 // CHECK:           quake.h %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:           return

--- a/test/Quake/invalid.qke
+++ b/test/Quake/invalid.qke
@@ -71,3 +71,27 @@ func.func @test_struq() {
   %0 = quake.alloca !quake.struq<!quake.struq<!quake.veq<3>, !quake.ref>, !quake.veq<7>>
   return
 }
+
+// -----
+
+func.func @test_subveq(%0: !quake.veq<2>) {
+  // expected-error@+1 {{does not fully intersect}}
+  %1 = quake.subveq %0, 10, 10 : (!quake.veq<2>) -> !quake.veq<1>
+  return
+}
+
+// -----
+
+func.func @test_subveq(%0: !quake.veq<?>) {
+  // expected-error@+1 {{invalid subrange specified}}
+  %1 = quake.subveq %0, 10, 4 : (!quake.veq<?>) -> !quake.veq<?>
+  return
+}
+
+// -----
+
+func.func @test_subveq(%0: !quake.veq<?>) {
+  // expected-error@+1 {{incorrect size for result}}
+  %1 = quake.subveq %0, 8, 35 : (!quake.veq<?>) -> !quake.veq<1>
+  return
+}


### PR DESCRIPTION
There was some technical debt with quake.subveq where constant operands were not folded into the operation like extract_ref and many others.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
