### PR TITLE
Fix notebooks

### DIFF
--- a/docs/sphinx/applications/python/quantum_pagerank.ipynb
+++ b/docs/sphinx/applications/python/quantum_pagerank.ipynb
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/sphinx/applications/python/quantum_pagerank.ipynb
+++ b/docs/sphinx/applications/python/quantum_pagerank.ipynb
@@ -199,18 +199,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import cudaq\n",
-    "from cudaq import ElementaryOperator, Schedule\n",
+    "from cudaq import operators, Schedule\n",
     "\n",
     "# Construct the Hamiltonian based on the adjacency matrix of the social network\n",
     "H = np.array(nx.to_numpy_array(graph), dtype=np.complex128)\n",
     "\n",
     "# Defines an elementary operator named \"hamiltonian\", allowing creation with the name and its degrees of freedom.\n",
-    "ElementaryOperator.define(\"hamiltonian\",\n",
+    "operators.define(\"hamiltonian\",\n",
     "                          expected_dimensions=[N],\n",
     "                          create=lambda: H)"
    ]
@@ -246,7 +246,7 @@
     "for i in range(N):\n",
     "    for j in range(N):\n",
     "        exec(f\"\"\"\n",
-    "ElementaryOperator.define(\n",
+    "operators.define(\n",
     "    f\"lindblad_{i,j}\",\n",
     "    expected_dimensions=[N],\n",
     "    create=lambda: lindblad_op({i}, {j}),\n",
@@ -254,7 +254,7 @@
     "        \"\"\")\n",
     "\n",
     "lindblad_ops = [\n",
-    "    np.sqrt(P[i, j]) * ElementaryOperator(f\"lindblad_{i,j}\", [0])\n",
+    "    np.sqrt(P[i, j]) * operators.instantiate(f\"lindblad_{i,j}\", [0])\n",
     "    for i in range(N)\n",
     "    for j in range(N)\n",
     "]"
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +288,7 @@
     "    rho = np.identity(N, dtype=np.complex128) / N\n",
     "\n",
     "    # Define the Hamiltonian and collapse operators based on the value of omega\n",
-    "    hamiltonian = (1 - omega) * ElementaryOperator(\"hamiltonian\", [0])\n",
+    "    hamiltonian = (1 - omega) * operators.instantiate(\"hamiltonian\", [0])\n",
     "    collapse_operators = [np.sqrt(omega) * op for op in lindblad_ops]\n",
     "\n",
     "    result = cudaq.evolve(\n",


### PR DESCRIPTION
Publishing is failing[0] due to `quantum_pagerank.ipynb` using the old operator definitions.

Tested on GH200:
```bash
cudaq@utskinnyjoe-dvt-41:/tmp/cuda-quantum/docs$ echo "nvidia dynamics" | python3 notebook_validation.py
[NbConvertApp] Converting notebook sphinx/applications/python/quantum_pagerank.ipynb to notebook
[NbConvertApp] Writing 331518 bytes to sphinx/applications/python/quantum_pagerank.nbconvert.ipynb
Time taken for nbconvert : 20.35 seconds for 'sphinx/applications/python/quantum_pagerank.ipynb'
Success! The following notebook(s) executed successfully:
sphinx/applications/python/quantum_pagerank.ipynb
```

[0] - https://github.com/NVIDIA/cuda-quantum/actions/runs/15456943140/job/43512604468