### PR TITLE
Fixing performance of the python bindings

### DIFF
--- a/docs/sphinx/using/examples/dynamics_examples.rst
+++ b/docs/sphinx/using/examples/dynamics_examples.rst
@@ -2,6 +2,10 @@ CUDA-Q Dynamics
 ===============
 .. _dynamics_examples:
 
+
+This page contains a number of examples that use CUDA-Q dynamics to simulate a range of fundamental physical systems and specific qubit modalities. All example problems simulate systems of very low dimension so that the code can be run quickly on any device. For small problems, the GPU will not provide a significant performance advantage over the CPU. The GPU will start to outperform the CPU for cases where the total dimension of all subsystems is O(1000).
+
+
 Cavity QED
 ---------------
 .. _cavity_qed:

--- a/python/runtime/cudaq/operators/py_boson_op.cpp
+++ b/python/runtime/cudaq/operators/py_boson_op.cpp
@@ -269,7 +269,15 @@ void bindBosonOperator(py::module &mod) {
       .def(py::self -= boson_op_term(), py::is_operator())
       .def(py::self *= py::self, py::is_operator())
       .def(py::self += py::self, py::is_operator())
+      // see issue https://github.com/pybind/pybind11/issues/1893
+      #ifdef __clang__
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wself-assign-overloaded"
+      #endif
       .def(py::self -= py::self, py::is_operator())
+      #ifdef __clang__
+      #pragma clang diagnostic pop
+      #endif
 
       // right-hand arithmetics
 

--- a/python/runtime/cudaq/operators/py_boson_op.cpp
+++ b/python/runtime/cudaq/operators/py_boson_op.cpp
@@ -243,260 +243,79 @@ void bindBosonOperator(py::module &mod) {
 
       // unary operators
 
-      .def(
-          "__neg__", [](const boson_op &self) { return -self; },
-          py::is_operator())
-      .def(
-          "__pos__", [](const boson_op &self) { return +self; },
-          py::is_operator())
+      .def(-py::self, py::is_operator())
+      .def(+py::self, py::is_operator())
 
       // in-place arithmetics
 
-      .def(
-          "__itruediv__",
-          [](boson_op &self, int other) { return self /= other; },
-          py::is_operator())
-      .def(
-          "__imul__", [](boson_op &self, int other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__iadd__", [](boson_op &self, int other) { return self += other; },
-          py::is_operator())
-      .def(
-          "__isub__", [](boson_op &self, int other) { return self -= other; },
-          py::is_operator())
-      .def(
-          "__itruediv__",
-          [](boson_op &self, const scalar_operator &other) {
-            return self /= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](boson_op &self, const scalar_operator &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](boson_op &self, const scalar_operator &other) {
-            return self += other;
-          },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](boson_op &self, const scalar_operator &other) {
-            return self -= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](boson_op &self, const boson_op_term &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](boson_op &self, const boson_op_term &other) {
-            return self += other;
-          },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](boson_op &self, const boson_op_term &other) {
-            return self -= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](boson_op &self, const boson_op &other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](boson_op &self, const boson_op &other) { return self += other; },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](boson_op &self, const boson_op &other) { return self -= other; },
-          py::is_operator())
+      .def(py::self /= int(), py::is_operator())
+      .def(py::self *= int(), py::is_operator())
+      .def(py::self += int(), py::is_operator())
+      .def(py::self -= int(), py::is_operator())
+      .def(py::self /= double(), py::is_operator())
+      .def(py::self *= double(), py::is_operator())
+      .def(py::self += double(), py::is_operator())
+      .def(py::self -= double(), py::is_operator())
+      .def(py::self /= std::complex<double>(), py::is_operator())
+      .def(py::self *= std::complex<double>(), py::is_operator())
+      .def(py::self += std::complex<double>(), py::is_operator())
+      .def(py::self -= std::complex<double>(), py::is_operator())
+      .def(py::self /= scalar_operator(), py::is_operator())
+      .def(py::self *= scalar_operator(), py::is_operator())
+      .def(py::self += scalar_operator(), py::is_operator())
+      .def(py::self -= scalar_operator(), py::is_operator())
+      .def(py::self *= boson_op_term(), py::is_operator())
+      .def(py::self += boson_op_term(), py::is_operator())
+      .def(py::self -= boson_op_term(), py::is_operator())
+      .def(py::self *= py::self, py::is_operator())
+      .def(py::self += py::self, py::is_operator())
+      .def(py::self -= py::self, py::is_operator())
 
       // right-hand arithmetics
 
-      .def(
-          "__truediv__",
-          [](const boson_op &self, int other) { return self / other; },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op &self, int other) { return self * other; },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op &self, int other) { return self + other; },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op &self, int other) { return self - other; },
-          py::is_operator())
-      .def(
-          "__truediv__",
-          [](const boson_op &self, const scalar_operator &other) {
-            return self / other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op &self, const scalar_operator &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op &self, const scalar_operator &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op &self, const scalar_operator &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op &self, const boson_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op &self, const boson_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op &self, const boson_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op &self, const boson_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op &self, const boson_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op &self, const boson_op &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op &self, const matrix_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op &self, const matrix_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op &self, const matrix_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op &self, const matrix_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op &self, const matrix_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op &self, const matrix_op &other) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(py::self / int(), py::is_operator())
+      .def(py::self * int(), py::is_operator())
+      .def(py::self + int(), py::is_operator())
+      .def(py::self - int(), py::is_operator())
+      .def(py::self / double(), py::is_operator())
+      .def(py::self * double(), py::is_operator())
+      .def(py::self + double(), py::is_operator())
+      .def(py::self - double(), py::is_operator())
+      .def(py::self / std::complex<double>(), py::is_operator())
+      .def(py::self * std::complex<double>(), py::is_operator())
+      .def(py::self + std::complex<double>(), py::is_operator())
+      .def(py::self - std::complex<double>(), py::is_operator())
+      .def(py::self / scalar_operator(), py::is_operator())
+      .def(py::self * scalar_operator(), py::is_operator())
+      .def(py::self + scalar_operator(), py::is_operator())
+      .def(py::self - scalar_operator(), py::is_operator())
+      .def(py::self * boson_op_term(), py::is_operator())
+      .def(py::self + boson_op_term(), py::is_operator())
+      .def(py::self - boson_op_term(), py::is_operator())
+      .def(py::self * py::self, py::is_operator())
+      .def(py::self + py::self, py::is_operator())
+      .def(py::self - py::self, py::is_operator())
+      .def(py::self * matrix_op_term(), py::is_operator())
+      .def(py::self + matrix_op_term(), py::is_operator())
+      .def(py::self - matrix_op_term(), py::is_operator())
+      .def(py::self * matrix_op(), py::is_operator())
+      .def(py::self + matrix_op(), py::is_operator())
+      .def(py::self - matrix_op(), py::is_operator())
 
       // left-hand arithmetics
 
-      .def(
-          "__rmul__",
-          [](const boson_op &other, int self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const boson_op &other, int self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const boson_op &other, int self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const boson_op &other, double self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const boson_op &other, double self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const boson_op &other, double self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const boson_op &other, std::complex<double> self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const boson_op &other, std::complex<double> self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const boson_op &other, std::complex<double> self) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const boson_op &other, const scalar_operator &self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const boson_op &other, const scalar_operator &self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const boson_op &other, const scalar_operator &self) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(int() * py::self, py::is_operator())
+      .def(int() + py::self, py::is_operator())
+      .def(int() - py::self, py::is_operator())
+      .def(double() * py::self, py::is_operator())
+      .def(double() + py::self, py::is_operator())
+      .def(double() - py::self, py::is_operator())
+      .def(std::complex<double>() * py::self, py::is_operator())
+      .def(std::complex<double>() + py::self, py::is_operator())
+      .def(std::complex<double>() - py::self, py::is_operator())
+      .def(scalar_operator() * py::self, py::is_operator())
+      .def(scalar_operator() + py::self, py::is_operator())
+      .def(scalar_operator() - py::self, py::is_operator())
 
       // common operators
 
@@ -727,219 +546,66 @@ void bindBosonOperator(py::module &mod) {
 
       // unary operators
 
-      .def(
-          "__neg__", [](const boson_op_term &self) { return -self; },
-          py::is_operator())
-      .def(
-          "__pos__", [](const boson_op_term &self) { return +self; },
-          py::is_operator())
+      .def(-py::self, py::is_operator())
+      .def(+py::self, py::is_operator())
 
       // in-place arithmetics
 
-      .def(
-          "__itruediv__",
-          [](boson_op_term &self, int other) { return self /= other; },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](boson_op_term &self, int other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__itruediv__",
-          [](boson_op_term &self, const scalar_operator &other) {
-            return self /= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](boson_op_term &self, const scalar_operator &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](boson_op_term &self, const boson_op_term &other) {
-            return self *= other;
-          },
-          py::is_operator())
+      .def(py::self /= int(), py::is_operator())
+      .def(py::self *= int(), py::is_operator())
+      .def(py::self /= double(), py::is_operator())
+      .def(py::self *= double(), py::is_operator())
+      .def(py::self /= std::complex<double>(), py::is_operator())
+      .def(py::self *= std::complex<double>(), py::is_operator())
+      .def(py::self /= scalar_operator(), py::is_operator())
+      .def(py::self *= scalar_operator(), py::is_operator())
+      .def(py::self *= py::self, py::is_operator())
 
       // right-hand arithmetics
 
-      .def(
-          "__truediv__",
-          [](const boson_op_term &self, int other) { return self / other; },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op_term &self, int other) { return self * other; },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op_term &self, int other) { return self + other; },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op_term &self, int other) { return self - other; },
-          py::is_operator())
-      .def(
-          "__truediv__",
-          [](const boson_op_term &self, const scalar_operator &other) {
-            return self / other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op_term &self, const scalar_operator &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op_term &self, const scalar_operator &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op_term &self, const scalar_operator &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op_term &self, const boson_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op_term &self, const boson_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op_term &self, const boson_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op_term &self, const boson_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op_term &self, const boson_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op_term &self, const boson_op &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op_term &self, const matrix_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op_term &self, const matrix_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op_term &self, const matrix_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const boson_op_term &self, const matrix_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const boson_op_term &self, const matrix_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const boson_op_term &self, const matrix_op &other) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(py::self / int(), py::is_operator())
+      .def(py::self * int(), py::is_operator())
+      .def(py::self + int(), py::is_operator())
+      .def(py::self - int(), py::is_operator())
+      .def(py::self / double(), py::is_operator())
+      .def(py::self * double(), py::is_operator())
+      .def(py::self + double(), py::is_operator())
+      .def(py::self - double(), py::is_operator())
+      .def(py::self / std::complex<double>(), py::is_operator())
+      .def(py::self * std::complex<double>(), py::is_operator())
+      .def(py::self + std::complex<double>(), py::is_operator())
+      .def(py::self - std::complex<double>(), py::is_operator())
+      .def(py::self / scalar_operator(), py::is_operator())
+      .def(py::self * scalar_operator(), py::is_operator())
+      .def(py::self + scalar_operator(), py::is_operator())
+      .def(py::self - scalar_operator(), py::is_operator())
+      .def(py::self * py::self, py::is_operator())
+      .def(py::self + py::self, py::is_operator())
+      .def(py::self - py::self, py::is_operator())
+      .def(py::self * boson_op(), py::is_operator())
+      .def(py::self + boson_op(), py::is_operator())
+      .def(py::self - boson_op(), py::is_operator())
+      .def(py::self * matrix_op_term(), py::is_operator())
+      .def(py::self + matrix_op_term(), py::is_operator())
+      .def(py::self - matrix_op_term(), py::is_operator())
+      .def(py::self * matrix_op(), py::is_operator())
+      .def(py::self + matrix_op(), py::is_operator())
+      .def(py::self - matrix_op(), py::is_operator())
 
       // left-hand arithmetics
 
-      .def(
-          "__rmul__",
-          [](const boson_op_term &other, int self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const boson_op_term &other, int self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const boson_op_term &other, int self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const boson_op_term &other, double self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const boson_op_term &other, double self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const boson_op_term &other, double self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const boson_op_term &other, std::complex<double> self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const boson_op_term &other, std::complex<double> self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const boson_op_term &other, std::complex<double> self) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const boson_op_term &other, const scalar_operator &self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const boson_op_term &other, const scalar_operator &self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const boson_op_term &other, const scalar_operator &self) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(int() * py::self, py::is_operator())
+      .def(int() + py::self, py::is_operator())
+      .def(int() - py::self, py::is_operator())
+      .def(double() * py::self, py::is_operator())
+      .def(double() + py::self, py::is_operator())
+      .def(double() - py::self, py::is_operator())
+      .def(std::complex<double>() * py::self, py::is_operator())
+      .def(std::complex<double>() + py::self, py::is_operator())
+      .def(std::complex<double>() - py::self, py::is_operator())
+      .def(scalar_operator() * py::self, py::is_operator())
+      .def(scalar_operator() + py::self, py::is_operator())
+      .def(scalar_operator() - py::self, py::is_operator())
 
       // general utility functions
 

--- a/python/runtime/cudaq/operators/py_boson_op.cpp
+++ b/python/runtime/cudaq/operators/py_boson_op.cpp
@@ -269,15 +269,15 @@ void bindBosonOperator(py::module &mod) {
       .def(py::self -= boson_op_term(), py::is_operator())
       .def(py::self *= py::self, py::is_operator())
       .def(py::self += py::self, py::is_operator())
-      // see issue https://github.com/pybind/pybind11/issues/1893
-      #ifdef __clang__
-      #pragma clang diagnostic push
-      #pragma clang diagnostic ignored "-Wself-assign-overloaded"
-      #endif
+// see issue https://github.com/pybind/pybind11/issues/1893
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif
       .def(py::self -= py::self, py::is_operator())
-      #ifdef __clang__
-      #pragma clang diagnostic pop
-      #endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
       // right-hand arithmetics
 

--- a/python/runtime/cudaq/operators/py_fermion_op.cpp
+++ b/python/runtime/cudaq/operators/py_fermion_op.cpp
@@ -264,15 +264,15 @@ void bindFermionOperator(py::module &mod) {
       .def(py::self -= fermion_op_term(), py::is_operator())
       .def(py::self *= py::self, py::is_operator())
       .def(py::self += py::self, py::is_operator())
-      // see issue https://github.com/pybind/pybind11/issues/1893
-      #ifdef __clang__
-      #pragma clang diagnostic push
-      #pragma clang diagnostic ignored "-Wself-assign-overloaded"
-      #endif
+// see issue https://github.com/pybind/pybind11/issues/1893
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif
       .def(py::self -= py::self, py::is_operator())
-      #ifdef __clang__
-      #pragma clang diagnostic pop
-      #endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
       // right-hand arithmetics
 

--- a/python/runtime/cudaq/operators/py_fermion_op.cpp
+++ b/python/runtime/cudaq/operators/py_fermion_op.cpp
@@ -238,266 +238,79 @@ void bindFermionOperator(py::module &mod) {
 
       // unary operators
 
-      .def(
-          "__neg__", [](const fermion_op &self) { return -self; },
-          py::is_operator())
-      .def(
-          "__pos__", [](const fermion_op &self) { return +self; },
-          py::is_operator())
+      .def(-py::self, py::is_operator())
+      .def(+py::self, py::is_operator())
 
       // in-place arithmetics
 
-      .def(
-          "__itruediv__",
-          [](fermion_op &self, int other) { return self /= other; },
-          py::is_operator())
-      .def(
-          "__imul__", [](fermion_op &self, int other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__iadd__", [](fermion_op &self, int other) { return self += other; },
-          py::is_operator())
-      .def(
-          "__isub__", [](fermion_op &self, int other) { return self -= other; },
-          py::is_operator())
-      .def(
-          "__itruediv__",
-          [](fermion_op &self, const scalar_operator &other) {
-            return self /= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](fermion_op &self, const scalar_operator &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](fermion_op &self, const scalar_operator &other) {
-            return self += other;
-          },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](fermion_op &self, const scalar_operator &other) {
-            return self -= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](fermion_op &self, const fermion_op_term &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](fermion_op &self, const fermion_op_term &other) {
-            return self += other;
-          },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](fermion_op &self, const fermion_op_term &other) {
-            return self -= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](fermion_op &self, const fermion_op &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](fermion_op &self, const fermion_op &other) {
-            return self += other;
-          },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](fermion_op &self, const fermion_op &other) {
-            return self -= other;
-          },
-          py::is_operator())
+      .def(py::self /= int(), py::is_operator())
+      .def(py::self *= int(), py::is_operator())
+      .def(py::self += int(), py::is_operator())
+      .def(py::self -= int(), py::is_operator())
+      .def(py::self /= double(), py::is_operator())
+      .def(py::self *= double(), py::is_operator())
+      .def(py::self += double(), py::is_operator())
+      .def(py::self -= double(), py::is_operator())
+      .def(py::self /= std::complex<double>(), py::is_operator())
+      .def(py::self *= std::complex<double>(), py::is_operator())
+      .def(py::self += std::complex<double>(), py::is_operator())
+      .def(py::self -= std::complex<double>(), py::is_operator())
+      .def(py::self /= scalar_operator(), py::is_operator())
+      .def(py::self *= scalar_operator(), py::is_operator())
+      .def(py::self += scalar_operator(), py::is_operator())
+      .def(py::self -= scalar_operator(), py::is_operator())
+      .def(py::self *= fermion_op_term(), py::is_operator())
+      .def(py::self += fermion_op_term(), py::is_operator())
+      .def(py::self -= fermion_op_term(), py::is_operator())
+      .def(py::self *= py::self, py::is_operator())
+      .def(py::self += py::self, py::is_operator())
+      .def(py::self -= py::self, py::is_operator())
 
       // right-hand arithmetics
 
-      .def(
-          "__truediv__",
-          [](const fermion_op &self, int other) { return self / other; },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op &self, int other) { return self * other; },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op &self, int other) { return self + other; },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op &self, int other) { return self - other; },
-          py::is_operator())
-      .def(
-          "__truediv__",
-          [](const fermion_op &self, const scalar_operator &other) {
-            return self / other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op &self, const scalar_operator &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op &self, const scalar_operator &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op &self, const scalar_operator &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op &self, const fermion_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op &self, const fermion_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op &self, const fermion_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op &self, const fermion_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op &self, const fermion_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op &self, const fermion_op &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op &self, const matrix_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op &self, const matrix_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op &self, const matrix_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op &self, const matrix_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op &self, const matrix_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op &self, const matrix_op &other) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(py::self / int(), py::is_operator())
+      .def(py::self * int(), py::is_operator())
+      .def(py::self + int(), py::is_operator())
+      .def(py::self - int(), py::is_operator())
+      .def(py::self / double(), py::is_operator())
+      .def(py::self * double(), py::is_operator())
+      .def(py::self + double(), py::is_operator())
+      .def(py::self - double(), py::is_operator())
+      .def(py::self / std::complex<double>(), py::is_operator())
+      .def(py::self * std::complex<double>(), py::is_operator())
+      .def(py::self + std::complex<double>(), py::is_operator())
+      .def(py::self - std::complex<double>(), py::is_operator())
+      .def(py::self / scalar_operator(), py::is_operator())
+      .def(py::self * scalar_operator(), py::is_operator())
+      .def(py::self + scalar_operator(), py::is_operator())
+      .def(py::self - scalar_operator(), py::is_operator())
+      .def(py::self * fermion_op_term(), py::is_operator())
+      .def(py::self + fermion_op_term(), py::is_operator())
+      .def(py::self - fermion_op_term(), py::is_operator())
+      .def(py::self * py::self, py::is_operator())
+      .def(py::self + py::self, py::is_operator())
+      .def(py::self - py::self, py::is_operator())
+      .def(py::self * matrix_op_term(), py::is_operator())
+      .def(py::self + matrix_op_term(), py::is_operator())
+      .def(py::self - matrix_op_term(), py::is_operator())
+      .def(py::self * matrix_op(), py::is_operator())
+      .def(py::self + matrix_op(), py::is_operator())
+      .def(py::self - matrix_op(), py::is_operator())
 
       // left-hand arithmetics
 
-      .def(
-          "__rmul__",
-          [](const fermion_op &other, int self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const fermion_op &other, int self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const fermion_op &other, int self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const fermion_op &other, double self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const fermion_op &other, double self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const fermion_op &other, double self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const fermion_op &other, std::complex<double> self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const fermion_op &other, std::complex<double> self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const fermion_op &other, std::complex<double> self) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const fermion_op &other, const scalar_operator &self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const fermion_op &other, const scalar_operator &self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const fermion_op &other, const scalar_operator &self) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(int() * py::self, py::is_operator())
+      .def(int() + py::self, py::is_operator())
+      .def(int() - py::self, py::is_operator())
+      .def(double() * py::self, py::is_operator())
+      .def(double() + py::self, py::is_operator())
+      .def(double() - py::self, py::is_operator())
+      .def(std::complex<double>() * py::self, py::is_operator())
+      .def(std::complex<double>() + py::self, py::is_operator())
+      .def(std::complex<double>() - py::self, py::is_operator())
+      .def(scalar_operator() * py::self, py::is_operator())
+      .def(scalar_operator() + py::self, py::is_operator())
+      .def(scalar_operator() - py::self, py::is_operator())
 
       // common operators
 
@@ -729,225 +542,66 @@ void bindFermionOperator(py::module &mod) {
 
       // unary operators
 
-      .def(
-          "__neg__", [](const fermion_op_term &self) { return -self; },
-          py::is_operator())
-      .def(
-          "__pos__", [](const fermion_op_term &self) { return +self; },
-          py::is_operator())
+      .def(-py::self, py::is_operator())
+      .def(+py::self, py::is_operator())
 
       // in-place arithmetics
 
-      .def(
-          "__itruediv__",
-          [](fermion_op_term &self, int other) { return self /= other; },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](fermion_op_term &self, int other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__itruediv__",
-          [](fermion_op_term &self, const scalar_operator &other) {
-            return self /= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](fermion_op_term &self, const scalar_operator &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](fermion_op_term &self, const fermion_op_term &other) {
-            return self *= other;
-          },
-          py::is_operator())
+      .def(py::self /= int(), py::is_operator())
+      .def(py::self *= int(), py::is_operator())
+      .def(py::self /= double(), py::is_operator())
+      .def(py::self *= double(), py::is_operator())
+      .def(py::self /= std::complex<double>(), py::is_operator())
+      .def(py::self *= std::complex<double>(), py::is_operator())
+      .def(py::self /= scalar_operator(), py::is_operator())
+      .def(py::self *= scalar_operator(), py::is_operator())
+      .def(py::self *= py::self, py::is_operator())
 
       // right-hand arithmetics
 
-      .def(
-          "__truediv__",
-          [](const fermion_op_term &self, int other) { return self / other; },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op_term &self, int other) { return self * other; },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op_term &self, int other) { return self + other; },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op_term &self, int other) { return self - other; },
-          py::is_operator())
-      .def(
-          "__truediv__",
-          [](const fermion_op_term &self, const scalar_operator &other) {
-            return self / other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op_term &self, const scalar_operator &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op_term &self, const scalar_operator &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op_term &self, const scalar_operator &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op_term &self, const fermion_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op_term &self, const fermion_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op_term &self, const fermion_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op_term &self, const fermion_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op_term &self, const fermion_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op_term &self, const fermion_op &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op_term &self, const matrix_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op_term &self, const matrix_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op_term &self, const matrix_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const fermion_op_term &self, const matrix_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const fermion_op_term &self, const matrix_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const fermion_op_term &self, const matrix_op &other) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(py::self / int(), py::is_operator())
+      .def(py::self * int(), py::is_operator())
+      .def(py::self + int(), py::is_operator())
+      .def(py::self - int(), py::is_operator())
+      .def(py::self / double(), py::is_operator())
+      .def(py::self * double(), py::is_operator())
+      .def(py::self + double(), py::is_operator())
+      .def(py::self - double(), py::is_operator())
+      .def(py::self / std::complex<double>(), py::is_operator())
+      .def(py::self * std::complex<double>(), py::is_operator())
+      .def(py::self + std::complex<double>(), py::is_operator())
+      .def(py::self - std::complex<double>(), py::is_operator())
+      .def(py::self / scalar_operator(), py::is_operator())
+      .def(py::self * scalar_operator(), py::is_operator())
+      .def(py::self + scalar_operator(), py::is_operator())
+      .def(py::self - scalar_operator(), py::is_operator())
+      .def(py::self * py::self, py::is_operator())
+      .def(py::self + py::self, py::is_operator())
+      .def(py::self - py::self, py::is_operator())
+      .def(py::self * fermion_op(), py::is_operator())
+      .def(py::self + fermion_op(), py::is_operator())
+      .def(py::self - fermion_op(), py::is_operator())
+      .def(py::self * matrix_op_term(), py::is_operator())
+      .def(py::self + matrix_op_term(), py::is_operator())
+      .def(py::self - matrix_op_term(), py::is_operator())
+      .def(py::self * matrix_op(), py::is_operator())
+      .def(py::self + matrix_op(), py::is_operator())
+      .def(py::self - matrix_op(), py::is_operator())
 
       // left-hand arithmetics
 
-      .def(
-          "__rmul__",
-          [](const fermion_op_term &other, int self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const fermion_op_term &other, int self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const fermion_op_term &other, int self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const fermion_op_term &other, double self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const fermion_op_term &other, double self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const fermion_op_term &other, double self) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const fermion_op_term &other, std::complex<double> self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const fermion_op_term &other, std::complex<double> self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const fermion_op_term &other, std::complex<double> self) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const fermion_op_term &other, const scalar_operator &self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const fermion_op_term &other, const scalar_operator &self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const fermion_op_term &other, const scalar_operator &self) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(int() * py::self, py::is_operator())
+      .def(int() + py::self, py::is_operator())
+      .def(int() - py::self, py::is_operator())
+      .def(double() * py::self, py::is_operator())
+      .def(double() + py::self, py::is_operator())
+      .def(double() - py::self, py::is_operator())
+      .def(std::complex<double>() * py::self, py::is_operator())
+      .def(std::complex<double>() + py::self, py::is_operator())
+      .def(std::complex<double>() - py::self, py::is_operator())
+      .def(scalar_operator() * py::self, py::is_operator())
+      .def(scalar_operator() + py::self, py::is_operator())
+      .def(scalar_operator() - py::self, py::is_operator())
 
       // general utility functions
 

--- a/python/runtime/cudaq/operators/py_fermion_op.cpp
+++ b/python/runtime/cudaq/operators/py_fermion_op.cpp
@@ -264,7 +264,15 @@ void bindFermionOperator(py::module &mod) {
       .def(py::self -= fermion_op_term(), py::is_operator())
       .def(py::self *= py::self, py::is_operator())
       .def(py::self += py::self, py::is_operator())
+      // see issue https://github.com/pybind/pybind11/issues/1893
+      #ifdef __clang__
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wself-assign-overloaded"
+      #endif
       .def(py::self -= py::self, py::is_operator())
+      #ifdef __clang__
+      #pragma clang diagnostic pop
+      #endif
 
       // right-hand arithmetics
 

--- a/python/runtime/cudaq/operators/py_matrix_op.cpp
+++ b/python/runtime/cudaq/operators/py_matrix_op.cpp
@@ -232,7 +232,15 @@ void bindMatrixOperator(py::module &mod) {
       .def(py::self -= matrix_op_term(), py::is_operator())
       .def(py::self *= py::self, py::is_operator())
       .def(py::self += py::self, py::is_operator())
+      // see issue https://github.com/pybind/pybind11/issues/1893
+      #ifdef __clang__
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wself-assign-overloaded"
+      #endif
       .def(py::self -= py::self, py::is_operator())
+      #ifdef __clang__
+      #pragma clang diagnostic pop
+      #endif
 
       // right-hand arithmetics
 

--- a/python/runtime/cudaq/operators/py_matrix_op.cpp
+++ b/python/runtime/cudaq/operators/py_matrix_op.cpp
@@ -232,15 +232,15 @@ void bindMatrixOperator(py::module &mod) {
       .def(py::self -= matrix_op_term(), py::is_operator())
       .def(py::self *= py::self, py::is_operator())
       .def(py::self += py::self, py::is_operator())
-      // see issue https://github.com/pybind/pybind11/issues/1893
-      #ifdef __clang__
-      #pragma clang diagnostic push
-      #pragma clang diagnostic ignored "-Wself-assign-overloaded"
-      #endif
+// see issue https://github.com/pybind/pybind11/issues/1893
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif
       .def(py::self -= py::self, py::is_operator())
-      #ifdef __clang__
-      #pragma clang diagnostic pop
-      #endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
       // right-hand arithmetics
 

--- a/python/runtime/cudaq/operators/py_matrix_op.cpp
+++ b/python/runtime/cudaq/operators/py_matrix_op.cpp
@@ -206,224 +206,73 @@ void bindMatrixOperator(py::module &mod) {
 
       // unary operators
 
-      .def(
-          "__neg__", [](const matrix_op &self) { return -self; },
-          py::is_operator())
-      .def(
-          "__pos__", [](const matrix_op &self) { return +self; },
-          py::is_operator())
+      .def(-py::self, py::is_operator())
+      .def(+py::self, py::is_operator())
 
       // in-place arithmetics
 
-      .def(
-          "__itruediv__",
-          [](matrix_op &self, int other) { return self /= other; },
-          py::is_operator())
-      .def(
-          "__imul__", [](matrix_op &self, int other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__iadd__", [](matrix_op &self, int other) { return self += other; },
-          py::is_operator())
-      .def(
-          "__isub__", [](matrix_op &self, int other) { return self -= other; },
-          py::is_operator())
-      .def(
-          "__itruediv__",
-          [](matrix_op &self, const scalar_operator &other) {
-            return self /= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](matrix_op &self, const scalar_operator &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](matrix_op &self, const scalar_operator &other) {
-            return self += other;
-          },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](matrix_op &self, const scalar_operator &other) {
-            return self -= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](matrix_op &self, const matrix_op_term &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](matrix_op &self, const matrix_op_term &other) {
-            return self += other;
-          },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](matrix_op &self, const matrix_op_term &other) {
-            return self -= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](matrix_op &self, const matrix_op &other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](matrix_op &self, const matrix_op &other) { return self += other; },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](matrix_op &self, const matrix_op &other) { return self -= other; },
-          py::is_operator())
+      .def(py::self /= int(), py::is_operator())
+      .def(py::self *= int(), py::is_operator())
+      .def(py::self += int(), py::is_operator())
+      .def(py::self -= int(), py::is_operator())
+      .def(py::self /= double(), py::is_operator())
+      .def(py::self *= double(), py::is_operator())
+      .def(py::self += double(), py::is_operator())
+      .def(py::self -= double(), py::is_operator())
+      .def(py::self /= std::complex<double>(), py::is_operator())
+      .def(py::self *= std::complex<double>(), py::is_operator())
+      .def(py::self += std::complex<double>(), py::is_operator())
+      .def(py::self -= std::complex<double>(), py::is_operator())
+      .def(py::self /= scalar_operator(), py::is_operator())
+      .def(py::self *= scalar_operator(), py::is_operator())
+      .def(py::self += scalar_operator(), py::is_operator())
+      .def(py::self -= scalar_operator(), py::is_operator())
+      .def(py::self *= matrix_op_term(), py::is_operator())
+      .def(py::self += matrix_op_term(), py::is_operator())
+      .def(py::self -= matrix_op_term(), py::is_operator())
+      .def(py::self *= py::self, py::is_operator())
+      .def(py::self += py::self, py::is_operator())
+      .def(py::self -= py::self, py::is_operator())
 
       // right-hand arithmetics
 
-      .def(
-          "__truediv__",
-          [](const matrix_op &self, int other) { return self / other; },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const matrix_op &self, int other) { return self * other; },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const matrix_op &self, int other) { return self + other; },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const matrix_op &self, int other) { return self - other; },
-          py::is_operator())
-      .def(
-          "__truediv__",
-          [](const matrix_op &self, const scalar_operator &other) {
-            return self / other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const matrix_op &self, const scalar_operator &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const matrix_op &self, const scalar_operator &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const matrix_op &self, const scalar_operator &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const matrix_op &self, const matrix_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const matrix_op &self, const matrix_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const matrix_op &self, const matrix_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const matrix_op &self, const matrix_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const matrix_op &self, const matrix_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const matrix_op &self, const matrix_op &other) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(py::self / int(), py::is_operator())
+      .def(py::self * int(), py::is_operator())
+      .def(py::self + int(), py::is_operator())
+      .def(py::self - int(), py::is_operator())
+      .def(py::self / double(), py::is_operator())
+      .def(py::self * double(), py::is_operator())
+      .def(py::self + double(), py::is_operator())
+      .def(py::self - double(), py::is_operator())
+      .def(py::self / std::complex<double>(), py::is_operator())
+      .def(py::self * std::complex<double>(), py::is_operator())
+      .def(py::self + std::complex<double>(), py::is_operator())
+      .def(py::self - std::complex<double>(), py::is_operator())
+      .def(py::self / scalar_operator(), py::is_operator())
+      .def(py::self * scalar_operator(), py::is_operator())
+      .def(py::self + scalar_operator(), py::is_operator())
+      .def(py::self - scalar_operator(), py::is_operator())
+      .def(py::self * matrix_op_term(), py::is_operator())
+      .def(py::self + matrix_op_term(), py::is_operator())
+      .def(py::self - matrix_op_term(), py::is_operator())
+      .def(py::self * py::self, py::is_operator())
+      .def(py::self + py::self, py::is_operator())
+      .def(py::self - py::self, py::is_operator())
 
       // left-hand arithmetics
 
-      .def(
-          "__rmul__",
-          [](const matrix_op &other, int self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const matrix_op &other, int self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const matrix_op &other, int self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const matrix_op &other, double self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const matrix_op &other, double self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const matrix_op &other, double self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const matrix_op &other, std::complex<double> self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const matrix_op &other, std::complex<double> self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const matrix_op &other, std::complex<double> self) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const matrix_op &other, const scalar_operator &self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const matrix_op &other, const scalar_operator &self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const matrix_op &other, const scalar_operator &self) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(int() * py::self, py::is_operator())
+      .def(int() + py::self, py::is_operator())
+      .def(int() - py::self, py::is_operator())
+      .def(double() * py::self, py::is_operator())
+      .def(double() + py::self, py::is_operator())
+      .def(double() - py::self, py::is_operator())
+      .def(std::complex<double>() * py::self, py::is_operator())
+      .def(std::complex<double>() + py::self, py::is_operator())
+      .def(std::complex<double>() - py::self, py::is_operator())
+      .def(scalar_operator() * py::self, py::is_operator())
+      .def(scalar_operator() + py::self, py::is_operator())
+      .def(scalar_operator() - py::self, py::is_operator())
 
       // common operators
 
@@ -621,183 +470,60 @@ void bindMatrixOperator(py::module &mod) {
 
       // unary operators
 
-      .def(
-          "__neg__", [](const matrix_op_term &self) { return -self; },
-          py::is_operator())
-      .def(
-          "__pos__", [](const matrix_op_term &self) { return +self; },
-          py::is_operator())
+      .def(-py::self, py::is_operator())
+      .def(+py::self, py::is_operator())
 
       // in-place arithmetics
 
-      .def(
-          "__itruediv__",
-          [](matrix_op_term &self, int other) { return self /= other; },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](matrix_op_term &self, int other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__itruediv__",
-          [](matrix_op_term &self, const scalar_operator &other) {
-            return self /= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](matrix_op_term &self, const scalar_operator &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](matrix_op_term &self, const matrix_op_term &other) {
-            return self *= other;
-          },
-          py::is_operator())
+      .def(py::self /= int(), py::is_operator())
+      .def(py::self *= int(), py::is_operator())
+      .def(py::self /= double(), py::is_operator())
+      .def(py::self *= double(), py::is_operator())
+      .def(py::self /= std::complex<double>(), py::is_operator())
+      .def(py::self *= std::complex<double>(), py::is_operator())
+      .def(py::self /= scalar_operator(), py::is_operator())
+      .def(py::self *= scalar_operator(), py::is_operator())
+      .def(py::self *= py::self, py::is_operator())
 
       // right-hand arithmetics
 
-      .def(
-          "__truediv__",
-          [](const matrix_op_term &self, int other) { return self / other; },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const matrix_op_term &self, int other) { return self * other; },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const matrix_op_term &self, int other) { return self + other; },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const matrix_op_term &self, int other) { return self - other; },
-          py::is_operator())
-      .def(
-          "__truediv__",
-          [](const matrix_op_term &self, const scalar_operator &other) {
-            return self / other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const matrix_op_term &self, const scalar_operator &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const matrix_op_term &self, const scalar_operator &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const matrix_op_term &self, const scalar_operator &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const matrix_op_term &self, const matrix_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const matrix_op_term &self, const matrix_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const matrix_op_term &self, const matrix_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const matrix_op_term &self, const matrix_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const matrix_op_term &self, const matrix_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const matrix_op_term &self, const matrix_op &other) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(py::self / int(), py::is_operator())
+      .def(py::self * int(), py::is_operator())
+      .def(py::self + int(), py::is_operator())
+      .def(py::self - int(), py::is_operator())
+      .def(py::self / double(), py::is_operator())
+      .def(py::self * double(), py::is_operator())
+      .def(py::self + double(), py::is_operator())
+      .def(py::self - double(), py::is_operator())
+      .def(py::self / std::complex<double>(), py::is_operator())
+      .def(py::self * std::complex<double>(), py::is_operator())
+      .def(py::self + std::complex<double>(), py::is_operator())
+      .def(py::self - std::complex<double>(), py::is_operator())
+      .def(py::self / scalar_operator(), py::is_operator())
+      .def(py::self * scalar_operator(), py::is_operator())
+      .def(py::self + scalar_operator(), py::is_operator())
+      .def(py::self - scalar_operator(), py::is_operator())
+      .def(py::self * py::self, py::is_operator())
+      .def(py::self + py::self, py::is_operator())
+      .def(py::self - py::self, py::is_operator())
+      .def(py::self * matrix_op(), py::is_operator())
+      .def(py::self + matrix_op(), py::is_operator())
+      .def(py::self - matrix_op(), py::is_operator())
 
       // left-hand arithmetics
 
-      .def(
-          "__rmul__",
-          [](const matrix_op_term &other, int self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const matrix_op_term &other, int self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const matrix_op_term &other, int self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const matrix_op_term &other, double self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const matrix_op_term &other, double self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const matrix_op_term &other, double self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const matrix_op_term &other, std::complex<double> self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const matrix_op_term &other, std::complex<double> self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const matrix_op_term &other, std::complex<double> self) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const matrix_op_term &other, const scalar_operator &self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const matrix_op_term &other, const scalar_operator &self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const matrix_op_term &other, const scalar_operator &self) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(int() * py::self, py::is_operator())
+      .def(int() + py::self, py::is_operator())
+      .def(int() - py::self, py::is_operator())
+      .def(double() * py::self, py::is_operator())
+      .def(double() + py::self, py::is_operator())
+      .def(double() - py::self, py::is_operator())
+      .def(std::complex<double>() * py::self, py::is_operator())
+      .def(std::complex<double>() + py::self, py::is_operator())
+      .def(std::complex<double>() - py::self, py::is_operator())
+      .def(scalar_operator() * py::self, py::is_operator())
+      .def(scalar_operator() + py::self, py::is_operator())
+      .def(scalar_operator() - py::self, py::is_operator())
 
       // general utility functions
 

--- a/python/runtime/cudaq/operators/py_spin_op.cpp
+++ b/python/runtime/cudaq/operators/py_spin_op.cpp
@@ -331,7 +331,15 @@ void bindSpinOperator(py::module &mod) {
       .def(py::self -= spin_op_term(), py::is_operator())
       .def(py::self *= py::self, py::is_operator())
       .def(py::self += py::self, py::is_operator())
+      // see issue https://github.com/pybind/pybind11/issues/1893
+      #ifdef __clang__
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wself-assign-overloaded"
+      #endif
       .def(py::self -= py::self, py::is_operator())
+      #ifdef __clang__
+      #pragma clang diagnostic pop
+      #endif
 
       // right-hand arithmetics
 

--- a/python/runtime/cudaq/operators/py_spin_op.cpp
+++ b/python/runtime/cudaq/operators/py_spin_op.cpp
@@ -305,260 +305,79 @@ void bindSpinOperator(py::module &mod) {
 
       // unary operators
 
-      .def(
-          "__neg__", [](const spin_op &self) { return -self; },
-          py::is_operator())
-      .def(
-          "__pos__", [](const spin_op &self) { return +self; },
-          py::is_operator())
+      .def(-py::self, py::is_operator())
+      .def(+py::self, py::is_operator())
 
       // in-place arithmetics
 
-      .def(
-          "__itruediv__",
-          [](spin_op &self, int other) { return self /= other; },
-          py::is_operator())
-      .def(
-          "__imul__", [](spin_op &self, int other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__iadd__", [](spin_op &self, int other) { return self += other; },
-          py::is_operator())
-      .def(
-          "__isub__", [](spin_op &self, int other) { return self -= other; },
-          py::is_operator())
-      .def(
-          "__itruediv__",
-          [](spin_op &self, const scalar_operator &other) {
-            return self /= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](spin_op &self, const scalar_operator &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](spin_op &self, const scalar_operator &other) {
-            return self += other;
-          },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](spin_op &self, const scalar_operator &other) {
-            return self -= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](spin_op &self, const spin_op_term &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](spin_op &self, const spin_op_term &other) {
-            return self += other;
-          },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](spin_op &self, const spin_op_term &other) {
-            return self -= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](spin_op &self, const spin_op &other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__iadd__",
-          [](spin_op &self, const spin_op &other) { return self += other; },
-          py::is_operator())
-      .def(
-          "__isub__",
-          [](spin_op &self, const spin_op &other) { return self -= other; },
-          py::is_operator())
+      .def(py::self /= int(), py::is_operator())
+      .def(py::self *= int(), py::is_operator())
+      .def(py::self += int(), py::is_operator())
+      .def(py::self -= int(), py::is_operator())
+      .def(py::self /= double(), py::is_operator())
+      .def(py::self *= double(), py::is_operator())
+      .def(py::self += double(), py::is_operator())
+      .def(py::self -= double(), py::is_operator())
+      .def(py::self /= std::complex<double>(), py::is_operator())
+      .def(py::self *= std::complex<double>(), py::is_operator())
+      .def(py::self += std::complex<double>(), py::is_operator())
+      .def(py::self -= std::complex<double>(), py::is_operator())
+      .def(py::self /= scalar_operator(), py::is_operator())
+      .def(py::self *= scalar_operator(), py::is_operator())
+      .def(py::self += scalar_operator(), py::is_operator())
+      .def(py::self -= scalar_operator(), py::is_operator())
+      .def(py::self *= spin_op_term(), py::is_operator())
+      .def(py::self += spin_op_term(), py::is_operator())
+      .def(py::self -= spin_op_term(), py::is_operator())
+      .def(py::self *= py::self, py::is_operator())
+      .def(py::self += py::self, py::is_operator())
+      .def(py::self -= py::self, py::is_operator())
 
       // right-hand arithmetics
 
-      .def(
-          "__truediv__",
-          [](const spin_op &self, int other) { return self / other; },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op &self, int other) { return self * other; },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op &self, int other) { return self + other; },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op &self, int other) { return self - other; },
-          py::is_operator())
-      .def(
-          "__truediv__",
-          [](const spin_op &self, const scalar_operator &other) {
-            return self / other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op &self, const scalar_operator &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op &self, const scalar_operator &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op &self, const scalar_operator &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op &self, const spin_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op &self, const spin_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op &self, const spin_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op &self, const spin_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op &self, const spin_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op &self, const spin_op &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op &self, const matrix_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op &self, const matrix_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op &self, const matrix_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op &self, const matrix_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op &self, const matrix_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op &self, const matrix_op &other) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(py::self / int(), py::is_operator())
+      .def(py::self * int(), py::is_operator())
+      .def(py::self + int(), py::is_operator())
+      .def(py::self - int(), py::is_operator())
+      .def(py::self / double(), py::is_operator())
+      .def(py::self * double(), py::is_operator())
+      .def(py::self + double(), py::is_operator())
+      .def(py::self - double(), py::is_operator())
+      .def(py::self / std::complex<double>(), py::is_operator())
+      .def(py::self * std::complex<double>(), py::is_operator())
+      .def(py::self + std::complex<double>(), py::is_operator())
+      .def(py::self - std::complex<double>(), py::is_operator())
+      .def(py::self / scalar_operator(), py::is_operator())
+      .def(py::self * scalar_operator(), py::is_operator())
+      .def(py::self + scalar_operator(), py::is_operator())
+      .def(py::self - scalar_operator(), py::is_operator())
+      .def(py::self * spin_op_term(), py::is_operator())
+      .def(py::self + spin_op_term(), py::is_operator())
+      .def(py::self - spin_op_term(), py::is_operator())
+      .def(py::self * py::self, py::is_operator())
+      .def(py::self + py::self, py::is_operator())
+      .def(py::self - py::self, py::is_operator())
+      .def(py::self * matrix_op_term(), py::is_operator())
+      .def(py::self + matrix_op_term(), py::is_operator())
+      .def(py::self - matrix_op_term(), py::is_operator())
+      .def(py::self * matrix_op(), py::is_operator())
+      .def(py::self + matrix_op(), py::is_operator())
+      .def(py::self - matrix_op(), py::is_operator())
 
       // left-hand arithmetics
 
-      .def(
-          "__rmul__",
-          [](const spin_op &other, int self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const spin_op &other, int self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const spin_op &other, int self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const spin_op &other, double self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const spin_op &other, double self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const spin_op &other, double self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const spin_op &other, std::complex<double> self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const spin_op &other, std::complex<double> self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const spin_op &other, std::complex<double> self) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const spin_op &other, const scalar_operator &self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const spin_op &other, const scalar_operator &self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const spin_op &other, const scalar_operator &self) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(int() * py::self, py::is_operator())
+      .def(int() + py::self, py::is_operator())
+      .def(int() - py::self, py::is_operator())
+      .def(double() * py::self, py::is_operator())
+      .def(double() + py::self, py::is_operator())
+      .def(double() - py::self, py::is_operator())
+      .def(std::complex<double>() * py::self, py::is_operator())
+      .def(std::complex<double>() + py::self, py::is_operator())
+      .def(std::complex<double>() - py::self, py::is_operator())
+      .def(scalar_operator() * py::self, py::is_operator())
+      .def(scalar_operator() + py::self, py::is_operator())
+      .def(scalar_operator() - py::self, py::is_operator())
 
       // common operators
 
@@ -980,219 +799,66 @@ void bindSpinOperator(py::module &mod) {
 
       // unary operators
 
-      .def(
-          "__neg__", [](const spin_op_term &self) { return -self; },
-          py::is_operator())
-      .def(
-          "__pos__", [](const spin_op_term &self) { return +self; },
-          py::is_operator())
+      .def(-py::self, py::is_operator())
+      .def(+py::self, py::is_operator())
 
       // in-place arithmetics
 
-      .def(
-          "__itruediv__",
-          [](spin_op_term &self, int other) { return self /= other; },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](spin_op_term &self, int other) { return self *= other; },
-          py::is_operator())
-      .def(
-          "__itruediv__",
-          [](spin_op_term &self, const scalar_operator &other) {
-            return self /= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](spin_op_term &self, const scalar_operator &other) {
-            return self *= other;
-          },
-          py::is_operator())
-      .def(
-          "__imul__",
-          [](spin_op_term &self, const spin_op_term &other) {
-            return self *= other;
-          },
-          py::is_operator())
+      .def(py::self /= int(), py::is_operator())
+      .def(py::self *= int(), py::is_operator())
+      .def(py::self /= double(), py::is_operator())
+      .def(py::self *= double(), py::is_operator())
+      .def(py::self /= std::complex<double>(), py::is_operator())
+      .def(py::self *= std::complex<double>(), py::is_operator())
+      .def(py::self /= scalar_operator(), py::is_operator())
+      .def(py::self *= scalar_operator(), py::is_operator())
+      .def(py::self *= py::self, py::is_operator())
 
       // right-hand arithmetics
 
-      .def(
-          "__truediv__",
-          [](const spin_op_term &self, int other) { return self / other; },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op_term &self, int other) { return self * other; },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op_term &self, int other) { return self + other; },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op_term &self, int other) { return self - other; },
-          py::is_operator())
-      .def(
-          "__truediv__",
-          [](const spin_op_term &self, const scalar_operator &other) {
-            return self / other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op_term &self, const scalar_operator &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op_term &self, const scalar_operator &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op_term &self, const scalar_operator &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op_term &self, const spin_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op_term &self, const spin_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op_term &self, const spin_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op_term &self, const spin_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op_term &self, const spin_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op_term &self, const spin_op &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op_term &self, const matrix_op_term &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op_term &self, const matrix_op_term &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op_term &self, const matrix_op_term &other) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__mul__",
-          [](const spin_op_term &self, const matrix_op &other) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__add__",
-          [](const spin_op_term &self, const matrix_op &other) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__sub__",
-          [](const spin_op_term &self, const matrix_op &other) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(py::self / int(), py::is_operator())
+      .def(py::self * int(), py::is_operator())
+      .def(py::self + int(), py::is_operator())
+      .def(py::self - int(), py::is_operator())
+      .def(py::self / double(), py::is_operator())
+      .def(py::self * double(), py::is_operator())
+      .def(py::self + double(), py::is_operator())
+      .def(py::self - double(), py::is_operator())
+      .def(py::self / std::complex<double>(), py::is_operator())
+      .def(py::self * std::complex<double>(), py::is_operator())
+      .def(py::self + std::complex<double>(), py::is_operator())
+      .def(py::self - std::complex<double>(), py::is_operator())
+      .def(py::self / scalar_operator(), py::is_operator())
+      .def(py::self * scalar_operator(), py::is_operator())
+      .def(py::self + scalar_operator(), py::is_operator())
+      .def(py::self - scalar_operator(), py::is_operator())
+      .def(py::self * py::self, py::is_operator())
+      .def(py::self + py::self, py::is_operator())
+      .def(py::self - py::self, py::is_operator())
+      .def(py::self * spin_op(), py::is_operator())
+      .def(py::self + spin_op(), py::is_operator())
+      .def(py::self - spin_op(), py::is_operator())
+      .def(py::self * matrix_op_term(), py::is_operator())
+      .def(py::self + matrix_op_term(), py::is_operator())
+      .def(py::self - matrix_op_term(), py::is_operator())
+      .def(py::self * matrix_op(), py::is_operator())
+      .def(py::self + matrix_op(), py::is_operator())
+      .def(py::self - matrix_op(), py::is_operator())
 
       // left-hand arithmetics
 
-      .def(
-          "__rmul__",
-          [](const spin_op_term &other, int self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const spin_op_term &other, int self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const spin_op_term &other, int self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const spin_op_term &other, double self) { return self * other; },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const spin_op_term &other, double self) { return self + other; },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const spin_op_term &other, double self) { return self - other; },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const spin_op_term &other, std::complex<double> self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const spin_op_term &other, std::complex<double> self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const spin_op_term &other, std::complex<double> self) {
-            return self - other;
-          },
-          py::is_operator())
-      .def(
-          "__rmul__",
-          [](const spin_op_term &other, const scalar_operator &self) {
-            return self * other;
-          },
-          py::is_operator())
-      .def(
-          "__radd__",
-          [](const spin_op_term &other, const scalar_operator &self) {
-            return self + other;
-          },
-          py::is_operator())
-      .def(
-          "__rsub__",
-          [](const spin_op_term &other, const scalar_operator &self) {
-            return self - other;
-          },
-          py::is_operator())
+      .def(int() * py::self, py::is_operator())
+      .def(int() + py::self, py::is_operator())
+      .def(int() - py::self, py::is_operator())
+      .def(double() * py::self, py::is_operator())
+      .def(double() + py::self, py::is_operator())
+      .def(double() - py::self, py::is_operator())
+      .def(std::complex<double>() * py::self, py::is_operator())
+      .def(std::complex<double>() + py::self, py::is_operator())
+      .def(std::complex<double>() - py::self, py::is_operator())
+      .def(scalar_operator() * py::self, py::is_operator())
+      .def(scalar_operator() + py::self, py::is_operator())
+      .def(scalar_operator() - py::self, py::is_operator())
 
       // general utility functions
 

--- a/python/runtime/cudaq/operators/py_spin_op.cpp
+++ b/python/runtime/cudaq/operators/py_spin_op.cpp
@@ -331,15 +331,15 @@ void bindSpinOperator(py::module &mod) {
       .def(py::self -= spin_op_term(), py::is_operator())
       .def(py::self *= py::self, py::is_operator())
       .def(py::self += py::self, py::is_operator())
-      // see issue https://github.com/pybind/pybind11/issues/1893
-      #ifdef __clang__
-      #pragma clang diagnostic push
-      #pragma clang diagnostic ignored "-Wself-assign-overloaded"
-      #endif
+// see issue https://github.com/pybind/pybind11/issues/1893
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif
       .def(py::self -= py::self, py::is_operator())
-      #ifdef __clang__
-      #pragma clang diagnostic pop
-      #endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
       // right-hand arithmetics
 

--- a/runtime/cudaq/operators/sum_op.cpp
+++ b/runtime/cudaq/operators/sum_op.cpp
@@ -36,7 +36,8 @@ namespace cudaq {
 template <typename HandlerTy>
 void sum_op<HandlerTy>::insert(const product_op<HandlerTy> &other) {
   assert(!this->is_default);
-  auto [it, inserted] = this->term_map.try_emplace(other.get_term_id(), this->terms.size());
+  auto [it, inserted] =
+      this->term_map.try_emplace(other.get_term_id(), this->terms.size());
   if (inserted) {
     this->coefficients.push_back(other.coefficient);
     this->terms.push_back(other.operators);
@@ -49,7 +50,8 @@ void sum_op<HandlerTy>::insert(const product_op<HandlerTy> &other) {
 template <typename HandlerTy>
 void sum_op<HandlerTy>::insert(product_op<HandlerTy> &&other) {
   assert(!this->is_default);
-  auto [it, inserted] = this->term_map.try_emplace(other.get_term_id(), this->terms.size());
+  auto [it, inserted] =
+      this->term_map.try_emplace(other.get_term_id(), this->terms.size());
   if (inserted) {
     this->coefficients.push_back(std::move(other.coefficient));
     this->terms.push_back(std::move(other.operators));

--- a/runtime/cudaq/operators/sum_op.cpp
+++ b/runtime/cudaq/operators/sum_op.cpp
@@ -36,12 +36,9 @@ namespace cudaq {
 template <typename HandlerTy>
 void sum_op<HandlerTy>::insert(const product_op<HandlerTy> &other) {
   assert(!this->is_default);
-  auto term_id = other.get_term_id();
-  auto it = this->term_map.find(term_id);
-  if (it == this->term_map.cend()) {
+  auto [it, inserted] = this->term_map.try_emplace(other.get_term_id(), this->terms.size());
+  if (inserted) {
     this->coefficients.push_back(other.coefficient);
-    this->term_map.insert(
-        it, std::make_pair(std::move(term_id), this->terms.size()));
     this->terms.push_back(other.operators);
   } else {
     this->coefficients[it->second] += other.coefficient;
@@ -52,12 +49,9 @@ void sum_op<HandlerTy>::insert(const product_op<HandlerTy> &other) {
 template <typename HandlerTy>
 void sum_op<HandlerTy>::insert(product_op<HandlerTy> &&other) {
   assert(!this->is_default);
-  auto term_id = other.get_term_id();
-  auto it = this->term_map.find(term_id);
-  if (it == this->term_map.cend()) {
+  auto [it, inserted] = this->term_map.try_emplace(other.get_term_id(), this->terms.size());
+  if (inserted) {
     this->coefficients.push_back(std::move(other.coefficient));
-    this->term_map.insert(
-        it, std::make_pair(std::move(term_id), this->terms.size()));
     this->terms.push_back(std::move(other.operators));
   } else {
     this->coefficients[it->second] += other.coefficient;
@@ -1756,22 +1750,23 @@ sum_op<HandlerTy>::sum_op(const std::vector<double> &input_vec) {
 
 HANDLER_SPECIFIC_TEMPLATE_DEFINITION(spin_handler)
 product_op<HandlerTy> sum_op<HandlerTy>::from_word(const std::string &word) {
-  auto prod = sum_op<HandlerTy>::identity();
+  std::vector<HandlerTy> ops;
+  ops.reserve(word.length());
   for (std::size_t i = 0; i < word.length(); i++) {
     auto letter = word[i];
     if (letter == 'Y')
-      prod *= sum_op<HandlerTy>::y(i);
+      ops.push_back(HandlerTy::y(i));
     else if (letter == 'X')
-      prod *= sum_op<HandlerTy>::x(i);
+      ops.push_back(HandlerTy::x(i));
     else if (letter == 'Z')
-      prod *= sum_op<HandlerTy>::z(i);
+      ops.push_back(HandlerTy::z(i));
     else if (letter == 'I')
-      prod *= sum_op<HandlerTy>::i(i);
+      ops.push_back(HandlerTy(i));
     else
       throw std::runtime_error(
           "Invalid Pauli for spin_op::from_word, must be X, Y, Z, or I.");
   }
-  return prod;
+  return product_op<HandlerTy>(1., std::move(ops));
 }
 
 HANDLER_SPECIFIC_TEMPLATE_DEFINITION(spin_handler)


### PR DESCRIPTION
Concludes the fix for https://github.com/NVIDIA/cuda-quantum/issues/2437. 

Timing on my machine for the case reported in https://github.com/NVIDIA/cuda-quantum/issues/2437:

Version 0.8.0:
SpinOperator creation: 0.0391254186630249
cudaq.observe duration: 0.4048661708831787

Version with this PR:
SpinOperator creation: 0.015355110168457031
cudaq.observe duration: 0.2769707441329956

Edit: timing varies a bit though, and I've only run it a couple of times. All in all, comparable perf I'd say.