### PR TITLE
Add documentation missing from #2632 initial pasqal integration

### DIFF
--- a/docs/sphinx/targets/python/pasqal.py
+++ b/docs/sphinx/targets/python/pasqal.py
@@ -8,7 +8,7 @@ from cudaq.operator import *
 #
 # Contact Pasqal at help@pasqal.com or through https://community.pasqal.com for assistance.
 #
-# Visit our documentation portal, https://docs.pasqal.com/, to find further
+# Visit the documentation portal, https://docs.pasqal.com/, to find further
 # documentation on Pasqal's devices, emulators and the cloud platform.
 #
 # For more details on the EMU_MPS emulator see the documentation of the open-source

--- a/docs/sphinx/targets/python/pasqal.py
+++ b/docs/sphinx/targets/python/pasqal.py
@@ -28,7 +28,9 @@ os.environ["PASQAL_AUTH_TOKEN"] = str(sdk.user_token())
 # It is also mandatory to specify the project against which the execution will be billed.
 # Uncomment this line to set it from Python, or export it as an environment variable
 # prior to execution. You can find your projects here: https://portal.pasqal.cloud/projects.
+# ```
 # os.environ['PASQAL_PROJECT_ID'] = 'your project id'
+# ```
 
 # Set the target including specifying optional arguments like target machine
 cudaq.set_target("pasqal",

--- a/docs/sphinx/targets/python/pasqal.py
+++ b/docs/sphinx/targets/python/pasqal.py
@@ -2,34 +2,41 @@ import cudaq
 from cudaq.operator import *
 
 # This example illustrates how to use Pasqal's EMU_MPS emulator over Pasqal's cloud via CUDA-Q.
-
-# To obtain the authentication token we recommend logging in
-# by using Pasqal's Python SDK.
-# Fill in the  username and password via the environment variables.
-# The password can be left empty in an interactive session to be
-# prompted to enter the it securely via the command line interface.
+#
+# To obtain the authentication token for the cloud  we recommend logging in with
+# Pasqal's Python SDK. See our documentation https://docs.pasqal.com/cloud/ for more.
 #
 # Contact Pasqal at help@pasqal.com or through https://community.pasqal.com for assistance.
 #
-# See our general docs https://docs.pasqal.com/cloud/set-up/
-# to see how to get this setup, or the CUDA-Q documentation at
-# https://nvidia.github.io/cuda-quantum/latest/using/backends/hardware/neutralatom.html#pasqal
+# Visit our documentation portal, https://docs.pasqal.com/, to find further
+# documentation on Pasqal's devices, emulators and the cloud platform.
+#
+# For more details on the EMU_MPS emulator see the documentation of the open-source
+# package: https://pasqal-io.github.io/emulators/latest/emu_mps/.
 from pasqal_cloud import SDK
 import os
 
+# We recommend leaving the password empty in an interactive session as you will be
+# prompted to enter it securely via the command line interface.
 sdk = SDK(
     username=os.environ.get("PASQAL_USERNAME"),
     password=os.environ.get("PASQAL_PASSWORD", None),
 )
-token = sdk._client.authenticator.token_provider.get_token()
 
-os.environ["PASQAL_AUTH_TOKEN"] = str(token)
+os.environ["PASQAL_AUTH_TOKEN"] = str(sdk.user_token())
 
+# It is also mandatory to specify the project against which the execution will be billed.
+# Uncomment this line to set it from Python, or export it as an environment variable
+# prior to execution. You can find your projects here: https://portal.pasqal.cloud/projects.
+# os.environ['PASQAL_PROJECT_ID'] = 'your project id'
+
+# Set the target including specifying optional arguments like target machine
 cudaq.set_target("pasqal",
                  machine=os.environ.get("PASQAL_MACHINE_TARGET", "EMU_MPS"))
 
 # ```
-# cudaq.set_target("pasqal", machine="FRESNEL") ## To target QPU
+## To target QPU set FRESNEL as the machine, see our cloud portal for latest machine names
+# cudaq.set_target("pasqal", machine="FRESNEL")
 # ```
 
 # Define the 2-dimensional atom arrangement

--- a/docs/sphinx/using/backends/hardware/neutralatom.rst
+++ b/docs/sphinx/using/backends/hardware/neutralatom.rst
@@ -139,8 +139,11 @@ The currently available Pasqal QPUs are analog quantum computers, and one, named
 portal.
 
 In order to access Pasqal's devices you need an account for `Pasqal's cloud platform <https://portal.pasqal.cloud>`__
-and an active project. Although a different interface, `Pasqal's Pulser library <https://pulser.readthedocs.io/en/latest/>`__, is a good
-resource for getting started with analog neutral atom quantum computing. For support you can also use `Pasqal Community <https://community.pasqal.com/>`__.
+and an active project. Please see our `cloud documentation <https://docs.pasqal.cloud/cloud/>`__ for more details if needed.
+
+Although a different SDK, `Pasqal's Pulser library <https://pulser.readthedocs.io/en/latest/>`__, is a good
+resource for getting started with analog neutral atom quantum computing.
+For support you can also join the `Pasqal Community <https://community.pasqal.com/>`__.
 
 
 .. _pasqal-backend:
@@ -161,7 +164,8 @@ For example from Python one can use the `pasqal-cloud package <https://github.co
         password=os.environ.get('PASQAL_PASSWORD', None)
     )
 
-    token = sdk._client.authenticator.token_provider.get_token()
+    token = sdk.user_token()
+
     os.environ['PASQAL_AUTH_TOKEN'] = str(token)
     os.environ['PASQAL_PROJECT_ID'] = 'your project id'
 
@@ -184,10 +188,25 @@ can be controlled with the ``cudaq::set_target()`` function.
     cudaq.set_target('pasqal')
 
 
+This accepts an optional argument, ``machine``, which is used in the cloud platform to
+select the corresponding Pasqal QPU or emulator to execute on.
+See the `Pasqal cloud portal <https://portal.pasqal.cloud/>`__ for an up to date list.
+The default value is ``EMU_MPS`` which is an open-source ensor network emulator based on the
+Matrix Product State formalism running in Pasqal's cloud platform. You can see the
+documentation for the publicly accessible emulator `here <https://pasqal-io.github.io/emulators/latest/emu_mps/>`__.
+
+To target the QPU use the FRESNEL machine name. Note that there are restrictions
+regarding the values of the pulses as well as the register layout. We invite you to
+consult our `documentation <https://docs.pasqal.com/cloud/fresnel-job>`__. Note that
+the CUDA-Q integration currently only works with `arbitrary layouts <https://docs.pasqal.com/cloud/fresnel-job/#arbitrary-layouts>`__
+which are implemented with automatic calibration for less than 30 qubits. For jobs
+larger than 30 qubits please use the `atom_sites` to define the layout, and use the
+`atom_filling` to select sites as filled or not filled in order to define the register.
+
 Due to the nature of the underlying hardware, this target only supports the 
 ``evolve`` and ``evolve_async`` APIs.
-The `hamiltonian` must be an `Operator` of the type `RydbergHamiltonian`. Only 
-other parameters supported are `schedule` (mandatory) and `shots_count` (optional).
+The `hamiltonian` must be an `Operator` of the type `RydbergHamiltonian`. The only
+other supported parameters are `schedule` (mandatory) and `shots_count` (optional).
 
 For example,
 

--- a/docs/sphinx/using/backends/hardware/neutralatom.rst
+++ b/docs/sphinx/using/backends/hardware/neutralatom.rst
@@ -191,7 +191,7 @@ can be controlled with the ``cudaq::set_target()`` function.
 This accepts an optional argument, ``machine``, which is used in the cloud platform to
 select the corresponding Pasqal QPU or emulator to execute on.
 See the `Pasqal cloud portal <https://portal.pasqal.cloud/>`__ for an up to date list.
-The default value is ``EMU_MPS`` which is an open-source ensor network emulator based on the
+The default value is ``EMU_MPS`` which is an open-source tensor network emulator based on the
 Matrix Product State formalism running in Pasqal's cloud platform. You can see the
 documentation for the publicly accessible emulator `here <https://pasqal-io.github.io/emulators/latest/emu_mps/>`__.
 


### PR DESCRIPTION
### Description
In #2632 there were some left-over comments on the documentation from @efratshabtai. This PR attempts to address them.


[x] Discourage password in env var (https://github.com/NVIDIA/cuda-quantum/pull/2632#discussion_r1974132495)
[x] Link to machine names (https://github.com/NVIDIA/cuda-quantum/pull/2632#discussion_r1974133825)
[x] Up to date token link - Note, we will add a section on our docs too to make this clearer (https://github.com/NVIDIA/cuda-quantum/pull/2632#discussion_r1974150935)
[x] Clarify the `cudaq.set_target` options (https://github.com/NVIDIA/cuda-quantum/pull/2632#discussion_r1974162081)
[x] Typos in neutralatoms section (https://github.com/NVIDIA/cuda-quantum/pull/2632#discussion_r1974170087 and https://github.com/NVIDIA/cuda-quantum/pull/2632#discussion_r1974170542)