### PR TITLE
[Python] Missing import in code snippet

### DIFF
--- a/docs/sphinx/snippets/python/using/backends/dynamics.py
+++ b/docs/sphinx/snippets/python/using/backends/dynamics.py
@@ -78,6 +78,8 @@ omega_a = 4 * np.pi
 Omega = 0.5
 
 #[Begin Jaynes-Cummings]
+from cudaq import operators
+
 hamiltonian = omega_c * operators.create(1) * operators.annihilate(1) \
                 + (omega_a / 2) * spin.z(0) \
                 + (Omega / 2) * (operators.annihilate(1) * spin.plus(0) + operators.create(1) * spin.minus(0))


### PR DESCRIPTION
* Fixes the 'Docker image validation' stage in the Publishing pipeline

Ref: https://github.com/NVIDIA/cuda-quantum/actions/runs/14769540256/job/41468918730
Error -
```
2025-05-01T06:22:36.5791833Z Testing dynamics:
2025-05-01T06:22:36.5796752Z Source: snippets/using/backends/dynamics.py
2025-05-01T06:22:47.5852428Z NameError: name 'operators' is not defined
```
