### PR TITLE
Remove homebrew gzip decompress

### DIFF
--- a/runtime/common/RestClient.cpp
+++ b/runtime/common/RestClient.cpp
@@ -10,44 +10,9 @@
 #include "Logger.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include <cpr/cpr.h>
-#include <zlib.h>
 
 namespace cudaq {
 constexpr long validHttpCode = 205;
-
-/// Decompress GZIP data. Throws an exception on error.
-std::string decompress_gzip(const std::string &data) {
-  if (data.empty())
-    return data;
-
-  std::string decompressed;
-  z_stream zs{};
-  zs.avail_in = data.size();
-  zs.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(data.data()));
-
-  // Add 16 to indicate gzip decoding
-  if (inflateInit2(&zs, 16 + MAX_WBITS) != Z_OK)
-    throw std::runtime_error("inflateInit2 failed while decompressing.");
-
-  // Uncompress 32 KB at a time
-  constexpr auto buffSize = 32678;
-  auto buffer = std::make_unique<char[]>(buffSize);
-  int ret;
-  do {
-    zs.avail_out = buffSize;
-    zs.next_out = reinterpret_cast<Bytef *>(buffer.get());
-    ret = inflate(&zs, 0);
-    if (decompressed.size() < zs.total_out)
-      decompressed.append(buffer.get(), zs.total_out - decompressed.size());
-  } while (ret == Z_OK);
-
-  inflateEnd(&zs);
-
-  if (ret != Z_STREAM_END)
-    throw std::runtime_error("Exception during zlib decompression");
-
-  return decompressed;
-}
 
 RestClient::RestClient() : sslOptions(std::make_unique<cpr::SslOptions>()) {
   auto caInfo = [&]() -> std::string {
@@ -156,12 +121,6 @@ nlohmann::json RestClient::get(const std::string_view remoteUrl,
     throw std::runtime_error("HTTP GET Error - status code " +
                              std::to_string(r.status_code) + ": " +
                              r.error.message + ": " + r.text);
-
-  // cpr used to do this automatically but no longer does as of PR #1010
-  if (r.header["Content-Encoding"] == "gzip") {
-    auto tmp = decompress_gzip(r.text);
-    r.text = tmp;
-  }
   return nlohmann::json::parse(r.text);
 }
 


### PR DESCRIPTION
Updating cpr seems to have broken our homebrew gzip decompression, likely because cpr handles that transparently now.
https://github.com/NVIDIA/cuda-quantum/commit/b89969d4c2a258a01fa3cd0ba37302eccdec141d

This essentially reverts https://github.com/NVIDIA/cuda-quantum/commit/ad164b9089f25928979289aab5de3bfcc8319b3d which is no longer needed.

Manually verified with the following script:
```
nvq++ -v bug_qubit.cpp --target ionq
./a.out
```
(`IONQ_API_KEY` env var is necessary to run the above)

Before this PR, it throws an error:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Exception during zlib decompression
Aborted (core dumped)
```

Printing the payload given to `decompress_gzip` shows it is, in fact, not gzip encoded, even though the `Content-Encoding` header is still `gzip`.

This should fix the issues related to gzip with our integration tests:
https://github.com/NVIDIA/cuda-quantum/actions/runs/15600865169/job/43940480226