### PR TITLE
Pin buildx/buildkit to v0.19.0 to fix qemu crashes during multi-platform build

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -218,7 +218,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
-          driver-opts: network=host
+          version: v0.19.0
+          driver-opts: |
+            network=host
+            image=moby/buildkit:v0.19.0
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -161,7 +161,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
-          driver-opts: network=host
+          version: v0.19.0
+          driver-opts: |
+            network=host
+            image=moby/buildkit:v0.19.0
 
       - name: Build Open MPI
         id: docker_build
@@ -308,7 +311,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
-          driver-opts: network=host
+          version: v0.19.0
+          driver-opts: |
+            network=host
+            image=moby/buildkit:v0.19.0
 
       - name: Extract metadata
         id: metadata
@@ -512,7 +518,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
-          driver-opts: network=host
+          version: v0.19.0
+          driver-opts: |
+            network=host
+            image=moby/buildkit:v0.19.0
 
       - name: Extract cuda-quantum-dev metadata
         id: cudaqdev_metadata

--- a/.github/workflows/generate_cc.yml
+++ b/.github/workflows/generate_cc.yml
@@ -60,6 +60,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Build CUDA Quantum
         id: cudaq_build

--- a/.github/workflows/gh_registry.yml
+++ b/.github/workflows/gh_registry.yml
@@ -121,6 +121,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Prepare push
         id: metadata

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -121,6 +121,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Extract metadata
         id: metadata
@@ -195,6 +198,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Login to NGC container registry
         uses: docker/login-action@v3

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -127,7 +127,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
-          driver-opts: network=host
+          version: v0.19.0
+          driver-opts: |
+            network=host
+            image=moby/buildkit:v0.19.0
 
       - name: Extract metadata
         id: metadata
@@ -225,6 +228,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -430,6 +430,10 @@ jobs:
 
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Extract cuda-quantum metadata
         id: metadata
@@ -586,6 +590,10 @@ jobs:
 
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Build installer
         uses: docker/build-push-action@v5
@@ -696,7 +704,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
-          driver-opts: network=host
+          version: v0.19.0
+          driver-opts: |
+            network=host
+            image=moby/buildkit:v0.19.0
 
       - name: Build cuda-quantum wheel
         id: build_wheel

--- a/.github/workflows/publishing_stable.yml
+++ b/.github/workflows/publishing_stable.yml
@@ -115,6 +115,10 @@ jobs:
 
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Update cuda-quantum metadata
         id: metadata

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -129,7 +129,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
-          driver-opts: network=host
+          version: v0.19.0
+          driver-opts: |
+            network=host
+            image=moby/buildkit:v0.19.0
 
       - name: Build wheel
         id: wheel_build

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -61,6 +61,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Build CUDA Quantum
         run: |
@@ -191,6 +194,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           endpoint: builder_context
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
 
       - name: Set up dev environment
         id: dev_env


### PR DESCRIPTION
[BuildKit v0.20.0](https://github.com/moby/buildkit/releases/tag/v0.20.0) was just released, and it is segfaulting for us, possibly due to this change:

> Embedded binfmt emulators in the release image have been updated to QEMU v9.2.0 https://github.com/moby/buildkit/pull/5695 https://github.com/moby/buildkit/pull/5736

Ref: https://github.com/tonistiigi/binfmt/issues/240#issuecomment-2675891118 and https://github.com/tonistiigi/binfmt/issues/240#issuecomment-2675900299

Note: this may or may not be related, but our GHA runners are currently pinned to an old kernel version due to https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2096782. However, I have done prior testing using a newer kernel combined with QEMU v9.2.0, and it was not working on our runners.

Specific logs that were working and then failing right after the update to v0.20.0:
failed: https://github.com/NVIDIA/cuda-quantum/actions/runs/13448242057/job/37578259867
worked: https://github.com/NVIDIA/cuda-quantum/actions/runs/13426413990/job/37510410910