### PR TITLE
Support conversion from operators to multi-diagonal matrix representation 

### DIFF
--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -24,7 +24,7 @@ Operators
     - ``std::vector<std::size_t>``: Indices.
     - ``std::vector<std::size_t>``: Sizes.
 
-.. cpp:type:: dia_spmatrix = std::pair<std::vector<std::complex<double>>, std::vector<std::int64_t>>
+.. cpp:type:: mdiag_sparse_matrix = std::pair<std::vector<std::complex<double>>, std::vector<std::int64_t>>
 
     Alias for a pair, in the multi-diagonal representation, containing vectors for complex values and diagonal offsets.  
 

--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -24,6 +24,10 @@ Operators
     - ``std::vector<std::size_t>``: Indices.
     - ``std::vector<std::size_t>``: Sizes.
 
+.. cpp:type:: dia_spmatrix = std::pair<std::vector<std::complex<double>>, std::vector<std::int64_t>>
+
+    Alias for a pair, in the multi-diagonal representation, containing vectors for complex values and diagonal offsets.  
+
 .. doxygenclass:: cudaq::operator_handler
 
 .. doxygenclass:: cudaq::spin_handler

--- a/runtime/cudaq/boson_op.h
+++ b/runtime/cudaq/boson_op.h
@@ -71,7 +71,7 @@ private:
   /// @brief Computes the multi-diagonal matrix representation of the string
   /// encoding of a bosonic product operator. Private method since this encoding
   /// is not very user friendly.
-  static dia_spmatrix
+  static mdiag_sparse_matrix
   to_diagonal_matrix(const std::string &fermi_word,
                      const std::vector<std::int64_t> &dimensions = {},
                      std::complex<double> coeff = 1.,

--- a/runtime/cudaq/boson_op.h
+++ b/runtime/cudaq/boson_op.h
@@ -68,6 +68,14 @@ private:
                                   const std::vector<std::int64_t> &dimensions,
                                   std::complex<double> coeff = 1.,
                                   bool invert_order = false);
+  /// @brief Computes the multi-diagonal matrix representation of the string
+  /// encoding of a bosonic product operator. Private method since this encoding
+  /// is not very user friendly.
+  static dia_spmatrix
+  to_diagonal_matrix(const std::string &fermi_word,
+                     const std::vector<std::int64_t> &dimensions = {},
+                     std::complex<double> coeff = 1.,
+                     bool invert_order = false);
 
 public:
   // read-only properties

--- a/runtime/cudaq/fermion_op.h
+++ b/runtime/cudaq/fermion_op.h
@@ -87,7 +87,7 @@ private:
   /// @brief Computes the multi-diagonal matrix representation of the string
   /// encoding of a fermionic product operator. Private method since this
   /// encoding is not very user friendly.
-  static dia_spmatrix
+  static mdiag_sparse_matrix
   to_diagonal_matrix(const std::string &fermi_word,
                      const std::vector<std::int64_t> &dimensions = {},
                      std::complex<double> coeff = 1.,

--- a/runtime/cudaq/fermion_op.h
+++ b/runtime/cudaq/fermion_op.h
@@ -84,6 +84,15 @@ private:
             const std::vector<std::int64_t> &dimensions = {},
             std::complex<double> coeff = 1., bool invert_order = false);
 
+  /// @brief Computes the multi-diagonal matrix representation of the string
+  /// encoding of a fermionic product operator. Private method since this
+  /// encoding is not very user friendly.
+  static dia_spmatrix
+  to_diagonal_matrix(const std::string &fermi_word,
+                     const std::vector<std::int64_t> &dimensions = {},
+                     std::complex<double> coeff = 1.,
+                     bool invert_order = false);
+
 public:
   static constexpr commutation_relations commutation_group =
       operator_handler::fermion_commutation_relations;

--- a/runtime/cudaq/operators.h
+++ b/runtime/cudaq/operators.h
@@ -820,6 +820,24 @@ public:
           {},
       bool invert_order = false) const;
 
+  /// @brief Return the multi-diagonal matrix representation of the operator.
+  /// By default, the matrix is ordered according to the convention (endianness)
+  /// used in CUDA-Q, and the ordering returned by `degrees`. See
+  /// the documentation for `degrees` for more detail.
+  /// @arg `dimensions` : A mapping that specifies the number of levels,
+  ///                      that is, the dimension of each degree of freedom
+  ///                      that the operator acts on. Example for two, 2-level
+  ///                      degrees of freedom: `{0:2, 1:2}`.
+  /// @arg `parameters` : A map of the parameter names to their concrete,
+  /// complex values.
+  /// @arg `invert_order`: if set to true, the ordering convention is reversed.
+  PROPERTY_SPECIFIC_TEMPLATE(product_op<T>::supports_inplace_mult)
+  dia_spmatrix to_diagonal_matrix(
+      std::unordered_map<std::size_t, std::int64_t> dimensions = {},
+      const std::unordered_map<std::string, std::complex<double>> &parameters =
+          {},
+      bool invert_order = false) const;
+
   HANDLER_SPECIFIC_TEMPLATE(spin_handler)
   std::vector<double> get_data_representation() const;
 
@@ -1652,6 +1670,24 @@ public:
   /// @arg `invert_order`: if set to true, the ordering convention is reversed.
   PROPERTY_SPECIFIC_TEMPLATE(product_op<T>::supports_inplace_mult)
   csr_spmatrix to_sparse_matrix(
+      std::unordered_map<std::size_t, std::int64_t> dimensions = {},
+      const std::unordered_map<std::string, std::complex<double>> &parameters =
+          {},
+      bool invert_order = false) const;
+
+  /// @brief Return the multi-diagonal matrix representation of the operator.
+  /// By default, the matrix is ordered according to the convention (endianness)
+  /// used in CUDA-Q, and the ordering returned by `degrees`. See
+  /// the documentation for `degrees` for more detail.
+  /// @arg `dimensions` : A mapping that specifies the number of levels,
+  ///                      that is, the dimension of each degree of freedom
+  ///                      that the operator acts on. Example for two, 2-level
+  ///                      degrees of freedom: `{0:2, 1:2}`.
+  /// @arg `parameters` : A map of the parameter names to their concrete,
+  /// complex values.
+  /// @arg `invert_order`: if set to true, the ordering convention is reversed.
+  PROPERTY_SPECIFIC_TEMPLATE(product_op<T>::supports_inplace_mult)
+  dia_spmatrix to_diagonal_matrix(
       std::unordered_map<std::size_t, std::int64_t> dimensions = {},
       const std::unordered_map<std::string, std::complex<double>> &parameters =
           {},

--- a/runtime/cudaq/operators.h
+++ b/runtime/cudaq/operators.h
@@ -832,7 +832,7 @@ public:
   /// complex values.
   /// @arg `invert_order`: if set to true, the ordering convention is reversed.
   PROPERTY_SPECIFIC_TEMPLATE(product_op<T>::supports_inplace_mult)
-  dia_spmatrix to_diagonal_matrix(
+  mdiag_sparse_matrix to_diagonal_matrix(
       std::unordered_map<std::size_t, std::int64_t> dimensions = {},
       const std::unordered_map<std::string, std::complex<double>> &parameters =
           {},
@@ -1687,7 +1687,7 @@ public:
   /// complex values.
   /// @arg `invert_order`: if set to true, the ordering convention is reversed.
   PROPERTY_SPECIFIC_TEMPLATE(product_op<T>::supports_inplace_mult)
-  dia_spmatrix to_diagonal_matrix(
+  mdiag_sparse_matrix to_diagonal_matrix(
       std::unordered_map<std::size_t, std::int64_t> dimensions = {},
       const std::unordered_map<std::string, std::complex<double>> &parameters =
           {},

--- a/runtime/cudaq/operators/boson_op.cpp
+++ b/runtime/cudaq/operators/boson_op.cpp
@@ -286,6 +286,21 @@ complex_matrix boson_handler::to_matrix(
   return boson_handler::to_matrix(boson_word, relevant_dims);
 }
 
+dia_spmatrix boson_handler::to_diagonal_matrix(
+    const std::string &boson_word, const std::vector<std::int64_t> &dimensions,
+    std::complex<double> coeff, bool invert_order) {
+  std::int64_t dim = 1;
+  for (auto d : dimensions)
+    dim *= d;
+  return cudaq::detail::create_dia_matrix(
+      dim, coeff,
+      [&boson_word, &dimensions, invert_order](
+          const std::function<void(std::size_t, std::size_t,
+                                   std::complex<double>)> &process_entry) {
+        create_matrix(boson_word, dimensions, process_entry, invert_order);
+      });
+}
+
 std::string boson_handler::to_string(bool include_degrees) const {
   if (include_degrees)
     return this->unique_id(); // unique id for consistency with keys in some

--- a/runtime/cudaq/operators/boson_op.cpp
+++ b/runtime/cudaq/operators/boson_op.cpp
@@ -286,13 +286,13 @@ complex_matrix boson_handler::to_matrix(
   return boson_handler::to_matrix(boson_word, relevant_dims);
 }
 
-dia_spmatrix boson_handler::to_diagonal_matrix(
+mdiag_sparse_matrix boson_handler::to_diagonal_matrix(
     const std::string &boson_word, const std::vector<std::int64_t> &dimensions,
     std::complex<double> coeff, bool invert_order) {
   std::int64_t dim = 1;
   for (auto d : dimensions)
     dim *= d;
-  return cudaq::detail::create_dia_matrix(
+  return cudaq::detail::create_mdiag_sparse_matrix(
       dim, coeff,
       [&boson_word, &dimensions, invert_order](
           const std::function<void(std::size_t, std::size_t,

--- a/runtime/cudaq/operators/fermion_op.cpp
+++ b/runtime/cudaq/operators/fermion_op.cpp
@@ -245,6 +245,19 @@ complex_matrix fermion_handler::to_matrix(
       this->canonical_form(dimensions, relevant_dims));
 }
 
+dia_spmatrix fermion_handler::to_diagonal_matrix(
+    const std::string &fermi_word, const std::vector<std::int64_t> &dimensions,
+    std::complex<double> coeff, bool invert_order) {
+  auto dim = 1 << fermi_word.size();
+  return cudaq::detail::create_dia_matrix(
+      dim, coeff,
+      [&fermi_word, invert_order](
+          const std::function<void(std::size_t, std::size_t,
+                                   std::complex<double>)> &process_entry) {
+        create_matrix(fermi_word, process_entry, invert_order);
+      });
+}
+
 std::string fermion_handler::to_string(bool include_degrees) const {
   if (include_degrees)
     return this->unique_id(); // unique id for consistency with keys in some

--- a/runtime/cudaq/operators/fermion_op.cpp
+++ b/runtime/cudaq/operators/fermion_op.cpp
@@ -245,11 +245,11 @@ complex_matrix fermion_handler::to_matrix(
       this->canonical_form(dimensions, relevant_dims));
 }
 
-dia_spmatrix fermion_handler::to_diagonal_matrix(
+mdiag_sparse_matrix fermion_handler::to_diagonal_matrix(
     const std::string &fermi_word, const std::vector<std::int64_t> &dimensions,
     std::complex<double> coeff, bool invert_order) {
   auto dim = 1 << fermi_word.size();
-  return cudaq::detail::create_dia_matrix(
+  return cudaq::detail::create_mdiag_sparse_matrix(
       dim, coeff,
       [&fermi_word, invert_order](
           const std::function<void(std::size_t, std::size_t,

--- a/runtime/cudaq/operators/helpers.cpp
+++ b/runtime/cudaq/operators/helpers.cpp
@@ -222,7 +222,7 @@ cudaq::csr_spmatrix to_csr_spmatrix(const EigenSparseMatrix &matrix,
   return std::make_tuple(values, rows, cols);
 }
 
-dia_spmatrix create_dia_matrix(
+mdiag_sparse_matrix create_mdiag_sparse_matrix(
     std::size_t dim, std::complex<double> coeff,
     const std::function<void(const std::function<void(std::size_t, std::size_t,
                                                       std::complex<double>)> &)>
@@ -256,7 +256,8 @@ dia_spmatrix create_dia_matrix(
   return std::make_pair(std::move(diaData), std::move(offset));
 }
 
-void inplace_accumulate(dia_spmatrix &accumulated, const dia_spmatrix &matrix) {
+void inplace_accumulate(mdiag_sparse_matrix &accumulated,
+                        const mdiag_sparse_matrix &matrix) {
   auto &[acc_buffer, acc_offsets] = accumulated;
   const auto &[add_buffer, add_offsets] = matrix;
   if (add_offsets.empty())

--- a/runtime/cudaq/operators/helpers.h
+++ b/runtime/cudaq/operators/helpers.h
@@ -44,7 +44,7 @@ using csr_spmatrix =
 // elements), we use a fixed-size 2-D vector (flattened into a 1-D vector with
 // constant stride) so that it can be used directly with cudensitymat.
 // Note: the list of offsets must be unique.
-using dia_spmatrix =
+using mdiag_sparse_matrix =
     std::pair<std::vector<std::complex<double>>, std::vector<std::int64_t>>;
 
 namespace detail {
@@ -109,14 +109,15 @@ csr_spmatrix to_csr_spmatrix(const EigenSparseMatrix &matrix,
 /// Helper function for multi-diagonal matrix creation.
 /// The matrix creation function should call its function argument for
 /// every entry in the matrix.
-dia_spmatrix create_dia_matrix(
+mdiag_sparse_matrix create_mdiag_sparse_matrix(
     std::size_t dim, std::complex<double> coeff,
     const std::function<void(const std::function<void(std::size_t, std::size_t,
                                                       std::complex<double>)> &)>
         &create);
 
 /// Add (in-place) a multi-diagonal matrix to another one
-void inplace_accumulate(dia_spmatrix &accumulated, const dia_spmatrix &matrix);
+void inplace_accumulate(mdiag_sparse_matrix &accumulated,
+                        const mdiag_sparse_matrix &matrix);
 
 } // namespace detail
 } // namespace cudaq

--- a/runtime/cudaq/operators/helpers.h
+++ b/runtime/cudaq/operators/helpers.h
@@ -26,6 +26,27 @@ using csr_spmatrix =
     std::tuple<std::vector<std::complex<double>>, std::vector<std::size_t>,
                std::vector<std::size_t>>;
 
+// Multi-diagonal sparse format:
+// - Data buffer for diagonal elements (type std::vector<std::complex<double>>),
+// of size `dimension * num_diagonals`
+// - offsets: The diagonal offsets (std::vector<std::int64_t>) of length
+// `num_diagonals`. Note: if the number of elements is less than `dimension`,
+// e.g., for offset value != 0, the array should be padded with zero to make
+// sure access to buffer in constant stride.
+// For example,
+// buffer = {1, sqrt(2), 0}, offset = {-1} represents a sparse matrix with a
+// single lower diagonal line (just below the matrix diagonal), hence the offset
+// {-1}. The last element 0 in the array is irrelevant, just for padding
+// purposes.
+// This is equivalent to scipy's DIA format
+// (https://scipy-lectures.org/advanced/scipy_sparse/dia_matrix.html)
+// Instead of a nested vector with variable length (number of diagonal
+// elements), we use a fixed-size 2-D vector (flattened into a 1-D vector with
+// constant stride) so that it can be used directly with cudensitymat.
+// Note: the list of offsets must be unique.
+using dia_spmatrix =
+    std::pair<std::vector<std::complex<double>>, std::vector<std::int64_t>>;
+
 namespace detail {
 struct states_hash {
   int operator()(const std::vector<std::int64_t> &vect) const;
@@ -84,6 +105,18 @@ EigenSparseMatrix create_sparse_matrix(
 /// CUDA-Q.
 csr_spmatrix to_csr_spmatrix(const EigenSparseMatrix &matrix,
                              std::size_t estimated_num_entries);
+
+/// Helper function for multi-diagonal matrix creation.
+/// The matrix creation function should call its function argument for
+/// every entry in the matrix.
+dia_spmatrix create_dia_matrix(
+    std::size_t dim, std::complex<double> coeff,
+    const std::function<void(const std::function<void(std::size_t, std::size_t,
+                                                      std::complex<double>)> &)>
+        &create);
+
+/// Add (in-place) a multi-diagonal matrix to another one
+void inplace_accumulate(dia_spmatrix &accumulated, const dia_spmatrix &matrix);
 
 } // namespace detail
 } // namespace cudaq

--- a/runtime/cudaq/operators/product_op.cpp
+++ b/runtime/cudaq/operators/product_op.cpp
@@ -1499,7 +1499,7 @@ csr_spmatrix product_op<HandlerTy>::to_sparse_matrix(
 template <typename HandlerTy>
 PROPERTY_SPECIFIC_TEMPLATE_DEFINITION(HandlerTy,
                                       product_op<T>::supports_inplace_mult)
-dia_spmatrix product_op<HandlerTy>::to_diagonal_matrix(
+mdiag_sparse_matrix product_op<HandlerTy>::to_diagonal_matrix(
     std::unordered_map<std::size_t, std::int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const {
@@ -1532,15 +1532,15 @@ template csr_spmatrix product_op<boson_handler>::to_sparse_matrix(
     std::unordered_map<std::size_t, int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;
-template dia_spmatrix product_op<spin_handler>::to_diagonal_matrix(
+template mdiag_sparse_matrix product_op<spin_handler>::to_diagonal_matrix(
     std::unordered_map<std::size_t, std::int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;
-template dia_spmatrix product_op<fermion_handler>::to_diagonal_matrix(
+template mdiag_sparse_matrix product_op<fermion_handler>::to_diagonal_matrix(
     std::unordered_map<std::size_t, int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;
-template dia_spmatrix product_op<boson_handler>::to_diagonal_matrix(
+template mdiag_sparse_matrix product_op<boson_handler>::to_diagonal_matrix(
     std::unordered_map<std::size_t, int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;

--- a/runtime/cudaq/operators/product_op.cpp
+++ b/runtime/cudaq/operators/product_op.cpp
@@ -1496,6 +1496,25 @@ csr_spmatrix product_op<HandlerTy>::to_sparse_matrix(
       matrix, 1ul << terms[0].relevant_dimensions.size());
 }
 
+template <typename HandlerTy>
+PROPERTY_SPECIFIC_TEMPLATE_DEFINITION(HandlerTy,
+                                      product_op<T>::supports_inplace_mult)
+dia_spmatrix product_op<HandlerTy>::to_diagonal_matrix(
+    std::unordered_map<std::size_t, std::int64_t> dimensions,
+    const std::unordered_map<std::string, std::complex<double>> &parameters,
+    bool invert_order) const {
+  auto terms = std::move(
+      this->transform(
+              operator_arithmetics<operator_handler::canonical_evaluation>(
+                  dimensions, parameters))
+          .terms);
+  assert(terms.size() == 1);
+  auto matrix = HandlerTy::to_diagonal_matrix(
+      terms[0].encoding, terms[0].relevant_dimensions, terms[0].coefficient,
+      invert_order);
+  return matrix;
+}
+
 template std::size_t product_op<spin_handler>::num_qubits() const;
 template std::string
 product_op<spin_handler>::get_pauli_word(std::size_t pad_identities) const;
@@ -1510,6 +1529,18 @@ template csr_spmatrix product_op<fermion_handler>::to_sparse_matrix(
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;
 template csr_spmatrix product_op<boson_handler>::to_sparse_matrix(
+    std::unordered_map<std::size_t, int64_t> dimensions,
+    const std::unordered_map<std::string, std::complex<double>> &parameters,
+    bool invert_order) const;
+template dia_spmatrix product_op<spin_handler>::to_diagonal_matrix(
+    std::unordered_map<std::size_t, std::int64_t> dimensions,
+    const std::unordered_map<std::string, std::complex<double>> &parameters,
+    bool invert_order) const;
+template dia_spmatrix product_op<fermion_handler>::to_diagonal_matrix(
+    std::unordered_map<std::size_t, int64_t> dimensions,
+    const std::unordered_map<std::string, std::complex<double>> &parameters,
+    bool invert_order) const;
+template dia_spmatrix product_op<boson_handler>::to_diagonal_matrix(
     std::unordered_map<std::size_t, int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;

--- a/runtime/cudaq/operators/spin_op.cpp
+++ b/runtime/cudaq/operators/spin_op.cpp
@@ -202,6 +202,19 @@ complex_matrix spin_handler::to_matrix(
   return spin_handler::to_matrix(this->canonical_form(dimensions, rel_dims));
 }
 
+dia_spmatrix spin_handler::to_diagonal_matrix(
+    const std::string &pauli_word, const std::vector<std::int64_t> &dimensions,
+    std::complex<double> coeff, bool invert_order) {
+  auto dim = 1ul << pauli_word.size();
+  return cudaq::detail::create_dia_matrix(
+      dim, coeff,
+      [&pauli_word, invert_order](
+          const std::function<void(std::size_t, std::size_t,
+                                   std::complex<double>)> &process_entry) {
+        create_matrix(pauli_word, process_entry, invert_order);
+      });
+}
+
 std::string spin_handler::to_string(bool include_degrees) const {
   if (include_degrees)
     return this->unique_id(); // unique id for consistency with keys in some

--- a/runtime/cudaq/operators/spin_op.cpp
+++ b/runtime/cudaq/operators/spin_op.cpp
@@ -202,11 +202,11 @@ complex_matrix spin_handler::to_matrix(
   return spin_handler::to_matrix(this->canonical_form(dimensions, rel_dims));
 }
 
-dia_spmatrix spin_handler::to_diagonal_matrix(
+mdiag_sparse_matrix spin_handler::to_diagonal_matrix(
     const std::string &pauli_word, const std::vector<std::int64_t> &dimensions,
     std::complex<double> coeff, bool invert_order) {
   auto dim = 1ul << pauli_word.size();
-  return cudaq::detail::create_dia_matrix(
+  return cudaq::detail::create_mdiag_sparse_matrix(
       dim, coeff,
       [&pauli_word, invert_order](
           const std::function<void(std::size_t, std::size_t,

--- a/runtime/cudaq/operators/sum_op.cpp
+++ b/runtime/cudaq/operators/sum_op.cpp
@@ -1859,7 +1859,7 @@ csr_spmatrix sum_op<HandlerTy>::to_sparse_matrix(
 template <typename HandlerTy>
 PROPERTY_SPECIFIC_TEMPLATE_DEFINITION(HandlerTy,
                                       product_op<T>::supports_inplace_mult)
-dia_spmatrix sum_op<HandlerTy>::to_diagonal_matrix(
+mdiag_sparse_matrix sum_op<HandlerTy>::to_diagonal_matrix(
     std::unordered_map<std::size_t, std::int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const {
@@ -1868,7 +1868,7 @@ dia_spmatrix sum_op<HandlerTy>::to_diagonal_matrix(
                                                                    parameters));
 
   if (evaluated.terms.size() == 0)
-    return dia_spmatrix();
+    return mdiag_sparse_matrix();
 
   auto dia_matrix = HandlerTy::to_diagonal_matrix(
       evaluated.terms[0].encoding, evaluated.terms[0].relevant_dimensions,
@@ -1931,15 +1931,15 @@ template csr_spmatrix sum_op<boson_handler>::to_sparse_matrix(
     std::unordered_map<std::size_t, int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;
-template dia_spmatrix sum_op<spin_handler>::to_diagonal_matrix(
+template mdiag_sparse_matrix sum_op<spin_handler>::to_diagonal_matrix(
     std::unordered_map<std::size_t, std::int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;
-template dia_spmatrix sum_op<fermion_handler>::to_diagonal_matrix(
+template mdiag_sparse_matrix sum_op<fermion_handler>::to_diagonal_matrix(
     std::unordered_map<std::size_t, int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;
-template dia_spmatrix sum_op<boson_handler>::to_diagonal_matrix(
+template mdiag_sparse_matrix sum_op<boson_handler>::to_diagonal_matrix(
     std::unordered_map<std::size_t, int64_t> dimensions,
     const std::unordered_map<std::string, std::complex<double>> &parameters,
     bool invert_order) const;

--- a/runtime/cudaq/spin_op.h
+++ b/runtime/cudaq/spin_op.h
@@ -65,6 +65,13 @@ private:
                                   std::complex<double> coeff = 1.,
                                   bool invert_order = false);
 
+  // helper function for multi-diagonal matrix creations
+  static dia_spmatrix
+  to_diagonal_matrix(const std::string &fermi_word,
+                     const std::vector<std::int64_t> &dimensions = {},
+                     std::complex<double> coeff = 1.,
+                     bool invert_order = false);
+
 public:
   // read-only properties
 

--- a/runtime/cudaq/spin_op.h
+++ b/runtime/cudaq/spin_op.h
@@ -66,7 +66,7 @@ private:
                                   bool invert_order = false);
 
   // helper function for multi-diagonal matrix creations
-  static dia_spmatrix
+  static mdiag_sparse_matrix
   to_diagonal_matrix(const std::string &fermi_word,
                      const std::vector<std::int64_t> &dimensions = {},
                      std::complex<double> coeff = 1.,

--- a/runtime/cudaq/utils/matrix.cpp
+++ b/runtime/cudaq/utils/matrix.cpp
@@ -358,3 +358,12 @@ cudaq::complex_matrix cudaq::complex_matrix::adjoint() {
 
   return result;
 }
+
+std::vector<cudaq::complex_matrix::value_type>
+cudaq::complex_matrix::diagonal_elements(int index) const {
+  Eigen::Map<cudaq::complex_matrix::EigenMatrix> map(data, rows(), cols());
+  auto diag = map.diagonal(index);
+  std::vector<cudaq::complex_matrix::value_type> result(diag.begin(),
+                                                        diag.end());
+  return result;
+}

--- a/runtime/cudaq/utils/matrix.h
+++ b/runtime/cudaq/utils/matrix.h
@@ -159,6 +159,10 @@ public:
   /// Returns the conjugate transpose of a matrix.
   complex_matrix adjoint();
 
+  /// Returns diagonal elements
+  // Index can be used to get super/sub diagonal elements
+  std::vector<value_type> diagonal_elements(int index = 0) const;
+
   /// Return a square identity matrix for the given size.
   static complex_matrix identity(const std::size_t rows);
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -262,6 +262,7 @@ endif()
 # Create an executable for SpinOp UnitTests
 set(CUDAQ_SPIN_TEST_SOURCES 
    spin_op/SpinOpTester.cpp
+   operators/utils.cpp
 )
 add_executable(test_spin main.cpp ${CUDAQ_SPIN_TEST_SOURCES})
 target_link_libraries(test_spin
@@ -269,6 +270,7 @@ target_link_libraries(test_spin
   cudaq
   cudaq-operator
   gtest_main)
+target_include_directories(test_spin PRIVATE operators)
 gtest_discover_tests(test_spin)
 
 # Create an executable for operators UnitTests

--- a/unittests/operators/boson_op.cpp
+++ b/unittests/operators/boson_op.cpp
@@ -889,3 +889,71 @@ TEST(OperatorExpressions, checkCommutationRelations) {
   utils::checkEqual(rel11.to_matrix(dimensions), utils::zero_matrix(16));
   utils::checkEqual(rel12.to_matrix(dimensions), utils::zero_matrix(16));
 }
+
+TEST(OperatorExpressions, checkMultiDiagConversionBoson) {
+  cudaq::dimension_map dimensions = {{0, 10}, {1, 10}};
+  // Same degree of freedom
+  for (auto &H1 : {cudaq::boson_op::annihilate(0), cudaq::boson_op::create(0),
+                   cudaq::boson_op::number(0)}) {
+    for (auto &H2 : {cudaq::boson_op::annihilate(0), cudaq::boson_op::create(0),
+                     cudaq::boson_op::number(0)}) {
+      for (auto &H3 :
+           {cudaq::boson_op::annihilate(0), cudaq::boson_op::create(0),
+            cudaq::boson_op::number(0)}) {
+        for (auto &H4 :
+             {cudaq::boson_op::annihilate(0), cudaq::boson_op::create(0),
+              cudaq::boson_op::number(0)}) {
+          std::cout << H1.to_string() << " " << H2.to_string() << " "
+                    << H3.to_string() << " " << H4.to_string() << "\n";
+          auto H = H1 * H2 * H3 * H4;
+          utils::checkEqual(H.to_matrix(dimensions),
+                            H.to_diagonal_matrix(dimensions));
+        }
+      }
+    }
+  }
+
+  // Different degrees of freedom
+  for (auto &H1 : {cudaq::boson_op::annihilate(0), cudaq::boson_op::create(0),
+                   cudaq::boson_op::number(0)}) {
+    for (auto &H2 : {cudaq::boson_op::annihilate(0), cudaq::boson_op::create(0),
+                     cudaq::boson_op::number(0)}) {
+      for (auto &H3 :
+           {cudaq::boson_op::annihilate(1), cudaq::boson_op::create(1),
+            cudaq::boson_op::number(1)}) {
+        for (auto &H4 :
+             {cudaq::boson_op::annihilate(1), cudaq::boson_op::create(1),
+              cudaq::boson_op::number(1)}) {
+          std::cout << H1.to_string() << " " << H2.to_string() << " "
+                    << H3.to_string() << " " << H4.to_string() << "\n";
+          auto H = H1 * H2 * H3 * H4;
+          utils::checkEqual(H.to_matrix(dimensions),
+                            H.to_diagonal_matrix(dimensions));
+        }
+      }
+    }
+  }
+
+  // Sum op
+  for (auto &H1 : {cudaq::boson_op::annihilate(0), cudaq::boson_op::create(0),
+                   cudaq::boson_op::number(0)}) {
+    for (auto &H2 : {cudaq::boson_op::annihilate(1), cudaq::boson_op::create(1),
+                     cudaq::boson_op::number(1)}) {
+      for (auto &H3 :
+           {cudaq::boson_op::annihilate(0), cudaq::boson_op::create(0),
+            cudaq::boson_op::number(0)}) {
+        for (auto &H4 :
+             {cudaq::boson_op::annihilate(1), cudaq::boson_op::create(1),
+              cudaq::boson_op::number(1)}) {
+
+          auto H = H1 * H2 + H3 * H4;
+          std::cout << H1.to_string() << " " << H2.to_string() << " + "
+                    << H3.to_string() << " " << H4.to_string() << " = "
+                    << H.to_string() << "\n";
+          utils::checkEqual(H.to_matrix(dimensions),
+                            H.to_diagonal_matrix(dimensions));
+        }
+      }
+    }
+  }
+}

--- a/unittests/operators/fermion_op.cpp
+++ b/unittests/operators/fermion_op.cpp
@@ -832,3 +832,77 @@ TEST(OperatorExpressions, checkAntiCommutationRelations) {
   utils::checkEqual(rel15.to_matrix(), utils::zero_matrix(4));
   utils::checkEqual(rel16.to_matrix(), utils::zero_matrix(4));
 }
+
+TEST(OperatorExpressions, checkMultiDiagConversionFermion) {
+  cudaq::dimension_map dimensions = {{0, 2}, {1, 2}};
+  // Same degree of freedom
+  for (auto &H1 :
+       {cudaq::fermion_op::annihilate(0), cudaq::fermion_op::create(0),
+        cudaq::fermion_op::number(0)}) {
+    for (auto &H2 :
+         {cudaq::fermion_op::annihilate(0), cudaq::fermion_op::create(0),
+          cudaq::fermion_op::number(0)}) {
+      for (auto &H3 :
+           {cudaq::fermion_op::annihilate(0), cudaq::fermion_op::create(0),
+            cudaq::fermion_op::number(0)}) {
+        for (auto &H4 :
+             {cudaq::fermion_op::annihilate(0), cudaq::fermion_op::create(0),
+              cudaq::fermion_op::number(0)}) {
+          std::cout << H1.to_string() << " " << H2.to_string() << " "
+                    << H3.to_string() << " " << H4.to_string() << "\n";
+          auto H = H1 * H2 * H3 * H4;
+          utils::checkEqual(H.to_matrix(dimensions),
+                            H.to_diagonal_matrix(dimensions));
+        }
+      }
+    }
+  }
+
+  // Different degrees of freedom
+  for (auto &H1 :
+       {cudaq::fermion_op::annihilate(0), cudaq::fermion_op::create(0),
+        cudaq::fermion_op::number(0)}) {
+    for (auto &H2 :
+         {cudaq::fermion_op::annihilate(0), cudaq::fermion_op::create(0),
+          cudaq::fermion_op::number(0)}) {
+      for (auto &H3 :
+           {cudaq::fermion_op::annihilate(1), cudaq::fermion_op::create(1),
+            cudaq::fermion_op::number(1)}) {
+        for (auto &H4 :
+             {cudaq::fermion_op::annihilate(1), cudaq::fermion_op::create(1),
+              cudaq::fermion_op::number(1)}) {
+          std::cout << H1.to_string() << " " << H2.to_string() << " "
+                    << H3.to_string() << " " << H4.to_string() << "\n";
+          auto H = H1 * H2 * H3 * H4;
+          utils::checkEqual(H.to_matrix(dimensions),
+                            H.to_diagonal_matrix(dimensions));
+        }
+      }
+    }
+  }
+
+  // Sum op
+  for (auto &H1 :
+       {cudaq::fermion_op::annihilate(0), cudaq::fermion_op::create(0),
+        cudaq::fermion_op::number(0)}) {
+    for (auto &H2 :
+         {cudaq::fermion_op::annihilate(1), cudaq::fermion_op::create(1),
+          cudaq::fermion_op::number(1)}) {
+      for (auto &H3 :
+           {cudaq::fermion_op::annihilate(0), cudaq::fermion_op::create(0),
+            cudaq::fermion_op::number(0)}) {
+        for (auto &H4 :
+             {cudaq::fermion_op::annihilate(1), cudaq::fermion_op::create(1),
+              cudaq::fermion_op::number(1)}) {
+
+          auto H = H1 * H2 + H3 * H4;
+          std::cout << H1.to_string() << " " << H2.to_string() << " + "
+                    << H3.to_string() << " " << H4.to_string() << " = "
+                    << H.to_string() << "\n";
+          utils::checkEqual(H.to_matrix(dimensions),
+                            H.to_diagonal_matrix(dimensions));
+        }
+      }
+    }
+  }
+}

--- a/unittests/operators/utils.cpp
+++ b/unittests/operators/utils.cpp
@@ -53,6 +53,32 @@ void checkEqual(cudaq::complex_matrix a, cudaq::complex_matrix b) {
   }
 }
 
+void checkEqual(const cudaq::complex_matrix &denseMat,
+                const cudaq::dia_spmatrix &diaMat) {
+  int64_t dim = denseMat.rows();
+  const auto &[buffer, offsets] = diaMat;
+  for (int64_t i = -(dim - 1); i < dim; ++i) {
+    const auto iter = std::find(offsets.begin(), offsets.end(), i);
+    if (iter != offsets.end()) {
+      const auto idx = std::distance(offsets.begin(), iter);
+      const auto diags = denseMat.diagonal_elements(i);
+      for (std::size_t j = 0; j < diags.size(); ++j) {
+        EXPECT_NEAR(std::abs(diags[j] - buffer[dim * idx + j]), 0.0, 1e-8);
+      }
+      for (std::size_t j = diags.size(); j < dim; ++j) {
+        EXPECT_NEAR(std::abs(buffer[dim * idx + j]), 0.0, 1e-8);
+      }
+    } else {
+      // If the diagonal offset is not in the DIA format, check that the
+      // elements are zero.
+      const auto diags = denseMat.diagonal_elements(i);
+      for (std::size_t j = 0; j < diags.size(); ++j) {
+        EXPECT_NEAR(std::abs(diags[j]), 0.0, 1e-8);
+      }
+    }
+  }
+}
+
 cudaq::complex_matrix zero_matrix(std::size_t size) {
   auto mat = cudaq::complex_matrix(size, size);
   return mat;

--- a/unittests/operators/utils.cpp
+++ b/unittests/operators/utils.cpp
@@ -54,7 +54,7 @@ void checkEqual(cudaq::complex_matrix a, cudaq::complex_matrix b) {
 }
 
 void checkEqual(const cudaq::complex_matrix &denseMat,
-                const cudaq::dia_spmatrix &diaMat) {
+                const cudaq::mdiag_sparse_matrix &diaMat) {
   int64_t dim = denseMat.rows();
   const auto &[buffer, offsets] = diaMat;
   for (int64_t i = -(dim - 1); i < dim; ++i) {

--- a/unittests/operators/utils.h
+++ b/unittests/operators/utils.h
@@ -19,7 +19,8 @@ void assert_product_equal(
     const std::vector<cudaq::matrix_handler> &expected_terms);
 
 void checkEqual(cudaq::complex_matrix a, cudaq::complex_matrix b);
-
+void checkEqual(const cudaq::complex_matrix &denseMat,
+                const cudaq::dia_spmatrix &diaMat);
 cudaq::complex_matrix zero_matrix(std::size_t size);
 
 cudaq::complex_matrix id_matrix(std::size_t size);

--- a/unittests/operators/utils.h
+++ b/unittests/operators/utils.h
@@ -20,7 +20,7 @@ void assert_product_equal(
 
 void checkEqual(cudaq::complex_matrix a, cudaq::complex_matrix b);
 void checkEqual(const cudaq::complex_matrix &denseMat,
-                const cudaq::dia_spmatrix &diaMat);
+                const cudaq::mdiag_sparse_matrix &diaMat);
 cudaq::complex_matrix zero_matrix(std::size_t size);
 
 cudaq::complex_matrix id_matrix(std::size_t size);

--- a/unittests/spin_op/SpinOpTester.cpp
+++ b/unittests/spin_op/SpinOpTester.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/operators.h"
+#include "utils.h"
 #include <gtest/gtest.h>
 
 enum Pauli : int8_t { I = 0, X, Y, Z };
@@ -309,6 +310,67 @@ TEST(SpinOpTester, checkDistributeTerms) {
   EXPECT_EQ(distributed.size(), 2);
   EXPECT_EQ(distributed[0].num_terms(), 3);
   EXPECT_EQ(distributed[1].num_terms(), 2);
+}
+
+TEST(SpinOpTester, checkMultiDiagConversionSpin) {
+  for (auto &H : {cudaq::spin_op::i(0), cudaq::spin_op::x(0),
+                  cudaq::spin_op::y(0), cudaq::spin_op::z(0)}) {
+    utils::checkEqual(H.to_matrix(), H.to_diagonal_matrix());
+  }
+
+  // Product ops testing
+  for (auto &H1 : {cudaq::spin_op::i(0), cudaq::spin_op::x(0),
+                   cudaq::spin_op::y(0), cudaq::spin_op::z(0)}) {
+    for (auto &H2 : {cudaq::spin_op::i(1), cudaq::spin_op::x(1),
+                     cudaq::spin_op::y(1), cudaq::spin_op::z(1)}) {
+      auto H = H1 * H2;
+      std::cout << "Testing " << H.to_string() << "\n";
+      utils::checkEqual(H.to_matrix(), H.to_diagonal_matrix());
+    }
+  }
+
+  for (auto &H1 : {cudaq::spin_op::i(0), cudaq::spin_op::x(0),
+                   cudaq::spin_op::y(0), cudaq::spin_op::z(0)}) {
+    for (auto &H2 : {cudaq::spin_op::i(0), cudaq::spin_op::x(0),
+                     cudaq::spin_op::y(0), cudaq::spin_op::z(0)}) {
+      auto H = H1 * H2;
+      std::cout << "Testing " << H.to_string() << "\n";
+      utils::checkEqual(H.to_matrix(), H.to_diagonal_matrix());
+    }
+  }
+
+  // Sum ops testing
+  for (auto &H1 : {cudaq::spin_op::i(0), cudaq::spin_op::x(0),
+                   cudaq::spin_op::y(0), cudaq::spin_op::z(0)}) {
+    for (auto &H2 : {cudaq::spin_op::i(1), cudaq::spin_op::x(1),
+                     cudaq::spin_op::y(1), cudaq::spin_op::z(1)}) {
+      for (auto &H3 : {cudaq::spin_op::i(0), cudaq::spin_op::x(0),
+                       cudaq::spin_op::y(0), cudaq::spin_op::z(0)}) {
+        for (auto &H4 : {cudaq::spin_op::i(1), cudaq::spin_op::x(1),
+                         cudaq::spin_op::y(1), cudaq::spin_op::z(1)}) {
+          auto H = H1 * H2 + H3 * H4;
+          std::cout << "Testing " << H.to_string() << "\n";
+          utils::checkEqual(H.to_matrix(), H.to_diagonal_matrix());
+        }
+      }
+    }
+  }
+
+  for (auto &H1 : {cudaq::spin_op::i(0), cudaq::spin_op::x(0),
+                   cudaq::spin_op::y(0), cudaq::spin_op::z(0)}) {
+    for (auto &H2 : {cudaq::spin_op::i(1), cudaq::spin_op::x(1),
+                     cudaq::spin_op::y(1), cudaq::spin_op::z(1)}) {
+      for (auto &H3 : {cudaq::spin_op::i(1), cudaq::spin_op::x(1),
+                       cudaq::spin_op::y(1), cudaq::spin_op::z(1)}) {
+        for (auto &H4 : {cudaq::spin_op::i(2), cudaq::spin_op::x(2),
+                         cudaq::spin_op::y(2), cudaq::spin_op::z(2)}) {
+          auto H = H1 * H2 + H3 * H4;
+          std::cout << "Testing " << H.to_string() << "\n";
+          utils::checkEqual(H.to_matrix(), H.to_diagonal_matrix());
+        }
+      }
+    }
+  }
 }
 
 #if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER))


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
This PR

- Adds support for creating the multi-diagonal sparse matrix representation for spins, bosons, and fermions. The format is suitable for direct consumption by cudensitymat.

- Leverages the existing operator's `create_matrix` facility to construct the multi-diagonal representations.

- Implements a simple add function to compute the whole multi-diagonal representation for `sum_op`.

- Adds unit tests.
