### PR TITLE
[run] [parser] Throw error if missing data layout info when parsing struct / data class

### DIFF
--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -169,20 +169,15 @@ void cudaq::RecordLogParser::preallocateArray() {
 }
 
 void cudaq::RecordLogParser::preallocateTuple() {
+  if (dataLayoutInfo.first == 0)
+    throw std::runtime_error(
+        "Data layout information missing for the struct / tuple type.");
+  if (dataLayoutInfo.second.size() != containerMeta.tupleTypes.size())
+    throw std::runtime_error("Tuple size mismatch in kernel and label.");
   containerMeta.dataOffset = bufferHandler.getBufferSize();
-  if (dataLayoutInfo.first == 0) {
-    // Packed data allocation since alignment info is not provided
-    for (auto ty : containerMeta.tupleTypes) {
-      cudaq::details::DataHandlerBase &dh = getDataHandler(ty);
-      containerMeta.tupleOffsets.push_back(dh.allocateTuple(bufferHandler));
-    }
-  } else {
-    if (dataLayoutInfo.second.size() != containerMeta.tupleTypes.size())
-      throw std::runtime_error("Tuple size mismatch in kernel and label.");
-    // Directly allocate memory for the tuple, update offsets
-    bufferHandler.resizeBuffer(dataLayoutInfo.first);
-    containerMeta.tupleOffsets = dataLayoutInfo.second;
-  }
+  // Directly allocate memory for the tuple, update offsets
+  bufferHandler.resizeBuffer(dataLayoutInfo.first);
+  containerMeta.tupleOffsets = dataLayoutInfo.second;
 }
 
 void cudaq::RecordLogParser::processSingleRecord(const std::string &recValue,

--- a/unittests/output_record/RecordParserTester.cpp
+++ b/unittests/output_record/RecordParserTester.cpp
@@ -249,25 +249,7 @@ CUDAQ_TEST(ParserTester, checkTupleLabeled) {
                           "OUTPUT\tINT\t37\t.1\n"
                           "OUTPUT\tDOUBLE\t3.1416\t.2\n";
   cudaq::RecordLogParser parser;
-  parser.parse(log);
-  auto *origBuffer = parser.getBufferPtr();
-  std::size_t bufferSize = parser.getBufferSize();
-  char *buffer = static_cast<char *>(malloc(bufferSize));
-  std::memcpy(buffer, origBuffer, bufferSize);
-  bool tuple_0;
-  int tuple_1;
-  double tuple_2;
-  EXPECT_EQ(bufferSize, sizeof(tuple_0) + sizeof(tuple_1) + sizeof(tuple_2));
-  std::memcpy(&tuple_0, buffer, sizeof(tuple_0));
-  std::memcpy(&tuple_1, buffer + sizeof(tuple_0), sizeof(tuple_1));
-  std::memcpy(&tuple_2, buffer + sizeof(tuple_0) + sizeof(tuple_1),
-              sizeof(tuple_2));
-  EXPECT_EQ(true, tuple_0);
-  EXPECT_EQ(37, tuple_1);
-  EXPECT_EQ(3.1416, tuple_2);
-  free(buffer);
-  buffer = nullptr;
-  origBuffer = nullptr;
+  EXPECT_ANY_THROW(parser.parse("log"));
 }
 
 CUDAQ_TEST(ParserTester, checkMultipleShots) {


### PR DESCRIPTION
 The records log parser should not assume packed data layout - it leads to erroneous behavior.

