### PR TITLE
Remove buildkit config for GH runners

### DIFF
--- a/.github/workflows/gh_registry.yml
+++ b/.github/workflows/gh_registry.yml
@@ -127,7 +127,6 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
-          buildkitd-config: null # hard-coded to run on ubuntu-latest
           driver-opts: |
             image=moby/buildkit:v0.19.0
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -128,7 +128,6 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
-          buildkitd-config: null # hard-coded to run on ubuntu-latest
           driver-opts: |
             image=moby/buildkit:v0.19.0
 
@@ -211,7 +210,6 @@ jobs:
         with:
           endpoint: builder_context
           version: v0.19.0
-          buildkitd-config: null # hard-coded to run on ubuntu-latest
           driver-opts: |
             image=moby/buildkit:v0.19.0
 


### PR DESCRIPTION
This was incorrectly set to "none" which could be causing issues related to caching with the error tag of:

`
Error: buildx failed with: ERROR: failed to solve: [ghcr.io/nvidia/pypa/manylinux_2_28_x86_64:latest](http://ghcr.io/nvidia/pypa/manylinux_2_28_x86_64:latest): failed to resolve source metadata for [ghcr.io/nvidia/pypa/manylinux_2_28_x86_64:latest](http://ghcr.io/nvidia/pypa/manylinux_2_28_x86_64:latest): failed to copy: httpReadSeeker: failed open: content at https://ghcr.io/v2/nvidia/pypa/manylinux_2_28_x86_64/manifests/sha256:a52643541281f653a0bba351f3b97e12bc5301d17b52ffb311143332f91ed31b not found: not found
`

Since for these runners we don't want to set any config, let's just remove them.