### PR TITLE
fixing typo

### DIFF
--- a/docs/sphinx/applications/python/digitized_counterdiabatic_qaoa.ipynb
+++ b/docs/sphinx/applications/python/digitized_counterdiabatic_qaoa.ipynb
@@ -102,7 +102,7 @@
                 "#non_edges=[[u,v] for u in nodes for v in nodes if u<v and [u,v] not in edges]\n",
                 "#print('Edges: ', edges)\n",
                 "#print('Non-edges: ', non_edges)\n",
-                "#weights=[0.6686,0.6686,0.6886,0.1091,0.0770,0.0770,0.0770,0.0770]\n",
+                "#weights=[0.6686,0.6686,0.6686,0.1091,0.0770,0.0770,0.0770,0.0770]\n",
                 "#penalty=8.0\n",
                 "#num_layers=8"
             ]


### PR DESCRIPTION
Fixing typo in the digitized_counterdiabatic_qaoa notebook.

Fixes #3617.