### PR TITLE
[Logging] Log tensornet expectation calculation Flops as info

### DIFF
--- a/runtime/nvqir/cutensornet/tensornet_state.inc
+++ b/runtime/nvqir/cutensornet/tensornet_state.inc
@@ -814,6 +814,14 @@ TensorNetState<ScalarType>::computeExpVals(
                                       /*cudaStream*/ 0));
   }
 
+  if (::cudaq::details::should_log(::cudaq::details::LogLevel::info)) {
+    double flops = 0.0;
+    HANDLE_CUTN_ERROR(cutensornetExpectationGetInfo(
+        m_cutnHandle, tensorNetworkExpectation,
+        CUTENSORNET_EXPECTATION_INFO_FLOPS, &flops, sizeof(flops)));
+    cudaq::info("Total flop count = {} GFlop.", (flops / 1e9));
+  }
+
   // Attach the workspace buffer
   int64_t worksize{0};
   HANDLE_CUTN_ERROR(cutensornetWorkspaceGetMemorySize(
@@ -947,6 +955,14 @@ std::complex<ScalarType> TensorNetState<ScalarType>::computeExpVal(
     HANDLE_CUTN_ERROR(cutensornetExpectationPrepare(
         m_cutnHandle, tensorNetworkExpectation, scratchPad.scratchSize,
         workDesc, /*cudaStream*/ 0));
+  }
+
+  if (::cudaq::details::should_log(::cudaq::details::LogLevel::info)) {
+    double flops = 0.0;
+    HANDLE_CUTN_ERROR(cutensornetExpectationGetInfo(
+        m_cutnHandle, tensorNetworkExpectation,
+        CUTENSORNET_EXPECTATION_INFO_FLOPS, &flops, sizeof(flops)));
+    cudaq::info("Total flop count = {} GFlop.", (flops / 1e9));
   }
 
   // Attach the workspace buffer


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

This Flops info is exposed by cutensornet and could be useful to assess the optimality of the contraction path, e.g., to debug runtime variation.

 