### PR TITLE
Add support for -j option for build_cudaq.sh script

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -19,6 +19,10 @@ To build the CUDA-Q source code locally, fork this repository and follow the
 [instructions for setting up your environment](./Dev_Setup.md). Once you have
 done that, you should be able to run the [build
 script](./scripts/build_cudaq.sh) to build and install CUDA-Q in a local folder.
+If you run out of memory while building CUDA-Q, you can limit the number of
+parallel build jobs by passing `-j N` to the build script, where `N` is the
+number of parallel jobs you wish to allow. Lower values of `N` are less likely
+to run out of memory but will build slower.
 The path where CUDA-Q will be installed can be configured by setting the
 environment variable `CUDAQ_INSTALL_PREFIX`. If you customize this path or do
 not work in our development container, you either need to invoke the

--- a/scripts/build_cudaq.sh
+++ b/scripts/build_cudaq.sh
@@ -45,14 +45,17 @@ CUDAQ_INSTALL_PREFIX=${CUDAQ_INSTALL_PREFIX:-"$HOME/.cudaq"}
 build_configuration=${CMAKE_BUILD_TYPE:-Release}
 verbose=false
 install_toolchain=""
+num_jobs=""
 
 __optind__=$OPTIND
 OPTIND=1
-while getopts ":c:t:v" opt; do
+while getopts ":c:t:j:v" opt; do
   case $opt in
     c) build_configuration="$OPTARG"
     ;;
     t) install_toolchain="$OPTARG"
+    ;;
+    j) num_jobs="-j $OPTARG"
     ;;
     v) verbose=true
     ;;
@@ -194,11 +197,11 @@ fi
 echo "Building CUDA-Q with configuration $build_configuration..."
 logs_dir=`pwd`/logs
 if $verbose; then 
-  ninja install
+  ninja ${num_jobs} install
   status=$?
 else
   echo "The progress of the build is being logged to $logs_dir/ninja_output.txt."
-  ninja install 2> "$logs_dir/ninja_error.txt" 1> "$logs_dir/ninja_output.txt"
+  ninja ${num_jobs} install 2> "$logs_dir/ninja_error.txt" 1> "$logs_dir/ninja_output.txt"
   status=$?
 fi
 


### PR DESCRIPTION
This is needed for some build environments that have a high CPU-to-memory ratio because without this change, ninja spawns too many jobs, and the machine can run out of memory.