### PR TITLE
[core] Let loop unrolling be added as a nested func pass manager.

### DIFF
--- a/python/tests/mlir/control.py
+++ b/python/tests/mlir/control.py
@@ -277,13 +277,13 @@ def test_sample_control_qubit_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
-# CHECK-DAG:       %[[VAL_0:.*]] = quake.alloca !quake.ref
-# CHECK-DAG:       %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
-# CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()
-# CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %{{[0-2]}} = quake.alloca !quake.ref
+# CHECK:           %{{[0-2]}} = quake.alloca !quake.ref
+# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%{{[0-2]}}) : (!quake.ref) -> ()
+# CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}[%{{[0-2]}}] %{{[0-2]}} : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
+# CHECK:           %[[VAL_2:.*]] = quake.mz %{{[0-2]}} name "" : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 
@@ -338,7 +338,7 @@ def test_sample_control_qreg_args():
 # CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
 # CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_5]]] %[[VAL_6]] : (!quake.veq<2>, !quake.ref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}[%[[VAL_5]]] %[[VAL_6]] : (!quake.veq<2>, !quake.ref) -> ()
 # CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_6]] name "" : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
@@ -390,13 +390,13 @@ def test_sample_apply_call_control():
 
 # CHECK-LABEL: test_sample_apply_call_control
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
-# CHECK-DAG:       %[[VAL_0:.*]] = quake.alloca !quake.ref
-# CHECK-DAG:       %[[VAL_1:.*]] = quake.alloca !quake.ref
-# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
-# CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()
-# CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.mz %[[VAL_1]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %{{[0-2]}} = quake.alloca !quake.ref
+# CHECK:           %{{[0-2]}} = quake.alloca !quake.ref
+# CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%{{[0-2]}}) : (!quake.ref) -> ()
+# CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}[%{{[0-2]}} %{{[0-2]}} : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
+# CHECK:           %[[VAL_2:.*]] = quake.mz %{{[0-2]}} name "" : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/mlir/control.py
+++ b/python/tests/mlir/control.py
@@ -394,7 +394,7 @@ def test_sample_apply_call_control():
 # CHECK:           %{{[0-2]}} = quake.alloca !quake.ref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%{{[0-2]}}) : (!quake.ref) -> ()
 # CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
-# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}[%{{[0-2]}} %{{[0-2]}} : (!quake.ref, !quake.ref) -> ()
+# CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} [%{{[0-2]}}] %{{[0-2]}} : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
 # CHECK:           %[[VAL_2:.*]] = quake.mz %{{[0-2]}} name "" : (!quake.ref) -> !quake.measure
 # CHECK:           return

--- a/python/tests/mlir/control.py
+++ b/python/tests/mlir/control.py
@@ -277,8 +277,8 @@ def test_sample_control_qubit_args():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK-DAG:       %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK-DAG:       %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
 # CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()
@@ -333,8 +333,8 @@ def test_sample_control_qreg_args():
 
 # CHECK-LABEL: test_sample_control_qreg_args
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
-# CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
-# CHECK:           %[[VAL_6:.*]] = quake.alloca !quake.ref
+# CHECK-DAG:       %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
+# CHECK-DAG:       %[[VAL_6:.*]] = quake.alloca !quake.ref
 # CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
 # CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
@@ -390,8 +390,8 @@ def test_sample_apply_call_control():
 
 # CHECK-LABEL: test_sample_apply_call_control
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"} {
-# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
-# CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+# CHECK-DAG:       %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK-DAG:       %[[VAL_1:.*]] = quake.alloca !quake.ref
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
 # CHECK:           quake.h %[[VAL_1]] : (!quake.ref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}{{\[}}%[[VAL_1]]] %[[VAL_0]] : (!quake.ref, !quake.ref) -> ()

--- a/test/Quake/memtoreg-7.qke
+++ b/test/Quake/memtoreg-7.qke
@@ -102,9 +102,9 @@ func.func @__nvqpp__mlirgen__test() attributes {"cudaq-entrypoint", qubitMeasure
 // CHECK:         }
 
 // CANOE-LABEL:   func.func @__nvqpp__mlirgen__test() attributes {"cudaq-entrypoint", qubitMeasurementFeedback = true} {
-// CANOE:           %[[VAL_0:.*]] = arith.constant 2 : i64
-// CANOE:           %[[VAL_1:.*]] = arith.constant false
-// CANOE:           %[[VAL_2:.*]] = arith.constant true
+// CANOE-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i64
+// CANOE-DAG:       %[[VAL_1:.*]] = arith.constant false
+// CANOE-DAG:       %[[VAL_2:.*]] = arith.constant true
 // CANOE:           %[[VAL_3:.*]] = quake.alloca !quake.ref
 // CANOE:           %[[VAL_4:.*]] = quake.alloca !quake.ref
 // CANOE:           %[[VAL_5:.*]] = cc.undef i1


### PR DESCRIPTION
Fixes some technical debt wrt loop unrolling to allow it to be used as it was intended. That is, as a nested pass on func::FuncOp ops. Tunes the loop unrolling pipeline to use strictly nested passes for better locality and performance.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
