### PR TITLE
Apply LLVM customizations for Python wheel build

### DIFF
--- a/docker/build/devdeps.manylinux.Dockerfile
+++ b/docker/build/devdeps.manylinux.Dockerfile
@@ -85,8 +85,11 @@ RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.2
 # Build the the LLVM libraries and compiler toolchain needed to build CUDA-Q.
 ADD ./scripts/build_llvm.sh /scripts/build_llvm.sh
 ADD ./cmake/caches/LLVM.cmake /cmake/caches/LLVM.cmake
+ADD ./tpls/customizations/llvm/ /tpls/customizations/llvm/
 RUN LLVM_PROJECTS='clang;mlir' LLVM_SOURCE=/llvm-project \
     LLVM_CMAKE_CACHE=/cmake/caches/LLVM.cmake \
+    LLVM_CMAKE_PATCHES=/tpls/customizations/llvm \
+    LLVM_APPLY_PATCHES=true \
     bash /scripts/build_llvm.sh -c Release -v
     # No clean up of the build or source directory,
     # since we need to re-build llvm for each python version to get the bindings.

--- a/docker/build/devdeps.manylinux.Dockerfile
+++ b/docker/build/devdeps.manylinux.Dockerfile
@@ -89,7 +89,6 @@ ADD ./tpls/customizations/llvm/ /tpls/customizations/llvm/
 RUN LLVM_PROJECTS='clang;mlir' LLVM_SOURCE=/llvm-project \
     LLVM_CMAKE_CACHE=/cmake/caches/LLVM.cmake \
     LLVM_CMAKE_PATCHES=/tpls/customizations/llvm \
-    LLVM_APPLY_PATCHES=true \
     bash /scripts/build_llvm.sh -c Release -v
     # No clean up of the build or source directory,
     # since we need to re-build llvm for each python version to get the bindings.

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -86,6 +86,7 @@ if [ -z "${llvm_projects##*python-bindings;*}" ]; then
 fi
 
 # Prepare the source and build directory.
+LLVM_APPLY_PATCHES=${LLVM_APPLY_PATCHES:-false}
 if [ ! -d "$LLVM_SOURCE" ] || [ -z "$(ls -A "$LLVM_SOURCE"/* 2> /dev/null)" ]; then
   echo "Cloning LLVM submodule..."
   cd "$this_file_dir" && cd $(git rev-parse --show-toplevel)
@@ -93,6 +94,9 @@ if [ ! -d "$LLVM_SOURCE" ] || [ -z "$(ls -A "$LLVM_SOURCE"/* 2> /dev/null)" ]; t
   llvm_repo="$(git config --file=.gitmodules submodule.tpls/llvm.url)"
   llvm_commit="$(git submodule | grep tpls/llvm | cut -c2- | cut -d ' ' -f1)"
   git clone --filter=tree:0 "$llvm_repo" "$LLVM_SOURCE"
+  LLVM_APPLY_PATCHES=true
+fi
+if $LLVM_APPLY_PATCHES; then
   cd "$LLVM_SOURCE" && git checkout $llvm_commit
 
   LLVM_CMAKE_PATCHES=${LLVM_CMAKE_PATCHES:-"$this_file_dir/../tpls/customizations/llvm"}


### PR DESCRIPTION
This PR fixes an LLVM discrepancy in our Docker images vs our Python wheels. This should fix #1421 and #1799 for our Python wheels. (The Docker images were already correct.)

| Platform  | Are CUDA-Q Python Wheels Sensitive to the [LLVM ARM Relocation Overflow](https://github.com/llvm/llvm-project/issues/71963)?  | Are CUDA-Q Python Wheels Sensitive to the [MLIR Region Simplification Bug](https://github.com/llvm/llvm-project/issues/94520)? |
| ------ | ------------- | ------------- |
| **x86_64**  | 🟢 --> 🟢 (already good)  | 🔴 --> 🟢   |
| **aarch64**  | 🔴 --> 🟢    | 🔴 --> 🟢   |

Just to complicate things even more than they already are, our 0.9.*, the Python wheels were already showing correct behavior for the exact test case in #1799. The exact reason is spelled out in the details of #1799. However, the above table describes the theoretical situation that we **could've** been vulnerable to the region simplification bug in other conditions.

