### PR TITLE
[OpenQASM] Fixes the OpenQASM2 backend for use with exp_pauli.

### DIFF
--- a/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -63,6 +63,7 @@ void cudaq::opt::addPipelineTranslateToOpenQASM(PassManager &pm) {
   pm.addNestedPass<func::FuncOp>(createCSEPass());
   pm.addNestedPass<func::FuncOp>(createClassicalMemToReg());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<func::FuncOp>(createDeadStoreRemoval());
   pm.addPass(createSymbolDCEPass());
 }
 

--- a/python/tests/backends/emulateInfleqtion.py
+++ b/python/tests/backends/emulateInfleqtion.py
@@ -10,6 +10,7 @@ import cudaq, pytest, os
 from cudaq import spin
 import numpy as np
 
+
 @pytest.fixture(scope="session", autouse=True)
 def do_something():
     cudaq.set_target("infleqtion", emulate=True)
@@ -28,7 +29,7 @@ def test_deep_exp_pauli():
         for word in words:
             exp_pauli(0.5, q, word)
         mz(q)
-    
+
     words = ["XXI", "YYI", "IXX", "IYY"]
     counts = cudaq.sample(example, 3, words)
 

--- a/python/tests/backends/emulateInfleqtion.py
+++ b/python/tests/backends/emulateInfleqtion.py
@@ -1,0 +1,49 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import cudaq, pytest, os
+from cudaq import spin
+import numpy as np
+
+@pytest.fixture(scope="session", autouse=True)
+def do_something():
+    cudaq.set_target("infleqtion", emulate=True)
+    yield "Running the tests."
+    cudaq.__clearKernelRegistries()
+    cudaq.reset_target()
+
+
+def test_deep_exp_pauli():
+
+    @cudaq.kernel
+    def example(n: int, words: list[cudaq.pauli_word]):
+        q = cudaq.qvector(n)
+        for qi in q:
+            h(qi)
+        for word in words:
+            exp_pauli(0.5, q, word)
+        mz(q)
+    
+    words = ["XXI", "YYI", "IXX", "IYY"]
+    counts = cudaq.sample(example, 3, words)
+
+    counts.dump()
+    assert '000' in counts
+    assert '001' in counts
+    assert '010' in counts
+    assert '011' in counts
+    assert '100' in counts
+    assert '101' in counts
+    assert '110' in counts
+    assert '111' in counts
+
+
+# leave for gdb debugging
+if __name__ == "__main__":
+    loc = os.path.abspath(__file__)
+    pytest.main([loc, "-s"])


### PR DESCRIPTION
The OpenQASM assembly format does not support exp_pauli nor the string data type.  This requires that (1) the exp_pauli operations are decomposed and (2) residual string literals are cleaned up.

This PR addresses these issues and adds a regression test for Python.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
