### PR TITLE
[C++ bridge] Emit an error for bad storage classes.

### DIFF
--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -576,11 +576,27 @@ bool QuakeBridgeVisitor::VisitParmVarDecl(clang::ParmVarDecl *x) {
       "symbol table, but this parameter wasn't found.");
 }
 
+static bool isImplicitlyGlobalStorageClass(clang::StorageClass sc) {
+  switch (sc) {
+  case clang::SC_Extern:
+  case clang::SC_Static:
+  case clang::SC_PrivateExtern:
+    return true;
+  default:
+    return false;
+  }
+}
+
 // A variable declaration may or may not have an initializer. This custom
 // traversal makes sure that the type of the variable is visited and pushed so
 // that VisitVarDecl has the variable's type, whether an initialization
 // expression is present or not.
 bool QuakeBridgeVisitor::TraverseVarDecl(clang::VarDecl *x) {
+  auto storageClass = x->getStorageClass();
+  if (isImplicitlyGlobalStorageClass(storageClass)) {
+    reportClangError(x, mangler, "variable has invalid storage class");
+    return false;
+  }
   [[maybe_unused]] auto typeStackDepth = typeStack.size();
   for (unsigned i = 0; i < x->getNumTemplateParameterLists(); i++) {
     if (auto *tpl = x->getTemplateParameterList(i)) {

--- a/test/AST-error/static_var.cpp
+++ b/test/AST-error/static_var.cpp
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %cpp_std -verify -D CUDAQ_REMOTE_SIM=1 %s
+
+#include <cudaq.h>
+
+__qpu__ void k() {
+  // expected-error@+2 {{variable has invalid storage class}}
+  // expected-error@+1 {{statement not supported}}
+  static int i = 0;
+}
+
+__qpu__ void l() {
+  // expected-error@+2 {{variable has invalid storage class}}
+  // expected-error@+1 {{statement not supported}}
+  extern int i;
+}


### PR DESCRIPTION
Kernels may not contain static and extern declared variables.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
