### PR TITLE
Fix publishing pipeline after dynamics migration to pybind11 binding

### DIFF
--- a/docs/sphinx/examples/cpp/dynamics/heisenberg_model_mpi.cpp
+++ b/docs/sphinx/examples/cpp/dynamics/heisenberg_model_mpi.cpp
@@ -19,6 +19,13 @@
 #include <cudaq.h>
 
 int main() {
+  if (!cudaq::mpi::available()) {
+    std::cout << "MPI support is not available. Please refer to the "
+                 "documentation for instructions to activate MPI support in "
+                 "order to run this example.\n";
+    return 0;
+  }
+
   cudaq::mpi::initialize();
   std::cout << "Number of ranks = " << cudaq::mpi::num_ranks() << "\n";
   // Set up a 15-spin chain, where each spin is a two-level system.

--- a/python/cudaq/dynamics/cudm_solver.py
+++ b/python/cudaq/dynamics/cudm_solver.py
@@ -52,6 +52,10 @@ def evolve_dynamics(
             f"Integrator {type(integrator).__name__} does not support distributed state."
         )
 
+    if integrator is None:
+        # Default integrator if not provided.
+        integrator = RungeKuttaIntegrator()
+
     collapse_operators = [MatrixOperator(op) for op in collapse_operators]
     integrator.set_system(dimensions, schedule, MatrixOperator(hamiltonian),
                           collapse_operators)

--- a/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
@@ -420,9 +420,20 @@ cudaq::dynamics::CuDensityMatOpConverter::convertToCudensitymat(
     // i.e., ABC means C to be applied first.
     std::reverse(elemOps.begin(), elemOps.end());
     std::reverse(allDegrees.begin(), allDegrees.end());
-    result.emplace_back(std::make_pair(
-        productOp.get_coefficient(),
-        createProductOperatorTerm(elemOps, modeExtents, allDegrees, {})));
+    if (elemOps.empty()) {
+      // Constant term (no operator)
+      cudaq::product_op<cudaq::matrix_handler> constantTerm =
+          cudaq::sum_op<cudaq::matrix_handler>::identity(0);
+      cudensitymatElementaryOperator_t cudmElemOp = createElementaryOperator(
+          *constantTerm.begin(), parameters, modeExtents);
+      result.emplace_back(std::make_pair(
+          productOp.get_coefficient(),
+          createProductOperatorTerm({cudmElemOp}, modeExtents, {{0}}, {})));
+    } else {
+      result.emplace_back(std::make_pair(
+          productOp.get_coefficient(),
+          createProductOperatorTerm(elemOps, modeExtents, allDegrees, {})));
+    }
   }
   return result;
 }

--- a/unittests/dynamics/test_CuDensityMatTimeStepper.cpp
+++ b/unittests/dynamics/test_CuDensityMatTimeStepper.cpp
@@ -76,11 +76,6 @@ TEST_F(CuDensityMatTimeStepperTest, ComputeStepNoLiouvillian) {
   EXPECT_THROW(invalidStepper.compute(state_, 0.0, {}), std::runtime_error);
 }
 
-// Compute step with zero step size
-TEST_F(CuDensityMatTimeStepperTest, ComputeStepZeroStepSize) {
-  EXPECT_THROW(time_stepper_->compute(state_, 0.0, {}), std::runtime_error);
-}
-
 // Compute step with large time values
 TEST_F(CuDensityMatTimeStepperTest, ComputeStepLargeTimeValues) {
   EXPECT_NO_THROW(time_stepper_->compute(state_, 1e6, {}));


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Follow up for https://github.com/NVIDIA/cuda-quantum/pull/2853

- Default integrator in case the optional integrator is not provided. This was an oversight when I re-wrote the `evolve_dynamics` body.

- Handle a constant (no operator) term in conversion. This was handled in the original Python operator conversion utility but not in the C++ implementation.

- Handle no-mpi environment for the new example.

- Remove a stale test case, as we have removed the unused `step_size` argument.
