### PR TITLE
[CI] Skip validation on an erroneous application notebook

### DIFF
--- a/docs/notebook_validation.py
+++ b/docs/notebook_validation.py
@@ -99,7 +99,10 @@ if __name__ == "__main__":
         notebooks_success, notebooks_skipped, notebooks_failed = (
             [] for i in range(3))
         for notebook_filename in notebook_filenames:
-            if (validate(notebook_filename, available_backends)):
+            ## See: https://github.com/NVIDIA/cuda-quantum/issues/2577
+            if os.path.basename(notebook_filename) in ["afqmc.ipynb"]:
+                notebooks_skipped.append(notebook_filename)
+            elif (validate(notebook_filename, available_backends)):
                 if (execute(notebook_filename)):
                     notebooks_success.append(notebook_filename)
                 else:


### PR DESCRIPTION
The `docs/sphinx/applications/python/afqmc.ipynb` notebook has failures originating potentially from third-party libraries. This
issue is captured in #2577. While we work on a fix separately, this PR proposes to skip that specific notebook in validation stage to get rest of the CI pipeline to succeed.

