### PR TITLE
Nix Flake dev environment for CUDA-Q

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 use flake
+pre-commit install

--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ __pycache__/
 .cache/*
 
 # LLVM/MLIR files
-*.ll 
+*.ll
 *.bc
 
 # Build results
@@ -93,3 +93,6 @@ apps/
 
 # JetBrains IDE files
 .idea
+
+# direnv
+.direnv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
     rev: v1.3.0
     hooks:
       - id: nixpkgs-fmt
+  - repo: https://github.com/hukkin/mdformat
+    rev: 0.7.22
+    hooks:
+      - id: mdformat
+        args: ["--wrap", "80"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,14 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.7
+    rev: v16.0.6
     hooks:
       - id: clang-format
   - repo: https://github.com/google/yapf
     rev: v0.43.0
     hooks:
       - id: yapf-diff
+  - repo: https://github.com/nix-community/nixpkgs-fmt
+    rev: v1.3.0
+    hooks:
+      - id: nixpkgs-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.7
+    hooks:
+      - id: clang-format
+  - repo: https://github.com/google/yapf
+    rev: v0.43.0
+    hooks:
+      - id: yapf-diff

--- a/Dev_Setup.md
+++ b/Dev_Setup.md
@@ -6,11 +6,12 @@ you want to contribute to the code in this repository.
 ## Using Nix Flakes (experimental)
 
 This repository defines a Nix flake which will allow you to quickly bootstrap a
-development environment on any Linux system (OS X unsupported as of the time of
-writing). Unlike Docker containers, you will not need to build a container and
-spin it up, you can develop directly on your linux host. And unlike manually
-managing dependencies, Nix will (mostly) hermetically manage all the
-dependencies for you. All you **need** to install, ever, is Nix itself.
+development environment on any Linux system (WSL is supported, but OS X is
+unsupported as of the time of writing). Unlike Docker containers, you will not
+need to build a container and spin it up, you can develop directly on your linux
+host. And unlike manually managing dependencies, Nix will (mostly) hermetically
+manage all the dependencies for you. All you **need** to install, ever, is Nix
+itself.
 
 To setup using nix flakes, you will first have to install
 [Nix multi-user](https://nixos.org/download/), if you haven't done so already:

--- a/Dev_Setup.md
+++ b/Dev_Setup.md
@@ -3,6 +3,34 @@
 This document contains a guide for how to set up your development environment if
 you want to contribute to the code in this repository.
 
+## Using Nix Flakes (experimental)
+
+This repository defines a Nix flake which will allow you to quickly bootstrap a development environment on any Linux system (OS X unsupported as of the time of writing). Unlike Docker containers, you will not need to build a container and spin it up, you can develop directly on your linux host. And unlike manually managing dependencies, Nix will (mostly) hermetically manage all the dependencies for you. All you **need** to install, ever, is Nix itself.
+
+To setup using nix flakes, you will first have to install [Nix multi-user](https://nixos.org/download/), if you haven't done so already:
+
+```
+sh <(curl -L https://nixos.org/nix/install) --daemon
+```
+
+You can now trigger `nix develop` from the root of the repository and use the development shell. You will have to [enable flakes](https://wiki.nixos.org/wiki/Flakes) if you stop here. However, we recommend installing direnv, to enable nix development shell drop-in as soon as you cd into the repo. This should be available with your favorite package manager, e.g.
+```
+sudo apt-get install direnv
+```
+You will also have to add a direnv hook to your shell config, e.g. `~/.bashrc`
+```
+eval "$(direnv hook bash)"
+```
+Refer to `direnv` install instructions for more help:
+* [Installation](https://direnv.net/docs/installation.html)
+* [Hook](https://direnv.net/docs/hook.html)
+
+Once you have both nix and direnv installed, you will have to `direnv allow` in the repo root as a one-time step to allow direnv to trigger `nix develop` for you.
+
+At this experimental stage of Nix support, you will have to run `scripts/install_prerequisites.sh` as a one-time step as well. Keep in mind that the script will install prerequisites in `/usr/local/`, i.e. the nix development environment is currently leaky. This should be fixed in the future.
+
+If everything above was installed and configured correctly, use `scripts/build_cudaq.sh` to run your first build, and you can simply run `ninja` in the `build` directory for any future builds.
+
 ## Working inside the provided development container (recommended)
 
 This repository defines a development container to facilitate working in a

--- a/Dev_Setup.md
+++ b/Dev_Setup.md
@@ -5,31 +5,54 @@ you want to contribute to the code in this repository.
 
 ## Using Nix Flakes (experimental)
 
-This repository defines a Nix flake which will allow you to quickly bootstrap a development environment on any Linux system (OS X unsupported as of the time of writing). Unlike Docker containers, you will not need to build a container and spin it up, you can develop directly on your linux host. And unlike manually managing dependencies, Nix will (mostly) hermetically manage all the dependencies for you. All you **need** to install, ever, is Nix itself.
+This repository defines a Nix flake which will allow you to quickly bootstrap a
+development environment on any Linux system (OS X unsupported as of the time of
+writing). Unlike Docker containers, you will not need to build a container and
+spin it up, you can develop directly on your linux host. And unlike manually
+managing dependencies, Nix will (mostly) hermetically manage all the
+dependencies for you. All you **need** to install, ever, is Nix itself.
 
-To setup using nix flakes, you will first have to install [Nix multi-user](https://nixos.org/download/), if you haven't done so already:
+To setup using nix flakes, you will first have to install
+[Nix multi-user](https://nixos.org/download/), if you haven't done so already:
 
-```
+```bash
 sh <(curl -L https://nixos.org/nix/install) --daemon
 ```
 
-You can now trigger `nix develop` from the root of the repository and use the development shell. You will have to [enable flakes](https://wiki.nixos.org/wiki/Flakes) if you stop here. However, we recommend installing direnv, to enable nix development shell drop-in as soon as you cd into the repo. This should be available with your favorite package manager, e.g.
-```
+You can now trigger `nix develop` from the root of the repository and use the
+development shell. You will have to
+[enable flakes](https://wiki.nixos.org/wiki/Flakes) if you stop here. However,
+we recommend installing direnv, to enable nix development shell drop-in as soon
+as you cd into the repo. This should be available with your favorite package
+manager, e.g.
+
+```bash
 sudo apt-get install direnv
 ```
+
 You will also have to add a direnv hook to your shell config, e.g. `~/.bashrc`
-```
+
+```bash
 eval "$(direnv hook bash)"
 ```
+
 Refer to `direnv` install instructions for more help:
-* [Installation](https://direnv.net/docs/installation.html)
-* [Hook](https://direnv.net/docs/hook.html)
 
-Once you have both nix and direnv installed, you will have to `direnv allow` in the repo root as a one-time step to allow direnv to trigger `nix develop` for you.
+- [Installation](https://direnv.net/docs/installation.html)
+- [Hook](https://direnv.net/docs/hook.html)
 
-At this experimental stage of Nix support, you will have to run `scripts/install_prerequisites.sh` as a one-time step as well. Keep in mind that the script will install prerequisites in `/usr/local/`, i.e. the nix development environment is currently leaky. This should be fixed in the future.
+Once you have both nix and direnv installed, you will have to `direnv allow` in
+the repo root as a one-time step to allow direnv to trigger `nix develop` for
+you.
 
-If everything above was installed and configured correctly, use `scripts/build_cudaq.sh` to run your first build, and you can simply run `ninja` in the `build` directory for any future builds.
+At this experimental stage of Nix support, you will have to run
+`scripts/install_prerequisites.sh` as a one-time step as well. Keep in mind that
+the script will install prerequisites in `/usr/local/`, i.e. the nix development
+environment is currently leaky. This should be fixed in the future.
+
+If everything above was installed and configured correctly, use
+`scripts/build_cudaq.sh` to run your first build, and you can simply run `ninja`
+in the `build` directory for any future builds.
 
 ## Working inside the provided development container (recommended)
 
@@ -38,8 +61,8 @@ controlled environment that does not depend on, or interfere with, other
 software that is installed on your system. We recommend you work within it. To
 do so, please follow the instructions for enabling Docker on your respective
 operating system, and then proceed to set up your IDE following the
-recommendations for [developing with VS Code and
-Docker](#developing-with-vs-code-and-docker).
+recommendations for
+[developing with VS Code and Docker](#developing-with-vs-code-and-docker).
 
 ### Enabling Docker on Mac and Linux
 
@@ -55,26 +78,23 @@ consistent experience across all platforms.
 
 ### Enabling Docker on Windows
 
-If you are working with a Windows machine, please enable the [Windows Subsystem
-for Linux][wsl] by running the command `wsl --install`. The subsystem gives you
-an easy way to work with Docker containers, as well as to develop and test code
-locally for a variety of Linux distributions.
+If you are working with a Windows machine, please enable the
+[Windows Subsystem for Linux][wsl] by running the command `wsl --install`. The
+subsystem gives you an easy way to work with Docker containers, as well as to
+develop and test code locally for a variety of Linux distributions.
 
 Please install [Docker Desktop][docker_desktop_install] on Windows to manage
 your containers. It is not necessary to log into an account if you don't want to
 create one. Make sure to select "Use WSL 2 instead of Hyper-V" during
 installation.
 
-[wsl]: https://learn.microsoft.com/en-us/windows/wsl/install
-[docker_desktop_install]: https://docs.docker.com/get-docker
-
 ### Developing with VS Code and Docker
 
 [VS Code][vs_code] is a robust cross-platform IDE that integrates well with
 Docker through the use of an extension. Extensions let you add languages and
 others tools to support specialized development workflows. To work with our
-development container please install the [Development Containers
-extension][dev_container_extension].
+development container please install the
+[Development Containers extension][dev_container_extension].
 
 Create a local clone of your fork of the CUDA-Q repository, navigate to that
 folder, and open VS Code by executing the command `code .`. You should now get a
@@ -86,52 +106,43 @@ to build CUDA-Q:
 - On Windows: Select the option `Clone Repository in Container Volume` for the
   best performance. You can also select `Open Folder in Container`, which will
   ensure that changes you made inside the container environment are visible also
-  outside the container volume. For more information, see also [this
-  guide][clone_in_container].
+  outside the container volume. For more information, see also
+  [this guide][clone_in_container].
 
 After you have selected the above option to launch the container, the VS Code
 window will reload and you should see a green box in the lower left corner that
 states `Development Container: cudaq-dev`.
 
-The container also defines which extensions will be [loaded
-automatically](.devcontainer/devcontainer.json) when launching it. This does not
-impact your VS Code configuration outside the container environment.
+The container also defines which extensions will be
+[loaded automatically](.devcontainer/devcontainer.json) when launching it. This
+does not impact your VS Code configuration outside the container environment.
 
 You should now be all set to build CUDA-Q and run tests. Please open a terminal
 in VS Code and follow the instructions [here](./Building.md) to confirm that
 everything works as expected.
 
-[vs_code]: https://code.visualstudio.com/download
-[dev_container_extension]:
-    https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
-
-[clone_in_container]:
-    https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume
-
 ### Language server support for LLVM and MLIR dialects in VS Code
 
 The development container in this repository is configured with extensions to
-facilitate working with MLIR and LLVM files. The [MLIR
-extension][mlir_extension] requires a language server to work properly. The
-`cudaq-lsp-server` tool in this repository extends the [MLIR Language
-Server](https://mlir.llvm.org/docs/Tools/MLIRLSP/) to add support for CUDA-Q
-specific dialects. It recognizes files with extensions `.mlir` and `.qke`.
+facilitate working with MLIR and LLVM files. The
+[MLIR extension][mlir_extension] requires a language server to work properly.
+The `cudaq-lsp-server` tool in this repository extends the
+[MLIR Language Server](https://mlir.llvm.org/docs/Tools/MLIRLSP/) to add support
+for CUDA-Q specific dialects. It recognizes files with extensions `.mlir` and
+`.qke`.
 
-The `cudaq-lsp-server` is built when running the [CUDA-Q build
-script](./scripts/build_cudaq.sh) as described in [Building CUDA-Q from
-Source](./Building.md). If you customize the installation location, you will
-need to either add that location to your path, or edit the value of
-`mlir.server_path` in your workspace settings for the extension to work
+The `cudaq-lsp-server` is built when running the
+[CUDA-Q build script](./scripts/build_cudaq.sh) as described in
+[Building CUDA-Q from Source](./Building.md). If you customize the installation
+location, you will need to either add that location to your path, or edit the
+value of `mlir.server_path` in your workspace settings for the extension to work
 properly.
-
-[mlir_extension]:
-    https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-mlir
 
 ## Working in your own environment
 
 If you have followed the instructions for working inside the provided
-development container (recommended) you are all set and can proceed to [Getting
-Started with Developing CUDA-Q](./Building.md).
+development container (recommended) you are all set and can proceed to
+[Getting Started with Developing CUDA-Q](./Building.md).
 
 If you do not leverage the container definition provided in this repository, you
 will need to manually install all prerequisites for building the code on this
@@ -144,5 +155,10 @@ used for the build. For development purposes, components/certain prerequisites
 can be omitted as needed, and additional tools and flags for debugging purposes
 may be beneficial.
 
-[data_center_install]:
-    https://nvidia.github.io/cuda-quantum/latest/using/install/data_center_install.html
+[clone_in_container]: https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume
+[data_center_install]: https://nvidia.github.io/cuda-quantum/latest/using/install/data_center_install.html
+[dev_container_extension]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+[docker_desktop_install]: https://docs.docker.com/get-docker
+[mlir_extension]: https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-mlir
+[vs_code]: https://code.visualstudio.com/download
+[wsl]: https://learn.microsoft.com/en-us/windows/wsl/install

--- a/docker/build/cudaq.dev.Dockerfile
+++ b/docker/build/cudaq.dev.Dockerfile
@@ -10,9 +10,9 @@
 # Build from the repo root with
 #   docker build -t nvidia/cuda-quantum-dev:latest -f docker/build/cudaq.dev.Dockerfile .
 #
-# If a custom base image is used, then that image (i.e. the build environment) must 
+# If a custom base image is used, then that image (i.e. the build environment) must
 # 1) have all the necessary build dependendencies installed
-# 2) define the LLVM_INSTALL_PREFIX environment variable indicating where the 
+# 2) define the LLVM_INSTALL_PREFIX environment variable indicating where the
 #    the LLVM binaries that CUDA-Q depends on are installed
 # 3) set the CC and CXX environment variable to use the same compiler toolchain
 #    as the LLVM dependencies have been built with.
@@ -41,8 +41,13 @@ RUN if [ -n "$mpi" ]; \
 		fi \
     fi
 
+# Install pre-commit
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+&& python3 -m pip install --no-cache-dir pre-commit==4.1.0 \
+&& apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Configuring a base image that contains the necessary dependencies for GPU
-# accelerated components and passing a build argument 
+# accelerated components and passing a build argument
 #   install="CMAKE_BUILD_TYPE=Release CUDA_QUANTUM_VERSION=latest"
 # creates a dev image that can be used as argument to docker/release/cudaq.Dockerfile
 # to create the released cuda-quantum image.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-cmake": {
+      "locked": {
+        "lastModified": 1698547137,
+        "narHash": "sha256-C/6I3+Ybzlbad7XGZzeEtAE3tziONtjPCBWfVF0Pe14=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c9eb8d14da4455de9f05ce9429324e5b1b2bc638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c9eb8d14da4455de9f05ce9429324e5b1b2bc638",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-cmake": "nixpkgs-cmake"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,126 @@
+{
+  description = "CUDA Quantum development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-cmake.url = "github:NixOS/nixpkgs?rev=c9eb8d14da4455de9f05ce9429324e5b1b2bc638";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-cmake, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+            cudaSupport = true;
+          };
+        };
+        pkgs-cmake = import nixpkgs-cmake {
+          inherit system;
+        };
+        cmake_3_26 = pkgs-cmake.cmake;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            # CUDA Toolkit (required for GPU acceleration)
+            cudaPackages.cuda_cudart
+            cudaPackages.cuda_nvrtc
+            cudaPackages.cuda_nvcc
+            cudaPackages.libcusolver
+            cudaPackages.libcublas
+            cudaPackages.libnvjitlink
+
+            # CUDA-aware MPI
+            openmpi
+
+            # Core build tools
+            cmake_3_26
+            ninja
+            gcc11
+            gfortran11
+
+            # Python dependencies
+            python3
+            python3Packages.pip
+            python3Packages.pybind11
+            python3Packages.numpy
+            python3Packages.pytest
+            python3Packages.setuptools
+            python3Packages.wheel
+            python3Packages.fastapi
+            python3Packages.uvicorn
+            python3Packages.llvmlite
+
+            # Build tools
+            git
+            gnupg
+            wget
+            gnumake
+            automake
+            libtool
+            unzip
+            gtest
+            autoconf
+
+            # Dev tools
+            pre-commit
+
+            # Prerequisites
+            pkgsStatic.openblas
+            ncurses
+            libz.dev
+          ];
+
+          shellHook = ''
+            # CUDA setup
+            export CUDA_PATH="${pkgs.cudaPackages.cuda_cudart}"
+            export CUDA_HOME="${pkgs.cudaPackages.cuda_nvcc}"
+
+            # MPI setup
+            export MPI_PATH="${pkgs.openmpi}"
+            export OMPI_MCA_opal_warn_on_missing_libcuda=0
+
+            # Prerequisites - nix-managed
+            export BLAS_INSTALL_PREFIX="${pkgs.pkgsStatic.openblas}"
+
+            # Prerequisites - unmanaged
+            export ZLIB_INSTALL_PREFIX=/usr/local/zlib
+            export LLVM_INSTALL_PREFIX=/usr/local/llvm
+            export OPENSSL_INSTALL_PREFIX=/usr/local/openssl
+            export CURL_INSTALL_PREFIX=/usr/local/curl
+            export AWS_INSTALL_PREFIX=/usr/local/aws
+            export CUDAQ_INSTALL_PREFIX=/usr/local/cudaq
+            export CUQUANTUM_INSTALL_PREFIX=/usr/local/cuquantum
+            export CUTENSOR_INSTALL_PREFIX=/usr/local/cutensor
+
+            # Python setup
+            export PYTHONPATH="${pkgs.python3Packages.pybind11}/${pkgs.python3.sitePackages}:$PYTHONPATH"
+
+            # Compiler setup
+            export CC="${pkgs.gcc11}/bin/gcc"
+            export CXX="${pkgs.gcc11}/bin/g++"
+            export FC="${pkgs.gfortran11}/bin/gfortran"
+
+            # LLVM setup
+            export PATH="$PATH:$LLVM_INSTALL_PREFIX/bin/"
+
+            echo "CUDA Quantum development environment loaded"
+            echo "CUDA available at: $CUDA_PATH"
+            echo "MPI available at: $MPI_PATH"
+          '';
+
+          # Required for CUDA development
+          LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
+            cudaPackages.cuda_cudart
+            cudaPackages.cuda_nvrtc
+            cudaPackages.libcusolver
+            cudaPackages.libcublas
+            cudaPackages.libnvjitlink
+            openmpi
+          ];
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -47,46 +47,26 @@
             ninja
             gcc11
             gfortran11
+            gtest
 
-            # Python dependencies
-            python3
-            python3Packages.pip
-            python3Packages.pybind11
-            python3Packages.numpy
-            python3Packages.pytest
-            python3Packages.setuptools
-            python3Packages.wheel
-            python3Packages.fastapi
-            python3Packages.uvicorn
-            python3Packages.llvmlite
-
-            # Build tools
+            # Utils
             git
             gnupg
-            wget
-            gnumake
-            automake
-            libtool
-            unzip
-            gtest
-            autoconf
 
             # Dev tools
             pre-commit
 
             # Prerequisites
             pkgsStatic.openblas
-            ncurses
-            libz.dev
+            ncurses # TermInfo
           ];
 
           shellHook = ''
             # CUDA setup
-            export CUDA_PATH="${symlinkedCuda}"
             export CUDA_HOME="${symlinkedCuda}"
-            export CUDAToolkit_TARGET_DIR="${symlinkedCuda}"
 
             # Prerequisites - nix-managed
+            # TODO (nvidia-dobri): Move more deps from unmanaged to managed
             export BLAS_INSTALL_PREFIX="${pkgs.pkgsStatic.openblas}"
 
             # Prerequisites - unmanaged
@@ -95,13 +75,15 @@
             export OPENSSL_INSTALL_PREFIX=/usr/local/openssl
             export CURL_INSTALL_PREFIX=/usr/local/curl
             export AWS_INSTALL_PREFIX=/usr/local/aws
-            export CUDAQ_INSTALL_PREFIX=/usr/local/cudaq
             export CUQUANTUM_INSTALL_PREFIX=/usr/local/cuquantum
             export CUTENSOR_INSTALL_PREFIX=/usr/local/cutensor
 
-            # Python setup
+            # Install location
+            export CUDAQ_INSTALL_PREFIX=/usr/local/cudaq
+
+            # Python setup - unsupported
+            # TODO (nvidia-dobri): Figure out why fixup-linkage is not being built
             export CUDAQ_PYTHON_SUPPORT="FALSE"
-            export PYTHONPATH="${pkgs.python3Packages.pybind11}/${pkgs.python3.sitePackages}:$PYTHONPATH"
 
             # Compiler setup
             export CC="${pkgs.gcc11}/bin/gcc"

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
             cudaPackages.cuda_cudart
             cudaPackages.cuda_cccl
             cudaPackages.libcublas
+            cudaPackages.libcusolver
 
             # Core build tools
             cmake_3_26
@@ -99,6 +100,7 @@
             export CUTENSOR_INSTALL_PREFIX=/usr/local/cutensor
 
             # Python setup
+            export CUDAQ_PYTHON_SUPPORT="FALSE"
             export PYTHONPATH="${pkgs.python3Packages.pybind11}/${pkgs.python3.sitePackages}:$PYTHONPATH"
 
             # Compiler setup

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,11 @@
             # LLVM setup
             export PATH="$PATH:$LLVM_INSTALL_PREFIX/bin/"
           '';
+
+          LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
+            cudaPackages.libcusolver
+            cudaPackages.libcublas
+          ];
         };
       });
 }


### PR DESCRIPTION
This PR adds a Nix Flake dev environment to the repository, allowing devs to use it instead of managing dependencies manually or using a dev container.

## Why not dev containers?
Dev Containers are perfectly usable. This is a parallel dev environment that provides different pros and cons. Dev containers require a docker runtime and are ephemeral, making it harder to manage e.g. VS Code plugins. I want the simplicity of dev containers, while using my WSL Linux directly.

## Why not manage deps yourself?
Because every developer needs to do that independently, on different systems, in different ways. Before using nix, I never managed to get CUDA-Q to build on a linux host without using dev containers.

## The ideal dev path
I am a user with a brand new Linux box. Nothing is installed, except git. Here's my path to a full CUDA-Q build:
```bash
# Install nix & direnv
sh <(curl -L https://nixos.org/nix/install) --daemon
sudo apt-get install direnv
echo 'eval "$(direnv hook bash)"' >> ~/.bashrc

# Pull repo
git clone git@github.com:NVIDIA/cuda-quantum.git

# Allow the dev environment
cd cuda-quantum
direnv allow

# Install prereq (for now)
bash scripts/install_prerequisites.sh

# Build it!
bash scripts/build_cudaq.sh
```

## Why Nix?
[Nix](https://nixos.org/) is a declarative, ~fully~ mostly hermetic build system. Its main goal is reproducibility, independent of the host machine. Every package and dependency is built from source and linking is managed by Nix, where possible. In an ideal nix-managed environment, the host system configuration and state is irrelevant.

## Why flakes?
Turns out nix is only mostly reproducible. [Flakes](https://nixos.wiki/wiki/Flakes) increase reproducibility by pinning all dependencies in a lock file. This also has a side effect of improving incremental build times. Overall, it makes the environment setup faster and more reliable

## Why pre-commit?
Because we have more important things to do than breaking up files at 80 characters and manually calling clang-format.

## Caveats
This is a minimally-viable dev environment using Nix flakes. It still requires the user to run `install_prerequisites.sh` before being able to build with `build_cudaq.sh`. Since the script installs things on the host outside of the nix store, it is impure and cannot be ran by the flake itself. Additionally, Python is currently unsupported due to some issues with `fixup-linkage` that are probably very fixable.

## Improvements
We should be able to make the `install_prerequisites.sh` script unnecessary when using Nix. That would also imply a fully hermetic and pure dependency build, which would be cool for reproducibility reasons. When we get to that point, we can leverage the [nix build system](https://nix.dev/manual/nix/2.18/command-ref/nix-build) as well, since all the prerequisites will be in the nix store. 