### PR TITLE
[C++ bridge] Fix for issue 3239

### DIFF
--- a/test/AST-Quake/separate_compilation.cpp
+++ b/test/AST-Quake/separate_compilation.cpp
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %cpp_std %s | cudaq-opt | FileCheck %s
+
+#include "cudaq.h"
+
+__qpu__ uint64_t otherKernel(std::vector<cudaq::measure_result> &x);
+
+__qpu__ uint64_t test_entry_point() {
+  cudaq::qvector q(5);
+  auto results = cudaq::mz(q);
+  return otherKernel(results);
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_test_entry_point.
+// CHECK-SAME:      () -> i64 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+// CHECK:           %[[VAL_3:.*]] = call @__nvqpp__mlirgen__function_otherKernel.{{.*}}(%{{.*}}) : (!cc.stdvec<i1>) -> i64


### PR DESCRIPTION
Add code in the bridge to translate calls to host-side entry-point kernels directly into device-side calls in the bridge. This is meant to prevent exposing mysterious calling convention failures to the user.

Fixes #3239

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
