### PR TITLE
Revert "[Python] Expose noise model to the asynchronous sample API (#3054)"

### DIFF
--- a/python/tests/builder/test_NoiseModel.py
+++ b/python/tests/builder/test_NoiseModel.py
@@ -15,15 +15,6 @@ import cudaq
 import random
 
 
-@pytest.fixture(autouse=True)
-def do_something():
-    cudaq.reset_target()
-    yield
-    ## Ref: https://github.com/NVIDIA/cuda-quantum/issues/1954
-    # cudaq.__clearKernelRegistries()
-    cudaq.reset_target()
-
-
 @pytest.mark.parametrize('target', ['density-matrix-cpu', 'stim'])
 def test_depolarization_channel(target: str):
     """Tests the depolarization channel in the case of a non-zero probability."""
@@ -38,16 +29,6 @@ def test_depolarization_channel(target: str):
     noise.add_channel("x", [0], depol)
 
     counts = cudaq.sample(circuit, noise_model=noise, shots_count=100)
-    assert (len(counts) == 2)
-    assert ('0' in counts)
-    assert ('1' in counts)
-    assert (counts.count('0') + counts.count('1') == 100)
-
-    future = cudaq.sample_async(circuit,
-                                noise_model=noise,
-                                shots_count=100,
-                                qpu_id=0)
-    counts = future.get()
     assert (len(counts) == 2)
     assert ('0' in counts)
     assert ('1' in counts)
@@ -97,14 +78,7 @@ def test_depolarization_channel_simple(target: str):
     got_one_probability = noisy_counts.probability("1")
     assert np.isclose(got_zero_probability, want_probability, atol=.2)
     assert np.isclose(got_one_probability, want_probability, atol=.2)
-
-    # Asynchronous call
-    future = cudaq.sample_async(kernel, noise_model=noise, shots_count=10000)
-    noisy_counts = future.get()
-    got_zero_probability = noisy_counts.probability("0")
-    got_one_probability = noisy_counts.probability("1")
-    assert np.isclose(got_zero_probability, want_probability, atol=.2)
-    assert np.isclose(got_one_probability, want_probability, atol=.2)
+    cudaq.reset_target()
 
 
 def test_amplitude_damping_simple():
@@ -139,12 +113,7 @@ def test_amplitude_damping_simple():
     want_counts = 1000
     got_counts = noisy_counts["0"]
     assert (got_counts == want_counts)
-
-    # Asynchronous call
-    future = cudaq.sample_async(kernel, noise_model=noise)
-    noisy_counts = future.get()
-    got_counts = noisy_counts["0"]
-    assert (got_counts == want_counts)
+    cudaq.reset_target()
 
 
 @pytest.mark.parametrize('target', ['density-matrix-cpu', 'stim'])
@@ -181,6 +150,7 @@ def test_phase_flip_simple(target: str):
     noisy_counts = cudaq.sample(kernel, noise_model=noise)
     got_zero_counts = noisy_counts["0"]
     assert got_zero_counts == want_counts
+    cudaq.reset_target()
 
 
 @pytest.mark.parametrize('target', ['density-matrix-cpu', 'stim'])
@@ -223,6 +193,7 @@ def test_bit_flip_simple(target: str):
     noisy_counts.dump()
     got_one_zero_counts = noisy_counts["10"]
     assert got_one_zero_counts == want_counts
+    cudaq.reset_target()
 
 
 def test_kraus_channel():
@@ -258,6 +229,7 @@ def test_kraus_channel():
     assert (got_count_length == want_count_length)
     assert ('0' in counts)
     assert ('1' in counts)
+    cudaq.reset_target()
 
 
 def test_row_major():
@@ -283,6 +255,7 @@ def test_row_major():
     noisy_counts.dump()
     # Decay to |0> ~ error_prob
     assert np.isclose(noisy_counts.probability("0"), error_prob, atol=.2)
+    cudaq.reset_target()
 
 
 def test_column_major():
@@ -311,6 +284,7 @@ def test_column_major():
     noisy_counts.dump()
     # Decay to |0> ~ error_prob
     assert np.isclose(noisy_counts.probability("0"), error_prob, atol=.2)
+    cudaq.reset_target()
 
 
 def test_noise_u3():
@@ -336,6 +310,7 @@ def test_noise_u3():
     noisy_counts.dump()
     # Decay to |0> ~ error_prob
     assert np.isclose(noisy_counts.probability("0"), error_prob, atol=.1)
+    cudaq.reset_target()
 
 
 @pytest.mark.parametrize('target', ['density-matrix-cpu', 'stim'])
@@ -355,6 +330,7 @@ def test_all_qubit_channel(target: str):
     noisy_counts.dump()
     # Decay to |000>
     assert np.isclose(noisy_counts.probability("0" * num_qubits), 1.0)
+    cudaq.reset_target()
 
 
 def test_all_qubit_channel_with_control():
@@ -401,6 +377,7 @@ def test_all_qubit_channel_with_control():
         noisy_counts.dump()
         # All tests have some noisy states beside the bell pair.
         assert (len(noisy_counts) > 2)
+    cudaq.reset_target()
 
 
 def test_all_qubit_channel_with_control_prefix():
@@ -447,6 +424,7 @@ def test_all_qubit_channel_with_control_prefix():
         noisy_counts.dump()
         # All tests have some noisy states beside the bell pair.
         assert (len(noisy_counts) > 2)
+    cudaq.reset_target()
 
 
 def test_callback_channel():
@@ -470,10 +448,7 @@ def test_callback_channel():
     noisy_counts.dump()
     # All qubits, except q[2], are flipped.
     assert np.isclose(noisy_counts.probability("00100"), 1.0)
-    ## Ref: https://github.com/NVIDIA/cuda-quantum/issues/3193
-    # future = cudaq.sample_async(kernel, shots_count=shots, noise_model=noise)
-    # noisy_counts = future.get()
-    # assert np.isclose(noisy_counts.probability("00100"), 1.0)
+    cudaq.reset_target()
 
 
 def test_callback_channel_with_params():
@@ -510,6 +485,7 @@ def test_callback_channel_with_params():
     noisy_counts.dump()
     # Due to our custom setup, a negative angle will have no noise.
     assert np.isclose(noisy_counts.probability("1"), 1.0)
+    cudaq.reset_target()
 
 
 def check_custom_op_noise(noise_model):
@@ -525,6 +501,7 @@ def check_custom_op_noise(noise_model):
     counts = cudaq.sample(basic, shots_count=shots, noise_model=noise_model)
     counts.dump()
     assert np.isclose(counts.probability("0"), 1.0)
+    cudaq.reset_target()
 
 
 def test_custom_op():
@@ -554,7 +531,6 @@ def test_custom_op():
 
 def test_apply_noise_custom():
     cudaq.set_target('density-matrix-cpu')
-    cudaq.set_random_seed(13)
 
     class CustomNoiseChannelBad(cudaq.KrausChannel):
         # NEEDS num_parameters member, but it is missing, so this is Bad
@@ -668,11 +644,12 @@ def test_apply_noise_custom():
     counts.dump()
     assert len(counts) == 2 and '0' in counts and '1' in counts
 
+    cudaq.reset_target()
+
 
 @pytest.mark.parametrize('target', ['density-matrix-cpu', 'stim'])
 def test_apply_noise_builtin(target: str):
     cudaq.set_target(target)
-    cudaq.set_random_seed(13)
 
     noise = cudaq.NoiseModel()
 
@@ -765,11 +742,12 @@ def test_apply_noise_builtin(target: str):
     assert len(counts) == 4
     print(counts)
 
+    cudaq.reset_target()
+
 
 @pytest.mark.parametrize('target', ['density-matrix-cpu'])
 def test_noise_observe_reset(target: str):
     cudaq.set_target(target)
-    cudaq.set_random_seed(13)
     noise_model = cudaq.NoiseModel()
     # Amplitude damping channel with `1.0` probability of the qubit
     # decaying to the ground state.


### PR DESCRIPTION

This reverts commit f8415288570c32ca1db90e429a46856da07b74a8.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
