### PR TITLE
[nvqir] Fix handling of `phased_rx` gate.

### DIFF
--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -495,11 +495,7 @@ void __quantum__qis__cphase(double d, Qubit *q, Qubit *r) {
 
 void __quantum__qis__phased_rx(double theta, double phi, Qubit *q) {
   auto qI = qubitToSizeT(q);
-  std::complex<double> i(0, 1.);
-  std::vector<std::complex<double>> matrix{
-      std::cos(theta / 2.), -i * std::exp(-i * phi) * std::sin(theta / 2.),
-      -i * std::exp(i * phi) * std::sin(theta / 2.), std::cos(theta / 2.)};
-  nvqir::getCircuitSimulatorInternal()->applyCustomOperation(matrix, {}, {qI});
+  nvqir::getCircuitSimulatorInternal()->phased_rx(theta, phi, qI);
 }
 
 void __quantum__qis__phased_rx__body(double theta, double phi, Qubit *q) {


### PR DESCRIPTION
### Description
The circuit simulator has a dedicated method for applying `phased_rx` operations. If we don't use it, then printing circuits that use this operation will incorrectly print them as "unknown op".

