### PR TITLE
Use lld for builds if available

### DIFF
--- a/python/metadata.cmake
+++ b/python/metadata.cmake
@@ -15,7 +15,6 @@ if(NOT METADATA_FILE)
     message(FATAL_ERROR "METADATA_FILE is not defined")
 endif()
 
-message(STATUS "Creating metadata file in ${METADATA_FILE}.")
 if(CUDA_VERSION_MAJOR)
     file(WRITE ${METADATA_FILE} "cuda_major=${CUDA_VERSION_MAJOR}")
 else()

--- a/scripts/build_cudaq.sh
+++ b/scripts/build_cudaq.sh
@@ -133,7 +133,7 @@ if [ -x "$(command -v "$LLVM_INSTALL_PREFIX/bin/ld.lld")" ]; then
   echo "Configuring nvq++ and local build to use the lld linker by default."
   NVQPP_LD_PATH="$LLVM_INSTALL_PREFIX/bin/ld.lld"
   LINKER_TO_USE="lld"
-  LINKER_FLAGS="-fuse-ld=lld"
+  LINKER_FLAGS="-fuse-ld=lld -B$LLVM_INSTALL_PREFIX/bin"
 else
   echo "No lld linker detected. Using the system linker."
   LINKER_TO_USE="ld"

--- a/scripts/build_cudaq.sh
+++ b/scripts/build_cudaq.sh
@@ -130,8 +130,14 @@ fi
 
 # Determine linker and linker flags
 if [ -x "$(command -v "$LLVM_INSTALL_PREFIX/bin/ld.lld")" ]; then
-  echo "Configuring nvq++ to use the lld linker by default."
+  echo "Configuring nvq++ and local build to use the lld linker by default."
   NVQPP_LD_PATH="$LLVM_INSTALL_PREFIX/bin/ld.lld"
+  LINKER_TO_USE="lld"
+  LINKER_FLAGS="-fuse-ld=lld"
+else
+  echo "No lld linker detected. Using the system linker."
+  LINKER_TO_USE="ld"
+  LINKER_FLAGS=""
 fi
 
 # Determine CUDA flags
@@ -163,6 +169,9 @@ cmake_args="-G Ninja '"$repo_root"' \
   -DCMAKE_CUDA_COMPILER='"$cuda_driver"' \
   -DCMAKE_CUDA_FLAGS='"$CUDAFLAGS"' \
   -DCMAKE_CUDA_HOST_COMPILER='"${CUDAHOSTCXX:-$CXX}"' \
+  -DCMAKE_LINKER='"$LINKER_TO_USE"' \
+  -DCMAKE_EXE_LINKER_FLAGS='"$LINKER_FLAGS"' \
+  -DLLVM_USE_LINKER='"$LINKER_TO_USE"' \
   ${OpenMP_libomp_LIBRARY:+-DOpenMP_C_LIB_NAMES=lib$OpenMP_libomp_LIBRARY} \
   ${OpenMP_libomp_LIBRARY:+-DOpenMP_CXX_LIB_NAMES=lib$OpenMP_libomp_LIBRARY} \
   ${OpenMP_libomp_LIBRARY:+-DOpenMP_libomp_LIBRARY=$OpenMP_libomp_LIBRARY} \


### PR DESCRIPTION
Using lld instead of ld improves my link times when I make one small change and simply type `ninja` to rebuild. For example, some links would take ~10 seconds, and this improved it to ~2 seconds. This did not help _full-up_ builds in any significant way during my testing, but the improvement during the incremental builds still makes this worthwhile in my opinion.