### PR TITLE
[testing] [Python] Make the imports independent and non-fatal

### DIFF
--- a/utils/mock_qpu/__init__.py
+++ b/utils/mock_qpu/__init__.py
@@ -6,11 +6,67 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-from .anyon import *
-from .braket import *
-from .infleqtion import *
-from .ionq import *
-from .iqm import *
-from .qci import *
-from .quantinuum import *
-from .quantum_machines import *
+import warnings
+
+try:
+    from .anyon import *
+except ImportError as e:
+    warnings.warn(f"Failed to import `anyon` mock QPU: {e}",
+                  ImportWarning,
+                  stacklevel=2)
+
+try:
+    from .braket import *
+except ImportError as e:
+    warnings.warn(f"Failed to import `braket` mock QPU: {e}",
+                  ImportWarning,
+                  stacklevel=2)
+
+try:
+    from .infleqtion import *
+except ImportError as e:
+    warnings.warn(f"Failed to import `infleqtion` mock QPU: {e}",
+                  ImportWarning,
+                  stacklevel=2)
+
+try:
+    from .ionq import *
+except ImportError as e:
+    warnings.warn(f"Failed to import `ionq` mock QPU: {e}",
+                  ImportWarning,
+                  stacklevel=2)
+
+try:
+    from .iqm import *
+except ImportError as e:
+    warnings.warn(f"Failed to import `iqm` mock QPU: {e}",
+                  ImportWarning,
+                  stacklevel=2)
+
+try:
+    from .oqc import *
+except ImportError as e:
+    warnings.warn(f"Failed to import `oqc` mock QPU: {e}",
+                  ImportWarning,
+                  stacklevel=2)
+
+try:
+    from .qci import *
+except ImportError as e:
+    warnings.warn(f"Failed to import `qci` mock QPU: {e}",
+                  ImportWarning,
+                  stacklevel=2)
+
+try:
+    from .quantinuum import *
+except ImportError as e:
+    warnings.warn(f"Failed to import `quantinuum` mock QPU: {e}",
+                  ImportWarning,
+                  stacklevel=2)
+
+try:
+    from .quantum_machines import *
+except ImportError as e:
+    warnings.warn(f"Failed to import `quantum_machines` mock QPU: {e}",
+                  ImportWarning,
+                  stacklevel=2)


### PR DESCRIPTION
This PR improves the robustness of the `utils/mock_qpu` module's initialization by ensuring that import errors for individual mock QPU backends do not prevent the rest of the module from loading. Instead, warnings are issued for any failed imports.

