### PR TITLE
Mass update deprecated nvidia-fp64 target

### DIFF
--- a/python/tests/builder/test_cupy_integration.py
+++ b/python/tests/builder/test_cupy_integration.py
@@ -35,7 +35,7 @@ def test_state_vector_simple_py_float():
     # Create a state on GPU
     expected = cp.array([.707107, 0, 0, .707107])
 
-    # We are using the nvidia-fp32 target by default, it requires
+    # We are using the nvidia target, it requires
     # cupy overlaps to also have complex f32 data types, this
     # should throw since we are using float data types only
     with pytest.raises(RuntimeError) as error:

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -900,7 +900,7 @@ def test_state_capture():
 
 @skipIfNvidiaFP64NotInstalled
 def test_from_state0():
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     kernel, initState = cudaq.make_kernel(list[complex])
     qubits = kernel.qalloc(initState)
@@ -1396,7 +1396,7 @@ def test_u3_ctrl():
 @skipIfNvidiaFP64NotInstalled
 def test_builder_rotate_state():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [0., 0., 0., 1.]
 

--- a/python/tests/builder/test_qalloc_init.py
+++ b/python/tests/builder/test_qalloc_init.py
@@ -25,7 +25,7 @@ skipIfNvidiaNotInstalled = pytest.mark.skipif(
 def test_kernel_float_params_f64():
 
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     f = [1. / np.sqrt(2.), 0., 0., 1. / np.sqrt(2.)]
 
@@ -57,7 +57,7 @@ def test_kernel_float_params_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_float_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     f = [1. / np.sqrt(2.), 0., 0., 1. / np.sqrt(2.)]
 
@@ -89,7 +89,7 @@ def test_kernel_float_capture_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_float_np_array_from_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     f = [1. / np.sqrt(2.), 0., 0., 1. / np.sqrt(2.)]
 
@@ -121,7 +121,7 @@ def test_kernel_float_np_array_from_capture_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_float_definition_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     kernel = cudaq.make_kernel()
     qubits = kernel.qalloc([1. / np.sqrt(2.), 0., 0., 1. / np.sqrt(2.)])
@@ -152,7 +152,7 @@ def test_kernel_float_definition_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex_params_rotate_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [0. + 0j, 0., 0., 1.]
 
@@ -174,7 +174,7 @@ def test_kernel_complex_params_rotate_f64():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex_force_kron():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [0. + 0j] * 1024
     c[1023] = 1j
@@ -215,7 +215,7 @@ def test_kernel_complex_params_rotate_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex_params_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)]
 
@@ -247,7 +247,7 @@ def test_kernel_complex_params_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)]
 
@@ -279,7 +279,7 @@ def test_kernel_complex_capture_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex_np_array_from_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)]
 
@@ -311,7 +311,7 @@ def test_kernel_complex_np_array_from_capture_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex_definition_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     kernel = cudaq.make_kernel()
     q = kernel.qalloc([1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)])
@@ -342,7 +342,7 @@ def test_kernel_complex_definition_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_dtype_complex_params_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)]
     a = np.array(c, dtype=complex)
@@ -359,7 +359,7 @@ def test_kernel_dtype_complex_params_f64():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_dtype_complex128_params_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)]
     a = np.array(c, dtype=np.complex128)
@@ -395,7 +395,7 @@ def test_kernel_amplitudes_complex_params_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_simulation_dtype_np_array_from_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)]
 
@@ -427,7 +427,7 @@ def test_kernel_simulation_dtype_np_array_from_capture_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_simulation_dtype_np_array_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)]
 
@@ -468,7 +468,7 @@ def test_kernel_simulation_dtype_np_array_capture_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_error_invalid_array_size_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     kernel = cudaq.make_kernel()
 
@@ -480,7 +480,7 @@ def test_kernel_error_invalid_array_size_f64():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_error_invalid_list_size_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     kernel = cudaq.make_kernel()
 
@@ -519,7 +519,7 @@ def test_kernel_error_invalid_list_size_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_error_np_array_not_normalized_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     kernel = cudaq.make_kernel()
 
@@ -531,7 +531,7 @@ def test_kernel_error_np_array_not_normalized_f64():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_error_list_not_normalized_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     kernel = cudaq.make_kernel()
 
@@ -570,7 +570,7 @@ def test_kernel_error_list_not_normalized_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_error_invalid_initializer_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     kernel = cudaq.make_kernel()
 

--- a/python/tests/builder/test_qalloc_init_state.py
+++ b/python/tests/builder/test_qalloc_init_state.py
@@ -30,7 +30,7 @@ def assert_close(want, got, tolerance=1.e-5) -> bool:
 def test_kernel_float_params_f64():
 
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     f = np.array([1. / np.sqrt(2.), 0., 0., 1. / np.sqrt(2.)], dtype=float)
 
@@ -60,7 +60,7 @@ def test_kernel_float_params_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex_params_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = np.array([1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)],
                  dtype=complex)
@@ -79,7 +79,7 @@ def test_kernel_complex_params_f64():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex128_params_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = np.array([1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)],
                  dtype=np.complex128)
@@ -98,7 +98,7 @@ def test_kernel_complex128_params_f64():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex64_params_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = np.array([1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)],
                  dtype=np.complex64)
@@ -156,7 +156,7 @@ def test_kernel_complex_params_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = np.array([1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)],
                  dtype=complex)
@@ -175,7 +175,7 @@ def test_kernel_complex_capture_f64():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex128_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = np.array([1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)],
                  dtype=np.complex128)
@@ -194,7 +194,7 @@ def test_kernel_complex128_capture_f64():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_complex128_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = np.array([1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)],
                  dtype=np.complex64)
@@ -255,7 +255,7 @@ def test_kernel_complex_capture_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_simulation_dtype_complex_params_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = np.array([1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)],
                  dtype=cudaq.complex())
@@ -291,7 +291,7 @@ def test_kernel_simulation_dtype_complex_params_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_simulation_dtype_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = np.array([1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)],
                  dtype=cudaq.complex())
@@ -330,7 +330,7 @@ def test_kernel_simulation_dtype_capture_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_init_from_other_kernel_state_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     bell = cudaq.make_kernel()
     qubits = bell.qalloc(2)

--- a/python/tests/kernel/test_kernel_qvector_init.py
+++ b/python/tests/kernel/test_kernel_qvector_init.py
@@ -287,7 +287,7 @@ def test_kernel_dtype_complex64_params_f32():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_simulation_dtype_complex_params_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)]
 
@@ -358,7 +358,7 @@ def test_kernel_amplitudes_complex_from_capture():
 @skipIfNvidiaFP64NotInstalled
 def test_kernel_simulation_dtype_np_array_from_capture_f64():
     cudaq.reset_target()
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     c = [1. / np.sqrt(2.) + 0j, 0., 0., 1. / np.sqrt(2.)]
 

--- a/python/tests/kernel/test_state_kernel.py
+++ b/python/tests/kernel/test_state_kernel.py
@@ -31,7 +31,7 @@ def test_state_vector_simple():
     backend. Begins with a kernel, converts to state, then checks
     its member functions.
     """
-    cudaq.set_target('nvidia-fp64')
+    cudaq.set_target('nvidia', option='fp64')
 
     @cudaq.kernel
     def bell():


### PR DESCRIPTION
cudaq.set_target('nvidia-fp64') has been deprecated since 0.8.

This commit mass updates these targets to the following:

```
cudaq.set_target('nvidia', option='fp64')
```