### PR TITLE
Fix for nightly tests.

### DIFF
--- a/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -1932,9 +1932,8 @@ struct QuakeToQIRAPIFinalPass
     auto *ctx = &getContext();
     ModuleOp module = getOperation();
     RewritePatternSet patterns(ctx);
-    patterns.insert<MaterializeConstantArrayOpRewrite>(ctx);
-    if (api == "base-profile")
-      patterns.insert<AnnotateKernelsWithMeasurementStringsPattern>(ctx);
+    patterns.insert<MaterializeConstantArrayOpRewrite,
+                    AnnotateKernelsWithMeasurementStringsPattern>(ctx);
     if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns))))
       signalPassFailure();
   }


### PR DESCRIPTION
Add output_name map when generating adaptive profile.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
