### PR TITLE
[core] Add call with vararg to CC dialect.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -1459,8 +1459,8 @@ def cc_CallCallableOp : CCOp<"call_callable", [CallOpInterface]> {
   }];
 }
 
-def cc_CallIndirectCallableOp : CCOp<"call_indirect_callable",
-    [CallOpInterface]> {
+def cc_CallIndirectCallableOp :
+    CCOp<"call_indirect_callable", [CallOpInterface]> {
   let summary = "Call a C++ callable, unresolved, at run-time.";
   let description = [{
     This effectively connects a call from one kernel to another kernel, which
@@ -1646,6 +1646,43 @@ def cc_CallableClosureOp : CCOp<"callable_closure", [Pure]> {
 
   let assemblyFormat = [{
     $callable `:` functional-type(operands, results) attr-dict
+  }];
+}
+
+def cc_VarargCallOp :
+    CCOp<"call_vararg", [CallOpInterface, SymbolUserOpInterface]> {
+  let summary = "Create a call to an llvm.func with variadic arguments.";
+  let description = [{
+    This operation lets us create a call to an LLVMIR FuncOp with variadic
+    arguments without the restriction that all the arguments have to be
+    converted to LLVMIR types first. These conversions are just code bloat and
+    make the code harder to read.
+  }];
+
+  let arguments = (ins
+    FlatSymbolRefAttr:$callee,
+    Variadic<AnyType>:$args
+  );
+  let results = (outs Variadic<AnyType>);
+
+  let assemblyFormat = [{
+    $callee `(` $args `)` `:` functional-type(operands, results) attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    /// Return the callee of this operation.
+    mlir::CallInterfaceCallable getCallableForCallee() {
+      return getCalleeAttr();
+    }
+
+    mlir::LogicalResult verifySymbolUses(mlir::SymbolTableCollection &);
   }];
 }
 

--- a/lib/Optimizer/CodeGen/CCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/CCToLLVM.cpp
@@ -710,18 +710,33 @@ public:
     return success();
   }
 };
+
+class VarargCallPattern
+    : public ConvertOpToLLVMPattern<cudaq::cc::VarargCallOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(cudaq::cc::VarargCallOp vcall, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> types;
+    for (auto ty : vcall.getResultTypes())
+      types.push_back(getTypeConverter()->convertType(ty));
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(vcall, types, vcall.getCallee(),
+                                              adaptor.getArgs());
+    return success();
+  }
+};
 } // namespace
 
 void cudaq::opt::populateCCToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                           RewritePatternSet &patterns) {
-  patterns.insert<AddressOfOpPattern, AllocaOpPattern, CallableClosureOpPattern,
-                  CallableFuncOpPattern, CallCallableOpPattern,
-                  CallIndirectCallableOpPattern, CastOpPattern,
-                  ComputePtrOpPattern, CreateStringLiteralOpPattern,
-                  ExtractValueOpPattern, FuncToPtrOpPattern, GlobalOpPattern,
-                  InsertValueOpPattern, InstantiateCallableOpPattern,
-                  LoadOpPattern, OffsetOfOpPattern, PoisonOpPattern,
-                  SizeOfOpPattern, StdvecDataOpPattern, StdvecInitOpPattern,
-                  StdvecSizeOpPattern, StoreOpPattern, UndefOpPattern>(
-      typeConverter);
+  patterns.insert<
+      AddressOfOpPattern, AllocaOpPattern, CallableClosureOpPattern,
+      CallableFuncOpPattern, CallCallableOpPattern,
+      CallIndirectCallableOpPattern, CastOpPattern, ComputePtrOpPattern,
+      CreateStringLiteralOpPattern, ExtractValueOpPattern, FuncToPtrOpPattern,
+      GlobalOpPattern, InsertValueOpPattern, InstantiateCallableOpPattern,
+      LoadOpPattern, OffsetOfOpPattern, PoisonOpPattern, SizeOfOpPattern,
+      StdvecDataOpPattern, StdvecInitOpPattern, StdvecSizeOpPattern,
+      StoreOpPattern, UndefOpPattern, VarargCallPattern>(typeConverter);
 }

--- a/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -1150,8 +1150,8 @@ struct QuantumGatePattern : public OpConversionPattern<OP> {
     args.append(opTargs.begin(), opTargs.end());
 
     // Call the generalized version of the gate invocation.
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{},
-                                  cudaq::opt::NVQIRGeneralizedInvokeAny, args);
+    rewriter.create<cudaq::cc::VarargCallOp>(
+        loc, TypeRange{}, cudaq::opt::NVQIRGeneralizedInvokeAny, args);
     return forwardOrEraseOp();
   }
 

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -811,6 +811,23 @@ func.func @indirect_callable1(%arg : !cc.indirect_callable<() -> ()>) {
 // CHECK:           return
 // CHECK:         }
 
+func.func @varargs_test() {
+  %1 = arith.constant 12 : i32
+  %2 = cc.undef !cc.ptr<none>
+  cc.call_vararg @my_variadic(%1, %2) : (i32, !cc.ptr<none>) -> ()
+  return
+}
+
+llvm.func @my_variadic(i32, ...)
+
+// CHECK-LABEL:   func.func @varargs_test() {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 12 : i32
+// CHECK:           %[[VAL_1:.*]] = cc.undef !cc.ptr<none>
+// CHECK:           cc.call_vararg @my_variadic(%[[VAL_0]], %[[VAL_1]]) : (i32, !cc.ptr<none>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK:         llvm.func @my_variadic(i32, ...)
+
 func.func @indirect_callable2(%arg : !cc.indirect_callable<(i32) -> i64>) -> i64 {
   %cst = arith.constant 4 : i32
   %0 = cc.call_indirect_callable %arg, %cst : (!cc.indirect_callable<(i32) -> i64>, i32) -> i64


### PR DESCRIPTION
This op allows CC code to call a variadic function without having to prematurely convert all the arguments to LLVM dialect and clutter the code with casts. The LLVMIR dialect's LLVMFuncOp does allow us to declare a variadic function, however.

Use the new Op in the QIR codegen to prevent the LLVMIR verifier from whining about the use of LLVM types.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
