### PR TITLE
Proper handling of `evolve_async` input state 

### DIFF
--- a/runtime/cudaq/algorithms/evolve.h
+++ b/runtime/cudaq/algorithms/evolve.h
@@ -288,7 +288,8 @@ evolve_async(const HamTy &hamiltonian, const cudaq::dimension_map &dimensions,
        obs = std::move(observableOperators)]() {
         ExecutionContext context("evolve");
         cudaq::get_platform().set_exec_ctx(&context, qpu_id);
-        return evolve(hamiltonian, dimensions, schedule, initial_state,
+        state localizedState = cudaq::__internal__::migrateState(initial_state);
+        return evolve(hamiltonian, dimensions, schedule, localizedState,
                       *cloneIntegrator, cOps, obs, store_intermediate_results,
                       shots_count);
       },
@@ -325,7 +326,8 @@ evolve_async(const HamTy &hamiltonian, const cudaq::dimension_map &dimensions,
       [=]() {
         ExecutionContext context("evolve");
         cudaq::get_platform().set_exec_ctx(&context, qpu_id);
-        return evolve(hamiltonian, dimensions, schedule, initial_state,
+        state localizedState = cudaq::__internal__::migrateState(initial_state);
+        return evolve(hamiltonian, dimensions, schedule, localizedState,
                       *cloneIntegrator, collapse_operators, observables,
                       store_intermediate_results, shots_count);
       },

--- a/runtime/cudaq/algorithms/evolve_internal.h
+++ b/runtime/cudaq/algorithms/evolve_internal.h
@@ -157,6 +157,9 @@ evolve_async(std::function<evolve_result()> evolveFunctor,
   return f;
 }
 
+// Helper to migrate an input state to the current device if necessary
+state migrateState(const state &inputState);
+
 evolve_result evolveSingle(
     const sum_op<cudaq::matrix_handler> &hamiltonian,
     const cudaq::dimension_map &dimensions, const schedule &schedule,

--- a/runtime/nvqir/cudensitymat/CuDensityMatContext.h
+++ b/runtime/nvqir/cudensitymat/CuDensityMatContext.h
@@ -45,6 +45,9 @@ public:
   /// @return std::size_t Recommended workspace limit in bytes.
   static std::size_t getRecommendedWorkSpaceLimit();
 
+  /// @brief Return the device Id of the context
+  int getDeviceId() const { return m_deviceId; }
+
 private:
   /// @brief Construct a new Context object for a specific device.
   /// @param deviceId ID of the CUDA device.


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

The input state to `evolve_async` may be constructed on a different device (GPU), as this state is built on the main thread before the async. functor is executed.

Hence, adding a helper function to detect and migrate the state data if needed.
