### PR TITLE
Fix nbsphinx markdown rendering for quantum_pagerank.ipynb

### DIFF
--- a/docs/sphinx/applications/python/quantum_pagerank.ipynb
+++ b/docs/sphinx/applications/python/quantum_pagerank.ipynb
@@ -36,9 +36,9 @@
     "### Problem Definition\n",
     "**PageRank** is an algorithm used to rank nodes—such as web pages or individuals—in directed or undirected graphs based on their relative importance.\n",
     "\n",
-    "Given a graph $ G = (V, E) $:  \n",
-    "- $ V $ is the set of nodes (e.g., web pages, individuals).  \n",
-    "- $ E $ is the set of edges (e.g., hyperlinks/connections between pages/individuals).  \n",
+    "Given a graph $G = (V, E)$:  \n",
+    "- $V$ is the set of nodes (e.g., web pages, individuals).  \n",
+    "- $E$ is the set of edges (e.g., hyperlinks/connections between pages/individuals).  \n",
     "\n",
     "The goal is to assign an importance score to each node based on the number and importance of incoming links.\n",
     "\n",
@@ -81,17 +81,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The mathematical foundations of the PageRank algorithm include **Link matrix $\\mathbf{L}$** and **PageRank Matrix $\\mathbf{P}$**. Let’s explore their definitions and meanings:\n",
-    "For **Social Network Analysis (SNA)**, the **Link matrix $\\mathbf{L}$** is used to represent how influence, information, or relationships flow between people (nodes). The entry $L_{ij}$ in row $i$, column $j$ of the matrix shows how much influence person $j$ gives to person $i$ with the following definition:\n",
+    "The mathematical foundations of the PageRank algorithm include **Link matrix** $\\mathbf{L}$ and **PageRank Matrix** $\\mathbf{P}$. Let’s explore their definitions and meanings:\n",
+    "For **Social Network Analysis (SNA)**, the Link matrix $\\mathbf{L}$ is used to represent how influence, information, or relationships flow between people (nodes). The entry $L_{ij}$ in row $i$, column $j$ of the matrix shows how much influence person $j$ gives to person $i$ with the following definition:\n",
     "$$\n",
-    "L_{ij} = \n",
+    "L_{ij} =\n",
     "\\begin{cases}\n",
     "\\frac{1}{d_j^{\\text{out}}} & \\text{if there is a link from node } j \\text{ to node } i \\\\\n",
     "0 & \\text{otherwise}\n",
     "\\end{cases}\n",
     "$$\n",
     "\n",
-    "The Normalization $\\frac{1}{d_j^{\\text{out}}}$ by the out-degree of node $j$ can be interpreted as the normalized distribution of influence across the network. That is to say, \n",
+    "The Normalization $\\frac{1}{d_j^{\\text{out}}}$ by the out-degree of node $j$ can be interpreted as the normalized distribution of influence across the network. That is to say,\n",
     "if person $j$ follows a few people, then their \"vote of importance\" is evenly split among those $m$ people. So, $L_{ij} = \\frac{1}{m}$ for each connection."
    ]
   },
@@ -120,8 +120,8 @@
    "metadata": {},
    "source": [
     "To describe the dynamics of a random walker moving through the network, the **PageRank Matrix $\\mathbf{P}$** is introduced as below:\n",
-    "$$ \n",
-    "\\mathbf{P} = \\alpha \\mathbf{L} + (1 - \\alpha) \\frac{1}{N} \\mathbf{E} \n",
+    "$$\n",
+    "\\mathbf{P} = \\alpha \\mathbf{L} + (1 - \\alpha) \\frac{1}{N} \\mathbf{E}\n",
     "$$\n",
     "The matrix models the walker's behavior by capturing the probabilities of moving between nodes (with damping factor $\\alpha$), considering both the network's link structure (via link matrix $\\mathbf{L}$) and the possibility of random jumps through the teleportation matrix $\\mathbf{E}$, which ensures unbiased exploration of all nodes with a probability of $1/N$."
    ]
@@ -153,9 +153,9 @@
    "source": [
     "Instead of computing PageRank iteratively by [the power method](https://en.wikipedia.org/wiki/PageRank#Power_method), we aim to introduce a [quantum version of PageRank](https://www.nature.com/articles/srep00605) that solves the ranking problem by leveraging the principles of quantum mechanics, specifically [**Quantum Stochastic Walk (QSW)**](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.81.022323), which generalizes classical random walks by incorporating both **coherent quantum evolution** and **incoherent stochastic dynamics**, described by the **Lindblad master equation**:  \n",
     "\n",
-    "$\n",
+    "$$\n",
     "\\frac{d\\rho}{dt} = -i(1-\\omega)[H, \\rho] + \\omega \\sum_{k>0} \\gamma_k \\left( L_k \\rho L_k^\\dagger - \\frac{1}{2} \\{L_k^\\dagger L_k, \\rho\\} \\right)\n",
-    "$"
+    "$$"
    ]
   },
   {
@@ -166,20 +166,21 @@
     "\n",
     "**Hamiltonian Evolution (coherent):**\n",
     "\n",
-    "$ -i(1-\\omega)[H, \\rho] $\n",
+    "$$\n",
+    "-i(1-\\omega)[H, \\rho]\n",
+    "$$\n",
     "\n",
     "- $H$ is the Hamiltonian, governing coherent unitary evolution.\n",
     "- The factor $1 - \\omega$ determines the extent of quantum behavior in the system.\n",
     "\n",
     "**Dissipative Evolution (incoherent):**\n",
     "\n",
-    "$ \\omega \\sum_{k > 0} \\gamma_k \\left( L_k \\rho L_k^{\\dagger} - \\frac{1}{2} \\{ L_k^{\\dagger} L_k, \\rho\\} \\right) $\n",
+    "$$\n",
+    "\\omega \\sum_{k > 0} \\gamma_k \\left( L_k \\rho L_k^{\\dagger} - \\frac{1}{2} \\{ L_k^{\\dagger} L_k, \\rho\\} \\right)\n",
+    "$$\n",
     "\n",
     "- $\\gamma_k$ are rates associated with each dissipative process.\n",
     "- $L_k$ are Lindblad operators modeling incoherent jumps between states.\n",
-    "- The term:\n",
-    "  $ L_k \\rho L_k^{\\dagger} - \\frac{1}{2} \\{ L_k^{\\dagger} L_k, \\rho\\} $\n",
-    "  ensures that the system remains a valid density matrix (preserving trace and positivity).\n",
     "\n",
     "**Parameter $\\omega$ controls the interpolation:**\n",
     "\n",
@@ -210,9 +211,7 @@
     "H = np.array(nx.to_numpy_array(graph), dtype=np.complex128)\n",
     "\n",
     "# Defines an elementary operator named \"hamiltonian\", allowing creation with the name and its degrees of freedom.\n",
-    "operators.define(\"hamiltonian\",\n",
-    "                          expected_dimensions=[N],\n",
-    "                          create=lambda: H)"
+    "operators.define(\"hamiltonian\", expected_dimensions=[N], create=lambda: H)"
    ]
   },
   {
@@ -227,7 +226,7 @@
     "L(i,j) = |i\\rangle \\langle j| \\quad\n",
     "$$\n",
     "\n",
-    "where the indices $ i $ and $ j $ label the nodes in the network as well as the Lindblad operators. This notation indicates that the operator $ L(i,j) $ describes a **transition** from state $|j\\rangle$ to state $|i\\rangle$.\n"
+    "where the indices $i$ and $j$ label the nodes in the network as well as the Lindblad operators. This notation indicates that the operator $L(i,j)$ describes a **transition** from state $|j\\rangle$ to state $|i\\rangle$.\n"
    ]
   },
   {


### PR DESCRIPTION
nbsphinx does not correctly render markdown content in quantum_pagerank.ipynb. (not detected/corrected by the formatter nbqa yapf)
See: [notebook](https://github.com/NVIDIA/cuda-quantum/blob/feb481aa70c4954e9315e8d218b5f793f154ccf2/docs/sphinx/applications/python/quantum_pagerank.ipynb#L7) vs. [doc](https://nvidia.github.io/cuda-quantum/latest/applications/python/quantum_pagerank.html)

Fixed the issue by removing additional empty spaces, etc.