### PR TITLE
[ci] Fix tags

### DIFF
--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -147,9 +147,10 @@ Installer:
       - os: "os/linux-arm"
         perflab: ["perflab-arm"]
   tags:
-    - $os
-    - $perflab
+    - ${os}
+    - ${perflab}
     - type/docker
+  environment: ${os}/${perflab}
   interruptible: false
   artifacts:
     paths:

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -142,11 +142,10 @@ Installer:
   image: $CI_COMMIT_TITLE
   parallel:
     matrix:
-      include:
-        - os: "os/linux"
-          perflab: ["perflab"]
-        - os: "os/linux-arm"
-          perflab: ["perflab-arm"]
+      - os: "os/linux"
+        perflab: ["perflab"]
+      - os: "os/linux-arm"
+        perflab: ["perflab-arm"]
   tags:
     - $os
     - $perflab

--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -150,7 +150,6 @@ Installer:
     - ${os}
     - ${perflab}
     - type/docker
-  environment: ${os}/${perflab}
   interruptible: false
   artifacts:
     paths:


### PR DESCRIPTION
Removed the incorrect use of `include` (which is used in GitHub actions, not GitLab)

Following description here: https://docs.gitlab.com/ci/jobs/job_control/#select-different-runner-tags-for-each-parallel-matrix-job