### PR TITLE
Fix bug related to incorrect vector size computation

### DIFF
--- a/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
@@ -97,9 +97,11 @@ public:
     auto statePtrTy = cudaq::cc::PointerType::get(stateTy);
     auto i8PtrTy = cudaq::cc::PointerType::get(rewriter.getI8Type());
     auto cast = rewriter.create<cudaq::cc::CastOp>(loc, i8PtrTy, buffer);
+    auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, size.getType());
+    auto powsz = rewriter.create<arith::ShLIOp>(loc, size.getType(), one, size);
 
     rewriter.replaceOpWithNewOp<func::CallOp>(
-        createStateOp, statePtrTy, createStateFunc, ValueRange{cast, size});
+        createStateOp, statePtrTy, createStateFunc, ValueRange{cast, powsz});
     return success();
   }
 };


### PR DESCRIPTION
Codegen was computing the size of a veq incorrectly.

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
