### PR TITLE
install compiler headers for external plugin development

### DIFF
--- a/cmake/AddCUDAQ.cmake
+++ b/cmake/AddCUDAQ.cmake
@@ -86,3 +86,31 @@ function(add_target_mapping_arch providerName name)
   install(FILES ${name} DESTINATION targets/mapping/${providerName})
   configure_file(${name} ${CMAKE_BINARY_DIR}/targets/mapping/${providerName}/${name} COPYONLY)
 endfunction()
+
+function(install_cudaq_dialect_headers dialect_name)
+  # Parse the list of header files from the remaining arguments
+  set(header_files ${ARGN})
+  file(RELATIVE_PATH rel_source_dir ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+
+  # Install the handwritten source headers
+  install(
+    FILES ${header_files}
+    DESTINATION ${rel_source_dir}
+    COMPONENT ${dialect_name}Dialect
+  )
+  
+  # Generate the list of corresponding TableGen-generated header files
+  set(generated_headers)
+  foreach(header ${header_files})
+    # Remove the .h extension and add .h.inc
+    get_filename_component(header_base ${header} NAME_WE)
+    list(APPEND generated_headers ${CMAKE_CURRENT_BINARY_DIR}/${header_base}.h.inc)
+  endforeach()
+  
+  # Install the TableGen-generated headers
+  install(
+    FILES ${generated_headers}
+    DESTINATION ${rel_source_dir}
+    COMPONENT ${dialect_name}Dialect
+  )
+endfunction()

--- a/cmake/Modules/CUDAQConfig.cmake
+++ b/cmake/Modules/CUDAQConfig.cmake
@@ -28,9 +28,10 @@ find_dependency(CUDAQNlopt REQUIRED)
 
 set (CUDAQEnsmallen_DIR "${CUDAQ_CMAKE_DIR}")
 find_dependency(CUDAQEnsmallen REQUIRED)
-
-set (CUDAQPythonInterop_DIR "${CUDAQ_CMAKE_DIR}")
-find_dependency(CUDAQPythonInterop REQUIRED)
+if (EXISTS CUDAQPython_InteropConfig.cmake)
+  set (CUDAQPythonInterop_DIR "${CUDAQ_CMAKE_DIR}")
+  find_dependency(CUDAQPythonInterop REQUIRED)
+endif()
 
 get_filename_component(PARENT_DIRECTORY ${CUDAQ_CMAKE_DIR} DIRECTORY)
 get_filename_component(CUDAQ_LIBRARY_DIR ${PARENT_DIRECTORY} DIRECTORY)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -10,3 +10,7 @@ configure_file("${CMAKE_SOURCE_DIR}/include/nvqpp_config.h.in"
                "${CUDAQ_BINARY_DIR}/include/nvqpp_config.h" 
                @ONLY)
 add_subdirectory(cudaq)
+
+# Install compiler headers
+install (DIRECTORY cudaq DESTINATION include 
+            FILES_MATCHING PATTERN "*.h" )

--- a/include/cudaq/Optimizer/Dialect/CC/CMakeLists.txt
+++ b/include/cudaq/Optimizer/Dialect/CC/CMakeLists.txt
@@ -9,3 +9,9 @@
 add_cudaq_dialect(CC cc)
 add_cudaq_interface(CCInterfaces)
 add_cudaq_dialect_doc(CCDialect cc)
+install_cudaq_dialect_headers(CC 
+  CCDialect.h
+  CCOps.h
+  CCTypes.h
+  CCInterfaces.h
+)

--- a/include/cudaq/Optimizer/Dialect/Quake/CMakeLists.txt
+++ b/include/cudaq/Optimizer/Dialect/Quake/CMakeLists.txt
@@ -9,3 +9,9 @@
 add_cudaq_dialect(Quake quake)
 add_cudaq_interface(QuakeInterfaces)
 add_cudaq_dialect_doc(QuakeDialect quake)
+install_cudaq_dialect_headers(Quake 
+  QuakeDialect.h
+  QuakeOps.h
+  QuakeTypes.h
+  QuakeInterfaces.h
+)


### PR DESCRIPTION
Add Quake and CC headers (including tablegen headers) to the install target. This is required to enable downstream development of compiler passes. 