### PR TITLE
Addressing issue# 2830

### DIFF
--- a/lib/Optimizer/Transforms/QuakePropagateMetadata.cpp
+++ b/lib/Optimizer/Transforms/QuakePropagateMetadata.cpp
@@ -40,12 +40,7 @@ public:
     ModuleOp moduleOp = getOperation();
     /// NOTE: If the module has an occurrence of `quake.apply` then the step to
     /// build call graph fails. Hence, we skip the pass in such cases.
-    if (moduleOp->getRegion(0)
-            .walk([](Operation *op) {
-              if (isa<quake::ApplyOp>(op))
-                return WalkResult::interrupt();
-              return WalkResult::advance();
-            })
+    if (moduleOp.walk([](quake::ApplyOp op) { return WalkResult::interrupt(); })
             .wasInterrupted()) {
       LLVM_DEBUG(
           llvm::dbgs()

--- a/lib/Optimizer/Transforms/QuakePropagateMetadata.cpp
+++ b/lib/Optimizer/Transforms/QuakePropagateMetadata.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Analysis/CallGraph.h"
@@ -37,6 +38,20 @@ public:
   /// false positives.
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+    /// NOTE: If the module has an occurrence of `quake.apply` then the step to
+    /// build call graph fails. Hence, we skip the pass in such cases.
+    if (moduleOp->getRegion(0)
+            .walk([](Operation *op) {
+              if (isa<quake::ApplyOp>(op))
+                return WalkResult::interrupt();
+              return WalkResult::advance();
+            })
+            .wasInterrupted()) {
+      LLVM_DEBUG(
+          llvm::dbgs()
+          << "Skipping `QuakePropagateMetadataPass` due to `quake.apply`\n");
+      return;
+    }
     // Build the call graph of the module
     const mlir::CallGraph callGraph(moduleOp);
     // Use PostOrderTraversal to get the ordered list of FuncOps and a map of

--- a/python/tests/kernel/test_sample_kernel.py
+++ b/python/tests/kernel/test_sample_kernel.py
@@ -37,9 +37,6 @@ def test_simple_sampling_ghz():
     assert '0' * 10 in counts and '1' * 10 in counts
 
 
-# FIXME:https://github.com/NVIDIA/cuda-quantum/issues/2830
-# Crash due to conditional feedback:
-@pytest.mark.skip
 def test_simple_sampling_qpe():
     """Test that we can build up a set of kernels, compose them, and sample."""
 

--- a/test/Transforms/propagate_metadata_apply.qke
+++ b/test/Transforms/propagate_metadata_apply.qke
@@ -22,7 +22,7 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__controlled_operat
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__controlled_operation(
-// CHECK-SAME:                                                      %[[VAL_0:.*]]: !cc.callable<(!quake.ref) -> ()>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-SAME:               %[[VAL_0:.*]]: !cc.callable<(!quake.ref) -> ()>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
 // CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
 // CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_1]][0] : (!quake.veq<2>) -> !quake.ref
 // CHECK:           quake.h %[[VAL_2]] : (!quake.ref) -> ()

--- a/test/Transforms/propagate_metadata_apply.qke
+++ b/test/Transforms/propagate_metadata_apply.qke
@@ -1,4 +1,3 @@
-
 // ========================================================================== //
 // Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                 //
 // All rights reserved.                                                       //
@@ -20,6 +19,8 @@ module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__controlled_operat
     return
   }
 }
+
+// Test here is that this does not crash
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__controlled_operation(
 // CHECK-SAME:               %[[VAL_0:.*]]: !cc.callable<(!quake.ref) -> ()>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {

--- a/test/Transforms/propagate_metadata_apply.qke
+++ b/test/Transforms/propagate_metadata_apply.qke
@@ -1,0 +1,33 @@
+
+// ========================================================================== //
+// Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --quake-propagate-metadata %s | FileCheck %s
+
+module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__controlled_operation = "__nvqpp__mlirgen__controlled_operation_PyKernelEntryPointRewrite"}} {
+  func.func @__nvqpp__mlirgen__controlled_operation(%arg0: !cc.callable<(!quake.ref) -> ()>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+    %0 = quake.alloca !quake.veq<2>
+    %1 = quake.extract_ref %0[0] : (!quake.veq<2>) -> !quake.ref
+    quake.h %1 : (!quake.ref) -> ()
+    %2 = quake.extract_ref %0[1] : (!quake.veq<2>) -> !quake.ref
+    quake.apply %arg0 [%1] %2 : (!quake.ref, !quake.ref) -> ()
+    %measOut = quake.mz %0 : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__controlled_operation(
+// CHECK-SAME:                                                      %[[VAL_0:.*]]: !cc.callable<(!quake.ref) -> ()>) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[VAL_2:.*]] = quake.extract_ref %[[VAL_1]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           quake.h %[[VAL_2]] : (!quake.ref) -> ()
+// CHECK:           %[[VAL_3:.*]] = quake.extract_ref %[[VAL_1]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:           quake.apply %[[VAL_0]] {{\[}}%[[VAL_2]]] %[[VAL_3]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:           %[[VAL_4:.*]] = quake.mz %[[VAL_1]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
* Update the pass to propagate quake metadata to be skipped if the module has `quake.apply` instruction.
* The pass is expected to be called again in the QIR pipeline by the time apply specialization and other passes have been run.

https://github.com/NVIDIA/cuda-quantum/issues/2830