### PR TITLE
Run canonical patterns alongside lift-array-alloc

### DIFF
--- a/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
+++ b/lib/Optimizer/Transforms/LiftArrayAlloc.cpp
@@ -295,6 +295,12 @@ public:
     DominanceInfo domInfo(func);
     StringRef funcName = func.getName();
     RewritePatternSet patterns(ctx);
+
+    for (auto *dialect : ctx->getLoadedDialects())
+      dialect->getCanonicalizationPatterns(patterns);
+    for (RegisteredOperationName op : ctx->getRegisteredOperations())
+      op.getCanonicalizationPatterns(patterns, ctx);
+
     patterns.insert<AllocaPattern>(ctx, domInfo, funcName);
 
     LLVM_DEBUG(llvm::dbgs()

--- a/test/Quake/lift_array.qke
+++ b/test/Quake/lift_array.qke
@@ -159,17 +159,16 @@ func.func @test_two_stores() {
 }
 
 // CHECK-LABEL:   func.func @test_two_stores() {
-// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_2:.*]] = cc.const_array [1] : !cc.array<i64 x 1>
-// CHECK:           %[[VAL_3:.*]] = cc.extract_value %[[VAL_2]][0] : (!cc.array<i64 x 1>) -> i64
-// CHECK:           %[[VAL_4:.*]] = cc.alloca !cc.array<i64 x 1>
-// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<!cc.array<i64 x 1>>) -> !cc.ptr<i64>
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_5]] : !cc.ptr<i64>
-// CHECK:           cc.store %[[VAL_3]], %[[VAL_5]] : !cc.ptr<i64>
-// CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i64>
-// CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_1]][%[[VAL_6]]] : (!quake.veq<2>, i64) -> !quake.ref
-// CHECK:           quake.x %[[VAL_7]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.array<i64 x 1>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i64 x 1>>) -> !cc.ptr<i64>
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_4]] : !cc.ptr<i64>
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_4]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_2]][%[[VAL_5]]] : (!quake.veq<2>, i64) -> !quake.ref
+// CHECK:           quake.x %[[VAL_6]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/lift_array.qke
+++ b/test/Quake/lift_array.qke
@@ -195,3 +195,23 @@ func.func @test_complex_array() {
 // CHECK:           %[[VAL_4:.*]] = quake.init_state %[[VAL_3]], %[[VAL_2]] : (!quake.veq<1>, !cc.ptr<complex<f32>>) -> !quake.veq<1>
 // CHECK:           return
 // CHECK:         }
+
+func.func @test_array_copy() -> i1 {
+  %c0_i64 = arith.constant 0 : i64
+  %0 = cc.alloca !cc.array<i64 x 1>
+  %1 = cc.cast %0 : (!cc.ptr<!cc.array<i64 x 1>>) -> !cc.ptr<i64>
+  cc.store %c0_i64, %1 : !cc.ptr<i64>
+  %2 = cc.alloca !cc.array<i64 x 1>
+  %3 = cc.load %1 : !cc.ptr<i64>
+  %4 = cc.cast %2 : (!cc.ptr<!cc.array<i64 x 1>>) -> !cc.ptr<i64>
+  cc.store %3, %4 : !cc.ptr<i64>
+  %6 = cc.load %1 : !cc.ptr<i64>
+  %7 = cc.load %4 : !cc.ptr<i64>
+  %8 = arith.cmpi eq, %6, %7 : i64
+  return %8 : i1
+}
+
+// CHECK-LABEL:   func.func @test_array_copy() -> i1 {
+// CHECK:           %[[VAL_0:.*]] = arith.constant true
+// CHECK:           return %[[VAL_0]] : i1
+// CHECK:         }


### PR DESCRIPTION
### Description
Run canonical patterns alongside lift-array-alloc to make sure all constant arrays are lifted in case of array copy:

```python
arr = [0]
arr1 = [arr[0]]
return arr[0] == arr1[0]
```

Previously, we would need to run two iterations of `lift-array-alloc,canonicalize` to lift both arrays, as the first one needs to be lifted and then const-propped before the second one could be lifted as well.