### PR TITLE
[core] Workaround overly excitable MLIR inliner.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -1759,6 +1759,46 @@ def cc_CallableClosureOp : CCOp<"callable_closure", [Pure]> {
   }];
 }
 
+def cc_NoInlineCallOp :
+    CCOp<"noinline_call", [CallOpInterface, SymbolUserOpInterface]> {
+  let summary = "Create a call that the inliner will not inline.";
+  let description = [{
+    The MLIR inliner in LLVM 16 is too smart and will inline trivial calls.
+    Moreover, there is no mechanism in this version of MLIR to stop the inliner
+    from inlining these trivial functions.
+
+    The cc.noinline_call is therefore a special op that prevents the inliner
+    from doing the inlining by misreporting what function is called.
+  }];
+
+  let arguments = (ins
+    FlatSymbolRefAttr:$callee,
+    Variadic<AnyType>:$args
+  );
+  let results = (outs Variadic<AnyType>);
+
+  let assemblyFormat = [{
+    $callee `(` $args `)` `:` functional-type(operands, results) attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    /// DO NOT RETURN the callee of this operation. This fools the inliner into
+    /// not knowing what is actually called.
+    mlir::CallInterfaceCallable getCallableForCallee() {
+      return mlir::FlatSymbolRefAttr::get(getContext(), ".no.inline");
+    }
+
+    mlir::LogicalResult verifySymbolUses(mlir::SymbolTableCollection &);
+  }];
+}
+
 def cc_VarargCallOp :
     CCOp<"call_vararg", [CallOpInterface, SymbolUserOpInterface]> {
   let summary = "Create a call to an llvm.func with variadic arguments.";

--- a/lib/Optimizer/CodeGen/CCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/CCToLLVM.cpp
@@ -752,7 +752,7 @@ class NoInlineCallPattern
     SmallVector<Type> types;
     for (auto ty : nicall.getResultTypes())
       types.push_back(getTypeConverter()->convertType(ty));
-    rewriter.replaceOpWithNewOp<LLVM::CallOp>(nicall, types, nicall.getCallee(),
+    rewriter.replaceOpWithNewOp<func::CallOp>(nicall, types, nicall.getCallee(),
                                               adaptor.getArgs());
     return success();
   }

--- a/lib/Optimizer/CodeGen/CCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/CCToLLVM.cpp
@@ -741,17 +741,34 @@ class VarargCallPattern
     return success();
   }
 };
+
+class NoInlineCallPattern
+    : public ConvertOpToLLVMPattern<cudaq::cc::NoInlineCallOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(cudaq::cc::NoInlineCallOp nicall, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> types;
+    for (auto ty : nicall.getResultTypes())
+      types.push_back(getTypeConverter()->convertType(ty));
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(nicall, types, nicall.getCallee(),
+                                              adaptor.getArgs());
+    return success();
+  }
+};
 } // namespace
 
 void cudaq::opt::populateCCToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                           RewritePatternSet &patterns) {
-  patterns.insert<
-      AddressOfOpPattern, AllocaOpPattern, CallableClosureOpPattern,
-      CallableFuncOpPattern, CallCallableOpPattern,
-      CallIndirectCallableOpPattern, CastOpPattern, ComputePtrOpPattern,
-      CreateStringLiteralOpPattern, ExtractValueOpPattern, FuncToPtrOpPattern,
-      GlobalOpPattern, InsertValueOpPattern, InstantiateCallableOpPattern,
-      LoadOpPattern, OffsetOfOpPattern, PoisonOpPattern, SizeOfOpPattern,
-      StdvecDataOpPattern, StdvecInitOpPattern, StdvecSizeOpPattern,
-      StoreOpPattern, UndefOpPattern, VarargCallPattern>(typeConverter);
+  patterns
+      .insert<AddressOfOpPattern, AllocaOpPattern, CallableClosureOpPattern,
+              CallableFuncOpPattern, CallCallableOpPattern,
+              CallIndirectCallableOpPattern, CastOpPattern, ComputePtrOpPattern,
+              CreateStringLiteralOpPattern, ExtractValueOpPattern,
+              FuncToPtrOpPattern, GlobalOpPattern, InsertValueOpPattern,
+              InstantiateCallableOpPattern, LoadOpPattern, NoInlineCallPattern,
+              OffsetOfOpPattern, PoisonOpPattern, SizeOfOpPattern,
+              StdvecDataOpPattern, StdvecInitOpPattern, StdvecSizeOpPattern,
+              StoreOpPattern, UndefOpPattern, VarargCallPattern>(typeConverter);
 }

--- a/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -14,6 +14,7 @@ void cudaq::opt::commonPipelineConvertToQIR(PassManager &pm,
                                             StringRef codeGenFor,
                                             StringRef passConfigAs) {
   pm.addNestedPass<func::FuncOp>(createApplyControlNegations());
+  addAggressiveEarlyInlining(pm);
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(createUnwindLowering());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -2334,6 +2334,46 @@ MutableOperandRange cudaq::cc::ConditionOp::getMutableSuccessorOperands(
 }
 
 //===----------------------------------------------------------------------===//
+// NoInlineCallOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult cudaq::cc::NoInlineCallOp::verifySymbolUses(
+    SymbolTableCollection &symbolTable) {
+  // Check that the callee attribute was specified.
+  auto fnAttr = (*this)->getAttrOfType<FlatSymbolRefAttr>("callee");
+  if (!fnAttr)
+    return emitOpError("requires a 'callee' symbol reference attribute");
+  auto fn = symbolTable.lookupNearestSymbolFrom<func::FuncOp>(*this, fnAttr);
+  if (!fn)
+    return emitOpError() << "'" << fnAttr.getValue()
+                         << "' does not reference a valid function";
+
+  // Verify that the operand and result types match the callee.
+  auto fnType = fn.getFunctionType();
+  if (fnType.getNumInputs() != getNumOperands())
+    return emitOpError("incorrect number of operands for callee");
+
+  for (unsigned i = 0, e = fnType.getNumInputs(); i != e; ++i)
+    if (getOperand(i).getType() != fnType.getInput(i))
+      return emitOpError("operand type mismatch: expected operand type ")
+             << fnType.getInput(i) << ", but provided "
+             << getOperand(i).getType() << " for operand number " << i;
+
+  if (fnType.getNumResults() != getNumResults())
+    return emitOpError("incorrect number of results for callee");
+
+  for (unsigned i = 0, e = fnType.getNumResults(); i != e; ++i)
+    if (getResult(i).getType() != fnType.getResult(i)) {
+      auto diag = emitOpError("result type mismatch at index ") << i;
+      diag.attachNote() << "      op result types: " << getResultTypes();
+      diag.attachNote() << "function result types: " << fnType.getResults();
+      return diag;
+    }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // OffsetOfOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Optimizer/Transforms/GenKernelExecution.cpp
+++ b/lib/Optimizer/Transforms/GenKernelExecution.cpp
@@ -314,8 +314,8 @@ public:
       trailingData = t;
       args.push_back(a);
     }
-    auto call = builder.create<func::CallOp>(loc, funcTy.getResults(),
-                                             funcOp.getName(), args);
+    auto call = builder.create<cudaq::cc::NoInlineCallOp>(
+        loc, funcTy.getResults(), funcOp.getName(), args);
     const bool hasVectorResult =
         funcTy.getNumResults() == 1 &&
         isa<cudaq::cc::SpanLikeType>(funcTy.getResult(0));

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -152,7 +152,6 @@ ExecutionEngine *jitKernel(const std::string &name, MlirModule module,
     PassManager pm(context);
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createPySynthCallableBlockArgs(
         SmallVector<StringRef>(names.begin(), names.end())));
-    cudaq::opt::addAggressiveEarlyInlining(pm);
     pm.addPass(cudaq::opt::createGenerateDeviceCodeLoader({.jitTime = true}));
     pm.addPass(cudaq::opt::createGenerateKernelExecution(
         {.startingArgIdx = startingArgIdx}));

--- a/targettests/execution/trivial_inliner.cpp
+++ b/targettests/execution/trivial_inliner.cpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: nvq++ =fenable-cudaq-run %s -o %t && %t | FileCheck %s
+
+#include <cudaq.h>
+
+struct MyTuple {
+  bool boolVal;
+  std::int64_t i64Val;
+  double f64Val;
+};
+
+auto struct_test = [](MyTuple t) __qpu__ { return t; };
+
+int main() {
+  int c = 0;
+  {
+    MyTuple t = {true, 654, 9.123};
+    const auto results = cudaq::run(3, struct_test, t);
+    if (results.size() != 3) {
+      printf("FAILED! Expected 3 shots. Got %lu\n", results.size());
+    } else {
+      c = 0;
+      for (auto i : results)
+        printf("%d: {%s, %ld, %f}\n", c++, i.boolVal ? "true" : "false",
+               i.i64Val, i.f64Val);
+      printf("success!\n");
+    }
+  }
+  return 0;
+}
+
+// CHECK: 0: {true, 654, 9.123000}
+// CHECK: 1: {true, 654, 9.123000}
+// CHECK: 2: {true, 654, 9.123000}
+// CHECK: success!

--- a/targettests/execution/trivial_inliner.cpp
+++ b/targettests/execution/trivial_inliner.cpp
@@ -6,7 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ =fenable-cudaq-run %s -o %t && %t | FileCheck %s
+// RUN: nvq++ -fenable-cudaq-run %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 

--- a/test/Quake/kernel_exec-1.qke
+++ b/test/Quake/kernel_exec-1.qke
@@ -175,7 +175,7 @@ module attributes {quake.mangled_name_map = {
 // ALT:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // ALT:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i32>
 // ALT:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// ALT:           %[[VAL_8:.*]] = call @__nvqpp__mlirgen__ghz(%[[VAL_7]]) : (i32) -> f64
+// ALT:           %[[VAL_8:.*]] = cc.noinline_call @__nvqpp__mlirgen__ghz(%[[VAL_7]]) : (i32) -> f64
 // ALT:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
 // ALT:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<f64>
 // ALT:           %[[VAL_10:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>
@@ -411,7 +411,7 @@ module attributes {quake.mangled_name_map = {
 // HYBRID:           %[[VAL_5:.*]] = cc.compute_ptr %[[VAL_4]]{{\[}}%[[VAL_3]]] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
 // HYBRID:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_2]][0] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<i32>
 // HYBRID:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// HYBRID:           %[[VAL_8:.*]] = call @__nvqpp__mlirgen__ghz(%[[VAL_7]]) : (i32) -> f64
+// HYBRID:           %[[VAL_8:.*]] = cc.noinline_call @__nvqpp__mlirgen__ghz(%[[VAL_7]]) : (i32) -> f64
 // HYBRID:           %[[VAL_9:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, f64}>>) -> !cc.ptr<f64>
 // HYBRID:           cc.store %[[VAL_8]], %[[VAL_9]] : !cc.ptr<f64>
 // HYBRID:           %[[VAL_10:.*]] = call @__nvqpp_zeroDynamicResult() : () -> !cc.struct<{!cc.ptr<i8>, i64}>

--- a/test/Quake/return_vector.qke
+++ b/test/Quake/return_vector.qke
@@ -270,7 +270,7 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}> : i64
 // CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_6:.*]] = call @__nvqpp__mlirgen__test_0(%[[VAL_5]]) : (i32) -> !cc.stdvec<i32>
+// CHECK:           %[[VAL_6:.*]] = cc.noinline_call @__nvqpp__mlirgen__test_0(%[[VAL_5]]) : (i32) -> !cc.stdvec<i32>
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<i32>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<i32>, i64}>>) -> !cc.ptr<!cc.stdvec<i32>>
 // CHECK:           cc.store %[[VAL_6]], %[[VAL_8]] : !cc.ptr<!cc.stdvec<i32>>
@@ -325,7 +325,7 @@ func.func @test_1(%0: !cc.ptr<!cc.struct<{!cc.ptr<f64>, !cc.ptr<f64>, !cc.ptr<f6
 // CHECK:           %[[VAL_3:.*]] = cc.sizeof !cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}> : i64
 // CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<i8>) -> !cc.ptr<i32>
 // CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_6:.*]] = call @__nvqpp__mlirgen__test_1(%[[VAL_5]]) : (i32) -> !cc.stdvec<f64>
+// CHECK:           %[[VAL_6:.*]] = cc.noinline_call @__nvqpp__mlirgen__test_1(%[[VAL_5]]) : (i32) -> !cc.stdvec<f64>
 // CHECK:           %[[VAL_7:.*]] = cc.compute_ptr %[[VAL_2]][1] : (!cc.ptr<!cc.struct<{i32, !cc.struct<{!cc.ptr<f64>, i64}>}>>) -> !cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>
 // CHECK:           %[[VAL_8:.*]] = cc.cast %[[VAL_7]] : (!cc.ptr<!cc.struct<{!cc.ptr<f64>, i64}>>) -> !cc.ptr<!cc.stdvec<f64>>
 // CHECK:           cc.store %[[VAL_6]], %[[VAL_8]] : !cc.ptr<!cc.stdvec<f64>>

--- a/test/Translate/return_values.qke
+++ b/test/Translate/return_values.qke
@@ -376,69 +376,36 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:         ret i64 8
 // CHECK:       }
 
-// CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* nocapture 
-// CHECK-SAME:                          %[[VAL_0:.*]], i1
-// CHECK-SAME:                          %[[VAL_1:.*]]) {
+// CHECK-LABEL: define { i8*, i64 } @test_0.thunk(i8* nocapture
+// CHECK-SAME:       %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = bitcast i8* %[[VAL_0]] to i32*
 // CHECK:         %[[VAL_3:.*]] = load i32, i32* %[[VAL_2]], align 4
-// CHECK:         %[[VAL_4:.*]] = sext i32 %[[VAL_3]] to i64
-// CHECK:         %[[VAL_5:.*]] = tail call %[[VAL_6:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_4]])
-// CHECK:         %[[VAL_7:.*]] = tail call i64 @__quantum__rt__array_get_size_1d(%[[VAL_6]]* %[[VAL_5]])
-// CHECK:         %[[VAL_8:.*]] = icmp sgt i64 %[[VAL_7]], 0
-// CHECK:         br i1 %[[VAL_8]], label %[[VAL_9:.*]], label %[[VAL_10:.*]]
-// CHECK:       ._crit_edge.thread:                               ; preds = %[[VAL_11:.*]]
-// CHECK:         %[[VAL_12:.*]] = alloca i8, i64 %[[VAL_7]], align 1
-// CHECK:         br label %[[VAL_13:.*]]
-// CHECK:       .lr.ph:                                           ; preds = %[[VAL_11]], %[[VAL_9]]
-// CHECK:         %[[VAL_14:.*]] = phi i64 [ %[[VAL_15:.*]], %[[VAL_9]] ], [ 0, %[[VAL_11]] ]
-// CHECK:         %[[VAL_16:.*]] = tail call %[[VAL_17:.*]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_5]], i64 %[[VAL_14]])
-// CHECK:         %[[VAL_18:.*]] = load %[[VAL_17]]*, %[[VAL_17]]** %[[VAL_16]], align 8
-// CHECK:         tail call void @__quantum__qis__h(%[[VAL_17]]* %[[VAL_18]])
-// CHECK:         %[[VAL_15]] = add nuw nsw i64 %[[VAL_14]], 1
-// CHECK:         %[[VAL_19:.*]] = icmp eq i64 %[[VAL_15]], %[[VAL_7]]
-// CHECK:         br i1 %[[VAL_19]], label %[[VAL_20:.*]], label %[[VAL_9]]
-// CHECK:       ._crit_edge:                                      ; preds = %[[VAL_9]]
-// CHECK:         %[[VAL_21:.*]] = alloca i8, i64 %[[VAL_7]], align 1
-// CHECK:         br i1 %[[VAL_8]], label %[[VAL_22:.*]], label %[[VAL_13]]
-// CHECK:       .lr.ph6:                                          ; preds = %[[VAL_20]], %[[VAL_22]]
-// CHECK:         %[[VAL_23:.*]] = phi i64 [ %[[VAL_24:.*]], %[[VAL_22]] ], [ 0, %[[VAL_20]] ]
-// CHECK:         %[[VAL_25:.*]] = tail call %[[VAL_17]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_5]], i64 %[[VAL_23]])
-// CHECK:         %[[VAL_26:.*]] = load %[[VAL_17]]*, %[[VAL_17]]** %[[VAL_25]], align 8
-// CHECK:         %[[VAL_27:.*]] = tail call %[[VAL_28:.*]]* @__quantum__qis__mz(%[[VAL_17]]* %[[VAL_26]])
-// CHECK:         %[[VAL_29:.*]] = bitcast %[[VAL_28]]* %[[VAL_27]] to i1*
-// CHECK:         %[[VAL_30:.*]] = load i1, i1* %[[VAL_29]], align 1
-// CHECK:         %[[VAL_31:.*]] = getelementptr i8, i8* %[[VAL_21]], i64 %[[VAL_23]]
-// CHECK:         %[[VAL_32:.*]] = zext i1 %[[VAL_30]] to i8
-// CHECK:         store i8 %[[VAL_32]], i8* %[[VAL_31]], align 1
-// CHECK:         %[[VAL_24]] = add nuw nsw i64 %[[VAL_23]], 1
-// CHECK:         %[[VAL_33:.*]] = icmp eq i64 %[[VAL_24]], %[[VAL_7]]
-// CHECK:         br i1 %[[VAL_33]], label %[[VAL_13]], label %[[VAL_22]]
-// CHECK:       ._crit_edge7:                                     ; preds = %[[VAL_22]], %[[VAL_10]], %[[VAL_20]]
-// CHECK:         %[[VAL_34:.*]] = phi i8* [ %[[VAL_12]], %[[VAL_10]] ], [ %[[VAL_21]], %[[VAL_20]] ], [ %[[VAL_21]], %[[VAL_22]] ]
-// CHECK:         %[[VAL_35:.*]] = call i8* @__nvqpp_vectorCopyCtor(i8* nonnull %[[VAL_34]], i64 %[[VAL_7]], i64 1)
-// CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_5]])
-// CHECK:         %[[VAL_36:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
-// CHECK:         %[[VAL_37:.*]] = bitcast i8* %[[VAL_36]] to i8**
-// CHECK:         store i8* %[[VAL_35]], i8** %[[VAL_37]], align 8
-// CHECK:         %[[VAL_38:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
-// CHECK:         %[[VAL_39:.*]] = bitcast i8* %[[VAL_38]] to i64*
-// CHECK:         store i64 %[[VAL_7]], i64* %[[VAL_39]], align 8
-// CHECK:         br i1 %[[VAL_1]], label %[[VAL_40:.*]], label %[[VAL_41:.*]]
-// CHECK:       common.ret:                                       ; preds = %[[VAL_13]], %[[VAL_40]]
-// CHECK:         %[[VAL_42:.*]] = phi { i8*, i64 } [ %[[VAL_43:.*]], %[[VAL_40]] ], [ zeroinitializer, %[[VAL_13]] ]
-// CHECK:         ret { i8*, i64 } %[[VAL_42]]
-// CHECK:       29:                                               ; preds = %[[VAL_13]]
-// CHECK:         %[[VAL_44:.*]] = add i64 %[[VAL_7]], 24
-// CHECK:         %[[VAL_45:.*]] = call i8* @malloc(i64 %[[VAL_44]])
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_45]], i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_0]], i64 24, i1 false)
-// CHECK:         %[[VAL_46:.*]] = getelementptr i8, i8* %[[VAL_45]], i64 24
-// CHECK:         call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_46]], i8* align 1 %[[VAL_35]], i64 %[[VAL_7]], i1 false)
-// CHECK:         %[[VAL_47:.*]] = insertvalue { i8*, i64 } undef, i8* %[[VAL_45]], 0
-// CHECK:         %[[VAL_43]] = insertvalue { i8*, i64 } %[[VAL_47]], i64 %[[VAL_44]], 1
-// CHECK:         %[[VAL_48:.*]] = getelementptr i8, i8* %[[VAL_45]], i64 8
-// CHECK:         %[[VAL_49:.*]] = bitcast i8* %[[VAL_48]] to i8**
-// CHECK:         store i8* %[[VAL_46]], i8** %[[VAL_49]], align 8
-// CHECK:         br label %[[VAL_41]]
+// CHECK:         %[[VAL_4:.*]] = tail call { i1*, i64 } @__nvqpp__mlirgen__test_0(i32 %[[VAL_3]])
+// CHECK:         %[[VAL_5:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 8
+// CHECK:         %[[VAL_6:.*]] = bitcast i8* %[[VAL_5]] to i1**
+// CHECK:         %[[VAL_7:.*]] = extractvalue { i1*, i64 } %[[VAL_4]], 0
+// CHECK:         store i1* %[[VAL_7]], i1** %[[VAL_6]], align 8
+// CHECK:         %[[VAL_8:.*]] = getelementptr i8, i8* %[[VAL_0]], i64 16
+// CHECK:         %[[VAL_9:.*]] = bitcast i8* %[[VAL_8]] to i64*
+// CHECK:         %[[VAL_10:.*]] = extractvalue { i1*, i64 } %[[VAL_4]], 1
+// CHECK:         store i64 %[[VAL_10]], i64* %[[VAL_9]], align 8
+// CHECK:         br i1 %[[VAL_1]], label %[[VAL_11:.*]], label %[[VAL_12:.*]]
+// CHECK:       common.ret:                                       ; preds = %[[VAL_13:.*]], %[[VAL_11]]
+// CHECK:         %[[VAL_14:.*]] = phi { i8*, i64 } [ %[[VAL_15:.*]], %[[VAL_11]] ], [ zeroinitializer, %[[VAL_13]] ]
+// CHECK:         ret { i8*, i64 } %[[VAL_14]]
+// CHECK:       8:                                                ; preds = %[[VAL_13]]
+// CHECK:         %[[VAL_16:.*]] = bitcast i1* %[[VAL_7]] to i8*
+// CHECK:         %[[VAL_17:.*]] = add i64 %[[VAL_10]], 24
+// CHECK:         %[[VAL_18:.*]] = tail call i8* @malloc(i64 %[[VAL_17]])
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_18]], i8* noundef nonnull align 1 dereferenceable(24) %[[VAL_0]], i64 24, i1 false)
+// CHECK:         %[[VAL_19:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 24
+// CHECK:         tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %[[VAL_19]], i8* align 1 %[[VAL_16]], i64 %[[VAL_10]], i1 false)
+// CHECK:         %[[VAL_20:.*]] = insertvalue { i8*, i64 } undef, i8* %[[VAL_18]], 0
+// CHECK:         %[[VAL_15]] = insertvalue { i8*, i64 } %[[VAL_20]], i64 %[[VAL_17]], 1
+// CHECK:         %[[VAL_21:.*]] = getelementptr i8, i8* %[[VAL_18]], i64 8
+// CHECK:         %[[VAL_22:.*]] = bitcast i8* %[[VAL_21]] to i8**
+// CHECK:         store i8* %[[VAL_19]], i8** %[[VAL_22]], align 8
+// CHECK:         br label %[[VAL_12]]
 // CHECK:       }
 
 // CHECK-LABEL: define i64 @test_0.argsCreator(i8** nocapture readonly 
@@ -464,9 +431,8 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:         ret i64 0
 // CHECK:       }
 
-// CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* nocapture writeonly 
-// CHECK-SAME:                                                            %[[VAL_0:.*]], i1
-// CHECK-SAME:                                                            %[[VAL_1:.*]]) {
+// CHECK-LABEL: define { i8*, i64 } @test_1.thunk(i8* nocapture writeonly
+// CHECK-SAME:    %[[VAL_0:.*]], i1 %[[VAL_1:.*]]) {
 // CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate_array(i64 2)
 // CHECK:         %[[VAL_4:.*]] = tail call %[[VAL_5:.*]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_3]]* %[[VAL_2]], i64 0)
 // CHECK:         %[[VAL_6:.*]] = load %[[VAL_5]]*, %[[VAL_5]]** %[[VAL_4]], align 8
@@ -480,12 +446,12 @@ func.func @test_5(%sret: !cc.ptr<!cc.struct<{i64, f64}>> {llvm.sret = !cc.struct
 // CHECK:         %[[VAL_13:.*]] = load i1, i1* %[[VAL_12]], align 1
 // CHECK:         %[[VAL_14:.*]] = bitcast %[[VAL_10]]* %[[VAL_11]] to i1*
 // CHECK:         %[[VAL_15:.*]] = load i1, i1* %[[VAL_14]], align 1
+// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
 // CHECK:         %[[VAL_16:.*]] = bitcast i8* %[[VAL_0]] to i1*
 // CHECK:         store i1 %[[VAL_13]], i1* %[[VAL_16]], align 1
 // CHECK:         %[[VAL_17:.*]] = getelementptr inbounds i8, i8* %[[VAL_0]], i64 1
 // CHECK:         %[[VAL_18:.*]] = bitcast i8* %[[VAL_17]] to i1*
 // CHECK:         store i1 %[[VAL_15]], i1* %[[VAL_18]], align 1
-// CHECK:         tail call void @__quantum__rt__qubit_release_array(%[[VAL_3]]* %[[VAL_2]])
 // CHECK:         ret { i8*, i64 } zeroinitializer
 // CHECK:       }
 


### PR DESCRIPTION
Fix #3037.

We generally want the inliner to be super aggressive and inline all calls everywhere. Except in the case where the thunk layer is calling the kernel proper. In that one instance, inlining must be prevented. The existing checks do a decent job of preventing this from happening in the typical case, but there were some cases (involving trivial kernels) that leaked through.

This adds a special NoInlineCallOp to fool the Inliner into thinking it can't perform the inlining.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
