### PR TITLE
Add fixture for setting/resetting target

### DIFF
--- a/python/tests/kernel/test_target_attributes.py
+++ b/python/tests/kernel/test_target_attributes.py
@@ -9,25 +9,32 @@
 import pytest
 import cudaq
 
-skipIfNoMQPU = pytest.mark.skipif(
+skipIfNoGPU = pytest.mark.skipif(
     not (cudaq.num_available_gpus() > 0 and cudaq.has_target('nvidia')),
-    reason="nvidia-mqpu backend not available")
+    reason="nvidia backend not available")
 
 
-@skipIfNoMQPU
-def test_target_valid_option_attribute():
+@pytest.fixture
+def do_something():
+    cudaq.set_target("nvidia", option="fp32")
+    yield "Running the tests."
+    cudaq.__clearKernelRegistries()
+    cudaq.reset_target()
+
+
+@skipIfNoGPU
+def test_target_valid_option_attribute(do_something):
     """Tests the target valid option attribute."""
 
-    cudaq.set_target("nvidia", option="mqpu")
     target = cudaq.get_target()
-    assert target.platform == "mqpu"
+    assert target.platform == "default"
 
 
-@skipIfNoMQPU
+@skipIfNoGPU
 def test_target_invalid_options_attribute():
     """Tests the target invalid options attribute."""
 
     with pytest.raises(RuntimeError) as e:
-        cudaq.set_target("nvidia", options="mqpu")
+        cudaq.set_target("nvidia", options="fp32")
     assert "The keyword `options` argument is not supported in cudaq.set_target()" in str(
         e.value)


### PR DESCRIPTION
Fixes publishing failure: https://github.com/NVIDIA/cuda-quantum/actions/runs/16610388285/job/46994338957#step:7:9371

1. Following tests just needs a single GPU with a default platform.
2. Adds a fixture to set/reset the target for a valid option's test
