### PR TITLE
Update buildkit to use nvidia docker cache

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -224,6 +224,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: ${{ needs.metadata.outputs.runner != 'ubuntu-latest' && '/etc/buildkit/buildkitd.toml' || null }}
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -167,6 +167,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: ${{ needs.metadata.outputs.runner != 'ubuntu-latest' && '/etc/buildkit/buildkitd.toml' || null }}
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0
@@ -322,6 +323,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: ${{ needs.metadata.outputs.runner != 'ubuntu-latest' && '/etc/buildkit/buildkitd.toml' || null }}
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0
@@ -538,6 +540,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: ${{ needs.metadata.outputs.runner != 'ubuntu-latest' && '/etc/buildkit/buildkitd.toml' || null }}
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0

--- a/.github/workflows/generate_cc.yml
+++ b/.github/workflows/generate_cc.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             image=moby/buildkit:v0.19.0
 

--- a/.github/workflows/gh_registry.yml
+++ b/.github/workflows/gh_registry.yml
@@ -127,6 +127,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: none # hard-coded to run on ubuntu-latest
           driver-opts: |
             image=moby/buildkit:v0.19.0
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -128,6 +128,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: none # hard-coded to run on ubuntu-latest
           driver-opts: |
             image=moby/buildkit:v0.19.0
 
@@ -210,6 +211,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: none # hard-coded to run on ubuntu-latest
           driver-opts: |
             image=moby/buildkit:v0.19.0
 

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0
@@ -239,6 +240,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             image=moby/buildkit:v0.19.0
 

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -442,6 +442,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             image=moby/buildkit:v0.19.0
 
@@ -607,6 +608,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             image=moby/buildkit:v0.19.0
 
@@ -725,6 +727,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0

--- a/.github/workflows/publishing_stable.yml
+++ b/.github/workflows/publishing_stable.yml
@@ -122,6 +122,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           version: v0.19.0
+          buildkitd-config: none # hard-coded to run on ubuntu-latest
           driver-opts: |
             image=moby/buildkit:v0.19.0
 

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             image=moby/buildkit:v0.19.0
 
@@ -211,6 +212,7 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             image=moby/buildkit:v0.19.0
 


### PR DESCRIPTION
buildkit does not use the nvidia DockerHub cache by default. Pass through the configuration file only on our self-hosted runners.