### PR TITLE
[DRAFT] Implement new noise models

### DIFF
--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -218,6 +218,7 @@ Noisy Simulation
 
 .. autoclass:: cudaq::NoiseModel
     :members:
+    :exclude-members: register_channel
     :special-members: __init__
 
 .. autoclass:: cudaq::BitFlipChannel

--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -94,4 +94,7 @@ static constexpr const char QIRRecordOutput[] =
 static constexpr const char QIRClearResultMaps[] =
     "__quantum__rt__clear_result_maps";
 
+static constexpr const char QISApplyKrausChannel[] =
+    "__quantum__qis__apply_kraus_channel_generalized";
+
 } // namespace cudaq::opt

--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -94,6 +94,10 @@ static constexpr const char QIRRecordOutput[] =
 static constexpr const char QIRClearResultMaps[] =
     "__quantum__rt__clear_result_maps";
 
+/// Used to specify the type of the data elements in the `QISApplyKrausChannel`
+/// call. (`float` or `double`)
+enum class KrausChannelDataKind { FloatKind, DoubleKind };
+
 static constexpr const char QISApplyKrausChannel[] =
     "__quantum__qis__apply_kraus_channel_generalized";
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -493,7 +493,7 @@ def quake_ApplyNoiseOp : QuakeOp<"apply_noise", [AttrSizedOperandSegments]> {
 
   let arguments = (ins
     FlatSymbolRefAttr:$noise_func,
-    Optional<cc_PointerType>:$key,
+    Optional<AnySignlessInteger>:$key,
     Variadic<AnyType>:$parameters,
     Variadic<NonStruqRefType>:$qubits
   );

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -477,6 +477,37 @@ def quake_ComputeActionOp : QuakeOp<"compute_action"> {
   }];
 }
 
+def quake_ApplyNoiseOp : QuakeOp<"apply_noise", [AttrSizedOperandSegments]> {
+  let summary = "Apply a noise operation to qubits.";
+  let description = [{
+    This operation provides support for the `cudaq::apply_noise` template
+    function. This function is only valid is simulation contexts where the
+    simulator is part of the same process as the C++ host executable itself.
+
+    A noise operator is the application of a Kraus channel to a selected set
+    of qubits. This is a point-wise annotation approach that a user might
+    deploy to introduce "noise" to their circuit under simulation. It is unlike
+    a general (unitary) gate application in that there is no notion of controls
+    or an adjoint.
+  }];
+
+  let arguments = (ins
+    FlatSymbolRefAttr:$noise_func,
+    Optional<cc_PointerType>:$key,
+    Variadic<AnyType>:$parameters,
+    Variadic<NonStruqRefType>:$qubits
+  );
+
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    static constexpr mlir::StringRef getNoiseFuncAttrNameStr() {
+      return "noise_func";
+    }
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Memory and register conversion instructions: These operations are useful for
 // intermediate conversions between memory-SSA and value-SSA semantics and vice

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -492,7 +492,7 @@ def quake_ApplyNoiseOp : QuakeOp<"apply_noise", [AttrSizedOperandSegments]> {
   }];
 
   let arguments = (ins
-    FlatSymbolRefAttr:$noise_func,
+    OptionalAttr<FlatSymbolRefAttr>:$noise_func,
     Optional<AnySignlessInteger>:$key,
     Variadic<AnyType>:$parameters,
     Variadic<NonStruqRefType>:$qubits
@@ -500,6 +500,28 @@ def quake_ApplyNoiseOp : QuakeOp<"apply_noise", [AttrSizedOperandSegments]> {
 
   let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
+
+  let builders = [
+    OpBuilder<(ins "mlir::StringRef":$noise_func,
+                   "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$targets), [{
+      return build($_builder, $_state, mlir::TypeRange{},
+        mlir::FlatSymbolRefAttr::get($_builder.getContext(), noise_func), {},
+        parameters, targets);
+    }]>,
+    OpBuilder<(ins "mlir::FlatSymbolRefAttr":$noise_func,
+                   "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$targets), [{
+      return build($_builder, $_state, mlir::TypeRange{}, noise_func, {},
+        parameters, targets);
+    }]>,
+    OpBuilder<(ins "mlir::Value":$key,
+                   "mlir::ValueRange":$parameters,
+                   "mlir::ValueRange":$targets), [{
+      return build($_builder, $_state, mlir::TypeRange{},
+        mlir::FlatSymbolRefAttr{}, key, parameters, targets);
+    }]>
+  ];
 
   let extraClassDeclaration = [{
     static constexpr mlir::StringRef getNoiseFuncAttrNameStr() {

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -310,7 +310,16 @@ def DependencyAnalysis : Pass<"dep-analysis", "mlir::ModuleOp"> {
   ];
 }
 
-def EraseNopCalls : Pass<"erase-nop-calls", "mlir::func::FuncOp"> {
+def EraseNoise : Pass<"erase-noise"> {
+  let summary = "Erase the inject of noise via Kraus channels.";
+  let description = [{
+    Although CUDA-Q allows the user to specify the application of noise via
+    Kraus channels, these are not needed and must be removed if the code is to
+    run on quantum hardware, for example.
+  }];
+}
+
+def EraseNopCalls : Pass<"erase-nop-calls"> {
   let summary = "Erase calls to any builtin intrinsics that are NOPs.";
   let description = [{
     The code may contain marker function calls that do not generate any actual

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1503,6 +1503,61 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       return true;
     }
 
+    if (funcName == "apply_noise") {
+      SmallVector<Value> params;
+      SmallVector<Value> qubits;
+      bool inParams = true;
+      for (auto iter : llvm::enumerate(args)) {
+        auto a = iter.value();
+        Type aTy = a.getType();
+        if (inParams) {
+          if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(aTy))
+            if (isa<FloatType>(ptrTy.getElementType())) {
+              params.push_back(a);
+              continue;
+            }
+          if (auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(aTy))
+            if (stdvecTy.getElementType() == builder.getF64Type() &&
+                iter.index() == 0) {
+              params.push_back(a);
+              inParams = false;
+              continue;
+            }
+          inParams = false;
+        }
+        // The first argument that is not floating-point must be a qubit. If
+        // the user has interleaved floating-point and qubit arguments, that's
+        // an error.
+        if (isa<quake::RefType, quake::VeqType>(aTy)) {
+          qubits.push_back(a);
+        } else {
+          reportClangError(x, mangler,
+                           "apply_noise argument types not supported.");
+          return false;
+        }
+      }
+
+      if (auto callee = calleeOp.getDefiningOp<func::ConstantOp>()) {
+        auto calleeName = callee.getValue().str();
+        builder.create<quake::ApplyNoiseOp>(loc, TypeRange{}, calleeName,
+                                            Value{}, params, qubits);
+
+        // Add the declaration of the function to the module.
+        SmallVector<Type> argTys;
+        for (auto p : params)
+          argTys.push_back(p.getType());
+        for (auto q : qubits)
+          argTys.push_back(q.getType());
+        auto calleeTy = FunctionType::get(builder.getContext(), argTys, {});
+        cudaq::opt::factory::getOrAddFunc(loc, calleeName, calleeTy, module);
+        return true;
+      }
+
+      reportClangError(x, mangler,
+                       "apply_noise with a vector argument is deprecated.");
+      return false;
+    }
+
     if (funcName.equals("mx") || funcName.equals("my") ||
         funcName.equals("mz")) {
       // Measurements always return a bool or a std::vector<bool>.
@@ -1807,8 +1862,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
                                        kernelArgs);
         return inlinedFinishControlNegations();
       }
-      if (auto func =
-              dyn_cast_or_null<func::ConstantOp>(calleeValue.getDefiningOp())) {
+      if (auto func = calleeValue.getDefiningOp<func::ConstantOp>()) {
         auto funcTy = cast<FunctionType>(func.getType());
         auto callableSym = func.getValueAttr();
         inlinedStartControlNegations();
@@ -1920,8 +1974,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
                                               /*isAdjoint=*/true, ValueRange{},
                                               kernArgs);
       }
-      if (auto func =
-              dyn_cast_or_null<func::ConstantOp>(kernelValue.getDefiningOp())) {
+      if (auto func = kernelValue.getDefiningOp<func::ConstantOp>()) {
         auto kernSym = func.getValueAttr();
         auto funcTy = cast<FunctionType>(func.getType());
         auto kernArgs =

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -1538,9 +1538,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       }
 
       if (auto callee = calleeOp.getDefiningOp<func::ConstantOp>()) {
-        auto calleeName = callee.getValue().str();
-        builder.create<quake::ApplyNoiseOp>(loc, TypeRange{}, calleeName,
-                                            Value{}, params, qubits);
+        StringRef calleeName = callee.getValue();
+        builder.create<quake::ApplyNoiseOp>(loc, calleeName, params, qubits);
 
         // Add the declaration of the function to the module.
         SmallVector<Type> argTys;

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -435,7 +435,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__qis__custom_unitary__adj(!cc.ptr<complex<f64>>, !qir_array, !qir_array, !qir_charptr)
 
   llvm.func @generalizedInvokeWithRotationsControlsTargets(i64, i64, i64, i64, !qir_llvmptr, ...) attributes {sym_visibility = "private"}
-  llvm.func @__quantum__qis__apply_kraus_channel_generalized(i64, i64, i64, ...) attributes {sym_visibility = "private"}
+  llvm.func @__quantum__qis__apply_kraus_channel_generalized(i64, i64, i64, i64, ...) attributes {sym_visibility = "private"}
 )#"},
 
     // Declarations for base and adaptive profile QIR functions used by codegen.

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -435,7 +435,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__qis__custom_unitary__adj(!cc.ptr<complex<f64>>, !qir_array, !qir_array, !qir_charptr)
 
   llvm.func @generalizedInvokeWithRotationsControlsTargets(i64, i64, i64, i64, !qir_llvmptr, ...) attributes {sym_visibility = "private"}
-  llvm.func @__quantum__qis__apply_kraus_channel_generalized(i64, i64, ...) attributes {sym_visibility = "private"}
+  llvm.func @__quantum__qis__apply_kraus_channel_generalized(i64, i64, i64, ...) attributes {sym_visibility = "private"}
 )#"},
 
     // Declarations for base and adaptive profile QIR functions used by codegen.

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -435,6 +435,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__qis__custom_unitary__adj(!cc.ptr<complex<f64>>, !qir_array, !qir_array, !qir_charptr)
 
   llvm.func @generalizedInvokeWithRotationsControlsTargets(i64, i64, i64, i64, !qir_llvmptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__quantum__qis__apply_kraus_channel_generalized(i64, i64, ...) attributes {sym_visibility = "private"}
 )#"},
 
     // Declarations for base and adaptive profile QIR functions used by codegen.

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -435,7 +435,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__qis__custom_unitary__adj(!cc.ptr<complex<f64>>, !qir_array, !qir_array, !qir_charptr)
 
   llvm.func @generalizedInvokeWithRotationsControlsTargets(i64, i64, i64, i64, !qir_llvmptr, ...) attributes {sym_visibility = "private"}
-  llvm.func @__quantum__qis__apply_kraus_channel_generalized(i64, i64, i64, i64, ...) attributes {sym_visibility = "private"}
+  llvm.func @__quantum__qis__apply_kraus_channel_generalized(i64, i64, i64, i64, i64, ...) attributes {sym_visibility = "private"}
 )#"},
 
     // Declarations for base and adaptive profile QIR functions used by codegen.

--- a/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -281,7 +281,7 @@ struct ApplyNoiseOpRewrite : public OpConversionPattern<quake::ApplyNoiseOp> {
   matchAndRewrite(quake::ApplyNoiseOp noise, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = noise.getLoc();
-    if (!noise.getNoiseFuncAttr()) {
+    if (!noise.getNoiseFunc()) {
       // This is the key-based variant. Call the generalized version of the
       // apply_kraus_channel helper function. Let it do all the conversions into
       // contiguous buffers for us, greatly simplifying codegen here.
@@ -363,7 +363,7 @@ struct ApplyNoiseOpRewrite : public OpConversionPattern<quake::ApplyNoiseOp> {
       auto module = noise->getParentOfType<ModuleOp>();
       auto funcTy = FunctionType::get(ctx, {}, {});
       auto [fn, flag] = cudaq::opt::factory::getOrAddFunc(
-          loc, noise.getNoiseFunc(), funcTy, module);
+          loc, *noise.getNoiseFunc(), funcTy, module);
       funcTy = fn.getFunctionType();
       SmallVector<Type> inputTys{funcTy.getInputs().begin(),
                                  funcTy.getInputs().end()};
@@ -376,7 +376,7 @@ struct ApplyNoiseOpRewrite : public OpConversionPattern<quake::ApplyNoiseOp> {
     }
     args.append(adaptor.getQubits().begin(), adaptor.getQubits().end());
     rewriter.replaceOpWithNewOp<func::CallOp>(noise, TypeRange{},
-                                              noise.getNoiseFunc(), args);
+                                              *noise.getNoiseFunc(), args);
     return success();
   }
 };

--- a/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -297,7 +297,7 @@ struct ApplyNoiseOpRewrite : public OpConversionPattern<quake::ApplyNoiseOp> {
                   adaptor.getParameters().end());
       args.append(adaptor.getQubits().begin(), adaptor.getQubits().end());
 
-      rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      rewriter.replaceOpWithNewOp<cudaq::cc::VarargCallOp>(
           noise, TypeRange{}, cudaq::opt::QISApplyKrausChannel, args);
       return success();
     }

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -356,6 +356,8 @@ LogicalResult quake::ApplyNoiseOp::verify() {
   if (!getNoiseFuncAttr()) {
     if (!getKey())
       return emitOpError("must have a noise function or a key");
+    if (getKey().getType() != IntegerType::get(getContext(), 64))
+      return emitOpError("key must be i64");
   } else {
     if (getKey())
       return emitOpError("cannot have a noise function and a key");

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ add_cudaq_library(OptTransforms
   DecompositionPatterns.cpp
   DelayMeasurements.cpp
   DeleteStates.cpp
+  EraseNoise.cpp
   EraseNopCalls.cpp
   ExpandControlVeqs.cpp
   ExpandMeasurements.cpp

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -122,6 +122,7 @@ unset_noise = cudaq_runtime.unset_noise
 # Noise Modeling
 KrausChannel = cudaq_runtime.KrausChannel
 KrausOperator = cudaq_runtime.KrausOperator
+NoiseModelType = cudaq_runtime.NoiseModelType
 NoiseModel = cudaq_runtime.NoiseModel
 DepolarizationChannel = cudaq_runtime.DepolarizationChannel
 AmplitudeDampingChannel = cudaq_runtime.AmplitudeDampingChannel

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2424,7 +2424,7 @@ class PyASTBridge(ast.NodeVisitor):
                     ]
                     # They are in reverse order
                     values.reverse()
-                    # First one should be the number of kraus channel parameters
+                    # First one should be the number of Kraus channel parameters
                     numParamsVal = values[0]
                     # Shrink the arguments down 
                     values = values[1:]
@@ -2439,8 +2439,8 @@ class PyASTBridge(ast.NodeVisitor):
                     key = values[0]
                     values = values[1:]
 
-                    # Now we know the next numParams arguments are 
-                    # our kraus channel parameters
+                    # Now we know the next `numParams` arguments are
+                    # our Kraus channel parameters
                     params = values[:numParams]
                     for i, p in enumerate(params):
                         # If we have a F64 value, we want to 

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4196,7 +4196,7 @@ class PyASTBridge(ast.NodeVisitor):
                     self.pushValue(self.getConstantInt(hash(value)))
                     return
             except TypeError:
-               pass
+                pass
 
             self.emitFatalError(
                 f"Invalid type for variable ({node.id}) captured from parent scope (only int, bool, float, complex, cudaq.State, and list/np.ndarray[int|bool|float|complex] accepted, type was {errorType}).",

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2417,6 +2417,46 @@ class PyASTBridge(ast.NodeVisitor):
                                                                otherFuncName))
                     return
 
+                if node.func.attr == 'apply_noise':
+                    # Pop off all the arguments we need
+                    values = [
+                        self.popValue() for _ in range(len(self.valueStack))
+                    ]
+                    # They are in reverse order
+                    values.reverse()
+                    # First one should be the number of kraus channel parameters
+                    numParamsVal = values[0]
+                    # Shrink the arguments down 
+                    values = values[1:]
+
+                    # Need to get the number of parameters as an integer
+                    concreteIntAttr = IntegerAttr(
+                        numParamsVal.owner.attributes['value'])
+                    numParams = concreteIntAttr.value
+
+                    # Next Value is our generated key for the channel
+                    # Get it and shrink the list
+                    key = values[0]
+                    values = values[1:]
+
+                    # Now we know the next numParams arguments are 
+                    # our kraus channel parameters
+                    params = values[:numParams]
+                    for i, p in enumerate(params):
+                        # If we have a F64 value, we want to 
+                        # store it to a pointer
+                        if F64Type.isinstance(p.type):
+                            alloca = cc.AllocaOp(
+                                cc.PointerType.get(self.ctx, p.type),
+                                TypeAttr.get(p.type)).result
+                            cc.StoreOp(p, alloca)
+                            params[i] = alloca 
+                    
+                    # The remaining arguments are the qubits
+                    qubits = values[numParams:]
+                    quake.ApplyNoiseOp(params, qubits, key=key)
+                    return
+
                 if node.func.attr == 'compute_action':
                     # There can only be 2 arguments here.
                     action = None
@@ -4145,6 +4185,15 @@ class PyASTBridge(ast.NodeVisitor):
             errorType = type(value).__name__
             if (isinstance(value, list)):
                 errorType = f"{errorType}[{type(value[0]).__name__}]"
+
+            if issubclass(value, cudaq_runtime.KrausChannel):
+                # Here we have a KrausChannel as part of the AST
+                # We want to create a hash value from it, and 
+                # we then want to push the number of parameters and 
+                # that hash value. This can only be used with apply_noise
+                self.pushValue(self.getConstantInt(value.num_parameters))
+                self.pushValue(self.getConstantInt(hash(value)))
+                return
 
             self.emitFatalError(
                 f"Invalid type for variable ({node.id}) captured from parent scope (only int, bool, float, complex, cudaq.State, and list/np.ndarray[int|bool|float|complex] accepted, type was {errorType}).",

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2426,7 +2426,7 @@ class PyASTBridge(ast.NodeVisitor):
                     values.reverse()
                     # First one should be the number of Kraus channel parameters
                     numParamsVal = values[0]
-                    # Shrink the arguments down 
+                    # Shrink the arguments down
                     values = values[1:]
 
                     # Need to get the number of parameters as an integer
@@ -2443,15 +2443,15 @@ class PyASTBridge(ast.NodeVisitor):
                     # our Kraus channel parameters
                     params = values[:numParams]
                     for i, p in enumerate(params):
-                        # If we have a F64 value, we want to 
+                        # If we have a F64 value, we want to
                         # store it to a pointer
                         if F64Type.isinstance(p.type):
                             alloca = cc.AllocaOp(
                                 cc.PointerType.get(self.ctx, p.type),
                                 TypeAttr.get(p.type)).result
                             cc.StoreOp(p, alloca)
-                            params[i] = alloca 
-                    
+                            params[i] = alloca
+
                     # The remaining arguments are the qubits
                     qubits = values[numParams:]
                     quake.ApplyNoiseOp(params, qubits, key=key)
@@ -4188,8 +4188,8 @@ class PyASTBridge(ast.NodeVisitor):
 
             if issubclass(value, cudaq_runtime.KrausChannel):
                 # Here we have a KrausChannel as part of the AST
-                # We want to create a hash value from it, and 
-                # we then want to push the number of parameters and 
+                # We want to create a hash value from it, and
+                # we then want to push the number of parameters and
                 # that hash value. This can only be used with apply_noise
                 self.pushValue(self.getConstantInt(value.num_parameters))
                 self.pushValue(self.getConstantInt(hash(value)))

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4186,14 +4186,17 @@ class PyASTBridge(ast.NodeVisitor):
             if (isinstance(value, list)):
                 errorType = f"{errorType}[{type(value[0]).__name__}]"
 
-            if issubclass(value, cudaq_runtime.KrausChannel):
-                # Here we have a KrausChannel as part of the AST
-                # We want to create a hash value from it, and
-                # we then want to push the number of parameters and
-                # that hash value. This can only be used with apply_noise
-                self.pushValue(self.getConstantInt(value.num_parameters))
-                self.pushValue(self.getConstantInt(hash(value)))
-                return
+            try:
+                if issubclass(value, cudaq_runtime.KrausChannel):
+                    # Here we have a KrausChannel as part of the AST
+                    # We want to create a hash value from it, and
+                    # we then want to push the number of parameters and
+                    # that hash value. This can only be used with apply_noise
+                    self.pushValue(self.getConstantInt(value.num_parameters))
+                    self.pushValue(self.getConstantInt(hash(value)))
+                    return
+            except TypeError:
+               pass
 
             self.emitFatalError(
                 f"Invalid type for variable ({node.id}) captured from parent scope (only int, bool, float, complex, cudaq.State, and list/np.ndarray[int|bool|float|complex] accepted, type was {errorType}).",

--- a/python/runtime/common/py_NoiseModel.cpp
+++ b/python/runtime/common/py_NoiseModel.cpp
@@ -25,7 +25,8 @@ void extractKrausData(py::buffer_info &info, complex *data) {
         "Incompatible buffer format, must be np.complex128.");
 
   if (info.ndim != 2)
-    throw std::runtime_error("Incompatible buffer shape.");
+    throw std::runtime_error("Incompatible buffer shape " +
+                             std::to_string(info.ndim) + ".");
 
   constexpr bool rowMajor = true;
   typedef Eigen::MatrixXcd::Scalar Scalar;
@@ -56,6 +57,17 @@ void bindNoiseModel(py::module &mod) {
       "The `NoiseModel` defines a set of :class:`KrausChannel`'s applied to "
       "specific qubits after the invocation of specified quantum operations.")
       .def(py::init<>(), "Construct an empty noise model.")
+      .def(
+          "register_channel",
+          [](noise_model &self, const py::type krausT) {
+            auto key = py::hash(krausT);
+            self.register_channel(
+                key,
+                [krausT](const std::vector<double> &p) -> kraus_channel {
+                  return krausT(p).cast<kraus_channel>();
+                });
+          },
+          "")
       .def(
           "add_channel",
           [](noise_model &self, std::string &opName,
@@ -138,13 +150,37 @@ void bindKrausOp(py::module &mod) {
                     "this :class:`KrausOperator`.");
 }
 
+// Need a trampoline class to make this sub-class-able from Python
+class PyKrausChannel : public kraus_channel {
+  public: 
+  using kraus_channel::kraus_channel;
+};
+
 void bindNoiseChannels(py::module &mod) {
-  py::class_<kraus_channel>(mod, "KrausChannel",
+  py::enum_<cudaq::noise_model_type>(mod, "NoiseModelType")
+      .value("Unknown", cudaq::noise_model_type::unknown)
+      .value("DepolarizationChannel",
+             cudaq::noise_model_type::depolarization_channel)
+      .value("AmplitudeDampingChannel",
+             cudaq::noise_model_type::amplitude_damping_channel)
+      .value("BitFlipChannel", cudaq::noise_model_type::bit_flip_channel)
+      .value("PhaseFlipChannel", cudaq::noise_model_type::phase_flip_channel)
+      .value("XError", cudaq::noise_model_type::x_error)
+      .value("YError", cudaq::noise_model_type::y_error)
+      .value("ZError", cudaq::noise_model_type::z_error)
+      .value("AmplitudeDamping", cudaq::noise_model_type::amplitude_damping)
+      .value("PhaseDamping", cudaq::noise_model_type::phase_damping)
+      .value("Pauli1", cudaq::noise_model_type::pauli1)
+      .value("Pauli2", cudaq::noise_model_type::pauli2)
+      .value("Depolarization1", cudaq::noise_model_type::depolarization1)
+      .value("Depolarization2", cudaq::noise_model_type::depolarization2);
+
+  py::class_<kraus_channel, PyKrausChannel>(mod, "KrausChannel", py::dynamic_attr(),
                             "The `KrausChannel` is composed of a list of "
                             ":class:`KrausOperator`'s and "
                             "is applied to a specific qubit or set of qubits.")
       .def(py::init<>(), "Create an empty :class:`KrausChannel`")
-      .def(py::init<std::vector<kraus_op>>(),
+      .def(py::init<const std::vector<kraus_op> &>(),
            "Create a :class:`KrausChannel` composed of a list of "
            ":class:`KrausOperator`'s.")
       .def(py::init([](py::list ops) {
@@ -161,6 +197,8 @@ void bindNoiseChannels(py::module &mod) {
            }),
            "Create a :class:`KrausChannel` given a list of "
            ":class:`KrausOperator`'s.")
+      .def_readwrite("parameters", &kraus_channel::parameters)
+      .def_readwrite("noise_type", &kraus_channel::noise_type)
       .def(
           "__getitem__",
           [](kraus_channel &self, std::size_t idx) { return self[idx]; },

--- a/python/runtime/common/py_NoiseModel.cpp
+++ b/python/runtime/common/py_NoiseModel.cpp
@@ -62,8 +62,7 @@ void bindNoiseModel(py::module &mod) {
           [](noise_model &self, const py::type krausT) {
             auto key = py::hash(krausT);
             self.register_channel(
-                key,
-                [krausT](const std::vector<double> &p) -> kraus_channel {
+                key, [krausT](const std::vector<double> &p) -> kraus_channel {
                   return krausT(p).cast<kraus_channel>();
                 });
           },
@@ -152,7 +151,7 @@ void bindKrausOp(py::module &mod) {
 
 // Need a trampoline class to make this sub-class-able from Python
 class PyKrausChannel : public kraus_channel {
-  public: 
+public:
   using kraus_channel::kraus_channel;
 };
 
@@ -175,10 +174,11 @@ void bindNoiseChannels(py::module &mod) {
       .value("Depolarization1", cudaq::noise_model_type::depolarization1)
       .value("Depolarization2", cudaq::noise_model_type::depolarization2);
 
-  py::class_<kraus_channel, PyKrausChannel>(mod, "KrausChannel", py::dynamic_attr(),
-                            "The `KrausChannel` is composed of a list of "
-                            ":class:`KrausOperator`'s and "
-                            "is applied to a specific qubit or set of qubits.")
+  py::class_<kraus_channel, PyKrausChannel>(
+      mod, "KrausChannel", py::dynamic_attr(),
+      "The `KrausChannel` is composed of a list of "
+      ":class:`KrausOperator`'s and "
+      "is applied to a specific qubit or set of qubits.")
       .def(py::init<>(), "Create an empty :class:`KrausChannel`")
       .def(py::init<const std::vector<kraus_op> &>(),
            "Create a :class:`KrausChannel` composed of a list of "

--- a/python/runtime/common/py_NoiseModel.cpp
+++ b/python/runtime/common/py_NoiseModel.cpp
@@ -61,10 +61,11 @@ void bindNoiseModel(py::module &mod) {
           "register_channel",
           [](noise_model &self, const py::type krausT) {
             auto key = py::hash(krausT);
-            self.register_channel(
-                key, [krausT](const std::vector<double> &p) -> kraus_channel {
-                  return krausT(p).cast<kraus_channel>();
-                });
+            std::function<kraus_channel(const std::vector<double> &)> lambda =
+                [krausT](const std::vector<double> &p) -> kraus_channel {
+              return krausT(p).cast<kraus_channel>();
+            };
+            self.register_channel(key, lambda);
           },
           "")
       .def(

--- a/runtime/common/Logger.cpp
+++ b/runtime/common/Logger.cpp
@@ -41,7 +41,7 @@ bool isTimingTagEnabled(int tag) {
 /// level and optionally dump to file if specified.
 __attribute__((constructor)) void initializeLogger() {
   // Default to no logging
-  spdlog::set_level(spdlog::level::off);
+  spdlog::set_level(spdlog::level::warn);
 
   // but someone can specify CUDAQ_LOG_LEVEL=info (for example)
   // as an environment variable. Can also stack them
@@ -91,6 +91,7 @@ __attribute__((constructor)) void initializeLogger() {
 namespace details {
 void trace(const std::string_view msg) { spdlog::trace(msg); }
 void info(const std::string_view msg) { spdlog::info(msg); }
+void warn(const std::string_view msg) { spdlog::warn(msg); }
 void debug(const std::string_view msg) {
 #ifdef CUDAQ_DEBUG
   spdlog::debug(msg);
@@ -105,6 +106,9 @@ static_assert(static_cast<int>(LogLevel::trace) ==
               "log level enum mismatch");
 static_assert(static_cast<int>(LogLevel::info) ==
                   static_cast<int>(spdlog::level::info),
+              "log level enum mismatch");
+static_assert(static_cast<int>(LogLevel::warn) ==
+                  static_cast<int>(spdlog::level::warn),
               "log level enum mismatch");
 bool should_log(const LogLevel logLevel) {
   return spdlog::should_log(static_cast<spdlog::level::level_enum>(logLevel));

--- a/runtime/common/Logger.h
+++ b/runtime/common/Logger.h
@@ -23,11 +23,12 @@ bool isTimingTagEnabled(int tag);
 namespace details {
 // This enum must match spdlog::level enums. This is checked via static_assert
 // in Logger.cpp.
-enum class LogLevel { trace, debug, info };
+enum class LogLevel { trace, debug, info, warn };
 bool should_log(const LogLevel logLevel);
 void trace(const std::string_view msg);
 void info(const std::string_view msg);
 void debug(const std::string_view msg);
+void warn(const std::string_view msg);
 std::string pathToFileName(const std::string_view fullFilePath);
 } // namespace details
 
@@ -63,6 +64,7 @@ std::string pathToFileName(const std::string_view fullFilePath);
   NAME(const std::string_view, Args &&...) -> NAME<Args...>;
 
 CUDAQ_LOGGER_DEDUCTION_STRUCT(info);
+CUDAQ_LOGGER_DEDUCTION_STRUCT(warn);
 
 #ifdef CUDAQ_DEBUG
 CUDAQ_LOGGER_DEDUCTION_STRUCT(debug);

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -269,7 +269,9 @@ noise_model::get_channels(const std::string &quantumOp,
 }
 
 noise_model::noise_model() {
-  add_channel<bit_flip_channel>();
-  add_channel<phase_flip_channel>();
+  register_channel<bit_flip_channel>();
+  register_channel<phase_flip_channel>();
+  register_channel<depolarization_channel>();
+  register_channel<amplitude_damping_channel>();
 }
 } // namespace cudaq

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -79,7 +79,7 @@ void validateCompletenessRelation_fp64(const std::vector<kraus_op> &ops) {
 }
 
 kraus_channel::kraus_channel(const kraus_channel &other)
-    : ops(other.ops), noise_type(other.noise_type), name(other.name),
+    : ops(other.ops), noise_type(other.noise_type),
       parameters(other.parameters) {}
 
 std::size_t kraus_channel::size() const { return ops.size(); }
@@ -274,4 +274,25 @@ noise_model::noise_model() {
   register_channel<depolarization_channel>();
   register_channel<amplitude_damping_channel>();
 }
+
+constexpr std::array<const char *, 14> noise_model_strings = {
+    "unknown",
+    "depolarization_channel",
+    "amplitude_damping_channel",
+    "bit_flip_channel",
+    "phase_flip_channel",
+    "x_error",
+    "y_error",
+    "z_error",
+    "amplitude_damping",
+    "phase_damping",
+    "pauli1",
+    "pauli2",
+    "depolarization1",
+    "depolarization2"};
+
+std::string get_noise_model_type_name(noise_model_type type) {
+  return noise_model_strings[static_cast<std::size_t>(type)];
+}
+
 } // namespace cudaq

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -267,4 +267,6 @@ noise_model::get_channels(const std::string &quantumOp,
 
   return resultChannels;
 }
+
+noise_model::noise_model() { add_channel<bit_flip_channel>(); }
 } // namespace cudaq

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -79,7 +79,7 @@ void validateCompletenessRelation_fp64(const std::vector<kraus_op> &ops) {
 }
 
 kraus_channel::kraus_channel(const kraus_channel &other)
-    : ops(other.ops), noise_type(other.noise_type),
+    : ops(other.ops), noise_type(other.noise_type), name(other.name),
       parameters(other.parameters) {}
 
 std::size_t kraus_channel::size() const { return ops.size(); }
@@ -268,5 +268,8 @@ noise_model::get_channels(const std::string &quantumOp,
   return resultChannels;
 }
 
-noise_model::noise_model() { add_channel<bit_flip_channel>(); }
+noise_model::noise_model() {
+  add_channel<bit_flip_channel>();
+  add_channel<phase_flip_channel>();
+}
 } // namespace cudaq

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -276,20 +276,10 @@ noise_model::noise_model() {
 }
 
 constexpr std::array<const char *, 14> noise_model_strings = {
-    "unknown",
-    "depolarization_channel",
-    "amplitude_damping_channel",
-    "bit_flip_channel",
-    "phase_flip_channel",
-    "x_error",
-    "y_error",
-    "z_error",
-    "amplitude_damping",
-    "phase_damping",
-    "pauli1",
-    "pauli2",
-    "depolarization1",
-    "depolarization2"};
+#define X(name) #name,
+    NOISE_MODEL_TYPES
+#undef X
+};
 
 std::string get_noise_model_type_name(noise_model_type type) {
   return noise_model_strings[static_cast<std::size_t>(type)];

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -156,8 +156,9 @@ void generateUnitaryParameters_fp32(
     // data for this specific routine is actually fp32.
     const std::complex<float> *ptr =
         reinterpret_cast<const std::complex<float> *>(op.data.data());
+    // Use 2 * size because pointer arithmetic is on fp32 instead of fp64
     double_kraus_ops.emplace_back(
-        std::vector<std::complex<double>>(ptr, ptr + op.data.size()));
+        std::vector<std::complex<double>>(ptr, ptr + 2 * op.data.size()));
   }
 
   auto asUnitaryMixture = computeUnitaryMixture(double_kraus_ops);

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -269,10 +269,19 @@ noise_model::get_channels(const std::string &quantumOp,
 }
 
 noise_model::noise_model() {
-  register_channel<bit_flip_channel>();
-  register_channel<phase_flip_channel>();
   register_channel<depolarization_channel>();
   register_channel<amplitude_damping_channel>();
+  register_channel<bit_flip_channel>();
+  register_channel<phase_flip_channel>();
+  register_channel<x_error>();
+  register_channel<y_error>();
+  register_channel<z_error>();
+  register_channel<amplitude_damping>();
+  register_channel<phase_damping>();
+  register_channel<pauli1>();
+  register_channel<pauli2>();
+  register_channel<depolarization1>();
+  register_channel<depolarization2>();
 }
 
 constexpr std::array<const char *, 14> noise_model_strings = {

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -26,7 +26,7 @@ isScaledUnitary(const std::vector<std::complex<double>> &mat, double eps) {
   const int dim = std::log2(mat.size());
   Eigen::Map<const RowMajorMatTy> kMat(mat.data(), dim, dim);
   if (kMat.isZero())
-    return std::nullopt;
+    return 0.0;
   // Check that (K_dag * K) is a scaled identity matrix
   // i.e., the K matrix is a scaled unitary.
   auto kdK = kMat.adjoint() * kMat;
@@ -55,8 +55,12 @@ computeUnitaryMixture(
   const auto scaleMat = [](const std::vector<std::complex<double>> &mat,
                            double scaleFactor) {
     std::vector<std::complex<double>> scaledMat = mat;
-    for (auto &x : scaledMat)
-      x /= scaleFactor;
+    // If scaleFactor is 0, then it means the original matrix was likely all
+    // zeros. In that case, the probability will be 0, so the matrix doesn't
+    // matter, but we don't want NaNs to trickle in anywhere.
+    if (scaleFactor != 0.0)
+      for (auto &x : scaledMat)
+        x /= scaleFactor;
     return scaledMat;
   };
   for (const auto &op : krausOps) {
@@ -64,7 +68,7 @@ computeUnitaryMixture(
     if (!scaledFactor.has_value())
       return std::nullopt;
     probs.emplace_back(scaledFactor.value());
-    mats.emplace_back(scaleMat(op, scaledFactor.value()));
+    mats.emplace_back(scaleMat(op, std::sqrt(scaledFactor.value())));
   }
 
   if (std::abs(1.0 - std::reduce(probs.begin(), probs.end())) > tol)
@@ -175,7 +179,6 @@ void generateUnitaryParameters_fp64(
 
   auto asUnitaryMixture = computeUnitaryMixture(double_kraus_ops);
   if (asUnitaryMixture.has_value()) {
-    auto [probabilities, unitaries] = asUnitaryMixture.value();
     probabilities = std::move(asUnitaryMixture.value().first);
     unitary_ops = std::move(asUnitaryMixture.value().second);
   }

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -10,7 +10,68 @@
 #include "Logger.h"
 #include "common/CustomOp.h"
 #include "common/EigenDense.h"
+#include <numeric>
+#include <optional>
+
 namespace cudaq {
+
+// Helper to check whether a matrix is a scaled unitary matrix, i.e., `k * U`
+// where U is a unitary matrix. If so, it also returns the `k` factor.
+// Otherwise, return a nullopt.
+static std::optional<double>
+isScaledUnitary(const std::vector<std::complex<double>> &mat, double eps) {
+  typedef Eigen::Matrix<std::complex<double>, Eigen::Dynamic, Eigen::Dynamic,
+                        Eigen::RowMajor>
+      RowMajorMatTy;
+  const int dim = std::log2(mat.size());
+  Eigen::Map<const RowMajorMatTy> kMat(mat.data(), dim, dim);
+  if (kMat.isZero())
+    return std::nullopt;
+  // Check that (K_dag * K) is a scaled identity matrix
+  // i.e., the K matrix is a scaled unitary.
+  auto kdK = kMat.adjoint() * kMat;
+  if (!kdK.isDiagonal())
+    return std::nullopt;
+  // First element
+  std::complex<double> val = kdK(0, 0);
+  if (std::abs(val) > eps && std::abs(val.imag()) < eps) {
+    auto scaledKdK = (std::complex<double>{1.0} / val) * kdK;
+    if (scaledKdK.isIdentity())
+      return val.real();
+  }
+  return std::nullopt;
+}
+
+// Helper to determine if a vector of Kraus ops are actually a unitary mixture.
+// If so, it returns all the unitaries and the probabilities associated with
+// each one of those unitaries.
+static std::optional<std::pair<std::vector<double>,
+                               std::vector<std::vector<std::complex<double>>>>>
+computeUnitaryMixture(
+    const std::vector<std::vector<std::complex<double>>> &krausOps,
+    double tol = 1e-6) {
+  std::vector<double> probs;
+  std::vector<std::vector<std::complex<double>>> mats;
+  const auto scaleMat = [](const std::vector<std::complex<double>> &mat,
+                           double scaleFactor) {
+    std::vector<std::complex<double>> scaledMat = mat;
+    for (auto &x : scaledMat)
+      x /= scaleFactor;
+    return scaledMat;
+  };
+  for (const auto &op : krausOps) {
+    const auto scaledFactor = isScaledUnitary(op, tol);
+    if (!scaledFactor.has_value())
+      return std::nullopt;
+    probs.emplace_back(scaledFactor.value());
+    mats.emplace_back(scaleMat(op, scaledFactor.value()));
+  }
+
+  if (std::abs(1.0 - std::reduce(probs.begin(), probs.end())) > tol)
+    return std::nullopt;
+
+  return std::make_pair(probs, mats);
+}
 
 template <typename EigenMatTy>
 bool isIdentity(const EigenMatTy &mat, double threshold = 1e-9) {
@@ -78,9 +139,52 @@ void validateCompletenessRelation_fp64(const std::vector<kraus_op> &ops) {
         "Provided kraus_ops are not completely positive and trace preserving.");
 }
 
+void generateUnitaryParameters_fp32(
+    const std::vector<kraus_op> &ops,
+    std::vector<std::vector<std::complex<double>>> &unitary_ops,
+    std::vector<double> &probabilities) {
+  std::vector<std::vector<std::complex<double>>> double_kraus_ops;
+  double_kraus_ops.reserve(ops.size());
+  for (auto &op : ops) {
+    // WARNING: danger here. We are intentially treating the incoming op as fp32
+    // type instead of what the compiler thinks it is (fp64). We have to do this
+    // because this file is compiled with cudaq::real = fp64, but the incoming
+    // data for this specific routine is actually fp32.
+    const std::complex<float> *ptr =
+        reinterpret_cast<const std::complex<float> *>(op.data.data());
+    double_kraus_ops.emplace_back(
+        std::vector<std::complex<double>>(ptr, ptr + op.data.size()));
+  }
+
+  auto asUnitaryMixture = computeUnitaryMixture(double_kraus_ops);
+  if (asUnitaryMixture.has_value()) {
+    probabilities = std::move(asUnitaryMixture.value().first);
+    unitary_ops = std::move(asUnitaryMixture.value().second);
+  }
+}
+
+void generateUnitaryParameters_fp64(
+    const std::vector<kraus_op> &ops,
+    std::vector<std::vector<std::complex<double>>> &unitary_ops,
+    std::vector<double> &probabilities) {
+  std::vector<std::vector<std::complex<double>>> double_kraus_ops;
+  double_kraus_ops.reserve(ops.size());
+  for (auto &op : ops)
+    double_kraus_ops.emplace_back(
+        std::vector<std::complex<double>>(op.data.begin(), op.data.end()));
+
+  auto asUnitaryMixture = computeUnitaryMixture(double_kraus_ops);
+  if (asUnitaryMixture.has_value()) {
+    auto [probabilities, unitaries] = asUnitaryMixture.value();
+    probabilities = std::move(asUnitaryMixture.value().first);
+    unitary_ops = std::move(asUnitaryMixture.value().second);
+  }
+}
+
 kraus_channel::kraus_channel(const kraus_channel &other)
     : ops(other.ops), noise_type(other.noise_type),
-      parameters(other.parameters) {}
+      parameters(other.parameters), unitary_ops(other.unitary_ops),
+      probabilities(other.probabilities) {}
 
 std::size_t kraus_channel::size() const { return ops.size(); }
 
@@ -94,6 +198,8 @@ kraus_channel &kraus_channel::operator=(const kraus_channel &other) {
   ops = other.ops;
   noise_type = other.noise_type;
   parameters = other.parameters;
+  unitary_ops = other.unitary_ops;
+  probabilities = other.probabilities;
   return *this;
 }
 

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -196,12 +196,6 @@ public:
   void push_back(kraus_op op);
 };
 
-template<std::size_t NumTargets, std::size_t NumParams> 
-class named_kraus_channel : public kraus_channel {
-  constexpr static std::size_t num_targets = NumTargets; 
-  constexpr static std::size_t num_parameters = NumParams; 
-};
-
 /// @brief The noise_model type keeps track of a set of
 /// kraus_channels to be applied after the execution of
 /// quantum operations. Each quantum operation maps
@@ -332,8 +326,7 @@ public:
 
     registeredChannels.insert(
         {std::type_index(typeid(KrausChannelT)),
-         [typeName](
-             const std::vector<double> &params) -> kraus_channel {
+         [typeName](const std::vector<double> &params) -> kraus_channel {
            KrausChannelT userChannel(params);
            userChannel.parameters = params;
            if (userChannel.name == "unknown")
@@ -469,8 +462,8 @@ public:
 /// a single-qubit bit flipping error channel.
 class bit_flip_channel : public kraus_channel {
 public:
-  constexpr static std::size_t num_parameters = 1; 
-  constexpr static std::size_t num_targets = 1; 
+  constexpr static std::size_t num_parameters = 1;
+  constexpr static std::size_t num_targets = 1;
   bit_flip_channel(const std::vector<cudaq::real> &p) {
     cudaq::real probability = p[0];
     std::vector<cudaq::complex> k0v{std::sqrt(1 - probability), 0, 0,

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -39,6 +39,8 @@ enum class noise_model_type {
   depolarization2
 };
 
+std::string get_noise_model_type_name(noise_model_type type);
+
 /// @brief A kraus_op represents a single Kraus operation,
 /// described as a complex matrix of specific size. The matrix
 /// is represented here as a 1d array (specifically a std::vector).
@@ -142,10 +144,6 @@ public:
   /// @brief Noise type enumeration
   noise_model_type noise_type = noise_model_type::unknown;
 
-  // FIXME This may go away with a better key for
-  // the channel registry
-  std::string name = "unknown";
-
   /// @brief Noise parameter values
   // Use `double` as the uniform type to store channel parameters (for both
   // single- and double-precision channel definitions). Some
@@ -202,6 +200,10 @@ public:
 
   /// @brief Add a kraus_op to this channel.
   void push_back(kraus_op op);
+
+  std::string get_type_name() const {
+    return get_noise_model_type_name(noise_type);
+  }
 };
 
 #define REGISTER_KRAUS_CHANNEL(TYPE)                                           \

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -12,11 +12,8 @@
 
 #include <array>
 #include <complex>
-#include <cxxabi.h>
 #include <functional>
 #include <math.h>
-#include <memory>
-#include <typeindex>
 #include <unordered_map>
 #include <vector>
 
@@ -289,9 +286,6 @@ protected:
   std::unordered_map<std::intptr_t,
                      std::function<kraus_channel(const std::vector<double> &)>>
       registeredChannels;
-
-  // Kraus types to type index mapping
-  std::unordered_map<std::string, std::type_index> nameToType;
 
 public:
   /// @brief default constructor

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -196,6 +196,12 @@ public:
   void push_back(kraus_op op);
 };
 
+template<std::size_t NumTargets, std::size_t NumParams> 
+class named_kraus_channel : public kraus_channel {
+  constexpr static std::size_t num_targets = NumTargets; 
+  constexpr static std::size_t num_parameters = NumParams; 
+};
+
 /// @brief The noise_model type keeps track of a set of
 /// kraus_channels to be applied after the execution of
 /// quantum operations. Each quantum operation maps
@@ -313,7 +319,7 @@ public:
   template <typename KrausChannelT,
             typename = requires_constructor<KrausChannelT,
                                             const std::vector<double> &>>
-  void add_channel() {
+  void register_channel() {
 
     // Store the demangled type name mapped to its typeindex
     auto typeName = [](const char *mangled) -> std::string {
@@ -326,7 +332,8 @@ public:
 
     registeredChannels.insert(
         {std::type_index(typeid(KrausChannelT)),
-         [typeName](const std::vector<double> &params) -> kraus_channel {
+         [typeName](
+             const std::vector<double> &params) -> kraus_channel {
            KrausChannelT userChannel(params);
            userChannel.parameters = params;
            if (userChannel.name == "unknown")
@@ -462,6 +469,8 @@ public:
 /// a single-qubit bit flipping error channel.
 class bit_flip_channel : public kraus_channel {
 public:
+  constexpr static std::size_t num_parameters = 1; 
+  constexpr static std::size_t num_targets = 1; 
   bit_flip_channel(const std::vector<cudaq::real> &p) {
     cudaq::real probability = p[0];
     std::vector<cudaq::complex> k0v{std::sqrt(1 - probability), 0, 0,

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -206,7 +206,7 @@ public:
   }
 };
 
-#define REGISTER_KRAUS_CHANNEL(TYPE)                                           \
+#define REGISTER_KRAUS_CHANNEL()                                               \
   static std::intptr_t get_key() { return (std::intptr_t)&get_key; }
 
 /// @brief The noise_model type keeps track of a set of
@@ -334,7 +334,7 @@ public:
   }
 
   void register_channel(
-      std::size_t key,
+      std::intptr_t key,
       const std::function<kraus_channel(const std::vector<double> &)> &gen) {
     registeredChannels.insert({key, gen});
   }
@@ -451,7 +451,7 @@ public:
   }
   depolarization_channel(const real probability)
       : depolarization_channel(std::vector<cudaq::real>{probability}) {}
-  REGISTER_KRAUS_CHANNEL(depolarization_channel)
+  REGISTER_KRAUS_CHANNEL()
 };
 
 /// @brief amplitude_damping_channel is a kraus_channel that
@@ -472,7 +472,7 @@ public:
   }
   amplitude_damping_channel(const real probability)
       : amplitude_damping_channel(std::vector<cudaq::real>{probability}) {}
-  REGISTER_KRAUS_CHANNEL(amplitude_damping_channel)
+  REGISTER_KRAUS_CHANNEL()
 };
 
 /// @brief bit_flip_channel is a kraus_channel that
@@ -494,7 +494,7 @@ public:
   }
   bit_flip_channel(const real probability)
       : bit_flip_channel(std::vector<cudaq::real>{probability}) {}
-  REGISTER_KRAUS_CHANNEL(bit_flip_channel)
+  REGISTER_KRAUS_CHANNEL()
 };
 
 /// @brief phase_flip_channel is a kraus_channel that
@@ -517,6 +517,6 @@ public:
   }
   phase_flip_channel(const real probability)
       : phase_flip_channel(std::vector<cudaq::real>{probability}) {}
-  REGISTER_KRAUS_CHANNEL(phase_flip_channel)
+  REGISTER_KRAUS_CHANNEL()
 };
 } // namespace cudaq

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -156,6 +156,12 @@ struct kraus_op {
 
 void validateCompletenessRelation_fp32(const std::vector<kraus_op> &ops);
 void validateCompletenessRelation_fp64(const std::vector<kraus_op> &ops);
+void generateUnitaryParameters_fp32(
+    const std::vector<kraus_op> &ops,
+    std::vector<std::vector<std::complex<double>>> &, std::vector<double> &);
+void generateUnitaryParameters_fp64(
+    const std::vector<kraus_op> &ops,
+    std::vector<std::vector<std::complex<double>>> &, std::vector<double> &);
 
 /// @brief A kraus_channel represents a quantum noise channel
 /// on specific qubits. The action of the noise channel is
@@ -183,6 +189,16 @@ protected:
     validateCompletenessRelation_fp64(ops);
   }
 
+  /// @brief Checks if Kraus ops have unitary representations and saves them if
+  /// they do.
+  void generateUnitaryParameters() {
+    if constexpr (std::is_same_v<cudaq::complex::value_type, float>) {
+      generateUnitaryParameters_fp32(ops, this->unitary_ops, this->probabilities);
+      return;
+    }
+    generateUnitaryParameters_fp64(ops, this->unitary_ops, this->probabilities);
+  }
+
 public:
   /// @brief Noise type enumeration
   noise_model_type noise_type = noise_model_type::unknown;
@@ -196,6 +212,16 @@ public:
   // Hence, having a templated `parameters` member variable may cause data
   // corruption.
   std::vector<double> parameters;
+
+  /// @brief If all Kraus ops are - when scaled - unitary, this holds the
+  /// unitary versions of those ops. These values are always "double" regardless
+  /// of whether cudaq::real is float or double.
+  std::vector<std::vector<std::complex<double>>> unitary_ops;
+
+  /// @brief If all Kraus ops are - when scaled - unitary, this holds the
+  /// probabilities of those ops. These values are always "double" regardless
+  /// of whether cudaq::real is float or double.
+  std::vector<double> probabilities;
 
   virtual ~kraus_channel() = default;
 
@@ -212,12 +238,14 @@ public:
   kraus_channel(std::initializer_list<T> &&...inputLists) {
     (ops.emplace_back(std::move(inputLists)), ...);
     validateCompleteness();
+    generateUnitaryParameters();
   }
 
   /// @brief The constructor, take qubits and channel kraus_ops as lvalue
   /// reference
   kraus_channel(const std::vector<kraus_op> &inOps) : ops(inOps) {
     validateCompleteness();
+    generateUnitaryParameters();
   }
 
   /// @brief The constructor, take qubits and channel kraus_ops as rvalue
@@ -243,6 +271,9 @@ public:
 
   /// @brief Add a kraus_op to this channel.
   void push_back(kraus_op op);
+
+  /// @brief Returns whether or not this is a unitary mixture.
+  bool is_unitary_mixture() { return !unitary_ops.empty(); }
 
   std::string get_type_name() const {
     return get_noise_model_type_name(noise_type);
@@ -502,6 +533,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::depolarization_channel;
     validateCompleteness();
+    generateUnitaryParameters();
   }
   depolarization_channel(const real probability)
       : depolarization_channel(std::vector<cudaq::real>{probability}) {}
@@ -523,6 +555,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::amplitude_damping_channel;
     validateCompleteness();
+    generateUnitaryParameters();
   }
   amplitude_damping_channel(const real probability)
       : amplitude_damping_channel(std::vector<cudaq::real>{probability}) {}
@@ -545,6 +578,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::bit_flip_channel;
     validateCompleteness();
+    generateUnitaryParameters();
   }
   bit_flip_channel(const real probability)
       : bit_flip_channel(std::vector<cudaq::real>{probability}) {}
@@ -568,6 +602,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::phase_flip_channel;
     validateCompleteness();
+    generateUnitaryParameters();
   }
   phase_flip_channel(const real probability)
       : phase_flip_channel(std::vector<cudaq::real>{probability}) {}
@@ -640,6 +675,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::y_error;
     validateCompleteness();
+    generateUnitaryParameters();
   }
   y_error(const real probability)
       : y_error(std::vector<cudaq::real>{probability}) {}
@@ -683,6 +719,7 @@ public:
       this->parameters.push_back(pp);
     noise_type = cudaq::noise_model_type::pauli1;
     validateCompleteness();
+    generateUnitaryParameters();
   }
   REGISTER_KRAUS_CHANNEL()
 };
@@ -736,6 +773,7 @@ public:
       this->parameters.push_back(pp);
     noise_type = cudaq::noise_model_type::pauli2;
     validateCompleteness();
+    generateUnitaryParameters();
   }
   REGISTER_KRAUS_CHANNEL()
 };
@@ -780,6 +818,7 @@ public:
     this->parameters.push_back(probability);
     noise_type = cudaq::noise_model_type::depolarization2;
     validateCompleteness();
+    generateUnitaryParameters();
   }
   /// @brief Construct a two qubit kraus channel that applies a depolarization
   /// channel on either qubit independently.

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -19,7 +19,43 @@
 
 namespace cudaq::details {
 void warn(const std::string_view msg);
+
+/// @brief Typedef for a matrix wrapper using std::vector<cudaq::complex>
+using matrix_wrapper = std::vector<cudaq::complex>;
+
+/// @brief Compute the Kronecker product of two matrices
+///
+/// @param A First matrix
+/// @param rowsA Number of rows in matrix A
+/// @param colsA Number of columns in matrix A
+/// @param B Second matrix
+/// @param rowsB Number of rows in matrix B
+/// @param colsB Number of columns in matrix B
+/// @return matrix_wrapper Result of the Kronecker product
+inline matrix_wrapper kron(const matrix_wrapper &A, int rowsA, int colsA,
+                           const matrix_wrapper &B, int rowsB, int colsB) {
+  matrix_wrapper C((rowsA * rowsB) * (colsA * colsB));
+  for (int i = 0; i < rowsA; ++i) {
+    for (int j = 0; j < colsA; ++j) {
+      for (int k = 0; k < rowsB; ++k) {
+        for (int l = 0; l < colsB; ++l) {
+          C[(i * rowsB + k) * (colsA * colsB) + (j * colsB + l)] =
+              A[i * colsA + j] * B[k * colsB + l];
+        }
+      }
+    }
+  }
+  return C;
 }
+
+inline matrix_wrapper scale(const cudaq::real s, const matrix_wrapper &A) {
+  matrix_wrapper result;
+  result.reserve(A.size());
+  for (auto a : A)
+    result.push_back(s * a);
+  return result;
+}
+} // namespace details
 
 namespace cudaq {
 // Define the mapping in one place
@@ -537,4 +573,223 @@ public:
       : phase_flip_channel(std::vector<cudaq::real>{probability}) {}
   REGISTER_KRAUS_CHANNEL()
 };
+
+/// @brief amplitude_damping is the same as amplitude_damping_channel.
+class amplitude_damping : public amplitude_damping_channel {
+public:
+  amplitude_damping(const std::vector<cudaq::real> &p)
+      : amplitude_damping_channel(p) {
+    noise_type = noise_model_type::amplitude_damping;
+  }
+  amplitude_damping(const real probability)
+      : amplitude_damping_channel(probability) {
+    noise_type = noise_model_type::amplitude_damping;
+  }
+  REGISTER_KRAUS_CHANNEL()
+};
+
+/// @brief phase_damping is the same as phase_flip_channel.
+class phase_damping : public phase_flip_channel {
+public:
+  phase_damping(const std::vector<cudaq::real> &p) : phase_flip_channel(p) {
+    noise_type = noise_model_type::phase_damping;
+  }
+  phase_damping(const real probability) : phase_flip_channel(probability) {
+    noise_type = noise_model_type::phase_damping;
+  }
+  REGISTER_KRAUS_CHANNEL()
+};
+
+/// @brief z_error is the same as phase_flip_channel.
+class z_error : public phase_flip_channel {
+public:
+  z_error(const std::vector<cudaq::real> &p) : phase_flip_channel(p) {
+    noise_type = noise_model_type::z_error;
+  }
+  z_error(const real probability) : phase_flip_channel(probability) {
+    noise_type = noise_model_type::z_error;
+  }
+  REGISTER_KRAUS_CHANNEL()
+};
+
+
+/// @brief x_error is the same as bit_flip_channel
+class x_error : public bit_flip_channel {
+public:
+  x_error(const std::vector<cudaq::real> &p) : bit_flip_channel(p) {
+    noise_type = noise_model_type::x_error;
+  }
+  x_error(const real probability) : bit_flip_channel(probability) {
+    noise_type = noise_model_type::x_error;
+  }
+  REGISTER_KRAUS_CHANNEL()
+};
+
+/// @brief y_error is the same as bit_flip_channel
+class y_error : public kraus_channel {
+public:
+  constexpr static std::size_t num_parameters = 1;
+  constexpr static std::size_t num_targets = 1;
+  y_error(const std::vector<cudaq::real> &p) {
+    cudaq::real probability = p[0];
+    std::complex<cudaq::real> i{0, 1};
+    std::vector<cudaq::complex> k0v{std::sqrt(1 - probability), 0, 0,
+                                    std::sqrt(1 - probability)},
+        k1v{0, -i * std::sqrt(probability), i * std::sqrt(probability), 0};
+    ops = {k0v, k1v};
+    this->parameters.push_back(probability);
+    noise_type = noise_model_type::y_error;
+    validateCompleteness();
+  }
+  y_error(const real probability)
+      : y_error(std::vector<cudaq::real>{probability}) {}
+  REGISTER_KRAUS_CHANNEL()
+};
+
+class pauli1 : public kraus_channel {
+public:
+  constexpr static std::size_t num_parameters = 3;
+  constexpr static std::size_t num_targets = 1;
+  pauli1(const std::vector<cudaq::real> &p) {
+    if (p.size() == num_parameters)
+      throw std::runtime_error(
+          "Invalid number of elements to pauli1 constructor. Must be 3.");
+    cudaq::real sum = 0;
+    for (auto pp : p)
+      sum += pp;
+    // This is just a first-level error check. Additional checks are done in
+    // validateCompleteness.
+    if (sum > static_cast<cudaq::real>(1.0 + 1e-6))
+      throw std::runtime_error("Sum of pauli1 parameters is >1. Must be <= 1.");
+
+    std::complex<cudaq::real> i{0, 1};
+    cudaq::details::matrix_wrapper I({1, 0, 0, 1});
+    cudaq::details::matrix_wrapper X({0, 1, 1, 0});
+    cudaq::details::matrix_wrapper Y({0, -i, i, 0});
+    cudaq::details::matrix_wrapper Z({1, 0, 0, -1});
+    cudaq::real p0 =
+        std::sqrt(std::max(static_cast<cudaq::real>(1.0 - p[0] - p[1] - p[2]),
+                           static_cast<cudaq::real>(0)));
+    cudaq::real px = std::sqrt(p[0]);
+    cudaq::real py = std::sqrt(p[1]);
+    cudaq::real pz = std::sqrt(p[2]);
+    std::vector<cudaq::complex> k0v = details::scale(p0, I);
+    std::vector<cudaq::complex> k1v = details::scale(px, X);
+    std::vector<cudaq::complex> k2v = details::scale(py, Y);
+    std::vector<cudaq::complex> k3v = details::scale(pz, Z);
+    ops = {k0v, k1v, k2v, k3v};
+    this->parameters.reserve(p.size());
+    for (auto pp : p)
+      this->parameters.push_back(pp);
+    noise_type = cudaq::noise_model_type::pauli1;
+    validateCompleteness();
+  }
+  REGISTER_KRAUS_CHANNEL()
+};
+
+class pauli2 : public kraus_channel {
+public:
+  constexpr static std::size_t num_parameters = 15;
+  constexpr static std::size_t num_targets = 2;
+  pauli2(const std::vector<cudaq::real> &p) {
+    if (p.size() == num_parameters)
+      throw std::runtime_error(
+          "Invalid number of elements to pauli2 constructor. Must be 15.");
+    cudaq::real sum = 0;
+    for (auto pp : p)
+      sum += pp;
+    // This is just a first-level error check. Additional checks are done in
+    // validateCompleteness.
+    if (sum > static_cast<cudaq::real>(1.0 + 1e-6))
+      throw std::runtime_error("Sum of pauli2 parameters is >1. Must be <= 1.");
+    
+    std::complex<cudaq::real> i{0, 1};
+    cudaq::details::matrix_wrapper I({1, 0, 0, 1});
+    cudaq::details::matrix_wrapper X({0, 1, 1, 0});
+    cudaq::details::matrix_wrapper Y({0, -i, i, 0});
+    cudaq::details::matrix_wrapper Z({1, 0, 0, -1});
+    cudaq::real pii = std::sqrt(std::max(static_cast<cudaq::real>(1.0 - sum),
+                                         static_cast<cudaq::real>(0)));
+
+    ops.push_back(details::scale(pii, details::kron(I, 2, 2, I, 2, 2)));
+    ops.push_back(details::scale(p[0], details::kron(I, 2, 2, X, 2, 2)));
+    ops.push_back(details::scale(p[1], details::kron(I, 2, 2, Y, 2, 2)));
+    ops.push_back(details::scale(p[2], details::kron(I, 2, 2, Z, 2, 2)));
+
+    ops.push_back(details::scale(p[3], details::kron(X, 2, 2, I, 2, 2)));
+    ops.push_back(details::scale(p[4], details::kron(X, 2, 2, X, 2, 2)));
+    ops.push_back(details::scale(p[5], details::kron(X, 2, 2, Y, 2, 2)));
+    ops.push_back(details::scale(p[6], details::kron(X, 2, 2, Z, 2, 2)));
+
+    ops.push_back(details::scale(p[7], details::kron(Y, 2, 2, I, 2, 2)));
+    ops.push_back(details::scale(p[8], details::kron(Y, 2, 2, X, 2, 2)));
+    ops.push_back(details::scale(p[9], details::kron(Y, 2, 2, Y, 2, 2)));
+    ops.push_back(details::scale(p[10], details::kron(Y, 2, 2, Z, 2, 2)));
+
+    ops.push_back(details::scale(p[11], details::kron(Z, 2, 2, I, 2, 2)));
+    ops.push_back(details::scale(p[12], details::kron(Z, 2, 2, X, 2, 2)));
+    ops.push_back(details::scale(p[13], details::kron(Z, 2, 2, Y, 2, 2)));
+    ops.push_back(details::scale(p[14], details::kron(Z, 2, 2, Z, 2, 2)));
+
+    this->parameters.reserve(p.size());
+    for (auto pp : p)
+      this->parameters.push_back(pp);
+    noise_type = cudaq::noise_model_type::pauli2;
+    validateCompleteness();
+  }
+  REGISTER_KRAUS_CHANNEL()
+};
+
+/// @brief depolarization1 is the same as depolarization_channel
+class depolarization1 : public depolarization_channel {
+public:
+  depolarization1(const std::vector<cudaq::real> &p)
+      : depolarization_channel(p) {
+    noise_type = noise_model_type::depolarization1;
+  }
+  depolarization1(const real probability)
+      : depolarization_channel(probability) {
+    noise_type = noise_model_type::depolarization1;
+  }
+  REGISTER_KRAUS_CHANNEL()
+};
+
+class depolarization2 : public kraus_channel {
+public:
+  constexpr static std::size_t num_parameters = 1;
+  constexpr static std::size_t num_targets = 2;
+  depolarization2(const std::vector<cudaq::real> p) : kraus_channel() {
+    auto three = static_cast<cudaq::real>(3.);
+    auto negOne = static_cast<cudaq::real>(-1.);
+    auto probability = p[0];
+
+    std::vector<std::vector<cudaq::complex>> singleQubitKraus = {
+        {std::sqrt(1 - probability), 0, 0, std::sqrt(1 - probability)},
+        {0, std::sqrt(probability / three), std::sqrt(probability / three), 0},
+        {0, cudaq::complex{0, negOne * std::sqrt(probability / three)},
+         cudaq::complex{0, std::sqrt(probability / three)}, 0},
+        {std::sqrt(probability / three), 0, 0,
+         negOne * std::sqrt(probability / three)}};
+
+    // Generate 2-qubit Kraus operators
+    for (const auto &k1 : singleQubitKraus) {
+      for (const auto &k2 : singleQubitKraus) {
+        ops.push_back(details::kron(k1, 2, 2, k2, 2, 2));
+      }
+    }
+    this->parameters.push_back(probability);
+    noise_type = cudaq::noise_model_type::depolarization2;
+    validateCompleteness();
+  }
+  /// @brief Construct a two qubit kraus channel that applies a depolarization
+  /// channel on either qubit independently.
+  ///
+  /// @param p The probability of any depolarizing error happening in the 2
+  /// qubits. (Setting this to 1.0 ensures that "II" cannot happen; maximal
+  /// mixing occurs at p = 0.9375.)
+  depolarization2(const real probability)
+      : depolarization2(std::vector<cudaq::real>{probability}) {}
+  REGISTER_KRAUS_CHANNEL()
+};
+
 } // namespace cudaq

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -192,6 +192,8 @@ protected:
   /// @brief Checks if Kraus ops have unitary representations and saves them if
   /// they do.
   void generateUnitaryParameters() {
+    unitary_ops.clear();
+    probabilities.clear();
     if constexpr (std::is_same_v<cudaq::complex::value_type, float>) {
       generateUnitaryParameters_fp32(ops, this->unitary_ops, this->probabilities);
       return;
@@ -273,7 +275,7 @@ public:
   void push_back(kraus_op op);
 
   /// @brief Returns whether or not this is a unitary mixture.
-  bool is_unitary_mixture() { return !unitary_ops.empty(); }
+  bool is_unitary_mixture() const { return !unitary_ops.empty(); }
 
   std::string get_type_name() const {
     return get_noise_model_type_name(noise_type);

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -189,18 +189,6 @@ protected:
     validateCompletenessRelation_fp64(ops);
   }
 
-  /// @brief Checks if Kraus ops have unitary representations and saves them if
-  /// they do.
-  void generateUnitaryParameters() {
-    unitary_ops.clear();
-    probabilities.clear();
-    if constexpr (std::is_same_v<cudaq::complex::value_type, float>) {
-      generateUnitaryParameters_fp32(ops, this->unitary_ops, this->probabilities);
-      return;
-    }
-    generateUnitaryParameters_fp64(ops, this->unitary_ops, this->probabilities);
-  }
-
 public:
   /// @brief Noise type enumeration
   noise_model_type noise_type = noise_model_type::unknown;
@@ -279,6 +267,20 @@ public:
 
   std::string get_type_name() const {
     return get_noise_model_type_name(noise_type);
+  }
+
+  /// @brief Checks if Kraus ops have unitary representations and saves them if
+  /// they do. Users should only need to call this if they have modified the
+  /// Kraus ops and want to recompute these values.
+  void generateUnitaryParameters() {
+    unitary_ops.clear();
+    probabilities.clear();
+    if constexpr (std::is_same_v<cudaq::complex::value_type, float>) {
+      generateUnitaryParameters_fp32(ops, this->unitary_ops,
+                                     this->probabilities);
+      return;
+    }
+    generateUnitaryParameters_fp64(ops, this->unitary_ops, this->probabilities);
   }
 };
 
@@ -557,7 +559,8 @@ public:
     this->parameters.push_back(probability);
     noise_type = noise_model_type::amplitude_damping_channel;
     validateCompleteness();
-    generateUnitaryParameters();
+    // Note: amplitude damping is non-unitary, so there is no value in calling
+    // generateUnitaryParameters().
   }
   amplitude_damping_channel(const real probability)
       : amplitude_damping_channel(std::vector<cudaq::real>{probability}) {}

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -825,6 +825,7 @@ public:
     validateCompleteness();
     generateUnitaryParameters();
   }
+
   /// @brief Construct a two qubit kraus channel that applies a depolarization
   /// channel on either qubit independently.
   ///

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -128,6 +128,7 @@ public:
   }
 
   virtual void setNoiseModel(const noise_model *model) { noiseModel = model; }
+  virtual const noise_model *getNoiseModel() { return noiseModel; }
 
   /// Return the number of qubits
   std::size_t getNumQubits() { return numQubits; }

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -53,6 +53,14 @@ void quantum_platform::set_noise(const noise_model *model) {
   platformQPU->setNoiseModel(model);
 }
 
+const noise_model *quantum_platform::get_noise() {
+  if (executionContext)
+    return executionContext->noiseModel;
+
+  auto &platformQPU = platformQPUs[platformCurrentQPU];
+  return platformQPU->getNoiseModel();
+}
+
 void quantum_platform::reset_noise() { set_noise(nullptr); }
 
 std::future<sample_result>

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -125,6 +125,9 @@ public:
   /// quantum kernels.
   void set_noise(const noise_model *model);
 
+  /// @brief Return the current noise model or nullptr if none set.
+  const noise_model *get_noise();
+
   /// @brief Get the remote capabilities (only applicable for remote platforms)
   RemoteCapabilities get_remote_capabilities(const std::size_t qpuId = 0) const;
 

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -121,11 +121,10 @@ public:
   /// @brief Return true if QPU is locally emulating a remote QPU
   bool is_emulated(const std::size_t qpuId = 0) const;
 
-  /// @brief Set the noise model for future invocations of
-  /// quantum kernels.
+  /// @brief Set the noise model for future invocations of quantum kernels.
   void set_noise(const noise_model *model);
 
-  /// @brief Return the current noise model or nullptr if none set.
+  /// @brief Return the current noise model or `nullptr` if none set.
   const noise_model *get_noise();
 
   /// @brief Get the remote capabilities (only applicable for remote platforms)
@@ -147,8 +146,7 @@ public:
                  cudaq::optimizer &optimizer, const int n_params,
                  const std::size_t shots);
 
-  // This method is the hook for the kernel rewrites to invoke
-  // quantum kernels.
+  // This method is the hook for the kernel rewrites to invoke quantum kernels.
   [[nodiscard]] KernelThunkResultType
   launchKernel(std::string kernelName, KernelThunkType kernelFunc, void *args,
                std::uint64_t voidStarSize, std::uint64_t resultOffset,
@@ -225,11 +223,13 @@ extern "C" {
 [[nodiscard]] KernelThunkResultType
 altLaunchKernel(const char *kernelName, KernelThunkType kernel, void *args,
                 std::uint64_t argsSize, std::uint64_t resultOffset);
+
 // Streamlined interface for launching kernels. Argument synthesis and JIT
 // compilation *must* happen on the local machine.
 [[nodiscard]] KernelThunkResultType
 streamlinedLaunchKernel(const char *kernelName,
                         const std::vector<void *> &rawArgs);
+
 // Hybrid of the client-server and streamlined approaches. Letting JIT
 // compilation happen either early or late and can handle return values from
 // each kernel launch.

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -133,6 +133,7 @@ public:
                      const std::vector<QuditInfo> &targets,
                      bool isAdjoint = false, const spin_op op = spin_op()) = 0;
 
+  /// @brief Apply a fine-grain noise operation within a kernel. 
   virtual void applyNoise(const kraus_channel &channelName,
                           const std::vector<QuditInfo> &targets) = 0;
 

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "common/CustomOp.h"
+#include "common/NoiseModel.h"
 #include "common/QuditIdTracker.h"
 #include "cudaq/host_config.h"
 #include "cudaq/spin_op.h"
@@ -131,6 +132,9 @@ public:
                      const std::vector<QuditInfo> &controls,
                      const std::vector<QuditInfo> &targets,
                      bool isAdjoint = false, const spin_op op = spin_op()) = 0;
+
+  virtual void applyNoise(const kraus_channel &channelName,
+                          const std::vector<QuditInfo> &targets) = 0;
 
   /// Reset the qubit to the |0> state
   virtual void reset(const QuditInfo &target) = 0;

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -133,7 +133,7 @@ public:
                      const std::vector<QuditInfo> &targets,
                      bool isAdjoint = false, const spin_op op = spin_op()) = 0;
 
-  /// @brief Apply a fine-grain noise operation within a kernel. 
+  /// @brief Apply a fine-grain noise operation within a kernel.
   virtual void applyNoise(const kraus_channel &channelName,
                           const std::vector<QuditInfo> &targets) = 0;
 

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -28,9 +28,12 @@ namespace cudaq {
 /// (e.g. sampling)
 class BasicExecutionManager : public cudaq::ExecutionManager {
 protected:
+  
+  /// @brief Return true if we are in tracer mode
   bool isInTracerMode() {
     return executionContext && executionContext->name == "tracer";
   }
+
   /// @brief An instruction is composed of a operation name,
   /// a optional set of rotation parameters, control qudits,
   /// target qudits, and an optional spin_op.

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -27,12 +27,10 @@ namespace cudaq {
 /// measurement, allocation, and deallocation, and execution context handling
 /// (e.g. sampling)
 class BasicExecutionManager : public cudaq::ExecutionManager {
-private:
+protected:
   bool isInTracerMode() {
     return executionContext && executionContext->name == "tracer";
   }
-
-protected:
   /// @brief An instruction is composed of a operation name,
   /// a optional set of rotation parameters, control qudits,
   /// target qudits, and an optional spin_op.
@@ -233,6 +231,11 @@ public:
     // Add to the instruction queue
     instructionQueue.emplace_back(std::move(mutable_name), mutable_params,
                                   mutable_controls, mutable_targets, op);
+  }
+
+  void applyNoise(const kraus_channel &channel,
+                  const std::vector<QuditInfo> &targets) override {
+    return;
   }
 
   void synchronize() override {

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -28,7 +28,6 @@ namespace cudaq {
 /// (e.g. sampling)
 class BasicExecutionManager : public cudaq::ExecutionManager {
 protected:
-  
   /// @brief Return true if we are in tracer mode
   bool isInTracerMode() {
     return executionContext && executionContext->name == "tracer";

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -228,9 +228,9 @@ protected:
     flushGateQueue();
 
     if (channel.empty()) {
-      if (!simulator()->isValidNoiseChannelName(channel.name))
+      if (!simulator()->isValidNoiseChannel(channel.noise_type))
         throw std::runtime_error("this is not a valid kraus channel name (" +
-                                 channel.name +
+                                 channel.get_type_name() +
                                  "), no "
                                  "kraus ops available to construct it.");
     }
@@ -240,7 +240,7 @@ protected:
                    [](auto &&el) { return el.id; });
     cudaq::info(
         "[DefaultExecutionManager] Applying fine-grain kraus channel {}.",
-        channel.name);
+        channel.get_type_name());
     simulator()->applyNoise(channel, localT);
   }
 

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -221,6 +221,29 @@ protected:
         })();
   }
 
+  void applyNoise(const kraus_channel &channel,
+                  const std::vector<QuditInfo> &targets) override {
+    if (isInTracerMode())
+      return;
+    flushGateQueue();
+
+    if (channel.empty()) {
+      if (!simulator()->isValidNoiseChannelName(channel.name))
+        throw std::runtime_error("this is not a valid kraus channel name (" +
+                                 channel.name +
+                                 "), no "
+                                 "kraus ops available to construct it.");
+    }
+
+    std::vector<std::size_t> localT;
+    std::transform(targets.begin(), targets.end(), std::back_inserter(localT),
+                   [](auto &&el) { return el.id; });
+    cudaq::info(
+        "[DefaultExecutionManager] Applying fine-grain kraus channel {}.",
+        channel.name);
+    simulator()->applyNoise(channel, localT);
+  }
+
   int measureQudit(const cudaq::QuditInfo &q,
                    const std::string &registerName) override {
     flushRequestedAllocations();

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -225,15 +225,15 @@ protected:
                   const std::vector<QuditInfo> &targets) override {
     if (isInTracerMode())
       return;
+
     flushGateQueue();
 
-    if (channel.empty()) {
+    if (channel.empty())
       if (!simulator()->isValidNoiseChannel(channel.noise_type))
         throw std::runtime_error("this is not a valid kraus channel name (" +
                                  channel.get_type_name() +
                                  "), no "
                                  "kraus ops available to construct it.");
-    }
 
     std::vector<std::size_t> localT;
     std::transform(targets.begin(), targets.end(), std::back_inserter(localT),

--- a/runtime/cudaq/qis/qarray.h
+++ b/runtime/cudaq/qis/qarray.h
@@ -107,6 +107,8 @@ public:
 
 } // namespace cudaq
 
+// enable one to get the size of the qarray at 
+// compile time with std::tuple_size<qarray>
 namespace std {
 template <std::size_t N, std::size_t Levels>
 struct tuple_size<cudaq::qarray<N, Levels>>

--- a/runtime/cudaq/qis/qarray.h
+++ b/runtime/cudaq/qis/qarray.h
@@ -106,3 +106,10 @@ public:
 };
 
 } // namespace cudaq
+
+namespace std {
+template <std::size_t N, std::size_t Levels>
+struct tuple_size<cudaq::qarray<N, Levels>>
+    : public integral_constant<size_t, N> {
+}; // Inherits N from qarray's template
+} // namespace std

--- a/runtime/cudaq/qis/qarray.h
+++ b/runtime/cudaq/qis/qarray.h
@@ -107,7 +107,7 @@ public:
 
 } // namespace cudaq
 
-// enable one to get the size of the qarray at 
+// enable one to get the size of the qarray at
 // compile time with std::tuple_size<qarray>
 namespace std {
 template <std::size_t N, std::size_t Levels>

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -18,11 +18,9 @@
 #include "cudaq/qis/qreg.h"
 #include "cudaq/qis/qvector.h"
 #include "cudaq/spin_op.h"
-
 #include <algorithm>
 #include <cstring>
 #include <functional>
-#include <iostream>
 
 #define __qpu__ __attribute__((annotate("quantum")))
 

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -1222,9 +1222,10 @@ void genericApplicator(const std::string &gateName, Args &&...args) {
       tuple_slice_last<sizeof...(Args) - NUMP>(std::forward_as_tuple(args...)));
 }
 
-template <typename T, typename... RotationT, typename... QuantumT,
-          std::size_t NumPProvided = sizeof...(RotationT),
-          std::enable_if_t<T::num_parameters == NumPProvided, std::size_t> = 0>
+template <
+    typename T, typename... RotationT, typename... QuantumT,
+    std::size_t NumPProvided = sizeof...(RotationT),
+    std::enable_if_t<T::num_parameters == NumPProvided, std::size_t> = 0>
 void applyNoiseImpl(const std::tuple<RotationT...> &paramTuple,
                     const std::tuple<QuantumT...> &quantumTuple) {
   auto *ctx = get_platform().get_exec_ctx();
@@ -1254,7 +1255,6 @@ void applyNoiseImpl(const std::tuple<RotationT...> &paramTuple,
   auto channel = ctx->noiseModel->template get_channel<T>(parameters);
   getExecutionManager()->applyNoise(channel, qubits);
 }
-
 } // namespace cudaq::details
 
 namespace cudaq {

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -1174,7 +1174,7 @@ void applyQuantumOperation(const std::string &gateName,
         "cudaq does not support broadcast for multi-qubit operations.");
 
   // Operation on correct number of targets, no controls, possible broadcast
-  if ((std::is_same_v<mod, base> || std::is_same_v<mod, adj>) && NumT == 1) {
+  if ((std::is_same_v<mod, base> || std::is_same_v<mod, adj>)&&NumT == 1) {
     for (auto &qubit : qubits)
       getExecutionManager()->apply(gateName, parameters, {}, {qubit},
                                    std::is_same_v<mod, adj>);

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -1231,12 +1231,11 @@ template <typename T, typename... RotationT, typename... QuantumT,
           std::enable_if_t<T::num_parameters == NumPProvided, std::size_t> = 0>
 void applyNoiseImpl(const std::tuple<RotationT...> &paramTuple,
                     const std::tuple<QuantumT...> &quantumTuple) {
-  auto *ctx = get_platform().get_exec_ctx();
-  if (!ctx)
-    return;
+  auto &platform = get_platform();
+  const auto *noiseModel = platform.get_noise();
 
   // per-spec, no noise model provided, emit warning, no application
-  if (!ctx->noiseModel)
+  if (!noiseModel)
     return details::warn("apply_noise called without a noise model provided.");
 
   std::vector<double> parameters;
@@ -1260,7 +1259,7 @@ void applyNoiseImpl(const std::tuple<RotationT...> &paramTuple,
                                 std::to_string(qubits.size()));
   }
 
-  auto channel = ctx->noiseModel->template get_channel<T>(parameters);
+  auto channel = noiseModel->template get_channel<T>(parameters);
   // per spec - caller provides noise model, but channel not registered,
   // warning generated, no channel application.
   if (channel.empty())
@@ -1289,12 +1288,11 @@ template <typename T, typename... Q,
               !any_float<Q...>>>
 #endif
 void apply_noise(const std::vector<double> &params, Q &&...args) {
-  auto *ctx = get_platform().get_exec_ctx();
-  if (!ctx)
-    return;
+  auto &platform = get_platform();
+  const auto *noiseModel = platform.get_noise();
 
   // per-spec, no noise model provided, emit warning, no application
-  if (!ctx->noiseModel)
+  if (!noiseModel)
     return details::warn("apply_noise called without a noise model provided. "
                          "skipping kraus channel application.");
 
@@ -1310,7 +1308,7 @@ void apply_noise(const std::vector<double> &params, Q &&...args) {
     }
   });
 
-  auto channel = ctx->noiseModel->template get_channel<T>(params);
+  auto channel = noiseModel->template get_channel<T>(params);
   // per spec - caller provides noise model, but channel not registered,
   // warning generated, no channel application.
   if (channel.empty())

--- a/runtime/nvqir/CMakeLists.txt
+++ b/runtime/nvqir/CMakeLists.txt
@@ -47,7 +47,7 @@ if (CUTENSORNET_ROOT AND CUDA_FOUND)
   add_subdirectory(cutensornet)  
 endif()
 if (CUDA_FOUND)
-  add_subdirectory(cudensitymat)
+  # add_subdirectory(cudensitymat)
 endif()
 
 install(EXPORT nvqir-targets

--- a/runtime/nvqir/CMakeLists.txt
+++ b/runtime/nvqir/CMakeLists.txt
@@ -47,7 +47,7 @@ if (CUTENSORNET_ROOT AND CUDA_FOUND)
   add_subdirectory(cutensornet)  
 endif()
 if (CUDA_FOUND)
-  # add_subdirectory(cudensitymat)
+  add_subdirectory(cudensitymat)
 endif()
 
 install(EXPORT nvqir-targets

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -231,6 +231,13 @@ public:
   /// @brief Whether or not this is a state vector simulator
   virtual bool isStateVectorSimulator() const { return false; }
 
+  virtual bool isValidNoiseChannelName(const std::string &name) const {
+    return false;
+  }
+
+  virtual void applyNoise(const cudaq::kraus_channel &channel,
+                          const std::vector<std::size_t> &targets) {}
+
   /// @brief Apply a custom operation described by a matrix of data
   /// represented as 1-D vector of elements in row-major order, as well
   /// as the the control qubit and target indices

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -240,7 +240,10 @@ public:
   /// @brief Apply the given kraus_channel on the provided targets.
   /// Only supported for noise backends. By default do nothing
   virtual void applyNoise(const cudaq::kraus_channel &channel,
-                          const std::vector<std::size_t> &targets) {}
+                          const std::vector<std::size_t> &targets) {
+    cudaq::warn("kraus_channel application not supported on {} simulator.",
+                name());
+  }
 
   /// @brief Apply a custom operation described by a matrix of data
   /// represented as 1-D vector of elements in row-major order, as well

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -231,7 +231,7 @@ public:
   /// @brief Whether or not this is a state vector simulator
   virtual bool isStateVectorSimulator() const { return false; }
 
-  virtual bool isValidNoiseChannelName(const std::string &name) const {
+  virtual bool isValidNoiseChannel(const cudaq::noise_model_type &type) const {
     return false;
   }
 

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -231,10 +231,14 @@ public:
   /// @brief Whether or not this is a state vector simulator
   virtual bool isStateVectorSimulator() const { return false; }
 
+  /// @brief Subtypes can return true if the given noise_model_type is
+  /// supported. By default, return false
   virtual bool isValidNoiseChannel(const cudaq::noise_model_type &type) const {
     return false;
   }
 
+  /// @brief Apply the given kraus_channel on the provided targets.
+  /// Only supported for noise backends. By default do nothing
   virtual void applyNoise(const cudaq::kraus_channel &channel,
                           const std::vector<std::size_t> &targets) {}
 

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -635,6 +635,24 @@ void __quantum__qis__custom_unitary(std::complex<double> *unitary,
       unitaryMatrix, ctrlsVec, tgtsVec, name);
 }
 
+void __quantum__qis__apply_kraus_channel(const char *demangledName,
+                                         double *params, std::size_t numParams,
+                                         Array *qubits) {
+
+  auto *ctx = nvqir::getCircuitSimulatorInternal()->getExecutionContext();
+  if (!ctx)
+    return;
+
+  auto *noise = ctx->noiseModel;
+  if (!noise)
+    return;
+
+  std::vector<double> paramVec(params, params + numParams);
+  auto channel = noise->get_channel(demangledName, paramVec);
+  nvqir::getCircuitSimulatorInternal()->applyNoise(channel,
+                                                   arrayToVectorSizeT(qubits));
+}
+
 void __quantum__qis__custom_unitary__adj(std::complex<double> *unitary,
                                          Array *controls, Array *targets,
                                          const char *name) {

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -635,9 +635,8 @@ void __quantum__qis__custom_unitary(std::complex<double> *unitary,
       unitaryMatrix, ctrlsVec, tgtsVec, name);
 }
 
-void __quantum__qis__apply_kraus_channel(const char *demangledName,
-                                         double *params, std::size_t numParams,
-                                         Array *qubits) {
+void __quantum__qis__apply_kraus_channel(long krausChannelKey, double *params,
+                                         std::size_t numParams, Array *qubits) {
 
   auto *ctx = nvqir::getCircuitSimulatorInternal()->getExecutionContext();
   if (!ctx)
@@ -648,7 +647,7 @@ void __quantum__qis__apply_kraus_channel(const char *demangledName,
     return;
 
   std::vector<double> paramVec(params, params + numParams);
-  auto channel = noise->get_channel(demangledName, paramVec);
+  auto channel = noise->get_channel(krausChannelKey, paramVec);
   nvqir::getCircuitSimulatorInternal()->applyNoise(channel,
                                                    arrayToVectorSizeT(qubits));
 }

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -664,10 +664,10 @@ void __quantum__qis__apply_kraus_channel_generalized(
     auto *dblPtr = va_arg(args, double *);
     params[i] = *dblPtr;
   }
-  std::vector<std::size_t> qubits;
+  std::vector<std::size_t> qubits(numTargets);
   for (std::size_t i = 0; i < numTargets; ++i) {
     auto *qbPtr = va_arg(args, Qubit *);
-    qubits[i] = reinterpret_cast<std::size_t>(qbPtr);
+    qubits[i] = qubitToSizeT(qbPtr); 
   }
   auto *asArray = vectorSizetToArray(qubits);
   __quantum__qis__apply_kraus_channel(krausChannelKey, params, numParams,

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -675,7 +675,7 @@ void __quantum__qis__apply_kraus_channel_generalized(
       throw std::invalid_argument("Too many spans (> 1), not supported");
     basic_span *spans =
         reinterpret_cast<basic_span *>(alloca(numSpans * sizeof(basic_span)));
-    for (std::size_t i = 0; i < numParams; ++i) {
+    for (std::size_t i = 0; i < numSpans; ++i) {
       auto *dataPtr = va_arg(args, double *);
       auto dataLen = va_arg(args, std::size_t);
       spans[i] = basic_span{dataPtr, dataLen};

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
@@ -11,17 +11,6 @@
 #include "cutensornet.h"
 #include "tensornet_spin_op.h"
 
-namespace {
-const std::vector<std::complex<double>> matPauliI = {
-    {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}};
-const std::vector<std::complex<double>> matPauliX{
-    {0.0, 0.0}, {1.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}};
-const std::vector<std::complex<double>> matPauliY{
-    {0.0, 0.0}, {0.0, -1.0}, {0.0, 1.0}, {0.0, 0.0}};
-const std::vector<std::complex<double>> matPauliZ{
-    {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {-1.0, 0.0}};
-} // namespace
-
 namespace nvqir {
 
 SimulatorTensorNetBase::SimulatorTensorNetBase()
@@ -148,66 +137,7 @@ void SimulatorTensorNetBase::applyGate(const GateApplicationTask &task) {
   }
 }
 
-// Helper to check whether a matrix is a scaled unitary matrix, i.e., `k * U`
-// where U is a unitary matrix. If so, it also returns the `k` factor.
-// Otherwise, return a nullopt.
-template <typename T>
-std::optional<double> isScaledUnitary(const std::vector<std::complex<T>> &mat,
-                                      double eps) {
-  typedef Eigen::Matrix<std::complex<T>, Eigen::Dynamic, Eigen::Dynamic,
-                        Eigen::RowMajor>
-      RowMajorMatTy;
-  const int dim = std::log2(mat.size());
-  Eigen::Map<const RowMajorMatTy> kMat(mat.data(), dim, dim);
-  if (kMat.isZero())
-    return std::nullopt;
-  // Check that (K_dag * K) is a scaled identity matrix
-  // i.e., the K matrix is a scaled unitary.
-  auto kdK = kMat.adjoint() * kMat;
-  if (!kdK.isDiagonal())
-    return std::nullopt;
-  // First element
-  std::complex<T> val = kdK(0, 0);
-  if (std::abs(val) > eps && std::abs(val.imag()) < eps) {
-    auto scaledKdK = (std::complex<T>{1.0} / val) * kdK;
-    if (scaledKdK.isIdentity())
-      return val.real();
-  }
-  return std::nullopt;
-}
-
-std::optional<std::pair<
-    std::vector<double>,
-    std::vector<std::vector<std::complex<
-        double>>>>> static computeUnitaryMixture(const std::
-                                                     vector<std::vector<
-                                                         std::complex<double>>>
-                                                         &krausOps,
-                                                 double tol = 1e-6) {
-  std::vector<double> probs;
-  std::vector<std::vector<std::complex<double>>> mats;
-  const auto scaleMat = [](const std::vector<std::complex<double>> &mat,
-                           double scaleFactor) {
-    std::vector<std::complex<double>> scaledMat = mat;
-    for (auto &x : scaledMat)
-      x /= scaleFactor;
-    return scaledMat;
-  };
-  for (const auto &op : krausOps) {
-    const auto scaledFactor = isScaledUnitary(op, tol);
-    if (!scaledFactor.has_value())
-      return std::nullopt;
-    probs.emplace_back(scaledFactor.value());
-    mats.emplace_back(scaleMat(op, scaledFactor.value()));
-  }
-
-  if (std::abs(1.0 - std::reduce(probs.begin(), probs.end())) > tol)
-    return std::nullopt;
-
-  return std::make_pair(probs, mats);
-}
-
-// Helper to look up a device memory pointer from a  cache.
+// Helper to look up a device memory pointer from a cache.
 // If not found, allocate a new device memory buffer and put it to the cache.
 static void *
 getOrCacheMat(const std::string &key,
@@ -227,85 +157,16 @@ void SimulatorTensorNetBase::applyKrausChannel(
     const std::vector<int32_t> &qubits,
     const cudaq::kraus_channel &krausChannel) {
   LOG_API_TIME();
-  switch (krausChannel.noise_type) {
-  case cudaq::noise_model_type::depolarization_channel: {
-    if (krausChannel.parameters.size() != 1)
-      throw std::runtime_error(
-          fmt::format("Invalid parameters for a depolarization channel. "
-                      "Expecting 1 parameter, got {}.",
-                      krausChannel.parameters.size()));
-    const std::vector<void *> channelMats{
-        getOrCacheMat("PauliI", matPauliI, m_gateDeviceMemCache),
-        getOrCacheMat("PauliX", matPauliX, m_gateDeviceMemCache),
-        getOrCacheMat("PauliY", matPauliY, m_gateDeviceMemCache),
-        getOrCacheMat("PauliZ", matPauliZ, m_gateDeviceMemCache)};
-    const double p = krausChannel.parameters[0];
-    const std::vector<double> probabilities = {1 - p, p / 3., p / 3., p / 3.};
-    m_state->applyUnitaryChannel(qubits, channelMats, probabilities);
-    break;
-  }
-  case cudaq::noise_model_type::bit_flip_channel: {
-    if (krausChannel.parameters.size() != 1)
-      throw std::runtime_error(
-          fmt::format("Invalid parameters for a bit-flip channel. "
-                      "Expecting 1 parameter, got {}.",
-                      krausChannel.parameters.size()));
-
-    const std::vector<void *> channelMats{
-        getOrCacheMat("PauliI", matPauliI, m_gateDeviceMemCache),
-        getOrCacheMat("PauliX", matPauliX, m_gateDeviceMemCache)};
-    const double p = krausChannel.parameters[0];
-    const std::vector<double> probabilities = {1 - p, p};
-    m_state->applyUnitaryChannel(qubits, channelMats, probabilities);
-    break;
-  }
-  case cudaq::noise_model_type::phase_flip_channel: {
-    if (krausChannel.parameters.size() != 1)
-      throw std::runtime_error(
-          fmt::format("Invalid parameters for a phase-flip channel. "
-                      "Expecting 1 parameter, got {}.",
-                      krausChannel.parameters.size()));
-
-    const std::vector<void *> channelMats{
-        getOrCacheMat("PauliI", matPauliI, m_gateDeviceMemCache),
-        getOrCacheMat("PauliZ", matPauliZ, m_gateDeviceMemCache)};
-    const double p = krausChannel.parameters[0];
-    const std::vector<double> probabilities = {1 - p, p};
-    m_state->applyUnitaryChannel(qubits, channelMats, probabilities);
-    break;
-  }
-  case cudaq::noise_model_type::amplitude_damping_channel: {
-    if (krausChannel.parameters.size() != 1)
-      throw std::runtime_error(
-          fmt::format("Invalid parameters for a amplitude damping channel. "
-                      "Expecting 1 parameter, got {}.",
-                      krausChannel.parameters.size()));
-    if (krausChannel.parameters[0] != 0.0)
-      throw std::runtime_error("Non-unitary noise channels are not supported.");
-    break;
-  }
-  case cudaq::noise_model_type::unknown: {
-    std::vector<std::vector<std::complex<double>>> mats;
-    for (const auto &op : krausChannel.get_ops())
-      mats.emplace_back(op.data);
-    auto asUnitaryMixture = computeUnitaryMixture(mats);
-    if (asUnitaryMixture.has_value()) {
-      auto &[probabilities, unitaries] = asUnitaryMixture.value();
-      std::vector<void *> channelMats;
-      for (const auto &mat : unitaries)
-        channelMats.emplace_back(getOrCacheMat(
-            "ScaledUnitary_" + std::to_string(vecComplexHash(mat)), mat,
-            m_gateDeviceMemCache));
-      m_state->applyUnitaryChannel(qubits, channelMats, probabilities);
-    } else {
-      throw std::runtime_error("Non-unitary noise channels are not supported.");
-    }
-    break;
-  }
-  default:
-    throw std::runtime_error(
-        "Unsupported noise model type: " +
-        std::to_string(static_cast<int>(krausChannel.noise_type)));
+  if (krausChannel.is_unitary_mixture()) {
+    std::vector<void *> channelMats;
+    for (const auto &mat : krausChannel.unitary_ops)
+      channelMats.emplace_back(
+          getOrCacheMat("ScaledUnitary_" + std::to_string(vecComplexHash(mat)),
+                        mat, m_gateDeviceMemCache));
+    m_state->applyUnitaryChannel(qubits, channelMats,
+                                 krausChannel.probabilities);
+  } else {
+    throw std::runtime_error("Non-unitary noise channels are not supported.");
   }
 }
 

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
@@ -309,6 +309,33 @@ void SimulatorTensorNetBase::applyKrausChannel(
   }
 }
 
+bool SimulatorTensorNetBase::isValidNoiseChannel(
+    const cudaq::noise_model_type &type) const {
+  return true;
+}
+
+void SimulatorTensorNetBase::applyNoise(
+    const cudaq::kraus_channel &channel,
+    const std::vector<std::size_t> &targets) {
+  LOG_API_TIME();
+  // Do nothing if no execution context
+  if (!executionContext)
+    return;
+
+  // Do nothing if no noise model
+  if (!executionContext->noiseModel)
+    return;
+
+  // Apply all prior gates before applying noise.
+  std::vector<int32_t> qubits{targets.begin(), targets.end()};
+  cudaq::info(
+      "[SimulatorTensorNetBase] Applying kraus channel {} on qubits: {}",
+      cudaq::get_noise_model_type_name(channel.noise_type), qubits);
+
+  flushGateQueue();
+  applyKrausChannel(qubits, channel);
+}
+
 void SimulatorTensorNetBase::applyNoiseChannel(
     const std::string_view gateName, const std::vector<std::size_t> &controls,
     const std::vector<std::size_t> &targets,

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.cpp
@@ -311,6 +311,26 @@ void SimulatorTensorNetBase::applyKrausChannel(
 
 bool SimulatorTensorNetBase::isValidNoiseChannel(
     const cudaq::noise_model_type &type) const {
+  switch (type) {
+  case cudaq::noise_model_type::depolarization_channel:
+  case cudaq::noise_model_type::bit_flip_channel:
+  case cudaq::noise_model_type::phase_flip_channel:
+  case cudaq::noise_model_type::x_error:
+  case cudaq::noise_model_type::y_error:
+  case cudaq::noise_model_type::z_error:
+  case cudaq::noise_model_type::phase_damping:
+  case cudaq::noise_model_type::pauli1:
+  case cudaq::noise_model_type::pauli2:
+  case cudaq::noise_model_type::depolarization1:
+  case cudaq::noise_model_type::depolarization2:
+    return true;
+  // These are explicitly non-unitary and unsupported
+  case cudaq::noise_model_type::amplitude_damping_channel:
+  case cudaq::noise_model_type::amplitude_damping:
+    return false;
+  }
+  // This is either cudaq::noise_model_type::unknown or some other enum type
+  // that we don't know about at this time.
   return true;
 }
 

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.h
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.h
@@ -36,6 +36,12 @@ public:
                          const std::vector<std::size_t> &targets,
                          const std::vector<double> &params) override;
 
+  bool isValidNoiseChannel(const cudaq::noise_model_type &type) const override;
+
+  /// @brief Apply the given kraus_channel on the provided targets.
+  void applyNoise(const cudaq::kraus_channel &channel,
+                  const std::vector<std::size_t> &targets) override;
+
   // Override base calculateStateDim (we don't instantiate full state vector in
   // the tensornet backend). When the user want to retrieve the state vector, we
   // check if it is feasible to do so.

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -188,10 +188,12 @@ protected:
     }
   }
 
+  /// @brief This simulator supports all noise channels
   bool isValidNoiseChannel(const cudaq::noise_model_type &type) const override {
     return true; 
   }
 
+  /// @brief Apply the given noise channel
   void applyNoise(const cudaq::kraus_channel &channel,
                   const std::vector<std::size_t> &qubits) override {
     flushGateQueue();

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -188,6 +188,30 @@ protected:
     }
   }
 
+  void applyNoise(const cudaq::kraus_channel &channel,
+                  const std::vector<std::size_t> &qubits) override {
+    flushGateQueue();
+    cudaq::info("[qpp-dm] apply kraus channel {}", channel.name);
+    std::vector<std::size_t> casted_qubits;
+    for (auto index : qubits) {
+      casted_qubits.push_back(convertQubitIndex(index));
+    }
+    // Map our kraus ops to the qpp::cmat
+    std::vector<qpp::cmat> K;
+    auto ops = channel.get_ops();
+    std::transform(
+        ops.begin(), ops.end(), std::back_inserter(K), [&](auto &el) {
+          // Note: Kraus channel flattened matrix data is
+          // **row-major**.
+          return Eigen::Map<Eigen::Matrix<std::complex<double>, Eigen::Dynamic,
+                                          Eigen::Dynamic, Eigen::RowMajor>>(
+              el.data.data(), el.nRows, el.nCols);
+        });
+
+    // Apply K rho Kdag
+    state = qpp::apply(state, K, casted_qubits);
+  }
+
   /// @brief Grow the density matrix by one qubit.
   void addQubitToState() override { addQubitsToState(1); }
 

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -188,10 +188,14 @@ protected:
     }
   }
 
+  bool isValidNoiseChannel(const cudaq::noise_model_type &type) const override {
+    return true; 
+  }
+
   void applyNoise(const cudaq::kraus_channel &channel,
                   const std::vector<std::size_t> &qubits) override {
     flushGateQueue();
-    cudaq::info("[qpp-dm] apply kraus channel {}", channel.name);
+    cudaq::info("[qpp-dm] apply kraus channel {}", channel.get_type_name());
     std::vector<std::size_t> casted_qubits;
     for (auto index : qubits) {
       casted_qubits.push_back(convertQubitIndex(index));

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -190,7 +190,7 @@ protected:
 
   /// @brief This simulator supports all noise channels
   bool isValidNoiseChannel(const cudaq::noise_model_type &type) const override {
-    return true; 
+    return true;
   }
 
   /// @brief Apply the given noise channel

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -43,6 +43,7 @@ protected:
   std::optional<std::string>
   isValidStimNoiseChannel(const kraus_channel &channel) const {
 
+    // Check the old way first
     if (channel.noise_type == cudaq::noise_model_type::bit_flip_channel)
       return "X_ERROR";
 
@@ -58,7 +59,7 @@ protected:
 
     auto typeName = channel.name;
 
-    // Check the name of the channel, 
+    // Check the name of the channel,
     // map our builtin noise channels to STIM names
     if (contains(typeName, "cudaq::")) {
       if (contains(typeName, "bit_flip_channel"))
@@ -69,7 +70,7 @@ protected:
         return "DEPOLARIZE1";
     }
 
-    // Final check on the name of the channel, this is 
+    // Final check on the name of the channel, this is
     // for custom operations.
     auto className = [](const std::string &input) -> std::string {
       // Find the last occurrence of '::'
@@ -86,8 +87,11 @@ protected:
         std::find_if(stim::GATE_DATA.items.begin(), stim::GATE_DATA.items.end(),
                      [&](const auto &el) { return el.name == className; });
 
-    if (it != stim::GATE_DATA.items.end())
-      return className;
+    if (it != stim::GATE_DATA.items.end()) {
+      // Assert we have the correct number of params
+      if (it->arg_count == channel.parameters.size())
+        return className;
+    }
 
     return std::nullopt;
   }
@@ -209,7 +213,7 @@ protected:
 
   bool isValidNoiseChannelName(const std::string &name) const override {
     kraus_channel c;
-    c.name = name; 
+    c.name = name;
     return isValidStimNoiseChannel(c).has_value();
   }
 

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -44,14 +44,29 @@ protected:
   isValidStimNoiseChannel(const kraus_channel &channel) const {
 
     // Check the old way first
-    if (channel.noise_type == cudaq::noise_model_type::bit_flip_channel)
+    switch (channel.noise_type) {
+    case cudaq::noise_model_type::bit_flip_channel:
+    case cudaq::noise_model_type::x_error:
       return "X_ERROR";
-
-    if (channel.noise_type == cudaq::noise_model_type::phase_flip_channel)
+    case cudaq::noise_model_type::y_error:
+      return "Y_ERROR";
+    case cudaq::noise_model_type::phase_flip_channel:
+    case cudaq::noise_model_type::phase_damping:
+    case cudaq::noise_model_type::z_error:
       return "Z_ERROR";
-
-    if (channel.noise_type == cudaq::noise_model_type::depolarization_channel)
+    case cudaq::noise_model_type::depolarization_channel:
+    case cudaq::noise_model_type::depolarization1:
       return "DEPOLARIZE1";
+    case cudaq::noise_model_type::depolarization2:
+      return "DEPOLARIZE2";
+    case cudaq::noise_model_type::pauli1:
+      return "PAULI_CHANNEL_1";
+    case cudaq::noise_model_type::pauli2:
+      return "PAULI_CHANNEL_2";
+    case cudaq::noise_model_type::amplitude_damping_channel:
+    case cudaq::noise_model_type::amplitude_damping:
+      return std::nullopt;
+    }
 
     return std::nullopt;
   }

--- a/targettests/execution/test_explicit_measurements.cpp
+++ b/targettests/execution/test_explicit_measurements.cpp
@@ -10,7 +10,7 @@
 // clang-format off
 // RUN: nvq++ --target stim %s -o %t && CUDAQ_LOG_LEVEL=info %t | grep "Creating new Stim frame simulator" | wc -l | FileCheck %s
 // RUN: nvq++ --target anyon                    --emulate %s -o %t && %t 2>&1 | FileCheck %s -check-prefix=FAIL
-// RUN: nvq++ --target braket                   --emulate %s -o %t && %t 2>&1 | FileCheck %s -check-prefix=FAIL
+// RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t 2>&1 | FileCheck %s -check-prefix=FAIL ; fi
 // RUN: nvq++ --target infleqtion               --emulate %s -o %t && %t 2>&1 | FileCheck %s -check-prefix=FAIL
 // RUN: nvq++ --target ionq                     --emulate %s -o %t && %t 2>&1 | FileCheck %s -check-prefix=FAIL
 // RUN: nvq++ --target iqm --iqm-machine Apollo --emulate %s -o %t && %t 2>&1 | FileCheck %s -check-prefix=FAIL

--- a/test/AST-Quake/apply_noise.cpp
+++ b/test/AST-Quake/apply_noise.cpp
@@ -6,7 +6,6 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// REQUIRES: c++20
 // clang-format off
 // RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck --check-prefixes=CHECK,ALIVE %s
 // RUN: cudaq-quake %cpp_std %s | cudaq-opt -erase-noise | FileCheck --check-prefixes=CHECK,DEAD %s

--- a/test/AST-Quake/apply_noise.cpp
+++ b/test/AST-Quake/apply_noise.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck --check-prefixes=CHECK,ALIVE %s
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt -erase-noise | FileCheck --check-prefixes=CHECK,DEAD %s
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt | cudaq-translate --convert-to=qir | FileCheck --check-prefix=QIR %s
+// clang-format on
+
+#include <cudaq.h>
+
+struct SantaKraus : public cudaq::kraus_channel {
+  SantaKraus() {}
+};
+
+struct testApplyNoise {
+  void operator()() __qpu__ {
+    cudaq::qubit q0, q1;
+    cudaq::apply_noise<SantaKraus>(q0, q1);
+  }
+};
+
+// clang-format off
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__testApplyNoise() attributes
+// CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
+// ALIVE:           quake.apply_noise @_ZN5cudaq11apply_noiseI{{.*}}SantaKraus{{.*}}() %[[VAL_0]], %[[VAL_1]] : !quake.ref, !quake.ref
+// DEAD-NOT:        quake.apply_noise
+// CHECK:           return
+// CHECK:         }
+
+// QIR-LABEL: define void @__nvqpp__mlirgen__testApplyNoise() local_unnamed_addr {
+// QIR:         %[[VAL_0:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 2)
+// QIR:         %[[VAL_2:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 0)
+// QIR:         %[[VAL_4:.*]] = load %Qubit*, %Qubit** %[[VAL_2]], align 8
+// QIR:         %[[VAL_5:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 1)
+// QIR:         %[[VAL_6:.*]] = load %Qubit*, %Qubit** %[[VAL_5]], align 8
+// QIR:         tail call void @_ZN5cudaq11apply_noise{{.*}}SantaKraus{{.*}}(%Qubit* %[[VAL_4]], %Qubit* %[[VAL_6]])
+// QIR:         tail call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
+// QIR:         ret void
+// QIR:       }
+// clang-format on
+
+struct SarahKraus : public cudaq::kraus_channel {
+  SarahKraus(double dip, float around) {}
+};
+
+struct testApplyMoreNoise {
+  void operator()() __qpu__ {
+    double d = 4.0;
+    float f = 5.0f;
+    cudaq::qubit q0;
+    cudaq::apply_noise<SarahKraus>(d, f, q0);
+  }
+};
+
+// clang-format on
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__testApplyMoreNoise()
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 5.000000e+00 : f32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 4.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_3:.*]] = cc.alloca f32
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<f32>
+// CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
+// ALIVE:           quake.apply_noise @_ZN5cudaq11apply_noise{{.*}}SarahKraus{{.*}}(%[[VAL_2]], %[[VAL_3]]) %[[VAL_4]] : !cc.ptr<f64>, !cc.ptr<f32>, !quake.ref
+// DEAD-NOT:        quake.apply_noise
+// CHECK:           return
+// CHECK:         }
+
+// QIR-LABEL: define void @__nvqpp__mlirgen__testApplyMoreNoise() local_unnamed_addr {
+// QIR:         %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 1)
+// QIR:         %[[VAL_2:.*]] = alloca double, align 8
+// QIR:         store double 4.000000e+00, double* %[[VAL_2]], align 8
+// QIR:         %[[VAL_3:.*]] = alloca float, align 4
+// QIR:         store float 5.000000e+00, float* %[[VAL_3]], align 4
+// QIR:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
+// QIR:         %[[VAL_6:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_4]], align 8
+// QIR:         call void @_ZN5cudaq11apply_noise{{.*}}SarahKraus{{.*}}(double* nonnull %[[VAL_2]], float* nonnull %[[VAL_3]], %[[VAL_5]]* %[[VAL_6]])
+// QIR:         call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
+// QIR:         ret void
+// QIR:       }
+// clang-format off

--- a/test/AST-Quake/apply_noise.cpp
+++ b/test/AST-Quake/apply_noise.cpp
@@ -6,6 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+// REQUIRES: c++20
 // clang-format off
 // RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck --check-prefixes=CHECK,ALIVE %s
 // RUN: cudaq-quake %cpp_std %s | cudaq-opt -erase-noise | FileCheck --check-prefixes=CHECK,DEAD %s
@@ -15,6 +16,9 @@
 #include <cudaq.h>
 
 struct SantaKraus : public cudaq::kraus_channel {
+  constexpr static std::size_t num_parameters = 0;
+  constexpr static std::size_t num_targets = 2;
+  static std::size_t get_key() { return (std::size_t)&get_key; }
   SantaKraus() {}
 };
 
@@ -29,7 +33,7 @@ struct testApplyNoise {
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__testApplyNoise() attributes
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.ref
-// ALIVE:           quake.apply_noise @_ZN5cudaq11apply_noiseI{{.*}}SantaKraus{{.*}}() %[[VAL_0]], %[[VAL_1]] : !quake.ref, !quake.ref
+// ALIVE:           quake.apply_noise @_ZN5cudaq11apply_noiseI{{.*}}SantaKraus{{.*}}() %[[VAL_0]], %[[VAL_1]] : (!quake.ref, !quake.ref) -> ()
 // DEAD-NOT:        quake.apply_noise
 // CHECK:           return
 // CHECK:         }
@@ -47,6 +51,9 @@ struct testApplyNoise {
 // clang-format on
 
 struct SarahKraus : public cudaq::kraus_channel {
+  constexpr static std::size_t num_parameters = 2;
+  constexpr static std::size_t num_targets = 1;
+  static std::size_t get_key() { return (std::size_t)&get_key; }
   SarahKraus(double dip, float around) {}
 };
 
@@ -59,7 +66,7 @@ struct testApplyMoreNoise {
   }
 };
 
-// clang-format on
+// clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__testApplyMoreNoise()
 // CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 5.000000e+00 : f32
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 4.000000e+00 : f64
@@ -68,7 +75,7 @@ struct testApplyMoreNoise {
 // CHECK:           %[[VAL_3:.*]] = cc.alloca f32
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<f32>
 // CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.ref
-// ALIVE:           quake.apply_noise @_ZN5cudaq11apply_noise{{.*}}SarahKraus{{.*}}(%[[VAL_2]], %[[VAL_3]]) %[[VAL_4]] : !cc.ptr<f64>, !cc.ptr<f32>, !quake.ref
+// ALIVE:           quake.apply_noise @_ZN5cudaq11apply_noise{{.*}}SarahKraus{{.*}}(%[[VAL_2]], %[[VAL_3]]) %[[VAL_4]] : (!cc.ptr<f64>, !cc.ptr<f32>, !quake.ref) -> ()
 // DEAD-NOT:        quake.apply_noise
 // CHECK:           return
 // CHECK:         }
@@ -85,4 +92,4 @@ struct testApplyMoreNoise {
 // QIR:         call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
 // QIR:         ret void
 // QIR:       }
-// clang-format off
+// clang-format on

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -859,7 +859,7 @@ func.func @quantum_product_type() {
   %24 = quake.get_member %22[1] : (!quake.struq<!quake.veq<7>, !quake.veq<8>>) -> !quake.veq<8>
   %25 = quake.alloca !quake.struq<!quake.veq<8>, !quake.veq<5>>
   return
- }
+}
 
 // CHECK-LABEL:   func.func @quantum_product_type() {
 // CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.veq<3>
@@ -878,5 +878,28 @@ func.func @quantum_product_type() {
 // CHECK:           %[[VAL_13:.*]] = quake.get_member %[[VAL_12]][0] : (!quake.struq<!quake.veq<7>, !quake.veq<8>>) -> !quake.veq<7>
 // CHECK:           %[[VAL_14:.*]] = quake.get_member %[[VAL_12]][1] : (!quake.struq<!quake.veq<7>, !quake.veq<8>>) -> !quake.veq<8>
 // CHECK:           %[[VAL_15:.*]] = quake.alloca !quake.struq<!quake.veq<8>, !quake.veq<5>>
+// CHECK:           return
+// CHECK:         }
+
+func.func private @santa_kraus(!cc.ptr<f64>, !quake.ref)
+func.func private @otto_kraus(!quake.ref, !quake.veq<3>)
+func.func private @oskar_kraus(!cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>)
+
+func.func @quantum_apply_noise(%0 : !cc.ptr<f64>, %3 : !cc.ptr<f32>) {
+  %1 = quake.alloca !quake.ref
+  quake.apply_noise @santa_kraus(%0) %1 : !cc.ptr<f64>, !quake.ref
+  %2 = quake.alloca !quake.veq<3>
+  quake.apply_noise @otto_kraus() %1, %2 : !quake.ref, !quake.veq<3>
+  quake.apply_noise @oskar_kraus(%0, %3) %2 : !cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>
+  return
+}
+
+// CHECK-LABEL:   func.func @quantum_apply_noise(
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<f64>, %[[VAL_1:.*]]: !cc.ptr<f32>) {
+// CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.apply_noise @santa_kraus(%[[VAL_0]]) %[[VAL_2]] : !cc.ptr<f64>, !quake.ref
+// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<3>
+// CHECK:           quake.apply_noise @otto_kraus() %[[VAL_2]], %[[VAL_3]] : !quake.ref, !quake.veq<3>
+// CHECK:           quake.apply_noise @oskar_kraus(%[[VAL_0]], %[[VAL_1]]) %[[VAL_3]] : !cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>
 // CHECK:           return
 // CHECK:         }

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -887,19 +887,23 @@ func.func private @oskar_kraus(!cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>)
 
 func.func @quantum_apply_noise(%0 : !cc.ptr<f64>, %3 : !cc.ptr<f32>) {
   %1 = quake.alloca !quake.ref
-  quake.apply_noise @santa_kraus(%0) %1 : !cc.ptr<f64>, !quake.ref
+  quake.apply_noise @santa_kraus(%0) %1 : (!cc.ptr<f64>, !quake.ref) -> ()
   %2 = quake.alloca !quake.veq<3>
-  quake.apply_noise @otto_kraus() %1, %2 : !quake.ref, !quake.veq<3>
-  quake.apply_noise @oskar_kraus(%0, %3) %2 : !cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>
+  quake.apply_noise @otto_kraus() %1, %2 : (!quake.ref, !quake.veq<3>) -> ()
+  quake.apply_noise @oskar_kraus(%0, %3) %2 : (!cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>) -> ()
+  %key = arith.constant -872 : i64
+  quake.apply_noise %key (%0, %3) %2 : (i64, !cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>) -> ()
   return
 }
 
 // CHECK-LABEL:   func.func @quantum_apply_noise(
 // CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<f64>, %[[VAL_1:.*]]: !cc.ptr<f32>) {
 // CHECK:           %[[VAL_2:.*]] = quake.alloca !quake.ref
-// CHECK:           quake.apply_noise @santa_kraus(%[[VAL_0]]) %[[VAL_2]] : !cc.ptr<f64>, !quake.ref
+// CHECK:           quake.apply_noise @santa_kraus(%[[VAL_0]]) %[[VAL_2]] : (!cc.ptr<f64>, !quake.ref) -> ()
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<3>
-// CHECK:           quake.apply_noise @otto_kraus() %[[VAL_2]], %[[VAL_3]] : !quake.ref, !quake.veq<3>
-// CHECK:           quake.apply_noise @oskar_kraus(%[[VAL_0]], %[[VAL_1]]) %[[VAL_3]] : !cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>
+// CHECK:           quake.apply_noise @otto_kraus() %[[VAL_2]], %[[VAL_3]] : (!quake.ref, !quake.veq<3>) -> ()
+// CHECK:           quake.apply_noise @oskar_kraus(%[[VAL_0]], %[[VAL_1]]) %[[VAL_3]] : (!cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>) -> ()
+// CHECK:           %[[VAL_4:.*]] = arith.constant -872 : i64
+// CHECK:           quake.apply_noise %[[VAL_4]](%[[VAL_0]], %[[VAL_1]]) %[[VAL_3]] : (i64, !cc.ptr<f64>, !cc.ptr<f32>, !quake.veq<3>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Translate/apply_noise.qke
+++ b/test/Translate/apply_noise.qke
@@ -16,10 +16,10 @@ func.func @test0() {
 }
 
 // CHECK-LABEL: define void @test0() local_unnamed_addr {
-// CHECK:         %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 1)
-// CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
-// CHECK:         %[[VAL_4:.*]] = load %[[VAL_3]]*, %[[VAL_3]]** %[[VAL_2]], align 8
-// CHECK:         tail call void (i64, i64, ...) @__quantum__qis__apply_kraus_channel_generalized(i64 123456789, i64 0, i64 1, %[[VAL_3]]* %[[VAL_4]])
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
+// CHECK:         %[[VAL_0:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 1)
+// CHECK:         %[[VAL_2:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 0)
+// CHECK:         %[[VAL_4:.*]] = load %Qubit*, %Qubit** %[[VAL_2]]
+// CHECK:         tail call void (i64, i64, i64, ...) @__quantum__qis__apply_kraus_channel_generalized(i64 123456789, i64 0, i64 1, %Qubit* %[[VAL_4]])
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
 // CHECK:         ret void
 // CHECK:       }

--- a/test/Translate/apply_noise.qke
+++ b/test/Translate/apply_noise.qke
@@ -1,0 +1,25 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-translate --convert-to=qir %s | FileCheck %s
+
+func.func @test0() {
+  %key = arith.constant 123456789 : i64
+  %1 = quake.alloca !quake.ref
+  quake.apply_noise %key() %1 : (i64, !quake.ref) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @test0() local_unnamed_addr {
+// CHECK:         %[[VAL_0:.*]] = tail call %[[VAL_1:.*]]* @__quantum__rt__qubit_allocate_array(i64 1)
+// CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_1]]* %[[VAL_0]], i64 0)
+// CHECK:         %[[VAL_4:.*]] = load %[[VAL_3]]*, %[[VAL_3]]** %[[VAL_2]], align 8
+// CHECK:         tail call void (i64, i64, ...) @__quantum__qis__apply_kraus_channel_generalized(i64 123456789, i64 0, i64 1, %[[VAL_3]]* %[[VAL_4]])
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_1]]* %[[VAL_0]])
+// CHECK:         ret void
+// CHECK:       }

--- a/test/Translate/apply_noise.qke
+++ b/test/Translate/apply_noise.qke
@@ -19,7 +19,7 @@ func.func @test0() {
 // CHECK:         %[[VAL_0:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 1)
 // CHECK:         %[[VAL_2:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 0)
 // CHECK:         %[[VAL_4:.*]] = load %Qubit*, %Qubit** %[[VAL_2]]
-// CHECK:         tail call void (i64, i64, i64, ...) @__quantum__qis__apply_kraus_channel_generalized(i64 123456789, i64 0, i64 1, %Qubit* %[[VAL_4]])
+// CHECK:         tail call void (i64, i64, i64, i64, ...) @__quantum__qis__apply_kraus_channel_generalized(i64 123456789, i64 0, i64 0, i64 1, %Qubit* %[[VAL_4]])
 // CHECK:         tail call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
 // CHECK:         ret void
 // CHECK:       }

--- a/test/Translate/apply_noise.qke
+++ b/test/Translate/apply_noise.qke
@@ -19,7 +19,7 @@ func.func @test0() {
 // CHECK:         %[[VAL_0:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 1)
 // CHECK:         %[[VAL_2:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_0]], i64 0)
 // CHECK:         %[[VAL_4:.*]] = load %Qubit*, %Qubit** %[[VAL_2]]
-// CHECK:         tail call void (i64, i64, i64, i64, ...) @__quantum__qis__apply_kraus_channel_generalized(i64 123456789, i64 0, i64 0, i64 1, %Qubit* %[[VAL_4]])
+// CHECK:         tail call void (i64, i64, i64, i64, i64, ...) @__quantum__qis__apply_kraus_channel_generalized(i64 1, i64 123456789, i64 0, i64 0, i64 1, %Qubit* %[[VAL_4]])
 // CHECK:         tail call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_0]])
 // CHECK:         ret void
 // CHECK:       }

--- a/unittests/integration/noise_tester.cpp
+++ b/unittests/integration/noise_tester.cpp
@@ -53,7 +53,7 @@ __qpu__ void test2(double p) {
 CUDAQ_TEST(NoiseTest, checkFineGrain) {
 
   cudaq::noise_model noise;
-  noise.add_channel<test::hello::hello_world>();
+  noise.register_channel<test::hello::hello_world>();
 
   auto counts = cudaq::sample({.noise = noise}, test2, .7);
   counts.dump();

--- a/unittests/integration/noise_tester.cpp
+++ b/unittests/integration/noise_tester.cpp
@@ -34,7 +34,7 @@ struct bell {
 
 namespace test::hello {
 struct hello_world : public ::cudaq::kraus_channel {
-  void generate(const std::vector<double> &params) override {
+  hello_world(const std::vector<double> &params) {
     std::vector<cudaq::complex> k0v{std::sqrt(1 - params[0]), 0, 0,
                                     std::sqrt(1 - params[0])},
         k1v{0, std::sqrt(params[0]), std::sqrt(params[0]), 0};

--- a/unittests/integration/noise_tester.cpp
+++ b/unittests/integration/noise_tester.cpp
@@ -41,6 +41,7 @@ struct hello_world : public ::cudaq::kraus_channel {
     push_back(cudaq::kraus_op(k0v));
     push_back(cudaq::kraus_op(k1v));
   }
+  REGISTER_KRAUS_CHANNEL(hello_world);
 };
 } // namespace test::hello
 

--- a/unittests/integration/noise_tester.cpp
+++ b/unittests/integration/noise_tester.cpp
@@ -495,71 +495,71 @@ CUDAQ_TEST(NoiseTest, checkAllQubitChannel) {
 // Stim does not support arbitrary cudaq::kraus_op specification.
 
 static cudaq::kraus_channel create2pNoiseChannel() {
-  // 1% depolarization
-  cudaq::kraus_op op0{cudaq::complex{0.94868329805, 0.0},
+  // 20% depolarization
+  cudaq::kraus_op op0{cudaq::complex{0.894427191, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
-                      {0.94868329805, 0.0},
+                      {0.894427191, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
-                      {0.94868329805, 0.0},
+                      {0.894427191, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
                       {0.0, 0.0},
-                      {0.94868329805, 0.0}},
+                      {0.894427191, 0.0}},
       op1{cudaq::complex{0.0, 0.0},
           {0.0, 0.0},
-          {0.18257418583, 0.0},
+          {0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.18257418583, 0.0},
-          {0.18257418583, 0.0},
+          {0.25819888974, 0.0},
+          {0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.18257418583, 0.0},
+          {0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0}},
       op2{cudaq::complex{0.0, 0.0},
           {0.0, 0.0},
-          {0.0, -0.18257418583},
+          {0.0, -0.25819888974},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.0, -0.18257418583},
-          {0.0, 0.18257418583},
+          {0.0, -0.25819888974},
+          {0.0, 0.25819888974},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.0, 0.18257418583},
+          {0.0, 0.25819888974},
           {0.0, 0.0},
           {0.0, 0.0}},
-      op3{cudaq::complex{0.18257418583, 0.0},
+      op3{cudaq::complex{0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {0.18257418583, 0.0},
+          {0.25819888974, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
-          {-0.18257418583, 0.0},
+          {-0.25819888974, 0.0},
           {-0.0, 0.0},
           {0.0, 0.0},
           {0.0, 0.0},
           {-0.0, 0.0},
-          {-0.18257418583, 0.0}};
+          {-0.25819888974, 0.0}};
   cudaq::kraus_channel noise2q(
       std::vector<cudaq::kraus_op>{op0, op1, op2, op3});
   return noise2q;
@@ -598,6 +598,7 @@ CUDAQ_TEST(NoiseTest, checkAllQubitChannelWithControl) {
     auto counts =
         cudaq::sample({.shots = shots, .noise = noise}, bellRandom<numQubits>{},
                       qubitIds[0], qubitIds[1]);
+    counts.dump();
     // More than 2 entangled states due to the noise.
     EXPECT_GT(counts.size(), 2);
   } while (std::next_permutation(qubitIds.begin(), qubitIds.end()));
@@ -626,6 +627,7 @@ CUDAQ_TEST(NoiseTest, checkAllQubitChannelWithControlPrefix) {
     auto counts =
         cudaq::sample({.shots = shots, .noise = noise}, bellRandom<numQubits>{},
                       qubitIds[0], qubitIds[1]);
+    counts.dump();
     // More than 2 entangled states due to the noise.
     EXPECT_GT(counts.size(), 2);
   } while (std::next_permutation(qubitIds.begin(), qubitIds.end()));

--- a/unittests/integration/noise_tester.cpp
+++ b/unittests/integration/noise_tester.cpp
@@ -41,7 +41,7 @@ struct hello_world : public ::cudaq::kraus_channel {
     push_back(cudaq::kraus_op(k0v));
     push_back(cudaq::kraus_op(k1v));
   }
-  REGISTER_KRAUS_CHANNEL(hello_world);
+  REGISTER_KRAUS_CHANNEL();
 };
 } // namespace test::hello
 

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -69,6 +69,10 @@ void invokeWithControlQubits(const std::size_t nControls,
 void __quantum__qis__apply__general_qubit_array(Array *data, Array *qubits);
 void __quantum__qis__apply__general(Array *data, int64_t n_qubits, ...);
 
+void __quantum__qis__apply_kraus_channel(const char *demangledName,
+                                         double *params, std::size_t numParams,
+                                         Array *qubits);
+
 // Qubit array allocation / deallocation
 Array *__quantum__rt__qubit_allocate_array(uint64_t idx);
 Array *__quantum__rt__qubit_allocate_array_with_state_complex64(
@@ -585,4 +589,48 @@ CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromRetrievedStateExpand) {
   __quantum__rt__finalize();
 }
 
+#endif
+
+#ifdef CUDAQ_BACKEND_DM
+
+namespace test::hello {
+struct hello_world : public ::cudaq::kraus_channel {
+  void generate(const std::vector<double> &params) override {
+    cudaq::real p = params[0];
+    std::vector<cudaq::complex> k0v{std::sqrt(1 - p), 0, 0, std::sqrt(1 - p)},
+        k1v{0, std::sqrt(p), std::sqrt(p), 0};
+    push_back(cudaq::kraus_op(k0v));
+    push_back(cudaq::kraus_op(k1v));
+  }
+};
+} // namespace test::hello
+
+CUDAQ_TEST(NVQIRTester, checkKrausApply) {
+
+  const int shots = 100;
+  cudaq::ExecutionContext ctx("sample", shots);
+  cudaq::noise_model noise;
+  noise.add_channel<test::hello::hello_world>();
+  ctx.noiseModel = &noise;
+
+  std::vector<double> params{0.2};
+
+  __quantum__rt__setExecutionContext(&ctx);
+
+  __quantum__rt__initialize(0, nullptr);
+  auto qubits = __quantum__rt__qubit_allocate_array(1);
+  Qubit *q = *reinterpret_cast<Qubit **>(
+      __quantum__rt__array_get_element_ptr_1d(qubits, 0));
+
+  __quantum__qis__x(q);
+  __quantum__qis__apply_kraus_channel("test::hello::hello_world", params.data(),
+                                      params.size(), qubits);
+
+  __quantum__rt__qubit_release_array(qubits);
+  __quantum__rt__resetExecutionContext();
+
+  cudaq::sample_result counts = ctx.result;
+  counts.dump();
+  __quantum__rt__finalize();
+}
 #endif

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -595,7 +595,7 @@ CUDAQ_TEST(NVQIRTester, checkQubitAllocationFromRetrievedStateExpand) {
 
 namespace test::hello {
 struct hello_world : public ::cudaq::kraus_channel {
-  void generate(const std::vector<double> &params) override {
+  hello_world(const std::vector<double> &params) {
     cudaq::real p = params[0];
     std::vector<cudaq::complex> k0v{std::sqrt(1 - p), 0, 0, std::sqrt(1 - p)},
         k1v{0, std::sqrt(p), std::sqrt(p), 0};

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -69,9 +69,8 @@ void invokeWithControlQubits(const std::size_t nControls,
 void __quantum__qis__apply__general_qubit_array(Array *data, Array *qubits);
 void __quantum__qis__apply__general(Array *data, int64_t n_qubits, ...);
 
-void __quantum__qis__apply_kraus_channel(const char *demangledName,
-                                         double *params, std::size_t numParams,
-                                         Array *qubits);
+void __quantum__qis__apply_kraus_channel(long key, double *params,
+                                         std::size_t numParams, Array *qubits);
 
 // Qubit array allocation / deallocation
 Array *__quantum__rt__qubit_allocate_array(uint64_t idx);
@@ -602,6 +601,7 @@ struct hello_world : public ::cudaq::kraus_channel {
     push_back(cudaq::kraus_op(k0v));
     push_back(cudaq::kraus_op(k1v));
   }
+  REGISTER_KRAUS_CHANNEL(hello_world)
 };
 } // namespace test::hello
 
@@ -623,8 +623,8 @@ CUDAQ_TEST(NVQIRTester, checkKrausApply) {
       __quantum__rt__array_get_element_ptr_1d(qubits, 0));
 
   __quantum__qis__x(q);
-  __quantum__qis__apply_kraus_channel("test::hello::hello_world", params.data(),
-                                      params.size(), qubits);
+  __quantum__qis__apply_kraus_channel(test::hello::hello_world::get_key(),
+                                      params.data(), params.size(), qubits);
 
   __quantum__rt__qubit_release_array(qubits);
   __quantum__rt__resetExecutionContext();

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -610,7 +610,7 @@ CUDAQ_TEST(NVQIRTester, checkKrausApply) {
   const int shots = 100;
   cudaq::ExecutionContext ctx("sample", shots);
   cudaq::noise_model noise;
-  noise.add_channel<test::hello::hello_world>();
+  noise.register_channel<test::hello::hello_world>();
   ctx.noiseModel = &noise;
 
   std::vector<double> params{0.2};

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -601,7 +601,7 @@ struct hello_world : public ::cudaq::kraus_channel {
     push_back(cudaq::kraus_op(k0v));
     push_back(cudaq::kraus_op(k1v));
   }
-  REGISTER_KRAUS_CHANNEL(hello_world)
+  REGISTER_KRAUS_CHANNEL()
 };
 } // namespace test::hello
 

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -69,8 +69,9 @@ void invokeWithControlQubits(const std::size_t nControls,
 void __quantum__qis__apply__general_qubit_array(Array *data, Array *qubits);
 void __quantum__qis__apply__general(Array *data, int64_t n_qubits, ...);
 
-void __quantum__qis__apply_kraus_channel(long key, double *params,
-                                         std::size_t numParams, Array *qubits);
+void __quantum__qis__apply_kraus_channel_generalized(
+    std::int64_t krausChannelKey, std::size_t numSpans, std::size_t numParams,
+    std::size_t numTargets, ...);
 
 // Qubit array allocation / deallocation
 Array *__quantum__rt__qubit_allocate_array(uint64_t idx);
@@ -623,8 +624,9 @@ CUDAQ_TEST(NVQIRTester, checkKrausApply) {
       __quantum__rt__array_get_element_ptr_1d(qubits, 0));
 
   __quantum__qis__x(q);
-  __quantum__qis__apply_kraus_channel(test::hello::hello_world::get_key(),
-                                      params.data(), params.size(), qubits);
+  __quantum__qis__apply_kraus_channel_generalized(
+      test::hello::hello_world::get_key(), 1, 0, 1, params.data(),
+      params.size(), qubits);
 
   __quantum__rt__qubit_release_array(qubits);
   __quantum__rt__resetExecutionContext();

--- a/unittests/qir/NVQIRTester.cpp
+++ b/unittests/qir/NVQIRTester.cpp
@@ -70,8 +70,8 @@ void __quantum__qis__apply__general_qubit_array(Array *data, Array *qubits);
 void __quantum__qis__apply__general(Array *data, int64_t n_qubits, ...);
 
 void __quantum__qis__apply_kraus_channel_generalized(
-    std::int64_t krausChannelKey, std::size_t numSpans, std::size_t numParams,
-    std::size_t numTargets, ...);
+    std::int64_t dataKind, std::int64_t krausChannelKey, std::size_t numSpans,
+    std::size_t numParams, std::size_t numTargets, ...);
 
 // Qubit array allocation / deallocation
 Array *__quantum__rt__qubit_allocate_array(uint64_t idx);
@@ -625,7 +625,7 @@ CUDAQ_TEST(NVQIRTester, checkKrausApply) {
 
   __quantum__qis__x(q);
   __quantum__qis__apply_kraus_channel_generalized(
-      test::hello::hello_world::get_key(), 1, 0, 1, params.data(),
+      1, test::hello::hello_world::get_key(), 1, 0, 1, params.data(),
       params.size(), qubits);
 
   __quantum__rt__qubit_release_array(qubits);


### PR DESCRIPTION
This depends on #2635 and #2652, so it currently includes all of those changes in this PR. Those changes will be removed once those other PRs are merged to main. This is a draft now, so I can start exercising the CI on it.

Most of the relevant changes are the implementations of the new noise models in `runtime/common/NoiseModel.h`. While this PR contains Stim-specific updates, most of the other simulators will not need to be updated once #2652 is merged.