### PR TITLE
Allow setting noise on measurement operation and apply it accordingly

### DIFF
--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -256,7 +256,7 @@ protected:
   std::unordered_map<std::string, PredicateFuncTy> gatePredicates;
 
   static constexpr const char *availableOps[] = {
-      "x", "y", "z", "h", "s", "t", "rx", "ry", "rz", "r1", "u3"};
+      "x", "y", "z", "h", "s", "t", "rx", "ry", "rz", "r1", "u3", "mz"};
 
 public:
   /// @brief default constructor

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -1315,6 +1315,12 @@ public:
     // Flush the Gate Queue
     flushGateQueue();
 
+    // Apply measurement noise (if any)
+    // Note: gate noises are applied during flushGateQueue
+    if (executionContext && executionContext->noiseModel)
+      applyNoiseChannel(/*gateName=*/"mz", /*controls=*/{},
+                        /*targets=*/{qubitIdx}, /*params=*/{});
+
     // If sampling, just store the bit, do nothing else.
     if (handleBasicSampling(qubitIdx, registerName))
       return true;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- Add "mz" to the list of allowed ops (for validation purposes) in `NoiseModel`.

- Query noise channels for `mz` and apply them accordingly similar to the way we retrieve and apply gate noises.

- Add a unit test.
