### PR TITLE
Restructure `AsyncSampleResult` binding

### DIFF
--- a/runtime/common/Future.h
+++ b/runtime/common/Future.h
@@ -120,6 +120,10 @@ public:
     }
   }
 
+  virtual ~async_result() = default;
+  async_result(async_result &&) = default;
+  async_result &operator=(async_result &&other) = default;
+
   /// @brief Return the asynchronously computed data, will
   /// wait until the data is ready.
   T get() {


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

There is an oversight in PR #2800, where we created a wrapper for the underlying `async_sample_result` type.
This type is directly exposed in other binding code paths, hence a binding is required for the underlying type.

Hence, refactoring the implementation to make the wrapper a proper trampoline class of the `async_sample_result`.

Also, add a virtual destructor to enable trampoline inheritance.

