### PR TITLE
[core] Start to make cc.func_ptr obsolete.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -1179,64 +1179,23 @@ def cc_ConstantArrayOp : CCOp<"const_array", [Pure]> {
   }];
 }
 
-//===----------------------------------------------------------------------===//
-// Cast operation.
-//===----------------------------------------------------------------------===//
-
-def cc_CastOp : CCOp<"cast", [Pure]> {
-  let summary = "Overloads LLVM's casting instructions.";
+def cc_CreateStringLiteralOp : CCOp<"string_literal"> {
+  let summary = "Create a constant string literal.";
   let description = [{
-    A CastOp can be used to create one of LLVM's cast instructions. The signed
-    (unsigned) keyword can/must be used with otherwise sign agnostic integer
-    conversions to distinguish between sext (zext).
-
-    Example:
+    This operation creates a ASCIIZ string literal value. It's argument is a
+    constant MLIR String Attribute. The literal will have a null character
+    appended automatically.
 
     ```mlir
-      %11 = cc.cast %10 : (!cc.ptr<i8>) -> i64           // ptrtoint
-      %12 = cc.cast %11 : (i64) -> !cc.ptr<i32>          // inttoptr
-      %13 = cc.cast %12 : (!cc.ptr<i32>) -> !cc.ptr<f64> // bitcast
-      %14 = cc.cast %11 : (i64) -> f64                   // bitcast
-      %15 = cc.cast signed %11 : (i64) -> f64            // sitofp
-      %16 = cc.cast unsigned %11 : (i64) -> f64          // uitofp
-      %17 = cc.cast signed %15 : (f64) -> i32            // fptosi
-      %18 = cc.cast unsigned %16 : (f64) -> i16          // fptoui
-      %21 = cc.cast signed %20 : (i8) -> i32             // sext
-      %22 = cc.cast unsigned %20 : (i8) -> i32           // zext
-      %23 = cc.cast %22 : (i32) -> i16                   // trunc
-      %24 = cc.cast %16 : (f64) -> f32                   // fptrunc
-      %25 = cc.cast %24 : (f32) -> f64                   // fpext
+      %0 = cc.string_literal "Quantum Computing" : !cc.ptr<!cc.array<i8 x 18>>
     ```
   }];
 
-  let arguments = (ins
-    AnyType:$value,
-    OptionalAttr<UnitAttr>:$sint,
-    OptionalAttr<UnitAttr>:$zint
-  );
-  let results = (outs AnyType:$result);
-
-  let hasFolder = 1;
-  let hasCanonicalizer = 1;
-  let hasVerifier = 1;
-  
+  let arguments = (ins StrAttr:$stringLiteral);
+  let results = (outs cc_PointerType:$result);
   let assemblyFormat = [{
-    ( `signed` $sint^ ):( ( `unsigned` $zint^ )? )? $value `:`
-      functional-type(operands, results) attr-dict
+     $stringLiteral `:` qualified(type(results)) attr-dict
   }];
-
-  let builders = [
-    OpBuilder<(ins "mlir::Type":$resTy, "mlir::Value":$value), [{
-      return build($_builder, $_state, resTy, value, {}, {});
-    }]>,
-    OpBuilder<(ins "mlir::Type":$resTy, "mlir::Value":$value,
-        "CastOpMode":$mode), [{
-      auto unitAttr = mlir::UnitAttr::get($_builder.getContext());
-      if (mode == CastOpMode::Signed)
-        return build($_builder, $_state, resTy, value, /*signed=*/unitAttr, {});
-      return build($_builder, $_state, resTy, value, {}, /*unsigned=*/unitAttr);
-    }]>
-  ];
 }
 
 //===----------------------------------------------------------------------===//
@@ -1321,6 +1280,62 @@ def cc_StdvecSizeOp : CCOp<"stdvec_size", [Pure]> {
 // Type conversions.
 //===----------------------------------------------------------------------===//
 
+def cc_CastOp : CCOp<"cast", [Pure]> {
+  let summary = "Overloads LLVM's casting instructions.";
+  let description = [{
+    A CastOp can be used to create one of LLVM's cast instructions. The signed
+    (unsigned) keyword can/must be used with otherwise sign agnostic integer
+    conversions to distinguish between sext (zext).
+
+    Example:
+
+    ```mlir
+      %11 = cc.cast %10 : (!cc.ptr<i8>) -> i64           // ptrtoint
+      %12 = cc.cast %11 : (i64) -> !cc.ptr<i32>          // inttoptr
+      %13 = cc.cast %12 : (!cc.ptr<i32>) -> !cc.ptr<f64> // bitcast
+      %14 = cc.cast %11 : (i64) -> f64                   // bitcast
+      %15 = cc.cast signed %11 : (i64) -> f64            // sitofp
+      %16 = cc.cast unsigned %11 : (i64) -> f64          // uitofp
+      %17 = cc.cast signed %15 : (f64) -> i32            // fptosi
+      %18 = cc.cast unsigned %16 : (f64) -> i16          // fptoui
+      %21 = cc.cast signed %20 : (i8) -> i32             // sext
+      %22 = cc.cast unsigned %20 : (i8) -> i32           // zext
+      %23 = cc.cast %22 : (i32) -> i16                   // trunc
+      %24 = cc.cast %16 : (f64) -> f32                   // fptrunc
+      %25 = cc.cast %24 : (f32) -> f64                   // fpext
+    ```
+  }];
+
+  let arguments = (ins
+    AnyType:$value,
+    OptionalAttr<UnitAttr>:$sint,
+    OptionalAttr<UnitAttr>:$zint
+  );
+  let results = (outs AnyType:$result);
+
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+  
+  let assemblyFormat = [{
+    ( `signed` $sint^ ):( ( `unsigned` $zint^ )? )? $value `:`
+      functional-type(operands, results) attr-dict
+  }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$resTy, "mlir::Value":$value), [{
+      return build($_builder, $_state, resTy, value, {}, {});
+    }]>,
+    OpBuilder<(ins "mlir::Type":$resTy, "mlir::Value":$value,
+        "CastOpMode":$mode), [{
+      auto unitAttr = mlir::UnitAttr::get($_builder.getContext());
+      if (mode == CastOpMode::Signed)
+        return build($_builder, $_state, resTy, value, /*signed=*/unitAttr, {});
+      return build($_builder, $_state, resTy, value, {}, /*unsigned=*/unitAttr);
+    }]>
+  ];
+}
+
 def cc_FuncToPtrOp : CCOp<"func_ptr", [Pure]> {
   let summary = "Cast a function to a pointer.";
   let description = [{
@@ -1344,7 +1359,7 @@ def cc_FuncToPtrOp : CCOp<"func_ptr", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
-// Lambda (λ) expressions.
+// Lambda (λ) expressions and other calls.
 //===----------------------------------------------------------------------===//
 
 def cc_CreateLambdaOp : CCOp<"create_lambda",
@@ -1665,6 +1680,9 @@ def cc_VarargCallOp :
     arguments without the restriction that all the arguments have to be
     converted to LLVMIR types first. These conversions are just code bloat and
     make the code harder to read.
+
+    The use of LLVMIR dialect for varargs functions is required as MLIR's Func
+    dialect does not support varargs calls.
   }];
 
   let arguments = (ins
@@ -1694,24 +1712,9 @@ def cc_VarargCallOp :
   }];
 }
 
-def cc_CreateStringLiteralOp : CCOp<"string_literal"> {
-  let summary = "Create a constant string literal.";
-  let description = [{
-    This operation creates a ASCIIZ string literal value. It's argument is a
-    constant MLIR String Attribute. The literal will have a null character
-    appended automatically.
-
-    ```mlir
-      %0 = cc.string_literal "Quantum Computing" : !cc.ptr<!cc.array<i8 x 18>>
-    ```
-  }];
-
-  let arguments = (ins StrAttr:$stringLiteral);
-  let results = (outs cc_PointerType:$result);
-  let assemblyFormat = [{
-     $stringLiteral `:` qualified(type(results)) attr-dict
-  }];
-}
+//===----------------------------------------------------------------------===//
+// Argument synthesis support
+//===----------------------------------------------------------------------===//
 
 def cc_ArgumentSubstitutionOp : CCOp<"arg_subst",
   [IsolatedFromAbove, NoRegionArguments, NoTerminator, SingleBlock]> {

--- a/lib/Optimizer/CodeGen/CCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/CCToLLVM.cpp
@@ -295,6 +295,9 @@ public:
               .Case([&](LLVM::LLVMPointerType) {
                 boilerplate((LLVM::BitcastOp *)nullptr);
               })
+              .Case([&](LLVM::LLVMFunctionType) {
+                boilerplate((LLVM::BitcastOp *)nullptr);
+              })
               .Case([&](IntegerType) {
                 boilerplate((LLVM::IntToPtrOp *)nullptr);
               });

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -368,6 +368,15 @@ LogicalResult cudaq::cc::CastOp::verify() {
   } else if (isa<FunctionType>(inTy) && isa<cc::IndirectCallableType>(outTy)) {
     // ok, type conversion of a function to an indirect callable
     // Folding will remove this.
+  } else if (isa<FunctionType>(inTy) && isa<cc::PointerType>(outTy)) {
+    auto ptrTy = cast<cc::PointerType>(outTy);
+    auto eleTy = ptrTy.getElementType();
+    auto *ctx = eleTy.getContext();
+    if (eleTy == NoneType::get(ctx) || eleTy == IntegerType::get(ctx, 8)) {
+      // ok, type conversion of a function to a pointer.
+    } else {
+      return emitOpError("invalid cast.");
+    }
   } else {
     // Could support a bitcast of a float with pointer size bits to/from a
     // pointer, but that doesn't seem like it would be very common.

--- a/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
+++ b/test/Transforms/DecompositionPatterns/ExpPauliToHRyRzCX.qke
@@ -9,6 +9,7 @@
 // RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=ExpPauliDecomposition})' %s | FileCheck %s
 
 module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_ZZ4mainENK3$_0clEd"}} {
+
   func.func @__nvqpp__mlirgen__Z4mainE3$_0(%arg0: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
     %0 = cc.alloca f64
     cc.store %arg0, %0 : !cc.ptr<f64>
@@ -25,13 +26,13 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__Z4mainE3$_0(
 // CHECK-SAME:                                             %[[VAL_0:.*]]: f64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i64
-// CHECK:           %[[VAL_4:.*]] = arith.constant 3 : i64
-// CHECK:           %[[VAL_5:.*]] = arith.constant 1.5707963267948966 : f64
-// CHECK:           %[[VAL_6:.*]] = arith.constant -1.5707963267948966 : f64
-// CHECK:           %[[VAL_7:.*]] = cc.alloca f64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 3 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1.5707963267948966 : f64
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant -1.5707963267948966 : f64
+// CHECK-DAG:       %[[VAL_7:.*]] = cc.alloca f64
 // CHECK:           cc.store %[[VAL_0]], %[[VAL_7]] : !cc.ptr<f64>
 // CHECK:           %[[VAL_8:.*]] = quake.alloca !quake.veq<4>
 // CHECK:           %[[VAL_9:.*]] = quake.extract_ref %[[VAL_8]][0] : (!quake.veq<4>) -> !quake.ref
@@ -39,29 +40,28 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
 // CHECK:           %[[VAL_10:.*]] = quake.extract_ref %[[VAL_8]][1] : (!quake.veq<4>) -> !quake.ref
 // CHECK:           quake.x %[[VAL_10]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_11:.*]] = cc.load %[[VAL_7]] : !cc.ptr<f64>
-// CHECK:           %[[VAL_12:.*]] = cc.string_literal "XXXY" : !cc.ptr<!cc.array<i8 x 5>>
-// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_1]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           %[[VAL_13:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_13]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_14:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_2]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           %[[VAL_14:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_14]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_3]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           %[[VAL_15:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_3]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_15]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_4]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           %[[VAL_16:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_4]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:           quake.rx (%[[VAL_5]]) %[[VAL_16]] : (f64, !quake.ref) -> ()
-// CHECK:           quake.x {{\[}}%[[VAL_13]]] %[[VAL_14]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           quake.x {{\[}}%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           quake.x {{\[}}%[[VAL_15]]] %[[VAL_16]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.x [%[[VAL_13]]] %[[VAL_14]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.x [%[[VAL_15]]] %[[VAL_16]] : (!quake.ref, !quake.ref) -> ()
 // CHECK:           quake.rz (%[[VAL_11]]) %[[VAL_16]] : (f64, !quake.ref) -> ()
-// CHECK:           quake.x {{\[}}%[[VAL_15]]] %[[VAL_16]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           quake.x {{\[}}%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           quake.x {{\[}}%[[VAL_13]]] %[[VAL_14]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_4]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           quake.x [%[[VAL_15]]] %[[VAL_16]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.x [%[[VAL_14]]] %[[VAL_15]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           quake.x [%[[VAL_13]]] %[[VAL_14]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           %[[VAL_17:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_4]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:           quake.rx (%[[VAL_6]]) %[[VAL_17]] : (f64, !quake.ref) -> ()
-// CHECK:           %[[VAL_18:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_3]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           %[[VAL_18:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_3]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_18]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_19:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_2]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           %[[VAL_19:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_2]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_19]] : (!quake.ref) -> ()
-// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]]{{\[}}%[[VAL_1]]] : (!quake.veq<4>, i64) -> !quake.ref
+// CHECK:           %[[VAL_20:.*]] = quake.extract_ref %[[VAL_8]][%[[VAL_1]]] : (!quake.veq<4>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_20]] : (!quake.ref) -> ()
 // CHECK:           return
 // CHECK:         }
@@ -76,15 +76,16 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__Z4mainE3$_0 = "_Z
     quake.exp_pauli (%cst) %3 to %2 : (f64, !quake.veq<2>, !cc.charspan) -> ()
     return
   }
+
   llvm.mlir.global private constant @cstr.585900("XY\00") {addr_space = 0 : i32}
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test_param._Z10test_paramN5cudaq10pauli_wordE() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_2:.*]] = arith.constant 1.5707963267948966 : f64
-// CHECK:           %[[VAL_3:.*]] = arith.constant -1.5707963267948966 : f64
-// CHECK:           %[[VAL_4:.*]] = arith.constant 1.000000e+00 : f64
-// CHECK:           %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1.5707963267948966 : f64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant -1.5707963267948966 : f64
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_5:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_6:.*]] = quake.extract_ref %[[VAL_5]][%[[VAL_0]]] : (!quake.veq<2>, i64) -> !quake.ref
 // CHECK:           quake.h %[[VAL_6]] : (!quake.ref) -> ()
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_5]][%[[VAL_1]]] : (!quake.veq<2>, i64) -> !quake.ref

--- a/test/Translate/cast.qke
+++ b/test/Translate/cast.qke
@@ -1,0 +1,23 @@
+// ========================================================================== //
+// Copyright (c) 2025 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-translate --convert-to=qir %s | FileCheck %s
+
+func.func private @simp3()
+
+func.func @simp5() -> !cc.ptr<i8> {
+  %0 = func.constant @simp3 : () -> ()
+  %1 = cc.cast %0 : (() -> ()) -> !cc.ptr<i8>
+  func.return %1 : !cc.ptr<i8>
+}
+
+// CHECK-LABEL: declare void @simp3()
+
+// CHECK-LABEL: define nonnull i8* @simp5() local_unnamed_addr
+// CHECK:         ret i8* bitcast (void ()* @simp3 to i8*)
+// CHECK:       }


### PR DESCRIPTION
The cc.func_ptr op has been around forever in the project but is no longer really needed as the dialects have evolved. This PR starts the process of making cc.func_ptr obsolete by making cc.cast a capable alternative.

Includes some reorgnization of the .td file.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
