### PR TITLE
Fix the memory leak with vectors.

### DIFF
--- a/include/cudaq/Optimizer/Builder/Intrinsics.h
+++ b/include/cudaq/Optimizer/Builder/Intrinsics.h
@@ -21,6 +21,7 @@ static constexpr const char stdMoveBuiltin[] = ".std::move";
 
 static constexpr const char llvmMemCopyIntrinsic[] =
     "llvm.memcpy.p0i8.p0i8.i64";
+static constexpr const char llvmMemSetIntrinsic[] = "llvm.memset.p0i8.i64";
 
 // cudaq::range(count);
 static constexpr const char setCudaqRangeVector[] = "__nvqpp_CudaqRangeInit";

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -388,6 +388,11 @@ static constexpr IntrinsicCode intrinsicTable[] = {
      R"#(
   func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ())#"},
 
+    {cudaq::llvmMemSetIntrinsic, // llvm.memset.p0i8.i64
+     {},
+     R"#(
+  func.func private @llvm.memset.p0i8.i64(!cc.ptr<i8>, i8, i64, i1) -> ())#"},
+
     {"malloc", {}, "func.func private @malloc(i64) -> !cc.ptr<i8>"},
 
     // Declarations of QIR functions used by codegen that are common to all

--- a/lib/Optimizer/CodeGen/ReturnToOutputLog.cpp
+++ b/lib/Optimizer/CodeGen/ReturnToOutputLog.cpp
@@ -174,7 +174,23 @@ public:
                                             cudaq::opt::QIRArrayRecordOutput,
                                             ArrayRef<Value>{size, label});
               std::string preStr = prefix ? prefix->str() : std::string{};
-              auto rawBuffer = vecInit.getBuffer();
+              Value rawBuffer = vecInit.getBuffer();
+              if (auto callCopy = rawBuffer.getDefiningOp<func::CallOp>()) {
+                // We expect a call to __nvqpp_vectorCopyCtor here or, if that
+                // was inlined already, to memcpy.
+                auto calleeName = callCopy.getCallee();
+                if (calleeName == "__nvqpp_vectorCopyCtor") {
+                  rawBuffer = callCopy.getOperand(1);
+                  rewriter.eraseOp(callCopy);
+                } else if (calleeName == cudaq::llvmMemCopyIntrinsic) {
+                  rawBuffer = callCopy.getOperand(1);
+                  rewriter.eraseOp(callCopy);
+                  if (auto maybeMalloc =
+                          callCopy.getOperand(0).getDefiningOp<func::CallOp>())
+                    if (maybeMalloc.getCallee() == "malloc")
+                      rewriter.eraseOp(maybeMalloc);
+                }
+              }
               auto eleTy = vecTy.getElementType();
               auto buffTy = cudaq::cc::PointerType::get(eleTy);
               auto ptrArrTy =

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -656,49 +656,68 @@ public:
         // is, then we will need to convert it to a std::vector here. The vector
         // is constructed in-place on the sret memory block.
         Value arg0 = hostFuncEntryBlock->getArguments().front();
-        if (auto spanTy =
-                dyn_cast<cudaq::cc::SpanLikeType>(devFuncTy.getResult(0))) {
-          auto eleTy = spanTy.getElementType();
-          auto ptrTy = cudaq::cc::PointerType::get(eleTy);
-          auto gep0 = builder.create<cudaq::cc::ComputePtrOp>(
-              loc, cudaq::cc::PointerType::get(ptrTy), launchResult,
-              SmallVector<cudaq::cc::ComputePtrArg>{0});
-          auto dataPtr = builder.create<cudaq::cc::LoadOp>(loc, gep0);
-          auto lenPtrTy = cudaq::cc::PointerType::get(i64Ty);
-          auto gep1 = builder.create<cudaq::cc::ComputePtrOp>(
-              loc, lenPtrTy, launchResult,
-              SmallVector<cudaq::cc::ComputePtrArg>{1});
-          auto vecLen = builder.create<cudaq::cc::LoadOp>(loc, gep1);
-          if (spanTy.getElementType() == builder.getI1Type()) {
-            cudaq::opt::marshal::genStdvecBoolFromInitList(loc, builder, arg0,
-                                                           dataPtr, vecLen);
-          } else {
-            Value tSize =
-                builder.create<cudaq::cc::SizeOfOp>(loc, i64Ty, eleTy);
-            cudaq::opt::marshal::genStdvecTFromInitList(loc, builder, arg0,
-                                                        dataPtr, tSize, vecLen);
-          }
-          // free(nullptr) is defined to be a nop in the standard.
-          builder.create<func::CallOp>(loc, std::nullopt, "free",
-                                       ArrayRef<Value>{launchResultToFree});
-        } else {
-          // Otherwise, we can just copy the aggregate into the sret memory
-          // block. Uses the size of the host function's sret pointer element
-          // type for the memcpy, so the device should return an (aggregate)
-          // value of suitable size.
-          auto resPtr = builder.create<cudaq::cc::ComputePtrOp>(
-              loc, ptrResTy, msgBufferPrefix,
-              ArrayRef<cudaq::cc::ComputePtrArg>{offset});
-          auto castMsgBuff =
-              builder.create<cudaq::cc::CastOp>(loc, ptrI8Ty, resPtr);
-          Type eleTy =
-              cast<cudaq::cc::PointerType>(arg0.getType()).getElementType();
-          Value bytes = builder.create<cudaq::cc::SizeOfOp>(loc, i64Ty, eleTy);
-          auto notVolatile = builder.create<arith::ConstantIntOp>(loc, 0, 1);
-          auto castArg0 = builder.create<cudaq::cc::CastOp>(loc, ptrI8Ty, arg0);
+        if (module->hasAttr(cudaq::runtime::enableCudaqRun)) {
+          // In this case, the quantum kernel will never actually return
+          // anything. To make the C++ invocation behave correctly, we want to
+          // return an empty vector.
+          auto arg0PtrTy = cast<cudaq::cc::PointerType>(arg0.getType());
+          auto ptrI8Ty = cudaq::cc::PointerType::get(builder.getI8Type());
+          auto castedArg0 =
+              builder.create<cudaq::cc::CastOp>(loc, ptrI8Ty, arg0);
+          auto zero = builder.create<arith::ConstantIntOp>(loc, 0, 8);
+          auto numBytes = builder.create<cudaq::cc::SizeOfOp>(
+              loc, builder.getI64Type(), arg0PtrTy.getElementType());
+          auto falseVal = builder.create<arith::ConstantIntOp>(loc, 0, 1);
           builder.create<func::CallOp>(
-              loc, std::nullopt, cudaq::llvmMemCopyIntrinsic,
-              ValueRange{castArg0, castMsgBuff, bytes, notVolatile});
+              loc, std::nullopt, cudaq::llvmMemSetIntrinsic,
+              ValueRange{castedArg0, zero, numBytes, falseVal});
+        } else {
+          if (auto spanTy =
+                  dyn_cast<cudaq::cc::SpanLikeType>(devFuncTy.getResult(0))) {
+            auto eleTy = spanTy.getElementType();
+            auto ptrTy = cudaq::cc::PointerType::get(eleTy);
+            auto gep0 = builder.create<cudaq::cc::ComputePtrOp>(
+                loc, cudaq::cc::PointerType::get(ptrTy), launchResult,
+                SmallVector<cudaq::cc::ComputePtrArg>{0});
+            auto dataPtr = builder.create<cudaq::cc::LoadOp>(loc, gep0);
+            auto lenPtrTy = cudaq::cc::PointerType::get(i64Ty);
+            auto gep1 = builder.create<cudaq::cc::ComputePtrOp>(
+                loc, lenPtrTy, launchResult,
+                SmallVector<cudaq::cc::ComputePtrArg>{1});
+            auto vecLen = builder.create<cudaq::cc::LoadOp>(loc, gep1);
+            if (spanTy.getElementType() == builder.getI1Type()) {
+              cudaq::opt::marshal::genStdvecBoolFromInitList(loc, builder, arg0,
+                                                             dataPtr, vecLen);
+            } else {
+              Value tSize =
+                  builder.create<cudaq::cc::SizeOfOp>(loc, i64Ty, eleTy);
+              cudaq::opt::marshal::genStdvecTFromInitList(
+                  loc, builder, arg0, dataPtr, tSize, vecLen);
+            }
+            // free(nullptr) is defined to be a nop in the standard.
+            builder.create<func::CallOp>(loc, std::nullopt, "free",
+                                         ArrayRef<Value>{launchResultToFree});
+          } else {
+            // Otherwise, we can just copy the aggregate into the sret memory
+            // block. Uses the size of the host function's sret pointer element
+            // type for the memcpy, so the device should return an (aggregate)
+            // value of suitable size.
+            auto resPtr = builder.create<cudaq::cc::ComputePtrOp>(
+                loc, ptrResTy, msgBufferPrefix,
+                ArrayRef<cudaq::cc::ComputePtrArg>{offset});
+            auto castMsgBuff =
+                builder.create<cudaq::cc::CastOp>(loc, ptrI8Ty, resPtr);
+            Type eleTy =
+                cast<cudaq::cc::PointerType>(arg0.getType()).getElementType();
+            Value bytes =
+                builder.create<cudaq::cc::SizeOfOp>(loc, i64Ty, eleTy);
+            auto notVolatile = builder.create<arith::ConstantIntOp>(loc, 0, 1);
+            auto castArg0 =
+                builder.create<cudaq::cc::CastOp>(loc, ptrI8Ty, arg0);
+            builder.create<func::CallOp>(
+                loc, std::nullopt, cudaq::llvmMemCopyIntrinsic,
+                ValueRange{castArg0, castMsgBuff, bytes, notVolatile});
+          }
         }
       }
     }
@@ -834,6 +853,9 @@ public:
     if (failed(irBuilder.loadIntrinsic(module, cudaq::llvmMemCopyIntrinsic)))
       return module.emitError(std::string("could not load ") +
                               cudaq::llvmMemCopyIntrinsic);
+    if (failed(irBuilder.loadIntrinsic(module, cudaq::llvmMemSetIntrinsic)))
+      return module.emitError(std::string("could not load ") +
+                              cudaq::llvmMemSetIntrinsic);
     if (failed(irBuilder.loadIntrinsic(module, "__nvqpp_zeroDynamicResult")))
       return module.emitError("could not load __nvqpp_zeroDynamicResult");
     if (failed(irBuilder.loadIntrinsic(module, "__nvqpp_createDynamicResult")))


### PR DESCRIPTION
Fix the C++ entry point such that it returns a dummy (empty) object for the result when cudaq::run is enabled.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
