### PR TITLE
Add utility to skip tests based on host architecture

### DIFF
--- a/python/tests/utils/arch.py
+++ b/python/tests/utils/arch.py
@@ -1,0 +1,25 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+
+import platform
+import pytest
+
+def skip_if_not_arch(required_arch):
+    """
+    Skips the test if the current architecture does not match the required architecture.
+    """
+    if platform.machine() != required_arch:
+        pytest.skip(f"Test requires architecture: {required_arch}")
+
+def skip_if_not_arch_in(allowed_archs):
+    """
+    Skips the test if the current architecture is not in the list of allowed architectures.
+    """
+    if platform.machine() not in allowed_archs:
+        pytest.skip(f"Test requires one of: {allowed_archs}")


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [X] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
Fixes #2276 

This PR introduces a utility module (python/tests/utils/arch.py) that allows tests to be conditionally skipped based on the host architecture (e.g., x86_64, aarch64). This addresses the need for a portable, maintainable way to prevent platform-specific test failures.

This change does not alter any test behavior by default, but provides a clear and reusable mechanism for future architecture-specific test requirements.