### PR TITLE
[Testing] Fix noise channel test: use `p=0.75` for complete depolarizing channel

### DIFF
--- a/docs/sphinx/examples/cpp/basics/noise_depolarization.cpp
+++ b/docs/sphinx/examples/cpp/basics/noise_depolarization.cpp
@@ -21,16 +21,20 @@ int main() {
   cudaq::noise_model noise;
 
   // We define a depolarization channel setting the probability of the
-  // qubit state being scrambled to `1.0`.
-  cudaq::depolarization_channel depolarization(1.);
+  // qubit state being scrambled to `0.75` (25% of probability each for X, Y, or
+  // Z noise). The remaining 25% is for no noise, i.e., identity (I) operation.
+  // Note: This depolarizing channel (equal probability for I, X, Y, and Z)
+  // produced a so-called maximally-mixed state, which have a flat distribution
+  // on all measurement bases.
+  cudaq::depolarization_channel depolarization(0.75);
   // We will apply the channel to any Y-gate on qubit 0. In other words,
   // for each Y-gate on our qubit, the qubit will have a `1.0`
-  // probability of decaying into a mixed state.
+  // probability of decaying into a maximally-mixed state.
   noise.add_channel<cudaq::types::y>({0}, depolarization);
 
   // Our kernel will apply a Y-gate to qubit 0.
-  // This will bring the qubit to the |1> state, where it will remain
-  // with a probability of `1 - p = 0.0`.
+  // This will bring the qubit to the |1> state, where it will undergo an equal
+  // mixture of I, X, Y, Z depolarizing noise.
   auto kernel = []() __qpu__ {
     cudaq::qubit q;
     y(q);

--- a/unittests/integration/noise_tester.cpp
+++ b/unittests/integration/noise_tester.cpp
@@ -429,13 +429,17 @@ CUDAQ_TEST(NoiseTest, checkApplySimplePauliErrors) {
 
 CUDAQ_TEST(NoiseTest, checkDepolTypeSimple) {
   cudaq::set_random_seed(13);
-  cudaq::depolarization_channel depol(1.);
+  // Complete depolarizing channel
+  // (https://en.wikipedia.org/wiki/Quantum_depolarizing_channel) to produce a
+  // maximally-mixed state: lambda = 1.0 => p/3 == lambda/4 => p = 3/4 = 0.75
+  cudaq::depolarization_channel depol(0.75);
   cudaq::noise_model noise;
   noise.add_channel<cudaq::types::x>({0}, depol);
   cudaq::set_noise(noise);
   auto counts = cudaq::sample(xOp{});
   counts.dump();
   EXPECT_EQ(2, counts.size());
+  // maximally-mixed state (i.e., 50/50 distribution)
   EXPECT_NEAR(counts.probability("0"), .50, .2);
   EXPECT_NEAR(counts.probability("1"), .50, .2);
   cudaq::unset_noise(); // clear for subsequent tests


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->


The depolarizing noise channel test used an incorrect `p` value to create a complete depolarizing channel. The check conditions are designed for a maximally mixed state.

This leads to test instability, especially for tensornet trajectory-based simulators, where the noise channel sampling doesn't support setting the random seed.


This relates to https://github.com/NVIDIA/cuda-quantum/issues/1813, for which we have updated the documentation accordingly.