### PR TITLE
Deactivate testcase graph_coloring-1 for IQM backend

### DIFF
--- a/targettests/execution/graph_coloring-1.cpp
+++ b/targettests/execution/graph_coloring-1.cpp
@@ -9,7 +9,6 @@
 // REQUIRES: c++20
 // clang-format off
 // RUN: nvq++ %s -o %t --target infleqtion --emulate && %t | FileCheck %s
-// RUN: nvq++ %cpp_std --target iqm        --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_20.txt %t | FileCheck %s
 // RUN: nvq++ %s -o %t --target quantinuum --emulate && %t | FileCheck %s
 // RUN: if %braket_avail; then nvq++ %s -o %t --target braket --emulate && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ %cpp_std --target qci --emulate %s -o %t && %t | FileCheck %s; fi


### PR DESCRIPTION

<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
Testcase seems to be responsible for an increase of testtime by on hour on some architectures when executed for IQM QA.
Reported by @sacpis in comments to PR #3298. Please see: https://github.com/NVIDIA/cuda-quantum/pull/3298#issuecomment-3550908135
