### PR TITLE
Allow in-kernel enable/disable of noise

### DIFF
--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -192,7 +192,10 @@ kraus_channel::kraus_channel(const kraus_channel &other)
 
 std::size_t kraus_channel::size() const { return ops.size(); }
 
-bool kraus_channel::empty() const { return ops.empty(); }
+bool kraus_channel::empty() const {
+  return ops.empty() && noise_type != noise_model_type::global_disable &&
+         noise_type != noise_model_type::global_enable;
+}
 
 std::size_t kraus_channel::dimension() const { return ops[0].nRows; }
 
@@ -392,6 +395,8 @@ noise_model::noise_model() {
   register_channel<pauli2>();
   register_channel<depolarization1>();
   register_channel<depolarization2>();
+  register_channel<global_disable>();
+  register_channel<global_enable>();
 }
 
 std::string get_noise_model_type_name(noise_model_type type) {

--- a/runtime/common/NoiseModel.h
+++ b/runtime/common/NoiseModel.h
@@ -76,7 +76,9 @@ enum class noise_model_type {
   pauli1,
   pauli2,
   depolarization1,
-  depolarization2
+  depolarization2,
+  global_disable,
+  global_enable
 };
 
 // Keep the noise_model_type and noise_model_strings in sync. We don't use
@@ -95,7 +97,9 @@ static constexpr const char *noise_model_strings[] = {
     "pauli1",
     "pauli2",
     "depolarization1",
-    "depolarization2"};
+    "depolarization2",
+    "global_disable",
+    "global_enable"};
 
 std::string get_noise_model_type_name(noise_model_type type);
 
@@ -979,6 +983,36 @@ public:
       : depolarization2(std::vector<cudaq::real>{probability}) {}
   REGISTER_KRAUS_CHANNEL(
       noise_model_strings[(int)noise_model_type::depolarization2])
+};
+
+class global_disable : public kraus_channel {
+public:
+  // These would ideally be 0, but the template meta programming would need
+  // fixing to allow that.
+  constexpr static std::size_t num_parameters = 1;
+  constexpr static std::size_t num_targets = 1;
+  global_disable(const std::vector<cudaq::real> p) : kraus_channel() {
+    noise_type = cudaq::noise_model_type::global_disable;
+  }
+  global_disable(const real probability)
+      : global_disable(std::vector<cudaq::real>{probability}) {}
+  REGISTER_KRAUS_CHANNEL(
+      noise_model_strings[(int)noise_model_type::global_disable])
+};
+
+class global_enable : public kraus_channel {
+public:
+  // These would ideally be 0, but the template meta programming would need
+  // fixing to allow that.
+  constexpr static std::size_t num_parameters = 1;
+  constexpr static std::size_t num_targets = 1;
+  global_enable(const std::vector<cudaq::real> p) : kraus_channel() {
+    noise_type = cudaq::noise_model_type::global_enable;
+  }
+  global_enable(const real probability)
+      : global_enable(std::vector<cudaq::real>{probability}) {}
+  REGISTER_KRAUS_CHANNEL(
+      noise_model_strings[(int)noise_model_type::global_enable])
 };
 
 } // namespace cudaq

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -88,6 +88,10 @@ protected:
   /// Internal - At qudit deallocation, return the qudit index
   void returnIndex(std::size_t idx) { tracker.returnIndex(idx); }
 
+  /// Internal - whether or not noise is globally disabled in this
+  /// ExecutionManager (i.e. via apply_noise<cudaq::global_disable>())
+  bool noiseDisabled = false;
+
 public:
   ExecutionManager() = default;
 

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -226,6 +226,17 @@ protected:
     if (isInTracerMode())
       return;
 
+    if (channel.noise_type == cudaq::noise_model_type::global_disable) {
+      this->noiseDisabled = true;
+      return;
+    }
+    if (channel.noise_type == cudaq::noise_model_type::global_enable) {
+      this->noiseDisabled = false;
+      return;
+    }
+    if (this->noiseDisabled)
+      return;
+
     flushGateQueue();
 
     if (channel.empty())


### PR DESCRIPTION
Now that we have `cudaq::apply_noise`, we are halfway there to having explicit control in-kernel noise. This would be useful for QEC research where they wish to perform some noise-free operations for analysis purposes. (I.e. perhaps they want to apply noise to all X operations _except_ some at the beginning or end of a kernel.

This is just a draft for now.