### PR TITLE
Strip arch prefix from manifest:org.opencontainers.image.version

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -395,6 +395,7 @@ jobs:
 
           docker pull $cudaqbase_image
           base_tag=`docker inspect $cudaqbase_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"'`
+          base_tag=$(echo "$base_tag" | sed -E 's/^(arm64-|amd64-)//')
           image_title=`docker inspect $cudaqbase_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.title"'`
           image_description=`docker inspect $cudaqbase_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.description"'`
           docker image rm $cudaqbase_image


### PR DESCRIPTION
This was creating the following image:

```
nvcr.io/nvidia/nightly/cuda-quantum:amd64-cu12-latest
```

This is due to how publishing was getting the tag, through the image.version value, which now included amd64 even though the image is a multiplat image.

```
$ base_tag=$(docker inspect nvcr.io/nvidia/nightly/cuda-quantum:cu12-latest-base --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"')
$ echo $base_tag
amd64-cu12-latest-base
$ base_tag=$(echo "$base_tag" | sed -E 's/^(arm64-|amd64-)//')
$ echo $base_tag
cu12-latest-base
```


The reason this is an issue now and not before, is because of how the multiarch images were built with qemu. It's easier to explain by just showing an example:

on amd64:
```
mdzurick@gorby:~$ docker inspect nvcr.io/nvidia/nightly/cuda-quantum:cu12-latest-base | grep "version"
                "org.opencontainers.image.version": "amd64-cu12-latest-base"
```

On arm64:
```
mdzurick@utskinnyjoe-dvt-41:~$ docker inspect nvcr.io/nvidia/nightly/cuda-quantum:cu12-latest-base | grep "version"
                "org.opencontainers.image.version": "arm64-cu12-latest-base"
```

This example shows how `docker inspect` shows you the image tag of the local docker image cache, not the remote cache. The remote manifest list is called `cu12-latest-base` but when you do `docker pull` (Required for `docker inspect`) it will pull the specific digest that works on your arch. Since the manifest list is just a collection of digests, the `docker inspect` command inspects the arm64 or amd64 digest. The publishing runners run on amd64 always, so that means the prefix will always be amd64.