### PR TITLE
Ties the various pieces together to allow the grover example code to compile and execute

### DIFF
--- a/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -18,7 +18,6 @@ void cudaq::opt::commonPipelineConvertToQIR(PassManager &pm,
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(createUnwindLowering());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  pm.addPass(createApplySpecialization());
   pm.addNestedPass<func::FuncOp>(createExpandMeasurementsPass());
   pm.addNestedPass<func::FuncOp>(createClassicalMemToReg());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
@@ -31,6 +30,13 @@ void cudaq::opt::commonPipelineConvertToQIR(PassManager &pm,
   pm.addNestedPass<func::FuncOp>(createLoopUnroll(luo));
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(createCSEPass());
+  // A final round of apply specialization after loop unrolling. This should
+  // eliminate any residual control structures so the kernel specializations can
+  // succeed.
+  pm.addPass(createApplySpecialization());
+  // If there was any specialization, we want another round in inlining to
+  // inline the apply calls properly.
+  addAggressiveEarlyInlining(pm);
   pm.addNestedPass<func::FuncOp>(createLowerToCFGPass());
   pm.addNestedPass<func::FuncOp>(createCombineQuantumAllocations());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/python/tests/mlir/exp_pauli.py
+++ b/python/tests/mlir/exp_pauli.py
@@ -76,9 +76,9 @@ def test_exp_pauli():
 # CHECK-LABEL: define void @__nvqpp__mlirgen__kernel_ancilla_exp_pauli({ double*, i64 }
 # CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
 # CHECK:         %[[VAL_1:.*]] = alloca [1 x { i8*, i64 }], align 8
-# CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate()
+# CHECK:         %[[VAL_2:.*]] = tail call %Qubit* @__quantum__rt__qubit_allocate()
 # CHECK:         %[[VAL_4:.*]] = extractvalue { double*, i64 } %[[VAL_0]], 1
-# CHECK:         %[[VAL_5:.*]] = tail call %[[VAL_6:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_4]])
+# CHECK:         %[[VAL_5:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_4]])
 # CHECK:         %[[VAL_7:.*]] = icmp sgt i64 %[[VAL_4]], 0
 # CHECK:         br i1 %[[VAL_7]], label %[[VAL_8:.*]], label %[[VAL_9:.*]]
 # CHECK:       .lr.ph:                                           ; preds = %[[VAL_10:.*]]
@@ -88,24 +88,24 @@ def test_exp_pauli():
 # CHECK:         %[[VAL_13:.*]] = phi i64 [ 0, %[[VAL_8]] ], [ %[[VAL_14:.*]], %[[VAL_12]] ]
 # CHECK:         %[[VAL_15:.*]] = getelementptr double, double* %[[VAL_11]], i64 %[[VAL_13]]
 # CHECK:         %[[VAL_16:.*]] = load double, double* %[[VAL_15]], align 8
-# CHECK:         %[[VAL_17:.*]] = tail call %[[VAL_3]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_5]], i64 %[[VAL_13]])
-# CHECK:         %[[VAL_18:.*]] = load %[[VAL_3]]*, %[[VAL_3]]** %[[VAL_17]], align 8
-# CHECK:         tail call void @__quantum__qis__rx(double %[[VAL_16]], %[[VAL_3]]* %[[VAL_18]])
+# CHECK:         %[[VAL_17:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_5]], i64 %[[VAL_13]])
+# CHECK:         %[[VAL_18:.*]] = load %Qubit*, %Qubit** %[[VAL_17]], align 8
+# CHECK:         tail call void @__quantum__qis__rx(double %[[VAL_16]], %Qubit* %[[VAL_18]])
 # CHECK:         %[[VAL_14]] = add nuw nsw i64 %[[VAL_13]], 1
 # CHECK:         %[[VAL_19:.*]] = icmp eq i64 %[[VAL_14]], %[[VAL_4]]
 # CHECK:         br i1 %[[VAL_19]], label %[[VAL_9]], label %[[VAL_12]]
 # CHECK:       ._crit_edge:                                      ; preds = %[[VAL_12]], %[[VAL_10]]
-# CHECK:         tail call void @__quantum__qis__h(%[[VAL_3]]* %[[VAL_2]])
-# CHECK:         %[[VAL_20:.*]] = tail call %[[VAL_6]]* @__quantum__rt__array_create_1d(i32 8, i64 1)
-# CHECK:         %[[VAL_21:.*]] = tail call %[[VAL_3]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_20]], i64 0)
-# CHECK:         store %[[VAL_3]]* %[[VAL_2]], %[[VAL_3]]** %[[VAL_21]], align 8
+# CHECK:         tail call void @__quantum__qis__h(%Qubit* %[[VAL_2]])
+# CHECK:         %[[VAL_20:.*]] = tail call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+# CHECK:         %[[VAL_21:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_20]], i64 0)
+# CHECK:         store %Qubit* %[[VAL_2]], %Qubit** %[[VAL_21]], align 8
 # CHECK:         %[[VAL_22:.*]] = getelementptr inbounds [1 x { i8*, i64 }], [1 x { i8*, i64 }]* %[[VAL_1]], i64 0, i64 0, i32 0
 # CHECK:         store i8* getelementptr inbounds ([4 x i8], [4 x i8]* @cstr.58495900, i64 0, i64 0), i8** %[[VAL_22]], align 8
 # CHECK:         %[[VAL_23:.*]] = getelementptr inbounds [1 x { i8*, i64 }], [1 x { i8*, i64 }]* %[[VAL_1]], i64 0, i64 0, i32 1
 # CHECK:         store i64 3, i64* %[[VAL_23]], align 8
 # CHECK:         %[[VAL_24:.*]] = bitcast [1 x { i8*, i64 }]* %[[VAL_1]] to i8*
-# CHECK:         call void @__quantum__qis__exp_pauli__ctl(double 2.310000e+01, %[[VAL_6]]* %[[VAL_20]], %[[VAL_6]]* %[[VAL_5]], i8* nonnull %[[VAL_24]])
-# CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_5]])
-# CHECK:         call void @__quantum__rt__qubit_release(%[[VAL_3]]* %[[VAL_2]])
+# CHECK:         call void @__quantum__qis__exp_pauli__ctl(double 2.310000e+01, %Array* %[[VAL_20]], %Array* %[[VAL_5]], i8* nonnull %[[VAL_24]])
+# CHECK-DAG:     call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_5]])
+# CHECK-DAG:     call void @__quantum__rt__qubit_release(%Qubit* %[[VAL_2]])
 # CHECK:         ret void
 # CHECK:       }

--- a/python/tests/mlir/exp_pauli.py
+++ b/python/tests/mlir/exp_pauli.py
@@ -73,7 +73,7 @@ def test_exp_pauli():
     print(cudaq.translate(kernel_ancilla_exp_pauli, format='qir'))
 
 
-# CHECK-LABEL: define void @__nvqpp__mlirgen__kernel_ancilla_exp_pauli({ double*, i64 } 
+# CHECK-LABEL: define void @__nvqpp__mlirgen__kernel_ancilla_exp_pauli({ double*, i64 }
 # CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
 # CHECK:         %[[VAL_1:.*]] = alloca [1 x { i8*, i64 }], align 8
 # CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate()
@@ -109,4 +109,3 @@ def test_exp_pauli():
 # CHECK:         call void @__quantum__rt__qubit_release(%[[VAL_3]]* %[[VAL_2]])
 # CHECK:         ret void
 # CHECK:       }
-

--- a/python/tests/mlir/exp_pauli.py
+++ b/python/tests/mlir/exp_pauli.py
@@ -73,47 +73,40 @@ def test_exp_pauli():
     print(cudaq.translate(kernel_ancilla_exp_pauli, format='qir'))
 
 
-# CHECK-LABEL: define void @__nvqpp__mlirgen__U_exp_pauli.ctrl(
-# CHECK:         call void @__quantum__qis__exp_pauli__ctl(double 2.310000e+01, %Array* %{{.*}}, %Array* %{{.*}}, i8* nonnull %{{.*}})
-
-# CHECK-LABEL: define void @__nvqpp__mlirgen__U_exp_pauli(
-# CHECK:         call void @__quantum__qis__exp_pauli(double 2.310000e+01, %Array* %{{.*}}, i8* nonnull {{.*}})
-
-# CHECK-LABEL: define void @__nvqpp__mlirgen__kernel_ancilla_exp_pauli({ double*, i64 }
-# CHECK-SAME:    %[[VAL_0:.*]])
+# CHECK-LABEL: define void @__nvqpp__mlirgen__kernel_ancilla_exp_pauli({ double*, i64 } 
+# CHECK-SAME:    %[[VAL_0:.*]]) local_unnamed_addr {
 # CHECK:         %[[VAL_1:.*]] = alloca [1 x { i8*, i64 }], align 8
-# CHECK:         %[[VAL_2:.*]] = tail call %Qubit* @__quantum__rt__qubit_allocate()
+# CHECK:         %[[VAL_2:.*]] = tail call %[[VAL_3:.*]]* @__quantum__rt__qubit_allocate()
 # CHECK:         %[[VAL_4:.*]] = extractvalue { double*, i64 } %[[VAL_0]], 1
-# CHECK:         %[[VAL_5:.*]] = tail call %Array* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_4]])
+# CHECK:         %[[VAL_5:.*]] = tail call %[[VAL_6:.*]]* @__quantum__rt__qubit_allocate_array(i64 %[[VAL_4]])
 # CHECK:         %[[VAL_7:.*]] = icmp sgt i64 %[[VAL_4]], 0
 # CHECK:         br i1 %[[VAL_7]], label %[[VAL_8:.*]], label %[[VAL_9:.*]]
-# CHECK:       :                                           ; preds = %[[VAL_10:.*]]
+# CHECK:       .lr.ph:                                           ; preds = %[[VAL_10:.*]]
 # CHECK:         %[[VAL_11:.*]] = extractvalue { double*, i64 } %[[VAL_0]], 0
 # CHECK:         br label %[[VAL_12:.*]]
-# CHECK:       :                                                ; preds = %[[VAL_8]], %[[VAL_12]]
+# CHECK:       8:                                                ; preds = %[[VAL_8]], %[[VAL_12]]
 # CHECK:         %[[VAL_13:.*]] = phi i64 [ 0, %[[VAL_8]] ], [ %[[VAL_14:.*]], %[[VAL_12]] ]
 # CHECK:         %[[VAL_15:.*]] = getelementptr double, double* %[[VAL_11]], i64 %[[VAL_13]]
 # CHECK:         %[[VAL_16:.*]] = load double, double* %[[VAL_15]], align 8
-# CHECK:         %[[VAL_17:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_5]], i64 %[[VAL_13]])
-# CHECK:         %[[VAL_18:.*]] = load %Qubit*, %Qubit** %[[VAL_17]], align 8
-# CHECK:         tail call void @__quantum__qis__rx(double %[[VAL_16]], %Qubit* %[[VAL_18]])
+# CHECK:         %[[VAL_17:.*]] = tail call %[[VAL_3]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_5]], i64 %[[VAL_13]])
+# CHECK:         %[[VAL_18:.*]] = load %[[VAL_3]]*, %[[VAL_3]]** %[[VAL_17]], align 8
+# CHECK:         tail call void @__quantum__qis__rx(double %[[VAL_16]], %[[VAL_3]]* %[[VAL_18]])
 # CHECK:         %[[VAL_14]] = add nuw nsw i64 %[[VAL_13]], 1
 # CHECK:         %[[VAL_19:.*]] = icmp eq i64 %[[VAL_14]], %[[VAL_4]]
 # CHECK:         br i1 %[[VAL_19]], label %[[VAL_9]], label %[[VAL_12]]
-# CHECK:       :                                      ; preds = %[[VAL_12]], %[[VAL_10]]
-# CHECK:         tail call void @__quantum__qis__h(%Qubit* %[[VAL_2]])
-# CHECK:         %[[VAL_20:.*]] = tail call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-# CHECK:         %[[VAL_21:.*]] = tail call %Qubit** @__quantum__rt__array_get_element_ptr_1d(%Array* %[[VAL_20]], i64 0)
-# CHECK:         store %Qubit* %[[VAL_2]], %Qubit** %[[VAL_21]], align 8
-# CHECK:         %[[VAL_22:.*]] = bitcast [1 x { i8*, i64 }]* %[[VAL_1]] to i8*
-# CHECK:         call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %[[VAL_22]])
-# CHECK:         %[[VAL_23:.*]] = getelementptr inbounds [1 x { i8*, i64 }], [1 x { i8*, i64 }]* %[[VAL_1]], i64 0, i64 0, i32 0
-# CHECK:         store i8* getelementptr inbounds ([4 x i8], [4 x i8]* @cstr.58495900, i64 0, i64 0), i8** %[[VAL_23]], align 8
-# CHECK:         %[[VAL_24:.*]] = getelementptr inbounds [1 x { i8*, i64 }], [1 x { i8*, i64 }]* %[[VAL_1]], i64 0, i64 0, i32 1
-# CHECK:         store i64 3, i64* %[[VAL_24]], align 8
-# CHECK:         call void @__quantum__qis__exp_pauli__ctl(double 2.310000e+01, %Array* %[[VAL_20]], %Array* %[[VAL_5]], i8* nonnull %[[VAL_22]])
-# CHECK:         call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %[[VAL_22]])
-# CHECK-DAG:     call void @__quantum__rt__qubit_release(%Qubit* %[[VAL_2]])
-# CHECK-DAG:     call void @__quantum__rt__qubit_release_array(%Array* %[[VAL_5]])
+# CHECK:       ._crit_edge:                                      ; preds = %[[VAL_12]], %[[VAL_10]]
+# CHECK:         tail call void @__quantum__qis__h(%[[VAL_3]]* %[[VAL_2]])
+# CHECK:         %[[VAL_20:.*]] = tail call %[[VAL_6]]* @__quantum__rt__array_create_1d(i32 8, i64 1)
+# CHECK:         %[[VAL_21:.*]] = tail call %[[VAL_3]]** @__quantum__rt__array_get_element_ptr_1d(%[[VAL_6]]* %[[VAL_20]], i64 0)
+# CHECK:         store %[[VAL_3]]* %[[VAL_2]], %[[VAL_3]]** %[[VAL_21]], align 8
+# CHECK:         %[[VAL_22:.*]] = getelementptr inbounds [1 x { i8*, i64 }], [1 x { i8*, i64 }]* %[[VAL_1]], i64 0, i64 0, i32 0
+# CHECK:         store i8* getelementptr inbounds ([4 x i8], [4 x i8]* @cstr.58495900, i64 0, i64 0), i8** %[[VAL_22]], align 8
+# CHECK:         %[[VAL_23:.*]] = getelementptr inbounds [1 x { i8*, i64 }], [1 x { i8*, i64 }]* %[[VAL_1]], i64 0, i64 0, i32 1
+# CHECK:         store i64 3, i64* %[[VAL_23]], align 8
+# CHECK:         %[[VAL_24:.*]] = bitcast [1 x { i8*, i64 }]* %[[VAL_1]] to i8*
+# CHECK:         call void @__quantum__qis__exp_pauli__ctl(double 2.310000e+01, %[[VAL_6]]* %[[VAL_20]], %[[VAL_6]]* %[[VAL_5]], i8* nonnull %[[VAL_24]])
+# CHECK:         call void @__quantum__rt__qubit_release_array(%[[VAL_6]]* %[[VAL_5]])
+# CHECK:         call void @__quantum__rt__qubit_release(%[[VAL_3]]* %[[VAL_2]])
 # CHECK:         ret void
 # CHECK:       }
+

--- a/runtime/common/RuntimeMLIRCommonImpl.h
+++ b/runtime/common/RuntimeMLIRCommonImpl.h
@@ -385,7 +385,8 @@ mlir::LogicalResult verifyLLVMInstructions(llvm::Module *llvmModule,
             auto constExpr = llvm::dyn_cast_or_null<llvm::ConstantExpr>(arg);
             if (constExpr &&
                 constExpr->getOpcode() != llvm::Instruction::GetElementPtr &&
-                constExpr->getOpcode() != llvm::Instruction::IntToPtr) {
+                constExpr->getOpcode() != llvm::Instruction::IntToPtr &&
+                constExpr->getOpcode() != llvm::Instruction::BitCast) {
               llvm::errs() << "error - invalid instruction found: "
                            << *constExpr << '\n';
               return mlir::failure();

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/ionq.yml
@@ -18,7 +18,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),ionq-gate-set-mapping"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,func.func(canonicalize),apply-op-specialization{constant-prop=1},aggressive-early-inlining,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(canonicalize,multicontrol-decomposition),ionq-gate-set-mapping"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qir-base
   # Additional passes to run after lowering to QIR

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.yml
@@ -18,7 +18,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),quantinuum-gate-set-mapping"
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,func.func(canonicalize),apply-op-specialization{constant-prop=1},aggressive-early-inlining,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(canonicalize,multicontrol-decomposition),quantinuum-gate-set-mapping"
   # Tell the rest-qpu that we are generating Adaptive QIR.
   codegen-emission: qir-adaptive[int_computations]
   # Library mode is only for simulators, physical backends must turn this off

--- a/targettests/TargetConfig/RegressionValidation/ionq.config
+++ b/targettests/TargetConfig/RegressionValidation/ionq.config
@@ -18,7 +18,7 @@
 # CHECK-DAG: LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),ionq-gate-set-mapping"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,func.func(canonicalize),apply-op-specialization{constant-prop=1},aggressive-early-inlining,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(canonicalize,multicontrol-decomposition),ionq-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 # CHECK-DAG: CODEGEN_EMISSION=qir-base

--- a/targettests/TargetConfig/RegressionValidation/quantinuum.config
+++ b/targettests/TargetConfig/RegressionValidation/quantinuum.config
@@ -18,7 +18,7 @@
 # CHECK-DAG: LINKLIBS="${LINKLIBS} -lcudaq-rest-qpu"
 
 # Define the lowering pipeline, here we lower to Adaptive QIR
-# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-early-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(lower-to-cfg,canonicalize,multicontrol-decomposition),quantinuum-gate-set-mapping"
+# CHECK-DAG: PLATFORM_LOWERING_CONFIG="classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,func.func(canonicalize),apply-op-specialization{constant-prop=1},aggressive-early-inlining,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(canonicalize,multicontrol-decomposition),quantinuum-gate-set-mapping"
 
 # Tell the rest-qpu that we are generating QIR.
 # CHECK-DAG: CODEGEN_EMISSION=qir-adaptive

--- a/targettests/execution/grover.cpp
+++ b/targettests/execution/grover.cpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// REQUIRES: c++20
+// RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
+
+#include "cudaq.h"
+#include <cmath>
+#include <cstdio>
+#include <numbers>
+
+__qpu__ void reflect_about_uniform(cudaq::qvector<> &qs) {
+  auto ctrlQubits = qs.front(qs.size() - 1);
+  auto &lastQubit = qs.back();
+
+  // Compute (U) Action (V) produces
+  // U V U::Adjoint
+  cudaq::compute_action(
+      [&]() {
+        h(qs);
+        x(qs);
+      },
+      [&]() { z<cudaq::ctrl>(ctrlQubits, lastQubit); });
+}
+
+struct run_grover {
+  template <typename CallableKernel>
+  __qpu__ auto operator()(const int n_qubits, const long target_state,
+                          CallableKernel &&oracle) {
+    int n_iterations = round(0.25 * M_PI * sqrt(2 ^ n_qubits));
+
+    cudaq::qvector qs(n_qubits);
+    h(qs);
+    for (int i = 0; i < n_iterations; i++) {
+      oracle(target_state, qs);
+      reflect_about_uniform(qs);
+    }
+    mz(qs);
+  }
+};
+
+struct oracle {
+  void operator()(const long target_state, cudaq::qvector<> &qs) __qpu__ {
+    cudaq::compute_action(
+        [&]() {
+          for (int i = 1; i <= qs.size(); ++i) {
+            auto target_bit_set = (1 << (qs.size() - i)) & target_state;
+            if (!target_bit_set)
+              x(qs[i - 1]);
+          }
+        },
+        [&]() {
+          auto ctrlQubits = qs.front(qs.size() - 1);
+          z<cudaq::ctrl>(ctrlQubits, qs.back());
+        });
+  }
+};
+
+int main(int argc, char *argv[]) {
+  auto secret = 1 < argc ? strtol(argv[1], NULL, 2) : 0b1011;
+  auto counts = cudaq::sample(run_grover{}, 4, secret, oracle{});
+  printf("Found string %s\n", counts.most_probable().c_str());
+  return 0;
+}
+
+// CHECK: Found string 1011

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -53,11 +53,17 @@ function add_pass_to_pipeline {
 # Function that groups and handles all of our -f* and -fno-* flags.
 function f_option_handling {
 	case $1 in
+	-fPIC|-fpic)
+		# Pass to linker, library mode, and cudaq-quake
+		LINKER_FLAGS="${LINKER_FLAGS} $1"
+		ARGS="${ARGS} $1"
+		CUDAQ_QUAKE_ARGS="${CUDAQ_QUAKE_ARGS} --Xcudaq $1"
+		;;
 	-fno-device-code-loading)
-		ENABLE_DEVICE_CODE_LOADERS=false
+		ENABLE_DEVICE_CODE_LOADER=false
 		;;
 	-fdevice-code-loading)
-		ENABLE_DEVICE_CODE_LOADERS=true
+		ENABLE_DEVICE_CODE_LOADER=true
 		;;
 	-fno-unwind-lowering)
 		ENABLE_UNWIND_LOWERING=false
@@ -106,6 +112,12 @@ function f_option_handling {
 		;;
 	-fno-enable-cudaq-run)
 		ENABLE_CUDAQ_RUN=false
+		;;
+	-farray-conversion)
+		ENABLE_ARRAY_CONVERSION=true
+		;;
+	-fno-array-conversion)
+		ENABLE_ARRAY_CONVERSION=false
 		;;
 	*)
 		# Pass any unrecognized options on to the clang++ tool.
@@ -337,8 +349,9 @@ MAPPING_FILE=
 LLC_FLAGS=-O2
 DO_LINK=true
 SHOW_VERSION=false
+ENABLE_ARRAY_CONVERSION=true
 ENABLE_UNWIND_LOWERING=true
-ENABLE_DEVICE_CODE_LOADERS=true
+ENABLE_DEVICE_CODE_LOADER=true
 ENABLE_KERNEL_EXECUTION=true
 KERNEL_EXECUTION_KIND=
 ENABLE_AGGRESSIVE_EARLY_INLINE=true
@@ -565,12 +578,6 @@ while [ $# -ne 0 ]; do
 		LINKLIBS="${LINKLIBS} -l$2"
 		shift
 		;;
-	-fPIC|-fpic)
-		# Pass to linker, library mode, and cudaq-quake
-		LINKER_FLAGS="${LINKER_FLAGS} $1"
-		ARGS="${ARGS} $1"
-		CUDAQ_QUAKE_ARGS="${CUDAQ_QUAKE_ARGS} --Xcudaq $1"
-		;;
 	-c)
 		DO_LINK=false
 		;;
@@ -724,9 +731,18 @@ if ${ENABLE_AGGRESSIVE_EARLY_INLINE}; then
 		OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "indirect-to-direct-calls,inline")
 	fi
 fi
-if ${ENABLE_DEVICE_CODE_LOADERS}; then
+if ${ENABLE_ARRAY_CONVERSION}; then
 	RUN_OPT=true
-	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(quake-add-metadata,constant-propagation,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix,device-code-loader")
+	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(quake-add-metadata,constant-propagation,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix")
+fi
+if [[ -n "$CUDAQ_OPT_EXTRA_PASSES" ]]; then
+	RUN_OPT=true
+	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "$CUDAQ_OPT_EXTRA_PASSES")
+fi
+if ${ENABLE_DEVICE_CODE_LOADER}; then
+	# Note: the JIT compiler will pick up at this point.
+	RUN_OPT=true
+	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "device-code-loader")
 fi
 if ${ENABLE_LOWER_TO_CFG}; then
 	RUN_OPT=true
@@ -745,10 +761,6 @@ if [ ! -z "$TARGET_PASS_PIPELINE" ]; then
 	RUN_OPT=true
 	# Don't use add_pass_to_pipeline here.
 	OPT_PASSES="$TARGET_PASS_PIPELINE"
-fi
-
-if [ ! -z "$CUDAQ_OPT_EXTRA_PASSES" ]; then
-	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "$CUDAQ_OPT_EXTRA_PASSES")
 fi
 
 OPT_PASSES="builtin.module(${OPT_PASSES})"


### PR DESCRIPTION
[core] Continue work on improving apply specialization.

We want to specialize and constant prop into apply callees. This constant prop should be used to convert the specialized callee into a DAG form. Also specialize any relaxed veq types while we're at it.

Adjust pipelines and such on Ionq and Quantinuum to allow for Grover example to JIT compile and execute.

Also tidy up the nvq++ driver a bit.

Add test.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
