### PR TITLE
unitary_compiliation pin huggingface-hub to 0.36.0

### DIFF
--- a/docs/sphinx/applications/python/unitary_compilation_diffusion_models.ipynb
+++ b/docs/sphinx/applications/python/unitary_compilation_diffusion_models.ipynb
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install genQC==0.2.3 torch --break-system-packages -q"
+    "!pip install genQC==0.2.3 huggingface-hub==0.36.0 torch --break-system-packages -q"
    ]
   },
   {


### PR DESCRIPTION
`huggingface-hub` just released version `1.0.0`. This expects the removal of `use_auth_token` from genQC. `genQC` is pinned down in the notebook, thus creating a library mismatch.

This PR pins huggingface to the version we were using before this recent release.

Link to CI failure - https://github.com/NVIDIA/cuda-quantum/actions/runs/18845683375/job/53780873379?pr=3544#step:7:977

We should unpin both of these in the future, but this close to release, let's just pin to the sane values rather than refactoring this notebook even more.