### PR TITLE
Bump to Fedora:41 as Fedora:38/39 are EOL

### DIFF
--- a/.github/workflows/config/ghcr_config.json
+++ b/.github/workflows/config/ghcr_config.json
@@ -77,7 +77,7 @@
             "platforms": "linux/amd64,linux/arm64",
             "tags": 
             [
-                "38", "39"
+                "41"
             ]
         },
         {

--- a/.github/workflows/config/ghcr_config.json
+++ b/.github/workflows/config/ghcr_config.json
@@ -77,7 +77,7 @@
             "platforms": "linux/amd64,linux/arm64",
             "tags": 
             [
-                "41"
+                "38", "39", "41"
             ]
         },
         {

--- a/.github/workflows/config/ghcr_config.json
+++ b/.github/workflows/config/ghcr_config.json
@@ -77,7 +77,7 @@
             "platforms": "linux/amd64,linux/arm64",
             "tags": 
             [
-                "38", "39", "41"
+                "38", "39"
             ]
         },
         {

--- a/.github/workflows/config/validation_config.json
+++ b/.github/workflows/config/validation_config.json
@@ -77,7 +77,7 @@
             {
                 "libcdev_package": "glibc-devel",
                 "cudart_version": "12.4",
-                "cuda_distribution": "fedora39"
+                "cuda_distribution": "fedora41"
             }
         },
         {

--- a/.github/workflows/config/validation_config.json
+++ b/.github/workflows/config/validation_config.json
@@ -88,7 +88,7 @@
                 "ubuntu:22.04",
                 "redhat/ubi8:8.0",
                 "opensuse/leap:15.5",
-                "fedora:38"
+                "fedora:41"
             ],
             "ubuntu:22.04": 
             {
@@ -108,7 +108,7 @@
                 "cudart_version": "11.8",
                 "cuda_distribution": "opensuse15"
             },
-            "fedora:38": 
+            "fedora:41": 
             {
                 "libcdev_package": "glibc-devel",
                 "cudart_version": "11.8",
@@ -143,7 +143,7 @@
             [
                 "ubuntu:22.04",
                 "redhat/ubi8:8.0",
-                "fedora:38"
+                "fedora:41"
             ],
             "ubuntu:22.04": 
             { 
@@ -157,7 +157,7 @@
                 "cudart_version": "11.8",
                 "cuda_distribution": "rhel9"
             },
-            "fedora:38": 
+            "fedora:41": 
             {
                 "libcdev_package": "glibc-devel",
                 "cudart_version": "11.8",

--- a/.github/workflows/config/validation_config.json
+++ b/.github/workflows/config/validation_config.json
@@ -6,7 +6,7 @@
             "operating_systems": 
             [
                 "ubuntu:22.04",
-                "fedora:39"
+                "fedora:41"
             ]
         },
         {
@@ -15,7 +15,7 @@
             [
                 "ubuntu:22.04",
                 "debian:12",
-                "fedora:38",
+                "fedora:41",
                 "redhat/ubi9:9.2"
             ]
         },
@@ -24,7 +24,7 @@
             "operating_systems": 
             [
                 "ubuntu:24.04",
-                "fedora:39",
+                "fedora:41",
                 "redhat/ubi9:9.2"
             ]
         },
@@ -32,7 +32,7 @@
             "version": "3.13",
             "operating_systems":
             [
-                "fedora:39"
+                "fedora:41"
             ]
         }
     ],
@@ -47,7 +47,7 @@
                 "debian:12",
                 "redhat/ubi9:9.2",
                 "opensuse/leap:15.5",
-                "fedora:39"
+                "fedora:41"
             ],
             "ubuntu:22.04": 
             {
@@ -73,7 +73,7 @@
                 "cudart_version": "12.0",
                 "cuda_distribution": "opensuse15"
             },
-            "fedora:39": 
+            "fedora:41":
             {
                 "libcdev_package": "glibc-devel",
                 "cudart_version": "12.4",

--- a/docker/test/wheels/fedora.Dockerfile
+++ b/docker/test/wheels/fedora.Dockerfile
@@ -15,9 +15,7 @@ ARG preinstalled_modules="numpy pytest nvidia-cublas-cu12"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Some Python versions need the latest version of libexpat on Fedora, and the
-# base fedora:41 image doesn't have the latest version installed.
-RUN dnf update -y --nobest expat \
+RUN dnf install -y --refresh --setopt=install_weak_deps=False expat \
     && dnf install -y --nobest --setopt=install_weak_deps=False wget \
         python$(echo $python_version | tr -d .) \
     && python${python_version} -m ensurepip --upgrade

--- a/docker/test/wheels/fedora.Dockerfile
+++ b/docker/test/wheels/fedora.Dockerfile
@@ -6,7 +6,7 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-ARG base_image=fedora:38
+ARG base_image=fedora:41
 FROM ${base_image}
 
 ARG python_version=3.10
@@ -16,7 +16,7 @@ ARG preinstalled_modules="numpy pytest nvidia-cublas-cu12"
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Some Python versions need the latest version of libexpat on Fedora, and the
-# base fedora:38 image doesn't have the latest version installed.
+# base fedora:41 image doesn't have the latest version installed.
 RUN dnf update -y --nobest expat \
     && dnf install -y --nobest --setopt=install_weak_deps=False wget \
         python$(echo $python_version | tr -d .) \

--- a/docs/sphinx/using/install/data_center_install.rst
+++ b/docs/sphinx/using/install/data_center_install.rst
@@ -52,7 +52,7 @@ will be installed and used.
   with the `AlmaLinux 8 image <https://hub.docker.com/u/almalinux>`__ that
   serves as the base image for the `manylinux_2_28 image
   <https://github.com/pypa/manylinux>`__, and should work for the operating
-  systems CentOS 8, Debian 11 and 12, Fedora 38 and 39, OpenSUSE/SLED/SLES 15.5
+  systems CentOS 8, Debian 11 and 12, Fedora 41, OpenSUSE/SLED/SLES 15.5
   and 15.6, RHEL 8 and 9, Rocky 8 and 9, and Ubuntu 24.04 and 22.04. Other 
   operating systems may work, but have not been tested.
 - `Bash <https://www.gnu.org/software/bash/>`__ shell. The CUDA-Q 

--- a/docs/sphinx/using/install/local_installation.rst
+++ b/docs/sphinx/using/install/local_installation.rst
@@ -879,7 +879,7 @@ The following table summarizes the required components.
     * - Operating System
       - Linux
     * - Tested Distributions
-      - CentOS 8; Debian 11, 12; Fedora 38, 39; OpenSUSE/SLED/SLES 15.5, 15.6; RHEL 8, 9; Rocky 8, 9; Ubuntu 22.04, 24.04
+      - CentOS 8; Debian 11, 12; Fedora 41; OpenSUSE/SLED/SLES 15.5, 15.6; RHEL 8, 9; Rocky 8, 9; Ubuntu 22.04, 24.04
     * - Python versions
       - 3.10+
 


### PR DESCRIPTION
We are seeing network errors with Fedora:39 https://github.com/NVIDIA/cuda-quantum/actions/runs/16786910932/job/47541785386?pr=3309#step:6:67

Fedora:39 has been EOL for almost a year. Update our runners to use a supported version.

Also, remove suggestion for supported on Fedora:38/39 and update to Fedora:41

Upstream fedora bug - https://discussion.fedoraproject.org/t/error-504-404-when-updating-fedora-39/161798/2