### PR TITLE
Upgrade pytest to 8.3.0

### DIFF
--- a/docker/build/devdeps.Dockerfile
+++ b/docker/build/devdeps.Dockerfile
@@ -157,7 +157,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git gdb ninja-build file lldb \
         python3 python3-pip libpython3-dev \
     && python3 -m pip install --no-cache-dir --break-system-packages \
-        lit==18.1.4 pytest==8.2.0 numpy==1.26.4 requests==2.31.0 \
+        lit==18.1.4 pytest==8.3.0 numpy==1.26.4 requests==2.31.0 \
         fastapi==0.111.0 uvicorn==0.29.0 pydantic==2.7.1 llvmlite==0.42.0 \
         pyspelling==2.10 pymdown-extensions==10.8.1 yapf \
         scipy==1.11.4 openfermionpyscf==0.5 h5py==3.12.1 \

--- a/pyproject.toml.cu12
+++ b/pyproject.toml.cu12
@@ -61,7 +61,7 @@ visualization = [ "qutip<5" , "matplotlib>=3.5" ]
 integrators = [ "torchdiffeq" ]
 
 [build-system]
-requires = ["scikit-build-core==0.9.10", "cmake>=3.27,<3.29", "numpy>=1.24", "pytest==8.2.0"]
+requires = ["scikit-build-core==0.9.10", "cmake>=3.27,<3.29", "numpy>=1.24", "pytest==8.3.0"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/pyproject.toml.cu13
+++ b/pyproject.toml.cu13
@@ -62,7 +62,7 @@ visualization = [ "qutip<5" , "matplotlib>=3.5" ]
 integrators = [ "torchdiffeq" ]
 
 [build-system]
-requires = ["scikit-build-core==0.9.10", "cmake>=3.27,<3.29", "numpy>=1.24", "pytest==8.2.0"]
+requires = ["scikit-build-core==0.9.10", "cmake>=3.27,<3.29", "numpy>=1.24", "pytest==8.3.0"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
Upgrade pytest to 8.3.0 to include the fix for segfault in fixture.

Seems like the below error in the [job](https://github.com/NVIDIA/cuda-quantum/actions/runs/20087333345/job/57631843542?pr=3676#step:9:661) 
```
error file=prebuilt_binaries.yml::Sanity tests failed for side-by-side Python support.
```
is triggered by the [line](https://github.com/NVIDIA/cuda-quantum/actions/runs/20087333345/job/57631843542?pr=3676#step:9:661) (which is a fixture having `cudaq.reset_target()`)
```
test_evolve_simulators.py", line 21 in do_something
```
is caused as the pytest aborts when there is a [fixture error during teardown](https://github.com/pytest-dev/pytest/issues/11706). This is an issue in pytest which is fixed in pytest version [8.3.0 ](https://github.com/pytest-dev/pytest/releases/tag/8.3.0)(with PR [11721](https://github.com/pytest-dev/pytest/pull/11721)). We are using pytest 8.2.0.

Fixes #3678.