### PR TITLE
Remove vectorized instructions from LLVM IR for `cudaq::to_integer()`

### DIFF
--- a/.github/workflows/config/spelling_allowlist.txt
+++ b/.github/workflows/config/spelling_allowlist.txt
@@ -351,6 +351,7 @@ variadic
 variational
 vazirani
 vdots
+vectorization
 verifier
 vertices
 vqe

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -38,6 +38,8 @@ header:
     - 'docs/sphinx/_templates'
     - 'docs/sphinx/_static/cuda_quantum_icon.svg'
     - 'docker/test/installer/mpi_cuda_check.cpp'
+    - 'include/cudaq/Optimizer/CodeGen/OptUtils.h'
+    - 'lib/Optimizer/CodeGen/OptUtils.cpp'
     - 'runtime/cudaq/algorithms/optimizers/nlopt/nlopt-src'
 
   comment: on-failure

--- a/include/cudaq/Optimizer/CodeGen/OptUtils.h
+++ b/include/cudaq/Optimizer/CodeGen/OptUtils.h
@@ -1,0 +1,39 @@
+//===- OptUtils.h - MLIR Execution Engine opt pass utilities ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the utility functions to trigger LLVM optimizations from
+// MLIR Execution Engine.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_EXECUTIONENGINE_OPTUTILS_H
+#define MLIR_EXECUTIONENGINE_OPTUTILS_H
+
+#include <functional>
+#include <string>
+
+namespace llvm {
+class Module;
+class Error;
+class TargetMachine;
+} // namespace llvm
+
+namespace mlir {
+
+/// Create a module transformer function for MLIR ExecutionEngine that runs
+/// LLVM IR passes corresponding to the given speed and size optimization
+/// levels (e.g. -O2 or -Os). If not null, `targetMachine` is used to
+/// initialize passes that provide target-specific information to the LLVM
+/// optimizer. `targetMachine` must outlive the returned std::function.
+std::function<llvm::Error(llvm::Module *)>
+makeOptimizingTransformer(unsigned optLevel, unsigned sizeLevel,
+                          llvm::TargetMachine *targetMachine);
+
+} // namespace mlir
+
+#endif // MLIR_EXECUTIONENGINE_OPTUTILS_H

--- a/include/cudaq/Optimizer/CodeGen/OptUtils.h
+++ b/include/cudaq/Optimizer/CodeGen/OptUtils.h
@@ -6,16 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// Additional modifications by NVIDIA Corporation.
+// - Use cudaq namespace instead of mlir namespace.
+// - Add an allowVectorization parameter to makeOptimizingTransformer.
+//
+//===----------------------------------------------------------------------===//
+//
 // This file declares the utility functions to trigger LLVM optimizations from
 // MLIR Execution Engine.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_EXECUTIONENGINE_OPTUTILS_H
-#define MLIR_EXECUTIONENGINE_OPTUTILS_H
+#pragma once
 
 #include <functional>
-#include <string>
 
 namespace llvm {
 class Module;
@@ -23,17 +27,17 @@ class Error;
 class TargetMachine;
 } // namespace llvm
 
-namespace mlir {
+namespace cudaq {
 
 /// Create a module transformer function for MLIR ExecutionEngine that runs
 /// LLVM IR passes corresponding to the given speed and size optimization
 /// levels (e.g. -O2 or -Os). If not null, `targetMachine` is used to
 /// initialize passes that provide target-specific information to the LLVM
 /// optimizer. `targetMachine` must outlive the returned std::function.
+/// Note: this is a modified version of mlir::makeOptimizingTransformer that
+/// disables vectorization by default.
 std::function<llvm::Error(llvm::Module *)>
 makeOptimizingTransformer(unsigned optLevel, unsigned sizeLevel,
-                          llvm::TargetMachine *targetMachine);
-
-} // namespace mlir
-
-#endif // MLIR_EXECUTIONENGINE_OPTUTILS_H
+                          llvm::TargetMachine *targetMachine,
+                          bool allowVectorization = false);
+} // namespace cudaq

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -252,21 +252,21 @@ static Value toIntegerImpl(OpBuilder &builder, Location loc, Value bitVec) {
 
   // get bitVec size
   Value bitVecSize = builder.create<cudaq::cc::StdvecSizeOp>(
-      loc, builder.getI32Type(), bitVec);
+      loc, builder.getI64Type(), bitVec);
 
   // Useful types and values
-  auto i32Ty = builder.getI32Type();
-  Value one = builder.create<arith::ConstantIntOp>(loc, 1, i32Ty);
-  Value negOne = builder.create<arith::ConstantIntOp>(loc, -1, i32Ty);
+  auto i64Ty = builder.getI64Type();
+  Value one = builder.create<arith::ConstantIntOp>(loc, 1, i64Ty);
+  Value negOne = builder.create<arith::ConstantIntOp>(loc, -1, i64Ty);
 
   // Create int i = 0;
-  Value stackSlot = builder.create<cudaq::cc::AllocaOp>(loc, i32Ty);
-  Value zeroInt = builder.create<arith::ConstantIntOp>(loc, 0, i32Ty);
+  Value stackSlot = builder.create<cudaq::cc::AllocaOp>(loc, i64Ty);
+  Value zeroInt = builder.create<arith::ConstantIntOp>(loc, 0, i64Ty);
   builder.create<cudaq::cc::StoreOp>(loc, zeroInt, stackSlot);
 
   // Create the for loop
   Value rank = builder.create<cudaq::cc::CastOp>(
-      loc, builder.getI32Type(), bitVecSize, cudaq::cc::CastOpMode::Unsigned);
+      loc, builder.getI64Type(), bitVecSize, cudaq::cc::CastOpMode::Unsigned);
   cudaq::opt::factory::createInvariantLoop(
       builder, loc, rank,
       [&](OpBuilder &nestedBuilder, Location nestedLoc, Region &,
@@ -295,7 +295,7 @@ static Value toIntegerImpl(OpBuilder &builder, Location loc, Value bitVec) {
 
         // -bits[k]
         bitElement = builder.create<cudaq::cc::CastOp>(
-            loc, builder.getI32Type(), bitElement,
+            loc, builder.getI64Type(), bitElement,
             cudaq::cc::CastOpMode::Unsigned);
         bitElement = builder.create<arith::MulIOp>(loc, negOne, bitElement);
 

--- a/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -20,6 +20,7 @@ add_cudaq_library(OptCodeGen
   ConvertToQIRProfile.cpp
   ConvertToQIR.cpp
   ConvertToQIRAPI.cpp
+  OptUtils.cpp
   Passes.cpp
   Pipelines.cpp
   QuakeToCodegen.cpp

--- a/lib/Optimizer/CodeGen/OptUtils.cpp
+++ b/lib/Optimizer/CodeGen/OptUtils.cpp
@@ -1,0 +1,95 @@
+//===- OptUtils.cpp - MLIR Execution Engine optimization pass utilities ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the utility functions to trigger LLVM optimizations from
+// MLIR Execution Engine.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/ExecutionEngine/OptUtils.h"
+
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Passes/OptimizationLevel.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Target/TargetMachine.h"
+#include <optional>
+
+using namespace llvm;
+
+static std::optional<OptimizationLevel> mapToLevel(unsigned optLevel,
+                                                   unsigned sizeLevel) {
+  switch (optLevel) {
+  case 0:
+    return OptimizationLevel::O0;
+
+  case 1:
+    return OptimizationLevel::O1;
+
+  case 2:
+    switch (sizeLevel) {
+    case 0:
+      return OptimizationLevel::O2;
+
+    case 1:
+      return OptimizationLevel::Os;
+
+    case 2:
+      return OptimizationLevel::Oz;
+    }
+    break;
+  case 3:
+    return OptimizationLevel::O3;
+  }
+  return std::nullopt;
+}
+// Create and return a lambda that uses LLVM pass manager builder to set up
+// optimizations based on the given level.
+std::function<Error(Module *)>
+mlir::makeOptimizingTransformer(unsigned optLevel, unsigned sizeLevel,
+                                TargetMachine *targetMachine) {
+  return [optLevel, sizeLevel, targetMachine](Module *m) -> Error {
+    std::optional<OptimizationLevel> ol = mapToLevel(optLevel, sizeLevel);
+    if (!ol) {
+      return make_error<StringError>(
+          formatv("invalid optimization/size level {0}/{1}", optLevel,
+                  sizeLevel)
+              .str(),
+          inconvertibleErrorCode());
+    }
+    LoopAnalysisManager lam;
+    FunctionAnalysisManager fam;
+    CGSCCAnalysisManager cgam;
+    ModuleAnalysisManager mam;
+
+    PipelineTuningOptions tuningOptions;
+    tuningOptions.LoopUnrolling = true;
+    tuningOptions.LoopInterleaving = true;
+    tuningOptions.LoopVectorization = true;
+    tuningOptions.SLPVectorization = true;
+
+    PassBuilder pb(targetMachine, tuningOptions);
+
+    pb.registerModuleAnalyses(mam);
+    pb.registerCGSCCAnalyses(cgam);
+    pb.registerFunctionAnalyses(fam);
+    pb.registerLoopAnalyses(lam);
+    pb.crossRegisterProxies(lam, fam, cgam, mam);
+
+    ModulePassManager mpm;
+    if (*ol == OptimizationLevel::O0)
+      mpm.addPass(pb.buildO0DefaultPipeline(*ol));
+    else
+      mpm.addPass(pb.buildPerModuleDefaultPipeline(*ol));
+
+    mpm.run(*m, mam);
+    return Error::success();
+  };
+}

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -15,6 +15,7 @@
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/CAPI/Dialects.h"
 #include "cudaq/Optimizer/CodeGen/OpenQASMEmitter.h"
+#include "cudaq/Optimizer/CodeGen/OptUtils.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/CodeGen/Pipelines.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
@@ -651,7 +652,7 @@ std::string getQIR(const std::string &name, MlirModule module,
   llvm::LLVMContext llvmContext;
   llvmContext.setOpaquePointers(false);
   auto llvmModule = translateModuleToLLVMIR(cloned, llvmContext);
-  auto optPipeline = makeOptimizingTransformer(
+  auto optPipeline = cudaq::makeOptimizingTransformer(
       /*optLevel=*/3, /*sizeLevel=*/0,
       /*targetMachine=*/nullptr);
   if (auto err = optPipeline(llvmModule.get()))

--- a/runtime/common/RuntimeMLIRCommonImpl.h
+++ b/runtime/common/RuntimeMLIRCommonImpl.h
@@ -15,6 +15,7 @@
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/CodeGen/IQMJsonEmitter.h"
 #include "cudaq/Optimizer/CodeGen/OpenQASMEmitter.h"
+#include "cudaq/Optimizer/CodeGen/OptUtils.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/CodeGen/Pipelines.h"
 #include "cudaq/Optimizer/CodeGen/QIRAttributeNames.h"
@@ -75,7 +76,7 @@ bool setupTargetTriple(llvm::Module *llvmModule) {
 }
 
 void optimizeLLVM(llvm::Module *module) {
-  auto optPipeline = mlir::makeOptimizingTransformer(
+  auto optPipeline = cudaq::makeOptimizingTransformer(
       /*optLevel=*/3, /*sizeLevel=*/0,
       /*targetMachine=*/nullptr);
   if (auto err = optPipeline(module))

--- a/targettests/execution/to_integer.cpp
+++ b/targettests/execution/to_integer.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 // RUN: nvq++ %cpp_std %s -o %t && %t
+// TODO-FIX-KERNEL-EXEC
 // BROKEN: nvq++ %cpp_std -fkernel-exec-kind=2 %s -o %t && %t
 
 #include <cstdio>

--- a/test/AST-Quake/to_integer.cpp
+++ b/test/AST-Quake/to_integer.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// RUN: cudaq-quake %s | cudaq-opt | cudaq-translate --convert-to=qir | FileCheck %s
+// clang-format on
+
+#include <cudaq.h>
+#include "cudaq/qis/qubit_qis.h"
+
+void external_call_to_keep_result(std::int64_t results_int) {}
+
+struct kernel {
+  void operator()() __qpu__ {
+    cudaq::qvector q(16);
+    int64_t results_int = cudaq::to_integer(mz(q));
+    external_call_to_keep_result(results_int);
+  }
+};
+
+// clang-format off
+// CHECK-LABEL: define void @__nvqpp__mlirgen__kernel()
+// CHECK-NOT: llvm.vector
+

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -8,6 +8,7 @@
 
 #include "cudaq/Optimizer/CodeGen/IQMJsonEmitter.h"
 #include "cudaq/Optimizer/CodeGen/OpenQASMEmitter.h"
+#include "cudaq/Optimizer/CodeGen/OptUtils.h"
 #include "cudaq/Optimizer/CodeGen/Pipelines.h"
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
@@ -24,7 +25,6 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/ExecutionEngine/ExecutionEngine.h"
-#include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Parser/Parser.h"
@@ -207,8 +207,9 @@ int main(int argc, char **argv) {
   ExecutionEngine::setupTargetTriple(llvmModule.get());
 
   // Optionally run an optimization pipeline over the llvm module.
-  auto optPipeline = makeOptimizingTransformer(optLevel, sizeLevel,
-                                               /*targetMachine=*/nullptr);
+  auto optPipeline =
+      cudaq::makeOptimizingTransformer(optLevel, sizeLevel,
+                                       /*targetMachine=*/nullptr);
   if (auto err = optPipeline(llvmModule.get())) {
     llvm::errs() << "Failed to optimize LLVM IR " << err << '\n';
     std::exit(1);


### PR DESCRIPTION
This brings in MLIR's `makeOptimizingTransformer` function under our control since the one built-in to MLIR does not allow us to disable vectorization. The reason this change is important is because no QIR-based targets support LLVM's vectorized intrinsics. Maybe they will in the future, but I haven't heard of that being on anybody's near-term roadmap, so it would be best to disable that for now.

For review purposes, see 592d632f02aa004ea67c47549e163f10d3f95ca3 for the custom changes to the MLIR `makeOptimizingTransformer` function. (612d198bbda8d093c6f583a5f71b49c0c2df0ce5 is just bringing the original files into our source tree.)