### PR TITLE
[quera] Fix C++ frontend behavior

### DIFF
--- a/runtime/cudaq/platform/quera/CMakeLists.txt
+++ b/runtime/cudaq/platform/quera/CMakeLists.txt
@@ -6,21 +6,10 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-target_sources(cudaq-rest-qpu PRIVATE QuEraExecutor.cpp QuEraServerHelper.cpp)
-
-add_library(cudaq-serverhelper-quera SHARED QuEraExecutor.cpp QuEraServerHelper.cpp )
-target_link_libraries(cudaq-serverhelper-quera
-  PUBLIC 
-    cudaq-serverhelper-braket
-    cudaq-common 
-    fmt::fmt-header-only 
-)
-install(TARGETS cudaq-serverhelper-quera DESTINATION lib)
-
 set(LIBRARY_NAME cudaq-quera-qpu)
 message(STATUS "Building QuEra REST QPU.")
 
-add_library(${LIBRARY_NAME} SHARED QuEraRemoteRESTQPU.cpp)
+add_library(${LIBRARY_NAME} SHARED QuEraExecutor.cpp QuEraRemoteRESTQPU.cpp QuEraServerHelper.cpp)
 
 target_include_directories(${LIBRARY_NAME} PRIVATE .
     PUBLIC 

--- a/runtime/cudaq/platform/quera/QuEraBaseQPU.h
+++ b/runtime/cudaq/platform/quera/QuEraBaseQPU.h
@@ -63,7 +63,8 @@ public:
 
   void launchKernel(const std::string &kernelName,
                     const std::vector<void *> &rawArgs) override {
-    throw std::runtime_error("Not supported on this target.");
+    throw std::runtime_error(
+        "Arbitrary kernel execution is not supported on this target.");
   }
 };
 } // namespace cudaq

--- a/runtime/cudaq/platform/quera/quera.yml
+++ b/runtime/cudaq/platform/quera/quera.yml
@@ -11,6 +11,8 @@ description: "CUDA-Q target for QuEra."
 config:
   # Tell DefaultQuantumPlatform what QPU subtype to use
   platform-qpu: quera
+  # Tell NVQ++ to generate glue code to set the target backend name
+  gen-target-backend: true
   # Add the quera-qpu library to the link list
   link-libs: ["-lcudaq-quera-qpu"]
   # Library mode is only for simulators, physical backends must turn this off

--- a/targettests/quera/unsupported_arbitrary_kernel.cpp
+++ b/targettests/quera/unsupported_arbitrary_kernel.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ %cpp_std --target quera %s -o %t.x
+// RUN: not %t.x 2>&1 | FileCheck %s
+// RUN: nvq++ %cpp_std --target quera --emulate %s -o %t.x
+// RUN: not %t.x 2>&1 | FileCheck %s
+
+#include <cudaq.h>
+
+auto bell = []() __qpu__ {
+  cudaq::qvector q(2);
+  h(q[0]);
+  x<cudaq::ctrl>(q[0], q[1]);
+};
+
+int main() {
+  auto counts = cudaq::sample(bell);
+  counts.dump();
+  return 0;
+}
+
+// CHECK: Arbitrary kernel execution is not supported on this target


### PR DESCRIPTION
As of CUDA-Q release version 0.9.1, the `quera` backend is supported only on Python frontend.
Prior to the changes proposed in this PR, if `quera` target was set from C++, it proceeded to use the default simulator and executed the circuit. With this change, an error will be thrown.
