### PR TITLE
Fix `NoiseModel` for single-precision backends

### DIFF
--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -78,10 +78,6 @@ void validateCompletenessRelation_fp64(const std::vector<kraus_op> &ops) {
         "Provided kraus_ops are not completely positive and trace preserving.");
 }
 
-kraus_channel::kraus_channel(std::vector<kraus_op> &_ops) : ops(_ops) {
-  validateCompleteness();
-}
-
 kraus_channel::kraus_channel(const kraus_channel &other)
     : ops(other.ops), noise_type(other.noise_type),
       parameters(other.parameters) {}

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -109,6 +109,10 @@ protected:
   std::vector<kraus_op> ops;
 
   /// @brief Validate that Sum K_i^† K_i = I
+  // Important: as this function dispatches different implementations based on
+  // `cudaq::complex`, which is a pre-processor define, do not call this in
+  // `NoiseModel.cpp`. `NoiseModel.cpp` is compiled as a `cudaq-common` library,
+  // which is not aware of the backend complex type.
   void validateCompleteness() {
     if constexpr (std::is_same_v<cudaq::complex::value_type, float>) {
       validateCompletenessRelation_fp32(ops);
@@ -122,7 +126,14 @@ public:
   noise_model_type noise_type = noise_model_type::unknown;
 
   /// @brief Noise parameter values
-  std::vector<real> parameters;
+  // Use `double` as the uniform type to store channel parameters (for both
+  // single- and double-precision channel definitions). Some
+  // `kraus_channel` methods, e.g., copy constructor/assignment, are implemented
+  // in `NoiseModel.cpp`, which is compiled to `cudaq-common` with
+  // double-precision configuration regardless of the backends.
+  // Hence, having a templated `parameters` member variable may cause data
+  // corruption.
+  std::vector<double> parameters;
 
   ~kraus_channel() = default;
 
@@ -143,7 +154,9 @@ public:
 
   /// @brief The constructor, take qubits and channel kraus_ops as lvalue
   /// reference
-  kraus_channel(std::vector<kraus_op> &ops);
+  kraus_channel(const std::vector<kraus_op> &inOps) : ops(inOps) {
+    validateCompleteness();
+  }
 
   /// @brief The constructor, take qubits and channel kraus_ops as rvalue
   /// reference


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

`NoiseModel.cpp` is having some dangling dependency on `host_config.h` (defining target-dependent data type).
This may cause data corruption when a `fp32` backend links to `libcudaq-common`, which is always compiled with fp64 config. 

In particular,

- A single instance of `validateCompleteness` is called in `.cpp` file -> the fix is to move it to the header.

- The `kraus_channel::parameters` is declared as a `host_config.h`'s `real` type. As we don't expect channels with a long list of parameters, I think it makes sense to just use `double` type instead. This prevents subtle issues with copy operators being implemented in `NoiseModel.cpp`.  
