### PR TITLE
[REST] [client] Add the ability to retrieve raw text (default is JSON)

### DIFF
--- a/runtime/common/RestClient.cpp
+++ b/runtime/common/RestClient.cpp
@@ -114,10 +114,10 @@ void RestClient::put(const std::string_view remoteUrl,
                              r.error.message + ": " + r.text);
 }
 
-nlohmann::json
-RestClient::get(const std::string_view remoteUrl, const std::string_view path,
-                std::map<std::string, std::string> &headers, bool enableSsl,
-                const std::map<std::string, std::string> &cookies) {
+std::string RestClient::getRawText(
+    const std::string_view remoteUrl, const std::string_view path,
+    std::map<std::string, std::string> &headers, bool enableSsl,
+    const std::map<std::string, std::string> &cookies) {
   if (headers.empty())
     headers.insert(std::make_pair("Content-type", "application/json"));
 
@@ -136,7 +136,15 @@ RestClient::get(const std::string_view remoteUrl, const std::string_view path,
     throw std::runtime_error("HTTP GET Error - status code " +
                              std::to_string(r.status_code) + ": " +
                              r.error.message + ": " + r.text);
-  return nlohmann::json::parse(r.text);
+  return r.text;
+}
+
+nlohmann::json
+RestClient::get(const std::string_view remoteUrl, const std::string_view path,
+                std::map<std::string, std::string> &headers, bool enableSsl,
+                const std::map<std::string, std::string> &cookies) {
+  return nlohmann::json::parse(
+      getRawText(remoteUrl, path, headers, enableSsl, cookies));
 }
 
 void RestClient::del(const std::string_view remoteUrl,

--- a/runtime/common/RestClient.h
+++ b/runtime/common/RestClient.h
@@ -49,7 +49,12 @@ public:
                       bool enableLogging = true, bool enableSsl = false,
                       const std::map<std::string, std::string> &cookies = {},
                       std::map<std::string, std::string> *cookiesOut = nullptr);
-
+  /// Get the raw text contents of the remote server at the given URL and path.
+  std::string
+  getRawText(const std::string_view remoteUrl, const std::string_view path,
+             std::map<std::string, std::string> &headers,
+             bool enableSsl = false,
+             const std::map<std::string, std::string> &cookies = {});
   /// Get the contents of the remote server at the given URL and path.
   nlohmann::json get(const std::string_view remoteUrl,
                      const std::string_view path,


### PR DESCRIPTION
This PR refactors the `RestClient` class to introduce a new method for retrieving raw text responses from HTTP GET requests, improving flexibility when handling server responses.

Attempt to break up large PR https://github.com/NVIDIA/cuda-quantum/pull/3448 into smaller chunks.