### PR TITLE
Add missing `reset_exec_ctx` call in `evolve_async`

### DIFF
--- a/runtime/cudaq/algorithms/evolve.h
+++ b/runtime/cudaq/algorithms/evolve.h
@@ -701,12 +701,17 @@ evolve_async(const HamTy &hamiltonian, const cudaq::dimension_map &dimensions,
   return __internal__::evolve_async(
       [=, cOps = std::move(collapseOperators),
        obs = std::move(observableOperators)]() {
+        // This is a dummy/unused execution context.
+        // We used this to set the execution context for the QPU, which performs
+        // GPU Id selection based on the QPU Id.
         ExecutionContext context("evolve");
         cudaq::get_platform().set_exec_ctx(&context, qpu_id);
         state localizedState = cudaq::__internal__::migrateState(initial_state);
-        return evolve(hamiltonian, dimensions, schedule, localizedState,
-                      *cloneIntegrator, cOps, obs, store_intermediate_results,
-                      shots_count);
+        const auto result = evolve(hamiltonian, dimensions, schedule,
+                                   localizedState, *cloneIntegrator, cOps, obs,
+                                   store_intermediate_results, shots_count);
+        cudaq::get_platform().reset_exec_ctx(qpu_id);
+        return result;
       },
       qpu_id);
 
@@ -740,12 +745,17 @@ evolve_async(const HamTy &hamiltonian, const cudaq::dimension_map &dimensions,
   auto cloneIntegrator = integrator.clone();
   return __internal__::evolve_async(
       [=]() {
+        // This is a dummy/unused execution context.
+        // We used this to set the execution context for the QPU, which performs
+        // GPU Id selection based on the QPU Id.
         ExecutionContext context("evolve");
         cudaq::get_platform().set_exec_ctx(&context, qpu_id);
         state localizedState = cudaq::__internal__::migrateState(initial_state);
-        return evolve(hamiltonian, dimensions, schedule, localizedState,
-                      *cloneIntegrator, collapse_operators, observables,
-                      store_intermediate_results, shots_count);
+        auto result = evolve(hamiltonian, dimensions, schedule, localizedState,
+                             *cloneIntegrator, collapse_operators, observables,
+                             store_intermediate_results, shots_count);
+        cudaq::get_platform().reset_exec_ctx(qpu_id);
+        return result;
       },
       qpu_id);
 #else
@@ -775,12 +785,17 @@ evolve_async(const super_op &super_op, const cudaq::dimension_map &dimensions,
   auto observableOperators = cudaq::__internal__::convertOps(observables);
   return __internal__::evolve_async(
       [=, obs = std::move(observableOperators)]() {
+        // This is a dummy/unused execution context.
+        // We used this to set the execution context for the QPU, which performs
+        // GPU Id selection based on the QPU Id.
         ExecutionContext context("evolve");
         cudaq::get_platform().set_exec_ctx(&context, qpu_id);
         state localizedState = cudaq::__internal__::migrateState(initial_state);
-        return evolve(super_op, dimensions, schedule, localizedState,
-                      *cloneIntegrator, obs, store_intermediate_results,
-                      shots_count);
+        auto result = evolve(super_op, dimensions, schedule, localizedState,
+                             *cloneIntegrator, obs, store_intermediate_results,
+                             shots_count);
+        cudaq::get_platform().reset_exec_ctx(qpu_id);
+        return result;
       },
       qpu_id);
 
@@ -806,7 +821,9 @@ evolve_async(const cudaq::rydberg_hamiltonian &hamiltonian,
       [=]() {
         ExecutionContext context("evolve");
         cudaq::get_platform().set_exec_ctx(&context, qpu_id);
-        return evolve(hamiltonian, schedule, shots_count);
+        auto result = evolve(hamiltonian, schedule, shots_count);
+        cudaq::get_platform().reset_exec_ctx(qpu_id);
+        return result;
       },
       qpu_id);
 }

--- a/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
@@ -127,6 +127,18 @@ public:
     return std::make_unique<cudaq::CuDensityMatState>();
   }
 
+  void resetExecutionContext() override {
+    // If null, do nothing
+    if (!executionContext)
+      return;
+    // Just check that the dynamics target was not invoked in gate simulation
+    // contexts.
+    if (executionContext->name != "evolve")
+      throw std::runtime_error(fmt::format(
+          "[dynamics target] Execution context '{}' is not supported.",
+          executionContext->name));
+  }
+
   void addQubitToState() override {
     throw std::runtime_error(
         "[dynamics target] Quantum gate simulation is not supported.");

--- a/unittests/mqpu/dynamics_async_tester.cpp
+++ b/unittests/mqpu/dynamics_async_tester.cpp
@@ -203,3 +203,120 @@ TEST(DynamicsAsyncTester, checkInitializerArgs) {
     }
   }
 }
+
+TEST(DynamicsAsyncTester, checkSuperOp) {
+  auto &platform = cudaq::get_platform();
+  printf("Num QPUs %lu\n", platform.num_qpus());
+  auto jobHandle1 = []() {
+    const cudaq::dimension_map dims = {{0, 2}};
+    cudaq::product_op<cudaq::matrix_handler> ham_ =
+        2.0 * M_PI * 0.1 * cudaq::spin_op::x(0);
+    cudaq::sum_op<cudaq::matrix_handler> ham(ham_);
+    constexpr int numSteps = 10;
+    cudaq::schedule schedule(cudaq::linspace(0.0, 1.0, numSteps), {"t"});
+    auto initialState =
+        cudaq::state::from_data(std::vector<std::complex<double>>{1.0, 0.0});
+    cudaq::integrators::runge_kutta integrator(1, 0.001);
+    cudaq::super_op sup;
+    // Apply `-iH * psi` superop
+    sup +=
+        cudaq::super_op::left_multiply(std::complex<double>(0.0, -1.0) * ham);
+
+    auto resultFuture1 = cudaq::evolve_async(
+        sup, dims, schedule, initialState, integrator, {cudaq::spin_op::z(0)},
+        cudaq::IntermediateResultSave::ExpectationValue, 0);
+    std::cout << "Launched evolve job on QPU 0\n";
+    return resultFuture1;
+  }();
+
+  auto jobHandle2 = []() {
+    constexpr int N = 10;
+    constexpr int numSteps = 101;
+    cudaq::schedule schedule(cudaq::linspace(0.0, 1.0, numSteps), {"t"});
+    auto ham = cudaq::boson_op::number(0);
+    const cudaq::dimension_map dimensions{{0, N}};
+    std::vector<std::complex<double>> rho0_(N * N, 0.0);
+    rho0_.back() = 1.0;
+    auto initialState = cudaq::state::from_data(rho0_);
+    cudaq::integrators::runge_kutta integrator(4, 0.01);
+    cudaq::super_op sup;
+    // Apply `-i[H, rho]` superop
+    sup +=
+        cudaq::super_op::left_multiply(std::complex<double>(0.0, -1.0) * ham);
+    sup +=
+        cudaq::super_op::right_multiply(std::complex<double>(0.0, 1.0) * ham);
+
+    constexpr double decay_rate = 0.1;
+
+    auto td_function =
+        [decay_rate](const std::unordered_map<std::string, std::complex<double>>
+                         &parameters) {
+          auto entry = parameters.find("t");
+          if (entry == parameters.end())
+            throw std::runtime_error("Cannot find value of expected parameter");
+          const auto t = entry->second.real();
+          const auto result = std::sqrt(decay_rate * std::exp(-t));
+          return result;
+        };
+
+    auto L =
+        cudaq::scalar_operator(td_function) * cudaq::boson_op::annihilate(0);
+    auto L_dagger =
+        cudaq::scalar_operator(td_function) * cudaq::boson_op::create(0);
+    // Lindblad terms
+    // L * rho * L_dagger
+    sup += cudaq::super_op::left_right_multiply(L, L_dagger);
+    // -0.5 * L_dagger * L * rho
+    sup += cudaq::super_op::left_multiply(-0.5 * L_dagger * L);
+    // -0.5 * rho * L_dagger * L
+    sup += cudaq::super_op::right_multiply(-0.5 * L_dagger * L);
+    auto resultFuture =
+        cudaq::evolve_async(sup, dimensions, schedule, initialState, integrator,
+                            {cudaq::boson_op::number(0)},
+                            cudaq::IntermediateResultSave::ExpectationValue, 1);
+    std::cout << "Launched evolve job on QPU 1\n";
+    return resultFuture;
+  }();
+
+  std::cout << "Wait for all the evolve jobs complete...\n";
+  {
+    auto result = jobHandle1.get();
+    std::cout << "Checking the results from QPU 0\n";
+    constexpr int numSteps = 10;
+    EXPECT_TRUE(result.expectation_values.has_value());
+    EXPECT_EQ(result.expectation_values.value().size(), numSteps);
+    std::vector<double> theoryResults;
+    for (const auto &t : cudaq::linspace(0.0, 1.0, numSteps)) {
+      const double expected = std::cos(4.0 * M_PI * 0.1 * t);
+      theoryResults.emplace_back(expected);
+    }
+
+    int count = 0;
+    for (auto expVals : result.expectation_values.value()) {
+      EXPECT_EQ(expVals.size(), 1);
+      EXPECT_NEAR((double)expVals[0], theoryResults[count++], 1e-3);
+    }
+  }
+  {
+    auto result = jobHandle2.get();
+    std::cout << "Checking the results from QPU 1\n";
+    constexpr int N = 10;
+    constexpr double decay_rate = 0.1;
+    constexpr int numSteps = 101;
+    const auto steps = cudaq::linspace(0, 1, numSteps);
+    EXPECT_TRUE(result.expectation_values.has_value());
+    EXPECT_EQ(result.expectation_values.value().size(), numSteps);
+    std::vector<double> theoryResults;
+    for (const auto &t : steps) {
+      const double expected =
+          (N - 1) * std::exp(-decay_rate * (1.0 - std::exp(-t)));
+      theoryResults.emplace_back(expected);
+    }
+
+    int count = 0;
+    for (auto expVals : result.expectation_values.value()) {
+      EXPECT_EQ(expVals.size(), 1);
+      EXPECT_NEAR((double)expVals[0], theoryResults[count++], 1e-3);
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

We are using `set_exec_ctx` as a mechanism to set the GPU ID for `evolve_async`, as it doesn't perform a kernel launch. 
This was not properly `reset` afterward. Hence, adding the missing `reset_exec_ctx` calls.

The CudensityMat simulator handles (ignores) execution context resets, as the base implementation involves circuit simulation logic, such as qubit deallocation.

Adds a test for `evolve_async` to cover the `super_op` overload.

