### PR TITLE
[orca] Skip unnecessary call and avoid error condition

### DIFF
--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
@@ -108,11 +108,10 @@ public:
     cudaq::getExecutionManager()->setExecutionContext(contexts[tid]);
   }
 
-  /// @brief Overrides resetExecutionContext to forward to the ExecutionManager
+  /// @brief Overrides resetExecutionContext
   void resetExecutionContext() override {
     cudaq::info("OrcaRemoteRESTQPU::resetExecutionContext QPU {}", qpu_id);
     auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
-    cudaq::getExecutionManager()->resetExecutionContext();
     contexts[tid] = nullptr;
     contexts.erase(tid);
   }


### PR DESCRIPTION
  The `resetExecutionContext` was previously a no-op, except for resetting the context, since no 'qubits' are involved in this job.
  Recent changes check for presence of qubits and flag errors accordingly.
  This change removes the invocation of that function. We reset the context in next line anyway.

Should fix the nightly integration test failures for `orca` seen [here](https://github.com/NVIDIA/cuda-quantum/actions/runs/13582771746/job/37971715501).

Manually tested by locally running all the nightly integration tests.