### PR TITLE
Add missing registry to devdeps publishing data

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -507,6 +507,8 @@ jobs:
             refs="$refs $image"
           done
 
+          registry=$(echo "$image" | cut -d'@' -f1)
+
           # Retrieve image tag from DIGEST_JSON, just look at amd64 and filter it out
           key="amd64-cu${cuda}-dev-image"
           dev_image=$(echo "$DIGESTS_JSON" | jq -r --arg k "$key" '.image_tag[$k]')


### PR DESCRIPTION
release refactoring https://github.com/NVIDIA/cuda-quantum/commit/50510ffb8adf6434db9f4794c4ec1e9a64dae708 accidentally removed the registry from devdeps, which is still needed for the publishing metadata.