### PR TITLE
do not show progress bar for python notebook, as it will crash

### DIFF
--- a/docs/sphinx/applications/python/unitary_compilation_diffusion_models.ipynb
+++ b/docs/sphinx/applications/python/unitary_compilation_diffusion_models.ipynb
@@ -105,6 +105,8 @@
     "import genQC\n",
     "import os\n",
     "\n",
+    "os.environ['HF_HUB_DISABLE_PROGRESS_BARS'] = '1'\n",
+    "\n",
     "import genQC.utils.misc_utils as util\n",
     "from genQC.pipeline.diffusion_pipeline import DiffusionPipeline\n",
     "from genQC.pipeline.multimodal_diffusion_pipeline \\\n",
@@ -118,8 +120,7 @@
     "            import decode_tensors_to_backend, generate_compilation_tensors\n",
     "from genQC.inference.evaluation_helper import get_unitaries\n",
     "from genQC.inference.eval_metrics import UnitaryInfidelityNorm\n",
-    "\n",
-    "os.environ[\"HF_HUB_DISABLE_PROGRESS_BARS\"] = \"1\" # This crashes in CI, so disable here."
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
This is currently blocking CI.

you will see:

```
nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
------------------
discrete_pipeline = DiffusionPipeline.from_pretrained(
            repo_id="Floki00/qc_unitary_3qubit", # Download model from Hugging Face
            device=device)
```

in the validation stage - https://github.com/NVIDIA/cuda-quantum/actions/runs/18463430855/job/52615014928?pr=3502#step:7:968

This is because the progress bar crashes inside nbconvert, since it tries to look for a frontend which doesn't exist. This sets an environment variable to disable that progress bar (Which isn't shown anyways).