### PR TITLE
Follow-up to #2809 - only set linker flags if environment supports it

### DIFF
--- a/scripts/build_cudaq.sh
+++ b/scripts/build_cudaq.sh
@@ -134,10 +134,13 @@ if [ -x "$(command -v "$LLVM_INSTALL_PREFIX/bin/ld.lld")" ]; then
   NVQPP_LD_PATH="$LLVM_INSTALL_PREFIX/bin/ld.lld"
   LINKER_TO_USE="lld"
   LINKER_FLAGS="-fuse-ld=lld -B$LLVM_INSTALL_PREFIX/bin"
+  LINKER_FLAG_LIST="\
+    -DCMAKE_LINKER='"$LINKER_TO_USE"' \
+    -DCMAKE_EXE_LINKER_FLAGS='"$LINKER_FLAGS"' \
+    -DLLVM_USE_LINKER='"$LINKER_TO_USE"'"
 else
   echo "No lld linker detected. Using the system linker."
-  LINKER_TO_USE="ld"
-  LINKER_FLAGS=""
+  LINKER_FLAG_LIST=""
 fi
 
 # Determine CUDA flags
@@ -169,9 +172,7 @@ cmake_args="-G Ninja '"$repo_root"' \
   -DCMAKE_CUDA_COMPILER='"$cuda_driver"' \
   -DCMAKE_CUDA_FLAGS='"$CUDAFLAGS"' \
   -DCMAKE_CUDA_HOST_COMPILER='"${CUDAHOSTCXX:-$CXX}"' \
-  -DCMAKE_LINKER='"$LINKER_TO_USE"' \
-  -DCMAKE_EXE_LINKER_FLAGS='"$LINKER_FLAGS"' \
-  -DLLVM_USE_LINKER='"$LINKER_TO_USE"' \
+  ${LINKER_FLAG_LIST} \
   ${OpenMP_libomp_LIBRARY:+-DOpenMP_C_LIB_NAMES=lib$OpenMP_libomp_LIBRARY} \
   ${OpenMP_libomp_LIBRARY:+-DOpenMP_CXX_LIB_NAMES=lib$OpenMP_libomp_LIBRARY} \
   ${OpenMP_libomp_LIBRARY:+-DOpenMP_libomp_LIBRARY=$OpenMP_libomp_LIBRARY} \


### PR DESCRIPTION
Some environments (like our manylinux build environment that is based off of AlmaLinux) don't support things like `-fuse-ld=ld`. That is - even if `ld` is the system linker, the compiler doesn't support being told `-fuse-ld=ld`. This change omits setting CMake variables for cases like that, while still allowing the lld linker to be used in environments that support it.

This is needed for the CUDA-QX builds, which invoke the `build_cudaq.sh` script for the manylinux environment.

Example failure (before this PR): https://github.com/NVIDIA/cudaqx/actions/runs/14544697190/job/40808489265