### PR TITLE
Propagate some conditional feedback metadata from callees to callers

### DIFF
--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -1001,6 +1001,15 @@ def QuakeAddMetadata : Pass<"quake-add-metadata", "mlir::func::FuncOp"> {
   let constructor = "cudaq::opt::createQuakeAddMetadata()";
 }
 
+def QuakePropagateMetadata : Pass<"quake-propagate-metadata", "mlir::ModuleOp"> {
+  let summary = "Propagate metadata from callees to callers when needed.";
+  let description = [{
+   This pass propagates function metadata attributes added by `quake-add-metadata`
+   pass, such as `qubitMeasurementFeedback`, to all the callers of the function.
+   This makes sure the attributes are not missing after inlining.
+  }];
+}
+
 def QuakeSimplify : Pass<"quake-simplify"> {
   let summary = "Perform simplifications on the quake ops.";
   let description = [{

--- a/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -24,6 +24,7 @@ void cudaq::opt::commonPipelineConvertToQIR(PassManager &pm,
   pm.addNestedPass<func::FuncOp>(createCSEPass());
   pm.addNestedPass<func::FuncOp>(createQuakeAddDeallocs());
   pm.addNestedPass<func::FuncOp>(createQuakeAddMetadata());
+  pm.addPass(createQuakePropagateMetadata());
   pm.addNestedPass<func::FuncOp>(createLoopNormalize());
   LoopUnrollOptions luo;
   luo.allowBreak = passConfigAs == "qir-adaptive";

--- a/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/lib/Optimizer/Transforms/CMakeLists.txt
@@ -54,6 +54,7 @@ add_cudaq_library(OptTransforms
   PruneCtrlRelations.cpp
   PySynthCallableBlockArgs.cpp
   QuakeAddMetadata.cpp
+  QuakePropagateMetadata.cpp
   QuakeSimplify.cpp
   QuakeSynthesizer.cpp
   RefToVeqAlloc.cpp

--- a/lib/Optimizer/Transforms/QuakePropagateMetadata.cpp
+++ b/lib/Optimizer/Transforms/QuakePropagateMetadata.cpp
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/CallGraphFix.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "cudaq/Todo.h"
+#include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Analysis/CallGraph.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+
+// #include "cudaq/Optimizer/Builder/Factory.h"
+// #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h"
+// #include "mlir/Pass/Pass.h"
+// #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_QUAKEPROPAGATEMETADATA
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "quake-propagate-metadata"
+
+using namespace mlir;
+
+namespace {
+
+/// This pass will analyze Quake functions and attach metadata (as an MLIR
+/// function attribute) for specific features.
+class QuakePropagateMetadataPass
+    : public cudaq::opt::impl::QuakePropagateMetadataBase<
+          QuakePropagateMetadataPass> {
+protected:
+public:
+  using QuakePropagateMetadataBase::QuakePropagateMetadataBase;
+
+  /// This analysis is most effective if factor-quantum-alloc and memtoreg
+  /// have been run prior to this pass. If not, this pass may give false
+  /// positives. expand-measurements and loop-unrolling may further reduce
+  /// false positives.
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    // Build the call graph of the module
+    const mlir::CallGraph callGraph(moduleOp);
+    // Use PostOrderTraversal to get the ordered list of FuncOps and a map of
+    // callers for each function.
+    llvm::ReversePostOrderTraversal<const mlir::CallGraph *> rpot(&callGraph);
+    llvm::SmallVector<func::FuncOp> funcOps;
+    llvm::DenseMap<func::FuncOp, llvm::SmallVector<func::FuncOp>> callerOps;
+    for (auto &node : rpot) {
+      if (node->isExternal())
+        continue;
+
+      auto *callableRegion = node->getCallableRegion();
+      if (auto callerFnOp = callableRegion->getParentOfType<func::FuncOp>()) {
+        funcOps.insert(funcOps.begin(), callerFnOp);
+
+        for (auto it = node->begin(); it != node->end(); it++) {
+          auto edge = *it;
+          auto callee = edge.getTarget();
+          if (callee->isExternal())
+            continue;
+
+          auto *calleeCallableRegion = callee->getCallableRegion();
+          if (auto calleeFnOp =
+                  calleeCallableRegion->getParentOfType<func::FuncOp>()) {
+
+            if (callerOps.find(calleeFnOp) == callerOps.end()) {
+              SmallVector<func::FuncOp> v;
+              callerOps[calleeFnOp] = v;
+            }
+            callerOps[calleeFnOp].emplace_back(callerFnOp);
+          }
+        }
+      }
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "Module before propagating metadata:\n"
+                            << moduleOp << "\n\n");
+
+    for (auto &callee : funcOps) {
+      auto callers = callerOps[callee];
+      LLVM_DEBUG(llvm::dbgs() << "Visiting callee: "
+                              << callee.getName() << "\n\n");
+      for (auto caller : callers) {
+
+        LLVM_DEBUG(llvm::dbgs() << "  Caller: "
+                                << caller.getName() << "\n\n");
+        if (auto boolAttr = callee->getAttr("qubitMeasurementFeedback")
+                                .dyn_cast_or_null<mlir::BoolAttr>()) {
+          if (boolAttr.getValue()) {
+            LLVM_DEBUG(llvm::dbgs()
+                       << "  Propagating qubitMeasurementFeedback attr: "
+                       << boolAttr << "\n");
+            caller->setAttr("qubitMeasurementFeedback", boolAttr);
+          }
+        }
+      }
+    }
+    LLVM_DEBUG(llvm::dbgs() << "Module after propagating metadata:\n"
+                            << moduleOp << "\n\n");
+  }
+};
+
+} // namespace

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -4658,7 +4658,7 @@ def compile_to_mlir(astModule, capturedDataStorage: CapturedDataStorage,
 
     # Canonicalize the code, check for measurement(s) readout
     pm = PassManager.parse(
-        "builtin.module(canonicalize,cse,func.func(quake-add-metadata))",
+        "builtin.module(canonicalize,cse,func.func(quake-add-metadata),quake-propagate-metadata)",
         context=bridge.ctx)
 
     try:

--- a/runtime/cudaq/algorithms/get_state.h
+++ b/runtime/cudaq/algorithms/get_state.h
@@ -18,6 +18,7 @@
 #include "cudaq/qis/qkernel.h"
 #include "cudaq/qis/remote_state.h"
 #include "cudaq/qis/state.h"
+#include "cudaq/utils/cudaq_utils.h"
 #include "cudaq/utils/registry.h"
 #include <complex>
 #include <vector>

--- a/runtime/cudaq/algorithms/run.h
+++ b/runtime/cudaq/algorithms/run.h
@@ -15,6 +15,7 @@
 #include "cudaq/host_config.h"
 #include "cudaq/platform/QuantumExecutionQueue.h"
 #include "cudaq/qis/kernel_utils.h"
+#include "cudaq/utils/cudaq_utils.h"
 #include <cstdint>
 
 extern "C" {

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -967,6 +967,7 @@ jitCode(ImplicitLocOpBuilder &builder, ExecutionEngine *jit,
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
     pm.addNestedPass<func::FuncOp>(cudaq::opt::createQuakeAddMetadata());
+    pm.addPass(cudaq::opt::createQuakePropagateMetadata());
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(createCSEPass());
     pm.addPass(cudaq::opt::createGenerateDeviceCodeLoader({.jitTime = true}));

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -366,20 +366,20 @@ void *getArgPointer(T *arg) {
   return arg;
 }
 
-/// @brief The `kernel_builder_base` provides a base type for the templated
-/// kernel builder so that we can get a single handle on an instance within the
-/// runtime.
-class kernel_builder_base {
-public:
-  virtual std::string to_quake() const = 0;
-  virtual void jitCode(std::vector<std::string> extraLibPaths = {}) = 0;
-  virtual ~kernel_builder_base() = default;
+// /// @brief The `kernel_builder_base` provides a base type for the templated
+// /// kernel builder so that we can get a single handle on an instance within the
+// /// runtime.
+// class kernel_builder_base {
+// public:
+//   virtual std::string to_quake() const = 0;
+//   virtual void jitCode(std::vector<std::string> extraLibPaths = {}) = 0;
+//   virtual ~kernel_builder_base() = default;
 
-  /// @brief Write the kernel_builder to the given output stream. This outputs
-  /// the Quake representation.
-  friend std::ostream &operator<<(std::ostream &stream,
-                                  const kernel_builder_base &builder);
-};
+//   /// @brief Write the kernel_builder to the given output stream. This outputs
+//   /// the Quake representation.
+//   friend std::ostream &operator<<(std::ostream &stream,
+//                                   const kernel_builder_base &builder);
+// };
 
 } // namespace details
 

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -25,6 +25,8 @@
 #include <signal.h>
 #include <string>
 #include <vector>
+
+#include <iostream>
 namespace nvqir {
 void tearDownBeforeMPIFinalize();
 void setRandomSeed(std::size_t);
@@ -380,8 +382,10 @@ std::string get_quake_by_name(const std::string &kernelName,
 
 bool kernelHasConditionalFeedback(const std::string &kernelName) {
   auto quakeCode = get_quake_by_name(kernelName, false);
-  return !quakeCode.empty() &&
+  auto ret = !quakeCode.empty() &&
          quakeCode.find("qubitMeasurementFeedback = true") != std::string::npos;
+  std::cout << kernelName << " has qubitMeasurementFeedback: " << ret << std::endl;
+  return ret;
 }
 
 // Ignore warnings about deprecations in platform.set_shots and

--- a/runtime/cudaq/qis/kernel_utils.h
+++ b/runtime/cudaq/qis/kernel_utils.h
@@ -8,60 +8,61 @@
 
 #pragma once
 
-#include "common/ExecutionContext.h"
-#include "cudaq/concepts.h"
-#include "cudaq/utils/registry.h"
-#include "qkernel.h"
+// #include "common/ExecutionContext.h"
+// #include "cudaq/concepts.h"
+// #include "cudaq/utils/registry.h"
+// #include "qkernel.h"
 
-namespace cudaq::details {
 
-#ifdef CUDAQ_LIBRARY_MODE
-template <typename QuantumKernel>
-QuantumKernel createQKernel(QuantumKernel &&kernel) {
-  return kernel;
-}
-#else
+// namespace cudaq::details {
 
-#if CUDAQ_USE_STD20
-template <typename T>
-using remove_cvref_t = typename std::remove_cvref_t<T>;
-#else
-template <typename T>
-using remove_cvref_t = typename std::remove_cv_t<std::remove_reference_t<T>>;
-#endif
+// #ifdef CUDAQ_LIBRARY_MODE
+// template <typename QuantumKernel>
+// QuantumKernel createQKernel(QuantumKernel &&kernel) {
+//   return kernel;
+// }
+// #else
 
-template <typename QuantumKernel, typename Q = remove_cvref_t<QuantumKernel>,
-          typename Operator = typename cudaq::qkernel_deduction_guide_helper<
-              decltype(&Q::operator())>::type,
-          std::enable_if_t<std::is_class_v<Q>, bool> = true>
-cudaq::qkernel<Operator> createQKernel(QuantumKernel &&kernel) {
-  return {kernel};
-}
+// #if CUDAQ_USE_STD20
+// template <typename T>
+// using remove_cvref_t = typename std::remove_cvref_t<T>;
+// #else
+// template <typename T>
+// using remove_cvref_t = typename std::remove_cv_t<std::remove_reference_t<T>>;
+// #endif
 
-template <typename QuantumKernel, typename Q = remove_cvref_t<QuantumKernel>,
-          std::enable_if_t<!std::is_class_v<Q>, bool> = true>
-cudaq::qkernel<Q> createQKernel(QuantumKernel &&kernel) {
-  return {kernel};
-}
-#endif
+// template <typename QuantumKernel, typename Q = remove_cvref_t<QuantumKernel>,
+//           typename Operator = typename cudaq::qkernel_deduction_guide_helper<
+//               decltype(&Q::operator())>::type,
+//           std::enable_if_t<std::is_class_v<Q>, bool> = true>
+// cudaq::qkernel<Operator> createQKernel(QuantumKernel &&kernel) {
+//   return {kernel};
+// }
 
-template <typename QuantumKernel>
-std::string getKernelName(QuantumKernel &&kernel) {
-  if constexpr (has_name<QuantumKernel>::value) {
-    // kernel_builder kernel: need to JIT code to get it registered.
-    static_cast<cudaq::details::kernel_builder_base &>(kernel).jitCode();
-    return kernel.name();
-  } else {
-    // R (S::operator())(Args..) or R(*)(Args...) kernels are registered
-    // and made linkable in GenDeviceCodeLoader pass.
-    auto qKernel =
-        cudaq::details::createQKernel(std::forward<QuantumKernel>(kernel));
-    auto key = cudaq::registry::__cudaq_getLinkableKernelKey(&qKernel);
-    auto name = cudaq::registry::getLinkableKernelNameOrNull(key);
-    if (!name)
-      return __internal__::demangle_kernel(typeid(kernel).name());
-    return name;
-  }
-}
+// template <typename QuantumKernel, typename Q = remove_cvref_t<QuantumKernel>,
+//           std::enable_if_t<!std::is_class_v<Q>, bool> = true>
+// cudaq::qkernel<Q> createQKernel(QuantumKernel &&kernel) {
+//   return {kernel};
+// }
+// #endif
 
-} // namespace cudaq::details
+// template <typename QuantumKernel>
+// std::string getKernelName(QuantumKernel &&kernel) {
+//   if constexpr (has_name<QuantumKernel>::value) {
+//     // kernel_builder kernel: need to JIT code to get it registered.
+//     static_cast<cudaq::details::kernel_builder_base &>(kernel).jitCode();
+//     return kernel.name();
+//   } else {
+//     // R (S::operator())(Args..) or R(*)(Args...) kernels are registered
+//     // and made linkable in GenDeviceCodeLoader pass.
+//     auto qKernel =
+//         cudaq::details::createQKernel(std::forward<QuantumKernel>(kernel));
+//     auto key = cudaq::registry::__cudaq_getLinkableKernelKey(&qKernel);
+//     auto name = cudaq::registry::getLinkableKernelNameOrNull(key);
+//     if (!name)
+//       return __internal__::demangle_kernel(typeid(kernel).name());
+//     return name;
+//   }
+// }
+
+// } // namespace cudaq::details

--- a/targettests/execution/mid_circuit_measurement.cpp
+++ b/targettests/execution/mid_circuit_measurement.cpp
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// clang-format off
+// Simulators
+// RUN: nvq++ %cpp_std --enable-mlir  %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std --library-mode %s -o %t && %t | FileCheck %s
+
+// Quantum emulators
+// RUN: nvq++ %cpp_std --target quantinuum               --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std --target ionq                     --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std --target anyon                    --emulate %s -o %t && %t | FileCheck %s
+// 2 different IQM machines for 2 different topologies
+// RUN: nvq++ %cpp_std --target iqm --iqm-machine Adonis --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std --target iqm --iqm-machine Apollo --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %cpp_std --target oqc                      --emulate %s -o %t && %t | FileCheck %s
+// RUN: if %braket_avail; then nvq++ %cpp_std --target braket --emulate %s -o %t && %t | FileCheck %s; fi
+// clang-format on
+
+#include <cudaq.h>
+#include <iostream>
+#include <string>
+#include <vector>
+
+
+__qpu__ void callee(cudaq::qview<> r)  {
+  for (auto i = 0; i < 4; i++) {
+    if (i % 2 == 0)
+        x(r[i]);
+
+    auto m = mz(r[i]);
+    cudaq::reset(r[i]);
+
+    if (m)
+        x(r[i]);
+    else
+        h(r[i]);
+  }
+}
+
+struct caller {
+  void operator()() __qpu__ {
+    cudaq::qvector q(4);
+    callee(q);
+}
+};
+
+
+__qpu__ void c_caller()  {
+  cudaq::qvector q(4);
+    callee(q);
+}
+
+struct inlined {
+  void operator()() __qpu__ {
+  cudaq::qvector r(4);
+  for (auto i = 0; i < 4; i++) {
+    if (i % 2 == 0)
+        x(r[i]);
+
+    auto m = mz(r[i]);
+    cudaq::reset(r[i]);
+
+    if (m)
+        x(r[i]);
+    else
+        h(r[i]);
+  }
+}
+};
+
+
+__qpu__ void c_inlined() {
+  cudaq::qvector r(4);
+  for (auto i = 0; i < 4; i++) {
+    if (i % 2 == 0)
+        x(r[i]);
+
+    auto m = mz(r[i]);
+    cudaq::reset(r[i]);
+
+    if (m)
+        x(r[i]);
+    else
+        h(r[i]);
+  }
+}
+
+
+int main() {
+  // {
+  //   auto counts = cudaq::sample(1000, caller{});
+  //   counts.dump();
+
+  //   printf("%zu\n", counts.count("1010", "__global__"));
+  //   printf("%zu\n", counts.count("1011", "__global__"));
+  //   printf("%zu\n", counts.count("1110", "__global__"));
+  //   printf("%zu\n", counts.count("1111", "__global__"));
+  // }
+
+  // {
+  //   auto counts = cudaq::sample(1000, inlined{});
+  //   counts.dump();
+
+  //   printf("%zu\n", counts.count("1010", "__global__"));
+  //   printf("%zu\n", counts.count("1011", "__global__"));
+  //   printf("%zu\n", counts.count("1110", "__global__"));
+  //   printf("%zu\n", counts.count("1111", "__global__"));
+  // }
+
+  {
+    auto counts = cudaq::sample(1000, c_caller);
+    counts.dump();
+
+    printf("%zu\n", counts.count("1010", "__global__"));
+    printf("%zu\n", counts.count("1011", "__global__"));
+    printf("%zu\n", counts.count("1110", "__global__"));
+    printf("%zu\n", counts.count("1111", "__global__"));
+  }
+
+  {
+    auto counts = cudaq::sample(1000, c_inlined);
+    counts.dump();
+
+    printf("%zu\n", counts.count("1010", "__global__"));
+    printf("%zu\n", counts.count("1011", "__global__"));
+    printf("%zu\n", counts.count("1110", "__global__"));
+    printf("%zu\n", counts.count("1111", "__global__"));
+  }
+  return 0;
+}

--- a/test/Transforms/propagate-metadata.qke
+++ b/test/Transforms/propagate-metadata.qke
@@ -1,0 +1,40 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --quake-propagate-metadata %s | FileCheck %s
+func.func @callee(%arg0: !quake.veq<?>) attributes {"cudaq-kernel", qubitMeasurementFeedback = true} {
+  return
+}
+
+func.func @callee1(%arg0: !quake.veq<?>) attributes {"cudaq-kernel"} {
+  return
+}
+
+func.func @callee2(%arg0: !quake.veq<?>) attributes {"cudaq-kernel", qubitMeasurementFeedback = false} {
+  return
+}
+
+func.func @caller() attributes {"cudaq-kernel"} {
+  %0 = quake.alloca !quake.veq<4>
+  %1 = quake.relax_size %0 : (!quake.veq<4>) -> !quake.veq<?>
+  call @callee(%1) : (!quake.veq<?>) -> ()
+  call @callee1(%1) : (!quake.veq<?>) -> ()
+  call @callee2(%1) : (!quake.veq<?>) -> ()
+  return
+}
+
+func.func @caller1() attributes {"cudaq-kernel"} {
+  call @caller() : () -> ()
+  return
+}
+
+// CHECK:    func.func @callee(%arg0: !quake.veq<?>) attributes {"cudaq-kernel", qubitMeasurementFeedback = true} {
+// CHECK:    func.func @callee1(%arg0: !quake.veq<?>) attributes {"cudaq-kernel"} {
+// CHECK:    func.func @callee2(%arg0: !quake.veq<?>) attributes {"cudaq-kernel", qubitMeasurementFeedback = false} 
+// CHECK:    func.func @caller() attributes {"cudaq-kernel", qubitMeasurementFeedback = true} {
+// CHECK:    func.func @caller1() attributes {"cudaq-kernel", qubitMeasurementFeedback = true} {

--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -25,9 +25,9 @@ function error_exit {
 }
 
 function run() {
-	if $ECHO; then
+	# if $ECHO; then
 		echo "$*"
-	fi
+	# fi
 	$*
 	if [ $? -ne 0 ]; then
 		echo "failed: \"$*\"" >&2
@@ -733,7 +733,7 @@ if ${ENABLE_AGGRESSIVE_EARLY_INLINE}; then
 fi
 if ${ENABLE_ARRAY_CONVERSION}; then
 	RUN_OPT=true
-	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(quake-add-metadata,constant-propagation,lift-array-alloc),globalize-array-values,canonicalize,get-concrete-matrix")
+	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(quake-add-metadata,constant-propagation,lift-array-alloc),quake-propagate-metadata,globalize-array-values,canonicalize,get-concrete-matrix")
 fi
 if [[ -n "$CUDAQ_OPT_EXTRA_PASSES" ]]; then
 	RUN_OPT=true

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -78,6 +78,7 @@ LogicalResult lowerToLLVMDialect(ModuleOp module) {
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createQuakeAddDeallocs());
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createQuakeAddMetadata());
+  pm.addPass(cudaq::opt::createQuakePropagateMetadata());
   cudaq::opt::addLowerToCFG(pm);
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createCombineQuantumAllocations());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());


### PR DESCRIPTION
### Description
Propagate some conditional feedback metadata from callees to callers.

In python, we add metadata to the quake IR after it is created, but run an inliner later, and the metadata is not present on the caller if only the callee had it. The current fix propagates metadata from callees to all the callers up the callgraph.

- Add a pass to propagate metadata to callers
- Add tests

Closes: https://github.com/NVIDIA/cuda-quantum/issues/3160
