### PR TITLE
Fix docs for IONQ

### DIFF
--- a/docs/sphinx/using/backends/hardware/iontrap.rst
+++ b/docs/sphinx/using/backends/hardware/iontrap.rst
@@ -68,7 +68,7 @@ Submitting
 
         .. code:: bash
 
-        nvq++ --target ionq src.cpp
+            nvq++ --target ionq src.cpp
 
         This will take the API key and handle all authentication with, and submission to, the IonQ QPU(s). By default, quantum kernel code will be submitted to the IonQsimulator.
 


### PR DESCRIPTION
Adding a tab for a cmd to be shown inside the code block