### PR TITLE
Probably fix cusparse build issues

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -365,7 +365,7 @@ jobs:
         cuda_version=${{ matrix.cuda_version }}
         base_image=${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-gcc11', matrix.platform)] }}
         ompidev_image=${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-cu{1}-ompi', matrix.platform, matrix.cuda_version)] }}
-        ${{ matrix.cuda_version != '11.8' && 'cuda_packages=cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver libcusparse libnvjitlink' || '' }}
+        ${{ matrix.cuda_version != '11.8' && 'cuda_packages=cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver libcusparse-dev libnvjitlink' || '' }}
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
       update_registry_cache: ${{ needs.metadata.outputs.cache_target }}
       environment: ${{ needs.metadata.outputs.environment }}

--- a/docker/build/devdeps.ext.Dockerfile
+++ b/docker/build/devdeps.ext.Dockerfile
@@ -130,7 +130,7 @@ ENV UCX_TLS=rc,cuda_copy,cuda_ipc,gdr_copy,sm
 
 # Install CUDA
 
-ARG cuda_packages="cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver libcusparse"
+ARG cuda_packages="cuda-cudart cuda-nvrtc cuda-compiler libcublas-dev libcurand-dev libcusolver libcusparse-dev"
 RUN if [ -n "$cuda_packages" ]; then \
         arch_folder=$([ "$(uname -m)" == "aarch64" ] && echo sbsa || echo x86_64) \
         && cuda_packages=`printf '%s\n' $cuda_packages | xargs -I {} echo {}-$(echo ${CUDA_VERSION} | tr . -)` \


### PR DESCRIPTION
Before:

```
CMake Error at unittests/CMakeLists.txt:337 (target_link_libraries):
  Target "test_dynamics" links to:

    CUDA::cusparse

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



CMake Error at unittests/CMakeLists.txt:359 (target_link_libraries):
  Target "test_evolve_async" links to:

    CUDA::cusparse

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

After:
```
[767/978] Linking CXX executable unittests/test_mqpu
FAILED: unittests/test_mqpu unittests/test_mqpu[1]_tests.cmake /workspaces/cuda-quantum/build/unittests/test_mqpu[1]_tests.cmake 
: && /usr/local/llvm/bootstrap/cxx -Wno-attributes -Wno-ctad-maybe-unsupported -O3 -DNDEBUG -Wl,--export-dynamic -rdynamic  -Wl,--no-as-needed unittests/CMakeFiles/test_mqpu.dir/main.cpp.o unittests/CMakeFiles/test_mqpu.dir/mqpu/mqpu_tester.cpp.o -o unittests/test_mqpu  -Wl,-rpath,/workspaces/cuda-quantum/build/lib  lib/libcudaq-builder.so  lib/libcudaq-platform-mqpu.so  lib/libnvqir-custatevec-fp64.so  lib/libgtest_main.a  lib/libcudaq.so  lib/libcudaq-nlopt.so  lib/libcudaq-ensmallen.so  lib/libcudaq-em-default.so  -ldl  lib/libcudaq-common.so  lib/libcudaq-operator.so  lib/libgtest.a  -Wl,-rpath-link,/workspaces/cuda-quantum/build/lib && cd /workspaces/cuda-quantum/build/unittests && /usr/local/cmake-3.28/bin/cmake -D TEST_TARGET=test_mqpu -D TEST_EXECUTABLE=/workspaces/cuda-quantum/build/unittests/test_mqpu -D TEST_EXECUTOR= -D TEST_WORKING_DIR=/workspaces/cuda-quantum/build/unittests -D TEST_EXTRA_ARGS= -D "TEST_PROPERTIES=LABELS;gpu_required" -D TEST_PREFIX= -D TEST_SUFFIX= -D TEST_FILTER= -D NO_PRETTY_TYPES=FALSE -D NO_PRETTY_VALUES=FALSE -D TEST_LIST=test_mqpu_TESTS -D CTEST_FILE=/workspaces/cuda-quantum/build/unittests/test_mqpu[1]_tests.cmake -D TEST_DISCOVERY_TIMEOUT=5 -D TEST_XML_OUTPUT_DIR= -P /usr/local/cmake-3.28/share/cmake-3.28/Modules/GoogleTestAddTests.cmake
/usr/bin/ld: warning: libcublas.so.12, needed by /usr/local/lib/python3.10/dist-packages/cuquantum/lib/libcustatevec.so.1, not found (try using -rpath or -rpath-link)
/usr/bin/ld: warning: libcublasLt.so.12, needed by /usr/local/lib/python3.10/dist-packages/cuquantum/lib/libcustatevec.so.1, not found (try using -rpath or -rpath-link)
/usr/bin/ld: /usr/local/lib/python3.10/dist-packages/cuquantum/lib/libcustatevec.so.1: undefined reference to `cublasCgeam@libcublas.so.12'
/usr/bin/ld: /usr/local/lib/python3.10/dist-packages/cuquantum/lib/libcustatevec.so.1: undefined reference to `cublasCreate_v2@libcublas.so.12'
/usr/bin/ld: /usr/local/lib/python3.10/dist-packages/cuquantum/lib/libcustatevec.so.1: undefined reference to `cublasGemmEx@libcublas.so.12'
/usr/bin/ld: /usr/local/lib/python3.10/dist-packages/cuquantum/lib/libcustatevec.so.1: undefined reference to `cublasDestroy_v2@libcublas.so.12'
/usr/bin/ld: /usr/local/lib/python3.10/dist-packages/cuquantum/lib/libcustatevec.so.1: undefined reference to `cublasSetStream_v2@libcublas.so.12'
/usr/bin/ld: /usr/local/lib/python3.10/dist-packages/cuquantum/lib/libcustatevec.so.1: undefined reference to `cublasZgeam@libcublas.so.12'
/usr/bin/ld: /usr/local/lib/python3.10/dist-packages/cuquantum/lib/libcustatevec.so.1: undefined reference to `cublasNrm2Ex@libcublas.so.12'
collect2: error: ld returned 1 exit status
```