### PR TITLE
[oqc] Fix typos in examples and use consistent pipeline

### DIFF
--- a/docs/sphinx/targets/cpp/oqc.cpp
+++ b/docs/sphinx/targets/cpp/oqc.cpp
@@ -24,7 +24,6 @@ struct bell_state {
     h(q[0]);
     x<cudaq::ctrl>(q[0], q[1]);
     auto result = mz(q);
-    return result;
   }
 };
 

--- a/docs/sphinx/targets/python/oqc.py
+++ b/docs/sphinx/targets/python/oqc.py
@@ -19,7 +19,7 @@ cudaq.set_target("oqc")
 def kernel():
     qvector = cudaq.qvector(2)
     h(qvector[0])
-    x.ctrl[qvector[1], qvector[1]]
+    x.ctrl(qvector[0], qvector[1])
     mz(qvector)
 
 

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/oqc.yml
@@ -18,7 +18,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the lowering pipeline
-  platform-lowering-config: "func.func(erase-noise),classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,canonicalize,apply-op-specialization,aggressive-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},lower-to-cfg,func.func(canonicalize,multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce,distributed-device-call"
+  platform-lowering-config: "func.func(erase-noise),classical-optimization-pipeline,globalize-array-values,func.func(canonicalize,state-prep),unitary-synthesis,func.func(canonicalize),apply-op-specialization{constant-prop=1},aggressive-inlining,expand-measurements,classical-optimization-pipeline,decomposition{enable-patterns=U3ToRotations},lower-to-cfg,func.func(canonicalize,multicontrol-decomposition),oqc-gate-set-mapping,func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=file(%QPU_ARCH%)},func.func(regtomem),symbol-dce,distributed-device-call"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qir-base
   # Library mode is only for simulators, physical backends must turn this off


### PR DESCRIPTION
This PR introduces corrects both the Python and C++ OQC examples, as well as updates the lowering pipeline configuration for the OQC platform to match the latest updates to the corresponding passes. 
