### PR TITLE
Update mgpu sha and docs

### DIFF
--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: 966ff7b2f775128fa3339e19672892d8ff1a4e74
+nvidia-mgpu-commit: f06bd0227eb2965a47b6a1f9354e23385fc0892f

--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: f06bd0227eb2965a47b6a1f9354e23385fc0892f
+nvidia-mgpu-commit: 26080d1e82a4ce3bf42d9f662b9f31a2d7bdfa9f

--- a/docs/sphinx/using/backends/sims/svsims.rst
+++ b/docs/sphinx/using/backends/sims/svsims.rst
@@ -120,12 +120,24 @@ It is worth drawing attention to gate fusion, a powerful tool for improving simu
   * - ``CUDAQ_MAX_GPU_MEMORY_GB``
     - positive integer, or `NONE`
     - GPU memory (in GB) allowed for on-device state-vector allocation. As the state-vector size exceeds this limit, host memory will be utilized for migration. `NONE` means unlimited (up to physical memory constraints). This is the default.
-
+  * - ``CUDAQ_ALLOW_FP32_EMULATED``
+    - `TRUE` (`1`, `ON`) or `FALSE` (`0`, `OFF`)
+    - [Blackwell (compute capability 10.0+) only] Enable or disable floating point math emulation. If enabled, allows `FP32` emulation kernels using `BFloat16` (`BF16`) whenever possible. Enabled by default. 
 
 .. deprecated:: 0.8
     The :code:`nvidia-fp64` targets, which is equivalent setting the `fp64` option on the :code:`nvidia` target, 
     is deprecated and will be removed in a future release.
 
+.. note:: 
+
+    In host-device simulation, `CUDAQ_MAX_CPU_MEMORY_GB` is not 0, the backend automatically switching between inner product (default) and operator matrix-based 
+    methods for expectation calculations (`cudaq::observe`) depending on whether a clone of the state can be allocated or not. 
+
+    For example, when `CUDAQ_MAX_GPU_MEMORY_GB` is unconstrained, the quantum state vector would consume all device memory before utilizing host memory.
+    Thus, the backend would fall back to the operator matrix-based approach as cloning the state is not possible. 
+    For performance reason, only Pauli operator matrices of up to 8 qubits (identity padding not included) are allowed in this mode.
+    This constrain can be relaxed by setting the `CUDAQ_MATRIX_EXP_VAL_MAX_SIZE` environment variable. 
+    Users would need to take into account the full operator matrix size when increasing this setting.
 
 
 Multi-node multi-GPU 
@@ -246,6 +258,9 @@ the multi-node multi-GPU configuration. Any environment variables must be set pr
   * - ``CUDAQ_HOST_DEVICE_MIGRATION_LEVEL``
     - positive integer
     - Specify host-device memory migration w.r.t. the network structure. If provided, this setting determines the position to insert the number of migration index bits to the `CUDAQ_GLOBAL_INDEX_BITS` list. By default, if not set, the number of migration index bits (CPU-GPU data transfers) is appended to the end of the array of index bits (aka, state vector distribution scheme). This default behavior is optimized for systems with fast GPU-GPU interconnects (NVLink, InfiniBand, etc.) 
+  * - ``CUDAQ_DATA_TRANSFER_BUFFER_BITS``
+    - positive integer greater than or equal to 24
+    - Specify the temporary buffer size (:code:`1 << CUDAQ_DATA_TRANSFER_BUFFER_BITS` bytes) for inter-node data transfer. The default is set to 26 (64 MB). The minimum allowed value is 24 (16 MB). Depending on systems, setting a larger value to `CUDAQ_DATA_TRANSFER_BUFFER_BITS` can accelerate inter-node data transfers.
 
 .. deprecated:: 0.8
     The :code:`nvidia-mgpu` backend, which is equivalent to the multi-node multi-GPU double-precision option (`mgpu,fp64`) of the :code:`nvidia`


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->


- Add an option to change the mgpu backend transfer buffer size and the corresponding doc.

- Add the doc for the option to enable/disable math mode emulation (fp32).

- Fix a bug in multi-process random seed initialization (in 0.10) - https://github.com/NVIDIA/cuda-quantum/issues/2760

- Initial state vector allocation optimization.

- Handle certain cases (relatively sparse Pauli operators) in host-device simulation at high memory utilization: https://github.com/NVIDIA/cuda-quantum/issues/2749. Adding a note in the docs regarding this use case.   


