### PR TITLE
deployments: also stitch devdeps

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -491,9 +491,9 @@ jobs:
 
           stitched_output="{}"
 
-          echo "Creating stitched manifest for cuda-quantum-devdeps..."
+          echo "Creating stitched manifest for extdevdeps..."
           for cuda in 11.8 12.0; do
-            echo "Processing devdeps for CUDA $cuda..."
+            echo "Processing extdevdeps for CUDA $cuda..."
             for arch in amd64 arm64; do
               key="${arch}-cu${cuda}-dev-image"
               digest=$(echo "$DIGESTS_JSON" | jq -r ".digest[\"$key\"]")
@@ -517,7 +517,7 @@ jobs:
             unset ref
           done
 
-          echo "Creating stitched manifest for extdevdeps..."
+          echo "Creating stitched manifest for cuda-quantum-devdeps..."
           for cuda in 11.8 12.0; do
             cuda_major="${cuda%%.*}"
             key="arm64-cu${cuda}-ext"
@@ -528,7 +528,7 @@ jobs:
             amd64_image=$(echo "$EXT_JSON" | jq -r ".image_hash[\"$key\"]")
             echo "CUDA $cuda amd64 image: $amd64_image"
 
-            stitched_tag="ghcr.io/nvidia/cuda-quantum-dev:cu${cuda}-ext-${branch}"
+            stitched_tag="ghcr.io/nvidia/cuda-quantum-devdeps:cu${cuda}-ext-${branch}"
 
             refs="$arm64_image $amd64_image"
 

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -493,6 +493,32 @@ jobs:
 
           echo "Creating stitched manifest for cuda-quantum-devdeps..."
           for cuda in 11.8 12.0; do
+            echo "Processing devdeps for CUDA $cuda..."
+            for arch in amd64 arm64; do
+              key="${arch}-cu${cuda}-dev-image"
+              digest=$(echo "$DIGESTS_JSON" | jq -r ".digest[\"$key\"]")
+              if [[ -z "$digest" || "$digest" == "null" ]]; then
+                echo "::error::Missing digest for key $key"
+                exit 1
+              fi
+              ref="$ref ghcr.io/nvidia/cuda-quantum-dev@$digest"
+            done
+
+            tag_suffix="ext-cu${cuda}-gcc11-${branch}"
+            stitched_tag="ghcr.io/nvidia/cuda-quantum-devdeps:${tag_suffix}"
+
+            echo "Creating manifest for $stitched_tag"
+            docker buildx imagetools create --tag "$stitched_tag" $ref
+
+            digest=$(docker buildx imagetools inspect "$stitched_tag" | awk '/^Digest:/ { print $2 }')
+            stitched_key="devdeps-${tag_suffix}"
+            stitched_output=$(echo "$stitched_output" | jq --arg key "$stitched_key" --arg val "$digest" '. + {($key): $val}')
+
+            unset ref
+          done
+
+          echo "Creating stitched manifest for extdevdeps..."
+          for cuda in 11.8 12.0; do
             cuda_major="${cuda%%.*}"
             key="arm64-cu${cuda}-ext"
             arm64_image=$(echo "$EXT_JSON" | jq -r ".image_hash[\"$key\"]")


### PR DESCRIPTION
we have:
```
DIGESTS_JSON:
{
  "digest": {
    "arm64-cu11.8-image": "sha256:a76f90f777b8c18c78e6e4cfcfe2544422b1e7ab3fd38490d60097523a4d3771",
    "arm64-cu12.0-dev-image": "sha256:0857505fab3a625c62134f0d1ed09db08030e0c7bd68809c732d7c8608c15b3e",
    "arm64-cu12.0-image": "sha256:05c2d2aa62b27d5c5d850b9bdb29b25c4895b730f4935d33d9851b8a79e12382",
    "amd64-cu11.8-dev-image": "sha256:01651c6401a4a0d6cff7678ce926dd699d56e4655ac097adc9167081f01b7334",
    "arm64-cu11.8-dev-image": "sha256:6a70316f0b6c3a0c246ce7c7de792d28869591c027fa8abfaea89260f2fc52c7",
    "amd64-cu11.8-image": "sha256:6709a4c2b8176c839f43e68924198cfd729f4b19ea693ffb72f3244e48d6b70c",
    "amd64-cu12.0-dev-image": "sha256:a3fcfd79d57ab806eb50cecbfe4f1442c4cfff9f9ac5f846bd9036d72632fb7a",
    "amd64-cu12.0-image": "sha256:71fe6db91c75e5e06c002621f530beebeeb21fc00da59e52e25ed15cce6d82ea"
  },
  "image_tag": {
    "arm64-cu11.8-image": "ghcr.io/nvidia/cuda-quantum:arm64-cu11-latest-base",
    "arm64-cu12.0-dev-image": "ghcr.io/nvidia/cuda-quantum-dev:ext-arm64-cu12.0-gcc11-main",
    "arm64-cu12.0-image": "ghcr.io/nvidia/cuda-quantum:arm64-cu12-latest-base",
    "amd64-cu11.8-dev-image": "ghcr.io/nvidia/cuda-quantum-dev:ext-amd64-cu11.8-gcc11-main",
    "arm64-cu11.8-dev-image": "ghcr.io/nvidia/cuda-quantum-dev:ext-arm64-cu11.8-gcc11-main",
    "amd64-cu11.8-image": "ghcr.io/nvidia/cuda-quantum:amd64-cu11-latest-base",
    "amd64-cu12.0-dev-image": "ghcr.io/nvidia/cuda-quantum-dev:ext-amd64-cu12.0-gcc11-main",
    "amd64-cu12.0-image": "ghcr.io/nvidia/cuda-quantum:amd64-cu12-latest-base"
  }
}
```

This stitches `ghcr.io/nvidia/cuda-quantum-devdeps:ext-cu${cuda}-gcc11-${branch}` together, just like how the previous workflow. This is nice for cudaqx pipeline.