### PR TITLE
[rt] Add missing header.

### DIFF
--- a/runtime/cudaq/qis/pauli_word.h
+++ b/runtime/cudaq/qis/pauli_word.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <ctype.h>
 #include <string>
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
Missing `cstdint` header for `std::uint64_t`.
