### PR TITLE
Update BraketServerHelper to use ccnot instead of ccx

### DIFF
--- a/python/tests/backends/test_braket.py
+++ b/python/tests/backends/test_braket.py
@@ -498,6 +498,7 @@ def test_exp_pauli():
 
 
 def test_toffoli():
+
     @cudaq.kernel
     def kernel():
         q = cudaq.qvector(3)

--- a/python/tests/backends/test_braket.py
+++ b/python/tests/backends/test_braket.py
@@ -497,6 +497,20 @@ def test_exp_pauli():
     assert not '10' in counts
 
 
+def test_toffoli():
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(3)
+        x(q)
+        x.ctrl([q[0], q[1]], q[2])
+        mz(q)
+
+    counts = cudaq.sample(kernel)
+    counts.dump()
+    assert '110' in counts
+    assert len(counts) == 1
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)

--- a/runtime/cudaq/platform/default/rest/helpers/braket/BraketServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/BraketServerHelper.cpp
@@ -14,6 +14,8 @@ std::string prepareOpenQasm(std::string source) {
   source = std::regex_replace(source, includeRE, "");
   const std::regex cxToCnot{"\\scx\\s"};
   source = std::regex_replace(source, cxToCnot, " cnot ");
+  const std::regex ccxToCcnot{"\\sccx\\s"};
+  source = std::regex_replace(source, ccxToCcnot, " ccnot ");
   return source;
 }
 


### PR DESCRIPTION
Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.

### Description
I added a mapping from `ccx`->`ccnot` since that's the name of the gate on Braket in the exact same manner `cx` is already mapped to `cnot`.

This problem was mentioned on this previous issue:
https://github.com/NVIDIA/cuda-quantum/issues/2325#issuecomment-2518222251