### PR TITLE
[Python] Disallow returning `list` from CUDA-Q kernels for now

### DIFF
--- a/python/tests/kernel/test_direct_call_return_kernel.py
+++ b/python/tests/kernel/test_direct_call_return_kernel.py
@@ -6,14 +6,15 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-import os, time
+import os
 
 import pytest
 import numpy as np
-from typing import Callable, List, Tuple
 from dataclasses import dataclass
 
 import cudaq
+
+list_err_msg = 'Returning `list` from kernels is not yet supported'
 
 
 def is_close(actual, expected):
@@ -199,16 +200,18 @@ def test_return_list_bool():
     def simple_list_bool_no_args() -> list[bool]:
         return [True, False, True]
 
-    result = simple_list_bool_no_args()
-    assert result == [True, False, True]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_bool_no_args()
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_bool(n: int, t: list[bool]) -> list[bool]:
         qubits = cudaq.qvector(n)
         return t
 
-    result = simple_list_bool(2, [True, False, True])
-    assert result == [True, False, True]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_bool(2, [True, False, True])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int():
@@ -217,16 +220,18 @@ def test_return_list_int():
     def simple_list_int_no_args() -> list[int]:
         return [-13, 5, 42]
 
-    result = simple_list_int_no_args()
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int_no_args()
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int(n: int, t: list[int]) -> list[int]:
         qubits = cudaq.qvector(n)
         return t
 
-    result = simple_list_int(2, [-13, 5, 42])
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int(2, [-13, 5, 42])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int32():
@@ -235,16 +240,18 @@ def test_return_list_int32():
     def simple_list_int32_no_args() -> list[np.int32]:
         return [-13, 5, 42]
 
-    result = simple_list_int32_no_args()
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int32_no_args()
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int32(n: int, t: list[np.int32]) -> list[np.int32]:
         qubits = cudaq.qvector(n)
         return t
 
-    result = simple_list_int32(2, [-13, 5, 42])
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int32(2, [-13, 5, 42])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int16():
@@ -253,16 +260,18 @@ def test_return_list_int16():
     def simple_list_int16_no_args() -> list[np.int16]:
         return [-13, 5, 42]
 
-    result = simple_list_int16_no_args()
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int16_no_args()
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int16(n: int, t: list[np.int16]) -> list[np.int16]:
         qubits = cudaq.qvector(n)
         return t
 
-    result = simple_list_int16(2, [-13, 5, 42])
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int16(2, [-13, 5, 42])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int8():
@@ -271,16 +280,18 @@ def test_return_list_int8():
     def simple_list_int8_no_args() -> list[np.int8]:
         return [-13, 5, 42]
 
-    result = simple_list_int8_no_args()
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int8_no_args()
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int8(n: int, t: list[np.int8]) -> list[np.int8]:
         qubits = cudaq.qvector(n)
         return t
 
-    result = simple_list_int8(2, [-13, 5, 42])
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int8(2, [-13, 5, 42])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int64():
@@ -289,16 +300,18 @@ def test_return_list_int64():
     def simple_list_int64_no_args() -> list[np.int64]:
         return [-13, 5, 42]
 
-    result = simple_list_int64_no_args()
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int64_no_args()
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int64(n: int, t: list[np.int64]) -> list[np.int64]:
         qubits = cudaq.qvector(n)
         return t
 
-    result = simple_list_int64(2, [-13, 5, 42])
-    assert result == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_int64(2, [-13, 5, 42])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_float():
@@ -307,16 +320,18 @@ def test_return_list_float():
     def simple_list_float_no_args() -> list[float]:
         return [-13.2, 5., 42.99]
 
-    result = simple_list_float_no_args()
-    assert result == [-13.2, 5.0, 42.99]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_float_no_args()
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_float(n: int, t: list[float]) -> list[float]:
         qubits = cudaq.qvector(n)
         return t
 
-    result = simple_list_float(2, [-13.2, 5.0, 42.99])
-    assert result == [-13.2, 5.0, 42.99]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_float(2, [-13.2, 5.0, 42.99])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_float32():
@@ -325,17 +340,18 @@ def test_return_list_float32():
     def simple_list_float32_no_args() -> list[np.float32]:
         return [-13.2, 5., 42.99]
 
-    result = simple_list_float32_no_args()
-    print(result)
-    assert is_close_array(result, [-13.2, 5.0, 42.99])
+    with pytest.raises(RuntimeError) as e:
+        simple_list_float32_no_args()
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_float32(n: int, t: list[np.float32]) -> list[np.float32]:
         qubits = cudaq.qvector(n)
         return t
 
-    result = simple_list_float32(2, [-13.2, 5.0, 42.99])
-    assert is_close_array(result, [-13.2, 5.0, 42.99])
+    with pytest.raises(RuntimeError) as e:
+        simple_list_float32(2, [-13.2, 5.0, 42.99])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_float64():
@@ -344,16 +360,18 @@ def test_return_list_float64():
     def simple_list_float64_no_args() -> list[np.float64]:
         return [-13.2, 5., 42.99]
 
-    result = simple_list_float64_no_args()
-    assert result == [-13.2, 5.0, 42.99]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_float64_no_args()
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_float64(n: int, t: list[np.float64]) -> list[np.float64]:
         qubits = cudaq.qvector(n)
         return t
 
-    result = simple_list_float64(2, [-13.2, 5.0, 42.99])
-    assert result == [-13.2, 5.0, 42.99]
+    with pytest.raises(RuntimeError) as e:
+        simple_list_float64(2, [-13.2, 5.0, 42.99])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_tuple_int_float():

--- a/python/tests/kernel/test_run_kernel.py
+++ b/python/tests/kernel/test_run_kernel.py
@@ -10,10 +10,11 @@ import os, time
 
 import pytest
 import numpy as np
-from typing import Callable, List, Tuple
 from dataclasses import dataclass
 
 import cudaq
+
+list_err_msg = 'Returning `list` from kernels is not yet supported'
 
 
 def is_close(actual, expected):
@@ -331,49 +332,36 @@ def test_return_list_bool():
     def simple_list_bool_no_args() -> list[bool]:
         return [True, False, True]
 
-    results = cudaq.run(simple_list_bool_no_args, shots_count=2)
-    assert len(results) == 2
-    assert results[0] == [True, False, True]
-    assert results[1] == [True, False, True]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_bool_no_args, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_bool(n: int) -> list[bool]:
         qubits = cudaq.qvector(n)
         return [True, False, True]
 
-    results = cudaq.run(simple_list_bool, 2, shots_count=2)
-    assert len(results) == 2
-    assert results[0] == [True, False, True]
-    assert results[1] == [True, False, True]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_bool, 2, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_bool_args(n: int, t: list[bool]) -> list[bool]:
         qubits = cudaq.qvector(n)
         return t
 
-    results = cudaq.run(simple_list_bool_args,
-                        2, [True, False, True],
-                        shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [True, False, True]
-    # assert results[1] == [True, False, True]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_bool_args, 2, [True, False, True])
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_bool_args_no_broadcast(t: list[bool]) -> list[bool]:
         qubits = cudaq.qvector(2)
         return t
 
-    results = cudaq.run(simple_list_bool_args_no_broadcast, [True, False, True],
-                        shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [True, False, True]
-    # assert results[1] == [True, False, True]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_bool_args_no_broadcast, [True, False, True])
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int():
@@ -382,23 +370,18 @@ def test_return_list_int():
     def simple_list_int_no_args() -> list[int]:
         return [-13, 5, 42]
 
-    results = cudaq.run(simple_list_int_no_args, shots_count=2)
-    assert len(results) == 2
-    assert results[0] == [-13, 5, 42]
-    assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int_no_args, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int(n: int, t: list[int]) -> list[int]:
         qubits = cudaq.qvector(n)
         return t
 
-    results = cudaq.run(simple_list_int, 2, [-13, 5, 42], shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [-13, 5, 42]
-    # assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int, 2, [-13, 5, 42], shots_count=2)
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int8():
@@ -407,23 +390,18 @@ def test_return_list_int8():
     def simple_list_int8_no_args() -> list[np.int8]:
         return [-13, 5, 42]
 
-    results = cudaq.run(simple_list_int8_no_args, shots_count=2)
-    assert len(results) == 2
-    assert results[0] == [-13, 5, 42]
-    assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int8_no_args, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int8(n: int, t: list[np.int8]) -> list[np.int8]:
         qubits = cudaq.qvector(n)
         return t
 
-    results = cudaq.run(simple_list_int8, 2, [-13, 5, 42], shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [-13, 5, 42]
-    # assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int8, 2, [-13, 5, 42], shots_count=2)
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int16():
@@ -432,23 +410,18 @@ def test_return_list_int16():
     def simple_list_int16_no_args() -> list[np.int16]:
         return [-13, 5, 42]
 
-    results = cudaq.run(simple_list_int16_no_args, shots_count=2)
-    assert len(results) == 2
-    assert results[0] == [-13, 5, 42]
-    assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int16_no_args, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int16(n: int, t: list[np.int16]) -> list[np.int16]:
         qubits = cudaq.qvector(n)
         return t
 
-    results = cudaq.run(simple_list_int16, 2, [-13, 5, 42], shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [-13, 5, 42]
-    # assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int16, 2, [-13, 5, 42], shots_count=2)
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int32():
@@ -457,23 +430,18 @@ def test_return_list_int32():
     def simple_list_int32_no_args() -> list[np.int32]:
         return [-13, 5, 42]
 
-    results = cudaq.run(simple_list_int32_no_args, shots_count=2)
-    assert len(results) == 2
-    assert results[0] == [-13, 5, 42]
-    assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int32_no_args, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int32(n: int, t: list[np.int32]) -> list[np.int32]:
         qubits = cudaq.qvector(n)
         return t
 
-    results = cudaq.run(simple_list_int32, 2, [-13, 5, 42], shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [-13, 5, 42]
-    # assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int32, 2, [-13, 5, 42], shots_count=2)
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_int64():
@@ -482,23 +450,18 @@ def test_return_list_int64():
     def simple_list_int64_no_args() -> list[np.int64]:
         return [-13, 5, 42]
 
-    results = cudaq.run(simple_list_int64_no_args, shots_count=2)
-    assert len(results) == 2
-    assert results[0] == [-13, 5, 42]
-    assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int64_no_args, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_int64(n: int, t: list[np.int64]) -> list[np.int64]:
         qubits = cudaq.qvector(n)
         return t
 
-    results = cudaq.run(simple_list_int64, 2, [-13, 5, 42], shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [-13, 5, 42]
-    # assert results[1] == [-13, 5, 42]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_int64, 2, [-13, 5, 42], shots_count=2)
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_float():
@@ -507,25 +470,18 @@ def test_return_list_float():
     def simple_list_float_no_args() -> list[float]:
         return [-13.2, 5., 42.99]
 
-    results = cudaq.run(simple_list_float_no_args, shots_count=2)
-    assert len(results) == 2
-    assert results[0] == [-13.2, 5.0, 42.99]
-    assert results[1] == [-13.2, 5.0, 42.99]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_float_no_args, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_float(n: int, t: list[float]) -> list[float]:
         qubits = cudaq.qvector(n)
         return t
 
-    results = cudaq.run(simple_list_float,
-                        2, [-13.2, 5.0, 42.99],
-                        shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [-13.2, 5.0, 42.99]
-    # assert results[1] == [-13.2, 5.0, 42.99]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_float, 2, [-13.2, 5.0, 42.99], shots_count=2)
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_float32():
@@ -534,25 +490,18 @@ def test_return_list_float32():
     def simple_list_float32_no_args() -> list[np.float32]:
         return [-13.2, 5., 42.99]
 
-    results = cudaq.run(simple_list_float32_no_args, shots_count=2)
-    assert len(results) == 2
-    assert is_close_array(results[0], [-13.2, 5.0, 42.99])
-    assert is_close_array(results[1], [-13.2, 5.0, 42.99])
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_float32_no_args, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_float32(n: int, t: list[np.float32]) -> list[np.float32]:
         qubits = cudaq.qvector(n)
         return t
 
-    results = cudaq.run(simple_list_float32,
-                        2, [-13.2, 5.0, 42.99],
-                        shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [-13.2, 5.0, 42.99]
-    # assert results[1] == [-13.2, 5.0, 42.99]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_float32, 2, [-13.2, 5.0, 42.99], shots_count=2)
+    assert list_err_msg in str(e.value)
 
 
 def test_return_list_float64():
@@ -561,25 +510,18 @@ def test_return_list_float64():
     def simple_list_float64_no_args() -> list[np.float64]:
         return [-13.2, 5., 42.99]
 
-    results = cudaq.run(simple_list_float64_no_args, shots_count=2)
-    assert len(results) == 2
-    assert results[0] == [-13.2, 5.0, 42.99]
-    assert results[1] == [-13.2, 5.0, 42.99]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_float64_no_args, shots_count=2)
+    assert list_err_msg in str(e.value)
 
     @cudaq.kernel
     def simple_list_float64(n: int, t: list[np.float64]) -> list[np.float64]:
         qubits = cudaq.qvector(n)
         return t
 
-    results = cudaq.run(simple_list_float64,
-                        2, [-13.2, 5.0, 42.99],
-                        shots_count=2)
-    #FIXME: Non-const size of stdvec - ReturnToOutputLog does not create output.
-    #https://github.com/NVIDIA/cuda-quantum/issues/2963
-    assert len(results) == 0
-    # assert len(results) == 2
-    # assert results[0] == [-13.2, 5.0, 42.99]
-    # assert results[1] == [-13.2, 5.0, 42.99]
+    with pytest.raises(RuntimeError) as e:
+        cudaq.run(simple_list_float64, 2, [-13.2, 5.0, 42.99], shots_count=2)
+    assert list_err_msg in str(e.value)
 
 
 # Test tuples


### PR DESCRIPTION
Towards https://github.com/NVIDIA/cuda-quantum/issues/3013

Python counterpart for https://github.com/NVIDIA/cuda-quantum/pull/3010
