### PR TITLE
Fixing h11 vulnerability

### DIFF
--- a/docs/sphinx/applications/python/quantum_transformer_src/cuda_quantum_transformer_env.yml
+++ b/docs/sphinx/applications/python/quantum_transformer_src/cuda_quantum_transformer_env.yml
@@ -77,7 +77,7 @@ dependencies:
   - gnutls=3.7.9
   - graphite2=1.3.13
   - greenlet=3.1.1
-  - h11=0.14.0
+  - h11=0.16.0
   - h2=4.1.0
   - harfbuzz=10.1.0
   - hpack=4.0.0


### PR DESCRIPTION
Updating h11 to 0.16.0 (as it is patched) to fix CVE-2025-43859.
