### PR TITLE
Fixes for Python notebooks

### DIFF
--- a/docs/sphinx/applications/python/digitized_counterdiabatic_qaoa.ipynb
+++ b/docs/sphinx/applications/python/digitized_counterdiabatic_qaoa.ipynb
@@ -44,16 +44,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import cudaq\n",
     "from cudaq import spin\n",
-    "import numpy as np\n",
-    "\n",
-    "cudaq.set_target('nvidia')\n",
-    "# cudaq.set_target('qpp-cpu') # Uncomment this line if no GPUs are available"
+    "import numpy as np\n"
    ]
   },
   {
@@ -65,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {

--- a/docs/sphinx/applications/python/hadamard_test.ipynb
+++ b/docs/sphinx/applications/python/hadamard_test.ipynb
@@ -37,7 +37,7 @@
     "![Htest2](./images/htestfactored.png)\n",
     "\n",
     "By preparing this circuit, and repeatedly measuring the ancilla qubit, we estimate the expectation value as $$P(0)-P(1) = Re \\bra{\\psi} O \\ket{\\phi}.$$\n",
-    "\,
+    "\n",
     "\n",
     "The following sections demonstrate how this can be performed in CUDA-Q."
    ]


### PR DESCRIPTION
* Fix for invalid notebook - hadamard_test.ipynb
* Remove explicit setting of target (default target is `nvidia` if GPU(s) present) - digitized_counterdiabatic_qaoa.ipynb

Address CI failures [here](https://github.com/NVIDIA/cuda-quantum/actions/runs/12283525967/job/34278485828?pr=2469).

Follow-up to PR# [2455](https://github.com/NVIDIA/cuda-quantum/pull/2455) and PR# [2467](https://github.com/NVIDIA/cuda-quantum/pull/2467)


