### PR TITLE
re-enable python MPI tests after licensing issues are resolved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,7 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_READONLY_TOKEN: ${{ secrets.DOCKERHUB_READONLY_TOKEN }}
+      ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
     with:
       platform: linux/${{ matrix.platform }}
       python_version: ${{ matrix.python_version }}

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -725,6 +725,7 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_READONLY_TOKEN: ${{ secrets.DOCKERHUB_READONLY_TOKEN }}
+      ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
     with:
       platform: ${{ fromJson(needs.metadata.outputs.platforms)[format('{0}', matrix.platform)].docker_flag }}
       python_version: ${{ matrix.python_version }}

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -34,6 +34,8 @@ on:
         required: true
       DOCKERHUB_READONLY_TOKEN:
         required: true
+      ANACONDA_TOKEN:
+        required: true
 
 name: Python wheels
 
@@ -283,6 +285,13 @@ jobs:
             bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
             ~/miniconda3/bin/conda init bash
             source ~/.bashrc
+
+            # we have to accept the channels in order to install the package to sign in
+            conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+            conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+
+            conda install --name base anaconda-auth --yes
+            anaconda auth ${{ secrets.ANACONDA_TOKEN }}
 
             # Extract the setup script from Python wheel's readme
             cudaq_wheel=/tmp/cuda_quantum_cu*-manylinux_*_$(uname -m).whl

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -263,11 +263,8 @@ jobs:
               fi
             done
 
-      # TODO: enable
-      # if: matrix.os_image == 'redhat/ubi9:9.2'
-      # once conda license issues are resolved
       - name: Run Python MPI tests
-        if: false
+        if: matrix.os_image == 'redhat/ubi9:9.6'
         uses: ./.github/actions/run-in-docker
         with:
           image: wheel_validation:local

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -308,10 +308,12 @@ jobs:
               line=$(echo $line | sed -E "s/python(=)?3.[0-9]{1,}/python\1${{ inputs.python_version }}/g")
               # Install the wheel file
               line=${line//pip install cuda-quantum-cu${cuda_major}/pip install ${cudaq_wheel}}
+              echo "+ $line"
               eval "$line"
             done <<< "$conda_script"
             ompi_script="$(awk '/(Begin ompi setup)/{flag=1;next}/(End ompi setup)/{flag=0}flag' $metadata | grep . | sed '/^```/d')" 
             while IFS= read -r line; do
+                echo "+ $line"
                 eval "$line"
             done <<< "$ompi_script"
 


### PR DESCRIPTION
This is fallout from the anaconda licensing issues that was never reintroduced.