### PR TITLE
[Python] [testing] Restore the symbolic link to `system_models.py` from the `integrators`

### DIFF
--- a/python/tests/dynamics/integrators/system_models.py
+++ b/python/tests/dynamics/integrators/system_models.py
@@ -1,1 +1,1 @@
-/workspaces/cuda-quantum/python/tests/dynamics/system_models.py
+../system_models.py

--- a/python/tests/dynamics/integrators/system_models.py
+++ b/python/tests/dynamics/integrators/system_models.py
@@ -1,0 +1,1 @@
+/workspaces/cuda-quantum/python/tests/dynamics/system_models.py


### PR DESCRIPTION
* Follow-up to PR #2817 
* Should fix the error -
  `E   ModuleNotFoundError: No module named 'system_models'`

