### PR TITLE
[py] Fixes #2586 and #2531 and #2579

### DIFF
--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -92,7 +92,7 @@ class PyKernelDecorator(object):
         # Register any external class types that may be used
         # in the kernel definition
         for name, var in self.globalScopedVars.items():
-            if isinstance(var, type):
+            if isinstance(var, type) and hasattr(var, '__annotations__'):
                 globalRegisteredTypes[name] = (var, var.__annotations__)
 
         # Once the kernel is compiled to MLIR, we


### PR DESCRIPTION
### Description

Not all objects that pass the `isinstance(var, type)` check have the `__annotations__` attribute.

This is a quick fix, i.e., the change does not address the much deeper underlying issue: this code should not be globing all globals within a frame, and perhaps using `__annotations__` is undesirable. (Also, the best practices regarding the use of annotations have changed in python 3.10, so there are still unaddressed landmines here.)

Fixes #2586 #2531 #2579