### PR TITLE
Skip unitary compilation diffusion models

### DIFF
--- a/docs/notebook_validation.py
+++ b/docs/notebook_validation.py
@@ -109,6 +109,8 @@ if __name__ == "__main__":
 
         ## `quantum_transformer`:
         ## See: https://github.com/NVIDIA/cuda-quantum/issues/2689
+        ## `unitary_compilation_diffusion_models`
+        ## See: https://github.com/NVIDIA/cuda-quantum/issues/3194
         notebooks_skipped = ['quantum_transformer.ipynb', 'unitary_compilation_diffusion_models.ipynb']
 
         for notebook_filename in notebook_filenames:

--- a/docs/notebook_validation.py
+++ b/docs/notebook_validation.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
 
         ## `quantum_transformer`:
         ## See: https://github.com/NVIDIA/cuda-quantum/issues/2689
-        notebooks_skipped = ['quantum_transformer.ipynb']
+        notebooks_skipped = ['quantum_transformer.ipynb', 'unitary_compilation_diffusion_models.ipynb']
 
         for notebook_filename in notebook_filenames:
             base_name = os.path.basename(notebook_filename)

--- a/docs/notebook_validation.py
+++ b/docs/notebook_validation.py
@@ -111,7 +111,10 @@ if __name__ == "__main__":
         ## See: https://github.com/NVIDIA/cuda-quantum/issues/2689
         ## `unitary_compilation_diffusion_models`
         ## See: https://github.com/NVIDIA/cuda-quantum/issues/3194
-        notebooks_skipped = ['quantum_transformer.ipynb', 'unitary_compilation_diffusion_models.ipynb']
+        notebooks_skipped = [
+            'quantum_transformer.ipynb',
+            'unitary_compilation_diffusion_models.ipynb'
+        ]
 
         for notebook_filename in notebook_filenames:
             base_name = os.path.basename(notebook_filename)


### PR DESCRIPTION
I tested like so:

```
$ docker run --rm --gpus all --network host -it nvcr.io/nvidia/nightly/cuda-quantum:cu12-latest-base
$ git clone https://github.com/mitchdz/cuda-quantum.git -b main
$ cd cuda-quantum/docs
# modify notebook_validation.py to use notebook_filenames = ['sphinx/applications/python/unitary_compilation_diffusion_models.ipynb']
$ echo "nvidia" | python3 notebook_validation.py
::warning::Skipped validation for the following notebook(s):
quantum_transformer.ipynb unitary_compilation_diffusion_models.ipynb
```

