### PR TITLE
[rt] Add requirement to find `cudensitymat.h`

### DIFF
--- a/runtime/nvqir/cudensitymat/CMakeLists.txt
+++ b/runtime/nvqir/cudensitymat/CMakeLists.txt
@@ -19,6 +19,7 @@ find_file(CUDENSITYMAT_INC
         $ENV{CUQUANTUM_INSTALL_PREFIX}/include      
         /usr/include    
         ENV CPATH
+    REQUIRED
 )
 
 message(STATUS "cudensitymat header: ${CUDENSITYMAT_INC}")


### PR DESCRIPTION
### Description
When bulding the `cudensitymat` backend, finding this header is a requirment. The build will fail otherwise.
