### PR TITLE
Update run_kernel.rst

### DIFF
--- a/docs/sphinx/using/basics/run_kernel.rst
+++ b/docs/sphinx/using/basics/run_kernel.rst
@@ -155,7 +155,7 @@ count of qubits in state :math:`|1\rangle`:
         :end-before: [End Run1]
 
 The code above will execute the kernel multiple times (defined by `shots_count`) and return a list of 
-individual results. By default, the `shots_count` for `run` is 100.
+individual results. By default, the `shots_count` for `run` is 1000.
 
 You can process the results to get statistics or other insights:
 


### PR DESCRIPTION
The default shot_count for run is 1000 not 100.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
