### PR TITLE
[NFC] Make tensornet backend implementation templated

### DIFF
--- a/runtime/nvqir/cutensornet/CMakeLists.txt
+++ b/runtime/nvqir/cutensornet/CMakeLists.txt
@@ -63,7 +63,6 @@ message(STATUS "Found cutensornet version: ${CUTENSORNET_VERSION}")
 # We need cutensornet v2.7.0+ (cutensornetStateApplyGeneralChannel)
 if (${CUTENSORNET_VERSION} VERSION_GREATER_EQUAL "2.7")
   set (BASE_TENSOR_BACKEND_SRS  
-        simulator_cutensornet.cpp 
         tensornet_spin_op.cpp
         tensornet_state.cpp
         tensornet_utils.cpp)

--- a/runtime/nvqir/cutensornet/CMakeLists.txt
+++ b/runtime/nvqir/cutensornet/CMakeLists.txt
@@ -64,7 +64,6 @@ message(STATUS "Found cutensornet version: ${CUTENSORNET_VERSION}")
 if (${CUTENSORNET_VERSION} VERSION_GREATER_EQUAL "2.7")
   set (BASE_TENSOR_BACKEND_SRS  
         tensornet_spin_op.cpp
-        tensornet_state.cpp
         tensornet_utils.cpp)
   get_filename_component(CUTENSORNET_INCLUDE_DIR ${CUTENSORNET_INC} DIRECTORY)
   get_filename_component(CUTENSORNET_LIB_DIR ${CUTENSORNET_LIB} DIRECTORY)
@@ -81,8 +80,8 @@ if (${CUTENSORNET_VERSION} VERSION_GREATER_EQUAL "2.7")
     add_target_config(${LIBRARY_NAME})
   endmacro()
 
-  nvqir_create_cutn_plugin(tensornet ${BASE_TENSOR_BACKEND_SRS} simulator_tensornet_register.cpp tn_simulation_state.cpp)
-  nvqir_create_cutn_plugin(tensornet-mps ${BASE_TENSOR_BACKEND_SRS} simulator_mps_register.cpp mps_simulation_state.cpp)
+  nvqir_create_cutn_plugin(tensornet ${BASE_TENSOR_BACKEND_SRS} simulator_tensornet_register.cpp)
+  nvqir_create_cutn_plugin(tensornet-mps ${BASE_TENSOR_BACKEND_SRS} simulator_mps_register.cpp)
   add_library(tensornet-mpi-util OBJECT mpi_support.cpp)
   target_include_directories(tensornet-mpi-util PRIVATE ${CUDAToolkit_INCLUDE_DIRS} ${CUTENSORNET_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/runtime)
   target_link_libraries(tensornet-mpi-util PRIVATE cudaq-common fmt::fmt-header-only)

--- a/runtime/nvqir/cutensornet/mps_simulation_state.h
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.h
@@ -29,10 +29,11 @@ struct MPSSettings {
   MPSSettings();
 };
 
+template <typename ScalarType = double>
 class MPSSimulationState : public cudaq::SimulationState {
 
 public:
-  MPSSimulationState(std::unique_ptr<TensorNetState> inState,
+  MPSSimulationState(std::unique_ptr<TensorNetState<ScalarType>> inState,
                      const std::vector<MPSTensor> &mpsTensors,
                      ScratchDeviceMem &inScratchPad,
                      cutensornetHandle_t cutnHandle,
@@ -75,7 +76,7 @@ public:
   /// Encapsulate data needed to initialize an MPS state.
   struct MpsStateData {
     // Represents the tensor network state
-    std::unique_ptr<TensorNetState> networkState;
+    std::unique_ptr<TensorNetState<ScalarType>> networkState;
     // Individual MPS tensors
     std::vector<MPSTensor> tensors;
   };
@@ -99,7 +100,7 @@ protected:
 
   // The state that this owned.
   cutensornetHandle_t m_cutnHandle;
-  std::unique_ptr<TensorNetState> state;
+  std::unique_ptr<TensorNetState<ScalarType>> state;
   std::vector<MPSTensor> m_mpsTensors;
   ScratchDeviceMem &scratchPad;
   // Max number of qubits whereby the tensor network state should be contracted
@@ -111,3 +112,5 @@ protected:
 };
 
 } // namespace nvqir
+
+#include "mps_simulation_state.inc"

--- a/runtime/nvqir/cutensornet/mps_simulation_state.inc
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.inc
@@ -6,7 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "mps_simulation_state.h"
+#pragma once
+
 #include "common/EigenDense.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include <bitset>
@@ -26,17 +27,18 @@ std::size_t MPSSimulationState<ScalarType>::getNumQubits() const {
 }
 
 template <typename ScalarType>
-MPSSimulationState<ScalarType>::MPSSimulationState(std::unique_ptr<TensorNetState<ScalarType>> inState,
-                                       const std::vector<MPSTensor> &mpsTensors,
-                                       ScratchDeviceMem &inScratchPad,
-                                       cutensornetHandle_t cutnHandle,
-                                       std::mt19937 &randomEngine)
+MPSSimulationState<ScalarType>::MPSSimulationState(
+    std::unique_ptr<TensorNetState<ScalarType>> inState,
+    const std::vector<MPSTensor> &mpsTensors, ScratchDeviceMem &inScratchPad,
+    cutensornetHandle_t cutnHandle, std::mt19937 &randomEngine)
     : m_cutnHandle(cutnHandle), state(std::move(inState)),
       m_mpsTensors(mpsTensors), scratchPad(inScratchPad),
       m_randomEngine(randomEngine) {}
 
 template <typename ScalarType>
-MPSSimulationState<ScalarType>::~MPSSimulationState() { deallocate(); }
+MPSSimulationState<ScalarType>::~MPSSimulationState() {
+  deallocate();
+}
 
 template <typename ScalarType>
 std::complex<double> MPSSimulationState<ScalarType>::computeOverlap(
@@ -245,8 +247,8 @@ MPSSimulationState<ScalarType>::overlap(const cudaq::SimulationState &other) {
 }
 
 template <typename ScalarType>
-std::complex<double>
-MPSSimulationState<ScalarType>::getAmplitude(const std::vector<int> &basisState) {
+std::complex<double> MPSSimulationState<ScalarType>::getAmplitude(
+    const std::vector<int> &basisState) {
   if (getNumQubits() != basisState.size())
     throw std::runtime_error(
         fmt::format("[tensornet-state] getAmplitude with an invalid number "
@@ -383,7 +385,8 @@ static Eigen::MatrixXcd reshapeStateVec(const Eigen::VectorXcd &stateVec) {
 }
 
 template <typename ScalarType>
-MPSSimulationState<ScalarType>::MpsStateData MPSSimulationState<ScalarType>::createFromStateVec(
+MPSSimulationState<ScalarType>::MpsStateData
+MPSSimulationState<ScalarType>::createFromStateVec(
     cutensornetHandle_t cutnHandle, ScratchDeviceMem &inScratchPad,
     std::size_t size, std::complex<double> *ptr, int bondDim,
     std::mt19937 &randomEngine) {
@@ -476,15 +479,16 @@ MPSSimulationState<ScalarType>::MpsStateData MPSSimulationState<ScalarType>::cre
   stateTensor.extents = std::vector<int64_t>{numSingularValues.back(), 2};
   mpsTensors.emplace_back(stateTensor);
   assert(mpsTensors.size() == numQubits);
-  auto state = TensorNetState<ScalarType>::createFromMpsTensors(mpsTensors, inScratchPad,
-                                                    cutnHandle, randomEngine);
+  auto state = TensorNetState<ScalarType>::createFromMpsTensors(
+      mpsTensors, inScratchPad, cutnHandle, randomEngine);
   return {std::move(state), mpsTensors};
 }
 
 template <typename ScalarType>
 std::unique_ptr<cudaq::SimulationState>
-MPSSimulationState<ScalarType>::createFromSizeAndPtr(std::size_t size, void *ptr,
-                                         std::size_t dataType) {
+MPSSimulationState<ScalarType>::createFromSizeAndPtr(std::size_t size,
+                                                     void *ptr,
+                                                     std::size_t dataType) {
   if (dataType == cudaq::detail::variant_index<cudaq::state_data,
                                                cudaq::TensorStateData>()) {
     std::vector<MPSTensor> mpsTensors;
@@ -592,8 +596,8 @@ MPSSettings::MPSSettings() {
 }
 
 template <typename ScalarType>
-void MPSSimulationState<ScalarType>::toHost(std::complex<double> *clientAllocatedData,
-                                std::size_t numElements) const {
+void MPSSimulationState<ScalarType>::toHost(
+    std::complex<double> *clientAllocatedData, std::size_t numElements) const {
   auto stateVec = state->getStateVector();
   if (stateVec.size() != numElements)
     throw std::runtime_error(

--- a/runtime/nvqir/cutensornet/mps_simulation_state.inc
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.inc
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/****************************************************************-*- C++ -*-****
  * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
@@ -19,11 +19,14 @@ int deviceFromPointer(void *ptr) {
   HANDLE_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr));
   return attributes.device;
 }
-std::size_t MPSSimulationState::getNumQubits() const {
+
+template <typename ScalarType>
+std::size_t MPSSimulationState<ScalarType>::getNumQubits() const {
   return state->getNumQubits();
 }
 
-MPSSimulationState::MPSSimulationState(std::unique_ptr<TensorNetState> inState,
+template <typename ScalarType>
+MPSSimulationState<ScalarType>::MPSSimulationState(std::unique_ptr<TensorNetState<ScalarType>> inState,
                                        const std::vector<MPSTensor> &mpsTensors,
                                        ScratchDeviceMem &inScratchPad,
                                        cutensornetHandle_t cutnHandle,
@@ -32,9 +35,11 @@ MPSSimulationState::MPSSimulationState(std::unique_ptr<TensorNetState> inState,
       m_mpsTensors(mpsTensors), scratchPad(inScratchPad),
       m_randomEngine(randomEngine) {}
 
-MPSSimulationState::~MPSSimulationState() { deallocate(); }
+template <typename ScalarType>
+MPSSimulationState<ScalarType>::~MPSSimulationState() { deallocate(); }
 
-std::complex<double> MPSSimulationState::computeOverlap(
+template <typename ScalarType>
+std::complex<double> MPSSimulationState<ScalarType>::computeOverlap(
     const std::vector<MPSTensor> &m_mpsTensors,
     const std::vector<MPSTensor> &mpsOtherTensors) {
   LOG_API_TIME();
@@ -225,8 +230,9 @@ std::complex<double> MPSSimulationState::computeOverlap(
   return std::abs(overlap);
 }
 
+template <typename ScalarType>
 std::complex<double>
-MPSSimulationState::overlap(const cudaq::SimulationState &other) {
+MPSSimulationState<ScalarType>::overlap(const cudaq::SimulationState &other) {
 
   if (other.getNumTensors() != getNumTensors())
     throw std::runtime_error("[tensornet-state] overlap error - other state "
@@ -238,8 +244,9 @@ MPSSimulationState::overlap(const cudaq::SimulationState &other) {
   return computeOverlap(m_mpsTensors, mpsOtherTensors);
 }
 
+template <typename ScalarType>
 std::complex<double>
-MPSSimulationState::getAmplitude(const std::vector<int> &basisState) {
+MPSSimulationState<ScalarType>::getAmplitude(const std::vector<int> &basisState) {
   if (getNumQubits() != basisState.size())
     throw std::runtime_error(
         fmt::format("[tensornet-state] getAmplitude with an invalid number "
@@ -292,8 +299,9 @@ MPSSimulationState::getAmplitude(const std::vector<int> &basisState) {
   return amplitudes[idx];
 }
 
+template <typename ScalarType>
 cudaq::SimulationState::Tensor
-MPSSimulationState::getTensor(std::size_t tensorIdx) const {
+MPSSimulationState<ScalarType>::getTensor(std::size_t tensorIdx) const {
   if (tensorIdx >= getNumTensors())
     throw std::runtime_error(
         "[tensornet-mps-state] invalid tensor idx requested.");
@@ -306,8 +314,9 @@ MPSSimulationState::getTensor(std::size_t tensorIdx) const {
                                         extents, getPrecision()};
 }
 
+template <typename ScalarType>
 std::vector<cudaq::SimulationState::Tensor>
-MPSSimulationState::getTensors() const {
+MPSSimulationState<ScalarType>::getTensors() const {
   std::vector<cudaq::SimulationState::Tensor> tensors;
   for (auto &tensor : m_mpsTensors) {
     std::vector<std::size_t> extents;
@@ -318,23 +327,27 @@ MPSSimulationState::getTensors() const {
   return tensors;
 }
 
-std::size_t MPSSimulationState::getNumTensors() const {
+template <typename ScalarType>
+std::size_t MPSSimulationState<ScalarType>::getNumTensors() const {
   return m_mpsTensors.size();
 }
 
-void MPSSimulationState::deallocate() {
+template <typename ScalarType>
+void MPSSimulationState<ScalarType>::deallocate() {
   for (auto &tensor : m_mpsTensors)
     HANDLE_CUDA_ERROR(cudaFree(tensor.deviceData));
   m_mpsTensors.clear();
   state.reset();
 }
 
-void MPSSimulationState::destroyState() {
+template <typename ScalarType>
+void MPSSimulationState<ScalarType>::destroyState() {
   cudaq::info("mps-state destroying state vector handle.");
   deallocate();
 }
 
-void MPSSimulationState::dump(std::ostream &os) const {
+template <typename ScalarType>
+void MPSSimulationState<ScalarType>::dump(std::ostream &os) const {
   const auto printState = [&os](const auto &stateVec) {
     for (auto &t : stateVec)
       os << t << "\n";
@@ -369,13 +382,14 @@ static Eigen::MatrixXcd reshapeStateVec(const Eigen::VectorXcd &stateVec) {
   return reshapeMatrix(A);
 }
 
-MPSSimulationState::MpsStateData MPSSimulationState::createFromStateVec(
+template <typename ScalarType>
+MPSSimulationState<ScalarType>::MpsStateData MPSSimulationState<ScalarType>::createFromStateVec(
     cutensornetHandle_t cutnHandle, ScratchDeviceMem &inScratchPad,
     std::size_t size, std::complex<double> *ptr, int bondDim,
     std::mt19937 &randomEngine) {
   const std::size_t numQubits = std::log2(size);
   // Reverse the qubit order to match cutensornet convention
-  auto newStateVec = TensorNetState::reverseQubitOrder(
+  auto newStateVec = TensorNetState<ScalarType>::reverseQubitOrder(
       std::span<std::complex<double>>{ptr, size});
   auto stateVec =
       Eigen::Map<Eigen::VectorXcd>(newStateVec.data(), newStateVec.size());
@@ -389,7 +403,7 @@ MPSSimulationState::MpsStateData MPSSimulationState::createFromStateVec(
     MPSTensor stateTensor;
     stateTensor.deviceData = d_tensor;
     stateTensor.extents = std::vector<int64_t>{2};
-    auto state = TensorNetState::createFromMpsTensors(
+    auto state = TensorNetState<ScalarType>::createFromMpsTensors(
         {stateTensor}, inScratchPad, cutnHandle, randomEngine);
     return {std::move(state), std::vector<MPSTensor>{stateTensor}};
   }
@@ -462,13 +476,14 @@ MPSSimulationState::MpsStateData MPSSimulationState::createFromStateVec(
   stateTensor.extents = std::vector<int64_t>{numSingularValues.back(), 2};
   mpsTensors.emplace_back(stateTensor);
   assert(mpsTensors.size() == numQubits);
-  auto state = TensorNetState::createFromMpsTensors(mpsTensors, inScratchPad,
+  auto state = TensorNetState<ScalarType>::createFromMpsTensors(mpsTensors, inScratchPad,
                                                     cutnHandle, randomEngine);
   return {std::move(state), mpsTensors};
 }
 
+template <typename ScalarType>
 std::unique_ptr<cudaq::SimulationState>
-MPSSimulationState::createFromSizeAndPtr(std::size_t size, void *ptr,
+MPSSimulationState<ScalarType>::createFromSizeAndPtr(std::size_t size, void *ptr,
                                          std::size_t dataType) {
   if (dataType == cudaq::detail::variant_index<cudaq::state_data,
                                                cudaq::TensorStateData>()) {
@@ -489,7 +504,7 @@ MPSSimulationState::createFromSizeAndPtr(std::size_t size, void *ptr,
       MPSTensor stateTensor{d_tensor, mpsExtents};
       mpsTensors.emplace_back(stateTensor);
     }
-    auto state = TensorNetState::createFromMpsTensors(
+    auto state = TensorNetState<ScalarType>::createFromMpsTensors(
         mpsTensors, scratchPad, m_cutnHandle, m_randomEngine);
     return std::make_unique<MPSSimulationState>(
         std::move(state), mpsTensors, scratchPad, m_cutnHandle, m_randomEngine);
@@ -576,7 +591,8 @@ MPSSettings::MPSSettings() {
   }
 }
 
-void MPSSimulationState::toHost(std::complex<double> *clientAllocatedData,
+template <typename ScalarType>
+void MPSSimulationState<ScalarType>::toHost(std::complex<double> *clientAllocatedData,
                                 std::size_t numElements) const {
   auto stateVec = state->getStateVector();
   if (stateVec.size() != numElements)

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.h
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.h
@@ -17,6 +17,9 @@ namespace nvqir {
 template <typename ScalarType = double>
 class SimulatorTensorNetBase : public nvqir::CircuitSimulatorBase<ScalarType> {
 public:
+  using DataType = std::complex<ScalarType>;
+  static constexpr cudaDataType_t cudaDataType =
+      std::is_same_v<ScalarType, float> ? CUDA_C_32F : CUDA_C_64F;
   using GateApplicationTask =
       typename nvqir::CircuitSimulatorBase<ScalarType>::GateApplicationTask;
   using nvqir::CircuitSimulatorBase<ScalarType>::executionContext;
@@ -121,7 +124,7 @@ private:
 
 protected:
   cutensornetHandle_t m_cutnHandle;
-  std::unique_ptr<TensorNetState> m_state;
+  std::unique_ptr<TensorNetState<ScalarType>> m_state;
   std::unordered_map<std::string, void *> m_gateDeviceMemCache;
   ScratchDeviceMem scratchPad;
   // Random number generator for generating 32-bit numbers with a state size of

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.h
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.h
@@ -22,10 +22,6 @@ public:
       std::is_same_v<ScalarType, float> ? CUDA_C_32F : CUDA_C_64F;
   using GateApplicationTask =
       typename nvqir::CircuitSimulatorBase<ScalarType>::GateApplicationTask;
-  using nvqir::CircuitSimulatorBase<ScalarType>::executionContext;
-  using nvqir::CircuitSimulatorBase<ScalarType>::flushGateQueue;
-  using nvqir::CircuitSimulatorBase<ScalarType>::flushAnySamplingTasks;
-  using nvqir::CircuitSimulatorBase<ScalarType>::addQubitsToState;
   SimulatorTensorNetBase();
   SimulatorTensorNetBase(const SimulatorTensorNetBase &another) = delete;
   SimulatorTensorNetBase &

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.h
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.h
@@ -14,9 +14,15 @@
 
 namespace nvqir {
 /// @brief Base class of `cutensornet` simulator backends
-class SimulatorTensorNetBase : public nvqir::CircuitSimulatorBase<double> {
-
+template <typename ScalarType = double>
+class SimulatorTensorNetBase : public nvqir::CircuitSimulatorBase<ScalarType> {
 public:
+  using GateApplicationTask =
+      typename nvqir::CircuitSimulatorBase<ScalarType>::GateApplicationTask;
+  using nvqir::CircuitSimulatorBase<ScalarType>::executionContext;
+  using nvqir::CircuitSimulatorBase<ScalarType>::flushGateQueue;
+  using nvqir::CircuitSimulatorBase<ScalarType>::flushAnySamplingTasks;
+  using nvqir::CircuitSimulatorBase<ScalarType>::addQubitsToState;
   SimulatorTensorNetBase();
   SimulatorTensorNetBase(const SimulatorTensorNetBase &another) = delete;
   SimulatorTensorNetBase &
@@ -139,3 +145,5 @@ protected:
 };
 
 } // end namespace nvqir
+
+#include "simulator_cutensornet.inc"

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.inc
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.inc
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/****************************************************************-*- C++ -*-****
  * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
@@ -478,7 +478,7 @@ void SimulatorTensorNetBase<ScalarType>::setToZeroState() {
   const auto numQubits = m_state->getNumQubits();
   m_state.reset();
   // Re-create a zero state of the same size
-  m_state = std::make_unique<TensorNetState>(numQubits, scratchPad,
+  m_state = std::make_unique<TensorNetState<ScalarType>>(numQubits, scratchPad,
                                              m_cutnHandle, m_randomEngine);
 }
 

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.inc
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.inc
@@ -12,8 +12,8 @@
 #include "tensornet_spin_op.h"
 
 namespace nvqir {
-
-SimulatorTensorNetBase::SimulatorTensorNetBase()
+template <typename ScalarType>
+SimulatorTensorNetBase<ScalarType>::SimulatorTensorNetBase()
     : m_randomEngine(std::random_device()()) {
   int numDevices{0};
   HANDLE_CUDA_ERROR(cudaGetDeviceCount(&numDevices));
@@ -84,7 +84,8 @@ std::size_t vecComplexHash(const std::vector<std::complex<double>> &vec) {
   return seed;
 }
 
-void SimulatorTensorNetBase::applyGate(const GateApplicationTask &task) {
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::applyGate(const GateApplicationTask &task) {
   const auto &controls = task.controls;
   const auto &targets = task.targets;
   // Cache name lookup key:
@@ -153,7 +154,8 @@ getOrCacheMat(const std::string &key,
   return iter->second;
 };
 
-void SimulatorTensorNetBase::applyKrausChannel(
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::applyKrausChannel(
     const std::vector<int32_t> &qubits,
     const cudaq::kraus_channel &krausChannel) {
   LOG_API_TIME();
@@ -168,7 +170,7 @@ void SimulatorTensorNetBase::applyKrausChannel(
   } else {
     if (!canHandleGeneralNoiseChannel())
       throw std::runtime_error(
-          "General noise channels are not supported on simulator " + name());
+          "General noise channels are not supported on simulator " + this->name());
 
     std::vector<void *> channelMats;
     for (const auto &op : krausChannel.get_ops()) {
@@ -181,7 +183,8 @@ void SimulatorTensorNetBase::applyKrausChannel(
   }
 }
 
-bool SimulatorTensorNetBase::isValidNoiseChannel(
+template <typename ScalarType>
+bool SimulatorTensorNetBase<ScalarType>::isValidNoiseChannel(
     const cudaq::noise_model_type &type) const {
   switch (type) {
   case cudaq::noise_model_type::depolarization_channel:
@@ -205,7 +208,8 @@ bool SimulatorTensorNetBase::isValidNoiseChannel(
   }
 }
 
-void SimulatorTensorNetBase::applyNoise(
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::applyNoise(
     const cudaq::kraus_channel &channel,
     const std::vector<std::size_t> &targets) {
   LOG_API_TIME();
@@ -220,7 +224,8 @@ void SimulatorTensorNetBase::applyNoise(
   applyKrausChannel(qubits, channel);
 }
 
-void SimulatorTensorNetBase::applyNoiseChannel(
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::applyNoiseChannel(
     const std::string_view gateName, const std::vector<std::size_t> &controls,
     const std::vector<std::size_t> &targets,
     const std::vector<double> &params) {
@@ -255,7 +260,8 @@ void SimulatorTensorNetBase::applyNoiseChannel(
 }
 
 /// @brief Reset the state of a given qubit to zero
-void SimulatorTensorNetBase::resetQubit(const std::size_t qubitIdx) {
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::resetQubit(const std::size_t qubitIdx) {
   flushGateQueue();
   flushAnySamplingTasks();
   LOG_API_TIME();
@@ -298,12 +304,14 @@ void SimulatorTensorNetBase::resetQubit(const std::size_t qubitIdx) {
 }
 
 /// @brief Device synchronization
-void SimulatorTensorNetBase::synchronize() {
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::synchronize() {
   HANDLE_CUDA_ERROR(cudaDeviceSynchronize());
 }
 
 /// @brief Perform a measurement on a given qubit
-bool SimulatorTensorNetBase::measureQubit(const std::size_t qubitIdx) {
+template <typename ScalarType>
+bool SimulatorTensorNetBase<ScalarType>::measureQubit(const std::size_t qubitIdx) {
   LOG_API_TIME();
   // Prepare the state before RDM calculation
   prepareQubitTensorState();
@@ -338,8 +346,9 @@ bool SimulatorTensorNetBase::measureQubit(const std::size_t qubitIdx) {
 }
 
 /// @brief Sample a subset of qubits
+template <typename ScalarType>
 cudaq::ExecutionResult
-SimulatorTensorNetBase::sample(const std::vector<std::size_t> &measuredBits,
+SimulatorTensorNetBase<ScalarType>::sample(const std::vector<std::size_t> &measuredBits,
                                const int shots) {
   LOG_API_TIME();
   std::vector<int32_t> measuredBitIds(measuredBits.begin(), measuredBits.end());
@@ -378,7 +387,8 @@ SimulatorTensorNetBase::sample(const std::vector<std::size_t> &measuredBits,
   return counts;
 }
 
-bool SimulatorTensorNetBase::canHandleObserve() {
+template <typename ScalarType>
+bool SimulatorTensorNetBase<ScalarType>::canHandleObserve() {
   // Do not compute <H> from matrix if shots based sampling requested
   // i.e., a valid shots count value was set.
   // Note: -1 is also used to denote non-sampling execution. Hence, we need to
@@ -398,8 +408,9 @@ bool SimulatorTensorNetBase::canHandleObserve() {
 }
 
 /// @brief Evaluate the expectation value of a given observable
+template <typename ScalarType>
 cudaq::observe_result
-SimulatorTensorNetBase::observe(const cudaq::spin_op &ham) {
+SimulatorTensorNetBase<ScalarType>::observe(const cudaq::spin_op &ham) {
   assert(cudaq::spin_op::canonicalize(ham) == ham);
   LOG_API_TIME();
   prepareQubitTensorState();
@@ -443,12 +454,15 @@ SimulatorTensorNetBase::observe(const cudaq::spin_op &ham) {
   return cudaq::observe_result(expVal.real(), ham, perTermData);
 }
 
-nvqir::CircuitSimulator *SimulatorTensorNetBase::clone() { return nullptr; }
+template <typename ScalarType>
+nvqir::CircuitSimulator *SimulatorTensorNetBase<ScalarType>::clone() { return nullptr; }
 
-void SimulatorTensorNetBase::addQubitToState() { addQubitsToState(1); }
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::addQubitToState() { addQubitsToState(1); }
 
 /// @brief Destroy the entire qubit register
-void SimulatorTensorNetBase::deallocateStateImpl() {
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::deallocateStateImpl() {
   if (m_state) {
     m_state.reset();
     // Reset cuTensorNet library
@@ -458,7 +472,8 @@ void SimulatorTensorNetBase::deallocateStateImpl() {
 }
 
 /// @brief Reset all qubits to zero
-void SimulatorTensorNetBase::setToZeroState() {
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::setToZeroState() {
   LOG_API_TIME();
   const auto numQubits = m_state->getNumQubits();
   m_state.reset();
@@ -467,7 +482,8 @@ void SimulatorTensorNetBase::setToZeroState() {
                                              m_cutnHandle, m_randomEngine);
 }
 
-void SimulatorTensorNetBase::swap(const std::vector<std::size_t> &ctrlBits,
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::swap(const std::vector<std::size_t> &ctrlBits,
                                   const std::size_t srcIdx,
                                   const std::size_t tgtIdx) {
   if (ctrlBits.empty())
@@ -493,11 +509,13 @@ void SimulatorTensorNetBase::swap(const std::vector<std::size_t> &ctrlBits,
   }
 }
 
-void SimulatorTensorNetBase::setRandomSeed(std::size_t randomSeed) {
+template <typename ScalarType>
+void SimulatorTensorNetBase<ScalarType>::setRandomSeed(std::size_t randomSeed) {
   m_randomEngine = std::mt19937(randomSeed);
 }
 
-SimulatorTensorNetBase::~SimulatorTensorNetBase() {
+template <typename ScalarType>
+SimulatorTensorNetBase<ScalarType>::~SimulatorTensorNetBase() {
   m_state.reset();
   for (const auto &[key, dMem] : m_gateDeviceMemCache)
     HANDLE_CUDA_ERROR(cudaFree(dMem));

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.inc
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.inc
@@ -6,7 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "simulator_cutensornet.h"
+#pragma once
+
 #include "cudaq.h"
 #include "cutensornet.h"
 #include "tensornet_spin_op.h"
@@ -85,7 +86,8 @@ std::size_t vecComplexHash(const std::vector<std::complex<double>> &vec) {
 }
 
 template <typename ScalarType>
-void SimulatorTensorNetBase<ScalarType>::applyGate(const GateApplicationTask &task) {
+void SimulatorTensorNetBase<ScalarType>::applyGate(
+    const GateApplicationTask &task) {
   const auto &controls = task.controls;
   const auto &targets = task.targets;
   // Cache name lookup key:
@@ -170,7 +172,8 @@ void SimulatorTensorNetBase<ScalarType>::applyKrausChannel(
   } else {
     if (!canHandleGeneralNoiseChannel())
       throw std::runtime_error(
-          "General noise channels are not supported on simulator " + this->name());
+          "General noise channels are not supported on simulator " +
+          this->name());
 
     std::vector<void *> channelMats;
     for (const auto &op : krausChannel.get_ops()) {
@@ -220,7 +223,7 @@ void SimulatorTensorNetBase<ScalarType>::applyNoise(
       "[SimulatorTensorNetBase] Applying kraus channel {} on qubits: {}",
       cudaq::get_noise_model_type_name(channel.noise_type), qubits);
 
-  flushGateQueue();
+  this->flushGateQueue();
   applyKrausChannel(qubits, channel);
 }
 
@@ -231,11 +234,11 @@ void SimulatorTensorNetBase<ScalarType>::applyNoiseChannel(
     const std::vector<double> &params) {
   LOG_API_TIME();
   // Do nothing if no execution context
-  if (!executionContext)
+  if (!this->executionContext)
     return;
 
   // Do nothing if no noise model
-  if (!executionContext->noiseModel)
+  if (!this->executionContext->noiseModel)
     return;
 
   // Get the name as a string
@@ -244,7 +247,7 @@ void SimulatorTensorNetBase<ScalarType>::applyNoiseChannel(
   qubits.insert(qubits.end(), targets.begin(), targets.end());
 
   // Get the Kraus channels specified for this gate and qubits
-  auto krausChannels = executionContext->noiseModel->get_channels(
+  auto krausChannels = this->executionContext->noiseModel->get_channels(
       gName, targets, controls, params);
 
   // If none, do nothing
@@ -261,9 +264,10 @@ void SimulatorTensorNetBase<ScalarType>::applyNoiseChannel(
 
 /// @brief Reset the state of a given qubit to zero
 template <typename ScalarType>
-void SimulatorTensorNetBase<ScalarType>::resetQubit(const std::size_t qubitIdx) {
-  flushGateQueue();
-  flushAnySamplingTasks();
+void SimulatorTensorNetBase<ScalarType>::resetQubit(
+    const std::size_t qubitIdx) {
+  this->flushGateQueue();
+  this->flushAnySamplingTasks();
   LOG_API_TIME();
   // Prepare the state before RDM calculation
   prepareQubitTensorState();
@@ -277,7 +281,7 @@ void SimulatorTensorNetBase<ScalarType>::resetQubit(const std::size_t qubitIdx) 
 
   // One state => flip
   if (prob0 < 1e-9) {
-    x(qubitIdx);
+    this->x(qubitIdx);
     return;
   }
 
@@ -311,7 +315,8 @@ void SimulatorTensorNetBase<ScalarType>::synchronize() {
 
 /// @brief Perform a measurement on a given qubit
 template <typename ScalarType>
-bool SimulatorTensorNetBase<ScalarType>::measureQubit(const std::size_t qubitIdx) {
+bool SimulatorTensorNetBase<ScalarType>::measureQubit(
+    const std::size_t qubitIdx) {
   LOG_API_TIME();
   // Prepare the state before RDM calculation
   prepareQubitTensorState();
@@ -347,9 +352,8 @@ bool SimulatorTensorNetBase<ScalarType>::measureQubit(const std::size_t qubitIdx
 
 /// @brief Sample a subset of qubits
 template <typename ScalarType>
-cudaq::ExecutionResult
-SimulatorTensorNetBase<ScalarType>::sample(const std::vector<std::size_t> &measuredBits,
-                               const int shots) {
+cudaq::ExecutionResult SimulatorTensorNetBase<ScalarType>::sample(
+    const std::vector<std::size_t> &measuredBits, const int shots) {
   LOG_API_TIME();
   std::vector<int32_t> measuredBitIds(measuredBits.begin(), measuredBits.end());
   if (shots < 1) {
@@ -393,13 +397,13 @@ bool SimulatorTensorNetBase<ScalarType>::canHandleObserve() {
   // i.e., a valid shots count value was set.
   // Note: -1 is also used to denote non-sampling execution. Hence, we need to
   // check for this particular -1 value as being casted to an unsigned type.
-  if (executionContext && executionContext->shots > 0 &&
-      executionContext->shots != ~0ull) {
+  if (this->executionContext && this->executionContext->shots > 0 &&
+      this->executionContext->shots != ~0ull) {
     // This 'shots' mode is very slow for tensor network.
     // However, we need to respect the shots option.
     cudaq::info("[SimulatorTensorNetBase] Shots mode expectation calculation "
                 "is requested with {} shots.",
-                executionContext->shots);
+                this->executionContext->shots);
 
     return false;
   }
@@ -455,10 +459,14 @@ SimulatorTensorNetBase<ScalarType>::observe(const cudaq::spin_op &ham) {
 }
 
 template <typename ScalarType>
-nvqir::CircuitSimulator *SimulatorTensorNetBase<ScalarType>::clone() { return nullptr; }
+nvqir::CircuitSimulator *SimulatorTensorNetBase<ScalarType>::clone() {
+  return nullptr;
+}
 
 template <typename ScalarType>
-void SimulatorTensorNetBase<ScalarType>::addQubitToState() { addQubitsToState(1); }
+void SimulatorTensorNetBase<ScalarType>::addQubitToState() {
+  this->addQubitsToState(1);
+}
 
 /// @brief Destroy the entire qubit register
 template <typename ScalarType>
@@ -478,14 +486,14 @@ void SimulatorTensorNetBase<ScalarType>::setToZeroState() {
   const auto numQubits = m_state->getNumQubits();
   m_state.reset();
   // Re-create a zero state of the same size
-  m_state = std::make_unique<TensorNetState<ScalarType>>(numQubits, scratchPad,
-                                             m_cutnHandle, m_randomEngine);
+  m_state = std::make_unique<TensorNetState<ScalarType>>(
+      numQubits, scratchPad, m_cutnHandle, m_randomEngine);
 }
 
 template <typename ScalarType>
-void SimulatorTensorNetBase<ScalarType>::swap(const std::vector<std::size_t> &ctrlBits,
-                                  const std::size_t srcIdx,
-                                  const std::size_t tgtIdx) {
+void SimulatorTensorNetBase<ScalarType>::swap(
+    const std::vector<std::size_t> &ctrlBits, const std::size_t srcIdx,
+    const std::size_t tgtIdx) {
   if (ctrlBits.empty())
     return nvqir::CircuitSimulatorBase<double>::swap(ctrlBits, srcIdx, tgtIdx);
   // Controlled swap gate: using cnot decomposition of swap gate to perform

--- a/runtime/nvqir/cutensornet/simulator_mps_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_mps_register.cpp
@@ -207,7 +207,8 @@ public:
   /// @brief Sample a subset of qubits
   cudaq::ExecutionResult sample(const std::vector<std::size_t> &measuredBits,
                                 const int shots) override {
-    const bool hasNoise = this->executionContext && this->executionContext->noiseModel;
+    const bool hasNoise =
+        this->executionContext && this->executionContext->noiseModel;
     if (!hasNoise || shots < 1)
       return SimulatorTensorNetBase<ScalarType>::sample(measuredBits, shots);
 
@@ -277,7 +278,8 @@ public:
   cudaq::observe_result observe(const cudaq::spin_op &ham) override {
     assert(cudaq::spin_op::canonicalize(ham) == ham);
     LOG_API_TIME();
-    const bool hasNoise = this->executionContext && this->executionContext->noiseModel;
+    const bool hasNoise =
+        this->executionContext && this->executionContext->noiseModel;
     // If no noise, just use base class implementation.
     if (!hasNoise)
       return SimulatorTensorNetBase<ScalarType>::observe(ham);
@@ -332,10 +334,12 @@ public:
         m_state = std::make_unique<TensorNetState<ScalarType>>(
             numQubits, scratchPad, m_cutnHandle, m_randomEngine);
       } else {
-        auto [state, mpsTensors] = MPSSimulationState<ScalarType>::createFromStateVec(
-            m_cutnHandle, scratchPad, 1ULL << numQubits,
-            reinterpret_cast<std::complex<double> *>(const_cast<void *>(ptr)),
-            m_settings.maxBond, m_randomEngine);
+        auto [state, mpsTensors] =
+            MPSSimulationState<ScalarType>::createFromStateVec(
+                m_cutnHandle, scratchPad, 1ULL << numQubits,
+                reinterpret_cast<std::complex<double> *>(
+                    const_cast<void *>(ptr)),
+                m_settings.maxBond, m_randomEngine);
         m_state = std::move(state);
       }
     } else {
@@ -363,10 +367,12 @@ public:
             tensors, scratchPad, m_cutnHandle, m_randomEngine);
       } else {
         // Non-zero state needs to be factorized and appended.
-        auto [state, mpsTensors] = MPSSimulationState<ScalarType>::createFromStateVec(
-            m_cutnHandle, scratchPad, 1ULL << numQubits,
-            reinterpret_cast<std::complex<double> *>(const_cast<void *>(ptr)),
-            m_settings.maxBond, m_randomEngine);
+        auto [state, mpsTensors] =
+            MPSSimulationState<ScalarType>::createFromStateVec(
+                m_cutnHandle, scratchPad, 1ULL << numQubits,
+                reinterpret_cast<std::complex<double> *>(
+                    const_cast<void *>(ptr)),
+                m_settings.maxBond, m_randomEngine);
         auto tensors =
             m_state->factorizeMPS(m_settings.maxBond, m_settings.absCutoff,
                                   m_settings.relCutoff, m_settings.svdAlgo);
@@ -397,9 +403,9 @@ public:
       std::vector<MPSTensor> tensors =
           m_state->factorizeMPS(m_settings.maxBond, m_settings.absCutoff,
                                 m_settings.relCutoff, m_settings.svdAlgo);
-      return std::make_unique<MPSSimulationState<ScalarType>>(std::move(m_state), tensors,
-                                                  scratchPad, m_cutnHandle,
-                                                  m_randomEngine);
+      return std::make_unique<MPSSimulationState<ScalarType>>(
+          std::move(m_state), tensors, scratchPad, m_cutnHandle,
+          m_randomEngine);
     }
 
     auto [d_tensor, numElements] = m_state->contractStateVectorInternal({});

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -73,7 +73,7 @@ public:
 
   std::unique_ptr<cudaq::SimulationState> getSimulationState() override {
     LOG_API_TIME();
-    return std::make_unique<TensorNetSimulationState>(
+    return std::make_unique<TensorNetSimulationState<ScalarType>>(
         std::move(m_state), scratchPad, m_cutnHandle, m_randomEngine);
   }
 
@@ -81,13 +81,13 @@ public:
     LOG_API_TIME();
     if (!m_state) {
       if (!ptr) {
-        m_state = std::make_unique<TensorNetState>(
+        m_state = std::make_unique<TensorNetState<ScalarType>>(
             numQubits, scratchPad, m_cutnHandle, m_randomEngine);
       } else {
         auto *casted =
             reinterpret_cast<std::complex<double> *>(const_cast<void *>(ptr));
         std::span<std::complex<double>> stateVec(casted, 1ULL << numQubits);
-        m_state = TensorNetState::createFromStateVector(
+        m_state = TensorNetState<ScalarType>::createFromStateVector(
             stateVec, scratchPad, m_cutnHandle, m_randomEngine);
       }
     } else {
@@ -105,13 +105,13 @@ public:
   virtual void
   addQubitsToState(const cudaq::SimulationState &in_state) override {
     LOG_API_TIME();
-    const TensorNetSimulationState *const casted =
-        dynamic_cast<const TensorNetSimulationState *>(&in_state);
+    const TensorNetSimulationState<ScalarType> *const casted =
+        dynamic_cast<const TensorNetSimulationState<ScalarType> *>(&in_state);
     if (!casted)
       throw std::invalid_argument(
           "[Tensornet simulator] Incompatible state input");
     if (!m_state) {
-      m_state = TensorNetState::createFromOpTensors(
+      m_state = TensorNetState<ScalarType>::createFromOpTensors(
           in_state.getNumQubits(), casted->getAppliedTensors(), scratchPad,
           m_cutnHandle, m_randomEngine);
     } else {

--- a/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
+++ b/runtime/nvqir/cutensornet/simulator_tensornet_register.cpp
@@ -14,9 +14,17 @@
 extern "C" nvqir::CircuitSimulator *getCircuitSimulator_tensornet();
 
 namespace nvqir {
-class SimulatorTensorNet : public SimulatorTensorNetBase {
+template <typename ScalarType = double>
+class SimulatorTensorNet : public SimulatorTensorNetBase<ScalarType> {
+  using SimulatorTensorNetBase<ScalarType>::m_cutnHandle;
+  using SimulatorTensorNetBase<
+      ScalarType>::m_maxControlledRankForFullTensorExpansion;
+  using SimulatorTensorNetBase<ScalarType>::m_state;
+  using SimulatorTensorNetBase<ScalarType>::scratchPad;
+  using SimulatorTensorNetBase<ScalarType>::m_randomEngine;
+
 public:
-  SimulatorTensorNet() : SimulatorTensorNetBase() {
+  SimulatorTensorNet() : SimulatorTensorNetBase<ScalarType>() {
     // tensornet backend supports distributed tensor network contraction,
     // i.e., distributing tensor network contraction across multiple
     // GPUs/processes.
@@ -152,13 +160,13 @@ private:
 extern "C" {
 nvqir::CircuitSimulator *getCircuitSimulator_tensornet() {
   thread_local static auto simulator =
-      std::make_unique<nvqir::SimulatorTensorNet>();
+      std::make_unique<nvqir::SimulatorTensorNet<double>>();
   // Handle multiple runtime __nvqir__setCircuitSimulator calls before/after MPI
   // initialization. If the static simulator instance was created before MPI
   // initialization, it needs to be reset to support MPI if needed.
   if (cudaq::mpi::is_initialized() && !simulator->m_cutnMpiInitialized) {
     // Reset the static instance to pick up MPI.
-    simulator.reset(new nvqir::SimulatorTensorNet());
+    simulator.reset(new nvqir::SimulatorTensorNet<double>());
   }
   return simulator.get();
 }

--- a/runtime/nvqir/cutensornet/tensornet_state.h
+++ b/runtime/nvqir/cutensornet/tensornet_state.h
@@ -64,7 +64,9 @@ struct AppliedTensorOp {
 
 /// @brief Wrapper of cutensornetState_t to provide convenient API's for CUDA-Q
 /// simulator implementation.
+template <typename ScalarType = double>
 class TensorNetState {
+  using DataType = std::complex<ScalarType>;
 
 protected:
   std::size_t m_numQubits;
@@ -224,8 +226,9 @@ public:
   ~TensorNetState();
 
 private:
-  template <typename ScalarType>
+  template <typename ScalarTy>
   friend class SimulatorMPS;
+  template <typename ScalarTy>
   friend class TensorNetSimulationState;
   /// Internal method to contract the tensor network.
   /// Returns device memory pointer and size (number of elements).
@@ -253,3 +256,5 @@ private:
                 bool enableCacheWorkspace);
 };
 } // namespace nvqir
+
+#include "tensornet_state.inc"

--- a/runtime/nvqir/cutensornet/tensornet_state.h
+++ b/runtime/nvqir/cutensornet/tensornet_state.h
@@ -224,6 +224,7 @@ public:
   ~TensorNetState();
 
 private:
+  template <typename ScalarType>
   friend class SimulatorMPS;
   friend class TensorNetSimulationState;
   /// Internal method to contract the tensor network.

--- a/runtime/nvqir/cutensornet/tensornet_state.inc
+++ b/runtime/nvqir/cutensornet/tensornet_state.inc
@@ -6,7 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "tensornet_state.h"
+#pragma once
+
 #include "common/EigenDense.h"
 #include <algorithm>
 #include <bitset>
@@ -38,9 +39,9 @@ std::int32_t TensorNetState<ScalarType>::numHyperSamples = []() {
 
 template <typename ScalarType>
 TensorNetState<ScalarType>::TensorNetState(std::size_t numQubits,
-                               ScratchDeviceMem &inScratchPad,
-                               cutensornetHandle_t handle,
-                               std::mt19937 &randomEngine)
+                                           ScratchDeviceMem &inScratchPad,
+                                           cutensornetHandle_t handle,
+                                           std::mt19937 &randomEngine)
     : m_numQubits(numQubits), m_cutnHandle(handle), scratchPad(inScratchPad),
       m_randomEngine(randomEngine) {
   const std::vector<int64_t> qubitDims(m_numQubits, 2);
@@ -51,9 +52,9 @@ TensorNetState<ScalarType>::TensorNetState(std::size_t numQubits,
 
 template <typename ScalarType>
 TensorNetState<ScalarType>::TensorNetState(const std::vector<int> &basisState,
-                               ScratchDeviceMem &inScratchPad,
-                               cutensornetHandle_t handle,
-                               std::mt19937 &randomEngine)
+                                           ScratchDeviceMem &inScratchPad,
+                                           cutensornetHandle_t handle,
+                                           std::mt19937 &randomEngine)
     : TensorNetState(basisState.size(), inScratchPad, handle, randomEngine) {
   constexpr std::complex<double> h_xGate[4] = {0.0, 1.0, 1.0, 0.0};
   constexpr auto sizeBytes = 4 * sizeof(std::complex<double>);
@@ -71,17 +72,19 @@ TensorNetState<ScalarType>::TensorNetState(const std::vector<int> &basisState,
 }
 
 template <typename ScalarType>
-std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::clone() const {
+std::unique_ptr<TensorNetState<ScalarType>>
+TensorNetState<ScalarType>::clone() const {
   return createFromOpTensors(m_numQubits, m_tensorOps, scratchPad, m_cutnHandle,
                              m_randomEngine);
 }
 
 template <typename ScalarType>
-void TensorNetState<ScalarType>::applyGate(const std::vector<int32_t> &controlQubits,
-                               const std::vector<int32_t> &targetQubits,
-                               void *gateDeviceMem, bool adjoint) {
-  ScopedTraceWithContext("TensorNetState<ScalarType>::applyGate", controlQubits.size(),
-                         targetQubits.size());
+void TensorNetState<ScalarType>::applyGate(
+    const std::vector<int32_t> &controlQubits,
+    const std::vector<int32_t> &targetQubits, void *gateDeviceMem,
+    bool adjoint) {
+  ScopedTraceWithContext("TensorNetState<ScalarType>::applyGate",
+                         controlQubits.size(), targetQubits.size());
   if (controlQubits.empty()) {
     HANDLE_CUTN_ERROR(cutensornetStateApplyTensorOperator(
         m_cutnHandle, m_quantumState, targetQubits.size(), targetQubits.data(),
@@ -118,8 +121,8 @@ void TensorNetState<ScalarType>::applyUnitaryChannel(
 }
 
 template <typename ScalarType>
-void TensorNetState<ScalarType>::applyGeneralChannel(const std::vector<int32_t> &qubits,
-                                         const std::vector<void *> &krausOps) {
+void TensorNetState<ScalarType>::applyGeneralChannel(
+    const std::vector<int32_t> &qubits, const std::vector<void *> &krausOps) {
   LOG_API_TIME();
   HANDLE_CUTN_ERROR(cutensornetStateApplyGeneralChannel(
       m_cutnHandle, m_quantumState, /*numStateModes=*/qubits.size(),
@@ -132,8 +135,8 @@ void TensorNetState<ScalarType>::applyGeneralChannel(const std::vector<int32_t> 
 }
 
 template <typename ScalarType>
-void TensorNetState<ScalarType>::applyQubitProjector(void *proj_d,
-                                         const std::vector<int32_t> &qubitIdx) {
+void TensorNetState<ScalarType>::applyQubitProjector(
+    void *proj_d, const std::vector<int32_t> &qubitIdx) {
   LOG_API_TIME();
   HANDLE_CUTN_ERROR(cutensornetStateApplyTensorOperator(
       m_cutnHandle, m_quantumState, qubitIdx.size(), qubitIdx.data(), proj_d,
@@ -206,7 +209,8 @@ void TensorNetState<ScalarType>::addQubits(std::size_t numQubits) {
 }
 
 template <typename ScalarType>
-void TensorNetState<ScalarType>::addQubits(std::span<std::complex<double>> stateVec) {
+void TensorNetState<ScalarType>::addQubits(
+    std::span<std::complex<double>> stateVec) {
   LOG_API_TIME();
   const std::size_t numQubits = std::log2(stateVec.size());
   auto ket =
@@ -237,7 +241,8 @@ void TensorNetState<ScalarType>::addQubits(std::span<std::complex<double>> state
 
 template <typename ScalarType>
 std::pair<cutensornetStateSampler_t, cutensornetWorkspaceDescriptor_t>
-TensorNetState<ScalarType>::prepareSample(const std::vector<int32_t> &measuredBitIds) {
+TensorNetState<ScalarType>::prepareSample(
+    const std::vector<int32_t> &measuredBitIds) {
   LOG_API_TIME();
   // Create the quantum circuit sampler
   cutensornetStateSampler_t sampler;
@@ -299,10 +304,11 @@ TensorNetState<ScalarType>::prepareSample(const std::vector<int32_t> &measuredBi
 
 template <typename ScalarType>
 std::unordered_map<std::string, size_t>
-TensorNetState<ScalarType>::executeSample(cutensornetStateSampler_t &sampler,
-                              cutensornetWorkspaceDescriptor_t &workDesc,
-                              const std::vector<int32_t> &measuredBitIds,
-                              int32_t shots, bool enableCacheWorkspace) {
+TensorNetState<ScalarType>::executeSample(
+    cutensornetStateSampler_t &sampler,
+    cutensornetWorkspaceDescriptor_t &workDesc,
+    const std::vector<int32_t> &measuredBitIds, int32_t shots,
+    bool enableCacheWorkspace) {
   int64_t reqCacheSize{0};
   void *d_cache{nullptr};
   if (enableCacheWorkspace) {
@@ -367,7 +373,7 @@ TensorNetState<ScalarType>::executeSample(cutensornetStateSampler_t &sampler,
 template <typename ScalarType>
 std::unordered_map<std::string, size_t>
 TensorNetState<ScalarType>::sample(const std::vector<int32_t> &measuredBitIds,
-                       int32_t shots, bool enableCacheWorkspace) {
+                                   int32_t shots, bool enableCacheWorkspace) {
   LOG_API_TIME();
   auto [sampler, workDesc] = prepareSample(measuredBitIds);
   std::unordered_map<std::string, size_t> counts = executeSample(
@@ -380,7 +386,8 @@ TensorNetState<ScalarType>::sample(const std::vector<int32_t> &measuredBitIds,
 }
 
 template <typename ScalarType>
-std::pair<void *, std::size_t> TensorNetState<ScalarType>::contractStateVectorInternal(
+std::pair<void *, std::size_t>
+TensorNetState<ScalarType>::contractStateVectorInternal(
     const std::vector<int32_t> &projectedModes,
     const std::vector<int64_t> &in_projectedModeValues) {
   // Make sure that we don't overflow the memory size calculation.
@@ -394,8 +401,9 @@ std::pair<void *, std::size_t> TensorNetState<ScalarType>::contractStateVectorIn
   void *d_sv{nullptr};
   const uint64_t svDim = 1ull << (m_numQubits - projectedModes.size());
   {
-    ScopedTraceWithContext("TensorNetState<ScalarType>::contractStateVectorInternal "
-                           "State vector allocation");
+    ScopedTraceWithContext(
+        "TensorNetState<ScalarType>::contractStateVectorInternal "
+        "State vector allocation");
     HANDLE_CUDA_ERROR(cudaMalloc(&d_sv, svDim * sizeof(std::complex<double>)));
   }
   // Create the quantum state amplitudes accessor
@@ -462,10 +470,9 @@ std::pair<void *, std::size_t> TensorNetState<ScalarType>::contractStateVectorIn
 }
 
 template <typename ScalarType>
-std::vector<MPSTensor>
-TensorNetState<ScalarType>::setupMPSFactorize(int64_t maxExtent, double absCutoff,
-                                  double relCutoff,
-                                  cutensornetTensorSVDAlgo_t algo) {
+std::vector<MPSTensor> TensorNetState<ScalarType>::setupMPSFactorize(
+    int64_t maxExtent, double absCutoff, double relCutoff,
+    cutensornetTensorSVDAlgo_t algo) {
   LOG_API_TIME();
   if (m_numQubits == 0)
     return {};
@@ -521,7 +528,8 @@ TensorNetState<ScalarType>::setupMPSFactorize(int64_t maxExtent, double absCutof
 }
 
 template <typename ScalarType>
-void TensorNetState<ScalarType>::computeMPSFactorize(std::vector<MPSTensor> &mpsTensors) {
+void TensorNetState<ScalarType>::computeMPSFactorize(
+    std::vector<MPSTensor> &mpsTensors) {
   LOG_API_TIME();
   if (mpsTensors.empty())
     return;
@@ -693,8 +701,8 @@ TensorNetState<ScalarType>::computeRDM(const std::vector<int32_t> &qubits) {
 template <typename ScalarType>
 std::vector<MPSTensor>
 TensorNetState<ScalarType>::factorizeMPS(int64_t maxExtent, double absCutoff,
-                             double relCutoff,
-                             cutensornetTensorSVDAlgo_t algo) {
+                                         double relCutoff,
+                                         cutensornetTensorSVDAlgo_t algo) {
   LOG_API_TIME();
   auto mpsTensors = setupMPSFactorize(maxExtent, absCutoff, relCutoff, algo);
   computeMPSFactorize(mpsTensors);
@@ -960,7 +968,8 @@ std::complex<double> TensorNetState<ScalarType>::computeExpVal(
 }
 
 template <typename ScalarType>
-std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::createFromMpsTensors(
+std::unique_ptr<TensorNetState<ScalarType>>
+TensorNetState<ScalarType>::createFromMpsTensors(
     const std::vector<MPSTensor> &in_mpsTensors, ScratchDeviceMem &inScratchPad,
     cutensornetHandle_t handle, std::mt19937 &randomEngine) {
   LOG_API_TIME();
@@ -983,7 +992,8 @@ std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::createFr
 /// Reconstruct/initialize a tensor network state from a list of tensor
 /// operators.
 template <typename ScalarType>
-std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::createFromOpTensors(
+std::unique_ptr<TensorNetState<ScalarType>>
+TensorNetState<ScalarType>::createFromOpTensors(
     std::size_t numQubits, const std::vector<AppliedTensorOp> &opTensors,
     ScratchDeviceMem &inScratchPad, cutensornetHandle_t handle,
     std::mt19937 &randomEngine) {
@@ -1001,8 +1011,8 @@ std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::createFr
 }
 
 template <typename ScalarType>
-std::vector<std::complex<double>>
-TensorNetState<ScalarType>::reverseQubitOrder(std::span<std::complex<double>> stateVec) {
+std::vector<std::complex<double>> TensorNetState<ScalarType>::reverseQubitOrder(
+    std::span<std::complex<double>> stateVec) {
   std::vector<std::complex<double>> ket(stateVec.size());
   const std::size_t numQubits = std::log2(stateVec.size());
   for (std::size_t i = 0; i < stateVec.size(); ++i) {
@@ -1088,7 +1098,8 @@ void TensorNetState<ScalarType>::setZeroState() {
 }
 
 template <typename ScalarType>
-std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::createFromStateVector(
+std::unique_ptr<TensorNetState<ScalarType>>
+TensorNetState<ScalarType>::createFromStateVector(
     std::span<std::complex<double>> stateVec, ScratchDeviceMem &inScratchPad,
     cutensornetHandle_t handle, std::mt19937 &randomEngine) {
   LOG_API_TIME();

--- a/runtime/nvqir/cutensornet/tensornet_state.inc
+++ b/runtime/nvqir/cutensornet/tensornet_state.inc
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/****************************************************************-*- C++ -*-****
  * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
@@ -13,7 +13,8 @@
 #include <cassert>
 
 namespace nvqir {
-std::int32_t TensorNetState::numHyperSamples = []() {
+template <typename ScalarType>
+std::int32_t TensorNetState<ScalarType>::numHyperSamples = []() {
   constexpr int32_t defaultNumHyperSamples = 8;
   if (auto envVal = std::getenv("CUDAQ_TENSORNET_NUM_HYPER_SAMPLES")) {
     int32_t specifiedNumHyperSamples = 0;
@@ -35,7 +36,8 @@ std::int32_t TensorNetState::numHyperSamples = []() {
   return defaultNumHyperSamples;
 }();
 
-TensorNetState::TensorNetState(std::size_t numQubits,
+template <typename ScalarType>
+TensorNetState<ScalarType>::TensorNetState(std::size_t numQubits,
                                ScratchDeviceMem &inScratchPad,
                                cutensornetHandle_t handle,
                                std::mt19937 &randomEngine)
@@ -47,7 +49,8 @@ TensorNetState::TensorNetState(std::size_t numQubits,
       qubitDims.data(), CUDA_C_64F, &m_quantumState));
 }
 
-TensorNetState::TensorNetState(const std::vector<int> &basisState,
+template <typename ScalarType>
+TensorNetState<ScalarType>::TensorNetState(const std::vector<int> &basisState,
                                ScratchDeviceMem &inScratchPad,
                                cutensornetHandle_t handle,
                                std::mt19937 &randomEngine)
@@ -67,15 +70,17 @@ TensorNetState::TensorNetState(const std::vector<int> &basisState,
   }
 }
 
-std::unique_ptr<TensorNetState> TensorNetState::clone() const {
+template <typename ScalarType>
+std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::clone() const {
   return createFromOpTensors(m_numQubits, m_tensorOps, scratchPad, m_cutnHandle,
                              m_randomEngine);
 }
 
-void TensorNetState::applyGate(const std::vector<int32_t> &controlQubits,
+template <typename ScalarType>
+void TensorNetState<ScalarType>::applyGate(const std::vector<int32_t> &controlQubits,
                                const std::vector<int32_t> &targetQubits,
                                void *gateDeviceMem, bool adjoint) {
-  ScopedTraceWithContext("TensorNetState::applyGate", controlQubits.size(),
+  ScopedTraceWithContext("TensorNetState<ScalarType>::applyGate", controlQubits.size(),
                          targetQubits.size());
   if (controlQubits.empty()) {
     HANDLE_CUTN_ERROR(cutensornetStateApplyTensorOperator(
@@ -96,7 +101,8 @@ void TensorNetState::applyGate(const std::vector<int32_t> &controlQubits,
                                            controlQubits, adjoint, true});
 }
 
-void TensorNetState::applyUnitaryChannel(
+template <typename ScalarType>
+void TensorNetState<ScalarType>::applyUnitaryChannel(
     const std::vector<int32_t> &qubits, const std::vector<void *> &krausOps,
     const std::vector<double> &probabilities) {
   LOG_API_TIME();
@@ -111,7 +117,8 @@ void TensorNetState::applyUnitaryChannel(
   m_hasNoiseChannel = true;
 }
 
-void TensorNetState::applyGeneralChannel(const std::vector<int32_t> &qubits,
+template <typename ScalarType>
+void TensorNetState<ScalarType>::applyGeneralChannel(const std::vector<int32_t> &qubits,
                                          const std::vector<void *> &krausOps) {
   LOG_API_TIME();
   HANDLE_CUTN_ERROR(cutensornetStateApplyGeneralChannel(
@@ -124,7 +131,8 @@ void TensorNetState::applyGeneralChannel(const std::vector<int32_t> &qubits,
   m_hasNoiseChannel = true;
 }
 
-void TensorNetState::applyQubitProjector(void *proj_d,
+template <typename ScalarType>
+void TensorNetState<ScalarType>::applyQubitProjector(void *proj_d,
                                          const std::vector<int32_t> &qubitIdx) {
   LOG_API_TIME();
   HANDLE_CUTN_ERROR(cutensornetStateApplyTensorOperator(
@@ -135,7 +143,8 @@ void TensorNetState::applyQubitProjector(void *proj_d,
   m_tensorOps.emplace_back(AppliedTensorOp{proj_d, qubitIdx, {}, false, false});
 }
 
-void TensorNetState::addQubits(std::size_t numQubits) {
+template <typename ScalarType>
+void TensorNetState<ScalarType>::addQubits(std::size_t numQubits) {
   LOG_API_TIME();
   // Destroy the current quantum circuit state
   HANDLE_CUTN_ERROR(cutensornetDestroyState(m_quantumState));
@@ -196,7 +205,8 @@ void TensorNetState::addQubits(std::size_t numQubits) {
     }
 }
 
-void TensorNetState::addQubits(std::span<std::complex<double>> stateVec) {
+template <typename ScalarType>
+void TensorNetState<ScalarType>::addQubits(std::span<std::complex<double>> stateVec) {
   LOG_API_TIME();
   const std::size_t numQubits = std::log2(stateVec.size());
   auto ket =
@@ -225,8 +235,9 @@ void TensorNetState::addQubits(std::span<std::complex<double>> stateVec) {
   m_tempDevicePtrs.emplace_back(d_proj);
 }
 
+template <typename ScalarType>
 std::pair<cutensornetStateSampler_t, cutensornetWorkspaceDescriptor_t>
-TensorNetState::prepareSample(const std::vector<int32_t> &measuredBitIds) {
+TensorNetState<ScalarType>::prepareSample(const std::vector<int32_t> &measuredBitIds) {
   LOG_API_TIME();
   // Create the quantum circuit sampler
   cutensornetStateSampler_t sampler;
@@ -286,8 +297,9 @@ TensorNetState::prepareSample(const std::vector<int32_t> &measuredBitIds) {
   return std::make_pair(sampler, workDesc);
 }
 
+template <typename ScalarType>
 std::unordered_map<std::string, size_t>
-TensorNetState::executeSample(cutensornetStateSampler_t &sampler,
+TensorNetState<ScalarType>::executeSample(cutensornetStateSampler_t &sampler,
                               cutensornetWorkspaceDescriptor_t &workDesc,
                               const std::vector<int32_t> &measuredBitIds,
                               int32_t shots, bool enableCacheWorkspace) {
@@ -352,8 +364,9 @@ TensorNetState::executeSample(cutensornetStateSampler_t &sampler,
   return counts;
 }
 
+template <typename ScalarType>
 std::unordered_map<std::string, size_t>
-TensorNetState::sample(const std::vector<int32_t> &measuredBitIds,
+TensorNetState<ScalarType>::sample(const std::vector<int32_t> &measuredBitIds,
                        int32_t shots, bool enableCacheWorkspace) {
   LOG_API_TIME();
   auto [sampler, workDesc] = prepareSample(measuredBitIds);
@@ -366,7 +379,8 @@ TensorNetState::sample(const std::vector<int32_t> &measuredBitIds,
   return counts;
 }
 
-std::pair<void *, std::size_t> TensorNetState::contractStateVectorInternal(
+template <typename ScalarType>
+std::pair<void *, std::size_t> TensorNetState<ScalarType>::contractStateVectorInternal(
     const std::vector<int32_t> &projectedModes,
     const std::vector<int64_t> &in_projectedModeValues) {
   // Make sure that we don't overflow the memory size calculation.
@@ -380,7 +394,7 @@ std::pair<void *, std::size_t> TensorNetState::contractStateVectorInternal(
   void *d_sv{nullptr};
   const uint64_t svDim = 1ull << (m_numQubits - projectedModes.size());
   {
-    ScopedTraceWithContext("TensorNetState::contractStateVectorInternal "
+    ScopedTraceWithContext("TensorNetState<ScalarType>::contractStateVectorInternal "
                            "State vector allocation");
     HANDLE_CUDA_ERROR(cudaMalloc(&d_sv, svDim * sizeof(std::complex<double>)));
   }
@@ -447,8 +461,9 @@ std::pair<void *, std::size_t> TensorNetState::contractStateVectorInternal(
   return std::make_pair(d_sv, svDim);
 }
 
+template <typename ScalarType>
 std::vector<MPSTensor>
-TensorNetState::setupMPSFactorize(int64_t maxExtent, double absCutoff,
+TensorNetState<ScalarType>::setupMPSFactorize(int64_t maxExtent, double absCutoff,
                                   double relCutoff,
                                   cutensornetTensorSVDAlgo_t algo) {
   LOG_API_TIME();
@@ -505,7 +520,8 @@ TensorNetState::setupMPSFactorize(int64_t maxExtent, double absCutoff,
   return mpsTensors;
 }
 
-void TensorNetState::computeMPSFactorize(std::vector<MPSTensor> &mpsTensors) {
+template <typename ScalarType>
+void TensorNetState<ScalarType>::computeMPSFactorize(std::vector<MPSTensor> &mpsTensors) {
   LOG_API_TIME();
   if (mpsTensors.empty())
     return;
@@ -585,7 +601,8 @@ void TensorNetState::computeMPSFactorize(std::vector<MPSTensor> &mpsTensors) {
     free(hostWork);
 }
 
-std::vector<std::complex<double>> TensorNetState::getStateVector(
+template <typename ScalarType>
+std::vector<std::complex<double>> TensorNetState<ScalarType>::getStateVector(
     const std::vector<int32_t> &projectedModes,
     const std::vector<int64_t> &projectedModeValues) {
   auto [d_sv, svDim] =
@@ -600,8 +617,9 @@ std::vector<std::complex<double>> TensorNetState::getStateVector(
   return h_sv;
 }
 
+template <typename ScalarType>
 std::vector<std::complex<double>>
-TensorNetState::computeRDM(const std::vector<int32_t> &qubits) {
+TensorNetState<ScalarType>::computeRDM(const std::vector<int32_t> &qubits) {
   // Make sure that we don't overflow the memory size calculation.
   // Note: the actual limitation will depend on the system memory.
   if (qubits.size() >= 32 ||
@@ -672,8 +690,9 @@ TensorNetState::computeRDM(const std::vector<int32_t> &qubits) {
 
 // Returns MPS tensors (device mems)
 // Note: user needs to clean up these tensors
+template <typename ScalarType>
 std::vector<MPSTensor>
-TensorNetState::factorizeMPS(int64_t maxExtent, double absCutoff,
+TensorNetState<ScalarType>::factorizeMPS(int64_t maxExtent, double absCutoff,
                              double relCutoff,
                              cutensornetTensorSVDAlgo_t algo) {
   LOG_API_TIME();
@@ -682,7 +701,8 @@ TensorNetState::factorizeMPS(int64_t maxExtent, double absCutoff,
   return mpsTensors;
 }
 
-std::vector<std::complex<double>> TensorNetState::computeExpVals(
+template <typename ScalarType>
+std::vector<std::complex<double>> TensorNetState<ScalarType>::computeExpVals(
     const std::vector<cudaq::spin_op_term> &product_terms,
     const std::optional<std::size_t> &numberTrajectories) {
   LOG_API_TIME();
@@ -868,7 +888,8 @@ std::vector<std::complex<double>> TensorNetState::computeExpVals(
   return allExpVals;
 }
 
-std::complex<double> TensorNetState::computeExpVal(
+template <typename ScalarType>
+std::complex<double> TensorNetState<ScalarType>::computeExpVal(
     cutensornetNetworkOperator_t tensorNetworkOperator,
     const std::optional<std::size_t> &numberTrajectories) {
   LOG_API_TIME();
@@ -938,7 +959,8 @@ std::complex<double> TensorNetState::computeExpVal(
   return expVal;
 }
 
-std::unique_ptr<TensorNetState> TensorNetState::createFromMpsTensors(
+template <typename ScalarType>
+std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::createFromMpsTensors(
     const std::vector<MPSTensor> &in_mpsTensors, ScratchDeviceMem &inScratchPad,
     cutensornetHandle_t handle, std::mt19937 &randomEngine) {
   LOG_API_TIME();
@@ -960,7 +982,8 @@ std::unique_ptr<TensorNetState> TensorNetState::createFromMpsTensors(
 
 /// Reconstruct/initialize a tensor network state from a list of tensor
 /// operators.
-std::unique_ptr<TensorNetState> TensorNetState::createFromOpTensors(
+template <typename ScalarType>
+std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::createFromOpTensors(
     std::size_t numQubits, const std::vector<AppliedTensorOp> &opTensors,
     ScratchDeviceMem &inScratchPad, cutensornetHandle_t handle,
     std::mt19937 &randomEngine) {
@@ -977,8 +1000,9 @@ std::unique_ptr<TensorNetState> TensorNetState::createFromOpTensors(
   return state;
 }
 
+template <typename ScalarType>
 std::vector<std::complex<double>>
-TensorNetState::reverseQubitOrder(std::span<std::complex<double>> stateVec) {
+TensorNetState<ScalarType>::reverseQubitOrder(std::span<std::complex<double>> stateVec) {
   std::vector<std::complex<double>> ket(stateVec.size());
   const std::size_t numQubits = std::log2(stateVec.size());
   for (std::size_t i = 0; i < stateVec.size(); ++i) {
@@ -991,7 +1015,8 @@ TensorNetState::reverseQubitOrder(std::span<std::complex<double>> stateVec) {
   return ket;
 }
 
-bool TensorNetState::hasGeneralChannelApplied() const {
+template <typename ScalarType>
+bool TensorNetState<ScalarType>::hasGeneralChannelApplied() const {
   for (const auto &op : m_tensorOps)
     if (op.noiseChannel.has_value() && op.noiseChannel->probabilities.empty())
       return true;
@@ -999,7 +1024,8 @@ bool TensorNetState::hasGeneralChannelApplied() const {
   return false;
 }
 
-void TensorNetState::applyCachedOps() {
+template <typename ScalarType>
+void TensorNetState<ScalarType>::applyCachedOps() {
   int64_t tensorId = 0;
   for (auto &op : m_tensorOps)
     if (op.deviceData) {
@@ -1049,7 +1075,8 @@ void TensorNetState::applyCachedOps() {
     }
 }
 
-void TensorNetState::setZeroState() {
+template <typename ScalarType>
+void TensorNetState<ScalarType>::setZeroState() {
   LOG_API_TIME();
   // Destroy the current quantum circuit state
   HANDLE_CUTN_ERROR(cutensornetDestroyState(m_quantumState));
@@ -1060,7 +1087,8 @@ void TensorNetState::setZeroState() {
       qubitDims.data(), CUDA_C_64F, &m_quantumState));
 }
 
-std::unique_ptr<TensorNetState> TensorNetState::createFromStateVector(
+template <typename ScalarType>
+std::unique_ptr<TensorNetState<ScalarType>> TensorNetState<ScalarType>::createFromStateVector(
     std::span<std::complex<double>> stateVec, ScratchDeviceMem &inScratchPad,
     cutensornetHandle_t handle, std::mt19937 &randomEngine) {
   LOG_API_TIME();
@@ -1101,7 +1129,8 @@ std::unique_ptr<TensorNetState> TensorNetState::createFromStateVector(
   return state;
 }
 
-TensorNetState::~TensorNetState() {
+template <typename ScalarType>
+TensorNetState<ScalarType>::~TensorNetState() {
   // Destroy the quantum circuit state
   HANDLE_CUTN_ERROR(cutensornetDestroyState(m_quantumState));
   for (auto *ptr : m_tempDevicePtrs)

--- a/runtime/nvqir/cutensornet/tn_simulation_state.h
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.h
@@ -18,10 +18,11 @@
 
 namespace nvqir {
 
+template <typename ScalarType = double>
 class TensorNetSimulationState : public cudaq::SimulationState {
 
 public:
-  TensorNetSimulationState(std::unique_ptr<TensorNetState> inState,
+  TensorNetSimulationState(std::unique_ptr<TensorNetState<ScalarType>> inState,
                            ScratchDeviceMem &inScratchPad,
                            cutensornetHandle_t cutnHandle,
                            std::mt19937 &randomEngine);
@@ -71,7 +72,7 @@ public:
   }
 
 protected:
-  std::unique_ptr<TensorNetState> m_state;
+  std::unique_ptr<TensorNetState<ScalarType>> m_state;
   ScratchDeviceMem &scratchPad;
   cutensornetHandle_t m_cutnHandle;
   // Max number of qubits whereby the tensor network state should be contracted
@@ -82,3 +83,5 @@ protected:
   std::mt19937 &m_randomEngine;
 };
 } // namespace nvqir
+
+#include "tn_simulation_state.inc"

--- a/runtime/nvqir/cutensornet/tn_simulation_state.inc
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.inc
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/****************************************************************-*- C++ -*-****
  * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
@@ -16,20 +16,25 @@ int deviceFromPointer(void *ptr) {
   HANDLE_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr));
   return attributes.device;
 }
-std::size_t TensorNetSimulationState::getNumQubits() const {
+
+template <typename ScalarType>
+std::size_t TensorNetSimulationState<ScalarType>::getNumQubits() const {
   return m_state->getNumQubits();
 }
 
-TensorNetSimulationState::TensorNetSimulationState(
-    std::unique_ptr<TensorNetState> inState, ScratchDeviceMem &inScratchPad,
+template <typename ScalarType>
+TensorNetSimulationState<ScalarType>::TensorNetSimulationState(
+    std::unique_ptr<TensorNetState<ScalarType>> inState, ScratchDeviceMem &inScratchPad,
     cutensornetHandle_t cutnHandle, std::mt19937 &randomEngine)
     : m_state(std::move(inState)), scratchPad(inScratchPad),
       m_cutnHandle(cutnHandle), m_randomEngine(randomEngine) {}
 
-TensorNetSimulationState::~TensorNetSimulationState() {}
+template <typename ScalarType>
+TensorNetSimulationState<ScalarType>::~TensorNetSimulationState() {}
 
+template <typename ScalarType>
 std::complex<double>
-TensorNetSimulationState::overlap(const cudaq::SimulationState &other) {
+TensorNetSimulationState<ScalarType>::overlap(const cudaq::SimulationState &other) {
   const cudaq::SimulationState *const otherStatePtr = &other;
   const TensorNetSimulationState *const tnOther =
       dynamic_cast<const TensorNetSimulationState *>(otherStatePtr);
@@ -137,7 +142,7 @@ TensorNetSimulationState::overlap(const cudaq::SimulationState &other) {
         projectedModes.data(), nullptr, &accessor));
   }
 
-  const int32_t numHyperSamples = TensorNetState::numHyperSamples;
+  const int32_t numHyperSamples = TensorNetState<ScalarType>::numHyperSamples;
   {
     ScopedTraceWithContext("cutensornetAccessorConfigure");
     HANDLE_CUTN_ERROR(cutensornetAccessorConfigure(
@@ -189,8 +194,9 @@ TensorNetSimulationState::overlap(const cudaq::SimulationState &other) {
   return std::abs(h_overlap);
 }
 
+template <typename ScalarType>
 std::complex<double>
-TensorNetSimulationState::getAmplitude(const std::vector<int> &basisState) {
+TensorNetSimulationState<ScalarType>::getAmplitude(const std::vector<int> &basisState) {
   if (getNumQubits() != basisState.size())
     throw std::runtime_error(
         fmt::format("[tensornet-state] getAmplitude with an invalid number "
@@ -228,8 +234,9 @@ TensorNetSimulationState::getAmplitude(const std::vector<int> &basisState) {
   return subStateVec[0];
 }
 
+template <typename ScalarType>
 cudaq::SimulationState::Tensor
-TensorNetSimulationState::getTensor(std::size_t tensorIdx) const {
+TensorNetSimulationState<ScalarType>::getTensor(std::size_t tensorIdx) const {
   if (tensorIdx >= getNumTensors())
     throw std::out_of_range("Invalid tensor index");
   cudaq::SimulationState::Tensor tensor;
@@ -241,8 +248,9 @@ TensorNetSimulationState::getTensor(std::size_t tensorIdx) const {
   return tensor;
 }
 
+template <typename ScalarType>
 std::vector<cudaq::SimulationState::Tensor>
-TensorNetSimulationState::getTensors() const {
+TensorNetSimulationState<ScalarType>::getTensors() const {
   std::vector<cudaq::SimulationState::Tensor> tensors;
   tensors.reserve(m_state->m_tensorOps.size());
 
@@ -257,12 +265,14 @@ TensorNetSimulationState::getTensors() const {
   return tensors;
 }
 
-std::size_t TensorNetSimulationState::getNumTensors() const {
+template <typename ScalarType>
+std::size_t TensorNetSimulationState<ScalarType>::getNumTensors() const {
   return m_state->m_tensorOps.size();
 }
 
+template <typename ScalarType>
 std::unique_ptr<cudaq::SimulationState>
-TensorNetSimulationState::createFromSizeAndPtr(std::size_t size, void *ptr,
+TensorNetSimulationState<ScalarType>::createFromSizeAndPtr(std::size_t size, void *ptr,
                                                std::size_t dataType) {
   if (dataType == cudaq::detail::variant_index<cudaq::state_data,
                                                cudaq::TensorStateData>()) {
@@ -272,19 +282,21 @@ TensorNetSimulationState::createFromSizeAndPtr(std::size_t size, void *ptr,
   std::vector<std::complex<double>> vec(
       reinterpret_cast<std::complex<double> *>(ptr),
       reinterpret_cast<std::complex<double> *>(ptr) + size);
-  auto tensorNetState = TensorNetState::createFromStateVector(
+  auto tensorNetState = TensorNetState<ScalarType>::createFromStateVector(
       vec, scratchPad, m_cutnHandle, m_randomEngine);
 
-  return std::make_unique<TensorNetSimulationState>(
+  return std::make_unique<TensorNetSimulationState<ScalarType>>(
       std::move(tensorNetState), scratchPad, m_cutnHandle, m_randomEngine);
 }
 
-void TensorNetSimulationState::destroyState() {
+template <typename ScalarType>
+void TensorNetSimulationState<ScalarType>::destroyState() {
   cudaq::info("mps-state destroying state vector handle.");
   m_state.reset();
 }
 
-void TensorNetSimulationState::toHost(std::complex<double> *clientAllocatedData,
+template <typename ScalarType>
+void TensorNetSimulationState<ScalarType>::toHost(std::complex<double> *clientAllocatedData,
                                       std::size_t numElements) const {
   auto stateVec = m_state->getStateVector();
   if (stateVec.size() != numElements)
@@ -296,7 +308,8 @@ void TensorNetSimulationState::toHost(std::complex<double> *clientAllocatedData,
     clientAllocatedData[i] = stateVec[i];
 }
 
-void TensorNetSimulationState::dump(std::ostream &os) const {
+template <typename ScalarType>
+void TensorNetSimulationState<ScalarType>::dump(std::ostream &os) const {
   const auto printState = [&os](const auto &stateVec) {
     for (auto &t : stateVec)
       os << t << "\n";

--- a/runtime/nvqir/cutensornet/tn_simulation_state.inc
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.inc
@@ -6,7 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "tn_simulation_state.h"
+#pragma once
+
 #include "cudaq/utils/cudaq_utils.h"
 #include <cuComplex.h>
 
@@ -24,8 +25,9 @@ std::size_t TensorNetSimulationState<ScalarType>::getNumQubits() const {
 
 template <typename ScalarType>
 TensorNetSimulationState<ScalarType>::TensorNetSimulationState(
-    std::unique_ptr<TensorNetState<ScalarType>> inState, ScratchDeviceMem &inScratchPad,
-    cutensornetHandle_t cutnHandle, std::mt19937 &randomEngine)
+    std::unique_ptr<TensorNetState<ScalarType>> inState,
+    ScratchDeviceMem &inScratchPad, cutensornetHandle_t cutnHandle,
+    std::mt19937 &randomEngine)
     : m_state(std::move(inState)), scratchPad(inScratchPad),
       m_cutnHandle(cutnHandle), m_randomEngine(randomEngine) {}
 
@@ -33,8 +35,8 @@ template <typename ScalarType>
 TensorNetSimulationState<ScalarType>::~TensorNetSimulationState() {}
 
 template <typename ScalarType>
-std::complex<double>
-TensorNetSimulationState<ScalarType>::overlap(const cudaq::SimulationState &other) {
+std::complex<double> TensorNetSimulationState<ScalarType>::overlap(
+    const cudaq::SimulationState &other) {
   const cudaq::SimulationState *const otherStatePtr = &other;
   const TensorNetSimulationState *const tnOther =
       dynamic_cast<const TensorNetSimulationState *>(otherStatePtr);
@@ -195,8 +197,8 @@ TensorNetSimulationState<ScalarType>::overlap(const cudaq::SimulationState &othe
 }
 
 template <typename ScalarType>
-std::complex<double>
-TensorNetSimulationState<ScalarType>::getAmplitude(const std::vector<int> &basisState) {
+std::complex<double> TensorNetSimulationState<ScalarType>::getAmplitude(
+    const std::vector<int> &basisState) {
   if (getNumQubits() != basisState.size())
     throw std::runtime_error(
         fmt::format("[tensornet-state] getAmplitude with an invalid number "
@@ -272,8 +274,8 @@ std::size_t TensorNetSimulationState<ScalarType>::getNumTensors() const {
 
 template <typename ScalarType>
 std::unique_ptr<cudaq::SimulationState>
-TensorNetSimulationState<ScalarType>::createFromSizeAndPtr(std::size_t size, void *ptr,
-                                               std::size_t dataType) {
+TensorNetSimulationState<ScalarType>::createFromSizeAndPtr(
+    std::size_t size, void *ptr, std::size_t dataType) {
   if (dataType == cudaq::detail::variant_index<cudaq::state_data,
                                                cudaq::TensorStateData>()) {
     throw std::runtime_error(
@@ -296,8 +298,8 @@ void TensorNetSimulationState<ScalarType>::destroyState() {
 }
 
 template <typename ScalarType>
-void TensorNetSimulationState<ScalarType>::toHost(std::complex<double> *clientAllocatedData,
-                                      std::size_t numElements) const {
+void TensorNetSimulationState<ScalarType>::toHost(
+    std::complex<double> *clientAllocatedData, std::size_t numElements) const {
   auto stateVec = m_state->getStateVector();
   if (stateVec.size() != numElements)
     throw std::runtime_error(fmt::format(


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Note: no function changes yet. The template type would not affect the code, i.e., it would still only use cutensornet double precision.
