### PR TITLE
[core] Add argument conversion and code gen components to constant propagate through spans

### DIFF
--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -301,7 +301,7 @@ RUN cd /cuda-quantum && source scripts/configure_build.sh && \
         # The tests is marked correctly as requiring nvcc, but since nvcc
         # is available during the build we need to filter it manually.
         filtered=" --filter-out MixedLanguage/cuda-1"; \
-	filtered+="|AST-Quake/calling_convention"; \
+	filtered+="|AST-Quake/calling_convention|test_argument_conversion"; \
     fi && \
     "$LLVM_INSTALL_PREFIX/bin/llvm-lit" -v build/test \
         --param nvqpp_site_config=build/test/lit.site.cfg.py ${filtered} && \

--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -1175,6 +1175,19 @@ def cc_ConstantArrayOp : CCOp<"const_array", [Pure]> {
   let assemblyFormat = [{
     $constantValues `:` qualified(type($arrayType)) attr-dict
   }];
+
+  let extraClassDeclaration = [{
+    // The total number of array dimensions.
+    std::size_t arrayDimension() {
+      std::size_t depth = 0;
+      mlir::Type ty = getType();
+      while (auto arrTy = llvm::dyn_cast<cudaq::cc::ArrayType>(ty)) {
+        ty = arrTy.getElementType();
+        ++depth;
+      }
+      return depth;
+    }
+  }];
 }
 
 def cc_CreateStringLiteralOp : CCOp<"string_literal", [Pure]> {
@@ -1238,6 +1251,33 @@ def cc_ReifySpanOp : CCOp<"reify_span", [Pure]> {
   let results = (outs cc_StdVectorType:$spanType);
   let assemblyFormat = [{
     $elements `:` functional-type(operands, results) attr-dict
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    // The total number span dimensions. The total is the number of outer
+    // std::vector<T> classes plus one if the inner class is a std::string.
+    std::size_t spanDimension() {
+      std::size_t depth = 0;
+      mlir::Type ty = getType();
+      while (auto spanTy = llvm::dyn_cast<cudaq::cc::SpanLikeType>(ty)) {
+        ty = spanTy.getElementType();
+        ++depth;
+      }
+      return depth;
+    }
+
+    // The number of std::vector<T> dimensions.
+    std::size_t vectorDimension() {
+      std::size_t depth = 0;
+      mlir::Type ty = getType();
+      while (auto vecTy = llvm::dyn_cast<cudaq::cc::StdvecType>(ty)) {
+        ty = vecTy.getElementType();
+        ++depth;
+      }
+      return depth;
+    }
   }];
 }
 

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -503,12 +503,18 @@ def GlobalizeArrayValues : Pass<"globalize-array-values", "mlir::ModuleOp"> {
   let description = [{
     Often a `const_array` op can be canonicalized into scalar constants that
     are then constant propagated to their uses in the quake ops. When this
-    happens, the `const_array` may become unused and be eliminated.
+    happens, the `const_array` may become unused and can be eliminated.
 
     However, there can also be cases where the `const_array` remains alive, such
     as when it is used in a `state_init` op. In such cases, we may be able to go
     ahead and replace the `const_array` with a global constant. This pass makes
     such conversions.
+
+    A `const_array` may also be used as an image for a tree of spans which has
+    yet to be reified. In this case, the inner most array may be lowered to a
+    global object, but the tree of spans working outward from those objects
+    must be constructed. This pass can replace the reify_span operation with
+    smaller granularity operations that build these trees of spans.
   }];
 }
 

--- a/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -2242,6 +2242,7 @@ void cudaq::opt::addConvertToQIRAPIPipeline(OpPassManager &pm, StringRef api,
   QuakeToQIRAPIFinalOptions finalApiOpt{.api = api.str()};
   pm.addPass(cudaq::opt::createQuakeToQIRAPIFinal(finalApiOpt));
   pm.addPass(cudaq::opt::createGlobalizeArrayValues());
+  pm.addPass(createCanonicalizerPass());
 }
 
 namespace {

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -2342,6 +2342,19 @@ void cudaq::cc::OffsetOfOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
+// ReifySpanOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult cudaq::cc::ReifySpanOp::verify() {
+  auto conArr = getElements().getDefiningOp<cudaq::cc::ConstantArrayOp>();
+  if (!conArr && !isa<BlockArgument>(getElements()))
+    return emitOpError("requires a constant array argument.");
+  if (conArr.arrayDimension() != spanDimension())
+    return emitOpError("input array dimension must be same as span dimension.");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ReturnOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Optimizer/Transforms/DeleteStates.cpp
+++ b/lib/Optimizer/Transforms/DeleteStates.cpp
@@ -76,7 +76,7 @@ public:
 
 // clang-format off
 /// Remove `quake.create_state` instructions and pass their data directly to
-/// the `quake.state_init` instruction instead.
+/// the `quake.init_state` instruction instead.
 /// ```
 /// %2 = cc.cast %1 : (!cc.ptr<!cc.array<complex<f32> x 8>>) -> !cc.ptr<i8>
 /// %3 = quake.create_state %3, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.ptr<!quake.state>

--- a/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
+++ b/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
@@ -278,7 +278,7 @@ struct ReifySpanPattern : public OpRewritePattern<cudaq::cc::ReifySpanOp> {
     auto size = rewriter.create<arith::ConstantIntOp>(loc, members.size(), 64);
     auto buff = rewriter.create<cudaq::cc::AllocaOp>(loc, eleTy, size);
     for (auto iter : llvm::enumerate(members)) {
-      auto idx = iter.index();
+      std::int32_t idx = iter.index();
       auto m = iter.value();
       auto ptrEleTy = cudaq::cc::PointerType::get(eleTy);
       auto ptr = rewriter.create<cudaq::cc::ComputePtrOp>(

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -787,9 +787,11 @@ MlirModule synthesizeKernel(const std::string &name, MlirModule module,
   // Simulators have direct implementation of state initialization
   // in their runtime.
   if (!isSimulator) {
+    pm.addNestedPass<func::FuncOp>(cudaq::opt::createConstantPropagation());
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createConstPropComplex());
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createLiftArrayAlloc());
     pm.addPass(cudaq::opt::createGlobalizeArrayValues());
+    pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createStatePreparation());
   }
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
@@ -886,6 +888,7 @@ std::string getASM(const std::string &name, MlirModule module,
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createLiftArrayAlloc());
   pm.addPass(cudaq::opt::createGlobalizeArrayValues());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createStatePreparation());
   pm.addPass(cudaq::opt::createGetConcreteMatrix());
   pm.addPass(cudaq::opt::createUnitarySynthesis());

--- a/runtime/common/ArgumentConversion.cpp
+++ b/runtime/common/ArgumentConversion.cpp
@@ -92,12 +92,14 @@ static Value genConstant(OpBuilder &builder, const std::string &v,
 }
 
 // Forward declare aggregate type builder as they can be recursive.
-static Value genConstant(OpBuilder &, cudaq::cc::StdvecType, void *,
-                         ModuleOp substMod, llvm::DataLayout &);
-static Value genConstant(OpBuilder &, cudaq::cc::StructType, void *,
-                         ModuleOp substMod, llvm::DataLayout &);
-static Value genConstant(OpBuilder &, cudaq::cc::ArrayType, void *,
-                         ModuleOp substMod, llvm::DataLayout &);
+static Value genRecursiveSpan(OpBuilder &, cudaq::cc::StdvecType, void *,
+                              ModuleOp, llvm::DataLayout &);
+static Value genConstant(OpBuilder &, cudaq::cc::StdvecType, void *, ModuleOp,
+                         llvm::DataLayout &);
+static Value genConstant(OpBuilder &, cudaq::cc::StructType, void *, ModuleOp,
+                         llvm::DataLayout &);
+static Value genConstant(OpBuilder &, cudaq::cc::ArrayType, void *, ModuleOp,
+                         llvm::DataLayout &);
 
 /// Create callee.init_N that initializes the state
 ///
@@ -532,6 +534,13 @@ static Value genConstant(OpBuilder &builder, const cudaq::state *v,
   return {};
 }
 
+static bool isSupportedRecursiveSpan(cudaq::cc::StdvecType ty) {
+  Type eleTy = ty.getElementType();
+  while (auto ty = dyn_cast<cudaq::cc::SpanLikeType>(eleTy))
+    eleTy = ty.getElementType();
+  return isa<IntegerType, FloatType>(eleTy);
+}
+
 // Recursive step processing of aggregates.
 Value dispatchSubtype(OpBuilder &builder, Type ty, void *p, ModuleOp substMod,
                       llvm::DataLayout &layout) {
@@ -601,8 +610,107 @@ static std::size_t getHostSideElementSize(Type eleTy,
   return cudaq::opt::getDataSize(layout, eleTy);
 }
 
+/// Recursively builds an `ArrayAttr` containing the constants.
+ArrayAttr genRecursiveConstantArray(OpBuilder &builder,
+                                    cudaq::cc::StdvecType vecTy, void *p,
+                                    llvm::DataLayout &layout) {
+  typedef const char *VectorType[3];
+  VectorType *vecPtr = static_cast<VectorType *>(p);
+  auto delta = (*vecPtr)[1] - (*vecPtr)[0];
+  if (!delta)
+    return {};
+  auto eleTy = vecTy.getElementType();
+  unsigned stepBy = 0;
+  std::function<Attribute(char *)> genAttr;
+  if (auto innerTy = dyn_cast<cudaq::cc::StdvecType>(eleTy)) {
+    stepBy = sizeof(VectorType);
+    genAttr = [&](char *p) -> Attribute {
+      return genRecursiveConstantArray(builder, innerTy, p, layout);
+    };
+  } else if (auto stringTy = dyn_cast<cudaq::cc::CharspanType>(eleTy)) {
+    stepBy = sizeof(std::string);
+    genAttr = [=](char *p) -> Attribute {
+      std::string *s = reinterpret_cast<std::string *>(p);
+      return StringAttr::get(eleTy.getContext(), *s);
+    };
+  } else if (auto intTy = dyn_cast<IntegerType>(eleTy)) {
+    unsigned width = intTy.getWidth();
+    stepBy = (width + 7) / 8;
+    genAttr = [=](char *p) -> Attribute {
+      std::uint64_t val = 0;
+      switch (width) {
+      case 1:
+        val = *p != '\0';
+        break;
+      case 8:
+        val = *(reinterpret_cast<std::uint8_t *>(p));
+        break;
+      case 16:
+        val = *(reinterpret_cast<std::uint16_t *>(p));
+        break;
+      case 32:
+        val = *(reinterpret_cast<std::uint32_t *>(p));
+        break;
+      case 64:
+        val = *(reinterpret_cast<std::uint64_t *>(p));
+        break;
+      }
+      return IntegerAttr::get(intTy, val);
+    };
+  } else if (auto fltTy = dyn_cast<FloatType>(eleTy)) {
+    unsigned width = fltTy.getWidth();
+    stepBy = width / 8;
+    genAttr = [=](char *p) -> Attribute {
+      switch (width) {
+      case 32: {
+        float val = *(reinterpret_cast<float *>(p));
+        return FloatAttr::get(eleTy, APFloat{val});
+      }
+      case 64: {
+        double val = *(reinterpret_cast<double *>(p));
+        return FloatAttr::get(eleTy, APFloat{val});
+      }
+      default:
+        return FloatAttr::get(eleTy, APFloat{0.0});
+      }
+    };
+  } else {
+    return {};
+  }
+  SmallVector<Attribute> members;
+  for (char *item = const_cast<char *>((*vecPtr)[0]); item < (*vecPtr)[1];
+       item += stepBy)
+    members.push_back(genAttr(item));
+  return ArrayAttr::get(builder.getContext(), members);
+}
+
+static Type convertRecursiveSpanType(Type ty) {
+  if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(ty))
+    return cudaq::cc::ArrayType::get(
+        convertRecursiveSpanType(vecTy.getElementType()));
+  if (auto cspanTy = dyn_cast<cudaq::cc::CharspanType>(ty))
+    return cudaq::cc::ArrayType::get(IntegerType::get(ty.getContext(), 8));
+  return ty;
+}
+
+/// This generates a constant array to be used as an initializer for a
+/// `cc.reify_span` operation. This higher level semantics helps facilitate
+/// constant propagation through the recursive span structure. The reify
+/// operation will be lowered to more primitive ops on an as-needed basis.
+Value genRecursiveSpan(OpBuilder &builder, cudaq::cc::StdvecType ty, void *p,
+                       ModuleOp substMod, llvm::DataLayout &layout) {
+  ArrayAttr constants = genRecursiveConstantArray(builder, ty, p, layout);
+  auto loc = builder.getUnknownLoc();
+  auto arrTy = convertRecursiveSpanType(ty);
+  auto conArr =
+      builder.create<cudaq::cc::ConstantArrayOp>(loc, arrTy, constants);
+  return builder.create<cudaq::cc::ReifySpanOp>(loc, ty, conArr);
+}
+
 Value genConstant(OpBuilder &builder, cudaq::cc::StdvecType vecTy, void *p,
                   ModuleOp substMod, llvm::DataLayout &layout) {
+  if (isSupportedRecursiveSpan(vecTy))
+    return genRecursiveSpan(builder, vecTy, p, substMod, layout);
   typedef const char *VectorType[3];
   VectorType *vecPtr = static_cast<VectorType *>(p);
   auto delta = (*vecPtr)[1] - (*vecPtr)[0];

--- a/runtime/cudaq/platform/default/opt-test.yml
+++ b/runtime/cudaq/platform/default/opt-test.yml
@@ -22,19 +22,19 @@ configuration-matrix:
     config:
       nvqir-simulation-backend: cusvsim-fp32, custatevec-fp32
       preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP32"]
-      target-pass-pipeline: "func.func(unwind-lowering),canonicalize,lambda-lifting,func.func(memtoreg{quantum=0}),canonicalize,apply-op-specialization,kernel-execution,aggressive-early-inlining,func.func(quake-add-metadata,const-prop-complex,lift-array-alloc),globalize-array-values,get-concrete-matrix,device-code-loader{use-quake=1},canonicalize,cse,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce"
+      target-pass-pipeline: "func.func(unwind-lowering,canonicalize),lambda-lifting,func.func(memtoreg{quantum=0},canonicalize),apply-op-specialization,kernel-execution,aggressive-early-inlining,func.func(quake-add-metadata,constant-propagation,const-prop-complex,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix,device-code-loader{use-quake=1},func.func(canonicalize,cse,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce"
       library-mode: false
   - name: dep-analysis-fp64
     option-flags: [dep-analysis, fp64]
     config:
       nvqir-simulation-backend: cusvsim-fp64, custatevec-fp64
       preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]
-      target-pass-pipeline: "func.func(unwind-lowering),canonicalize,lambda-lifting,func.func(memtoreg{quantum=0}),canonicalize,apply-op-specialization,kernel-execution,aggressive-early-inlining,func.func(quake-add-metadata,const-prop-complex,lift-array-alloc),globalize-array-values,get-concrete-matrix,device-code-loader{use-quake=1},canonicalize,cse,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce"
+      target-pass-pipeline: "func.func(unwind-lowering,canonicalize),lambda-lifting,func.func(memtoreg{quantum=0},canonicalize),apply-op-specialization,kernel-execution,aggressive-early-inlining,func.func(quake-add-metadata,constant-propagation,const-prop-complex,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix,device-code-loader{use-quake=1},func.func(canonicalize,cse,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce"
       library-mode: false
   - name: dep-analysis-qpp
     option-flags: [dep-analysis, qpp]
     config:
       nvqir-simulation-backend: qpp
       preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]
-      target-pass-pipeline: "func.func(unwind-lowering),canonicalize,lambda-lifting,func.func(memtoreg{quantum=0}),canonicalize,apply-op-specialization,kernel-execution,aggressive-early-inlining,func.func(quake-add-metadata,const-prop-complex,lift-array-alloc),globalize-array-values,get-concrete-matrix,device-code-loader{use-quake=1},canonicalize,cse,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce"
+      target-pass-pipeline: "func.func(unwind-lowering,canonicalize),lambda-lifting,func.func(memtoreg{quantum=0},canonicalize),apply-op-specialization,kernel-execution,aggressive-early-inlining,func.func(quake-add-metadata,constant-propagation,const-prop-complex,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix,device-code-loader{use-quake=1},func.func(canonicalize,cse,add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),canonicalize,cse,add-wireset,func.func(assign-wire-indices),dep-analysis,func.func(regtomem),symbol-dce"
       library-mode: false

--- a/runtime/cudaq/platform/default/rest/helpers/anyon/anyon.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/anyon/anyon.yml
@@ -18,7 +18,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),anyon-%Q_GATE%-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),anyon-%Q_GATE%-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
   # Tell the rest-qpu that we are generating Adaptive QIR.
   codegen-emission: qir-adaptive
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the lowering pipeline
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,classical-optimization-pipeline,func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),decomposition{enable-patterns=SToR1,TToR1,R1ToU3,U3ToRotations,CHToCX,CCZToCX,CRzToCX,CRyToCX,CRxToCX,CR1ToCX,RxAdjToRx,RyAdjToRy,RzAdjToRz},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements),symbol-dce"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,classical-optimization-pipeline,func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),decomposition{enable-patterns=SToR1,TToR1,R1ToU3,U3ToRotations,CHToCX,CCZToCX,CRzToCX,CRyToCX,CRxToCX,CR1ToCX,RxAdjToRx,RyAdjToRy,RzAdjToRz},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements),symbol-dce"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/infleqtion/infleqtion.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/infleqtion/infleqtion.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the lowering pipeline
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,classical-optimization-pipeline,func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),decomposition{enable-patterns=SToR1,TToR1,CCZToCX,CRyToCX,CRxToCX,R1AdjToR1,RxAdjToRx,RyAdjToRy,RzAdjToRz},quake-to-cc-prep,func.func(memtoreg{quantum=0}),symbol-dce"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,classical-optimization-pipeline,func.func(lower-to-cfg),canonicalize,func.func(multicontrol-decomposition),decomposition{enable-patterns=SToR1,TToR1,CCZToCX,CRyToCX,CRxToCX,R1AdjToR1,RxAdjToRx,RyAdjToRy,RzAdjToRz},quake-to-cc-prep,func.func(memtoreg{quantum=0}),symbol-dce"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.yml
@@ -18,7 +18,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),ionq-gate-set-mapping"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),ionq-gate-set-mapping"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qir-base
   # Additional passes to run after lowering to QIR

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/iqm.yml
@@ -18,7 +18,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
   # Tell the rest-qpu that we are generating IQM JSON.
   codegen-emission: iqm
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
@@ -18,7 +18,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qir-base
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.yml
@@ -18,7 +18,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),quantinuum-gate-set-mapping"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),quantinuum-gate-set-mapping"
   # Tell the rest-qpu that we are generating Adaptive QIR.
   codegen-emission: qir-adaptive[int_computations]
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/fermioniq/fermioniq.yml
+++ b/runtime/cudaq/platform/fermioniq/fermioniq.yml
@@ -20,7 +20,7 @@ config:
   # Library mode is only for simulators, physical backends must turn this off
   library-mode: false
   # lowering config
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),fermioniq-gate-set-mapping"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),fermioniq-gate-set-mapping"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qir-base
 

--- a/runtime/test/test_argument_conversion.cpp
+++ b/runtime/test/test_argument_conversion.cpp
@@ -353,21 +353,8 @@ void test_vectors(mlir::MLIRContext *ctx) {
 // CHECK:       Substitution module:
 
 // CHECK-LABEL:   cc.arg_subst[0] {
-// CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.array<i32 x 4>
-// CHECK:           %[[VAL_1:.*]] = arith.constant 14581 : i32
-// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.array<i32 x 4>>) -> !cc.ptr<i32>
-// CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_3:.*]] = arith.constant 51966 : i32
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.array<i32 x 4>>) -> !cc.ptr<i32>
-// CHECK:           cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_5:.*]] = arith.constant 42 : i32
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_0]][2] : (!cc.ptr<!cc.array<i32 x 4>>) -> !cc.ptr<i32>
-// CHECK:           cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = arith.constant 48879 : i32
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_0]][3] : (!cc.ptr<!cc.array<i32 x 4>>) -> !cc.ptr<i32>
-// CHECK:           cc.store %[[VAL_7]], %[[VAL_8]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_9:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_10:.*]] = cc.stdvec_init %[[VAL_0]], %[[VAL_9]] : (!cc.ptr<!cc.array<i32 x 4>>, i64) -> !cc.stdvec<i32>
+// CHECK: %[[VAL_0:.*]] = cc.const_array [14581 : i32, 51966 : i32, 42 : i32, 48879 : i32] : !cc.array<i32 x ?>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<i32 x ?>) -> !cc.stdvec<i32>
 // CHECK:         }
   // clang-format on
 
@@ -379,21 +366,49 @@ void test_vectors(mlir::MLIRContext *ctx) {
   }
   // clang-format off
 // CHECK-LABEL:   cc.arg_subst[0] {
-// CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.array<!cc.charspan x 2>
-// CHECK:           %[[VAL_1:.*]] = cc.string_literal "XX" : !cc.ptr<!cc.array<i8 x 3>>
-// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i64
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_2]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.charspan
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
-// CHECK:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<!cc.charspan>
-// CHECK:           %[[VAL_6:.*]] = cc.string_literal "XY" : !cc.ptr<!cc.array<i8 x 3>>
-// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_8:.*]] = arith.constant 2 : i64
-// CHECK:           %[[VAL_9:.*]] = cc.stdvec_init %[[VAL_7]], %[[VAL_8]] : (!cc.ptr<i8>, i64) -> !cc.charspan
-// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
-// CHECK:           cc.store %[[VAL_9:.*]], %[[VAL_10:.*]] : !cc.ptr<!cc.charspan>
-// CHECK:           %[[VAL_11:.*]] = arith.constant 2 : i64
-// CHECK:           %[[VAL_12:.*]] = cc.stdvec_init %[[VAL_0]], %[[VAL_11]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>, i64) -> !cc.stdvec<!cc.charspan>
+// CHECK: %[[VAL_0:.*]] = cc.const_array ["XX", "XY"] : !cc.array<!cc.array<i8 x ?> x ?>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i8 x ?> x ?>) -> !cc.stdvec<!cc.charspan>
+ // CHECK:         }
+  // clang-format on
+
+  {
+    std::vector<std::vector<cudaq::pauli_word>> x = {
+        {cudaq::pauli_word{"XX"}, cudaq::pauli_word{"XY"}},
+        {cudaq::pauli_word{"ZI"}, cudaq::pauli_word{"YY"}},
+        {cudaq::pauli_word{"ZY"}, cudaq::pauli_word{"YX"}}};
+    std::vector<void *> v = {static_cast<void *>(&x)};
+    doSimpleTest(ctx, "!cc.stdvec<!cc.stdvec<!cc.charspan>>", v);
+  }
+  // clang-format off
+// CHECK-LABEL:   cc.arg_subst[0] {
+// CHECK: %[[VAL_0:.*]] = cc.const_array {{\[}}["XX", "XY"], ["ZI", "YY"], ["ZY", "YX"]] : !cc.array<!cc.array<!cc.array<i8 x ?> x ?> x ?>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<!cc.array<i8 x ?> x ?> x ?>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
+// CHECK:         }
+  // clang-format on
+
+  {
+    std::vector<std::vector<double>> x = {
+        {1.0, 2.0, 3.0}, {14.0, 15.0, 16.0}, {27.1, 28.2, 29.3}};
+    std::vector<void *> v = {static_cast<void *>(&x)};
+    doSimpleTest(ctx, "!cc.stdvec<!cc.stdvec<f64>>", v);
+  }
+  // clang-format off
+// CHECK-LABEL:   cc.arg_subst[0] {
+// CHECK: %[[VAL_0:.*]] = cc.const_array {{\[}}[1.000000e+00, 2.000000e+00, 3.000000e+00], [1.400000e+01, 1.500000e+01, 1.600000e+01], [2.710000e+01, 2.820000e+01, 2.930000e+01]] : !cc.array<!cc.array<f64 x ?> x ?>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<f64 x ?> x ?>) -> !cc.stdvec<!cc.stdvec<f64>>
+// CHECK:         }
+  // clang-format on
+
+  {
+    std::vector<std::vector<std::int64_t>> x = {
+        {1, 2, 3, 0}, {14, 15, 16, 13}, {127, 128, 129, 126}};
+    std::vector<void *> v = {static_cast<void *>(&x)};
+    doSimpleTest(ctx, "!cc.stdvec<!cc.stdvec<i64>>", v);
+  }
+  // clang-format off
+// CHECK-LABEL:   cc.arg_subst[0] {
+// CHECK: %[[VAL_0:.*]] = cc.const_array {{\[}}[1, 2, 3, 0], [14, 15, 16, 13], [127, 128, 129, 126]] : !cc.array<!cc.array<i64 x ?> x ?>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i64 x ?> x ?>) -> !cc.stdvec<!cc.stdvec<i64>>
 // CHECK:         }
   // clang-format on
 }
@@ -1045,21 +1060,8 @@ void test_combinations(mlir::MLIRContext *ctx) {
 // CHECK:       Substitution module:
 
 // CHECK-LABEL:   cc.arg_subst[0] {
-// CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.array<f32 x 4>
-// CHECK:           %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK:           %[[VAL_2:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
-// CHECK:           cc.store %[[VAL_1]], %[[VAL_2]] : !cc.ptr<f32>
-// CHECK:           %[[VAL_3:.*]] = arith.constant 1.750000e+00 : f32
-// CHECK:           %[[VAL_4:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
-// CHECK:           cc.store %[[VAL_3]], %[[VAL_4]] : !cc.ptr<f32>
-// CHECK:           %[[VAL_5:.*]] = arith.constant 4.17232506E-8 : f32
-// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_0]][2] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
-// CHECK:           cc.store %[[VAL_5]], %[[VAL_6]] : !cc.ptr<f32>
-// CHECK:           %[[VAL_7:.*]] = arith.constant 1.775000e+00 : f32
-// CHECK:           %[[VAL_8:.*]] = cc.compute_ptr %[[VAL_0]][3] : (!cc.ptr<!cc.array<f32 x 4>>) -> !cc.ptr<f32>
-// CHECK:           cc.store %[[VAL_7]], %[[VAL_8]] : !cc.ptr<f32>
-// CHECK:           %[[VAL_9:.*]] = arith.constant 4 : i64
-// CHECK:           %[[VAL_10:.*]] = cc.stdvec_init %[[VAL_0]], %[[VAL_9]] : (!cc.ptr<!cc.array<f32 x 4>>, i64) -> !cc.stdvec<f32>
+// CHECK: %[[VAL_0:.*]] = cc.const_array [0.000000e+00 : f32, 1.750000e+00 : f32, 4.17232506E-8 : f32, 1.775000e+00 : f32] : !cc.array<f32 x ?>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<f32 x ?>) -> !cc.stdvec<f32>
 // CHECK:         }
 // CHECK-LABEL:   cc.arg_subst[1] {
 // CHECK:           %[[VAL_0:.*]] = cc.address_of @[[VAL_GC:.*]] : !cc.ptr<!cc.array<complex<f64> x 8>>
@@ -1068,21 +1070,8 @@ void test_combinations(mlir::MLIRContext *ctx) {
 // CHECK:         }
 // CHECK-DAG:     cc.global constant private @[[VAL_GC]] (dense<[(0.70710678118654757,0.000000e+00), (0.70710678118654757,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<8xcomplex<f64>>) : !cc.array<complex<f64> x 8>
 // CHECK-LABEL:   cc.arg_subst[2] {
-// CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.array<!cc.charspan x 2>
-// CHECK:           %[[VAL_1:.*]] = cc.string_literal "XX" : !cc.ptr<!cc.array<i8 x 3>>
-// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i64
-// CHECK:           %[[VAL_4:.*]] = cc.stdvec_init %[[VAL_2]], %[[VAL_3]] : (!cc.ptr<i8>, i64) -> !cc.charspan
-// CHECK:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_0]][0] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
-// CHECK:           cc.store %[[VAL_4]], %[[VAL_5]] : !cc.ptr<!cc.charspan>
-// CHECK:           %[[VAL_6:.*]] = cc.string_literal "XY" : !cc.ptr<!cc.array<i8 x 3>>
-// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<i8 x 3>>) -> !cc.ptr<i8>
-// CHECK:           %[[VAL_8:.*]] = arith.constant 2 : i64
-// CHECK:           %[[VAL_9:.*]] = cc.stdvec_init %[[VAL_7]], %[[VAL_8]] : (!cc.ptr<i8>, i64) -> !cc.charspan
-// CHECK:           %[[VAL_10:.*]] = cc.compute_ptr %[[VAL_0]][1] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
-// CHECK:           cc.store %[[VAL_9]], %[[VAL_10]] : !cc.ptr<!cc.charspan>
-// CHECK:           %[[VAL_11:.*]] = arith.constant 2 : i64
-// CHECK:           %[[VAL_12:.*]] = cc.stdvec_init %[[VAL_0]], %[[VAL_11]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>, i64) -> !cc.stdvec<!cc.charspan>
+// CHECK: %[[VAL_0:.*]] = cc.const_array ["XX", "XY"] : !cc.array<!cc.array<i8 x ?> x ?>
+// CHECK: %[[VAL_1:.*]] = cc.reify_span %[[VAL_0]] : (!cc.array<!cc.array<i8 x ?> x ?>) -> !cc.stdvec<!cc.charspan>
 // CHECK:         }
   // clang-format on
 }

--- a/targettests/TargetConfig/RegressionValidation/anyon.config
+++ b/targettests/TargetConfig/RegressionValidation/anyon.config
@@ -20,7 +20,7 @@
 # Define the lowering pipeline. telegraph-8q has an 8-qubit ring topology, so mapping
 # uses ring(8).
 # Berkeley-25q uses a bidiratctional connectivity lattice with 8 connectivity per qubit in the bulk.
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),anyon-%Q_GATE%-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),anyon-%Q_GATE%-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
 
 
 # Tell the rest-qpu that we are generating QIR.

--- a/targettests/TargetConfig/RegressionValidation/ionq.config
+++ b/targettests/TargetConfig/RegressionValidation/ionq.config
@@ -18,7 +18,7 @@
 # CHECK-DAG: LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),ionq-gate-set-mapping"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),ionq-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 # CHECK-DAG: CODEGEN_EMISSION=qir-base

--- a/targettests/TargetConfig/RegressionValidation/iqm.config
+++ b/targettests/TargetConfig/RegressionValidation/iqm.config
@@ -20,7 +20,7 @@
 # Define the lowering pipeline, here we lower to Base QIR
 # Note: the runtime will dynamically substitute %QPU_ARCH% based on
 # qpu-architecture
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),iqm-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(delay-measurements,regtomem),symbol-dce,iqm-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating IQM JSON.
 # CHECK-DAG: CODEGEN_EMISSION=iqm

--- a/targettests/TargetConfig/RegressionValidation/oqc.config
+++ b/targettests/TargetConfig/RegressionValidation/oqc.config
@@ -20,7 +20,7 @@
 # Define the lowering pipeline. Lucy has an 8-qubit ring topology, so mapping
 # uses ring(8).
 # Toshiko uses a Kagome lattice with 2-3 connectivity per qubit
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce"
 
 
 # Tell the rest-qpu that we are generating QIR.

--- a/targettests/TargetConfig/RegressionValidation/quantinuum.config
+++ b/targettests/TargetConfig/RegressionValidation/quantinuum.config
@@ -18,7 +18,7 @@
 # CHECK-DAG: LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline, here we lower to Adaptive QIR
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),quantinuum-gate-set-mapping"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),quantinuum-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 # CHECK-DAG: CODEGEN_EMISSION=qir-adaptive

--- a/test/AST-Quake/custom_op_concrete_matrix.cpp
+++ b/test/AST-Quake/custom_op_concrete_matrix.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: cudaq-quake %cpp_std %s | cudaq-opt -const-prop-complex -lift-array-alloc -globalize-array-values -get-concrete-matrix | FileCheck %s
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt -constant-propagation -const-prop-complex -lift-array-alloc -globalize-array-values -canonicalize -get-concrete-matrix | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/test/Quake/lift_array.qke
+++ b/test/Quake/lift_array.qke
@@ -7,7 +7,7 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt -lift-array-alloc %s | FileCheck %s
-// RXN: cudaq-opt -lift-array-alloc -globalize-array-values %s | FileCheck --check-prefix=GLOBAL %s
+// RXN: cudaq-opt -lift-array-alloc -globalize-array-values -canonicalize %s | FileCheck --check-prefix=GLOBAL %s
 
 func.func @__nvqpp__mlirgen__function_test_complex_constant_array._Z27test_complex_constant_arrayv() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
   %cst = complex.constant [0.707106769 : f32, 0.000000e+00 : f32] : complex<f32>

--- a/test/Quake/reify_span-2.qke
+++ b/test/Quake/reify_span-2.qke
@@ -1,0 +1,55 @@
+// ========================================================================== //
+// Copyright (c) 2025 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt -globalize-array-values -canonicalize %s | FileCheck %s
+
+func.func private @pony_express(!cc.stdvec<!cc.stdvec<!cc.charspan>>)
+
+func.func @covered_wagon() {
+  %0 = cc.const_array [["XY", "ZI"], ["IZ", "YX"]] : !cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>
+  %1 = cc.reify_span %0 : (!cc.array<!cc.array<!cc.array<i8 x 3> x 2> x 2>) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
+  call @pony_express(%1) : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @covered_wagon() {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 3 : i64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 2 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = cc.string_literal "XY" : !cc.ptr<!cc.array<i8 x 3>>
+// CHECK:           %[[VAL_3:.*]] = cc.stdvec_init %[[VAL_2]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_4:.*]] = cc.string_literal "ZI" : !cc.ptr<!cc.array<i8 x 3>>
+// CHECK:           %[[VAL_5:.*]] = cc.stdvec_init %[[VAL_4]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_6:.*]] = cc.alloca !cc.array<!cc.charspan x 2>
+// CHECK:           %[[VAL_7:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
+// CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_6]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
+// CHECK:           cc.store %[[VAL_3]], %[[VAL_8]] : !cc.ptr<!cc.charspan>
+// CHECK:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_6]][1] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
+// CHECK:           cc.store %[[VAL_5]], %[[VAL_9]] : !cc.ptr<!cc.charspan>
+// CHECK:           %[[VAL_10:.*]] = cc.stdvec_init %[[VAL_7]], %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.charspan x ?>>, i64) -> !cc.stdvec<!cc.charspan>
+// CHECK:           %[[VAL_11:.*]] = cc.string_literal "IZ" : !cc.ptr<!cc.array<i8 x 3>>
+// CHECK:           %[[VAL_12:.*]] = cc.stdvec_init %[[VAL_11]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_13:.*]] = cc.string_literal "YX" : !cc.ptr<!cc.array<i8 x 3>>
+// CHECK:           %[[VAL_14:.*]] = cc.stdvec_init %[[VAL_13]], %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 3>>, i64) -> !cc.charspan
+// CHECK:           %[[VAL_15:.*]] = cc.alloca !cc.array<!cc.charspan x 2>
+// CHECK:           %[[VAL_16:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.array<!cc.charspan x ?>>
+// CHECK:           %[[VAL_17:.*]] = cc.cast %[[VAL_15]] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
+// CHECK:           cc.store %[[VAL_12]], %[[VAL_17]] : !cc.ptr<!cc.charspan>
+// CHECK:           %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_15]][1] : (!cc.ptr<!cc.array<!cc.charspan x 2>>) -> !cc.ptr<!cc.charspan>
+// CHECK:           cc.store %[[VAL_14]], %[[VAL_18]] : !cc.ptr<!cc.charspan>
+// CHECK:           %[[VAL_19:.*]] = cc.stdvec_init %[[VAL_16]], %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.charspan x ?>>, i64) -> !cc.stdvec<!cc.charspan>
+// CHECK:           %[[VAL_20:.*]] = cc.alloca !cc.array<!cc.stdvec<!cc.charspan> x 2>
+// CHECK:           %[[VAL_21:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x 2>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>
+// CHECK:           %[[VAL_22:.*]] = cc.cast %[[VAL_20]] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x 2>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
+// CHECK:           cc.store %[[VAL_10]], %[[VAL_22]] : !cc.ptr<!cc.stdvec<!cc.charspan>>
+// CHECK:           %[[VAL_23:.*]] = cc.compute_ptr %[[VAL_20]][1] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x 2>>) -> !cc.ptr<!cc.stdvec<!cc.charspan>>
+// CHECK:           cc.store %[[VAL_19]], %[[VAL_23]] : !cc.ptr<!cc.stdvec<!cc.charspan>>
+// CHECK:           %[[VAL_24:.*]] = cc.stdvec_init %[[VAL_21]], %[[VAL_1]] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.charspan> x ?>>, i64) -> !cc.stdvec<!cc.stdvec<!cc.charspan>>
+// CHECK:           call @pony_express(%[[VAL_24]]) : (!cc.stdvec<!cc.stdvec<!cc.charspan>>) -> ()
+// CHECK:           return
+// CHECK:         }
+

--- a/test/Translate/openqasm2_vector.cpp
+++ b/test/Translate/openqasm2_vector.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: cudaq-quake  %s | cudaq-opt -canonicalize -cse -lift-array-alloc -globalize-array-values -state-prep | cudaq-translate --convert-to=openqasm2 | FileCheck %s
+// RUN: cudaq-quake  %s | cudaq-opt -canonicalize -cse -lift-array-alloc -globalize-array-values -canonicalize -state-prep | cudaq-translate --convert-to=openqasm2 | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -722,7 +722,7 @@ if ${ENABLE_AGGRESSIVE_EARLY_INLINE}; then
 fi
 if ${ENABLE_DEVICE_CODE_LOADERS}; then
 	RUN_OPT=true
-	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(quake-add-metadata,const-prop-complex,lift-array-alloc),globalize-array-values,get-concrete-matrix,device-code-loader")
+	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(quake-add-metadata,constant-propagation,const-prop-complex,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix,device-code-loader")
 fi
 if ${ENABLE_LOWER_TO_CFG}; then
 	RUN_OPT=true


### PR DESCRIPTION
For codegen, the pass must expand the `reify_span` macro operation into a collection of smaller step primitives and thereby eliminate the `reify_span` and (most likely) the constant array value as well. This adds a new test for the new production in the globalize-array-values pass.

Add argument conversion to use reify span.  Add tests for vector of vector.  Add constant-propagation pass to the pipelines. Fix tests and pipelines.

Requires #2953 be merged first.