### PR TITLE
cuda_torchdiffeq_integrator.py: check if pytorch is built with cuda capabilities

### DIFF
--- a/python/cudaq/operator/integrators/cuda_torchdiffeq_integrator.py
+++ b/python/cudaq/operator/integrators/cuda_torchdiffeq_integrator.py
@@ -14,6 +14,7 @@ from .builtin_integrators import cuDensityMatTimeStepper
 has_cupy = True
 has_torch = True
 has_torchdiffeq = True
+has_torch_without_cuda = False
 
 try:
     import cupy as cp
@@ -24,6 +25,8 @@ try:
     import torch
     import torch.utils
     import torch.utils.dlpack
+    if torch.version.cuda is None:
+        has_torch_without_cuda = True
 except ImportError:
     has_torch = False
 
@@ -45,6 +48,10 @@ class CUDATorchDiffEqIntegrator(BaseIntegrator[CudmStateType]):
             # If users don't have torch (hence, no `torchdiffeq` as well), raise an error when they want to use it.
             raise ImportError(
                 'torch and torchdiffeq are required to use Torch-based integrators.'
+            )
+        if has_torch_without_cuda:
+            raise ImportError(
+                'Please install a compatible version of PyTorch with CUDA support.'
             )
         if not has_torchdiffeq:
             raise ImportError(


### PR DESCRIPTION
Check if the installed pytorch is cuda aware.

This seems to only be an issue in the field on `aarch64` systems where the pytorch in the default pip repository is not cuda aware.

This is a code check of the warning described in https://nvidia.github.io/cuda-quantum/latest/using/backends/dynamics.html#numerical-integrators.