### PR TITLE
[testing] Skip Python tests if dependency package missing

### DIFF
--- a/python/tests/operator/integrators/test_evolve_dynamics_torch_integrators.py
+++ b/python/tests/operator/integrators/test_evolve_dynamics_torch_integrators.py
@@ -7,6 +7,9 @@
 # ============================================================================ #
 import pytest
 import cudaq
+
+torch = pytest.importorskip("torch")
+
 # Note: the test model may create state, hence need to set the target to "dynamics"
 cudaq.set_target("dynamics")
 


### PR DESCRIPTION
Skip the 'test_evolve_dynamics_torch_integrators.py' tests if `torch` package not found.

