### PR TITLE
[refactoring] Common code for QIR processing

### DIFF
--- a/runtime/common/Future.cpp
+++ b/runtime/common/Future.cpp
@@ -46,7 +46,7 @@ sample_result future::get() {
           dynamic_cast<QirServerHelper *>(serverHelper.get());
       if (!qirServerHelper)
         throw std::runtime_error("To support `run` API, " + qpuName +
-                                 "must inherit `QirServerHelper` class");
+                                 " must inherit `QirServerHelper` class");
       if (!inFutureRawOutput)
         throw std::runtime_error(
             "cudaq::details::future::get() for 'run' requires a raw output "

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -8,13 +8,13 @@
 
 #pragma once
 
-#include "nlohmann/json.hpp"
-
 #include "ExecutionContext.h"
 #include "Future.h"
 #include "Registry.h"
 #include "RuntimeTarget.h"
 #include "SampleResult.h"
+#include "common/RecordLogParser.h"
+#include "nlohmann/json.hpp"
 #include <filesystem>
 
 namespace cudaq {
@@ -168,5 +168,42 @@ public:
   /// @return QIR output log
   virtual std::string extractOutputLog(ServerMessage &postJobResponse,
                                        std::string &jobId) = 0;
+
+  /// @brief Create a sampling result from the QIR output log
+  cudaq::sample_result
+  createSampleResultFromQirOutput(const std::string &qirOutputLog) {
+    // Parse the QIR output log
+    cudaq::RecordLogParser parser;
+    parser.parse(qirOutputLog);
+
+    // Get the buffer and length of buffer (in bytes) from the parser.
+    auto *origBuffer = parser.getBufferPtr();
+    std::size_t bufferSize = parser.getBufferSize();
+    char *buffer = static_cast<char *>(malloc(bufferSize));
+    std::memcpy(buffer, origBuffer, bufferSize);
+
+    std::vector<std::vector<bool>> results = {
+        reinterpret_cast<std::vector<bool> *>(buffer),
+        reinterpret_cast<std::vector<bool> *>(buffer + bufferSize)};
+    const auto numShots = results.size();
+    // Create the counts dictionary
+    cudaq::CountsDictionary globalCounts;
+    std::vector<std::string> globalSequentialData;
+    globalSequentialData.reserve(numShots);
+    for (const auto &shotResult : results) {
+      // Each shot is an array of tagged results
+      std::string bitString;
+      for (const auto &bitVal : shotResult) {
+        bitString.append(bitVal ? "1" : "0");
+      }
+      // Global register results
+      globalCounts[bitString]++;
+      globalSequentialData.push_back(bitString);
+    }
+
+    // Add the global register results
+    cudaq::ExecutionResult result{globalCounts, GlobalRegisterName};
+    return cudaq::sample_result({result});
+  }
 };
 } // namespace cudaq

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -203,6 +203,7 @@ public:
 
     // Add the global register results
     cudaq::ExecutionResult result{globalCounts, GlobalRegisterName};
+    result.sequentialData = globalSequentialData;
     return cudaq::sample_result({result});
   }
 };


### PR DESCRIPTION
This PR refactors how sample results are created from QIR output logs in the `QuantinuumServerHelper`, moving logic from the implementation file into a reusable method in the base server helper class.

Attempt to break up large PR #3448 into smaller chunks.
