### PR TITLE
[run] [bug-fix] Asynchronous API requires proper handling of QPU ids

### DIFF
--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -63,7 +63,7 @@ RunResultSpan pyRunTheKernel(const std::string &name, MlirModule module,
                              func::FuncOp funcOp,
                              cudaq::OpaqueArguments &runtimeArgs,
                              cudaq::quantum_platform &platform,
-                             std::size_t shots_count) {
+                             std::size_t shots_count, std::size_t qpu_id = 0) {
 
   auto returnTypes = funcOp.getResultTypes();
   if (returnTypes.empty() || returnTypes.size() > 1)
@@ -87,7 +87,7 @@ RunResultSpan pyRunTheKernel(const std::string &name, MlirModule module,
         pyLaunchKernel(name, thunk, mod, runtimeArgs, rawArgs, size,
                        returnOffset, {});
       },
-      platform, name, shots_count);
+      platform, name, shots_count, qpu_id);
 
   std::free(rawArgs);
   return results;
@@ -193,7 +193,7 @@ async_run_result pyRunAsync(py::object &kernel, py::args args,
     py::gil_scoped_release gil_release{};
     QuantumTask wrapped = detail::make_copyable_function(
         [sp = std::move(spanPromise), ep = std::move(errorPromise), shots_count,
-         argData, name, module, func,
+         qpu_id, argData, name, module, func,
          noise_model = std::move(noise_model)]() mutable {
           auto &platform = get_platform();
 
@@ -203,7 +203,7 @@ async_run_result pyRunAsync(py::object &kernel, py::args args,
 
           try {
             auto span = details::pyRunTheKernel(name, module, func, *argData,
-                                                platform, shots_count);
+                                                platform, shots_count, qpu_id);
             delete argData;
             sp.set_value(span);
             ep.set_value("");

--- a/python/tests/remote/test_remote_platform.py
+++ b/python/tests/remote/test_remote_platform.py
@@ -470,19 +470,20 @@ def test_capture_state():
         counts = cudaq.sample(kernel)
 
 
-def test_run():
+@cudaq.kernel
+def simple(numQubits: int) -> int:
+    qubits = cudaq.qvector(numQubits)
+    h(qubits.front())
+    for i, qubit in enumerate(qubits.front(numQubits - 1)):
+        x.ctrl(qubit, qubits[i + 1])
+    result = 0
+    for i in range(numQubits):
+        if mz(qubits[i]):
+            result += 1
+    return result
 
-    @cudaq.kernel
-    def simple(numQubits: int) -> int:
-        qubits = cudaq.qvector(numQubits)
-        h(qubits.front())
-        for i, qubit in enumerate(qubits.front(numQubits - 1)):
-            x.ctrl(qubit, qubits[i + 1])
-        result = 0
-        for i in range(numQubits):
-            if mz(qubits[i]):
-                result += 1
-        return result
+
+def test_run():
 
     shots = 100
     qubitCount = 4
@@ -495,6 +496,25 @@ def test_run():
         if result == qubitCount:
             non_zero_count += 1
     assert non_zero_count > 0
+
+
+def test_run_async():
+
+    shots = 10
+    qubitCount = 4
+
+    result_futures = []
+    for i in range(cudaq.get_target().num_qpus()):
+        result = cudaq.run_async(simple,
+                                 qubitCount,
+                                 shots_count=shots,
+                                 qpu_id=i)
+        result_futures.append(result)
+
+    for idx in range(len(result_futures)):
+        res = result_futures[idx].get()
+        print(f"{idx} : {res}")
+        assert len(res) == shots
 
 
 # leave for gdb debugging

--- a/runtime/cudaq/algorithms/run.h
+++ b/runtime/cudaq/algorithms/run.h
@@ -43,7 +43,8 @@ struct RunResultSpan {
 // pointer to a buffer and the size of that buffer in bytes.
 RunResultSpan runTheKernel(std::function<void()> &&kernel,
                            quantum_platform &platform,
-                           const std::string &kernel_name, std::size_t shots);
+                           const std::string &kernel_name, std::size_t shots,
+                           std::size_t qpu_id = 0);
 
 // Template to transfer the ownership of the buffer in a RunResultSpan to a
 // `std::vector<T>` object. This special code is required because a
@@ -245,7 +246,7 @@ run_async(std::size_t qpu_id, std::size_t shots, QuantumKernel &&kernel,
         const std::string kernelName{details::getKernelName(kernel)};
         details::RunResultSpan span = details::runTheKernel(
             [&]() mutable { kernel(std::forward<ARGS>(args)...); }, platform,
-            kernelName, shots);
+            kernelName, shots, qpu_id);
         std::vector<ResultTy> results;
         details::resultSpanToVectorViaOwnership<ResultTy>(results, span);
         p.set_value(std::move(results));
@@ -284,7 +285,7 @@ run_async(std::size_t qpu_id, std::size_t shots, QuantumKernel &&kernel,
                   },
                   std::move(args));
             },
-            platform, kernelName, shots);
+            platform, kernelName, shots, qpu_id);
         std::vector<ResultTy> results;
         details::resultSpanToVectorViaOwnership<ResultTy>(results, span);
         p.set_value(std::move(results));
@@ -356,7 +357,7 @@ run_async(std::size_t qpu_id, std::size_t shots,
         const std::string kernelName{details::getKernelName(kernel)};
         details::RunResultSpan span = details::runTheKernel(
             [&]() mutable { kernel(std::forward<ARGS>(args)...); }, platform,
-            kernelName, shots);
+            kernelName, shots, qpu_id);
         platform.reset_noise();
         std::vector<ResultTy> results;
         details::resultSpanToVectorViaOwnership<ResultTy>(results, span);
@@ -400,7 +401,7 @@ run_async(std::size_t qpu_id, std::size_t shots,
                   },
                   std::move(args));
             },
-            platform, kernelName, shots);
+            platform, kernelName, shots, qpu_id);
         platform.reset_noise();
         std::vector<ResultTy> results;
         details::resultSpanToVectorViaOwnership<ResultTy>(results, span);

--- a/targettests/Remote-Sim/cudaq_run_async.cpp
+++ b/targettests/Remote-Sim/cudaq_run_async.cpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// REQUIRES: remote-sim
+// REQUIRES: c++20
+
+// clang-format off
+// RUN: nvq++ %cpp_std --target remote-mqpu --remote-mqpu-auto-launch 4 %s -o %t && %t | FileCheck %s
+// clang-format on
+
+#include "remote_test_assert.h"
+#include <cudaq.h>
+
+__qpu__ int unary_test(int count) {
+  unsigned result = 0;
+  cudaq::qvector v(count);
+  h(v);
+  z(v);
+  for (int i = 0; i < count; i++) {
+    bool w = mz(v[i]);
+    result |= ((unsigned)w) << (count - 1 - i);
+  }
+  return result;
+}
+
+int main() {
+  for (int q = 0; q < 4; q++) {
+    const auto results =
+        cudaq::run_async(/*qpu_id=*/q, 10, unary_test, 4).get();
+    int c = 0;
+    if (results.size() != 10) {
+      printf("FAILED! Expected 10 shots. Got %lu\n", results.size());
+    } else {
+      for (auto i : results)
+        printf("%d: %d\n", c++, i);
+      printf("success!\n");
+    }
+  }
+
+  return 0;
+}
+
+// CHECK: success!
+// CHECK: success!
+// CHECK: success!
+// CHECK: success!


### PR DESCRIPTION
Propagate `qpu_id` so it can be set correctly on the platform
