### PR TITLE
Cache Fedora 42 && redhat10

### DIFF
--- a/.github/workflows/config/ghcr_config.json
+++ b/.github/workflows/config/ghcr_config.json
@@ -77,7 +77,7 @@
             "platforms": "linux/amd64,linux/arm64",
             "tags": 
             [
-                "38", "39", "41"
+                "38", "39", "41", "42"
             ]
         },
         {
@@ -94,6 +94,14 @@
             "tags": 
             [
                 "9.2"
+            ]
+        },
+        {
+            "source": "redhat/ubi10",
+            "platforms": "linux/amd64,linux/arm64",
+            "tags":
+            [
+                "10.0"
             ]
         },
         {


### PR DESCRIPTION
Fedora 42 is out as the latest version, and so is redhat10.

Fedora always has a 13 month cadence to EOL versions. Fedora 41 will EOL this year, 2025 on November 19th[0].

[0] - https://fedorapeople.org/groups/schedule/f-41/f-41-key-tasks.html