### PR TITLE
Follow-up to PR#2817: Update the user facing Python examples

### DIFF
--- a/docs/sphinx/targets/python/pasqal.py
+++ b/docs/sphinx/targets/python/pasqal.py
@@ -54,12 +54,13 @@ schedule = Schedule(steps, ["t"])
 omega_max = 1000000
 delta_end = 1000000
 delta_start = 0.0
-omega = ScalarOperator(lambda t: omega_max if time_ramp < t < time_max else 0.0)
+omega = ScalarOperator(lambda t: omega_max
+                       if time_ramp < t.real < time_max else 0.0)
 # Global phase at each step
 phi = ScalarOperator.const(0.0)
 # Global detuning at each step
 delta = ScalarOperator(lambda t: delta_end
-                       if time_ramp < t < time_max else delta_start)
+                       if time_ramp < t.real < time_max else delta_start)
 
 async_result = cudaq.evolve_async(RydbergHamiltonian(atom_sites=register,
                                                      amplitude=omega,

--- a/docs/sphinx/targets/python/quera_basic.py
+++ b/docs/sphinx/targets/python/quera_basic.py
@@ -35,12 +35,13 @@ delta_end = 5 * omega_max
 steps = [0.0, time_ramp, time_max - time_ramp, time_max]
 schedule = Schedule(steps, ["t"])
 # Rabi frequencies at each step
-omega = ScalarOperator(lambda t: omega_max if time_ramp < t < time_max else 0.0)
+omega = ScalarOperator(lambda t: omega_max
+                       if time_ramp < t.real < time_max else 0.0)
 # Global phase at each step
 phi = ScalarOperator.const(0.0)
 # Global detuning at each step
 delta = ScalarOperator(lambda t: delta_end
-                       if time_ramp < t < time_max else delta_start)
+                       if time_ramp < t.real < time_max else delta_start)
 
 async_result = cudaq.evolve_async(RydbergHamiltonian(atom_sites=register,
                                                      amplitude=omega,

--- a/docs/sphinx/targets/python/quera_intro.py
+++ b/docs/sphinx/targets/python/quera_intro.py
@@ -37,11 +37,11 @@ schedule = Schedule(steps, ["t"])
 def trapezoidal_signal(t):
     slope = omega_const / time_ramp
     y_intercept = slope * time_max
-    if 0 < t < time_ramp + time_plateau:
+    if 0 < t.real < time_ramp + time_plateau:
         return slope * t
-    if time_ramp < t < time_max:
+    if time_ramp < t.real < time_max:
         return omega_const
-    if time_ramp + time_plateau < t < time_max:
+    if time_ramp + time_plateau < t.real < time_max:
         return (-slope * t) + y_intercept
     return 0.0
 


### PR DESCRIPTION
* Fixes for the `quera` and `pasqal` target examples to comply with the latest changes for operators.
* Should fix the failing nightly test for Pasqal. (Ref: https://github.com/NVIDIA/cuda-quantum/actions/runs/14787999707/job/41519909590)
* Manually tested
