### PR TITLE
Gracefully handle expectation of an empty `sample_result`

### DIFF
--- a/runtime/common/MeasureCounts.cpp
+++ b/runtime/common/MeasureCounts.cpp
@@ -366,7 +366,10 @@ bool sample_result::has_expectation(const std::string_view registerName) const {
 }
 
 double sample_result::expectation(const std::string_view registerName) const {
-  const auto &result = retrieve_result(registerName.data());
+  auto [found, result] = try_retrieve_result(registerName.data());
+  if (!found)
+    return 0.0;
+
   if (result.expectationValue.has_value())
     return result.expectationValue.value();
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This is a regression since PR#2710.
Previously, `sample_result::expectation` would return 0.0 if the register name could not be found. 
In 2710, we changed it to a 'strict' version (`retrieve_result`), which throws.

This PR changes it back to a non-throw `try_retrieve_result` and returns 0.0 if not found.

This caused problems (exceptions) when observing an empty spin op, e.g., when distributing observe over more QPUs than the number of terms. 
