### PR TITLE
Support input state batching in dynamics `evolve`

### DIFF
--- a/docs/sphinx/examples/cpp/dynamics/qubit_dynamics_batched.cpp
+++ b/docs/sphinx/examples/cpp/dynamics/qubit_dynamics_batched.cpp
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Compile and run with:
+// ```
+// nvq++ --target dynamics qubit_dynamics.cpp -o a.out && ./a.out
+// ```
+
+#include "cudaq/algorithms/evolve.h"
+#include "cudaq/algorithms/integrator.h"
+#include "cudaq/operators.h"
+#include "export_csv_helper.h"
+#include <cudaq.h>
+
+int main() {
+  // Qubit `hamiltonian`: 2 * pi * 0.1 * sigma_x
+  // Physically, this represents a qubit (a two-level system) driven by a weak
+  // transverse field along the x-axis.
+  auto hamiltonian = 2.0 * M_PI * 0.1 * cudaq::spin_op::x(0);
+
+  // Dimensions: one subsystem of dimension 2 (a two-level system).
+  const cudaq::dimension_map dimensions = {{0, 2}};
+
+  // Initial state: ground state
+  std::vector<std::complex<double>> initial_state_zero = {1.0, 0.0};
+  std::vector<std::complex<double>> initial_state_one = {0.0, 1.0};
+
+  auto psi0 = cudaq::state::from_data(initial_state_zero);
+  auto psi1 = cudaq::state::from_data(initial_state_one);
+
+  // Create a schedule of time steps from 0 to 10 with 101 points
+  std::vector<double> steps = cudaq::linspace(0.0, 10.0, 101);
+  cudaq::schedule schedule(steps);
+
+  // Runge-`Kutta` integrator with a time step of 0.01 and order 4
+  cudaq::integrators::runge_kutta integrator(4, 0.01);
+
+  // Run the simulation without collapse operators (ideal evolution)
+  auto evolve_results =
+      cudaq::evolve(hamiltonian, dimensions, schedule, {psi0, psi1}, integrator,
+                    {}, {cudaq::spin_op::y(0), cudaq::spin_op::z(0)}, true);
+
+  // Lambda to extract expectation values for a given observable index
+  auto get_expectation = [](int idx, auto &result) -> std::vector<double> {
+    std::vector<double> expectations;
+
+    auto all_exps = result.expectation_values.value();
+    for (auto exp_vals : all_exps) {
+      expectations.push_back((double)exp_vals[idx]);
+    }
+    return expectations;
+  };
+
+  auto result_state0_y = get_expectation(0, evolve_results[0]);
+  auto result_state0_z = get_expectation(1, evolve_results[0]);
+  auto result_state1_y = get_expectation(0, evolve_results[1]);
+  auto result_state1_z = get_expectation(1, evolve_results[1]);
+
+  export_csv("qubit_dynamics_state_0.csv", "time", steps, "sigma_y",
+             result_state0_y, "sigma_z", result_state0_z);
+  export_csv("qubit_dynamics_state_1.csv", "time", steps, "sigma_y",
+             result_state1_y, "sigma_z", result_state1_z);
+
+  std::cout << "Results exported to qubit_dynamics_state_0.csv and "
+               "qubit_dynamics_state_1.csv"
+            << std::endl;
+
+  return 0;
+}

--- a/docs/sphinx/examples/python/dynamics/cross_resonance.py
+++ b/docs/sphinx/examples/python/dynamics/cross_resonance.py
@@ -41,59 +41,40 @@ psi_10 = cudaq.State.from_data(
 steps = np.linspace(0.0, 1.0, 1001)
 schedule = Schedule(steps, ["time"])
 
-# Run the simulation.
-# Control bit = 0
-evolution_result_00 = cudaq.evolve(hamiltonian,
-                                   dimensions,
-                                   schedule,
-                                   psi_00,
-                                   observables=[
-                                       spin.x(0),
-                                       spin.y(0),
-                                       spin.z(0),
-                                       spin.x(1),
-                                       spin.y(1),
-                                       spin.z(1)
-                                   ],
-                                   collapse_operators=[],
-                                   store_intermediate_results=True,
-                                   integrator=ScipyZvodeIntegrator())
-
-# Control bit = 1
-evolution_result_10 = cudaq.evolve(hamiltonian,
-                                   dimensions,
-                                   schedule,
-                                   psi_10,
-                                   observables=[
-                                       spin.x(0),
-                                       spin.y(0),
-                                       spin.z(0),
-                                       spin.x(1),
-                                       spin.y(1),
-                                       spin.z(1)
-                                   ],
-                                   collapse_operators=[],
-                                   store_intermediate_results=True,
-                                   integrator=ScipyZvodeIntegrator())
+# Run the simulations (batched).
+evolution_results = cudaq.evolve(hamiltonian,
+                                 dimensions,
+                                 schedule, [psi_00, psi_10],
+                                 observables=[
+                                     spin.x(0),
+                                     spin.y(0),
+                                     spin.z(0),
+                                     spin.x(1),
+                                     spin.y(1),
+                                     spin.z(1)
+                                 ],
+                                 collapse_operators=[],
+                                 store_intermediate_results=True,
+                                 integrator=ScipyZvodeIntegrator())
 
 get_result = lambda idx, res: [
     exp_vals[idx].expectation() for exp_vals in res.expectation_values()
 ]
 results_00 = [
-    get_result(0, evolution_result_00),
-    get_result(1, evolution_result_00),
-    get_result(2, evolution_result_00),
-    get_result(3, evolution_result_00),
-    get_result(4, evolution_result_00),
-    get_result(5, evolution_result_00)
+    get_result(0, evolution_results[0]),
+    get_result(1, evolution_results[0]),
+    get_result(2, evolution_results[0]),
+    get_result(3, evolution_results[0]),
+    get_result(4, evolution_results[0]),
+    get_result(5, evolution_results[0])
 ]
 results_10 = [
-    get_result(0, evolution_result_10),
-    get_result(1, evolution_result_10),
-    get_result(2, evolution_result_10),
-    get_result(3, evolution_result_10),
-    get_result(4, evolution_result_10),
-    get_result(5, evolution_result_10)
+    get_result(0, evolution_results[1]),
+    get_result(1, evolution_results[1]),
+    get_result(2, evolution_results[1]),
+    get_result(3, evolution_results[1]),
+    get_result(4, evolution_results[1]),
+    get_result(5, evolution_results[1])
 ]
 
 # The changes in recession frequencies of the target qubit when control qubit is in |1> state allow us to implement two-qubit conditional gates.

--- a/docs/sphinx/examples/python/dynamics/cross_resonance.py
+++ b/docs/sphinx/examples/python/dynamics/cross_resonance.py
@@ -60,22 +60,8 @@ evolution_results = cudaq.evolve(hamiltonian,
 get_result = lambda idx, res: [
     exp_vals[idx].expectation() for exp_vals in res.expectation_values()
 ]
-results_00 = [
-    get_result(0, evolution_results[0]),
-    get_result(1, evolution_results[0]),
-    get_result(2, evolution_results[0]),
-    get_result(3, evolution_results[0]),
-    get_result(4, evolution_results[0]),
-    get_result(5, evolution_results[0])
-]
-results_10 = [
-    get_result(0, evolution_results[1]),
-    get_result(1, evolution_results[1]),
-    get_result(2, evolution_results[1]),
-    get_result(3, evolution_results[1]),
-    get_result(4, evolution_results[1]),
-    get_result(5, evolution_results[1])
-]
+results_00 = [get_result(i, evolution_results[0]) for i in range(6)]
+results_10 = [get_result(i, evolution_results[1]) for i in range(6)]
 
 # The changes in recession frequencies of the target qubit when control qubit is in |1> state allow us to implement two-qubit conditional gates.
 fig = plt.figure(figsize=(18, 6))

--- a/docs/sphinx/examples/python/dynamics/qubit_dynamics_tomography.py
+++ b/docs/sphinx/examples/python/dynamics/qubit_dynamics_tomography.py
@@ -1,0 +1,76 @@
+import cudaq
+from cudaq import spin, Schedule, RungeKuttaIntegrator
+import numpy as np
+import cupy as cp
+import os
+import matplotlib.pyplot as plt
+
+# Set the target to our dynamics simulator
+cudaq.set_target("dynamics")
+
+# Qubit Hamiltonian
+hamiltonian = 2 * np.pi * 0.1 * spin.x(0)
+
+# Dimensions of sub-system. We only have a single degree of freedom of dimension 2 (two-level system).
+dimensions = {0: 2}
+
+# Initial states in the `SIC-POVM` set: https://en.wikipedia.org/wiki/SIC-POVM
+psi_1 = cudaq.State.from_data(cp.array([1.0, 0.0], dtype=cp.complex128))
+psi_2 = cudaq.State.from_data(
+    cp.array([1.0 / np.sqrt(3.0), np.sqrt(2.0 / 3.0)], dtype=cp.complex128))
+psi_3 = cudaq.State.from_data(
+    cp.array([
+        1.0 / np.sqrt(3.0),
+        np.sqrt(2.0 / 3.0) * np.exp(1j * 2.0 * np.pi / 3.0)
+    ],
+             dtype=cp.complex128))
+psi_4 = cudaq.State.from_data(
+    cp.array([
+        1.0 / np.sqrt(3.0),
+        np.sqrt(2.0 / 3.0) * np.exp(1j * 4.0 * np.pi / 3.0)
+    ],
+             dtype=cp.complex128))
+
+# We run the evolution for all the SIC state to determine the process tomography.
+sic_states = [psi_1, psi_2, psi_3, psi_4]
+# Schedule of time steps.
+steps = np.linspace(0, 10, 101)
+schedule = Schedule(steps, ["time"])
+
+# Run the simulation.
+evolution_results = cudaq.evolve(hamiltonian,
+                                 dimensions,
+                                 schedule,
+                                 sic_states,
+                                 observables=[spin.x(0),
+                                              spin.y(0),
+                                              spin.z(0)],
+                                 collapse_operators=[],
+                                 store_intermediate_results=True,
+                                 integrator=RungeKuttaIntegrator())
+
+get_result = lambda idx, res: [
+    exp_vals[idx].expectation() for exp_vals in res.expectation_values()
+]
+tomography_results = [[
+    get_result(0, evolution_result),
+    get_result(1, evolution_result),
+    get_result(2, evolution_result)
+] for evolution_result in evolution_results]
+
+fig = plt.figure(figsize=(18, 12))
+for i in range(len(tomography_results)):
+    plt.subplot(2, 2, i + 1)
+    plt.plot(steps, tomography_results[i][0])
+    plt.plot(steps, tomography_results[i][1])
+    plt.plot(steps, tomography_results[i][2])
+    plt.ylim(-1.0, 1.0)
+    plt.ylabel("Expectation value")
+    plt.xlabel("Time")
+    plt.legend(("Sigma-X", "Sigma-Y", "Sigma-Z"))
+    plt.title(f"SIC state {i}")
+
+abspath = os.path.abspath(__file__)
+dname = os.path.dirname(abspath)
+os.chdir(dname)
+fig.savefig('qubit_dynamics_tomography.png', dpi=fig.dpi)

--- a/python/cudaq/dynamics/cudm_solver.py
+++ b/python/cudaq/dynamics/cudm_solver.py
@@ -26,15 +26,15 @@ from ..mlir._mlir_libs._quakeDialects.cudaq_runtime import MatrixOperator
 
 # Master-equation solver using `CuDensityMatState`
 def evolve_dynamics(
-        hamiltonian: Operator,
-        dimensions: Mapping[int, int],
-        schedule: Schedule,
-        initial_state: InitialStateArgT,
-        collapse_operators: Sequence[Operator] = [],
-        observables: Sequence[Operator] = [],
-        store_intermediate_results=False,
-        integrator: Optional[BaseIntegrator] = None
-) -> cudaq_runtime.EvolveResult:
+    hamiltonian: Operator,
+    dimensions: Mapping[int, int],
+    schedule: Schedule,
+    initial_state: InitialStateArgT | Sequence[cudaq_runtime.State],
+    collapse_operators: Sequence[Operator] = [],
+    observables: Sequence[Operator] = [],
+    store_intermediate_results=False,
+    integrator: Optional[BaseIntegrator] = None
+) -> cudaq_runtime.EvolveResult | Sequence[cudaq_runtime.EvolveResult]:
     if cudm is None:
         raise ImportError(
             "[dynamics target] Failed to import cuquantum density module. Please check your installation."
@@ -62,18 +62,28 @@ def evolve_dynamics(
         for observable in observables
     ]
 
-    if isinstance(initial_state, InitialState):
-        has_collapse_operators = len(collapse_operators) > 0
-        initial_state = bindings.createInitialState(initial_state, dimensions,
-                                                    has_collapse_operators)
+    batch_size = 1
+    is_batched_evolve = False
+    if isinstance(initial_state, Sequence):
+        batch_size = len(initial_state)
+        initial_state = bindings.createBatchedState(initial_state,
+                                                    hilbert_space_dims_list,
+                                                    len(collapse_operators) > 0)
+        is_batched_evolve = True
     else:
-        initial_state = bindings.initializeState(initial_state,
-                                                 hilbert_space_dims_list,
-                                                 len(collapse_operators) > 0)
+        if isinstance(initial_state, InitialState):
+            has_collapse_operators = len(collapse_operators) > 0
+            initial_state = bindings.createInitialState(initial_state,
+                                                        dimensions,
+                                                        has_collapse_operators)
+        else:
+            initial_state = bindings.initializeState(
+                initial_state, hilbert_space_dims_list,
+                len(collapse_operators) > 0, 1)
     integrator.set_state(initial_state, schedule._steps[0])
 
-    exp_vals = []
-    intermediate_states = []
+    exp_vals = [[] for _ in range(batch_size)]
+    intermediate_states = [[] for _ in range(batch_size)]
     for step_idx, parameters in enumerate(schedule):
         if step_idx > 0:
             with ScopeTimer("evolve.integrator.integrate") as timer:
@@ -81,22 +91,28 @@ def evolve_dynamics(
         # If we store intermediate values, compute them for each step.
         # Otherwise, just for the last step.
         if store_intermediate_results or step_idx == (len(schedule) - 1):
-            step_exp_vals = []
+            step_exp_vals = [[] for _ in range(batch_size)]
             for obs_idx, obs in enumerate(expectation_op):
                 _, state = integrator.get_state()
-                with ScopeTimer("evolve.prepare_expectation") as timer:
-                    obs.prepare(state)
-                with ScopeTimer("evolve.compute_expectation") as timer:
-                    exp_val = obs.compute(state, schedule.current_step)
-                step_exp_vals.append(exp_val)
-            exp_vals.append(step_exp_vals)
-        if store_intermediate_results:
-            _, state = integrator.get_state()
-            intermediate_states.append(state)
+                obs.prepare(state)
+                exp_val = obs.compute(state, schedule.current_step)
+                for i in range(batch_size):
+                    step_exp_vals[i].append(exp_val[i])
+            split_states = bindings.splitBatchedState(state)
+            for i in range(batch_size):
+                exp_vals[i].append(step_exp_vals[i])
+                intermediate_states[i].append(split_states[i])
 
     bindings.clearContext()
-    if store_intermediate_results:
-        return cudaq_runtime.EvolveResult(intermediate_states, exp_vals)
+    results = [
+        cudaq_runtime.EvolveResult(state, exp_val)
+        for state, exp_val in zip(intermediate_states, exp_vals)
+    ] if store_intermediate_results else [
+        cudaq_runtime.EvolveResult(state[-1], exp_val[-1])
+        for state, exp_val in zip(intermediate_states, exp_vals)
+    ]
+
+    if is_batched_evolve:
+        return results
     else:
-        _, state = integrator.get_state()
-        return cudaq_runtime.EvolveResult(state, exp_vals[-1])
+        return results[0]

--- a/python/cudaq/dynamics/cudm_solver.py
+++ b/python/cudaq/dynamics/cudm_solver.py
@@ -96,8 +96,8 @@ def evolve_dynamics(
         # Otherwise, just for the last step.
         if store_intermediate_results or step_idx == (len(schedule) - 1):
             step_exp_vals = [[] for _ in range(batch_size)]
+            _, state = integrator.get_state()
             for obs_idx, obs in enumerate(expectation_op):
-                _, state = integrator.get_state()
                 obs.prepare(state)
                 exp_val = obs.compute(state, schedule.current_step)
                 for i in range(batch_size):

--- a/python/cudaq/dynamics/integrators/scipy_integrators.py
+++ b/python/cudaq/dynamics/integrators/scipy_integrators.py
@@ -42,6 +42,7 @@ class ScipyZvodeIntegrator(BaseIntegrator[cudaq_runtime.State]):
         super().__init__(**kwargs)
         self.stepper = stepper
         self.is_density_state = None
+        self.batchSize = None
 
     def __init__(self, **kwargs):
         if not has_scipy:
@@ -51,7 +52,7 @@ class ScipyZvodeIntegrator(BaseIntegrator[cudaq_runtime.State]):
     def compute_rhs(self, t, vec):
         state = cudaq_runtime.State.from_data(vec)
         state = bindings.initializeState(state, list(self.dimensions),
-                                         self.is_density_state)
+                                         self.is_density_state, self.batch_size)
         result = self.stepper.compute(state, t)
         as_array = numpy.ravel(numpy.array(result))
         return as_array
@@ -85,9 +86,10 @@ class ScipyZvodeIntegrator(BaseIntegrator[cudaq_runtime.State]):
             self.schedule_ = bindings.Schedule(self.schedule._steps,
                                                list(self.schedule._parameters))
             if self.is_density_state is None:
-                self.is_density_state = math.prod(
-                    self.dimensions)**2 == self.state.getTensor(
-                    ).get_num_elements()
+                batch_size = bindings.getBatchSize(self.state)
+                self.is_density_state = (
+                    (math.prod(self.dimensions)**2 *
+                     batch_size) == self.state.getTensor().get_num_elements())
             self.stepper = cuDensityMatTimeStepper(self.schedule_,
                                                    self.hamiltonian,
                                                    self.collapse_operators,
@@ -100,13 +102,16 @@ class ScipyZvodeIntegrator(BaseIntegrator[cudaq_runtime.State]):
         new_state_vec = self.solver.integrate(t)
         self.state = cudaq_runtime.State.from_data(new_state_vec)
         self.state = bindings.initializeState(self.state, list(self.dimensions),
-                                              self.is_density_state)
+                                              self.is_density_state,
+                                              self.batch_size)
         self.t = t
 
     def set_state(self, state: cudaq_runtime.State, t: float = 0.0):
         super().set_state(state, t)
         as_array = numpy.ravel(numpy.array(self.state))
+        self.batch_size = bindings.getBatchSize(state)
         if self.dimensions is not None:
-            self.is_density_state = math.prod(
-                self.dimensions)**2 == len(as_array)
+            self.is_density_state = (
+                (self.batch_size *
+                 math.prod(self.dimensions)**2) == len(as_array))
         self.solver.set_initial_value(as_array, t)

--- a/python/runtime/cudaq/dynamics/pyDynamics.cpp
+++ b/python/runtime/cudaq/dynamics/pyDynamics.cpp
@@ -150,11 +150,11 @@ PYBIND11_MODULE(nvqir_dynamics_bindings, m) {
         });
 
   m.def("getBatchSize", [](cudaq::state &state) {
-    auto &castSimState = *asCudmState(state);
-    if (!castSimState.is_initialized())
+    auto &cudmSimState = *asCudmState(state);
+    if (!cudmSimState.is_initialized())
       throw std::runtime_error(
           "Cannot query batch size of an uninitialized state");
-    return castSimState.getBatchSize();
+    return cudmSimState.getBatchSize();
   });
   m.def("splitBatchedState",
         [](cudaq::state &state) -> std::vector<cudaq::state> {

--- a/python/runtime/cudaq/dynamics/pyDynamics.cpp
+++ b/python/runtime/cudaq/dynamics/pyDynamics.cpp
@@ -96,8 +96,12 @@ PYBIND11_MODULE(nvqir_dynamics_bindings, m) {
       .def("compute", [](cudaq::CuDensityMatExpectation &self,
                          cudaq::state &state, double t) {
         auto *cudmState = asCudmState(state);
-        assert(cudmState->is_initialized());
-        return self.compute(cudmState->get_impl(), t).real();
+        std::vector<double> expVals;
+        const auto results =
+            self.compute(cudmState->get_impl(), t, cudmState->getBatchSize());
+        for (const auto &result : results)
+          expVals.emplace_back(result.real());
+        return expVals;
       });
 
   // Schedule class
@@ -108,12 +112,12 @@ PYBIND11_MODULE(nvqir_dynamics_bindings, m) {
   // Helper to initialize a data buffer state
   m.def("initializeState",
         [](cudaq::state &state, const std::vector<int64_t> &modeExtents,
-           bool asDensityMat) {
+           bool asDensityMat, int64_t batchSize) {
           auto &castSimState = *asCudmState(state);
           if (!castSimState.is_initialized())
             castSimState.initialize_cudm(
                 cudaq::dynamics::Context::getCurrentContext()->getHandle(),
-                modeExtents);
+                modeExtents, batchSize);
           if (asDensityMat && !castSimState.is_density_matrix()) {
             return cudaq::state(
                 new cudaq::CuDensityMatState(castSimState.to_density_matrix()));
@@ -131,6 +135,42 @@ PYBIND11_MODULE(nvqir_dynamics_bindings, m) {
               initialStateType, dimensions, createDensityMatrix);
           assert(state->is_initialized());
           return cudaq::state(state.release());
+        });
+  m.def("createBatchedState",
+        [](std::vector<cudaq::state> &states,
+           const std::vector<int64_t> &modeExtents, bool asDensityMat) {
+          std::vector<cudaq::CuDensityMatState *> statePtrs;
+          for (auto &state : states) {
+            statePtrs.emplace_back(asCudmState(state));
+          }
+          auto batchedState = cudaq::CuDensityMatState::createBatchedState(
+              cudaq::dynamics::Context::getCurrentContext()->getHandle(),
+              statePtrs, modeExtents, asDensityMat);
+          return cudaq::state(batchedState.release());
+        });
+
+  m.def("getBatchSize", [](cudaq::state &state) {
+    auto &castSimState = *asCudmState(state);
+    if (!castSimState.is_initialized())
+      throw std::runtime_error(
+          "Cannot query batch size of an uninitialized state");
+    return castSimState.getBatchSize();
+  });
+  m.def("splitBatchedState",
+        [](cudaq::state &state) -> std::vector<cudaq::state> {
+          auto &castSimState = *asCudmState(state);
+          if (!castSimState.is_initialized())
+            throw std::runtime_error("Cannot split of an uninitialized state");
+          if (castSimState.getBatchSize() == 1)
+            return {state};
+          std::vector<cudaq::state> splitStates;
+          auto states =
+              cudaq::CuDensityMatState::splitBatchedState(castSimState);
+
+          for (auto *state : states) {
+            splitStates.emplace_back(cudaq::state(state));
+          }
+          return splitStates;
         });
 
   // Helper to clear context (performance/callback) after an evolve simulation.

--- a/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
+++ b/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
@@ -31,7 +31,7 @@ all_integrator_classes = [CUDATorchDiffEqDopri5Integrator]
 all_models = [
     TestCavityModel, TestCavityModelTimeDependentHam,
     TestCavityModelTimeDependentCollapseOp, TestCompositeSystems,
-    TestCrossResonance, TestCallbackTensor, TestInitialStateEnum
+    TestCrossResonance, TestCallbackTensor, TestInitialStateEnum, TestCavityModelBatchedInputState
 ]
 
 

--- a/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
+++ b/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
@@ -31,7 +31,8 @@ all_integrator_classes = [CUDATorchDiffEqDopri5Integrator]
 all_models = [
     TestCavityModel, TestCavityModelTimeDependentHam,
     TestCavityModelTimeDependentCollapseOp, TestCompositeSystems,
-    TestCrossResonance, TestCallbackTensor, TestInitialStateEnum, TestCavityModelBatchedInputState
+    TestCrossResonance, TestCallbackTensor, TestInitialStateEnum,
+    TestCavityModelBatchedInputState
 ]
 
 

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -28,7 +28,7 @@ all_integrator_classes = [RungeKuttaIntegrator, ScipyZvodeIntegrator]
 all_models = [
     TestCavityModel, TestCavityModelTimeDependentHam,
     TestCavityModelTimeDependentCollapseOp, TestCompositeSystems,
-    TestCrossResonance, TestCallbackTensor, TestInitialStateEnum
+    TestCrossResonance, TestCallbackTensor, TestInitialStateEnum, TestCavityModelBatchedInputState
 ]
 
 @pytest.mark.parametrize('integrator', all_integrator_classes)

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -28,8 +28,10 @@ all_integrator_classes = [RungeKuttaIntegrator, ScipyZvodeIntegrator]
 all_models = [
     TestCavityModel, TestCavityModelTimeDependentHam,
     TestCavityModelTimeDependentCollapseOp, TestCompositeSystems,
-    TestCrossResonance, TestCallbackTensor, TestInitialStateEnum, TestCavityModelBatchedInputState
+    TestCrossResonance, TestCallbackTensor, TestInitialStateEnum,
+    TestCavityModelBatchedInputState
 ]
+
 
 @pytest.mark.parametrize('integrator', all_integrator_classes)
 @pytest.mark.parametrize('model', all_models)

--- a/runtime/common/EvolveResult.h
+++ b/runtime/common/EvolveResult.h
@@ -88,6 +88,22 @@ public:
     expectation_values = result;
   }
 
+  // Construct result with a final state and intermediate expectations
+  evolve_result(state finalState,
+                const std::vector<std::vector<double>> &expectations)
+      : states(std::make_optional<std::vector<cudaq::state>>(
+            std::vector<cudaq::state>{std::move(finalState)})) {
+    std::vector<std::vector<observe_result>> result;
+    const spin_op emptyOp = spin_op::empty();
+    for (const auto &vec : expectations) {
+      std::vector<observe_result> subResult;
+      for (auto e : vec) {
+        subResult.push_back(observe_result(e, emptyOp));
+      }
+      result.push_back(subResult);
+    }
+    expectation_values = result;
+  }
   evolve_result(const sample_result &sr) : sampling_result(sr) {}
 };
 } // namespace cudaq

--- a/runtime/cudaq/algorithms/evolve.h
+++ b/runtime/cudaq/algorithms/evolve.h
@@ -209,13 +209,12 @@ evolve(const HamTy &hamiltonian, const cudaq::dimension_map &dimensions,
        bool store_intermediate_results = false,
        std::optional<int> shots_count = std::nullopt) {
 #if defined(CUDAQ_ANALOG_TARGET)
-  std::vector<evolve_result> results;
-  for (const auto &initial_state : initial_states)
-    results.emplace_back(evolve(hamiltonian, dimensions, schedule,
-                                initial_state, integrator, collapse_operators,
-                                observables, store_intermediate_results,
-                                shots_count));
-  return results;
+  return cudaq::__internal__::evolveBatched(
+      cudaq::__internal__::convertOp(hamiltonian), dimensions, schedule,
+      initial_states, integrator,
+      cudaq::__internal__::convertOps(collapse_operators),
+      cudaq::__internal__::convertOps(observables), store_intermediate_results,
+      shots_count);
 #else
   static_assert(
       false, "cudaq::evolve is only supported on the 'dynamics' target. Please "
@@ -244,13 +243,12 @@ evolve(const HamTy &hamiltonian, const cudaq::dimension_map &dimensions,
        bool store_intermediate_results = false,
        std::optional<int> shots_count = std::nullopt) {
 #if defined(CUDAQ_ANALOG_TARGET)
-  std::vector<evolve_result> results;
-  for (const auto &initial_state : initial_states)
-    results.emplace_back(evolve(
-        hamiltonian, dimensions, schedule, initial_states, integrator,
-        collapse_operators, initial_state, integrator, collapse_operators,
-        observables, store_intermediate_results, shots_count));
-  return results;
+  return cudaq::__internal__::evolveBatched(
+      cudaq::__internal__::convertOp(hamiltonian), dimensions, schedule,
+      initial_states, integrator,
+      cudaq::__internal__::convertOps(collapse_operators),
+      cudaq::__internal__::convertOps(observables), store_intermediate_results,
+      shots_count);
 #else
   static_assert(
       false, "cudaq::evolve is only supported on the 'dynamics' target. Please "

--- a/runtime/cudaq/algorithms/evolve_internal.h
+++ b/runtime/cudaq/algorithms/evolve_internal.h
@@ -175,6 +175,15 @@ evolve_result evolveSingle(
     bool store_intermediate_results = false,
     std::optional<int> shots_count = std::nullopt);
 
+std::vector<evolve_result> evolveBatched(
+    const sum_op<cudaq::matrix_handler> &hamiltonian,
+    const cudaq::dimension_map &dimensions, const schedule &schedule,
+    const std::vector<state> &initial_states, base_integrator &integrator,
+    const std::vector<sum_op<cudaq::matrix_handler>> &collapse_operators = {},
+    const std::vector<sum_op<cudaq::matrix_handler>> &observables = {},
+    bool store_intermediate_results = false,
+    std::optional<int> shots_count = std::nullopt);
+
 evolve_result evolveSingle(const cudaq::rydberg_hamiltonian &hamiltonian,
                            const cudaq::schedule &schedule,
                            std::optional<int> shots_count = std::nullopt);

--- a/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
@@ -60,7 +60,7 @@ evolve_result evolveSingle(
 
   auto *cudmState = asCudmState(const_cast<state &>(initialState));
   if (!cudmState->is_initialized())
-    cudmState->initialize_cudm(handle, dims);
+    cudmState->initialize_cudm(handle, dims, /*batchSize=*/1);
 
   state initial_State = [&]() {
     if (!collapseOperators.empty() && !cudmState->is_density_matrix())
@@ -89,9 +89,10 @@ evolve_result evolveSingle(
       for (auto &expectation : expectations) {
         auto *cudmState = asCudmState(currentState);
         expectation.prepare(cudmState->get_impl());
-        const auto expVal =
-            expectation.compute(cudmState->get_impl(), step.real());
-        expVals.emplace_back(expVal.real());
+        const auto expVal = expectation.compute(cudmState->get_impl(),
+                                                step.real(), /*batchSize=*/1);
+        assert(expVal.size() == 1);
+        expVals.emplace_back(expVal.front().real());
       }
       expectationVals.emplace_back(std::move(expVals));
       intermediateStates.emplace_back(currentState);
@@ -110,8 +111,10 @@ evolve_result evolveSingle(
     auto *cudmState = asCudmState(finalState);
     for (auto &expectation : expectations) {
       expectation.prepare(cudmState->get_impl());
-      const auto expVal = expectation.compute(cudmState->get_impl(), finalTime);
-      expVals.emplace_back(expVal.real());
+      const auto expVal = expectation.compute(cudmState->get_impl(), finalTime,
+                                              /*batchSize=*/1);
+      assert(expVal.size() == 1);
+      expVals.emplace_back(expVal.front().real());
     }
     return evolve_result(finalState, expVals);
   }
@@ -142,6 +145,103 @@ evolve_result evolveSingle(
   return evolveSingle(
       hamiltonian, dimensions, schedule, state(cudmState.release()), integrator,
       collapse_operators, observables, store_intermediate_results, shots_count);
+}
+
+std::vector<evolve_result> evolveBatched(
+    const sum_op<cudaq::matrix_handler> &hamiltonian,
+    const cudaq::dimension_map &dimensionsMap, const schedule &schedule,
+    const std::vector<state> &initialStates, base_integrator &integrator,
+    const std::vector<sum_op<cudaq::matrix_handler>> &collapseOperators,
+    const std::vector<sum_op<cudaq::matrix_handler>> &observables,
+    bool storeIntermediateResults, std::optional<int> shotsCount) {
+  LOG_API_TIME();
+  cudensitymatHandle_t handle =
+      dynamics::Context::getCurrentContext()->getHandle();
+  std::map<std::size_t, int64_t> dimensions =
+      convertToOrderedMap(dimensionsMap);
+  std::vector<int64_t> dims;
+  for (const auto &[id, dim] : dimensions)
+    dims.emplace_back(dim);
+  const auto asCudmState = [](cudaq::state &cudaqState) -> CuDensityMatState * {
+    auto *simState = cudaq::state_helper::getSimulationState(&cudaqState);
+    auto *castSimState = dynamic_cast<CuDensityMatState *>(simState);
+    if (!castSimState)
+      throw std::runtime_error("Invalid state.");
+    return castSimState;
+  };
+  std::vector<CuDensityMatState *> states;
+  for (auto &initialState : initialStates) {
+    states.emplace_back(asCudmState(const_cast<state &>(initialState)));
+  }
+  auto batchedState = CuDensityMatState::createBatchedState(
+      handle, states, dims, !collapseOperators.empty());
+  SystemDynamics system(dims, hamiltonian, collapseOperators);
+  cudaq::integrator_helper::init_system_dynamics(integrator, system, schedule);
+  integrator.setState(cudaq::state(batchedState.release()), 0.0);
+  std::vector<CuDensityMatExpectation> expectations;
+  for (auto &obs : observables)
+    expectations.emplace_back(CuDensityMatExpectation(
+        handle, cudaq::dynamics::Context::getCurrentContext()
+                    ->getOpConverter()
+                    .convertToCudensitymatOperator({}, obs, dims)));
+
+  std::vector<std::vector<std::vector<double>>> expectationVals(
+      initialStates.size());
+  std::vector<std::vector<cudaq::state>> intermediateStates(
+      initialStates.size());
+  for (const auto &step : schedule) {
+    integrator.integrate(step.real());
+    auto [t, currentState] = integrator.getState();
+    if (storeIntermediateResults) {
+      auto *cudmState = asCudmState(currentState);
+      std::vector<std::vector<double>> expVals(initialStates.size());
+      for (auto &expectation : expectations) {
+        expectation.prepare(cudmState->get_impl());
+        const auto expVal = expectation.compute(
+            cudmState->get_impl(), step.real(), initialStates.size());
+        assert(expVal.size() == initialStates.size());
+        for (int i = 0; i < expVal.size(); ++i) {
+          expVals[i].emplace_back(expVal[i].real());
+        }
+      }
+      auto states = CuDensityMatState::splitBatchedState(*cudmState);
+      assert(states.size() == initialStates.size());
+      for (int i = 0; i < initialStates.size(); ++i) {
+        expectationVals[i].emplace_back(expVals[i]);
+        intermediateStates[i].emplace_back(cudaq::state(states[i]));
+      }
+    }
+  }
+
+  if (storeIntermediateResults) {
+    std::vector<evolve_result> results;
+    for (int i = 0; i < initialStates.size(); ++i) {
+      results.emplace_back(
+          evolve_result(intermediateStates[i], expectationVals[i]));
+    }
+    return results;
+  } else {
+    // Only final state is needed
+    auto [finalTime, finalState] = integrator.getState();
+    auto *cudmState = asCudmState(finalState);
+    std::vector<std::vector<double>> expVals(initialStates.size());
+    for (auto &expectation : expectations) {
+      expectation.prepare(cudmState->get_impl());
+      const auto expVal = expectation.compute(cudmState->get_impl(), finalTime,
+                                              initialStates.size());
+      assert(expVal.size() == initialStates.size());
+      for (int i = 0; i < expVal.size(); ++i) {
+        expVals[i].emplace_back(expVal[i].real());
+      }
+    }
+    auto states = CuDensityMatState::splitBatchedState(*cudmState);
+    assert(states.size() == initialStates.size());
+    std::vector<evolve_result> results;
+    for (int i = 0; i < initialStates.size(); ++i) {
+      results.emplace_back(evolve_result(cudaq::state(states[i]), expVals[i]));
+    }
+    return results;
+  }
 }
 
 } // namespace cudaq::__internal__

--- a/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
@@ -200,11 +200,12 @@ std::vector<evolve_result> evolveBatched(
   cudaq::integrator_helper::init_system_dynamics(integrator, system, schedule);
   integrator.setState(cudaq::state(batchedState.release()), 0.0);
   std::vector<CuDensityMatExpectation> expectations;
-  for (auto &obs : observables)
-    expectations.emplace_back(CuDensityMatExpectation(
-        handle, cudaq::dynamics::Context::getCurrentContext()
-                    ->getOpConverter()
-                    .convertToCudensitymatOperator({}, obs, dims)));
+  auto &opConverter =
+      cudaq::dynamics::Context::getCurrentContext()->getOpConverter();
+  for (auto &obs : observables) {
+    auto cudmObsOp = opConverter.convertToCudensitymatOperator({}, obs, dims);
+    expectations.emplace_back(CuDensityMatExpectation(handle, cudmObsOp));
+  }
 
   std::vector<std::vector<std::vector<double>>> expectationVals(
       initialStates.size());

--- a/runtime/nvqir/cudensitymat/CuDensityMatExpectation.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatExpectation.cpp
@@ -32,8 +32,9 @@ void CuDensityMatExpectation::prepare(cudensitymatState_t state) {
       m_handle, m_expectation, state, CUDENSITYMAT_COMPUTE_64F,
       dynamics::Context::getRecommendedWorkSpaceLimit(), m_workspace, 0x0));
 }
-std::complex<double> CuDensityMatExpectation::compute(cudensitymatState_t state,
-                                                      double time) {
+std::vector<std::complex<double>>
+CuDensityMatExpectation::compute(cudensitymatState_t state, double time,
+                                 int64_t batchSize) {
   std::size_t requiredBufferSize = 0;
   HANDLE_CUDM_ERROR(cudensitymatWorkspaceGetMemorySize(
       m_handle, m_workspace, CUDENSITYMAT_MEMSPACE_DEVICE,
@@ -51,17 +52,17 @@ std::complex<double> CuDensityMatExpectation::compute(cudensitymatState_t state,
   }
 
   auto *expectationValue_d = cudaq::dynamics::createArrayGpu(
-      std::vector<std::complex<double>>(1, {0.0, 0.0}));
+      std::vector<std::complex<double>>(batchSize, {0.0, 0.0}));
   {
     cudaq::dynamics::PerfMetricScopeTimer metricTimer(
         "cudensitymatExpectationCompute");
     HANDLE_CUDM_ERROR(cudensitymatExpectationCompute(
-        m_handle, m_expectation, time, 1, 0, nullptr, state, expectationValue_d,
-        m_workspace, 0x0));
+        m_handle, m_expectation, time, batchSize, 0, nullptr, state,
+        expectationValue_d, m_workspace, 0x0));
   }
-  std::complex<double> result;
-  HANDLE_CUDA_ERROR(cudaMemcpy(&result, expectationValue_d,
-                               sizeof(std::complex<double>),
+  std::vector<std::complex<double>> result(batchSize);
+  HANDLE_CUDA_ERROR(cudaMemcpy(result.data(), expectationValue_d,
+                               batchSize * sizeof(std::complex<double>),
                                cudaMemcpyDefault));
   cudaq::dynamics::destroyArrayGpu(expectationValue_d);
   return result;

--- a/runtime/nvqir/cudensitymat/CuDensityMatExpectation.h
+++ b/runtime/nvqir/cudensitymat/CuDensityMatExpectation.h
@@ -9,6 +9,7 @@
 #pragma once
 #include <complex>
 #include <cudensitymat.h>
+#include <vector>
 namespace cudaq {
 
 class CuDensityMatExpectation {
@@ -36,10 +37,13 @@ public:
   void prepare(cudensitymatState_t state);
 
   /// @brief Compute the expectation value
-  /// @param state The state to compute the expectation value
+  /// @param state The state to compute the expectation value (could be a
+  /// batched state)
   /// @param time The time at which the expectation value is computed
-  /// @return The expectation value
-  std::complex<double> compute(cudensitymatState_t state, double time);
+  /// @param batchSize The batched size of the input state
+  /// @return The expectation value(s)
+  std::vector<std::complex<double>> compute(cudensitymatState_t state,
+                                            double time, int64_t batchSize);
 };
 
 } // namespace cudaq

--- a/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
@@ -560,7 +560,8 @@ cudaq::dynamics::CuDensityMatOpConverter::wrapScalarCallback(
       for (size_t i = 0; i < context->paramNames.size(); ++i) {
         param_map[context->paramNames[i]] =
             std::complex<double>(params[2 * i], params[2 * i + 1]);
-        cudaq::debug("Callback param name {}, value {}", context->paramNames[i],
+        cudaq::debug("Callback param name {}, batch size {}, value {}",
+                     context->paramNames[i], batchSize,
                      param_map[context->paramNames[i]]);
       }
 

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -325,6 +325,7 @@ CuDensityMatState CuDensityMatState::zero_like(const CuDensityMatState &other) {
   state.hilbertSpaceDims = other.hilbertSpaceDims;
   state.dimension = other.dimension;
   state.isDensityMatrix = other.isDensityMatrix;
+  state.batchSize = other.batchSize;
   const size_t dataSize = state.dimension * sizeof(std::complex<double>);
   state.devicePtr = cudaq::dynamics::DeviceAllocator::allocate(dataSize);
   HANDLE_CUDA_ERROR(cudaMemset(state.devicePtr, 0, dataSize));
@@ -334,7 +335,8 @@ CuDensityMatState CuDensityMatState::zero_like(const CuDensityMatState &other) {
   HANDLE_CUDM_ERROR(cudensitymatCreateState(
       state.cudmHandle, purity,
       static_cast<int32_t>(state.hilbertSpaceDims.size()),
-      state.hilbertSpaceDims.data(), 1, CUDA_C_64F, &state.cudmState));
+      state.hilbertSpaceDims.data(), state.batchSize, CUDA_C_64F,
+      &state.cudmState));
 
   // Attach initialized GPU storage to the input quantum state
   HANDLE_CUDM_ERROR(cudensitymatStateAttachComponentStorage(
@@ -355,6 +357,7 @@ CuDensityMatState::clone(const CuDensityMatState &other) {
   state->hilbertSpaceDims = other.hilbertSpaceDims;
   state->dimension = other.dimension;
   state->isDensityMatrix = other.isDensityMatrix;
+  state->batchSize = other.batchSize;
   const size_t dataSize = state->dimension * sizeof(std::complex<double>);
   state->devicePtr = cudaq::dynamics::DeviceAllocator::allocate(dataSize);
   HANDLE_CUDA_ERROR(cudaMemcpy(state->devicePtr, other.devicePtr, dataSize,
@@ -365,8 +368,8 @@ CuDensityMatState::clone(const CuDensityMatState &other) {
   HANDLE_CUDM_ERROR(cudensitymatCreateState(
       state->cudmHandle, purity,
       static_cast<int32_t>(state->hilbertSpaceDims.size()),
-      state->hilbertSpaceDims.data(), /*batchSize=*/1, CUDA_C_64F,
-      &state->cudmState));
+      state->hilbertSpaceDims.data(), /*batchSize=*/state->batchSize,
+      CUDA_C_64F, &state->cudmState));
 
   // Attach initialized GPU storage to the input quantum state
   HANDLE_CUDM_ERROR(cudensitymatStateAttachComponentStorage(
@@ -382,11 +385,12 @@ CuDensityMatState::clone(const CuDensityMatState &other) {
 CuDensityMatState::CuDensityMatState(CuDensityMatState &&other) noexcept
     : isDensityMatrix(other.isDensityMatrix), dimension(other.dimension),
       devicePtr(other.devicePtr), cudmState(other.cudmState),
-      cudmHandle(other.cudmHandle), hilbertSpaceDims(other.hilbertSpaceDims) {
+      cudmHandle(other.cudmHandle), hilbertSpaceDims(other.hilbertSpaceDims),
+      batchSize(other.batchSize) {
   other.isDensityMatrix = false;
   other.dimension = 0;
   other.devicePtr = nullptr;
-
+  other.batchSize = 1;
   other.cudmState = nullptr;
   other.cudmHandle = nullptr;
   other.hilbertSpaceDims.clear();
@@ -410,13 +414,14 @@ CuDensityMatState::operator=(CuDensityMatState &&other) noexcept {
     cudmState = other.cudmState;
     cudmHandle = other.cudmHandle;
     hilbertSpaceDims = std::move(other.hilbertSpaceDims);
-
+    batchSize = other.batchSize;
     // Nullify other
     other.isDensityMatrix = false;
     other.dimension = 0;
     other.devicePtr = nullptr;
 
     other.cudmState = nullptr;
+    other.batchSize = 1;
   }
   return *this;
 }
@@ -439,6 +444,10 @@ CuDensityMatState cudaq::CuDensityMatState::to_density_matrix() const {
   if (is_density_matrix())
     throw std::runtime_error("State is already a density matrix.");
 
+  if (batchSize > 1)
+    throw std::runtime_error(
+        "Convert a batched state to density matrix is not supported.");
+
   const std::size_t vectorSize = calculate_state_vector_size(hilbertSpaceDims);
   const std::size_t expectedDensityMatrixSize = vectorSize * vectorSize;
   const std::size_t dmSizeBytes =
@@ -455,7 +464,7 @@ CuDensityMatState cudaq::CuDensityMatState::to_density_matrix() const {
       vectorSize, &scalar, reinterpret_cast<const cuDoubleComplex *>(devicePtr),
       1, reinterpret_cast<const cuDoubleComplex *>(devicePtr), 1,
       reinterpret_cast<cuDoubleComplex *>(dmState.devicePtr), vectorSize));
-  dmState.initialize_cudm(cudmHandle, hilbertSpaceDims);
+  dmState.initialize_cudm(cudmHandle, hilbertSpaceDims, batchSize);
   assert(dmState.is_initialized());
   assert(dmState.is_density_matrix());
   return dmState;
@@ -476,7 +485,8 @@ cudensitymatHandle_t cudaq::CuDensityMatState::get_handle() const {
 }
 
 void CuDensityMatState::initialize_cudm(cudensitymatHandle_t handleToSet,
-                                        const std::vector<int64_t> &dims) {
+                                        const std::vector<int64_t> &dims,
+                                        int64_t batchSize) {
   assert(!is_initialized());
   cudmHandle = handleToSet;
   hilbertSpaceDims = dims;
@@ -485,22 +495,25 @@ void CuDensityMatState::initialize_cudm(cudensitymatHandle_t handleToSet,
   size_t expectedStateVectorSize =
       calculate_state_vector_size(hilbertSpaceDims);
 
-  if (dimension != expectedDensityMatrixSize &&
-      dimension != expectedStateVectorSize &&
-      cudaq::dynamics::getNumRanks() * dimension != expectedDensityMatrixSize &&
-      cudaq::dynamics::getNumRanks() * dimension != expectedStateVectorSize) {
+  if (dimension != batchSize * expectedDensityMatrixSize &&
+      dimension != batchSize * expectedStateVectorSize &&
+      cudaq::dynamics::getNumRanks() * dimension !=
+          batchSize * expectedDensityMatrixSize &&
+      cudaq::dynamics::getNumRanks() * dimension !=
+          batchSize * expectedStateVectorSize) {
     throw std::invalid_argument("Invalid hilbertSpaceDims for the state data");
   }
 
-  isDensityMatrix =
-      (dimension == expectedDensityMatrixSize ||
-       dimension * cudaq::dynamics::getNumRanks() == expectedDensityMatrixSize);
+  isDensityMatrix = (dimension == batchSize * expectedDensityMatrixSize ||
+                     dimension * cudaq::dynamics::getNumRanks() ==
+                         batchSize * expectedDensityMatrixSize);
   const cudensitymatStatePurity_t purity = isDensityMatrix
                                                ? CUDENSITYMAT_STATE_PURITY_MIXED
                                                : CUDENSITYMAT_STATE_PURITY_PURE;
+  this->batchSize = batchSize;
   HANDLE_CUDM_ERROR(cudensitymatCreateState(
       cudmHandle, purity, static_cast<int32_t>(hilbertSpaceDims.size()),
-      hilbertSpaceDims.data(), 1, CUDA_C_64F, &cudmState));
+      hilbertSpaceDims.data(), batchSize, CUDA_C_64F, &cudmState));
 
   std::size_t storageSize;
   HANDLE_CUDM_ERROR(cudensitymatStateGetComponentStorageSize(
@@ -591,5 +604,180 @@ cudaq::CuDensityMatState::operator*=(const std::complex<double> &scalar) {
                   reinterpret_cast<cuDoubleComplex *>(devicePtr), 1));
 
   return *this;
+}
+
+std::unique_ptr<CuDensityMatState> CuDensityMatState::createBatchedState(
+    cudensitymatHandle_t handle,
+    const std::vector<CuDensityMatState *> initial_states,
+    const std::vector<int64_t> &dimensions, bool createDensityState) {
+  if (initial_states.size() < 2)
+    throw std::invalid_argument(
+        "Batched state needs more than 1 input states.");
+  const auto firstStateDimension = initial_states[0]->dimension;
+  if (std::any_of(initial_states.begin(), initial_states.end(),
+                  [firstStateDimension](CuDensityMatState *state) {
+                    return state->dimension != firstStateDimension;
+                  }))
+    throw std::invalid_argument("All states must have the same dimension");
+
+  const size_t expectedDensityMatrixSize =
+      calculate_density_matrix_size(dimensions);
+  const size_t expectedStateVectorSize =
+      calculate_state_vector_size(dimensions);
+  if (firstStateDimension != expectedDensityMatrixSize &&
+      firstStateDimension != expectedStateVectorSize)
+    throw std::invalid_argument("Invalid hilbertSpaceDims for the state data");
+
+  const bool isDm = firstStateDimension == expectedDensityMatrixSize;
+  // These are state vectors but we need density matrices (e.g., with collapsed
+  // operators)
+  if (!isDm && createDensityState) {
+    std::vector<CuDensityMatState *> initialDensityMatrixStates;
+    const auto dmSizeBytes =
+        expectedDensityMatrixSize * sizeof(std::complex<double>);
+    for (auto *stateVecState : initial_states) {
+      auto cudmState = new CuDensityMatState();
+      cudmState->devicePtr =
+          cudaq::dynamics::DeviceAllocator::allocate(dmSizeBytes);
+      cudmState->isDensityMatrix = true;
+      HANDLE_CUDA_ERROR(cudaMemset(cudmState->devicePtr, 0, dmSizeBytes));
+      cudmState->dimension = expectedDensityMatrixSize;
+      cuDoubleComplex scalar{1.0, 0.0};
+      HANDLE_CUBLAS_ERROR(cublasZgerc(
+          dynamics::Context::getCurrentContext()->getCublasHandle(),
+          stateVecState->dimension, stateVecState->dimension, &scalar,
+          reinterpret_cast<const cuDoubleComplex *>(stateVecState->devicePtr),
+          1,
+          reinterpret_cast<const cuDoubleComplex *>(stateVecState->devicePtr),
+          1, reinterpret_cast<cuDoubleComplex *>(cudmState->devicePtr),
+          stateVecState->dimension));
+      initialDensityMatrixStates.emplace_back(cudmState);
+    }
+
+    auto batchedDmState = createBatchedState(handle, initialDensityMatrixStates,
+                                             dimensions, createDensityState);
+    for (auto *dmState : initialDensityMatrixStates) {
+      delete dmState;
+    }
+    return batchedDmState;
+  }
+
+  auto cudmState = std::make_unique<CuDensityMatState>();
+  cudmState->cudmHandle = handle;
+  cudmState->hilbertSpaceDims = dimensions;
+  cudmState->batchSize = initial_states.size();
+  cudmState->isDensityMatrix = isDm;
+  const cudensitymatStatePurity_t purity = cudmState->isDensityMatrix
+                                               ? CUDENSITYMAT_STATE_PURITY_MIXED
+                                               : CUDENSITYMAT_STATE_PURITY_PURE;
+  HANDLE_CUDM_ERROR(cudensitymatCreateState(
+      cudmState->cudmHandle, purity,
+      static_cast<int32_t>(cudmState->hilbertSpaceDims.size()),
+      cudmState->hilbertSpaceDims.data(), cudmState->batchSize, CUDA_C_64F,
+      &cudmState->cudmState));
+
+  std::size_t storageSize;
+  HANDLE_CUDM_ERROR(cudensitymatStateGetComponentStorageSize(
+      cudmState->cudmHandle, cudmState->cudmState,
+      1,              // only one storage component
+      &storageSize)); // storage size in bytes
+  const std::size_t stateVolume =
+      storageSize / sizeof(std::complex<double>); // quantum state tensor volume
+                                                  // (number of elements)
+  cudmState->devicePtr =
+      cudaq::dynamics::DeviceAllocator::allocate(storageSize);
+  cudmState->dimension = stateVolume;
+
+  if (stateVolume < cudmState->batchSize * firstStateDimension) {
+    int32_t numComponents = 0;
+    HANDLE_CUDM_ERROR(cudensitymatStateGetNumComponents(
+        cudmState->cudmHandle, cudmState->cudmState, &numComponents));
+    assert(numComponents == 1);
+    int32_t numModes{0};
+    int32_t stateComponentGlobalId{-1};
+    int32_t batchModeLocation{-1};
+    HANDLE_CUDM_ERROR(cudensitymatStateGetComponentNumModes(
+        cudmState->cudmHandle, cudmState->cudmState,
+        /*stateComponentLocalId=*/0, &stateComponentGlobalId, &numModes,
+        &batchModeLocation));
+    std::vector<int64_t> stateComponentModeExtents(numModes);
+    std::vector<int64_t> stateComponentModeOffsets(numModes);
+
+    HANDLE_CUDM_ERROR(cudensitymatStateGetComponentInfo(
+        cudmState->cudmHandle, cudmState->cudmState,
+        /*stateComponentLocalId=*/0, &stateComponentGlobalId, &numModes,
+        stateComponentModeExtents.data(), stateComponentModeOffsets.data()));
+    int64_t startIdx = 0;
+    int64_t accumulatedIdx = 1;
+    for (int32_t i = 0; i < numModes; ++i) {
+      accumulatedIdx *= stateComponentModeExtents[i];
+      startIdx += (stateComponentModeOffsets[i] * accumulatedIdx);
+    }
+    const int batchIdx = startIdx / firstStateDimension;
+    const int numStatesPerGpu = stateVolume / firstStateDimension;
+    if (batchIdx * firstStateDimension != startIdx)
+      throw std::runtime_error(
+          "Batched state cannot be evenly distributed across available GPUs");
+    for (int i = 0; i < numStatesPerGpu; ++i) {
+      auto *sourcePtr = initial_states[i + batchIdx]->devicePtr;
+      std::complex<double> *destPtr =
+          static_cast<std::complex<double> *>(cudmState->devicePtr) +
+          i * firstStateDimension;
+      HANDLE_CUDA_ERROR(
+          cudaMemcpy(destPtr, sourcePtr,
+                     firstStateDimension * sizeof(std::complex<double>),
+                     cudaMemcpyDefault));
+    }
+
+    // Attach initialized GPU storage to the input quantum state
+    HANDLE_CUDM_ERROR(cudensitymatStateAttachComponentStorage(
+        cudmState->cudmHandle, cudmState->cudmState,
+        1, // only one storage component (tensor)
+        std::vector<void *>({cudmState->devicePtr})
+            .data(), // pointer to the GPU storage for the quantum state
+        std::vector<std::size_t>({storageSize})
+            .data())); // size of the GPU storage for the quantum state
+  } else {
+    std::complex<double> *destPtr =
+        static_cast<std::complex<double> *>(cudmState->devicePtr);
+    for (auto *initial_state : initial_states) {
+      auto *sourcePtr = initial_state->devicePtr;
+      HANDLE_CUDA_ERROR(
+          cudaMemcpy(destPtr, sourcePtr,
+                     firstStateDimension * sizeof(std::complex<double>),
+                     cudaMemcpyDefault));
+      destPtr += firstStateDimension;
+    }
+    // Attach initialized GPU storage to the input quantum state
+    HANDLE_CUDM_ERROR(cudensitymatStateAttachComponentStorage(
+        cudmState->cudmHandle, cudmState->cudmState,
+        1, // only one storage component (tensor)
+        std::vector<void *>({cudmState->devicePtr})
+            .data(), // pointer to the GPU storage for the quantum state
+        std::vector<std::size_t>({storageSize})
+            .data())); // size of the GPU storage for the quantum state
+  }
+
+  return cudmState;
+}
+
+std::vector<CuDensityMatState *>
+CuDensityMatState::splitBatchedState(CuDensityMatState &batchedState) {
+  if (!batchedState.is_initialized()) {
+    throw std::runtime_error("Uninitialized state");
+  }
+
+  if (batchedState.batchSize <= 1) {
+    throw std::runtime_error("Input is not a batched state");
+  }
+  const int64_t stateSize = batchedState.dimension / batchedState.batchSize;
+  std::complex<double> *ptr =
+      static_cast<std::complex<double> *>(batchedState.devicePtr);
+  std::vector<CuDensityMatState *> splitStates;
+  for (int i = 0; i < batchedState.batchSize; ++i) {
+    splitStates.emplace_back(
+        new CuDensityMatState(stateSize, ptr + i * stateSize));
+  }
+  return splitStates;
 }
 } // namespace cudaq

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.h
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.h
@@ -24,6 +24,7 @@ private:
   cudensitymatState_t cudmState = nullptr;
   cudensitymatHandle_t cudmHandle = nullptr;
   std::vector<int64_t> hilbertSpaceDims;
+  std::size_t batchSize = 1;
 
 public:
   // Create a state with a size and data pointer.
@@ -39,6 +40,19 @@ public:
       cudensitymatHandle_t handle, cudaq::InitialState initial_state,
       const std::unordered_map<std::size_t, std::int64_t> &dimensions,
       bool createDensityMatrix);
+
+  // Create a batched state
+  static std::unique_ptr<CuDensityMatState>
+  createBatchedState(cudensitymatHandle_t handle,
+                     const std::vector<CuDensityMatState *> initial_states,
+                     const std::vector<int64_t> &dimensions,
+                     bool createDensityState);
+
+  // Split a batched state into individual states.
+  // The caller assumes the ownership of the state pointers, e.g., wrap them
+  // under `cudaq::state`.
+  static std::vector<CuDensityMatState *>
+  splitBatchedState(CuDensityMatState &batchedState);
 
   // Return the number of qubits
   std::size_t getNumQubits() const override;
@@ -138,9 +152,13 @@ public:
   /// @return The handle associated with the state
   cudensitymatHandle_t get_handle() const;
 
+  // Returns the batch size
+  std::size_t getBatchSize() const { return batchSize; }
+
   // Initialize a state with cudensitymat
   void initialize_cudm(cudensitymatHandle_t handleToSet,
-                       const std::vector<int64_t> &hilbertSpaceDims);
+                       const std::vector<int64_t> &hilbertSpaceDims,
+                       int64_t batchSize);
 
   /// @brief Accumulation in-place with a coefficient
   void accumulate_inplace(const CuDensityMatState &other,

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.h
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.h
@@ -172,6 +172,19 @@ public:
   /// @brief Scalar multiplication operator
   /// @return The new state after multiplying scalar with the current state.
   CuDensityMatState &operator*=(const std::complex<double> &scalar);
+
+private:
+  /// Helper method to transform a state vector states to density matrix states.
+  // The caller takes ownership of the returned states.
+  static std::vector<CuDensityMatState *> convertStateVecToDensityMatrix(
+      const std::vector<CuDensityMatState *> svStates, int64_t dmSize);
+
+  /// Helper to aggregate multiple input states into a distributed batched
+  /// state.
+  static void
+  distributeBatchedStateData(CuDensityMatState &batchedState,
+                             const std::vector<CuDensityMatState *> inputStates,
+                             int64_t singleStateDimension);
 };
 /// @endcond
 } // namespace cudaq

--- a/runtime/nvqir/cudensitymat/CuDensityMatTimeStepper.h
+++ b/runtime/nvqir/cudensitymat/CuDensityMatTimeStepper.h
@@ -23,7 +23,8 @@ public:
                     &parameters) override;
   void computeImpl(
       cudensitymatState_t inState, cudensitymatState_t outState, double t,
-      const std::unordered_map<std::string, std::complex<double>> &parameters);
+      const std::unordered_map<std::string, std::complex<double>> &parameters,
+      int64_t batchSize);
 
 private:
   cudensitymatHandle_t m_handle;

--- a/unittests/dynamics/test_CuDensityMatExpectation.cpp
+++ b/unittests/dynamics/test_CuDensityMatExpectation.cpp
@@ -50,9 +50,10 @@ TEST_F(CuDensityMatExpectationTest, checkCompute) {
     initialState[stateIdx] = 1.0;
     CuDensityMatState inputState(initialState.size(),
                                  cudaq::dynamics::createArrayGpu(initialState));
-    inputState.initialize_cudm(handle_, dims);
+    inputState.initialize_cudm(handle_, dims, /*batchSize=*/1);
     expectation.prepare(inputState.get_impl());
-    const auto expVal = expectation.compute(inputState.get_impl(), 0.0);
+    const auto expVal =
+        expectation.compute(inputState.get_impl(), 0.0, /*batchSize=*/1)[0];
     EXPECT_NEAR(expVal.real(), 1.0 * stateIdx, 1e-12);
     EXPECT_NEAR(expVal.imag(), 0.0, 1e-12);
   }
@@ -80,9 +81,10 @@ TEST_F(CuDensityMatExpectationTest, checkCompositeSystem) {
         initial_state_vec.data() + initial_state_vec.size());
     CuDensityMatState inputState(initialState.size(),
                                  cudaq::dynamics::createArrayGpu(initialState));
-    inputState.initialize_cudm(handle_, dims);
+    inputState.initialize_cudm(handle_, dims, /*batchSize=*/1);
     expectation.prepare(inputState.get_impl());
-    const auto expVal = expectation.compute(inputState.get_impl(), 0.0);
+    const auto expVal =
+        expectation.compute(inputState.get_impl(), 0.0, /*batchSize=*/1)[0];
     std::cout << "Result: " << expVal << "\n";
     EXPECT_NEAR(expVal.real(), 1.0 * stateIdx, 1e-12);
     EXPECT_NEAR(expVal.imag(), 0.0, 1e-12);
@@ -111,11 +113,12 @@ TEST_F(CuDensityMatExpectationTest, checkCompositeSystemDensityMatrix) {
         initial_state_vec.data() + initial_state_vec.size());
     CuDensityMatState inputPureState(
         initialState.size(), cudaq::dynamics::createArrayGpu(initialState));
-    inputPureState.initialize_cudm(handle_, dims);
+    inputPureState.initialize_cudm(handle_, dims, /*batchSize=*/1);
     auto inputState = inputPureState.to_density_matrix();
     inputState.dump(std::cout);
     expectation.prepare(inputState.get_impl());
-    const auto expVal = expectation.compute(inputState.get_impl(), 0.0);
+    const auto expVal =
+        expectation.compute(inputState.get_impl(), 0.0, /*batchSize=*/1)[0];
     std::cout << "Result: " << expVal << "\n";
     EXPECT_NEAR(expVal.real(), 1.0 * stateIdx, 1e-12);
     EXPECT_NEAR(expVal.imag(), 0.0, 1e-12);
@@ -144,12 +147,82 @@ TEST_F(CuDensityMatExpectationTest, checkCompositeSystemDensityMatrixKron) {
         initial_state_vec.data() + initial_state_vec.size());
     CuDensityMatState inputState(initialState.size(),
                                  cudaq::dynamics::createArrayGpu(initialState));
-    inputState.initialize_cudm(handle_, dims);
+    inputState.initialize_cudm(handle_, dims, /*batchSize=*/1);
     inputState.dump(std::cout);
     expectation.prepare(inputState.get_impl());
-    const auto expVal = expectation.compute(inputState.get_impl(), 0.0);
+    const auto expVal =
+        expectation.compute(inputState.get_impl(), 0.0, /*batchSize=*/1)[0];
     std::cout << "Result: " << expVal << "\n";
     EXPECT_NEAR(expVal.real(), 1.0 * stateIdx, 1e-12);
     EXPECT_NEAR(expVal.imag(), 0.0, 1e-12);
+  }
+}
+
+TEST_F(CuDensityMatExpectationTest, checkBatchedState1) {
+  const std::vector<int64_t> dims = {2};
+  auto op_t = cudaq::spin::z(0);
+  cudaq::sum_op<cudaq::matrix_handler> op(op_t);
+  auto cudmOp = cudaq::dynamics::Context::getCurrentContext()
+                    ->getOpConverter()
+                    .convertToCudensitymatOperator({}, op, dims);
+
+  CuDensityMatExpectation expectation(handle_, cudmOp);
+
+  std::vector<std::complex<double>> initial_state_zero = {1.0, 0.0};
+  std::vector<std::complex<double>> initial_state_one = {0.0, 1.0};
+  CuDensityMatState inputState0(
+      initial_state_zero.size(),
+      cudaq::dynamics::createArrayGpu(initial_state_zero));
+  CuDensityMatState inputState1(
+      initial_state_one.size(),
+      cudaq::dynamics::createArrayGpu(initial_state_one));
+  auto batchedState = CuDensityMatState::createBatchedState(
+      handle_, {&inputState0, &inputState1}, dims, false);
+  EXPECT_EQ(batchedState->getBatchSize(), 2);
+  expectation.prepare(batchedState->get_impl());
+  const auto expVals =
+      expectation.compute(batchedState->get_impl(), 0.0, /*batchSize=*/2);
+  EXPECT_EQ(expVals.size(), 2);
+  EXPECT_NEAR(std::abs(expVals[0] - 1.0), 0.0, 1e-6);
+  EXPECT_NEAR(std::abs(expVals[1] + 1.0), 0.0, 1e-6);
+}
+
+TEST_F(CuDensityMatExpectationTest, checkBatchedState2) {
+  constexpr int N = 10;
+  constexpr int numStates = 4;
+  const std::vector<int64_t> dims = {N};
+  auto op_t = cudaq::boson_op::number(0);
+  cudaq::sum_op<cudaq::matrix_handler> op(op_t);
+  auto cudmOp = cudaq::dynamics::Context::getCurrentContext()
+                    ->getOpConverter()
+                    .convertToCudensitymatOperator({}, op, dims);
+  CuDensityMatExpectation expectation(handle_, cudmOp);
+
+  std::vector<CuDensityMatState> initialStates;
+  for (int i = 0; i < numStates; ++i) {
+    std::vector<std::complex<double>> psi0_(N, 0.0);
+    psi0_[N - i - 1] = 1.0;
+    initialStates.emplace_back(
+        CuDensityMatState(N, cudaq::dynamics::createArrayGpu(psi0_)));
+  }
+  std::vector<CuDensityMatState *> initialStatePtrs;
+  for (auto &state : initialStates)
+    initialStatePtrs.emplace_back(&state);
+  auto batchedState = CuDensityMatState::createBatchedState(
+      handle_, initialStatePtrs, dims, true);
+  EXPECT_EQ(batchedState->getBatchSize(), numStates);
+
+  for (int test = 0; test < 10; ++test) {
+    auto clone = CuDensityMatState::clone(*batchedState);
+    expectation.prepare(clone->get_impl());
+    const auto expVals = expectation.compute(clone->get_impl(), 0.0,
+                                             /*batchSize=*/numStates);
+    EXPECT_EQ(expVals.size(), numStates);
+    int numPhotons = N - 1;
+    for (const auto &expVal : expVals) {
+      std::cout << "Exp val = " << expVal << "\n";
+      EXPECT_NEAR(std::abs(expVal - 1.0 * numPhotons), 0.0, 1e-6);
+      numPhotons--;
+    }
   }
 }

--- a/unittests/dynamics/test_CuDensityMatState.cpp
+++ b/unittests/dynamics/test_CuDensityMatState.cpp
@@ -54,7 +54,7 @@ protected:
 TEST_F(CuDensityMatStateTest, InitializeWithStateVector) {
   CuDensityMatState state(stateVectorData.size(),
                           cudaq::dynamics::createArrayGpu(stateVectorData));
-  state.initialize_cudm(handle, hilbertSpaceDims);
+  state.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
   EXPECT_TRUE(state.is_initialized());
   EXPECT_FALSE(state.is_density_matrix());
   EXPECT_NO_THROW(state.dump(std::cout));
@@ -63,7 +63,7 @@ TEST_F(CuDensityMatStateTest, InitializeWithStateVector) {
 TEST_F(CuDensityMatStateTest, InitializeWithDensityMatrix) {
   CuDensityMatState state(densityMatrixData.size(),
                           cudaq::dynamics::createArrayGpu(densityMatrixData));
-  state.initialize_cudm(handle, hilbertSpaceDims);
+  state.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
   EXPECT_TRUE(state.is_initialized());
   EXPECT_TRUE(state.is_density_matrix());
   EXPECT_NO_THROW(state.dump(std::cout));
@@ -74,14 +74,14 @@ TEST_F(CuDensityMatStateTest, InvalidInitialization) {
   std::vector<std::complex<double>> invalidData = {{1.0, 0.0}, {0.0, 0.0}};
   CuDensityMatState state(invalidData.size(),
                           cudaq::dynamics::createArrayGpu(invalidData));
-  EXPECT_THROW(state.initialize_cudm(handle, hilbertSpaceDims),
+  EXPECT_THROW(state.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1),
                std::invalid_argument);
 }
 
 TEST_F(CuDensityMatStateTest, ToDensityMatrixConversion) {
   CuDensityMatState state(stateVectorData.size(),
                           cudaq::dynamics::createArrayGpu(stateVectorData));
-  state.initialize_cudm(handle, hilbertSpaceDims);
+  state.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
   EXPECT_FALSE(state.is_density_matrix());
 
   CuDensityMatState densityMatrixState = state.to_density_matrix();
@@ -97,7 +97,7 @@ TEST_F(CuDensityMatStateTest, ToDensityMatrixConversionCorrectnessCheck) {
     std::vector<std::complex<double>> initialState(
         randomVec.data(), randomVec.data() + randomVec.size());
     CuDensityMatState state(N, cudaq::dynamics::createArrayGpu(initialState));
-    state.initialize_cudm(handle, {N});
+    state.initialize_cudm(handle, {N}, /*batchSize=*/1);
     EXPECT_FALSE(state.is_density_matrix());
     Eigen::MatrixXcd expectedDensityMatrix = randomVec * randomVec.adjoint();
     std::cout << "Expected:\n" << expectedDensityMatrix << "\n";
@@ -114,7 +114,7 @@ TEST_F(CuDensityMatStateTest, ToDensityMatrixConversionCorrectnessCheck) {
 TEST_F(CuDensityMatStateTest, AlreadyDensityMatrixConversion) {
   CuDensityMatState state(densityMatrixData.size(),
                           cudaq::dynamics::createArrayGpu(densityMatrixData));
-  state.initialize_cudm(handle, hilbertSpaceDims);
+  state.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
   EXPECT_TRUE(state.is_density_matrix());
   EXPECT_THROW(state.to_density_matrix(), std::runtime_error);
 }
@@ -140,7 +140,7 @@ TEST_F(CuDensityMatStateTest, ConversionForSingleQubitSystem) {
   stateVectorData = {{1.0, 0.0}, {0.0, 0.0}};
   CuDensityMatState state(stateVectorData.size(),
                           cudaq::dynamics::createArrayGpu(stateVectorData));
-  state.initialize_cudm(handle, hilbertSpaceDims);
+  state.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
 
   EXPECT_FALSE(state.is_density_matrix());
 
@@ -155,14 +155,14 @@ TEST_F(CuDensityMatStateTest, InvalidHilbertSpaceDims) {
   hilbertSpaceDims = {3, 3};
   CuDensityMatState state(stateVectorData.size(),
                           cudaq::dynamics::createArrayGpu(stateVectorData));
-  EXPECT_THROW(state.initialize_cudm(handle, hilbertSpaceDims),
+  EXPECT_THROW(state.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1),
                std::invalid_argument);
 }
 
 TEST_F(CuDensityMatStateTest, DumpWorksForInitializedState) {
   CuDensityMatState state(stateVectorData.size(),
                           cudaq::dynamics::createArrayGpu(stateVectorData));
-  state.initialize_cudm(handle, hilbertSpaceDims);
+  state.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
   EXPECT_NO_THROW(state.dump(std::cout));
 }
 

--- a/unittests/dynamics/test_CuDensityMatTimeStepper.cpp
+++ b/unittests/dynamics/test_CuDensityMatTimeStepper.cpp
@@ -38,7 +38,8 @@ protected:
     auto *simState = cudaq::state_helper::getSimulationState(&state_);
     auto *castSimState = dynamic_cast<CuDensityMatState *>(simState);
     EXPECT_TRUE(castSimState != nullptr);
-    castSimState->initialize_cudm(handle_, mock_hilbert_space_dims());
+    castSimState->initialize_cudm(handle_, mock_hilbert_space_dims(),
+                                  /*batchSize=*/1);
     ASSERT_TRUE(castSimState->is_initialized());
   }
 
@@ -94,7 +95,7 @@ TEST_F(CuDensityMatTimeStepperTest, ComputeStepCheckOutput) {
   auto *simState = cudaq::state_helper::getSimulationState(&inputState);
   auto *castSimState = dynamic_cast<CuDensityMatState *>(simState);
   EXPECT_TRUE(castSimState != nullptr);
-  castSimState->initialize_cudm(handle_, dims);
+  castSimState->initialize_cudm(handle_, dims, /*batchSize=*/1);
 
   cudaq::boson_op_term op_1 = cudaq::boson_op::create(0);
   cudaq::sum_op<cudaq::matrix_handler> op(op_1);
@@ -128,7 +129,7 @@ TEST_F(CuDensityMatTimeStepperTest, TimeSteppingWithLindblad) {
   auto *simState = cudaq::state_helper::getSimulationState(&input_state);
   auto *castSimState = dynamic_cast<CuDensityMatState *>(simState);
   EXPECT_TRUE(castSimState != nullptr);
-  castSimState->initialize_cudm(handle_, dims);
+  castSimState->initialize_cudm(handle_, dims, /*batchSize=*/1);
   cudaq::product_op<cudaq::matrix_handler> c_op_0 =
       cudaq::boson_op::annihilate(0);
   cudaq::sum_op<cudaq::matrix_handler> c_op(c_op_0);
@@ -162,7 +163,7 @@ TEST_F(CuDensityMatTimeStepperTest, CheckScalarCallback) {
   auto *simState = cudaq::state_helper::getSimulationState(&inputState);
   auto *castSimState = dynamic_cast<CuDensityMatState *>(simState);
   EXPECT_TRUE(castSimState != nullptr);
-  castSimState->initialize_cudm(handle_, dims);
+  castSimState->initialize_cudm(handle_, dims, /*batchSize=*/1);
   const std::string paramName = "alpha";
   const std::complex<double> paramValue{2.0, 3.0};
   std::unordered_map<std::string, std::complex<double>> params{
@@ -209,7 +210,7 @@ TEST_F(CuDensityMatTimeStepperTest, CheckTensorCallback) {
   auto *simState = cudaq::state_helper::getSimulationState(&inputState);
   auto *castSimState = dynamic_cast<CuDensityMatState *>(simState);
   EXPECT_TRUE(castSimState != nullptr);
-  castSimState->initialize_cudm(handle_, dims);
+  castSimState->initialize_cudm(handle_, dims, /*batchSize=*/1);
 
   const std::string paramName = "beta";
   const std::complex<double> paramValue{2.0, 3.0};
@@ -267,7 +268,7 @@ TEST_F(CuDensityMatTimeStepperTest, ComputeOperatorOrder) {
   auto *simState = cudaq::state_helper::getSimulationState(&inputState);
   auto *castSimState = dynamic_cast<CuDensityMatState *>(simState);
   EXPECT_TRUE(castSimState != nullptr);
-  castSimState->initialize_cudm(handle_, dims);
+  castSimState->initialize_cudm(handle_, dims, /*batchSize=*/1);
 
   cudaq::product_op<cudaq::matrix_handler> op_t =
       cudaq::boson_op::create(0) *
@@ -307,7 +308,7 @@ TEST_F(CuDensityMatTimeStepperTest, ComputeOperatorOrderDensityMatrix) {
   auto *simState = cudaq::state_helper::getSimulationState(&inputState);
   auto *castSimState = dynamic_cast<CuDensityMatState *>(simState);
   EXPECT_TRUE(castSimState != nullptr);
-  castSimState->initialize_cudm(handle_, dims);
+  castSimState->initialize_cudm(handle_, dims, /*batchSize=*/1);
 
   cudaq::product_op<cudaq::matrix_handler> op_t =
       cudaq::boson_op::create(0) *

--- a/unittests/dynamics/test_EvolveApi.cpp
+++ b/unittests/dynamics/test_EvolveApi.cpp
@@ -118,3 +118,110 @@ TEST(EvolveAPITester, checkTimeDependent) {
     EXPECT_NEAR((double)expVals[0], theoryResults[count++], 1e-3);
   }
 }
+
+TEST(EvolveAPITester, checkBatchedSimple) {
+  const cudaq::dimension_map dimensions = {{0, 2}};
+  auto hamiltonian = 2.0 * M_PI * 0.1 * cudaq::spin_op::x(0);
+  // Initial state: ground state
+  std::vector<std::complex<double>> initial_state_zero = {1.0, 0.0};
+  std::vector<std::complex<double>> initial_state_one = {0.0, 1.0};
+
+  auto psi0 = cudaq::state::from_data(initial_state_zero);
+  auto psi1 = cudaq::state::from_data(initial_state_one);
+
+  // Create a schedule of time steps from 0 to 10 with 101 points
+  int numSteps = 101;
+  std::vector<double> steps = cudaq::linspace(0.0, 10.0, 101);
+  cudaq::schedule schedule(steps);
+
+  // Runge-`Kutta` integrator with a time step of 0.01 and order 4
+  cudaq::integrators::runge_kutta integrator(4, 0.01);
+
+  // Run the simulation without collapse operators (ideal evolution)
+  auto results = cudaq::evolve(hamiltonian, dimensions, schedule, {psi0, psi1},
+                               integrator, {}, {cudaq::spin_op::z(0)}, true);
+  EXPECT_EQ(results.size(), 2);
+  EXPECT_TRUE(results[0].expectation_values.has_value());
+  EXPECT_EQ(results[0].expectation_values.value().size(), numSteps);
+  EXPECT_TRUE(results[1].expectation_values.has_value());
+  EXPECT_EQ(results[1].expectation_values.value().size(), numSteps);
+
+  std::vector<double> theoryResults0;
+  std::vector<double> theoryResults1;
+  for (const auto &t : schedule) {
+    const double expected = std::cos(2 * 2.0 * M_PI * 0.1 * t.real());
+    theoryResults0.emplace_back(expected);
+    theoryResults1.emplace_back(-expected);
+  }
+
+  int count = 0;
+  for (auto expVals : results[0].expectation_values.value()) {
+    EXPECT_EQ(expVals.size(), 1);
+    EXPECT_NEAR((double)expVals[0], theoryResults0[count++], 1e-3);
+  }
+
+  count = 0;
+  for (auto expVals : results[1].expectation_values.value()) {
+    EXPECT_EQ(expVals.size(), 1);
+    EXPECT_NEAR((double)expVals[0], theoryResults1[count++], 1e-3);
+  }
+}
+
+TEST(EvolveAPITester, checkCavityModelBatchedState) {
+  constexpr int N = 10;
+  constexpr int numStates = 4;
+  constexpr int numSteps = 101;
+  cudaq::schedule schedule(cudaq::linspace(0.0, 1.0, numSteps), {"t"});
+  auto hamiltonian = cudaq::boson_op::number(0);
+  const cudaq::dimension_map dimensions{{0, N}};
+  std::vector<cudaq::state> initialStates;
+  for (int i = 0; i < numStates; ++i) {
+    std::vector<std::complex<double>> psi0_(N, 0.0);
+    psi0_[N - i - 1] = 1.0;
+    initialStates.emplace_back(cudaq::state::from_data(psi0_));
+  }
+
+  constexpr double decay_rate = 0.1;
+
+  auto td_function =
+      [decay_rate](const std::unordered_map<std::string, std::complex<double>>
+                       &parameters) {
+        auto entry = parameters.find("t");
+        if (entry == parameters.end())
+          throw std::runtime_error("Cannot find value of expected parameter");
+        const auto t = entry->second.real();
+        const auto result = std::sqrt(decay_rate * std::exp(-t));
+        return result;
+      };
+
+  auto collapseOperator =
+      cudaq::scalar_operator(td_function) * cudaq::boson_op::annihilate(0);
+  cudaq::integrators::runge_kutta integrator(4, 0.01);
+  auto results =
+      cudaq::evolve(hamiltonian, dimensions, schedule, initialStates,
+                    integrator, {collapseOperator}, {hamiltonian}, true);
+  EXPECT_EQ(results.size(), numStates);
+  for (int i = 0; i < numStates; ++i) {
+    auto &result = results[i];
+    const auto numPhotons = N - i;
+    std::cout << "Checking results for the initial state with " << numPhotons
+              << " photons.\n";
+    EXPECT_TRUE(result.expectation_values.has_value());
+    EXPECT_EQ(result.expectation_values.value().size(), numSteps);
+    std::vector<double> theoryResults;
+    for (const auto &t : schedule) {
+      const double expected =
+          (numPhotons - 1) *
+          std::exp(-decay_rate * (1.0 - std::exp(-t.real())));
+      theoryResults.emplace_back(expected);
+    }
+
+    int count = 0;
+    for (auto expVals : result.expectation_values.value()) {
+      EXPECT_EQ(expVals.size(), 1);
+      std::cout << "Result = " << (double)expVals[0] << "; expected "
+                << theoryResults[count] << "\n";
+      EXPECT_NEAR((double)expVals[0], theoryResults[count++], 0.01);
+    }
+  }
+}

--- a/unittests/dynamics/test_RungeKuttaIntegrator.cpp
+++ b/unittests/dynamics/test_RungeKuttaIntegrator.cpp
@@ -35,7 +35,8 @@ protected:
     state_ = std::make_unique<CuDensityMatState>(
         mock_initial_state_data().size(),
         cudaq::dynamics::createArrayGpu(mock_initial_state_data()));
-    state_->initialize_cudm(handle_, mock_hilbert_space_dims());
+    state_->initialize_cudm(handle_, mock_hilbert_space_dims(),
+                            /*batchSize=*/1);
     ASSERT_NE(state_, nullptr);
     ASSERT_TRUE(state_->is_initialized());
 
@@ -77,7 +78,7 @@ TEST_F(RungeKuttaIntegratorTest, CheckEvolve) {
     auto *simState = cudaq::state_helper::getSimulationState(&initialState);
     auto *castSimState = dynamic_cast<CuDensityMatState *>(simState);
     EXPECT_TRUE(castSimState != nullptr);
-    castSimState->initialize_cudm(handle_, dims);
+    castSimState->initialize_cudm(handle_, dims, /*batchSize=*/1);
     integrator.setState(initialState, 0.0);
     std::vector<std::complex<double>> steps;
     for (double t : cudaq::linspace(0.0, 1.0 * numDataPoints, numDataPoints)) {


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Aggregate input states into a batch for more efficient cudensitymat simulation.


Note: We already had this API (list of states as initial states). Previously, we ran them sequentially. Now, we combine them into a batched state.
