### PR TITLE
Update metapackage validation CUDA 12.4 -> 12.6

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1139,7 +1139,7 @@ jobs:
         # Note: this is the version of the conda 'nvidia/label/cuda' channel.
         # Specifically, 'nvidia/label/cuda-13.0.0' does not contain proper CUDA 13 packages,
         # hence we need to use later channels.
-        cuda_version_conda: ['12.4.0', '13.0.2']
+        cuda_version_conda: ['12.6.0', '13.0.2']
       fail-fast: false
 
     # Must have environment to access environment secreats


### PR DESCRIPTION
The oldest CUDA that the most recent Torch supports is CUDA 12.6. Also, the reset of our validation checks are occurring on 12.6. And finally, pyproject.toml.cu12 says the minimum support nvidia-cusparse-cu12 version is 12.5, so 12.4 will not work.

Link to publishing test run: https://github.com/NVIDIA/cuda-quantum/actions/runs/19215945041