### PR TITLE
[nvq++] Remove use of QTX.

### DIFF
--- a/lib/Optimizer/Transforms/PassDetails.h
+++ b/lib/Optimizer/Transforms/PassDetails.h
@@ -19,10 +19,6 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 
-namespace qtx {
-class CircuitOp;
-}
-
 namespace cudaq::opt {
 
 #define GEN_PASS_CLASSES


### PR DESCRIPTION
### Description
We missed this spot when `qtx` was absorbed into `quake`. 👻 
