### PR TITLE
measuring_kernels.ipynb: fix small typo

### DIFF
--- a/docs/sphinx/examples/python/measuring_kernels.ipynb
+++ b/docs/sphinx/examples/python/measuring_kernels.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "### Mid-circuit Measurement and Conditional Logic\n",
     "\n",
-    "In certain cases, it it is helpful for some operations in a quantum kernel to depend on measurement results following previous operations. This is accomplished in the following example by performing a Hadamard on qubit 0, then measuring qubit 0 and saving the result as `b0`. Then, qubit 0 can be reset and used later in the computation.  In this case it is flipped ot a 1. Finally, an if statement performs a Hadamard on qubit 1 if `b0` is 1. \n",
+    "In certain cases, it it is helpful for some operations in a quantum kernel to depend on measurement results following previous operations. This is accomplished in the following example by performing a Hadamard on qubit 0, then measuring qubit 0 and saving the result as `b0`. Then, qubit 0 can be reset and used later in the computation.  In this case it is flipped to a 1. Finally, an if statement performs a Hadamard on qubit 1 if `b0` is 1. \n",
     "\n",
     "The results show qubit 0 is one, indicating the reset worked, and qubit 1 has a 75/25 distribution, demonstrating the mid-circuit measurement worked as expexted."
    ]


### PR DESCRIPTION
Small typo in docs

`ot` -> `to`