### PR TITLE
[features/run] Enable new QIR codegen in python

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Pipelines.h
+++ b/include/cudaq/Optimizer/CodeGen/Pipelines.h
@@ -30,19 +30,10 @@ void commonPipelineConvertToQIR(mlir::PassManager &pm,
                                 mlir::StringRef codeGenFor = "qir",
                                 mlir::StringRef passConfigAs = "qir");
 
-/// \deprecated{Only for Python, since it can't use the new QIR codegen.}
-void commonPipelineConvertToQIR_PythonWorkaround(
-    mlir::PassManager &pm, const std::optional<mlir::StringRef> &convertTo);
-
 /// \brief Pipeline builder to convert Quake to QIR.
 /// Does not specify a particular QIR profile.
 inline void addPipelineConvertToQIR(mlir::PassManager &pm) {
   commonPipelineConvertToQIR(pm);
-}
-
-/// \deprecated{Only for Python, since it can't use the new QIR codegen.}
-inline void addPipelineConvertToQIR_PythonWorkaround(mlir::PassManager &pm) {
-  commonPipelineConvertToQIR_PythonWorkaround(pm, std::nullopt);
 }
 
 /// \brief Pipeline builder to convert Quake to QIR.
@@ -50,14 +41,6 @@ inline void addPipelineConvertToQIR_PythonWorkaround(mlir::PassManager &pm) {
 /// \p pm Pass manager to append passes to
 /// \p convertTo name of QIR profile (e.g., `qir-base`, `qir-adaptive`, ...)
 void addPipelineConvertToQIR(mlir::PassManager &pm, mlir::StringRef convertTo);
-
-/// \deprecated{Only for Python, since it can't use the new QIR codegen.}
-inline void
-addPipelineConvertToQIR_PythonWorkaround(mlir::PassManager &pm,
-                                         mlir::StringRef convertTo) {
-  commonPipelineConvertToQIR_PythonWorkaround(pm, convertTo);
-  addQIRProfilePipeline(pm, convertTo);
-}
 
 void addLowerToCCPipeline(mlir::OpPassManager &pm);
 

--- a/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -51,37 +51,6 @@ void cudaq::opt::commonPipelineConvertToQIR(PassManager &pm,
   pm.addPass(createCCToLLVM());
 }
 
-void cudaq::opt::commonPipelineConvertToQIR_PythonWorkaround(
-    PassManager &pm, const std::optional<StringRef> &convertTo) {
-  pm.addNestedPass<func::FuncOp>(createApplyControlNegations());
-  addAggressiveEarlyInlining(pm);
-  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<func::FuncOp>(createUnwindLoweringPass());
-  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  pm.addPass(createApplyOpSpecializationPass());
-  pm.addNestedPass<func::FuncOp>(createExpandMeasurementsPass());
-  pm.addNestedPass<func::FuncOp>(createClassicalMemToReg());
-  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<func::FuncOp>(createCSEPass());
-  pm.addNestedPass<func::FuncOp>(createQuakeAddDeallocs());
-  pm.addNestedPass<func::FuncOp>(createQuakeAddMetadata());
-  pm.addNestedPass<func::FuncOp>(createLoopNormalize());
-  LoopUnrollOptions luo;
-  luo.allowBreak = convertTo && (*convertTo == "qir-adaptive");
-  pm.addNestedPass<func::FuncOp>(createLoopUnroll(luo));
-  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<func::FuncOp>(createCSEPass());
-  pm.addNestedPass<func::FuncOp>(createLowerToCFGPass());
-  pm.addNestedPass<func::FuncOp>(createCombineQuantumAllocations());
-  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<func::FuncOp>(createCSEPass());
-  if (convertTo && (*convertTo == "qir-base"))
-    pm.addNestedPass<func::FuncOp>(createDelayMeasurementsPass());
-  pm.addPass(createConvertMathToFuncs());
-  pm.addPass(createSymbolDCEPass());
-  pm.addPass(createConvertToQIR());
-}
-
 void cudaq::opt::addPipelineTranslateToOpenQASM(PassManager &pm) {
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(createCSEPass());

--- a/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
+++ b/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
@@ -87,6 +87,23 @@ convertArrayAttrToGlobalConstant(MLIRContext *ctx, Location loc,
 }
 
 namespace {
+
+// This pattern replaces a cc.const_array with a global constant. It can
+// recognize a couple of usage patterns and will generate efficient IR in those
+// cases.
+//
+// Pattern 1: The entire constant array is stored to a stack variable(s). Here
+// we can eliminate the stack allocation and use the global constant.
+//
+// Pattern 2: Individual elements at dynamic offsets are extracted from the
+// constant array and used. This can be replaced with a compute pointer
+// operation using the global constant and a load of the element at the computed
+// offset.
+//
+// Default: If the usage is not recognized, the constant array value is replaced
+// with a load of the entire global variable. In this case, LLVM's optimizations
+// are counted on to help demote the (large?) sequence value to primitive memory
+// address arithmetic.
 struct ConstantArrayPattern
     : public OpRewritePattern<cudaq::cc::ConstantArrayOp> {
   explicit ConstantArrayPattern(MLIRContext *ctx, ModuleOp module,
@@ -95,21 +112,31 @@ struct ConstantArrayPattern
 
   LogicalResult matchAndRewrite(cudaq::cc::ConstantArrayOp conarr,
                                 PatternRewriter &rewriter) const override {
-    SmallVector<cudaq::cc::AllocaOp> allocas;
-    SmallVector<cudaq::cc::StoreOp> stores;
-    for (auto *usr : conarr->getUsers()) {
-      auto store = dyn_cast<cudaq::cc::StoreOp>(usr);
-      if (!store)
-        return failure();
-      auto alloca = store.getPtrvalue().getDefiningOp<cudaq::cc::AllocaOp>();
-      if (!alloca)
-        return failure();
-      stores.push_back(store);
-      allocas.push_back(alloca);
-    }
     auto func = conarr->getParentOfType<func::FuncOp>();
     if (!func)
       return failure();
+
+    SmallVector<cudaq::cc::AllocaOp> allocas;
+    SmallVector<cudaq::cc::StoreOp> stores;
+    SmallVector<cudaq::cc::ExtractValueOp> extracts;
+    bool loadAsValue = false;
+    for (auto *usr : conarr->getUsers()) {
+      auto store = dyn_cast<cudaq::cc::StoreOp>(usr);
+      auto extract = dyn_cast<cudaq::cc::ExtractValueOp>(usr);
+      if (store) {
+        auto alloca = store.getPtrvalue().getDefiningOp<cudaq::cc::AllocaOp>();
+        if (!alloca)
+          continue;
+        stores.push_back(store);
+        allocas.push_back(alloca);
+        continue;
+      }
+      if (extract) {
+        extracts.push_back(extract);
+        continue;
+      }
+      loadAsValue = true;
+    }
     std::string globalName =
         func.getName().str() + ".rodata_" + std::to_string(counter++);
     auto *ctx = rewriter.getContext();
@@ -118,12 +145,39 @@ struct ConstantArrayPattern
     if (failed(convertArrayAttrToGlobalConstant(ctx, conarr.getLoc(), valueAttr,
                                                 module, globalName, eleTy)))
       return failure();
-    for (auto alloca : allocas)
-      rewriter.replaceOpWithNewOp<cudaq::cc::AddressOfOp>(
-          alloca, alloca.getType(), globalName);
-    for (auto store : stores)
-      rewriter.eraseOp(store);
-    rewriter.eraseOp(conarr);
+    auto loc = conarr.getLoc();
+    if (!extracts.empty()) {
+      auto base = rewriter.create<cudaq::cc::AddressOfOp>(
+          loc, cudaq::cc::PointerType::get(conarr.getType()), globalName);
+      auto elePtrTy = cudaq::cc::PointerType::get(eleTy);
+      for (auto extract : extracts) {
+        SmallVector<cudaq::cc::ComputePtrArg> args;
+        unsigned i = 0;
+        for (auto arg : extract.getRawConstantIndices()) {
+          if (arg == cudaq::cc::ExtractValueOp::getDynamicIndexValue())
+            args.push_back(extract.getDynamicIndices()[i++]);
+          else
+            args.push_back(arg);
+        }
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(extract);
+        auto addrVal =
+            rewriter.create<cudaq::cc::ComputePtrOp>(loc, elePtrTy, base, args);
+        rewriter.replaceOpWithNewOp<cudaq::cc::LoadOp>(extract, addrVal);
+      }
+    }
+    if (!stores.empty()) {
+      for (auto alloca : allocas)
+        rewriter.replaceOpWithNewOp<cudaq::cc::AddressOfOp>(
+            alloca, alloca.getType(), globalName);
+      for (auto store : stores)
+        rewriter.eraseOp(store);
+    }
+    if (loadAsValue) {
+      auto base = rewriter.create<cudaq::cc::AddressOfOp>(
+          loc, cudaq::cc::PointerType::get(conarr.getType()), globalName);
+      rewriter.replaceOpWithNewOp<cudaq::cc::LoadOp>(conarr, base);
+    }
     return success();
   }
 

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -1749,9 +1749,12 @@ class PyASTBridge(ast.NodeVisitor):
                     self.ctx) if len(qubits) == 1 and quake.RefType.isinstance(
                         qubits[0].type) else cc.StdvecType.get(
                             self.ctx, quake.MeasureType.get(self.ctx))
+                label = registerName
+                if not label:
+                    label = None
                 measureResult = opCtor(measTy, [],
                                        qubits,
-                                       registerName=registerName).result
+                                       registerName=label).result
                 if pushResultToStack:
                     self.pushValue(
                         quake.DiscriminateOp(resTy, measureResult).result)
@@ -3151,6 +3154,72 @@ class PyASTBridge(ast.NodeVisitor):
                                             stepVal=stepVal,
                                             isDecrementing=isDecrementing)
                 return
+
+        # We can simplify `for i,j in enumerate(L)` MLIR code immensely
+        # by just building a for loop over the iterable object L and using
+        # the index into that iterable and the element.
+        if isinstance(node.iter, ast.Call):
+            if node.iter.func.id == 'enumerate':
+                [self.visit(arg) for arg in node.iter.args]
+                if len(self.valueStack) == 2:
+                    iterable = self.popValue()
+                    self.popValue()
+                else:
+                    assert len(self.valueStack) == 1
+                    iterable = self.popValue()
+                iterable = self.ifPointerThenLoad(iterable)
+                totalSize = None
+                extractFunctor = None
+                varNames = []
+                for elt in node.target.elts:
+                    varNames.append(elt.id)
+
+                beEfficient = False
+                if quake.VeqType.isinstance(iterable.type):
+                    totalSize = quake.VeqSizeOp(self.getIntegerType(),
+                                                iterable).result
+
+                    def functor(seq, idx):
+                        q = quake.ExtractRefOp(self.getRefType(),
+                                               seq,
+                                               -1,
+                                               index=idx).result
+                        return [idx, q]
+
+                    extractFunctor = functor
+                    beEfficient = True
+                elif cc.StdvecType.isinstance(iterable.type):
+                    totalSize = cc.StdvecSizeOp(self.getIntegerType(),
+                                                iterable).result
+
+                    def functor(seq, idx):
+                        vecTy = cc.StdvecType.getElementType(seq.type)
+                        dataTy = cc.PointerType.get(self.ctx, vecTy)
+                        arrTy = vecTy
+                        if not cc.ArrayType.isinstance(arrTy):
+                            arrTy = cc.ArrayType.get(self.ctx, vecTy)
+                        dataArrTy = cc.PointerType.get(self.ctx, arrTy)
+                        data = cc.StdvecDataOp(dataArrTy, seq).result
+                        v = cc.ComputePtrOp(
+                            dataTy, data, [idx],
+                            DenseI32ArrayAttr.get([kDynamicPtrIndex],
+                                                  context=self.ctx)).result
+                        return [idx, v]
+
+                    extractFunctor = functor
+                    beEfficient = True
+
+                if beEfficient:
+                    def bodyBuilder(iterVar):
+                        self.symbolTable.pushScope()
+                        values = extractFunctor(iterable, iterVar)
+                        for i, v in enumerate(values):
+                            self.symbolTable[varNames[i]] = v
+                        [self.visit(b) for b in node.body]
+                        self.symbolTable.popScope()
+
+                    self.createInvariantForLoop(totalSize, bodyBuilder)
+                    return
 
         self.visit(node.iter)
         assert len(self.valueStack) > 0 and len(self.valueStack) < 3

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -1752,8 +1752,7 @@ class PyASTBridge(ast.NodeVisitor):
                 label = registerName
                 if not label:
                     label = None
-                measureResult = opCtor(measTy, [],
-                                       qubits,
+                measureResult = opCtor(measTy, [], qubits,
                                        registerName=label).result
                 if pushResultToStack:
                     self.pushValue(
@@ -3210,6 +3209,7 @@ class PyASTBridge(ast.NodeVisitor):
                     beEfficient = True
 
                 if beEfficient:
+
                     def bodyBuilder(iterVar):
                         self.symbolTable.pushScope()
                         values = extractFunctor(iterable, iterVar)

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -1077,9 +1077,9 @@ class PyKernel(object):
                 retTy = stdvecTy
                 measTy = cc.StdvecType.get(self.ctx, measTy)
             if regName is not None:
-                res = quake.MzOp(
-                    measTy, [], [target.mlirValue],
-                    registerName=StringAttr.get(regName, context=self.ctx))
+                res = quake.MzOp(measTy, [], [target.mlirValue],
+                                 registerName=StringAttr.get(regName,
+                                                             context=self.ctx))
             else:
                 res = quake.MzOp(measTy, [], [target.mlirValue])
             disc = quake.DiscriminateOp(retTy, res)

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -1076,10 +1076,12 @@ class PyKernel(object):
             if quake.VeqType.isinstance(target.mlirValue.type):
                 retTy = stdvecTy
                 measTy = cc.StdvecType.get(self.ctx, measTy)
-            res = quake.MzOp(
-                measTy, [], [target.mlirValue],
-                registerName=StringAttr.get(regName, context=self.ctx)
-                if regName is not None else '')
+            if regName is not None:
+                res = quake.MzOp(
+                    measTy, [], [target.mlirValue],
+                    registerName=StringAttr.get(regName, context=self.ctx))
+            else:
+                res = quake.MzOp(measTy, [], [target.mlirValue])
             disc = quake.DiscriminateOp(retTy, res)
             return self.__createQuakeValue(disc.result)
 

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -104,7 +104,7 @@ jitAndCreateArgs(const std::string &name, MlirModule module,
         {.startingArgIdx = startingArgIdx}));
     pm.addPass(cudaq::opt::createLambdaLiftingPass());
     pm.addPass(createSymbolDCEPass());
-    cudaq::opt::addPipelineConvertToQIR_PythonWorkaround(pm);
+    cudaq::opt::addPipelineConvertToQIR(pm);
 
     DefaultTimingManager tm;
     tm.setEnabled(cudaq::isTimingTagEnabled(cudaq::TIMING_JIT_PASSES));
@@ -596,9 +596,9 @@ std::string getQIR(const std::string &name, MlirModule module,
   PassManager pm(context);
   pm.addPass(cudaq::opt::createLambdaLiftingPass());
   if (profile.empty())
-    cudaq::opt::addPipelineConvertToQIR_PythonWorkaround(pm);
+    cudaq::opt::addPipelineConvertToQIR(pm);
   else
-    cudaq::opt::addPipelineConvertToQIR_PythonWorkaround(pm, profile);
+    cudaq::opt::addPipelineConvertToQIR(pm, profile);
   DefaultTimingManager tm;
   tm.setEnabled(cudaq::isTimingTagEnabled(cudaq::TIMING_JIT_PASSES));
   auto timingScope = tm.getRootScope(); // starts the timer

--- a/python/tests/mlir/adjoint.py
+++ b/python/tests/mlir/adjoint.py
@@ -241,7 +241,7 @@ def test_sample_adjoint_qubit():
 # CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_0]]) : (!quake.ref) -> ()
 # CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_0]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 
@@ -302,7 +302,7 @@ def test_sample_adjoint_qreg():
 # CHECK:           } {invariant}
 # CHECK:           call @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}(%[[VAL_3]]) : (!quake.veq<?>) -> ()
 # CHECK:           quake.apply<adj> @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} %[[VAL_3]] : (!quake.veq<?>) -> ()
-# CHECK:           %[[VAL_13:.*]] = quake.mz %0 name "" : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
+# CHECK:           %[[VAL_13:.*]] = quake.mz %0 : (!quake.veq<?>) -> !cc.stdvec<!quake.measure>
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/mlir/ast_elif.py
+++ b/python/tests/mlir/ast_elif.py
@@ -37,44 +37,23 @@ def test_elif():
 # CHECK-DAG:           %[[VAL_4:.*]] = arith.constant 4 : i64
 # CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<4>
 # CHECK:           %[[VAL_6:.*]] = cc.stdvec_size %[[VAL_0]] : (!cc.stdvec<f64>) -> i64
-# CHECK:           %[[VAL_7:.*]] = cc.alloca !cc.struct<{i64, f64}>{{\[}}%[[VAL_6]] : i64]
-# CHECK:           %[[VAL_8:.*]] = cc.loop while ((%[[VAL_9:.*]] = %[[VAL_3]]) -> (i64)) {
-# CHECK:             %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_6]] : i64
-# CHECK:             cc.condition %[[VAL_10]](%[[VAL_9]] : i64)
-# CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_11:.*]]: i64):
-# CHECK:             %[[VAL_12:.*]] = cc.undef !cc.struct<{i64, f64}>
-# CHECK:             %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-# CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][%[[VAL_11]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
-# CHECK:             %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<f64>
-# CHECK:             %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_11]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, f64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, f64}>>
-# CHECK:             %[[VAL_17:.*]] = cc.insert_value %[[VAL_11]], %[[VAL_12]][0] : (!cc.struct<{i64, f64}>, i64) -> !cc.struct<{i64, f64}>
-# CHECK:             %[[VAL_18:.*]] = cc.insert_value %[[VAL_15]], %[[VAL_17]][1] : (!cc.struct<{i64, f64}>, f64) -> !cc.struct<{i64, f64}>
-# CHECK:             cc.store %[[VAL_18]], %[[VAL_16]] : !cc.ptr<!cc.struct<{i64, f64}>>
-# CHECK:             cc.continue %[[VAL_11]] : i64
-# CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_19:.*]]: i64):
-# CHECK:             %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_2]] : i64
-# CHECK:             cc.continue %[[VAL_20]] : i64
-# CHECK:           } {invariant}
 # CHECK:           %[[VAL_21:.*]] = cc.loop while ((%[[VAL_22:.*]] = %[[VAL_3]]) -> (i64)) {
 # CHECK:             %[[VAL_23:.*]] = arith.cmpi slt, %[[VAL_22]], %[[VAL_6]] : i64
 # CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_24:.*]]: i64):
-# CHECK:             %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_24]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, f64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, f64}>>
-# CHECK:             %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<!cc.struct<{i64, f64}>>
-# CHECK:             %[[VAL_27:.*]] = cc.extract_value %[[VAL_26]][0] : (!cc.struct<{i64, f64}>) -> i64
-# CHECK:             %[[VAL_28:.*]] = cc.extract_value %[[VAL_26]][1] : (!cc.struct<{i64, f64}>) -> f64
-# CHECK:             %[[VAL_29:.*]] = arith.remui %[[VAL_27]], %[[VAL_1]] : i64
+# CHECK:             %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<i64 x ?>>
+# CHECK:             %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_7]][%[[VAL_24]]] : (!cc.ptr<!cc.array<f64> x ?>>, i64) -> !cc.ptr<f64>
+# CHECK:             %[[VAL_29:.*]] = arith.remui %[[VAL_24]], %[[VAL_1]] : i64
 # CHECK:             %[[VAL_30:.*]] = arith.cmpi ne, %[[VAL_29]], %[[VAL_3]] : i64
+# CHECK:             %[[VAL_28:.*]] = cc.load %[[VAL_25]] : !cc.ptr<f64>
 # CHECK:             cc.if(%[[VAL_30]]) {
-# CHECK:               %[[VAL_31:.*]] = arith.remui %[[VAL_27]], %[[VAL_4]] : i64
-# CHECK:               %[[VAL_32:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_31]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:               %[[VAL_31:.*]] = arith.remui %[[VAL_24]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_32:.*]] = quake.extract_ref %[[VAL_5]][%[[VAL_31]]] : (!quake.veq<4>, i64) -> !quake.ref
 # CHECK:               quake.ry (%[[VAL_28]]) %[[VAL_32]] : (f64, !quake.ref) -> ()
 # CHECK:             } else {
-# CHECK:               %[[VAL_33:.*]] = arith.remui %[[VAL_27]], %[[VAL_4]] : i64
-# CHECK:               %[[VAL_34:.*]] = quake.extract_ref %[[VAL_5]]{{\[}}%[[VAL_33]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:               %[[VAL_33:.*]] = arith.remui %[[VAL_24]], %[[VAL_4]] : i64
+# CHECK:               %[[VAL_34:.*]] = quake.extract_ref %[[VAL_5]][%[[VAL_33]]] : (!quake.veq<4>, i64) -> !quake.ref
 # CHECK:               quake.rx (%[[VAL_28]]) %[[VAL_34]] : (f64, !quake.ref) -> ()
 # CHECK:             }
 # CHECK:             cc.continue %[[VAL_24]] : i64

--- a/python/tests/mlir/ast_list_init.py
+++ b/python/tests/mlir/ast_list_init.py
@@ -48,37 +48,16 @@ def test_list_init():
 # CHECK:           cc.store %[[VAL_13]], %[[VAL_14]] : !cc.ptr<!cc.stdvec<f64>>
 # CHECK:           %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.stdvec<f64>>
 # CHECK:           %[[VAL_16:.*]] = cc.stdvec_size %[[VAL_15]] : (!cc.stdvec<f64>) -> i64
-# CHECK:           %[[VAL_17:.*]] = cc.alloca !cc.struct<{i64, f64}>[%[[VAL_16]] : i64]
-# CHECK:           %[[VAL_18:.*]] = cc.loop while ((%[[VAL_19:.*]] = %[[VAL_1]]) -> (i64)) {
-# CHECK:             %[[VAL_20:.*]] = arith.cmpi slt, %[[VAL_19]], %[[VAL_16]] : i64
-# CHECK:             cc.condition %[[VAL_20]](%[[VAL_19]] : i64)
-# CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_21:.*]]: i64):
-# CHECK:             %[[VAL_22:.*]] = cc.undef !cc.struct<{i64, f64}>
-# CHECK:             %[[VAL_23:.*]] = cc.stdvec_data %[[VAL_15]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
-# CHECK:             %[[VAL_24:.*]] = cc.compute_ptr %[[VAL_23]][%[[VAL_21]]] : (!cc.ptr<!cc.array<f64 x ?>>, i64) -> !cc.ptr<f64>
-# CHECK:             %[[VAL_25:.*]] = cc.load %[[VAL_24]] : !cc.ptr<f64>
-# CHECK:             %[[VAL_26:.*]] = cc.compute_ptr %[[VAL_17]][%[[VAL_21]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, f64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, f64}>>
-# CHECK:             %[[VAL_27:.*]] = cc.insert_value %[[VAL_21]], %[[VAL_22]][0] : (!cc.struct<{i64, f64}>, i64) -> !cc.struct<{i64, f64}>
-# CHECK:             %[[VAL_28:.*]] = cc.insert_value %[[VAL_25]], %[[VAL_27]][1] : (!cc.struct<{i64, f64}>, f64) -> !cc.struct<{i64, f64}>
-# CHECK:             cc.store %[[VAL_28]], %[[VAL_26]] : !cc.ptr<!cc.struct<{i64, f64}>>
-# CHECK:             cc.continue %[[VAL_21]] : i64
-# CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_29:.*]]: i64):
-# CHECK:             %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_0]] : i64
-# CHECK:             cc.continue %[[VAL_30]] : i64
-# CHECK:           } {invariant}
 # CHECK:           %[[VAL_31:.*]] = cc.loop while ((%[[VAL_32:.*]] = %[[VAL_1]]) -> (i64)) {
 # CHECK:             %[[VAL_33:.*]] = arith.cmpi slt, %[[VAL_32]], %[[VAL_16]] : i64
 # CHECK:             cc.condition %[[VAL_33]](%[[VAL_32]] : i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_34:.*]]: i64):
-# CHECK:             %[[VAL_35:.*]] = cc.compute_ptr %[[VAL_17]]{{\[}}%[[VAL_34]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, f64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, f64}>>
-# CHECK:             %[[VAL_36:.*]] = cc.load %[[VAL_35]] : !cc.ptr<!cc.struct<{i64, f64}>>
-# CHECK:             %[[VAL_37:.*]] = cc.extract_value %[[VAL_36]][0] : (!cc.struct<{i64, f64}>) -> i64
-# CHECK:             %[[VAL_38:.*]] = cc.extract_value %[[VAL_36]][1] : (!cc.struct<{i64, f64}>) -> f64
-# CHECK:             %[[VAL_39:.*]] = quake.extract_ref %[[VAL_7]]{{\[}}%[[VAL_37]]] : (!quake.veq<6>, i64) -> !quake.ref
-# CHECK:             quake.ry (%[[VAL_38]]) %[[VAL_39]] : (f64, !quake.ref) -> ()
+# CHECK:             %[[VAL_17:.*]] = cc.stdvec_data %[[VAL_15]] : (!cc.stdvec<f64>) -> !cc.ptr<!cc.array<f64 x ?>>
+# CHECK:             %[[VAL_35:.*]] = cc.compute_ptr %[[VAL_17]][%[[VAL_34]]] : (!cc.ptr<!cc.array<f64> x ?>>, i64) -> !cc.ptr<f64>
+# CHECK:             %[[VAL_36:.*]] = cc.load %[[VAL_35]] : !cc.ptr<f64>
+# CHECK:             %[[VAL_39:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_34]]] : (!quake.veq<6>, i64) -> !quake.ref
+# CHECK:             quake.ry (%[[VAL_36]]) %[[VAL_39]] : (f64, !quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_34]] : i64
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_40:.*]]: i64):

--- a/python/tests/mlir/ast_list_int.py
+++ b/python/tests/mlir/ast_list_int.py
@@ -26,46 +26,24 @@ def test_list_int():
 
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen__oracle(
-# CHECK-SAME:                %[[VAL_0:.*]]: !quake.veq<?>,
-# CHECK-SAME:                %[[VAL_1:.*]]: !quake.ref,
-# CHECK-SAME:                %[[VAL_2:.*]]: !cc.stdvec<i64>)
-# CHECK-DAG:           %[[VAL_3:.*]] = arith.constant 1 : i64
-# CHECK-DAG:           %[[VAL_4:.*]] = arith.constant 0 : i64
+# CHECK-SAME:          %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !quake.ref,
+# CHECK-SAME:          %[[VAL_2:.*]]: !cc.stdvec<i64>)
+# CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
+# CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i64
 # CHECK:           %[[VAL_5:.*]] = cc.stdvec_size %[[VAL_2]] : (!cc.stdvec<i64>) -> i64
 # CHECK:           %[[VAL_6:.*]] = cc.alloca i64
 # CHECK:           cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<i64>
-# CHECK:           %[[VAL_7:.*]] = cc.alloca !cc.struct<{i64, i64}>{{\[}}%[[VAL_5]] : i64]
-# CHECK:           %[[VAL_8:.*]] = cc.loop while ((%[[VAL_9:.*]] = %[[VAL_4]]) -> (i64)) {
-# CHECK:             %[[VAL_10:.*]] = arith.cmpi slt, %[[VAL_9]], %[[VAL_5]] : i64
-# CHECK:             cc.condition %[[VAL_10]](%[[VAL_9]] : i64)
-# CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_11:.*]]: i64):
-# CHECK:             %[[VAL_12:.*]] = cc.undef !cc.struct<{i64, i64}>
-# CHECK:             %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-# CHECK:             %[[VAL_14:.*]] = cc.compute_ptr %[[VAL_13]][%[[VAL_11]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
-# CHECK:             %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<i64>
-# CHECK:             %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_11]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, i64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, i64}>>
-# CHECK:             %[[VAL_17:.*]] = cc.insert_value %[[VAL_11]], %[[VAL_12]][0] : (!cc.struct<{i64, i64}>, i64) -> !cc.struct<{i64, i64}>
-# CHECK:             %[[VAL_18:.*]] = cc.insert_value %[[VAL_15]], %[[VAL_17]][1] : (!cc.struct<{i64, i64}>, i64) -> !cc.struct<{i64, i64}>
-# CHECK:             cc.store %[[VAL_18]], %[[VAL_16]] : !cc.ptr<!cc.struct<{i64, i64}>>
-# CHECK:             cc.continue %[[VAL_11]] : i64
-# CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_19:.*]]: i64):
-# CHECK:             %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_3]] : i64
-# CHECK:             cc.continue %[[VAL_20]] : i64
-# CHECK:           } {invariant}
 # CHECK:           %[[VAL_21:.*]] = cc.loop while ((%[[VAL_22:.*]] = %[[VAL_4]]) -> (i64)) {
 # CHECK:             %[[VAL_23:.*]] = arith.cmpi slt, %[[VAL_22]], %[[VAL_5]] : i64
 # CHECK:             cc.condition %[[VAL_23]](%[[VAL_22]] : i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_24:.*]]: i64):
-# CHECK:             %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_7]]{{\[}}%[[VAL_24]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, i64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, i64}>>
-# CHECK:             %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<!cc.struct<{i64, i64}>>
-# CHECK:             %[[VAL_27:.*]] = cc.extract_value %[[VAL_26]][0] : (!cc.struct<{i64, i64}>) -> i64
-# CHECK:             %[[VAL_28:.*]] = cc.extract_value %[[VAL_26]][1] : (!cc.struct<{i64, i64}>) -> i64
-# CHECK:             %[[VAL_29:.*]] = arith.cmpi eq, %[[VAL_28]], %[[VAL_3]] : i64
+# CHECK:             %[[VAL_7:.*]] = cc.stdvec_data %[[VAL_2]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+# CHECK:             %[[VAL_25:.*]] = cc.compute_ptr %[[VAL_7]][%[[VAL_24]]] : (!cc.ptr<!cc.array<i64> x ?>>, i64) -> !cc.ptr<i64>
+# CHECK:             %[[VAL_26:.*]] = cc.load %[[VAL_25]] : !cc.ptr<i64>
+# CHECK:             %[[VAL_29:.*]] = arith.cmpi eq, %[[VAL_26]], %[[VAL_3]] : i64
 # CHECK:             cc.if(%[[VAL_29]]) {
-# CHECK:               %[[VAL_30:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_27]]] : (!quake.veq<?>, i64) -> !quake.ref
+# CHECK:               %[[VAL_30:.*]] = quake.extract_ref %[[VAL_0]][%[[VAL_27]]] : (!quake.veq<?>, i64) -> !quake.ref
 # CHECK:               quake.x {{\[}}%[[VAL_30]]] %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:             }
 # CHECK:             cc.continue %[[VAL_24]] : i64

--- a/python/tests/mlir/ast_qreg_slice.py
+++ b/python/tests/mlir/ast_qreg_slice.py
@@ -97,38 +97,17 @@ def test_slice():
 # CHECK:           cc.store %[[VAL_28]], %[[VAL_29]] : !cc.ptr<!cc.stdvec<i64>>
 # CHECK:           %[[VAL_30:.*]] = cc.load %[[VAL_29]] : !cc.ptr<!cc.stdvec<i64>>
 # CHECK:           %[[VAL_31:.*]] = cc.stdvec_size %[[VAL_30]] : (!cc.stdvec<i64>) -> i64
-# CHECK:           %[[VAL_32:.*]] = cc.alloca !cc.struct<{i64, i64}>{{\[}}%[[VAL_31]] : i64]
-# CHECK:           %[[VAL_33:.*]] = cc.loop while ((%[[VAL_34:.*]] = %[[VAL_6]]) -> (i64)) {
-# CHECK:             %[[VAL_35:.*]] = arith.cmpi slt, %[[VAL_34]], %[[VAL_31]] : i64
-# CHECK:             cc.condition %[[VAL_35]](%[[VAL_34]] : i64)
-# CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_36:.*]]: i64):
-# CHECK:             %[[VAL_37:.*]] = cc.undef !cc.struct<{i64, i64}>
-# CHECK:             %[[VAL_38:.*]] = cc.stdvec_data %[[VAL_30]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
-# CHECK:             %[[VAL_39:.*]] = cc.compute_ptr %[[VAL_38]][%[[VAL_36]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
-# CHECK:             %[[VAL_40:.*]] = cc.load %[[VAL_39]] : !cc.ptr<i64>
-# CHECK:             %[[VAL_41:.*]] = cc.compute_ptr %[[VAL_32]]{{\[}}%[[VAL_36]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, i64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, i64}>>
-# CHECK:             %[[VAL_42:.*]] = cc.insert_value %[[VAL_36]], %[[VAL_37]][0] : (!cc.struct<{i64, i64}>, i64) -> !cc.struct<{i64, i64}>
-# CHECK:             %[[VAL_43:.*]] = cc.insert_value %[[VAL_40]], %[[VAL_42]][1] : (!cc.struct<{i64, i64}>, i64) -> !cc.struct<{i64, i64}>
-# CHECK:             cc.store %[[VAL_43]], %[[VAL_41]] : !cc.ptr<!cc.struct<{i64, i64}>>
-# CHECK:             cc.continue %[[VAL_36]] : i64
-# CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_44:.*]]: i64):
-# CHECK:             %[[VAL_45:.*]] = arith.addi %[[VAL_44]], %[[VAL_3]] : i64
-# CHECK:             cc.continue %[[VAL_45]] : i64
-# CHECK:           } {invariant}
 # CHECK:           %[[VAL_46:.*]] = cc.loop while ((%[[VAL_47:.*]] = %[[VAL_6]]) -> (i64)) {
 # CHECK:             %[[VAL_48:.*]] = arith.cmpi slt, %[[VAL_47]], %[[VAL_31]] : i64
 # CHECK:             cc.condition %[[VAL_48]](%[[VAL_47]] : i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_49:.*]]: i64):
-# CHECK:             %[[VAL_50:.*]] = cc.compute_ptr %[[VAL_32]]{{\[}}%[[VAL_49]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, i64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, i64}>>
-# CHECK:             %[[VAL_51:.*]] = cc.load %[[VAL_50]] : !cc.ptr<!cc.struct<{i64, i64}>>
-# CHECK:             %[[VAL_52:.*]] = cc.extract_value %[[VAL_51]][0] : (!cc.struct<{i64, i64}>) -> i64
-# CHECK:             %[[VAL_53:.*]] = cc.extract_value %[[VAL_51]][1] : (!cc.struct<{i64, i64}>) -> i64
-# CHECK:             %[[VAL_54:.*]] = arith.remui %[[VAL_52]], %[[VAL_1]] : i64
-# CHECK:             %[[VAL_55:.*]] = quake.extract_ref %[[VAL_7]]{{\[}}%[[VAL_54]]] : (!quake.veq<4>, i64) -> !quake.ref
-# CHECK:             %[[VAL_56:.*]] = arith.sitofp %[[VAL_53]] : i64 to f64
+# CHECK:             %[[VAL_32:.*]] = cc.stdvec_data %[[VAL_30]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+# CHECK:             %[[VAL_50:.*]] = cc.compute_ptr %[[VAL_32]][%[[VAL_49]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, i64}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, i64}>>
+# CHECK:             %[[VAL_51:.*]] = cc.load %[[VAL_50]] : !cc.ptr<i64>
+# CHECK:             %[[VAL_54:.*]] = arith.remui %[[VAL_49]], %[[VAL_1]] : i64
+# CHECK:             %[[VAL_55:.*]] = quake.extract_ref %[[VAL_7]][%[[VAL_54]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:             %[[VAL_56:.*]] = arith.sitofp %[[VAL_51]] : i64 to f64
 # CHECK:             quake.ry (%[[VAL_56]]) %[[VAL_55]] : (f64, !quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_49]] : i64
 # CHECK:           } step {

--- a/python/tests/mlir/conditional.py
+++ b/python/tests/mlir/conditional.py
@@ -59,7 +59,7 @@ def test_kernel_conditional():
 # CHECK:           %[[VAL_9:.*]] = quake.discriminate %[[VAL_8]] : (!quake.measure) -> i1
 # CHECK:           cc.if(%[[VAL_9]]) {
 # CHECK:             quake.x %[[VAL_7]] : (!quake.ref) -> ()
-# CHECK:             %[[VAL_10:.*]] = quake.mz %[[VAL_7]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:             %[[VAL_10:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> !quake.measure
 # CHECK:           }
 # CHECK:           %[[VAL_11:.*]] = cc.loop while ((%[[VAL_12:.*]] = %[[VAL_2]]) -> (i64)) {
 # CHECK:             %[[VAL_13:.*]] = arith.cmpi slt, %[[VAL_12]], %[[VAL_0]] : i64
@@ -76,7 +76,7 @@ def test_kernel_conditional():
 # CHECK:           } {invariant}
 # CHECK:           cc.if(%[[VAL_9]]) {
 # CHECK:             quake.x %[[VAL_7]] : (!quake.ref) -> ()
-# CHECK:             %[[VAL_18:.*]] = quake.mz %[[VAL_7]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:             %[[VAL_18:.*]] = quake.mz %[[VAL_7]] : (!quake.ref) -> !quake.measure
 # CHECK:           }
 # CHECK:           return
 # CHECK:         }
@@ -117,7 +117,7 @@ def test_kernel_conditional_with_sample():
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 # CHECK:           quake.x %[[VAL_0]] : (!quake.ref) -> ()
-# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> !quake.measure
 # CHECK:           %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!quake.measure) -> i1
 # CHECK:           cc.if(%[[VAL_2]]) {
 # CHECK:             quake.x %[[VAL_0]] : (!quake.ref) -> ()

--- a/python/tests/mlir/control.py
+++ b/python/tests/mlir/control.py
@@ -288,7 +288,7 @@ def test_sample_control_qubit_args():
 # CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}[%{{[0-2]}}] %{{[0-2]}} : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.mz %{{[0-2]}} name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_2:.*]] = quake.mz %{{[0-2]}} : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 
@@ -345,7 +345,7 @@ def test_sample_control_qreg_args():
 # CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
 # CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}[%[[VAL_5]]] %[[VAL_6]] : (!quake.veq<2>, !quake.ref) -> ()
-# CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_6]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_19:.*]] = quake.mz %[[VAL_6]] : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 
@@ -403,7 +403,7 @@ def test_sample_apply_call_control():
 # CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
 # CHECK:           quake.apply @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}} [%{{[0-2]}}] %{{[0-2]}} : (!quake.ref, !quake.ref) -> ()
 # CHECK:           quake.h %{{[0-2]}} : (!quake.ref) -> ()
-# CHECK:           %[[VAL_2:.*]] = quake.mz %{{[0-2]}} name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_2:.*]] = quake.mz %{{[0-2]}} : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/mlir/ghz.py
+++ b/python/tests/mlir/ghz.py
@@ -77,36 +77,14 @@ def test_ghz():
 # CHECK:           %[[VAL_9:.*]] = arith.subi %[[VAL_8]], %[[VAL_1]] : i64
 # CHECK:           %[[VAL_10:.*]] = quake.subveq %[[VAL_6]], 0, %[[VAL_9]] : (!quake.veq<?>, i64) -> !quake.veq<?>
 # CHECK:           %[[VAL_11:.*]] = quake.veq_size %[[VAL_10]] : (!quake.veq<?>) -> i64
-# CHECK:           %[[VAL_12:.*]] = cc.alloca !cc.struct<{i64, !quake.ref}>{{\[}}%[[VAL_11]] : i64]
-# CHECK:           %[[VAL_13:.*]] = cc.loop while ((%[[VAL_14:.*]] = %[[VAL_3]]) -> (i64)) {
-# CHECK:             %[[VAL_15:.*]] = arith.cmpi slt, %[[VAL_14]], %[[VAL_11]] : i64
-# CHECK:             cc.condition %[[VAL_15]](%[[VAL_14]] : i64)
-# CHECK:           } do {
-# CHECK:           ^bb0(%[[VAL_16:.*]]: i64):
-# CHECK:             %[[VAL_17:.*]] = cc.undef !cc.struct<{i64, !quake.ref}>
-# CHECK:             %[[VAL_18:.*]] = quake.extract_ref %[[VAL_10]]{{\[}}%[[VAL_16]]] : (!quake.veq<?>, i64) -> !quake.ref
-# CHECK:             %[[VAL_19:.*]] = cc.compute_ptr %[[VAL_12]]{{\[}}%[[VAL_16]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, !quake.ref}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, !quake.ref}>>
-# CHECK:             %[[VAL_20:.*]] = cc.insert_value %[[VAL_16]], %[[VAL_17]][0] : (!cc.struct<{i64, !quake.ref}>, i64) -> !cc.struct<{i64, !quake.ref}>
-# CHECK:             %[[VAL_21:.*]] = cc.insert_value %[[VAL_18]], %[[VAL_20]][1] : (!cc.struct<{i64, !quake.ref}>, !quake.ref) -> !cc.struct<{i64, !quake.ref}>
-# CHECK:             cc.store %[[VAL_21]], %[[VAL_19]] : !cc.ptr<!cc.struct<{i64, !quake.ref}>>
-# CHECK:             cc.continue %[[VAL_16]] : i64
-# CHECK:           } step {
-# CHECK:           ^bb0(%[[VAL_22:.*]]: i64):
-# CHECK:             %[[VAL_23:.*]] = arith.addi %[[VAL_22]], %[[VAL_2]] : i64
-# CHECK:             cc.continue %[[VAL_23]] : i64
-# CHECK:           } {invariant}
 # CHECK:           %[[VAL_24:.*]] = cc.loop while ((%[[VAL_25:.*]] = %[[VAL_3]]) -> (i64)) {
 # CHECK:             %[[VAL_26:.*]] = arith.cmpi slt, %[[VAL_25]], %[[VAL_11]] : i64
 # CHECK:             cc.condition %[[VAL_26]](%[[VAL_25]] : i64)
 # CHECK:           } do {
 # CHECK:           ^bb0(%[[VAL_27:.*]]: i64):
-# CHECK:             %[[VAL_28:.*]] = cc.compute_ptr %[[VAL_12]]{{\[}}%[[VAL_27]]] : (!cc.ptr<!cc.array<!cc.struct<{i64, !quake.ref}> x ?>>, i64) -> !cc.ptr<!cc.struct<{i64, !quake.ref}>>
-# CHECK:             %[[VAL_29:.*]] = cc.load %[[VAL_28]] : !cc.ptr<!cc.struct<{i64, !quake.ref}>>
-# CHECK:             %[[VAL_30:.*]] = cc.extract_value %[[VAL_29]][0] : (!cc.struct<{i64, !quake.ref}>) -> i64
-# CHECK:             %[[VAL_31:.*]] = cc.extract_value %[[VAL_29]][1] : (!cc.struct<{i64, !quake.ref}>) -> !quake.ref
-# CHECK:             %[[VAL_32:.*]] = arith.addi %[[VAL_30]], %[[VAL_2]] : i64
-# CHECK:             %[[VAL_33:.*]] = quake.extract_ref %[[VAL_6]]{{\[}}%[[VAL_32]]] : (!quake.veq<?>, i64) -> !quake.ref
-# CHECK:             quake.x {{\[}}%[[VAL_31]]] %[[VAL_33]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:             %[[VAL_32:.*]] = arith.addi %[[VAL_27]], %[[VAL_2]] : i64
+# CHECK:             %[[VAL_33:.*]] = quake.extract_ref %[[VAL_6]][%[[VAL_32]]] : (!quake.veq<?>, i64) -> !quake.ref
+# CHECK:             quake.x [%[[VAL_31]]] %[[VAL_33]] : (!quake.ref, !quake.ref) -> ()
 # CHECK:             cc.continue %[[VAL_27]] : i64
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_34:.*]]: i64):

--- a/python/tests/mlir/measure.py
+++ b/python/tests/mlir/measure.py
@@ -41,12 +41,12 @@ def test_kernel_measure_1q():
 # CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
 # CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_2]][0] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_2]][1] : (!quake.veq<2>) -> !quake.ref
-# CHECK:           %[[VAL_5:.*]] = quake.mx %[[VAL_3]] name "" : (!quake.ref) -> !quake.measure
-# CHECK:           %[[VAL_6:.*]] = quake.mx %[[VAL_4]] name "" : (!quake.ref) -> !quake.measure
-# CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] name "" : (!quake.ref) -> !quake.measure
-# CHECK:           %[[VAL_8:.*]] = quake.my %[[VAL_4]] name "" : (!quake.ref) -> !quake.measure
-# CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_3]] name "" : (!quake.ref) -> !quake.measure
-# CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_4]] name "" : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_5:.*]] = quake.mx %[[VAL_3]] : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_6:.*]] = quake.mx %[[VAL_4]] : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_7:.*]] = quake.my %[[VAL_3]] : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_8:.*]] = quake.my %[[VAL_4]] : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_9:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> !quake.measure
+# CHECK:           %[[VAL_10:.*]] = quake.mz %[[VAL_4]] : (!quake.ref) -> !quake.measure
 # CHECK:           return
 # CHECK:         }
 
@@ -70,9 +70,9 @@ def test_kernel_measure_qreg():
 
 # CHECK-LABEL:   func.func @__nvqpp__mlirgen____nvqppBuilderKernel_{{.*}}() attributes {"cudaq-entrypoint"
 # CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
-# CHECK:           %[[VAL_1:.*]] = quake.mx %[[VAL_0]] name "" : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
-# CHECK:           %[[VAL_2:.*]] = quake.my %[[VAL_0]] name "" : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
-# CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] name "" : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
+# CHECK:           %[[VAL_1:.*]] = quake.mx %[[VAL_0]] : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
+# CHECK:           %[[VAL_2:.*]] = quake.my %[[VAL_0]] : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
+# CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<3>) -> !cc.stdvec<!quake.measure>
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/mlir/swap.py
+++ b/python/tests/mlir/swap.py
@@ -39,7 +39,7 @@ def test_swap_2q():
 # CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_0]][1] : (!quake.veq<2>) -> !quake.ref
 # CHECK:           quake.x %[[VAL_1]] : (!quake.ref) -> ()
 # CHECK:           quake.swap %[[VAL_1]], %[[VAL_2]] : (!quake.ref, !quake.ref) -> ()
-# CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] name "" : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+# CHECK:           %[[VAL_3:.*]] = quake.mz %[[VAL_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/mlir/test_output_qir.py
+++ b/python/tests/mlir/test_output_qir.py
@@ -25,64 +25,69 @@ def test_synth_and_qir():
     print(cudaq.translate(ghz_synth, format='qir-base'))
 
 
-# CHECK:         %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_2:.*]])
-# CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
+# CHECK-LABEL: define void @__nvqpp__mlirgen__ghz(i64 
+# CHECK-SAME:                               %[[VAL_0:.*]]) local_unnamed_addr {
+# CHECK:         %[[VAL_1:.*]] = tail call %[[VAL_2:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_0]])
+# CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 0)
 # CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to %[[VAL_5:.*]]**
 # CHECK:         %[[VAL_6:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_4]], align 8
 # CHECK:         tail call void @__quantum__qis__h(%[[VAL_5]]* %[[VAL_6]])
-# CHECK:         %[[VAL_7:.*]] = add i64 %[[VAL_2]], -1
+# CHECK:         %[[VAL_7:.*]] = add i64 %[[VAL_0]], -1
 # CHECK:         %[[VAL_8:.*]] = tail call i64 @llvm.abs.i64(i64 %[[VAL_7]], i1 false)
 # CHECK:         %[[VAL_9:.*]] = alloca i64, i64 %[[VAL_8]], align 8
 # CHECK:         %[[VAL_10:.*]] = icmp sgt i64 %[[VAL_7]], 0
 # CHECK:         br i1 %[[VAL_10]], label %[[VAL_11:.*]], label %[[VAL_12:.*]]
-# CHECK:       .lr.ph:                                           ; preds = %[[VAL_13:.*]], %[[VAL_11]]
+# CHECK:       :                                           ; preds = %[[VAL_13:.*]], %[[VAL_11]]
 # CHECK:         %[[VAL_14:.*]] = phi i64 [ %[[VAL_15:.*]], %[[VAL_11]] ], [ 0, %[[VAL_13]] ]
 # CHECK:         %[[VAL_16:.*]] = getelementptr i64, i64* %[[VAL_9]], i64 %[[VAL_14]]
 # CHECK:         store i64 %[[VAL_14]], i64* %[[VAL_16]], align 8
 # CHECK:         %[[VAL_15]] = add nuw nsw i64 %[[VAL_14]], 1
 # CHECK:         %[[VAL_17:.*]] = icmp slt i64 %[[VAL_15]], %[[VAL_7]]
-# CHECK:         br i1 %[[VAL_17]], label %[[VAL_11]], label %[[VAL_21:.*]]
-# CHECK:       ._crit_edge:                                      ; preds = %[[VAL_11]]
-# CHECK:         %[[VAL_18:.*]] = alloca { i64, i64 }, i64 %[[VAL_7]], align 8
-# CHECK:         br i1 %[[VAL_10]], label %[[VAL_20:.*]], label %[[VAL_21]]
-# CHECK:       .preheader:                                       ; preds = %[[VAL_20]]
-# CHECK:         br i1 %[[VAL_10]], label %[[VAL_22:.*]], label %[[VAL_21]]
-# CHECK:       .lr.ph10:                                          ; preds = %[[VAL_21]], %[[VAL_20]]
-# CHECK:         %[[VAL_23:.*]] = phi i64 [ %[[VAL_24:.*]], %[[VAL_20]] ], [ 0, %[[VAL_21]] ]
-# CHECK:         %[[VAL_25:.*]] = getelementptr i64, i64* %[[VAL_9]], i64 %[[VAL_23]]
-# CHECK:         %[[VAL_26:.*]] = load i64, i64* %[[VAL_25]], align 8
-# CHECK:         %[[VAL_27:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_18]], i64 %[[VAL_23]], i32 0
-# CHECK:         store i64 %[[VAL_23]], i64* %[[VAL_27]], align 8
-# CHECK:         %[[VAL_28:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_18]], i64 %[[VAL_23]], i32 1
-# CHECK:         store i64 %[[VAL_26]], i64* %[[VAL_28]], align 8
-# CHECK:         %[[VAL_24]] = add nuw nsw i64 %[[VAL_23]], 1
-# CHECK:         %[[VAL_29:.*]] = icmp slt i64 %[[VAL_24]], %[[VAL_7]]
-# CHECK:         br i1 %[[VAL_29]], label %[[VAL_20]], label %[[VAL_30:.*]]
-# CHECK:       .lr.ph11:                                         ; preds = %[[VAL_30]], %[[VAL_22]]
-# CHECK:         %[[VAL_31:.*]] = phi i64 [ %[[VAL_32:.*]], %[[VAL_22]] ], [ 0, %[[VAL_30]] ]
-# CHECK:         %[[VAL_33:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_18]], i64 %[[VAL_31]], i32 0
-# CHECK:         %[[VAL_34:.*]] = load i64, i64* %[[VAL_33]], align 8
-# CHECK:         %[[VAL_35:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_18]], i64 %[[VAL_31]], i32 1
-# CHECK:         %[[VAL_36:.*]] = load i64, i64* %[[VAL_35]], align 8
-# CHECK:         %[[VAL_37:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 %[[VAL_34]])
-# CHECK:         %[[VAL_38:.*]] = bitcast i8* %[[VAL_37]] to %[[VAL_5]]**
-# CHECK:         %[[VAL_39:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_38]], align 8
-# CHECK:         %[[VAL_40:.*]] = add i64 %[[VAL_36]], 1
-# CHECK:         %[[VAL_41:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 %[[VAL_40]])
-# CHECK:         %[[VAL_42:.*]] = bitcast i8* %[[VAL_41]] to %[[VAL_5]]**
-# CHECK:         %[[VAL_43:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_42]], align 8
-# CHECK:         tail call void (i64, void (%[[VAL_1]]*, %[[VAL_5]]*)*, ...) @invokeWithControlQubits(i64 1, void (%[[VAL_1]]*, %[[VAL_5]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_5]]* %[[VAL_39]], %[[VAL_5]]* %[[VAL_43]])
-# CHECK:         %[[VAL_32]] = add nuw nsw i64 %[[VAL_31]], 1
-# CHECK:         %[[VAL_44:.*]] = icmp slt i64 %[[VAL_32]], %[[VAL_7]]
-# CHECK:         br i1 %[[VAL_44]], label %[[VAL_22]], label %[[VAL_21]]
-# CHECK:       ._crit_edge12:                                    ; preds = %[[VAL_22]], %[[VAL_13]], %[[VAL_21]], %[[VAL_30]]
-# CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
+# CHECK:         br i1 %[[VAL_17]], label %[[VAL_11]], label %[[VAL_18:.*]]
+# CHECK:       :                                      ; preds = %[[VAL_11]]
+# CHECK:         %[[VAL_19:.*]] = alloca { i64, i64 }, i64 %[[VAL_7]], align 8
+# CHECK:         br i1 %[[VAL_10]], label %[[VAL_20:.*]], label %[[VAL_12]]
+# CHECK:       :                                       ; preds = %[[VAL_20]]
+# CHECK:         br i1 %[[VAL_10]], label %[[VAL_21:.*]], label %[[VAL_12]]
+# CHECK:       .lr.ph10:                                         ; preds = %[[VAL_18]], %[[VAL_20]]
+# CHECK:         %[[VAL_22:.*]] = phi i64 [ %[[VAL_23:.*]], %[[VAL_20]] ], [ 0, %[[VAL_18]] ]
+# CHECK:         %[[VAL_24:.*]] = getelementptr i64, i64* %[[VAL_9]], i64 %[[VAL_22]]
+# CHECK:         %[[VAL_25:.*]] = load i64, i64* %[[VAL_24]], align 8
+# CHECK:         %[[VAL_26:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_19]], i64 %[[VAL_22]], i32 0
+# CHECK:         store i64 %[[VAL_22]], i64* %[[VAL_26]], align 8
+# CHECK:         %[[VAL_27:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_19]], i64 %[[VAL_22]], i32 1
+# CHECK:         store i64 %[[VAL_25]], i64* %[[VAL_27]], align 8
+# CHECK:         %[[VAL_23]] = add nuw nsw i64 %[[VAL_22]], 1
+# CHECK:         %[[VAL_28:.*]] = icmp slt i64 %[[VAL_23]], %[[VAL_7]]
+# CHECK:         br i1 %[[VAL_28]], label %[[VAL_20]], label %[[VAL_29:.*]]
+# CHECK:       :                                         ; preds = %[[VAL_29]], %[[VAL_21]]
+# CHECK:         %[[VAL_30:.*]] = phi i64 [ %[[VAL_31:.*]], %[[VAL_21]] ], [ 0, %[[VAL_29]] ]
+# CHECK:         %[[VAL_32:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_19]], i64 %[[VAL_30]], i32 0
+# CHECK:         %[[VAL_33:.*]] = load i64, i64* %[[VAL_32]], align 8
+# CHECK:         %[[VAL_34:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_19]], i64 %[[VAL_30]], i32 1
+# CHECK:         %[[VAL_35:.*]] = load i64, i64* %[[VAL_34]], align 8
+# CHECK:         %[[VAL_36:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 %[[VAL_33]])
+# CHECK:         %[[VAL_37:.*]] = bitcast i8* %[[VAL_36]] to %[[VAL_5]]**
+# CHECK:         %[[VAL_38:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_37]], align 8
+# CHECK:         %[[VAL_39:.*]] = add i64 %[[VAL_35]], 1
+# CHECK:         %[[VAL_40:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 %[[VAL_39]])
+# CHECK:         %[[VAL_41:.*]] = bitcast i8* %[[VAL_40]] to %[[VAL_5]]**
+# CHECK:         %[[VAL_42:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_41]], align 8
+# CHECK:         tail call void (i64, void (%[[VAL_2]]*, %[[VAL_5]]*)*, ...) @invokeWithControlQubits(i64 1, void (%[[VAL_2]]*, %[[VAL_5]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_5]]* %[[VAL_38]], %[[VAL_5]]* %[[VAL_42]])
+# CHECK:         %[[VAL_31]] = add nuw nsw i64 %[[VAL_30]], 1
+# CHECK:         %[[VAL_43:.*]] = icmp slt i64 %[[VAL_31]], %[[VAL_7]]
+# CHECK:         br i1 %[[VAL_43]], label %[[VAL_21]], label %[[VAL_12]]
+# CHECK:       :                                    ; preds = %[[VAL_21]], %[[VAL_13]], %[[VAL_18]], %[[VAL_29]]
+# CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_2]]* %[[VAL_1]])
 # CHECK:         ret void
+# CHECK:       }
 
-# CHECK:   tail call void @__quantum__qis__h__body(
-# CHECK:                                            %[[VAL_0:.*]]* null)
+# CHECK-LABEL: define void @__nvqpp__mlirgen__ghz()
+# CHECK:         tail call void @__quantum__qis__h__body(%[[VAL_0:.*]]* null)
 # CHECK:         tail call void @__quantum__qis__cnot__body(%[[VAL_0]]* null, %[[VAL_0]]* nonnull inttoptr (i64 1 to %[[VAL_0]]*))
 # CHECK:         tail call void @__quantum__qis__cnot__body(%[[VAL_0]]* nonnull inttoptr (i64 1 to %[[VAL_0]]*), %[[VAL_0]]* nonnull inttoptr (i64 2 to %[[VAL_0]]*))
 # CHECK:         tail call void @__quantum__qis__cnot__body(%[[VAL_0]]* nonnull inttoptr (i64 2 to %[[VAL_0]]*), %[[VAL_0]]* nonnull inttoptr (i64 3 to %[[VAL_0]]*))
 # CHECK:         tail call void @__quantum__qis__cnot__body(%[[VAL_0]]* nonnull inttoptr (i64 3 to %[[VAL_0]]*), %[[VAL_0]]* nonnull inttoptr (i64 4 to %[[VAL_0]]*))
 # CHECK:         ret void
+# CHECK:       }
+

--- a/python/tests/mlir/test_output_translate_qir.py
+++ b/python/tests/mlir/test_output_translate_qir.py
@@ -25,12 +25,15 @@ def test_synth_and_translate():
     print(cudaq.translate(ghz_synth, format='qir-base'))
 
 
-# CHECK:         %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_2:.*]])
-# CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
+
+# CHECK-LABEL: define void @__nvqpp__mlirgen__ghz(i64 
+# CHECK-SAME:                       %[[VAL_0:.*]]) local_unnamed_addr {
+# CHECK:         %[[VAL_1:.*]] = tail call %[[VAL_2:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_0]])
+# CHECK:         %[[VAL_3:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 0)
 # CHECK:         %[[VAL_4:.*]] = bitcast i8* %[[VAL_3]] to %[[VAL_5:.*]]**
 # CHECK:         %[[VAL_6:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_4]], align 8
 # CHECK:         tail call void @__quantum__qis__h(%[[VAL_5]]* %[[VAL_6]])
-# CHECK:         %[[VAL_7:.*]] = add i64 %[[VAL_2]], -1
+# CHECK:         %[[VAL_7:.*]] = add i64 %[[VAL_0]], -1
 # CHECK:         %[[VAL_8:.*]] = tail call i64 @llvm.abs.i64(i64 %[[VAL_7]], i1 false)
 # CHECK:         %[[VAL_9:.*]] = alloca i64, i64 %[[VAL_8]], align 8
 # CHECK:         %[[VAL_10:.*]] = icmp sgt i64 %[[VAL_7]], 0
@@ -41,48 +44,51 @@ def test_synth_and_translate():
 # CHECK:         store i64 %[[VAL_14]], i64* %[[VAL_16]], align 8
 # CHECK:         %[[VAL_15]] = add nuw nsw i64 %[[VAL_14]], 1
 # CHECK:         %[[VAL_17:.*]] = icmp slt i64 %[[VAL_15]], %[[VAL_7]]
-# CHECK:         br i1 %[[VAL_17]], label %[[VAL_11]], label %[[VAL_21:.*]]
-# CHECK:       ._crit_edge:                                      ; preds = %[[VAL_11]]
-# CHECK:         %[[VAL_18:.*]] = alloca { i64, i64 }, i64 %[[VAL_7]], align 8
-# CHECK:         br i1 %[[VAL_10]], label %[[VAL_20:.*]], label %[[VAL_21]]
-# CHECK:       .preheader:                                       ; preds = %[[VAL_20]]
-# CHECK:         br i1 %[[VAL_10]], label %[[VAL_22:.*]], label %[[VAL_21]]
-# CHECK:       .lr.ph10:                                          ; preds = %[[VAL_21]], %[[VAL_20]]
-# CHECK:         %[[VAL_23:.*]] = phi i64 [ %[[VAL_24:.*]], %[[VAL_20]] ], [ 0, %[[VAL_21]] ]
-# CHECK:         %[[VAL_25:.*]] = getelementptr i64, i64* %[[VAL_9]], i64 %[[VAL_23]]
-# CHECK:         %[[VAL_26:.*]] = load i64, i64* %[[VAL_25]], align 8
-# CHECK:         %[[VAL_27:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_18]], i64 %[[VAL_23]], i32 0
-# CHECK:         store i64 %[[VAL_23]], i64* %[[VAL_27]], align 8
-# CHECK:         %[[VAL_28:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_18]], i64 %[[VAL_23]], i32 1
-# CHECK:         store i64 %[[VAL_26]], i64* %[[VAL_28]], align 8
-# CHECK:         %[[VAL_24]] = add nuw nsw i64 %[[VAL_23]], 1
-# CHECK:         %[[VAL_29:.*]] = icmp slt i64 %[[VAL_24]], %[[VAL_7]]
-# CHECK:         br i1 %[[VAL_29]], label %[[VAL_20]], label %[[VAL_30:.*]]
-# CHECK:       .lr.ph11:                                         ; preds = %[[VAL_30]], %[[VAL_22]]
-# CHECK:         %[[VAL_31:.*]] = phi i64 [ %[[VAL_32:.*]], %[[VAL_22]] ], [ 0, %[[VAL_30]] ]
-# CHECK:         %[[VAL_33:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_18]], i64 %[[VAL_31]], i32 0
-# CHECK:         %[[VAL_34:.*]] = load i64, i64* %[[VAL_33]], align 8
-# CHECK:         %[[VAL_35:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_18]], i64 %[[VAL_31]], i32 1
-# CHECK:         %[[VAL_36:.*]] = load i64, i64* %[[VAL_35]], align 8
-# CHECK:         %[[VAL_37:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 %[[VAL_34]])
-# CHECK:         %[[VAL_38:.*]] = bitcast i8* %[[VAL_37]] to %[[VAL_5]]**
-# CHECK:         %[[VAL_39:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_38]], align 8
-# CHECK:         %[[VAL_40:.*]] = add i64 %[[VAL_36]], 1
-# CHECK:         %[[VAL_41:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 %[[VAL_40]])
-# CHECK:         %[[VAL_42:.*]] = bitcast i8* %[[VAL_41]] to %[[VAL_5]]**
-# CHECK:         %[[VAL_43:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_42]], align 8
-# CHECK:         tail call void (i64, void (%[[VAL_1]]*, %[[VAL_5]]*)*, ...) @invokeWithControlQubits(i64 1, void (%[[VAL_1]]*, %[[VAL_5]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_5]]* %[[VAL_39]], %[[VAL_5]]* %[[VAL_43]])
-# CHECK:         %[[VAL_32]] = add nuw nsw i64 %[[VAL_31]], 1
-# CHECK:         %[[VAL_44:.*]] = icmp slt i64 %[[VAL_32]], %[[VAL_7]]
-# CHECK:         br i1 %[[VAL_44]], label %[[VAL_22]], label %[[VAL_21]]
-# CHECK:       ._crit_edge12:                                    ; preds = %[[VAL_22]], %[[VAL_13]], %[[VAL_21]], %[[VAL_30]]
-# CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
+# CHECK:         br i1 %[[VAL_17]], label %[[VAL_11]], label %[[VAL_18:.*]]
+# CHECK:       :                                      ; preds = %[[VAL_11]]
+# CHECK:         %[[VAL_19:.*]] = alloca { i64, i64 }, i64 %[[VAL_7]], align 8
+# CHECK:         br i1 %[[VAL_10]], label %[[VAL_20:.*]], label %[[VAL_12]]
+# CHECK:       :                                       ; preds = %[[VAL_20]]
+# CHECK:         br i1 %[[VAL_10]], label %[[VAL_21:.*]], label %[[VAL_12]]
+# CHECK:       .lr.ph10:                                         ; preds = %[[VAL_18]], %[[VAL_20]]
+# CHECK:         %[[VAL_22:.*]] = phi i64 [ %[[VAL_23:.*]], %[[VAL_20]] ], [ 0, %[[VAL_18]] ]
+# CHECK:         %[[VAL_24:.*]] = getelementptr i64, i64* %[[VAL_9]], i64 %[[VAL_22]]
+# CHECK:         %[[VAL_25:.*]] = load i64, i64* %[[VAL_24]], align 8
+# CHECK:         %[[VAL_26:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_19]], i64 %[[VAL_22]], i32 0
+# CHECK:         store i64 %[[VAL_22]], i64* %[[VAL_26]], align 8
+# CHECK:         %[[VAL_27:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_19]], i64 %[[VAL_22]], i32 1
+# CHECK:         store i64 %[[VAL_25]], i64* %[[VAL_27]], align 8
+# CHECK:         %[[VAL_23]] = add nuw nsw i64 %[[VAL_22]], 1
+# CHECK:         %[[VAL_28:.*]] = icmp slt i64 %[[VAL_23]], %[[VAL_7]]
+# CHECK:         br i1 %[[VAL_28]], label %[[VAL_20]], label %[[VAL_29:.*]]
+# CHECK:       :                                         ; preds = %[[VAL_29]], %[[VAL_21]]
+# CHECK:         %[[VAL_30:.*]] = phi i64 [ %[[VAL_31:.*]], %[[VAL_21]] ], [ 0, %[[VAL_29]] ]
+# CHECK:         %[[VAL_32:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_19]], i64 %[[VAL_30]], i32 0
+# CHECK:         %[[VAL_33:.*]] = load i64, i64* %[[VAL_32]], align 8
+# CHECK:         %[[VAL_34:.*]] = getelementptr { i64, i64 }, { i64, i64 }* %[[VAL_19]], i64 %[[VAL_30]], i32 1
+# CHECK:         %[[VAL_35:.*]] = load i64, i64* %[[VAL_34]], align 8
+# CHECK:         %[[VAL_36:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 %[[VAL_33]])
+# CHECK:         %[[VAL_37:.*]] = bitcast i8* %[[VAL_36]] to %[[VAL_5]]**
+# CHECK:         %[[VAL_38:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_37]], align 8
+# CHECK:         %[[VAL_39:.*]] = add i64 %[[VAL_35]], 1
+# CHECK:         %[[VAL_40:.*]] = tail call i8* @__quantum__rt__array_get_element_ptr_1d(%[[VAL_2]]* %[[VAL_1]], i64 %[[VAL_39]])
+# CHECK:         %[[VAL_41:.*]] = bitcast i8* %[[VAL_40]] to %[[VAL_5]]**
+# CHECK:         %[[VAL_42:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_41]], align 8
+# CHECK:         tail call void (i64, void (%[[VAL_2]]*, %[[VAL_5]]*)*, ...) @invokeWithControlQubits(i64 1, void (%[[VAL_2]]*, %[[VAL_5]]*)* nonnull @__quantum__qis__x__ctl, %[[VAL_5]]* %[[VAL_38]], %[[VAL_5]]* %[[VAL_42]])
+# CHECK:         %[[VAL_31]] = add nuw nsw i64 %[[VAL_30]], 1
+# CHECK:         %[[VAL_43:.*]] = icmp slt i64 %[[VAL_31]], %[[VAL_7]]
+# CHECK:         br i1 %[[VAL_43]], label %[[VAL_21]], label %[[VAL_12]]
+# CHECK:       :                                    ; preds = %[[VAL_21]], %[[VAL_13]], %[[VAL_18]], %[[VAL_29]]
+# CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_2]]* %[[VAL_1]])
 # CHECK:         ret void
+# CHECK:       }
 
-# CHECK:   tail call void @__quantum__qis__h__body(
-# CHECK:                                            %[[VAL_0:.*]]* null)
+# CHECK-LABEL: define void @__nvqpp__mlirgen__ghz()
+# CHECK:         tail call void @__quantum__qis__h__body(%[[VAL_0:.*]]* null)
 # CHECK:         tail call void @__quantum__qis__cnot__body(%[[VAL_0]]* null, %[[VAL_0]]* nonnull inttoptr (i64 1 to %[[VAL_0]]*))
 # CHECK:         tail call void @__quantum__qis__cnot__body(%[[VAL_0]]* nonnull inttoptr (i64 1 to %[[VAL_0]]*), %[[VAL_0]]* nonnull inttoptr (i64 2 to %[[VAL_0]]*))
 # CHECK:         tail call void @__quantum__qis__cnot__body(%[[VAL_0]]* nonnull inttoptr (i64 2 to %[[VAL_0]]*), %[[VAL_0]]* nonnull inttoptr (i64 3 to %[[VAL_0]]*))
 # CHECK:         tail call void @__quantum__qis__cnot__body(%[[VAL_0]]* nonnull inttoptr (i64 3 to %[[VAL_0]]*), %[[VAL_0]]* nonnull inttoptr (i64 4 to %[[VAL_0]]*))
 # CHECK:         ret void
+# CHECK:       }
+

--- a/runtime/common/Trace.cpp
+++ b/runtime/common/Trace.cpp
@@ -10,11 +10,10 @@
 #include <algorithm>
 #include <cassert>
 
-namespace cudaq {
-
-void Trace::appendInstruction(std::string_view name, std::vector<double> params,
-                              std::vector<QuditInfo> controls,
-                              std::vector<QuditInfo> targets) {
+void cudaq::Trace::appendInstruction(std::string_view name,
+                                     std::vector<double> params,
+                                     std::vector<QuditInfo> controls,
+                                     std::vector<QuditInfo> targets) {
   assert(!targets.empty() && "An instruction must have at least one target");
   auto findMaxID = [](const std::vector<QuditInfo> &qudits) -> std::size_t {
     return std::max_element(qudits.cbegin(), qudits.cend(),
@@ -27,5 +26,3 @@ void Trace::appendInstruction(std::string_view name, std::vector<double> params,
   numQudits = std::max(numQudits, maxID + 1);
   instructions.emplace_back(name, params, controls, targets);
 }
-
-} // namespace cudaq

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -1062,7 +1062,7 @@ void generalizedInvokeWithRotationsControlsTargets(
     controls[i] = va_arg(args, Qubit *);
   }
   for (i = 0; i < numControlQubitOperands; ++i) {
-    arrayAndLength[i] = 0;
+    arrayAndLength[numControlArrayOperands + i] = 0;
     controls[numControlArrayOperands + i] = va_arg(args, Qubit *);
   }
   for (i = 0; i < numTargetOperands; ++i)


### PR DESCRIPTION
Remove the python hooks to the old codegen. This exposes all the python problems in the tests.

Eliminate the expansion of python enumerate().

Remove use of empty labels for all measurements.

This eliminates a loop, a data structure, and the invalid mixing of quantum and classical data values in classical memory.

Fix bugs in AST bridge.

Fix #2538 - measurement register name cannot be empty.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
