### PR TITLE
Fix bug#3326: tensor wrapper needs to use global dimension map

### DIFF
--- a/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
+++ b/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
@@ -40,7 +40,7 @@ all_models = [
     TestBatchedCavityModelTimeDependentCollapseOp,
     TestBatchedCavityModelSuperOperator, TestBatchedCavityModelWithBatchSize,
     TestBatchedCavityModelSuperOperatorBroadcastInputState,
-    TestBatchedCavityModelSuperOperatorWithBatchSize
+    TestBatchedCavityModelSuperOperatorWithBatchSize, TestBug3326
 ]
 
 

--- a/python/tests/dynamics/system_models.py
+++ b/python/tests/dynamics/system_models.py
@@ -414,6 +414,99 @@ class TestCallbackTensor(TestSystem):
         np.testing.assert_allclose(ideal_results[2][-1], -1, atol=0.1)
 
 
+class TestBug3326(TestSystem):
+
+    def case1(self, integrator):
+        # This test is to reproduce the bug reported in issue #3326
+        # Number of spins
+        N = 3
+        dimensions = {i: 2 for i in range(N)}
+
+        # Observable
+        observables = []
+        for i in range(N):
+            ob = spin.empty()
+            ob += spin.z(i) / N
+            observables.append(ob)
+
+        H = spin.empty()
+        for i in range(N):
+            H += spin.x(i)
+        for i in range(N - 1):
+            H += spin.y(i) * spin.z(i + 1)
+
+        steps = np.linspace(0.0, 1, 200)
+        schedule = Schedule(steps, ["time"])
+
+        gamma_dephasing = 0.05
+
+        # Run the simulation
+        evolution_result = cudaq.evolve(
+            H,
+            dimensions,
+            schedule,
+            initial_state=cudaq.dynamics.InitialState.ZERO,
+            observables=observables,
+            collapse_operators=[np.sqrt(gamma_dephasing) * spin.z(0)],
+            store_intermediate_results=cudaq.IntermediateResultSave.
+            EXPECTATION_VALUE,
+            integrator=integrator())
+        assert len(evolution_result.expectation_values()) == len(steps)
+
+    def case2(self, integrator):
+        # This test is to reproduce the bug reported in issue #3326 (comment)
+        w_q0 = 5
+        w_q1 = 5
+        w_tunc = 7
+
+        anharmonicity = 0.21
+        tunc_anharmonicity = 0.13
+        N_tuncs = 3
+        dim = {0: N_tuncs, 1: N_tuncs, 2: N_tuncs}
+
+        H_q0 = w_q0 * boson.number(0) - anharmonicity * boson.number(0) * (
+            boson.number(0) - 1) / 2
+        H_q1 = w_q1 * boson.number(1) - anharmonicity * boson.number(1) * (
+            boson.number(1) - 1) / 2
+        H_tc = w_tunc * boson.create(2) * boson.annihilate(
+            2) - tunc_anharmonicity * boson.number(2) * (boson.number(2) -
+                                                         1) / 2
+        H = H_tc + H_q0 + H_q1
+
+        q0_state = cp.zeros((N_tuncs, N_tuncs), dtype=cp.complex128)
+        q0_state[1, 1] = 1.0
+
+        q1_state = cp.zeros((N_tuncs, N_tuncs), dtype=cp.complex128)
+        q1_state[0, 0] = 1.0
+
+        tc_state = cp.zeros((N_tuncs, N_tuncs), dtype=cp.complex128)
+        tc_state[0, 0] = 1.0
+
+        composite_state = cp.kron(cp.kron(tc_state, q1_state), q0_state)
+        rho0 = cudaq.State.from_data(composite_state)
+
+        steps = np.linspace(0, 10, 1000)
+        schedule = Schedule(steps, ["t"])
+
+        evolution_result = cudaq.evolve(
+            H,
+            dim,
+            schedule,
+            rho0,
+            observables=[boson.number(0),
+                         boson.number(1),
+                         boson.number(2)],
+            collapse_operators=[],
+            store_intermediate_results=cudaq.IntermediateResultSave.
+            EXPECTATION_VALUE,
+            integrator=integrator())
+        assert len(evolution_result.expectation_values()) == len(steps)
+
+    def run_tests(self, integrator):
+        self.case1(integrator)
+        self.case2(integrator)
+
+
 class TestInitialStateEnum(TestSystem):
 
     def run_tests(self, integrator):

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -37,7 +37,7 @@ all_models = [
     TestBatchedCavityModelTimeDependentCollapseOp,
     TestBatchedCavityModelSuperOperator, TestBatchedCavityModelWithBatchSize,
     TestBatchedCavityModelSuperOperatorBroadcastInputState,
-    TestBatchedCavityModelSuperOperatorWithBatchSize
+    TestBatchedCavityModelSuperOperatorWithBatchSize, TestBug3326
 ]
 
 

--- a/runtime/nvqir/cudensitymat/CuDensityMatCallbackConverter.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatCallbackConverter.cpp
@@ -76,8 +76,10 @@ cudaq::dynamics::CuDensityMatOpConverter::wrapScalarCallback(
 cudensitymatWrappedTensorCallback_t
 cudaq::dynamics::CuDensityMatOpConverter::wrapTensorCallback(
     const std::vector<matrix_handler> &matrixOps,
-    const std::vector<std::string> &paramNames) {
-  m_tensorCallbacks.push_back(TensorCallBackContext(matrixOps, paramNames));
+    const std::vector<std::string> &paramNames,
+    const cudaq::dimension_map &dims) {
+  m_tensorCallbacks.push_back(
+      TensorCallBackContext(matrixOps, paramNames, dims));
   TensorCallBackContext *storedCallbackContext = &m_tensorCallbacks.back();
   using WrapperFuncType = int32_t (*)(
       cudensitymatTensorCallback_t, cudensitymatElementaryOperatorSparsity_t,
@@ -123,10 +125,9 @@ cudaq::dynamics::CuDensityMatOpConverter::wrapTensorCallback(
                      context->paramNames[i], param_map[context->paramNames[i]]);
       }
 
-      cudaq::dimension_map dimensions;
+      cudaq::dimension_map &dimensions = context->dimensions;
       std::size_t totalDim = 1;
       for (std::size_t i = 0; i < num_modes; ++i) {
-        dimensions[i] = modeExtents[i];
         totalDim *= modeExtents[i];
       }
 

--- a/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
@@ -201,6 +201,7 @@ cudaq::dynamics::CuDensityMatOpConverter::createElementaryOperator(
     opNames.emplace_back(cudaq::spin_op::y(0).begin()->to_string(false));
     opNames.emplace_back(opNames.back() + "_dagger");
     opNames.emplace_back(cudaq::spin_op::z(0).begin()->to_string(false));
+    opNames.emplace_back(opNames.back() + "_dagger");
     return opNames;
   }();
 
@@ -221,7 +222,7 @@ cudaq::dynamics::CuDensityMatOpConverter::createElementaryOperator(
         parameters.begin(), parameters.end());
     auto ks = std::views::keys(sortedParameters);
     const std::vector<std::string> keys{ks.begin(), ks.end()};
-    wrappedTensorCallback = wrapTensorCallback(elemOps, keys);
+    wrappedTensorCallback = wrapTensorCallback(elemOps, keys, dimensions);
   }
 
   const auto batchSize = elemOps.size();

--- a/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.h
+++ b/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.h
@@ -107,10 +107,12 @@ private:
   struct TensorCallBackContext {
     std::vector<matrix_handler> tensorOps;
     std::vector<std::string> paramNames;
+    cudaq::dimension_map dimensions;
 
     TensorCallBackContext(const std::vector<matrix_handler> &tensor_ops,
-                          const std::vector<std::string> &param_names)
-        : tensorOps(tensor_ops), paramNames(param_names){};
+                          const std::vector<std::string> &param_names,
+                          const cudaq::dimension_map &dims)
+        : tensorOps(tensor_ops), paramNames(param_names), dimensions(dims){};
   };
 
   cudensitymatWrappedScalarCallback_t
@@ -118,7 +120,8 @@ private:
                      const std::vector<std::string> &paramNames);
   cudensitymatWrappedTensorCallback_t
   wrapTensorCallback(const std::vector<matrix_handler> &matrixOps,
-                     const std::vector<std::string> &paramNames);
+                     const std::vector<std::string> &paramNames,
+                     const cudaq::dimension_map &dims);
   void appendToCudensitymatOperator(
       cudensitymatOperator_t &cudmOperator,
       const std::unordered_map<std::string, std::complex<double>> &parameters,


### PR DESCRIPTION


<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

The wrapper for the tensor callback shouldn't use the `mode_extents` callback arguments as the dimension map, as it was referring to the extents of the tensors, not the sub-systems' dimensions.

Hence, add the dimension map, which is required by `op.to_matrix`, to the wrapper context.

Adding test cases based on bug reports.


Resolved #3326 