### PR TITLE
[features/python.redesign] Refactor `cudaq.vqe` in `test_chemistry` 

### DIFF
--- a/python/tests/domains/test_chemistry.py
+++ b/python/tests/domains/test_chemistry.py
@@ -55,10 +55,12 @@ def testUCCSD():
 
     # Run VQE
     optimizer = cudaq.optimizers.COBYLA()
-    energy, params = cudaq.vqe(kernel,
-                               molecule,
-                               optimizer,
-                               parameter_count=num_parameters)
+
+    def objective(x):
+        exp_val = cudaq.observe(kernel, molecule, x).expectation()
+        return exp_val
+
+    energy, params = optimizer.optimize(num_parameters, objective)
     print(energy, params)
     assert np.isclose(-1.137, energy, rtol=1e-3)
 
@@ -88,10 +90,12 @@ def testHWE():
     # Run VQE
     optimizer = cudaq.optimizers.COBYLA()
     optimizer.max_iterations = 500
-    energy, params = cudaq.vqe(kernel,
-                               molecule,
-                               optimizer,
-                               parameter_count=num_parameters)
+
+    def objective(x):
+        exp_val = cudaq.observe(kernel, molecule, x).expectation()
+        return exp_val
+
+    energy, params = optimizer.optimize(num_parameters, objective)
     print(energy, params)
     assert np.isclose(-1.13, energy, rtol=1e-2)
 
@@ -121,10 +125,12 @@ def test_uccsd_kernel():
     print(cudaq.observe(ansatz, molecule, xInit).expectation())
 
     optimizer = cudaq.optimizers.COBYLA()
-    energy, params = cudaq.vqe(ansatz,
-                               molecule,
-                               optimizer,
-                               parameter_count=num_parameters)
+
+    def objective(x):
+        exp_val = cudaq.observe(ansatz, molecule, x).expectation()
+        return exp_val
+
+    energy, params = optimizer.optimize(num_parameters, objective)
     print(energy, params)
 
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
`cudaq.vqe` has been migrated to CUDA-QX (runtime error if trying to use). Hence, refactor the corresponding tests.

Note: these tests are kept as they used a specific feature of kernel builder calling an imported kernel decorator via `apply_call`.