### PR TITLE
Fix #2525: Make exp_pauli a fully functional operator.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -1080,7 +1080,9 @@ class TwoTargetOp<string mnemonic, list<Trait> traits = []> :
 // Unitary quantum transformations
 //===----------------------------------------------------------------------===//
 
-def quake_ExpPauliOp : QuakeOp<"exp_pauli"> {
+def quake_ExpPauliOp : QuakeOp<"exp_pauli",
+    [QuantumGate, AttrSizedOperandSegments, OperatorInterface,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "General Pauli tensor product rotation";
   let description = [{
     This operation affects a general Pauli tensor product rotation on 
@@ -1090,16 +1092,138 @@ def quake_ExpPauliOp : QuakeOp<"exp_pauli"> {
   }];
   
   let arguments = (ins
-    AnyFloat:$parameter,
-    VeqType:$qubits,
-    Optional<AnyTypeOf<[cc_PointerType, cc_StdVectorType, cc_CharSpanType]>>:$pauli,
-    OptionalAttr<StrAttr>:$constantPauli
+    UnitAttr:$is_adj,
+    Variadic<AnyFloat>:$parameters,
+    Variadic<AnyQType>:$controls,
+    Variadic<AnyQTargetType>:$targets,
+    OptionalAttr<DenseBoolArrayAttr>:$negated_qubit_controls,
+    Optional<AnyTypeOf<[cc_PointerType, cc_CharSpanType]>>:$pauli,
+    OptionalAttr<StrAttr>:$pauliLiteral
   );
-  let results = (outs);
+  let results = (outs
+    Variadic<WireType>:$wires
+  );
 
   let assemblyFormat = [{
-    $parameter `,` $qubits `,` $pauli `:` functional-type(operands, results)
-      attr-dict
+    ( `<` `adj` $is_adj^ `>` )? ( `(` $parameters^ `)` )?
+      ( `[` $controls^ ( `neg` $negated_qubit_controls^ )? `]` )? $targets
+      `to` custom<RawString>($pauli, $pauliLiteral) `:`
+      functional-type(operands, results) attr-dict
+  }];
+
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "mlir::UnitAttr":$is_adj,
+                   "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::DenseBoolArrayAttr":$negates,
+                   "mlir::Value":$pauli), [{
+      return build($_builder, $_state, mlir::TypeRange{}, is_adj, parameters,
+                   controls, targets, negates, pauli, mlir::StringAttr{});
+    }]>,
+    OpBuilder<(ins "mlir::UnitAttr":$is_adj,
+                   "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::DenseBoolArrayAttr":$negates,
+                   "mlir::StringRef":$pauliLiteral), [{
+      return build($_builder, $_state, mlir::TypeRange{}, is_adj, parameters,
+                   controls, targets, negates, mlir::Value{},
+                   $_builder.getStringAttr(pauliLiteral));
+    }]>,
+    OpBuilder<(ins "bool":$is_adj,
+                   "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::Value":$pauli), [{
+      return build($_builder, $_state, mlir::TypeRange{}, is_adj, parameters,
+                   controls, targets, {}, pauli, mlir::StringAttr{});
+    }]>,
+    OpBuilder<(ins "bool":$is_adj,
+                   "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::StringRef":$pauliLiteral), [{
+      return build($_builder, $_state, mlir::TypeRange{}, is_adj, parameters,
+                   controls, targets, {}, mlir::Value{},
+                   $_builder.getStringAttr(pauliLiteral));
+    }]>,
+    OpBuilder<(ins "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::Value":$pauli), [{
+      return build($_builder, $_state, mlir::TypeRange{}, /*is_adj=*/false,
+                   parameters, controls, targets, {}, pauli,
+                   mlir::StringAttr{});
+    }]>,
+    OpBuilder<(ins "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::StringRef":$pauliLiteral), [{
+      return build($_builder, $_state, mlir::TypeRange{}, /*is_adj=*/false,
+                   parameters, controls, targets, {}, mlir::Value{},
+                   $_builder.getStringAttr(pauliLiteral));
+    }]>,
+    OpBuilder<(ins "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::Value":$pauli), [{
+      return build($_builder, $_state, mlir::TypeRange{}, /*is_adj=*/false,
+                   {}, controls, targets, {}, pauli, mlir::StringAttr{});
+    }]>,
+    OpBuilder<(ins "mlir::ValueRange":$controls,
+                   "mlir::ValueRange":$targets,
+                   "mlir::StringRef":$pauliLiteral), [{
+      return build($_builder, $_state, mlir::TypeRange{}, /*is_adj=*/false,
+                   {}, controls, targets, {}, mlir::Value{},
+                   $_builder.getStringAttr(pauliLiteral));
+    }]>,
+    OpBuilder<(ins "mlir::ValueRange":$targets,
+                   "mlir::Value":$pauli), [{
+      return build($_builder, $_state, mlir::TypeRange{}, /*is_adj=*/false,
+                   {}, {}, targets, {}, pauli, mlir::StringAttr{});
+    }]>,
+    OpBuilder<(ins "mlir::ValueRange":$targets,
+                   "mlir::StringRef":$pauliLiteral), [{
+      return build($_builder, $_state, mlir::TypeRange{}, /*is_adj=*/false,
+                   {}, {}, targets, {}, mlir::Value{},
+                   $_builder.getStringAttr(pauliLiteral));
+    }]>
+  ];
+
+  code extraClassDeclaration = [{
+    //===------------------------------------------------------------------===//
+    // MemoryEffects interface
+    //===------------------------------------------------------------------===//
+
+    void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::EffectInstance<
+      mlir::MemoryEffects::Effect>> &effects) {
+      quake::getOperatorEffectsImpl(effects, getControls(), getTargets());
+    }
+
+    //===------------------------------------------------------------------===//
+    // Properties
+    //===------------------------------------------------------------------===//
+
+    bool isAdj() { return getIsAdj(); }
+
+    //===------------------------------------------------------------------===//
+    // Element Access
+    //===------------------------------------------------------------------===//
+
+    mlir::Value getParameter(unsigned i = 0u) { return getParameters()[i]; }
+
+    mlir::Value getTarget(unsigned i = 0u) { return getTargets()[i]; }
+
+    //===------------------------------------------------------------------===//
+    // Operator interface
+    //===------------------------------------------------------------------===//
+
+    using Matrix = mlir::SmallVectorImpl<std::complex<double>>;
+
+    void getOperatorMatrix(Matrix &matrix) { matrix.clear(); }
   }];
 }
 
@@ -1445,8 +1569,8 @@ def CustomUnitarySymbolOp :
 
   let assemblyFormat = [{ $generator
     ( `<` `adj` $is_adj^ `>` )? ( `(` $parameters^ `)` )?
-    (`[` $controls^ (`neg` $negated_qubit_controls^ )? `]`)?
-    $targets `:` functional-type(operands, results) attr-dict
+      (`[` $controls^ (`neg` $negated_qubit_controls^ )? `]`)?
+      $targets `:` functional-type(operands, results) attr-dict
   }];
 }
 

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -430,7 +430,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__qis__rz__ctl(f64, !qir_array, !qir_qubit)
   func.func private @__quantum__qis__r1__ctl(f64, !qir_array, !qir_qubit)
 
-  func.func private @__quantum__qis__exp_pauli(f64, !qir_array, !qir_charptr)
+  func.func private @__quantum__qis__exp_pauli__ctl(f64, !qir_array, !qir_array, !qir_charptr)
   func.func private @__quantum__qis__custom_unitary(!cc.ptr<complex<f64>>, !qir_array, !qir_array, !qir_charptr)
   func.func private @__quantum__qis__custom_unitary__adj(!cc.ptr<complex<f64>>, !qir_array, !qir_array, !qir_charptr)
 
@@ -463,6 +463,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__qis__ry__body(f64, !qir_qubit)
   func.func private @__quantum__qis__rz__body(f64, !qir_qubit)
   func.func private @__quantum__qis__r1__body(f64, !qir_qubit)
+  func.func private @__quantum__qis__exp_pauli__body(f64, !qir_array, !qir_charptr)
 
   func.func private @__quantum__rt__result_record_output(!qir_result, !qir_charptr)
   func.func private @__quantum__qis__cnot__body(!qir_qubit, !qir_qubit)
@@ -493,6 +494,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__qis__ry(f64, !qir_qubit)
   func.func private @__quantum__qis__rz(f64, !qir_qubit)
   func.func private @__quantum__qis__r1(f64, !qir_qubit)
+  func.func private @__quantum__qis__exp_pauli(f64, !qir_array, !qir_charptr)
     )#"},
 
     // Choose one of the two QIR typing conventions. Opaque pointers are the

--- a/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
@@ -478,6 +478,14 @@ public:
     // a pauli_word directly `{i8*,i64}` or a string literal
     // `ptr<i8>`. If it is a string literal, we need to map it to
     // a pauli word.
+    if (instOp.getPauliLiteralAttr()) {
+      auto builder = cudaq::IRBuilder::atBlockEnd(parentModule.getBody());
+      auto pauliConst = builder.genCStringLiteralAppendNul(
+          loc, parentModule, *instOp.getPauliLiteral());
+      operands.push_back(rewriter.create<LLVM::AddressOfOp>(
+          loc, cudaq::opt::factory::getPointerType(pauliConst.getType()),
+          pauliConst.getSymName()));
+    }
     auto pauliWord = operands.back();
     if (auto ptrTy = dyn_cast<LLVM::LLVMPointerType>(pauliWord.getType())) {
       // Make sure we have the right types to extract the

--- a/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -15,6 +15,25 @@
 
 namespace {
 
+struct AdjustAdjointExpPauliPattern : OpRewritePattern<quake::ExpPauliOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(quake::ExpPauliOp pauli,
+                                PatternRewriter &rewriter) const override {
+    if (!pauli.isAdj())
+      return failure();
+    SmallVector<Value> negp;
+    if (!pauli.getParameters().empty())
+      negp.push_back(rewriter.create<arith::NegFOp>(pauli.getLoc(),
+                                                    pauli.getParameters()[0]));
+    rewriter.replaceOpWithNewOp<quake::ExpPauliOp>(
+        pauli, pauli.getResultTypes(), UnitAttr{}, negp, pauli.getControls(),
+        pauli.getTargets(), pauli.getNegatedQubitControlsAttr(),
+        pauli.getPauli(), pauli.getPauliLiteralAttr());
+    return success();
+  }
+};
+
 // %4 = quake.veq_size %3 : (!quake.veq<10>) -> 164
 // ────────────────────────────────────────────────
 // %4 = constant 10 : i64

--- a/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -336,9 +336,12 @@ struct ExpPauliDecomposition : public OpRewritePattern<quake::ExpPauliOp> {
                                 PatternRewriter &rewriter) const override {
     auto loc = expPauliOp.getLoc();
     auto module = expPauliOp->getParentOfType<ModuleOp>();
-    auto qubits = expPauliOp.getQubits();
+    auto qubits = expPauliOp.getTarget();
     auto theta = expPauliOp.getParameter();
     auto pauliWord = expPauliOp.getPauli();
+
+    if (expPauliOp.isAdj())
+      theta = rewriter.create<arith::NegFOp>(loc, theta);
 
     std::optional<StringRef> optPauliWordStr;
     if (auto defOp =

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -1985,7 +1985,7 @@ class PyASTBridge(ast.NodeVisitor):
                 theta = self.popValue()
                 if IntegerType.isinstance(theta.type):
                     theta = arith.SIToFPOp(self.getFloatType(), theta).result
-                quake.ExpPauliOp(theta, qubits, pauli=pauliWord)
+                quake.ExpPauliOp([], [theta], [], [qubits], pauli=pauliWord)
                 return
 
             elif node.func.id == 'int':

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -888,7 +888,8 @@ class PyKernel(object):
                 quantumVal = quake.ConcatOp(quake.VeqType.get(
                     self.ctx), [quantumVal] if quantumVal is not None else [] +
                                             qubitsList).result
-            quake.ExpPauliOp(thetaVal, quantumVal, pauli=pauliWordVal)
+            quake.ExpPauliOp([], [thetaVal], [], [quantumVal],
+                             pauli=pauliWordVal)
 
     def givens_rotation(self, angle, qubitA, qubitB):
         """

--- a/python/tests/mlir/exp_pauli.py
+++ b/python/tests/mlir/exp_pauli.py
@@ -1,0 +1,119 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# RUN: PYTHONPATH=../../ pytest -rP  %s | FileCheck %s
+
+import numpy as np
+import cudaq
+
+
+def test_exp_pauli():
+
+    @cudaq.kernel
+    def kernel_initial_state(angles: list[float]):
+        qreg = cudaq.qvector(len(angles))
+        for i in range(len(angles)):
+            rx(angles[i], qreg[i])
+
+    @cudaq.kernel
+    def U_exp_pauli(qubits: cudaq.qview):
+        exp_pauli(23.1, qubits, 'XIY')
+
+    @cudaq.kernel
+    def kernel_ancilla_exp_pauli(angles: list[float]):
+        ancilla = cudaq.qubit()
+        qreg = cudaq.qvector(len(angles))
+        for i in range(len(angles)):
+            rx(angles[i], qreg[i])
+        h(ancilla)
+        cudaq.control(U_exp_pauli, ancilla, qreg)
+
+    @cudaq.kernel
+    def rotate_y(qubit: cudaq.qview):
+        ry(0.88, qubit)
+
+    @cudaq.kernel
+    def kernel_ancilla_rotation(angles: list[float]):
+        ancilla = cudaq.qubit()
+        qreg = cudaq.qvector(len(angles))
+        for i in range(len(angles)):
+            rx(angles[i], qreg[i])
+        h(ancilla)
+        cudaq.control(rotate_y, ancilla, qreg)
+
+    @cudaq.kernel
+    def kernel_noancilla_rotation(angles: list[float]):
+        qreg = cudaq.qvector(len(angles))
+        for i in range(len(angles)):
+            rx(angles[i], qreg[i])
+        rotate_y(qreg)
+
+    cudaq.set_target('qpp-cpu')
+    angles = [0.34, 1.2, 1.6]
+
+    # create the initial state (using the initial state)
+    initial = np.array(cudaq.get_state(kernel_initial_state, angles))
+
+    # create the initial state + ancilla, hadamard, then perform a
+    # controlled rotation on the |1> subspace of the ancilla
+    full = np.array(cudaq.get_state(kernel_ancilla_rotation, angles))
+
+    # create the initial state and perform a rotation (for comparison with full)
+    rotation = np.array(cudaq.get_state(kernel_noancilla_rotation, angles))
+
+    # create the initial state + ancilla, hadamard, then perform a
+    # controlled exp_pauli on the |1> subspace of the ancilla
+    epauli = np.array(cudaq.get_state(kernel_ancilla_exp_pauli, angles))
+
+    print(cudaq.translate(kernel_ancilla_exp_pauli, format='qir'))
+
+
+# CHECK-LABEL: define void @__nvqpp__mlirgen__U_exp_pauli.ctrl(
+# CHECK:         call void @__quantum__qis__exp_pauli__ctl(double 2.310000e+01, %Array* %{{.*}}, %Array* %{{.*}}, i8* nonnull %{{.*}})
+
+# CHECK-LABEL: define void @__nvqpp__mlirgen__U_exp_pauli(
+# CHECK:         call void @__quantum__qis__exp_pauli(double 2.310000e+01, %Array* %{{.*}}, i8* nonnull {{.*}})
+
+# CHECK-LABEL: define void @__nvqpp__mlirgen__kernel_ancilla_exp_pauli({ double*, i64 }
+# CHECK-SAME:    %[[VAL_0:.*]])
+# CHECK:         %[[VAL_1:.*]] = alloca [1 x { i8*, i64 }], align 8
+# CHECK:         %[[VAL_2:.*]] = tail call %Qubit* @__quantum__rt__qubit_allocate()
+# CHECK:         %[[VAL_4:.*]] = extractvalue { double*, i64 } %[[VAL_0]], 1
+# CHECK:         %[[VAL_5:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_4]])
+# CHECK:         %[[VAL_7:.*]] = icmp sgt i64 %[[VAL_4]], 0
+# CHECK:         br i1 %[[VAL_7]], label %[[VAL_8:.*]], label %[[VAL_9:.*]]
+# CHECK:       :                                           ; preds = %[[VAL_10:.*]]
+# CHECK:         %[[VAL_11:.*]] = extractvalue { double*, i64 } %[[VAL_0]], 0
+# CHECK:         br label %[[VAL_12:.*]]
+# CHECK:       :                                                ; preds = %[[VAL_8]], %[[VAL_12]]
+# CHECK:         %[[VAL_13:.*]] = phi i64 [ 0, %[[VAL_8]] ], [ %[[VAL_14:.*]], %[[VAL_12]] ]
+# CHECK:         %[[VAL_15:.*]] = getelementptr double, double* %[[VAL_11]], i64 %[[VAL_13]]
+# CHECK:         %[[VAL_16:.*]] = load double, double* %[[VAL_15]], align 8
+# CHECK:         %[[VAL_17:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_5]], i64 %[[VAL_13]])
+# CHECK:         %[[VAL_18:.*]] = load %Qubit*, %Qubit** %[[VAL_17]], align 8
+# CHECK:         tail call void @__quantum__qis__rx(double %[[VAL_16]], %Qubit* %[[VAL_18]])
+# CHECK:         %[[VAL_14]] = add nuw nsw i64 %[[VAL_13]], 1
+# CHECK:         %[[VAL_19:.*]] = icmp slt i64 %[[VAL_14]], %[[VAL_4]]
+# CHECK:         br i1 %[[VAL_19]], label %[[VAL_12]], label %[[VAL_9]]
+# CHECK:       :                                      ; preds = %[[VAL_12]], %[[VAL_10]]
+# CHECK:         tail call void @__quantum__qis__h(%Qubit* %[[VAL_2]])
+# CHECK:         %[[VAL_20:.*]] = tail call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+# CHECK:         %[[VAL_21:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_20]], i64 0)
+# CHECK:         store %Qubit* %[[VAL_2]], %Qubit** %[[VAL_21]], align 8
+# CHECK:         %[[VAL_22:.*]] = bitcast [1 x { i8*, i64 }]* %[[VAL_1]] to i8*
+# CHECK:         call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %[[VAL_22]])
+# CHECK:         %[[VAL_23:.*]] = getelementptr inbounds [1 x { i8*, i64 }], [1 x { i8*, i64 }]* %[[VAL_1]], i64 0, i64 0, i32 0
+# CHECK:         store i8* getelementptr inbounds ([4 x i8], [4 x i8]* @cstr.58495900, i64 0, i64 0), i8** %[[VAL_23]], align 8
+# CHECK:         %[[VAL_24:.*]] = getelementptr inbounds [1 x { i8*, i64 }], [1 x { i8*, i64 }]* %[[VAL_1]], i64 0, i64 0, i32 1
+# CHECK:         store i64 3, i64* %[[VAL_24]], align 8
+# CHECK:         call void @__quantum__qis__exp_pauli__ctl(double 2.310000e+01, %Array* %[[VAL_20]], %Array* %[[VAL_5]], i8* nonnull %[[VAL_22]])
+# CHECK:         call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %[[VAL_22]])
+# CHECK-DAG:     call void @__quantum__rt__qubit_release(%Qubit* %[[VAL_2]])
+# CHECK-DAG:     call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_5]])
+# CHECK:         ret void
+# CHECK:       }

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -212,12 +212,9 @@ void exp_pauli(ImplicitLocOpBuilder &builder, const QuakeValue &theta,
                              "type as first argument.");
   cudaq::info("kernel_builder apply exp_pauli {}", pauliWord);
 
-  auto strLitTy = cc::PointerType::get(cc::ArrayType::get(
-      builder.getContext(), builder.getI8Type(), pauliWord.size() + 1));
-  Value stringLiteral = builder.create<cc::CreateStringLiteralOp>(
-      strLitTy, builder.getStringAttr(pauliWord));
-  SmallVector<Value> args{thetaVal, qubitsVal, stringLiteral};
-  builder.create<quake::ExpPauliOp>(TypeRange{}, args);
+  auto stringLiteral = builder.getStringAttr(pauliWord);
+  builder.create<quake::ExpPauliOp>(ValueRange{thetaVal}, ValueRange{},
+                                    ValueRange{qubitsVal}, stringLiteral);
 }
 
 /// @brief Search the given `FuncOp` for all `CallOps` recursively.

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -607,6 +607,26 @@ void __quantum__qis__exp_pauli(double theta, Array *qubits, char *pauliWord) {
   return;
 }
 
+void __quantum__qis__exp_pauli__ctl(double theta, Array *ctrls, Array *qubits,
+                                    char *pauliWord) {
+  struct CLikeString {
+    char *ptr = nullptr;
+    int64_t length = 0;
+  };
+  auto *castedString = reinterpret_cast<CLikeString *>(pauliWord);
+  std::string pauliWordStr(castedString->ptr, castedString->length);
+  auto ctrlQubitsVec = arrayToVectorSizeT(ctrls);
+  auto qubitsVec = arrayToVectorSizeT(qubits);
+  nvqir::getCircuitSimulatorInternal()->applyExpPauli(
+      theta, ctrlQubitsVec, qubitsVec, cudaq::spin_op::from_word(pauliWordStr));
+  return;
+}
+
+void __quantum__qis__exp_pauli__body(double theta, Array *qubits,
+                                     char *pauliWord) {
+  return __quantum__qis__exp_pauli(theta, qubits, pauliWord);
+}
+
 void __quantum__rt__result_record_output(Result *r, int8_t *name) {
   if (name && qubitPtrIsIndex)
     __quantum__qis__mz__to__register(measRes2QB[r],

--- a/test/AST-Quake/exp_pauli-1.cpp
+++ b/test/AST-Quake/exp_pauli-1.cpp
@@ -30,6 +30,6 @@ int main() {
 // CHECK:           quake.x %[[VAL_4]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_1]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_6:.*]] = cc.string_literal "XXXY" : !cc.ptr<!cc.array<i8 x 5>>
-// CHECK:           quake.exp_pauli %[[VAL_5]], %[[VAL_2]], %[[VAL_6]] : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
+// CHECK:           quake.exp_pauli (%[[VAL_5]]) %[[VAL_2]] to %[[VAL_6]] : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/exp_pauli-2.cpp
+++ b/test/AST-Quake/exp_pauli-2.cpp
@@ -30,7 +30,7 @@ int main() {
 // CHECK:           %[[VAL_5:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<4>) -> !quake.ref
 // CHECK:           quake.x %[[VAL_5]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_6:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
-// CHECK:           quake.exp_pauli %[[VAL_6]], %[[VAL_3]], %[[VAL_1]] : (f64, !quake.veq<4>, !cc.ptr<i8>) -> ()
+// CHECK:           quake.exp_pauli (%[[VAL_6]]) %[[VAL_3]] to %[[VAL_1]] : (f64, !quake.veq<4>, !cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/AST-Quake/exp_pauli-3.cpp
+++ b/test/AST-Quake/exp_pauli-3.cpp
@@ -35,6 +35,6 @@ int main() {
 // CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_2]][2] : (!quake.veq<4>) -> !quake.ref
 // CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_2]][3] : (!quake.veq<4>) -> !quake.ref
 // CHECK:           %[[VAL_11:.*]] = quake.concat %[[VAL_7]], %[[VAL_8]], %[[VAL_9]], %[[VAL_10]] : (!quake.ref, !quake.ref, !quake.ref, !quake.ref) -> !quake.veq<4>
-// CHECK:           quake.exp_pauli %[[VAL_5]], %[[VAL_11]], %[[VAL_6]] : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
+// CHECK:           quake.exp_pauli (%[[VAL_5]]) %[[VAL_11]] to %[[VAL_6]] : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/AST-Quake/pauli_word.cpp
+++ b/test/AST-Quake/pauli_word.cpp
@@ -28,7 +28,7 @@ __qpu__ void pauli_word_vec(std::vector<cudaq::pauli_word> words,
 // CHECK:           %[[VAL_5:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.charspan>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
 // CHECK:           %[[VAL_6:.*]] = cc.cast %[[VAL_5]] : (!cc.ptr<!cc.array<!cc.charspan x ?>>) -> !cc.ptr<!cc.charspan>
 // CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<!cc.charspan>
-// CHECK:           quake.exp_pauli %[[VAL_4]], %[[VAL_3]], %[[VAL_7]] : (f64, !quake.veq<4>, !cc.charspan) -> ()
+// CHECK:           quake.exp_pauli (%[[VAL_4]]) %[[VAL_3]] to %[[VAL_7]] : (f64, !quake.veq<4>, !cc.charspan) -> ()
 // CHECK:           return
 // CHECK:         }
 // clang-format on
@@ -46,7 +46,7 @@ __qpu__ void pauli_word(cudaq::pauli_word wordle, double theta) {
 // CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_4:.*]] = cc.load %[[VAL_2]] : !cc.ptr<f64>
-// CHECK:           quake.exp_pauli %[[VAL_4]], %[[VAL_3]], %[[VAL_0]] : (f64, !quake.veq<4>, !cc.charspan) -> ()
+// CHECK:           quake.exp_pauli (%[[VAL_4]]) %[[VAL_3]] to %[[VAL_0]] : (f64, !quake.veq<4>, !cc.charspan) -> ()
 // CHECK:           return
 // CHECK:         }
 // clang-format on

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -151,7 +151,8 @@ func.func @quantum_ops() {
   // Exp Pauli and StringLiteral
   %f2 = arith.constant 12.0 : f64
   %48 = cc.string_literal "XXY" : !cc.ptr<!cc.array<i8 x 4>>
-  quake.exp_pauli %f2, %46, %48 : (f64, !quake.veq<3>, !cc.ptr<!cc.array<i8 x 4>>) -> ()
+  quake.exp_pauli (%f2) %46 to %48 : (f64, !quake.veq<3>, !cc.ptr<!cc.array<i8 x 4>>) -> ()
+  quake.exp_pauli (%f2) %46 to "XYZ" : (f64, !quake.veq<3>) -> ()
   
   // State
   %i8 = arith.constant 8 : i64
@@ -278,7 +279,8 @@ cc.global constant private @quantum_ops.rodata_synth_0 (dense<[(0.707106769,0.00
 // CHECK:           quake.u3 (%[[VAL_20]], %[[VAL_21]], %[[VAL_53]]) {{\[}}%[[VAL_54]]] %[[VAL_10]] : (f32, f32, f64, !quake.veq<3>, !quake.ref) -> ()
 // CHECK:           %[[VAL_59:.*]] = arith.constant 1.200000e+01 : f64
 // CHECK:           %[[VAL_60:.*]] = cc.string_literal "XXY" : !cc.ptr<!cc.array<i8 x 4>>
-// CHECK:           quake.exp_pauli %[[VAL_59]], %[[VAL_54]], %[[VAL_60]] : (f64, !quake.veq<3>, !cc.ptr<!cc.array<i8 x 4>>) -> ()
+// CHECK:           quake.exp_pauli (%[[VAL_59]]) %[[VAL_54]] to %[[VAL_60]] : (f64, !quake.veq<3>, !cc.ptr<!cc.array<i8 x 4>>) -> ()
+// CHECK:           quake.exp_pauli (%[[VAL_59]]) %[[VAL_54]] to "XYZ" : (f64, !quake.veq<3>) -> ()
 // CHECK:           %[[VAL_61:.*]] = arith.constant 8 : i64
 // CHECK:           %[[VAL_62:.*]] = cc.address_of @quantum_ops.rodata_synth_0 : !cc.ptr<!cc.array<complex<f32> x 8>>
 // CHECK:           %[[VAL_63:.*]] = quake.create_state %[[VAL_62]], %[[VAL_61]] : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!cc.state>

--- a/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
+++ b/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
@@ -19,7 +19,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
     quake.x %3 : (!quake.ref) -> ()
     %4 = cc.load %0 : !cc.ptr<f64>
     %5 = cc.string_literal "XXXY" : !cc.ptr<!cc.array<i8 x 5>>
-    quake.exp_pauli %4, %1, %5 : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
+    quake.exp_pauli (%4) %1 to %5 : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
     return
   }
 
@@ -73,7 +73,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
     %1 = cc.cast %0 : (!cc.ptr<!llvm.array<3 x i8>>) -> !cc.ptr<i8>
     %2 = cc.stdvec_init %1, %c2_i64 : (!cc.ptr<i8>, i64) -> !cc.charspan
     %3 = quake.alloca !quake.veq<2>
-    quake.exp_pauli %cst, %3, %2 : (f64, !quake.veq<2>, !cc.charspan) -> ()
+    quake.exp_pauli (%cst) %3 to %2 : (f64, !quake.veq<2>, !cc.charspan) -> ()
     return
   }
   llvm.mlir.global private constant @cstr.585900("XY\00") {addr_space = 0 : i32}

--- a/test/Transforms/qir_base_profile.qke
+++ b/test/Transforms/qir_base_profile.qke
@@ -187,7 +187,7 @@ module attributes {cc.sizeof_string = 32 : i64, llvm.data_layout = "e-m:e-p270:3
 // CHECK:         func.func private @__quantum__qis__ry__ctl(f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<!llvm.struct<"Qubit", opaque>>)
 // CHECK:         func.func private @__quantum__qis__rz__ctl(f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<!llvm.struct<"Qubit", opaque>>)
 // CHECK:         func.func private @__quantum__qis__r1__ctl(f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<!llvm.struct<"Qubit", opaque>>)
-// CHECK:         func.func private @__quantum__qis__exp_pauli(f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<i8>)
+// CHECK:         func.func private @__quantum__qis__exp_pauli__ctl(f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<i8>)
 // CHECK:         func.func private @__quantum__qis__custom_unitary(!cc.ptr<complex<f64>>, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<i8>)
 // CHECK:         func.func private @__quantum__qis__custom_unitary__adj(!cc.ptr<complex<f64>>, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<i8>)
 // CHECK:         llvm.func @generalizedInvokeWithRotationsControlsTargets(i64, i64, i64, i64, !llvm.ptr<i8>, ...) attributes {sym_visibility = "private"}
@@ -208,6 +208,7 @@ module attributes {cc.sizeof_string = 32 : i64, llvm.data_layout = "e-m:e-p270:3
 // CHECK:         func.func private @__quantum__qis__ry__body(f64, !cc.ptr<!llvm.struct<"Qubit", opaque>>)
 // CHECK:         func.func private @__quantum__qis__rz__body(f64, !cc.ptr<!llvm.struct<"Qubit", opaque>>)
 // CHECK:         func.func private @__quantum__qis__r1__body(f64, !cc.ptr<!llvm.struct<"Qubit", opaque>>)
+// CHECK:         func.func private @__quantum__qis__exp_pauli__body(f64, !cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<i8>)
 // CHECK:         func.func private @__quantum__rt__result_record_output(!cc.ptr<!llvm.struct<"Result", opaque>>, !cc.ptr<i8>)
 // CHECK:         func.func private @__quantum__qis__cnot__body(!cc.ptr<!llvm.struct<"Qubit", opaque>>, !cc.ptr<!llvm.struct<"Qubit", opaque>>)
 // CHECK:         func.func private @__quantum__qis__cz__body(!cc.ptr<!llvm.struct<"Qubit", opaque>>, !cc.ptr<!llvm.struct<"Qubit", opaque>>)

--- a/test/Translate/exp_pauli-1.qke
+++ b/test/Translate/exp_pauli-1.qke
@@ -19,7 +19,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
     quake.x %3 : (!quake.ref) -> ()
     %4 = cc.load %0 : !cc.ptr<f64>
     %5 = cc.string_literal "XXXY" : !cc.ptr<!cc.array<i8 x 5>>
-    quake.exp_pauli %4, %1, %5 : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
+    quake.exp_pauli (%4) %1 to %5 : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
     return
   }
 }

--- a/test/Translate/exp_pauli-3.qke
+++ b/test/Translate/exp_pauli-3.qke
@@ -25,7 +25,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
     %8 = quake.extract_ref %1[2] : (!quake.veq<4>) -> !quake.ref
     %9 = quake.extract_ref %1[3] : (!quake.veq<4>) -> !quake.ref
     %10 = quake.concat %6, %7, %8, %9 : (!quake.ref, !quake.ref, !quake.ref, !quake.ref) -> !quake.veq<4>
-    quake.exp_pauli %4, %10, %5 : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
+    quake.exp_pauli (%4) %10 to %5 : (f64, !quake.veq<4>, !cc.ptr<!cc.array<i8 x 5>>) -> ()
     return
   }
 }


### PR DESCRIPTION
These changes extend the quake.exp_pauli operation to be more fully functional like the other builtin quake operators.  This operator will now use a similar syntax, support adjoint, controls, etc.

Update the roundtrip test for syntax changes. Update tests. Add a new python regression test from the issue #2525.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
