### PR TITLE
Restore error reporting under non-composable option.

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -792,10 +792,17 @@ def MappingFunc: Pass<"qubit-mapping-func", "mlir::func::FuncOp"> {
   }];
 
   let options = [
-    Option<"extendedLayerSize", "extendedLayerSize", "unsigned", /*default=*/"20", "Extended layer size">,
-    Option<"extendedLayerWeight", "extendedLayerWeight", "float", /*default=*/"0.5", "Extended layer weight">,
-    Option<"decayDelta", "decayDelta", "float", /*default=*/"0.5", "Decay delta">,
-    Option<"roundsDecayReset", "roundsDecayReset", "unsigned", /*default=*/"5", "Number of rounds before decay is reset">
+    Option<"extendedLayerSize", "extendedLayerSize", "unsigned",
+           /*default=*/"20", "Extended layer size">,
+    Option<"extendedLayerWeight", "extendedLayerWeight", "float",
+           /*default=*/"0.5", "Extended layer weight">,
+    Option<"decayDelta", "decayDelta", "float", /*default=*/"0.5",
+           "Decay delta">,
+    Option<"roundsDecayReset", "roundsDecayReset", "unsigned", /*default=*/"5",
+           "Number of rounds before decay is reset">,
+    Option<"nonComposable", "raise-fatal-errors", "bool", /*default=*/"false",
+           "Run the pass in a non-composable way, which may cause immediate "
+           "internal compiler errors">
   ];
 }
 
@@ -808,7 +815,11 @@ def MappingPrep: Pass<"qubit-mapping-prep", "mlir::ModuleOp"> {
 
   let options = [
     Option<"device", "device", "std::string", /*default=*/"\"-\"",
-      "Device topology: path(N), ring(N), star(N), star(N,c), grid(w,h), file(/path/to/file), bypass">,
+      "Device topology: path(N), ring(N), star(N), star(N,c), grid(w,h), "
+      "file(/path/to/file), bypass">,
+    Option<"nonComposable", "raise-fatal-errors", "bool", /*default=*/"false",
+           "Run the pass in a non-composable way, which may cause immediate "
+           "internal compiler errors">
   ];
 }
 

--- a/test/Transforms/mapping_errors.qke
+++ b/test/Transforms/mapping_errors.qke
@@ -6,8 +6,9 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --qubit-mapping=device=path\(3\) %s -split-input-file -verify-diagnostics
+// RUN: cudaq-opt --qubit-mapping='device=path(3) raise-fatal-errors=1' %s -split-input-file -verify-diagnostics
 
+// expected-error@+1 {{no borrow_wire ops found in test_00}}
 func.func @test_00() {
   %0 = quake.null_wire
   %1 = quake.null_wire
@@ -57,6 +58,7 @@ func.func @test_02() {
 
 quake.wire_set @wires_03[10]
 
+// expected-error@+1 {{no borrow_wire ops found in test_03}}
 func.func @test_03() {
   return
 }


### PR DESCRIPTION
This restores some of the error reporting functionality that was baked into the mapping pass. The user must explicitly set a flag to make these passes non-composable.

TODO: finish removing the non-compositional aspects of these passes in general.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
