### PR TITLE
[Python] Add utility to register callbacks for Python target changes 

### DIFF
--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -84,6 +84,8 @@ Backend Configuration
 .. autofunction:: cudaq::reset_target
 .. autofunction:: cudaq::set_noise
 .. autofunction:: cudaq::unset_noise
+.. autofunction:: cudaq::register_set_target_callback
+.. autofunction:: cudaq::unregister_set_target_callback
 
 .. function:: cudaq.apply_noise(error_type, parameters..., targets...)
 

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -125,6 +125,8 @@ mpi = cudaq_runtime.mpi
 num_available_gpus = cudaq_runtime.num_available_gpus
 set_noise = cudaq_runtime.set_noise
 unset_noise = cudaq_runtime.unset_noise
+register_set_target_callback = cudaq_runtime.register_set_target_callback
+unregister_set_target_callback = cudaq_runtime.unregister_set_target_callback
 
 # Noise Modeling
 KrausChannel = cudaq_runtime.KrausChannel

--- a/python/runtime/cudaq/target/py_runtime_target.cpp
+++ b/python/runtime/cudaq/target/py_runtime_target.cpp
@@ -11,8 +11,36 @@
 #include "common/FmtCore.h"
 #include "common/Logger.h"
 #include "cudaq/platform.h"
+#include <functional>
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+
+namespace {
+using SetTargetCallbackFnTy = std::function<void(const cudaq::RuntimeTarget &)>;
+// List of `set_target` callbacks to be executed during target changes.
+// We use a string identifier for so that the subscriber can identify itself,
+// e.g., to unsubscribe/replace the callback.
+static std::unordered_map<std::string, SetTargetCallbackFnTy> g_callbacks;
+void registerSetTargetCallback(
+    std::function<void(const cudaq::RuntimeTarget &)> callback,
+    const std::string &id) {
+  CUDAQ_INFO("Register set_target callback with id '{}'.", id);
+  g_callbacks[id] = callback;
+}
+
+void unregisterSetTargetCallback(const std::string &id) {
+  CUDAQ_INFO("Unregister set_target callback with id '{}'.", id);
+  g_callbacks.erase(id);
+}
+
+void onTargetChange(const cudaq::RuntimeTarget &newTarget) {
+  for (auto &[name, callback] : g_callbacks) {
+    CUDAQ_INFO("Execute set target callback named '{}'", name);
+    callback(newTarget);
+  }
+}
+} // namespace
 
 namespace cudaq {
 
@@ -110,7 +138,11 @@ void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
       [&](const std::string &name) { return holder.hasTarget(name); },
       "Return true if the `cudaq.Target` with the given name exists.");
   mod.def(
-      "reset_target", [&]() { return holder.resetTarget(); },
+      "reset_target",
+      [&]() {
+        holder.resetTarget();
+        onTargetChange(holder.getTarget());
+      },
       "Reset the current `cudaq.Target` to the default.");
   mod.def(
       "get_target",
@@ -129,6 +161,7 @@ void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
       [&](const cudaq::RuntimeTarget &target, py::kwargs extraConfig) {
         auto config = parseTargetKwArgs(extraConfig);
         holder.setTarget(target.name, config);
+        onTargetChange(target);
       },
       "Set the `cudaq.Target` to be used for CUDA-Q kernel execution. "
       "Can provide optional, target-specific configuration data via Python "
@@ -138,10 +171,31 @@ void bindRuntimeTarget(py::module &mod, LinkedLibraryHolder &holder) {
       [&](const std::string &name, py::kwargs extraConfig) {
         auto config = parseTargetKwArgs(extraConfig);
         holder.setTarget(name, config);
+        onTargetChange(holder.getTarget());
       },
       "Set the `cudaq.Target` with given name to be used for CUDA-Q "
       "kernel execution. Can provide optional, target-specific configuration "
       "data via Python kwargs.");
+  mod.def(
+      "register_set_target_callback",
+      [&](std::function<void(const cudaq::RuntimeTarget &)> callback,
+          const std::string &id) {
+        registerSetTargetCallback(callback, id);
+        // Execute the callback on the current target
+        callback(holder.getTarget());
+      },
+      "Register a callback function to be executed when the runtime target is "
+      "changed. The string `id` can be used to identify the callback for "
+      "replacement/removal purposes.");
+  mod.def(
+      "unregister_set_target_callback",
+      [](const std::string &id) { unregisterSetTargetCallback(id); },
+      "Unregister a callback identified by the input identifier.");
+
+  py::module_::import("atexit").attr("register")(py::cpp_function([]() {
+    // Perform cleanup of registered callbacks, which might be Python objects.
+    g_callbacks.clear();
+  }));
 }
 
 } // namespace cudaq

--- a/python/tests/utils/test_set_target_callback.py
+++ b/python/tests/utils/test_set_target_callback.py
@@ -1,0 +1,74 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import cudaq
+import os
+import pytest
+
+
+def test_register_callback():
+    cudaq.set_target("density-matrix-cpu")
+
+    sim_name = ""  # to be updated by the callback
+
+    def callback(target):
+        nonlocal sim_name
+        sim_name = target.name
+
+    cudaq.register_set_target_callback(callback, "my_callback")
+    assert sim_name == "density-matrix-cpu"
+
+    # Register another one
+    called = False
+
+    def another_callback(target):
+        nonlocal called
+        called = True
+
+    cudaq.register_set_target_callback(another_callback, "another_callback")
+    assert called
+
+    called = False
+    sim_name = ""
+
+    # Change target
+    cudaq.set_target("stim")
+    assert sim_name == "stim"
+    assert called
+
+    called = False
+    sim_name = ""
+
+    # Unregister
+    cudaq.unregister_set_target_callback("another_callback")
+    cudaq.set_target("density-matrix-cpu")
+    assert sim_name == "density-matrix-cpu"
+    assert not called
+
+    # Reset target also triggers callback
+    cudaq.reset_target()
+    assert sim_name == "nvidia" or sim_name == "qpp-cpu"
+
+    # Check other target info
+    is_remote = None
+
+    def yet_another_callback(target):
+        nonlocal is_remote
+        is_remote = target.is_remote()
+
+    cudaq.set_target("quantinuum", emulated=True)
+    cudaq.register_set_target_callback(yet_another_callback,
+                                       "yet_another_callback")
+    assert is_remote
+    assert sim_name == "quantinuum"
+
+
+# leave for gdb debugging
+if __name__ == "__main__":
+    loc = os.path.abspath(__file__)
+    pytest.main([loc, "-rP"])


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

Add functions to register/unregister callbacks to be executed when the runtime target changes.

Upon registration, we also invoke the callback with the current target. 
