### PR TITLE
Sanitize tag in deployments stage

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -483,6 +483,26 @@ jobs:
           DIGESTS_JSON='${{ needs.digest_config.outputs.json }}'
           EXT_JSON='${{ needs.ext_config.outputs.json }}'
 
+          is_versioned=${{ github.ref_type == 'tag' || startsWith(github.ref_name, 'releases/') || startsWith(github.ref_name, 'staging/') }}
+          has_continuous_deployment=${{ startsWith(github.ref_name, 'experimental/') || github.ref_name == 'main' }}
+          push_to_ngc=`($is_versioned || $has_continuous_deployment) && echo true || echo`
+
+          image_tag="cu${cuda_major}-"
+          if ${{ github.event.pull_request.number != '' }} || [ -n "$(echo ${{ github.ref_name }} | grep pull-request/)" ]; then
+            pr_number=`echo ${{ github.ref_name }} | grep -o [0-9]*`
+            image_tag+=pr-${pr_number:-${{ github.event.pull_request.number }}}
+          elif ${{ github.ref_type == 'branch' && github.ref_name == 'main' }}; then
+            image_tag+="latest"
+          elif "$is_versioned" == "true"; then
+            image_tag+=`echo ${{ github.ref_name }} | egrep -o "([0-9]{1,}\.)+[0-9]{1,}"`
+          else
+            image_tag+=`echo ${{ github.ref_name }} | tr '/' '-'`
+          fi
+
+          echo "$is_versioned" | tee -a "$GITHUB_OUTPUT"
+          echo "$push_to_ngc" | tee -a "$GITHUB_OUTPUT"
+          echo "$image_tag" | tee -a "$GITHUB_OUTPUT"
+
           echo "digests_json<<EOF" | tee -a "$GITHUB_OUTPUT"
           echo "$DIGESTS_JSON" | tee -a "$GITHUB_OUTPUT"
           echo "EOF" | tee -a "$GITHUB_OUTPUT"
@@ -510,11 +530,13 @@ jobs:
           registry=$(echo "$image" | cut -d'@' -f1)
           gcc_version=$(echo "$EXT_JSON" | jq -r ".build_cache[\"$key\"]" | grep -o 'gcc[0-9]\+' || echo "gccXX")
 
-          # example: releases/0.12.0 -> releases-0.12.0
-          sanitized_ref_name="${{ github.ref_name }}"
-          sanitized_ref_name="${sanitized_ref_name//\//-}"
+          if [[ "${{ steps.metadata.outputs.is_versioned }}" == "true" ]]; then
+            ref_name="${{ steps.metadata.outputs.image_tag }}"
+          else
+            ref_name=`echo ${{ github.ref_name }} | tr '/' '-'`
+          fi
 
-          tag="ext-cu${cuda}-${gcc_version}-${sanitized_ref_name}"
+          tag="ext-cu${cuda}-${gcc_version}-${ref_name}"
           stitched_tag="${registry}:${tag}"
 
           echo "Stitching devdeps image with tag: $stitched_tag"
@@ -545,11 +567,13 @@ jobs:
             refs="$refs $registry@$digest"
           done
 
-          # example: releases/0.12.0 -> releases-0.12.0
-          sanitized_ref_name="${{ github.ref_name }}"
-          sanitized_ref_name="${sanitized_ref_name//\//-}"
+          if [[ "${{ steps.metadata.outputs.is_versioned }}" == "true" ]]; then
+            ref_name="${{ steps.metadata.outputs.image_tag }}"
+          else
+            ref_name=`echo ${{ github.ref_name }} | tr '/' '-'`
+          fi
 
-          stitched_tag="$registry:cu${cuda_major}-${sanitized_ref_name}-base"
+          stitched_tag="$registry:cu${cuda_major}-${ref_name}-base"
 
           echo "Stitching debug image with tag: $stitched_tag"
           echo "References: $refs"
@@ -579,30 +603,12 @@ jobs:
             refs="$refs $registry@$digest"
           done
 
-          is_versioned=${{ github.ref_type == 'tag' || startsWith(github.ref_name, 'releases/') || startsWith(github.ref_name, 'staging/') }}
-          has_continuous_deployment=${{ startsWith(github.ref_name, 'experimental/') || github.ref_name == 'main' }}
-          push_to_ngc=`($is_versioned || $has_continuous_deployment) && echo true || echo`
-
-          echo "push to NGC? $push_to_ngc"
-
-          if [[ "$push_to_ngc" == "true" ]]; then
+          if [[ "${{ steps.metadata.outputs.push_to_ngc }}" == "true" ]]; then
             registry=${registry/ghcr.io\/nvidia/nvcr.io\/nvidia\/nightly}
           fi
 
-          image_tag="cu${cuda_major}-"
-          if ${{ github.event.pull_request.number != '' }} || [ -n "$(echo ${{ github.ref_name }} | grep pull-request/)" ]; then
-            pr_number=`echo ${{ github.ref_name }} | grep -o [0-9]*`
-            image_tag+=pr-${pr_number:-${{ github.event.pull_request.number }}}
-          elif ${{ github.ref_type == 'branch' && github.ref_name == 'main' }}; then
-            image_tag+="latest"
-          elif "$is_versioned" == "true"; then
-            image_tag+=`echo ${{ github.ref_name }} | egrep -o "([0-9]{1,}\.)+[0-9]{1,}"`
-          else
-            image_tag+=`echo ${{ github.ref_name }} | tr '/' '-'`
-          fi
-
           suffix="-base"
-          image_tag="${image_tag}${suffix}"
+          image_tag="${{ steps.metadata.outputs.image_tag }}${suffix}"
 
           stitched_tag="${registry}:${image_tag}"
 

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -480,31 +480,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          cuda="${{ matrix.cuda }}"
-          cuda_major="${cuda%%.*}"
-
           DIGESTS_JSON='${{ needs.digest_config.outputs.json }}'
           EXT_JSON='${{ needs.ext_config.outputs.json }}'
-
-          is_versioned=${{ github.ref_type == 'tag' || startsWith(github.ref_name, 'releases/') || startsWith(github.ref_name, 'staging/') }}
-          has_continuous_deployment=${{ startsWith(github.ref_name, 'experimental/') || github.ref_name == 'main' }}
-          push_to_ngc=`($is_versioned || $has_continuous_deployment) && echo true || echo`
-
-          image_tag="cu${cuda_major}-"
-          if ${{ github.event.pull_request.number != '' }} || [ -n "$(echo ${{ github.ref_name }} | grep pull-request/)" ]; then
-            pr_number=`echo ${{ github.ref_name }} | grep -o [0-9]*`
-            image_tag+=pr-${pr_number:-${{ github.event.pull_request.number }}}
-          elif ${{ github.ref_type == 'branch' && github.ref_name == 'main' }}; then
-            image_tag+="latest"
-          elif "$is_versioned" == "true"; then
-            image_tag+=`echo ${{ github.ref_name }} | egrep -o "([0-9]{1,}\.)+[0-9]{1,}"`
-          else
-            image_tag+=`echo ${{ github.ref_name }} | tr '/' '-'`
-          fi
-
-          echo "is_versioned=$is_versioned" | tee -a "$GITHUB_OUTPUT"
-          echo "push_to_ngc=$push_to_ngc" | tee -a "$GITHUB_OUTPUT"
-          echo "image_tag=$image_tag" | tee -a "$GITHUB_OUTPUT"
 
           echo "digests_json<<EOF" | tee -a "$GITHUB_OUTPUT"
           echo "$DIGESTS_JSON" | tee -a "$GITHUB_OUTPUT"
@@ -537,6 +514,9 @@ jobs:
           # Remove 'amd64-' from the whole string
           stitched_tag="${dev_image/amd64-/}"
 
+          # push to cuda-quantum-devdeps instead of cuda-quantum-dev
+          stitched_tag="${stitched_tag/cuda-quantum-dev:/cuda-quantum-devdeps:}"
+
           echo "Stitching devdeps image with tag: $stitched_tag"
           echo "References: $refs"
 
@@ -554,16 +534,22 @@ jobs:
 
           cuda="${{ matrix.cuda }}"
           cuda_major="${cuda%%.*}"
-          image="dev-image"
 
           refs=""
           for arch in amd64 arm64; do
-            key="${arch}-cu${cuda}-${image}"
+            key="${arch}-cu${cuda}-dev-image"
             digest=$(echo "$DIGESTS_JSON" | jq -r ".digest[\"$key\"]")
             arch_reference=$(echo "$DIGESTS_JSON" | jq -r ".image_tag[\"$key\"]")
             registry=$(echo "$arch_reference" | cut -d':' -f1)
             refs="$refs $registry@$digest"
           done
+
+          # Retrieve image tag from DIGEST_JSON, just look at amd64 and filter it out
+          key="amd64-cu${cuda}-dev-image"
+          dev_image=$(echo "$DIGESTS_JSON" | jq -r --arg k "$key" '.image_tag[$k]')
+
+          # Remove 'amd64-' from the whole string
+          stitched_tag="${dev_image/amd64-/}"
 
           stitched_tag="$registry:${{ steps.metadata.outputs.image_tag }}-base"
 
@@ -595,12 +581,30 @@ jobs:
             refs="$refs $registry@$digest"
           done
 
-          if [[ "${{ steps.metadata.outputs.push_to_ngc }}" == "true" ]]; then
+          is_versioned=${{ github.ref_type == 'tag' || startsWith(github.ref_name, 'releases/') || startsWith(github.ref_name, 'staging/') }}
+          has_continuous_deployment=${{ startsWith(github.ref_name, 'experimental/') || github.ref_name == 'main' }}
+          push_to_ngc=`($is_versioned || $has_continuous_deployment) && echo true || echo`
+
+          echo "push to NGC? $push_to_ngc"
+
+          if [[ "$push_to_ngc" == "true" ]]; then
             registry=${registry/ghcr.io\/nvidia/nvcr.io\/nvidia\/nightly}
           fi
 
+          image_tag="cu${cuda_major}-"
+          if ${{ github.event.pull_request.number != '' }} || [ -n "$(echo ${{ github.ref_name }} | grep pull-request/)" ]; then
+            pr_number=`echo ${{ github.ref_name }} | grep -o [0-9]*`
+            image_tag+=pr-${pr_number:-${{ github.event.pull_request.number }}}
+          elif ${{ github.ref_type == 'branch' && github.ref_name == 'main' }}; then
+            image_tag+="latest"
+          elif "$is_versioned" == "true"; then
+            image_tag+=`echo ${{ github.ref_name }} | egrep -o "([0-9]{1,}\.)+[0-9]{1,}"`
+          else
+            image_tag+=`echo ${{ github.ref_name }} | tr '/' '-'`
+          fi
+
           suffix="-base"
-          image_tag="${{ steps.metadata.outputs.image_tag }}${suffix}"
+          image_tag="${image_tag}${suffix}"
 
           stitched_tag="${registry}:${image_tag}"
 

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -480,6 +480,9 @@ jobs:
         run: |
           set -euo pipefail
 
+          cuda="${{ matrix.cuda }}"
+          cuda_major="${cuda%%.*}"
+
           DIGESTS_JSON='${{ needs.digest_config.outputs.json }}'
           EXT_JSON='${{ needs.ext_config.outputs.json }}'
 

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -530,17 +530,12 @@ jobs:
             refs="$refs $image"
           done
 
-          registry=$(echo "$image" | cut -d'@' -f1)
-          gcc_version=$(echo "$EXT_JSON" | jq -r ".build_cache[\"$key\"]" | grep -o 'gcc[0-9]\+' || echo "gccXX")
+          # Retrieve image tag from DIGEST_JSON, just look at amd64 and filter it out
+          key="amd64-cu${cuda}-dev-image"
+          dev_image=$(echo "$DIGESTS_JSON" | jq -r --arg k "$key" '.image_tag[$k]')
 
-          if [[ "${{ steps.metadata.outputs.is_versioned }}" == "true" ]]; then
-            ref_name="${{ steps.metadata.outputs.image_tag }}"
-          else
-            ref_name=`echo ${{ github.ref_name }} | tr '/' '-'`
-          fi
-
-          tag="ext-cu${cuda}-${gcc_version}-${ref_name}"
-          stitched_tag="${registry}:${tag}"
+          # Remove 'amd64-' from the whole string
+          stitched_tag="${dev_image/amd64-/}"
 
           echo "Stitching devdeps image with tag: $stitched_tag"
           echo "References: $refs"
@@ -570,13 +565,7 @@ jobs:
             refs="$refs $registry@$digest"
           done
 
-          if [[ "${{ steps.metadata.outputs.is_versioned }}" == "true" ]]; then
-            ref_name="${{ steps.metadata.outputs.image_tag }}"
-          else
-            ref_name=`echo ${{ github.ref_name }} | tr '/' '-'`
-          fi
-
-          stitched_tag="$registry:cu${cuda_major}-${ref_name}-base"
+          stitched_tag="$registry:${{ steps.metadata.outputs.image_tag }}-base"
 
           echo "Stitching debug image with tag: $stitched_tag"
           echo "References: $refs"

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -502,9 +502,9 @@ jobs:
             image_tag+=`echo ${{ github.ref_name }} | tr '/' '-'`
           fi
 
-          echo "$is_versioned" | tee -a "$GITHUB_OUTPUT"
-          echo "$push_to_ngc" | tee -a "$GITHUB_OUTPUT"
-          echo "$image_tag" | tee -a "$GITHUB_OUTPUT"
+          echo "is_versioned=$is_versioned" | tee -a "$GITHUB_OUTPUT"
+          echo "push_to_ngc=$push_to_ngc" | tee -a "$GITHUB_OUTPUT"
+          echo "image_tag=$image_tag" | tee -a "$GITHUB_OUTPUT"
 
           echo "digests_json<<EOF" | tee -a "$GITHUB_OUTPUT"
           echo "$DIGESTS_JSON" | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -509,7 +509,12 @@ jobs:
 
           registry=$(echo "$image" | cut -d'@' -f1)
           gcc_version=$(echo "$EXT_JSON" | jq -r ".build_cache[\"$key\"]" | grep -o 'gcc[0-9]\+' || echo "gccXX")
-          tag="ext-cu${cuda}-${gcc_version}-${{ github.ref_name }}"
+
+          # example: releases/0.12.0 -> releases-0.12.0
+          sanitized_ref_name="${{ github.ref_name }}"
+          sanitized_ref_name="${sanitized_ref_name//\//-}"
+
+          tag="ext-cu${cuda}-${gcc_version}-${sanitized_ref_name}"
           stitched_tag="${registry}:${tag}"
 
           echo "Stitching devdeps image with tag: $stitched_tag"
@@ -540,8 +545,11 @@ jobs:
             refs="$refs $registry@$digest"
           done
 
-          branch="${{ github.ref_name }}"
-          stitched_tag="$registry:cu${cuda_major}-${branch}-base"
+          # example: releases/0.12.0 -> releases-0.12.0
+          sanitized_ref_name="${{ github.ref_name }}"
+          sanitized_ref_name="${sanitized_ref_name//\//-}"
+
+          stitched_tag="$registry:cu${cuda_major}-${sanitized_ref_name}-base"
 
           echo "Stitching debug image with tag: $stitched_tag"
           echo "References: $refs"

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -551,8 +551,6 @@ jobs:
           # Remove 'amd64-' from the whole string
           stitched_tag="${dev_image/amd64-/}"
 
-          stitched_tag="$registry:${{ steps.metadata.outputs.image_tag }}-base"
-
           echo "Stitching debug image with tag: $stitched_tag"
           echo "References: $refs"
 


### PR DESCRIPTION
When creating a release branch for example, the tag is `releases/v0.12.0`. This breaks because you can not have slashes in the docker tag.

This updates the tag to pull it from the JSON files created from `docker_images.yml` and strips away the arch tag.

To help with reviewing this PR, DIGEST_JSON looks like this:
```
{
  "digest": {
    "arm64-cu12.0-image": "sha256:b225393b9a8baf7ba1e6e6a1cc9096b0b03eba1b669bf0774b6a6e73d6ffa68c",
    "arm64-cu12.0-dev-image": "sha256:9488561a700173b6ddebd09a03ce923e30ebfb44adf8afd38bcfb1b86d2bac45",
    "arm64-cu11.8-dev-image": "sha256:06c3c7dd943ba7911f6e51a7b82c31e46015b60db664692ade3e278acc1d2228",
    "arm64-cu11.8-image": "sha256:f327b06340617c8d5d6b0a18ebe0f1daa13c045e7866992281a5fa2d29458387",
    "amd64-cu11.8-image": "sha256:fabed2dda10f124e0d526652a1ef5e40ed04ae01ccd5ac86d002e4eb15d49564",
    "amd64-cu11.8-dev-image": "sha256:c2003f810423522f0f0e3a4c623fadf388b1bc6c1df461310a29eb5a8814911d",
    "amd64-cu12.0-image": "sha256:818ad94ac4cec90d41e5416e8c1da48409eb1d5b02724e8127c9f8de72935619",
    "amd64-cu12.0-dev-image": "sha256:a0be936db2a4eef76a0fecfe84ae128507d07d492384bf4c13f1c634dd63fba2"
  },
  "image_tag": {
    "arm64-cu12.0-image": "ghcr.io/nvidia/cuda-quantum:arm64-cu12-latest-base",
    "arm64-cu12.0-dev-image": "ghcr.io/nvidia/cuda-quantum-dev:ext-arm64-cu12.0-gcc11-main",
    "arm64-cu11.8-dev-image": "ghcr.io/nvidia/cuda-quantum-dev:ext-arm64-cu11.8-gcc11-main",
    "arm64-cu11.8-image": "ghcr.io/nvidia/cuda-quantum:arm64-cu11-latest-base",
    "amd64-cu11.8-image": "ghcr.io/nvidia/cuda-quantum:amd64-cu11-latest-base",
    "amd64-cu11.8-dev-image": "ghcr.io/nvidia/cuda-quantum-dev:ext-amd64-cu11.8-gcc11-main",
    "amd64-cu12.0-image": "ghcr.io/nvidia/cuda-quantum:amd64-cu12-latest-base",
    "amd64-cu12.0-dev-image": "ghcr.io/nvidia/cuda-quantum-dev:ext-amd64-cu12.0-gcc11-main"
  }
}
```



This should print the devdeps image to:

```
ghcr.io/nvidia/cuda-quantum-devdeps:ext-cu11.8-gcc11-main
```

And the debug image to:
```
ghcr.io/nvidia/cuda-quantum-dev:ext-cu11.8-gcc11-main
```