### PR TITLE
Add a precision `enum` to `kraus_op` to track the underlying data type

### DIFF
--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: fdea89e034c7ac6b6b3d0e239d8924bcd2c08f96
+nvidia-mgpu-commit: 02cb381cb54b0c11de8b8aaa75ccff2fdd0a2e0d

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -46,6 +46,15 @@ struct kraus_op {
   /// NOTE we currently assume nRows == nCols
   std::size_t nCols = 0;
 
+  /// @brief The precision of the underlying data
+  // This data is populated when a `kraus_op` is created and can be used to
+  // introspect `kraus_op` objects across library boundary (e.g., when dynamic
+  // linking is involved).
+  const cudaq::simulation_precision precision =
+      std::is_same_v<cudaq::complex::value_type, float>
+          ? cudaq::simulation_precision::fp32
+          : cudaq::simulation_precision::fp64;
+
   /// @brief Copy constructor
   kraus_op(const kraus_op &) = default;
 

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -51,9 +51,8 @@ struct kraus_op {
   // introspect `kraus_op` objects across library boundary (e.g., when dynamic
   // linking is involved).
   const cudaq::simulation_precision precision =
-      std::is_same_v<cudaq::complex::value_type, float>
-          ? cudaq::simulation_precision::fp32
-          : cudaq::simulation_precision::fp64;
+      std::is_same_v<cudaq::real, float> ? cudaq::simulation_precision::fp32
+                                         : cudaq::simulation_precision::fp64;
 
   /// @brief Copy constructor
   kraus_op(const kraus_op &) = default;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

(1) Adding a const `enum` data member to `kraus_op`, which tracks the actual data type of the matrix at the point of construction.

This allows introspection when not all codes are compiled in the same compilation unit, e.g., our Python binding lib and the backend lib. 


Addressing https://github.com/NVIDIA/cuda-quantum/issues/2550

This issue only surfaced since https://github.com/NVIDIA/cuda-quantum/pull/2466, which adds an fp32 simulator backend that can handle noise.

(2) Update the downstream gitlab commit hash containing the corresponding change.
