### PR TITLE
Fix devdeps tag, remove regular devdeps as unneeded

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -511,7 +511,7 @@ jobs:
             amd64_image=$(echo "$EXT_JSON" | jq -r ".image_hash[\"$key\"]")
             echo "CUDA $cuda amd64 image: $amd64_image"
 
-            stitched_tag="ghcr.io/nvidia/cuda-quantum-devdeps:ext-cu${cuda}-gcc11-main
+            stitched_tag="ghcr.io/nvidia/cuda-quantum-devdeps:ext-cu${cuda}-gcc11-${branch}"
 
             refs="$arm64_image $amd64_image"
 

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -500,32 +500,6 @@ jobs:
 
           stitched_output="{}"
 
-          echo "Creating stitched manifest for extdevdeps..."
-          for cuda in 11.8 12.0; do
-            echo "Processing extdevdeps for CUDA $cuda..."
-            for arch in amd64 arm64; do
-              key="${arch}-cu${cuda}-dev-image"
-              digest=$(echo "$DIGESTS_JSON" | jq -r ".digest[\"$key\"]")
-              if [[ -z "$digest" || "$digest" == "null" ]]; then
-                echo "::error::Missing digest for key $key"
-                exit 1
-              fi
-              ref="$ref ghcr.io/nvidia/cuda-quantum-dev@$digest"
-            done
-
-            tag_suffix="ext-cu${cuda}-gcc11-${branch}"
-            stitched_tag="ghcr.io/nvidia/cuda-quantum-devdeps:${tag_suffix}"
-
-            echo "Creating manifest for $stitched_tag"
-            docker buildx imagetools create --tag "$stitched_tag" $ref
-
-            digest=$(docker buildx imagetools inspect "$stitched_tag" | awk '/^Digest:/ { print $2 }')
-            stitched_key="devdeps-${tag_suffix}"
-            stitched_output=$(echo "$stitched_output" | jq --arg key "$stitched_key" --arg val "$digest" '. + {($key): $val}')
-
-            unset ref
-          done
-
           echo "Creating stitched manifest for cuda-quantum-devdeps..."
           for cuda in 11.8 12.0; do
             cuda_major="${cuda%%.*}"
@@ -537,7 +511,7 @@ jobs:
             amd64_image=$(echo "$EXT_JSON" | jq -r ".image_hash[\"$key\"]")
             echo "CUDA $cuda amd64 image: $amd64_image"
 
-            stitched_tag="ghcr.io/nvidia/cuda-quantum-devdeps:cu${cuda}-ext-${branch}"
+            stitched_tag="ghcr.io/nvidia/cuda-quantum-devdeps:ext-cu${cuda}-gcc11-main
 
             refs="$arm64_image $amd64_image"
 


### PR DESCRIPTION
This will produce a devdeps image at

http://ghcr.io/nvidia/cuda-quantum-devdeps:ext-cu12.0-gcc11-main

Like it was before. The incorrect key was used previously, publishing the regular devdeps image, not ext.devdeps. This now publishes ext.devdeps with the extra dependencies such as cuQuantum, cuTensor, and the CUDA packages necessary.

Removes stitching the development dependencies image, as no one consumes that tag, and the build pipeline uses hashes instead.