### PR TITLE
[braket] Add the `symbol-dce` pass to the lowering pipeline

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
@@ -17,7 +17,7 @@ config:
   # Tell NVQ++ to generate glue code to set the target backend name
   gen-target-backend: true
   # Define the lowering pipeline
-  platform-lowering-config: "func.func(const-prop-complex,canonicalize,cse,lift-array-alloc),globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,unrolling-pipeline,func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),decomposition{enable-patterns=SToR1,TToR1,R1ToU3,U3ToRotations,CHToCX,CCZToCX,CRzToCX,CRyToCX,CRxToCX,CR1ToCX,RxAdjToRx,RyAdjToRy,RzAdjToRz},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  platform-lowering-config: "func.func(const-prop-complex,canonicalize,cse,lift-array-alloc),globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,unrolling-pipeline,func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),decomposition{enable-patterns=SToR1,TToR1,R1ToU3,U3ToRotations,CHToCX,CCZToCX,CRzToCX,CRyToCX,CRxToCX,CR1ToCX,RxAdjToRx,RyAdjToRy,RzAdjToRz},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements),symbol-dce"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
   # Library mode is only for simulators, physical backends must turn this off


### PR DESCRIPTION
This also fixes the following (non-fatal) error seen during 'observe' `error: 'func.func' op Invalid number of binary-symplectic elements provided. Must provide 2 * NQubits = 0`
(Ref: https://github.com/NVIDIA/cuda-quantum/pull/2539)

* Manually ran the Braket test suite.


```
root@87c14fc11e0a:/workspaces/cuda-quantum/build# python3 -m pytest -rP ../python/tests/backends/test_braket.py
...                                                                                                                                   

../python/tests/backends/test_braket.py .......................                                                                                  [100%]

================================= PASSES =====================================
...
====================== 23 passed in 180.69s (0:03:00) ========================
{ 00:79 11:21 }
{ 00:25 01:19 10:26 11:30 }
{ 00:100 }
{ 0:53 1:47 }


root@87c14fc11e0a:/workspaces/cuda-quantum/build# bin/nvq++ --target braket ../docs/sphinx/targets/cpp/braket.cpp -o out.x && ./out.x
{ 00000:517 11111:483 }
{ 00000:494 11111:506 }

root@87c14fc11e0a:/workspaces/cuda-quantum/build# python3 ../docs/sphinx/targets/python/braket.py
{ 00:530 11:470 }

{ 00:507 11:493 }

```
