### PR TITLE
DNM - Accept conda tos in CI and docs

### DIFF
--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -292,6 +292,9 @@ jobs:
             unzip $tmploc/$archive_name -d $tmploc/cudaq_wheel && rm -rf $tmploc/$archive_name
             metadata=$tmploc/cudaq_wheel/*.dist-info/METADATA
 
+            conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+            conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+
             # Parse README content to install openmpi
             conda_script="$(awk '/(Begin conda install)/{flag=1;next}/(End conda install)/{flag=0}flag' $metadata | grep . | sed '/^```/d')" 
             while IFS= read -r line; do

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -292,9 +292,6 @@ jobs:
             unzip $tmploc/$archive_name -d $tmploc/cudaq_wheel && rm -rf $tmploc/$archive_name
             metadata=$tmploc/cudaq_wheel/*.dist-info/METADATA
 
-            conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
-            conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
-
             # Parse README content to install openmpi
             conda_script="$(awk '/(Begin conda install)/{flag=1;next}/(End conda install)/{flag=0}flag' $metadata | grep . | sed '/^```/d')" 
             while IFS= read -r line; do

--- a/python/README.md.in
+++ b/python/README.md.in
@@ -52,16 +52,11 @@ following [miniconda instructions here](https://docs.anaconda.com/miniconda/).
 The following commands will create and activate a complete environment for 
 CUDA-Q with all its dependencies:
 
-**Note**: You may need to accept conda tos in your environment like so:
+[//]: # (Begin conda install)
 
 ```console
 conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
 conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
-```
-
-[//]: # (Begin conda install)
-
-```console
 cuda_version=${{ cuda_version_conda }} # set this variable to version ${{ cuda_version_requirement }}
 conda create -y -n cudaq-env python=3.11 pip
 conda install -y -n cudaq-env -c "nvidia/label/cuda-${cuda_version}" cuda

--- a/python/README.md.in
+++ b/python/README.md.in
@@ -52,6 +52,13 @@ following [miniconda instructions here](https://docs.anaconda.com/miniconda/).
 The following commands will create and activate a complete environment for 
 CUDA-Q with all its dependencies:
 
+**Note**: You may need to accept conda tos in your environment like so:
+
+```console
+conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+```
+
 [//]: # (Begin conda install)
 
 ```console


### PR DESCRIPTION
Do not merge - testing in https://github.com/NVIDIA/cuda-quantum/actions/runs/16331755361 currently

Why now? Anaconda updated TOS yesterday.
https://www.anaconda.com/legal/terms/terms-of-service