### PR TITLE
Do not allow failure for Python Wheels,Installer,Docker Image

### DIFF
--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -131,7 +131,6 @@ Python Wheels:
     - (bash build.sh $READ_ACCESS_TOKEN && built=true) || built=false
     - cp -R artifacts/* $ARTIFACTS_DIR
     - if $built; then `exit 0`; else `exit 1`; fi
-  allow_failure: true
 
 Installer:
   rules:
@@ -166,7 +165,6 @@ Installer:
     - mkdir -p ../artifacts/$(uname -m)/mgmn_svsim && mv artifacts/* ../artifacts/$(uname -m)/mgmn_svsim
     - cd .. && rm -rf cudaq_mgmn_svsim
     - if $built; then `exit 0`; else `exit 1`; fi
-  allow_failure: true
 
 Docker Image:
   rules:
@@ -199,7 +197,6 @@ Docker Image:
     - mkdir -p ../artifacts/$(uname -m)/mgmn_svsim && mv artifacts/* ../artifacts/$(uname -m)/mgmn_svsim
     - cd .. && rm -rf cudaq_mgmn_svsim
     - if $built; then `exit 0`; else `exit 1`; fi
-  allow_failure: true
 
 Push to GitHub:
   only:


### PR DESCRIPTION
Allow failure was on, this could lead to interesting scenarios where publishing thinks everything is okay and continues on when waiting for assets. This caused an issue recently when doing the native ARM build where the python wheel name changed, and so the assets were just a text files, and no shared libraries were provided.