### PR TITLE
Misc. bug fixes and improvements.

### DIFF
--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -726,7 +726,7 @@ public:
     void addFunctionDecl(const clang::FunctionDecl *funcDecl,
                          details::QuakeBridgeVisitor &visitor,
                          mlir::FunctionType funcTy,
-                         mlir::StringRef devFuncName);
+                         mlir::StringRef devFuncName, bool isDecl);
 
   public:
     ASTBridgeConsumer(clang::CompilerInstance &compiler,

--- a/include/cudaq/Frontend/nvqpp/ASTBridge.h
+++ b/include/cudaq/Frontend/nvqpp/ASTBridge.h
@@ -725,8 +725,8 @@ public:
     /// pipelines which erase private declarations.
     void addFunctionDecl(const clang::FunctionDecl *funcDecl,
                          details::QuakeBridgeVisitor &visitor,
-                         mlir::FunctionType funcTy,
-                         mlir::StringRef devFuncName, bool isDecl);
+                         mlir::FunctionType funcTy, mlir::StringRef devFuncName,
+                         bool isDecl);
 
   public:
     ASTBridgeConsumer(clang::CompilerInstance &compiler,

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1225,7 +1225,7 @@ def UpdateRegisterNames : Pass<"update-register-names"> {
   }];
 }
 
-def VariableCoalesce : Pass<"variable-coalesce"> {
+def VariableCoalesce : Pass<"variable-coalesce", "mlir::func::FuncOp"> {
   let summary = "Coalesce variables in functions.";
   let description = [{
     This pass will move temporaries from inner scopes to the outermost,
@@ -1233,6 +1233,11 @@ def VariableCoalesce : Pass<"variable-coalesce"> {
     live-ranges. It relies on the correct and proper construction and use of
     `cc.scope` ops.
   }];
+
+  let options = [
+    Option<"hoistOnly", "hoist-only", "bool", /*default=*/"false",
+      "Hoist the variables only.">
+  ];
 }
 
 def WriteAfterWriteElimination : Pass<"write-after-write-elimination"> {

--- a/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/lib/Optimizer/Builder/Intrinsics.cpp
@@ -268,7 +268,7 @@ static constexpr IntrinsicCode intrinsicTable[] = {
     {cudaq::cudaqConvertToInteger, {}, R"#(
   func.func private @__nvqpp_cudaqConvertToInteger(%arg : !cc.stdvec<i1>) -> i64 {
     %size = cc.stdvec_size %arg : (!cc.stdvec<i1>) -> i64
-    %data = cc.stdvec_data %arg : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i1 x ?>>
+    %data = cc.stdvec_data %arg : (!cc.stdvec<i1>) -> !cc.ptr<!cc.array<i8 x ?>>
     %zero = arith.constant 0 : i64
     %one = arith.constant 1 : i64
     %res:2 = cc.loop while ((%i = %zero, %v = %zero) -> (i64, i64)) {
@@ -277,9 +277,9 @@ static constexpr IntrinsicCode intrinsicTable[] = {
     } do {
       ^bb1(%j : i64, %v : i64):
         %2 = arith.shli %one, %j : i64
-        %3 = cc.compute_ptr %data[%j] : (!cc.ptr<!cc.array<i1 x ?>>, i64) -> !cc.ptr<i1>
-        %4 = cc.load %3 : !cc.ptr<i1>
-        %5 = cc.cast unsigned %4 : (i1) -> i64
+        %3 = cc.compute_ptr %data[%j] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+        %4 = cc.load %3 : !cc.ptr<i8>
+        %5 = cc.cast unsigned %4 : (i8) -> i64
         %6 = arith.subi %zero, %5 : i64
         %7 = arith.xori %6, %v : i64
         %8 = arith.andi %7, %2 : i64

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -1308,8 +1308,7 @@ LogicalResult cudaq::cc::StdvecInitOp::verify() {
 namespace {
 struct ForwardStdvecInitData
     : public OpRewritePattern<cudaq::cc::StdvecDataOp> {
-  using Base = OpRewritePattern<cudaq::cc::StdvecDataOp>;
-  using Base::Base;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(cudaq::cc::StdvecDataOp data,
                                 PatternRewriter &rewriter) const override {
@@ -1320,9 +1319,8 @@ struct ForwardStdvecInitData
     // and unwrapped by stdvec_data is the same pointer value. This pattern will
     // arise after inlining, for example.
     if (auto ini = data.getStdvec().getDefiningOp<cudaq::cc::StdvecInitOp>()) {
-      Value cast = rewriter.create<cudaq::cc::CastOp>(
-          data.getLoc(), data.getType(), ini.getBuffer());
-      rewriter.replaceOp(data, cast);
+      rewriter.replaceOpWithNewOp<cudaq::cc::CastOp>(data, data.getType(),
+                                                     ini.getBuffer());
       return success();
     }
     return failure();

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -1872,9 +1872,10 @@ bool hasAllocation(Region &region) {
         if (mem.hasEffect<MemoryEffects::Allocate>())
           if (quantumAllocs || !isa<quake::AllocaOp>(op))
             return true;
-      for (auto &opReg : op.getRegions())
-        if (hasAllocation<quantumAllocs>(opReg))
-          return true;
+      if (!isa<cudaq::cc::ScopeOp>(op))
+        for (auto &opReg : op.getRegions())
+          if (hasAllocation<quantumAllocs>(opReg))
+            return true;
     }
   return false;
 }

--- a/lib/Optimizer/Transforms/EraseVectorCopyCtor.cpp
+++ b/lib/Optimizer/Transforms/EraseVectorCopyCtor.cpp
@@ -59,7 +59,8 @@ public:
     auto newStackSlot = casted.getValue().getDefiningOp<cudaq::cc::AllocaOp>();
     if (!newStackSlot)
       return failure();
-    rewriter.replaceOp(newStackSlot, analysis.copyFrom.getOperand(1));
+    rewriter.replaceOpWithNewOp<cudaq::cc::CastOp>(
+        newStackSlot, newStackSlot.getType(), analysis.copyFrom.getOperand(1));
     rewriter.eraseOp(analysis.copyFrom);
     rewriter.eraseOp(analysis.copyTo);
     rewriter.eraseOp(analysis.freeMem);

--- a/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/lib/Optimizer/Transforms/MemToReg.cpp
@@ -341,8 +341,18 @@ public:
   }
 
   void maybeAddBalancedLiveInToBlock(Block *block, MemRef mr) {
-    if (liveOutSet.count(mr))
+    if (liveOutSet.count(mr)) {
+      if (block->getPredecessors().empty()) {
+        if (liveInMap[block].count(mr))
+          if (isa<BlockArgument>(liveInMap[block][mr]))
+            return;
+        auto ty = dereferencedType(mr.getType());
+        SSAReg newReg = block->addArgument(ty, mr.getLoc());
+        liveInMap[block][mr] = newReg;
+        return;
+      }
       maybeAddLiveInToBlock(block, mr);
+    }
   }
 
   /// Record the memory reference \p mr as live-in to \p block. The live-in

--- a/test/AST-Quake/compute_action-2.cpp
+++ b/test/AST-Quake/compute_action-2.cpp
@@ -37,7 +37,6 @@ struct ctrlHeisenberg {
 // CHECK:           cc.scope {
 // CHECK:             cc.loop while {
 // CHECK:             } do {
-// CHECK:               cc.scope {
 // CHECK:                 cc.scope {
 // CHECK:                   cc.loop while {
 // CHECK:                   } do {
@@ -59,7 +58,6 @@ struct ctrlHeisenberg {
 // CHECK:                   } step {
 // CHECK:                   }
 // CHECK:                 }
-// CHECK:               }
 // CHECK:             } step {
 // CHECK:             }
 // CHECK:           }
@@ -96,7 +94,6 @@ struct ctrlHeisenberg {
 // LAMBDA:           cc.scope {
 // LAMBDA:             cc.loop while {
 // LAMBDA:             } do {
-// LAMBDA:               cc.scope {
 // LAMBDA:                 cc.scope {
 // LAMBDA:                   cc.loop while {
 // LAMBDA:                   } do {
@@ -115,7 +112,6 @@ struct ctrlHeisenberg {
 // LAMBDA:                   } step {
 // LAMBDA:                   }
 // LAMBDA:                 }
-// LAMBDA:               }
 // LAMBDA:             } step {
 // LAMBDA:             }
 // LAMBDA:           }

--- a/test/AST-Quake/qpe.cpp
+++ b/test/AST-Quake/qpe.cpp
@@ -299,7 +299,6 @@ int main() {
 // CHECK:               %[[VAL_39:.*]] = arith.cmpi slt, %[[VAL_37]], %[[VAL_38]] : i32
 // CHECK:               cc.condition %[[VAL_39]]
 // CHECK:             } do {
-// CHECK:               cc.scope {
 // CHECK:                 cc.scope {
 // CHECK:                   %[[VAL_40:.*]] = cc.alloca i32
 // CHECK:                   cc.store %[[VAL_5]], %[[VAL_40]] : !cc.ptr<i32>
@@ -323,7 +322,6 @@ int main() {
 // CHECK:                     cc.store %[[VAL_51]], %[[VAL_40]] : !cc.ptr<i32>
 // CHECK:                   }
 // CHECK:                 }
-// CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
 // CHECK:               %[[VAL_52:.*]] = cc.load %[[VAL_36]] : !cc.ptr<i32>

--- a/test/AST-Quake/vector_vector.cpp
+++ b/test/AST-Quake/vector_vector.cpp
@@ -43,7 +43,6 @@ struct VectorVectorReader {
 // CHECK:               %[[VAL_8:.*]] = arith.cmpi ult, %[[VAL_6]], %[[VAL_7]] : i64
 // CHECK:               cc.condition %[[VAL_8]]
 // CHECK:             } do {
-// CHECK:               cc.scope {
 // CHECK:                 %[[VAL_9:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i64>
 // CHECK:                 %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
 // CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][%[[VAL_9]]] : (!cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>, i64) -> !cc.ptr<!cc.stdvec<f64>>
@@ -73,7 +72,6 @@ struct VectorVectorReader {
 // CHECK:                     cc.store %[[VAL_25]], %[[VAL_12]] : !cc.ptr<i64>
 // CHECK:                   }
 // CHECK:                 }
-// CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
 // CHECK:               %[[VAL_26:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i64>
@@ -115,7 +113,6 @@ struct TripleVectorReader {
 // CHECK:               %[[VAL_8:.*]] = arith.cmpi ult, %[[VAL_6]], %[[VAL_7]] : i64
 // CHECK:               cc.condition %[[VAL_8]]
 // CHECK:             } do {
-// CHECK:               cc.scope {
 // CHECK:                 %[[VAL_9:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i64>
 // CHECK:                 %[[VAL_10:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<!cc.stdvec<f64>>>) -> !cc.ptr<!cc.array<!cc.stdvec<!cc.stdvec<f64>> x ?>>
 // CHECK:                 %[[VAL_11:.*]] = cc.compute_ptr %[[VAL_10]][%[[VAL_9]]] : (!cc.ptr<!cc.array<!cc.stdvec<!cc.stdvec<f64>> x ?>>, i64) -> !cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>
@@ -132,7 +129,6 @@ struct TripleVectorReader {
 // CHECK:                     %[[VAL_18:.*]] = arith.cmpi ult, %[[VAL_16]], %[[VAL_17]] : i64
 // CHECK:                     cc.condition %[[VAL_18]]
 // CHECK:                   } do {
-// CHECK:                     cc.scope {
 // CHECK:                       %[[VAL_19:.*]] = cc.load %[[VAL_12]] : !cc.ptr<i64>
 // CHECK:                       %[[VAL_20:.*]] = cc.load %[[VAL_11]] : !cc.ptr<!cc.stdvec<!cc.stdvec<f64>>>
 // CHECK:                       %[[VAL_21:.*]] = cc.stdvec_data %[[VAL_20]] : (!cc.stdvec<!cc.stdvec<f64>>) -> !cc.ptr<!cc.array<!cc.stdvec<f64> x ?>>
@@ -163,7 +159,6 @@ struct TripleVectorReader {
 // CHECK:                           cc.store %[[VAL_36]], %[[VAL_23]] : !cc.ptr<i64>
 // CHECK:                         }
 // CHECK:                       }
-// CHECK:                     }
 // CHECK:                     cc.continue
 // CHECK:                   } step {
 // CHECK:                     %[[VAL_37:.*]] = cc.load %[[VAL_12]] : !cc.ptr<i64>
@@ -171,7 +166,6 @@ struct TripleVectorReader {
 // CHECK:                     cc.store %[[VAL_38]], %[[VAL_12]] : !cc.ptr<i64>
 // CHECK:                   }
 // CHECK:                 }
-// CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
 // CHECK:               %[[VAL_39:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i64>
@@ -211,7 +205,6 @@ struct VectorVectorWriter {
 // CHECK:               %[[VAL_9:.*]] = arith.cmpi ult, %[[VAL_7]], %[[VAL_8]] : i64
 // CHECK:               cc.condition %[[VAL_9]]
 // CHECK:             } do {
-// CHECK:               cc.scope {
 // CHECK:                 %[[VAL_10:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
 // CHECK:                 %[[VAL_11:.*]] = cc.stdvec_data %[[VAL_0]] : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>
 // CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][%[[VAL_10]]] : (!cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
@@ -240,7 +233,6 @@ struct VectorVectorWriter {
 // CHECK:                     cc.store %[[VAL_25]], %[[VAL_13]] : !cc.ptr<i64>
 // CHECK:                   }
 // CHECK:                 }
-// CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
 // CHECK:               %[[VAL_26:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
@@ -281,7 +273,6 @@ struct VectorVectorBilingual {
 // CHECK:               %[[VAL_9:.*]] = arith.cmpi ult, %[[VAL_7]], %[[VAL_8]] : i64
 // CHECK:               cc.condition %[[VAL_9]]
 // CHECK:             } do {
-// CHECK:               cc.scope {
 // CHECK:                 %[[VAL_10:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>
 // CHECK:                 %[[VAL_11:.*]] = cc.stdvec_data %[[VAL_1]] : (!cc.stdvec<!cc.stdvec<i32>>) -> !cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>
 // CHECK:                 %[[VAL_12:.*]] = cc.compute_ptr %[[VAL_11]][%[[VAL_10]]] : (!cc.ptr<!cc.array<!cc.stdvec<i32> x ?>>, i64) -> !cc.ptr<!cc.stdvec<i32>>
@@ -319,7 +310,6 @@ struct VectorVectorBilingual {
 // CHECK:                     cc.store %[[VAL_34]], %[[VAL_16]] : !cc.ptr<i64>
 // CHECK:                   }
 // CHECK:                 }
-// CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
 // CHECK:               %[[VAL_35:.*]] = cc.load %[[VAL_4]] : !cc.ptr<i64>

--- a/test/Quake/canonical-1.qke
+++ b/test/Quake/canonical-1.qke
@@ -98,7 +98,7 @@ func.func @test_qextract_2(%arg0: i1) {
 }
 
 // CHECK-LABEL:   func.func @test_qextract_2(
-// CHECK-SAME:                               %[[VAL_0:.*]]: i1) {
+// CHECK-SAME:      %[[VAL_0:.*]]: i1) {
 // CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_4:.*]] = quake.extract_ref %[[VAL_3]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.h %[[VAL_4]] :
@@ -109,4 +109,20 @@ func.func @test_qextract_2(%arg0: i1) {
 // CHECK:           %[[VAL_7:.*]] = quake.extract_ref %[[VAL_3]][1] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.x [%[[VAL_4]]] %[[VAL_7]] :
 // CHECK:           return
-// CHECK:         }
+
+func.func private @scope_test.1(!cc.ptr<i32>)
+
+func.func @scope_test() {
+  cc.scope {
+    cc.scope {
+      %1 = cc.alloca i32
+      func.call @scope_test.1(%1) : (!cc.ptr<i32>) -> ()
+    }
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @scope_test(
+// CHECK:           cc.scope {
+// CHECK-NOT:       cc.scope {
+// CHECK:           cc.alloca i32

--- a/test/Quake/coalesce.qke
+++ b/test/Quake/coalesce.qke
@@ -74,6 +74,7 @@ func.func @f1() {
 // CHECK-DAG:       %[[VAL_13:.*]] = cc.alloca i32
 // CHECK-DAG:       %[[VAL_14:.*]] = cc.alloca i32
 // CHECK-DAG:       %[[VAL_15:.*]] = cc.alloca f64
+// CHECK-NOT:       cc.alloca
 // CHECK:           cc.store %[[VAL_9]], %[[VAL_14]] : !cc.ptr<i32>
 // CHECK:           cc.store %[[VAL_8]], %[[VAL_15]] : !cc.ptr<f64>
 // CHECK:           call @test(%[[VAL_14]], %[[VAL_15]]) : (!cc.ptr<i32>, !cc.ptr<f64>) -> ()
@@ -99,3 +100,74 @@ func.func @f1() {
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }
+
+func.func @f2() {
+  %0 = cc.alloca i32
+  %1 = cc.alloca f64
+  %c0 = arith.constant 1 : i32
+  cc.store %c0, %0 : !cc.ptr<i32>
+  %c1 = arith.constant 3.0 : f64
+  cc.store %c1, %1 : !cc.ptr<f64>
+  call @test(%0, %1) : (!cc.ptr<i32>, !cc.ptr<f64>) -> ()
+  cc.scope {
+    %2 = cc.alloca i32 {name = "a"}
+    %3 = cc.alloca f64 {name = "b"}
+    %c2 = arith.constant 2 : i32
+    cc.store %c2, %2 : !cc.ptr<i32>
+    %c3 = arith.constant 4.0 : f64
+    cc.store %c3, %3 : !cc.ptr<f64>
+    func.call @test(%2, %3) : (!cc.ptr<i32>, !cc.ptr<f64>) -> ()
+    cc.loop while {
+      %c10 = arith.constant 10 : i32
+      %a = cc.load %2 : !cc.ptr<i32>
+      %b = arith.cmpi slt, %a, %c10 : i32
+      cc.condition %b
+    } do {
+      cc.scope {
+        %4 = cc.alloca i32 {name = "c"}
+        %5 = cc.alloca f64 {name = "d"}
+        %c4 = arith.constant 4 : i32
+        cc.store %c4, %4 : !cc.ptr<i32>
+        %c5 = arith.constant 5.0 : f64
+        cc.store %c5, %5 : !cc.ptr<f64>
+        func.call @test(%4, %5) : (!cc.ptr<i32>, !cc.ptr<f64>) -> ()
+      }
+      cc.scope {
+        %6 = cc.alloca i32 {name = "e"}
+        %7 = cc.alloca f64 {name = "f"}
+        %c6 = arith.constant 6 : i32
+        cc.store %c6, %6 : !cc.ptr<i32>
+        %c7 = arith.constant 6.0 : f64
+        cc.store %c7, %7 : !cc.ptr<f64>
+        func.call @test(%6, %7) : (!cc.ptr<i32>, !cc.ptr<f64>) -> ()
+      }
+      cc.continue
+    } step {
+      %a = cc.load %2 : !cc.ptr<i32>
+      %c10 = arith.constant 1 : i32
+      %b = arith.addi %a, %c10 : i32
+      cc.store %b, %2 : !cc.ptr<i32>
+    }
+    cc.scope {
+      %8 = cc.alloca i32 {name = "g"}
+      %9 = cc.alloca f64 {name = "h"}
+      %c8 = arith.constant 8 : i32
+      cc.store %c8, %8 : !cc.ptr<i32>
+      %c9 = arith.constant 7.0 : f64
+      cc.store %c9, %9 : !cc.ptr<f64>
+      func.call @test(%8, %9) : (!cc.ptr<i32>, !cc.ptr<f64>) -> ()
+    }
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @f2() {
+// CHECK-DAG:       %[[VAL_11:.*]] = cc.alloca f64
+// CHECK-DAG:       %[[VAL_12:.*]] = cc.alloca i32
+// CHECK-DAG:       %[[VAL_13:.*]] = cc.alloca f64
+// CHECK-DAG:       %[[VAL_14:.*]] = cc.alloca i32
+// CHECK-DAG:       %[[VAL_15:.*]] = cc.alloca i32
+// CHECK-DAG:       %[[VAL_16:.*]] = cc.alloca f64
+// CHECK-NOT:       cc.alloca
+// CHECK:           cc.scope
+// CHECK:           cc.loop while

--- a/test/Quake/erase_vcc.qke
+++ b/test/Quake/erase_vcc.qke
@@ -7,6 +7,7 @@
 // ========================================================================== //
 
 // RUN: cudaq-opt --erase-vector-copy-ctor %s | FileCheck %s
+// RUN: cudaq-opt --erase-vector-copy-ctor --canonicalize %s | FileCheck --check-prefix=CANON %s
 
 func.func @test_it() {
   %false = arith.constant 0 : i1
@@ -32,6 +33,15 @@ func.func private @free(!cc.ptr<i8>)
 // CHECK-LABEL:   func.func @test_it() {
 // CHECK:           %[[VAL_0:.*]] = cc.alloca !cc.array<i8 x 24>
 // CHECK:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 24>>) -> !cc.ptr<i8>
-// CHECK:           call @ok(%[[VAL_1]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i8 x ?>>
+// CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+// CHECK:           call @ok(%[[VAL_3]]) : (!cc.ptr<i8>) -> ()
 // CHECK:           return
 // CHECK:         }
+
+// CANON-LABEL:   func.func @test_it() {
+// CANON:           %[[VAL_0:.*]] = cc.alloca !cc.array<i8 x 24>
+// CANON:           %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (!cc.ptr<!cc.array<i8 x 24>>) -> !cc.ptr<i8>
+// CANON:           call @ok(%[[VAL_1]]) : (!cc.ptr<i8>) -> ()
+// CANON:           return
+// CANON:         }

--- a/test/Quake/memtoreg-6.qke
+++ b/test/Quake/memtoreg-6.qke
@@ -38,3 +38,134 @@ func.func @__nvqpp__mlirgen__dummy() {
 // CHECK:           quake.sink %[[VAL_5]]#0 : !quake.wire
 // CHECK:           return
 // CHECK:         }
+
+func.func @test_2(%arg0: !quake.veq<?>, %arg1: !quake.veq<?>, %arg2: !quake.veq<?>, %arg3: i64, %arg4: !cc.stdvec<i64>, %arg5: !cc.stdvec<i64>, %arg6: i1, %arg7: i1, %arg8: f64, %arg9: !cc.stdvec<i64>, %arg10: i32) attributes {"cudaq-kernel", no_this} {
+  %false = arith.constant false
+  %cst = arith.constant 0.000000e+00 : f64
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i64 = arith.constant 0 : i64
+  %0 = cc.alloca i64
+  %1 = cc.alloca i64
+  %2 = cc.alloca i64
+  %3 = cc.alloca i64
+  %4 = cc.alloca i64
+  cc.store %arg3, %4 : !cc.ptr<i64>
+  %5 = cc.alloca i1
+  cc.store %arg6, %5 : !cc.ptr<i1>
+  %6 = cc.alloca i1
+  cc.store %arg7, %6 : !cc.ptr<i1>
+  %7 = cc.alloca f64
+  cc.store %arg8, %7 : !cc.ptr<f64>
+  %8 = cc.alloca i32
+  cc.store %arg10, %8 : !cc.ptr<i32>
+  %9 = quake.make_struq %arg0, %arg1, %arg2 : (!quake.veq<?>, !quake.veq<?>, !quake.veq<?>) -> !quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>
+    cc.store %c0_i64, %3 : !cc.ptr<i64>
+    cc.loop while {
+      %10 = cc.load %3 : !cc.ptr<i64>
+      %11 = cc.load %4 : !cc.ptr<i64>
+      %12 = arith.cmpi ult, %10, %11 : i64
+      cc.condition %12
+    } do {
+      cc.scope {
+        %10 = func.call @test_2.a(%9, %arg5) : (!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.stdvec<i64>) -> !cc.stdvec<i1>
+        %11 = cc.stdvec_data %10 : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+        %12 = cc.stdvec_size %10 : (!cc.stdvec<i1>) -> i64
+        %13 = cc.alloca i8[%12 : i64]
+        %14 = cc.cast %13 : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+        func.call @test_2.b(%14, %11, %12) : (!cc.ptr<i8>, !cc.ptr<i8>, i64) -> ()
+        %15 = cc.stdvec_init %13, %12 : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.stdvec<i1>
+        %16 = func.call @test_2.c(%9, %arg4) : (!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.stdvec<i64>) -> !cc.stdvec<i1>
+        %17 = cc.stdvec_data %16 : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+        %18 = cc.stdvec_size %16 : (!cc.stdvec<i1>) -> i64
+        %19 = cc.alloca i8[%18 : i64]
+        %20 = cc.cast %19 : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+        func.call @test_2.b(%20, %17, %18) : (!cc.ptr<i8>, !cc.ptr<i8>, i64) -> ()
+        %21 = cc.stdvec_init %19, %18 : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.stdvec<i1>
+        %22 = func.call @test_2.d(%15) : (!cc.stdvec<i1>) -> i64
+        cc.store %22, %3 : !cc.ptr<i64>
+        %23 = func.call @test_2.d(%21) : (!cc.stdvec<i1>) -> i64
+        cc.store %23, %2 : !cc.ptr<i64>
+        %24 = cc.load %2 : !cc.ptr<i64>
+        %25 = arith.shli %24, %12 : i64
+        %26 = cc.load %3 : !cc.ptr<i64>
+        %27 = arith.ori %25, %26 : i64
+        cc.store %27, %1 : !cc.ptr<i64>
+        %28 = cc.load %1 : !cc.ptr<i64>
+        %29 = cc.load %8 : !cc.ptr<i32>
+        %30 = cc.cast signed %29 : (i32) -> i64
+        %31 = cc.stdvec_data %arg9 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+        %32 = cc.compute_ptr %31[%30] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
+        %33 = cc.load %32 : !cc.ptr<i64>
+        %34 = arith.xori %28, %33 : i64
+        cc.store %34, %0 : !cc.ptr<i64>
+        %35 = cc.load %5 : !cc.ptr<i1>
+        cc.if(%35) {
+          %44 = cc.load %8 : !cc.ptr<i32>
+          %45 = cc.cast signed %44 : (i32) -> i64
+          %46 = cc.load %3 : !cc.ptr<i64>
+          %47 = cc.load %4 : !cc.ptr<i64>
+          %48 = arith.subi %47, %c1_i64 : i64
+          %49 = arith.cmpi eq, %46, %48 : i64
+          %50 = arith.addi %12, %18 : i64
+          %51 = cc.load %0 : !cc.ptr<i64>
+          func.call @test_2.e(%45, %49, %false, %50, %51) : (i64, i1, i1, i64, i64) -> ()
+        }
+        %36 = cc.load %8 : !cc.ptr<i32>
+        %37 = cc.cast signed %36 : (i32) -> i64
+        %38 = cc.stdvec_data %arg9 : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+        %39 = cc.compute_ptr %38[%37] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
+        %40 = cc.load %1 : !cc.ptr<i64>
+        cc.store %40, %39 : !cc.ptr<i64>
+        %41 = cc.load %6 : !cc.ptr<i1>
+        %42 = arith.cmpi eq, %41, %false : i1
+        %43 = cc.if(%42) -> i1 {
+          cc.continue %false : i1
+        } else {
+          %44 = cc.load %3 : !cc.ptr<i64>
+          %45 = cc.load %4 : !cc.ptr<i64>
+          %46 = arith.subi %45, %c1_i64 : i64
+          %47 = arith.cmpi ult, %44, %46 : i64
+          cc.continue %47 : i1
+        }
+        cc.if(%43) {
+          %44 = cc.load %7 : !cc.ptr<f64>
+          func.call @test_2.f(%9, %44, %cst, %cst) : (!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, f64, f64, f64) -> ()
+        }
+      }
+      cc.continue
+    } step {
+      %10 = cc.load %3 : !cc.ptr<i64>
+      %11 = arith.addi %10, %c1_i64 : i64
+      cc.store %11, %3 : !cc.ptr<i64>
+    }
+  return
+}
+
+func.func private @test_2.a(!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.stdvec<i64>) -> !cc.stdvec<i1>
+func.func private @test_2.b(!cc.ptr<i8>, !cc.ptr<i8>, i64) -> ()
+func.func private @test_2.c(!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, !cc.stdvec<i64>) -> !cc.stdvec<i1>
+func.func private @test_2.d(!cc.stdvec<i1>) -> i64
+func.func private @test_2.e(i64, i1, i1, i64, i64) -> ()
+func.func private @test_2.f(!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, f64, f64, f64) -> ()
+
+// CHECK-LABEL:   func.func @test_2(
+// CHECK:           %[[VAL_25:.*]]:4 = cc.loop while ((%[[VAL_26:.*]] = %{{.*}}, %[[VAL_27:.*]] = %{{.*}}, %[[VAL_28:.*]] = %{{.*}}, %[[VAL_29:.*]] = %{{.*}}) -> (i64, i64, i64, i64)) {
+// CHECK:             %[[VAL_30:.*]] = arith.cmpi ult, %[[VAL_26]], %{{.*}} : i64
+// CHECK:             cc.condition %[[VAL_30]](%[[VAL_26]], %[[VAL_27]], %[[VAL_28]], %[[VAL_29]] : i64, i64, i64, i64)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_31:.*]]: i64, %[[VAL_32:.*]]: i64, %[[VAL_33:.*]]: i64, %[[VAL_34:.*]]: i64):
+// CHECK:             %[[VAL_35:.*]]:4 = cc.scope -> (i64, i64, i64, i64) {
+// CHECK:               cc.if(%[[VAL_68:.*]]) {
+// CHECK:                 func.call @test_2.f(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!quake.struq<!quake.veq<?>, !quake.veq<?>, !quake.veq<?>>, f64, f64, f64) -> ()
+// CHECK:               } else {
+// CHECK:               }
+// CHECK:               cc.continue %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i64
+// CHECK:             }
+// CHECK:             cc.continue %[[VAL_69:.*]]#0, %[[VAL_69]]#1, %[[VAL_69]]#2, %[[VAL_69]]#3 : i64, i64, i64, i64
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_70:.*]]: i64, %[[VAL_71:.*]]: i64, %[[VAL_72:.*]]: i64, %[[VAL_73:.*]]: i64):
+// CHECK:             %[[VAL_74:.*]] = arith.addi %[[VAL_70]], %{{.*}} : i64
+// CHECK:             cc.continue %[[VAL_74]], %[[VAL_71]], %[[VAL_72]], %[[VAL_73]] : i64, i64, i64, i64
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
Guard against nullptr.

Fix bug in memtoreg. When an entry block has no definitions other than from within an enclosed Region, the live-in set must be promoted to block arguments, since there is no dominating Block in the Region.

Add checks to verify that variable-coalesce is run as a FuncOp pass.

Add hoist-only option.

Fine tune canonicalization of cc.scope.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
