### PR TITLE
[CI] Enforce Python formatting (with `yapf`) on the `python/tests` directory

### DIFF
--- a/.github/workflows/repo_checks.yml
+++ b/.github/workflows/repo_checks.yml
@@ -94,7 +94,7 @@ jobs:
           create_output cxx '*.cpp *.h *.hpp :!:test :!:targettests :!:tpls :!:**/nlopt-src/*'
           create_output cxx_headers '*.h *.hpp :!:test :!:targettests :!:tpls :!:**/nlopt-src/*'
           create_output cxx_examples 'docs/sphinx/examples/**/*.cpp' 'docs/sphinx/applications/cpp/*.cpp' 'docs/sphinx/targets/cpp/*.cpp'
-          create_output python '*.py :!:python/tests :!:test :!:targettests :!:tpls :!:docs/sphinx/conf.py'
+          create_output python '*.py :!:test :!:targettests :!:tpls :!:docs/sphinx/conf.py'
           create_output markdown '*.md :!:tpls'
           create_output rst '*.rst :!:tpls :!:docs/sphinx/_templates/**/*.rst'
           echo "json=$(echo $json)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fix issue https://github.com/NVIDIA/cuda-quantum/issues/630