### PR TITLE
Allow Return Value Optimization instead of forcing moves

### DIFF
--- a/runtime/cudaq/operators.h
+++ b/runtime/cudaq/operators.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <functional>
+#include <random>
 #include <set>
 #include <type_traits>
 #include <unordered_map>
@@ -17,7 +18,6 @@
 #include "operators/evaluation.h"
 #include "operators/operator_leafs.h"
 #include "operators/templates.h"
-#include "utils/cudaq_utils.h"
 #include "utils/matrix.h"
 
 namespace cudaq {

--- a/runtime/cudaq/operators/boson_op.cpp
+++ b/runtime/cudaq/operators/boson_op.cpp
@@ -47,7 +47,7 @@ std::string boson_handler::op_code_to_string() const {
     str += "Ad";
   for (auto i = 0; i > this->additional_terms; --i)
     str += "A";
-  return std::move(str);
+  return str;
 }
 
 std::string boson_handler::op_code_to_string(
@@ -186,7 +186,7 @@ complex_matrix boson_handler::to_matrix(
         mat[{i, i}] *= (i + offset);
     }
   }
-  return std::move(mat);
+  return mat;
 }
 
 std::string boson_handler::to_string(bool include_degrees) const {

--- a/runtime/cudaq/operators/fermion_op.cpp
+++ b/runtime/cudaq/operators/fermion_op.cpp
@@ -160,7 +160,7 @@ complex_matrix fermion_handler::to_matrix(
     mat[{1, 0}] = 1.;
   if (this->op_code & 8)
     mat[{1, 1}] = 1.;
-  return std::move(mat);
+  return mat;
 }
 
 std::string fermion_handler::to_string(bool include_degrees) const {

--- a/runtime/cudaq/operators/product_op.cpp
+++ b/runtime/cudaq/operators/product_op.cpp
@@ -277,7 +277,7 @@ EvalTy product_op<HandlerTy>::evaluate(
       EvalTy eval = arithmetics.evaluate(this->operators[op_idx]);
       prod = arithmetics.tensor(std::move(prod), std::move(eval));
     }
-    return std::move(prod);
+    return prod;
   }
 }
 
@@ -378,7 +378,7 @@ std::string product_op<HandlerTy>::get_term_id() const {
   std::string term_id;
   for (const auto &op : this->operators)
     term_id += op.unique_id();
-  return std::move(term_id);
+  return term_id;
 }
 
 template <typename HandlerTy>
@@ -881,7 +881,7 @@ product_op<HandlerTy>::operator*(const product_op<HandlerTy> &other) const & {
                              this->operators.size() + other.operators.size());
   for (HandlerTy op : other.operators)
     prod.insert(std::move(op));
-  return std::move(prod);
+  return prod;
 }
 
 template <typename HandlerTy>
@@ -902,7 +902,7 @@ product_op<HandlerTy>::operator*(product_op<HandlerTy> &&other) const & {
                              this->operators.size() + other.operators.size());
   for (auto &&op : other.operators)
     prod.insert(std::move(op));
-  return std::move(prod);
+  return prod;
 }
 
 template <typename HandlerTy>
@@ -960,7 +960,7 @@ product_op<HandlerTy>::operator*(const sum_op<HandlerTy> &other) const {
         *this * product_op<HandlerTy>(other.coefficients[i], other.terms[i]);
     sum.insert(std::move(prod));
   }
-  return std::move(sum);
+  return sum;
 }
 
 #define PRODUCT_ADDITION_SUM(op)                                               \
@@ -977,7 +977,7 @@ product_op<HandlerTy>::operator*(const sum_op<HandlerTy> &other) const {
     for (auto &coeff : other.coefficients)                                     \
       sum.coefficients.push_back(op coeff);                                    \
     sum.insert(*this);                                                         \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -992,7 +992,7 @@ product_op<HandlerTy>::operator*(const sum_op<HandlerTy> &other) const {
     for (auto &coeff : other.coefficients)                                     \
       sum.coefficients.push_back(op coeff);                                    \
     sum.insert(std::move(*this));                                              \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
   template <typename HandlerTy>                                                \
   sum_op<HandlerTy> product_op<HandlerTy>::operator op(                        \
@@ -1001,7 +1001,7 @@ product_op<HandlerTy>::operator*(const sum_op<HandlerTy> &other) const {
       return *this;                                                            \
     sum_op<HandlerTy> sum(op std::move(other));                                \
     sum.insert(*this);                                                         \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -1011,7 +1011,7 @@ product_op<HandlerTy>::operator*(const sum_op<HandlerTy> &other) const {
       return *this;                                                            \
     sum_op<HandlerTy> sum(op std::move(other));                                \
     sum.insert(std::move(*this));                                              \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }
 
 PRODUCT_ADDITION_SUM(+)

--- a/runtime/cudaq/operators/sum_op.cpp
+++ b/runtime/cudaq/operators/sum_op.cpp
@@ -592,7 +592,7 @@ sum_op<HandlerTy> sum_op<HandlerTy>::operator-() const & {
   sum.terms = this->terms;
   for (auto &coeff : this->coefficients)
     sum.coefficients.push_back(-1. * coeff);
-  return std::move(sum);
+  return sum;
 }
 
 template <typename HandlerTy>
@@ -646,7 +646,7 @@ sum_op<HandlerTy>::operator*(const scalar_operator &other) const & {
   sum.terms = this->terms;
   for (const auto &coeff : this->coefficients)
     sum.coefficients.push_back(coeff * other);
-  return std::move(sum);
+  return sum;
 }
 
 template <typename HandlerTy>
@@ -671,7 +671,7 @@ sum_op<HandlerTy>::operator/(const scalar_operator &other) const & {
   sum.terms = this->terms;
   for (const auto &coeff : this->coefficients)
     sum.coefficients.push_back(coeff / other);
-  return std::move(sum);
+  return sum;
 }
 
 template <typename HandlerTy>
@@ -691,7 +691,7 @@ sum_op<HandlerTy>::operator/(const scalar_operator &other) && {
       const scalar_operator &other) const & {                                  \
     sum_op<HandlerTy> sum(*this, false, this->terms.size() + 1);               \
     sum.insert(product_op<HandlerTy>(op other));                               \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -699,7 +699,7 @@ sum_op<HandlerTy>::operator/(const scalar_operator &other) && {
       const & {                                                                \
     sum_op<HandlerTy> sum(*this, false, this->terms.size() + 1);               \
     sum.insert(product_op<HandlerTy>(op std::move(other)));                    \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -772,7 +772,7 @@ sum_op<HandlerTy>::operator*(const product_op<HandlerTy> &other) const {
       prod.insert(std::move(op));
     sum.insert(std::move(prod));
   }
-  return std::move(sum);
+  return sum;
 }
 
 #define SUM_ADDITION_PRODUCT(op)                                               \
@@ -782,7 +782,7 @@ sum_op<HandlerTy>::operator*(const product_op<HandlerTy> &other) const {
       const product_op<HandlerTy> &other) const & {                            \
     sum_op<HandlerTy> sum(*this, false, this->terms.size() + 1);               \
     sum.insert(op other);                                                      \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -798,7 +798,7 @@ sum_op<HandlerTy>::operator*(const product_op<HandlerTy> &other) const {
       product_op<HandlerTy> &&other) const & {                                 \
     sum_op<HandlerTy> sum(*this, false, this->terms.size() + 1);               \
     sum.insert(op std::move(other));                                           \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -835,7 +835,7 @@ sum_op<HandlerTy>::operator*(const sum_op<HandlerTy> &other) const {
       sum.insert(std::move(prod));
     }
   }
-  return std::move(sum);
+  return sum;
 }
 
 #define SUM_ADDITION_SUM(op)                                                   \
@@ -849,7 +849,7 @@ sum_op<HandlerTy>::operator*(const sum_op<HandlerTy> &other) const {
       product_op<HandlerTy> prod(op other.coefficients[i], other.terms[i]);    \
       sum.insert(std::move(prod));                                             \
     }                                                                          \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -877,7 +877,7 @@ sum_op<HandlerTy>::operator*(const sum_op<HandlerTy> &other) const {
                                  std::move(other.terms[i]));                   \
       sum.insert(std::move(prod));                                             \
     }                                                                          \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -1149,7 +1149,7 @@ sum_op<HandlerTy> operator*(const scalar_operator &other,
   sum.term_map = self.term_map;
   for (const auto &coeff : self.coefficients)
     sum.coefficients.push_back(coeff * other);
-  return std::move(sum);
+  return sum;
 }
 
 template <typename HandlerTy>
@@ -1173,7 +1173,7 @@ sum_op<HandlerTy> operator*(const scalar_operator &other,
     sum_op<HandlerTy> sum(op self);                                            \
     sum.is_default = false;                                                    \
     sum.insert(product_op<HandlerTy>(other));                                  \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -1184,7 +1184,7 @@ sum_op<HandlerTy> operator*(const scalar_operator &other,
     sum_op<HandlerTy> sum(op self);                                            \
     sum.is_default = false;                                                    \
     sum.insert(product_op<HandlerTy>(std::move(other)));                       \
-    return std::move(sum);                                                     \
+    return sum;                                                                \
   }                                                                            \
                                                                                \
   template <typename HandlerTy>                                                \
@@ -1552,7 +1552,7 @@ std::string sum_op<HandlerTy>::to_string() const {
   std::string str = it->to_string();
   while (++it != this->end())
     str += " + " + it->to_string();
-  return std::move(str);
+  return str;
 }
 
 template <typename HandlerTy>
@@ -1648,7 +1648,7 @@ sum_op<HandlerTy>::distribute_terms(std::size_t numChunks) const {
     // needs to be empty (is_default = false), since it should zero out any
     // multiplication
     chunks.push_back(sum_op<HandlerTy>(false));
-  return std::move(chunks);
+  return chunks;
 }
 
 #define INSTANTIATE_SUM_UTILITY_FUNCTIONS(HandlerTy)                           \
@@ -1817,7 +1817,7 @@ sum_op<HandlerTy> sum_op<HandlerTy>::random(std::size_t nQubits,
     }
     sum += std::move(prod);
   }
-  return std::move(sum);
+  return sum;
 }
 
 HANDLER_SPECIFIC_TEMPLATE_DEFINITION(spin_handler)

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "common/CustomOp.h"
+#include "common/MeasureCounts.h"
 #include "common/NoiseModel.h"
 #include "common/QuditIdTracker.h"
 #include "cudaq/host_config.h"


### PR DESCRIPTION
This PR changes some of the operator functions to not use `std::move` when it is preventing Return Value Optimization, as that causes additional unnecessary processing.