### PR TITLE
[nfc] Use logging macros everywhere

### DIFF
--- a/docs/sphinx/using/extending/backend.rst
+++ b/docs/sphinx/using/extending/backend.rst
@@ -83,7 +83,7 @@ Here's a template for implementing a server helper class:
     
       /// @brief Example implementation of backend initialization.
       void initialize(BackendConfig config) override {
-        cudaq::info("Initializing Provider Name Backend");
+        CUDAQ_INFO("Initializing Provider Name Backend");
         backendConfig = config;
         
         if (!backendConfig.count("url"))
@@ -143,7 +143,7 @@ Here's a template for implementing a server helper class:
       /// This is the place to do that.
       cudaq::sample_result processResults(ServerMessage &getJobResponse,
                                          std::string &jobId) override {
-        cudaq::info("Processing results: {}", getJobResponse.dump());
+        CUDAQ_INFO("Processing results: {}", getJobResponse.dump());
         
         // Extract measurement results from the response
         auto samplesJson = getJobResponse["results"]["counts"];

--- a/python/extension/CUDAQuantumExtension.cpp
+++ b/python/extension/CUDAQuantumExtension.cpp
@@ -75,7 +75,7 @@ PYBIND11_MODULE(_quakeDialects, m) {
   cudaqRuntime.def(
       "initialize_cudaq",
       [&](py::kwargs kwargs) {
-        cudaq::info("Calling initialize_cudaq.");
+        CUDAQ_INFO("Calling initialize_cudaq.");
         if (!kwargs)
           return;
 
@@ -93,7 +93,7 @@ PYBIND11_MODULE(_quakeDialects, m) {
         for (auto &[keyPy, valuePy] : kwargs) {
           std::string key = py::str(keyPy);
           std::string value = py::str(valuePy);
-          cudaq::info("Processing Python Arg: {} - {}", key, value);
+          CUDAQ_INFO("Processing Python Arg: {} - {}", key, value);
           if (key == "target")
             holder->setTarget(value, extraConfig);
         }

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -240,8 +240,8 @@ void bindPyState(py::module &mod, LinkedLibraryHolder &holder) {
             dataPtr = reinterpret_cast<void *>(hostData);
           }
           hostDataFromDevice.emplace_back(dataPtr, [](void *data) {
-            cudaq::info("freeing data that was copied from GPU device for "
-                        "compatibility with NumPy");
+            CUDAQ_INFO("freeing data that was copied from GPU device for "
+                       "compatibility with NumPy");
             free(data);
           });
         } else

--- a/python/runtime/utils/PyFermioniqRESTQPU.cpp
+++ b/python/runtime/utils/PyFermioniqRESTQPU.cpp
@@ -56,7 +56,7 @@ protected:
   std::tuple<ModuleOp, MLIRContext *>
   extractQuakeCodeAndContextImpl(const std::string &kernelName) {
 
-    cudaq::info("extract quake code\n");
+    CUDAQ_INFO("extract quake code\n");
 
     MLIRContext *context = createContext();
 

--- a/python/runtime/utils/PyRemoteSimulatorQPU.cpp
+++ b/python/runtime/utils/PyRemoteSimulatorQPU.cpp
@@ -122,7 +122,7 @@ public:
                  cudaq::gradient *gradient, const cudaq::spin_op &H,
                  cudaq::optimizer &optimizer, const int n_params,
                  const std::size_t shots) override {
-    cudaq::info(
+    CUDAQ_INFO(
         "PyRemoteSimulatorQPU: Launch VQE kernel named '{}' remote QPU {} "
         "(simulator = {})",
         name, qpu_id, m_simName);
@@ -135,9 +135,9 @@ public:
                void *args, std::uint64_t voidStarSize,
                std::uint64_t resultOffset,
                const std::vector<void *> &rawArgs) override {
-    cudaq::info("PyRemoteSimulatorQPU: Launch kernel named '{}' remote QPU {} "
-                "(simulator = {})",
-                name, qpu_id, m_simName);
+    CUDAQ_INFO("PyRemoteSimulatorQPU: Launch kernel named '{}' remote QPU {} "
+               "(simulator = {})",
+               name, qpu_id, m_simName);
     ::launchKernelImpl(getExecutionContextForMyThread(), m_client, m_simName,
                        name, make_degenerate_kernel_type(kernelFunc), args,
                        voidStarSize, resultOffset, rawArgs);
@@ -147,10 +147,10 @@ public:
 
   void launchKernel(const std::string &name,
                     const std::vector<void *> &rawArgs) override {
-    cudaq::info("PyRemoteSimulatorQPU: Streamline launch kernel named '{}' "
-                "remote QPU {} "
-                "(simulator = {})",
-                name, qpu_id, m_simName);
+    CUDAQ_INFO("PyRemoteSimulatorQPU: Streamline launch kernel named '{}' "
+               "remote QPU {} "
+               "(simulator = {})",
+               name, qpu_id, m_simName);
     ::launchKernelStreamlineImpl(getExecutionContextForMyThread(), m_client,
                                  m_simName, name, rawArgs);
   }
@@ -173,10 +173,9 @@ public:
                  cudaq::gradient *gradient, const cudaq::spin_op &H,
                  cudaq::optimizer &optimizer, const int n_params,
                  const std::size_t shots) override {
-    cudaq::info(
-        "PyNvcfSimulatorQPU: Launch VQE kernel named '{}' remote QPU {} "
-        "(simulator = {})",
-        name, qpu_id, m_simName);
+    CUDAQ_INFO("PyNvcfSimulatorQPU: Launch VQE kernel named '{}' remote QPU {} "
+               "(simulator = {})",
+               name, qpu_id, m_simName);
     ::launchVqeImpl(getExecutionContextForMyThread(), m_client, m_simName, name,
                     kernelArgs, gradient, H, optimizer, n_params, shots);
   }
@@ -186,9 +185,9 @@ public:
                void *args, std::uint64_t voidStarSize,
                std::uint64_t resultOffset,
                const std::vector<void *> &rawArgs) override {
-    cudaq::info("PyNvcfSimulatorQPU: Launch kernel named '{}' remote QPU {} "
-                "(simulator = {})",
-                name, qpu_id, m_simName);
+    CUDAQ_INFO("PyNvcfSimulatorQPU: Launch kernel named '{}' remote QPU {} "
+               "(simulator = {})",
+               name, qpu_id, m_simName);
     ::launchKernelImpl(getExecutionContextForMyThread(), m_client, m_simName,
                        name, make_degenerate_kernel_type(kernelFunc), args,
                        voidStarSize, resultOffset, rawArgs);
@@ -198,10 +197,10 @@ public:
 
   void launchKernel(const std::string &name,
                     const std::vector<void *> &rawArgs) override {
-    cudaq::info("PyNvcfSimulatorQPU: Streamline launch kernel named '{}' "
-                "remote QPU {} "
-                "(simulator = {})",
-                name, qpu_id, m_simName);
+    CUDAQ_INFO("PyNvcfSimulatorQPU: Streamline launch kernel named '{}' "
+               "remote QPU {} "
+               "(simulator = {})",
+               name, qpu_id, m_simName);
     ::launchKernelStreamlineImpl(getExecutionContextForMyThread(), m_client,
                                  m_simName, name, rawArgs);
   }

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -42,14 +42,14 @@ static constexpr const char IS_FP64_SIMULATION[] =
 int countGPUs() {
   int retCode = std::system("nvidia-smi >/dev/null 2>&1");
   if (0 != retCode) {
-    cudaq::info("nvidia-smi: command not found");
+    CUDAQ_INFO("nvidia-smi: command not found");
     return -1;
   }
 
   char tmpFile[] = "/tmp/.cmd.capture.XXXXXX";
   int fileDescriptor = mkstemp(tmpFile);
   if (-1 == fileDescriptor) {
-    cudaq::info("Failed to create a temporary file to capture output");
+    CUDAQ_INFO("Failed to create a temporary file to capture output");
     return -1;
   }
 
@@ -57,7 +57,7 @@ int countGPUs() {
   command.append(tmpFile);
   retCode = std::system(command.c_str());
   if (0 != retCode) {
-    cudaq::info("Encountered error while invoking 'nvidia-smi'");
+    CUDAQ_INFO("Encountered error while invoking 'nvidia-smi'");
     return -1;
   }
 
@@ -97,18 +97,18 @@ void parseRuntimeTarget(const std::filesystem::path &cudaqLibPath,
 #else
       const std::string libSuffix = "so";
 #endif
-      cudaq::info("CUDA-Q Library Path is {}.", cudaqLibPath.string());
+      CUDAQ_INFO("CUDA-Q Library Path is {}.", cudaqLibPath.string());
       const auto libName =
           fmt::format("libnvqir-{}.{}", simulatorName, libSuffix);
 
       if (std::filesystem::exists(cudaqLibPath / libName)) {
-        cudaq::info("Use {} simulator for target {}", simulatorName,
-                    target.name);
+        CUDAQ_INFO("Use {} simulator for target {}", simulatorName,
+                   target.name);
         foundSimulatorName =
             std::regex_replace(simulatorName, std::regex("-"), "_");
       } else {
-        cudaq::info("Skip {} simulator for target {} since it is not available",
-                    simulatorName, target.name);
+        CUDAQ_INFO("Skip {} simulator for target {} since it is not available",
+                   simulatorName, target.name);
       }
     } else if (line.find(IS_FP64_SIMULATION) != std::string::npos) {
       precision = simulation_precision::fp64;
@@ -153,7 +153,7 @@ void findAvailableTargets(
       cudaq::config::TargetConfig config;
       llvm::yaml::Input Input(configFileContent.c_str());
       Input >> config;
-      cudaq::info("Found Target {} with config file {}", targetName, fileName);
+      CUDAQ_INFO("Found Target {} with config file {}", targetName, fileName);
       const std::string defaultTargetConfigStr =
           cudaq::config::processRuntimeArgs(config, {});
       RuntimeTarget target;
@@ -162,8 +162,8 @@ void findAvailableTargets(
       target.description = config.Description;
       auto cudaqLibPath = targetPath.parent_path() / "lib";
       parseRuntimeTarget(cudaqLibPath, target, defaultTargetConfigStr);
-      cudaq::info("Found Target: {} -> (sim={}, platform={})", targetName,
-                  target.simulatorName, target.platformName);
+      CUDAQ_INFO("Found Target: {} -> (sim={}, platform={})", targetName,
+                 target.simulatorName, target.platformName);
       // Add the target.
       targets.emplace(targetName, target);
 
@@ -173,7 +173,7 @@ void findAvailableTargets(
 }
 
 LinkedLibraryHolder::LinkedLibraryHolder() {
-  cudaq::info("Init infrastructure for pythonic builder.");
+  CUDAQ_INFO("Init infrastructure for pythonic builder.");
 
   if (!cudaq::__internal__::canModifyTarget())
     return;
@@ -198,7 +198,7 @@ LinkedLibraryHolder::LinkedLibraryHolder() {
   auto targetPath = cudaqLibPath.parent_path() / "targets";
   findAvailableTargets(targetPath, targets, simulationTargets);
 
-  cudaq::info("Init: Library Path is {}.", cudaqLibPath.string());
+  CUDAQ_INFO("Init: Library Path is {}.", cudaqLibPath.string());
 
   // We have to ensure that nvqir and cudaq are loaded
   std::vector<std::filesystem::path> libPaths{
@@ -210,7 +210,7 @@ LinkedLibraryHolder::LinkedLibraryHolder() {
     std::string dynlib;
     std::stringstream ss((std::string(dynlibs_var)));
     while (std::getline(ss, dynlib, ':')) {
-      cudaq::info("Init: add dynamic library path {}.", dynlib);
+      CUDAQ_INFO("Init: add dynamic library path {}.", dynlib);
       libPaths.push_back(dynlib);
     }
   }
@@ -259,9 +259,9 @@ LinkedLibraryHolder::LinkedLibraryHolder() {
           loadFailed = true;
           // Retrieve the error message
           char *error_msg = dlerror();
-          cudaq::info("Failed to load NVQIR backend '{}' from {}. Error: {}",
-                      simName, path.string(),
-                      (error_msg ? std::string(error_msg) : "unknown."));
+          CUDAQ_INFO("Failed to load NVQIR backend '{}' from {}. Error: {}",
+                     simName, path.string(),
+                     (error_msg ? std::string(error_msg) : "unknown."));
         }
       }
 
@@ -269,7 +269,7 @@ LinkedLibraryHolder::LinkedLibraryHolder() {
         // Load the plugin and get the CircuitSimulator.
         // Skip adding simulator name to the availableSimulators list if failed
         // to load.
-        cudaq::info("Found simulator plugin {}.", simName);
+        CUDAQ_INFO("Found simulator plugin {}.", simName);
         availableSimulators.push_back(simName);
       }
 
@@ -290,7 +290,7 @@ LinkedLibraryHolder::LinkedLibraryHolder() {
 
       // Load the plugin and get the CircuitSimulator.
       availablePlatforms.push_back(platformName);
-      cudaq::info("Found platform plugin {}.", platformName);
+      CUDAQ_INFO("Found platform plugin {}.", platformName);
     }
   }
 
@@ -310,20 +310,20 @@ LinkedLibraryHolder::LinkedLibraryHolder() {
                     target.simulatorName) != availableSimulators.end())
         defaultTarget = nvidiaTarget;
       else
-        cudaq::info(
+        CUDAQ_INFO(
             "GPU(s) found but cannot select nvidia target because simulator "
             "is not available. Are all dependencies installed?");
     } else {
-      cudaq::info("GPU(s) found but cannot select nvidia target because nvidia "
-                  "target not found.");
+      CUDAQ_INFO("GPU(s) found but cannot select nvidia target because nvidia "
+                 "target not found.");
     }
   }
   auto env = std::getenv("CUDAQ_DEFAULT_SIMULATOR");
   if (env) {
-    cudaq::info("'CUDAQ_DEFAULT_SIMULATOR' = {}", env);
+    CUDAQ_INFO("'CUDAQ_DEFAULT_SIMULATOR' = {}", env);
     auto iter = simulationTargets.find(env);
     if (iter != simulationTargets.end()) {
-      cudaq::info("Valid target");
+      CUDAQ_INFO("Valid target");
       defaultTarget = iter->second.name;
     }
   }
@@ -420,8 +420,8 @@ void LinkedLibraryHolder::setTarget(
       cudaq::config::processRuntimeArgs(target.config, argv);
   parseRuntimeTarget(cudaqLibPath, target, targetConfigStr);
 
-  cudaq::info("Setting target={} (sim={}, platform={})", targetName,
-              target.simulatorName, target.platformName);
+  CUDAQ_INFO("Setting target={} (sim={}, platform={})", targetName,
+             target.simulatorName, target.platformName);
 
   __nvqir__setCircuitSimulator(getSimulator(target.simulatorName));
   auto *platform = getPlatform(target.platformName);

--- a/runtime/common/AnalogRemoteRESTQPU.h
+++ b/runtime/common/AnalogRemoteRESTQPU.h
@@ -51,7 +51,7 @@ public:
       throw std::runtime_error(
           "Local emulation is not yet supported on this target.");
 
-    cudaq::info("Launching remote kernel ({})", kernelName);
+    CUDAQ_INFO("Launching remote kernel ({})", kernelName);
     std::vector<cudaq::KernelExecution> codes;
     std::string name = kernelName;
     char *charArgs = (char *)(args);

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -222,8 +222,8 @@ public:
           "Illegal use of resource counter simulator! (Did you attempt to run "
           "a kernel inside of a choice function?)");
 
-    cudaq::info("Remote Rest QPU setting execution context to {}",
-                context->name);
+    CUDAQ_INFO("Remote Rest QPU setting execution context to {}",
+               context->name);
 
     // Execution context is valid
     executionContext = context;
@@ -240,7 +240,7 @@ public:
   /// CUDA-Q installation) and extract MLIR lowering pipelines and
   /// specific code generation output required by this backend (QIR/QASM2).
   void setTargetBackend(const std::string &backend) override {
-    cudaq::info("Remote REST platform is targeting {}.", backend);
+    CUDAQ_INFO("Remote REST platform is targeting {}.", backend);
 
     // First we see if the given backend has extra config params
     auto mutableBackend = backend;
@@ -262,8 +262,8 @@ public:
           if (auto err = llvm::decodeBase64(split[i + 1], decoded_vec))
             throw std::runtime_error("DecodeBase64 error");
           std::string decodedStr(decoded_vec.data(), decoded_vec.size());
-          cudaq::info("Decoded {} parameter from '{}' to '{}'", split[i],
-                      split[i + 1], decodedStr);
+          CUDAQ_INFO("Decoded {} parameter from '{}' to '{}'", split[i],
+                     split[i + 1], decodedStr);
           backendConfig.insert({split[i], decodedStr});
         } else {
           backendConfig.insert({split[i], split[i + 1]});
@@ -297,7 +297,7 @@ public:
     /// pipeline.
     std::string fileName = mutableBackend + std::string(".yml");
     auto configFilePath = platformPath / fileName;
-    cudaq::info("Config file path = {}", configFilePath.string());
+    CUDAQ_INFO("Config file path = {}", configFilePath.string());
     std::ifstream configFile(configFilePath.string());
     std::string configYmlContents((std::istreambuf_iterator<char>(configFile)),
                                   std::istreambuf_iterator<char>());
@@ -306,24 +306,24 @@ public:
     Input >> config;
     if (config.BackendConfig.has_value()) {
       if (!config.BackendConfig->PlatformLoweringConfig.empty()) {
-        cudaq::info("Appending lowering pipeline: {}",
-                    config.BackendConfig->PlatformLoweringConfig);
+        CUDAQ_INFO("Appending lowering pipeline: {}",
+                   config.BackendConfig->PlatformLoweringConfig);
         passPipelineConfig +=
             "," + config.BackendConfig->PlatformLoweringConfig;
       }
       const auto codeGenSpec = config.getCodeGenSpec(backendConfig);
       if (!codeGenSpec.empty()) {
-        cudaq::info("Set codegen translation: {}", codeGenSpec);
+        CUDAQ_INFO("Set codegen translation: {}", codeGenSpec);
         codegenTranslation = codeGenSpec;
         auto [codeGenName, codeGenVersion, codeGenOptions] =
             parseCodeGenTranslationString(codegenTranslation);
         if (codeGenName == "qir-adaptive") {
           for (auto option : codeGenOptions) {
             if (option == "int_computations") {
-              cudaq::info("Enable int_computations extension");
+              CUDAQ_INFO("Enable int_computations extension");
               qirIntegerExtension = true;
             } else if (option == "float_computations") {
-              cudaq::info("Enable float_computations extension");
+              CUDAQ_INFO("Enable float_computations extension");
               qirFloatExtension = true;
             } else {
               throw std::runtime_error(
@@ -340,8 +340,8 @@ public:
         }
       }
       if (!config.BackendConfig->PostCodeGenPasses.empty()) {
-        cudaq::info("Adding post-codegen lowering pipeline: {}",
-                    config.BackendConfig->PostCodeGenPasses);
+        CUDAQ_INFO("Adding post-codegen lowering pipeline: {}",
+                   config.BackendConfig->PostCodeGenPasses);
         postCodeGenPasses = config.BackendConfig->PostCodeGenPasses;
       }
     }
@@ -364,9 +364,9 @@ public:
       std::string replacement("$1qubit-mapping{$2device=bypass$3}$4");
       passPipelineConfig =
           std::regex_replace(passPipelineConfig, qubitMapping, replacement);
-      cudaq::info("disable_qubit_mapping option found, so updated lowering "
-                  "pipeline to {}",
-                  passPipelineConfig);
+      CUDAQ_INFO("disable_qubit_mapping option found, so updated lowering "
+                 "pipeline to {}",
+                 passPipelineConfig);
     }
 
     // Set the qpu name
@@ -379,9 +379,9 @@ public:
 
     serverHelper->initialize(backendConfig);
     serverHelper->updatePassPipeline(platformPath, passPipelineConfig);
-    cudaq::info("Retrieving executor with name {}", qpuName);
-    cudaq::info("Is this executor registered? {}",
-                cudaq::registry::isRegistered<cudaq::Executor>(qpuName));
+    CUDAQ_INFO("Retrieving executor with name {}", qpuName);
+    CUDAQ_INFO("Is this executor registered? {}",
+               cudaq::registry::isRegistered<cudaq::Executor>(qpuName));
     executor = cudaq::registry::isRegistered<cudaq::Executor>(qpuName)
                    ? cudaq::registry::get<cudaq::Executor>(qpuName)
                    : std::make_unique<cudaq::Executor>();
@@ -408,7 +408,7 @@ public:
     if (codegenTranslation.starts_with("qir")) {
       // decodeBase64 will throw a runtime exception if it fails
       if (llvm::decodeBase64(codeStr, bitcode)) {
-        cudaq::info("Could not decode codeStr {}", codeStr);
+        CUDAQ_INFO("Could not decode codeStr {}", codeStr);
       } else {
         llvm::LLVMContext llvmContext;
         auto buffer = llvm::MemoryBuffer::getMemBufferCopy(
@@ -594,7 +594,7 @@ public:
       mlir::PassManager pm(&context);
       std::string errMsg;
       llvm::raw_string_ostream os(errMsg);
-      cudaq::info("Pass pipeline for {} = {}", kernelName, pipeline);
+      CUDAQ_INFO("Pass pipeline for {} = {}", kernelName, pipeline);
       if (failed(parsePassPipeline(pipeline, pm, os)))
         throw std::runtime_error(
             "Remote rest platform failed to add passes to pipeline (" + errMsg +
@@ -610,7 +610,7 @@ public:
     if (!rawArgs.empty() || updatedArgs) {
       mlir::PassManager pm(&context);
       if (!rawArgs.empty()) {
-        cudaq::info("Run Argument Synth.\n");
+        CUDAQ_INFO("Run Argument Synth.\n");
         // For quantum devices, we generate a collection of `init` and
         // `num_qubits` functions and their substitutions created
         // from a kernel and arguments that generated a state argument.
@@ -642,7 +642,7 @@ public:
             opt::createReplaceStateWithKernel());
         pm.addPass(mlir::createSymbolDCEPass());
       } else if (updatedArgs) {
-        cudaq::info("Run Quake Synth.\n");
+        CUDAQ_INFO("Run Quake Synth.\n");
         pm.addPass(cudaq::opt::createQuakeSynthesizer(kernelName, updatedArgs));
       }
       pm.addPass(mlir::createCanonicalizerPass());
@@ -652,7 +652,7 @@ public:
         auto resource_counts = nvqir::getResourceCounts();
         std::function<void(std::string, size_t, size_t)> f =
             [&](std::string gate, size_t nControls, size_t count) {
-              cudaq::info("Appending: {}", gate);
+              CUDAQ_INFO("Appending: {}", gate);
               resource_counts->appendInstruction(gate, nControls, count);
             };
         cudaq::opt::ResourceCountPreprocessOptions opt{f};
@@ -677,9 +677,9 @@ public:
       std::string replacement("$1$3");
       passPipelineConfig =
           std::regex_replace(passPipelineConfig, combine, replacement);
-      cudaq::info("Delaying combine-measurements pass due to emulation. "
-                  "Updating pipeline to {}",
-                  passPipelineConfig);
+      CUDAQ_INFO("Delaying combine-measurements pass due to emulation. "
+                 "Updating pipeline to {}",
+                 passPipelineConfig);
     }
 
     runPassPipeline(passPipelineConfig, moduleOp);
@@ -801,7 +801,7 @@ public:
 
   void launchKernel(const std::string &kernelName,
                     const std::vector<void *> &rawArgs) override {
-    cudaq::info("launching remote rest kernel ({})", kernelName);
+    CUDAQ_INFO("launching remote rest kernel ({})", kernelName);
 
     // TODO future iterations of this should support non-void return types.
     if (!executionContext)
@@ -823,7 +823,7 @@ public:
                void *args, std::uint64_t voidStarSize,
                std::uint64_t resultOffset,
                const std::vector<void *> &rawArgs) override {
-    cudaq::info("launching remote rest kernel ({})", kernelName);
+    CUDAQ_INFO("launching remote rest kernel ({})", kernelName);
 
     // TODO future iterations of this should support non-void return types.
     if (!executionContext)

--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -83,7 +83,7 @@ public:
   }
 
   void enqueue(cudaq::QuantumTask &task) override {
-    cudaq::info("BaseRemoteSimulatorQPU: Enqueue Task on QPU {}", qpu_id);
+    CUDAQ_INFO("BaseRemoteSimulatorQPU: Enqueue Task on QPU {}", qpu_id);
     execution_queue->enqueue(task);
   }
 
@@ -132,10 +132,9 @@ public:
                    void *args, std::uint64_t voidStarSize,
                    std::uint64_t resultOffset,
                    const std::vector<void *> *rawArgs) {
-    cudaq::info(
-        "BaseRemoteSimulatorQPU: Launch kernel named '{}' remote QPU {} "
-        "(simulator = {})",
-        name, qpu_id, m_simName);
+    CUDAQ_INFO("BaseRemoteSimulatorQPU: Launch kernel named '{}' remote QPU {} "
+               "(simulator = {})",
+               name, qpu_id, m_simName);
 
     if (in_resource_estimation)
       throw std::runtime_error(
@@ -229,7 +228,7 @@ public:
   launchSerializedCodeExecution(const std::string &name,
                                 cudaq::SerializedCodeExecutionContext
                                     &serializeCodeExecutionObject) override {
-    cudaq::info(
+    CUDAQ_INFO(
         "BaseRemoteSimulatorQPU: Launch remote code named '{}' remote QPU {} "
         "(simulator = {})",
         name, qpu_id, m_simName);
@@ -260,13 +259,13 @@ public:
   }
 
   void setExecutionContext(cudaq::ExecutionContext *context) override {
-    cudaq::info("BaseRemoteSimulatorQPU::setExecutionContext QPU {}", qpu_id);
+    CUDAQ_INFO("BaseRemoteSimulatorQPU::setExecutionContext QPU {}", qpu_id);
     std::scoped_lock<std::mutex> lock(m_contextMutex);
     m_contexts[std::this_thread::get_id()] = context;
   }
 
   void resetExecutionContext() override {
-    cudaq::info("BaseRemoteSimulatorQPU::resetExecutionContext QPU {}", qpu_id);
+    CUDAQ_INFO("BaseRemoteSimulatorQPU::resetExecutionContext QPU {}", qpu_id);
     std::scoped_lock<std::mutex> lock(m_contextMutex);
     m_contexts.erase(std::this_thread::get_id());
   }

--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -163,7 +163,7 @@ public:
     if (rawArgs || args) {
       mlir::PassManager pm(&mlirContext);
       if (rawArgs && !rawArgs->empty()) {
-        cudaq::info("Run Argument Synth.\n");
+        CUDAQ_INFO("Run Argument Synth.\n");
         opt::ArgumentConverter argCon(name, moduleOp);
         argCon.gen_drop_front(*rawArgs, startingArgIdx);
 
@@ -193,7 +193,7 @@ public:
             opt::createReplaceStateWithKernel());
         pm.addPass(mlir::createSymbolDCEPass());
       } else if (args) {
-        cudaq::info("Run Quake Synth.\n");
+        CUDAQ_INFO("Run Quake Synth.\n");
         pm.addPass(opt::createQuakeSynthesizer(name, args, startingArgIdx));
       }
       pm.addPass(mlir::createCanonicalizerPass());
@@ -411,7 +411,7 @@ public:
       cudaq::RestClient restClient;
       auto resultJs =
           restClient.post(m_url, "job", requestJson, headers, false);
-      cudaq::debug("Response: {}", resultJs.dump(/*indent=*/2));
+      CUDAQ_DBG("Response: {}", resultJs.dump(/*indent=*/2));
 
       if (!resultJs.contains("executionContext")) {
         std::stringstream errorMsg;
@@ -528,7 +528,7 @@ protected:
     auto versionDataJs = m_restClient.get(
         fmt::format("https://{}/nvcf/functions/{}", m_baseUrl, m_functionId),
         "/versions", headers, /*enableSsl=*/true);
-    cudaq::info("Version data: {}", versionDataJs.dump());
+    CUDAQ_INFO("Version data: {}", versionDataJs.dump());
     std::vector<cudaq::NvcfFunctionVersionInfo> versions;
     versionDataJs["functions"].get_to(versions);
     return versions;
@@ -776,8 +776,8 @@ public:
     m_availableFuncs =
         getAllAvailableDeployments(functionOverride, versionOverride);
     for (const auto &[funcId, info] : m_availableFuncs)
-      cudaq::info("Function Id {} (API version {}.{}) has {} GPUs.", funcId,
-                  info.majorVersion, info.minorVersion, info.numGpus);
+      CUDAQ_INFO("Function Id {} (API version {}.{}) has {} GPUs.", funcId,
+                 info.majorVersion, info.minorVersion, info.numGpus);
     {
       if (funcIdIter != configs.end()) {
         // User overrides a specific function Id.
@@ -796,8 +796,8 @@ public:
               "functions tab, or try to regenerate the key.");
 
         // Determine the function Id based on the number of GPUs
-        cudaq::info("Looking for an NVQC deployment that has {} GPUs.",
-                    numGpusRequested);
+        CUDAQ_INFO("Looking for an NVQC deployment that has {} GPUs.",
+                   numGpusRequested);
         for (const auto &[funcId, info] : m_availableFuncs) {
           if (info.numGpus == numGpusRequested) {
             m_functionId = funcId;
@@ -861,8 +861,8 @@ public:
                     return a.createdAt > b.createdAt;
                   });
         for (const auto &versionInfo : versions)
-          cudaq::info("Found version Id {}, created at {}",
-                      versionInfo.versionId, versionInfo.createdAt);
+          CUDAQ_INFO("Found version Id {}, created at {}",
+                     versionInfo.versionId, versionInfo.createdAt);
 
         auto activeVersions =
             versions |
@@ -878,8 +878,8 @@ public:
                           m_functionId));
 
         m_functionVersionId = activeVersions.front().versionId;
-        cudaq::info("Selected the latest version Id {} for function Id {}",
-                    m_functionVersionId, m_functionId);
+        CUDAQ_INFO("Selected the latest version Id {} for function Id {}",
+                   m_functionVersionId, m_functionId);
       }
     }
   }
@@ -895,7 +895,7 @@ public:
     if (!m_availableFuncs.contains(m_functionId)) {
       // The user has manually overridden an NVQC function selection, but it
       // wasn't found in m_availableFuncs.
-      cudaq::info(
+      CUDAQ_INFO(
           "Function id overriden ({}) but cannot retrieve its remote "
           "capabilities because a deployment for it was not found. Will assume "
           "all optional remote capabilities are unsupported. You can set "
@@ -989,7 +989,7 @@ public:
     // `sendRequest` function exits (success or not).
     ScopeExit deleteAssetOnExit([&]() {
       if (assetId.has_value()) {
-        cudaq::info("Deleting NVQC Asset Id {}", assetId.value());
+        CUDAQ_INFO("Deleting NVQC Asset Id {}", assetId.value());
         auto headers = getHeaders();
         m_restClient.del(nvcfAssetUrl(), std::string("/") + assetId.value(),
                          headers, /*enableLogging=*/false, /*enableSsl=*/true);
@@ -1022,7 +1022,7 @@ public:
 
     try {
       // Making the request
-      cudaq::debug("Sending NVQC request to {}", nvcfInvocationUrl());
+      CUDAQ_DBG("Sending NVQC request to {}", nvcfInvocationUrl());
       auto lastQueuePos = std::numeric_limits<std::size_t>::max();
 
       if (m_logLevel > LogLevel::Info)
@@ -1030,7 +1030,7 @@ public:
       auto resultJs =
           m_restClient.post(nvcfInvocationUrl(), "", requestJson, jobHeader,
                             /*enableLogging=*/false, /*enableSsl=*/true);
-      cudaq::debug("Response: {}", resultJs.dump());
+      CUDAQ_DBG("Response: {}", resultJs.dump());
 
       // Call getQueuePosition() until we're at the front of the queue. If log
       // level is "none", then skip all this because we don't need to show the
@@ -1131,8 +1131,8 @@ public:
         // This is a large response that needs to be downloaded
         const std::string downloadUrl = resultJs["responseReference"];
         const std::string reqId = resultJs["reqId"];
-        cudaq::info("Download result for Request Id {} at {}", reqId,
-                    downloadUrl);
+        CUDAQ_INFO("Download result for Request Id {} at {}", reqId,
+                   downloadUrl);
         llvm::SmallString<32> tempDir;
         llvm::sys::path::system_temp_directory(/*ErasedOnReboot*/ true,
                                                tempDir);
@@ -1140,7 +1140,7 @@ public:
             std::filesystem::path(tempDir.c_str()) / (reqId + ".zip");
         m_restClient.download(downloadUrl, resultFilePath.string(),
                               /*enableLogging=*/false, /*enableSsl=*/true);
-        cudaq::info("Downloaded zip file {}", resultFilePath.string());
+        CUDAQ_INFO("Downloaded zip file {}", resultFilePath.string());
         std::filesystem::path unzipDir =
             std::filesystem::path(tempDir.c_str()) / reqId;
         // Unzip the response
@@ -1165,7 +1165,7 @@ public:
                             resultJsonFile.string());
           return false;
         }
-        cudaq::info(
+        CUDAQ_INFO(
             "Delete response zip file {} and its inflated contents in {}",
             resultFilePath.c_str(), unzipDir.c_str());
         std::filesystem::remove(resultFilePath);
@@ -1278,8 +1278,8 @@ public:
                             /*enableLogging=*/false, /*enableSsl=*/true);
       const std::string uploadUrl = resultJs["uploadUrl"];
       const std::string assetId = resultJs["assetId"];
-      cudaq::info("Upload NVQC job request as NVCF Asset Id {} to {}", assetId,
-                  uploadUrl);
+      CUDAQ_INFO("Upload NVQC job request as NVCF Asset Id {} to {}", assetId,
+                 uploadUrl);
       std::map<std::string, std::string> uploadHeader;
       // This must match the request to create the upload link
       uploadHeader["Content-Type"] = "application/json";

--- a/runtime/common/BraketExecutor.h
+++ b/runtime/common/BraketExecutor.h
@@ -39,7 +39,7 @@ protected:
 
   public:
     ScopedApi(Aws::SDKOptions &options) : options(options) {
-      cudaq::debug("Initializing AWS API");
+      CUDAQ_DBG("Initializing AWS API");
       /// FIXME: Allow setting following flag via CUDA-Q frontend
       // options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
       Aws::InitAPI(options);

--- a/runtime/common/DeviceCodeRegistry.cpp
+++ b/runtime/common/DeviceCodeRegistry.cpp
@@ -36,7 +36,7 @@ void cudaq::registry::__cudaq_deviceCodeHolderAdd(const char *key,
   auto it = std::find_if(quakeRegistry.begin(), quakeRegistry.end(),
                          [&](const auto &pair) { return pair.first == key; });
   if (it != quakeRegistry.end()) {
-    cudaq::info("Replacing code for kernel {}", key);
+    CUDAQ_INFO("Replacing code for kernel {}", key);
     it->second = code;
     return;
   }

--- a/runtime/common/Executor.cpp
+++ b/runtime/common/Executor.cpp
@@ -15,8 +15,8 @@ details::future Executor::execute(std::vector<KernelExecution> &codesToExecute,
 
   serverHelper->setShots(shots);
 
-  cudaq::info("Executor creating {} jobs to execute with the {} helper.",
-              codesToExecute.size(), serverHelper->name());
+  CUDAQ_INFO("Executor creating {} jobs to execute with the {} helper.",
+             codesToExecute.size(), serverHelper->name());
 
   // Create the Job Payload, composed of job post path, headers,
   // and the job json messages themselves
@@ -26,14 +26,14 @@ details::future Executor::execute(std::vector<KernelExecution> &codesToExecute,
 
   std::vector<details::future::Job> ids;
   for (std::size_t i = 0; auto &job : jobs) {
-    cudaq::info("Job (name={}) created, posting to {}", codesToExecute[i].name,
-                jobPostPath);
+    CUDAQ_INFO("Job (name={}) created, posting to {}", codesToExecute[i].name,
+               jobPostPath);
 
     // Post it, get the response
     auto response = client.post(jobPostPath, "", job, headers, true, false,
                                 serverHelper->getCookies());
-    cudaq::info("Job (name={}) posted, response was {}", codesToExecute[i].name,
-                response.dump());
+    CUDAQ_INFO("Job (name={}) posted, response was {}", codesToExecute[i].name,
+               response.dump());
 
     // Add the job id and the job name.
     auto task_id = serverHelper->extractJobId(response);
@@ -42,7 +42,7 @@ details::future Executor::execute(std::vector<KernelExecution> &codesToExecute,
       serverHelper->constructGetJobPath(tmp[0]);
       task_id = tmp[0].at("task_id");
     }
-    cudaq::info("Task ID is {}", task_id);
+    CUDAQ_INFO("Task ID is {}", task_id);
     ids.emplace_back(task_id, codesToExecute[i].name);
     config["output_names." + task_id] = codesToExecute[i].output_names.dump();
 

--- a/runtime/common/Future.cpp
+++ b/runtime/common/Future.cpp
@@ -26,11 +26,11 @@ sample_result future::get() {
   auto headers = serverHelper->getHeaders();
   std::vector<ExecutionResult> results;
   for (auto &id : jobs) {
-    cudaq::info("Future retrieving results for {}.", id.first);
+    CUDAQ_INFO("Future retrieving results for {}.", id.first);
 
     auto jobGetPath = serverHelper->constructGetJobPath(id.first);
 
-    cudaq::info("Future got job retrieval path as {}.", jobGetPath);
+    CUDAQ_INFO("Future got job retrieval path as {}.", jobGetPath);
     auto resultResponse =
         client.get(jobGetPath, "", headers, false, serverHelper->getCookies());
     while (!serverHelper->jobIsDone(resultResponse)) {

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -233,15 +233,15 @@ void noise_model::add_channel(const std::string &quantumOp,
   auto key = std::make_pair(quantumOp, qubits);
   auto iter = noiseModel.find(key);
   if (iter == noiseModel.end()) {
-    cudaq::info("Adding new kraus_channel to noise_model ({}, {})", quantumOp,
-                qubits);
+    CUDAQ_INFO("Adding new kraus_channel to noise_model ({}, {})", quantumOp,
+               qubits);
     noiseModel.insert({key, {channel}});
     return;
   }
 
-  cudaq::info("kraus_channel existed for {}, adding new kraus_channel to "
-              "noise_model (qubits = {})",
-              quantumOp, qubits);
+  CUDAQ_INFO("kraus_channel existed for {}, adding new kraus_channel to "
+             "noise_model (qubits = {})",
+             quantumOp, qubits);
 
   iter->second.push_back(channel);
 }
@@ -274,16 +274,16 @@ void noise_model::add_all_qubit_channel(const std::string &quantumOp,
   GateIdentifier key(actualGateName, numControls);
   auto iter = defaultNoiseModel.find(key);
   if (iter == defaultNoiseModel.end()) {
-    cudaq::info("Adding new all-qubit kraus_channel to noise_model ({}, number "
-                "of control bits = {})",
-                actualGateName, numControls);
+    CUDAQ_INFO("Adding new all-qubit kraus_channel to noise_model ({}, number "
+               "of control bits = {})",
+               actualGateName, numControls);
     defaultNoiseModel.insert({key, {channel}});
     return;
   }
 
-  cudaq::info("kraus_channel existed for {}, adding new kraus_channel to "
-              "noise_model (number of control bits = {})",
-              actualGateName, numControls);
+  CUDAQ_INFO("kraus_channel existed for {}, adding new kraus_channel to "
+             "noise_model (number of control bits = {})",
+             actualGateName, numControls);
 
   iter->second.push_back(channel);
 }
@@ -297,8 +297,8 @@ void noise_model::add_channel(const std::string &quantumOp,
         "Invalid quantum op for noise_model::add_channel (" + quantumOp + ").");
   auto iter = gatePredicates.find(quantumOp);
   if (iter == gatePredicates.end()) {
-    cudaq::info("Adding new callback kraus_channel to noise_model for {}.",
-                quantumOp);
+    CUDAQ_INFO("Adding new callback kraus_channel to noise_model for {}.",
+               quantumOp);
     gatePredicates.insert({quantumOp, pred});
     return;
   }
@@ -330,7 +330,7 @@ noise_model::get_channels(const std::string &quantumOp,
   auto iter = noiseModel.find(key);
   // Note: we've validated the channel dimension in the 'add_channel' method.
   if (iter != noiseModel.end()) {
-    cudaq::info("Found kraus_channel for {} on {}.", quantumOp, qubits);
+    CUDAQ_INFO("Found kraus_channel for {} on {}.", quantumOp, qubits);
     const auto &krausChannel = iter->second;
     resultChannels.insert(resultChannels.end(), krausChannel.begin(),
                           krausChannel.end());
@@ -340,7 +340,7 @@ noise_model::get_channels(const std::string &quantumOp,
   auto defaultIter =
       defaultNoiseModel.find(GateIdentifier(quantumOp, controlQubits.size()));
   if (defaultIter != defaultNoiseModel.end()) {
-    cudaq::info(
+    CUDAQ_INFO(
         "Found default kraus_channel setting for {} with {} control bits.",
         quantumOp, controlQubits.size());
 
@@ -359,7 +359,7 @@ noise_model::get_channels(const std::string &quantumOp,
   // Look up predicate-specific noise settings
   auto predIter = gatePredicates.find(quantumOp);
   if (predIter != gatePredicates.end()) {
-    cudaq::info("Found callback kraus_channel setting for {}.", quantumOp);
+    CUDAQ_INFO("Found callback kraus_channel setting for {}.", quantumOp);
     const auto krausChannel = predIter->second(qubits, params);
     if (!verifyChannelDimension({krausChannel}))
       throw std::runtime_error(fmt::format(
@@ -373,7 +373,7 @@ noise_model::get_channels(const std::string &quantumOp,
   }
 
   if (resultChannels.empty())
-    cudaq::info("No kraus_channel available for {} on {}.", quantumOp, qubits);
+    CUDAQ_INFO("No kraus_channel available for {} on {}.", quantumOp, qubits);
 
   return resultChannels;
 }

--- a/runtime/common/PluginUtils.h
+++ b/runtime/common/PluginUtils.h
@@ -21,8 +21,8 @@ namespace cudaq {
 template <typename PluginPointerType>
 PluginPointerType *getUniquePluginInstance(const std::string_view symbolName,
                                            const char *libName = nullptr) {
-  cudaq::info("Requesting {} plugin via symbol name {}.",
-              typeid(PluginPointerType).name(), symbolName);
+  CUDAQ_INFO("Requesting {} plugin via symbol name {}.",
+             typeid(PluginPointerType).name(), symbolName);
   std::mutex m;
   std::lock_guard<std::mutex> l(m);
   using GetPluginFunction = PluginPointerType *(*)();
@@ -33,7 +33,7 @@ PluginPointerType *getUniquePluginInstance(const std::string_view symbolName,
     throw std::runtime_error(
         fmt::format("Could not load the requested plugin. \n{}\n", dlerror()));
 
-  cudaq::info("Successfully loaded the plugin.");
+  CUDAQ_INFO("Successfully loaded the plugin.");
   return fcn();
 }
 } // namespace cudaq

--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -12,7 +12,7 @@
 
 void cudaq::RecordLogParser::parse(const std::string &outputLog) {
   ScopedTraceWithContext(cudaq::TIMING_RUN, "RecordLogParser::parse");
-  cudaq::debug("Parsing log:\n{}", outputLog);
+  CUDAQ_DBG("Parsing log:\n{}", outputLog);
   std::vector<std::string> lines = cudaq::split(outputLog, '\n');
   if (lines.empty())
     return;

--- a/runtime/common/RestClient.cpp
+++ b/runtime/common/RestClient.cpp
@@ -20,7 +20,7 @@ RestClient::RestClient() : sslOptions(std::make_unique<cpr::SslOptions>()) {
       if (std::filesystem::exists(curlCABundleStr))
         return curlCABundleStr;
       else
-        cudaq::info(
+        CUDAQ_INFO(
             "{} does not exist. Will fall back on CUDA-Q installed certs",
             curlCABundleStr);
     }
@@ -28,7 +28,7 @@ RestClient::RestClient() : sslOptions(std::make_unique<cpr::SslOptions>()) {
     auto certPath = cudaqLibPath.parent_path().parent_path() / "cacert.pem";
     if (std::filesystem::exists(certPath))
       return certPath.string();
-    cudaq::info(
+    CUDAQ_INFO(
         "{} does not exist, so we will rely on CURL finding the correct "
         "certificate authority bundles. If this does not work, try setting "
         "the CURL_CA_BUNDLE environment variable to a valid path to a CA "
@@ -66,8 +66,7 @@ RestClient::post(const std::string_view remoteUrl, const std::string_view path,
 
   // Allow caller to disable logging for things like passwords/tokens
   if (enableLogging)
-    cudaq::info("Posting to {}/{} with data = {}", remoteUrl, path,
-                post.dump());
+    CUDAQ_INFO("Posting to {}/{} with data = {}", remoteUrl, path, post.dump());
 
   auto actualPath = std::string(remoteUrl) + std::string(path);
   auto r = cpr::Post(cpr::Url{actualPath}, cpr::Body(post.dump()), cprHeaders,
@@ -102,8 +101,8 @@ void RestClient::put(const std::string_view remoteUrl,
     cprCookies.emplace_back({kv.first, kv.second});
   // Allow caller to disable logging for things like passwords/tokens
   if (enableLogging)
-    cudaq::info("Putting to {}/{} with data = {}", remoteUrl, path,
-                putData.dump());
+    CUDAQ_INFO("Putting to {}/{} with data = {}", remoteUrl, path,
+               putData.dump());
 
   auto actualPath = std::string(remoteUrl) + std::string(path);
   auto r = cpr::Put(cpr::Url{actualPath}, cpr::Body(putData.dump()), cprHeaders,
@@ -154,7 +153,7 @@ void RestClient::del(const std::string_view remoteUrl,
   cpr::Parameters cprParams;
   auto actualPath = std::string(remoteUrl) + std::string(path);
   if (enableLogging)
-    cudaq::info("Delete resource at path {}/{}", remoteUrl, path);
+    CUDAQ_INFO("Delete resource at path {}/{}", remoteUrl, path);
   auto r = cpr::Delete(cpr::Url{actualPath}, cprHeaders, cprParams,
                        cpr::VerifySsl(enableSsl), *sslOptions, cprCookies);
 
@@ -181,8 +180,8 @@ void RestClient::download(const std::string_view remoteUrl,
                              r.error.message + ": " + r.text);
 
   if (enableLogging)
-    cudaq::info("Downloading {} bytes from {} to file {}", r.text.size(),
-                remoteUrl, filePath);
+    CUDAQ_INFO("Downloading {} bytes from {} to file {}", r.text.size(),
+               remoteUrl, filePath);
 
   try {
     // Write the downloaded content to file.

--- a/runtime/common/RunTheKernel.cpp
+++ b/runtime/common/RunTheKernel.cpp
@@ -69,7 +69,7 @@ extractLayout(const std::string &kernelName, const std::string &quakeCode) {
     throw std::runtime_error("module is malformed. missing data layout.");
   StringRef dataLayoutSpec = cast<StringAttr>(attr);
   auto dataLayout = llvm::DataLayout(dataLayoutSpec);
-  cudaq::info("Data Layout: {}", dataLayout.getStringRepresentation());
+  CUDAQ_INFO("Data Layout: {}", dataLayout.getStringRepresentation());
   llvm::LLVMContext context;
   LLVMTypeConverter converter(kernelFunc.getContext());
   cudaq::opt::initializeTypeConversions(converter);

--- a/runtime/cudaq/algorithms/evolve.cpp
+++ b/runtime/cudaq/algorithms/evolve.cpp
@@ -84,7 +84,7 @@ evolve_result evolveSingle(const cudaq::rydberg_hamiltonian &hamiltonian,
   platform.set_exec_ctx(ctx.get());
 
   auto programString = programJson.dump();
-  cudaq::debug("Program JSON: {}", programString);
+  CUDAQ_DBG("Program JSON: {}", programString);
 
   auto dynamicResult = cudaq::altLaunchKernel(
       programName.str().c_str(), KernelThunkType(nullptr),

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -45,9 +45,9 @@ cudaq::MPIPlugin *getMpiPlugin(bool unsafe) {
   const char *mpiLibPath = std::getenv("CUDAQ_MPI_COMM_LIB");
   if (mpiLibPath) {
     // The user has set the environment variable.
-    cudaq::info("Load MPI comm plugin from CUDAQ_MPI_COMM_LIB environment "
-                "variable at '{}'",
-                mpiLibPath);
+    CUDAQ_INFO("Load MPI comm plugin from CUDAQ_MPI_COMM_LIB environment "
+               "variable at '{}'",
+               mpiLibPath);
     g_plugin = std::make_unique<cudaq::MPIPlugin>(mpiLibPath);
   } else {
     // Try locate MPI plugins in the install directory
@@ -63,8 +63,8 @@ cudaq::MPIPlugin *getMpiPlugin(bool unsafe) {
     const auto activatedInterfaceLibFile =
         distributedInterfacesDir / activatedInterfaceLibFilename;
     if (std::filesystem::exists(activatedInterfaceLibFile)) {
-      cudaq::info("Load MPI comm plugin from '{}'",
-                  activatedInterfaceLibFile.c_str());
+      CUDAQ_INFO("Load MPI comm plugin from '{}'",
+                 activatedInterfaceLibFile.c_str());
       g_plugin =
           std::make_unique<cudaq::MPIPlugin>(activatedInterfaceLibFile.c_str());
     } else {
@@ -79,8 +79,8 @@ cudaq::MPIPlugin *getMpiPlugin(bool unsafe) {
           pluginsPath / fmt::format("libcudaq-comm-plugin.{}", libSuffix);
       if (std::filesystem::exists(pluginLibFile) &&
           cudaq::MPIPlugin::isValidInterfaceLib(pluginLibFile.c_str())) {
-        cudaq::info("Load builtin MPI comm plugin at '{}'",
-                    pluginLibFile.c_str());
+        CUDAQ_INFO("Load builtin MPI comm plugin at '{}'",
+                   pluginLibFile.c_str());
         g_plugin = std::make_unique<cudaq::MPIPlugin>(pluginLibFile.c_str());
       }
     }
@@ -110,7 +110,7 @@ void initialize(int argc, char **argv) {
   const auto pid = commPlugin->rank();
   const auto np = commPlugin->num_ranks();
   if (pid == 0)
-    cudaq::info("MPI Initialized, nRanks = {}", np);
+    CUDAQ_INFO("MPI Initialized, nRanks = {}", np);
 }
 
 int rank() { return getMpiPlugin()->rank(); }
@@ -185,7 +185,7 @@ void finalize() {
   auto *commPlugin = getMpiPlugin();
   if (!commPlugin->is_finalized()) {
     if (rank() == 0)
-      cudaq::info("Finalizing MPI.");
+      CUDAQ_INFO("Finalizing MPI.");
     commPlugin->finalize();
   }
 }

--- a/runtime/cudaq/distributed/mpi_plugin.cpp
+++ b/runtime/cudaq/distributed/mpi_plugin.cpp
@@ -133,7 +133,7 @@ void MPIPlugin::finalize() {
     return;
 
   if (rank() == 0)
-    cudaq::info("Finalizing MPI.");
+    CUDAQ_INFO("Finalizing MPI.");
 
   // Finalize
   HANDLE_MPI_ERROR(m_distributedInterface->finalize());

--- a/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
+++ b/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
@@ -85,7 +85,7 @@ public:
     threadToQpuId.clear();
     platformQPUs.emplace_back(std::make_unique<DefaultQPU>());
 
-    cudaq::info("Backend string is {}", backend);
+    CUDAQ_INFO("Backend string is {}", backend);
     std::map<std::string, std::string> configMap;
     auto mutableBackend = backend;
     if (mutableBackend.find(";") != std::string::npos) {
@@ -102,7 +102,7 @@ public:
     /// Once we know the backend, we should search for the config file
     /// from there we can get the URL/PORT and the required MLIR pass pipeline.
     auto configFilePath = platformPath / fileName;
-    cudaq::info("Config file path = {}", configFilePath.string());
+    CUDAQ_INFO("Config file path = {}", configFilePath.string());
 
     // Don't try to load something that doesn't exist.
     if (!std::filesystem::exists(configFilePath)) {
@@ -120,7 +120,7 @@ public:
     if (config.BackendConfig.has_value() &&
         !config.BackendConfig->PlatformQpu.empty()) {
       auto qpuName = config.BackendConfig->PlatformQpu;
-      cudaq::info("Default platform QPU subtype name: {}", qpuName);
+      CUDAQ_INFO("Default platform QPU subtype name: {}", qpuName);
       platformQPUs.clear();
       threadToQpuId.clear();
       platformQPUs.emplace_back(cudaq::registry::get<cudaq::QPU>(qpuName));

--- a/runtime/cudaq/platform/default/rest/helpers/anyon/AnyonServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/anyon/AnyonServerHelper.cpp
@@ -134,9 +134,8 @@ AnyonServerHelper::createJob(std::vector<KernelExecution> &circuitCodes) {
   // Get the headers
   RestHeaders headers = generateRequestHeader();
 
-  cudaq::info(
-      "Created job payload for anyon, language is QIR 1.0, targeting {}",
-      machine);
+  CUDAQ_INFO("Created job payload for anyon, language is QIR 1.0, targeting {}",
+             machine);
 
   // return the payload
   return std::make_tuple(baseUrl + "job", headers, messages);
@@ -187,7 +186,7 @@ AnyonServerHelper::processResults(ServerMessage &postJobResponse,
   //                      "r1" : ["1", "0", ...]  } }
   auto results = postJobResponse[0]["results"];
 
-  cudaq::info("Results message: {}", results.dump());
+  CUDAQ_INFO("Results message: {}", results.dump());
 
   std::vector<ExecutionResult> srs;
 
@@ -209,8 +208,8 @@ AnyonServerHelper::processResults(ServerMessage &postJobResponse,
 
   auto &output_names = outputNames[jobId];
   for (auto &[result, info] : output_names) {
-    cudaq::info("Qubit {} Result {} Name {}", info.qubitNum, result,
-                info.registerName);
+    CUDAQ_INFO("Qubit {} Result {} Name {}", info.qubitNum, result,
+               info.registerName);
   }
 
   // The local mock server tests don't work the same way as the true Anyon
@@ -348,7 +347,7 @@ void AnyonServerHelper::refreshTokens(bool force_refresh) {
   // If we are getting close to an 30 min, then we will refresh
   bool needsRefresh = secondsDuration.count() * (1. / 1800.) > .85;
   if (needsRefresh || force_refresh) {
-    cudaq::info("Refreshing id_token");
+    CUDAQ_INFO("Refreshing id_token");
     std::stringstream ss;
     ss << "\"refresh_token\":\"" << refreshKey << "\"";
     auto headers = generateRequestHeader(refreshKey);

--- a/runtime/cudaq/platform/default/rest/helpers/braket/BraketExecutor.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/BraketExecutor.cpp
@@ -34,13 +34,13 @@ void tryCreateBucket(Aws::S3Crt::S3CrtClient &client, std::string const &region,
             GetBucketLocationConstraintForName(region));
   }
   createReq.SetCreateBucketConfiguration(config);
-  cudaq::info("Attempting to create S3 bucket \"s3://{}\"", bucketName);
+  CUDAQ_INFO("Attempting to create S3 bucket \"s3://{}\"", bucketName);
   auto createResponse = client.CreateBucket(createReq);
   if (!createResponse.IsSuccess()) {
     auto error = createResponse.GetError();
     if (error.GetErrorType() ==
         Aws::S3Crt::S3CrtErrors::BUCKET_ALREADY_OWNED_BY_YOU) {
-      cudaq::info("\"s3://{}\" already exists", bucketName);
+      CUDAQ_INFO("\"s3://{}\" already exists", bucketName);
       return;
     } else if (error.GetErrorType() ==
                Aws::S3Crt::S3CrtErrors::BUCKET_ALREADY_EXISTS) {
@@ -129,7 +129,7 @@ void BraketExecutor::setServerHelper(ServerHelper *helper) {
   s3ClientConfig.verifySSL = false;
   if (!region.empty()) {
     if (region != clientConfig.region) {
-      cudaq::info("Auto-routing to AWS region {}", region);
+      CUDAQ_INFO("Auto-routing to AWS region {}", region);
       clientConfig.region = region;
       s3ClientConfig.region = region;
     }
@@ -154,8 +154,8 @@ void BraketExecutor::setServerHelper(ServerHelper *helper) {
           }
         }
         tryCreateBucket(*s3ClientPtr, region, bucketName);
-        cudaq::info("Braket task results will use S3 bucket \"s3://{}\"",
-                    bucketName);
+        CUDAQ_INFO("Braket task results will use S3 bucket \"s3://{}\"",
+                   bucketName);
         return bucketName;
       }).share();
 }
@@ -167,7 +167,7 @@ ServerJobPayload BraketExecutor::checkHelperAndCreateJob(
   braketServerHelper->setShots(shots);
 
   auto config = braketServerHelper->getConfig();
-  cudaq::info("Backend config: {}, shots {}", config, shots);
+  CUDAQ_INFO("Backend config: {}, shots {}", config, shots);
   config.insert({"shots", std::to_string(shots)});
 
   return braketServerHelper->createJob(codesToExecute);
@@ -231,7 +231,7 @@ BraketExecutor::execute(std::vector<KernelExecution> &codesToExecute,
           }
           std::string taskArn = createResponse.GetResult().GetQuantumTaskArn();
 
-          cudaq::info("Created Braket quantum task {}", taskArn);
+          CUDAQ_INFO("Created Braket quantum task {}", taskArn);
           setOutputNames(codesToExecute[i], taskArn);
 
           Aws::Braket::Model::GetQuantumTaskRequest req;
@@ -265,9 +265,9 @@ BraketExecutor::execute(std::vector<KernelExecution> &codesToExecute,
           std::string outBucket = getResult.GetOutputS3Bucket();
           std::string outPrefix = getResult.GetOutputS3Directory();
 
-          cudaq::info("Fetching braket quantum task {} results from "
-                      "s3://{}/{}/results.json",
-                      taskArn, outBucket, outPrefix);
+          CUDAQ_INFO("Fetching braket quantum task {} results from "
+                     "s3://{}/{}/results.json",
+                     taskArn, outBucket, outPrefix);
 
           Aws::S3Crt::Model::GetObjectRequest resultsJsonRequest;
           resultsJsonRequest.SetBucket(outBucket);

--- a/runtime/cudaq/platform/default/rest/helpers/braket/BraketServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/BraketServerHelper.cpp
@@ -40,22 +40,22 @@ BraketServerHelper::getValueOrDefault(const BackendConfig &config,
 
 // Initialize the Braket server helper with a given backend configuration
 void BraketServerHelper::initialize(BackendConfig config) {
-  cudaq::info("Initializing Amazon Braket backend.");
+  CUDAQ_INFO("Initializing Amazon Braket backend.");
   // Fetch machine info before checking emulate because we want to be able to
   // emulate specific machines, defaults to state vector simulator
   auto machine =
       getValueOrDefault(config, "machine",
                         "arn:aws:braket:::device/quantum-simulator/amazon/sv1");
   auto deviceArn = checkDeviceArn(machine);
-  cudaq::info("Running on device {}", deviceArn);
+  CUDAQ_INFO("Running on device {}", deviceArn);
   config["defaultBucket"] = getValueOrDefault(config, "default_bucket", "");
   config["deviceArn"] = deviceArn;
   if (!config["shots"].empty())
     this->setShots(std::stoul(config["shots"]));
   const auto emulate_it = config.find("emulate");
   if (emulate_it != config.end() && emulate_it->second == "true") {
-    cudaq::info("Emulation is enabled, ignore all Amazon Braket connection "
-                "specific information.");
+    CUDAQ_INFO("Emulation is enabled, ignore all Amazon Braket connection "
+               "specific information.");
     backendConfig = std::move(config);
     return;
   }
@@ -84,9 +84,9 @@ BraketServerHelper::createJob(std::vector<KernelExecution> &circuitCodes) {
     taskRequest["shots"] = shots;
     tasks.push_back(taskRequest);
   }
-  cudaq::info("Created job payload for braket, language is OpenQASM 2.0, "
-              "targeting device {}",
-              backendConfig.at("deviceArn"));
+  CUDAQ_INFO("Created job payload for braket, language is OpenQASM 2.0, "
+             "targeting device {}",
+             backendConfig.at("deviceArn"));
   return ret;
 };
 
@@ -98,8 +98,8 @@ sample_result BraketServerHelper::processResults(ServerMessage &resultsJson,
 
   auto &output_names = outputNames[jobID];
   for (auto &[result, info] : output_names) {
-    cudaq::info("Qubit {} Result {} Name {}", info.qubitNum, result,
-                info.registerName);
+    CUDAQ_INFO("Qubit {} Result {} Name {}", info.qubitNum, result,
+               info.registerName);
   }
 
   CountsDictionary counts;

--- a/runtime/cudaq/platform/default/rest/helpers/infleqtion/InfleqtionServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/infleqtion/InfleqtionServerHelper.cpp
@@ -107,7 +107,7 @@ private:
 
 // Initialize the Infleqtion server helper with a given backend configuration
 void InfleqtionServerHelper::initialize(BackendConfig config) {
-  cudaq::info("Initializing Infleqtion Backend.");
+  CUDAQ_INFO("Initializing Infleqtion Backend.");
 
   // Move the passed config into the member variable backendConfig
   backendConfig = config;

--- a/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/ionq/IonQServerHelper.cpp
@@ -92,7 +92,7 @@ private:
 
 // Initialize the IonQ server helper with a given backend configuration
 void IonQServerHelper::initialize(BackendConfig config) {
-  cudaq::info("Initializing IonQ Backend.");
+  CUDAQ_INFO("Initializing IonQ Backend.");
   // Move the passed config into the member variable backendConfig
   // Set the necessary configuration variables for the IonQ API
   backendConfig["url"] = getValueOrDefault(config, "url", DEFAULT_URL);
@@ -362,23 +362,23 @@ IonQServerHelper::processResults(ServerMessage &postJobResponse,
 
   // Get the number of qubits. This assumes the all qubits are measured,
   // which is a safe assumption for now but may change in the future.
-  cudaq::debug("postJobResponse message: {}", postJobResponse.dump());
+  CUDAQ_DBG("postJobResponse message: {}", postJobResponse.dump());
   auto &jobs = postJobResponse.at("jobs");
   if (!jobs[0].contains("qubits"))
     throw std::runtime_error(
         "ServerMessage doesn't tell us how many qubits there were");
 
   auto nQubits = jobs[0].at("qubits").get<int>();
-  cudaq::debug("nQubits is : {}", nQubits);
-  cudaq::debug("Results message: {}", results.dump());
+  CUDAQ_DBG("nQubits is : {}", nQubits);
+  CUDAQ_DBG("Results message: {}", results.dump());
 
   if (outputNames.find(jobID) == outputNames.end())
     throw std::runtime_error("Could not find output names for job " + jobID);
 
   auto &output_names = outputNames[jobID];
   for (auto &[result, info] : output_names) {
-    cudaq::info("Qubit {} Result {} Name {}", info.qubitNum, result,
-                info.registerName);
+    CUDAQ_INFO("Qubit {} Result {} Name {}", info.qubitNum, result,
+               info.registerName);
   }
 
   cudaq::CountsDictionary counts;

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
@@ -39,7 +39,7 @@ protected:
   /// @brief Parse cortex-cli tokens JSON for the API access token
   std::optional<std::string> readApiToken() const {
     if (!tokensFilePath.has_value()) {
-      cudaq::info(
+      CUDAQ_INFO(
           "tokensFilePath is not set, assuming no authentication is required");
       return std::nullopt;
     }
@@ -63,7 +63,7 @@ protected:
     auto quantumArchitecture =
         client.get(iqmServerUrl, "quantum-architecture", headers);
     try {
-      cudaq::debug("quantumArchitecture = {}", quantumArchitecture.dump());
+      CUDAQ_DBG("quantumArchitecture = {}", quantumArchitecture.dump());
       return quantumArchitecture["quantum_architecture"]["name"]
           .get<std::string>();
     } catch (const std::exception &e) {
@@ -94,7 +94,7 @@ public:
     }
     qpuArchitecture = iter->second;
     std::replace(qpuArchitecture.begin(), qpuArchitecture.end(), '_', ' ');
-    cudaq::debug("qpuArchitecture = {}", qpuArchitecture);
+    CUDAQ_DBG("qpuArchitecture = {}", qpuArchitecture);
 
     // Set an alternate base URL if provided.
     iter = backendConfig.find("url");
@@ -103,7 +103,7 @@ public:
       // For running unittests
       if (iqmServerUrl.find("localhost") != std::string::npos) {
         std::replace(qpuArchitecture.begin(), qpuArchitecture.end(), ' ', '_');
-        cudaq::debug("qpuArchitecture = {}", qpuArchitecture);
+        CUDAQ_DBG("qpuArchitecture = {}", qpuArchitecture);
       }
     }
 
@@ -118,11 +118,10 @@ public:
 
     if (!iqmServerUrl.ends_with("/"))
       iqmServerUrl += "/";
-    cudaq::debug("iqmServerUrl = {}", iqmServerUrl);
+    CUDAQ_DBG("iqmServerUrl = {}", iqmServerUrl);
 
     if (emulate) {
-      cudaq::info(
-          "Emulation is enabled, ignore tokens file and IQM Server URL");
+      CUDAQ_INFO("Emulation is enabled, ignore tokens file and IQM Server URL");
       return;
     }
 
@@ -130,18 +129,18 @@ public:
     auto envTokenFilePath = getenv("IQM_TOKENS_FILE");
     auto defaultTokensFilePath =
         std::string(getenv("HOME")) + "/.cache/iqm-cortex-cli/tokens.json";
-    cudaq::debug("defaultTokensFilePath = {}", defaultTokensFilePath);
+    CUDAQ_DBG("defaultTokensFilePath = {}", defaultTokensFilePath);
     if (envTokenFilePath) {
       tokensFilePath = std::string(envTokenFilePath);
     } else if (cudaq::fileExists(defaultTokensFilePath)) {
       tokensFilePath = defaultTokensFilePath;
     }
-    cudaq::debug("tokensFilePath = {}", tokensFilePath.value_or("not set"));
+    CUDAQ_DBG("tokensFilePath = {}", tokensFilePath.value_or("not set"));
 
     // Fetch quantum-architecture program was compiled with
     auto configuredTargetArchitecture = getQuantumArchitectureName();
-    cudaq::debug("configuredTargetArchitecture = {}",
-                 configuredTargetArchitecture);
+    CUDAQ_DBG("configuredTargetArchitecture = {}",
+              configuredTargetArchitecture);
 
     // Does it match the compiled architecture?
     if (qpuArchitecture != configuredTargetArchitecture) {
@@ -220,7 +219,7 @@ IQMServerHelper::nextResultPollingInterval(ServerMessage &postResponse) {
 };
 
 bool IQMServerHelper::jobIsDone(ServerMessage &getJobResponse) {
-  cudaq::debug("getJobResponse: {}", getJobResponse.dump());
+  CUDAQ_DBG("getJobResponse: {}", getJobResponse.dump());
 
   auto jobStatus = getJobResponse["status"].get<std::string>();
   std::unordered_set<std::string> terminalStatuses = {"ready", "failed",
@@ -231,7 +230,7 @@ bool IQMServerHelper::jobIsDone(ServerMessage &getJobResponse) {
 cudaq::sample_result
 IQMServerHelper::processResults(ServerMessage &postJobResponse,
                                 std::string &jobID) {
-  cudaq::info("postJobResponse: {}", postJobResponse.dump());
+  CUDAQ_INFO("postJobResponse: {}", postJobResponse.dump());
 
   // check if the job succeeded
   auto jobStatus = postJobResponse["status"].get<std::string>();

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -146,7 +146,7 @@ void check_machine_allowed(const std::string &machine) {
 // Initialize the OQC server helper with a given backend configuration
 void OQCServerHelper::initialize(BackendConfig config) {
 
-  cudaq::info("Initializing OQC Backend.");
+  CUDAQ_INFO("Initializing OQC Backend.");
 
   // Fetch machine info before checking emulate because we want to be able to
   // emulate specific machines.
@@ -155,8 +155,8 @@ void OQCServerHelper::initialize(BackendConfig config) {
   config["machine"] = machine;
   const auto emulate_it = config.find("emulate");
   if (emulate_it != config.end() && emulate_it->second == "true") {
-    cudaq::info("Emulation is enabled, ignore all oqc connection specific "
-                "information.");
+    CUDAQ_INFO("Emulation is enabled, ignore all oqc connection specific "
+               "information.");
     backendConfig = std::move(config);
     return;
   }
@@ -353,7 +353,7 @@ OQCServerHelper::processResults(ServerMessage &postJobResponse,
     throw std::runtime_error("OQC backend error message: " +
                              postJobResponse["task_error"].dump());
   }
-  cudaq::info("postJobResponse is {}", postJobResponse.dump());
+  CUDAQ_INFO("postJobResponse is {}", postJobResponse.dump());
   const auto &jsonResults = postJobResponse.at("results");
 
   cudaq::sample_result sampleResult; // value to return
@@ -376,8 +376,8 @@ OQCServerHelper::processResults(ServerMessage &postJobResponse,
 
   auto &output_names = outputNames[jobId];
   for (auto &[result, info] : output_names) {
-    cudaq::info("Qubit {} Result {} Name {}", info.qubitNum, result,
-                info.registerName);
+    CUDAQ_INFO("Qubit {} Result {} Name {}", info.qubitNum, result,
+               info.registerName);
   }
 
   CountsDictionary countsDict;
@@ -386,9 +386,9 @@ OQCServerHelper::processResults(ServerMessage &postJobResponse,
     // there is only 1 CountsDictionary and 1 register name in use, so throw a
     // warning if that isn't true.
     if (jsonResults.size() != 1)
-      cudaq::info("WARNING: unexpected jsonResults size ({}). Continuing to "
-                  "parse anyway.",
-                  jsonResults.size());
+      CUDAQ_INFO("WARNING: unexpected jsonResults size ({}). Continuing to "
+                 "parse anyway.",
+                 jsonResults.size());
 
     // Note: `name` contains a concatenated list of measurement names as
     // specified in the sent QIR program, separated by underscores. They are
@@ -419,9 +419,9 @@ OQCServerHelper::processResults(ServerMessage &postJobResponse,
   std::sort(idx.begin(), idx.end(), [&](std::size_t i1, std::size_t i2) {
     return qirQubitMeasurements[i1] < qirQubitMeasurements[i2];
   });
-  cudaq::info("Reordering global result to map QIR result order to QIR qubit "
-              "allocation order is {}",
-              idx);
+  CUDAQ_INFO("Reordering global result to map QIR result order to QIR qubit "
+             "allocation order is {}",
+             idx);
   sampleResult.reorder(idx);
 
   // Now reorder according to reorderIdx[]. This sorts the global bitstring in

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/QuantinuumServerHelper.cpp
@@ -518,7 +518,7 @@ void QuantinuumServerHelper::refreshTokens(bool force_refresh) {
   }();
 
   if (needsRefresh || force_refresh) {
-    cudaq::info("Refreshing id-token");
+    CUDAQ_INFO("Refreshing id-token");
     RestHeaders cookies{{"myqos_oat", refreshKey}};
     RestCookies headers = generateRequestHeader();
     nlohmann::json j;
@@ -552,8 +552,8 @@ cudaq::ExtraPayloadProvider *QuantinuumServerHelper::getExtraPayloadProvider() {
   if (it == extraProviders.end())
     throw std::runtime_error("ExtraPayloadProvider with name " +
                              extraPayloadProviderName + " not found.");
-  cudaq::info("[QuantinuumServerHelper] Found extra payload provider '{}'.",
-              extraPayloadProviderName);
+  CUDAQ_INFO("[QuantinuumServerHelper] Found extra payload provider '{}'.",
+             extraPayloadProviderName);
   return it->get();
 }
 

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/QuantumMachinesServerHelper.cpp
@@ -54,7 +54,7 @@ public:
   /// @brief Initializes the server helper with the provided backend
   /// configuration.
   void initialize(BackendConfig config) override {
-    cudaq::info("Initializing Quantum Machines Backend");
+    CUDAQ_INFO("Initializing Quantum Machines Backend");
     backendConfig = config;
     backendConfig["url"] = getValueOrDefault(config, "url", DEFAULT_URL);
     backendConfig["version"] =
@@ -70,8 +70,8 @@ public:
     }
     backendConfig["api_key"] = apiKey;
 
-    cudaq::info("Initializing Quantum Machines Backend. config: {}",
-                backendConfig);
+    CUDAQ_INFO("Initializing Quantum Machines Backend. config: {}",
+               backendConfig);
   }
 
   /// @brief Creates a quantum computation job using the provided kernel
@@ -82,7 +82,7 @@ public:
   //    std::tuple<std::string, RestHeaders, std::vector<ServerMessage>>;
   ServerJobPayload
   createJob(std::vector<KernelExecution> &circuitCodes) override {
-    cudaq::info("In createJob. code: {}", circuitCodes[0].code);
+    CUDAQ_INFO("In createJob. code: {}", circuitCodes[0].code);
     ServerMessage job;
     job["content"] = circuitCodes[0].code;
     job["source"] = "oq2";
@@ -95,7 +95,7 @@ public:
 
   /// @brief Extracts the job ID from the server's response to a job submission.
   std::string extractJobId(ServerMessage &postResponse) override {
-    cudaq::info("In extractJobId. {}", postResponse.dump());
+    CUDAQ_INFO("In extractJobId. {}", postResponse.dump());
     if (!postResponse.contains("id"))
       return "";
 
@@ -106,14 +106,14 @@ public:
   /// @brief Constructs the URL for retrieving a job based on the server's
   /// response to a job submission.
   std::string constructGetJobPath(ServerMessage &postResponse) override {
-    // cudaq::info("In constructGetJobPath(postResponse)");
-    cudaq::info("In constructGetJobPath(postResponse={})", postResponse.dump());
+    // CUDAQ_INFO("In constructGetJobPath(postResponse)");
+    CUDAQ_INFO("In constructGetJobPath(postResponse={})", postResponse.dump());
     return extractJobId(postResponse);
   }
 
   /// @brief Constructs the URL for retrieving a job based on a job ID.
   std::string constructGetJobPath(std::string &jobId) override {
-    cudaq::info("In constructGetJobPath(std::string &jobId)");
+    CUDAQ_INFO("In constructGetJobPath(std::string &jobId)");
     std::string results_url = backendConfig["url"] + "/v1/results/" + jobId;
     return results_url;
   }
@@ -121,7 +121,7 @@ public:
   /// @brief Checks if a job is done based on the server's response to a job
   /// retrieval request.
   bool jobIsDone(ServerMessage &getJobResponse) override {
-    cudaq::info("jobIsDone");
+    CUDAQ_INFO("jobIsDone");
     std::string status = getJobResponse.at("status");
     return status == "Done" || status == "Failed";
   }
@@ -130,7 +130,7 @@ public:
   /// maps the results back to sample results.
   cudaq::sample_result processResults(ServerMessage &getJobResponse,
                                       std::string &jobId) override {
-    cudaq::info("Sample results: {}", getJobResponse.dump());
+    CUDAQ_INFO("Sample results: {}", getJobResponse.dump());
     auto samplesJson = getJobResponse["samples"];
     cudaq::CountsDictionary counts;
     for (auto &item : samplesJson.items()) {
@@ -148,7 +148,7 @@ public:
   /// @brief Override the polling interval method
   std::chrono::microseconds
   nextResultPollingInterval(ServerMessage &postResponse) override {
-    cudaq::info("nextResultPollingInterval");
+    CUDAQ_INFO("nextResultPollingInterval");
     return std::chrono::seconds(1);
   }
 };

--- a/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteServer.cpp
+++ b/runtime/cudaq/platform/default/rest_server/helpers/RestRemoteServer.cpp
@@ -168,7 +168,7 @@ public:
 
           std::string mutableReq;
           for (const auto &[k, v] : headers)
-            cudaq::info("Request Header: {} : {}", k, v);
+            CUDAQ_INFO("Request Header: {} : {}", k, v);
           // Checking if this request has its body sent on as NVCF assets.
           const auto dirIter = headers.find("NVCF-ASSET-DIR");
           const auto assetIdIter = headers.find("NVCF-FUNCTION-ASSET-IDS");
@@ -477,7 +477,7 @@ protected:
   std::unique_ptr<ExecutionEngine>
   jitMlirCode(ModuleOp currentModule, const std::vector<std::string> &passes,
               const std::vector<std::string> &extraLibPaths = {}) {
-    cudaq::info("Running jitCode.");
+    CUDAQ_INFO("Running jitCode.");
     auto module = currentModule.clone();
     ExecutionEngineOptions opts;
     opts.transformer = [](llvm::Module *m) { return llvm::ErrorSuccess(); };
@@ -485,7 +485,7 @@ protected:
     opts.jitCodeGenOptLevel = llvm::CodeGenOpt::None;
     SmallVector<StringRef, 4> sharedLibs;
     for (auto &lib : extraLibPaths) {
-      cudaq::info("Extra library loaded: {}", lib);
+      CUDAQ_INFO("Extra library loaded: {}", lib);
       sharedLibs.push_back(lib);
     }
     opts.sharedLibPaths = sharedLibs;
@@ -509,7 +509,7 @@ protected:
         throw std::runtime_error(
             "Remote rest platform: applying IR passes failed.");
 
-      cudaq::info("- Pass manager was applied.");
+      CUDAQ_INFO("- Pass manager was applied.");
     }
     // Verify MLIR conforming to the NVQIR-spec (known runtime functions and/or
     // QIR functions)
@@ -537,7 +537,7 @@ protected:
         throw std::runtime_error(
             "Failed to IR compliance verification against NVQIR runtime.");
 
-      cudaq::info("- Finish IR input verification.");
+      CUDAQ_INFO("- Finish IR input verification.");
     }
 
     opts.llvmModuleBuilder =
@@ -553,11 +553,11 @@ protected:
       return llvmModule;
     };
 
-    cudaq::info("- Creating the MLIR ExecutionEngine");
+    CUDAQ_INFO("- Creating the MLIR ExecutionEngine");
     auto uniqueJit =
         getValueOrThrow(ExecutionEngine::create(module, opts),
                         "Failed to create MLIR JIT ExecutionEngine");
-    cudaq::info("- MLIR ExecutionEngine created successfully.");
+    CUDAQ_INFO("- MLIR ExecutionEngine created successfully.");
     return uniqueJit;
   }
 
@@ -639,8 +639,7 @@ protected:
     const auto simLibPath =
         cudaqLibPath.parent_path() /
         fmt::format("libnvqir-{}.{}", simulatorName, libSuffix);
-    cudaq::info("Request simulator {} at {}", simulatorName,
-                simLibPath.c_str());
+    CUDAQ_INFO("Request simulator {} at {}", simulatorName, simLibPath.c_str());
     void *simLibHandle = dlopen(simLibPath.c_str(), RTLD_GLOBAL | RTLD_NOW);
     if (!simLibHandle) {
       char *error_msg = dlerror();
@@ -704,7 +703,7 @@ protected:
         // level.
         cudaq::log(os.str());
       } else {
-        cudaq::info(os.str());
+        CUDAQ_INFO(os.str());
       }
 
       // Verify REST API version of the incoming request

--- a/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
@@ -46,7 +46,7 @@ public:
                void *args, std::uint64_t voidStarSize,
                std::uint64_t resultOffset,
                const std::vector<void *> &rawArgs) override {
-    cudaq::info("FermioniqBaseQPU launching kernel ({})", kernelName);
+    CUDAQ_INFO("FermioniqBaseQPU launching kernel ({})", kernelName);
 
     // TODO future iterations of this should support non-void return types.
     if (!executionContext)

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
@@ -25,7 +25,7 @@ protected:
   extractQuakeCodeAndContext(const std::string &kernelName,
                              void *data) override {
 
-    cudaq::info("extract quake code\n");
+    CUDAQ_INFO("extract quake code\n");
 
     auto contextPtr = cudaq::initializeMLIR();
     MLIRContext &context = *contextPtr.get();

--- a/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
+++ b/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
@@ -85,8 +85,8 @@ public:
     auto platformPath = cudaqLibPath.parent_path().parent_path() / "targets";
     std::string targetConfigFileName = targetName + std::string(".yml");
     auto configFilePath = platformPath / targetConfigFileName;
-    cudaq::info("Config file path for target {} = {}", targetName,
-                configFilePath.string());
+    CUDAQ_INFO("Config file path for target {} = {}", targetName,
+               configFilePath.string());
     // Don't try to load something that doesn't exist.
     if (!std::filesystem::exists(configFilePath))
       return "";
@@ -117,7 +117,7 @@ public:
         return "";
       for (std::size_t i = 0; i < splitParts.size() - 1; ++i) {
         if (splitParts[i] == prefix) {
-          cudaq::debug(
+          CUDAQ_DBG(
               "Retrieved option '{}' for the key '{}' from input string '{}'",
               splitParts[i + 1], prefix, str);
           if (splitParts[i + 1].starts_with("base64_")) {
@@ -126,8 +126,8 @@ public:
             if (auto err = llvm::decodeBase64(splitParts[i + 1], decoded_vec))
               throw std::runtime_error("DecodeBase64 error");
             std::string decodedStr(decoded_vec.data(), decoded_vec.size());
-            cudaq::info("Decoded {} parameter from '{}' to '{}'", splitParts[i],
-                        splitParts[i + 1], decodedStr);
+            CUDAQ_INFO("Decoded {} parameter from '{}' to '{}'", splitParts[i],
+                       splitParts[i + 1], decodedStr);
             return decodedStr;
           }
           return splitParts[i + 1];
@@ -230,7 +230,7 @@ public:
           // Default to launching one instance if no other setting is available.
           const int numInstances =
               numInstanceStr.empty() ? 1 : std::stoi(numInstanceStr);
-          cudaq::info("Auto launch {} REST servers", numInstances);
+          CUDAQ_INFO("Auto launch {} REST servers", numInstances);
           for (int i = 0; i < numInstances; ++i) {
             m_remoteServers.emplace_back(
                 std::make_unique<cudaq::AutoLaunchRestServerProcess>(i));

--- a/runtime/cudaq/platform/mqpu/custatevec/GPUEmulatedQPU.cpp
+++ b/runtime/cudaq/platform/mqpu/custatevec/GPUEmulatedQPU.cpp
@@ -34,7 +34,7 @@ public:
   void enqueue(cudaq::QuantumTask &task) override {
     // Note: enqueue is executed on the main thread, not the QPU execution
     // thread. Hence, do not set the CUDA device here.
-    cudaq::info("Enqueue Task on QPU {}", qpu_id);
+    CUDAQ_INFO("Enqueue Task on QPU {}", qpu_id);
     execution_queue->enqueue(task);
   }
 
@@ -42,7 +42,7 @@ public:
   launchKernel(const std::string &name, cudaq::KernelThunkType kernelFunc,
                void *args, std::uint64_t, std::uint64_t,
                const std::vector<void *> &rawArgs) override {
-    cudaq::info("QPU::launchKernel GPU {}", qpu_id);
+    CUDAQ_INFO("QPU::launchKernel GPU {}", qpu_id);
     cudaSetDevice(qpu_id);
     return kernelFunc(args, /*differentMemorySpace=*/false);
   }
@@ -51,7 +51,7 @@ public:
   void setExecutionContext(cudaq::ExecutionContext *context) override {
     cudaSetDevice(qpu_id);
 
-    cudaq::info("MultiQPUPlatform::setExecutionContext QPU {}", qpu_id);
+    CUDAQ_INFO("MultiQPUPlatform::setExecutionContext QPU {}", qpu_id);
     auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
     contexts.emplace(tid, context);
     if (noiseModel)
@@ -63,7 +63,7 @@ public:
   /// Overrides resetExecutionContext to forward to
   /// the ExecutionManager. Also handles observe post-processing
   void resetExecutionContext() override {
-    cudaq::info("MultiQPUPlatform::resetExecutionContext QPU {}", qpu_id);
+    CUDAQ_INFO("MultiQPUPlatform::resetExecutionContext QPU {}", qpu_id);
     auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
     auto ctx = contexts[tid];
     handleObservation(ctx);

--- a/runtime/cudaq/platform/mqpu/helpers/MQPUUtils.cpp
+++ b/runtime/cudaq/platform/mqpu/helpers/MQPUUtils.cpp
@@ -70,18 +70,18 @@ static std::optional<std::string> getRandomAvailablePort(int seed) {
         return std::to_string(randomPort);
     }
   }
-  cudaq::info("Failed to find a random TCP/IP port after {} trials.",
-              MAX_RETRIES);
+  CUDAQ_INFO("Failed to find a random TCP/IP port after {} trials.",
+             MAX_RETRIES);
   return {};
 }
 
 cudaq::AutoLaunchRestServerProcess::AutoLaunchRestServerProcess(
     int seed_offset) {
-  cudaq::info("Auto launch REST server");
+  CUDAQ_INFO("Auto launch REST server");
   const std::string serverExeName = "cudaq-qpud";
   const std::filesystem::path cudaqLibPath{cudaq::getCUDAQLibraryPath()};
   const auto binPath = cudaqLibPath.parent_path().parent_path() / "bin";
-  cudaq::info("Search for {} in {} directory.", serverExeName, binPath.c_str());
+  CUDAQ_INFO("Search for {} in {} directory.", serverExeName, binPath.c_str());
   auto serverApp =
       llvm::sys::findProgramByName(serverExeName.c_str(), {binPath.c_str()});
   if (!serverApp)
@@ -151,8 +151,8 @@ cudaq::AutoLaunchRestServerProcess::AutoLaunchRestServerProcess(
     if (executionFailed)
       throw std::runtime_error("Failed to launch " + serverExeName +
                                " at port " + port.value() + ": " + errorMsg);
-    cudaq::info("Auto launch REST server at http://localhost:{} (PID {})",
-                port.value(), processInfo.Pid);
+    CUDAQ_INFO("Auto launch REST server at http://localhost:{} (PID {})",
+               port.value(), processInfo.Pid);
     m_pid = processInfo.Pid;
     m_url = fmt::format("localhost:{}", port.value());
 
@@ -177,9 +177,9 @@ cudaq::AutoLaunchRestServerProcess::AutoLaunchRestServerProcess(
       try {
         std::map<std::string, std::string> headers;
         [[maybe_unused]] auto pingResult = restClient.get(m_url, "", headers);
-        cudaq::info("Successfully connected to the REST server at "
-                    "http://localhost:{} (PID {}) after {} milliseconds.",
-                    port.value(), processInfo.Pid, totalWaitTimeMs);
+        CUDAQ_INFO("Successfully connected to the REST server at "
+                   "http://localhost:{} (PID {}) after {} milliseconds.",
+                   port.value(), processInfo.Pid, totalWaitTimeMs);
         return;
       } catch (...) {
         // Wait and retry
@@ -188,16 +188,16 @@ cudaq::AutoLaunchRestServerProcess::AutoLaunchRestServerProcess(
         std::this_thread::sleep_for(std::chrono::milliseconds(delay));
       }
     }
-    cudaq::info(
+    CUDAQ_INFO(
         "Timeout Error: No response from the server. Look for another port...");
-    cudaq::info("Shutting down REST server process {}", m_pid);
+    CUDAQ_INFO("Shutting down REST server process {}", m_pid);
     ::kill(m_pid, SIGKILL);
   }
   throw std::runtime_error("No usable ports available");
 }
 
 cudaq::AutoLaunchRestServerProcess::~AutoLaunchRestServerProcess() {
-  cudaq::info("Shutting down REST server process {}", m_pid);
+  CUDAQ_INFO("Shutting down REST server process {}", m_pid);
   ::kill(m_pid, SIGKILL);
 }
 

--- a/runtime/cudaq/platform/orca/OrcaExecutor.cpp
+++ b/runtime/cudaq/platform/orca/OrcaExecutor.cpp
@@ -17,18 +17,18 @@ details::future OrcaExecutor::execute(cudaq::orca::TBIParameters params,
   auto orcaServerHelper = dynamic_cast<OrcaServerHelper *>(serverHelper);
   assert(orcaServerHelper);
   orcaServerHelper->setShots(shots);
-  cudaq::info("Executor creating job to execute with the {} helper.",
-              orcaServerHelper->name());
+  CUDAQ_INFO("Executor creating job to execute with the {} helper.",
+             orcaServerHelper->name());
   // Create the Job Payload, composed of job post path, headers,
   // and the job json messages themselves
   auto [jobPostPath, headers, jobs] = orcaServerHelper->createJob(params);
   auto job = jobs[0];
   auto config = orcaServerHelper->getConfig();
   std::vector<cudaq::details::future::Job> ids;
-  cudaq::info("Job created, posting to {}", jobPostPath);
+  CUDAQ_INFO("Job created, posting to {}", jobPostPath);
   // Post it, get the response
   auto response = client.post(jobPostPath, "", job, headers);
-  cudaq::info("Job posted, response was {}", response.dump());
+  CUDAQ_INFO("Job posted, response was {}", response.dump());
   // Add the job id and the job name.
   auto job_id = orcaServerHelper->extractJobId(response);
   if (job_id.empty()) {

--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.cpp
@@ -14,8 +14,8 @@ namespace cudaq {
 /// @brief This setTargetBackend override is in charge of reading the
 /// specific target backend configuration file.
 void OrcaRemoteRESTQPU::setTargetBackend(const std::string &backend) {
-  cudaq::info("OrcaRemoteRESTQPU platform is targeting {} with qpu_id = {}.",
-              backend, qpu_id);
+  CUDAQ_INFO("OrcaRemoteRESTQPU platform is targeting {} with qpu_id = {}.",
+             backend, qpu_id);
 
   // First we see if the given backend has extra config params
   auto mutableBackend = backend;
@@ -37,8 +37,8 @@ void OrcaRemoteRESTQPU::setTargetBackend(const std::string &backend) {
         if (auto err = llvm::decodeBase64(split[i + 1], decoded_vec))
           throw std::runtime_error("DecodeBase64 error");
         std::string decodedStr(decoded_vec.data(), decoded_vec.size());
-        cudaq::info("Decoded {} parameter from '{}' to '{}'", split[i],
-                    split[i + 1], decodedStr);
+        CUDAQ_INFO("Decoded {} parameter from '{}' to '{}'", split[i],
+                   split[i + 1], decodedStr);
         backendConfig.insert({split[i], decodedStr});
       } else {
         backendConfig.insert({split[i], split[i + 1]});
@@ -64,8 +64,8 @@ KernelThunkResultType OrcaRemoteRESTQPU::launchKernel(
     std::uint64_t voidStarSize, std::uint64_t resultOffset,
     const std::vector<void *> &rawArgs) {
 
-  cudaq::info("OrcaRemoteRESTQPU: Launch kernel named '{}' remote QPU {}",
-              kernelName, qpu_id);
+  CUDAQ_INFO("OrcaRemoteRESTQPU: Launch kernel named '{}' remote QPU {}",
+             kernelName, qpu_id);
 
   auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
   auto ctx = contexts[tid];

--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
@@ -78,7 +78,7 @@ public:
 
   /// @brief Enqueue a quantum task on the asynchronous execution queue.
   void enqueue(cudaq::QuantumTask &task) override {
-    cudaq::info("OrcaRemoteRESTQPU: Enqueue Task on QPU {}", qpu_id);
+    CUDAQ_INFO("OrcaRemoteRESTQPU: Enqueue Task on QPU {}", qpu_id);
     execution_queue->enqueue(task);
   }
 
@@ -102,7 +102,7 @@ public:
 
   /// @brief Store the execution context for launching kernel
   void setExecutionContext(cudaq::ExecutionContext *context) override {
-    cudaq::info("OrcaRemoteRESTQPU::setExecutionContext QPU {}", qpu_id);
+    CUDAQ_INFO("OrcaRemoteRESTQPU::setExecutionContext QPU {}", qpu_id);
     auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
     contexts.emplace(tid, context);
     cudaq::getExecutionManager()->setExecutionContext(contexts[tid]);
@@ -110,7 +110,7 @@ public:
 
   /// @brief Overrides resetExecutionContext
   void resetExecutionContext() override {
-    cudaq::info("OrcaRemoteRESTQPU::resetExecutionContext QPU {}", qpu_id);
+    CUDAQ_INFO("OrcaRemoteRESTQPU::resetExecutionContext QPU {}", qpu_id);
     auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
     contexts[tid] = nullptr;
     contexts.erase(tid);

--- a/runtime/cudaq/platform/orca/OrcaServerHelper.cpp
+++ b/runtime/cudaq/platform/orca/OrcaServerHelper.cpp
@@ -116,11 +116,11 @@ bool OrcaServerHelper::jobIsDone(ServerMessage &getJobResponse) {
     return true;
   } else if (!status) {
     auto job_status = getJobResponse["job_status"].get<std::string>();
-    cudaq::info("job_status {}", job_status);
+    CUDAQ_INFO("job_status {}", job_status);
     return false;
   } else {
     auto error_message = getJobResponse["error_message"].get<std::string>();
-    cudaq::info("error_message {}", error_message);
+    CUDAQ_INFO("error_message {}", error_message);
     if (error_message == "Job can't be found") {
       return false;
     } else {

--- a/runtime/cudaq/platform/pasqal/PasqalServerHelper.cpp
+++ b/runtime/cudaq/platform/pasqal/PasqalServerHelper.cpp
@@ -16,13 +16,13 @@
 namespace cudaq {
 
 void PasqalServerHelper::initialize(BackendConfig config) {
-  cudaq::info("Initialize Pasqal Cloud.");
+  CUDAQ_INFO("Initialize Pasqal Cloud.");
 
   // Hard-coded for now.
   const std::string MACHINE = "EMU_MPS";
   const int MAX_QUBITS = 100;
 
-  cudaq::info("Running on device {}", MACHINE);
+  CUDAQ_INFO("Running on device {}", MACHINE);
 
   if (!config.contains("machine"))
     config["machine"] = MACHINE;
@@ -73,8 +73,8 @@ PasqalServerHelper::createJob(std::vector<KernelExecution> &circuitCodes) {
     tasks.push_back(message);
   }
 
-  cudaq::info("Created job payload for Pasqal, targeting device {}",
-              backendConfig.at("machine"));
+  CUDAQ_INFO("Created job payload for Pasqal, targeting device {}",
+             backendConfig.at("machine"));
 
   // Return a tuple containing the job path, headers, and the job message
   return std::make_tuple(baseUrl + apiPath + "/v1/cudaq/job", getHeaders(),

--- a/runtime/cudaq/platform/quera/QuEraExecutor.cpp
+++ b/runtime/cudaq/platform/quera/QuEraExecutor.cpp
@@ -22,7 +22,7 @@ public:
     queraServerHelper->setShots(shots);
 
     auto config = queraServerHelper->getConfig();
-    cudaq::info("Backend config: {}, shots {}", config, shots);
+    CUDAQ_INFO("Backend config: {}, shots {}", config, shots);
     config.insert({"shots", std::to_string(shots)});
 
     return queraServerHelper->createJob(codesToExecute);

--- a/runtime/cudaq/platform/quera/QuEraServerHelper.cpp
+++ b/runtime/cudaq/platform/quera/QuEraServerHelper.cpp
@@ -12,10 +12,10 @@
 namespace cudaq {
 
 void QuEraServerHelper::initialize(BackendConfig config) {
-  cudaq::info("Initializing QuEra via Amazon Braket.");
+  CUDAQ_INFO("Initializing QuEra via Amazon Braket.");
   // Hard-coded for now
   auto deviceArn = "arn:aws:braket:us-east-1::device/qpu/quera/Aquila";
-  cudaq::info("Running on device {}", deviceArn);
+  CUDAQ_INFO("Running on device {}", deviceArn);
   config["defaultBucket"] = getValueOrDefault(config, "default_bucket", "");
   config["deviceArn"] = deviceArn;
   if (!config["shots"].empty())
@@ -45,8 +45,8 @@ QuEraServerHelper::createJob(std::vector<KernelExecution> &circuitCodes) {
 
     tasks.push_back(taskRequest);
   }
-  cudaq::info("Created job payload for QuEra, targeting device {}",
-              backendConfig.at("deviceArn"));
+  CUDAQ_INFO("Created job payload for QuEra, targeting device {}",
+             backendConfig.at("deviceArn"));
   return ret;
 }
 

--- a/runtime/cudaq/qis/execution_manager.cpp
+++ b/runtime/cudaq/qis/execution_manager.cpp
@@ -13,12 +13,12 @@ namespace cudaq {
 static ExecutionManager *execution_manager;
 
 void setExecutionManagerInternal(ExecutionManager *em) {
-  cudaq::info("external caller setting the execution manager.");
+  CUDAQ_INFO("external caller setting the execution manager.");
   execution_manager = em;
 }
 
 void resetExecutionManagerInternal() {
-  cudaq::info("external caller clearing the execution manager.");
+  CUDAQ_INFO("external caller clearing the execution manager.");
   execution_manager = nullptr;
 }
 

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -149,9 +149,9 @@ protected:
 
   void handleExecutionContextEnded() override {
     if (!requestedAllocations.empty()) {
-      cudaq::info("[DefaultExecutionManager] Flushing remaining {} allocations "
-                  "at handleExecutionContextEnded.",
-                  requestedAllocations.size());
+      CUDAQ_INFO("[DefaultExecutionManager] Flushing remaining {} allocations "
+                 "at handleExecutionContextEnded.",
+                 requestedAllocations.size());
       // If there are pending allocations, flush them to the simulator.
       // Making sure the simulator's state is consistent with the number of
       // allocations even though the circuit might be empty.
@@ -238,7 +238,7 @@ protected:
     std::vector<std::size_t> localT;
     std::transform(targets.begin(), targets.end(), std::back_inserter(localT),
                    [](auto &&el) { return el.id; });
-    cudaq::info(
+    CUDAQ_INFO(
         "[DefaultExecutionManager] Applying fine-grain kraus channel {}.",
         channel.get_type_name());
     simulator()->applyNoise(channel, localT);
@@ -263,8 +263,8 @@ protected:
 
 public:
   DefaultExecutionManager() {
-    cudaq::info("[DefaultExecutionManager] Creating the {} backend.",
-                simulator()->name());
+    CUDAQ_INFO("[DefaultExecutionManager] Creating the {} backend.",
+               simulator()->name());
   }
   virtual ~DefaultExecutionManager() = default;
 

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -176,7 +176,7 @@ protected:
         ids.push_back(s.id);
       }
       if (executionContext->name == "sample") {
-        cudaq::info("Sampling");
+        CUDAQ_INFO("Sampling");
         auto shots = executionContext->shots;
         auto sampleResult =
             qpp::sample(shots, state, ids, sampleQudits.begin()->levels);
@@ -195,7 +195,7 @@ protected:
         }
         executionContext->result.append(counts);
       } else if (executionContext->name == "extract-state") {
-        cudaq::info("Extracting state");
+        CUDAQ_INFO("Extracting state");
         // If here, then we care about the result qudit, so compute it.
         for (auto &q : sampleQudits) {
           const auto measurement_tuple = qpp::measure(
@@ -246,7 +246,7 @@ protected:
     state = Eigen::Map<const qpp::ket>(collapsed_state.data(),
                                        collapsed_state.size());
 
-    cudaq::info("Measured qubit {} -> {}", q.id, measurement_result);
+    CUDAQ_INFO("Measured qubit {} -> {}", q.id, measurement_result);
     return measurement_result;
   }
 
@@ -362,7 +362,7 @@ public:
       for (int i = 1; i < d; i++) {
         u(i, i - 1) = 1;
       }
-      cudaq::info("Applying create on {}<{}>", target.id, target.levels);
+      CUDAQ_INFO("Applying create on {}<{}>", target.id, target.levels);
       state = qpp::apply(state, u, {target.id}, target.levels);
     });
 
@@ -375,7 +375,7 @@ public:
       for (int i = 0; i < d - 1; i++) {
         u(i, i + 1) = 1;
       }
-      cudaq::info("Applying annihilate on {}<{}>", target.id, target.levels);
+      CUDAQ_INFO("Applying annihilate on {}<{}>", target.id, target.levels);
       state = qpp::apply(state, u, {target.id}, target.levels);
     });
 
@@ -388,7 +388,7 @@ public:
       for (int i = 1; i < d; i++) {
         u(i, i - 1) = 1;
       }
-      cudaq::info("Applying plus on {}<{}>", target.id, target.levels);
+      CUDAQ_INFO("Applying plus on {}<{}>", target.id, target.levels);
       state = qpp::apply(state, u, {target.id}, target.levels);
     });
 
@@ -400,8 +400,8 @@ public:
       const double theta = params[0];
       qpp::cmat BS{qpp::cmat::Zero(d * d, d * d)};
       beam_splitter(theta, BS);
-      cudaq::info("Applying beam_splitter on {}<{}> and {}<{}>", target1.id,
-                  target1.levels, target2.id, target2.levels);
+      CUDAQ_INFO("Applying beam_splitter on {}<{}> and {}<{}>", target1.id,
+                 target1.levels, target2.id, target2.levels);
       state = qpp::apply(state, BS, {target1.id, target2.id}, d);
     });
 
@@ -415,7 +415,7 @@ public:
       for (size_t n = 0; n < d; n++) {
         PS(n, n) = std::exp(n * phi * i);
       }
-      cudaq::info("Applying phase_shift on {}<{}>", target.id, target.levels);
+      CUDAQ_INFO("Applying phase_shift on {}<{}>", target.id, target.levels);
       state = qpp::apply(state, PS, {target.id}, target.levels);
     });
   }

--- a/runtime/cudaq/qis/remote_state.cpp
+++ b/runtime/cudaq/qis/remote_state.cpp
@@ -108,7 +108,7 @@ void RemoteSimulationState::toHost(std::complex<double> *clientAllocatedData,
   if (state->getPrecision() == cudaq::SimulationState::precision::fp64) {
     state->toHost(clientAllocatedData, numElements);
   } else {
-    cudaq::info("[RemoteSimulationState] Perform data conversion in toHost");
+    CUDAQ_INFO("[RemoteSimulationState] Perform data conversion in toHost");
     std::vector<std::complex<float>> temp(numElements);
     state->toHost(temp.data(), numElements);
     std::copy(temp.begin(), temp.end(), clientAllocatedData);
@@ -122,7 +122,7 @@ void RemoteSimulationState::toHost(std::complex<float> *clientAllocatedData,
   if (state->getPrecision() == cudaq::SimulationState::precision::fp32) {
     state->toHost(clientAllocatedData, numElements);
   } else {
-    cudaq::info("[RemoteSimulationState] Perform data conversion in toHost");
+    CUDAQ_INFO("[RemoteSimulationState] Perform data conversion in toHost");
     std::vector<std::complex<double>> temp(numElements);
     state->toHost(temp.data(), numElements);
     std::copy(temp.begin(), temp.end(), clientAllocatedData);
@@ -198,9 +198,9 @@ std::size_t RemoteSimulationState::maxQubitCountForFullStateTransfer() {
   if (auto envVal = std::getenv("CUDAQ_REMOTE_STATE_MAX_QUBIT_COUNT")) {
 
     const int val = std::stoi(envVal);
-    cudaq::info("[RemoteSimulationState] Setting remote state data transfer "
-                "qubit count threshold to {}.",
-                val);
+    CUDAQ_INFO("[RemoteSimulationState] Setting remote state data transfer "
+               "qubit count threshold to {}.",
+               val);
     return val;
   }
   return NUM_QUBITS_STATE_TRANSFER;

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -614,8 +614,8 @@ protected:
         }
       }
 
-      cudaq::info("Handling Sampling With Conditionals: {}, {}, {}", qubitIdx,
-                  bitResult, mutableRegisterName);
+      CUDAQ_INFO("Handling Sampling With Conditionals: {}, {}, {}", qubitIdx,
+                 bitResult, mutableRegisterName);
       // See if we've observed this register before, if not
       // start a vector of bit results, if we have, add the
       // bit result to the existing vector
@@ -740,8 +740,8 @@ protected:
       sampleQubits.erase(last, sampleQubits.end());
     }
 
-    cudaq::info("Sampling the current state, with measure qubits = {}",
-                sampleQubits);
+    CUDAQ_INFO("Sampling the current state, with measure qubits = {}",
+               sampleQubits);
 
     // Ask the subtype to sample the current state
     auto execResult = sample(sampleQubits, getNumShotsToExec());
@@ -941,8 +941,8 @@ public:
         return newIdx;
     }
 
-    cudaq::info("Allocating new qubit with idx {} (nQ={}, dim={})", newIdx,
-                nQubitsAllocated, stateDimension);
+    CUDAQ_INFO("Allocating new qubit with idx {} (nQ={}, dim={})", newIdx,
+               nQubitsAllocated, stateDimension);
 
     // Increment the number of qubits and set
     // the new state dimension
@@ -1001,7 +1001,7 @@ public:
         count = qubits.back() + 1 - nQubitsAllocated;
     }
 
-    cudaq::info("Allocating {} new qubits.", count);
+    CUDAQ_INFO("Allocating {} new qubits.", count);
 
     previousStateDimension = stateDimension;
     nQubitsAllocated += count;
@@ -1047,7 +1047,7 @@ public:
         count = qubits.back() + 1 - nQubitsAllocated;
     }
 
-    cudaq::info("Allocating {} new qubits.", count);
+    CUDAQ_INFO("Allocating {} new qubits.", count);
 
     previousStateDimension = stateDimension;
     nQubitsAllocated += count;
@@ -1068,12 +1068,12 @@ public:
   /// @brief Deallocate the qubit with give index
   void deallocate(const std::size_t qubitIdx) override {
     if (executionContext && executionContext->name != "tracer") {
-      cudaq::info("Deferring qubit {} deallocation", qubitIdx);
+      CUDAQ_INFO("Deferring qubit {} deallocation", qubitIdx);
       deferredDeallocation.push_back(qubitIdx);
       return;
     }
 
-    cudaq::info("Deallocating qubit {}", qubitIdx);
+    CUDAQ_INFO("Deallocating qubit {}", qubitIdx);
 
     // Reset the qubit
     if (!isInTracerMode())
@@ -1085,7 +1085,7 @@ public:
 
     // Reset the state if we've deallocated all qubits.
     if (tracker.allDeallocated()) {
-      cudaq::info("Deallocated all qubits, reseting state vector.");
+      CUDAQ_INFO("Deallocated all qubits, reseting state vector.");
       // all qubits deallocated,
       deallocateState();
       while (!gateQueue.empty())
@@ -1103,14 +1103,14 @@ public:
 
     if (executionContext) {
       for (auto &qubitIdx : qubits) {
-        cudaq::info("Deferring qubit {} deallocation", qubitIdx);
+        CUDAQ_INFO("Deferring qubit {} deallocation", qubitIdx);
         deferredDeallocation.push_back(qubitIdx);
       }
       return;
     }
 
     if (qubits.size() == tracker.numAllocated()) {
-      cudaq::info("Deallocate all qubits.");
+      CUDAQ_INFO("Deallocate all qubits.");
       deallocateState();
       for (auto &q : qubits)
         tracker.returnIndex(q);
@@ -1218,11 +1218,11 @@ public:
     // Reset the state if we've deallocated all qubits.
     if (tracker.allDeallocated()) {
       if (shouldSetToZero) {
-        cudaq::info("In batch mode currently, reset state to |0>");
+        CUDAQ_INFO("In batch mode currently, reset state to |0>");
         // Do not deallocate the state, but reset it to |0>
         setToZeroState();
       } else {
-        cudaq::info("Deallocated all qubits, reseting state vector.");
+        CUDAQ_INFO("Deallocated all qubits, reseting state vector.");
         // all qubits deallocated,
         deallocateState();
       }
@@ -1237,7 +1237,7 @@ public:
     executionContext = context;
     executionContext->canHandleObserve = canHandleObserve();
     currentCircuitName = context->kernelName;
-    cudaq::info("Setting current circuit name to {}", currentCircuitName);
+    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
   }
 
   /// @brief Return the current execution context
@@ -1392,7 +1392,7 @@ public:
   void swap(const std::vector<std::size_t> &ctrlBits, const std::size_t srcIdx,
             const std::size_t tgtIdx) override {
     flushAnySamplingTasks();
-    cudaq::info(gateToString("swap", ctrlBits, {}, {srcIdx, tgtIdx}));
+    CUDAQ_INFO(gateToString("swap", ctrlBits, {}, {srcIdx, tgtIdx}));
     std::vector<std::complex<ScalarType>> matrix{
         {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0},
         {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0},
@@ -1459,7 +1459,7 @@ public:
       throw std::runtime_error(
           "measuring a sum of spin operators is not supported");
 
-    cudaq::info("Measure {}", op.to_string());
+    CUDAQ_INFO("Measure {}", op.to_string());
     std::vector<std::size_t> qubitsToMeasure;
     std::vector<std::function<void(bool)>> basisChange;
 

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -71,7 +71,7 @@ void __nvqir__setCircuitSimulator(nvqir::CircuitSimulator *sim) {
     delete ptr;
   }
   externSimGenerator = std::make_unique<ExternallyProvidedSimGenerator>(sim);
-  cudaq::info("[runtime] Setting the circuit simulator to {}.", sim->name());
+  CUDAQ_INFO("[runtime] Setting the circuit simulator to {}.", sim->name());
 }
 }
 
@@ -94,7 +94,7 @@ CircuitSimulator *getCircuitSimulatorInternal() {
 
   simulator = cudaq::getUniquePluginInstance<CircuitSimulator>(
       GetCircuitSimulatorSymbol);
-  cudaq::info("Creating the {} backend.", simulator->name());
+  CUDAQ_INFO("Creating the {} backend.", simulator->name());
   return simulator;
 }
 
@@ -194,8 +194,8 @@ std::unique_ptr<std::complex<To>[]> convertToComplex(std::complex<From> *data,
   auto size = pow(2, numQubits);
   constexpr auto toType = typeName<To>();
   constexpr auto fromType = typeName<From>();
-  cudaq::info("copying {} complex<{}> values to complex<{}>", size, fromType,
-              toType);
+  CUDAQ_INFO("copying {} complex<{}> values to complex<{}>", size, fromType,
+             toType);
 
   auto convertData = std::make_unique<std::complex<To>[]>(size);
   for (std::size_t i = 0; i < size; ++i)
@@ -213,7 +213,7 @@ std::unique_ptr<std::complex<To>[]> convertToComplex(From *data,
   auto size = pow(2, numQubits);
   constexpr auto toType = typeName<To>();
   constexpr auto fromType = typeName<From>();
-  cudaq::info("copying {} {} values to complex<{}>", size, fromType, toType);
+  CUDAQ_INFO("copying {} {} values to complex<{}>", size, fromType, toType);
 
   auto convertData = std::make_unique<std::complex<To>[]>(size);
   for (std::size_t i = 0; i < size; ++i)
@@ -284,9 +284,9 @@ void __quantum__rt__setExecutionContext(cudaq::ExecutionContext *ctx) {
 
   if (ctx) {
     ScopedTraceWithContext("NVQIR::setExecutionContext", ctx->name);
-    cudaq::info("Setting execution context: {}{}", ctx ? ctx->name : "basic",
-                ctx->hasConditionalsOnMeasureResults ? " with conditionals"
-                                                     : "");
+    CUDAQ_INFO("Setting execution context: {}{}", ctx ? ctx->name : "basic",
+               ctx->hasConditionalsOnMeasureResults ? " with conditionals"
+                                                    : "");
     nvqir::getCircuitSimulatorInternal()->setExecutionContext(ctx);
   }
 }
@@ -294,7 +294,7 @@ void __quantum__rt__setExecutionContext(cudaq::ExecutionContext *ctx) {
 /// @brief Reset the Execution Context
 void __quantum__rt__resetExecutionContext() {
   ScopedTraceWithContext("NVQIR::resetExecutionContext");
-  cudaq::info("Resetting execution context.");
+  CUDAQ_INFO("Resetting execution context.");
   nvqir::getCircuitSimulatorInternal()->resetExecutionContext();
 }
 
@@ -915,7 +915,7 @@ static std::vector<Pauli> extractPauliTermIds(Array *paulis) {
 /// @param qubits
 /// @return
 Result *__quantum__qis__measure__body(Array *pauli_arr, Array *qubits) {
-  cudaq::info("NVQIR measuring in pauli basis");
+  CUDAQ_INFO("NVQIR measuring in pauli basis");
   ScopedTraceWithContext("NVQIR::observe_measure_body");
 
   auto *circuitSimulator = nvqir::getCircuitSimulatorInternal();
@@ -975,7 +975,7 @@ Result *__quantum__qis__measure__body(Array *pauli_arr, Array *qubits) {
 
   // Reverse the measurements bases change.
   if (!reverser.empty()) {
-    cudaq::info("NVQIR reverse pauli bases change for measurement.");
+    CUDAQ_INFO("NVQIR reverse pauli bases change for measurement.");
     for (auto it = reverser.rbegin(); it != reverser.rend(); ++it) {
       if (it->first == "X") {
         circuitSimulator->h(it->second);
@@ -1014,7 +1014,7 @@ void __quantum__qis__exp__body(Array *paulis, double angle, Array *qubits) {
     // do nothing since this is the ID term
     std::string msg = "Applying exp (i theta H), where H is the identity";
     msg += "(warning, no non-identity terms in H. Not applying exp())";
-    cudaq::info(msg.c_str());
+    CUDAQ_INFO(msg.c_str());
     return;
   }
 

--- a/runtime/nvqir/cudensitymat/CuDensityMatCallbackConverter.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatCallbackConverter.cpp
@@ -47,15 +47,15 @@ cudaq::dynamics::CuDensityMatOpConverter::wrapScalarCallback(
       for (size_t i = 0; i < context->paramNames.size(); ++i) {
         param_map[context->paramNames[i]] =
             std::complex<double>(params[2 * i], params[2 * i + 1]);
-        cudaq::debug("Callback param name {}, batch size {}, value {}",
-                     context->paramNames[i], batchSize,
-                     param_map[context->paramNames[i]]);
+        CUDAQ_DBG("Callback param name {}, batch size {}, value {}",
+                  context->paramNames[i], batchSize,
+                  param_map[context->paramNames[i]]);
       }
       for (int64_t i = 0; i < batchSize; ++i) {
         scalar_operator &storedOp = context->scalarOps[i];
         tdCoef[i] = storedOp.is_constant() ? storedOp.evaluate()
                                            : storedOp.evaluate(param_map);
-        cudaq::debug("Scalar callback constant value = {}", tdCoef[i]);
+        CUDAQ_DBG("Scalar callback constant value = {}", tdCoef[i]);
       }
       return CUDENSITYMAT_STATUS_SUCCESS;
     } catch (const std::exception &e) {
@@ -121,8 +121,8 @@ cudaq::dynamics::CuDensityMatOpConverter::wrapTensorCallback(
       for (size_t i = 0; i < context->paramNames.size(); ++i) {
         param_map[context->paramNames[i]] =
             std::complex<double>(params[2 * i], params[2 * i + 1]);
-        cudaq::debug("Tensor callback param name {}, value {}",
-                     context->paramNames[i], param_map[context->paramNames[i]]);
+        CUDAQ_DBG("Tensor callback param name {}, value {}",
+                  context->paramNames[i], param_map[context->paramNames[i]]);
       }
 
       cudaq::dimension_map &dimensions = context->dimensions;

--- a/runtime/nvqir/cudensitymat/CuDensityMatContext.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatContext.cpp
@@ -29,7 +29,7 @@ Context *Context::getCurrentContext() {
   std::lock_guard<std::mutex> guard(g_contextMutex);
   const auto iter = g_contexts.find(currentDevice);
   if (iter == g_contexts.end()) {
-    cudaq::info("Create cudensitymat context for device Id {}", currentDevice);
+    CUDAQ_INFO("Create cudensitymat context for device Id {}", currentDevice);
     const auto [insertedIter, success] = g_contexts.emplace(std::make_pair(
         currentDevice, std::unique_ptr<Context>(new Context(currentDevice))));
     if (!success)
@@ -50,8 +50,8 @@ void *Context::getScratchSpace(std::size_t minSizeBytes) {
       cudaq::dynamics::DeviceAllocator::free(m_scratchSpace);
     }
 
-    cudaq::info("Allocate scratch buffer of size {} bytes on device {}",
-                minSizeBytes, m_deviceId);
+    CUDAQ_INFO("Allocate scratch buffer of size {} bytes on device {}",
+               minSizeBytes, m_deviceId);
 
     m_scratchSpace = cudaq::dynamics::DeviceAllocator::allocate(minSizeBytes);
     m_scratchSpaceSizeBytes = minSizeBytes;
@@ -108,8 +108,8 @@ Context::Context(int deviceId) : m_deviceId(deviceId) {
     if (dupStatus != 0 || dupComm == nullptr)
       throw std::runtime_error("Failed to duplicate the MPI communicator when "
                                "initializing cuDensityMat MPI");
-    cudaq::info("cudensitymatResetDistributedConfiguration for handle {}\n",
-                m_cudmHandle);
+    CUDAQ_INFO("cudensitymatResetDistributedConfiguration for handle {}\n",
+               m_cudmHandle);
     HANDLE_CUDM_ERROR(cudensitymatResetDistributedConfiguration(
         m_cudmHandle, CUDENSITYMAT_DISTRIBUTED_PROVIDER_MPI, dupComm->commPtr,
         dupComm->commSize));

--- a/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatEvolution.cpp
@@ -35,8 +35,8 @@ state migrateState(const state &inputState) {
   if (currentDeviceId == stateDeviceId)
     return inputState;
 
-  cudaq::info("Migrate state data from device {} to {}\n", stateDeviceId,
-              currentDeviceId);
+  CUDAQ_INFO("Migrate state data from device {} to {}\n", stateDeviceId,
+             currentDeviceId);
   const int64_t dim = inputState.get_tensor().get_num_elements();
   const int64_t arraySizeBytes = dim * sizeof(std::complex<double>);
   auto localizedState =
@@ -588,9 +588,9 @@ evolveBatched(const std::vector<sum_op<cudaq::matrix_handler>> &hamiltonians,
 
     if (!batch_size.has_value()) {
       // Otherwise, just log a warning:
-      cudaq::warn("Hamiltonian operators and collapse operators are not "
-                  "compatible for batching. "
-                  "Falling back to single evolution for each Hamiltonian.");
+      CUDAQ_WARN("Hamiltonian operators and collapse operators are not "
+                 "compatible for batching. "
+                 "Falling back to single evolution for each Hamiltonian.");
     }
   }
 
@@ -706,9 +706,9 @@ evolveBatched(const std::vector<super_op> &superOps,
 
     if (!batch_size.has_value()) {
       // Otherwise, just log a warning:
-      cudaq::warn("The input super-operators are not "
-                  "compatible for batching. "
-                  "Falling back to single evolution for each Hamiltonian.");
+      CUDAQ_WARN("The input super-operators are not "
+                 "compatible for batching. "
+                 "Falling back to single evolution for each Hamiltonian.");
     }
   }
 

--- a/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatOpConverter.cpp
@@ -121,8 +121,7 @@ cudaq::dynamics::CuDensityMatOpConverter::CuDensityMatOpConverter(
     const auto minDim =
         getIntEnvVarIfPresent("CUDAQ_DYNAMICS_MIN_MULTIDIAGONAL_DIMENSION");
     if (minDim.has_value()) {
-      cudaq::info("Setting multi-diagonal min dimension to {}.",
-                  minDim.value());
+      CUDAQ_INFO("Setting multi-diagonal min dimension to {}.", minDim.value());
       m_minDimensionDiag = minDim.value();
     }
   }
@@ -131,8 +130,8 @@ cudaq::dynamics::CuDensityMatOpConverter::CuDensityMatOpConverter(
     const auto maxDiags = getIntEnvVarIfPresent(
         "CUDAQ_DYNAMICS_MAX_DIAGONAL_COUNT_FOR_MULTIDIAGONAL");
     if (maxDiags.has_value()) {
-      cudaq::info("Setting multi-diagonal max number of diagonals to {}.",
-                  maxDiags.value());
+      CUDAQ_INFO("Setting multi-diagonal max number of diagonals to {}.",
+                 maxDiags.value());
       m_maxDiagonalsDiag = maxDiags.value();
     }
   }

--- a/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
@@ -51,10 +51,10 @@ void initCuDensityMatCommLib() {
   // If CUDENSITYMAT_COMM_LIB environment variable is not set,
   // use this builtin plugin shim (redirect MPI calls to CUDA-Q plugin)
   if (std::getenv("CUDENSITYMAT_COMM_LIB") == nullptr) {
-    cudaq::info("Enabling cuDensityMat MPI without environment variable "
-                "CUDENSITYMAT_COMM_LIB. \nUse the builtin cuDensityMat "
-                "communicator lib from '{}' - CUDA-Q MPI plugin {}.",
-                getThisSharedLibFilePath(), getMpiPluginFilePath());
+    CUDAQ_INFO("Enabling cuDensityMat MPI without environment variable "
+               "CUDENSITYMAT_COMM_LIB. \nUse the builtin cuDensityMat "
+               "communicator lib from '{}' - CUDA-Q MPI plugin {}.",
+               getThisSharedLibFilePath(), getMpiPluginFilePath());
     setenv("CUDENSITYMAT_COMM_LIB", getThisSharedLibFilePath(), 0);
   }
 }
@@ -100,7 +100,7 @@ public:
       const bool enableMemPool =
           cudaq::getEnvBool("CUDAQ_ENABLE_MEMPOOL", true);
       if (!enableMemPool) {
-        cudaq::info("Mempool is disabled.");
+        CUDAQ_INFO("Mempool is disabled.");
       } else {
         // Check if mempool is available
         int device{0};
@@ -109,7 +109,7 @@ public:
         HANDLE_CUDA_ERROR(cudaDeviceGetAttribute(
             &supported, cudaDevAttrMemoryPoolsSupported, device));
         if (!supported) {
-          cudaq::info("Memory pools are unsupported on this GPU");
+          CUDAQ_INFO("Memory pools are unsupported on this GPU");
         } else {
           cudaMemPool_t memPool;
           HANDLE_CUDA_ERROR(cudaDeviceGetDefaultMemPool(&memPool, device));

--- a/runtime/nvqir/cudensitymat/CuDensityMatSuperOpCtor.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatSuperOpCtor.cpp
@@ -308,7 +308,7 @@ cudaq::dynamics::CuDensityMatOpConverter::constructLiouvillian(
                   });
 
   if (!isMasterEquation && noCollapseOperators) {
-    cudaq::info("Construct state vector Liouvillian");
+    CUDAQ_INFO("Construct state vector Liouvillian");
     std::vector<sum_op<cudaq::matrix_handler>> liouvillians;
     liouvillians.reserve(batchSize);
     for (const auto &ham : hamOperators) {
@@ -316,7 +316,7 @@ cudaq::dynamics::CuDensityMatOpConverter::constructLiouvillian(
     }
     return convertToCudensitymatOperator(parameters, liouvillians, modeExtents);
   } else {
-    cudaq::info("Construct density matrix Liouvillian");
+    CUDAQ_INFO("Construct density matrix Liouvillian");
     cudensitymatOperator_t liouvillian;
     HANDLE_CUDM_ERROR(cudensitymatCreateOperator(
         m_handle, static_cast<int32_t>(modeExtents.size()), modeExtents.data(),

--- a/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cpp
+++ b/runtime/nvqir/custatevec/CuStateVecCircuitSimulator.cpp
@@ -167,7 +167,7 @@ protected:
 
     int dev;
     HANDLE_CUDA_ERROR(cudaGetDevice(&dev));
-    cudaq::info("GPU {} Allocating new qubit array of size {}.", dev, count);
+    CUDAQ_INFO("GPU {} Allocating new qubit array of size {}.", dev, count);
 
     constexpr int32_t threads_per_block = 256;
     uint32_t n_blocks =

--- a/runtime/nvqir/custatevec/CuStateVecState.h
+++ b/runtime/nvqir/custatevec/CuStateVecState.h
@@ -146,9 +146,9 @@ public:
       return std::abs(std::complex<ScalarType>(cmplx.real, cmplx.imaginary));
     } else {
       // If we reach here, then we have to copy the data from host.
-      cudaq::info("[custatevec-state] overlap computation requested with a "
-                  "state that is "
-                  "in host memory. Host data will be copied to GPU.");
+      CUDAQ_INFO("[custatevec-state] overlap computation requested with a "
+                 "state that is "
+                 "in host memory. Host data will be copied to GPU.");
 
       auto cmplx = nvqir::innerProduct<ScalarType>(
           devicePtr, other.getTensor().data, size, true);
@@ -291,9 +291,9 @@ public:
       cudaSetDevice(device);
 
     cudaGetDevice(&currentDev);
-    cudaq::info("custatevec-state destroying state vector handle (devicePtr "
-                "GPU = {}, currentDevice = {}).",
-                device, currentDev);
+    CUDAQ_INFO("custatevec-state destroying state vector handle (devicePtr "
+               "GPU = {}, currentDevice = {}).",
+               device, currentDev);
 
     HANDLE_CUDA_ERROR(cudaFree(devicePtr));
   }

--- a/runtime/nvqir/cutensornet/mpi_support.cpp
+++ b/runtime/nvqir/cutensornet/mpi_support.cpp
@@ -82,10 +82,10 @@ void initCuTensornetComm(cutensornetHandle_t cutnHandle) {
   // If CUTENSORNET_COMM_LIB environment variable is not set,
   // use this builtin plugin shim (redirect MPI calls to CUDA-Q plugin)
   if (std::getenv("CUTENSORNET_COMM_LIB") == nullptr) {
-    cudaq::info("Enabling cuTensorNet MPI without environment variable "
-                "CUTENSORNET_COMM_LIB. \nUse the builtin cuTensorNet "
-                "communicator lib from '{}' - CUDA-Q MPI plugin {}.",
-                getThisSharedLibFilePath(), getMpiPluginFilePath());
+    CUDAQ_INFO("Enabling cuTensorNet MPI without environment variable "
+               "CUTENSORNET_COMM_LIB. \nUse the builtin cuTensorNet "
+               "communicator lib from '{}' - CUDA-Q MPI plugin {}.",
+               getThisSharedLibFilePath(), getMpiPluginFilePath());
     setenv("CUTENSORNET_COMM_LIB", getThisSharedLibFilePath(), 0);
   }
 

--- a/runtime/nvqir/cutensornet/mps_simulation_state.inc
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.inc
@@ -345,7 +345,7 @@ void MPSSimulationState<ScalarType>::deallocate() {
 
 template <typename ScalarType>
 void MPSSimulationState<ScalarType>::destroyState() {
-  cudaq::info("mps-state destroying state vector handle.");
+  CUDAQ_INFO("mps-state destroying state vector handle.");
   deallocate();
 }
 
@@ -565,7 +565,7 @@ MPSSettings::MPSSettings() {
                                "a positive number. Got: " +
                                maxBondStr);
 
-    cudaq::info("Setting MPS max bond dimension to {}.", maxBond);
+    CUDAQ_INFO("Setting MPS max bond dimension to {}.", maxBond);
   }
   // Cutoff values
   if (auto *absCutoffEnvVar = std::getenv("CUDAQ_MPS_ABS_CUTOFF")) {
@@ -580,7 +580,7 @@ MPSSettings::MPSSettings() {
                                "a number in range (0.0, 1.0). Got: " +
                                absCutoffStr);
 
-    cudaq::info("Setting MPS absolute cutoff to {}.", absCutoff);
+    CUDAQ_INFO("Setting MPS absolute cutoff to {}.", absCutoff);
   }
   if (auto *relCutoffEnvVar = std::getenv("CUDAQ_MPS_RELATIVE_CUTOFF")) {
     const std::string relCutoffStr(relCutoffEnvVar);
@@ -595,7 +595,7 @@ MPSSettings::MPSSettings() {
           "a number in range (0.0, 1.0). Got: " +
           relCutoffStr);
 
-    cudaq::info("Setting MPS relative cutoff to {}.", relCutoff);
+    CUDAQ_INFO("Setting MPS relative cutoff to {}.", relCutoff);
   }
   using namespace std::literals::string_view_literals;
   using SvdPair = std::pair<std::string_view, cutensornetTensorSVDAlgo_t>;
@@ -622,7 +622,7 @@ MPSSettings::MPSSettings() {
       throw std::runtime_error(errorMsg.str());
     }
     svdAlgo = iter->second;
-    cudaq::info("Setting MPS SVD algorithm to {} ({}).",
+    CUDAQ_INFO("Setting MPS SVD algorithm to {} ({}).",
                 fmt::underlying(svdAlgo), iter->first);
   }
 
@@ -649,7 +649,7 @@ MPSSettings::MPSSettings() {
       throw std::runtime_error(errorMsg.str());
     }
     gaugeOption = iter->second;
-    cudaq::info("Setting MPS GAUGE option to {} ({}).", iter->first,
+    CUDAQ_INFO("Setting MPS GAUGE option to {} ({}).", iter->first,
                 fmt::underlying(iter->second));
   }
 }

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.inc
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.inc
@@ -238,7 +238,7 @@ void SimulatorTensorNetBase<ScalarType>::applyNoise(
 
   // Apply all prior gates before applying noise.
   std::vector<int32_t> qubits{targets.begin(), targets.end()};
-  cudaq::info(
+  CUDAQ_INFO(
       "[SimulatorTensorNetBase] Applying kraus channel {} on qubits: {}",
       cudaq::get_noise_model_type_name(channel.noise_type), qubits);
 
@@ -273,7 +273,7 @@ void SimulatorTensorNetBase<ScalarType>::applyNoiseChannel(
   if (krausChannels.empty())
     return;
 
-  cudaq::info(
+  CUDAQ_INFO(
       "[SimulatorTensorNetBase] Applying {} kraus channels on qubits: {}",
       krausChannels.size(), qubits);
 
@@ -293,7 +293,7 @@ void SimulatorTensorNetBase<ScalarType>::resetQubit(
   const auto rdm = m_state->computeRDM({static_cast<int32_t>(qubitIdx)});
   assert(rdm.size() == 4);
   const ScalarType prob0 = rdm[0].real();
-  cudaq::info("Reset qubit {} with prob(|0>) = {}", qubitIdx, prob0);
+  CUDAQ_INFO("Reset qubit {} with prob(|0>) = {}", qubitIdx, prob0);
   // If this is a zero state, no need to do anything.
   if (std::abs(1.0 - prob0) < 1e-9)
     return;
@@ -429,7 +429,7 @@ bool SimulatorTensorNetBase<ScalarType>::canHandleObserve() {
       this->executionContext->shots != ~0ull) {
     // This 'shots' mode is very slow for tensor network.
     // However, we need to respect the shots option.
-    cudaq::info("[SimulatorTensorNetBase] Shots mode expectation calculation "
+    CUDAQ_INFO("[SimulatorTensorNetBase] Shots mode expectation calculation "
                 "is requested with {} shots.",
                 this->executionContext->shots);
 

--- a/runtime/nvqir/cutensornet/simulator_mps.h
+++ b/runtime/nvqir/cutensornet/simulator_mps.h
@@ -150,8 +150,8 @@ public:
     if (controls.empty() && qubitIds.size() == 2 &&
         shouldHandlePauliOp(pauli_word)) {
       this->flushGateQueue();
-      cudaq::info("[SimulatorMPS] (apply) exp(i*{}*{}) ({}, {}).", theta,
-                  op.to_string(), qubitIds[0], qubitIds[1]);
+      CUDAQ_INFO("[SimulatorMPS] (apply) exp(i*{}*{}) ({}, {}).", theta,
+                 op.to_string(), qubitIds[0], qubitIds[1]);
       const GateApplicationTask task = [&]() {
         // Note: Rxx(angle) ==  exp(-i*angle/2 XX)
         // i.e., exp(i*theta XX) == Rxx(-2 * theta)

--- a/runtime/nvqir/cutensornet/simulator_tensornet.h
+++ b/runtime/nvqir/cutensornet/simulator_tensornet.h
@@ -53,9 +53,9 @@ public:
                         "positive integer value, got '{}'.",
                         maxControlledRank));
 
-      cudaq::info("Setting max controlled rank for full tensor expansion from "
-                  "{} to {}.",
-                  m_maxControlledRankForFullTensorExpansion, maxControlledRank);
+      CUDAQ_INFO("Setting max controlled rank for full tensor expansion from "
+                 "{} to {}.",
+                 m_maxControlledRankForFullTensorExpansion, maxControlledRank);
       m_maxControlledRankForFullTensorExpansion = maxControlledRank;
     }
   }

--- a/runtime/nvqir/cutensornet/tensornet_state.inc
+++ b/runtime/nvqir/cutensornet/tensornet_state.inc
@@ -25,7 +25,7 @@ std::int32_t TensorNetState<ScalarType>::numHyperSamples = []() {
         // for the 'catch' below to handle.
         throw std::invalid_argument("must be a positive number");
       }
-      cudaq::info("Update number of hyper samples from {} to {}.",
+      CUDAQ_INFO("Update number of hyper samples from {} to {}.",
                   defaultNumHyperSamples, specifiedNumHyperSamples);
       return specifiedNumHyperSamples;
     } catch (...) {
@@ -320,14 +320,14 @@ TensorNetState<ScalarType>::executeSample(
     const std::size_t cacheSizeAvailable =
         std::min(static_cast<size_t>(reqCacheSize),
                  size_t(freeSize * 0.9) - (size_t(freeSize * 0.9) % 4096));
-    cudaq::info("Cache size = {} bytes", cacheSizeAvailable);
+    CUDAQ_INFO("Cache size = {} bytes", cacheSizeAvailable);
     const auto errCode = cudaMalloc(&d_cache, cacheSizeAvailable);
     if (errCode == cudaSuccess) {
       HANDLE_CUTN_ERROR(cutensornetWorkspaceSetMemory(
           m_cutnHandle, workDesc, CUTENSORNET_MEMSPACE_DEVICE,
           CUTENSORNET_WORKSPACE_CACHE, d_cache, cacheSizeAvailable));
     } else {
-      cudaq::info("Failed to allocate cache workspace memory.");
+      CUDAQ_INFO("Failed to allocate cache workspace memory.");
       d_cache = nullptr;
     }
   }
@@ -819,7 +819,7 @@ TensorNetState<ScalarType>::computeExpVals(
     HANDLE_CUTN_ERROR(cutensornetExpectationGetInfo(
         m_cutnHandle, tensorNetworkExpectation,
         CUTENSORNET_EXPECTATION_INFO_FLOPS, &flops, sizeof(flops)));
-    cudaq::info("Total flop count = {} GFlop.", (flops / 1e9));
+    CUDAQ_INFO("Total flop count = {} GFlop.", (flops / 1e9));
   }
 
   // Attach the workspace buffer
@@ -962,7 +962,7 @@ std::complex<ScalarType> TensorNetState<ScalarType>::computeExpVal(
     HANDLE_CUTN_ERROR(cutensornetExpectationGetInfo(
         m_cutnHandle, tensorNetworkExpectation,
         CUTENSORNET_EXPECTATION_INFO_FLOPS, &flops, sizeof(flops)));
-    cudaq::info("Total flop count = {} GFlop.", (flops / 1e9));
+    CUDAQ_INFO("Total flop count = {} GFlop.", (flops / 1e9));
   }
 
   // Attach the workspace buffer

--- a/runtime/nvqir/cutensornet/tensornet_utils.cpp
+++ b/runtime/nvqir/cutensornet/tensornet_utils.cpp
@@ -40,7 +40,7 @@ ScratchDeviceMem::ScratchDeviceMem() {
           minScratchSizePercent, maxScratchSizePercent, scratchSizePercent));
 
     freeMemRatio = static_cast<double>(envIntVal) / 100.0;
-    cudaq::info("Setting scratch size ratio to {}.", freeMemRatio);
+    CUDAQ_INFO("Setting scratch size ratio to {}.", freeMemRatio);
   }
 }
 

--- a/runtime/nvqir/cutensornet/tn_simulation_state.inc
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.inc
@@ -303,7 +303,7 @@ TensorNetSimulationState<ScalarType>::createFromSizeAndPtr(
 
 template <typename ScalarType>
 void TensorNetSimulationState<ScalarType>::destroyState() {
-  cudaq::info("mps-state destroying state vector handle.");
+  CUDAQ_INFO("mps-state destroying state vector handle.");
   m_state.reset();
 }
 

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -284,7 +284,7 @@ protected:
                                           collapsed_state.rows(),
                                           collapsed_state.cols());
     }
-    cudaq::info("Measured qubit {} -> {}", qubitIdx, measurement_result);
+    CUDAQ_INFO("Measured qubit {} -> {}", qubitIdx, measurement_result);
     return measurement_result == 1 ? true : false;
   }
 
@@ -351,7 +351,7 @@ public:
                                 const int shots) override {
     if (shots < 1) {
       double expectationValue = calculateExpectationValue(qubits);
-      cudaq::info("Computed expectation value = {}", expectationValue);
+      CUDAQ_INFO("Computed expectation value = {}", expectationValue);
       return cudaq::ExecutionResult{{}, expectationValue};
     }
 

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -177,7 +177,7 @@ protected:
     stim::simd_bit_table<W> msmSample = sampleSim->m_record.storage;
     // Disabled because it's too verbose, but left here as comments for
     // reference.
-    // cudaq::info("msmSample is {} {}\n{}", msm_err_count, num_cols,
+    // CUDAQ_INFO("msmSample is {} {}\n{}", msm_err_count, num_cols,
     //             msmSample.str(num_measurements, num_cols).c_str());
 
     // Now it's msmSample[error_mechanism_index][measure_idx]
@@ -206,7 +206,7 @@ protected:
                                "initialization of qubits from state data.");
 
     if (!tableau) {
-      cudaq::info("Creating new Stim Tableau simulator");
+      CUDAQ_INFO("Creating new Stim Tableau simulator");
       // Bump the randomEngine before cloning and giving to the Tableau
       // simulator.
       randomEngine.discard(
@@ -235,8 +235,8 @@ protected:
       circuit_stats.num_measurements = anticipated_num_measurements;
 
       auto batch_size = getBatchSize();
-      cudaq::info("Creating new Stim frame simulator with batch size {}",
-                  batch_size);
+      CUDAQ_INFO("Creating new Stim frame simulator with batch size {}",
+                 batch_size);
       // Bump the randomEngine before cloning and giving to the sample
       // simulator.
       randomEngine.discard(
@@ -273,7 +273,7 @@ protected:
     if (targets.empty())
       return;
     stim::Circuit tempCircuit;
-    cudaq::info("Calling applyOpToSims {} - {}", gate_name, targets);
+    CUDAQ_INFO("Calling applyOpToSims {} - {}", gate_name, targets);
     tempCircuit.safe_append_u(gate_name, targets);
     tableau->safe_do_circuit(tempCircuit);
     sampleSim->safe_do_circuit(tempCircuit);
@@ -311,8 +311,8 @@ protected:
     if (krausChannels.empty())
       return;
 
-    cudaq::info("Applying {} kraus channels to qubits {}", krausChannels.size(),
-                stimTargets);
+    CUDAQ_INFO("Applying {} kraus channels to qubits {}", krausChannels.size(),
+               stimTargets);
 
     for (auto &channel : krausChannels)
       applyNoise(channel, stimTargets);
@@ -333,8 +333,8 @@ protected:
 
   void applyNoise(const cudaq::kraus_channel &channel,
                   const std::vector<std::uint32_t> &qubits) {
-    cudaq::info("[stim] apply kraus channel {}, is_msm_mode = {}",
-                channel.get_type_name(), is_msm_mode);
+    CUDAQ_INFO("[stim] apply kraus channel {}, is_msm_mode = {}",
+               channel.get_type_name(), is_msm_mode);
 
     // If we have a valid operation, apply it
     if (auto res = isValidStimNoiseChannel(channel)) {

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -105,7 +105,7 @@ protected:
     state = Eigen::Map<const qpp::ket>(collapsed_state.data(),
                                        collapsed_state.size());
 
-    cudaq::info("Measured qubit {} -> {}", q.id, measurement_result);
+    CUDAQ_INFO("Measured qubit {} -> {}", q.id, measurement_result);
     return measurement_result;
   }
 
@@ -118,7 +118,7 @@ public:
       u << 0, 0, 1, 1, 0, 0, 0, 1, 0;
       auto &[gateName, params, controls, qudits, op] = inst;
       auto target = qudits[0];
-      cudaq::info("Applying plusGate on {}<{}>", target.id, target.levels);
+      CUDAQ_INFO("Applying plusGate on {}<{}>", target.id, target.levels);
       state = qpp::apply(state, u, {target.id}, target.levels);
     });
   }


### PR DESCRIPTION
This PR standardizes logging throughout the codebase by replacing all instances of the CUDA-Q logging functions with their corresponding logging macros introduced in PR https://github.com/NVIDIA/cuda-quantum/pull/2970. 
