### PR TITLE
update adapt_qaoa tutorial: fix the mixer_pool issue

### DIFF
--- a/docs/sphinx/applications/python/adapt_qaoa.ipynb
+++ b/docs/sphinx/applications/python/adapt_qaoa.ipynb
@@ -28,7 +28,7 @@
     "Below is a schematic representation of the ADAPT-QAOA algorithm explained above.\n",
     "\n",
     "<div>\n",
-    "<img src=\"images/adapt-qaoa.png\" width=\"600\">\n",
+    "<img src=\"images/adapt-qaoa.png\" width=\"1000\">\n",
     "</div>\n",
     "\n",
     "\n"
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -231,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,20 +282,20 @@
     "\n",
     "@cudaq.kernel\n",
     "def kernel_qaoa(qubits_num:int, ham_word:list[cudaq.pauli_word], ham_coef:list[complex],\n",
-    "        mixer_pool:list[cudaq.pauli_word], gamma:list[float], beta:list[float], layer:list[int], num_layer:int):\n",
+    "        mixer_pool:list[list[cudaq.pauli_word]], gamma:list[float], beta:list[float], num_layer:int):\n",
     "\n",
     "    qubits = cudaq.qvector(qubits_num)\n",
     "\n",
     "    h(qubits)\n",
     "\n",
-    "    idx = 0\n",
+    "    \n",
     "    for p in range(num_layer):\n",
     "        for i in range(len(ham_coef)):\n",
     "            exp_pauli(gamma[p] * ham_coef[i].real, qubits, ham_word[i])\n",
-    "\n",
-    "        for j in range(layer[p]):\n",
-    "            exp_pauli(beta[idx+j], qubits, mixer_pool[idx+j])\n",
-    "        idx = idx + layer[p]\n"
+    "        \n",
+    "        for word in mixer_pool[p]:\n",
+    "            exp_pauli(beta[p], qubits, word)\n",
+    "        "
    ]
   },
   {
@@ -304,12 +304,12 @@
    "source": [
     "### Beginning of ADAPT-QAOA iteration:\n",
     "\n",
-    "Note that, here in this tutorial, we set the seed for the random number generator. This ensures that the random choices are reproducible in each step of iteration when choosing operator pools if more than one operator pool has the same value. For production, users need to change that."
+    "Note that here in this tutorial, we set the seed for the random number generator. This ensures that the random choices are reproducible in each step of iteration when choosing operator pools if more than one operator pool has the same value. For production, users need to remove that."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -319,7 +319,7 @@
       "Step:  1\n",
       "Norm of the gradient:  3.468398683655509\n",
       "Mixer pool at step 1\n",
-      "['IIZIY']\n",
+      "[['IIZIY']]\n",
       "Number of layers:  1\n",
       "Result from the step  1\n",
       "Optmized Energy:  -3.4999999999998064\n",
@@ -329,7 +329,7 @@
       "Step:  2\n",
       "Norm of the gradient:  2.4501630553527365\n",
       "Mixer pool at step 2\n",
-      "['IIZIY', 'ZIIYI']\n",
+      "[['IIZIY'], ['ZIIYI']]\n",
       "Number of layers:  2\n",
       "Result from the step  2\n",
       "Optmized Energy:  -3.999999999998128\n",
@@ -339,7 +339,7 @@
       "Step:  3\n",
       "Norm of the gradient:  1.99990001175888\n",
       "Mixer pool at step 3\n",
-      "['IIZIY', 'ZIIYI', 'ZYIII']\n",
+      "[['IIZIY'], ['ZIIYI'], ['ZYIII']]\n",
       "Number of layers:  3\n",
       "Result from the step  3\n",
       "Optmized Energy:  -4.499999999929474\n",
@@ -349,7 +349,7 @@
       "Step:  4\n",
       "Norm of the gradient:  0.014141961855183087\n",
       "Mixer pool at step 4\n",
-      "['IIZIY', 'ZIIYI', 'ZYIII', 'IIXIX']\n",
+      "[['IIZIY'], ['ZIIYI'], ['ZYIII'], ['IIXIX']]\n",
       "Number of layers:  4\n",
       "Result from the step  4\n",
       "Optmized Energy:  -4.999999999996581\n",
@@ -361,7 +361,7 @@
       "\n",
       " Final Result:  \n",
       "\n",
-      "Final mixer_pool:  ['IIZIY', 'ZIIYI', 'ZYIII', 'IIXIX']\n",
+      "Final mixer_pool:  [['IIZIY'], ['ZIIYI'], ['ZYIII'], ['IIXIX']]\n",
       "Number of layers:  4\n",
       "Number of mixer pool in each layer:  [1, 1, 1, 1]\n",
       "Final Energy:  -4.999999999996581\n"
@@ -375,8 +375,8 @@
     "gamma = []\n",
     "\n",
     "mixer_pool = []\n",
-    "layer = []\n",
-    "\n",
+    "mixer_pool_str = []\n",
+    "layer=[]\n",
     "\n",
     "istep = 1\n",
     "while True:\n",
@@ -398,7 +398,7 @@
     "    \n",
     "    if norm <= threshold:\n",
     "        print('\\n', 'Final Result: ', '\\n')\n",
-    "        print('Final mixer_pool: ', mixer_pool)\n",
+    "        print('Final mixer_pool: ', mixer_pool_str)\n",
     "        print('Number of layers: ', len(layer))\n",
     "        print('Number of mixer pool in each layer: ', layer)\n",
     "        print('Final Energy: ', result_vqe.fun)\n",
@@ -425,14 +425,17 @@
     "        random_mixer = random.choice(temp_pool)\n",
     "        \n",
     "        pool_added = []\n",
+    "        pool_added_str = []\n",
     "        for term in random_mixer:\n",
-    "            pool_added.append(term.get_pauli_word(qubits_num))\n",
+    "            pool_added.append(cudaq.pauli_word(term.get_pauli_word(qubits_num)))\n",
+    "            pool_added_str.append(term.get_pauli_word(qubits_num))\n",
     "            \n",
-    "        mixer_pool = mixer_pool + pool_added\n",
+    "        mixer_pool.append(pool_added)\n",
+    "        mixer_pool_str.append(pool_added_str)\n",
     "        \n",
     "    \n",
     "        print('Mixer pool at step', istep)\n",
-    "        print(mixer_pool)\n",
+    "        print(mixer_pool_str)\n",
     "        \n",
     "        num_layer = len(layer)\n",
     "        print('Number of layers: ', num_layer)\n",
@@ -451,7 +454,7 @@
     "\n",
     "            \n",
     "            energy = cudaq.observe(kernel_qaoa, ham, qubits_num, ham_word, ham_coef,\n",
-    "                                    mixer_pool, gamma, beta, layer, num_layer).expectation()\n",
+    "                                    mixer_pool, gamma, beta, num_layer).expectation()\n",
     "            #print(energy)\n",
     "            return energy\n",
     "        \n",
@@ -470,7 +473,7 @@
     "        \n",
     "        if dE <= e_stop:\n",
     "            print('\\n', 'Final Result: ', '\\n')\n",
-    "            print('Final mixer_pool: ', mixer_pool)\n",
+    "            print('Final mixer_pool: ', mixer_pool_str)\n",
     "            print('Number of layers: ', len(layer))\n",
     "            print('Number of mixer pool in each layer: ', layer)\n",
     "            print('Final Energy= ', erg)\n",
@@ -480,7 +483,7 @@
     "        else:\n",
     "\n",
     "            # Compute the state of this current step for the gradient\n",
-    "            state = cudaq.get_state(kernel_qaoa, qubits_num, ham_word, ham_coef,mixer_pool, gamma, beta, layer, num_layer)\n",
+    "            state = cudaq.get_state(kernel_qaoa, qubits_num, ham_word, ham_coef,mixer_pool, gamma, beta, num_layer)\n",
     "            #print('State at step ', istep)\n",
     "            #print(state)\n",
     "            istep+=1\n",
@@ -490,7 +493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -500,8 +503,8 @@
       "\n",
       " Sampling the Final ADAPT QAOA circuit \n",
       "\n",
-      "The most probable max cut:  10100\n",
-      "All bitstring from circuit sampling:  { 01011:2499 10100:2501 }\n",
+      "The most probable max cut:  01011\n",
+      "All bitstring from circuit sampling:  { 01011:2519 10100:2481 }\n",
       "\n"
      ]
     }
@@ -509,21 +512,21 @@
    "source": [
     "print('\\n', 'Sampling the Final ADAPT QAOA circuit', '\\n')\n",
     "# Sample the circuit\n",
-    "count=cudaq.sample(kernel_qaoa, qubits_num, ham_word, ham_coef,mixer_pool, gamma, beta, layer, num_layer, shots_count=5000)\n",
+    "count=cudaq.sample(kernel_qaoa, qubits_num, ham_word, ham_coef,mixer_pool, gamma, beta, num_layer, shots_count=5000)\n",
     "print('The most probable max cut: ', count.most_probable())\n",
     "print('All bitstring from circuit sampling: ', count)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CUDA-Q Version cu12-latest (https://github.com/NVIDIA/cuda-quantum 974716fa2024267f7c12a2ed86ffbfe314d37a36)\n"
+      "CUDA-Q Version cu12-latest (https://github.com/NVIDIA/cuda-quantum 615d91910310605c83ea59f6afe6e7ae6dfecd28)\n"
      ]
     }
    ],


### PR DESCRIPTION
The pool includes the qaoa_mixer which is a sum of Pauli_x. When converting this into Pauli word, it results into a group of Pauli words. As a results, the mixer_pool is a list of list. The way the mixer pool was flatten was incorrect, and it was not observed because the example employed does not pick the qaoa_mixer. Hence, the issue was not observed. In this PR, I fixed this issue and I employed the list of list feature that was recently added in cudaq. 

I added these lines to correct the mixer_pool:
```
        pool_added = []
        pool_added_str = []
        for term in random_mixer:
            pool_added.append(cudaq.pauli_word(term.get_pauli_word(qubits_num)))
            pool_added_str.append(term.get_pauli_word(qubits_num))
            
        mixer_pool.append(pool_added)
        mixer_pool_str.append(pool_added_str)
```

I also updated the quantum kernel accordingly:
```
@cudaq.kernel
def kernel_qaoa(qubits_num:int, ham_word:list[cudaq.pauli_word], ham_coef:list[complex],
        mixer_pool:list[list[cudaq.pauli_word]], gamma:list[float], beta:list[float], num_layer:int):

    qubits = cudaq.qvector(qubits_num)

    h(qubits)

    
    for p in range(num_layer):
        for i in range(len(ham_coef)):
            exp_pauli(gamma[p] * ham_coef[i].real, qubits, ham_word[i])
        
        for word in mixer_pool[p]:
            exp_pauli(beta[p], qubits, word)
```