### PR TITLE
activate_custom_mpi.sh: do not link against mlir

### DIFF
--- a/runtime/cudaq/distributed/builtin/activate_custom_mpi.sh
+++ b/runtime/cudaq/distributed/builtin/activate_custom_mpi.sh
@@ -48,7 +48,9 @@ fi
 
 echo "Using $CXX to build the MPI plugin for MPI installation in $MPI_PATH."
 lib_mpi_plugin="$this_file_dir/libcudaq_distributed_interface_mpi.so"
+# --disable-mlir-links for https://github.com/NVIDIA/cuda-quantum/issues/2892
 $CXX -shared -std=c++17 -fPIC \
+    --disable-mlir-links \
     -I"${MPI_PATH}/include" \
     -I"$this_file_dir" \
     "$this_file_dir/mpi_comm_impl.cpp" \


### PR DESCRIPTION
See https://github.com/NVIDIA/cuda-quantum/issues/2892

It might be worth it to further trim down what the ELF file links against, but the other files seem benign for now.

```
cudaq@2570547-lcedt:/opt/nvidia/cudaq/distributed_interfaces$ readelf -d libcudaq_distributed_interface_mpi.so  | grep cudaq
 0x000000000000001d (RUNPATH)            Library runpath: [/usr/local/llvm/lib:/opt/nvidia/cudaq/lib:/opt/nvidia/cudaq/lib/plugins:/opt/nvidia/cudaq/distributed_interfaces:/usr/local/openmpi/lib64:/usr/local/openmpi/lib]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq-common.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq-ensmallen.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq-nlopt.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq-spin.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq-operator.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq-comm-plugin.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq-pyscf.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq-em-default.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcudaq-platform-default.so]
 ```