### PR TITLE
[fix] [sample] Correctly parse QIR log for results that are out of order

### DIFF
--- a/runtime/common/RecordLogParser.cpp
+++ b/runtime/common/RecordLogParser.cpp
@@ -103,6 +103,7 @@ void cudaq::RecordLogParser::handleOutput(
   const std::string &recType = entries[1];
   const std::string &recValue = entries[2];
   std::string recLabel = (entries.size() == 4) ? entries[3] : "";
+  cudaq::trim(recLabel);
   if (recType == "RESULT") {
     // Sample-type QIR output, where we have an array of `RESULT` per shot. For
     // example,
@@ -128,11 +129,18 @@ void cudaq::RecordLogParser::handleOutput(
       preallocateArray();
     }
 
-    // Note: we expect the results are sequential in the same order that mz
-    // operations are called. This may include results in named registers
-    // (specified in kernel code) and other auto-generated register names.
-    processArrayEntry(recValue,
-                      fmt::format("[{}]", containerMeta.processedElements));
+    // Get the index from the label, if available.
+    if (!recLabel.empty() && recLabel[0] == 'r' && recLabel.back() >= '0' &&
+        recLabel.back() <= '9') {
+      recLabel = recLabel.substr(1);
+    } else {
+      // Note: we expect the results are sequential in the same order that mz
+      // operations are called. This may include results in named registers
+      // (specified in kernel code) and other auto-generated register names.
+      recLabel = std::to_string(containerMeta.processedElements);
+    }
+
+    processArrayEntry(recValue, fmt::format("[{}]", recLabel));
     containerMeta.processedElements++;
     return;
   }

--- a/unittests/output_record/RecordParserTester.cpp
+++ b/unittests/output_record/RecordParserTester.cpp
@@ -687,3 +687,57 @@ CUDAQ_TEST(ParserTester, checkFailedShot_3) {
   buffer = nullptr;
   origBuffer = nullptr;
 }
+
+CUDAQ_TEST(ParserTester, checkOrder) {
+  const std::string log =
+      "HEADER\tschema_id\tlabeled\n"
+      "HEADER\tschema_version\t1.0\n"
+      "START\n"
+      "METADATA\tentry_point\n"
+      "METADATA\toutput_labeling_schema\tschema_id\n"
+      "METADATA\toutput_names\t[[[0,[0,\"r00000\"]],[1,[1,\"r00001\"]],[2,[2,"
+      "\"r00002\"]],[3,[3,\"r00003\"]],[4,[4,\"r00004\"]],[5,[5,\"r00005\"]],["
+      "6,[6,\"r00006\"]],[7,[7,\"r00007\"]]]]\n"
+      "METADATA\tqir_profiles\tbase_profile\n"
+      "METADATA\trequiredQubits\t8\n"
+      "METADATA\trequiredResults\t8\n"
+      "OUTPUT\tRESULT\t1\tr00003\n"
+      "OUTPUT\tRESULT\t0\tr00002\n"
+      "OUTPUT\tRESULT\t0\tr00000\n"
+      "OUTPUT\tRESULT\t1\tr00004\n"
+      "OUTPUT\tRESULT\t1\tr00006\n"
+      "OUTPUT\tRESULT\t1\tr00001\n"
+      "OUTPUT\tRESULT\t0\tr00007\n"
+      "OUTPUT\tRESULT\t0\tr00005\n"
+      "END\t0";
+
+  cudaq::RecordLogParser parser;
+  parser.parse(log);
+  auto *origBuffer = parser.getBufferPtr();
+  std::size_t bufferSize = parser.getBufferSize();
+  char *buffer = static_cast<char *>(malloc(bufferSize));
+  std::memcpy(buffer, origBuffer, bufferSize);
+  cudaq::details::RunResultSpan span = {buffer, bufferSize};
+  // This is parsed as a vector of bool vectors
+  std::vector<std::vector<bool>> results = {
+      reinterpret_cast<std::vector<bool> *>(span.data),
+      reinterpret_cast<std::vector<bool> *>(span.data + span.lengthInBytes)};
+  // 1 shot
+  EXPECT_EQ(1, results.size());
+  for (const auto &result : results) {
+    // 8 measured bits each
+    EXPECT_EQ(8, result.size());
+    EXPECT_EQ(false, result[0]); // r00000
+    EXPECT_EQ(true, result[1]);  // r00001
+    EXPECT_EQ(false, result[2]); // r00002
+    EXPECT_EQ(true, result[3]);  // r00003
+    EXPECT_EQ(true, result[4]);  // r00004
+    EXPECT_EQ(false, result[5]); // r00005
+    EXPECT_EQ(true, result[6]);  // r00006
+    EXPECT_EQ(false, result[7]); // r00007
+  }
+
+  free(buffer);
+  buffer = nullptr;
+  origBuffer = nullptr;
+}


### PR DESCRIPTION
This PR improves the parsing and handling of output labels in the `RecordLogParser` and adds a new unit test to verify correct ordering of parsed results. 
