### PR TITLE
Support parsing register names and populate the `sample_result`

### DIFF
--- a/runtime/common/Future.cpp
+++ b/runtime/common/Future.cpp
@@ -24,7 +24,6 @@ sample_result future::get() {
   auto serverHelper = registry::get<ServerHelper>(qpuName);
   serverHelper->initialize(serverConfig);
   auto headers = serverHelper->getHeaders();
-  auto cookies = serverHelper->getCookies();
   std::vector<ExecutionResult> results;
   for (auto &id : jobs) {
     cudaq::info("Future retrieving results for {}.", id.first);
@@ -32,12 +31,14 @@ sample_result future::get() {
     auto jobGetPath = serverHelper->constructGetJobPath(id.first);
 
     cudaq::info("Future got job retrieval path as {}.", jobGetPath);
-    auto resultResponse = client.get(jobGetPath, "", headers, false, cookies);
+    auto resultResponse =
+        client.get(jobGetPath, "", headers, false, serverHelper->getCookies());
     while (!serverHelper->jobIsDone(resultResponse)) {
       auto polling_interval =
           serverHelper->nextResultPollingInterval(resultResponse);
       std::this_thread::sleep_for(polling_interval);
-      resultResponse = client.get(jobGetPath, "", headers, false, cookies);
+      resultResponse = client.get(jobGetPath, "", headers, false,
+                                  serverHelper->getCookies());
     }
     auto c = serverHelper->processResults(resultResponse, id.first);
 

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
@@ -35,7 +35,7 @@ protected:
   std::string userSpecifiedCredentials = "";
   std::string credentialsPath = "";
   // Access token lifetime in seconds
-  static constexpr int tokenExpirySecs = 60;
+  static constexpr int tokenExpirySecs = 5 * 60; // 5 minutes
   // Rest client to send additional requests
   RestClient restClient;
 
@@ -237,27 +237,47 @@ QuantinuumServerHelper::processResults(ServerMessage &jobResponse,
   CUDAQ_INFO("Retrieving results from path: {}", resultPath);
   RestHeaders headers = generateRequestHeader();
   RestCookies cookies = getCookies();
+  // Retrieve the results
   auto resultResponse = restClient.get(resultPath, "", headers, false, cookies);
   CUDAQ_INFO("Job result response: {}\n", resultResponse.dump());
   auto results = resultResponse["data"]["attributes"]["counts_formatted"];
-  CUDAQ_INFO("Count data: {}", results.dump());
+  CUDAQ_DBG("Count data: {}", results.dump());
+  // Get the register names
+  auto bitResults = resultResponse["data"]["attributes"]["bits"];
+  std::vector<std::string> outputNames;
+  for (auto item : bitResults) {
+    CUDAQ_DBG("Bit data: {}", item.dump());
+    const auto registerName = item[0].get<std::string>();
+    outputNames.push_back(registerName);
+  }
 
-  // TODO: handle register mapping and qubit numbers
-  // This is just a very basic implementation that assumes all qubits are
-  // measured.
-  cudaq::CountsDictionary counts;
+  std::vector<CountsDictionary> registerResults(outputNames.size());
+  cudaq::CountsDictionary globalCounts;
   std::vector<std::string> bitStrings;
   for (const auto &element : results) {
     const auto bitString = element["bitstring"].get<std::string>();
+    assert(bitString.length() == outputNames.size());
     const auto count = element["count"].get<std::size_t>();
-    counts[bitString] = count;
+    globalCounts[bitString] = count;
     for (std::size_t i = 0; i < count; ++i) {
       bitStrings.push_back(bitString);
     }
+    // Populate the register results
+    for (std::size_t i = 0; i < outputNames.size(); ++i) {
+      registerResults[i][std::string{bitString[i]}] += count;
+    }
   }
-  cudaq::ExecutionResult result{counts, GlobalRegisterName};
+  std::vector<cudaq::ExecutionResult> allResults;
+  allResults.reserve(outputNames.size() + 1);
+  for (std::size_t i = 0; i < outputNames.size(); ++i) {
+    allResults.push_back({registerResults[i], outputNames[i]});
+  }
+
+  // Add the global register results
+  cudaq::ExecutionResult result{globalCounts, GlobalRegisterName};
   result.sequentialData = bitStrings;
-  return cudaq::sample_result{result};
+  allResults.push_back(result);
+  return cudaq::sample_result{allResults};
 }
 
 std::map<std::string, std::string>


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->


- Populate the sub-register results (indexed by register names) in the `sample_result`.

- Update the token expiry duration to 5 minutes.

- Update the result polling loop to check cookies during the loop, as the cookies may have expired while waiting.

