### PR TITLE
Remove stale PR folders from docs/preview branch

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -206,6 +206,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Only run once per day (at midnight UTC)
+          if [ "$(date -u +%H%M)" != "0000" ]; then
+            echo "Skipping stale PR cleanup."
+            exit 0
+          fi
+
           git config --global user.name "cuda-quantum-bot"
           git config --global user.email "cuda-quantum-bot@users.noreply.github.com"
           git config pull.rebase true
@@ -220,11 +226,11 @@ jobs:
           stale_prs=$(gh pr list \
             --repo "${{ github.repository }}" \
             --state open \
-            -- limit 200 \
+            --limit 200 \
             --json number,createdAt \
             --jq ".[] | select((.createdAt | fromdate) < $cutoff) | .number")
 
-          if [ -z "stale_prs" ]; then
+          if [ -z "$stale_prs" ]; then
             echo "No stale PR previews to delete."
             exit 0
           fi
@@ -238,7 +244,7 @@ jobs:
           done
 
           # If nothing matches, skip commit/push
-          if git diff --quiet; then
+          if git diff --cached --quiet; then
             echo "No preview folders were removed (nothing to commit)."
             exit 0
           fi


### PR DESCRIPTION
Fixes No space left on device error.

* Removes stale PR (open >5 days) folder from docs/preview branch
* Keeps the available limited memory for the new PRs doc
* Runs with the current scheduled job
* Current step for the closed/merged PRs remains intact

The branch [docs/preview](https://github.com/NVIDIA/cuda-quantum/tree/docs/preview) gets full with the Old open PRs docs. The following error is seen in the [documentation job](https://github.com/NVIDIA/cuda-quantum/actions/runs/19449024863) in CI

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251118-001100-utc.log'
```

Note: I had manually purged these folders twice in order to make space for the new incoming PRs. This PR just automated the process. 