### PR TITLE
[features/py-redesign] Remove phantom `CUDAQDefaultQPU` target

### DIFF
--- a/cmake/Modules/CUDAQConfig.cmake
+++ b/cmake/Modules/CUDAQConfig.cmake
@@ -23,9 +23,6 @@ find_dependency(CUDAQEmDefault REQUIRED)
 set (CUDAQPlatformDefault_DIR "${CUDAQ_CMAKE_DIR}")
 find_dependency(CUDAQPlatformDefault REQUIRED)
 
-set (CUDAQDefaultQPU_DIR "${CUDAQ_CMAKE_DIR}")
-find_dependency(CUDAQDefaultQPU REQUIRED)
-
 set (CUDAQNlopt_DIR "${CUDAQ_CMAKE_DIR}")
 find_dependency(CUDAQNlopt REQUIRED)
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

We don't have this `CUDAQDefaultQPU` target, properly a phantom line from experimental work.
