### PR TITLE
Remove deprecated platform-wide shot count

### DIFF
--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -205,22 +205,12 @@ bool kernelHasConditionalFeedback(const std::string &kernelName);
 /// @brief Provide a hook to set the target backend.
 void set_target_backend(const char *backend);
 
-/// @brief Utility function for setting the shots on the platform
-[[deprecated("Specify the number of shots in the using the overloaded sample() "
-             "and observe() functions")]] void
-set_shots(const std::size_t nShots);
-
 /// @brief Set a custom noise model for simulation. The caller must also call
 /// `cudaq::unset_noise` before `model` gets deallocated or goes out of scope.
 void set_noise(const cudaq::noise_model &model);
 
 /// @brief Remove an existing noise model from simulation.
 void unset_noise();
-
-/// @brief Utility function for clearing the shots
-[[deprecated("Specify the number of shots in the using the overloaded sample() "
-             "and observe() functions")]] void
-clear_shots(const std::size_t nShots);
 
 /// @brief Set a seed for any random number
 /// generators used in backend simulations.

--- a/runtime/cudaq/algorithms/observe.h
+++ b/runtime/cudaq/algorithms/observe.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -219,13 +219,12 @@ observe_result observe(QuantumKernel &&kernel, const spin_op &H,
                        Args &&...args) {
   // Run this SHOTS times
   auto &platform = cudaq::get_platform();
-  auto shots = platform.get_shots().value_or(-1);
   auto kernelName = cudaq::getKernelName(kernel);
   return details::runObservation(
              [&kernel, &args...]() mutable {
                kernel(std::forward<Args>(args)...);
              },
-             H, platform, shots, kernelName)
+             H, platform, /*shots=*/-1, kernelName)
       .value();
 }
 
@@ -246,7 +245,6 @@ std::vector<observe_result> observe(QuantumKernel &&kernel,
 
   // Run this SHOTS times
   auto &platform = cudaq::get_platform();
-  auto shots = platform.get_shots().value_or(-1);
   auto kernelName = cudaq::getKernelName(kernel);
 
   // Convert all spin_ops to a single summed spin_op
@@ -259,7 +257,7 @@ std::vector<observe_result> observe(QuantumKernel &&kernel,
                     [&kernel, &args...]() mutable {
                       kernel(std::forward<Args>(args)...);
                     },
-                    op, platform, shots, kernelName)
+                    op, platform, /*shots=*/-1, kernelName)
                     .value();
 
   // Convert back to a vector of results
@@ -355,10 +353,9 @@ template <typename DistributionType, typename QuantumKernel, typename... Args>
   requires ObserveCallValid<QuantumKernel, Args...>
 observe_result observe(QuantumKernel &&kernel, const spin_op &H,
                        Args &&...args) {
-  auto &platform = cudaq::get_platform();
-  auto shots = platform.get_shots().value_or(-1);
-  return observe<DistributionType>(shots, std::forward<QuantumKernel>(kernel),
-                                   H, std::forward<Args>(args)...);
+  return observe<DistributionType>(/*shots=*/-1,
+                                   std::forward<QuantumKernel>(kernel), H,
+                                   std::forward<Args>(args)...);
 }
 /// \endcond
 
@@ -426,14 +423,13 @@ auto observe_async(const std::size_t qpu_id, QuantumKernel &&kernel,
                    const spin_op &H, Args &&...args) {
   // Run this SHOTS times
   auto &platform = cudaq::get_platform();
-  auto shots = platform.get_shots().value_or(-1);
   auto kernelName = cudaq::getKernelName(kernel);
 
   return details::runObservationAsync(
       [&kernel, ... args = std::forward<Args>(args)]() mutable {
         kernel(std::forward<Args>(args)...);
       },
-      H, platform, shots, kernelName, qpu_id);
+      H, platform, /*shots=*/-1, kernelName, qpu_id);
 }
 
 /// \brief Asynchronously compute the expected value of `H` with respect to
@@ -483,14 +479,14 @@ std::vector<observe_result> observe(QuantumKernel &&kernel, const spin_op &H,
   details::BroadcastFunctorType<observe_result, Args...> functor =
       [&](std::size_t qpuId, std::size_t counter, std::size_t N,
           Args &...singleIterParameters) -> observe_result {
-    auto shots = platform.get_shots().value_or(-1);
     auto kernelName = cudaq::getKernelName(kernel);
-    auto ret = details::runObservation(
-                   [&kernel, &singleIterParameters...]() mutable {
-                     kernel(std::forward<Args>(singleIterParameters)...);
-                   },
-                   H, platform, shots, kernelName, qpuId, nullptr, counter, N)
-                   .value();
+    auto ret =
+        details::runObservation(
+            [&kernel, &singleIterParameters...]() mutable {
+              kernel(std::forward<Args>(singleIterParameters)...);
+            },
+            H, platform, /*shots=*/-1, kernelName, qpuId, nullptr, counter, N)
+            .value();
     return ret;
   };
 

--- a/runtime/cudaq/algorithms/sample.h
+++ b/runtime/cudaq/algorithms/sample.h
@@ -14,6 +14,8 @@
 #include "cudaq/concepts.h"
 #include "cudaq/host_config.h"
 
+constexpr int DEFAULT_NUM_SHOTS = 1000;
+
 namespace cudaq {
 bool kernelHasConditionalFeedback(const std::string &);
 namespace detail {
@@ -183,7 +185,7 @@ auto runSamplingAsync(KernelFunctor &&wrappedKernel, quantum_platform &platform,
 /// @param explicit_measurements whether or not to form the global register
 /// based on user-supplied measurement order.
 struct sample_options {
-  std::size_t shots = 1000;
+  std::size_t shots = DEFAULT_NUM_SHOTS;
   cudaq::noise_model noise;
   bool explicit_measurements = false;
 };
@@ -212,11 +214,11 @@ sample_result sample(QuantumKernel &&kernel, Args &&...args) {
 
   // Run this SHOTS times
   auto &platform = cudaq::get_platform();
-  auto shots = platform.get_shots().value_or(1000);
   auto kernelName = cudaq::getKernelName(kernel);
   return details::runSampling(
              [&]() mutable { kernel(std::forward<Args>(args)...); }, platform,
-             kernelName, shots, /*explicitMeasurements=*/false)
+             kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
+             /*explicitMeasurements=*/false)
       .value();
 }
 
@@ -312,16 +314,15 @@ async_sample_result sample_async(const std::size_t qpu_id,
     static_cast<cudaq::details::kernel_builder_base &>(kernel).jitCode();
   }
 
-  // Run this SHOTS times
   auto &platform = cudaq::get_platform();
-  auto shots = platform.get_shots().value_or(1000);
   auto kernelName = cudaq::getKernelName(kernel);
 
   return details::runSamplingAsync(
       [&kernel, ... args = std::forward<Args>(args)]() mutable {
         kernel(std::forward<Args>(args)...);
       },
-      platform, kernelName, shots, /*explicitMeasurements=*/false, qpu_id);
+      platform, kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
+      /*explicitMeasurements=*/false, qpu_id);
 }
 
 /// @brief Sample the given kernel expression asynchronously and return
@@ -439,14 +440,13 @@ std::vector<sample_result> sample(QuantumKernel &&kernel,
   details::BroadcastFunctorType<sample_result, Args...> functor =
       [&](std::size_t qpuId, std::size_t counter, std::size_t N,
           Args &...singleIterParameters) -> sample_result {
-    auto shots = platform.get_shots().value_or(1000);
     auto kernelName = cudaq::getKernelName(kernel);
     auto ret = details::runSampling(
                    [&kernel, &singleIterParameters...]() mutable {
                      kernel(std::forward<Args>(singleIterParameters)...);
                    },
-                   platform, kernelName, shots, /*explicitMeasurements=*/false,
-                   qpuId, nullptr, counter, N)
+                   platform, kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
+                   /*explicitMeasurements=*/false, qpuId, nullptr, counter, N)
                    .value();
     return ret;
   };
@@ -558,14 +558,13 @@ sample_n(QuantumKernel &&kernel, ArgumentSet<Args...> &&params) {
   details::BroadcastFunctorType<sample_result, Args...> functor =
       [&](std::size_t qpuId, std::size_t counter, std::size_t N,
           Args &...singleIterParameters) -> sample_result {
-    auto shots = platform.get_shots().value_or(1000);
     auto kernelName = cudaq::getKernelName(kernel);
     auto ret = details::runSampling(
                    [&kernel, &singleIterParameters...]() mutable {
                      kernel(std::forward<Args>(singleIterParameters)...);
                    },
-                   platform, kernelName, shots, /*explicitMeasurements=*/false,
-                   qpuId, nullptr, counter, N)
+                   platform, kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
+                   /*explicitMeasurements=*/false, qpuId, nullptr, counter, N)
                    .value();
     return ret;
   };

--- a/runtime/cudaq/cudaq.cpp
+++ b/runtime/cudaq/cudaq.cpp
@@ -213,26 +213,6 @@ void set_target_backend(const char *backend) {
   platform.setTargetBackend(std::string(backend));
 }
 
-// Ignore warnings about deprecations in platform.set_shots and
-// platform.clear_shots because the functions that are using them here
-// (cudaq::set_shots and cudaq::clear_shots are also deprecated and will be
-// removed at the same time.)
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-void set_shots(const std::size_t nShots) {
-  auto &platform = cudaq::get_platform();
-  platform.set_shots(nShots);
-}
-void clear_shots(const std::size_t nShots) {
-  auto &platform = cudaq::get_platform();
-  platform.clear_shots();
-}
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
-
 void set_noise(const cudaq::noise_model &model) {
   auto &platform = cudaq::get_platform();
   platform.set_noise(&model);

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -77,24 +77,6 @@ public:
   /// @brief Return true if this platform exposes multiple QPUs and
   /// supports parallel distribution of quantum tasks.
   virtual bool supports_task_distribution() const { return false; }
-
-  /// Getter for the shots. This will be deprecated once `set_shots` and
-  /// `clear_shots` are removed.
-  std::optional<int> get_shots() { return platformNumShots; }
-
-  /// Setter for the shots
-  [[deprecated("Specify the number of shots in the using the overloaded "
-               "sample() and observe() functions")]] virtual void
-  set_shots(int numShots) {
-    platformNumShots = numShots;
-  }
-
-  /// Reset shots
-  [[deprecated("Specify the number of shots in the using the overloaded "
-               "sample() and observe() functions")]] virtual void
-  clear_shots() {
-    platformNumShots = std::nullopt;
-  }
 
   /// Specify the execution context for the current thread.
   void set_exec_ctx(ExecutionContext *ctx);
@@ -213,9 +195,6 @@ protected:
 
   /// Name of the platform.
   std::string platformName;
-
-  /// Optional number of shots.
-  std::optional<int> platformNumShots;
 
   /// Keep a per-thread pointer to the current execution context.
   // TODO: Remove this


### PR DESCRIPTION
Continuing the clean up of `quantum_platform`, this removes the `platformNumShots` attribute, and its associated getters and setters.

These were already deprecated.