### PR TITLE
Make sure that we also set the default target name in the `nvq++` driver script

### DIFF
--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -361,9 +361,12 @@ SET_TARGET_BACKEND=true
 
 # Provide a default backend, user can override
 NVQIR_SIMULATION_BACKEND="qpp"
-# Check availability of NVIDA GPU(s)
+# Check availability of NVIDIA GPU(s)
 gpu_found=$(query_gpu)
 if ${gpu_found} && [ -f "${install_dir}/lib/libnvqir-custatevec-fp32.so" ]; then
+	# Set the default target name to "nvidia".
+	# This will make sure that the target configuration yml file is processed.
+	TARGET_CONFIG="nvidia"
 	NVQIR_SIMULATION_BACKEND="custatevec-fp32"
 fi
 

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -360,6 +360,7 @@ CUDAQ_OPT_EXTRA_PASSES=
 SET_TARGET_BACKEND=true
 
 # Provide a default backend, user can override
+TARGET_CONFIG="qpp-cpu"
 NVQIR_SIMULATION_BACKEND="qpp"
 # Check availability of NVIDIA GPU(s)
 gpu_found=$(query_gpu)


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->


As the `nvidia` target configuration can pick up the closed-source `cusvsim-fp32` if available (in addition to the open-source `custatevec-fp32`), we need to set the `nvidia` target when choosing the default simulator.

This also matches the Python implementation, whereby we [selected](https://github.com/NVIDIA/cuda-quantum/blob/189f9bec98f081d899f8f923adb8e280d7a28d11/python/utils/LinkedLibraryHolder.cpp#L340) the default target by name. 

Related to https://github.com/NVIDIA/cuda-quantum/pull/1890, where we introduced the ability to match different lib files to the target based on availability.