### PR TITLE
Enable anyon test

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -317,7 +317,7 @@ jobs:
           # Determine which providers to test based on inputs and event type
           # Disabling anyon, please see https://github.com/NVIDIA/cuda-quantum/issues/3598
           if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.target }}" == "nightly" ]]; then
-            providers='["fermioniq", "infleqtion", "ionq", "iqm", "oqc", "orca", "pasqal", "qci", "quantinuum"]'
+            providers='["anyon", "fermioniq", "infleqtion", "ionq", "iqm", "oqc", "orca", "pasqal", "qci", "quantinuum"]'
           else
             # Just run the specified target provider
             providers="[\"${{ inputs.target }}\"]"


### PR DESCRIPTION
Enable anyon test. The server URL was down due to a power outage issue. It is back online now.

Fixes issue #3598.