### PR TITLE
Add parser for the legacy tagged output format

### DIFF
--- a/unittests/output_record/RecordParserTester.cpp
+++ b/unittests/output_record/RecordParserTester.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "CUDAQTestUtils.h"
+#include "TestSamples.h"
 #include "common/RecordLogDecoder.h"
 #include <cudaq.h>
 
@@ -49,4 +50,26 @@ CUDAQ_TEST(ParserTester, checkDoubles) {
   std::memcpy(buffer, origBuffer, bufferSize);
   EXPECT_EQ(3.14, buffer[0]);
   EXPECT_EQ(2.717, buffer[1]);
+}
+
+CUDAQ_TEST(ParserTester, checkTaggedFormatBool) {
+  cudaq::TaggedRecordLogDecoder parser({"r00000"});
+  parser.decode(taggedFormatSample1);
+  auto *origBuffer = parser.getBufferPtr();
+  std::size_t bufferSize = parser.getBufferSize();
+  EXPECT_EQ(25, bufferSize / sizeof(bool));
+  bool *buffer = static_cast<bool *>(origBuffer);
+  for (int i = 0; i < 25; ++i)
+    EXPECT_FALSE(buffer[i]);
+}
+
+CUDAQ_TEST(ParserTester, checkTaggedFormatInt) {
+  cudaq::TaggedRecordLogDecoder parser({"r00000"});
+  parser.decode(taggedFormatSample2);
+  auto *origBuffer = parser.getBufferPtr();
+  std::size_t bufferSize = parser.getBufferSize();
+  EXPECT_EQ(25, bufferSize / sizeof(int32_t));
+  int32_t *buffer = static_cast<int32_t *>(origBuffer);
+  for (int32_t i = 0; i < 25; ++i)
+    EXPECT_EQ(buffer[i], i);
 }

--- a/unittests/output_record/TestSamples.h
+++ b/unittests/output_record/TestSamples.h
@@ -1,0 +1,217 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+static const char *taggedFormatSample1 =
+    R"(METADATA	OUTPUT_RECORD_FORMAT	tagged
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	0	"r00000"
+RESULT	0	"i1"
+END
+START
+RESULT	1	"r00000"
+RESULT	0	"i1"
+END
+)";
+
+static const char *taggedFormatSample2 =
+    R"(METADATA	OUTPUT_RECORD_FORMAT	tagged
+START
+RESULT	1	"r00000"
+RESULT	0	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	1	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	2	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	3	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	4	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	5	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	6	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	7	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	8	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	9	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	10	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	11	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	12	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	13	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	14	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	15	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	16	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	17	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	18	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	19	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	20	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	21	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	22	"i32"
+END
+START
+RESULT	0	"r00000"
+RESULT	23	"i32"
+END
+START
+RESULT	1	"r00000"
+RESULT	24	"i32"
+END
+)";


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Add extension points to the `RecordLogDecoder`:

- Key to detect if this is an output line (default is `OUTPUT`)

- Pull the handling code into a virtual method for derived classes to modify.

- Add a flag to indicate whether the `END` line has shot status or not.


Add the decoder for tagged output: use `RESULT` key to detect the output line, only use label to detect the type, and filter `mz` result registers.

Add a couple of test cases with synthetic data. 

  
