### PR TITLE
Checking for the build config status

### DIFF
--- a/scripts/build_cudaq.sh
+++ b/scripts/build_cudaq.sh
@@ -186,7 +186,7 @@ fi
 # Check if cmake succeeded
 if [ "$status" -ne 0 ]; then
   echo -e "\e[01;31mError: CMake configuration failed. Please check logs/cmake_error.txt for details.\e[0m" >&2
-  cat logs/cmake_error.txt
+  cat logs/cmake_error.txt >&2
   cd "$working_dir" && (return 0 2>/dev/null) && return 1 || exit 1
 fi
 


### PR DESCRIPTION
Fixes #2410 

# Output

Tried setting CUQUANTUM_INSTALL_PREFIX to some invalid path

```
root@0a258c0dfa5e:/workspaces/cuda-quantum# bash scripts/build_cudaq.sh
CUDA version 12.0 detected.
No cuQuantum installation detected. Please set the environment variable CUQUANTUM_INSTALL_PREFIX to enable cuQuantum integration.
Some backends will be omitted from the build.
Using cuTensor installation in /usr/local/lib/python3.10/dist-packages/cutensor.
find: ‘/invalid/path’: No such file or directory
Preparing CUDA-Q build with LLVM installation in /invalid/path...
Error: CMake configuration failed. Please check logs/cmake_error.txt for details.
Skipping submodule 'tpls/llvm'
WARNING: Skipped stim_test target. `GTest` not found. To fix, follow Standalone CMake Project install instructions at https://github.com/google/googletest/blob/master/googletest/README.md
WARNING: Skipped stim_python_bindings target. `pybind11` not found. To fix, install pybind11. On debian based distributions, the package name is `pybind11-dev`
CMake Error at runtime/nvqir/custatevec/CMakeLists.txt:27 (message):
  

  Unable to find custatevec installation.  Please ensure it is correctly
  installed and set and define CUSTATEVEC_ROOT if necessary (currently set
  to: /invalid/path).
```