### PR TITLE
[Tensornet] Update observe calculation

### DIFF
--- a/docs/sphinx/using/backends/simulators.rst
+++ b/docs/sphinx/using/backends/simulators.rst
@@ -497,6 +497,12 @@ Specific aspects of the simulation can be configured by setting the following of
   As we use an opaque spin operator term as a placeholder for contraction path optimization, the resulting contraction path is not as optimal as if the actual spin operator is used.
   For instance, if the spin operator is sparse (only acting on a few qubits), the contraction can be significantly simplified.  
 
+.. note:: 
+
+  :code:`tensornet` backends only return the overall expectation value for a :class:`cudaq.SpinOperator` when using the `cudaq::observe` method. 
+  Term-by-term expectation values will not be available in the resulting `ObserveResult` object.
+  If needed, these values can be computed by calling `cudaq::observe` on individual terms instead.  
+
 Matrix product state 
 +++++++++++++++++++++++++++++++++++
 

--- a/docs/sphinx/using/backends/simulators.rst
+++ b/docs/sphinx/using/backends/simulators.rst
@@ -482,6 +482,7 @@ Specific aspects of the simulation can be configured by setting the following of
 * **`OMP_PLACES=cores`**: Set this environment variable to improve CPU parallelization.
 * **`OMP_NUM_THREADS=X`**: To enable CPU parallelization, set X to `NUMBER_OF_CORES_PER_NODE/NUMBER_OF_GPUS_PER_NODE`.
 * **`CUDAQ_TENSORNET_CONTROLLED_RANK=X`**: Specify the number of controlled qubits whereby the full tensor body of the controlled gate is expanded. If the number of controlled qubits is greater than this value, the gate is applied as a controlled tensor operator to the tensor network state. Default value is 1.
+* **`CUDAQ_TENSORNET_OBSERVE_CONTRACT_PATH_REUSE=X`**: Set this environment variable to `TRUE` (`ON`) or `FALSE` (`OFF`) to enable or disable contraction path reuse when computing expectation values. Default is `OFF`.
 
 .. note:: 
 
@@ -489,6 +490,12 @@ Specific aspects of the simulation can be configured by setting the following of
   If you do not have these dependencies installed, you may encounter an error stating `Invalid simulator requested`. 
   See the section :ref:`dependencies-and-compatibility` for more information about how to install dependencies.
 
+.. note:: 
+
+  When using contraction path reuse (`CUDAQ_TENSORNET_OBSERVE_CONTRACT_PATH_REUSE=TRUE`), :code:`tensornet` backends perform a single contraction path optimization with an opaque spin operator term. This path is then used to contract all the actual terms in the spin operator, hence saving the path finding time.
+
+  As we use an opaque spin operator term as a placeholder for contraction path optimization, the resulting contraction path is not as optimal as if the actual spin operator is used.
+  For instance, if the spin operator is sparse (only acting on a few qubits), the contraction can be significantly simplified.  
 
 Matrix product state 
 +++++++++++++++++++++++++++++++++++

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.h
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.h
@@ -103,6 +103,12 @@ protected:
   // cutensornetStateApplyControlledTensorOperator). Tensornet supports
   // arbitrary values.
   std::size_t m_maxControlledRankForFullTensorExpansion = 1;
+
+  // Should we reuse contraction path when computing the expectation value
+  // (observe)? Reusing the path, while saving the path finding time, prevents
+  // lightcone simplification, e.g., when the spin op is sparse (only acting on
+  // a few quibits).
+  bool m_reuseContractionPathObserve = false;
 };
 
 } // end namespace nvqir

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.h
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.h
@@ -104,10 +104,12 @@ protected:
   // arbitrary values.
   std::size_t m_maxControlledRankForFullTensorExpansion = 1;
 
-  // Should we reuse contraction path when computing the expectation value
-  // (observe)? Reusing the path, while saving the path finding time, prevents
-  // lightcone simplification, e.g., when the spin op is sparse (only acting on
-  // a few quibits).
+  // Flag to enable contraction path reuse when computing the expectation value
+  // (observe).
+  //   Default is off (no contraction path reuse).
+  //   Reusing the path, while saving the path finding time, prevents lightcone
+  //   simplification, e.g., when the spin op is sparse (only acting on a few
+  //   qubits).
   bool m_reuseContractionPathObserve = false;
 };
 

--- a/runtime/nvqir/cutensornet/tensornet_state.h
+++ b/runtime/nvqir/cutensornet/tensornet_state.h
@@ -151,6 +151,11 @@ public:
   std::vector<std::complex<double>>
   computeExpVals(const std::vector<std::vector<bool>> &symplecticRepr);
 
+  /// @brief Evaluate the expectation value of a given
+  /// `cutensornetNetworkOperator_t`
+  std::complex<double>
+  computeExpVal(cutensornetNetworkOperator_t tensorNetworkOperator);
+
   /// @brief Number of qubits that this state represents.
   std::size_t getNumQubits() const { return m_numQubits; }
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -221,6 +221,28 @@ if(TARGET nvqir-tensornet)
       endif() # NGPUS
     endif() # NVIDIA_SMI
   endif() # MPI_CXX_FOUND
+  
+  # Test CUDAQ_TENSORNET_OBSERVE_CONTRACT_PATH_REUSE=ON mode (on a few test cases that have cudaq::observe)
+  add_executable(test_tensornet_observe_path_reuse 
+    integration/builder_tester.cpp  
+    integration/deuteron_variational_tester.cpp
+    integration/observe_result_tester.cpp
+  )
+  target_include_directories(test_tensornet_observe_path_reuse PRIVATE .)
+  target_compile_definitions(test_tensornet_observe_path_reuse 
+                             PRIVATE -DNVQIR_BACKEND_NAME=tensornet)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
+    target_link_options(test_tensornet_observe_path_reuse PRIVATE -Wl,--no-as-needed)
+  endif()
+  target_link_libraries(test_tensornet_observe_path_reuse
+    PRIVATE 
+    cudaq
+    cudaq-builder
+    cudaq-platform-default
+    nvqir-tensornet
+    gtest_main)
+  # Run this test with "CUDAQ_TENSORNET_OBSERVE_CONTRACT_PATH_REUSE=TRUE"
+  gtest_discover_tests(test_tensornet_observe_path_reuse TEST_SUFFIX _PathReuse PROPERTIES ENVIRONMENT "CUDAQ_TENSORNET_OBSERVE_CONTRACT_PATH_REUSE=ON" PROPERTIES LABELS "gpu_required")
 endif() 
 
 # Create an executable for SpinOp UnitTests

--- a/unittests/integration/observe_result_tester.cpp
+++ b/unittests/integration/observe_result_tester.cpp
@@ -83,6 +83,9 @@ CUDAQ_TEST(ObserveResult, checkSimple) {
   EXPECT_TRUE(x0x1Counts.size() == 4);
 }
 
+// By default, tensornet backends only compute the overall expectation value in
+// observe, i.e., no sub-term calculations.
+#ifndef CUDAQ_BACKEND_TENSORNET
 CUDAQ_TEST(ObserveResult, checkExpValBug) {
 
   auto kernel = []() __qpu__ {
@@ -111,4 +114,5 @@ CUDAQ_TEST(ObserveResult, checkExpValBug) {
   printf("exp %lf \n", exp);
   EXPECT_NEAR(exp, .79, 1e-1);
 }
+#endif
 #endif


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- Restore the code path for computing expectation value by `cutensornetNetworkOperator_t`. This was removed in https://github.com/NVIDIA/cuda-quantum/pull/2397.

- Add an environment variable to select the two modes.

- Remove the state norm calculation.
