### PR TITLE
[py] Remove wrong verbose prints in the bridge

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -993,8 +993,7 @@ class PyASTBridge(ast.NodeVisitor):
         if self.buildingEntryPoint:
             # This is an inner function def, we will
             # treat it as a cc.callable (cc.create_lambda)
-            if self.verbose:
-                print("Visiting inner FunctionDef {}".format(node.name))
+            self.debug_msg(lambda: f'Visiting inner FunctionDef {node.name}')
 
             arguments = node.args.args
             if len(arguments):
@@ -3950,10 +3949,6 @@ class PyASTBridge(ast.NodeVisitor):
         """
         Map tuples in the Python AST to equivalents in MLIR.
         """
-        if self.verbose:
-            print("[Visit Tuple = {}]".format(
-                ast.unparse(node) if hasattr(ast, 'unparse') else node))
-
         self.generic_visit(node)
         self.currentNode = node
 


### PR DESCRIPTION
### Description
PR #2956 change the way to print verbose messages. With multiple PRs changing the bridge around the same time, these statements ended up left behind.
