### PR TITLE
Refactor noise model for unitary mixtures

### DIFF
--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -156,8 +156,9 @@ void generateUnitaryParameters_fp32(
     // data for this specific routine is actually fp32.
     const std::complex<float> *ptr =
         reinterpret_cast<const std::complex<float> *>(op.data.data());
+    // Use 2 * size because pointer arithmetic is on fp32 instead of fp64
     double_kraus_ops.emplace_back(
-        std::vector<std::complex<double>>(ptr, ptr + op.data.size()));
+        std::vector<std::complex<double>>(ptr, ptr + 2 * op.data.size()));
   }
 
   auto asUnitaryMixture = computeUnitaryMixture(double_kraus_ops);

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -10,7 +10,68 @@
 #include "Logger.h"
 #include "common/CustomOp.h"
 #include "common/EigenDense.h"
+#include <numeric>
+#include <optional>
+
 namespace cudaq {
+
+// Helper to check whether a matrix is a scaled unitary matrix, i.e., `k * U`
+// where U is a unitary matrix. If so, it also returns the `k` factor.
+// Otherwise, return a nullopt.
+static std::optional<double>
+isScaledUnitary(const std::vector<std::complex<double>> &mat, double eps) {
+  typedef Eigen::Matrix<std::complex<double>, Eigen::Dynamic, Eigen::Dynamic,
+                        Eigen::RowMajor>
+      RowMajorMatTy;
+  const int dim = std::log2(mat.size());
+  Eigen::Map<const RowMajorMatTy> kMat(mat.data(), dim, dim);
+  if (kMat.isZero())
+    return std::nullopt;
+  // Check that (K_dag * K) is a scaled identity matrix
+  // i.e., the K matrix is a scaled unitary.
+  auto kdK = kMat.adjoint() * kMat;
+  if (!kdK.isDiagonal())
+    return std::nullopt;
+  // First element
+  std::complex<double> val = kdK(0, 0);
+  if (std::abs(val) > eps && std::abs(val.imag()) < eps) {
+    auto scaledKdK = (std::complex<double>{1.0} / val) * kdK;
+    if (scaledKdK.isIdentity())
+      return val.real();
+  }
+  return std::nullopt;
+}
+
+// Helper to determine if a vector of Kraus ops are actually a unitary mixture.
+// If so, it returns all the unitaries and the probabilities associated with
+// each one of those unitaries.
+static std::optional<std::pair<std::vector<double>,
+                               std::vector<std::vector<std::complex<double>>>>>
+computeUnitaryMixture(
+    const std::vector<std::vector<std::complex<double>>> &krausOps,
+    double tol = 1e-6) {
+  std::vector<double> probs;
+  std::vector<std::vector<std::complex<double>>> mats;
+  const auto scaleMat = [](const std::vector<std::complex<double>> &mat,
+                           double scaleFactor) {
+    std::vector<std::complex<double>> scaledMat = mat;
+    for (auto &x : scaledMat)
+      x /= scaleFactor;
+    return scaledMat;
+  };
+  for (const auto &op : krausOps) {
+    const auto scaledFactor = isScaledUnitary(op, tol);
+    if (!scaledFactor.has_value())
+      return std::nullopt;
+    probs.emplace_back(scaledFactor.value());
+    mats.emplace_back(scaleMat(op, scaledFactor.value()));
+  }
+
+  if (std::abs(1.0 - std::reduce(probs.begin(), probs.end())) > tol)
+    return std::nullopt;
+
+  return std::make_pair(probs, mats);
+}
 
 template <typename EigenMatTy>
 bool isIdentity(const EigenMatTy &mat, double threshold = 1e-9) {
@@ -78,9 +139,51 @@ void validateCompletenessRelation_fp64(const std::vector<kraus_op> &ops) {
         "Provided kraus_ops are not completely positive and trace preserving.");
 }
 
+void generateUnitaryParameters_fp32(
+    const std::vector<kraus_op> &ops,
+    std::vector<std::vector<std::complex<double>>> &unitary_ops,
+    std::vector<double> &probabilities) {
+  std::vector<std::vector<std::complex<double>>> double_kraus_ops;
+  double_kraus_ops.reserve(ops.size());
+  for (auto &op : ops) {
+    // WARNING: danger here. We are intentially treating the incoming op as fp32
+    // type instead of what the compiler thinks it is (fp64). We have to do this
+    // because this file is compiled with cudaq::real = fp64, but the incoming
+    // data for this specific routine is actually fp32.
+    const std::complex<float> *ptr =
+        reinterpret_cast<const std::complex<float> *>(op.data.data());
+    double_kraus_ops.emplace_back(
+        std::vector<std::complex<double>>(ptr, ptr + op.data.size()));
+  }
+
+  auto asUnitaryMixture = computeUnitaryMixture(double_kraus_ops);
+  if (asUnitaryMixture.has_value()) {
+    probabilities = std::move(asUnitaryMixture.value().first);
+    unitary_ops = std::move(asUnitaryMixture.value().second);
+  }
+}
+
+void generateUnitaryParameters_fp64(
+    const std::vector<kraus_op> &ops,
+    std::vector<std::vector<std::complex<double>>> &unitary_ops,
+    std::vector<double> &probabilities) {
+  std::vector<std::vector<std::complex<double>>> double_kraus_ops;
+  double_kraus_ops.reserve(ops.size());
+  for (auto &op : ops)
+    double_kraus_ops.emplace_back(
+        std::vector<std::complex<double>>(op.data.begin(), op.data.end()));
+
+  auto asUnitaryMixture = computeUnitaryMixture(double_kraus_ops);
+  if (asUnitaryMixture.has_value()) {
+    probabilities = std::move(asUnitaryMixture.value().first);
+    unitary_ops = std::move(asUnitaryMixture.value().second);
+  }
+}
+
 kraus_channel::kraus_channel(const kraus_channel &other)
     : ops(other.ops), noise_type(other.noise_type),
-      parameters(other.parameters) {}
+      parameters(other.parameters), unitary_ops(other.unitary_ops),
+      probabilities(other.probabilities) {}
 
 std::size_t kraus_channel::size() const { return ops.size(); }
 
@@ -94,6 +197,8 @@ kraus_channel &kraus_channel::operator=(const kraus_channel &other) {
   ops = other.ops;
   noise_type = other.noise_type;
   parameters = other.parameters;
+  unitary_ops = other.unitary_ops;
+  probabilities = other.probabilities;
   return *this;
 }
 

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -102,6 +102,12 @@ struct kraus_op {
 
 void validateCompletenessRelation_fp32(const std::vector<kraus_op> &ops);
 void validateCompletenessRelation_fp64(const std::vector<kraus_op> &ops);
+void generateUnitaryParameters_fp32(
+    const std::vector<kraus_op> &ops,
+    std::vector<std::vector<std::complex<double>>> &, std::vector<double> &);
+void generateUnitaryParameters_fp64(
+    const std::vector<kraus_op> &ops,
+    std::vector<std::vector<std::complex<double>>> &, std::vector<double> &);
 
 /// @brief A kraus_channel represents a quantum noise channel
 /// on specific qubits. The action of the noise channel is
@@ -143,7 +149,17 @@ public:
   // corruption.
   std::vector<double> parameters;
 
-  ~kraus_channel() = default;
+  /// @brief If all Kraus ops are - when scaled - unitary, this holds the
+  /// unitary versions of those ops. These values are always "double" regardless
+  /// of whether cudaq::real is float or double.
+  std::vector<std::vector<std::complex<double>>> unitary_ops;
+
+  /// @brief If all Kraus ops are - when scaled - unitary, this holds the
+  /// probabilities of those ops. These values are always "double" regardless
+  /// of whether cudaq::real is float or double.
+  std::vector<double> probabilities;
+
+  virtual ~kraus_channel() = default;
 
   /// @brief The nullary constructor
   kraus_channel() = default;
@@ -158,12 +174,14 @@ public:
   kraus_channel(std::initializer_list<T> &&...inputLists) {
     (ops.emplace_back(std::move(inputLists)), ...);
     validateCompleteness();
+    generateUnitaryParameters();
   }
 
   /// @brief The constructor, take qubits and channel kraus_ops as lvalue
   /// reference
   kraus_channel(const std::vector<kraus_op> &inOps) : ops(inOps) {
     validateCompleteness();
+    generateUnitaryParameters();
   }
 
   /// @brief The constructor, take qubits and channel kraus_ops as rvalue
@@ -189,6 +207,23 @@ public:
 
   /// @brief Add a kraus_op to this channel.
   void push_back(kraus_op op);
+
+  /// @brief Returns whether or not this is a unitary mixture.
+  bool is_unitary_mixture() const { return !unitary_ops.empty(); }
+
+  /// @brief Checks if Kraus ops have unitary representations and saves them if
+  /// they do. Users should only need to call this if they have modified the
+  /// Kraus ops and want to recompute these values.
+  void generateUnitaryParameters() {
+    unitary_ops.clear();
+    probabilities.clear();
+    if constexpr (std::is_same_v<cudaq::complex::value_type, float>) {
+      generateUnitaryParameters_fp32(ops, this->unitary_ops,
+                                     this->probabilities);
+      return;
+    }
+    generateUnitaryParameters_fp64(ops, this->unitary_ops, this->probabilities);
+  }
 };
 
 /// @brief The noise_model type keeps track of a set of
@@ -381,6 +416,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::depolarization_channel;
     validateCompleteness();
+    generateUnitaryParameters();
   }
 };
 
@@ -396,6 +432,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::amplitude_damping_channel;
     validateCompleteness();
+    generateUnitaryParameters();
   }
 };
 
@@ -412,6 +449,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::bit_flip_channel;
     validateCompleteness();
+    generateUnitaryParameters();
   }
 };
 
@@ -429,6 +467,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::phase_flip_channel;
     validateCompleteness();
+    generateUnitaryParameters();
   }
 };
 } // namespace cudaq

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -432,7 +432,8 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::amplitude_damping_channel;
     validateCompleteness();
-    generateUnitaryParameters();
+    // Note: amplitude damping is non-unitary, so there is no value in calling
+    // generateUnitaryParameters().
   }
 };
 

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
@@ -11,17 +11,6 @@
 #include "cutensornet.h"
 #include "tensornet_spin_op.h"
 
-namespace {
-const std::vector<std::complex<double>> matPauliI = {
-    {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}};
-const std::vector<std::complex<double>> matPauliX{
-    {0.0, 0.0}, {1.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}};
-const std::vector<std::complex<double>> matPauliY{
-    {0.0, 0.0}, {0.0, -1.0}, {0.0, 1.0}, {0.0, 0.0}};
-const std::vector<std::complex<double>> matPauliZ{
-    {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {-1.0, 0.0}};
-} // namespace
-
 namespace nvqir {
 
 SimulatorTensorNetBase::SimulatorTensorNetBase()
@@ -148,66 +137,7 @@ void SimulatorTensorNetBase::applyGate(const GateApplicationTask &task) {
   }
 }
 
-// Helper to check whether a matrix is a scaled unitary matrix, i.e., `k * U`
-// where U is a unitary matrix. If so, it also returns the `k` factor.
-// Otherwise, return a nullopt.
-template <typename T>
-std::optional<double> isScaledUnitary(const std::vector<std::complex<T>> &mat,
-                                      double eps) {
-  typedef Eigen::Matrix<std::complex<T>, Eigen::Dynamic, Eigen::Dynamic,
-                        Eigen::RowMajor>
-      RowMajorMatTy;
-  const int dim = std::log2(mat.size());
-  Eigen::Map<const RowMajorMatTy> kMat(mat.data(), dim, dim);
-  if (kMat.isZero())
-    return std::nullopt;
-  // Check that (K_dag * K) is a scaled identity matrix
-  // i.e., the K matrix is a scaled unitary.
-  auto kdK = kMat.adjoint() * kMat;
-  if (!kdK.isDiagonal())
-    return std::nullopt;
-  // First element
-  std::complex<T> val = kdK(0, 0);
-  if (std::abs(val) > eps && std::abs(val.imag()) < eps) {
-    auto scaledKdK = (std::complex<T>{1.0} / val) * kdK;
-    if (scaledKdK.isIdentity())
-      return val.real();
-  }
-  return std::nullopt;
-}
-
-std::optional<std::pair<
-    std::vector<double>,
-    std::vector<std::vector<std::complex<
-        double>>>>> static computeUnitaryMixture(const std::
-                                                     vector<std::vector<
-                                                         std::complex<double>>>
-                                                         &krausOps,
-                                                 double tol = 1e-6) {
-  std::vector<double> probs;
-  std::vector<std::vector<std::complex<double>>> mats;
-  const auto scaleMat = [](const std::vector<std::complex<double>> &mat,
-                           double scaleFactor) {
-    std::vector<std::complex<double>> scaledMat = mat;
-    for (auto &x : scaledMat)
-      x /= scaleFactor;
-    return scaledMat;
-  };
-  for (const auto &op : krausOps) {
-    const auto scaledFactor = isScaledUnitary(op, tol);
-    if (!scaledFactor.has_value())
-      return std::nullopt;
-    probs.emplace_back(scaledFactor.value());
-    mats.emplace_back(scaleMat(op, scaledFactor.value()));
-  }
-
-  if (std::abs(1.0 - std::reduce(probs.begin(), probs.end())) > tol)
-    return std::nullopt;
-
-  return std::make_pair(probs, mats);
-}
-
-// Helper to look up a device memory pointer from a  cache.
+// Helper to look up a device memory pointer from a cache.
 // If not found, allocate a new device memory buffer and put it to the cache.
 static void *
 getOrCacheMat(const std::string &key,
@@ -227,85 +157,16 @@ void SimulatorTensorNetBase::applyKrausChannel(
     const std::vector<int32_t> &qubits,
     const cudaq::kraus_channel &krausChannel) {
   LOG_API_TIME();
-  switch (krausChannel.noise_type) {
-  case cudaq::noise_model_type::depolarization_channel: {
-    if (krausChannel.parameters.size() != 1)
-      throw std::runtime_error(
-          fmt::format("Invalid parameters for a depolarization channel. "
-                      "Expecting 1 parameter, got {}.",
-                      krausChannel.parameters.size()));
-    const std::vector<void *> channelMats{
-        getOrCacheMat("PauliI", matPauliI, m_gateDeviceMemCache),
-        getOrCacheMat("PauliX", matPauliX, m_gateDeviceMemCache),
-        getOrCacheMat("PauliY", matPauliY, m_gateDeviceMemCache),
-        getOrCacheMat("PauliZ", matPauliZ, m_gateDeviceMemCache)};
-    const double p = krausChannel.parameters[0];
-    const std::vector<double> probabilities = {1 - p, p / 3., p / 3., p / 3.};
-    m_state->applyUnitaryChannel(qubits, channelMats, probabilities);
-    break;
-  }
-  case cudaq::noise_model_type::bit_flip_channel: {
-    if (krausChannel.parameters.size() != 1)
-      throw std::runtime_error(
-          fmt::format("Invalid parameters for a bit-flip channel. "
-                      "Expecting 1 parameter, got {}.",
-                      krausChannel.parameters.size()));
-
-    const std::vector<void *> channelMats{
-        getOrCacheMat("PauliI", matPauliI, m_gateDeviceMemCache),
-        getOrCacheMat("PauliX", matPauliX, m_gateDeviceMemCache)};
-    const double p = krausChannel.parameters[0];
-    const std::vector<double> probabilities = {1 - p, p};
-    m_state->applyUnitaryChannel(qubits, channelMats, probabilities);
-    break;
-  }
-  case cudaq::noise_model_type::phase_flip_channel: {
-    if (krausChannel.parameters.size() != 1)
-      throw std::runtime_error(
-          fmt::format("Invalid parameters for a phase-flip channel. "
-                      "Expecting 1 parameter, got {}.",
-                      krausChannel.parameters.size()));
-
-    const std::vector<void *> channelMats{
-        getOrCacheMat("PauliI", matPauliI, m_gateDeviceMemCache),
-        getOrCacheMat("PauliZ", matPauliZ, m_gateDeviceMemCache)};
-    const double p = krausChannel.parameters[0];
-    const std::vector<double> probabilities = {1 - p, p};
-    m_state->applyUnitaryChannel(qubits, channelMats, probabilities);
-    break;
-  }
-  case cudaq::noise_model_type::amplitude_damping_channel: {
-    if (krausChannel.parameters.size() != 1)
-      throw std::runtime_error(
-          fmt::format("Invalid parameters for a amplitude damping channel. "
-                      "Expecting 1 parameter, got {}.",
-                      krausChannel.parameters.size()));
-    if (krausChannel.parameters[0] != 0.0)
-      throw std::runtime_error("Non-unitary noise channels are not supported.");
-    break;
-  }
-  case cudaq::noise_model_type::unknown: {
-    std::vector<std::vector<std::complex<double>>> mats;
-    for (const auto &op : krausChannel.get_ops())
-      mats.emplace_back(op.data);
-    auto asUnitaryMixture = computeUnitaryMixture(mats);
-    if (asUnitaryMixture.has_value()) {
-      auto &[probabilities, unitaries] = asUnitaryMixture.value();
-      std::vector<void *> channelMats;
-      for (const auto &mat : unitaries)
-        channelMats.emplace_back(getOrCacheMat(
-            "ScaledUnitary_" + std::to_string(vecComplexHash(mat)), mat,
-            m_gateDeviceMemCache));
-      m_state->applyUnitaryChannel(qubits, channelMats, probabilities);
-    } else {
-      throw std::runtime_error("Non-unitary noise channels are not supported.");
-    }
-    break;
-  }
-  default:
-    throw std::runtime_error(
-        "Unsupported noise model type: " +
-        std::to_string(static_cast<int>(krausChannel.noise_type)));
+  if (krausChannel.is_unitary_mixture()) {
+    std::vector<void *> channelMats;
+    for (const auto &mat : krausChannel.unitary_ops)
+      channelMats.emplace_back(
+          getOrCacheMat("ScaledUnitary_" + std::to_string(vecComplexHash(mat)),
+                        mat, m_gateDeviceMemCache));
+    m_state->applyUnitaryChannel(qubits, channelMats,
+                                 krausChannel.probabilities);
+  } else {
+    throw std::runtime_error("Non-unitary noise channels are not supported.");
   }
 }
 

--- a/unittests/integration/noise_tester.cpp
+++ b/unittests/integration/noise_tester.cpp
@@ -378,71 +378,71 @@ CUDAQ_TEST(NoiseTest, checkAllQubitChannel) {
 // Stim does not support arbitrary cudaq::kraus_op specification.
 
 static cudaq::kraus_channel create2pNoiseChannel() {
-  // 1% depolarization
-  cudaq::kraus_op op0{cudaq::complex{0.94868329805, 0.0},
+  // 20% depolarization
+  cudaq::kraus_op op0{cudaq::complex{0.894427191, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
-                      {0.94868329805, 0.0},
+                      {0.894427191, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
-                      {0.94868329805, 0.0},
+                      {0.894427191, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
-                      {0.94868329805, 0.0}},
+                      {0.894427191, 0.0}},
       op1{cudaq::complex{0.0, 0.0},
           {0.0, 0.0},
-          {0.18257418583, 0.0},
+          {0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.18257418583, 0.0},
-          {0.18257418583, 0.0},
+          {0.25819888974, 0.0},
+          {0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.18257418583, 0.0},
+          {0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0}},
       op2{cudaq::complex{0.0, 0.0},
           {0.0, 0.0},
-          {0.0, -0.18257418583},
+          {0.0, -0.25819888974},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.0, -0.18257418583},
-          {0.0, 0.18257418583},
+          {0.0, -0.25819888974},
+          {0.0, 0.25819888974},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.0, 0.18257418583},
+          {0.0, 0.25819888974},
           {0.0, 0.0},
           {0.0, 0.0}},
-      op3{cudaq::complex{0.18257418583, 0.0},
+      op3{cudaq::complex{0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.18257418583, 0.0},
+          {0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {-0.18257418583, 0.0},
+          {-0.25819888974, 0.0},
           {-0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {-0.0, 0.0},
-          {-0.18257418583, 0.0}};
+          {-0.25819888974, 0.0}};
   cudaq::kraus_channel noise2q(
       std::vector<cudaq::kraus_op>{op0, op1, op2, op3});
   return noise2q;
@@ -481,6 +481,7 @@ CUDAQ_TEST(NoiseTest, checkAllQubitChannelWithControl) {
     auto counts =
         cudaq::sample({.shots = shots, .noise = noise}, bellRandom<numQubits>{},
                       qubitIds[0], qubitIds[1]);
+    counts.dump();
     // More than 2 entangled states due to the noise.
     EXPECT_GT(counts.size(), 2);
   } while (std::next_permutation(qubitIds.begin(), qubitIds.end()));
@@ -509,6 +510,7 @@ CUDAQ_TEST(NoiseTest, checkAllQubitChannelWithControlPrefix) {
     auto counts =
         cudaq::sample({.shots = shots, .noise = noise}, bellRandom<numQubits>{},
                       qubitIds[0], qubitIds[1]);
+    counts.dump();
     // More than 2 entangled states due to the noise.
     EXPECT_GT(counts.size(), 2);
   } while (std::next_permutation(qubitIds.begin(), qubitIds.end()));


### PR DESCRIPTION
In support of the upcoming simulator work that is related to https://github.com/NVIDIA/cuda-quantum/pull/2635, this PR performs some refactoring that will enable easier support of the additional incoming noise models.

The basic idea of this PR is to move some logic that was only in the `tensornet` simulators and move it into the common `NoiseModel` section of code. There were a few minor changes as a result of those moves. For review purposes, those important changes are isolated to 06c8cf203d39948efbbb3fa1bac81589a2244936. (It is still worth reviewing the other commits, too.)

Note: despite this being related to #2635, this can go in independently of that PR.

Note, since the per-PR CI does not test tensornet, I ran these local tests to verify correctness:
```bash
$ ctest -R NoiseTest
Test project /workspaces/cuda-quantum/build
      Start 183: dm_NoiseTest.checkSimple
 1/63 Test #183: dm_NoiseTest.checkSimple ........................................   Passed    0.05 sec
      Start 184: dm_NoiseTest.checkAmplitudeDamping
 2/63 Test #184: dm_NoiseTest.checkAmplitudeDamping ..............................   Passed    0.04 sec
      Start 185: dm_NoiseTest.checkCNOT
 3/63 Test #185: dm_NoiseTest.checkCNOT ..........................................   Passed    0.04 sec
      Start 186: dm_NoiseTest.checkExceptions
 4/63 Test #186: dm_NoiseTest.checkExceptions ....................................   Passed    0.03 sec
      Start 187: dm_NoiseTest.checkDepolType
 5/63 Test #187: dm_NoiseTest.checkDepolType .....................................   Passed    0.05 sec
      Start 188: dm_NoiseTest.checkDepolTypeSimple
 6/63 Test #188: dm_NoiseTest.checkDepolTypeSimple ...............................   Passed    0.05 sec
      Start 189: dm_NoiseTest.checkAmpDampType
 7/63 Test #189: dm_NoiseTest.checkAmpDampType ...................................   Passed    0.04 sec
      Start 190: dm_NoiseTest.checkAmpDampTypeSimple
 8/63 Test #190: dm_NoiseTest.checkAmpDampTypeSimple .............................   Passed    0.04 sec
      Start 191: dm_NoiseTest.checkBitFlipType
 9/63 Test #191: dm_NoiseTest.checkBitFlipType ...................................   Passed    0.03 sec
      Start 192: dm_NoiseTest.checkBitFlipTypeSimple
10/63 Test #192: dm_NoiseTest.checkBitFlipTypeSimple .............................   Passed    0.03 sec
      Start 193: dm_NoiseTest.checkBitFlipTypeSimpleOptions
11/63 Test #193: dm_NoiseTest.checkBitFlipTypeSimpleOptions ......................   Passed    0.03 sec
      Start 194: dm_NoiseTest.checkPhaseFlipType
12/63 Test #194: dm_NoiseTest.checkPhaseFlipType .................................   Passed    0.03 sec
      Start 195: dm_NoiseTest.checkAllQubitChannel
13/63 Test #195: dm_NoiseTest.checkAllQubitChannel ...............................   Passed    0.03 sec
      Start 196: dm_NoiseTest.checkAllQubitChannelWithControl
14/63 Test #196: dm_NoiseTest.checkAllQubitChannelWithControl ....................   Passed    0.48 sec
      Start 197: dm_NoiseTest.checkAllQubitChannelWithControlPrefix
15/63 Test #197: dm_NoiseTest.checkAllQubitChannelWithControlPrefix ..............   Passed    0.47 sec
      Start 198: dm_NoiseTest.checkCallbackChannel
16/63 Test #198: dm_NoiseTest.checkCallbackChannel ...............................   Passed    0.08 sec
      Start 199: dm_NoiseTest.checkCallbackChannelWithParams
17/63 Test #199: dm_NoiseTest.checkCallbackChannelWithParams .....................   Passed    0.03 sec
      Start 200: dm_NoiseTest.checkCustomOperation
18/63 Test #200: dm_NoiseTest.checkCustomOperation ...............................   Passed    0.05 sec
      Start 201: dm_NoiseTest.checkMeasurementNoise
19/63 Test #201: dm_NoiseTest.checkMeasurementNoise ..............................   Passed    0.05 sec
      Start 202: dm_NoiseTest.checkObserveHamiltonianWithNoise
20/63 Test #202: dm_NoiseTest.checkObserveHamiltonianWithNoise ...................   Passed    0.03 sec
      Start 255: stim_NoiseTest.checkDepolType
21/63 Test #255: stim_NoiseTest.checkDepolType ...................................   Passed    0.03 sec
      Start 256: stim_NoiseTest.checkDepolTypeSimple
22/63 Test #256: stim_NoiseTest.checkDepolTypeSimple .............................   Passed    0.03 sec
      Start 257: stim_NoiseTest.checkBitFlipType
23/63 Test #257: stim_NoiseTest.checkBitFlipType .................................   Passed    0.04 sec
      Start 258: stim_NoiseTest.checkBitFlipTypeSimple
24/63 Test #258: stim_NoiseTest.checkBitFlipTypeSimple ...........................   Passed    0.05 sec
      Start 259: stim_NoiseTest.checkBitFlipTypeSimpleOptions
25/63 Test #259: stim_NoiseTest.checkBitFlipTypeSimpleOptions ....................   Passed    0.03 sec
      Start 260: stim_NoiseTest.checkPhaseFlipType
26/63 Test #260: stim_NoiseTest.checkPhaseFlipType ...............................   Passed    0.03 sec
      Start 261: stim_NoiseTest.checkAllQubitChannel
27/63 Test #261: stim_NoiseTest.checkAllQubitChannel .............................   Passed    0.03 sec
      Start 262: stim_NoiseTest.checkCallbackChannel
28/63 Test #262: stim_NoiseTest.checkCallbackChannel .............................   Passed    0.03 sec
      Start 263: stim_NoiseTest.checkMeasurementNoise
29/63 Test #263: stim_NoiseTest.checkMeasurementNoise ............................   Passed    0.03 sec
      Start 498: tensornet_NoiseTest.checkSimple
30/63 Test #498: tensornet_NoiseTest.checkSimple .................................   Passed    5.01 sec
      Start 499: tensornet_NoiseTest.checkCNOT
31/63 Test #499: tensornet_NoiseTest.checkCNOT ...................................   Passed    3.68 sec
      Start 500: tensornet_NoiseTest.checkDepolType
32/63 Test #500: tensornet_NoiseTest.checkDepolType ..............................   Passed    3.97 sec
      Start 501: tensornet_NoiseTest.checkDepolTypeSimple
33/63 Test #501: tensornet_NoiseTest.checkDepolTypeSimple ........................   Passed    3.70 sec
      Start 502: tensornet_NoiseTest.checkBitFlipType
34/63 Test #502: tensornet_NoiseTest.checkBitFlipType ............................   Passed    3.99 sec
      Start 503: tensornet_NoiseTest.checkBitFlipTypeSimple
35/63 Test #503: tensornet_NoiseTest.checkBitFlipTypeSimple ......................   Passed    4.95 sec
      Start 504: tensornet_NoiseTest.checkBitFlipTypeSimpleOptions
36/63 Test #504: tensornet_NoiseTest.checkBitFlipTypeSimpleOptions ...............   Passed    5.36 sec
      Start 505: tensornet_NoiseTest.checkPhaseFlipType
37/63 Test #505: tensornet_NoiseTest.checkPhaseFlipType ..........................   Passed    3.77 sec
      Start 506: tensornet_NoiseTest.checkAllQubitChannel
38/63 Test #506: tensornet_NoiseTest.checkAllQubitChannel ........................   Passed    3.94 sec
      Start 507: tensornet_NoiseTest.checkAllQubitChannelWithControl
39/63 Test #507: tensornet_NoiseTest.checkAllQubitChannelWithControl .............   Passed    6.15 sec
      Start 508: tensornet_NoiseTest.checkAllQubitChannelWithControlPrefix
40/63 Test #508: tensornet_NoiseTest.checkAllQubitChannelWithControlPrefix .......   Passed    4.78 sec
      Start 509: tensornet_NoiseTest.checkCallbackChannel
41/63 Test #509: tensornet_NoiseTest.checkCallbackChannel ........................   Passed    4.04 sec
      Start 510: tensornet_NoiseTest.checkCallbackChannelWithParams
42/63 Test #510: tensornet_NoiseTest.checkCallbackChannelWithParams ..............   Passed    3.86 sec
      Start 511: tensornet_NoiseTest.checkCustomOperation
43/63 Test #511: tensornet_NoiseTest.checkCustomOperation ........................   Passed    4.08 sec
      Start 512: tensornet_NoiseTest.checkMeasurementNoise
44/63 Test #512: tensornet_NoiseTest.checkMeasurementNoise .......................   Passed    4.36 sec
      Start 513: tensornet_NoiseTest.checkObserveHamiltonianWithNoise
45/63 Test #513: tensornet_NoiseTest.checkObserveHamiltonianWithNoise ............   Passed    4.77 sec
      Start 514: tensornet_NoiseTest.checkNoiseMatrixRepresentation
46/63 Test #514: tensornet_NoiseTest.checkNoiseMatrixRepresentation ..............   Passed    3.99 sec
      Start 617: tensornet_mps_NoiseTest.checkSimple
47/63 Test #617: tensornet_mps_NoiseTest.checkSimple .............................   Passed    4.70 sec
      Start 618: tensornet_mps_NoiseTest.checkCNOT
48/63 Test #618: tensornet_mps_NoiseTest.checkCNOT ...............................   Passed    4.81 sec
      Start 619: tensornet_mps_NoiseTest.checkDepolType
49/63 Test #619: tensornet_mps_NoiseTest.checkDepolType ..........................   Passed    4.52 sec
      Start 620: tensornet_mps_NoiseTest.checkDepolTypeSimple
50/63 Test #620: tensornet_mps_NoiseTest.checkDepolTypeSimple ....................   Passed    4.69 sec
      Start 621: tensornet_mps_NoiseTest.checkBitFlipType
51/63 Test #621: tensornet_mps_NoiseTest.checkBitFlipType ........................   Passed    6.33 sec
      Start 622: tensornet_mps_NoiseTest.checkBitFlipTypeSimple
52/63 Test #622: tensornet_mps_NoiseTest.checkBitFlipTypeSimple ..................   Passed    4.44 sec
      Start 623: tensornet_mps_NoiseTest.checkBitFlipTypeSimpleOptions
53/63 Test #623: tensornet_mps_NoiseTest.checkBitFlipTypeSimpleOptions ...........   Passed    4.10 sec
      Start 624: tensornet_mps_NoiseTest.checkPhaseFlipType
54/63 Test #624: tensornet_mps_NoiseTest.checkPhaseFlipType ......................   Passed    6.60 sec
      Start 625: tensornet_mps_NoiseTest.checkAllQubitChannel
55/63 Test #625: tensornet_mps_NoiseTest.checkAllQubitChannel ....................   Passed    5.35 sec
      Start 626: tensornet_mps_NoiseTest.checkAllQubitChannelWithControl
56/63 Test #626: tensornet_mps_NoiseTest.checkAllQubitChannelWithControl .........   Passed   25.27 sec
      Start 627: tensornet_mps_NoiseTest.checkAllQubitChannelWithControlPrefix
57/63 Test #627: tensornet_mps_NoiseTest.checkAllQubitChannelWithControlPrefix ...   Passed   28.50 sec
      Start 628: tensornet_mps_NoiseTest.checkCallbackChannel
58/63 Test #628: tensornet_mps_NoiseTest.checkCallbackChannel ....................   Passed    4.60 sec
      Start 629: tensornet_mps_NoiseTest.checkCallbackChannelWithParams
59/63 Test #629: tensornet_mps_NoiseTest.checkCallbackChannelWithParams ..........   Passed    4.15 sec
      Start 630: tensornet_mps_NoiseTest.checkCustomOperation
60/63 Test #630: tensornet_mps_NoiseTest.checkCustomOperation ....................   Passed    5.11 sec
      Start 631: tensornet_mps_NoiseTest.checkMeasurementNoise
61/63 Test #631: tensornet_mps_NoiseTest.checkMeasurementNoise ...................   Passed    7.29 sec
      Start 632: tensornet_mps_NoiseTest.checkObserveHamiltonianWithNoise
62/63 Test #632: tensornet_mps_NoiseTest.checkObserveHamiltonianWithNoise ........   Passed   10.97 sec
      Start 633: tensornet_mps_NoiseTest.checkNoiseMatrixRepresentation
63/63 Test #633: tensornet_mps_NoiseTest.checkNoiseMatrixRepresentation ..........   Passed    4.87 sec

100% tests passed, 0 tests failed out of 63

Label Time Summary:
gpu_required    = 210.70 sec*proc (34 tests)

Total Test time (real) = 212.78 sec
```