### PR TITLE
Update tensornet backend docs + expose MPS Gauge option (cuquantum 25.03 feature)

### DIFF
--- a/docs/sphinx/using/backends/sims/tnsims.rst
+++ b/docs/sphinx/using/backends/sims/tnsims.rst
@@ -145,7 +145,7 @@ To execute a program on the :code:`tensornet-mps` target, use the following comm
     
     .. code:: python 
 
-        cudaq.set_target('tensornet-mps', option = 'fp32')
+        cudaq.set_target('tensornet-mps', option='fp32')
 
     for the single-precision setting.   
 

--- a/docs/sphinx/using/backends/sims/tnsims.rst
+++ b/docs/sphinx/using/backends/sims/tnsims.rst
@@ -117,7 +117,7 @@ Matrix product state
 The :code:`tensornet-mps` backend is based on the matrix product state (MPS) representation of the state vector/wave function, exploiting the sparsity in the tensor network via tensor decomposition techniques such as QR and SVD. As such, this backend is an approximate simulator, whereby the number of singular values may be truncated to keep the MPS size tractable. 
 The :code:`tensornet-mps` backend only supports single-GPU simulation. Its approximate nature allows the :code:`tensornet-mps` backend to handle a large number of qubits for certain classes of quantum circuits on a relatively small memory footprint.
 
-The code:`tensornet` target supports both single and double floating point precision.
+The code:`tensornet-mps` target supports both single and double floating point precision.
 
 To execute a program on the :code:`tensornet-mps` target, use the following commands:
 

--- a/docs/sphinx/using/backends/sims/tnsims.rst
+++ b/docs/sphinx/using/backends/sims/tnsims.rst
@@ -17,7 +17,7 @@ The :code:`tensornet` backend represents quantum states and circuits as tensor n
 Measurement samples and expectation values are computed via tensor network contractions. 
 This backend supports multi-GPU, multi-node distribution of tensor operations required to evaluate and simulate the circuit.
 
-The code:`tensornet` target supports both floating point precisions.
+The code:`tensornet` target supports both single and double floating point precision.
 
 To execute a program on the :code:`tensornet` target using a *single GPU*, use the following commands:
 
@@ -117,7 +117,7 @@ Matrix product state
 The :code:`tensornet-mps` backend is based on the matrix product state (MPS) representation of the state vector/wave function, exploiting the sparsity in the tensor network via tensor decomposition techniques such as QR and SVD. As such, this backend is an approximate simulator, whereby the number of singular values may be truncated to keep the MPS size tractable. 
 The :code:`tensornet-mps` backend only supports single-GPU simulation. Its approximate nature allows the :code:`tensornet-mps` backend to handle a large number of qubits for certain classes of quantum circuits on a relatively small memory footprint.
 
-The code:`tensornet` target supports both floating point precisions.
+The code:`tensornet` target supports both single and double floating point precision.
 
 To execute a program on the :code:`tensornet-mps` target, use the following commands:
 

--- a/docs/sphinx/using/backends/sims/tnsims.rst
+++ b/docs/sphinx/using/backends/sims/tnsims.rst
@@ -17,19 +17,37 @@ The :code:`tensornet` backend represents quantum states and circuits as tensor n
 Measurement samples and expectation values are computed via tensor network contractions. 
 This backend supports multi-GPU, multi-node distribution of tensor operations required to evaluate and simulate the circuit.
 
+The code:`tensornet` target supports both floating point precisions.
+
 To execute a program on the :code:`tensornet` target using a *single GPU*, use the following commands:
 
 .. tab:: Python
+
+    Double Precision (Default): 
 
     .. code:: bash 
 
         python3 program.py [...] --target tensornet
 
+    Single Precision:
+    
+     .. code:: bash 
+
+        python3 program.py [...] --target tensornet --target-option fp32
+    
     The target can also be defined in the application code by calling
 
     .. code:: python 
 
         cudaq.set_target('tensornet')
+
+    for the default double-precision setting, or
+    
+    .. code:: python 
+
+        cudaq.set_target('tensornet', option = 'fp32')
+
+    for the single-precision setting.   
 
     If a target is set in the application code, this target will override the :code:`--target` command line flag given during program invocation.
 
@@ -99,27 +117,54 @@ Matrix product state
 The :code:`tensornet-mps` backend is based on the matrix product state (MPS) representation of the state vector/wave function, exploiting the sparsity in the tensor network via tensor decomposition techniques such as QR and SVD. As such, this backend is an approximate simulator, whereby the number of singular values may be truncated to keep the MPS size tractable. 
 The :code:`tensornet-mps` backend only supports single-GPU simulation. Its approximate nature allows the :code:`tensornet-mps` backend to handle a large number of qubits for certain classes of quantum circuits on a relatively small memory footprint.
 
+The code:`tensornet` target supports both floating point precisions.
+
 To execute a program on the :code:`tensornet-mps` target, use the following commands:
 
 .. tab:: Python
 
+    Double Precision (Default): 
+    
     .. code:: bash 
 
         python3 program.py [...] --target tensornet-mps
 
+    Single Precision:
+
+    .. code:: bash 
+
+        python3 program.py [...] --target tensornet-mps --target-option fp32
+    
     The target can also be defined in the application code by calling
 
     .. code:: python 
 
         cudaq.set_target('tensornet-mps')
 
+    for the default double-precision setting, or
+    
+    .. code:: python 
+
+        cudaq.set_target('tensornet-mps', option = 'fp32')
+
+    for the single-precision setting.   
+
     If a target is set in the application code, this target will override the :code:`--target` command line flag given during program invocation.
 
 .. tab:: C++
 
+    Double Precision (Default): 
+
     .. code:: bash 
 
         nvq++ --target tensornet-mps program.cpp [...] -o program.x
+        ./program.x
+
+    Single Precision:
+
+    .. code:: bash 
+
+        nvq++ --target tensornet-mps --target-option fp32 program.cpp [...] -o program.x
         ./program.x
 
 Specific aspects of the simulation can be configured by defining the following environment variables:
@@ -150,6 +195,13 @@ Specific aspects of the simulation can be configured by defining the following e
     Valid setting must be between 5% and 95%. 
     Users may encounter runtime errors, e.g., insufficient workspace or CUDA memory allocation errors,
     when setting `CUDAQ_TENSORNET_SCRATCH_SIZE_PERCENTAGE` toward its limits.
+
+
+.. note::
+
+    All floating-point data, e.g., gate matrices, noise channel Kraus operator matrices, contracted state vector, etc., are converted to
+    the target's precision setting, if not already in that precision format. Hence, users would need to take into account potential precision 
+    lost when using the single precision setting.
 
 
 Fermioniq

--- a/docs/sphinx/using/backends/sims/tnsims.rst
+++ b/docs/sphinx/using/backends/sims/tnsims.rst
@@ -173,6 +173,7 @@ Specific aspects of the simulation can be configured by defining the following e
 * **`CUDAQ_MPS_ABS_CUTOFF=X`**: The cutoff for the largest singular value during truncation. Eigenvalues that are smaller will be trimmed out. Default: 1e-5.
 * **`CUDAQ_MPS_RELATIVE_CUTOFF=X`**: The cutoff for the maximal singular value relative to the largest eigenvalue. Eigenvalues that are smaller than this fraction of the largest singular value will be trimmed out. Default: 1e-5
 * **`CUDAQ_MPS_SVD_ALGO=X`**: The SVD algorithm to use. Valid values are: `GESVD` (QR algorithm), `GESVDJ` (Jacobi method), `GESVDP` (`polar decomposition <https://epubs.siam.org/doi/10.1137/090774999>`__), `GESVDR` (`randomized methods <https://epubs.siam.org/doi/10.1137/090771806>`__). Default: `GESVDJ`.
+* **`CUDAQ_MPS_GAUGE=X`**: The optional gauge option to improve accuracy of the MPS simulation. Valid values are: `FREE` (gauge is disabled) or `SIMPLE` (simple update algorithm). By default, no gauge configuration is set, thus the default `cuquantum` MPS setting will be used (see `cuquantum` `doc <https://docs.nvidia.com/cuda/cuquantum/latest/cutensornet/api/types.html#cutensornetstatempsgaugeoption-t>`__).  
 
 .. note:: 
 

--- a/docs/sphinx/using/backends/sims/tnsims.rst
+++ b/docs/sphinx/using/backends/sims/tnsims.rst
@@ -45,7 +45,7 @@ To execute a program on the :code:`tensornet` target using a *single GPU*, use t
     
     .. code:: python 
 
-        cudaq.set_target('tensornet', option = 'fp32')
+        cudaq.set_target('tensornet', option='fp32')
 
     for the single-precision setting.   
 

--- a/docs/sphinx/using/backends/simulators.rst
+++ b/docs/sphinx/using/backends/simulators.rst
@@ -42,13 +42,13 @@ technical details and code examples for using each circuit simulator.
      - Tensor Network
      - Shallow-depth (low-entanglement) and high width circuits (exact)
      - multi-GPU multi-node
-     - double
+     - double (default) / single
      - Thousands 
    * - `tensornet-mps` *
      - Matrix Product State
      - Square-shaped circuits (approximate)
      - Single GPU
-     - double
+     - double (default) / single
      - Hundreds
    * - `fermioniq`
      - Matrix Product State

--- a/runtime/nvqir/cutensornet/mps_simulation_state.h
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.h
@@ -26,6 +26,8 @@ struct MPSSettings {
   double relCutoff = 1e-5;
   // Default SVD algorithm (Jacobi)
   cutensornetTensorSVDAlgo_t svdAlgo = CUTENSORNET_TENSOR_SVD_ALGO_GESVDJ;
+  // Optional gauge option
+  std::optional<cutensornetStateMPSGaugeOption_t> gaugeOption;
   MPSSettings();
 };
 

--- a/runtime/nvqir/cutensornet/mps_simulation_state.inc
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.inc
@@ -282,7 +282,8 @@ std::complex<double> MPSSimulationState<ScalarType>::getAmplitude(
     // Note: this is a basis state, hence bond dim == 1
     std::vector<MPSTensor> basisStateTensors = basisTensorNetState.factorizeMPS(
         1, std::numeric_limits<double>::min(),
-        std::numeric_limits<double>::min(), MPSSettings().svdAlgo);
+        std::numeric_limits<double>::min(), MPSSettings().svdAlgo,
+        MPSSettings().gaugeOption);
     const auto overlap = computeOverlap(m_mpsTensors, basisStateTensors);
     for (auto &mpsTensor : basisStateTensors) {
       HANDLE_CUDA_ERROR(cudaFree(mpsTensor.deviceData));
@@ -622,6 +623,33 @@ MPSSettings::MPSSettings() {
     }
     svdAlgo = iter->second;
     cudaq::info("Setting MPS SVD algorithm to {} ({}).", svdAlgo, iter->first);
+  }
+
+  using GaugePair =
+      std::pair<std::string_view, cutensornetStateMPSGaugeOption_t>;
+  constexpr std::array<GaugePair, 2> g_stringToGaugeEnum = {
+      GaugePair{"FREE"sv, CUTENSORNET_STATE_MPS_GAUGE_FREE},
+      GaugePair{"SIMPLE"sv, CUTENSORNET_STATE_MPS_GAUGE_SIMPLE}};
+  if (auto *gaugeEnvVar = std::getenv("CUDAQ_MPS_GAUGE")) {
+    std::string gaugeOptionStr(gaugeEnvVar);
+    std::transform(gaugeOptionStr.begin(), gaugeOptionStr.end(),
+                   gaugeOptionStr.begin(), ::toupper);
+    const auto iter = std::lower_bound(
+        g_stringToGaugeEnum.begin(), g_stringToGaugeEnum.end(), gaugeOptionStr,
+        [](const GaugePair &pair, const std::string &key) {
+          return pair.first < key;
+        });
+    if (iter == g_stringToGaugeEnum.end() || iter->first != gaugeOptionStr) {
+      std::stringstream errorMsg;
+      errorMsg << "Unknown CUDAQ_MPS_GAUGE value ('" << gaugeEnvVar
+               << "').\nValid values are:\n";
+      for (const auto &[configStr, _] : g_stringToGaugeEnum)
+        errorMsg << "  - " << configStr << "\n";
+      throw std::runtime_error(errorMsg.str());
+    }
+    gaugeOption = iter->second;
+    cudaq::info("Setting MPS GAUGE option to {} ({}).", iter->first,
+                iter->second);
   }
 }
 

--- a/runtime/nvqir/cutensornet/simulator_mps.h
+++ b/runtime/nvqir/cutensornet/simulator_mps.h
@@ -39,9 +39,9 @@ public:
     m_mpsTensors_d.clear();
     // Factorize the state:
     if (m_state->getNumQubits() > 1)
-      m_mpsTensors_d =
-          m_state->factorizeMPS(m_settings.maxBond, m_settings.absCutoff,
-                                m_settings.relCutoff, m_settings.svdAlgo);
+      m_mpsTensors_d = m_state->factorizeMPS(
+          m_settings.maxBond, m_settings.absCutoff, m_settings.relCutoff,
+          m_settings.svdAlgo, m_settings.gaugeOption);
   }
 
   virtual std::size_t calculateStateDim(const std::size_t numQubits) override {
@@ -62,9 +62,9 @@ public:
     } else {
       // Expand an existing state: Append MPS tensors
       // Factor the existing state
-      auto tensors =
-          m_state->factorizeMPS(m_settings.maxBond, m_settings.absCutoff,
-                                m_settings.relCutoff, m_settings.svdAlgo);
+      auto tensors = m_state->factorizeMPS(
+          m_settings.maxBond, m_settings.absCutoff, m_settings.relCutoff,
+          m_settings.svdAlgo, m_settings.gaugeOption);
       // The right most MPS tensor needs to have one more extra leg (no longer
       // the boundary tensor).
       tensors.back().extents.emplace_back(1);
@@ -209,9 +209,9 @@ public:
           "MPS noisy simulation currently does not support the case where "
           "number of qubit is equal to 1");
     m_mpsTensors_d.clear();
-    m_mpsTensors_d =
-        m_state->setupMPSFactorize(m_settings.maxBond, m_settings.absCutoff,
-                                   m_settings.relCutoff, m_settings.svdAlgo);
+    m_mpsTensors_d = m_state->setupMPSFactorize(
+        m_settings.maxBond, m_settings.absCutoff, m_settings.relCutoff,
+        m_settings.svdAlgo, m_settings.gaugeOption);
   }
 
   /// @brief Sample a subset of qubits
@@ -357,9 +357,9 @@ public:
       }
     } else {
       if (!ptr) {
-        auto tensors =
-            m_state->factorizeMPS(m_settings.maxBond, m_settings.absCutoff,
-                                  m_settings.relCutoff, m_settings.svdAlgo);
+        auto tensors = m_state->factorizeMPS(
+            m_settings.maxBond, m_settings.absCutoff, m_settings.relCutoff,
+            m_settings.svdAlgo, m_settings.gaugeOption);
         // The right most MPS tensor needs to have one more extra leg (no longer
         // the boundary tensor).
         tensors.back().extents.emplace_back(1);
@@ -386,9 +386,9 @@ public:
                 reinterpret_cast<std::complex<ScalarType> *>(
                     const_cast<void *>(ptr)),
                 m_settings.maxBond, m_randomEngine);
-        auto tensors =
-            m_state->factorizeMPS(m_settings.maxBond, m_settings.absCutoff,
-                                  m_settings.relCutoff, m_settings.svdAlgo);
+        auto tensors = m_state->factorizeMPS(
+            m_settings.maxBond, m_settings.absCutoff, m_settings.relCutoff,
+            m_settings.svdAlgo, m_settings.gaugeOption);
         // Adjust the extents of the last tensor in the original state
         tensors.back().extents.emplace_back(1);
 
@@ -413,9 +413,9 @@ public:
           m_cutnHandle, m_randomEngine);
 
     if (m_state->getNumQubits() > 1) {
-      std::vector<MPSTensor> tensors =
-          m_state->factorizeMPS(m_settings.maxBond, m_settings.absCutoff,
-                                m_settings.relCutoff, m_settings.svdAlgo);
+      std::vector<MPSTensor> tensors = m_state->factorizeMPS(
+          m_settings.maxBond, m_settings.absCutoff, m_settings.relCutoff,
+          m_settings.svdAlgo, m_settings.gaugeOption);
       return std::make_unique<MPSSimulationState<ScalarType>>(
           std::move(m_state), tensors, scratchPad, m_cutnHandle,
           m_randomEngine);

--- a/runtime/nvqir/cutensornet/tensornet_state.h
+++ b/runtime/nvqir/cutensornet/tensornet_state.h
@@ -186,9 +186,10 @@ public:
   /// Returns MPS tensors in GPU device memory.
   /// Note: the caller assumes the ownership of these pointers, thus needs to
   /// clean them up properly (with cudaFree).
-  std::vector<MPSTensor> factorizeMPS(int64_t maxExtent, double absCutoff,
-                                      double relCutoff,
-                                      cutensornetTensorSVDAlgo_t algo);
+  std::vector<MPSTensor>
+  factorizeMPS(int64_t maxExtent, double absCutoff, double relCutoff,
+               cutensornetTensorSVDAlgo_t algo,
+               const std::optional<cutensornetStateMPSGaugeOption_t> &gauge);
 
   /// @brief Compute the expectation value of an observable
   /// @param product_terms the terms of the observable (operator sum)
@@ -240,9 +241,10 @@ private:
   // Note: `factorizeMPS` is an end-to-end API for factorization.
   // This factorization can be split into `cutensornetStateFinalizeMPS` and
   // `cutensornetStateCompute` to facilitate reuse.
-  std::vector<MPSTensor> setupMPSFactorize(int64_t maxExtent, double absCutoff,
-                                           double relCutoff,
-                                           cutensornetTensorSVDAlgo_t algo);
+  std::vector<MPSTensor> setupMPSFactorize(
+      int64_t maxExtent, double absCutoff, double relCutoff,
+      cutensornetTensorSVDAlgo_t algo,
+      const std::optional<cutensornetStateMPSGaugeOption_t> &gauge);
   void computeMPSFactorize(std::vector<MPSTensor> &mpsTensors);
 
   /// Internal methods for sampling

--- a/runtime/nvqir/cutensornet/tensornet_state.inc
+++ b/runtime/nvqir/cutensornet/tensornet_state.inc
@@ -478,7 +478,8 @@ TensorNetState<ScalarType>::contractStateVectorInternal(
 template <typename ScalarType>
 std::vector<MPSTensor> TensorNetState<ScalarType>::setupMPSFactorize(
     int64_t maxExtent, double absCutoff, double relCutoff,
-    cutensornetTensorSVDAlgo_t algo) {
+    cutensornetTensorSVDAlgo_t algo,
+    const std::optional<cutensornetStateMPSGaugeOption_t> &gauge) {
   LOG_API_TIME();
   if (m_numQubits == 0)
     return {};
@@ -530,6 +531,12 @@ std::vector<MPSTensor> TensorNetState<ScalarType>::setupMPSFactorize(
   HANDLE_CUTN_ERROR(cutensornetStateConfigure(
       m_cutnHandle, m_quantumState, CUTENSORNET_STATE_CONFIG_MPS_SVD_REL_CUTOFF,
       &relCutoff, sizeof(relCutoff)));
+  if (gauge.has_value()) {
+    cutensornetStateMPSGaugeOption_t gaugeOption = gauge.value();
+    HANDLE_CUTN_ERROR(cutensornetStateConfigure(
+        m_cutnHandle, m_quantumState, CUTENSORNET_STATE_CONFIG_MPS_GAUGE_OPTION,
+        &gaugeOption, sizeof(gaugeOption)));
+  }
   return mpsTensors;
 }
 
@@ -706,12 +713,13 @@ TensorNetState<ScalarType>::computeRDM(const std::vector<int32_t> &qubits) {
 // Returns MPS tensors (device mems)
 // Note: user needs to clean up these tensors
 template <typename ScalarType>
-std::vector<MPSTensor>
-TensorNetState<ScalarType>::factorizeMPS(int64_t maxExtent, double absCutoff,
-                                         double relCutoff,
-                                         cutensornetTensorSVDAlgo_t algo) {
+std::vector<MPSTensor> TensorNetState<ScalarType>::factorizeMPS(
+    int64_t maxExtent, double absCutoff, double relCutoff,
+    cutensornetTensorSVDAlgo_t algo,
+    const std::optional<cutensornetStateMPSGaugeOption_t> &gauge) {
   LOG_API_TIME();
-  auto mpsTensors = setupMPSFactorize(maxExtent, absCutoff, relCutoff, algo);
+  auto mpsTensors =
+      setupMPSFactorize(maxExtent, absCutoff, relCutoff, algo, gauge);
   computeMPSFactorize(mpsTensors);
   return mpsTensors;
 }


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->


- Add docs for single-precision tensor network backends (related to https://github.com/NVIDIA/cuda-quantum/pull/2820)


- Expose the gauge option for MPS (a new option in cuquantum 25.03 release, which was not exposed https://docs.nvidia.com/cuda/cuquantum/latest/cutensornet/release-notes.html#cutensornet-v2-7-0) and the associated doc.
