### PR TITLE
Fix #2625: reduce invalid subvec operations to poison values.

### DIFF
--- a/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -329,7 +329,7 @@ struct FuseConstantToSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
     auto veqSize = [&]() -> std::int64_t {
       auto size = cast<quake::VeqType>(subveq.getVeq().getType()).getSize();
       // Note: do not support more than 2^32 qubits.
-      if (size == quake::SubVeqOp::kDynamicIndex)
+      if (size == quake::VeqType::kDynamicSize)
         return std::numeric_limits<std::int32_t>::max();
       return size - 1;
     }();

--- a/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -326,6 +326,13 @@ struct FuseConstantToSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
       return failure();
     bool regen = false;
     std::int64_t lo = subveq.getConstantLowerBound();
+    auto veqSize = [&]() -> std::int64_t {
+      auto size = cast<quake::VeqType>(subveq.getVeq().getType()).getSize();
+      // Note: do not support more than 2^32 qubits.
+      if (size == quake::SubVeqOp::kDynamicIndex)
+        return std::numeric_limits<std::int32_t>::max();
+      return size - 1;
+    }();
     Value loVal = subveq.getLower();
     if (!subveq.hasConstantLowerBound())
       if (auto olo = cudaq::opt::factory::getIntIfConstant(subveq.getLower())) {
@@ -345,8 +352,17 @@ struct FuseConstantToSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
 
     if (!regen)
       return failure();
-    rewriter.replaceOpWithNewOp<quake::SubVeqOp>(
-        subveq, subveq.getType(), subveq.getVeq(), loVal, hiVal, lo, hi);
+    if ((!loVal && (lo < 0 || lo > veqSize)) ||
+        (!hiVal && (hi < 0 || hi > veqSize)) || (!loVal && !hiVal && lo > hi)) {
+      // If any invalid conditions with the constants then replace the subveq
+      // with a poison value.
+      auto poison = rewriter.replaceOpWithNewOp<cudaq::cc::PoisonOp>(
+          subveq, subveq.getType());
+      poison.emitWarning("subrange of qvector is invalid.");
+    } else {
+      rewriter.replaceOpWithNewOp<quake::SubVeqOp>(
+          subveq, subveq.getType(), subveq.getVeq(), loVal, hiVal, lo, hi);
+    }
     return success();
   }
 };

--- a/python/tests/mlir/invalid_subrange.py
+++ b/python/tests/mlir/invalid_subrange.py
@@ -28,7 +28,7 @@ print('sample bar:')
 x = cudaq.sample(bar, shots_count=shots)
 print(x)
 
-# CHECK-LABEL:   func.func @__nvqpp__mlirgen__bar() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+# CHECK-LABEL:   func.func
 # CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 4 : i64
 # CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
 # CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64

--- a/python/tests/mlir/invalid_subrange.py
+++ b/python/tests/mlir/invalid_subrange.py
@@ -1,0 +1,66 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# RUN: PYTHONPATH=../../ pytest -rP  %s | FileCheck %s
+
+import cudaq
+
+@cudaq.kernel
+def bar():
+    ancilla = cudaq.qubit()
+    qubits = cudaq.qvector(4)
+    qubit_num = qubits.size()
+
+    for i in range(qubit_num):
+        if i == 0:
+            x.ctrl(ancilla, qubits[0])
+        else:
+            x.ctrl([ancilla, qubits[0:i]], qubits[i])
+
+print(bar)
+shots=10000
+print('sample bar:')
+x = cudaq.sample(bar, shots_count=shots)
+print(x)
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__bar() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+# CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 4 : i64
+# CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+# CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
+# CHECK-DAG:       %[[VAL_3:.*]] = quake.alloca !quake.ref
+# CHECK-DAG:       %[[VAL_4:.*]] = quake.alloca !quake.veq<4>
+# CHECK-DAG:       %[[VAL_5:.*]] = cc.alloca i64
+# CHECK:           cc.store %[[VAL_0]], %[[VAL_5]] : !cc.ptr<i64>
+# CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i64>
+# CHECK:           %[[VAL_7:.*]] = cc.loop while ((%[[VAL_8:.*]] = %[[VAL_2]]) -> (i64)) {
+# CHECK:             %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_6]] : i64
+# CHECK:             cc.condition %[[VAL_9]](%[[VAL_8]] : i64)
+# CHECK:           } do {
+# CHECK:           ^bb0(%[[VAL_10:.*]]: i64):
+# CHECK:             %[[VAL_11:.*]] = arith.cmpi eq, %[[VAL_10]], %[[VAL_2]] : i64
+# CHECK:             cc.if(%[[VAL_11]]) {
+# CHECK:               %[[VAL_12:.*]] = quake.extract_ref %[[VAL_4]][0] : (!quake.veq<4>) -> !quake.ref
+# CHECK:               quake.x {{\[}}%[[VAL_3]]] %[[VAL_12]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:             } else {
+# CHECK:               %[[VAL_13:.*]] = arith.subi %[[VAL_10]], %[[VAL_1]] : i64
+# CHECK:               %[[VAL_14:.*]] = quake.subveq %[[VAL_4]], 0, %[[VAL_13]] : (!quake.veq<4>, i64) -> !quake.veq<?>
+# CHECK:               %[[VAL_15:.*]] = quake.concat %[[VAL_3]], %[[VAL_14]] : (!quake.ref, !quake.veq<?>) -> !quake.veq<?>
+# CHECK:               %[[VAL_16:.*]] = quake.extract_ref %[[VAL_4]]{{\[}}%[[VAL_10]]] : (!quake.veq<4>, i64) -> !quake.ref
+# CHECK:               quake.x {{\[}}%[[VAL_15]]] %[[VAL_16]] : (!quake.veq<?>, !quake.ref) -> ()
+# CHECK:             }
+# CHECK:             cc.continue %[[VAL_10]] : i64
+# CHECK:           } step {
+# CHECK:           ^bb0(%[[VAL_17:.*]]: i64):
+# CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_1]] : i64
+# CHECK:             cc.continue %[[VAL_18]] : i64
+# CHECK:           } {invariant}
+# CHECK:           return
+# CHECK:         }
+
+# CHECK-LABEL: sample bar:
+# CHECK: { 00000:10000 }

--- a/python/tests/mlir/invalid_subrange.py
+++ b/python/tests/mlir/invalid_subrange.py
@@ -10,23 +10,25 @@
 
 import cudaq
 
-@cudaq.kernel
-def bar():
-    ancilla = cudaq.qubit()
-    qubits = cudaq.qvector(4)
-    qubit_num = qubits.size()
 
-    for i in range(qubit_num):
-        if i == 0:
-            x.ctrl(ancilla, qubits[0])
-        else:
-            x.ctrl([ancilla, qubits[0:i]], qubits[i])
-
-print(bar)
-shots=10000
-print('sample bar:')
-x = cudaq.sample(bar, shots_count=shots)
-print(x)
+def test_banjo():
+    @cudaq.kernel
+    def bar():
+        ancilla = cudaq.qubit()
+        qubits = cudaq.qvector(4)
+        qubit_num = qubits.size()
+    
+        for i in range(qubit_num):
+            if i == 0:
+                x.ctrl(ancilla, qubits[0])
+            else:
+                x.ctrl([ancilla, qubits[0:i]], qubits[i])
+    
+    print(bar)
+    shots=10000
+    print('sample bar:')
+    x = cudaq.sample(bar, shots_count=shots)
+    print(x)
 
 # CHECK-LABEL:   func.func
 # CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 4 : i64


### PR DESCRIPTION
Add checks for invalid ranges on the input veq. If the ranges are constant and invalid, then turn the subveq operation into a poison value. If this value is not optimized away, then the user's code contains errors per the CUDA-Q Spec.

Add regression test.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
