### PR TITLE
Fix intermittent bug with ObserveAnsatzPass

### DIFF
--- a/lib/Optimizer/Transforms/ObserveAnsatz.cpp
+++ b/lib/Optimizer/Transforms/ObserveAnsatz.cpp
@@ -257,11 +257,9 @@ struct AppendMeasurements : public OpRewritePattern<func::FuncOp> {
 
       for (auto result : op->getResults())
         if (quake::isLinearType(result.getType()))
-          result.replaceAllUsesWith(op->getOperand(0));
+          rewriter.replaceAllUsesWith(result, op->getOperand(0));
 
-      // Force remove `op`.
-      op->dropAllReferences();
-      op->erase();
+      rewriter.eraseOp(op);
     }
 
     // We want to insert after the last quantum operation. We must perform this


### PR DESCRIPTION
### Summary

I was able to reproduce the intermittent crash that was occurring in some of our CI runs on an internal machine. On the internal machine, the failure was occurring about 8-10 times out of 200 attempts (when running `cudaq_observe_term.cpp` w/ OQC target). With this PR applied, the failure occurs 0 out 200 times.

### Details

After reproducing the problem on the internal machine, I wanted to get a good stack trace of the segfault, so I rebuilt CUDA-Q with `Debug`. Unfortunately, the problem disappeared. So I rebuilt with `RelWithDebInfo` and saw that the segfault was occurring in the ObserveAnsatz pass, but it wasn't clear precisely where because LLVM was deep inside the (non-debug) LLVM code inside that pass.

I scanned the code and the recent changes, and I discovered that if I commented out a change in #2288 (`op->dropAllReferences();`), then the segfault disappeared. However, despite the new `dropAllReferences` code coinciding with the segfaults, it's not clear that calling `dropAllReferences` *should've* been causing any segfaults.

Since this code is in `matchAndRewrite`, I figured it would be better to use the `rewriter` to manipulate these ops rather than calling `op->dropAllReferences()` and `op->erase()` inside the function. My understanding is that the rewriter will handle any and all references and clean them up when done, and it will do so safely. @schweitzpgi to confirm.

The following issues are related, so I'm tagging them here, but I don't know if they fix these issues or not at this time:
- #2249
- #1712 