### PR TITLE
Fix masked publishing failures

### DIFF
--- a/docs/sphinx/applications/python/krylov.ipynb
+++ b/docs/sphinx/applications/python/krylov.ipynb
@@ -69,6 +69,7 @@
     "import numpy as np\n",
     "import scipy\n",
     "\n",
+    "%pip install cppe\n",
     "%pip install pyscf\n",
     "\n",
     "# Single-node, single gpu\n",


### PR DESCRIPTION
Fix masked publishing failures

1. Adding missing cppe lib for krylov nb