### PR TITLE
ci: bump python 3.10 -> python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
     strategy:
       matrix:
         platform: [amd64, arm64]
-        python_version: ['3.10', '3.13']
+        python_version: ['3.11', '3.13']
         cuda_version: ["11.8", "12.0"]
       fail-fast: false
     uses: ./.github/workflows/python_wheels.yml
@@ -255,7 +255,7 @@ jobs:
     uses: ./.github/workflows/python_metapackages.yml
     with:
       cudaq_version: ${{ needs.python_wheels.outputs.cudaq_version }}
-      python_versions: "['3.10', '3.13']"
+      python_versions: "['3.11', '3.13']"
       cuda_versions: "['', '11.8', '12.0']"
       wheel_artifacts: 'pycudaq-*'
 


### PR DESCRIPTION
Build Python 3.11 as the minimum version for CI, since we now build Python 3.13 and will drop 3.10 soon.