### PR TITLE
Fixing for Quantinuum tests

### DIFF
--- a/targettests/execution/qspan_slices.cpp
+++ b/targettests/execution/qspan_slices.cpp
@@ -32,8 +32,7 @@ __qpu__ void foo() {
   cudaq::qvector qubits(4);
   x(qubits);
   bar(qubits);
-
-  auto result = mz(qubits);
+  mz(qubits);
 }
 
 int main() {

--- a/targettests/execution/sudoku_2x2-reg_name.cpp
+++ b/targettests/execution/sudoku_2x2-reg_name.cpp
@@ -48,7 +48,7 @@ __qpu__ void grover() {
   oracle(qubits, ancilla);
   reflect_uniform(qubits);
 
-  auto groverQubits = mz(qubits);
+  mz(qubits);
 };
 
 int main() {


### PR DESCRIPTION
Removing assignment of a measurement result in a kernel

Fixes the errors below
```
Job failed to execute msg = [1000: Compile error: -1 Duplicate result tag: result]
```

and

```
Job failed to execute msg = [1000: Compile error: -1 Duplicate result tag: groverQubits]
```