### PR TITLE
Update `mgpu` sha to pick up a fix for `apply_noise`

### DIFF
--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: 250c2cacb48a8564e27abe5b8e9777dfd9709868
+nvidia-mgpu-commit: 86ea9c7c3f2ebc155514754fa2e816e642a2ad44


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This updated SHA contains a fix for `applyNoise` in mgpu repo. 

The direct `applyNoise` operation might be applied out-of-order w.r.t. the sequence of gates in the kernel.  This is fixed in `cuquantum-mgpu` merge request 59. Hence, update the sha to pick up the fix.