### PR TITLE
Replace H1-* devices with H2-* devices

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -34,7 +34,7 @@ on:
       target_machine:
         type: string
         required: false
-        description: 'Target machine (e.g., H1-1E).'
+        description: 'Target machine (e.g., H2-1E).'
       cudaq_test_image:
         type: string
         required: false
@@ -407,7 +407,7 @@ jobs:
             case $filename in
               targettests/quantinuum/*)
                 [ -e "$filename" ] || echo "::error::Couldn't find files ($filename)"
-                nvq++ -v $filename -DSYNTAX_CHECK --target quantinuum --quantinuum-machine H1-1SC --quantinuum-project ${{ secrets.QUANTINUUM_NEXUS_PROJECT_ID }}
+                nvq++ -v $filename -DSYNTAX_CHECK --target quantinuum --quantinuum-machine H2-1SC --quantinuum-project ${{ secrets.QUANTINUUM_NEXUS_PROJECT_ID }}
                 test_status=$?
                 if [ $test_status -eq 0 ]; then
                   ./a.out

--- a/docs/sphinx/targets/cpp/quantinuum.cpp
+++ b/docs/sphinx/targets/cpp/quantinuum.cpp
@@ -1,6 +1,6 @@
 // Compile and run with:
 // ```
-// nvq++ --target quantinuum --quantinuum-machine H1-2E --quantinuum-project \
+// nvq++ --target quantinuum --quantinuum-machine H2-1E --quantinuum-project \
 // <nexus_project> quantinuum.cpp  -o out.x && ./out.x
 // ```
 // Assumes a valid set of credentials have been stored.

--- a/docs/sphinx/targets/python/quantinuum.py
+++ b/docs/sphinx/targets/python/quantinuum.py
@@ -40,7 +40,7 @@ if (syntax_check):
 # Now we can update the target to the Quantinuum emulator and
 # execute our program.
 cudaq.set_target("quantinuum",
-                 machine="H1-1E",
+                 machine="H2-1E",
                  project=os.environ.get("QUANTINUUM_NEXUS_PROJECT", None))
 
 # Option B:

--- a/docs/sphinx/using/backends/hardware/iontrap.rst
+++ b/docs/sphinx/using/backends/hardware/iontrap.rst
@@ -152,12 +152,12 @@ Create a project in the Nexus portal. You can find the project ID in the URL of 
 
         .. code:: python
 
-            cudaq.set_target('quantinuum', machine='H1-2')
+            cudaq.set_target('quantinuum', machine='H2-2')
 
-        where ``H1-2`` is an example of a physical QPU. Hardware specific
-        emulators may be accessed by appending an ``E`` to the end (e.g, ``H1-2E``). For 
+        where ``H2-2`` is an example of a physical QPU. Hardware specific
+        emulators may be accessed by appending an ``E`` to the end (e.g, ``H2-2E``). For 
         access to the syntax checker for the provided machine, you may append an ``SC`` 
-        to the end (e.g, ``H1-1SC``).
+        to the end (e.g, ``H2-1SC``).
 
         For a comprehensive list of available machines, login to your `Quantinuum Nexus user account <https://nexus.quantinuum.com/>`__ 
         and navigate to the "Profile" tab, where you should find a table titled "Quantinuum Systems Access".
@@ -199,12 +199,12 @@ Create a project in the Nexus portal. You can find the project ID in the URL of 
 
         .. code:: bash
 
-            nvq++ --target quantinuum --quantinuum-machine H1-2 src.cpp ...
+            nvq++ --target quantinuum --quantinuum-machine H2-2 src.cpp ...
 
-        where ``H1-2`` is an example of a physical QPU. Hardware specific
-        emulators may be accessed by appending an ``E`` to the end (e.g, ``H1-2E``). For 
+        where ``H2-2`` is an example of a physical QPU. Hardware specific
+        emulators may be accessed by appending an ``E`` to the end (e.g, ``H2-2E``). For 
         access to the syntax checker for the provided machine, you may append an ``SC`` 
-        to the end (e.g, ``H1-1SC``).
+        to the end (e.g, ``H2-1SC``).
 
         For a comprehensive list of available machines, login to your `Quantinuum Nexus user account <https://nexus.quantinuum.com/>`__ 
         and navigate to the "Profile" tab, where you should find a table titled "Quantinuum Systems Access".
@@ -221,7 +221,7 @@ Create a project in the Nexus portal. You can find the project ID in the URL of 
 .. note:: 
 
        Quantinuum's syntax checker for Helios (e.g., ``Helios-1SC``) only performs QIR code validation and does not return any results.
-       Thus, it always returns an empty result set. This is different from other Quantinuum backends (e.g., ``H1-1SC``) where the syntax checker returns dummy results.
+       Thus, it always returns an empty result set. This is different from other Quantinuum backends (e.g., ``H2-1SC``) where the syntax checker returns dummy results.
        As a result, when using the Helios syntax checker, we may receive this warning message:
 
         .. code:: text

--- a/python/tests/mlir/qir_profile.py
+++ b/python/tests/mlir/qir_profile.py
@@ -21,7 +21,7 @@ def test_qir_profile():
         mz(q)
 
     # This device requires qir:0.1
-    cudaq.set_target('quantinuum', emulate=True, machine='H1-2E')
+    cudaq.set_target('quantinuum', emulate=True, machine='H2-2E')
     result = cudaq.sample(my_kernel)
 
 

--- a/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantinuum/quantinuum.yml
@@ -39,12 +39,7 @@ target-arguments:
     machine-config:
       - arch-name: H-series
         machine-names: 
-          - H1-1
-          - H1-1SC
-          - H1-1E
-          - H1-2
-          - H1-2SC
-          - H1-2E
+          - H2-1SC
           - H2-1
           - H2-1SC
           - H2-1E

--- a/targettests/execution/qir_cond_for_loop-1.cpp
+++ b/targettests/execution/qir_cond_for_loop-1.cpp
@@ -57,7 +57,7 @@ int main() {
 
   auto &platform = cudaq::get_platform();
 
-  // If you run this on quantinuum hardware (i.e. H1-1E), the following parity
+  // If you run this on quantinuum hardware (i.e. H2-1E), the following parity
   // check will check that the results look reasonable. Skip the parity check on
   // `--emulate` runs because the unnamed measurement is not saved and therefore
   // cannot be compared in a parity check.

--- a/targettests/execution/qir_profile.cpp
+++ b/targettests/execution/qir_profile.cpp
@@ -9,7 +9,7 @@
 // REQUIRES: c++20
 // clang-format off
 // RUN: nvq++ %cpp_std %s -o %t --target quantinuum --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2>&1 | FileCheck %s 
-// RUN: nvq++ %cpp_std %s -o %t --target quantinuum --quantinuum-machine H1-1SC --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2>&1 | FileCheck %s 
+// RUN: nvq++ %cpp_std %s -o %t --target quantinuum --quantinuum-machine H2-1SC --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2>&1 | FileCheck %s 
 // RUN: nvq++ %cpp_std %s -o %t --target quantinuum --quantinuum-machine Helios-1SC --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2>&1 | FileCheck %s --check-prefix=CHECK-NG
 // clang-format on
 


### PR DESCRIPTION
This PR updates configuration, tests and documentation to use the newer Quantinuum H2-series machines instead of the older H1-series machines. 