### PR TITLE
[testing] Give more wiggle room while keeping tests fast

### DIFF
--- a/python/tests/backends/test_QCI.py
+++ b/python/tests/backends/test_QCI.py
@@ -25,7 +25,7 @@ port = 62449
 
 
 def assert_close(got) -> bool:
-    return got < -1.1 and got > -2.2
+    return got < -1.1 and got > -2.9
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/unittests/backends/qci/QCITester.cpp
+++ b/unittests/backends/qci/QCITester.cpp
@@ -17,7 +17,7 @@ std::string backendString = "qci;emulate;false";
 
 bool isValidExpVal(double value) {
   // give us some wiggle room while keep the tests fast
-  return value < -1.1 && value > -2.3;
+  return value < -1.1 && value > -2.9;
 }
 
 CUDAQ_TEST(QCITester, checkSampleSync) {


### PR DESCRIPTION
(Checked with real server, the result is -1.8xxx, so this should be okay)

Follow-up to PR https://github.com/NVIDIA/cuda-quantum/pull/3367