### PR TITLE
[testing] [Python] Follow-up to PR#3163

### DIFF
--- a/python/tests/parallel/test_mpi_mqpu.py
+++ b/python/tests/parallel/test_mpi_mqpu.py
@@ -33,6 +33,12 @@ def do_something():
 def check_mpi(entity):
     target = cudaq.get_target()
     numQpus = target.num_qpus()
+    if numQpus == 0:
+        pytest.skip("No QPUs available for target, skipping MPI test")
+    else:
+        print(
+            f"Target: {target}, NumQPUs: {numQpus}, MPI Ranks: {cudaq.mpi.num_ranks()}"
+        )
     # Define its spin Hamiltonian.
     hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
         0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)

--- a/python/tests/parallel/test_mqpu.py
+++ b/python/tests/parallel/test_mqpu.py
@@ -157,7 +157,10 @@ def testLargeProblem_kernel():
 def check_accuracy(entity):
     target = cudaq.get_target()
     numQpus = target.num_qpus()
-    assert numQpus > 0
+    if numQpus == 0:
+        pytest.skip("No QPUs available for target, skipping test")
+    else:
+        print(f"Target: {target}, NumQPUs: {numQpus}")
     # Define its spin Hamiltonian.
     hamiltonian = 5.907 - 2.1433 * spin.x(0) * spin.x(1) - 2.1433 * spin.y(
         0) * spin.y(1) + .21829 * spin.z(0) - 6.125 * spin.z(1)


### PR DESCRIPTION
When running the full test suite, the `nvidia-mqpu` target might be initialized without any actual QPUs being available. With the fix in PR #3163, this throws error instead of silently failing. Updating the tests to check QPU availability before proceeding. 
Note - these tests don't fail if run in isolation.

Fixes following crash when running full Python test suite:
```python/tests/parallel/test_mpi_mqpu.py::testMPI Fatal Python error: Floating point exception```
