### PR TITLE
[runtime refactoring] Simplify handling of QIR attributes and avoid re-lookup

### DIFF
--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -9,6 +9,7 @@
 #include "RecordLogParser.h"
 #include "Logger.h"
 #include "Timing.h"
+#include "cudaq/Optimizer/CodeGen/QIRAttributeNames.h"
 
 void cudaq::RecordLogParser::parse(const std::string &outputLog) {
   ScopedTraceWithContext(cudaq::TIMING_RUN, "RecordLogParser::parse");
@@ -60,7 +61,16 @@ void cudaq::RecordLogParser::handleMetadata(
     const std::vector<std::string> &entries) {
   if (entries.size() < 2 || entries.size() > 3)
     cudaq::info("Unexpected METADATA record: {}. Ignored.\n", entries);
-  metadata[entries[1]] = entries.size() == 3 ? entries[2] : "";
+  if (entries.size() == 3) {
+    if (entries[1] == cudaq::opt::qir0_2::RequiredResultsAttrName ||
+        entries[1] == cudaq::opt::qir0_1::RequiredResultsAttrName) {
+      metadata[ResultCountMetadataName] = entries[2];
+    } else {
+      metadata[entries[1]] = entries[2];
+    }
+  } else {
+    metadata[entries[1]] = "";
+  }
 }
 
 void cudaq::RecordLogParser::handleStart(
@@ -107,14 +117,8 @@ void cudaq::RecordLogParser::handleOutput(
       // records, not wrapped in an ARRAY. Hence, we treat it as an array of
       // results.
       containerMeta.m_type = ContainerType::ARRAY;
-      const auto it = metadata.find("required_num_results");
-      if (it != metadata.end()) {
-        containerMeta.elementCount = std::stoul(it->second);
-      } else {
-        cudaq::info("No required_num_results metadata found, defaulting to 1.");
-        containerMeta.elementCount = 1;
-      }
-
+      containerMeta.elementCount =
+          std::stoul(metadata[ResultCountMetadataName]);
       containerMeta.arrayType = "i1";
       preallocateArray();
     }

--- a/runtime/common/RecordLogParser.h
+++ b/runtime/common/RecordLogParser.h
@@ -41,9 +41,9 @@ public:
 class BooleanConverter : public TypeConverterBase<bool> {
 public:
   bool convert(const std::string &value) const override {
-    if (value == "true" || value == "1")
+    if (value == "true" || value == "True" || value == "1")
       return true;
-    if (value == "false" || value == "0")
+    if (value == "false" || value == "False" || value == "0")
       return false;
     throw std::runtime_error("Invalid boolean value");
   }
@@ -280,6 +280,12 @@ public:
 
 } // namespace details
 
+namespace {
+// Simplify look up of the required number of results by using a common
+// identifier instead of different QIR versions (0.1 and 0.2)
+constexpr char ResultCountMetadataName[] = "required_results";
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // Main record log parser and decoder class
 //===----------------------------------------------------------------------===//
@@ -340,6 +346,7 @@ private:
   std::pair<std::optional<std::size_t>, std::vector<std::size_t>>
       dataLayoutInfo = {std::nullopt, {}};
   /// Metadata information extracted from the log
-  std::unordered_map<std::string, std::string> metadata;
+  std::unordered_map<std::string, std::string> metadata = {
+      {ResultCountMetadataName, "1"}};
 };
 } // namespace cudaq


### PR DESCRIPTION
This PR simplifies the code that deals with different QIR versions in the metadata handling in the `RecordLogParser`.
Also makes Boolean value parsing more robust. 

Attempt to break up large PR https://github.com/NVIDIA/cuda-quantum/pull/3448 into smaller chunks.