### PR TITLE
Add Stim support for sdg gate (required for `my` measurements)

### DIFF
--- a/python/tests/backends/test_stim.py
+++ b/python/tests/backends/test_stim.py
@@ -32,6 +32,7 @@ def test_stim_non_clifford():
     with pytest.raises(RuntimeError) as e:
         # Cannot perform non-Clifford gates in Stim simulator
         cudaq.sample(kernel)
+    assert 'Gate not supported by Stim simulator' in repr(e)
 
 
 def test_stim_toffoli_gates():
@@ -44,6 +45,7 @@ def test_stim_toffoli_gates():
     with pytest.raises(RuntimeError) as e:
         # Cannot perform Toffoli gates in Stim simulator
         cudaq.sample(kernel)
+    assert 'Gates with >1 controls not supported by Stim simulator' in repr(e)
 
 
 def test_stim_sample():
@@ -61,6 +63,19 @@ def test_stim_sample():
     assert (len(counts) == 2)
     assert ('0' * 250 in counts)
     assert ('1' * 250 in counts)
+
+
+def test_stim_all_mz_types():
+    # Create the kernel we'd like to execute on Stim
+    @cudaq.kernel
+    def kernel():
+        qubits = cudaq.qvector(10)
+        mx(qubits)
+        my(qubits)
+        mz(qubits)
+
+    counts = cudaq.sample(kernel)
+    assert (len(counts) > 1)
 
 
 def test_stim_state_preparation():

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -772,7 +772,8 @@ protected:
       } catch (std::exception &e) {
         while (!gateQueue.empty())
           gateQueue.pop();
-        throw e;
+        throw std::runtime_error(
+            std::string("Exception in applyGate: ") + e.what());
       } catch (...) {
         while (!gateQueue.empty())
           gateQueue.pop();

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -174,10 +174,12 @@ protected:
           fmt::format("Gate not supported by Stim simulator: {}. Note that "
                       "Stim can only simulate Clifford gates.",
                       task.operationName));
+    else if (gateName == "SDG")
+      gateName = "S_DAG";
 
     if (task.controls.size() > 1)
       throw std::runtime_error(
-          "Gates with >1 controls not supported by stim simulator");
+          "Gates with >1 controls not supported by Stim simulator");
     if (task.controls.size() >= 1)
       gateName = "C" + gateName;
     for (auto c : task.controls)


### PR DESCRIPTION
We convert `my` measurements to a sequence of `sdg` + `h` + `mz` operations, so we need to support `sdg` gates. (We actually need to support `sdg` gates independent of `my` measurements; this is just a motivating use case to need to support them.)

* Also produce better error messages if gates are unsupported (fixes #2265)