### PR TITLE
Adding queue threshold

### DIFF
--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -245,6 +245,11 @@ public:
     // Add to the instruction queue
     instructionQueue.emplace_back(std::move(mutable_name), mutable_params,
                                   mutable_controls, mutable_targets, op);
+
+    static constexpr std::size_t kMaxQueueSize = 1024;
+    if (!isInTracerMode() && instructionQueue.size() >= kMaxQueueSize) {
+      synchronize();
+    }
   }
 
   void applyNoise(const kraus_channel &channel,

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -812,6 +812,10 @@ protected:
                  matrix, controls, targets, params);
 
     gateQueue.emplace(name, matrix, controls, targets, params);
+
+    static constexpr std::size_t kMaxGateQueueSize = 1024;
+    if (gateQueue.size() >= kMaxGateQueueSize)
+      flushGateQueue();
   }
 
   /// @brief This pure virtual method is meant for subtypes


### PR DESCRIPTION
Adding queue threshold and flushing it when the instructions in the queue reaches the threshold.

Fixes #218

Note: This can be further optimized by determining the queue threshold dynamically based on the available memory.