### PR TITLE
[python] Fix incorrect alignment of structure elements in python

### DIFF
--- a/python/runtime/cudaq/algorithms/py_vqe.cpp
+++ b/python/runtime/cudaq/algorithms/py_vqe.cpp
@@ -152,6 +152,7 @@ pyVQE_remote_cpp(cudaq::quantum_platform &platform, py::object &kernel,
     // Serialize arguments (all concrete parameters except for the first one)
     // into kernelArgs buffer space.
     auto kernelFunc = getKernelFuncOp(kernelMod, kernelName);
+    setDataLayout(kernelMod);
     cudaq::packArgs(
         args, runtimeArgs, kernelFunc,
         [](OpaqueArguments &, py::object &) { return false; }, startingArgIdx);

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -28,7 +28,11 @@
 #include "runtime/cudaq/algorithms/py_utils.h"
 #include "utils/OpaqueArguments.h"
 #include "utils/PyTypes.h"
+#include "llvm/MC/SubtargetFeature.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/Host.h"
+#include "llvm/Target/TargetMachine.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "mlir/CAPI/ExecutionEngine.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -68,6 +72,53 @@ static std::unique_ptr<PyStateVectorStorage> stateStorage =
 
 static std::unique_ptr<PyStateStorage> cudaqStateStorage =
     std::make_unique<PyStateStorage>();
+
+static std::string createDataLayout() {
+  // Setup the machine properties from the current architecture.
+  auto targetTriple = llvm::sys::getDefaultTargetTriple();
+  std::string errorMessage;
+  const auto *target =
+      llvm::TargetRegistry::lookupTarget(targetTriple, errorMessage);
+  if (!target)
+    throw std::runtime_error("Cannot create target");
+
+  std::string cpu(llvm::sys::getHostCPUName());
+  llvm::SubtargetFeatures features;
+  llvm::StringMap<bool> hostFeatures;
+
+  if (llvm::sys::getHostCPUFeatures(hostFeatures))
+    for (auto &f : hostFeatures)
+      features.AddFeature(f.first(), f.second);
+
+  std::unique_ptr<llvm::TargetMachine> machine(target->createTargetMachine(
+      targetTriple, cpu, features.getString(), {}, {}));
+  if (!machine)
+    throw std::runtime_error("Cannot create target machine");
+
+  return machine->createDataLayout().getStringRepresentation();
+}
+
+void setDataLayout(MlirModule module) {
+  auto mod = unwrap(module);
+  if (!mod->hasAttr(opt::factory::targetDataLayoutAttrName)) {
+    auto dataLayout = createDataLayout();
+    mod->setAttr(opt::factory::targetDataLayoutAttrName,
+                 StringAttr::get(mod->getContext(), dataLayout));
+  }
+}
+
+/// @brief Create a new OpaqueArguments pointer and pack the
+/// python arguments in it. Clients must delete the memory.
+OpaqueArguments *toOpaqueArgs(py::args &args, MlirModule mod,
+                              const std::string &name) {
+  auto kernelFunc = getKernelFuncOp(mod, name);
+  auto *argData = new cudaq::OpaqueArguments();
+  args = simplifiedValidateInputArguments(args);
+  setDataLayout(mod);
+  cudaq::packArgs(*argData, args, kernelFunc,
+                  [](OpaqueArguments &, py::object &) { return false; });
+  return argData;
+}
 
 std::tuple<ExecutionEngine *, void *, std::size_t, std::int32_t>
 jitAndCreateArgs(const std::string &name, MlirModule module,
@@ -840,6 +891,7 @@ void bindAltLaunchKernel(py::module &mod) {
         auto kernelFunc = getKernelFuncOp(module, kernelName);
 
         cudaq::OpaqueArguments args;
+        setDataLayout(module);
         cudaq::packArgs(args, runtimeArgs, kernelFunc, callableArgHandler);
         pyAltLaunchKernel(kernelName, module, args, callable_names);
       },
@@ -853,6 +905,7 @@ void bindAltLaunchKernel(py::module &mod) {
         auto kernelFunc = getKernelFuncOp(module, kernelName);
 
         cudaq::OpaqueArguments args;
+        setDataLayout(module);
         cudaq::packArgs(args, runtimeArgs, kernelFunc, callableArgHandler);
         return pyAltLaunchKernelR(kernelName, module, returnType, args,
                                   callable_names);
@@ -875,6 +928,7 @@ void bindAltLaunchKernel(py::module &mod) {
     auto name = kernel.attr("name").cast<std::string>();
     auto kernelFuncOp = getKernelFuncOp(module, name);
     cudaq::OpaqueArguments args;
+    setDataLayout(module);
     cudaq::packArgs(args, runtimeArgs, kernelFuncOp,
                     [](OpaqueArguments &, py::object &) { return false; });
     return synthesizeKernel(name, module, args);

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.h
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.h
@@ -22,6 +22,14 @@ namespace py = pybind11;
 
 namespace cudaq {
 
+/// @brief Set current architecture's data layout attribute on a module.
+void setDataLayout(MlirModule module);
+
+/// @brief Create a new OpaqueArguments pointer and pack the
+/// python arguments in it. Clients must delete the memory.
+OpaqueArguments *toOpaqueArgs(py::args &args, MlirModule mod,
+                              const std::string &name);
+
 inline std::size_t byteSize(mlir::Type ty) {
   if (isa<mlir::ComplexType>(ty)) {
     auto eleTy = cast<mlir::ComplexType>(ty).getElementType();

--- a/python/tests/kernel/test_run_kernel.py
+++ b/python/tests/kernel/test_run_kernel.py
@@ -311,41 +311,20 @@ def test_return_tuple():
         qubits = cudaq.qvector(n)
         return t
 
-    # TODO: fix alignment
     results = cudaq.run(simple_tuple_bool_int, 2, (True, 13), shots_count=2)
-    ## DEBUG NOTE - input log to `cudaq::RecordLogParser::parse()` function
-    '''
-    OUTPUT  TUPLE   2       tuple<i1, i64>
-    OUTPUT  BOOL    true    .0
-    OUTPUT  INT     0       .1
-    OUTPUT  TUPLE   2       tuple<i1, i64>
-    OUTPUT  BOOL    true    .0
-    OUTPUT  INT     0       .1
-    '''
     assert len(results) == 2
-    # assert results[0] == (True, 13)
-    # assert results[1] == (True, 13)
+    assert results[0] == (True, 13)
+    assert results[1] == (True, 13)
 
     @cudaq.kernel
     def simple_tuple_int_bool(n: int, t: tuple[int, bool]) -> tuple[int, bool]:
         qubits = cudaq.qvector(n)
         return t
 
-    # TODO: fix alignment
     results = cudaq.run(simple_tuple_int_bool, 2, (13, True), shots_count=2)
-    ## DEBUG NOTE - input log to `cudaq::RecordLogParser::parse()` function
-    '''
-    OUTPUT  TUPLE   2       tuple<i64, i1>
-    OUTPUT  INT     13      .0
-    OUTPUT  BOOL    true    .1
-    OUTPUT  TUPLE   2       tuple<i64, i1>
-    OUTPUT  INT     13      .0
-    OUTPUT  BOOL    true    .1
-    '''
     assert len(results) == 2
-    ## FIXME: Fails on arm64 in CI
-    # assert results[0] == (13, True)
-    # assert results[1] == (13, True)
+    assert results[0] == (13, True)
+    assert results[1] == (13, True)
 
     @cudaq.kernel
     def simple_tuple_bool_int_float(
@@ -353,24 +332,12 @@ def test_return_tuple():
         qubits = cudaq.qvector(n)
         return t
 
-    # TODO: fix alignment
     results = cudaq.run(simple_tuple_bool_int_float,
                         2, (True, 13, 42.3),
                         shots_count=2)
-    ## DEBUG NOTE - input log to `cudaq::RecordLogParser::parse()` function
-    '''
-    OUTPUT  TUPLE   3       tuple<i1, i64, f64>
-    OUTPUT  BOOL    true    .0
-    OUTPUT  INT     0       .1
-    OUTPUT  DOUBLE  42.3    .2
-    OUTPUT  TUPLE   3       tuple<i1, i64, f64>
-    OUTPUT  BOOL    true    .0
-    OUTPUT  INT     0       .1
-    OUTPUT  DOUBLE  42.3    .2
-    '''
     assert len(results) == 2
-    # assert results[0] == (True, 13, 42.3)
-    # assert results[1] == (True, 13, 42.3)
+    assert results[0] == (True, 13, 42.3)
+    assert results[1] == (True, 13, 42.3)
 
 
 def test_return_dataclass_int_bool():
@@ -390,9 +357,8 @@ def test_return_dataclass_int_bool():
                         MyClass(16, True),
                         shots_count=2)
     assert len(results) == 2
-    # TODO: fix alignment
-    # assert results[0] == MyClass(16, True)
-    # assert results[1] == MyClass(16, True)
+    assert results[0] == MyClass(16, True)
+    assert results[1] == MyClass(16, True)
 
 
 def test_return_dataclass_bool_int():
@@ -412,9 +378,8 @@ def test_return_dataclass_bool_int():
                         MyClass(True, 17),
                         shots_count=2)
     assert len(results) == 2
-    # TODO: fix alignment
-    # assert results[0] == MyClass(True, 17)
-    # assert results[1] == MyClass(True, 17)
+    assert results[0] == MyClass(True, 17)
+    assert results[1] == MyClass(True, 17)
 
 
 def test_return_dataclass_float_int():

--- a/python/utils/OpaqueArguments.h
+++ b/python/utils/OpaqueArguments.h
@@ -199,6 +199,9 @@ getTargetLayout(func::FuncOp func, cudaq::cc::StructType structTy) {
   StringRef dataLayoutSpec = "";
   if (auto attr = mod->getAttr(cudaq::opt::factory::targetDataLayoutAttrName))
     dataLayoutSpec = cast<StringAttr>(attr);
+  else
+    throw std::runtime_error("No data layout attribute is set on the module.");
+
   auto dataLayout = llvm::DataLayout(dataLayoutSpec);
   // Convert bufferTy to llvm.
   llvm::LLVMContext context;
@@ -516,18 +519,6 @@ inline bool isBroadcastRequest(kernel_builder<> &builder, py::args &args) {
   }
 
   return false;
-}
-
-/// @brief Create a new OpaqueArguments pointer and pack the
-/// python arguments in it. Clients must delete the memory.
-inline OpaqueArguments *toOpaqueArgs(py::args &args, MlirModule mod,
-                                     const std::string &name) {
-  auto kernelFunc = getKernelFuncOp(mod, name);
-  auto *argData = new cudaq::OpaqueArguments();
-  args = simplifiedValidateInputArguments(args);
-  cudaq::packArgs(*argData, args, kernelFunc,
-                  [](OpaqueArguments &, py::object &) { return false; });
-  return argData;
 }
 
 } // namespace cudaq


### PR DESCRIPTION
### Description
Fix incorrect alignment of structure elements in python

#### Details

Set data layout attribute on module before processing arguments and return values in python (`packArgs` and `convertResults`)