### PR TITLE
use -j$(nproc) for ctest

### DIFF
--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -98,7 +98,7 @@ jobs:
               echo "::error file=test_in_devenv.yml::Python interop tests failed with status $pytest_status."
               exit 1
             fi
-            ctest --output-on-failure --test-dir build -E "ctest-nvqpp|ctest-targettests"
+            ctest -j$(nproc) --output-on-failure --test-dir build -E "ctest-nvqpp|ctest-targettests"
             ctest_status=$?
             $LLVM_INSTALL_PREFIX/bin/llvm-lit -v --time-tests --param nvqpp_site_config=build/test/lit.site.cfg.py build/test
             lit_status=$?
@@ -135,7 +135,7 @@ jobs:
             echo $CUDAQ_MPI_COMM_LIB
             # Rerun the MPI plugin test
             cd $CUDAQ_REPO_ROOT
-            ctest --test-dir build -R MPIApiTest -V
+            ctest -j$(nproc) --test-dir build -R MPIApiTest -V
             external_plugin_status=$?   
             if [ ! $external_plugin_status -eq 0 ] ; then
               echo "::error file=test_in_devenv.yml::Test CUDA Quantum MPI Plugin Activation failed with status $external_plugin_status."


### PR DESCRIPTION
note that llvm-lit is not explicitly added as well since it by default uses all available cpus[0].

[0] - https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-j