### PR TITLE
Fix uninitialized memory issue for the result buffer in kron call

### DIFF
--- a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cpp
+++ b/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cpp
@@ -216,7 +216,8 @@ protected:
     void *newDeviceStateVector;
     HANDLE_CUDA_ERROR(cudaMalloc((void **)&newDeviceStateVector,
                                  stateDimension * sizeof(CudaDataType)));
-
+    HANDLE_CUDA_ERROR(cudaMemset(newDeviceStateVector, 0,
+                                 stateDimension * sizeof(CudaDataType)));
     // Place the state data on device. Could be that
     // we just need the zero state, or the user could have provided one
     void *otherState;
@@ -282,6 +283,8 @@ protected:
     // Allocate new vector to place the kron prod result
     void *newDeviceStateVector;
     HANDLE_CUDA_ERROR(cudaMalloc((void **)&newDeviceStateVector,
+                                 stateDimension * sizeof(CudaDataType)));
+    HANDLE_CUDA_ERROR(cudaMemset(newDeviceStateVector, 0,
                                  stateDimension * sizeof(CudaDataType)));
     constexpr int32_t threads_per_block = 256;
     uint32_t n_blocks =


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

The kron kernel performs an accumulation-type operation (not an assignment) on the result buffer. Hence, this buffer must be initialized.

https://github.com/NVIDIA/cuda-quantum/blob/5785e44256b757263879580c82cb84adc85bcf5a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cu#L81

This issue only popped up intermittently if `cudaMalloc` returns a dirty buffer but can be observed reliably with `compute-sanitizer` (thanks @bmhowe23) 
