### PR TITLE
Maintenance: refactor canonicalization patterns for clarity.

### DIFF
--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -430,8 +430,12 @@ struct SimplifyIntegerCompare : public OpRewritePattern<arith::CmpIOp> {
     return failure();
   }
 };
+} // namespace
 
-// Ad hoc pattern to erase complex.create. (MLIR doesn't do this.)
+namespace {
+// Ad hoc pattern to erase complex.create. (MLIR doesn't do this.) This pattern
+// gets piggybacked into the canonicalizations, but does NOT have anything to do
+// with cc::CastOp.
 struct FuseComplexCreate : public OpRewritePattern<complex::CreateOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(complex::CreateOp create,
@@ -453,10 +457,16 @@ struct FuseComplexCreate : public OpRewritePattern<complex::CreateOp> {
 };
 } // namespace
 
+static void
+getArbitraryCustomCanonicalizationPatterns(RewritePatternSet &patterns,
+                                           MLIRContext *context) {
+  patterns.add<FuseComplexCreate>(context);
+}
+
 void cudaq::cc::CastOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                                     MLIRContext *context) {
-  patterns.add<FuseCastCascade, SimplifyIntegerCompare, FuseComplexCreate>(
-      context);
+  patterns.add<FuseCastCascade, SimplifyIntegerCompare>(context);
+  getArbitraryCustomCanonicalizationPatterns(patterns, context);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Adds a bit of documentation and refactors to physically partition the canonicalization patterns of two completely unrelated Ops that happen to use the same hook for convenience. (One of the Ops is defined in MLIR, so this adds a canonicalization pattern by letting it ride the coattails of another Op and evade security.)

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
