### PR TITLE
Enable variable coalescing by default.

### DIFF
--- a/tools/nvqpp/nvq++.in
+++ b/tools/nvqpp/nvq++.in
@@ -739,7 +739,7 @@ if ${ENABLE_VARIABLE_COALESCE}; then
 fi
 if ${ENABLE_UNWIND_LOWERING}; then
 	RUN_OPT=true
-	OPT_PASSES="func.func(unwind-lowering)"
+	OPT_PASSES=$(add_pass_to_pipeline "${OPT_PASSES}" "func.func(unwind-lowering)")
 fi
 if ${ENABLE_LAMBDA_LIFTING}; then
 	RUN_OPT=true


### PR DESCRIPTION
This enables variable coalescing by default in the driver.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
