### PR TITLE
Update untagged manifests limit from 200 to 400

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -82,7 +82,7 @@ jobs:
         with: 
           package-name: ${{ matrix.image_name }}
           package-type: 'container'
-          min-versions-to-keep: 200
+          min-versions-to-keep: 400
           delete-only-untagged-versions: 'true'
 
       - name: Log in to the container registry


### PR DESCRIPTION
With ongoing experiments with deployments, cache has been getting overwritten frequently. This is an issue as cudaqx needs devdeps images.

The max cache size is 10GB.

I don't recall seeing any warnings of us nearing cache limits, so this should be fine. Github will warn and automatically evict older manifests if it reaches the cache limit anyways.