### PR TITLE
bot/data: Update gitlab workflow to find multiplat wheel

### DIFF
--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -117,7 +117,7 @@ Python Wheels:
     - export python=python3.10 
     # Install CUDA Quantum wheel for a particular Python version (could be any version) 
     - cuda_major=$(echo $CUDA_VERSION | cut -d . -f1)
-    - cd /tmp/wheels/ && $python -m pip install cuda_quantum_cu${cuda_major}*-cp310-cp310-manylinux_*_$(uname -m).whl
+    - cd /tmp/wheels/ && $python -m pip install cuda_quantum_cu${cuda_major}*-cp310-cp310-manylinux_*_$(uname -m)*.whl
     - export CUQUANTUM_INSTALL_PREFIX="$($python -m pip show cuquantum-python-cu$cuda_major | sed -nE 's/Location. (.*)$/\1/p')/cuquantum"
     - export CUDAQ_INSTALL_PREFIX="$($python -m pip show cuda-quantum-cu${cuda_major} | sed -nE 's/Location. (.*)$/\1/p')"
     - cp -R $CUDAQ_INSTALL_PREFIX/lib64/cmake/fmt $CUDAQ_INSTALL_PREFIX/lib/cmake


### PR DESCRIPTION
With the changes to build natively on arm, the wheel has a double suffix. Adding this glob to enable the development of native arm and still allow the old build to go through.