### PR TITLE
Prepend registry to deployment cloudposse write

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -518,7 +518,7 @@ jobs:
           docker buildx imagetools create --tag "$stitched_tag" $refs
           digest=$(docker buildx imagetools inspect "$stitched_tag" | awk '/^Digest:/ { print $2 }')
           stitched_output=$(cat stitched_digests.json 2>/dev/null || echo '{}')
-          stitched_output=$(echo "$stitched_output" | jq --arg key "devdeps-cu${cuda_major}" --arg val "$digest" '. + {($key): $val}')
+          stitched_output=$(echo "$stitched_output" | jq --arg key "devdeps-cu${cuda_major}" --arg val "$registry@$digest" '. + {($key): $val}')
           echo "$stitched_output" | tee stitched_digests.json
 
       - name: Stitch debug image
@@ -549,7 +549,7 @@ jobs:
           docker buildx imagetools create --tag "$stitched_tag" $refs
           digest=$(docker buildx imagetools inspect "$stitched_tag" | awk '/^Digest:/ { print $2 }')
           stitched_output=$(cat stitched_digests.json 2>/dev/null || echo '{}')
-          stitched_output=$(echo "$stitched_output" | jq --arg key "dev-cu${cuda_major}" --arg val "$digest" '. + {($key): $val}')
+          stitched_output=$(echo "$stitched_output" | jq --arg key "dev-cu${cuda_major}" --arg val "$registry@$digest" '. + {($key): $val}')
           echo "$stitched_output" | tee stitched_digests.json
 
       - name: Stitch release image
@@ -604,7 +604,7 @@ jobs:
           docker buildx imagetools create --tag "$stitched_tag" $refs
           digest=$(docker buildx imagetools inspect "$stitched_tag" | awk '/^Digest:/ { print $2 }')
           stitched_output=$(cat stitched_digests.json 2>/dev/null || echo '{}')
-          stitched_output=$(echo "$stitched_output" | jq --arg key "base-cu${cuda_major}" --arg val "$digest" '. + {($key): $val}')
+          stitched_output=$(echo "$stitched_output" | jq --arg key "base-cu${cuda_major}" --arg val "$registry@$digest" '. + {($key): $val}')
           echo "$stitched_output" | tee stitched_digests.json
 
       - name: Read stitched_digests.json


### PR DESCRIPTION
Currently, the outputted `image_cu${cuda}_publishing` file from deployments looks like this:
```
source-sha: cc0a89f8c1be6b530c36ebb2dbe67a9e1a3bb709
cuda-quantum-image: sha256:7446fd70abb12604509d40a4f029898b0e1e8143fd2215e1d7a6c1198a609972
cuda-quantum-dev-image: sha256:99f897b2d488ee8884bc0f23543878bb0119a764e43f9de83cca1d3a0434ea9c
cuda-quantum-devdeps-image: sha256:a3cb49aed713fc0812488da3bfff56cf381cd376e43507d6681a28648c33bc92
platforms: linux/arm64,linux/amd64
cuda-version: 12.0
nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
nvidia-mgpu-commit: bfccb143f12b42be129ed2fbf16c39428eaba7b7
```

It should include the registry in these values like so:
```
source-sha: db81fa583d4e17acd38dd6f03cbde998462db719
cuda-quantum-image: nvcr.io/nvidia/nightly/cuda-quantum@sha256:b927a7f439c0f7b6359c47837d9e6c851d80bfe23bfce73444d548ff2dccd016
cuda-quantum-dev-image: ghcr.io/nvidia/cuda-quantum-dev@sha256:182402f6a60ce19a4c412b579ebc38763f7781ae3dc40db605f0d42d40ad17c7
cuda-quantum-devdeps-image: ghcr.io/nvidia/cuda-quantum-devdeps@sha256:5c704420fd06050994df7a209d5485f766762b1943b9394a4347b3098f3001e4
platforms: linux/arm64,linux/amd64
cuda-version: 12.0
nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
nvidia-mgpu-commit: bfccb143f12b42be129ed2fbf16c39428eaba7b7
```