### PR TITLE
Improve error handling for analog targets when local emulation is requested

### DIFF
--- a/docs/sphinx/using/backends/hardware/neutralatom.rst
+++ b/docs/sphinx/using/backends/hardware/neutralatom.rst
@@ -228,6 +228,10 @@ set to 100.
 
 To see a complete example for using Pasqal's backend, take a look at our :doc:`Python examples <../../examples/hardware_providers>`.
 
+.. note:: 
+
+    Local emulation via ``emulate`` flag is not yet supported on the `pasqal` target.
+
 
 QuEra Computing
 ++++++++++++++++
@@ -298,3 +302,7 @@ set to 100.
     cudaq.evolve(RydbergHamiltonian(...), schedule=s, shots_count=1000)
 
 To see a complete example for using QuEra's backend, take a look at our :doc:`Python examples <../../examples/hardware_providers>`.
+
+.. note:: 
+
+    Local emulation via ``emulate`` flag is not yet supported on the `quera` target.

--- a/runtime/cudaq/platform/pasqal/PasqalBaseQPU.h
+++ b/runtime/cudaq/platform/pasqal/PasqalBaseQPU.h
@@ -36,10 +36,13 @@ public:
                std::uint64_t resultOffset,
                const std::vector<void *> &rawArgs) override {
 
-    if (kernelName.find(cudaq::runtime::cudaqAHKPrefixName) != 0) {
+    if (kernelName.find(cudaq::runtime::cudaqAHKPrefixName) != 0)
       throw std::runtime_error(
           "Arbitrary kernel execution is not supported on this target.");
-    }
+
+    if (emulate)
+      throw std::runtime_error(
+          "Local emulation is not yet supported on this target.");
 
     cudaq::info("Launching remote kernel ({})", kernelName);
     std::vector<cudaq::KernelExecution> codes;

--- a/runtime/cudaq/platform/quera/QuEraBaseQPU.h
+++ b/runtime/cudaq/platform/quera/QuEraBaseQPU.h
@@ -36,6 +36,10 @@ public:
       throw std::runtime_error(
           "Arbitrary kernel execution is not supported on this target.");
 
+    if (emulate)
+      throw std::runtime_error(
+          "Local emulation is not yet supported on this target.");
+
     cudaq::info("Launching remote kernel ({})", kernelName);
     std::vector<cudaq::KernelExecution> codes;
 


### PR DESCRIPTION
Local emulation is not yet supported on analog hardware targets like `pasqal` and `quera`. Prior to the changes proposed in this PR if user set `emulate=True`, it was ignored and proceeded as if the flag was not present. This change will throw an error.

