### PR TITLE
typo in  qm_mm_pe.ipynb

### DIFF
--- a/docs/sphinx/applications/python/qm_mm_pe.ipynb
+++ b/docs/sphinx/applications/python/qm_mm_pe.ipynb
@@ -13,7 +13,7 @@
     "- Self-Consistent Field (SCF) – a classical iterative method used in quantum chemistry.\n",
     "- Polarizable Embedding (PE) – a technique to model the effect of an environment (like a solvent or protein) on a quantum system.\n",
     "\n",
-    "The goal is to simulate chemical systems on quantum computers (or simulator) by embedding them in a polarizable environment. In this tutorial, we will use CUDA-Q to implemnet the QM/MM framework and the CUDA-Q GPU accelerated simulator for running the simulation.\n",
+    "The goal is to simulate chemical systems on quantum computers (or simulator) by embedding them in a polarizable environment. In this tutorial, we will use CUDA-Q to implement the QM/MM framework and the CUDA-Q GPU accelerated simulator for running the simulation.\n",
     "\n",
     "## Key concepts:\n",
     "\n",


### PR DESCRIPTION
implemnet -> implement


### Description
There was a typo in the QMMM example notebook `implemnet`.
