### PR TITLE
Fixes for cuTensorNet v2.8.0

### DIFF
--- a/runtime/nvqir/cutensornet/tensornet_state.inc
+++ b/runtime/nvqir/cutensornet/tensornet_state.inc
@@ -262,16 +262,6 @@ TensorNetState<ScalarType>::prepareSample(
     HANDLE_CUTN_ERROR(cutensornetSamplerConfigure(
         m_cutnHandle, sampler, CUTENSORNET_SAMPLER_CONFIG_NUM_HYPER_SAMPLES,
         &numHyperSamples, sizeof(numHyperSamples)));
-
-    // Generate a random seed from the backend simulator's random engine.
-    // Note: Even after a random seed setting at the user's level,
-    // consecutive `cudaq::sample` calls will still return different results
-    // (yet deterministic), i.e., the seed that we send to cutensornet should
-    // not be the user's seed.
-    const int32_t rndSeed = m_randomEngine();
-    HANDLE_CUTN_ERROR(cutensornetSamplerConfigure(
-        m_cutnHandle, sampler, CUTENSORNET_SAMPLER_CONFIG_DETERMINISTIC,
-        &rndSeed, sizeof(rndSeed)));
   }
 
   // Prepare the quantum circuit sampler
@@ -345,11 +335,23 @@ TensorNetState<ScalarType>::executeSample(
   std::unordered_map<std::string, size_t> counts;
   // If this is a trajectory simulation, each shot needs an independent
   // trajectory sampling.
-  const int MAX_SHOTS_PER_RUNS = m_hasNoiseChannel ? 1 : 10000;
-  int shotsToRun = shots;
+  const int64_t MAX_SHOTS_PER_RUNS = m_hasNoiseChannel ? 1 : shots;
+  int64_t shotsToRun = shots;
   while (shotsToRun > 0) {
-    const int numShots = std::min(shotsToRun, MAX_SHOTS_PER_RUNS);
+    const int64_t numShots = std::min(shotsToRun, MAX_SHOTS_PER_RUNS);
     std::vector<int64_t> samples(measuredBitIds.size() * numShots);
+    {
+      // Generate a random seed from the backend simulator's random engine.
+      // Note: Even after a random seed setting at the user's level,
+      // consecutive `cudaq::sample` calls will still return different results
+      // (yet deterministic), i.e., the seed that we send to cutensornet should
+      // not be the user's seed.
+      const int32_t rndSeed = m_randomEngine();
+      HANDLE_CUTN_ERROR(cutensornetSamplerConfigure(
+          m_cutnHandle, sampler, CUTENSORNET_SAMPLER_CONFIG_DETERMINISTIC,
+          &rndSeed, sizeof(rndSeed)));
+    }
+
     {
       ScopedTraceWithContext("cutensornetSamplerSample");
       HANDLE_CUTN_ERROR(cutensornetSamplerSample(
@@ -359,7 +361,7 @@ TensorNetState<ScalarType>::executeSample(
 
     const auto numMeasuredQubits = measuredBitIds.size();
     std::string bitstring(numMeasuredQubits, '0');
-    for (int i = 0; i < numShots; ++i) {
+    for (int64_t i = 0; i < numShots; ++i) {
       constexpr char digits[2] = {'0', '1'};
       for (std::size_t j = 0; j < numMeasuredQubits; ++j)
         bitstring[j] = digits[samples[i * numMeasuredQubits + j]];

--- a/unittests/integration/kernels_tester.cpp
+++ b/unittests/integration/kernels_tester.cpp
@@ -181,6 +181,25 @@ CUDAQ_TEST(KernelsTester, checkFromState) {
   }
 }
 
+CUDAQ_TEST(KernelsTester, checkSampleBug2937) {
+  constexpr int qubit_count = 20;
+  auto kernel = cudaq::make_kernel();
+  auto qubits = kernel.qalloc(qubit_count);
+  constexpr int depth = qubit_count / 5;
+  for (int i = 0; i < depth; i++) {
+    kernel.h(qubits[i * 5]);
+    for (int j = 0; j < 4; j++) {
+      kernel.x<cudaq::ctrl>(qubits[i * 5 + j], qubits[i * 5 + j + 1]);
+    }
+  }
+
+  kernel.mz(qubits);
+  auto counts = cudaq::sample(kernel);
+  counts.dump();
+  // Expect 16 unique bitstrings
+  EXPECT_EQ(counts.size(), 16);
+}
+
 #endif
 
 #if defined(CUDAQ_BACKEND_STIM)


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

[cuTensorNet v2.8.0](https://docs.nvidia.com/cuda/cuquantum/latest/cutensornet/release-notes.html#cutensornet-v2-8-0) introduces a change to the way to use the sampler:

>  "Fixed a bug in the sampling functionalities cutensornetSamplerSample() where setting CUTENSORNET_SAMPLER_CONFIG_DETERMINISTIC can lead to incorrect results for large tensor network state."

This requires us to update the sampling code in the CUDA Quantum to always configure the seed before calling `cutensornetSamplerSample`.

Also, add a test case for #2937, which is fixed in cuTensorNet v2.8.0.
