### PR TITLE
Allow Installer failure

### DIFF
--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -170,6 +170,7 @@ Installer:
     - mkdir -p ../artifacts/$(uname -m)/mgmn_svsim && mv artifacts/* ../artifacts/$(uname -m)/mgmn_svsim
     - cd .. && rm -rf cudaq_mgmn_svsim
     - if $built; then `exit 0`; else `exit 1`; fi
+  allow_failure: true
 
 Docker Image:
   rules:


### PR DESCRIPTION
The Installer portion has been failing for a while. I manually confirmed the assets files are available, and they should be good. The downstream installer tests are also happy.

Let's re-enable allow failure for now.

The issue is that it tries to use the same sha256 for both amd64/arm64:

```
Pulling docker image ghcr.io/nvidia/cuda-quantum-assets@sha256:a8c3e8564fbffe120a4547d70ab31563a65c9b552fd9a9cec00394f85a6284b8 ...
WARNING: Failed to pull image with policy "always": no matching manifest for linux/arm64/v8 in the manifest list entries (manager.go:251:0s)
```

Whereas the manifest looks like this:
```
$ docker buildx imagetools inspect ghcr.io/nvidia/cuda-quantum-assets@sha256:a8c3e8564fbffe120a4547d70ab31563a65c9b552fd9a9cec00394f85a6284b8              
Name:      ghcr.io/nvidia/cuda-quantum-assets@sha256:a8c3e8564fbffe120a4547d70ab31563a65c9b552fd9a9cec00394f85a6284b8
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:a8c3e8564fbffe120a4547d70ab31563a65c9b552fd9a9cec00394f85a6284b8
           
Manifests: 
  Name:        ghcr.io/nvidia/cuda-quantum-assets@sha256:6ea4a2c313a98bced6a039f7c5485f29f80e2b1ef98077b609230788af5f8d1a
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/amd64
               
  Name:        ghcr.io/nvidia/cuda-quantum-assets@sha256:af7b8d2585de2ae83c69dc10c03b6b13e1d1634f27bffc2f4f0aa3142e2ecae8
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:6ea4a2c313a98bced6a039f7c5485f29f80e2b1ef98077b609230788af5f8d1a
    vnd.docker.reference.type:   attestation-manifest
```