### PR TITLE
[core] Add translation of QIR Array -> cudaq::qvector.

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -101,4 +101,13 @@ enum class KrausChannelDataKind { FloatKind, DoubleKind };
 static constexpr const char QISApplyKrausChannel[] =
     "__quantum__qis__apply_kraus_channel_generalized";
 
+/// Since apply noise is actually a call back to `C++` code, the `QIR` data type
+/// `Array` of `Qubit*` must be converted into a `cudaq::qvector`, which is
+/// presently a `std::vector<cudaq::qubit>` but with an extremely restricted
+/// interface.
+static constexpr const char QISConvertArrayToStdvec[] =
+    "__quantum__qis__convert_array_to_stdvector";
+static constexpr const char QISFreeConvertedStdvec[] =
+    "__quantum__qis__free_converted_stdvector";
+
 } // namespace cudaq::opt

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -434,6 +434,9 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__qis__custom_unitary(!cc.ptr<complex<f64>>, !qir_array, !qir_array, !qir_charptr)
   func.func private @__quantum__qis__custom_unitary__adj(!cc.ptr<complex<f64>>, !qir_array, !qir_array, !qir_charptr)
 
+  func.func private @__quantum__qis__convert_array_to_stdvector(!qir_array) -> !qir_array
+  func.func private @__quantum__qis__free_converted_stdvector(!qir_array)
+
   llvm.func @generalizedInvokeWithRotationsControlsTargets(i64, i64, i64, i64, !qir_llvmptr, ...) attributes {sym_visibility = "private"}
   llvm.func @__quantum__qis__apply_kraus_channel_generalized(i64, i64, i64, i64, i64, ...) attributes {sym_visibility = "private"}
 )#"},

--- a/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -277,6 +277,7 @@ struct AllocaOpToIntRewrite : public OpConversionPattern<quake::AllocaOp> {
   }
 };
 
+template <typename M>
 struct ApplyNoiseOpRewrite : public OpConversionPattern<quake::ApplyNoiseOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -419,9 +420,25 @@ struct ApplyNoiseOpRewrite : public OpConversionPattern<quake::ApplyNoiseOp> {
       args.append(adaptor.getParameters().begin(),
                   adaptor.getParameters().end());
     }
-    args.append(adaptor.getQubits().begin(), adaptor.getQubits().end());
+    SmallVector<Value> qubits;
+    SmallVector<Value> converted;
+    Type qirArrTy = M::getArrayType(rewriter.getContext());
+    for (auto [qb, oa] : llvm::zip(adaptor.getQubits(), noise.getQubits())) {
+      if ((oa && isa<quake::VeqType>(oa.getType())) ||
+          (!oa && (qb.getType() == qirArrTy))) {
+        auto svec = rewriter.create<func::CallOp>(
+            loc, qirArrTy, cudaq::opt::QISConvertArrayToStdvec, ValueRange{qb});
+        qb = svec.getResult(0);
+        converted.push_back(qb);
+      }
+      qubits.push_back(qb);
+    }
+    args.append(qubits.begin(), qubits.end());
     rewriter.replaceOpWithNewOp<func::CallOp>(noise, TypeRange{},
                                               *noise.getNoiseFunc(), args);
+    for (auto v : converted)
+      rewriter.create<func::CallOp>(
+          loc, TypeRange{}, cudaq::opt::QISFreeConvertedStdvec, ValueRange{v});
     return success();
   }
 };
@@ -1672,8 +1689,8 @@ static void commonClassicalHandlingPatterns(RewritePatternSet &patterns,
 static void commonQuakeHandlingPatterns(RewritePatternSet &patterns,
                                         TypeConverter &typeConverter,
                                         MLIRContext *ctx) {
-  patterns.insert<ApplyNoiseOpRewrite, GetMemberOpRewrite, MakeStruqOpRewrite,
-                  RelaxSizeOpErase, VeqSizeOpRewrite>(typeConverter, ctx);
+  patterns.insert<GetMemberOpRewrite, MakeStruqOpRewrite, RelaxSizeOpErase,
+                  VeqSizeOpRewrite>(typeConverter, ctx);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1712,6 +1729,7 @@ struct FullQIR {
         /* Irregular quantum operators. */
         CustomUnitaryOpPattern<Self>, ExpPauliOpPattern<Self>,
         MeasurementOpPattern<Self>, ResetOpPattern<Self>,
+        ApplyNoiseOpRewrite<Self>,
 
         /* Regular quantum operators. */
         QuantumGatePattern<Self, quake::HOp>,
@@ -1778,7 +1796,7 @@ struct AnyProfileQIR {
 
         /* Irregular quantum operators. */
         CustomUnitaryOpPattern<Self>, ExpPauliOpPattern<Self>,
-        ResetOpPattern<Self>,
+        ResetOpPattern<Self>, ApplyNoiseOpRewrite<Self>,
 
         /* Regular quantum operators. */
         QuantumGatePattern<Self, quake::HOp>,

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -10,6 +10,7 @@
 #include "QIRTypes.h"
 #include "common/Logger.h"
 #include "common/PluginUtils.h"
+#include "cudaq/qis/qudit.h"
 #include "cudaq/qis/state.h"
 #include <cmath>
 #include <complex>
@@ -750,6 +751,32 @@ void __quantum__qis__apply_kraus_channel_generalized(
     throw std::runtime_error("apply_noise: unknown data kind.");
   }
   va_end(args);
+}
+
+namespace details {
+struct FakeQubit {
+  std::int8_t *id;
+  bool negated;
+};
+static_assert(sizeof(FakeQubit) == sizeof(cudaq::qudit<2>) &&
+              "FakeQubit must have the same memory layout as cudaq::qudit<>");
+} // namespace details
+
+std::vector<details::FakeQubit> *
+__quantum__qis__convert_array_to_stdvector(Array *arr) {
+  const std::size_t size = arr->size();
+  std::vector<details::FakeQubit> *result = new std::vector<details::FakeQubit>;
+  result->reserve(size);
+  for (std::size_t i = 0; i < size; ++i) {
+    (*result)[i].id = (*arr)[i];
+    (*result)[i].negated = false;
+  }
+  return result;
+}
+
+void __quantum__qis__free_converted_stdvector(
+    std::vector<details::FakeQubit> *veq) {
+  delete veq;
 }
 
 void __quantum__qis__custom_unitary(std::complex<double> *unitary,

--- a/test/Quake/apply_noise_conversion.qke
+++ b/test/Quake/apply_noise_conversion.qke
@@ -1,0 +1,55 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --convert-to-qir-api=api=full --symbol-dce %s | FileCheck %s
+
+func.func @__nvqpp__mlirgen__bell_error_vecI10SantaKrausE(%arg0: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %0 = cc.alloca f64
+  cc.store %arg0, %0 : !cc.ptr<f64>
+  %1 = quake.alloca !quake.veq<2>
+  %2 = quake.extract_ref %1[0] : (!quake.veq<2>) -> !quake.ref
+  quake.h %2 : (!quake.ref) -> ()
+  %3 = quake.extract_ref %1[0] : (!quake.veq<2>) -> !quake.ref
+  %4 = quake.extract_ref %1[1] : (!quake.veq<2>) -> !quake.ref
+  quake.x [%3] %4 : (!quake.ref, !quake.ref) -> ()
+  quake.apply_noise @_ZN5cudaq11apply_noiseI10SantaKrausJRdRNS_7qvectorILm2EEEEEEvDpOT0_(%0) %1 : (!cc.ptr<f64>, !quake.veq<2>) -> ()
+  return
+}
+
+func.func private @_ZN5cudaq11apply_noiseI10SantaKrausJRdRNS_7qvectorILm2EEEEEEvDpOT0_(!cc.ptr<f64>, !quake.veq<?>)
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__bell_error_vecI10SantaKrausE(
+// CHECK-SAME:      %[[VAL_0:.*]]: f64) attributes {"cudaq-entrypoint", "cudaq-kernel", "qir-api"} {
+// CHECK:           %[[VAL_1:.*]] = constant @__quantum__qis__x__ctl : (!cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<!llvm.struct<"Qubit", opaque>>) -> ()
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_4:.*]] = arith.constant 2 : i64
+// CHECK:           %[[VAL_5:.*]] = cc.alloca f64
+// CHECK:           cc.store %[[VAL_0]], %[[VAL_5]] : !cc.ptr<f64>
+// CHECK:           %[[VAL_6:.*]] = call @__quantum__rt__qubit_allocate_array(%[[VAL_4]]) : (i64) -> !cc.ptr<!llvm.struct<"Array", opaque>>
+// CHECK:           %[[VAL_7:.*]] = call @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]], %[[VAL_3]]) : (!cc.ptr<!llvm.struct<"Array", opaque>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
+// CHECK:           %[[VAL_8:.*]] = cc.load %[[VAL_7]] : !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
+// CHECK:           call @__quantum__qis__h(%[[VAL_8]]) : (!cc.ptr<!llvm.struct<"Qubit", opaque>>) -> ()
+// CHECK:           %[[VAL_9:.*]] = call @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]], %[[VAL_3]]) : (!cc.ptr<!llvm.struct<"Array", opaque>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
+// CHECK:           %[[VAL_10:.*]] = cc.load %[[VAL_9]] : !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
+// CHECK:           %[[VAL_11:.*]] = call @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]], %[[VAL_2]]) : (!cc.ptr<!llvm.struct<"Array", opaque>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
+// CHECK:           %[[VAL_12:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.ptr<!llvm.struct<"Qubit", opaque>>>
+// CHECK:           %[[VAL_13:.*]] = cc.cast %[[VAL_10]] : (!cc.ptr<!llvm.struct<"Qubit", opaque>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = cc.func_ptr %[[VAL_1]] : ((!cc.ptr<!llvm.struct<"Array", opaque>>, !cc.ptr<!llvm.struct<"Qubit", opaque>>) -> ()) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_15:.*]] = cc.cast %[[VAL_12]] : (!cc.ptr<!llvm.struct<"Qubit", opaque>>) -> !llvm.ptr<i8>
+// CHECK:           cc.call_vararg @generalizedInvokeWithRotationsControlsTargets(%[[VAL_3]], %[[VAL_3]], %[[VAL_2]], %[[VAL_2]], %[[VAL_14]], %[[VAL_13]], %[[VAL_15]]) : (i64, i64, i64, i64, !llvm.ptr<i8>, !llvm.ptr<i8>, !llvm.ptr<i8>) -> ()
+// CHECK:           %[[VAL_16:.*]] = call @__quantum__qis__convert_array_to_stdvector(%[[VAL_6]]) : (!cc.ptr<!llvm.struct<"Array", opaque>>) -> !cc.ptr<!llvm.struct<"Array", opaque>>
+// CHECK:           call @_ZN5cudaq11apply_noiseI10SantaKrausJRdRNS_7qvectorILm2EEEEEEvDpOT0_(%[[VAL_5]], %[[VAL_16]]) : (!cc.ptr<f64>, !cc.ptr<!llvm.struct<"Array", opaque>>) -> ()
+// CHECK:           call @__quantum__qis__free_converted_stdvector(%[[VAL_16]]) : (!cc.ptr<!llvm.struct<"Array", opaque>>) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-DAG:     func.func private @_ZN5cudaq11apply_noiseI10SantaKrausJRdRNS_7qvectorILm2EEEEEEvDpOT0_(!cc.ptr<f64>, !cc.ptr<!llvm.struct<"Array", opaque>>) attributes {"qir-api"}
+// CHECK-DAG:     func.func private @__quantum__qis__convert_array_to_stdvector(!cc.ptr<!llvm.struct<"Array", opaque>>) -> !cc.ptr<!llvm.struct<"Array", opaque>>
+// CHECK-DAG:     func.func private @__quantum__qis__free_converted_stdvector(!cc.ptr<!llvm.struct<"Array", opaque>>)
+


### PR DESCRIPTION
When calling back to a noise function from within a kernel (QPU space), the data type of a vector of qubits must be translated from QIR's Array type to CUDA-Q's cudaq::qvector type. This patch does that translation.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
