### PR TITLE
docker_images: pull is_versioned for all images

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -59,14 +59,14 @@ jobs:
     steps:
       - id: info
         run: |
+          is_versioned=${{ github.ref_type == 'tag' || startsWith(github.ref_name, 'releases/') || startsWith(github.ref_name, 'staging/') }}
+          echo "is_versioned=$is_versioned" >> $GITHUB_OUTPUT
           if [ -n "$(echo ${{ inputs.platforms }} | grep ',')" ]; then
             # multi-platform builds get no platform tag
             echo "runner=linux-amd64-cpu16" >> $GITHUB_OUTPUT
             echo "build_docs=${{ inputs.build_docs != 'false' }}" >> $GITHUB_OUTPUT
-            is_versioned=${{ github.ref_type == 'tag' || startsWith(github.ref_name, 'releases/') || startsWith(github.ref_name, 'staging/') }}
             has_continuous_deployment=${{ startsWith(github.ref_name, 'experimental/') || github.ref_name == 'main' }}
             push_to_ngc=`${{ inputs.environment && secrets.NGC_CREDENTIALS != '' }} && ($is_versioned || $has_continuous_deployment) && echo true || echo`
-            echo "is_versioned=$is_versioned" >> $GITHUB_OUTPUT
             echo "push_to_ngc=$push_to_ngc" >> $GITHUB_OUTPUT
           elif [ -n "$(echo ${{ inputs.platforms }} | grep -i arm)" ]; then
             platform_tag=`echo ${{ inputs.platforms }} | sed 's/linux\///g' | tr -d ' '`


### PR DESCRIPTION
Finished test - https://github.com/NVIDIA/cuda-quantum/actions/runs/16523873753/job/46735217782

Tested `test_native_arm` branch to make sure the manifest looks good for regular images -

```
$ cudaq_image=ghcr.io/nvidia/cuda-quantum@sha256:3d91d5e2efda119a44b5a5b2aad08b341f5eaf1b116b21c48daea87ae5cb2244
$ docker inspect $cudaq_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"'
amd64-cu11-test_native_arm-base
```



This is attempting to fix the releases image. Due to how releases works, it pulls the docker container and then looks at `org.opencontainers.image.version` from `docker inspect`.

Which causes it to be:

```
$ base_tag=`docker inspect $cudaqbase_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"'`
$ echo $base_tag
amd64-cu12-releases-v0.12.0-base
$ base_tag=$(echo "$base_tag" | sed -E 's/^(arm64-|amd64-)//')
$ echo $base_tag
cu12-releases-v0.12.0-base
```

This pulls out the `is_versioned` logic to both amd64/arm64 images, so that way when publishing does `docker inspect`, the logic is handled properly.

**Note**: I kept `push_to_ngc` logic strictly for multiplat, since we don't want to push plat specific images to ngc.