### PR TITLE
[readability] Update warning for applyNoise

### DIFF
--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -262,8 +262,7 @@ public:
   /// Only supported for noise backends. By default do nothing
   virtual void applyNoise(const cudaq::kraus_channel &channel,
                           const std::vector<std::size_t> &targets) {
-    CUDAQ_WARN("kraus_channel application not supported on {} simulator.",
-               name());
+    CUDAQ_WARN("Applying noise is not supported on {} simulator.", name());
   }
 
   /// @brief Apply a custom operation described by a matrix of data

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -840,7 +840,9 @@ protected:
   virtual void applyNoiseChannel(const std::string_view gateName,
                                  const std::vector<std::size_t> &controls,
                                  const std::vector<std::size_t> &targets,
-                                 const std::vector<double> &params) {}
+                                 const std::vector<double> &params) {
+    CUDAQ_WARN("Applying noise is not supported on {} simulator.", name());
+  }
 
   /// @brief Flush the gate queue, run all queued gate
   /// application tasks.


### PR DESCRIPTION
Closes #3088

Updates the wording for the warning given when a circuit simulator doesn't support noise.