### PR TITLE
Convert !cc.state to !quake.state

### DIFF
--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -19,12 +19,15 @@
 #include <complex>
 #include <vector>
 
+namespace quake {
+class StateType;
+}
+
 namespace cudaq {
 namespace cc {
 class CharspanType;
 class LoopOp;
 class PointerType;
-class StateType;
 class StructType;
 } // namespace cc
 

--- a/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -291,28 +291,6 @@ def cc_CharSpanType
 def IsSpanLikePred : CPred<"$_self.isa<cudaq::cc::SpanLikeType>()">;
 def SpanningType : Type<IsSpanLikePred, "dynamic length type">;
 
-//===----------------------------------------------------------------------===//
-// StateType
-//===----------------------------------------------------------------------===//
-
-def cc_StateType : CCType<"State", "state"> {
-  let summary = "Proxy for the cudaq::state class.";
-  let description = [{
-    The cudaq::state class is an abstraction for any data that may be used to
-    describe the initial state of a set of qubits. It would typically be used
-    in a simulation environment.
-
-    The CUDA-Q runtime will implement an ABI of intrinsic functions for the
-    compiler generated code to interface with this information in a generic
-    manner.
-
-    There are no legal operations in Quake/CC on a value of type `!cc.state`.
-    Only pointers to such values should exist in the IR for the purposes of
-    passing references to state objects to runtime functions at codegen.
-  }];
-  let genStorageClass = 0;
-}
-
 def AnyStateInitLike : TypeConstraint<cc_PointerType.predicate,
                          "state initializer types">;
 def AnyStateInitType : Type<AnyStateInitLike.predicate, "initial state type">;

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -1587,7 +1587,7 @@ def quake_CreateStateOp : QuakeOp<"create_state", [Pure]> {
     by an intrinsic runtime call on simulators.
 
     ```mlir
-      %0 = quake.create_state %data %len : (!cc.ptr<!cc.array<complex<f64> x 8>>, i64) -> !cc.ptr<!cc.state>
+      %0 = quake.create_state %data %len : (!cc.ptr<!cc.array<complex<f64> x 8>>, i64) -> !cc.ptr<!quake.state>
     ```
   }];
 
@@ -1609,7 +1609,7 @@ def QuakeOp_DeleteStateOp : QuakeOp<"delete_state", [] > {
     by an intrinsic runtime call on simulators.
 
     ```mlir
-      quake.delete_state %state : !cc.ptr<!cc.state>
+      quake.delete_state %state : !cc.ptr<!quake.state>
     ```
   }];
 
@@ -1629,7 +1629,7 @@ def quake_GetNumberOfQubitsOp : QuakeOp<"get_number_of_qubits", [Pure] > {
     intrinsic runtime call when the target is one of the simulators.
 
     ```mlir
-      %0 = quake.get_number_of_qubits %state : (!cc.ptr<!cc.state>) -> i64
+      %0 = quake.get_number_of_qubits %state : (!cc.ptr<!quake.state>) -> i64
     ```
   }];
 
@@ -1649,7 +1649,7 @@ def QuakeOp_GetStateOp : QuakeOp<"get_state", [Pure] > {
     to the kernel with the provided name in ReplaceStateByKernel pass.
 
     ```mlir
-      %0 = quake.get_state "callee" : !cc.ptr<!cc.state>
+      %0 = quake.get_state "callee" : !cc.ptr<!quake.state>
     ```
   }];
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -221,6 +221,28 @@ def MeasureType : QuakeType<"Measure", "measure"> {
   let genStorageClass = 0;
 }
 
+//===----------------------------------------------------------------------===//
+// StateType
+//===----------------------------------------------------------------------===//
+
+def quake_StateType : QuakeType<"State", "state"> {
+  let summary = "Proxy for the cudaq::state class.";
+  let description = [{
+    The cudaq::state class is an abstraction for any data that may be used to
+    describe the initial state of a set of qubits. It would typically be used
+    in a simulation environment.
+
+    The CUDA-Q runtime will implement an ABI of intrinsic functions for the
+    compiler generated code to interface with this information in a generic
+    manner.
+
+    There are no legal operations in Quake/CC on a value of type `!quake.state`.
+    Only pointers to such values should exist in the IR for the purposes of
+    passing references to state objects to runtime functions at codegen.
+  }];
+  let genStorageClass = 0;
+}
+
 def AnyQTypeLike : TypeConstraint<Or<[WireType.predicate, VeqType.predicate,
         ControlType.predicate, RefType.predicate, StruqType.predicate]>,
         "quake quantum types">;

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -814,10 +814,10 @@ def DeleteStates : Pass<"delete-states", "mlir::ModuleOp"> {
     func.func @foo() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
       %c8_i64 = arith.constant 8 : i64
       %0 = cc.address_of @foo.rodata_synth_0 : !cc.ptr<!cc.array<complex<f32> x 8>>
-      %4 = cc.create_state %3, %c8_i64  : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!cc.state>
-      %5 = cc.get_number_of_qubits %4 : (!cc.ptr<!cc.state>) -> i64
+      %4 = cc.create_state %3, %c8_i64  : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!quake.state>
+      %5 = cc.get_number_of_qubits %4 : (!cc.ptr<!quake.state>) -> i64
       %6 = quake.alloca !quake.veq<?>[%5 : i64]
-      %7 = quake.init_state %6, %4 : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+      %7 = quake.init_state %6, %4 : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 
       return
     }
@@ -841,8 +841,8 @@ def DeleteStates : Pass<"delete-states", "mlir::ModuleOp"> {
     Before DeleteStates (delete-states):
     ```  func.func @foo() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
       ...
-      %4 = call @__nvqpp_cudaq_state_createFromData_fp32(%3, %c8_i64) : (!cc.ptr<i8>, i64) -> !cc.ptr<!cc.state>
-      call @__nvqpp__mlirgen__sub_kernel(%4) : (!cc.ptr<!cc.state>) -> ()
+      %4 = call @__nvqpp_cudaq_state_createFromData_fp32(%3, %c8_i64) : (!cc.ptr<i8>, i64) -> !cc.ptr<!quake.state>
+      call @__nvqpp__mlirgen__sub_kernel(%4) : (!cc.ptr<!quake.state>) -> ()
       return
     }
     ```
@@ -851,9 +851,9 @@ def DeleteStates : Pass<"delete-states", "mlir::ModuleOp"> {
     ```
     func.func @foo() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
       ...
-      %4 = call @__nvqpp_cudaq_state_createFromData_fp32(%3, %c8_i64) : (!cc.ptr<i8>, i64) -> !cc.ptr<!cc.state>
-      call @__nvqpp__mlirgen__sub_kernel(%4) : (!cc.ptr<!cc.state>) -> ()
-      call @__nvqpp_cudaq_state_delete(%4) : (!cc.ptr<!cc.state>) -> ()
+      %4 = call @__nvqpp_cudaq_state_createFromData_fp32(%3, %c8_i64) : (!cc.ptr<i8>, i64) -> !cc.ptr<!quake.state>
+      call @__nvqpp__mlirgen__sub_kernel(%4) : (!cc.ptr<!quake.state>) -> ()
+      call @__nvqpp_cudaq_state_delete(%4) : (!cc.ptr<!quake.state>) -> ()
       return
     }
     ```

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -158,7 +158,7 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
     if (name.equals("qvector") || name.equals("qview"))
       return pushType(quake::VeqType::getUnsized(ctx));
     if (name.equals("state"))
-      return pushType(cc::StateType::get(ctx));
+      return pushType(quake::StateType::get(ctx));
     if (name.equals("pauli_word"))
       return pushType(cc::CharspanType::get(ctx));
     if (name.equals("qkernel")) {

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -2722,7 +2722,7 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
       // lambda determines: is `t` a cudaq::state* ?
       auto isStateType = [&](Type t) {
         if (auto ptrTy = dyn_cast<cc::PointerType>(t))
-          return isa<cc::StateType>(ptrTy.getElementType());
+          return isa<quake::StateType>(ptrTy.getElementType());
         return false;
       };
 
@@ -2756,7 +2756,7 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
           return pushValue(builder.create<quake::AllocaOp>(
               loc, quake::VeqType::getUnsized(ctx), initials));
         }
-        if (isa<cc::StateType>(initials.getType())) {
+        if (isa<quake::StateType>(initials.getType())) {
           if (auto load = initials.getDefiningOp<cudaq::cc::LoadOp>())
             initials = load.getPtrvalue();
         }

--- a/lib/Frontend/nvqpp/ConvertType.cpp
+++ b/lib/Frontend/nvqpp/ConvertType.cpp
@@ -511,7 +511,7 @@ SmallVector<Type> QuakeBridgeVisitor::lastTypes(unsigned n) {
 
 static bool isReferenceToCudaqStateType(Type t) {
   if (auto ptrTy = dyn_cast<cc::PointerType>(t))
-    return isa<cc::StateType>(ptrTy.getElementType());
+    return isa<quake::StateType>(ptrTy.getElementType());
   return false;
 }
 

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -273,18 +273,18 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   })#"},
 
     {cudaq::createCudaqStateFromDataFP32, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_createFromData_fp32(%p : !cc.ptr<i8>, %s : i64) -> !cc.ptr<!cc.state>
+  func.func private @__nvqpp_cudaq_state_createFromData_fp32(%p : !cc.ptr<i8>, %s : i64) -> !cc.ptr<!quake.state>
   )#"},
     {cudaq::createCudaqStateFromDataFP64, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_createFromData_fp64(%p : !cc.ptr<i8>, %s : i64) -> !cc.ptr<!cc.state>
+  func.func private @__nvqpp_cudaq_state_createFromData_fp64(%p : !cc.ptr<i8>, %s : i64) -> !cc.ptr<!quake.state>
   )#"},
 
     {cudaq::deleteCudaqState, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_delete(%p : !cc.ptr<!cc.state>) -> ()
+  func.func private @__nvqpp_cudaq_state_delete(%p : !cc.ptr<!quake.state>) -> ()
   )#"},
 
     {cudaq::getNumQubitsFromCudaqState, {}, R"#(
-  func.func private @__nvqpp_cudaq_state_numberOfQubits(%p : !cc.ptr<!cc.state>) -> i64
+  func.func private @__nvqpp_cudaq_state_numberOfQubits(%p : !cc.ptr<!quake.state>) -> i64
   )#"},
 
     {"__nvqpp_getStateVectorData_fp32", {}, R"#(
@@ -404,7 +404,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__rt__qubit_allocate_array_with_state_complex64(i64, !cc.ptr<complex<f64>>) -> !qir_array
   func.func private @__quantum__rt__qubit_allocate_array_with_state_complex32(i64, !cc.ptr<complex<f32>>) -> !qir_array
   func.func private @__quantum__rt__qubit_allocate_array_with_state_ptr(!cc.ptr<none>) -> !qir_array
-  func.func private @__quantum__rt__qubit_allocate_array_with_cudaq_state_ptr(i64, !cc.ptr<!cc.state>) -> !qir_array
+  func.func private @__quantum__rt__qubit_allocate_array_with_cudaq_state_ptr(i64, !cc.ptr<!quake.state>) -> !qir_array
 
   func.func private @__quantum__rt__qubit_release_array(!qir_array)
   func.func private @__quantum__rt__qubit_release(!qir_qubit)

--- a/lib/Optimizer/CodeGen/ConvertCCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/ConvertCCToLLVM.cpp
@@ -12,6 +12,7 @@
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
 #include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ComplexToLLVM/ComplexToLLVM.h"
@@ -72,7 +73,7 @@ void cudaq::opt::populateCCTypeConversions(LLVMTypeConverter *converter) {
     return LLVM::LLVMArrayType::get(eleTy, type.getSize());
   });
   converter->addConversion(
-      [](cc::StateType type) { return factory::stateImplType(type); });
+      [](quake::StateType type) { return factory::stateImplType(type); });
   converter->addConversion([converter](cc::StructType type) -> Type {
     SmallVector<Type> members;
     for (auto t : type.getMembers())

--- a/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -739,10 +739,10 @@ struct QmemRAIIOpRewrite : public OpConversionPattern<cudaq::codegen::RAIIOp> {
     // Cascade to set functionName.
     StringRef functionName;
     Type ptrTy;
-    if (isa<cudaq::cc::StateType>(eleTy)) {
+    if (isa<quake::StateType>(eleTy)) {
       functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithCudaqStatePtr;
       ptrTy = cudaq::cc::PointerType::get(
-          cudaq::cc::StateType::get(rewriter.getContext()));
+          quake::StateType::get(rewriter.getContext()));
     } else if (eleTy == rewriter.getF64Type()) {
       if (fromComplex) {
         functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex64;

--- a/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
@@ -93,7 +93,7 @@ public:
     auto result = irBuilder.loadIntrinsic(module, createStateFunc);
     assert(succeeded(result) && "loading intrinsic should never fail");
 
-    auto stateTy = cudaq::cc::StateType::get(ctx);
+    auto stateTy = quake::StateType::get(ctx);
     auto statePtrTy = cudaq::cc::PointerType::get(stateTy);
     auto i8PtrTy = cudaq::cc::PointerType::get(rewriter.getI8Type());
     auto cast = rewriter.create<cudaq::cc::CastOp>(loc, i8PtrTy, buffer);

--- a/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
@@ -115,7 +115,7 @@ public:
       fromComplex = true;
       eleTy = complexTy.getElementType();
     }
-    if (isa<cudaq::cc::StateType>(eleTy))
+    if (isa<quake::StateType>(eleTy))
       functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithCudaqStatePtr;
     if (eleTy == rewriter.getF64Type())
       functionName =

--- a/lib/Optimizer/Dialect/CC/CCTypes.cpp
+++ b/lib/Optimizer/Dialect/CC/CCTypes.cpp
@@ -207,7 +207,7 @@ CallableType CallableType::getNoSignature(MLIRContext *ctx) {
 
 void CCDialect::registerTypes() {
   addTypes<ArrayType, CallableType, CharspanType, IndirectCallableType,
-           PointerType, StdvecType, StateType, StructType>();
+           PointerType, StdvecType, StructType>();
 }
 
 } // namespace cudaq::cc

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -565,7 +565,7 @@ LogicalResult quake::InitializeStateOp::verify() {
     }
     if (!isa<FloatType, ComplexType>(arrTy.getElementType()))
       return emitOpError("invalid data pointer type");
-  } else if (!isa<FloatType, ComplexType, cudaq::cc::StateType>(ty)) {
+  } else if (!isa<FloatType, ComplexType, quake::StateType>(ty)) {
     return emitOpError("invalid data pointer type");
   }
   return success();

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -127,5 +127,6 @@ std::size_t quake::getAllocationSize(Type ty) {
 //===----------------------------------------------------------------------===//
 
 void quake::QuakeDialect::registerTypes() {
-  addTypes<ControlType, MeasureType, RefType, StruqType, VeqType, WireType>();
+  addTypes<ControlType, MeasureType, RefType, StateType, StruqType, VeqType,
+           WireType>();
 }

--- a/lib/Optimizer/Transforms/DeleteStates.cpp
+++ b/lib/Optimizer/Transforms/DeleteStates.cpp
@@ -47,12 +47,12 @@ static std::size_t getStateSize(Operation *op) {
 /// Replace `quake.get_number_of_qubits` by a constant.
 /// ```
 /// %c8_i64 = arith.constant 8 : i64
-/// %2 = quake.create_state %3, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.ptr<!cc.state>
+/// %2 = quake.create_state %3, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.ptr<!quake.state>
 /// %3 = quake.get_number_of_qubits %2 : i64
 /// ...
 /// ───────────────────────────────────────────
 /// %c8_i64 = arith.constant 8 : i64
-/// %2 = quake.create_state %3, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.ptr<!cc.state>
+/// %2 = quake.create_state %3, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.ptr<!quake.state>
 /// %3 = arith.constant 3 : i64
 /// ```
 // clang-format on
@@ -79,9 +79,9 @@ public:
 /// the `quake.state_init` instruction instead.
 /// ```
 /// %2 = cc.cast %1 : (!cc.ptr<!cc.array<complex<f32> x 8>>) -> !cc.ptr<i8>
-/// %3 = quake.create_state %3, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.ptr<!cc.state>
+/// %3 = quake.create_state %3, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.ptr<!quake.state>
 /// %4 = quake.alloca !quake.veq<?>[%0 : i64]
-/// %5 = quake.init_state %4, %3 : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+/// %5 = quake.init_state %4, %3 : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 /// ───────────────────────────────────────────
 /// ...
 /// %4 = quake.alloca !quake.veq<?>[%0 : i64]

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -50,7 +50,7 @@ static bool isCodegenArgumentGather(std::size_t kind) {
 
 static bool isStateType(Type ty) {
   if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(ty))
-    return isa<cudaq::cc::StateType>(ptrTy.getElementType());
+    return isa<quake::StateType>(ptrTy.getElementType());
   return false;
 }
 

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -538,7 +538,7 @@ public:
       }
 
       if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(type)) {
-        if (isa<cudaq::cc::StateType>(ptrTy.getElementType())) {
+        if (isa<quake::StateType>(ptrTy.getElementType())) {
           // Special case of a `cudaq::state*` which must be in the same address
           // space. This references a container to a set of simulation
           // amplitudes.
@@ -549,8 +549,7 @@ public:
                   Value rawPtr = builder.create<arith::ConstantIntOp>(
                       loc, reinterpret_cast<std::intptr_t>(*concrete),
                       sizeof(void *) * 8);
-                  auto stateTy =
-                      cudaq::cc::StateType::get(builder.getContext());
+                  auto stateTy = quake::StateType::get(builder.getContext());
                   return builder.create<cudaq::cc::CastOp>(
                       loc, cudaq::cc::PointerType::get(stateTy), rawPtr);
                 });

--- a/python/extension/CUDAQuantumExtension.cpp
+++ b/python/extension/CUDAQuantumExtension.cpp
@@ -32,16 +32,13 @@
 #include "runtime/cudaq/spin/py_spin_op.h"
 #include "runtime/cudaq/target/py_runtime_target.h"
 #include "runtime/cudaq/target/py_testing_utils.h"
+#include "runtime/interop/PythonCppInterop.h"
 #include "runtime/mlir/py_register_dialects.h"
 #include "utils/LinkedLibraryHolder.h"
 #include "utils/OpaqueArguments.h"
-
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
-
-#include "runtime/interop/PythonCppInterop.h"
-
 #include <pybind11/complex.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>

--- a/python/runtime/mlir/py_register_dialects.cpp
+++ b/python/runtime/mlir/py_register_dialects.cpp
@@ -160,9 +160,9 @@ void registerCCDialectAndTypes(py::module &m) {
   });
 
   mlir_type_subclass(ccMod, "StateType", [](MlirType type) {
-    return unwrap(type).isa<cudaq::cc::StateType>();
+    return unwrap(type).isa<quake::StateType>();
   }).def_classmethod("get", [](py::object cls, MlirContext ctx) {
-    return wrap(cudaq::cc::StateType::get(unwrap(ctx)));
+    return wrap(quake::StateType::get(unwrap(ctx)));
   });
 
   mlir_type_subclass(

--- a/python/utils/OpaqueArguments.h
+++ b/python/utils/OpaqueArguments.h
@@ -14,6 +14,7 @@
 #include "cudaq/Optimizer/CodeGen/QIRFunctionNames.h"
 #include "cudaq/Optimizer/CodeGen/QIROpaqueStructTypes.h"
 #include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
 #include "cudaq/builder/kernel_builder.h"
 #include "cudaq/qis/pauli_word.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -334,7 +335,7 @@ inline void packArgs(OpaqueArguments &argData, py::args args,
           addArgument(argData, arg.cast<cudaq::pauli_word>().str());
         })
         .Case([&](cudaq::cc::PointerType ty) {
-          if (isa<cudaq::cc::StateType>(ty.getElementType())) {
+          if (isa<quake::StateType>(ty.getElementType())) {
             valueArgument(argData, arg.cast<cudaq::state *>());
           } else {
             throw std::runtime_error("Invalid pointer type argument: " +

--- a/runtime/common/ArgumentConversion.cpp
+++ b/runtime/common/ArgumentConversion.cpp
@@ -140,7 +140,7 @@ static Value genConstant(OpBuilder &builder, const cudaq::state *v,
                           : genConArray.template operator()<float>();
 
     auto arrSize = builder.create<arith::ConstantIntOp>(loc, size, 64);
-    auto stateTy = cudaq::cc::StateType::get(ctx);
+    auto stateTy = quake::StateType::get(ctx);
     auto statePtrTy = cudaq::cc::PointerType::get(stateTy);
 
     return builder.create<quake::CreateStateOp>(loc, statePtrTy, buffer,
@@ -400,7 +400,7 @@ void cudaq::opt::ArgumentConverter::gen(const std::vector<void *> &arguments) {
                                 substModule);
             })
             .Case([&](cc::PointerType ptrTy) -> cc::ArgumentSubstitutionOp {
-              if (ptrTy.getElementType() == cc::StateType::get(ctx))
+              if (ptrTy.getElementType() == quake::StateType::get(ctx))
                 return buildSubst(static_cast<const state *>(argPtr),
                                   substModule, dataLayout, kernelName,
                                   isSimulator);

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -126,7 +126,7 @@ KernelBuilderType convertArgumentTypeToMLIR(std::vector<cudaq::pauli_word> &) {
 
 KernelBuilderType convertArgumentTypeToMLIR(cudaq::state *&) {
   return KernelBuilderType([](MLIRContext *ctx) {
-    return cudaq::cc::PointerType::get(cudaq::cc::StateType::get(ctx));
+    return cudaq::cc::PointerType::get(quake::StateType::get(ctx));
   });
 }
 
@@ -507,7 +507,7 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder, QuakeValue &sizeOrVec) {
 
   if (auto statePtrTy = dyn_cast<cc::PointerType>(type)) {
     auto eleTy = statePtrTy.getElementType();
-    if (auto stateTy = dyn_cast<cc::StateType>(eleTy)) {
+    if (auto stateTy = dyn_cast<quake::StateType>(eleTy)) {
       // get the number of qubits
       auto numQubits = builder.create<quake::GetNumberOfQubitsOp>(
           builder.getI64Type(), value);
@@ -645,7 +645,7 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder,
 QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder, cudaq::state *state,
                   StateVectorStorage &stateVectorStorage) {
   auto *context = builder.getContext();
-  auto statePtrTy = cudaq::cc::PointerType::get(cc::StateType::get(context));
+  auto statePtrTy = cudaq::cc::PointerType::get(quake::StateType::get(context));
   auto statePtr = builder.create<cc::CastOp>(
       builder.getLoc(), statePtrTy,
       builder.create<arith::ConstantIntOp>(

--- a/runtime/test/test_argument_conversion.cpp
+++ b/runtime/test/test_argument_conversion.cpp
@@ -367,18 +367,18 @@ void test_state(mlir::MLIRContext *ctx) {
                                            0.,        0.,        0., 0.};
     auto x = cudaq::state(new FakeSimulationState(data.size(), data.data()));
     std::vector<void *> v = {static_cast<void *>(&x)};
-    doSimpleTest(ctx, "!cc.ptr<!cc.state>", v);
+    doSimpleTest(ctx, "!cc.ptr<!quake.state>", v);
   }
 
   // clang-format off
 // CHECK:       Source module:
-// CHECK:         func.func private @callee(!cc.ptr<!cc.state>)
+// CHECK:         func.func private @callee(!cc.ptr<!quake.state>)
 // CHECK:       Substitution module:
 
 // CHECK-LABEL:   cc.arg_subst[0] {
 // CHECK:           %[[VAL_0:.*]] = cc.address_of @[[VAL_GC:.*]] : !cc.ptr<!cc.array<complex<f64> x 8>>
 // CHECK:           %[[VAL_1:.*]] = arith.constant 8 : i64
-// CHECK:           %[[VAL_2:.*]] = quake.create_state %[[VAL_0]], %[[VAL_1]] : (!cc.ptr<!cc.array<complex<f64> x 8>>, i64) -> !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_2:.*]] = quake.create_state %[[VAL_0]], %[[VAL_1]] : (!cc.ptr<!cc.array<complex<f64> x 8>>, i64) -> !cc.ptr<!quake.state>
 // CHECK:        }
 // CHECK-DAG:    cc.global constant private @[[VAL_GC]] (dense<[(0.70710678118654757,0.000000e+00), (0.70710678118654757,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<8xcomplex<f64>>) : !cc.array<complex<f64> x 8>
   // clang-format on
@@ -452,14 +452,14 @@ void test_combinations(mlir::MLIRContext *ctx) {
 
     std::vector<void *> v = {static_cast<void *>(&x), static_cast<void *>(&y),
                              static_cast<void *>(&z)};
-    std::vector<std::string> t = {"!cc.stdvec<f32>", "!cc.ptr<!cc.state>",
+    std::vector<std::string> t = {"!cc.stdvec<f32>", "!cc.ptr<!quake.state>",
                                   "!cc.stdvec<!cc.charspan>"};
     doTest(ctx, t, v);
   }
 
   // clang-format off
 // CHECK:       Source module:
-// CHECK:         func.func private @callee(!cc.stdvec<f32>, !cc.ptr<!cc.state>, !cc.stdvec<!cc.charspan>)
+// CHECK:         func.func private @callee(!cc.stdvec<f32>, !cc.ptr<!quake.state>, !cc.stdvec<!cc.charspan>)
 // CHECK:       Substitution module:
 
 // CHECK-LABEL:   cc.arg_subst[0] {
@@ -482,7 +482,7 @@ void test_combinations(mlir::MLIRContext *ctx) {
 // CHECK-LABEL:   cc.arg_subst[1] {
 // CHECK:           %[[VAL_0:.*]] = cc.address_of @[[VAL_GC:.*]] : !cc.ptr<!cc.array<complex<f64> x 8>>
 // CHECK:           %[[VAL_1:.*]] = arith.constant 8 : i64
-// CHECK:           %[[VAL_5:.*]] = quake.create_state %[[VAL_0]], %[[VAL_1]] : (!cc.ptr<!cc.array<complex<f64> x 8>>, i64) -> !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_5:.*]] = quake.create_state %[[VAL_0]], %[[VAL_1]] : (!cc.ptr<!cc.array<complex<f64> x 8>>, i64) -> !cc.ptr<!quake.state>
 // CHECK:         }
 // CHECK-DAG:     cc.global constant private @[[VAL_GC]] (dense<[(0.70710678118654757,0.000000e+00), (0.70710678118654757,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<8xcomplex<f64>>) : !cc.array<complex<f64> x 8>
 // CHECK-LABEL:   cc.arg_subst[2] {

--- a/test/AST-Quake/qalloc_state.cpp
+++ b/test/AST-Quake/qalloc_state.cpp
@@ -19,10 +19,10 @@ struct Eins {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Eins(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!cc.state>) -> i64
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 
 struct Zwei {
   std::vector<bool> operator()(const cudaq::state *state) __qpu__ {
@@ -33,10 +33,10 @@ struct Zwei {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Zwei(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!cc.state>) -> i64
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 
 struct Drei {
   std::vector<bool> operator()(cudaq::state &state) __qpu__ {
@@ -47,10 +47,10 @@ struct Drei {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Drei(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!cc.state>) -> i64
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 
 struct Vier {
   std::vector<bool> operator()(const cudaq::state &state) __qpu__ {
@@ -61,8 +61,8 @@ struct Vier {
 };
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Vier(
-// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!cc.state>) -> !cc.stdvec<i1>
-// CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!cc.state>) -> i64
+// CHECK-SAME:      %[[VAL_0:.*]]: !cc.ptr<!quake.state>) -> !cc.stdvec<i1>
+// CHECK:           %[[VAL_3:.*]] = quake.get_number_of_qubits %[[VAL_0]] : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<?>[%[[VAL_3]] : i64]
-// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+// CHECK:           %[[VAL_6:.*]] = quake.init_state %[[VAL_5]], %[[VAL_0]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 

--- a/test/Quake/codegen_dialect.qke
+++ b/test/Quake/codegen_dialect.qke
@@ -104,15 +104,15 @@ func.func @testc4(%arg : !cc.ptr<!cc.array<complex<f32> x 4>>) {
 // CHECK:           return
 // CHECK:         }
 
-func.func @teststate(%arg : !cc.ptr<!cc.state>) {
+func.func @teststate(%arg : !cc.ptr<!quake.state>) {
   %0 = quake.alloca !quake.veq<2>
-  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<!cc.state>) -> !quake.veq<2>
+  %1 = quake.init_state %0, %arg : (!quake.veq<2>, !cc.ptr<!quake.state>) -> !quake.veq<2>
   return
 }
 
 // CHECK-LABEL:   func.func @teststate(
-// CHECK-SAME:                         %[[VAL_0:.*]]: !cc.ptr<!cc.state>) {
-// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from !cc.state onto !quake.veq<2> : (!cc.ptr<!cc.state>) -> !quake.veq<2>
+// CHECK-SAME:                         %[[VAL_0:.*]]: !cc.ptr<!quake.state>) {
+// CHECK:           %[[VAL_1:.*]] = codegen.qmem_raii %[[VAL_0]] from !quake.state onto !quake.veq<2> : (!cc.ptr<!quake.state>) -> !quake.veq<2>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Quake/delete_states.qke
+++ b/test/Quake/delete_states.qke
@@ -12,10 +12,10 @@ module {
   func.func @test_state_param() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
     %c8_i64 = arith.constant 8 : i64
     %0 = cc.address_of @test_state_param.rodata_synth_0 : !cc.ptr<!cc.array<complex<f32> x 8>>
-    %1 = quake.create_state %0, %c8_i64 : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!cc.state>
-    %2 = quake.get_number_of_qubits %1 : (!cc.ptr<!cc.state>) -> i64
+    %1 = quake.create_state %0, %c8_i64 : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!quake.state>
+    %2 = quake.get_number_of_qubits %1 : (!cc.ptr<!quake.state>) -> i64
     %3 = quake.alloca !quake.veq<?>[%2 : i64]
-    %4 = quake.init_state %3, %1 : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+    %4 = quake.init_state %3, %1 : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
     return
   }
   cc.global constant private @test_state_param.rodata_synth_0 (dense<[(0.707106769,0.000000e+00), (0.707106769,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<8xcomplex<f32>>) : !cc.array<complex<f32> x 8>
@@ -28,36 +28,36 @@ module {
 // CHECK:         }
 // CHECK-DAG:    cc.global constant private @test_state_param.rodata_synth_0 (dense<[(0.707106769,0.000000e+00), (0.707106769,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<8xcomplex<f32>>) : !cc.array<complex<f32> x 8>
 
-  func.func @sub_kernel(%arg : !cc.ptr<!cc.state>) attributes {"cudaq-kernel", no_this} {
-    %0 = quake.get_number_of_qubits %arg : (!cc.ptr<!cc.state>) -> i64
+  func.func @sub_kernel(%arg : !cc.ptr<!quake.state>) attributes {"cudaq-kernel", no_this} {
+    %0 = quake.get_number_of_qubits %arg : (!cc.ptr<!quake.state>) -> i64
     %1 = quake.alloca !quake.veq<?>[%0 : i64]
-    %2 = quake.init_state %1, %arg : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+    %2 = quake.init_state %1, %arg : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
     return
   }
 
   func.func @test_state_param1() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
     %c8_i64 = arith.constant 8 : i64
     %0 = cc.address_of @test_state_param1.rodata_synth_0 : !cc.ptr<!cc.array<complex<f32> x 8>>
-    %1 = quake.create_state %0, %c8_i64 : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!cc.state>
-    call @sub_kernel(%1) : (!cc.ptr<!cc.state>) -> ()
+    %1 = quake.create_state %0, %c8_i64 : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!quake.state>
+    call @sub_kernel(%1) : (!cc.ptr<!quake.state>) -> ()
     return
   }
 
   cc.global constant private @test_state_param1.rodata_synth_0 (dense<[(0.707106769,0.000000e+00), (0.707106769,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00
 ,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<8xcomplex<f32>>) : !cc.array<complex<f32> x 8>
 
-// CHECK:         func.func @sub_kernel(%arg0: !cc.ptr<!cc.state>) attributes {"cudaq-kernel", no_this} {
-// CHECK:           %[[VAL_0:.*]] = quake.get_number_of_qubits %arg0 : (!cc.ptr<!cc.state>) -> i64
+// CHECK:         func.func @sub_kernel(%arg0: !cc.ptr<!quake.state>) attributes {"cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_0:.*]] = quake.get_number_of_qubits %arg0 : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<?>[%[[VAL_0]] : i64]
-// CHECK:           %[[VAL_2:.*]] = quake.init_state %[[VAL_1]], %arg0 : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+// CHECK:           %[[VAL_2:.*]] = quake.init_state %[[VAL_1]], %arg0 : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 // CHECK:           return
 // CHECK:         }
 // CHECK:         func.func @test_state_param1() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 8 : i64
 // CHECK:           %[[VAL_1:.*]] = cc.address_of @test_state_param1.rodata_synth_0 : !cc.ptr<!cc.array<complex<f32> x 8>>
-// CHECK:           %[[VAL_2:.*]] = quake.create_state %[[VAL_1]], %[[VAL_0]] : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!cc.state>
-// CHECK:           call @sub_kernel(%[[VAL_2]]) : (!cc.ptr<!cc.state>) -> ()
-// CHECK:           quake.delete_state %[[VAL_2]] : !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_2:.*]] = quake.create_state %[[VAL_1]], %[[VAL_0]] : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!quake.state>
+// CHECK:           call @sub_kernel(%[[VAL_2]]) : (!cc.ptr<!quake.state>) -> ()
+// CHECK:           quake.delete_state %[[VAL_2]] : !cc.ptr<!quake.state>
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:     cc.global constant private @test_state_param1.rodata_synth_0 (dense<[(0.707106769,0.000000e+00), (0.707106769,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<8xcomplex<f32>>) : !cc.array<complex<f32> x 8>

--- a/test/Quake/roundtrip-ops.qke
+++ b/test/Quake/roundtrip-ops.qke
@@ -157,13 +157,13 @@ func.func @quantum_ops() {
   // State
   %i8 = arith.constant 8 : i64
   %49 = cc.address_of @quantum_ops.rodata_synth_0 : !cc.ptr<!cc.array<complex<f32> x 8>>
-  %50 = quake.create_state %49, %i8 : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!cc.state>
-  %51 = quake.get_number_of_qubits %50 : (!cc.ptr<!cc.state>) -> i64
+  %50 = quake.create_state %49, %i8 : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!quake.state>
+  %51 = quake.get_number_of_qubits %50 : (!cc.ptr<!quake.state>) -> i64
   %52 = quake.alloca !quake.veq<?>[%51 : i64]
-  %53 = quake.init_state %52, %50 : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
+  %53 = quake.init_state %52, %50 : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
 
-  %54 = quake.create_state %49, %i8 : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!cc.state>
-  quake.delete_state %54: !cc.ptr<!cc.state>
+  %54 = quake.create_state %49, %i8 : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!quake.state>
+  quake.delete_state %54: !cc.ptr<!quake.state>
   return
 }
 
@@ -283,12 +283,12 @@ cc.global constant private @quantum_ops.rodata_synth_0 (dense<[(0.707106769,0.00
 // CHECK:           quake.exp_pauli (%[[VAL_59]]) %[[VAL_54]] to "XYZ" : (f64, !quake.veq<3>) -> ()
 // CHECK:           %[[VAL_61:.*]] = arith.constant 8 : i64
 // CHECK:           %[[VAL_62:.*]] = cc.address_of @quantum_ops.rodata_synth_0 : !cc.ptr<!cc.array<complex<f32> x 8>>
-// CHECK:           %[[VAL_63:.*]] = quake.create_state %[[VAL_62]], %[[VAL_61]] : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!cc.state>
-// CHECK:           %[[VAL_64:.*]] = quake.get_number_of_qubits %[[VAL_63]] : (!cc.ptr<!cc.state>) -> i64
+// CHECK:           %[[VAL_63:.*]] = quake.create_state %[[VAL_62]], %[[VAL_61]] : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!quake.state>
+// CHECK:           %[[VAL_64:.*]] = quake.get_number_of_qubits %[[VAL_63]] : (!cc.ptr<!quake.state>) -> i64
 // CHECK:           %[[VAL_65:.*]] = quake.alloca !quake.veq<?>[%[[VAL_64]] : i64]
-// CHECK:           %[[VAL_66:.*]] = quake.init_state %[[VAL_65]], %[[VAL_63]] : (!quake.veq<?>, !cc.ptr<!cc.state>) -> !quake.veq<?>
-// CHECK:           %[[VAL_67:.*]] = quake.create_state %[[VAL_62]], %[[VAL_61]] : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!cc.state>
-// CHECK:           quake.delete_state %[[VAL_67]] : !cc.ptr<!cc.state>
+// CHECK:           %[[VAL_66:.*]] = quake.init_state %[[VAL_65]], %[[VAL_63]] : (!quake.veq<?>, !cc.ptr<!quake.state>) -> !quake.veq<?>
+// CHECK:           %[[VAL_67:.*]] = quake.create_state %[[VAL_62]], %[[VAL_61]] : (!cc.ptr<!cc.array<complex<f32> x 8>>, i64) -> !cc.ptr<!quake.state>
+// CHECK:           quake.delete_state %[[VAL_67]] : !cc.ptr<!quake.state>
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Transforms/qir_base_profile.qke
+++ b/test/Transforms/qir_base_profile.qke
@@ -165,7 +165,7 @@ module attributes {cc.sizeof_string = 32 : i64, llvm.data_layout = "e-m:e-p270:3
 // CHECK:         func.func private @__quantum__rt__qubit_allocate_array_with_state_complex64(i64, !cc.ptr<complex<f64>>) -> !cc.ptr<!llvm.struct<"Array", opaque>>
 // CHECK:         func.func private @__quantum__rt__qubit_allocate_array_with_state_complex32(i64, !cc.ptr<complex<f32>>) -> !cc.ptr<!llvm.struct<"Array", opaque>>
 // CHECK:         func.func private @__quantum__rt__qubit_allocate_array_with_state_ptr(!cc.ptr<none>) -> !cc.ptr<!llvm.struct<"Array", opaque>>
-// CHECK:         func.func private @__quantum__rt__qubit_allocate_array_with_cudaq_state_ptr(i64, !cc.ptr<!cc.state>) -> !cc.ptr<!llvm.struct<"Array", opaque>>
+// CHECK:         func.func private @__quantum__rt__qubit_allocate_array_with_cudaq_state_ptr(i64, !cc.ptr<!quake.state>) -> !cc.ptr<!llvm.struct<"Array", opaque>>
 // CHECK:         func.func private @__quantum__rt__qubit_release_array(!cc.ptr<!llvm.struct<"Array", opaque>>)
 // CHECK:         func.func private @__quantum__rt__qubit_release(!cc.ptr<!llvm.struct<"Qubit", opaque>>)
 // CHECK:         func.func private @__quantum__rt__array_create_1d(i32, i64) -> !cc.ptr<!llvm.struct<"Array", opaque>>


### PR DESCRIPTION
Although it seems reasonable for the cudaq::state object to be classified as a classical compute data structure, it is equally reasonable to classify it as quantum compute since it is only ever used with quantum allocations.

After some discussion, we leaned towards making StateType a member of the quake quantum types.

This PR just moves StateType from the cc dialect to the quake dialect as a result.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
