### PR TITLE
[Bug fix] Python `observe`: missing `unset_noise` on a return code path

### DIFF
--- a/python/cudaq/runtime/observe.py
+++ b/python/cudaq/runtime/observe.py
@@ -147,6 +147,9 @@ Returns:
 
         observeResult = cudaq_runtime.ObserveResult(expVal, localOp, res)
         if not isinstance(spin_operator, list):
+            if noise_model != None:
+                cudaq_runtime.unset_noise()
+
             return observeResult
 
         results = []

--- a/python/tests/builder/test_NoiseModel.py
+++ b/python/tests/builder/test_NoiseModel.py
@@ -745,6 +745,31 @@ def test_apply_noise_builtin(target: str):
     cudaq.reset_target()
 
 
+@pytest.mark.parametrize('target', ['density-matrix-cpu'])
+def test_noise_observe_reset(target: str):
+    cudaq.set_target(target)
+    noise_model = cudaq.NoiseModel()
+    # Amplitude damping channel with `1.0` probability of the qubit
+    # decaying to the ground state.
+    amplitude_damping = cudaq.AmplitudeDampingChannel(1.0)
+
+    noise_model.add_all_qubit_channel('x', amplitude_damping)
+
+    test_x = cudaq.make_kernel()
+    qubit = test_x.qalloc(1)
+    test_x.x(qubit)
+
+    observable = cudaq.spin.z(0)
+    for i in range(10):
+        # Run this in a loop to check that noise model argument is isolated to each observe call.
+        result_noiseless = cudaq.observe(test_x, observable)
+        result_noisy = cudaq.observe(test_x,
+                                     observable,
+                                     noise_model=noise_model)
+        assert np.isclose(result_noiseless.expectation(), -1.)
+        assert np.isclose(result_noisy.expectation(), 1.)
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This seems to be a bug since we refactored Python to support kernel mode.

We have multiple `return` statements, and one of them missed the noise model cleanup, causing the noise model to 'leak' into the global context. 

Also, adding a test case.
