### PR TITLE
Dev Container psi-header extension: retain original copyright year

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -229,7 +229,7 @@
 					{
 						"language": "*",
 						"template": [
-							"Copyright (c) <<projectCreationYear>> - <<year>> <<copyrightholder>>.",
+							"Copyright (c) <<yeartoyear(fc!P,now)>> <<copyrightholder>>.",
 							"All rights reserved.",
 							"",
 							"This source code and the accompanying materials are made available under",


### PR DESCRIPTION
For those of us using VSCode dev containers, this makes the `psi-header` extension work with other projects that don't all have 2022 as a starting point. More specifically - with this change, the extension will attempt to retain the existing starting copyright year and update only the ending copyright year if it exists (rather than updating both the start copyright year and current copyright year).

Additionally, if the file is a new file, it will use "now" as the starting copyright year, which is more correct anyway.

Ref: https://github.com/davidquinn/psi-header

> A particularly useful case is yeartoyear(fc!P, now) to use file creation date for a new header, and then always keep the same from date no matter how the file migrates filesystems, version control systems, etc.
