### PR TITLE
Cache redhat/ubi8:8.10 and redhat/ubi9:9.6

### DIFF
--- a/.github/workflows/config/ghcr_config.json
+++ b/.github/workflows/config/ghcr_config.json
@@ -93,7 +93,7 @@
             "platforms": "linux/amd64,linux/arm64",
             "tags": 
             [
-                "9.2", "9.10"
+                "9.2", "9.6"
             ]
         },
         {

--- a/.github/workflows/config/ghcr_config.json
+++ b/.github/workflows/config/ghcr_config.json
@@ -85,7 +85,7 @@
             "platforms": "linux/amd64,linux/arm64",
             "tags": 
             [
-                "8.0"
+                "8.0", "8.10"
             ]
         },
         {
@@ -93,7 +93,7 @@
             "platforms": "linux/amd64,linux/arm64",
             "tags": 
             [
-                "9.2"
+                "9.2", "9.10"
             ]
         },
         {


### PR DESCRIPTION
The CI currently uses the following versions:
* redhat/ubi8:8.0
* redhat/ubi9:9.2

`8.0` and `9.2` is EOL.[0]

Update to use the latest tags which will be supported until 2029 for `8.10` and 2027 for `9.6`. This PR just adds the newest tags so they can be tested in a future PR. Once the old tags are not being used, they will be removed.

<img width="720" height="368" alt="image" src="https://github.com/user-attachments/assets/65b67943-2fb3-476a-8f5a-cf43804a1d11" />

<img width="719" height="389" alt="image" src="https://github.com/user-attachments/assets/66289330-e251-4bbb-bfd5-1894888d4782" />


[0] - https://access.redhat.com/support/policy/updates/errata
