### PR TITLE
bot/data: cp310 to cp311

### DIFF
--- a/.gitlab/workflows.yml
+++ b/.gitlab/workflows.yml
@@ -106,7 +106,7 @@ Python Wheels:
           url=`echo $artifact | jq -r '.url'`
           gh api $url > _pycudaq.zip
           unzip -d _pycudaq _pycudaq.zip && cd _pycudaq
-          for wheel in `ls cuda_quantum*-cp310-cp310-manylinux_*_$(uname -m)*.whl 2> /dev/null`; do
+          for wheel in `ls cuda_quantum*-cp311-cp311-manylinux_*_$(uname -m)*.whl 2> /dev/null`; do
             echo "Adding wheel $wheel."
             mv $wheel "/tmp/wheels/$wheel"
           done
@@ -119,7 +119,7 @@ Python Wheels:
     - export python=python3.10 
     # Install CUDA Quantum wheel for a particular Python version (could be any version) 
     - cuda_major=$(echo $CUDA_VERSION | cut -d . -f1)
-    - wheel=$(ls /tmp/wheels/cuda_quantum_cu${cuda_major}-*-cp310-cp310-manylinux_*_$(uname -m)*.whl)
+    - wheel=$(ls /tmp/wheels/cuda_quantum_cu${cuda_major}-*-cp311-cp311-manylinux_*_$(uname -m)*.whl)
     - if [ -z "$wheel" ]; then echo "No matching wheel found!"; exit 1; fi
     - echo "Installing wheel $wheel"
     - $python -m pip install $wheel


### PR DESCRIPTION
Since we got rid of Python 3.10 wheels, stop referencing them. This was causing the publishing pipeline to stall.