### PR TITLE
[ci] Fix tags

### DIFF
--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -140,6 +140,12 @@ Installer:
   dependencies: 
     - Metadata
   image: $CI_COMMIT_TITLE
+  parallel:
+    matrix:
+      - os: "os/linux"
+        perflab: ["perflab"]
+      - os: "os/linux-arm"
+        perflab: ["perflab-arm"]
   tags:
     - $os
     - $perflab


### PR DESCRIPTION
The tags for 'installer' are showing up as `$os` and `$perflab` instead of their values. 
Hence adding a matrix similar to the Docker image job (since that has correct tags).

