### PR TITLE
[CI] [Testing] Follow-up to PR#2875

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -706,7 +706,7 @@ jobs:
           export PASQAL_MACHINE_TARGET="EMU_FREE" # Speedup queuing time
           set +e # Allow script to keep going through errors
           echo "### Generating Pasqal auth token" >> $GITHUB_STEP_SUMMARY
-          PASQAL_AUTH_TOKEN=$(python3 -c "import pasqal_cloud; import os; import sys; sdk = SDK(username=os.environ.get("PASQAL_USERNAME"), password=os.environ.get("PASQAL_PASSWORD")); sys.stdout.write(str(sdk.user_token()))")
+          PASQAL_AUTH_TOKEN=$(python3 -c "from pasqal_cloud import SDK; import os; import sys; sdk = SDK(username=os.environ.get('PASQAL_USERNAME'), password=os.environ.get('PASQAL_PASSWORD')); sys.stdout.write(str(sdk.user_token()))")
           export PASQAL_AUTH_TOKEN
           test_err_sum=0
           cpp_tests="docs/sphinx/targets/cpp/pasqal.cpp"


### PR DESCRIPTION
Follow-up to PR #2875 
* Fix the import statement in Python script.
* Update quotes for correct evaluation.

Manually tested in local environment as -
```
$ PASQAL_AUTH_TOKEN=$(python3 -c "from pasqal_cloud import SDK; import os; import sys; sdk = SDK(username=os.environ.get('PASQAL_USERNAME'), password=os.environ.get('PASQAL_PASSWORD')); sys.stdout.write(str(sdk.user_token()))")
$ export PASQAL_AUTH_TOKEN
$ bin/nvq++ --target pasqal  --pasqal-machine $PASQAL_MACHINE_TARGET ../docs/sphinx/targets/cpp/pasqal.cpp
$ ./a.out 
{ 000:52 001:14 010:19 100:15 }
```
Should fix the nightly integration test failure seen [here](https://github.com/NVIDIA/cuda-quantum/actions/runs/14963104309/job/42028329960#step:15:92).