### PR TITLE
Try installing cublas first

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -959,6 +959,8 @@ jobs:
           dpkg -i cuda-keyring_1.1-1_all.deb
           cuda_version_suffix="$(echo ${{ matrix.cuda_version }} | tr . -)"
           apt-get update
+          # Install cublas first so it can be found. For some reason, cublas is
+          # not found if we install it after the other CUDA libraries.
           apt-get install -y --no-install-recommends \
             libcublas-$cuda_version_suffix
           if [ $(echo ${{ matrix.cuda_version }} | cut -d . -f1) -gt 11 ]; then 

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -959,12 +959,13 @@ jobs:
           dpkg -i cuda-keyring_1.1-1_all.deb
           cuda_version_suffix="$(echo ${{ matrix.cuda_version }} | tr . -)"
           apt-get update
+          apt-get install -y --no-install-recommends \
+            libcublas-$cuda_version_suffix
           if [ $(echo ${{ matrix.cuda_version }} | cut -d . -f1) -gt 11 ]; then 
             apt-get install -y --no-install-recommends \
             libnvjitlink-$cuda_version_suffix
           fi
           apt-get install -y --no-install-recommends \
-            libcublas-$cuda_version_suffix \
             libcurand-$cuda_version_suffix \
             cuda-cudart-$cuda_version_suffix \
             libcusolver-$cuda_version_suffix \


### PR DESCRIPTION
We have seen strange behavior in CI that is not reproducible locally.

The error is:
```
./a.out: error while loading shared libraries: libcublas.so.12: cannot open shared object file: No such file or directory
```
e.g. https://github.com/NVIDIA/cuda-quantum/actions/runs/16464800187/job/46543007819

There is a theory that installing cublas first will fix this.