### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.7
+    hooks:
+      - id: clang-format
+  - repo: https://github.com/google/yapf
+    rev: v0.43.0
+    hooks:
+      - id: yapf-diff

--- a/Developing.md
+++ b/Developing.md
@@ -61,6 +61,11 @@ for Python. The CUDA-Q internals on the other hand follow the [MLIR/LLVM style
 guide][llvm_style]. Please ensure that your code includes comprehensive doc
 comments as well as a comment at the top of the file to indicating its purpose.
 
+`pre-commit` is being test-flown in this repository. If you have the tool
+installed or are using the provided Dev container, run `pre-commit install` to
+enable the hooks. `clang-format` and `yapf` will be automatically run on all
+staged changes.
+
 [python_style]: https://google.github.io/styleguide/pyguide.html
 [cpp_style]: https://www.gnu.org/prep/standards/standards.html
 [llvm_style]: https://llvm.org/docs/CodingStandards.html

--- a/docker/build/cudaq.dev.Dockerfile
+++ b/docker/build/cudaq.dev.Dockerfile
@@ -10,9 +10,9 @@
 # Build from the repo root with
 #   docker build -t nvidia/cuda-quantum-dev:latest -f docker/build/cudaq.dev.Dockerfile .
 #
-# If a custom base image is used, then that image (i.e. the build environment) must 
+# If a custom base image is used, then that image (i.e. the build environment) must
 # 1) have all the necessary build dependendencies installed
-# 2) define the LLVM_INSTALL_PREFIX environment variable indicating where the 
+# 2) define the LLVM_INSTALL_PREFIX environment variable indicating where the
 #    the LLVM binaries that CUDA-Q depends on are installed
 # 3) set the CC and CXX environment variable to use the same compiler toolchain
 #    as the LLVM dependencies have been built with.
@@ -41,8 +41,13 @@ RUN if [ -n "$mpi" ]; \
 		fi \
     fi
 
+# Install pre-commit
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && python3 -m pip install --no-cache-dir pre-commit==4.1.0 \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Configuring a base image that contains the necessary dependencies for GPU
-# accelerated components and passing a build argument 
+# accelerated components and passing a build argument
 #   install="CMAKE_BUILD_TYPE=Release CUDA_QUANTUM_VERSION=latest"
 # creates a dev image that can be used as argument to docker/release/cudaq.Dockerfile
 # to create the released cuda-quantum image.


### PR DESCRIPTION
### Description
Adds `pre-commit` to the repository on an opt-in basis. Requires a one-time `pre-commit install` from either inside the dev container or a user setup that already has `pre-commit` installed.
