### PR TITLE
Update mock server test timeouts

### DIFF
--- a/unittests/backends/anyon/AnyonStartServerAndTest.sh.in
+++ b/unittests/backends/anyon/AnyonStartServerAndTest.sh.in
@@ -43,7 +43,7 @@ n=0
 while ! checkServerConnection; do
   sleep 1
   n=$((n+1))
-  if [ "$n" -eq "10" ]; then
+  if [ "$n" -eq "20" ]; then
     kill -INT $pid
     exit 99
   fi

--- a/unittests/backends/braket/BraketStartServerAndTest.sh.in
+++ b/unittests/backends/braket/BraketStartServerAndTest.sh.in
@@ -43,7 +43,7 @@ n=0
 while ! checkServerConnection; do
   sleep 1
   n=$((n+1))
-  if [ "$n" -eq "10" ]; then
+  if [ "$n" -eq "20" ]; then
     kill -INT $pid
     exit 99
   fi

--- a/unittests/backends/infleqtion/InfleqtionStartServerAndTest.sh.in
+++ b/unittests/backends/infleqtion/InfleqtionStartServerAndTest.sh.in
@@ -28,7 +28,7 @@ n=0
 while ! checkServerConnection; do
   sleep 1
   n=$((n+1))
-  if [ "$n" -eq "10" ]; then
+  if [ "$n" -eq "20" ]; then
     kill -INT $pid
     exit 99
   fi

--- a/unittests/backends/ionq/IonQStartServerAndTest.sh.in
+++ b/unittests/backends/ionq/IonQStartServerAndTest.sh.in
@@ -28,7 +28,7 @@ n=0
 while ! checkServerConnection; do
   sleep 1
   n=$((n+1))
-  if [ "$n" -eq "10" ]; then
+  if [ "$n" -eq "20" ]; then
     kill -INT $pid
     exit 99
   fi

--- a/unittests/backends/iqm/IQMStartServerAndTest.sh.in
+++ b/unittests/backends/iqm/IQMStartServerAndTest.sh.in
@@ -38,7 +38,7 @@ n=0
 while ! checkServerConnection; do
   sleep 1
   n=$((n+1))
-  if [ "$n" -eq "10" ]; then
+  if [ "$n" -eq "20" ]; then
     kill -INT $pid
     exit 99
   fi

--- a/unittests/backends/oqc/OQCStartServerAndTest.sh.in
+++ b/unittests/backends/oqc/OQCStartServerAndTest.sh.in
@@ -30,7 +30,7 @@ n=0
 while ! checkServerConnection; do
   sleep 1
   n=$((n+1))
-  if [ "$n" -eq "10" ]; then
+  if [ "$n" -eq "20" ]; then
     kill -INT $pid
     exit 99
   fi

--- a/unittests/backends/quantinuum/QuantinuumStartServerAndTest.sh.in
+++ b/unittests/backends/quantinuum/QuantinuumStartServerAndTest.sh.in
@@ -27,7 +27,7 @@ n=0
 while ! checkServerConnection; do
   sleep 1
   n=$((n+1))
-  if [ "$n" -eq "10" ]; then
+  if [ "$n" -eq "20" ]; then
     kill -INT $pid
     exit 99
   fi


### PR DESCRIPTION
Importing `cudaq` is taking a long time, especially in Debug builds. Since QA is doing some of their testing with Debug builds, we need to extend the timeouts for some mock server tests.

See nvbug 5268521.