### PR TITLE
Fix publishing deprecated backend usage

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1091,11 +1091,13 @@ jobs:
           set +e # Allow script to keep going through errors
           # Verify that the necessary GPU targets are installed and usable
           # Note nvidia-mgpu requires MPI, so it is not available with this method.
-          for tgt in nvidia nvidia-fp64 tensornet; do
-              echo "Running with target ${tgt}"
-              python3 docs/sphinx/examples/python/intro.py --target ${tgt}
+          # List of full target options
+          targets=("--target nvidia" "--target nvidia --target-option fp64" "--target tensornet")
+          for tgt in "${targets[@]}"; do
+              echo "Running with ${tgt}"
+              python3 docs/sphinx/examples/python/intro.py $tgt
               if [ $? -ne 0 ]; then 
-                  echo -e "\e[01;31mPython trivial test for target ${tgt} failed.\e[0m" >&2
+                  echo -e "\e[01;31mPython trivial test for ${tgt} failed.\e[0m" >&2
                   status_sum=$((status_sum+1))
               fi
           done

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -875,10 +875,17 @@ jobs:
           bash github-repo/scripts/validate_container.sh $backends_to_test | tee /tmp/validation.out
 
           # Check that the tests included the nvidia-mgpu backend:
-          relevant_line=`grep -n "Testing backends:" /tmp/validation.out | cut -d : -f1`
-          tested_backends=`cat /tmp/validation.out | tail -n +$relevant_line | sed -e '/^$/,$d'`
-          if [ -z "$(echo $tested_backends | grep nvidia-mgpu)" ]; then 
-            echo "::error::Missing tests for nvidia-mgpu backend."
+          # Grab the line where "Testing on nvidia target..." starts
+          nvidia_block_start=$(grep -n "Testing on nvidia target..." /tmp/validation.out | cut -d: -f1)
+
+          # From that line, extract the block until the next "Testing on" or EOF
+          nvidia_block=$(tail -n +$((nvidia_block_start + 1)) /tmp/validation.out | sed -n '/^Testing on /q;p')
+
+          # Check if "fp32,mgpu" is present
+          if ! echo "$nvidia_block" | grep -q "fp32,mgpu"; then
+            echo "::error::Missing tests for nvidia fp32,mgpu backend."
+            echo "Observed target options:"
+            echo "$nvidia_block"
             exit 1
           fi
 
@@ -1011,13 +1018,19 @@ jobs:
           bash -l scripts/validate_container.sh | tee /tmp/validation.out
 
           # Check that the tests included the nvidia-mgpu backend:
-          relevant_line=`grep -n "Testing backends:" /tmp/validation.out | cut -d : -f1`
-          tested_backends=`cat /tmp/validation.out | tail -n +$relevant_line | sed -e '/^$/,$d'`
-          if [ -z "$(echo $tested_backends | grep nvidia-mgpu)" ]; then 
-            echo "::error::Missing tests for nvidia-mgpu backend."
+          # Grab the line where "Testing on nvidia target..." starts
+          nvidia_block_start=$(grep -n "Testing on nvidia target..." /tmp/validation.out | cut -d: -f1)
+
+          # From that line, extract the block until the next "Testing on" or EOF
+          nvidia_block=$(tail -n +$((nvidia_block_start + 1)) /tmp/validation.out | sed -n '/^Testing on /q;p')
+
+          # Check if "fp32,mgpu" is present
+          if ! echo "$nvidia_block" | grep -q "fp32,mgpu"; then
+            echo "::error::Missing tests for nvidia fp32,mgpu backend."
+            echo "Observed target options:"
+            echo "$nvidia_block"
             exit 1
           fi
-
   wheel_validation_piponly:
     name: Wheel validation, pip only
     needs: [assets, cudaq_wheels, cudaq_metapackages]

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -875,8 +875,10 @@ jobs:
           bash github-repo/scripts/validate_container.sh $backends_to_test | tee /tmp/validation.out
 
           # Check that the tests included the nvidia-mgpu backend:
-          # Grab the line where "Testing on nvidia target..." starts
-          nvidia_block_start=$(grep -n "Testing on nvidia target..." /tmp/validation.out | cut -d: -f1)
+          # Grab the first line where "Testing on nvidia target..." starts
+          # The first should be okay, since any target being tested against
+          # nvidia should be using all the options for the validation script.
+          nvidia_block_start=$(grep -n "Testing on nvidia target..." /tmp/validation.out | head -n1 | cut -d: -f1)
 
           # From that line, extract the block until the next "Testing on" or EOF
           nvidia_block=$(tail -n +$((nvidia_block_start + 1)) /tmp/validation.out | sed -n '/^Testing on /q;p')
@@ -1018,8 +1020,10 @@ jobs:
           bash -l scripts/validate_container.sh | tee /tmp/validation.out
 
           # Check that the tests included the nvidia-mgpu backend:
-          # Grab the line where "Testing on nvidia target..." starts
-          nvidia_block_start=$(grep -n "Testing on nvidia target..." /tmp/validation.out | cut -d: -f1)
+          # Grab the first line where "Testing on nvidia target..." starts
+          # The first should be okay, since any target being tested against
+          # nvidia should be using all the options for the validation script.
+          nvidia_block_start=$(grep -n "Testing on nvidia target..." /tmp/validation.out | head -n1 | cut -d: -f1)
 
           # From that line, extract the block until the next "Testing on" or EOF
           nvidia_block=$(tail -n +$((nvidia_block_start + 1)) /tmp/validation.out | sed -n '/^Testing on /q;p')
@@ -1031,6 +1035,7 @@ jobs:
             echo "$nvidia_block"
             exit 1
           fi
+
   wheel_validation_piponly:
     name: Wheel validation, pip only
     needs: [assets, cudaq_wheels, cudaq_metapackages]


### PR DESCRIPTION
Fixes failing pipelines - https://github.com/NVIDIA/cuda-quantum/actions/runs/15694498377/job/44218950832

Recently, the deprecated backends were removed from the validation script https://github.com/NVIDIA/cuda-quantum/pull/3060. This has the knock-on effect that the publishing pipeline is now breaking because it was looking for those deprecated backends. 
This updates the logic to :
* use the non-deprecated backend
* check for the non-deprecated backend for `fp32,mgpu`.

If a failure occurs, the pipeline will print the block it sees that failed to find `fp32,mgpu` like so:
```
::error::Missing tests for nvidia fp32,mgpu backend.
Observed target options:
  Testing nvidia target option: fp32
  Exited with code 0
  Testing nvidia target option: fp64
  Exited with code 0
  ...
```

I tested this in a manual way by copying `validation.out` to `/tmp/` and just running the bash code that is changed.

```bash
$ head /tmp/validation.out 
Installed backends:
default
anyon
braket
density-matrix-cpu
dynamics
fermioniq
infleqtion
ionq
iqm
$ cat test.sh
          # Check that the tests included the nvidia-mgpu backend:
          # Grab the first line where "Testing on nvidia target..." starts
          # The first should be okay, since any target being tested against
          # nvidia should be using all the options for the validation script.
          nvidia_block_start=$(grep -n "Testing on nvidia target..." /tmp/validation.out | head -n1 | cut -d: -f1)

          # From that line, extract the block until the next "Testing on" or EOF
          nvidia_block=$(tail -n +$((nvidia_block_start + 1)) /tmp/validation.out | sed -n '/^Testing on /q;p')

          # Check if "fp32,mgpu" is present
          if ! echo "$nvidia_block" | grep -q "fp32,mgpu"; then
            echo "::error::Missing tests for nvidia fp32,mgpu backend."
            echo "Observed target options:"
            echo "$nvidia_block"
            exit 1
          fi

$ bash test.sh 
$ echo $?
0
```

The intro changes were easy, I just ran that in a fresh container.

```
# cat test.sh
          status_sum=0
          set +e # Allow script to keep going through errors
          # Verify that the necessary GPU targets are installed and usable
          # Note nvidia-mgpu requires MPI, so it is not available with this method.
          # List of full target options
          targets=("--target nvidia" "--target nvidia --target-option fp64" "--target tensornet")
          for tgt in "${targets[@]}"; do
              echo "Running with ${tgt}"
              python3 docs/sphinx/examples/python/intro.py $tgt
              if [ $? -ne 0 ]; then 
                  echo -e "\e[01;31mPython trivial test for ${tgt} failed.\e[0m" >&2
                  status_sum=$((status_sum+1))
              fi
          done

          set -e # Re-enable exit code error checking
          if [ "$status_sum" -ne "0" ]; then
            echo "::error::Error running validation script" 
            exit $status_sum
          fi

# file docs/sphinx/examples/python/intro.py
docs/sphinx/examples/python/intro.py: Python script, ASCII text executable
# bash test.sh
Running with --target nvidia
{ 0:487 1:513 }

Running with --target nvidia --target-option fp64
{ 0:501 1:499 }

Running with --target tensornet
{ 0:494 1:506 }

# echo $?
0
```