### PR TITLE
Separating installation libs for cuda version 11 and version 12

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -960,7 +960,7 @@ jobs:
           cuda_version_suffix="$(echo ${{ matrix.cuda_version }} | tr . -)"
           apt-get update
           if [ $(echo ${{ matrix.cuda_version }} | cut -d . -f1) -gt 11 ]; then
-            apt-get install --reinstall -y --no-install-recommends \
+            apt-get install -y --no-install-recommends \
             cuda-cudart-$cuda_version_suffix \
             cuda-nvrtc-$cuda_version_suffix \
             libnvjitlink-$cuda_version_suffix \
@@ -969,7 +969,7 @@ jobs:
             libcusparse-$cuda_version_suffix \
             libcusolver-$cuda_version_suffix
           else
-            apt-get install --reinstall -y --no-install-recommends \
+            apt-get install -y --no-install-recommends \
             cuda-cudart-$cuda_version_suffix \
             cuda-nvrtc-$cuda_version_suffix \
             libcurand-$cuda_version_suffix \


### PR DESCRIPTION
Separating installation steps for cuda version 11 and version 12, as having a condition for `libnvjitlink` is causing apt-get install to install libs in diff order. 

Apt determines the dependencies, build a plan to install packages and dependencies and installs them in an order.