### PR TITLE
update mgpu commit to fix publishing pipeline

### DIFF
--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: 78647f6d2a9b09f6ae4b0c4bbd693e20dd14017f
+nvidia-mgpu-commit: 8346e5d327318e49d1d6a117fccdd2eea78a803d


### PR DESCRIPTION
This mgpu commit update handles the updated Ubuntu 24.04 changes in the gitlab CI.