### PR TITLE
[CI] [validation script] Update regex to match single quoted strings as well

### DIFF
--- a/scripts/validate_container.sh
+++ b/scripts/validate_container.sh
@@ -313,7 +313,7 @@ do
     let "samples+=1"
 
     skip_example=false
-    explicit_targets=`cat $ex | grep -Po '^\s*cudaq.set_target\("\K.*(?=")'`
+    explicit_targets=`cat $ex | grep -Po '^\s*cudaq.set_target\(['"]\K[^'"]+(?=['"])'`
     for t in $explicit_targets; do
         if [ -z "$(echo $requested_backends | grep $t)" ]; then 
             echo "Explicitly set target $t not available."


### PR DESCRIPTION
* Allow use of single-quotes as well since both `cudaq.set_target("foo")` and `cudaq.set_target('foo')` are valid and
the script needs to skip both.

