### PR TITLE
Follow on work for #3180, #3192, and #3205. 

### DIFF
--- a/include/cudaq/Support/TargetConfig.h
+++ b/include/cudaq/Support/TargetConfig.h
@@ -97,6 +97,8 @@ struct BackendEndConfigEntry {
   SimulationBackendSetting SimulationBackend;
   /// Any conditional compile/link flags configurations.
   std::vector<ConditionalBuildConfig> ConditionalBuildConfigs;
+  // Optional entry to manually specify / override server helper
+  std::optional<std::string> ServerHelper = std::nullopt;
 };
 
 /// Feature option mapping for NVIDIA target.

--- a/lib/Support/Config/TargetConfig.cpp
+++ b/lib/Support/Config/TargetConfig.cpp
@@ -321,6 +321,7 @@ void MappingTraits<cudaq::config::BackendEndConfigEntry>::mapping(
   io.mapOptional("linker-flags", info.LinkerFlags);
   io.mapOptional("nvqir-simulation-backend", info.SimulationBackend);
   io.mapOptional("rules", info.ConditionalBuildConfigs);
+  io.mapOptional("server-helper", info.ServerHelper);
 }
 
 void MappingTraits<cudaq::config::BackendFeatureMap>::mapping(

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -354,13 +354,19 @@ public:
 
     // Set the qpu name
     qpuName = mutableBackend;
-    // Create the ServerHelper for this QPU and give it the backend config
-    serverHelper = cudaq::registry::get<cudaq::ServerHelper>(qpuName);
-    if (!serverHelper) {
-      throw std::runtime_error("ServerHelper not found for target");
-    }
+
+    // Create the ServerHelper for this QPU and give it the backend config,
+    // may be overridden by the target yaml, by default should be same as target
+    // name
+    auto maybeSH = config.BackendConfig->ServerHelper;
+    auto shName = maybeSH ? maybeSH.value() : qpuName;
+    serverHelper = cudaq::registry::get<cudaq::ServerHelper>(shName);
+    if (!serverHelper)
+      throw std::runtime_error(
+          fmt::format("ServerHelper not found for target ({})", shName));
     serverHelper->initialize(backendConfig);
     serverHelper->updatePassPipeline(platformPath, passPipelineConfig);
+
     cudaq::info("Retrieving executor with name {}", qpuName);
     cudaq::info("Is this executor registered? {}",
                 cudaq::registry::isRegistered<cudaq::Executor>(qpuName));

--- a/runtime/cudaq/platform/default/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/CMakeLists.txt
@@ -43,6 +43,7 @@ if (OPENSSL_FOUND AND CUDAQ_ENABLE_REST)
 endif()
   
 add_target_config(opt-test)
+add_target_config(horizon) 
 
 if (CUSTATEVEC_ROOT AND CUDA_FOUND)
   add_target_config(nvidia)

--- a/runtime/cudaq/platform/default/horizon.yml
+++ b/runtime/cudaq/platform/default/horizon.yml
@@ -1,0 +1,41 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+name: horizon
+description: "the horizon target describes a hypothetical qir-adaptive platform"
+config:
+  # Tell DefaultQuantumPlatform what QPU subtype to use
+  platform-qpu: remote_rest
+  # Tell NVQ++ to generate glue code to set the target backend name
+  gen-target-backend: true
+  # Add preprocessor defines to compilation
+  preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
+  # Add the rest-qpu library to the link list
+  link-libs: ["-lcudaq-rest-qpu"]
+  # Define the lowering pipeline
+  platform-lowering-config: "classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,func.func(canonicalize),apply-op-specialization{constant-prop=1},aggressive-early-inlining,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},func.func(canonicalize,multicontrol-decomposition),distributed-device-call"
+  # Tell the rest-qpu that we are generating Adaptive QIR.
+  codegen-emission: qir-adaptive[int_computations]
+  # Library mode is only for simulators, physical backends must turn this off
+  library-mode: false
+  
+  # This target does not use a ServerHelper, but RemoteRESTQPU still 
+  # has to have one, so just pick one 
+  server-helper: ionq
+
+target-arguments:
+  - key: url
+    required: false
+    type: string
+    platform-arg: url 
+    help-string: "Specify the URL."
+  - key: machine
+    required: false
+    type: string
+    platform-arg: machine 
+    help-string: "Specify QPU."

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -754,7 +754,7 @@ if ${ENABLE_CUDAQ_RUN}; then
 	fi
 fi
 if ${RUN_OPT}; then
-	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "canonicalize,cse")
+	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "distributed-device-call,canonicalize,cse")
 fi
 
 # If TARGET_PASS_PIPELINE is set, then use that exact pipeline (while still


### PR DESCRIPTION
Additional work for #3180, #3192, and #3205. 

Allow `cc.device_call` function call operations to survive the VerifyQIRProfile pass. 

Tag `cc.device_call` functions with ID attribute in DistributedDeviceCall. 

Add the `horizon` test target. 

