### PR TITLE
Update polling interval for Braket backend

### DIFF
--- a/python/tests/backends/test_braket.py
+++ b/python/tests/backends/test_braket.py
@@ -433,6 +433,13 @@ def test_other_simulators(device_arn):
     cudaq.reset_target()
 
 
+@pytest.mark.parametrize("polling_interval_ms", [10, 100])
+def test_polling_interval(polling_interval_ms):
+    cudaq.set_target("braket", polling_interval_ms=polling_interval_ms)
+    test_qvector_kernel()
+    cudaq.reset_target()
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)

--- a/runtime/common/BraketExecutor.h
+++ b/runtime/common/BraketExecutor.h
@@ -57,7 +57,7 @@ protected:
   char const *jobToken;
   char const *reservationArn;
 
-  std::chrono::microseconds pollingInterval = std::chrono::milliseconds{100};
+  std::chrono::microseconds pollingInterval = std::chrono::milliseconds{2000};
 
   /// @brief Utility function to check the type of ServerHelper and use it to
   /// create job

--- a/runtime/cudaq/platform/default/rest/helpers/braket/BraketExecutor.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/BraketExecutor.cpp
@@ -113,6 +113,16 @@ void BraketExecutor::setServerHelper(ServerHelper *helper) {
       Aws::Utils::ARN(helper->getConfig().at("deviceArn")).GetRegion();
   std::string defaultBucket = helper->getConfig().at("defaultBucket");
 
+  if (helper->getConfig().contains("polling_interval_ms")) {
+    long pollingIntervalMs{
+        std::stol(helper->getConfig().at("polling_interval_ms"))};
+    if (pollingIntervalMs <= 0) {
+      throw std::runtime_error(
+          "polling_interval_ms must be a positive integer.");
+    }
+    pollingInterval = std::chrono::milliseconds{pollingIntervalMs};
+  }
+
   Aws::Client::ClientConfiguration clientConfig;
   clientConfig.verifySSL = false;
   Aws::S3Crt::ClientConfiguration s3ClientConfig;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Description
Increase default polling interval for Braket to 2000ms, and introduce a `polling_interval_ms` argument to make it user-configurable.
