### PR TITLE
unify the pool type in adapt-qaoa

### DIFF
--- a/docs/sphinx/applications/python/adapt_qaoa.ipynb
+++ b/docs/sphinx/applications/python/adapt_qaoa.ipynb
@@ -36,12 +36,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import cudaq\n",
+    "from cudaq import spin\n",
     "from scipy.optimize import minimize\n",
     "import random\n",
     "\n",
@@ -59,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,16 +158,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
     "def qaoa_mixer(n):\n",
     "\n",
-    "    term = cudaq.spin.x(0)\n",
+    "    term = spin.x(0)\n",
     "\n",
     "    for i in range(1, n):\n",
-    "        term = term + cudaq.spin.x(i)\n",
+    "        term = term + spin.x(i)\n",
     "\n",
     "    pool = [term]\n",
     "    return pool\n",
@@ -176,7 +177,7 @@
     "    pool = []\n",
     "\n",
     "    for i in range(n):\n",
-    "        pool.append(cudaq.spin.x(i))\n",
+    "        pool.append(cudaq.SpinOperator(spin.x(i)))\n",
     "\n",
     "    return pool\n",
     "\n",
@@ -186,10 +187,10 @@
     "\n",
     "    for i in range(n-1):\n",
     "        for j in range(i+1, n):\n",
-    "            pool.append(cudaq.spin.x(i) * cudaq.spin.x(j))\n",
-    "            pool.append(cudaq.spin.y(i) * cudaq.spin.y(j))\n",
-    "            pool.append(cudaq.spin.y(i) * cudaq.spin.z(j))\n",
-    "            pool.append(cudaq.spin.z(i) * cudaq.spin.y(j))\n",
+    "            pool.append(cudaq.SpinOperator(spin.x(i)) * cudaq.SpinOperator(spin.x(j)))\n",
+    "            pool.append(cudaq.SpinOperator(spin.y(i)) * cudaq.SpinOperator(spin.y(j)))\n",
+    "            pool.append(cudaq.SpinOperator(spin.y(i)) * cudaq.SpinOperator(spin.z(j)))\n",
+    "            pool.append(cudaq.SpinOperator(spin.z(i)) * cudaq.SpinOperator(spin.y(j)))\n",
     "\n",
     "    return pool\n",
     "\n",
@@ -203,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -230,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -423,7 +424,12 @@
     "        layer.append(1) \n",
     "        random_mixer = random.choice(temp_pool)\n",
     "        \n",
-    "        mixer_pool = mixer_pool + [random_mixer.get_pauli_word(qubits_num)]\n",
+    "        pool_added = []\n",
+    "        for term in random_mixer:\n",
+    "            pool_added.append(term.get_pauli_word(qubits_num))\n",
+    "            \n",
+    "        mixer_pool = mixer_pool + pool_added\n",
+    "        \n",
     "    \n",
     "        print('Mixer pool at step', istep)\n",
     "        print(mixer_pool)\n",
@@ -484,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -494,8 +500,8 @@
       "\n",
       " Sampling the Final ADAPT QAOA circuit \n",
       "\n",
-      "The most probable max cut:  01011\n",
-      "All bitstring from circuit sampling:  { 01011:2550 10100:2450 }\n",
+      "The most probable max cut:  10100\n",
+      "All bitstring from circuit sampling:  { 01011:2499 10100:2501 }\n",
       "\n"
      ]
     }
@@ -510,14 +516,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CUDA-Q Version cu12-latest (https://github.com/NVIDIA/cuda-quantum 05873efb8973bd60fcf7cfe193e6ab54c6edee60)\n"
+      "CUDA-Q Version cu12-latest (https://github.com/NVIDIA/cuda-quantum 974716fa2024267f7c12a2ed86ffbfe314d37a36)\n"
      ]
     }
    ],


### PR DESCRIPTION
The old code has operator pool of different type. In some examples that will cause issues. Thanks to @bmhowe23 who helped me find this issue and fix it. In the new version, I updated the pool to generate pool of same type (SpinOperator). 
