### PR TITLE
Update to cuquantum 25.06

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -365,7 +365,7 @@ jobs:
         cuda_version=${{ matrix.cuda_version }}
         base_image=${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-gcc11', matrix.platform)] }}
         ompidev_image=${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-cu{1}-ompi', matrix.platform, matrix.cuda_version)] }}
-        ${{ matrix.cuda_version != '11.8' && 'cuda_packages=cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver libnvjitlink' || '' }}
+        ${{ matrix.cuda_version != '11.8' && 'cuda_packages=cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver libcusparse libnvjitlink' || '' }}
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
       update_registry_cache: ${{ needs.metadata.outputs.cache_target }}
       environment: ${{ needs.metadata.outputs.environment }}

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -739,10 +739,6 @@ jobs:
           fi
 
           docker run --rm -dit --network host --name cuda-quantum-dev $cudaqdev_image
-          # Unfortunately, we need to install cuquantum for docs generation to work properly, 
-          # since using mock imports in the autodocs configuration doesn't work properly. 
-          # See also https://github.com/sphinx-doc/sphinx/issues/11211. 
-          docker exec cuda-quantum-dev bash -c "python3 -m pip install cuquantum-python-cu12~=25.03"
           
           (docker exec cuda-quantum-dev bash -c "export $docs_version && bash scripts/build_docs.sh" && built=true) || built=false
           if $built; then docker cp cuda-quantum-dev:"/usr/local/cudaq/docs/." docs; \

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -977,6 +977,7 @@ jobs:
             libcurand-$cuda_version_suffix \
             cuda-cudart-$cuda_version_suffix \
             libcusolver-$cuda_version_suffix \
+            libcusparse-$cuda_version_suffix \
             cuda-nvrtc-$cuda_version_suffix
           if [ $(echo ${{ matrix.cuda_version }} | cut -d . -f1) -gt 11 ]; then 
             apt-get install -y --no-install-recommends \

--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -226,9 +226,11 @@ RUN echo "Patching up wheel using auditwheel..." && \
         --exclude libcublasLt.so.11 \
         --exclude libcurand.so.10 \
         --exclude libcusolver.so.11 \
+        --exclude libcusparse.so.11 \
         --exclude libcutensor.so.2 \
         --exclude libcutensornet.so.2 \
         --exclude libcustatevec.so.1 \
+        --exclude libcudensitymat.so.0 \
         --exclude libcudart.so.11.0 \
         --exclude libnvToolsExt.so.1 \
         --exclude libnvidia-ml.so.1 \

--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -263,7 +263,7 @@ RUN gcc_packages=$(dnf list installed "gcc*" | sed '/Installed Packages/d' | cut
 
 ## [Python MLIR tests]
 RUN cd /cuda-quantum && source scripts/configure_build.sh && \
-    python3 -m pip install lit pytest scipy cuquantum-python-cu$(echo ${CUDA_VERSION} | cut -d . -f1)~=25.03 && \
+    python3 -m pip install lit pytest scipy && \
     "${LLVM_INSTALL_PREFIX}/bin/llvm-lit" -v _skbuild/python/tests/mlir \
         --param nvqpp_site_config=_skbuild/python/tests/mlir/lit.site.cfg.py
 # The other tests for the Python wheel are run post-installation.
@@ -324,7 +324,8 @@ RUN . /cuda-quantum/scripts/configure_build.sh install-gcc && \
         cuda-compiler-$(echo ${CUDA_VERSION} | tr . -) \
         cuda-cudart-devel-$(echo ${CUDA_VERSION} | tr . -) \
         libcublas-devel-$(echo ${CUDA_VERSION} | tr . -) \
-        libcurand-devel-$(echo ${CUDA_VERSION} | tr . -) && \
+        libcurand-devel-$(echo ${CUDA_VERSION} | tr . -) \
+        libcusparse-devel-$(echo ${CUDA_VERSION} | tr . -) && \
     if [ $(echo $CUDA_VERSION | cut -d "." -f1) -ge 12 ]; then \
         dnf install -y --nobest --setopt=install_weak_deps=False \
             libnvjitlink-$(echo ${CUDA_VERSION} | tr . -); \

--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -189,8 +189,10 @@ RUN dnf install -y --nobest --setopt=install_weak_deps=False ${PYTHON}-devel && 
 RUN cd /cuda-quantum && source scripts/configure_build.sh && \
     if [ "${CUDA_VERSION#11.}" != "${CUDA_VERSION}" ]; then \
         cublas_version=11.11 && \
+        cusparse_version=11.7 && \
         sed -i "s/-cu12/-cu11/g" pyproject.toml && \
         sed -i -E "s/(nvidia-cublas-cu[0-9]* ~= )[0-9\.]*/\1${cublas_version}/g" pyproject.toml && \
+        sed -i -E "s/(nvidia-cusparse-cu[0-9]* ~= )[0-9\.]*/\1${cusparse_version}/g" pyproject.toml && \
         sed -i -E "s/(nvidia-cuda-nvrtc-cu[0-9]* ~= )[0-9\.]*/\1${CUDA_VERSION}/g" pyproject.toml && \
         sed -i -E "s/(nvidia-cuda-runtime-cu[0-9]* ~= )[0-9\.]*/\1${CUDA_VERSION}/g" pyproject.toml; \
     fi && \

--- a/docker/build/devdeps.ext.Dockerfile
+++ b/docker/build/devdeps.ext.Dockerfile
@@ -130,7 +130,7 @@ ENV UCX_TLS=rc,cuda_copy,cuda_ipc,gdr_copy,sm
 
 # Install CUDA
 
-ARG cuda_packages="cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver"
+ARG cuda_packages="cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver libcusparse-dev"
 RUN if [ -n "$cuda_packages" ]; then \
         arch_folder=$([ "$(uname -m)" == "aarch64" ] && echo sbsa || echo x86_64) \
         && cuda_packages=`printf '%s\n' $cuda_packages | xargs -I {} echo {}-$(echo ${CUDA_VERSION} | tr . -)` \
@@ -164,7 +164,7 @@ ENV PATH="${CUDA_INSTALL_PREFIX}/lib64/:${CUDA_INSTALL_PREFIX}/bin:${PATH}"
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    python3 -m pip install cuquantum-python-cu$(echo $CUDA_VERSION | cut -d . -f1)~=25.03 && \
+    python3 -m pip install cuquantum-cu$(echo $CUDA_VERSION | cut -d . -f1)~=25.06 && \
     if [ "$(python3 --version | grep -o [0-9\.]* | cut -d . -f -2)" != "3.10" ]; then \
         echo "expecting Python version 3.10"; \
     fi

--- a/docker/build/devdeps.ext.Dockerfile
+++ b/docker/build/devdeps.ext.Dockerfile
@@ -130,7 +130,7 @@ ENV UCX_TLS=rc,cuda_copy,cuda_ipc,gdr_copy,sm
 
 # Install CUDA
 
-ARG cuda_packages="cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver libcusparse-dev"
+ARG cuda_packages="cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver libcusparse"
 RUN if [ -n "$cuda_packages" ]; then \
         arch_folder=$([ "$(uname -m)" == "aarch64" ] && echo sbsa || echo x86_64) \
         && cuda_packages=`printf '%s\n' $cuda_packages | xargs -I {} echo {}-$(echo ${CUDA_VERSION} | tr . -)` \

--- a/docker/build/devdeps.manylinux.Dockerfile
+++ b/docker/build/devdeps.manylinux.Dockerfile
@@ -105,7 +105,8 @@ RUN arch_folder=$([ "$(uname -m)" == "aarch64" ] && echo sbsa || echo x86_64) \
         cuda-compiler-$(echo ${CUDA_VERSION} | tr . -) \
         cuda-cudart-devel-$(echo ${CUDA_VERSION} | tr . -) \
         libcublas-devel-$(echo ${CUDA_VERSION} | tr . -) \
-        libcurand-devel-$(echo ${CUDA_VERSION} | tr . -)
+        libcurand-devel-$(echo ${CUDA_VERSION} | tr . -) \
+        libcusparse-devel-$(echo ${CUDA_VERSION} | tr . -)
 
 ENV CUDA_INSTALL_PREFIX=/usr/local/cuda-$CUDA_VERSION
 ENV CUDA_HOME="$CUDA_INSTALL_PREFIX"

--- a/docker/release/cudaq.ext.Dockerfile
+++ b/docker/release/cudaq.ext.Dockerfile
@@ -30,7 +30,7 @@ RUN if [ -d "$CUDA_QUANTUM_PATH/assets/documentation" ]; then \
 
 # Install additional runtime dependencies.
 RUN cuda_version_suffix=$(echo ${CUDA_VERSION} | tr . -) && \
-    for cudart_dependency in libcusolver libcublas libcurand cuda-cudart cuda-nvrtc; do \
+    for cudart_dependency in libcusolver libcusparse libcublas libcurand cuda-cudart cuda-nvrtc; do \
         if [ -z "$(apt list --installed | grep -o ${cudart_dependency}-${cuda_version_suffix})" ]; then \
             apt-get install -y --no-install-recommends \
                 ${cudart_dependency}-${cuda_version_suffix}; \

--- a/docker/release/cudaq.wheel.Dockerfile
+++ b/docker/release/cudaq.wheel.Dockerfile
@@ -80,10 +80,11 @@ RUN echo "Building wheel for python${python_version}." \
         $python -m auditwheel -v repair dist/cuda_quantum*linux_*.whl \
             --exclude libcustatevec.so.1 \
             --exclude libcutensornet.so.2 \
+            --exclude libcudensitymat.so.0 \
             --exclude libcublas.so.$cudaq_major \
             --exclude libcublasLt.so.$cudaq_major \
             --exclude libcurand.so.10 \
-            --exclude libcusolver.so.$cudaq_major \
+            --exclude libcusolver.so.11 \
             --exclude libcutensor.so.2 \
             --exclude libnvToolsExt.so.1 \ 
             --exclude libcudart.so.$cudart_libsuffix \

--- a/docker/release/cudaq.wheel.Dockerfile
+++ b/docker/release/cudaq.wheel.Dockerfile
@@ -41,8 +41,10 @@ RUN echo "Building MLIR bindings for python${python_version}" && \
 RUN sed -i "s/README.md.in/README.md/g" cuda-quantum/pyproject.toml && \
     if [ "${CUDA_VERSION#11.}" != "${CUDA_VERSION}" ]; then \
         cublas_version=11.11 && \
+        cusparse_version=11.7 && \
         sed -i "s/-cu12/-cu11/g" cuda-quantum/pyproject.toml && \
         sed -i -E "s/(nvidia-cublas-cu[0-9]* ~= )[0-9\.]*/\1${cublas_version}/g" cuda-quantum/pyproject.toml && \
+        sed -i -E "s/(nvidia-cusparse-cu[0-9]* ~= )[0-9\.]*/\1${cusparse_version}/g" cuda-quantum/pyproject.toml && \
         sed -i -E "s/(nvidia-cuda-nvrtc-cu[0-9]* ~= )[0-9\.]*/\1${CUDA_VERSION}/g" cuda-quantum/pyproject.toml && \
         sed -i -E "s/(nvidia-cuda-runtime-cu[0-9]* ~= )[0-9\.]*/\1${CUDA_VERSION}/g" cuda-quantum/pyproject.toml; \
     fi

--- a/docker/release/cudaq.wheel.Dockerfile
+++ b/docker/release/cudaq.wheel.Dockerfile
@@ -85,6 +85,7 @@ RUN echo "Building wheel for python${python_version}." \
             --exclude libcublasLt.so.$cudaq_major \
             --exclude libcurand.so.10 \
             --exclude libcusolver.so.11 \
+            --exclude libcusparse.so.$cudaq_major \
             --exclude libcutensor.so.2 \
             --exclude libnvToolsExt.so.1 \ 
             --exclude libcudart.so.$cudart_libsuffix \

--- a/docker/test/installer/runtime_dependencies.sh
+++ b/docker/test/installer/runtime_dependencies.sh
@@ -34,7 +34,7 @@ esac
 CUDA_DOWNLOAD_URL=https://developer.download.nvidia.com/compute/cuda/repos
 CUDA_ARCH_FOLDER=$([ "$(uname -m)" == "aarch64" ] && echo sbsa || echo x86_64)
 CUDA_VERSION_SUFFIX=$(echo ${CUDART_VERSION:-'12.0'} | tr . -)
-CUDA_PACKAGES=$(echo "cuda-cudart cuda-nvrtc libcusolver libcublas libcurand" | sed "s/[^ ]*/&-${CUDA_VERSION_SUFFIX} /g")
+CUDA_PACKAGES=$(echo "cuda-cudart cuda-nvrtc libcusolver libcublas libcurand libcusparse" | sed "s/[^ ]*/&-${CUDA_VERSION_SUFFIX} /g")
 if [ $(echo ${CUDART_VERSION} | cut -d . -f1) -gt 11 ]; then 
     CUDA_PACKAGES+=" libnvjitlink-${CUDA_VERSION_SUFFIX}"
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   'requests >= 2.31',
   'nvidia-cublas-cu12 ~= 12.0',
   'nvidia-curand-cu12 ~= 10.3',
+  'nvidia-cusparse-cu12 ~= 12.5',
   'nvidia-cuda-runtime-cu12 ~= 12.0',
   'nvidia-cusolver-cu12 ~= 11.4',
   'nvidia-cuda-nvrtc-cu12 ~= 12.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.10"
 license = { file="LICENSE" }
 dependencies = [
   'astpretty ~= 3.0',
-  'cuquantum-python-cu12 >= 25.03',
+  'cuquantum-cu12 >= 25.06',
   'numpy >= 1.24',
   'scipy >= 1.10.1',
   'requests >= 2.31',

--- a/runtime/nvqir/cudensitymat/CMakeLists.txt
+++ b/runtime/nvqir/cudensitymat/CMakeLists.txt
@@ -51,53 +51,73 @@ endif()
 message(STATUS "CUDENSITYMAT_INC: ${CUDENSITYMAT_INC}")
 message(STATUS "CUDENSITYMAT_LIB: ${CUDENSITYMAT_LIB}")
 
-get_filename_component(CUDENSITYMAT_INCLUDE_DIR ${CUDENSITYMAT_INC} DIRECTORY)
-get_filename_component(CUDENSITYMAT_LIB_DIR ${CUDENSITYMAT_LIB} DIRECTORY)
-get_filename_component(CUTENSOR_LIB_DIR ${CUTENSOR_LIB} DIRECTORY)
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${CUDENSITYMAT_LIB_DIR}:${CUTENSOR_LIB_DIR}")
+# Determine cudensitymat version
+file(READ "${CUDENSITYMAT_INC}" cudensitymat_header)
+string(REGEX MATCH "CUDENSITYMAT_MAJOR ([0-9]*)" _ ${cudensitymat_header})
+set(CUDENSITYMAT_MAJOR ${CMAKE_MATCH_1})
 
-add_library(${LIBRARY_NAME} SHARED
-  CuDensityMatSim.cpp
-  mpi_support.cpp
-  CuDensityMatTimeStepper.cpp
-  RungeKuttaIntegrator.cpp
-  CuDensityMatExpectation.cpp
-  CuDensityMatEvolution.cpp
-  CuDensityMatState.cpp
-  CuDensityMatContext.cpp
-  CuDensityMatOpConverter.cpp
-  CuDensityMatUtils.cpp
-)
+string(REGEX MATCH "CUDENSITYMAT_MINOR ([0-9]*)" _ ${cudensitymat_header})
+set(CUDENSITYMAT_MINOR ${CMAKE_MATCH_1})
 
-message("CUDAToolkit_INCLUDE_DIRS: ${CUDAToolkit_INCLUDE_DIRS}")
-target_include_directories(${LIBRARY_NAME}
-  PRIVATE 
-    . .. 
-    ${CUDAToolkit_INCLUDE_DIRS} 
-    ${CMAKE_SOURCE_DIR}/runtime/common
-    ${CUDENSITYMAT_INCLUDE_DIR}
-)
+string(REGEX MATCH "CUDENSITYMAT_PATCH ([0-9]*)" _ ${cudensitymat_header})
+set(CUDENSITYMAT_PATCH ${CMAKE_MATCH_1})
 
-target_include_directories(${LIBRARY_NAME}
-  PUBLIC
-    . ..
-    ${CUDAToolkit_INCLUDE_DIRS}
-    ${CMAKE_SOURCE_DIR}/runtime/common
-    ${CUDENSITYMAT_INCLUDE_DIR}
-)
+set(CUDENSITYMAT_VERSION ${CUDENSITYMAT_MAJOR}.${CUDENSITYMAT_MINOR}.${CUDENSITYMAT_PATCH})
+message(STATUS "Found cudensitymat version: ${CUDENSITYMAT_VERSION}")
 
-target_link_libraries(${LIBRARY_NAME}
-                      PRIVATE
-                        fmt::fmt-header-only
-                        cudaq-common
+# We need cudensitymat v0.2.0 
+if (${CUDENSITYMAT_VERSION} VERSION_GREATER_EQUAL "0.2")
+
+  get_filename_component(CUDENSITYMAT_INCLUDE_DIR ${CUDENSITYMAT_INC} DIRECTORY)
+  get_filename_component(CUDENSITYMAT_LIB_DIR ${CUDENSITYMAT_LIB} DIRECTORY)
+  get_filename_component(CUTENSOR_LIB_DIR ${CUTENSOR_LIB} DIRECTORY)
+  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${CUDENSITYMAT_LIB_DIR}:${CUTENSOR_LIB_DIR}")
+
+  add_library(${LIBRARY_NAME} SHARED
+    CuDensityMatSim.cpp
+    mpi_support.cpp
+    CuDensityMatTimeStepper.cpp
+    RungeKuttaIntegrator.cpp
+    CuDensityMatExpectation.cpp
+    CuDensityMatEvolution.cpp
+    CuDensityMatState.cpp
+    CuDensityMatContext.cpp
+    CuDensityMatOpConverter.cpp
+    CuDensityMatUtils.cpp
+  )
+
+  message("CUDAToolkit_INCLUDE_DIRS: ${CUDAToolkit_INCLUDE_DIRS}")
+  target_include_directories(${LIBRARY_NAME}
+    PRIVATE 
+      . .. 
+      ${CUDAToolkit_INCLUDE_DIRS} 
+      ${CMAKE_SOURCE_DIR}/runtime/common
+      ${CUDENSITYMAT_INCLUDE_DIR}
+  )
+
+  target_include_directories(${LIBRARY_NAME}
+    PUBLIC
+      . ..
+      ${CUDAToolkit_INCLUDE_DIRS}
+      ${CMAKE_SOURCE_DIR}/runtime/common
+      ${CUDENSITYMAT_INCLUDE_DIR}
+  )
+
+  target_link_libraries(${LIBRARY_NAME}
+                        PRIVATE
+                          fmt::fmt-header-only
+                          cudaq-common
+                          ${CUDENSITYMAT_LIB}
+                          ${CUTENSOR_LIB}
+                          CUDA::cudart_static
+                      )
+  target_link_libraries(${LIBRARY_NAME}
+                      PUBLIC
+                        cudaq-operator
                         ${CUDENSITYMAT_LIB}
-                        ${CUTENSOR_LIB}
-                        CUDA::cudart_static
-                     )
-target_link_libraries(${LIBRARY_NAME}
-                     PUBLIC
-                       cudaq-operator
-                       ${CUDENSITYMAT_LIB}
-                    )
-install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
-add_target_config(dynamics)
+                      )
+  install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
+  add_target_config(dynamics)
+else()
+  message(FATAL_ERROR "Cudensitymat version ${CUDENSITYMAT_VERSION} is not supported. Please use version 0.2.0 or higher.")
+endif()

--- a/runtime/nvqir/cudensitymat/CuDensityMatContext.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatContext.cpp
@@ -122,7 +122,17 @@ Context::Context(int deviceId) : m_deviceId(deviceId) {
 /// @brief Destroy the Context object and release resources.
 Context::~Context() {
   m_opConverter.reset();
-  cudensitymatDestroy(m_cudmHandle);
+  // Prevent spurious error message during shutdown when destroying the
+  // cudensitymat handle.
+  {
+    std::stringstream out;
+    auto cerrBuffer = std::cerr.rdbuf();
+    std::cerr.rdbuf(out.rdbuf()); // Redirect std::cerr to the stringstream.
+    cudensitymatDestroy(m_cudmHandle);
+    // Restore cerr buffer
+    std::cerr.rdbuf(cerrBuffer);
+  }
+
   cublasDestroy(m_cublasHandle);
   if (m_scratchSpaceSizeBytes > 0) {
     cudaq::dynamics::DeviceAllocator::free(m_scratchSpace);

--- a/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
@@ -225,25 +225,25 @@ cudaq::dynamics::CuDensityMatOpConverter::constructLiouvillian(
         HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
             m_handle, liouvillian, term, 0,
             make_cuDoubleComplex(leftCoeff.real(), leftCoeff.imag()),
-            wrappedCallback));
+            wrappedCallback, cudensitymatScalarGradientCallbackNone));
 
         // +i constant (right multiplication, i.e., dual)
         const auto rightCoeff = std::complex<double>(0.0, 1.0) * coeffVal;
         HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
             m_handle, liouvillian, term, 1,
             make_cuDoubleComplex(rightCoeff.real(), rightCoeff.imag()),
-            wrappedCallback));
+            wrappedCallback, cudensitymatScalarGradientCallbackNone));
       } else {
         wrappedCallback = wrapScalarCallback(coeff, keys);
         // -i constant (left multiplication)
         HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
             m_handle, liouvillian, term, 0, make_cuDoubleComplex(0.0, -1.0),
-            wrappedCallback));
+            wrappedCallback, cudensitymatScalarGradientCallbackNone));
 
         // +i constant (right multiplication, i.e., dual)
         HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
             m_handle, liouvillian, term, 1, make_cuDoubleComplex(0.0, 1.0),
-            wrappedCallback));
+            wrappedCallback, cudensitymatScalarGradientCallbackNone));
       }
     }
 
@@ -258,12 +258,12 @@ cudaq::dynamics::CuDensityMatOpConverter::constructLiouvillian(
           HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
               m_handle, liouvillian, term, 0,
               make_cuDoubleComplex(coeffVal.real(), coeffVal.imag()),
-              wrappedCallback));
+              wrappedCallback, cudensitymatScalarGradientCallbackNone));
         } else {
           wrappedCallback = wrapScalarCallback(coeff, keys);
           HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
               m_handle, liouvillian, term, 0, make_cuDoubleComplex(1.0, 0.0),
-              wrappedCallback));
+              wrappedCallback, cudensitymatScalarGradientCallbackNone));
         }
       }
     }
@@ -369,12 +369,14 @@ cudaq::dynamics::CuDensityMatOpConverter::createElementaryOperator(
         m_handle, static_cast<int32_t>(subspaceExtents.size()),
         subspaceExtents.data(), CUDENSITYMAT_OPERATOR_SPARSITY_MULTIDIAGONAL,
         offsets.size(), diagonalOffsets.data(), CUDA_C_64F, elementaryMat_d,
-        wrappedTensorCallback, &cudmElemOp));
+        wrappedTensorCallback, cudensitymatTensorGradientCallbackNone,
+        &cudmElemOp));
   } else {
     HANDLE_CUDM_ERROR(cudensitymatCreateElementaryOperator(
         m_handle, static_cast<int32_t>(subspaceExtents.size()),
         subspaceExtents.data(), CUDENSITYMAT_OPERATOR_SPARSITY_NONE, 0, nullptr,
-        CUDA_C_64F, elementaryMat_d, wrappedTensorCallback, &cudmElemOp));
+        CUDA_C_64F, elementaryMat_d, wrappedTensorCallback,
+        cudensitymatTensorGradientCallbackNone, &cudmElemOp));
   }
 
   if (!cudmElemOp) {
@@ -447,7 +449,8 @@ cudaq::dynamics::CuDensityMatOpConverter::createProductOperatorTerm(
   HANDLE_CUDM_ERROR(cudensitymatOperatorTermAppendElementaryProduct(
       m_handle, term, static_cast<int32_t>(elemOps.size()), elemOps.data(),
       allDegrees.data(), allModeActionDuality.data(),
-      make_cuDoubleComplex(1.0, 0.0), cudensitymatScalarCallbackNone));
+      make_cuDoubleComplex(1.0, 0.0), cudensitymatScalarCallbackNone,
+      cudensitymatScalarGradientCallbackNone));
   return term;
 }
 
@@ -478,12 +481,12 @@ cudaq::dynamics::CuDensityMatOpConverter::convertToCudensitymatOperator(
       HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
           m_handle, cudmOperator, term, 0,
           make_cuDoubleComplex(coeffVal.real(), coeffVal.imag()),
-          wrappedCallback));
+          wrappedCallback, cudensitymatScalarGradientCallbackNone));
     } else {
       wrappedCallback = wrapScalarCallback(coeff, keys);
       HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
           m_handle, cudmOperator, term, 0, make_cuDoubleComplex(1.0, 0.0),
-          wrappedCallback));
+          wrappedCallback, cudensitymatScalarGradientCallbackNone));
     }
   }
 
@@ -859,12 +862,12 @@ cudaq::dynamics::CuDensityMatOpConverter::constructLiouvillian(
           HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
               m_handle, liouvillian, term, 0,
               make_cuDoubleComplex(coeffVal.real(), coeffVal.imag()),
-              wrappedCallback));
+              wrappedCallback, cudensitymatScalarGradientCallbackNone));
         } else {
           wrappedCallback = wrapScalarCallback(coeff, keys);
           HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
               m_handle, liouvillian, term, 0, make_cuDoubleComplex(1.0, 0.0),
-              wrappedCallback));
+              wrappedCallback, cudensitymatScalarGradientCallbackNone));
         }
       } else {
         for (auto &[coeff, term] : convertToCudensitymat(
@@ -876,12 +879,12 @@ cudaq::dynamics::CuDensityMatOpConverter::constructLiouvillian(
             HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
                 m_handle, liouvillian, term, 0,
                 make_cuDoubleComplex(coeffVal.real(), coeffVal.imag()),
-                wrappedCallback));
+                wrappedCallback, cudensitymatScalarGradientCallbackNone));
           } else {
             wrappedCallback = wrapScalarCallback(coeff, keys);
             HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
                 m_handle, liouvillian, term, 0, make_cuDoubleComplex(1.0, 0.0),
-                wrappedCallback));
+                wrappedCallback, cudensitymatScalarGradientCallbackNone));
           }
         }
       }
@@ -896,12 +899,12 @@ cudaq::dynamics::CuDensityMatOpConverter::constructLiouvillian(
             HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
                 m_handle, liouvillian, term, 1,
                 make_cuDoubleComplex(coeffVal.real(), coeffVal.imag()),
-                wrappedCallback));
+                wrappedCallback, cudensitymatScalarGradientCallbackNone));
           } else {
             wrappedCallback = wrapScalarCallback(coeff, keys);
             HANDLE_CUDM_ERROR(cudensitymatOperatorAppendTerm(
                 m_handle, liouvillian, term, 1, make_cuDoubleComplex(1.0, 0.0),
-                wrappedCallback));
+                wrappedCallback, cudensitymatScalarGradientCallbackNone));
           }
         }
       } else {

--- a/scripts/configure_build.sh
+++ b/scripts/configure_build.sh
@@ -57,6 +57,7 @@ if [ "$1" == "install-cudart" ]; then
         cuda-cudart-${version_suffix} \
         cuda-nvrtc-${version_suffix} \
         libcusolver-${version_suffix} \
+        libcusparse-${version_suffix} \
         libcublas-${version_suffix} \
         libcurand-${version_suffix}
     if [ $(echo ${CUDA_VERSION} | cut -d . -f1) -gt 11 ]; then 

--- a/scripts/configure_build.sh
+++ b/scripts/configure_build.sh
@@ -71,7 +71,7 @@ if [ "$1" == "install-cuquantum" ]; then
     CUDA_ARCH_FOLDER=$([ "$(uname -m)" == "aarch64" ] && echo sbsa || echo x86_64)
 
 # [>cuQuantumInstall]
-    CUQUANTUM_VERSION=25.03.0.11
+    CUQUANTUM_VERSION=25.06.0.10
     CUQUANTUM_DOWNLOAD_URL=https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum
 
     cuquantum_archive=cuquantum-linux-${CUDA_ARCH_FOLDER}-${CUQUANTUM_VERSION}_cuda$(echo ${CUDA_VERSION} | cut -d . -f1)-archive.tar.xz

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -333,6 +333,7 @@ if (CUDA_FOUND)
     CUDA::cudart
     CUDA::cublas
     ${CUTENSOR_LIB}
+    CUDA::cusparse
     gtest_main
     fmt::fmt-header-only)
   target_include_directories(test_dynamics PRIVATE ${CMAKE_SOURCE_DIR}/runtime/nvqir/cudensitymat)
@@ -354,6 +355,7 @@ if (CUDA_FOUND)
     CUDA::cudart
     CUDA::cublas
     ${CUTENSOR_LIB}
+    CUDA::cusparse
     gtest_main
     fmt::fmt-header-only)
   # Count the number of GPUs

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -310,6 +310,16 @@ if (CUDA_FOUND)
         ${CUTENSOR_ROOT}/lib/${CUDAToolkit_VERSION_MAJOR}
   )
 
+  find_library(CUTENSORNET_LIB
+    NAMES   cutensornet libcutensornet.so.2
+    HINTS   
+        ${CUTENSORNET_ROOT}/lib64
+        ${CUTENSORNET_ROOT}/lib
+        ${CUTENSORNET_ROOT}/lib64/${CUDAToolkit_VERSION_MAJOR}
+        ${CUTENSORNET_ROOT}/lib/${CUDAToolkit_VERSION_MAJOR}
+        ${CUDENSITYMAT_ROOT}/lib/
+)
+
   # Create an executable for dynamics UnitTests
   set(CUDAQ_DYNAMICS_TEST_SOURCES
     dynamics/test_RungeKuttaIntegrator.cpp
@@ -334,6 +344,7 @@ if (CUDA_FOUND)
     CUDA::cublas
     ${CUTENSOR_LIB}
     CUDA::cusparse
+    ${CUTENSORNET_LIB}
     gtest_main
     fmt::fmt-header-only)
   target_include_directories(test_dynamics PRIVATE ${CMAKE_SOURCE_DIR}/runtime/nvqir/cudensitymat)
@@ -356,6 +367,7 @@ if (CUDA_FOUND)
     CUDA::cublas
     ${CUTENSOR_LIB}
     CUDA::cusparse
+    ${CUTENSORNET_LIB}
     gtest_main
     fmt::fmt-header-only)
   # Count the number of GPUs


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- Remove dependency to cuquantum-**python**, just the binary distribution.

**Note**: cuquantum-python 25.06 no longer supports Python 3.10.

- Add cusparse dependency. This is a new dependency of cudensitymat.

- Fix cudensitymat API usage according to the new version, need the new gradient callback param.

- Modify the dynamics CMake to check cudensitymat version as the code is no longer compatible with the previous version.

- Workaround spurious error log (related to synchronization) from cudensitymat during shutdown. We will look into the issue later. This occurs during the final shutdown, hence it is safe to ignore for the time being.

- Fix a typo in audit-wheel exclude: cusolver doesn't follow the cuda version, e.g., it has version 11.7 in CUDA toolkit 12.x (https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)


