### PR TITLE
[py] Fix loop creation in PyASTBridge

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -627,7 +627,7 @@ class PyASTBridge(ast.NodeVisitor):
                                             [iterVar], rawIndex).result
             cc.StoreOp(castedEle, targetEleAddr)
 
-        self.createInvariantForLoop(sourceSize, bodyBuilder)
+        self.createForLoop(sourceSize, bodyBuilder, invariant=True)
         return cc.StdvecInitOp(targetVecTy, targetPtr, length=sourceSize).result
 
     def __insertDbgStmt(self, value, dbgStmt):
@@ -808,15 +808,16 @@ class PyASTBridge(ast.NodeVisitor):
             for i, target in enumerate(targets)
         ]
 
-    def createInvariantForLoop(self,
-                               endVal,
-                               bodyBuilder,
-                               startVal=None,
-                               stepVal=None,
-                               isDecrementing=False,
-                               elseStmts=None):
+    def createForLoop(self,
+                      endVal,
+                      bodyBuilder,
+                      startVal=None,
+                      stepVal=None,
+                      isDecrementing=False,
+                      elseStmts=None,
+                      invariant=False):
         """
-        Create an invariant loop using the CC dialect. 
+        Create a loop using the CC dialect. 
         """
         startVal = self.getConstantInt(0) if startVal == None else startVal
         stepVal = self.getConstantInt(1) if stepVal == None else stepVal
@@ -860,7 +861,9 @@ class PyASTBridge(ast.NodeVisitor):
                     cc.ContinueOp(elseBlock.arguments)
                 self.symbolTable.popScope()
 
-        loop.attributes.__setitem__('invariant', UnitAttr.get())
+        if invariant:
+            loop.attributes['invariant'] = UnitAttr.get()
+
         return
 
     def __applyQuantumOperation(self, opName, parameters, targets):
@@ -877,7 +880,7 @@ class PyASTBridge(ast.NodeVisitor):
 
                 veqSize = quake.VeqSizeOp(self.getIntegerType(),
                                           quantumValue).result
-                self.createInvariantForLoop(veqSize, bodyBuilder)
+                self.createForLoop(veqSize, bodyBuilder, invariant=True)
             elif quake.RefType.isinstance(quantumValue.type):
                 opCtor([], parameters, [], [quantumValue])
             else:
@@ -1711,11 +1714,12 @@ class PyASTBridge(ast.NodeVisitor):
                     incrementedCounter = arith.AddIOp(loadedCounter, one).result
                     cc.StoreOp(incrementedCounter, counter)
 
-                self.createInvariantForLoop(endVal,
-                                            bodyBuilder,
-                                            startVal=startVal,
-                                            stepVal=stepVal,
-                                            isDecrementing=isDecrementing)
+                self.createForLoop(endVal,
+                                   bodyBuilder,
+                                   startVal=startVal,
+                                   stepVal=stepVal,
+                                   isDecrementing=isDecrementing,
+                                   invariant=True)
 
                 self.pushValue(iterable)
                 self.pushValue(actualSize)
@@ -1812,7 +1816,7 @@ class PyASTBridge(ast.NodeVisitor):
                         DenseI64ArrayAttr.get([1], context=self.ctx)).result
                     cc.StoreOp(element, eleAddr)
 
-                self.createInvariantForLoop(totalSize, bodyBuilder)
+                self.createForLoop(totalSize, bodyBuilder, invariant=True)
                 self.pushValue(enumIterable)
                 self.pushValue(totalSize)
                 return
@@ -1921,7 +1925,7 @@ class PyASTBridge(ast.NodeVisitor):
 
                     veqSize = quake.VeqSizeOp(self.getIntegerType(),
                                               target).result
-                    self.createInvariantForLoop(veqSize, bodyBuilder)
+                    self.createForLoop(veqSize, bodyBuilder, invariant=True)
                     return
                 elif quake.RefType.isinstance(target.type):
                     opCtor([], [], [], [target], is_adj=True)
@@ -2002,7 +2006,7 @@ class PyASTBridge(ast.NodeVisitor):
 
                     veqSize = quake.VeqSizeOp(self.getIntegerType(),
                                               target).result
-                    self.createInvariantForLoop(veqSize, bodyBuilder)
+                    self.createForLoop(veqSize, bodyBuilder, invariant=True)
                     return
                 self.emitFatalError(
                     'reset quantum operation on incorrect type {}.'.format(
@@ -2772,7 +2776,7 @@ class PyASTBridge(ast.NodeVisitor):
 
                         veqSize = quake.VeqSizeOp(self.getIntegerType(),
                                                   target).result
-                        self.createInvariantForLoop(veqSize, bodyBuilder)
+                        self.createForLoop(veqSize, bodyBuilder, invariant=True)
                         return
                     elif quake.RefType.isinstance(target.type):
                         opCtor([], [], [], [target], is_adj=True)
@@ -2852,7 +2856,7 @@ class PyASTBridge(ast.NodeVisitor):
 
                         veqSize = quake.VeqSizeOp(self.getIntegerType(),
                                                   target).result
-                        self.createInvariantForLoop(veqSize, bodyBuilder)
+                        self.createForLoop(veqSize, bodyBuilder, invariant=True)
                         return
                     elif quake.RefType.isinstance(target.type):
                         opCtor([], [param], [], [target], is_adj=True)
@@ -2930,7 +2934,7 @@ class PyASTBridge(ast.NodeVisitor):
 
                         veqSize = quake.VeqSizeOp(self.getIntegerType(),
                                                   target).result
-                        self.createInvariantForLoop(veqSize, bodyBuilder)
+                        self.createForLoop(veqSize, bodyBuilder, invariant=True)
                         return
                     elif quake.RefType.isinstance(target.type):
                         opCtor([], params, [], [target], is_adj=True)
@@ -3031,14 +3035,21 @@ class PyASTBridge(ast.NodeVisitor):
                            node.generators[0].iter)
             if quake.VeqType.isinstance(
                     self.symbolTable[node.generators[0].iter.id].type):
-                # now we know we have `[expr(r) for r in iterable]`
-                # reuse what we do in `visit_For()`
-                forNode = ast.For()
-                forNode.iter = node.generators[0].iter
-                forNode.target = node.generators[0].target
-                forNode.body = [node.elt]
-                forNode.orelse = []
-                self.visit_For(forNode)
+                iterable = self.symbolTable[node.generators[0].iter.id]
+                totalSize = quake.VeqSizeOp(self.getIntegerType(),
+                                            iterable).result
+
+                def bodyBuilder(iterVar):
+                    self.symbolTable.pushScope()
+                    q = quake.ExtractRefOp(self.getRefType(),
+                                           iterable,
+                                           -1,
+                                           index=iterVar).result
+                    self.symbolTable[node.generators[0].target.id] = q
+                    self.visit(node.elt)
+                    self.symbolTable.popScope()
+
+                self.createForLoop(totalSize, bodyBuilder, invariant=True)
                 return
 
         # General case of
@@ -3107,7 +3118,7 @@ class PyASTBridge(ast.NodeVisitor):
             cc.StoreOp(result, listValueAddr)
             self.symbolTable.popScope()
 
-        self.createInvariantForLoop(iterableSize, bodyBuilder)
+        self.createForLoop(iterableSize, bodyBuilder, invariant=True)
         self.pushValue(
             cc.StdvecInitOp(cc.StdvecType.get(listComputePtrTy),
                             listValue,
@@ -3454,12 +3465,12 @@ class PyASTBridge(ast.NodeVisitor):
                     [self.visit(b) for b in node.body]
                     self.symbolTable.popScope()
 
-                self.createInvariantForLoop(endVal,
-                                            bodyBuilder,
-                                            startVal=startVal,
-                                            stepVal=stepVal,
-                                            isDecrementing=isDecrementing,
-                                            elseStmts=node.orelse)
+                self.createForLoop(endVal,
+                                   bodyBuilder,
+                                   startVal=startVal,
+                                   stepVal=stepVal,
+                                   isDecrementing=isDecrementing,
+                                   elseStmts=node.orelse)
 
                 return
 
@@ -3528,9 +3539,9 @@ class PyASTBridge(ast.NodeVisitor):
                         [self.visit(b) for b in node.body]
                         self.symbolTable.popScope()
 
-                    self.createInvariantForLoop(totalSize,
-                                                bodyBuilder,
-                                                elseStmts=node.orelse)
+                    self.createForLoop(totalSize,
+                                       bodyBuilder,
+                                       elseStmts=node.orelse)
                     return
 
         self.visit(node.iter)
@@ -3648,9 +3659,7 @@ class PyASTBridge(ast.NodeVisitor):
             [self.visit(b) for b in node.body]
             self.symbolTable.popScope()
 
-        self.createInvariantForLoop(totalSize,
-                                    bodyBuilder,
-                                    elseStmts=node.orelse)
+        self.createForLoop(totalSize, bodyBuilder, elseStmts=node.orelse)
 
     def visit_While(self, node):
         """
@@ -3895,8 +3904,9 @@ class PyASTBridge(ast.NodeVisitor):
                 current = cc.LoadOp(accumulator).result
                 cc.StoreOp(arith.OrIOp(current, cmp_result.result), accumulator)
 
-            self.createInvariantForLoop(self.__get_vector_size(right_val),
-                                        check_element)
+            self.createForLoop(self.__get_vector_size(right_val),
+                               check_element,
+                               invariant=True)
 
             final_result = cc.LoadOp(accumulator).result
             if isinstance(op, ast.NotIn):

--- a/python/tests/mlir/ast_break.py
+++ b/python/tests/mlir/ast_break.py
@@ -60,6 +60,6 @@ def test_break():
 # CHECK:           ^bb0(%[[VAL_21:.*]]: i64):
 # CHECK:             %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_3]] : i64
 # CHECK:             cc.continue %[[VAL_22]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/ast_continue.py
+++ b/python/tests/mlir/ast_continue.py
@@ -64,5 +64,5 @@ def test_continue():
 # CHECK:           ^bb0(%[[VAL_23:.*]]: i64):
 # CHECK:             %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_3]] : i64
 # CHECK:             cc.continue %[[VAL_24]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:          }

--- a/python/tests/mlir/ast_decrementing_range.py
+++ b/python/tests/mlir/ast_decrementing_range.py
@@ -46,6 +46,6 @@ def test_decrementing_range():
 # CHECK:           ^bb0(%[[VAL_13:.*]]: i64):
 # CHECK:             %[[VAL_14:.*]] = arith.addi %[[VAL_13]], %[[VAL_2]] : i64
 # CHECK:             cc.continue %[[VAL_14]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/ast_elif.py
+++ b/python/tests/mlir/ast_elif.py
@@ -66,7 +66,7 @@ def test_elif():
 # CHECK:           ^bb0(%[[VAL_25:.*]]: i64):
 # CHECK:             %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_5]] : i64
 # CHECK:             cc.continue %[[VAL_26]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }
 
@@ -103,6 +103,6 @@ def test_elif():
 # CHECK:           ^bb0(%[[VAL_21:.*]]: i64):
 # CHECK:             %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_2]] : i64
 # CHECK:             cc.continue %[[VAL_22]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/ast_for_stdvec.py
+++ b/python/tests/mlir/ast_for_stdvec.py
@@ -54,6 +54,6 @@ def test_elif():
 # CHECK:           ^bb0(%[[VAL_17:.*]]: i64):
 # CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_1]] : i64
 # CHECK:             cc.continue %[[VAL_18]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/ast_iterate_loop_init.py
+++ b/python/tests/mlir/ast_iterate_loop_init.py
@@ -63,6 +63,6 @@ def test_iterate_list_init():
 # CHECK:           ^bb0(%[[VAL_26:.*]]: i64):
 # CHECK:             %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_3]] : i64
 # CHECK:             cc.continue %[[VAL_27]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/ast_list_init.py
+++ b/python/tests/mlir/ast_list_init.py
@@ -63,6 +63,6 @@ def test_list_init():
 # CHECK:           ^bb0(%[[VAL_26:.*]]: i64):
 # CHECK:             %[[VAL_27:.*]] = arith.addi %[[VAL_26]], %[[VAL_0]] : i64
 # CHECK:             cc.continue %[[VAL_27]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/ast_list_int.py
+++ b/python/tests/mlir/ast_list_int.py
@@ -52,6 +52,6 @@ def test_list_int():
 # CHECK:           ^bb0(%[[VAL_16:.*]]: i64):
 # CHECK:             %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_3]] : i64
 # CHECK:             cc.continue %[[VAL_17]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/ast_qreg_slice.py
+++ b/python/tests/mlir/ast_qreg_slice.py
@@ -114,7 +114,7 @@ def test_slice():
 # CHECK:           ^bb0(%[[VAL_43:.*]]: i64):
 # CHECK:             %[[VAL_44:.*]] = arith.addi %[[VAL_43]], %[[VAL_3]] : i64
 # CHECK:             cc.continue %[[VAL_44]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           %[[VAL_45:.*]] = quake.extract_ref %[[VAL_7]][3] : (!quake.veq<4>) -> !quake.ref
 # CHECK:           quake.rz (%[[VAL_4]]) %[[VAL_45]] : (f64, !quake.ref) -> ()
 # CHECK:           return

--- a/python/tests/mlir/bug_1777.py
+++ b/python/tests/mlir/bug_1777.py
@@ -61,7 +61,7 @@ def test_bug_1777():
 # CHECK:           ^bb0(%[[VAL_18:.*]]: i64):
 # CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_1]] : i64
 # CHECK:             cc.continue %[[VAL_19]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           %[[VAL_20:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i1>
 # CHECK:           %[[VAL_21:.*]] = arith.cmpi eq, %[[VAL_20]], %[[VAL_3]] : i1
 # CHECK:           cc.if(%[[VAL_21]]) {

--- a/python/tests/mlir/ghz.py
+++ b/python/tests/mlir/ghz.py
@@ -48,7 +48,7 @@ def test_ghz():
     # CHECK:           ^bb0(%[[VAL_16:.*]]: i64):
     # CHECK:             %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_1]] : i64
     # CHECK:             cc.continue %[[VAL_17]] : i64
-    # CHECK:           } {invariant}
+    # CHECK:           }
     # CHECK:           return
     # CHECK:         }
 
@@ -91,6 +91,6 @@ def test_ghz():
 # CHECK:           ^bb0(%[[VAL_19:.*]]: i64):
 # CHECK:             %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_2]] : i64
 # CHECK:             cc.continue %[[VAL_20]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }

--- a/python/tests/mlir/invalid_subrange.py
+++ b/python/tests/mlir/invalid_subrange.py
@@ -62,7 +62,7 @@ def test_banjo():
 # CHECK:           ^bb0(%[[VAL_17:.*]]: i64):
 # CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_1]] : i64
 # CHECK:             cc.continue %[[VAL_18]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }
 

--- a/python/tests/mlir/qft.py
+++ b/python/tests/mlir/qft.py
@@ -60,7 +60,7 @@ def test_qft():
 # CHECK:           ^bb0(%[[VAL_19:.*]]: i64):
 # CHECK:             %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_3]] : i64
 # CHECK:             cc.continue %[[VAL_20]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           %[[VAL_21:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i64>
 # CHECK:           %[[VAL_22:.*]] = arith.subi %[[VAL_21]], %[[VAL_3]] : i64
 # CHECK:           %[[VAL_23:.*]] = cc.loop while ((%[[VAL_24:.*]] = %[[VAL_4]]) -> (i64)) {
@@ -91,13 +91,13 @@ def test_qft():
 # CHECK:             ^bb0(%[[VAL_41:.*]]: i64):
 # CHECK:               %[[VAL_42:.*]] = arith.addi %[[VAL_41]], %[[VAL_2]] : i64
 # CHECK:               cc.continue %[[VAL_42]] : i64
-# CHECK:             } {invariant}
+# CHECK:             }
 # CHECK:             cc.continue %[[VAL_26]] : i64
 # CHECK:           } step {
 # CHECK:           ^bb0(%[[VAL_43:.*]]: i64):
 # CHECK:             %[[VAL_44:.*]] = arith.addi %[[VAL_43]], %[[VAL_3]] : i64
 # CHECK:             cc.continue %[[VAL_44]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           %[[VAL_45:.*]] = cc.load %[[VAL_7]] : !cc.ptr<i64>
 # CHECK:           %[[VAL_46:.*]] = arith.subi %[[VAL_45]], %[[VAL_3]] : i64
 # CHECK:           %[[VAL_47:.*]] = quake.extract_ref %[[VAL_0]]{{\[}}%[[VAL_46]]] : (!quake.veq<?>, i64) -> !quake.ref

--- a/python/tests/mlir/qreg_iterable.py
+++ b/python/tests/mlir/qreg_iterable.py
@@ -43,6 +43,6 @@ def test_qreg_iter():
 # CHECK:           ^bb0(%[[VAL_12:.*]]: i64):
 # CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : i64
 # CHECK:             cc.continue %[[VAL_13]] : i64
-# CHECK:           } {invariant}
+# CHECK:           }
 # CHECK:           return
 # CHECK:         }


### PR DESCRIPTION
According to our definitions: A "invariant loop" is a loop that is _guaranteed_ to execute the body of the loop `totalIterations` times. _Early exits are not allowed_.

Loops created through `createInvariantForLoop` are not guaranteed to be invariant. This change renames `createInvariantForLoop` to `createForLoop` and add a flag parameter that signals whether the loop is indeed invariant.
