### PR TITLE
Remove ubi8 from validation python3.10

### DIFF
--- a/.github/workflows/config/validation_config.json
+++ b/.github/workflows/config/validation_config.json
@@ -6,7 +6,6 @@
             "operating_systems": 
             [
                 "ubuntu:22.04",
-                "redhat/ubi8:8.10",
                 "fedora:42"
             ]
         },


### PR DESCRIPTION
ubi8 was mistakenly added to the validation for python3.10.

ubi8 does not have python3.10 in the repository available for download, thus deployments will fail when attempting to do the full verificaiton.

See https://github.com/NVIDIA/cuda-quantum/actions/runs/16979068912/job/48136131947#step:6:90