### PR TITLE
[py] Update bindings to follow MLIR arg ordering.

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -141,8 +141,8 @@ class PyASTBridge(ast.NodeVisitor):
         else:
             self.ctx = Context()
             register_all_dialects(self.ctx)
-            quake.register_dialect(self.ctx)
-            cc.register_dialect(self.ctx)
+            quake.register_dialect(context=self.ctx)
+            cc.register_dialect(context=self.ctx)
             cudaq_runtime.registerLLVMDialectTranslation(self.ctx)
             self.loc = Location.unknown(context=self.ctx)
             self.module = Module.create(loc=self.loc)
@@ -267,14 +267,14 @@ class PyASTBridge(ast.NodeVisitor):
         Return a `quake.VeqType`. Pass the size of the `quake.veq` if known. 
         """
         if size == None:
-            return quake.VeqType.get(self.ctx)
-        return quake.VeqType.get(self.ctx, size)
+            return quake.VeqType.get()
+        return quake.VeqType.get(size)
 
     def getRefType(self):
         """
         Return a `quake.RefType`.
         """
-        return quake.RefType.get(self.ctx)
+        return quake.RefType.get()
 
     def isQuantumType(self, ty):
         """
@@ -536,7 +536,7 @@ class PyASTBridge(ast.NodeVisitor):
         return the slot address.
         """
         if not cc.PointerType.isinstance(value.type):
-            slot = cc.AllocaOp(cc.PointerType.get(self.ctx, value.type),
+            slot = cc.AllocaOp(cc.PointerType.get(value.type),
                                TypeAttr.get(value.type)).result
             cc.StoreOp(value, slot)
             return slot
@@ -545,14 +545,14 @@ class PyASTBridge(ast.NodeVisitor):
     def __createStdvecWithKnownValues(self, size, listElementValues):
         # Turn this List into a StdVec<T>
         arrSize = self.getConstantInt(size)
-        arrTy = cc.ArrayType.get(self.ctx, listElementValues[0].type)
-        alloca = cc.AllocaOp(cc.PointerType.get(self.ctx, arrTy),
+        arrTy = cc.ArrayType.get(listElementValues[0].type)
+        alloca = cc.AllocaOp(cc.PointerType.get(arrTy),
                              TypeAttr.get(listElementValues[0].type),
                              seqSize=arrSize).result
 
         for i, v in enumerate(listElementValues):
             eleAddr = cc.ComputePtrOp(
-                cc.PointerType.get(self.ctx, listElementValues[0].type), alloca,
+                cc.PointerType.get(listElementValues[0].type), alloca,
                 [self.getConstantInt(i)],
                 DenseI32ArrayAttr.get([kDynamicPtrIndex],
                                       context=self.ctx)).result
@@ -562,8 +562,7 @@ class PyASTBridge(ast.NodeVisitor):
         if cc.PointerType.isinstance(vecTy):
             vecTy = cc.PointerType.getElementType(vecTy)
 
-        return cc.StdvecInitOp(cc.StdvecType.get(self.ctx, vecTy),
-                               alloca,
+        return cc.StdvecInitOp(cc.StdvecType.get(vecTy), alloca,
                                length=arrSize).result
 
     def getStructMemberIdx(self, memberName, structTy):
@@ -614,17 +613,17 @@ class PyASTBridge(ast.NodeVisitor):
         if (sourceEleType == targetEleType):
             return sourcePtr
 
-        sourceArrType = cc.ArrayType.get(self.ctx, sourceEleType)
-        sourceElePtrTy = cc.PointerType.get(self.ctx, sourceEleType)
-        sourceArrElePtrTy = cc.PointerType.get(self.ctx, sourceArrType)
+        sourceArrType = cc.ArrayType.get(sourceEleType)
+        sourceElePtrTy = cc.PointerType.get(sourceEleType)
+        sourceArrElePtrTy = cc.PointerType.get(sourceArrType)
         sourceValue = self.ifPointerThenLoad(sourcePtr)
         sourceDataPtr = cc.StdvecDataOp(sourceArrElePtrTy, sourceValue).result
         sourceSize = cc.StdvecSizeOp(self.getIntegerType(), sourceValue).result
 
-        targetElePtrType = cc.PointerType.get(self.ctx, targetEleType)
-        targetTy = cc.ArrayType.get(self.ctx, targetEleType)
-        targetArrElePtrTy = cc.PointerType.get(self.ctx, targetTy)
-        targetVecTy = cc.StdvecType.get(self.ctx, targetEleType)
+        targetElePtrType = cc.PointerType.get(targetEleType)
+        targetTy = cc.ArrayType.get(targetEleType)
+        targetArrElePtrTy = cc.PointerType.get(targetTy)
+        targetVecTy = cc.StdvecType.get(targetEleType)
         targetPtr = cc.AllocaOp(targetArrElePtrTy,
                                 TypeAttr.get(targetEleType),
                                 seqSize=sourceSize).result
@@ -651,7 +650,7 @@ class PyASTBridge(ast.NodeVisitor):
         value = self.ifPointerThenLoad(value)
         printFunc = None
         printStr = '[cudaq-ast-dbg] '
-        argsTy = [cc.PointerType.get(self.ctx, self.getIntegerType(8))]
+        argsTy = [cc.PointerType.get(self.getIntegerType(8))]
         if dbgStmt == 'print_i64':
             if not IntegerType.isinstance(value.type):
                 self.emitFatalError(
@@ -694,12 +693,11 @@ class PyASTBridge(ast.NodeVisitor):
                 f"Invalid cudaq.dbg.ast statement - {dbgStmt}")
 
         strLitTy = cc.PointerType.get(
-            self.ctx,
-            cc.ArrayType.get(self.ctx, self.getIntegerType(8),
+            cc.ArrayType.get(self.getIntegerType(8),
                              len(printStr) + 1))
         strLit = cc.CreateStringLiteralOp(strLitTy,
                                           StringAttr.get(printStr)).result
-        strLit = cc.CastOp(cc.PointerType.get(self.ctx, self.getIntegerType(8)),
+        strLit = cc.CastOp(cc.PointerType.get(self.getIntegerType(8)),
                            strLit).result
         func.CallOp(printFunc, [strLit, value])
         return
@@ -733,20 +731,16 @@ class PyASTBridge(ast.NodeVisitor):
         if cc.StdvecType.isinstance(vector.type):
             data_ptr = cc.StdvecDataOp(
                 cc.PointerType.get(
-                    self.ctx,
-                    cc.ArrayType.get(self.ctx,
-                                     cc.StdvecType.getElementType(
-                                         vector.type))), vector).result
+                    cc.ArrayType.get(cc.StdvecType.getElementType(
+                        vector.type))), vector).result
             return cc.LoadOp(
                 cc.ComputePtrOp(
-                    cc.PointerType.get(
-                        self.ctx,
-                        cc.StdvecType.getElementType(vector.type)), data_ptr,
-                    [index], DenseI32ArrayAttr.get([kDynamicPtrIndex]))).result
+                    cc.PointerType.get(cc.StdvecType.getElementType(
+                        vector.type)), data_ptr, [index],
+                    DenseI32ArrayAttr.get([kDynamicPtrIndex]))).result
         return cc.LoadOp(
             cc.ComputePtrOp(
                 cc.PointerType.get(
-                    self.ctx,
                     cc.ArrayType.getElementType(
                         cc.PointerType.getElementType(vector.type))), vector,
                 [index], DenseI32ArrayAttr.get([kDynamicPtrIndex]))).result
@@ -1001,7 +995,7 @@ class PyASTBridge(ast.NodeVisitor):
                 self.emitFatalError(
                     "inner function definitions cannot have arguments.", node)
 
-            ty = cc.CallableType.get(self.ctx, [])
+            ty = cc.CallableType.get([])
             createLambda = cc.CreateLambdaOp(ty)
             initRegion = createLambda.initRegion
             initBlock = Block.create_at_start(initRegion, [])
@@ -1071,9 +1065,8 @@ class PyASTBridge(ast.NodeVisitor):
                 blockArgs = self.entry.arguments
                 for i, b in enumerate(blockArgs):
                     if self.needsStackSlot(b.type):
-                        stackSlot = cc.AllocaOp(
-                            cc.PointerType.get(self.ctx, b.type),
-                            TypeAttr.get(b.type)).result
+                        stackSlot = cc.AllocaOp(cc.PointerType.get(b.type),
+                                                TypeAttr.get(b.type)).result
                         cc.StoreOp(b, stackSlot)
                         self.symbolTable[argNames[i]] = stackSlot
                     else:
@@ -1157,7 +1150,7 @@ class PyASTBridge(ast.NodeVisitor):
         if len(arguments):
             self.emitFatalError("CUDA-Q lambdas cannot have arguments.", node)
 
-        ty = cc.CallableType.get(self.ctx, [])
+        ty = cc.CallableType.get([])
         createLambda = cc.CreateLambdaOp(ty)
         initBlock = Block.create_at_start(createLambda.initRegion, [])
         with InsertionPoint(initBlock):
@@ -1229,7 +1222,6 @@ class PyASTBridge(ast.NodeVisitor):
                     if cc.ArrayType.isinstance(ptrEleType):
                         ptrVal = cc.CastOp(
                             cc.PointerType.get(
-                                self.ctx,
                                 cc.ArrayType.getElementType(ptrEleType)),
                             ptrVal).result
 
@@ -1313,7 +1305,7 @@ class PyASTBridge(ast.NodeVisitor):
                 self.symbolTable[varNames[i]] = value
             else:
                 # We should allocate and store
-                alloca = cc.AllocaOp(cc.PointerType.get(self.ctx, value.type),
+                alloca = cc.AllocaOp(cc.PointerType.get(value.type),
                                      TypeAttr.get(value.type)).result
                 cc.StoreOp(value, alloca)
                 self.symbolTable[varNames[i]] = alloca
@@ -1349,7 +1341,7 @@ class PyASTBridge(ast.NodeVisitor):
                     structIdx, memberTy = self.getStructMemberIdx(
                         node.attr, eleType)
                     eleAddr = cc.ComputePtrOp(
-                        cc.PointerType.get(self.ctx, memberTy), value, [],
+                        cc.PointerType.get(memberTy), value, [],
                         DenseI32ArrayAttr.get([structIdx],
                                               context=self.ctx)).result
 
@@ -1640,8 +1632,8 @@ class PyASTBridge(ast.NodeVisitor):
                                           math.AbsIOp(stepVal).result).result
 
                 # Create an array of i64 of the total size
-                arrTy = cc.ArrayType.get(self.ctx, iTy)
-                iterable = cc.AllocaOp(cc.PointerType.get(self.ctx, arrTy),
+                arrTy = cc.ArrayType.get(iTy)
+                iterable = cc.AllocaOp(cc.PointerType.get(arrTy),
                                        TypeAttr.get(iTy),
                                        seqSize=totalSize).result
 
@@ -1650,7 +1642,7 @@ class PyASTBridge(ast.NodeVisitor):
                 # array = [start, start +- step, start +- 2*step, start +- 3*step, ...]
                 # So we need to know the start and step (already have them),
                 # but we also need to keep track of a counter
-                counter = cc.AllocaOp(cc.PointerType.get(self.ctx, iTy),
+                counter = cc.AllocaOp(cc.PointerType.get(iTy),
                                       TypeAttr.get(iTy)).result
                 cc.StoreOp(zero, counter)
 
@@ -1659,8 +1651,7 @@ class PyASTBridge(ast.NodeVisitor):
                     tmp = arith.MulIOp(loadedCounter, stepVal).result
                     arrElementVal = arith.AddIOp(startVal, tmp).result
                     eleAddr = cc.ComputePtrOp(
-                        cc.PointerType.get(self.ctx, iTy), iterable,
-                        [loadedCounter],
+                        cc.PointerType.get(iTy), iterable, [loadedCounter],
                         DenseI32ArrayAttr.get([kDynamicPtrIndex],
                                               context=self.ctx))
                     cc.StoreOp(arrElementVal, eleAddr)
@@ -1705,9 +1696,9 @@ class PyASTBridge(ast.NodeVisitor):
                                                     iterable).result
 
                         def extractFunctor(idxVal):
-                            arrEleTy = cc.ArrayType.get(self.ctx, iterEleTy)
-                            elePtrTy = cc.PointerType.get(self.ctx, iterEleTy)
-                            arrPtrTy = cc.PointerType.get(self.ctx, arrEleTy)
+                            arrEleTy = cc.ArrayType.get(iterEleTy)
+                            elePtrTy = cc.PointerType.get(iterEleTy)
+                            arrPtrTy = cc.PointerType.get(arrEleTy)
                             vecPtr = cc.StdvecDataOp(arrPtrTy, iterable).result
                             eleAddr = cc.ComputePtrOp(
                                 elePtrTy, vecPtr, [idxVal],
@@ -1732,8 +1723,7 @@ class PyASTBridge(ast.NodeVisitor):
 
                     def localFunc(idxVal):
                         eleAddr = cc.ComputePtrOp(
-                            cc.PointerType.get(self.ctx, iterEleTy), iterable,
-                            [idxVal],
+                            cc.PointerType.get(iterEleTy), iterable, [idxVal],
                             DenseI32ArrayAttr.get([kDynamicPtrIndex],
                                                   context=self.ctx)).result
                         return cc.LoadOp(eleAddr).result
@@ -1742,10 +1732,9 @@ class PyASTBridge(ast.NodeVisitor):
 
                 # Enumerate returns a iterable of tuple(i64, T) for type T
                 # Allocate an array of struct<i64, T> == tuple (for us)
-                structTy = cc.StructType.get(self.ctx,
-                                             [self.getIntegerType(), iterEleTy])
-                arrTy = cc.ArrayType.get(self.ctx, structTy)
-                enumIterable = cc.AllocaOp(cc.PointerType.get(self.ctx, arrTy),
+                structTy = cc.StructType.get([self.getIntegerType(), iterEleTy])
+                arrTy = cc.ArrayType.get(structTy)
+                enumIterable = cc.AllocaOp(cc.PointerType.get(arrTy),
                                            TypeAttr.get(structTy),
                                            seqSize=totalSize).result
 
@@ -1757,8 +1746,7 @@ class PyASTBridge(ast.NodeVisitor):
                     extracted = extractFunctor(iterVar)
                     # Get the pointer to the enumeration iterable so we can set it
                     eleAddr = cc.ComputePtrOp(
-                        cc.PointerType.get(self.ctx, structTy), enumIterable,
-                        [iterVar],
+                        cc.PointerType.get(structTy), enumIterable, [iterVar],
                         DenseI32ArrayAttr.get([kDynamicPtrIndex],
                                               context=self.ctx))
                     # Set the index value
@@ -1918,11 +1906,11 @@ class PyASTBridge(ast.NodeVisitor):
                 opCtor = getattr(quake, '{}Op'.format(node.func.id.title()))
                 i1Ty = self.getIntegerType(1)
                 resTy = i1Ty if len(qubits) == 1 and quake.RefType.isinstance(
-                    qubits[0].type) else cc.StdvecType.get(self.ctx, i1Ty)
+                    qubits[0].type) else cc.StdvecType.get(i1Ty)
                 measTy = quake.MeasureType.get(
-                    self.ctx) if len(qubits) == 1 and quake.RefType.isinstance(
-                        qubits[0].type) else cc.StdvecType.get(
-                            self.ctx, quake.MeasureType.get(self.ctx))
+                ) if len(qubits) == 1 and quake.RefType.isinstance(
+                    qubits[0].type) else cc.StdvecType.get(
+                        quake.MeasureType.get())
                 label = registerName
                 if not label:
                     label = None
@@ -2156,8 +2144,7 @@ class PyASTBridge(ast.NodeVisitor):
                     if not self.isQuantumType(fieldTy):
                         isStruq = False
                 if isStruq:
-                    structTy = quake.StruqType.getNamed(self.ctx, node.func.id,
-                                                        structTys)
+                    structTy = quake.StruqType.getNamed(node.func.id, structTys)
                     # Disallow recursive quantum struct types.
                     for fieldTy in structTys:
                         if self.isQuantumStructType(fieldTy):
@@ -2165,8 +2152,7 @@ class PyASTBridge(ast.NodeVisitor):
                                 'recursive quantum struct types not allowed.',
                                 node)
                 else:
-                    structTy = cc.StructType.getNamed(self.ctx, node.func.id,
-                                                      structTys)
+                    structTy = cc.StructType.getNamed(node.func.id, structTys)
 
                 # Disallow user specified methods on structs
                 if len({
@@ -2189,7 +2175,7 @@ class PyASTBridge(ast.NodeVisitor):
                     self.pushValue(quake.MakeStruqOp(structTy, ctorArgs).result)
                     return
 
-                stackSlot = cc.AllocaOp(cc.PointerType.get(self.ctx, structTy),
+                stackSlot = cc.AllocaOp(cc.PointerType.get(structTy),
                                         TypeAttr.get(structTy)).result
 
                 if len(ctorArgs) != len(structTys):
@@ -2202,7 +2188,7 @@ class PyASTBridge(ast.NodeVisitor):
 
                 for i, ty in enumerate(structTys):
                     eleAddr = cc.ComputePtrOp(
-                        cc.PointerType.get(self.ctx, ty), stackSlot, [],
+                        cc.PointerType.get(ty), stackSlot, [],
                         DenseI32ArrayAttr.get([i], context=self.ctx)).result
                     cc.StoreOp(ctorArgs[i], eleAddr)
                 self.pushValue(stackSlot)
@@ -2418,10 +2404,10 @@ class PyASTBridge(ast.NodeVisitor):
                         # TODO: Dynamically check if number of qubits is power of 2
                         # and if the state is normalized
 
-                        ptrTy = cc.PointerType.get(self.ctx, eleTy)
-                        arrTy = cc.ArrayType.get(self.ctx, eleTy)
-                        ptrArrTy = cc.PointerType.get(self.ctx, arrTy)
-                        veqTy = quake.VeqType.get(self.ctx)
+                        ptrTy = cc.PointerType.get(eleTy)
+                        arrTy = cc.ArrayType.get(eleTy)
+                        ptrArrTy = cc.PointerType.get(arrTy)
+                        veqTy = quake.VeqType.get()
 
                         qubits = quake.AllocaOp(veqTy, size=numQubits).result
                         data = cc.StdvecDataOp(ptrArrTy, value).result
@@ -2438,7 +2424,7 @@ class PyASTBridge(ast.NodeVisitor):
                         numQubits = quake.GetNumberOfQubitsOp(i64Ty,
                                                               statePtr).result
 
-                        veqTy = quake.VeqType.get(self.ctx)
+                        veqTy = quake.VeqType.get()
                         qubits = quake.AllocaOp(veqTy, size=numQubits).result
                         init = quake.InitializeStateOp(veqTy, qubits,
                                                        statePtr).result
@@ -2558,9 +2544,8 @@ class PyASTBridge(ast.NodeVisitor):
                         # If we have a F64 value, we want to
                         # store it to a pointer
                         if F64Type.isinstance(p.type):
-                            alloca = cc.AllocaOp(
-                                cc.PointerType.get(self.ctx, p.type),
-                                TypeAttr.get(p.type)).result
+                            alloca = cc.AllocaOp(cc.PointerType.get(p.type),
+                                                 TypeAttr.get(p.type)).result
                             cc.StoreOp(p, alloca)
                             params[i] = alloca
 
@@ -3033,35 +3018,34 @@ class PyASTBridge(ast.NodeVisitor):
         listValue = None
         listComputePtrTy = arrayEleTy
         if not isinstance(node.elt, ast.List):
-            listValue = cc.AllocaOp(cc.PointerType.get(self.ctx, arrayTy),
+            listValue = cc.AllocaOp(cc.PointerType.get(arrayTy),
                                     TypeAttr.get(arrayEleTy),
                                     seqSize=iterableSize).result
         else:
-            listComputePtrTy = cc.StdvecType.get(self.ctx, arrayEleTy)
-            arrOfStdvecTy = cc.ArrayType.get(self.ctx, listComputePtrTy)
-            listValue = cc.AllocaOp(cc.PointerType.get(self.ctx, arrOfStdvecTy),
+            listComputePtrTy = cc.StdvecType.get(arrayEleTy)
+            arrOfStdvecTy = cc.ArrayType.get(listComputePtrTy)
+            listValue = cc.AllocaOp(cc.PointerType.get(arrOfStdvecTy),
                                     TypeAttr.get(listComputePtrTy),
                                     seqSize=iterableSize).result
 
         def bodyBuilder(iterVar):
             self.symbolTable.pushScope()
             eleAddr = cc.ComputePtrOp(
-                cc.PointerType.get(self.ctx, arrayEleTy), iterable, [iterVar],
+                cc.PointerType.get(arrayEleTy), iterable, [iterVar],
                 DenseI32ArrayAttr.get([kDynamicPtrIndex], context=self.ctx))
             loadedEle = cc.LoadOp(eleAddr).result
             self.symbolTable[node.generators[0].target.id] = loadedEle
             self.visit(node.elt)
             result = self.popValue()
             listValueAddr = cc.ComputePtrOp(
-                cc.PointerType.get(self.ctx, listComputePtrTy), listValue,
-                [iterVar],
+                cc.PointerType.get(listComputePtrTy), listValue, [iterVar],
                 DenseI32ArrayAttr.get([kDynamicPtrIndex], context=self.ctx))
             cc.StoreOp(result, listValueAddr)
             self.symbolTable.popScope()
 
         self.createInvariantForLoop(iterableSize, bodyBuilder)
         self.pushValue(
-            cc.StdvecInitOp(cc.StdvecType.get(self.ctx, listComputePtrTy),
+            cc.StdvecInitOp(cc.StdvecType.get(listComputePtrTy),
                             listValue,
                             length=iterableSize).result)
         return
@@ -3169,8 +3153,7 @@ class PyASTBridge(ast.NodeVisitor):
                     return
 
             strLitTy = cc.PointerType.get(
-                self.ctx,
-                cc.ArrayType.get(self.ctx, self.getIntegerType(8),
+                cc.ArrayType.get(self.getIntegerType(8),
                                  len(node.value) + 1))
             self.pushValue(
                 cc.CreateStringLiteralOp(strLitTy,
@@ -3254,9 +3237,9 @@ class PyASTBridge(ast.NodeVisitor):
                                    upper=upperVal).result)
             elif cc.StdvecType.isinstance(var.type):
                 eleTy = cc.StdvecType.getElementType(var.type)
-                ptrTy = cc.PointerType.get(self.ctx, eleTy)
-                arrTy = cc.ArrayType.get(self.ctx, eleTy)
-                ptrArrTy = cc.PointerType.get(self.ctx, arrTy)
+                ptrTy = cc.PointerType.get(eleTy)
+                arrTy = cc.ArrayType.get(eleTy)
+                ptrArrTy = cc.PointerType.get(arrTy)
                 nElementsVal = arith.SubIOp(upperVal, lowerVal).result
                 # need to compute the distance between `upperVal` and `lowerVal`
                 # then slice is `stdvecdataOp + computeptr[lower] + stdvecinit[ptr,distance]`
@@ -3314,9 +3297,9 @@ class PyASTBridge(ast.NodeVisitor):
 
         if cc.StdvecType.isinstance(var.type):
             eleTy = cc.StdvecType.getElementType(var.type)
-            elePtrTy = cc.PointerType.get(self.ctx, eleTy)
-            arrTy = cc.ArrayType.get(self.ctx, eleTy)
-            ptrArrTy = cc.PointerType.get(self.ctx, arrTy)
+            elePtrTy = cc.PointerType.get(eleTy)
+            arrTy = cc.ArrayType.get(eleTy)
+            ptrArrTy = cc.PointerType.get(arrTy)
             vecPtr = cc.StdvecDataOp(ptrArrTy, var).result
             eleAddr = cc.ComputePtrOp(
                 elePtrTy, vecPtr, [idx],
@@ -3337,7 +3320,7 @@ class PyASTBridge(ast.NodeVisitor):
             if cc.ArrayType.isinstance(ptrEleTy):
                 # Here we want subscript on `ptr<array<>>`
                 arrayEleTy = cc.ArrayType.getElementType(ptrEleTy)
-                ptrEleTy = cc.PointerType.get(self.ctx, arrayEleTy)
+                ptrEleTy = cc.PointerType.get(arrayEleTy)
                 casted = cc.CastOp(ptrEleTy, var).result
                 eleAddr = cc.ComputePtrOp(
                     ptrEleTy, casted, [idx],
@@ -3367,8 +3350,8 @@ class PyASTBridge(ast.NodeVisitor):
 
             structPtr = self.ifNotPointerThenStore(var)
             eleAddr = cc.ComputePtrOp(
-                cc.PointerType.get(self.ctx, memberTys[idxValue]), structPtr,
-                [], DenseI32ArrayAttr.get([idxValue], context=self.ctx)).result
+                cc.PointerType.get(memberTys[idxValue]), structPtr, [],
+                DenseI32ArrayAttr.get([idxValue], context=self.ctx)).result
 
             # Return the pointer if someone asked for it
             if self.subscriptPushPointerValue:
@@ -3453,11 +3436,11 @@ class PyASTBridge(ast.NodeVisitor):
 
                     def functor(seq, idx):
                         vecTy = cc.StdvecType.getElementType(seq.type)
-                        dataTy = cc.PointerType.get(self.ctx, vecTy)
+                        dataTy = cc.PointerType.get(vecTy)
                         arrTy = vecTy
                         if not cc.ArrayType.isinstance(arrTy):
-                            arrTy = cc.ArrayType.get(self.ctx, vecTy)
-                        dataArrTy = cc.PointerType.get(self.ctx, arrTy)
+                            arrTy = cc.ArrayType.get(vecTy)
+                        dataArrTy = cc.PointerType.get(arrTy)
                         data = cc.StdvecDataOp(dataArrTy, seq).result
                         v = cc.ComputePtrOp(
                             dataTy, data, [idx],
@@ -3519,9 +3502,9 @@ class PyASTBridge(ast.NodeVisitor):
                                             iterable).result
 
                 def functor(iter, idxVal):
-                    elePtrTy = cc.PointerType.get(self.ctx, iterEleTy)
-                    arrTy = cc.ArrayType.get(self.ctx, iterEleTy)
-                    ptrArrTy = cc.PointerType.get(self.ctx, arrTy)
+                    elePtrTy = cc.PointerType.get(iterEleTy)
+                    arrTy = cc.ArrayType.get(iterEleTy)
+                    ptrArrTy = cc.PointerType.get(arrTy)
                     vecPtr = cc.StdvecDataOp(ptrArrTy, iter).result
                     eleAddr = cc.ComputePtrOp(
                         elePtrTy, vecPtr, [idxVal],
@@ -3550,7 +3533,7 @@ class PyASTBridge(ast.NodeVisitor):
 
             def functor(iter, idx):
                 eleAddr = cc.ComputePtrOp(
-                    cc.PointerType.get(self.ctx, elementType), iter, [idx],
+                    cc.PointerType.get(elementType), iter, [idx],
                     DenseI32ArrayAttr.get([kDynamicPtrIndex],
                                           context=self.ctx)).result
                 loaded = cc.LoadOp(eleAddr).result
@@ -3807,7 +3790,7 @@ class PyASTBridge(ast.NodeVisitor):
 
             # Loop setup
             i1_type = self.getIntegerType(1)
-            accumulator = cc.AllocaOp(cc.PointerType.get(self.ctx, i1_type),
+            accumulator = cc.AllocaOp(cc.PointerType.get(i1_type),
                                       TypeAttr.get(i1_type)).result
             cc.StoreOp(self.getConstantInt(0, 1), accumulator)
 
@@ -3971,9 +3954,9 @@ class PyASTBridge(ast.NodeVisitor):
             symName = '__nvqpp_vectorCopyCtor'
             load_intrinsic(self.module, symName)
             eleTy = cc.StdvecType.getElementType(result.type)
-            ptrTy = cc.PointerType.get(self.ctx, self.getIntegerType(8))
-            arrTy = cc.ArrayType.get(self.ctx, self.getIntegerType(8))
-            ptrArrTy = cc.PointerType.get(self.ctx, arrTy)
+            ptrTy = cc.PointerType.get(self.getIntegerType(8))
+            arrTy = cc.ArrayType.get(self.getIntegerType(8))
+            ptrArrTy = cc.PointerType.get(arrTy)
             resBuf = cc.StdvecDataOp(ptrArrTy, result).result
             # TODO Revisit this calculation
             byteWidth = 16 if ComplexType.isinstance(eleTy) else 8
@@ -4017,15 +4000,15 @@ class PyASTBridge(ast.NodeVisitor):
                 f'tuple constructor requires {len(structTys)} arguments, '
                 f'but was given {len(elementValues)}.', node)
 
-        structTy = cc.StructType.getNamed(self.ctx, "tuple", structTys)
-        stackSlot = cc.AllocaOp(cc.PointerType.get(self.ctx, structTy),
+        structTy = cc.StructType.getNamed("tuple", structTys)
+        stackSlot = cc.AllocaOp(cc.PointerType.get(structTy),
                                 TypeAttr.get(structTy)).result
 
         # loop over each type and `compute_ptr` / store
 
         for i, ty in enumerate(structTys):
             eleAddr = cc.ComputePtrOp(
-                cc.PointerType.get(self.ctx, ty), stackSlot, [],
+                cc.PointerType.get(ty), stackSlot, [],
                 DenseI32ArrayAttr.get([i], context=self.ctx)).result
             cc.StoreOp(elementValues[i], eleAddr)
         self.pushValue(stackSlot)
@@ -4343,9 +4326,8 @@ class PyASTBridge(ast.NodeVisitor):
             if mlirValCreator != None:
                 with InsertionPoint.at_block_begin(self.entry):
                     mlirVal = mlirValCreator()
-                    stackSlot = cc.AllocaOp(
-                        cc.PointerType.get(self.ctx, mlirVal.type),
-                        TypeAttr.get(mlirVal.type)).result
+                    stackSlot = cc.AllocaOp(cc.PointerType.get(mlirVal.type),
+                                            TypeAttr.get(mlirVal.type)).result
                     cc.StoreOp(mlirVal, stackSlot)
                     # Store at the top-level
                     self.symbolTable.add(node.id, stackSlot, 0)

--- a/python/cudaq/kernel/captured_data.py
+++ b/python/cudaq/kernel/captured_data.py
@@ -72,7 +72,7 @@ class CapturedDataStorage(object):
         # Compute a unique ID for the state data
         stateID = self.name + str(uuid.uuid4())
         stateTy = cc.StateType.get(self.ctx)
-        statePtrTy = cc.PointerType.get(self.ctx, stateTy)
+        statePtrTy = cc.PointerType.get(stateTy, self.ctx)
 
         # Generate a function that stores the state value in a global
         globalTy = statePtrTy
@@ -90,9 +90,9 @@ class CapturedDataStorage(object):
             entry = setStateFunc.add_entry_block()
             with InsertionPoint(entry):
                 zero = self.getConstantInt(0)
-                address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),
+                address = cc.AddressOfOp(cc.PointerType.get(globalTy, self.ctx),
                                          FlatSymbolRefAttr.get(globalName))
-                ptr = cc.CastOp(cc.PointerType.get(self.ctx, statePtrTy),
+                ptr = cc.CastOp(cc.PointerType.get(statePtrTy, self.ctx),
                                 address)
 
                 cc.StoreOp(entry.arguments[0], ptr)
@@ -107,9 +107,9 @@ class CapturedDataStorage(object):
 
         # Return the pointer to the stored state
         zero = self.getConstantInt(0)
-        address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),
+        address = cc.AddressOfOp(cc.PointerType.get(globalTy, self.ctx),
                                  FlatSymbolRefAttr.get(globalName)).result
-        ptr = cc.CastOp(cc.PointerType.get(self.ctx, statePtrTy),
+        ptr = cc.CastOp(cc.PointerType.get(statePtrTy, self.ctx),
                         address).result
         statePtr = cc.LoadOp(ptr).result
         return statePtr
@@ -127,9 +127,9 @@ class CapturedDataStorage(object):
         ) if simulationPrecision == cudaq_runtime.SimulationPrecision.fp64 else F32Type.get(
             self.ctx)
         complexType = ComplexType.get(floatType)
-        ptrComplex = cc.PointerType.get(self.ctx, complexType)
+        ptrComplex = cc.PointerType.get(complexType, self.ctx)
         i32Ty = self.getIntegerType(32)
-        globalTy = cc.StructType.get(self.ctx, [ptrComplex, i32Ty])
+        globalTy = cc.StructType.get([ptrComplex, i32Ty], self.ctx)
         globalName = f'nvqpp.state.{arrayId}'
         setStateName = f'nvqpp.set.state.{arrayId}'
         with InsertionPoint.at_block_begin(self.module.body):
@@ -144,18 +144,18 @@ class CapturedDataStorage(object):
             entry = setStateFunc.add_entry_block()
             with InsertionPoint(entry):
                 zero = self.getConstantInt(0)
-                address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),
+                address = cc.AddressOfOp(cc.PointerType.get(globalTy, self.ctx),
                                          FlatSymbolRefAttr.get(globalName))
-                ptr = cc.CastOp(cc.PointerType.get(self.ctx, ptrComplex),
+                ptr = cc.CastOp(cc.PointerType.get(ptrComplex, self.ctx),
                                 address)
                 cc.StoreOp(entry.arguments[0], ptr)
                 func.ReturnOp([])
 
         zero = self.getConstantInt(0)
 
-        address = cc.AddressOfOp(cc.PointerType.get(self.ctx, globalTy),
+        address = cc.AddressOfOp(cc.PointerType.get(globalTy, self.ctx),
                                  FlatSymbolRefAttr.get(globalName))
-        ptr = cc.CastOp(cc.PointerType.get(self.ctx, ptrComplex), address)
+        ptr = cc.CastOp(cc.PointerType.get(ptrComplex, self.ctx), address)
 
         # Record the unique hash value
         if arrayId not in self.arrayIDs:

--- a/python/cudaq/kernel/quake_value.py
+++ b/python/cudaq/kernel/quake_value.py
@@ -326,10 +326,10 @@ class QuakeValue(object):
         with self.ctx, Location.unknown(), self.pyKernel.insertPoint:
             if cc.StdvecType.isinstance(self.mlirValue.type):
                 eleTy = cc.StdvecType.getElementType(self.mlirValue.type)
-                arrTy = cc.ArrayType.get(self.ctx, eleTy)
-                arrPtrTy = cc.PointerType.get(self.ctx, arrTy)
+                arrTy = cc.ArrayType.get(eleTy)
+                arrPtrTy = cc.PointerType.get(arrTy)
                 vecPtr = cc.StdvecDataOp(arrPtrTy, self.mlirValue).result
-                elePtrTy = cc.PointerType.get(self.ctx, eleTy)
+                elePtrTy = cc.PointerType.get(eleTy)
                 eleAddr = None
                 i64Ty = IntegerType.get_signless(64)
                 if isinstance(idx, QuakeValue):
@@ -355,7 +355,7 @@ class QuakeValue(object):
                                                                     idx)).result
                 else:
                     raise RuntimeError("invalid idx passed to QuakeValue.")
-                op = quake.ExtractRefOp(quake.RefType.get(self.ctx),
+                op = quake.ExtractRefOp(quake.RefType.get(),
                                         self.mlirValue,
                                         -1,
                                         index=processedIdx)

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -122,9 +122,9 @@ def mlirTypeFromAnnotation(annotation, ctx, raiseError=False):
     if hasattr(annotation, 'attr') and hasattr(annotation.value, 'id'):
         if annotation.value.id == 'cudaq':
             if annotation.attr in ['qview', 'qvector']:
-                return quake.VeqType.get(ctx)
+                return quake.VeqType.get(context=ctx)
             if annotation.attr in ['State']:
-                return cc.PointerType.get(ctx, cc.StateType.get(ctx))
+                return cc.PointerType.get(cc.StateType.get(ctx), ctx)
             if annotation.attr == 'qubit':
                 return quake.RefType.get(ctx)
             if annotation.attr == 'pauli_word':
@@ -132,7 +132,7 @@ def mlirTypeFromAnnotation(annotation, ctx, raiseError=False):
 
         if annotation.value.id in ['numpy', 'np']:
             if annotation.attr in ['array', 'ndarray']:
-                return cc.StdvecType.get(ctx, F64Type.get())
+                return cc.StdvecType.get(F64Type.get(), ctx)
             if annotation.attr == 'complex128':
                 return ComplexType.get(F64Type.get())
             if annotation.attr == 'complex64':
@@ -167,7 +167,7 @@ def mlirTypeFromAnnotation(annotation, ctx, raiseError=False):
                 f"Unable to get list elements when inferring type from annotation ({ast.unparse(annotation) if hasattr(ast, 'unparse') else annotation})."
             )
         argTypes = [mlirTypeFromAnnotation(a, ctx) for a in firstElement.elts]
-        return cc.CallableType.get(ctx, argTypes)
+        return cc.CallableType.get(argTypes, ctx)
 
     if isinstance(annotation,
                   ast.Subscript) and (annotation.value.id == 'list' or
@@ -180,7 +180,7 @@ def mlirTypeFromAnnotation(annotation, ctx, raiseError=False):
         eleTypeNode = annotation.slice
         # expected that slice is a Name node
         listEleTy = mlirTypeFromAnnotation(eleTypeNode, ctx)
-        return cc.StdvecType.get(ctx, listEleTy)
+        return cc.StdvecType.get(listEleTy, ctx)
 
     if isinstance(annotation,
                   ast.Subscript) and (annotation.value.id == 'tuple' or
@@ -278,9 +278,9 @@ def mlirTypeFromAnnotation(annotation, ctx, raiseError=False):
                 )
             if numStruqMemberTys != 0:
                 emitFatalError(f'recursive quantum struct types not allowed.')
-            return quake.StruqType.getNamed(ctx, id, structTys)
+            return quake.StruqType.getNamed(id, structTys, ctx)
 
-        return cc.StructType.getNamed(ctx, id, structTys)
+        return cc.StructType.getNamed(id, structTys, ctx)
 
     localEmitFatalError(
         f"{ast.unparse(annotation) if hasattr(ast, 'unparse') else annotation} is not a supported type."
@@ -342,7 +342,7 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
     if argType == pauli_word:
         return cc.CharspanType.get(ctx)
     if argType == State:
-        return cc.PointerType.get(ctx, cc.StateType.get(ctx))
+        return cc.PointerType.get(cc.StateType.get(ctx), ctx)
 
     if get_origin(argType) == list:
         result = re.search(r'ist\[(.*)\]', str(argType))
@@ -354,10 +354,10 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
 
     if argType in [list, np.ndarray, List]:
         if 'argInstance' not in kwargs:
-            return cc.StdvecType.get(ctx, mlirTypeFromPyType(float, ctx))
+            return cc.StdvecType.get(mlirTypeFromPyType(float, ctx), ctx)
         if argType != np.ndarray:
             if kwargs['argInstance'] == None:
-                return cc.StdvecType.get(ctx, mlirTypeFromPyType(float, ctx))
+                return cc.StdvecType.get(mlirTypeFromPyType(float, ctx), ctx)
 
         argInstance = kwargs['argInstance']
         argTypeToCompareTo = kwargs[
@@ -368,20 +368,19 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
                 emitFatalError('Cannot infer runtime argument type')
 
             eleTy = cc.StdvecType.getElementType(argTypeToCompareTo)
-            return cc.StdvecType.get(ctx, eleTy)
+            return cc.StdvecType.get(eleTy, ctx)
 
         if isinstance(argInstance[0], list):
             return cc.StdvecType.get(
-                ctx,
                 mlirTypeFromPyType(
                     type(argInstance[0]),
                     ctx,
                     argInstance=argInstance[0],
                     argTypeToCompareTo=cc.StdvecType.getElementType(
-                        argTypeToCompareTo)))
+                        argTypeToCompareTo)), ctx)
 
-        return cc.StdvecType.get(ctx,
-                                 mlirTypeFromPyType(type(argInstance[0]), ctx))
+        return cc.StdvecType.get(mlirTypeFromPyType(type(argInstance[0]), ctx),
+                                 ctx)
 
     if get_origin(argType) == tuple:
         #FIXME: re-enable tuple support after we have the spec.
@@ -399,7 +398,7 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
                 emitFatalError(f'Invalid tuple element type ({eleTyName})')
             eleTypes.append(mlirTypeFromPyType(type(pyInstance), ctx))
         eleTypes.reverse()
-        return cc.StructType.getNamed(ctx, "tuple", eleTypes)
+        return cc.StructType.getNamed("tuple", eleTypes, ctx)
 
     if (argType == tuple):
         #FIXME: re-enable tuple support after we have the spec.
@@ -409,10 +408,10 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
         if argInstance == None or (len(argInstance) == 0):
             emitFatalError(f'Cannot infer runtime argument type for {argType}')
         eleTypes = [mlirTypeFromPyType(type(ele), ctx) for ele in argInstance]
-        return cc.StructType.getNamed(ctx, "tuple", eleTypes)
+        return cc.StructType.getNamed("tuple", eleTypes, ctx)
 
     if argType == qvector or argType == qreg or argType == qview:
-        return quake.VeqType.get(ctx)
+        return quake.VeqType.get(context=ctx)
     if argType == qubit:
         return quake.RefType.get(ctx)
     if argType == pauli_word:
@@ -421,7 +420,7 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
     if 'argInstance' in kwargs:
         argInstance = kwargs['argInstance']
         if isinstance(argInstance, Callable):
-            return cc.CallableType.get(ctx, argInstance.argTypes)
+            return cc.CallableType.get(argInstance.argTypes, ctx)
 
     for name in globalRegisteredTypes.classes:
         customTy, memberTys = globalRegisteredTypes.getClassAttributes(name)
@@ -444,15 +443,15 @@ def mlirTypeFromPyType(argType, ctx, **kwargs):
                 if numStruqMemberTys != 0:
                     emitFatalError(
                         f'recursive quantum struct types not allowed.')
-                return quake.StruqType.getNamed(ctx, name, structTys)
+                return quake.StruqType.getNamed(name, structTys, ctx)
 
-            return cc.StructType.getNamed(ctx, name, structTys)
+            return cc.StructType.getNamed(name, structTys, ctx)
 
     if 'argInstance' not in kwargs:
         if argType == list[int]:
-            return cc.StdvecType.get(ctx, mlirTypeFromPyType(int, ctx))
+            return cc.StdvecType.get(mlirTypeFromPyType(int, ctx), ctx)
         if argType == list[float]:
-            return cc.StdvecType.get(ctx, mlirTypeFromPyType(float, ctx))
+            return cc.StdvecType.get(mlirTypeFromPyType(float, ctx), ctx)
 
     emitFatalError(
         f"Can not handle conversion of python type {argType} to MLIR type.")

--- a/python/runtime/mlir/py_register_dialects.cpp
+++ b/python/runtime/mlir/py_register_dialects.cpp
@@ -35,7 +35,7 @@ void registerQuakeDialectAndTypes(py::module &m) {
 
   quakeMod.def(
       "register_dialect",
-      [](MlirContext context, bool load) {
+      [](bool load, MlirContext context) {
         MlirDialectHandle handle = mlirGetDialectHandle__quake__();
         mlirDialectHandleRegisterDialect(handle, context);
         if (load)
@@ -46,30 +46,39 @@ void registerQuakeDialectAndTypes(py::module &m) {
           registered = true;
         }
       },
-      py::arg("context") = py::none(), py::arg("load") = true);
+      py::arg("load") = true, py::arg("context") = py::none());
 
-  mlir_type_subclass(quakeMod, "RefType", [](MlirType type) {
-    return unwrap(type).isa<quake::RefType>();
-  }).def_classmethod("get", [](py::object cls, MlirContext ctx) {
-    return wrap(quake::RefType::get(unwrap(ctx)));
-  });
+  mlir_type_subclass(
+      quakeMod, "RefType",
+      [](MlirType type) { return unwrap(type).isa<quake::RefType>(); })
+      .def_classmethod(
+          "get",
+          [](py::object cls, MlirContext context) {
+            return wrap(quake::RefType::get(unwrap(context)));
+          },
+          py::arg("cls"), py::arg("context") = py::none());
 
-  mlir_type_subclass(quakeMod, "MeasureType", [](MlirType type) {
-    return unwrap(type).isa<quake::MeasureType>();
-  }).def_classmethod("get", [](py::object cls, MlirContext ctx) {
-    return wrap(quake::MeasureType::get(unwrap(ctx)));
-  });
+  mlir_type_subclass(
+      quakeMod, "MeasureType",
+      [](MlirType type) { return unwrap(type).isa<quake::MeasureType>(); })
+      .def_classmethod(
+          "get",
+          [](py::object cls, MlirContext context) {
+            return wrap(quake::MeasureType::get(unwrap(context)));
+          },
+          py::arg("cls"), py::arg("context") = py::none());
 
   mlir_type_subclass(
       quakeMod, "VeqType",
       [](MlirType type) { return unwrap(type).isa<quake::VeqType>(); })
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctx, std::size_t size) {
-            return wrap(quake::VeqType::get(unwrap(ctx), size));
+          [](py::object cls, std::size_t size, MlirContext context) {
+            return wrap(quake::VeqType::get(unwrap(context), size));
           },
-          py::arg("cls"), py::arg("context"),
-          py::arg("size") = std::numeric_limits<std::size_t>::max())
+          py::arg("cls"),
+          py::arg("size") = std::numeric_limits<std::size_t>::max(),
+          py::arg("context") = py::none())
       .def_staticmethod(
           "hasSpecifiedSize",
           [](MlirType type) {
@@ -98,23 +107,27 @@ void registerQuakeDialectAndTypes(py::module &m) {
       [](MlirType type) { return unwrap(type).isa<quake::StruqType>(); })
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctx, py::list aggregateTypes) {
+          [](py::object cls, py::list aggregateTypes, MlirContext context) {
             SmallVector<Type> inTys;
             for (auto &t : aggregateTypes)
               inTys.push_back(unwrap(t.cast<MlirType>()));
 
-            return wrap(quake::StruqType::get(unwrap(ctx), inTys));
-          })
-      .def_classmethod("getNamed",
-                       [](py::object cls, MlirContext ctx,
-                          const std::string &name, py::list aggregateTypes) {
-                         SmallVector<Type> inTys;
-                         for (auto &t : aggregateTypes)
-                           inTys.push_back(unwrap(t.cast<MlirType>()));
+            return wrap(quake::StruqType::get(unwrap(context), inTys));
+          },
+          py::arg("cls"), py::arg("aggregateTypes"),
+          py::arg("context") = py::none())
+      .def_classmethod(
+          "getNamed",
+          [](py::object cls, const std::string &name, py::list aggregateTypes,
+             MlirContext context) {
+            SmallVector<Type> inTys;
+            for (auto &t : aggregateTypes)
+              inTys.push_back(unwrap(t.cast<MlirType>()));
 
-                         return wrap(
-                             quake::StruqType::get(unwrap(ctx), name, inTys));
-                       })
+            return wrap(quake::StruqType::get(unwrap(context), name, inTys));
+          },
+          py::arg("cls"), py::arg("name"), py::arg("aggregateTypes"),
+          py::arg("context") = py::none())
       .def_classmethod(
           "getTypes",
           [](py::object cls, MlirType structTy) {
@@ -144,26 +157,34 @@ void registerCCDialectAndTypes(py::module &m) {
 
   ccMod.def(
       "register_dialect",
-      [](MlirContext context, bool load) {
+      [](bool load, MlirContext context) {
         MlirDialectHandle ccHandle = mlirGetDialectHandle__cc__();
         mlirDialectHandleRegisterDialect(ccHandle, context);
         if (load) {
           mlirDialectHandleLoadDialect(ccHandle, context);
         }
       },
-      py::arg("context") = py::none(), py::arg("load") = true);
+      py::arg("load") = true, py::arg("context") = py::none());
 
-  mlir_type_subclass(ccMod, "CharspanType", [](MlirType type) {
-    return unwrap(type).isa<cudaq::cc::CharspanType>();
-  }).def_classmethod("get", [](py::object cls, MlirContext ctx) {
-    return wrap(cudaq::cc::CharspanType::get(unwrap(ctx)));
-  });
+  mlir_type_subclass(
+      ccMod, "CharspanType",
+      [](MlirType type) { return unwrap(type).isa<cudaq::cc::CharspanType>(); })
+      .def_classmethod(
+          "get",
+          [](py::object cls, MlirContext context) {
+            return wrap(cudaq::cc::CharspanType::get(unwrap(context)));
+          },
+          py::arg("cls"), py::arg("context") = py::none());
 
-  mlir_type_subclass(ccMod, "StateType", [](MlirType type) {
-    return unwrap(type).isa<quake::StateType>();
-  }).def_classmethod("get", [](py::object cls, MlirContext ctx) {
-    return wrap(quake::StateType::get(unwrap(ctx)));
-  });
+  mlir_type_subclass(
+      ccMod, "StateType",
+      [](MlirType type) { return unwrap(type).isa<quake::StateType>(); })
+      .def_classmethod(
+          "get",
+          [](py::object cls, MlirContext context) {
+            return wrap(quake::StateType::get(unwrap(context)));
+          },
+          py::arg("cls"), py::arg("context") = py::none());
 
   mlir_type_subclass(
       ccMod, "PointerType",
@@ -180,10 +201,13 @@ void registerCCDialectAndTypes(py::module &m) {
             return wrap(casted.getElementType());
           })
       .def_classmethod(
-          "get", [](py::object cls, MlirContext ctx, MlirType elementType) {
-            return wrap(
-                cudaq::cc::PointerType::get(unwrap(ctx), unwrap(elementType)));
-          });
+          "get",
+          [](py::object cls, MlirType elementType, MlirContext context) {
+            return wrap(cudaq::cc::PointerType::get(unwrap(context),
+                                                    unwrap(elementType)));
+          },
+          py::arg("cls"), py::arg("elementType"),
+          py::arg("context") = py::none());
 
   mlir_type_subclass(
       ccMod, "ArrayType",
@@ -201,36 +225,42 @@ void registerCCDialectAndTypes(py::module &m) {
           })
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctx, MlirType elementType,
-             std::int64_t size) {
-            return wrap(cudaq::cc::ArrayType::get(unwrap(ctx),
+          [](py::object cls, MlirType elementType, std::int64_t size,
+             MlirContext context) {
+            return wrap(cudaq::cc::ArrayType::get(unwrap(context),
                                                   unwrap(elementType), size));
           },
-          py::arg("cls"), py::arg("ctx"), py::arg("elementType"),
-          py::arg("size") = std::numeric_limits<std::int64_t>::min());
+          py::arg("cls"), py::arg("elementType"),
+          py::arg("size") = std::numeric_limits<std::int64_t>::min(),
+          py::arg("context") = py::none());
 
   mlir_type_subclass(
       ccMod, "StructType",
       [](MlirType type) { return unwrap(type).isa<cudaq::cc::StructType>(); })
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctx, py::list aggregateTypes) {
+          [](py::object cls, py::list aggregateTypes, MlirContext context) {
             SmallVector<Type> inTys;
             for (auto &t : aggregateTypes)
               inTys.push_back(unwrap(t.cast<MlirType>()));
 
-            return wrap(cudaq::cc::StructType::get(unwrap(ctx), inTys));
-          })
+            return wrap(cudaq::cc::StructType::get(unwrap(context), inTys));
+          },
+          py::arg("cls"), py::arg("aggregateTypes"),
+          py::arg("context") = py::none())
       .def_classmethod(
           "getNamed",
-          [](py::object cls, MlirContext ctx, const std::string &name,
-             py::list aggregateTypes) {
+          [](py::object cls, const std::string &name, py::list aggregateTypes,
+             MlirContext context) {
             SmallVector<Type> inTys;
             for (auto &t : aggregateTypes)
               inTys.push_back(unwrap(t.cast<MlirType>()));
 
-            return wrap(cudaq::cc::StructType::get(unwrap(ctx), name, inTys));
-          })
+            return wrap(
+                cudaq::cc::StructType::get(unwrap(context), name, inTys));
+          },
+          py::arg("cls"), py::arg("name"), py::arg("aggregateTypes"),
+          py::arg("context") = py::none())
       .def_classmethod(
           "getTypes",
           [](py::object cls, MlirType structTy) {
@@ -256,16 +286,18 @@ void registerCCDialectAndTypes(py::module &m) {
   mlir_type_subclass(
       ccMod, "CallableType",
       [](MlirType type) { return unwrap(type).isa<cudaq::cc::CallableType>(); })
-      .def_classmethod("get",
-                       [](py::object cls, MlirContext ctx, py::list inTypes) {
-                         SmallVector<Type> inTys;
-                         for (auto &t : inTypes)
-                           inTys.push_back(unwrap(t.cast<MlirType>()));
+      .def_classmethod(
+          "get",
+          [](py::object cls, py::list inTypes, MlirContext context) {
+            SmallVector<Type> inTys;
+            for (auto &t : inTypes)
+              inTys.push_back(unwrap(t.cast<MlirType>()));
 
-                         return wrap(cudaq::cc::CallableType::get(
-                             unwrap(ctx), FunctionType::get(unwrap(ctx), inTys,
-                                                            TypeRange{})));
-                       })
+            return wrap(cudaq::cc::CallableType::get(
+                unwrap(context),
+                FunctionType::get(unwrap(context), inTys, TypeRange{})));
+          },
+          py::arg("cls"), py::arg("inTypes"), py::arg("context") = py::none())
       .def_classmethod("getFunctionType", [](py::object cls, MlirType type) {
         return wrap(
             dyn_cast<cudaq::cc::CallableType>(unwrap(type)).getSignature());
@@ -286,10 +318,13 @@ void registerCCDialectAndTypes(py::module &m) {
             return wrap(casted.getElementType());
           })
       .def_classmethod(
-          "get", [](py::object cls, MlirContext ctx, MlirType elementType) {
-            return wrap(
-                cudaq::cc::StdvecType::get(unwrap(ctx), unwrap(elementType)));
-          });
+          "get",
+          [](py::object cls, MlirType elementType, MlirContext context) {
+            return wrap(cudaq::cc::StdvecType::get(unwrap(context),
+                                                   unwrap(elementType)));
+          },
+          py::arg("cls"), py::arg("elementType"),
+          py::arg("context") = py::none());
 }
 
 void bindRegisterDialects(py::module &mod) {

--- a/python/tests/mlir/bare.py
+++ b/python/tests/mlir/bare.py
@@ -19,8 +19,8 @@ with Context() as ctx:
         f = func.FuncOp('main', ([], []))
         entry_block = f.add_entry_block()
         with InsertionPoint(entry_block):
-            t = quake.RefType.get(ctx)
-            v = quake.VeqType.get(ctx, 10)
+            t = quake.RefType.get()
+            v = quake.VeqType.get(10)
             iTy = IntegerType.get_signless(64)
             iAttr = IntegerAttr.get(iTy, 43)
             s = arith.ConstantOp(iTy, iAttr)
@@ -29,7 +29,7 @@ with Context() as ctx:
             target = quake.AllocaOp(t)
 
             qveq = quake.AllocaOp(v)
-            dyn = quake.AllocaOp(quake.VeqType.get(ctx), size=s)
+            dyn = quake.AllocaOp(quake.VeqType.get(), size=s)
             quake.HOp([], [], [], [qubit])
             quake.XOp([], [], [qubit], [target])
             ret = func.ReturnOp([])


### PR DESCRIPTION
### Description
This commit updates argument ordering in several type retrieval functions, e.g., `cc.PointerType.get(...)`. The current ordering is different from MLIR's core IR one. More importantly, however, is the fact that our current ordering adds awkwardness and prevents supporting the composability of function arguments. For example, `cc.PointerType.get`, requires `Context` as the first argument, even when using a context manager.

In Python, trailing keyword arguments to the right are the most composable, enabling a variety of strategies such as kwarg passthrough, default values, etc. Thus, keeping function signatures composable can reduce boilerplate in IR construction. Indeed, by being consistent here, we can avoid most needs for explicit contexts, locations and insertion points when building the IR, while leaving the possibility of extra control for edge cases.
