### PR TITLE
Fixing the spell check tags and source link

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -65,6 +65,8 @@ extensions = [
 
 html_static_path = ['_static']
 html_js_files = ['filter.js']
+# Disable source links in the HTML output.
+html_show_sourcelink = False
 
 # Enable dynamic filtering in sphinx-needs
 needs_include_needs = True  # Enable needs processing

--- a/docs/sphinx/using/applications.rst
+++ b/docs/sphinx/using/applications.rst
@@ -6,7 +6,7 @@ CUDA-Q Applications
 .. 2. Add an html block along with any tags
 .. 3. Add a preview image in the _static folder
 
-:spellcheck-disable:
+.. |:spellcheck-disable:| replace:: \
 
 .. toctree::
    :maxdepth: 1
@@ -42,8 +42,7 @@ CUDA-Q Applications
    /applications/python/mps_encoding
    /applications/python/qm_mm_pe
 
-:spellcheck-enable:
-
+.. |:spellcheck-enable:| replace:: \
 
 .. raw:: html
 


### PR DESCRIPTION
Fixing the spell check tags and source link

# Before
<img width="720" height="382" alt="image_720" src="https://github.com/user-attachments/assets/f1082117-3090-4165-9371-320e981899d4" />

# After
<img width="1441" height="894" alt="image" src="https://github.com/user-attachments/assets/8cd0f41e-2a40-46f0-b826-6a9de654ecec" />
