### PR TITLE
Follow-up to PR#2705: Update the C++ examples of analog targets

### DIFF
--- a/docs/sphinx/targets/cpp/pasqal.cpp
+++ b/docs/sphinx/targets/cpp/pasqal.cpp
@@ -4,8 +4,7 @@
 // ./out.x
 // ```
 // Assumes a valid set of credentials (`PASQAL_AUTH_TOKEN`, `PASQAL_PROJECT_ID`)
-// have been set. To set `PASQAL_AUTH_TOKEN` from Pasqal Cloud username and
-// password, use `pasqal_auth.py` in this folder.
+// have been set.
 
 #include "cudaq/algorithms/evolve.h"
 #include "cudaq/algorithms/integrator.h"
@@ -64,7 +63,7 @@ int main() {
 
   // Evolve the system
   auto result = cudaq::evolve(hamiltonian, schedule, 100);
-  result.get_sampling_result()->dump();
+  result.sampling_result->dump();
 
   return 0;
 }

--- a/docs/sphinx/targets/cpp/quera_basic.cpp
+++ b/docs/sphinx/targets/cpp/quera_basic.cpp
@@ -76,7 +76,7 @@ int main() {
 
   // Evolve the system
   auto result = cudaq::evolve_async(hamiltonian, schedule, 10).get();
-  result.get_sampling_result()->dump();
+  result.sampling_result->dump();
 
   return 0;
 }

--- a/docs/sphinx/targets/cpp/quera_intro.cpp
+++ b/docs/sphinx/targets/cpp/quera_intro.cpp
@@ -79,7 +79,7 @@ int main() {
 
   // Evolve the system
   auto result = cudaq::evolve(hamiltonian, schedule);
-  result.get_sampling_result()->dump();
+  result.sampling_result->dump();
 
   return 0;
 }


### PR DESCRIPTION
* Follow-up to PR #2705 
* Update the analog target examples (`quera`, and `pasqal`) according to the spec
* Manually tested

```
# bin/nvq++  --target pasqal ../docs/sphinx/targets/cpp/pasqal.cpp
# ./a.out 
{ 000:45 001:18 010:19 100:17 101:1 }
```