### PR TITLE
workflows: use tonistiigi/binfmt:qemu-v9.2.2-52

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -210,6 +210,11 @@ jobs:
           ref: "${{ (inputs.pull_request_number != '' && (inputs.pull_request_commit || format('refs/pull/{0}/merge', inputs.pull_request_number))) || '' }}"
           submodules: ${{ inputs.checkout_submodules }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
           docker context create builder_context

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -153,6 +153,11 @@ jobs:
             org.opencontainers.image.title=open-mpi
             org.opencontainers.image.description=Open MPI dependencies of CUDA Quantum
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
           docker context create builder_context
@@ -303,8 +308,15 @@ jobs:
             echo "docker_output=type=docker,dest=$tar_archive" >> $GITHUB_OUTPUT
           fi
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
+          echo uname -rv
+          uname -rv
           docker context create builder_context
 
       - name: Set up buildx runner
@@ -514,8 +526,15 @@ jobs:
             echo "docker_output=type=docker,dest=$tar_archive" >> $GITHUB_OUTPUT
           fi
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
+          echo uname -rv
+          uname -rv
           docker context create builder_context
 
       - name: Set up buildx runner

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -315,8 +315,6 @@ jobs:
 
       - name: Set up context for buildx
         run: |
-          echo uname -rv
-          uname -rv
           docker context create builder_context
 
       - name: Set up buildx runner
@@ -533,8 +531,6 @@ jobs:
 
       - name: Set up context for buildx
         run: |
-          echo uname -rv
-          uname -rv
           docker context create builder_context
 
       - name: Set up buildx runner

--- a/.github/workflows/generate_cc.yml
+++ b/.github/workflows/generate_cc.yml
@@ -52,6 +52,11 @@ jobs:
           key: ${{ inputs.devdeps_cache }}
           fail-on-cache-miss: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
           docker context create builder_context

--- a/.github/workflows/gh_registry.yml
+++ b/.github/workflows/gh_registry.yml
@@ -113,6 +113,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
           docker context create builder_context

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -114,6 +114,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
           docker context create builder_context
@@ -190,6 +195,11 @@ jobs:
         with:
           ref: ${{ needs.metadata.outputs.cudaq_commit }}
           fetch-depth: 1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
 
       - name: Set up context for buildx
         run: |

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -119,6 +119,11 @@ jobs:
             echo multiline
           } >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
           docker context create builder_context
@@ -219,6 +224,11 @@ jobs:
           cache_to="${build_cache},mode=max,ignore-error=false"
           echo "cache_to=$cache_to" >> $GITHUB_OUTPUT
           echo "build_cache=$build_cache" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
 
       - name: Set up context for buildx
         run: |

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -433,6 +433,11 @@ jobs:
           username: '$oauthtoken'
           password: ${{ secrets.NGC_CREDENTIALS }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v3
         with:
@@ -593,6 +598,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v3
         with:
@@ -700,6 +710,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
 
       - name: Set up context for buildx
         run: |

--- a/.github/workflows/publishing_stable.yml
+++ b/.github/workflows/publishing_stable.yml
@@ -113,6 +113,11 @@ jobs:
             echo multiline
           } >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up buildx runner
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -121,6 +121,11 @@ jobs:
           # do not change this prefix without adjusting other workflows
           echo "artifact_name=pycudaq-$cache_id" >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
           docker context create builder_context

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -53,6 +53,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
+
       - name: Set up context for buildx
         run: |
           docker context create builder_context
@@ -185,6 +190,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
 
       - name: Set up context for buildx
         run: |


### PR DESCRIPTION
This should fix the recent Deployment failures we are seeing now that the runners upgraded to Ubuntu 24.04.

This has been tested in `test_seg_fault` branch at https://github.com/NVIDIA/cuda-quantum/actions/runs/15426758970