### PR TITLE
Fix dynamics.py by importing operators earlier

### DIFF
--- a/docs/sphinx/snippets/python/using/backends/dynamics.py
+++ b/docs/sphinx/snippets/python/using/backends/dynamics.py
@@ -13,7 +13,7 @@ omega_x = 4.0
 omega_d = 0.5
 
 import numpy as np
-from cudaq import spin, ScalarOperator
+from cudaq import operators, spin, ScalarOperator
 
 # Qubit Hamiltonian
 hamiltonian = 0.5 * omega_z * spin.z(0)
@@ -96,7 +96,7 @@ H = H0 + ScalarOperator(lambda t: np.cos(omega * t)) * H1
 #[Begin DefineOp]
 import numpy
 import scipy
-from cudaq import operators, NumericType
+from cudaq import NumericType
 from numpy.typing import NDArray
 
 


### PR DESCRIPTION
Fallout from PR#2817 where operators needs to be explicitly imported

This is failing the publishing pipeline, e.g. https://github.com/NVIDIA/cuda-quantum/actions/runs/14807741212/job/41579353853

Tested on `cu12-latest` which is on version
```bash
cudaq@2570547-lcedt:~$ nvq++ --version
nvq++ Version cu12-latest (https://github.com/NVIDIA/cuda-quantum c455a16091c7db988fa768729bf3dc4cb43eea26)
```

Before:
```
cudaq@2570547-lcedt:~$ python3 dynamics.py 
NameError: name 'operators' is not defined
```

After:
```
cudaq@2570547-lcedt:~$ python3 dynamics.py 
cudaq@2570547-lcedt:~$ 
```