### PR TITLE
Fix binary output directory of dynamics bindings to be compatible with using CUDA-Q python from build directory

### DIFF
--- a/python/runtime/cudaq/dynamics/CMakeLists.txt
+++ b/python/runtime/cudaq/dynamics/CMakeLists.txt
@@ -32,5 +32,7 @@ target_include_directories(nvqir_dynamics_bindings
         ${CUDENSITYMAT_INCLUDE_DIR}
         ${CUDAToolkit_INCLUDE_DIRS})
 target_link_libraries(nvqir_dynamics_bindings PRIVATE fmt::fmt-header-only)
+# Set output directory for ctest-based python test invocation, which uses cudaq python from the build directory. 
+set_target_properties(nvqir_dynamics_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python/cudaq/dynamics)
 install(TARGETS nvqir_dynamics_bindings DESTINATION cudaq/dynamics)
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

When invoking some Python checks hooked to cmake (ctest), we use the CUDA-Q Python package in build directory, not install directory. Hence, the path must be consistent.

Thanks, @khalatepradnya for spotting it!
