### PR TITLE
Updating docs version index

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -694,7 +694,7 @@ jobs:
           fi
 
           image_tag=`docker inspect $cudaq_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"'`
-          docs_version="CUDA_QUANTUM_VERSION=${image_tag%-base}"
+          docs_version="CUDA_QUANTUM_VERSION=$(echo $image_tag | sed -re 's/^(cu[0-9]+-)?(.*)-base$/\2/')"
           docker image rm $cudaq_image
           docker image prune --force
 

--- a/docs/sphinx/applications/python/divisive_clustering_src/main_divisive_clustering.py
+++ b/docs/sphinx/applications/python/divisive_clustering_src/main_divisive_clustering.py
@@ -27,7 +27,7 @@ argparser.add_argument(
     type=str,
     choices=["qpp-cpu", "nvidia", "nvidia-mgpu"],
     help=
-    "Quantum simulator backend. Default is qpp-cpu. See https://nvidia.github.io/cuda-quantum/0.6.0/using/simulators.html for more options.",
+    "Quantum simulator backend. Default is qpp-cpu. See https://nvidia.github.io/cuda-quantum for more options.",
 )
 argparser.add_argument(
     "-d",

--- a/docs/sphinx/applications/python/vqe_advanced.ipynb
+++ b/docs/sphinx/applications/python/vqe_advanced.ipynb
@@ -331,7 +331,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[\u001b[38;2;255;000;000mwarning\u001b[0m] Target \u001b[38;2;000;000;255mnvidia-mqpu\u001b[0m: \u001b[38;2;000;000;255mThis target is deprecating. Please use the 'nvidia' target with option 'mqpu,fp32' or 'mqpu' (fp32 is the default precision option) by adding the command line option '--target-option mqpu,fp32' or passing it as cudaq.set_target('nvidia', option='mqpu,fp32') in Python. Please refer to CUDA-Q \u001b]8;;https://nvidia.github.io/cuda-quantum/latest/using/backends/platform.html#nvidia-mqpu-platform\u001b\\documentation\u001b]8;;\u001b\\ for more information.\u001b[0m\n"
+      "[\u001b[38;2;255;000;000mwarning\u001b[0m] Target \u001b[38;2;000;000;255mnvidia-mqpu\u001b[0m: \u001b[38;2;000;000;255mThis target is deprecating. Please use the 'nvidia' target with option 'mqpu,fp32' or 'mqpu' (fp32 is the default precision option) by adding the command line option '--target-option mqpu,fp32' or passing it as cudaq.set_target('nvidia', option='mqpu,fp32') in Python. Please refer to CUDA-Q \u001b]8;;https://nvidia.github.io/cuda-quantum/latest/using/backends/platform\u001b\\documentation\u001b]8;;\u001b\\ for more information.\u001b[0m\n"
      ]
     }
    ],

--- a/docs/sphinx/examples/python/building_kernels.ipynb
+++ b/docs/sphinx/examples/python/building_kernels.ipynb
@@ -145,7 +145,7 @@
     "### Applying Gates\n",
     "\n",
     "\n",
-    "After a kernel is constructed, gates can be applied to start building out a quantum circuit. All the predefined gates in CUDA-Q can be found [here](https://nvidia.github.io/cuda-quantum/latest/api/default_ops.html#unitary-operations-on-qubits).\n",
+    "After a kernel is constructed, gates can be applied to start building out a quantum circuit. All the predefined gates in CUDA-Q can be found [here](https://nvidia.github.io/cuda-quantum/latest/api/default_ops).\n",
     "\n",
     "\n",
     "Gates can be applied to all qubits in a register:"

--- a/docs/sphinx/examples/python/building_kernels.py
+++ b/docs/sphinx/examples/python/building_kernels.py
@@ -100,8 +100,8 @@ kernel(state_to_pass)
 # ### Applying Gates
 #
 #
-# After a kernel is constructed, gates can be applied to start building out a quantum circuit. 
-# All the predefined gates in CUDA-Q can be found here: 
+# After a kernel is constructed, gates can be applied to start building out a quantum circuit.
+# All the predefined gates in CUDA-Q can be found here:
 # https://nvidia.github.io/cuda-quantum/api/default_ops.
 #
 #

--- a/docs/sphinx/examples/python/building_kernels.py
+++ b/docs/sphinx/examples/python/building_kernels.py
@@ -100,7 +100,9 @@ kernel(state_to_pass)
 # ### Applying Gates
 #
 #
-# After a kernel is constructed, gates can be applied to start building out a quantum circuit. All the predefined gates in CUDA-Q can be found [here](https://nvidia.github.io/cuda-quantum/latest/api/default_ops.html#unitary-operations-on-qubits).
+# After a kernel is constructed, gates can be applied to start building out a quantum circuit. 
+# All the predefined gates in CUDA-Q can be found here: 
+# https://nvidia.github.io/cuda-quantum/api/default_ops.
 #
 #
 # Gates can be applied to all qubits in a register:

--- a/docs/sphinx/examples/python/executing_kernels.ipynb
+++ b/docs/sphinx/examples/python/executing_kernels.ipynb
@@ -78,7 +78,7 @@
    "source": [
     "Note that there is a subtle difference between how `sample` is executed with the target device set to a simulator or with the target device set to a QPU. In simulation mode, the quantum state is built once and then sampled $s$ times where $s$ equals the `shots_count`. In hardware execution mode, the quantum state collapses upon measurement and hence needs to be rebuilt over and over again.\n",
     "\n",
-    "There are a number of helpful tools that can be found in the API [here](https://nvidia.github.io/cuda-quantum/latest/api/languages/python_api.html#cudaq.SampleResult) to process the `Sample_Result` object produced by `sample`."
+    "There are a number of helpful tools that can be found in the [API docs](https://nvidia.github.io/cuda-quantum/latest/api/languages/python_api) to process the `Sample_Result` object produced by `sample`."
    ]
   },
   {

--- a/docs/sphinx/releases.rst
+++ b/docs/sphinx/releases.rst
@@ -4,11 +4,34 @@ CUDA-Q Releases
 
 **latest**
 
-The latest version of CUDA-Q is on the main branch of our `GitHub repository <https://github.com/NVIDIA/cuda-quantum>`__ and is also available as a Docker image. More information about installing the nightly builds can be found :doc:`here <using/install/install>`
+The latest version of CUDA-Q is on the main branch of our `GitHub repository <https://github.com/NVIDIA/cuda-quantum>`__ 
+and is also available as a Docker image. More information about installing the nightly builds can be found 
+:doc:`here <using/install/install>`
 
 - `Docker image (nightly builds) <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nightly/containers/cuda-quantum>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/latest>`__
 - `Examples <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examples>`__
+
+**0.9.0**
+
+We are very excited to share a new toolset added for modeling and manipulating the dynamics of physical systems. 
+The new API allows to define and execute a time evolution under arbitrary operators. For more information, take 
+a look at the `docs <https://nvidia.github.io/cuda-quantum/0.9.0/using/backends/dynamics.html>`__.
+The 0.9.0 release furthermore includes a range of contribution to add new backends to CUDA-Q, including backends 
+from `Anyon Technologies <https://nvidia.github.io/cuda-quantum/0.9.0/using/backends/hardware.html#anyon-technologies-anyon-computing>`__, 
+`Ferimioniq <https://nvidia.github.io/cuda-quantum/0.9.0/using/backends/simulators.html#fermioniq>`__, and 
+`QuEra Computing <https://nvidia.github.io/cuda-quantum/0.9.0/using/backends/hardware.html#quera-computing>`__, 
+as well as updates to existing backends from `ORCA <https://nvidia.github.io/cuda-quantum/latest/using/backends/hardware.html#orca-computing>`__ 
+and `OQC <https://nvidia.github.io/cuda-quantum/0.9.0/using/backends/hardware.html#oqc>`__.
+We hope you enjoy the new features - also check out our new notebooks and examples to dive into CUDA-Q.
+
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum>`__
+- `Python wheel <https://pypi.org/project/cuda-quantum/0.9.0>`__
+- `C++ installer <https://github.com/NVIDIA/cuda-quantum/releases/0.9.0>`__
+- `Documentation <https://nvidia.github.io/cuda-quantum/0.9.0>`__
+- `Examples <https://github.com/NVIDIA/cuda-quantum/tree/releases/v0.9.0/docs/sphinx/examples>`__
+
+The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/releases/0.9.0>`__.
 
 **0.8.0**
 
@@ -17,7 +40,7 @@ The changes listed below highlight some of what we think will be the most useful
 to know about. While the listed changes do not capture all of the great contributions, we would like 
 to extend many thanks for every contribution, in particular those from external contributors.
 
-- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum>`__
+- `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.8.0>`__
 - `C++ installer <https://github.com/NVIDIA/cuda-quantum/releases/0.8.0>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.8.0>`__
@@ -30,7 +53,7 @@ The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/r
 The 0.7.1 release adds simulator optimizations with significant performance improvements and 
 extends their functionalities. The `nvidia-mgpu` backend now supports user customization of the 
 gate fusion level as controlled by the `CUDAQ_MGPU_FUSE` environment variable documented 
-`here <https://nvidia.github.io/cuda-quantum/latest/using/backends/simulators.html>`__.
+`here <https://nvidia.github.io/cuda-quantum/0.7.1/using/backends/simulators.html>`__.
 It furthermore adds a range of bug fixes and changes the Python wheel installation instructions.
 
 - `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/quantum/containers/cuda-quantum/tags>`__
@@ -46,7 +69,7 @@ The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/r
 The 0.7.0 release adds support for using :doc:`NVIDIA Quantum Cloud <using/backends/nvqc>`,
 giving you access to our most powerful GPU-accelerated simulators even if you don't have an NVIDIA GPU.
 With 0.7.0, we have furthermore greatly increased expressiveness of the Python and C++ language frontends. 
-Check out our `documentation <https://nvidia.github.io/cuda-quantum/latest/using/quick_start.html>`__ 
+Check out our `documentation <https://nvidia.github.io/cuda-quantum/0.7.0/using/quick_start.html>`__ 
 to get started with the new Python syntax support we have added, and `follow our blog <https://developer.nvidia.com/cuda-q>`__
 to learn more about the new setup and its performance benefits.
 


### PR DESCRIPTION
Forgot to do that before...
Links to docs in notebooks and python files are generally suboptimal; there is no way for them to link to the correct docs version, so we need to necessarily direct them to the latest. The links are also not validated, and will break without anything failing if the page is removed in future versions on the docs. I don't have a better idea than to try and keep them somewhat general and unlikely to break.