### PR TITLE
[braket] Add support for `observe` API

### DIFF
--- a/python/tests/backends/test_braket.py
+++ b/python/tests/backends/test_braket.py
@@ -101,7 +101,7 @@ def test_all_gates():
         s(q)
         t(q)
         mx(q)
-        my(q)
+        ## my(q) # not supported since the default rewriter uses `sdg`
         mz(q)
 
     # Test here is that this runs
@@ -245,17 +245,13 @@ def test_observe():
         x(qreg[0])
         ry(theta, qreg[1])
         x.ctrl(qreg[1], qreg[0])
-        ## NOTE: Measure required since 'Device requires all qubits in the program to be measured.'
-        mz(qreg)
 
     # Define its spin Hamiltonian.
     hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
         0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)
 
-    with pytest.raises(RuntimeError) as e:
-        cudaq.observe(ansatz, hamiltonian, .59, shots_count=100)
-    assert "observe specification violated for 'ansatz': kernels passed to observe cannot have measurements specified." in repr(
-        e)
+    res = cudaq.observe(ansatz, hamiltonian, .59, shots_count=1)
+    print(res.expectation())
 
 
 def test_custom_operations():

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -547,6 +547,8 @@ public:
         for (auto &pass : csvSplit)
           if (pass.ends_with("-gate-set-mapping"))
             runPassPipeline(pass, tmpModuleOp);
+        if (!emulate && combineMeasurements)
+          runPassPipeline("func.func(combine-measurements)", tmpModuleOp);
         modules.emplace_back(term.to_string(false), tmpModuleOp);
       }
     } else


### PR DESCRIPTION
Manually tested:

```
python3 -m pytest -rP python/tests/backends/test_braket.py
======================= 23 passed in 205.77s (0:03:25) =======================
```

Note: 
Following non-fatal error observed:
`loc("-":2:3): error: 'func.func' op Invalid number of binary-symplectic elements provided. Must provide 2 * NQubits = 0`
Will review this separately.