### PR TITLE
Updated warning for conda-forge users

### DIFF
--- a/python/README.md.in
+++ b/python/README.md.in
@@ -45,12 +45,12 @@ ${{ deprecation_notice }}
  other causing issues.
 
 
-If you want to perform multi-GPU simulations, additional components must be installed. We
-recommend using [Conda](https://docs.conda.io/en/latest/) to do so. If you are
-not already using Conda, you can install a minimal version following the
-instructions [here](https://docs.anaconda.com/miniconda/). The following
-commands will create and activate a complete environment for CUDA-Q with all its
-dependencies:
+If you want to perform multi-GPU simulations, additional components must be 
+installed. We recommend using [Conda](https://docs.conda.io/en/latest/) to do 
+so. If you are not already using Conda, you can install a minimal version 
+following [miniconda instructions here](https://docs.anaconda.com/miniconda/). 
+The following commands will create and activate a complete environment for 
+CUDA-Q with all its dependencies:
 
 [//]: # (Begin conda install)
 


### PR DESCRIPTION
Updated warning for conda-forge users. 

There is a segmentation fault related to the recent Python versions, as mentioned (and reproed) in the issue #3104. 