### PR TITLE
[CI] Fix the asset creation for installer

### DIFF
--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -142,10 +142,11 @@ Installer:
   image: $CI_COMMIT_TITLE
   parallel:
     matrix:
-      - os: "os/linux"
-        perflab: ["perflab"]
-      - os: "os/linux-arm"
-        perflab: ["perflab-arm"]
+      include:
+        - os: "os/linux"
+          perflab: ["perflab"]
+        - os: "os/linux-arm"
+          perflab: ["perflab-arm"]
   tags:
     - $os
     - $perflab


### PR DESCRIPTION
We don't want to populate full matrix.
x86 installer only on x86 and arm64 installer only on arm64.

Ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-adding-configurations
