### PR TITLE
Use legacy cgi

### DIFF
--- a/.github/workflows/python_metapackages.yml
+++ b/.github/workflows/python_metapackages.yml
@@ -152,7 +152,9 @@ jobs:
 
           python=python${{ matrix.python_version }}
           $python -m pip install pip3-autoremove
-          $python -m pip install legacy-cgi # for pypiserver
+          if [ "${{ matrix.python_version }}" = "3.13" ]; then
+            $python -m pip install legacy-cgi  # for pypiserver
+          fi
           # autoremove is in an odd location that isn't found unless we search for it...
           autoremove="$python $($python -m pip show pip3-autoremove |  grep -e 'Location: .*$' | cut -d ' ' -f2)/pip_autoremove.py"
           $python -m pip install pypiserver
@@ -199,6 +201,9 @@ jobs:
       - name: Test installation error
         run: |
           python=python${{ matrix.python_version }}
+          if [ "${{ matrix.python_version }}" = "3.13" ]; then
+            $python -m pip install legacy-cgi  # for pypiserver
+          fi
           $python -m pip install pypiserver
           server="$python $($python -m pip show pypiserver | grep -e 'Location: .*$' | cut -d ' ' -f2)/pypiserver/__main__.py"
           $server run -p 8080 /tmp/packages & 


### PR DESCRIPTION
cgi has been deprecated from python3.13 https://peps.python.org/pep-0594/. Fall back to legacy-cgi for python3.13