### PR TITLE
[testing] Update passing tests

### DIFF
--- a/python/tests/backends/test_braket.py
+++ b/python/tests/backends/test_braket.py
@@ -51,10 +51,10 @@ def test_multi_qubit_kernel():
         mz(q0)
         mz(q1)
 
-    with pytest.raises(RuntimeError) as e:
-        cudaq.sample(kernel, shots_count=100)
-    assert "cannot declare a qubit register. Only 1 qubit register(s) is/are supported" in repr(
-        e)
+    counts = cudaq.sample(kernel, shots_count=100)
+    assert len(counts) == 2
+    assert "00" in counts
+    assert "11" in counts
 
 
 def test_qvector_kernel():
@@ -129,10 +129,8 @@ def test_multi_qvector():
         h(ancilla)
         mz(ancilla)
 
-    with pytest.raises(RuntimeError) as e:
-        cudaq.sample(kernel, shots_count=100)
-    assert "cannot declare a qubit register. Only 1 qubit register(s) is/are supported" in repr(
-        e)
+    # Test here is that this runs
+    cudaq.sample(kernel, shots_count=100).dump()
 
 
 def test_control_modifier():


### PR DESCRIPTION
Multiple qubit and qvector allocations and measurements are supported on the `braket` target with changes from PR# [2416](https://github.com/NVIDIA/cuda-quantum/pull/2416) . Hence, two of the tests pass, no longer raising error(s) - mark them as such.

