### PR TITLE
[testing] Fix test behavior for missing subset of measured qubits

### DIFF
--- a/targettests/execution/sudoku_2x2-bit_names.cpp
+++ b/targettests/execution/sudoku_2x2-bit_names.cpp
@@ -17,8 +17,8 @@
 // RUN: if %qci_avail; then nvq++ %cpp_std --target qci --emulate %s -o %t && %t | FileCheck %s; fi
 // clang-format on
 
-#include <cudaq.h>
 #include <algorithm>
+#include <cudaq.h>
 #include <iostream>
 #include <unordered_set>
 
@@ -55,19 +55,11 @@ __qpu__ void grover() {
   auto groverQubits3 = mz(qubits[3]);
 };
 
-int main() {
-  auto result = cudaq::sample(1000, grover);
-  result.dump();
-
-  auto& platform = cudaq::get_platform();
-  if (platform.is_remote() || platform.is_emulated()) {
-    // Make sure that the get_marginal() results for the individual register names
-    // match the subset of the bits from the global register.
-    // Note that this will fail if you only compile this in library mode.
-    auto numBits = result.begin()->first.size();
-    std::cout << "Checking " << numBits << " bits against global register\n";
-    for (size_t b = 0;  b < numBits; b++) {
-      auto regName = "groverQubits" + std::to_string(b);
+bool validateMarginals(const cudaq::sample_result &result) {
+  size_t numBits = result.begin()->first.size();
+  for (size_t b = 0; b < numBits; b++) {
+    auto regName = "groverQubits" + std::to_string(b);
+    try {
       auto valFromRegName = result.get_marginal({0}, regName);
       auto valFromGlobal = result.get_marginal({b});
       if (valFromRegName.to_map() != valFromGlobal.to_map()) {
@@ -77,6 +69,24 @@ int main() {
         // Mark test failure
         assert(valFromRegName.to_map() == valFromGlobal.to_map());
       }
+    } catch (const std::exception &e) {
+      return false;
+    }
+  }
+  return true;
+}
+
+int main() {
+  auto result = cudaq::sample(1000, grover);
+  result.dump();
+
+  auto &platform = cudaq::get_platform();
+  if (platform.is_remote() || platform.is_emulated()) {
+    // Make sure that the get_marginal() results for the individual register
+    // names match the subset of the bits from the global register. Note that
+    // this will fail if you only compile this in library mode.
+    if (!validateMarginals(result)) {
+      std::cout << "Unsupported API, use `run` instead!\n";
     }
   }
 
@@ -85,7 +95,7 @@ int main() {
   for (auto &&[bits, count] : result) {
     strings.push_back(bits);
   }
-  std::sort(strings.begin(), strings.end(), [&](auto& a, auto& b) {
+  std::sort(strings.begin(), strings.end(), [&](auto &a, auto &b) {
     return result.count(a) > result.count(b);
   });
   std::cout << strings[0] << '\n';


### PR DESCRIPTION
This PR refactors the marginal validation logic in the `sudoku_2x2-bit_names.cpp` test to make it optional, and non-fatal. When parsing from QIR output log, it is not expected to populate the sub-registers. Using `run` API is appropriate for such cases.