### PR TITLE
Added timing tag for `run` API

### DIFF
--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -8,8 +8,10 @@
 
 #include "RecordLogParser.h"
 #include "Logger.h"
+#include "Timing.h"
 
 void cudaq::RecordLogParser::parse(const std::string &outputLog) {
+  ScopedTraceWithContext(cudaq::TIMING_RUN, "RecordLogParser::parse");
   cudaq::debug("Parsing log:\n{}", outputLog);
   std::vector<std::string> lines = cudaq::split(outputLog, '\n');
   if (lines.empty())

--- a/runtime/common/RunTheKernel.cpp
+++ b/runtime/common/RunTheKernel.cpp
@@ -104,6 +104,7 @@ cudaq::details::LayoutExtractor::extractLayout(const std::string &kernelName,
 cudaq::details::RunResultSpan cudaq::details::runTheKernel(
     std::function<void()> &&kernel, quantum_platform &platform,
     const std::string &kernel_name, std::size_t shots) {
+  ScopedTraceWithContext(cudaq::TIMING_RUN, "runTheKernel");
   // 1. Clear the outputLog.
   auto *circuitSimulator = nvqir::getCircuitSimulatorInternal();
 

--- a/runtime/common/Timing.h
+++ b/runtime/common/Timing.h
@@ -20,6 +20,7 @@ static constexpr int TIMING_SAMPLE = 4;
 static constexpr int TIMING_GATE_COUNT = 5;
 static constexpr int TIMING_JIT = 6;
 static constexpr int TIMING_JIT_PASSES = 7;
-static constexpr int TIMING_MAX_VALUE = 7;
+static constexpr int TIMING_RUN = 8;
+static constexpr int TIMING_MAX_VALUE = 8;
 bool isTimingTagEnabled(int tag);
 } // namespace cudaq


### PR DESCRIPTION
Use `CUDAQ_TIMING_TAGS=8`

Sample output:
```
$ CUDAQ_TIMING_TAGS=8 ./a.out 
[2025-06-04 17:22:28.605] - [tag=8] [RecordLogParser.cpp:14] RecordLogParser::parse executed in 0.255 ms.
[2025-06-04 17:22:28.605] [tag=8] [RunTheKernel.cpp:107] runTheKernel executed in 1836.06 ms.
```