### PR TITLE
[core] Turn apply op specialization into a greedy pass.

### DIFF
--- a/test/AST-Quake/adjoint-3.cpp
+++ b/test/AST-Quake/adjoint-3.cpp
@@ -90,96 +90,78 @@ struct run_circuit {
 
 // ADJOINT-LABEL:   func.func private @__nvqpp__mlirgen__statePrep_A.adj(
 // ADJOINT-SAME:      %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: f64) {
-// ADJOINT-DAG:       %[[VAL_2:.*]] = arith.constant 2.000000e+00 : f64
-// ADJOINT-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i64
-// ADJOINT-DAG:       %[[VAL_6:.*]] = arith.constant 0 : i64
-// ADJOINT-DAG:       %[[VAL_7:.*]] = arith.constant 1 : i32
-// ADJOINT:           %[[VAL_8:.*]] = quake.veq_size %[[VAL_0]] : (!quake.veq<?>) -> i64
-// ADJOINT:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (i64) -> i32
-// ADJOINT:           %[[VAL_10:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
-// ADJOINT:           %[[VAL_11:.*]] = cc.cast signed %[[VAL_10]] : (i32) -> i64
-// ADJOINT:           %[[VAL_12:.*]] = arith.subi %[[VAL_11]], %[[VAL_5]] : i64
-// ADJOINT:           %[[VAL_13:.*]] = quake.subveq %[[VAL_0]], 0, %[[VAL_12]] : (!quake.veq<?>, i64) -> !quake.veq<?>
-// ADJOINT:           %[[VAL_14:.*]] = quake.veq_size %[[VAL_13]] : (!quake.veq<?>) -> i64
-// ADJOINT:           %[[VAL_16:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
-// ADJOINT:           %[[VAL_18:.*]] = math.fpowi %[[VAL_2]], %[[VAL_16]] : f64, i32
-// ADJOINT:           %[[VAL_19:.*]] = arith.divf %[[VAL_1]], %[[VAL_18]] : f64
-// ADJOINT:           %[[VAL_20:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
-// ADJOINT:           %[[VAL_21:.*]] = cc.cast signed %[[VAL_20]] : (i32) -> i64
-// ADJOINT:           %[[VAL_22:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_21]]] : (!quake.veq<?>, i64) -> !quake.ref
-// ADJOINT:           %[[VAL_23:.*]] = arith.constant 0 : i32
-// ADJOINT:           %[[VAL_24:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
-// ADJOINT:           %[[VAL_25:.*]] = arith.constant 1 : i32
-// ADJOINT:           %[[VAL_26:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_23]] : i32
-// ADJOINT:           %[[VAL_27:.*]] = arith.constant -1 : i32
-// ADJOINT:           %[[VAL_28:.*]] = arith.select %[[VAL_26]], %[[VAL_25]], %[[VAL_27]] : i32
-// ADJOINT:           %[[VAL_29:.*]] = arith.addi %[[VAL_24]], %[[VAL_28]] : i32
-// ADJOINT:           %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_7]] : i32
-// ADJOINT:           %[[VAL_31:.*]] = arith.cmpi sgt, %[[VAL_30]], %[[VAL_23]] : i32
-// ADJOINT:           %[[VAL_32:.*]] = arith.select %[[VAL_31]], %[[VAL_30]], %[[VAL_23]] : i32
-// ADJOINT:           %[[VAL_33:.*]] = arith.subi %[[VAL_32]], %[[VAL_25]] : i32
-// ADJOINT:           %[[VAL_34:.*]] = arith.addi %[[VAL_7]], %[[VAL_33]] : i32
-// ADJOINT:           %[[VAL_35:.*]] = arith.constant 0 : i32
-// ADJOINT:           %[[VAL_36:.*]]:2 = cc.loop while ((%[[VAL_37:.*]] = %[[VAL_34]], %[[VAL_40:.*]] = %[[VAL_32]]) -> (i32, i32)) {
-// ADJOINT:             %[[VAL_41:.*]] = arith.cmpi slt, %[[VAL_37]], %[[VAL_9]] : i32
-// ADJOINT:             %[[VAL_42:.*]] = arith.cmpi sgt, %[[VAL_40]], %[[VAL_35]] : i32
-// ADJOINT:             cc.condition %[[VAL_42]](%[[VAL_37]], %[[VAL_40]] : i32, i32)
-// ADJOINT:           } do {
-// ADJOINT:           ^bb0(%[[VAL_43:.*]]: i32, %[[VAL_46:.*]]: i32):
-// ADJOINT:             %[[VAL_47:.*]] = arith.subi %[[VAL_9]], %[[VAL_43]] : i32
-// ADJOINT:             %[[VAL_48:.*]] = arith.subi %[[VAL_47]], %[[VAL_7]] : i32
-// ADJOINT:             %[[VAL_50:.*]] = math.fpowi %[[VAL_2]], %[[VAL_48]] : f64, i32
-// ADJOINT:             %[[VAL_51:.*]] = arith.divf %[[VAL_1]], %[[VAL_50]] : f64
-// ADJOINT:             %[[VAL_52:.*]] = arith.subi %[[VAL_43]], %[[VAL_7]] : i32
-// ADJOINT:             %[[VAL_53:.*]] = cc.cast signed %[[VAL_52]] : (i32) -> i64
-// ADJOINT:             %[[VAL_54:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_53]]] : (!quake.veq<?>, i64) -> !quake.ref
-// ADJOINT:             %[[VAL_55:.*]] = arith.subi %[[VAL_9]], %[[VAL_7]] : i32
-// ADJOINT:             %[[VAL_56:.*]] = cc.cast signed %[[VAL_55]] : (i32) -> i64
-// ADJOINT:             %[[VAL_57:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_56]]] : (!quake.veq<?>, i64) -> !quake.ref
-// ADJOINT:             %[[VAL_58:.*]] = arith.negf %[[VAL_51]] : f64
-// ADJOINT:             quake.ry (%[[VAL_58]]) [%[[VAL_54]]] %[[VAL_57]] : (f64, !quake.ref, !quake.ref) -> ()
-// ADJOINT:             cc.continue %[[VAL_43]], %[[VAL_46]] : i32, i32
-// ADJOINT:           } step {
-// ADJOINT:           ^bb0(%[[VAL_59:.*]]: i32, %[[VAL_62:.*]]: i32):
-// ADJOINT:             %[[VAL_63:.*]] = arith.addi %[[VAL_59]], %[[VAL_7]] : i32
-// ADJOINT:             %[[VAL_64:.*]] = arith.subi %[[VAL_59]], %[[VAL_7]] : i32
-// ADJOINT:             %[[VAL_65:.*]] = arith.constant 1 : i32
-// ADJOINT:             %[[VAL_66:.*]] = arith.subi %[[VAL_62]], %[[VAL_65]] : i32
-// ADJOINT:             cc.continue %[[VAL_64]], %[[VAL_66]] : i32, i32
-// ADJOINT:           }
-// ADJOINT:           %[[VAL_67:.*]] = arith.negf %[[VAL_19]] : f64
-// ADJOINT:           quake.ry (%[[VAL_67]]) %[[VAL_22]] : (f64, !quake.ref) -> ()
-// ADJOINT:           %[[VAL_68:.*]] = arith.constant 0 : i64
-// ADJOINT:           %[[VAL_69:.*]] = arith.constant 1 : i64
-// ADJOINT:           %[[VAL_70:.*]] = arith.cmpi slt, %[[VAL_5]], %[[VAL_68]] : i64
-// ADJOINT:           %[[VAL_71:.*]] = arith.constant -1 : i64
-// ADJOINT:           %[[VAL_72:.*]] = arith.select %[[VAL_70]], %[[VAL_69]], %[[VAL_71]] : i64
-// ADJOINT:           %[[VAL_73:.*]] = arith.addi %[[VAL_14]], %[[VAL_72]] : i64
-// ADJOINT:           %[[VAL_74:.*]] = arith.addi %[[VAL_73]], %[[VAL_5]] : i64
-// ADJOINT:           %[[VAL_75:.*]] = arith.cmpi sgt, %[[VAL_74]], %[[VAL_68]] : i64
-// ADJOINT:           %[[VAL_76:.*]] = arith.select %[[VAL_75]], %[[VAL_74]], %[[VAL_68]] : i64
-// ADJOINT:           %[[VAL_77:.*]] = arith.subi %[[VAL_76]], %[[VAL_69]] : i64
-// ADJOINT:           %[[VAL_78:.*]] = arith.addi %[[VAL_6]], %[[VAL_77]] : i64
-// ADJOINT:           %[[VAL_79:.*]] = arith.constant 0 : i64
-// ADJOINT:           %[[VAL_80:.*]]:2 = cc.loop while ((%[[VAL_81:.*]] = %[[VAL_78]], %[[VAL_82:.*]] = %[[VAL_76]]) -> (i64, i64)) {
-// ADJOINT:             %[[VAL_83:.*]] = arith.cmpi slt, %[[VAL_81]], %[[VAL_14]] : i64
-// ADJOINT:             %[[VAL_84:.*]] = arith.cmpi sgt, %[[VAL_82]], %[[VAL_79]] : i64
-// ADJOINT:             cc.condition %[[VAL_84]](%[[VAL_81]], %[[VAL_82]] : i64, i64)
-// ADJOINT:           } do {
-// ADJOINT:           ^bb0(%[[VAL_85:.*]]: i64, %[[VAL_86:.*]]: i64):
-// ADJOINT:             %[[VAL_87:.*]] = quake.extract_ref %[[VAL_13]]{{\[}}%[[VAL_85]]] : (!quake.veq<?>, i64) -> !quake.ref
-// ADJOINT:             quake.h %[[VAL_87]] : (!quake.ref) -> ()
-// ADJOINT:             cc.continue %[[VAL_85]], %[[VAL_86]] : i64, i64
-// ADJOINT:           } step {
-// ADJOINT:           ^bb0(%[[VAL_88:.*]]: i64, %[[VAL_89:.*]]: i64):
-// ADJOINT:             %[[VAL_90:.*]] = arith.addi %[[VAL_88]], %[[VAL_5]] : i64
-// ADJOINT:             %[[VAL_91:.*]] = arith.subi %[[VAL_88]], %[[VAL_5]] : i64
-// ADJOINT:             %[[VAL_92:.*]] = arith.constant 1 : i64
-// ADJOINT:             %[[VAL_93:.*]] = arith.subi %[[VAL_89]], %[[VAL_92]] : i64
-// ADJOINT:             cc.continue %[[VAL_91]], %[[VAL_93]] : i64, i64
-// ADJOINT:           }
-// ADJOINT:           return
+// ADJOINT-DAG:     %[[VAL_2:.*]] = arith.constant -1 : i64
+// ADJOINT-DAG:     %[[VAL_3:.*]] = arith.constant -1 : i32
+// ADJOINT-DAG:     %[[VAL_4:.*]] = arith.constant 0 : i32
+// ADJOINT-DAG:     %[[VAL_5:.*]] = arith.constant 2.000000e+00 : f64
+// ADJOINT-DAG:     %[[VAL_6:.*]] = arith.constant 1 : i64
+// ADJOINT-DAG:     %[[VAL_7:.*]] = arith.constant 0 : i64
+// ADJOINT-DAG:     %[[VAL_8:.*]] = arith.constant 1 : i32
+// ADJOINT:         %[[VAL_9:.*]] = quake.veq_size %[[VAL_0]] : (!quake.veq<?>) -> i64
+// ADJOINT:         %[[VAL_10:.*]] = cc.cast %[[VAL_9]] : (i64) -> i32
+// ADJOINT:         %[[VAL_11:.*]] = arith.subi %[[VAL_10]], %[[VAL_8]] : i32
+// ADJOINT:         %[[VAL_12:.*]] = cc.cast signed %[[VAL_11]] : (i32) -> i64
+// ADJOINT:         %[[VAL_13:.*]] = arith.subi %[[VAL_12]], %[[VAL_6]] : i64
+// ADJOINT:         %[[VAL_14:.*]] = quake.subveq %[[VAL_0]], 0, %[[VAL_13]] : (!quake.veq<?>, i64) -> !quake.veq<?>
+// ADJOINT:         %[[VAL_15:.*]] = quake.veq_size %[[VAL_14]] : (!quake.veq<?>) -> i64
+// ADJOINT:         %[[VAL_16:.*]] = arith.subi %[[VAL_10]], %[[VAL_8]] : i32
+// ADJOINT:         %[[VAL_17:.*]] = math.fpowi %[[VAL_5]], %[[VAL_16]] : f64, i32
+// ADJOINT:         %[[VAL_18:.*]] = arith.divf %[[VAL_1]], %[[VAL_17]] : f64
+// ADJOINT:         %[[VAL_19:.*]] = arith.subi %[[VAL_10]], %[[VAL_8]] : i32
+// ADJOINT:         %[[VAL_20:.*]] = cc.cast signed %[[VAL_19]] : (i32) -> i64
+// ADJOINT:         %[[VAL_21:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_20]]] : (!quake.veq<?>, i64) -> !quake.ref
+// ADJOINT:         %[[VAL_22:.*]] = arith.subi %[[VAL_10]], %[[VAL_8]] : i32
+// ADJOINT:         %[[VAL_23:.*]] = arith.addi %[[VAL_22]], %[[VAL_3]] : i32
+// ADJOINT:         %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_8]] : i32
+// ADJOINT:         %[[VAL_25:.*]] = arith.cmpi sgt, %[[VAL_24]], %[[VAL_4]] : i32
+// ADJOINT:         %[[VAL_26:.*]] = arith.select %[[VAL_25]], %[[VAL_24]], %[[VAL_4]] : i32
+// ADJOINT:         %[[VAL_27:.*]]:2 = cc.loop while ((%[[VAL_28:.*]] = %[[VAL_26]], %[[VAL_29:.*]] = %[[VAL_26]]) -> (i32, i32)) {
+// ADJOINT:           %[[VAL_30:.*]] = arith.cmpi sgt, %[[VAL_29]], %[[VAL_4]] : i32
+// ADJOINT:           cc.condition %[[VAL_30]](%[[VAL_28]], %[[VAL_29]] : i32, i32)
+// ADJOINT:         } do {
+// ADJOINT:         ^bb0(%[[VAL_31:.*]]: i32, %[[VAL_32:.*]]: i32):
+// ADJOINT:           %[[VAL_33:.*]] = arith.subi %[[VAL_10]], %[[VAL_31]] : i32
+// ADJOINT:           %[[VAL_34:.*]] = arith.subi %[[VAL_33]], %[[VAL_8]] : i32
+// ADJOINT:           %[[VAL_35:.*]] = math.fpowi %[[VAL_5]], %[[VAL_34]] : f64, i32
+// ADJOINT:           %[[VAL_36:.*]] = arith.divf %[[VAL_1]], %[[VAL_35]] : f64
+// ADJOINT:           %[[VAL_37:.*]] = arith.subi %[[VAL_31]], %[[VAL_8]] : i32
+// ADJOINT:           %[[VAL_38:.*]] = cc.cast signed %[[VAL_37]] : (i32) -> i64
+// ADJOINT:           %[[VAL_39:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_38]]] : (!quake.veq<?>, i64) -> !quake.ref
+// ADJOINT:           %[[VAL_40:.*]] = arith.subi %[[VAL_10]], %[[VAL_8]] : i32
+// ADJOINT:           %[[VAL_41:.*]] = cc.cast signed %[[VAL_40]] : (i32) -> i64
+// ADJOINT:           %[[VAL_42:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_41]]] : (!quake.veq<?>, i64) -> !quake.ref
+// ADJOINT:           %[[VAL_43:.*]] = arith.negf %[[VAL_36]] : f64
+// ADJOINT:           quake.ry (%[[VAL_43]]) {{\[}}%[[VAL_39]]] %[[VAL_42]] : (f64, !quake.ref, !quake.ref) -> ()
+// ADJOINT:           cc.continue %[[VAL_31]], %[[VAL_32]] : i32, i32
+// ADJOINT:         } step {
+// ADJOINT:         ^bb0(%[[VAL_44:.*]]: i32, %[[VAL_45:.*]]: i32):
+// ADJOINT:           %[[VAL_46:.*]] = arith.subi %[[VAL_44]], %[[VAL_8]] : i32
+// ADJOINT:           %[[VAL_47:.*]] = arith.subi %[[VAL_45]], %[[VAL_8]] : i32
+// ADJOINT:           cc.continue %[[VAL_46]], %[[VAL_47]] : i32, i32
 // ADJOINT:         }
+// ADJOINT:         %[[VAL_48:.*]] = arith.negf %[[VAL_18]] : f64
+// ADJOINT:         quake.ry (%[[VAL_48]]) %[[VAL_21]] : (f64, !quake.ref) -> ()
+// ADJOINT:         %[[VAL_49:.*]] = arith.addi %[[VAL_15]], %[[VAL_2]] : i64
+// ADJOINT:         %[[VAL_50:.*]] = arith.addi %[[VAL_49]], %[[VAL_6]] : i64
+// ADJOINT:         %[[VAL_51:.*]] = arith.cmpi sgt, %[[VAL_50]], %[[VAL_7]] : i64
+// ADJOINT:         %[[VAL_52:.*]] = arith.select %[[VAL_51]], %[[VAL_50]], %[[VAL_7]] : i64
+// ADJOINT:         %[[VAL_53:.*]] = arith.subi %[[VAL_52]], %[[VAL_6]] : i64
+// ADJOINT:         %[[VAL_54:.*]]:2 = cc.loop while ((%[[VAL_55:.*]] = %[[VAL_53]], %[[VAL_56:.*]] = %[[VAL_52]]) -> (i64, i64)) {
+// ADJOINT:           %[[VAL_57:.*]] = arith.cmpi sgt, %[[VAL_56]], %[[VAL_7]] : i64
+// ADJOINT:           cc.condition %[[VAL_57]](%[[VAL_55]], %[[VAL_56]] : i64, i64)
+// ADJOINT:         } do {
+// ADJOINT:         ^bb0(%[[VAL_58:.*]]: i64, %[[VAL_59:.*]]: i64):
+// ADJOINT:           %[[VAL_60:.*]] = quake.extract_ref %[[VAL_14]]{{\[}}%[[VAL_58]]] : (!quake.veq<?>, i64) -> !quake.ref
+// ADJOINT:           quake.h %[[VAL_60]] : (!quake.ref) -> ()
+// ADJOINT:           cc.continue %[[VAL_58]], %[[VAL_59]] : i64, i64
+// ADJOINT:         } step {
+// ADJOINT:         ^bb0(%[[VAL_61:.*]]: i64, %[[VAL_62:.*]]: i64):
+// ADJOINT:           %[[VAL_63:.*]] = arith.subi %[[VAL_61]], %[[VAL_6]] : i64
+// ADJOINT:           %[[VAL_64:.*]] = arith.subi %[[VAL_62]], %[[VAL_6]] : i64
+// ADJOINT:           cc.continue %[[VAL_63]], %[[VAL_64]] : i64, i64
+// ADJOINT:         }
+// ADJOINT:         return
+// ADJOINT:       }
 
 // ADJOINT-LABEL:   func.func @__nvqpp__mlirgen__QernelZero(
 

--- a/test/Quake/adjoint-2.qke
+++ b/test/Quake/adjoint-2.qke
@@ -6,10 +6,12 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --apply-op-specialization -verify-diagnostics %s
+// Test that the compiler will not construct the adjoint of a kernel
+// with a measurement.
+
+// RUN: cudaq-opt --apply-op-specialization %s | FileCheck %s
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel_alpha = "_ZN12kernel_alphaclERN4cudaq5quditILm2EEE", __nvqpp__mlirgen__kernel_beta = "_ZN11kernel_betaclEv"}} {
-  // expected-error @+1 {{cannot make adjoint of kernel with a measurement}}
   func.func @__nvqpp__mlirgen__kernel_alpha(%arg0: !quake.ref) attributes {"cudaq-kernel"} {
     %0 = quake.mx %arg0 : (!quake.ref) -> !quake.measure
     return
@@ -22,3 +24,5 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__kernel_alpha = "_
   }
 }
 
+// CHECK-NOT: __nvqpp__mlirgen__kernel_alpha.adj
+// CHECK: quake.apply<adj> @__nvqpp__mlirgen__kernel_alpha

--- a/test/Quake/apply-1.qke
+++ b/test/Quake/apply-1.qke
@@ -27,10 +27,9 @@
 
 // CHECK-LABEL: func.func private @test.adj.ctrl(
 // CHECK-SAME:     %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !quake.ref) {
-// CHECK:         %[[VAL_2:.*]] = arith.constant 1.0{{.*}} : f32
+// CHECK:         %[[VAL_2:.*]] = arith.constant -1.0{{.*}} : f32
 // CHECK-DAG:     quake.x [%[[VAL_0]]] %[[VAL_1]] :
-// CHECK-DAG:     %[[VAL_3:.*]] = arith.negf %[[VAL_2]] : f32
-// CHECK:         quake.rx (%[[VAL_3]]) [%[[VAL_0]]] %[[VAL_1]] :
+// CHECK:         quake.rx (%[[VAL_2]]) [%[[VAL_0]]] %[[VAL_1]] :
 // CHECK:         quake.h [%[[VAL_0]]] %[[VAL_1]] :
 // CHECK:         quake.t<adj> [%[[VAL_0]]] %[[VAL_1]] : (!quake.veq<?>,
 // CHECK:         return
@@ -41,9 +40,9 @@
 
 // CHECK-LABEL:   func.func private @test.ctrl(
 // CHECK-SAME:       %[[VAL_0:.*]]: !quake.veq<?>, %[[VAL_1:.*]]: !quake.ref) {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK:           quake.t [%[[VAL_0]]] %[[VAL_1]]
 // CHECK:           quake.h [%[[VAL_0]]] %[[VAL_1]]
-// CHECK:           %[[VAL_2:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK:           quake.rx (%[[VAL_2]]) [%[[VAL_0]]] %[[VAL_1]]
 // CHECK:           quake.x [%[[VAL_0]]] %[[VAL_1]]
 // CHECK:           return
@@ -51,9 +50,9 @@
 
 // CHECK-LABEL:   func.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !quake.ref) {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK:           quake.t %[[VAL_0]] :
 // CHECK:           quake.h %[[VAL_0]] :
-// CHECK:           %[[VAL_1:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK:           quake.rx (%[[VAL_1]]) %[[VAL_0]] :
 // CHECK:           quake.x %[[VAL_0]] :
 // CHECK:           return


### PR DESCRIPTION
This pass was too presumptive about its ability to translate all quake apply ops into calls. Turning it into a greedy pass and turning the pass into a compositional pass without hard crashes. The intention being that this pass need not fail in the AOT compiler, but can be run at JIT time after argument synthesis to achieve the desired IR.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
