### PR TITLE
[fix] Update example - reset qubit after measurement

### DIFF
--- a/docs/sphinx/examples/python/random_walk_qpe.py
+++ b/docs/sphinx/examples/python/random_walk_qpe.py
@@ -35,13 +35,13 @@ def rwpe_kernel(n_iter: int, mu: float, sigma: float) -> float:
         x.ctrl(aux, target)
         h(aux)
         if mz(aux):
-            x(aux)
             mu = mu + sigma * .6065
         else:
             mu = mu - sigma * .6065
 
         sigma *= .7951
         iteration += 1
+        reset(aux)
 
     return 2.0 * mu
 


### PR DESCRIPTION
Follow-up to similar change in PR https://github.com/NVIDIA/cuda-quantum/pull/3332
The change improves the correctness of the quantum walk by resetting the `aux` qubit after each iteration.

