### PR TITLE
Fix `test_qnn.py` for more than 2 GPUs

### DIFF
--- a/python/tests/domains/test_qnn.py
+++ b/python/tests/domains/test_qnn.py
@@ -59,7 +59,8 @@ def test_observeAsync_QNN():
     target = cudaq.get_target('nvidia-mqpu')
 
     cudaq.set_target(target)
-    num_qpus = target.num_qpus()
+    # The number of parameters can only be split between a maximum of 2 QPUs.
+    num_qpus = min(target.num_qpus(), 2)
 
     n_qubits = 2
     n_samples = 2
@@ -80,7 +81,6 @@ def test_observeAsync_QNN():
         kernel.ry(params[i + n_qubits], qubits[i])
     for i in range(n_qubits):
         kernel.rz(params[i + n_qubits * 2], qubits[i])
-
     xi = np.split(parameters, num_qpus)
     asyncresults = []
     for i in range(len(xi)):


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
On systems with more than 2 GPUs, we got this error
```
ValueError: array split does not result in an equal division
```

Hence, limit a maximum of 2 virtual QPUs to participate in this test.