### PR TITLE
cudaq::realtime

### DIFF
--- a/realtime/.clang-format
+++ b/realtime/.clang-format
@@ -1,0 +1,12 @@
+BasedOnStyle: LLVM
+AlwaysBreakTemplateDeclarations: Yes
+IncludeCategories:
+  - Regex:           '^<'
+    Priority:        4
+  - Regex:           '^"cudaq/'
+    Priority:        3
+  - Regex:           '^"(nvqlink|\.\.)/'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        1
+InsertNewlineAtEOF: Yes

--- a/realtime/.devcontainer/devcontainer.json
+++ b/realtime/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+    "name": "NVQLink Development",
+    "image": "nvqlink-prototype:0.1.0",
+    "capAdd": ["SYS_PTRACE", "NET_ADMIN", "SYS_MODULE", "IPC_LOCK"],
+	"securityOpt": [ "seccomp=unconfined" ],
+    "mounts": [
+        "source=/sys/bus/pci/devices,target=/sys/bus/pci/devices,type=bind",
+        "source=/sys/kernel/mm/hugepages,target=/sys/kernel/mm/hugepages,type=bind",
+        "source=/dev,target=/dev,type=bind",
+        "source=/sys/devices,target=/sys/devices,type=bind",
+        "source=/opt/mellanox/gdrcopy,target=/opt/mellanox/gdrcopy,type=bind"
+    ],
+    "overrideCommand": true,
+    "remoteUser": "root",
+    "runArgs": [
+        "--privileged",
+        "--gpus=all",
+        "--network=host",
+        "--device=/dev/gdrdrv"
+    ]
+}

--- a/realtime/.gitignore
+++ b/realtime/.gitignore
@@ -1,0 +1,99 @@
+# Editor backup files
+*~
+
+# Patch files
+*.orig
+*.rej
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+*.x
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+**/Output/
+**/.lit*.txt
+
+# Executables
+*.exe
+*.out
+*.app
+**/out/
+/*build*/
+/*Build/
+/plugins/
+/other_library_builds/
+/.cproject
+/.project
+/.settings/
+**/*.jar
+**/.ptp*
+*.ab
+/dist/
+/*egg*/
+/python/*egg*
+/*tmp*/
+/wheelhouse/
+**/.ipynb_checkpoints
+compile_commands.json
+**/*.dat
+**/.antlr
+__pycache__/
+
+# IDE files
+.vscode/*
+.theia/*
+
+# Container files
+**/.docker/*
+
+# LSP files
+.cache/*
+
+# LLVM/MLIR files
+*.ll 
+*.bc
+
+# Build results
+[Bb]in/
+[Oo]bj/
+*.bson
+*.csv
+*.bin
+docs/sphinx/_doxygen
+docs/sphinx/_mdgen
+**/_build/*
+**/_skbuild/*
+_version.py
+
+# third party integrations
+simulators/
+apps/
+
+# macOS
+.DS_Store
+
+# JetBrains IDE files
+.idea
+
+# vim files
+*.tmp

--- a/realtime/CMakeLists.txt
+++ b/realtime/CMakeLists.txt
@@ -1,0 +1,131 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Requiring the same version as the others.
+cmake_minimum_required(VERSION 3.28 FATAL_ERROR)
+
+include(FetchContent)
+
+# Set a default build type if none was specified. Must set this before
+# project().
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel")
+
+# Set a default install prefix if none was specified.
+set(CMAKE_INSTALL_PREFIX "$ENV{HOME}/.cudaqx" CACHE STRING
+    "Install path prefix, prepended onto install directories")
+
+# Project setup
+# ==============================================================================
+
+# Check if core is built as a standalone project.
+project(cudaq-nvqlink)
+set(CUDAQ_NVQLINK_STANDALONE_BUILD TRUE)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# The following must go after `project(...)` 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
+set(CUDAQ_NVQLINK_SOURCE_DIR  ${CMAKE_CURRENT_SOURCE_DIR})
+set(CUDAQ_NVQLINK_INCLUDE_DIR ${CUDAQ_NVQLINK_SOURCE_DIR}/include)
+
+# Add cmake directory to module path for custom Find modules
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Options
+# ==============================================================================
+
+option(NVQLINK_BUILD_TESTS
+       "Generate build targets for the NVQLINK unit tests" ON)
+option(NVQLINK_BUILD_EXAMPLES
+       "Generate build targets for the NVQLINK example programs" ON)
+option(NVQLINK_ENABLE_ROCE
+       "Enable RoCE backend using libibverbs" OFF)
+option(NVQLINK_ENABLE_DOCA
+       "Enable DOCA GPUNetIO backend for GPU-controlled RDMA" OFF)
+
+# Profiler backend selection
+set(NVQLINK_PROFILER_BACKEND "NONE" CACHE STRING "Profiler backend (NONE, NVTX, TRACY)")
+set_property(CACHE NVQLINK_PROFILER_BACKEND PROPERTY STRINGS NONE NVTX TRACY)
+
+# Logging backend selection
+set(NVQLINK_LOGGING_BACKEND "NONE" CACHE STRING "Logging backend (NONE, QUILL)")
+set_property(CACHE NVQLINK_LOGGING_BACKEND PROPERTY STRINGS NONE QUILL)
+
+# Compile-time log level filtering (lower levels become no-ops)
+set(NVQLINK_LOGGING_LEVEL "INFO" CACHE STRING "Minimum log level (TRACE, DEBUG, INFO, WARNING, ERROR)")
+set_property(CACHE NVQLINK_LOGGING_LEVEL PROPERTY STRINGS TRACE DEBUG INFO WARNING ERROR)
+
+# Check for CUDA Support (ref: cuda-quantum/CMakeLists.txt)
+# ==============================================================================
+include(CheckLanguage)
+check_language(CUDA)
+set(CUDA_FOUND FALSE)
+# Generate -gencode arch=compute_XX,code=sm_XX for list of supported
+# arch values.
+# List should be sorted in increasing order.
+function(CUDA_get_gencode_args out_args_string arch_values)
+  # allow the user to pass the list like a normal variable
+  set(arch_list ${arch_values} ${ARGN})
+  set(out "")
+  foreach(arch IN LISTS arch_list)
+    set(out "${out} -gencode arch=compute_${arch},code=sm_${arch}")
+  endforeach(arch)
+
+  # Repeat the last one as to ensure the generation of PTX for most
+  # recent virtual architecture for forward compatibility
+  list(GET arch_list -1 last_arch)
+  set(out "${out} -gencode arch=compute_${last_arch},code=compute_${last_arch}")
+  set(${out_args_string} ${out} PARENT_SCOPE)
+endfunction()
+
+if(CMAKE_CUDA_COMPILER)
+  if (NOT CUDA_TARGET_ARCHS)
+    # Ampere, Hopper
+    set(CUDA_TARGET_ARCHS  "80;90")
+  endif()
+  CUDA_get_gencode_args(CUDA_gencode_flags ${CUDA_TARGET_ARCHS})
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -shared -std=c++17 ${CUDA_gencode_flags} --compiler-options -fPIC")
+
+  enable_language(CUDA)
+  set(CUDA_FOUND TRUE)
+  set(CMAKE_CUDA_STANDARD 17)
+  set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
+  find_package(CUDAToolkit REQUIRED)
+  message(STATUS "Cuda language found.")
+endif()
+
+# External Dependencies 
+# ==============================================================================
+
+find_package(Threads REQUIRED)
+
+add_subdirectory(lib)
+
+if (NVQLINK_BUILD_EXAMPLES)
+  add_subdirectory(examples/roce)
+  add_subdirectory(examples/doca)
+endif()
+
+if (NVQLINK_BUILD_TESTS)
+  add_custom_target(NVQLINKUnitTests)
+  include(CTest)
+
+  add_custom_target(run_tests
+    COMMAND ${CMAKE_COMMAND} -E env 
+            PYTHONPATH="${CUDAQ_INSTALL_DIR}:${CMAKE_BINARY_DIR}/python"
+            ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS NVQLINKUnitTests
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+  add_subdirectory(unittests)
+endif()
+

--- a/realtime/README.md
+++ b/realtime/README.md
@@ -1,0 +1,37 @@
+# CUDA-Q NVQLink Library
+
+CUDA-Q NVQLink is a library for describing a tightly integrated Logical QPU. 
+Programmers can leverage this library to describe component devices that 
+enable real-time coprocessing during qubit coherence times. 
+
+This is very early protoype work. Bugs and issues are likely to be hit. All feedback 
+is welcome. This work will continue to rapidly evolve as we learn what works and what doesn't. 
+
+## Getting Started
+
+```bash
+# Configure, need cmake 3.28+
+cmake -G Ninja .. -DNVQLINK_BUILD_TESTS=ON
+# Build
+ninja 
+# Test
+ctest 
+```
+
+## Extending the library 
+
+Check out the tests in the `unittests` folder as well as the example codes in `examples`. 
+
+3rd parties can extend this library with new `device` types. The goal is to define 
+a subclass of `device_mixin` that allows you specify device traits that your `device` exposes. 
+There are a number of traits available, and they are specified in the `device.h` file. There are 
+example devices in the `devices/` folder there too. 
+
+3rd parties can also provide custom compiler implementations. Compilers take generic 
+code strings and return a `compiled_kernel`. There is one compiler implemented as of 
+today, and it is the CUDA-Q compiler. For simplicity, this compiler simply delegates to 
+the command line CUDA-Q toolchain. Subclasses should be able to override the `cudaq-opt` 
+pass flags. This would allow one to handle CUDA-Q IR operations in a target specific manner 
+(e.g., custom lowering of the device_call op).
+
+

--- a/realtime/docker/Dockerfile
+++ b/realtime/docker/Dockerfile
@@ -1,0 +1,66 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+ARG base_image=ghcr.io/nvidia/cuda-quantum-dev:ext-cu13.0-gcc11-main
+FROM $base_image
+
+ARG TARGETARCH
+ARG DOCA_VERSION=3.1.0
+ARG CACHEBUST=1
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN echo "Target architecture is $TARGETARCH"
+
+WORKDIR /opt
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gpg \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure the DOCA APT repository
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+        DOCA_ARCH="x86_64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        DOCA_ARCH="arm64-sbsa"; \
+    else \
+        echo "Unknown architecture: $TARGETARCH"; \
+        exit 1; \
+    fi \
+    && DISTRO=$(. /etc/os-release && echo ${ID}${VERSION_ID}) \
+    && DOCA_REPO_LINK=https://linux.mellanox.com/public/repo/doca/${DOCA_VERSION}/${DISTRO}/${DOCA_ARCH} \
+    && echo "Using DOCA_REPO_LINK=${DOCA_REPO_LINK}" \
+    && LOCAL_GPG_KEY_PATH="/usr/share/keyrings/mellanox-archive-keyring.gpg" \
+    && curl -fsSL ${DOCA_REPO_LINK}/GPG-KEY-Mellanox.pub | gpg --dearmor | tee ${LOCAL_GPG_KEY_PATH} > /dev/null \
+    && echo "deb [signed-by=${LOCAL_GPG_KEY_PATH}] ${DOCA_REPO_LINK} ./" | tee /etc/apt/sources.list.d/mellanox.list
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkgconf \
+        mlnx-dpdk-dev \
+        doca-sdk \
+        libdoca-sdk-gpunetio-dev \
+        libdoca-sdk-verbs-dev \
+        mlnx-ofed-kernel-utils \
+        ibverbs-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Soft-RoCE (rxe) support packages
+# Note: To use Soft-RoCE in the container, run with:
+#   --cap-add=NET_ADMIN --cap-add=SYS_MODULE --device=/dev/infiniband
+# And ensure rdma_rxe kernel module is loaded on the host:
+#   modprobe rdma_rxe
+#   rdma link add rxe0 type rxe netdev <interface>
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        rdma-core \
+        libibverbs-dev \
+        librdmacm-dev \
+        iproute2 \
+        kmod \
+        perftest \
+        infiniband-diags \
+    && rm -rf /var/lib/apt/lists/*

--- a/realtime/docker/alpha/sept_2025/Dockerfile
+++ b/realtime/docker/alpha/sept_2025/Dockerfile
@@ -1,0 +1,27 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Make sure cudaq-qclink-main.tar.gz is in cwd. 
+# 
+# run 
+# docker build --network host -t cudaq-qclink-alpha . 
+#
+
+# ARG base_image=ghcr.io/nvidia/cuda-quantum-devdeps:ext-amd64-cu12.0-gcc11-main
+ARG base_image=ghcr.io/nvidia/cuda-quantum-dev:ext-cu12.0-gcc11-main
+ARG TARGETARCH=
+
+FROM $base_image
+WORKDIR /workspaces
+
+ADD cudaq-qclink-main.tar.gz .
+
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+
+RUN cd cudaq-qclink-main && mkdir build && cd build && cmake .. -G Ninja -DCUDAQ_QCLINK_INCLUDE_TESTS=ON \
+  && LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH} ninja

--- a/realtime/docker/build.sh
+++ b/realtime/docker/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+set -o errexit
+umask 0
+
+SCRIPT=`realpath "$0"`
+HERE=`dirname "$SCRIPT"`
+ROOT=`realpath "$HERE/.."`
+VERSION="latest"
+
+# Detect CUDA version on host
+CUDA_VERSION=""
+if command -v nvidia-smi &> /dev/null; then
+    # Get CUDA version from nvidia-smi
+    CUDA_VERSION=$(nvidia-smi | grep "CUDA Version" | sed -n 's/.*CUDA Version: \([0-9]\+\)\.\([0-9]\+\).*/\1.\2/p')
+    echo "Detected CUDA version from nvidia-smi: $CUDA_VERSION"
+fi
+
+# Determine base image based on CUDA major version
+if [[ "$CUDA_VERSION" == 12.* ]]; then
+    BASE_IMAGE="ghcr.io/nvidia/cuda-quantum-dev:ext-cu12.6-gcc11-main"
+    echo "Using CUDA 12 base image: $BASE_IMAGE"
+elif [[ "$CUDA_VERSION" == 13.* ]]; then
+    BASE_IMAGE="ghcr.io/nvidia/cuda-quantum-dev:ext-cu13.0-gcc11-main"
+    echo "Using CUDA 13 base image: $BASE_IMAGE"
+else
+    echo "Warning: Could not detect CUDA version or unsupported version ($CUDA_VERSION)"
+    echo "Defaulting to CUDA 13 base image"
+    BASE_IMAGE="ghcr.io/nvidia/cuda-quantum-dev:ext-cu13.0-gcc11-main"
+fi
+
+DOCKER_BUILDKIT=1 docker build \
+    --network=host \
+    --build-arg base_image="$BASE_IMAGE" \
+    -t nvqlink-prototype:$VERSION \
+    -f $HERE/Dockerfile \
+    $ROOT

--- a/realtime/docker/run_softrce.sh
+++ b/realtime/docker/run_softrce.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Helper script to run the container with Soft-RoCE (rxe) support
+
+set -o errexit
+
+SCRIPT=`realpath "$0"`
+HERE=`dirname "$SCRIPT"`
+ROOT=`realpath "$HERE/.."`
+VERSION=`cat $ROOT/VERSION 2>/dev/null || echo "latest"`
+
+# Check if rdma_rxe kernel module is loaded on host
+if ! lsmod | grep -q rdma_rxe; then
+    echo "Warning: rdma_rxe kernel module is not loaded on the host."
+    echo "To load it, run:"
+    echo "  sudo modprobe rdma_rxe"
+    echo ""
+fi
+
+# Check if any rxe devices exist
+if ! rdma link show 2>/dev/null | grep -q rxe; then
+    echo "Warning: No rxe devices found on the host."
+    echo "To create one, run (replace eth0 with your network interface):"
+    echo "  sudo rdma link add rxe0 type rxe netdev eth0"
+    echo ""
+fi
+
+echo "Starting container with Soft-RoCE and GPU support..."
+
+docker run -it --rm \
+    --gpus all \
+    --cap-add=NET_ADMIN \
+    --cap-add=SYS_MODULE \
+    --cap-add=IPC_LOCK \
+    --device=/dev/infiniband \
+    --network=host \
+    --ulimit memlock=-1:-1 \
+    -v "$ROOT:/workspace" \
+    -w /workspace \
+    nvqlink-prototype:$VERSION \
+    "$@"
+

--- a/realtime/docs/ARCHITECTURE.md
+++ b/realtime/docs/ARCHITECTURE.md
@@ -1,0 +1,1294 @@
+# NVQLink Architecture (WIP)
+
+## 1. Introduction and Goals
+
+NVQLink is a platform architecture for tightly coupling high-performance
+computing (HPC) resources to quantum processing unit (QPU) control systems. It
+addresses the critical need for real-time classical coprocessing in
+fault-tolerant quantum computing, with quantum error correction (QEC) decoding
+as the primary driving workload.
+
+### 1.1 Requirements Overview
+
+#### Functional Requirements
+
+- Provide ultra-low latency communication between QCS (Quantum Control Systems) and RTH (Real-time Hosts)
+- Enable classical coprocessing during quantum algorithm execution
+- Integrate with existing HPC infrastructure via standard networking
+- Support quantum error correction decoding workflows
+
+#### Driving Forces
+
+- Fault-tolerant quantum computing requires real-time classical feedback
+- QEC decoding must complete within strict timing budgets to prevent logical errors
+- QPU control systems have limited compute resources and must offload heavy processing
+- Algorithm researchers need development environments without hardware access
+
+### 1.2 Quality Goals
+
+The following quality goals drive fundamental architectural decisions, ordered
+by priority:
+
+| Priority | Quality Goal | Scenario |
+|----------|-------------|----------|
+| 1 | **Ultra-Low Latency** | A QEC decoder receives syndrome data and must return corrections before the next feedforward event. The round-trip latency (QCS → RTH → QCS) must be < 10 µs to prevent logical errors from accumulating during the wait. |
+| 2 | **Extensibility** | A QCS vendor integrates their proprietary PPU firmware without exposing instruction set details. They implement a custom `Channel` and provide a VPPU emulator; no changes to NVQLink core are required. |
+| 3 | **Scalability** | A 1000-logical-qubit algorithm runs with lattice surgery. The decoder uses parallel window processing across multiple GPUs, each handling independent spatial/temporal blocks.|
+| 4 | **Zero Overhead** | During peak syndrome streaming at 1 MHz, the system processes 1M packets/second. No memory allocation, exception handling, or virtual dispatch occurs in the packet processing path. |
+| 5 | **Productivity** | A researcher develops a new AI-based decoder on their laptop using VPPU simulation. Once validated, the same code deploys to physical hardware by changing a config flag—no code modifications needed. |
+
+### 1.3 Stakeholders
+
+| Role | Representative | Expectations |
+|------|----------------|--------------|
+| **QCS Builder** | Quantum Machines, Qblox, Zurich Instruments, Keysight | Integration requires minimal changes to existing firmware; proprietary PPU instruction sets remain private; clear Network Interface specification |
+| **QPU Operator** | National labs, quantum computing centers | System runs reliably under fault-tolerant workloads; latency metrics are measurable and documented; calibration workflows are well-defined |
+| **Algorithm Researcher** | University research groups, NVIDIA | Can develop and test QEC protocols without hardware access; documentation explains programming model and device callback semantics |
+| **HPC Integrator** | Supercomputing centers (ORNL, LBNL) | Uses standard networking (Ethernet/RDMA); fits into existing HPC infrastructure |
+| **Decoder Developer** | QEC research teams | Understands how to register decoder functions; knows GPU execution model; documentation covers real-time constraints and data flow |
+
+## 2. Architecture Constraints
+
+### 2.1 Technical Constraints
+
+| Constraint | Description |
+|------------|-------------|
+| **RDMA Networking** | Data plane requires RDMA-capable NICs (RoCE v2) for ultra-low latency |
+| **Linux OS** | System relies on `libibverbs` API, the Linux kernel RDMA stack, and NVIDIA DOCA GPUNetIO for GPU-direct NIC control |
+| **C++17 Minimum** | Codebase uses modern C++ features for template metaprogramming |
+| **CUDA Optional** | GPU acceleration requires NVIDIA GPUs with CUDA 12+ |
+
+### 2.2 Organizational Constraints
+
+| Constraint | Description |
+|------------|-------------|
+| **CUDA-Q Integration** | Must integrate with NVIDIA CUDA-Q quantum compiler ecosystem |
+| **Vendor Independence** | Architecture must support multiple QCS vendors without core changes |
+| **Standard + NVIDIA APIs** | Data plane uses standard `libibverbs` API; also uses NVIDIA DOCA GPUNetIO for GPU-direct NIC control |
+
+### 2.3 Conventions
+
+| Convention | Description |
+|------------|-------------|
+| **RAII Resource Management** | All hardware resources use RAII patterns |
+| **No Hot Path Allocation** | Memory allocation forbidden in packet processing paths |
+| **Header-Only GPU Code** | GPU stream classes are header-only for device compilation |
+
+## 3. System Scope and Context
+
+### 3.1 Business Context
+
+NVQLink connects quantum control systems (which execute quantum programs) to
+high-performance computing resources (which provide real-time classical
+processing such as QEC decoding).
+
+**External Systems:**
+
+| System | Description | Interface |
+|--------|-------------|-----------|
+| **Quantum Control System (QCS)** | FPGA/pulse processor executing quantum applications (e.g., Quantum Machines OPX1000, QubiC) | RDMA data plane, UDP control plane |
+| **QPU** | Physical quantum processor controlled by QCS | Not directly interfaced by NVQLink |
+| **HPC Cluster** | Provides GPU compute resources for decoding | Internal resource allocation |
+
+### 3.2 Technical Context
+
+```text
+┌──────────────────────────────────────────────────┐
+│            Quantum Control System (QCS)          │
+│               FPGA / Pulse Processor             │
+│                                                  │
+│  ┌────────────────────────────────────────────┐  │
+│  │     Quantum Application                    │  │
+│  │     (CUDA-Q Quantum Kernels)               │  │
+│  │                                            │  │
+│  │  • Quantum gate execution                  │  │
+│  │  • Issues device_call() for RTH callbacks  │  │
+│  └────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────┘
+        │                              │
+        │  ▼ RPC requests              │  ▲ Connection params
+        │  ▲ RPC responses             │  ▲ START/STOP cmds
+        │                              │  ▼ ACK/status
+  ══════╪══════════════════════════════╪══════════════════
+        │    Data Plane                │  Control Plane
+        │    (RDMA WRITE/SEND)         │  (UDP packets)
+  ══════╪══════════════════════════════╪══════════════════
+        │                              │
+┌───────┴──────────────────────────────┴───────────┐
+│               Real-time Host (RTH)               │
+│                NVQLink Framework                 │
+│                                                  │
+│  • Daemon: handles device_call() RPC requests    │
+│  • Channel: RDMA network transport               │
+│  • QCSDevice: UDP control plane management       │
+│  • Callbacks: QEC decoding, classical processing │
+└──────────────────────────────────────────────────┘
+
+═══════════════════════════════════════════════════
+         Network Infrastructure (Medium)
+
+  • RoCE/RDMA NICs (Mellanox ConnectX)
+  • RDMA-capable Ethernet switches
+  • Quantum Machines Opnic
+═══════════════════════════════════════════════════
+
+Legend:
+  │       Vertical line (connection)
+  ▼       Downward flow (QCS → RTH)
+  ▲       Upward flow (RTH → QCS)
+  ═════   Network medium (physical infrastructure)
+```
+
+**Systems:**
+
+- **QCS (Quantum Control System)**: FPGA/pulse processor executing quantum applications
+  - Runs CUDA-Q quantum kernels
+  - Issues `device_call()` to invoke RTH processing
+  - Examples: Quantum Machines OPX1000, QubiC, custom FPGA implementations
+
+- **RTH (Real-time Host)**: HPC node running NVQLink Framework
+  - Implements quantum callback functions (QEC decoding, classical processing)
+  - Provides ultra-low latency RPC services
+  - Examples: CPU/GPU servers with RDMA NICs
+
+**Communication:**
+
+- **Data Plane** (left arrows): High-performance RPC traffic
+  - Protocol: RDMA WRITE (requests) and RDMA SEND (responses)
+  - ▼ QCS → RTH: `device_call()` RPC requests
+  - ▲ RTH → QCS: RPC responses (results)
+
+- **Control Plane** (right arrows): Out-of-band configuration via UDP
+  - ▲ RTH → QCS: Connection parameters (QPN, GID, vaddr, rkey)
+  - ▲ RTH → QCS: START/STOP/ABORT commands
+  - ▼ QCS → RTH: ACK, status, COMPLETE notifications
+
+**System Boundary:** NVQLink runs on the RTH and provides the communication
+layer for QCS to invoke callbacks on RTH compute resources.
+
+## 4. Solution Strategy
+
+The following design principles guide all architectural decisions:
+
+### 4.1 Component-Based Architecture
+
+The system uses composition over inheritance with clear component boundaries:
+
+- **Channel**: Self-sufficient network I/O, owns all hardware resources
+- **VerbsContext**: Optional shared InfiniBand context for memory sharing
+- **FlowSwitch**: Optional traffic steering coordinator
+- **Daemon**: RPC layer that uses Channel for network I/O
+- **QCSDevice**: Control plane that configures `Channel` but doesn't own it
+
+Each component can function independently. Sharing is explicit and opt-in.
+
+### 4.2 Zero-Copy Data Flow
+
+```text
+NIC → DMA → Buffer → Stream (pointer) → User Code → Stream (pointer) → Buffer → DMA → NIC
+       ▲                                                                         ▲
+       └──────────────────────── Same memory region ─────────────────────────────┘
+```
+
+Techniques:
+
+- Pre-allocated buffer pools (no allocation in hot path)
+- Direct DMA buffer access via streams
+- Pointer arithmetic instead of memcpy
+- Buffer `reset()` for backend-specific memory wrapping
+
+### 4.3 Unified Stream Abstraction
+
+Single stream API works across different contexts:
+
+- **Channel mode**: Persistent streams managing packet lifecycle
+- **Buffer mode**: Temporary streams for RPC handlers
+- **CPU/GPU variants**: Same conceptual API, different implementations
+
+Non-polymorphic design enables compile-time optimization and zero overhead.
+
+### 4.4 Separation of Concerns
+
+**Control Plane (UDP)**: Configuration, connection setup, execution control
+
+- Uses `QCSDevice` and `ControlServer`
+- Out-of-band communication
+- Simple UDP protocol
+
+**Data Plane (RoCE)**: High-performance RPC traffic
+
+- Uses `Daemon` and `Channel`
+- RDMA for low latency
+- Zero-copy packet processing
+
+### 4.5 Type-Safe Serialization
+
+Automatic marshalling via `NVQLINK_RPC_HANDLE` macro:
+
+- Eliminates manual serialization boilerplate
+- Compile-time type checking
+- No runtime overhead
+
+```cpp
+// User writes this
+int add(int a, int b) { return a + b; }
+daemon.register_function(NVQLINK_RPC_HANDLE(add));
+
+// System automatically generates:
+// - Argument deserialization
+// - Return value serialization
+// - Function dispatch wrapper
+```
+
+### 4.6 Explicit Resource Management
+
+- No hidden singletons or global state
+- RAII-based lifecycle management
+- Clear ownership: `Channel` owns buffers, `Daemon` owns `Channel`
+- Optional resource sharing is explicit (`VerbsContext`, `VerbsFlowSwitch`)
+
+## 5. Building Block View
+
+The architecture consists of three distinct layers:
+
+1. **Transport Layer (Channel)**: Hardware-abstracted network I/O with zero-copy buffer management
+2. **Service Layer (Daemon)**: RPC protocol with automatic function dispatch and type-safe serialization  
+3. **Control Layer (QCS)**: Out-of-band configuration and execution control via UDP
+
+The system supports multiple usage patterns:
+
+- **RPC Mode**: Full-featured server with automatic function registration (via Daemon)
+- **Direct I/O Mode**: Low-level packet access for custom protocols (via Channel directly)
+- **GPU Mode**: CUDA kernels with direct NIC queue access (via GPUChannel)
+
+All modes provide unified stream abstractions (`InputStream`/`OutputStream`) for
+type-safe, zero-copy data handling.
+
+### 5.1 Level 1: Container Diagram (C4)
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│                    NVQLink Framework (RTH)                       │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐    │
+│  │  Control Plane (out-of-band setup via UDP)               │    │
+│  │                                                          │    │
+│  │  ┌────────────────────┐    ┌─────────────────────────┐   │    │
+│  │  │  QCSDevice         │    │  ControlServer          │   │    │
+│  │  │  • trigger()       │───▶│  • UDP socket           │───┼────┼──▶ to QCS
+│  │  │  • abort()         │uses│  • send_command()       │   │    │
+│  │  │  • upload_program()│    │  • wait_for_response()  │◀──┼────┼─── from QCS
+│  │  └────────────────────┘    └────────────┬────────────┘   │    │
+│  │                                         │                │    │
+│  │    exchange_connection_params(channel): │                │    │
+│  │    ┌────────────────────────────────────┼────────────┐   │    │
+│  │    │ 1. READ channel params             │            │   │    │
+│  │    │ 2. SEND params ────────────────────┼────────────┼───┼────┼──▶ to QCS
+│  │    │ 3. RECV QCS params ◀───────────────┼────────────┼───┼────┼─── from QCS
+│  │    │ 4. WRITE remote QP to channel      │            │   │    │
+│  │    └────────────────────────────────────┼────────────┘   │    │
+│  └─────────────────────────────────────────┼────────────────┘    │
+│                                            │                     │
+│  ┌─────────────────────────────────────────┼────────────────┐    │
+│  │  Data Plane (high-performance RPC)      │                │    │
+│  │                     read/write          │                │    │
+│  │  ┌──────────────────────────────────────▼────────────┐   │    │
+│  │  │  Channel (Transport)                              │   │    │
+│  │  │  ┌─────────────────────────────────────────────┐  │   │    │
+│  │  │  │  RoCEChannel                                │  │   │    │
+│  │  │  │  • get_connection_params() → local params   │  │   │    │
+│  │  │  │  • set_remote_qp(qpn, gid) ← remote params  │  │   │    │
+│  │  │  │  • receive_burst() / send_burst()           │  │   │    │
+│  │  │  └─────────────────────────────────────────────┘  │   │    │
+│  │  └───────────────────────────┬───────────────────────┘   │    │
+│  │                              │ owned by                  │    │
+│  │  ┌───────────────────────────▼───────────────────────┐   │    │
+│  │  │  Daemon (Service)                                 │   │    │
+│  │  │  ┌──────────────┐  ┌──────────────┐               │   │    │
+│  │  │  │ Dispatcher   │  │  Function    │               │   │    │
+│  │  │  │ (CPU/GPU)    │─▶│  Registry    │               │   │    │
+│  │  │  └──────────────┘  └──────────────┘               │   │    │
+│  │  └───────────────────────────────────────────────────┘   │    │
+│  └──────────────────────────────────────────────────────────┘    │
+│                                 │                                │
+│                                 │ libibverbs API                 │
+│                                 ▼                                │
+│                    ┌───────────────────────────┐                 │
+│                    │   Network Hardware (NIC)  │─────────────────┼──▶ RDMA to QCS
+│                    └───────────────────────────┘                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Container Relationships:**
+
+1. **Control Plane** (`QCSDevice` + `ControlServer`):
+   - **READS** `Channel`'s local RDMA params (QPN, GID, vaddr, rkey)
+   - **SENDS** those params **TO external QCS** via UDP
+   - **RECEIVES** QCS's params back from QCS
+   - **WRITES** remote QP info **INTO Channel** (`set_remote_qp`)
+   - Has NO relationship with `Daemon`
+
+2. **Data Plane** (`Daemon` + `Channel`):
+   - **Daemon owns Channel** for data plane operations
+   - Channel handles network I/O (RDMA WRITE/SEND)
+   - Daemon dispatches RPC requests to registered functions
+
+**Key Flow**: `Channel` is created first (with its own RDMA resources). Control
+plane extracts `Channel`'s params and sends them to QCS. QCS sends back its
+params, which are then written into the `Channel`. Only after this exchange does
+`Daemon` take ownership for data plane operations.
+
+> **Note**: With Hololink, the Control Plane, more specifically the
+> `ControlServer`, will be slightly different. One big difference is that the
+> QCS that uses Hololink won't send back QP information back to the RTH.
+
+### 5.2 Level 2: Component Diagram (C4)
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                  Daemon (Service Layer)                         │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │                    Daemon Core                            │  │
+│  │  • start() / stop()                                       │  │
+│  │  • register_function()                                    │  │
+│  │  • get_stats()                                            │  │
+│  └──────┬─────────────────────────┬──────────────────────────┘  │
+│         │ owns                    │ uses                        │
+│  ┌──────▼──────────────┐   ┌──────▼───────────────────────────┐ │
+│  │    Dispatcher       │   │     FunctionRegistry             │ │
+│  │  ┌──────────────┐   │   │  ┌─────────────────────────┐     │ │
+│  │  │CPUDispatcher │   │   │  │ • function_id → wrapper │     │ │
+│  │  │              │   │   │  │ • Hash-based lookup     │     │ │
+│  │  │ while(run) { │   │   │  │ • Type inference        │     │ │
+│  │  │   rx_burst() │   │   │  │ • Auto-marshal          │     │ │
+│  │  │   dispatch() │   │   │  └─────────────────────────┘     │ │
+│  │  │   tx_burst() │   │   │  ┌─────────────────────────┐     │ │
+│  │  │ }            │   │   │  │  FunctionWrapper        │     │ │
+│  │  └──────────────┘   │   │  │  • Deserialize args     │     │ │
+│  │  ┌──────────────┐   │   │  │  • Call user function   │     │ │
+│  │  │GPUDispatcher │   │   │  │  • Serialize result     │     │ │
+│  │  │              │   │   │  └─────────────────────────┘     │ │
+│  │  │ persistent   │   │   └──────────────────────────────────┘ │
+│  │  │ kernel       │   │                                        │
+│  │  │ polls NIC    │   │   ┌──────────────────────────────────┐ │
+│  │  └──────────────┘   │   │     Serialization                │ │
+│  └─────────┬───────────┘   │  ┌─────────────────────────────┐ │ │
+│            │ uses          │  │ InputStream / OutputStream  │ │ │
+│            │               │  │                             │ │ │
+│            │               │  │ • read<T>() / write<T>()    │ │ │
+│            │               │  │ • Dual-mode construction    │ │ │
+│            │               │  │   - Channel (persistent)    │ │ │
+│            │               │  │   - Buffer (RPC handler)    │ │ │
+│            │               │  │ • Zero-copy via pointers    │ │ │
+│            │               │  └─────────────────────────────┘ │ │
+│            │               │  ┌─────────────────────────────┐ │ │
+│            │               │  │ GPU Streams (device-side)   │ │ │
+│            │               │  │                             │ │ │
+│            │               │  │ • GPUInputStream            │ │ │
+│            │               │  │ • GPUOutputStream           │ │ │
+│            │               │  │ • Header-only               │ │ │
+│            │               │  └─────────────────────────────┘ │ │
+│            │               └──────────────────────────────────┘ │
+└────────────┼────────────────────────────────────────────────────┘
+             │ uses
+             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                 Channel (Transport Layer)                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │               Channel (Abstract)                          │  │
+│  │  • receive_burst(Buffer**, max) → count                   │  │
+│  │  • send_burst(Buffer**, count) → count                    │  │
+│  │  • acquire_buffer() → Buffer*                             │  │
+│  │  • release_buffer(Buffer*)                                │  │
+│  │  • register_memory(addr, size)                            │  │
+│  └────────────┬──────────────────────────────────────────────┘  │
+│               │ implements                                      │
+│  ┌────────────▼──────────────────────────────────────────────┐  │
+│  │            RoCEChannel                                    │  │
+│  │  ┌────────────────────────────────────────────────────┐   │  │
+│  │  │  InfiniBand Resources (self-contained)             │   │  │
+│  │  │  • ibv_context  • ibv_pd  • ibv_qp  • ibv_cq       │   │  │
+│  │  └────────────────────────────────────────────────────┘   │  │
+│  │  ┌────────────────────────────────────────────────────┐   │  │
+│  │  │  RoCEBufferPool                                    │   │  │
+│  │  │  • Pre-allocated DMA buffers                       │   │  │
+│  │  │  • Wraps ring buffer slots (zero-copy)             │   │  │
+│  │  └────────────────────────────────────────────────────┘   │  │
+│  │  ┌────────────────────────────────────────────────────┐   │  │
+│  │  │  RoCERingBuffer                                    │   │  │
+│  │  │  • RDMA WRITE target                               │   │  │
+│  │  │  • Sequence number polling                         │   │  │
+│  │  │  • [Header|Slot0|Slot1|...]                        │   │  │
+│  │  └────────────────────────────────────────────────────┘   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  Optional Shared Components (composition):                      │
+│  ┌──────────────────────┐     ┌─────────────────────────────┐   │
+│  │   VerbsContext       │     │   VerbsFlowSwitch           │   │
+│  │                      │     │                             │   │
+│  │  • Shared ibv_context│     │  • ibv_create_flow()        │   │
+│  │  • Shared ibv_pd     │     │  • UDP port → QP routing    │   │
+│  │  • For memory sharing│     │  • Hardware steering        │   │
+│  │  • Optional          │     │  • Optional                 │   │
+│  └──────────────────────┘     └─────────────────────────────┘   │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │              Buffer (Memory)                              │  │
+│  │                                                           │  │
+│  │  [Headroom | Data | Tailroom]                             │  │
+│  │   ^         ^                                             │  │
+│  │   base      data_ptr                                      │  │
+│  │                                                           │  │
+│  │  • prepend() - add headers                                │  │
+│  │  • Zero-copy via pointer manipulation                     │  │
+│  │  • Wraps backend-specific memory                          │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                 QCS (Control Layer)                             │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │              QCSDevice                                    │  │
+│  │  • establish_connection(RoCEChannel*)                     │  │
+│  │  • upload_program(binary)                                 │  │
+│  │  • trigger() / abort()                                    │  │
+│  │  • is_connected() / is_complete()                         │  │
+│  └────────────────┬──────────────────────────────────────────┘  │
+│                   │ uses                                        │
+│  ┌────────────────▼──────────────────────────────────────────┐  │
+│  │           ControlServer (UDP)                             │  │
+│  │                                                           │  │
+│  │  Protocol:                                                │  │
+│  │  1. Wait for QCS DISCOVER packet                          │  │
+│  │  2. Send Channel params (QPN, GID, vaddr, rkey)           │  │
+│  │  3. Receive QCS params (QPN, GID)                         │  │
+│  │  4. Configure Channel with remote QP                      │  │
+│  │  5. Send START/STOP commands                              │  │
+│  │                                                           │  │
+│  │  • exchange_connection_params(RoCEChannel*)               │  │
+│  │  • send_command(cmd, params)                              │  │
+│  │  • wait_for_response(timeout)                             │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Component Relationships:**
+
+- **Daemon** owns a **Channel** and uses **FunctionRegistry** for dispatch
+- **Dispatcher** (CPU or GPU) polls **Channel** and invokes registered functions
+- **FunctionRegistry** contains **FunctionWrappers** with automatic serialization
+- **Streams** work over **Channel** (persistent) or **Buffer** (temporary)
+- **RoCEChannel** contains **RoCEBufferPool** and **RoCERingBuffer**
+- **RoCEChannel** optionally uses **VerbsContext** (shared resources) or **VerbsFlowSwitch** (steering)
+- **QCSDevice** uses **ControlServer** for UDP protocol and configures **RoCEChannel**
+- **Buffer** provides zero-copy abstraction over backend-specific memory
+
+### 5.3 Level 3: Code Structure
+
+#### 5.3.1 Transport Layer (Channel)
+
+**Location:** `include/cudaq/nvqlink/network/`
+
+The Channel abstraction provides hardware-independent network I/O:
+
+```cpp
+class Channel {
+public:
+  // Lifecycle
+  virtual void initialize() = 0;
+  virtual void cleanup() = 0;
+  
+  // Packet I/O (zero-copy)
+  virtual uint32_t receive_burst(Buffer** buffers, uint32_t max) = 0;
+  virtual uint32_t send_burst(Buffer** buffers, uint32_t count) = 0;
+  
+  // Buffer management (pre-allocated pool)
+  virtual Buffer* acquire_buffer() = 0;
+  virtual void release_buffer(Buffer* buffer) = 0;
+  
+  // Memory registration for RDMA
+  virtual void register_memory(void* addr, size_t size) = 0;
+  
+  // Configuration
+  virtual void configure_queues(const std::vector<uint32_t>& queue_ids) = 0;
+  
+  // Execution model
+  virtual ChannelModel get_execution_model() const = 0;
+};
+```
+
+**Key Characteristics:**
+
+- **Self-sufficient**: Each Channel manages its own hardware resources
+- **Zero-copy**: Direct access to NIC DMA buffers
+- **Pre-allocated**: Buffer pools created at initialization (no allocation in hot path)
+- **Abstract**: Works with RoCE, mock implementations, and future backends (DOCA, Opnic)
+
+**Implemented Channels:**
+
+- `RoCEChannel`: RDMA over Converged Ethernet (libibverbs)
+- Mock channels in `examples/mock/` for testing
+
+#### 5.3.2 Service Layer (Daemon)
+
+**Location:** `include/cudaq/nvqlink/daemon/`
+
+The Daemon provides RPC functionality on top of any Channel:
+
+```cpp
+class Daemon {
+public:
+  explicit Daemon(DaemonConfig config, std::unique_ptr<Channel> channel);
+  
+  // Lifecycle
+  void start();
+  void stop();
+  bool is_running() const;
+  
+  // Function registration (automatic serialization)
+  template<typename F>
+  void register_function(F&& fn, std::string_view name);
+  
+  // Statistics
+  struct Stats { uint64_t packets_received, packets_sent, errors; };
+  Stats get_stats() const;
+};
+```
+
+**Sub-components:**
+
+- **FunctionRegistry** (`daemon/registry/`): Automatic type inference, hash-based lookup, compile-time wrapper generation
+- **Dispatcher** (`daemon/dispatcher/`): `CPUDispatcher` and `GPUDispatcher` for packet processing
+- **Serialization** (`network/serialization/`): `InputStream`/`OutputStream` and GPU variants
+
+#### 5.3.3 Control Layer (QCS)
+
+**Location:** `include/cudaq/nvqlink/qcs/`
+
+```cpp
+class QCSDevice {
+public:
+  explicit QCSDevice(const QCSDeviceConfig& config);
+  
+  void establish_connection(RoCEChannel* channel);
+  bool is_connected() const;
+  void disconnect();
+  
+  void upload_program(const std::vector<std::byte>& binary);
+  void trigger();
+  bool is_complete() const;
+  void abort();
+};
+
+class ControlServer {
+public:
+  explicit ControlServer(uint16_t port);
+  
+  void start();
+  void stop();
+  bool exchange_connection_params(RoCEChannel* channel);
+  void send_command(const std::string& cmd, const nlohmann::json& params = {});
+  nlohmann::json wait_for_response(std::chrono::milliseconds timeout);
+};
+```
+
+## 6. Runtime View
+
+This section describes the key runtime scenarios based on actual code in
+`examples/roce/`, `lib/daemon/`, and `lib/network/channels/roce/`.
+
+### 6.1 Connection Setup
+
+The RTH (server) starts first and controls the connection sequence.
+
+```text
+      RTH (Server)                                      QCS (Client)
+           │                                                 │
+           │  Initialize channel & control server            │
+           │  ────────────────────────────────────           │
+           │  channel = RoCEChannel(device, port)            │
+           │  channel->initialize()                          │
+           │  control_server.start()  // UDP:9999            │
+           │                                                 │
+           │◀─────────────── DISCOVER ───────────────────────│
+           │                  (UDP)                          │
+           │                                                 │
+           │─────────────── CONNECTION_PARAMS ──────────────▶│
+           │                 • qpn                           │
+           │                 • gid                           │  Create QP
+           │                 • vaddr (ring buffer)           │
+           │                 • rkey  (RDMA key)              │
+           │                 • num_slots, slot_size          │
+           │                                                 │
+           │◀───────────────── ACK ──────────────────────────│
+           │                 • client qpn                    │
+           │                 • client gid                    │
+           │                                                 │
+           │  set_remote_qp(qpn, gid)                        │
+           │  daemon->start()                                │
+           │                                                 │
+           │─────────────────── START ──────────────────────▶│
+           │                 {cmd: "START"}                  │  Transition QP
+           │                                                 │  to RTS
+         ══╪═════════════════════════════════════════════════╪══
+           │              Data plane active                  │
+         ══╪═════════════════════════════════════════════════╪══
+```
+
+**Source:**
+
+- `examples/roce/udp_control_server.cpp`
+- `examples/roce/roce_daemon_client.cpp`
+
+### 6.2 RPC Round-Trip
+
+Client sends requests via RDMA WRITE; server responds via RDMA SEND.
+
+```text
+        QCS (Client)                           RTH (Server)
+             │                                      │
+             │                                      │  Dispatcher polling...
+             │                                      │
+             │  Build packet:                       │
+             │  ┌──────────────────────┐            │
+             │  │ seq# | len | func_id │            │
+             │  │ arg_len | args...    │            │
+             │  └──────────────────────┘            │
+             │                                      │
+             │══════ RDMA WRITE ═══════════════════▶│  Ring buffer
+             │       to: vaddr + slot_offset        │  slot updated
+             │       rkey: server_rkey              │
+             │                                      │
+             │                                      │  poll_next() detects seq#
+             │                                      │         ▼
+             │                                      │  process_packet():
+             │                                      │    parse header
+             │                                      │    lookup function
+             │                                      │    func(in, out)
+             │                                      │         ▼
+             │                                      │  Prepare response:
+             │                                      │  ┌─────────────────┐
+             │                                      │  │ status | len    │
+             │                                      │  │ result...       │
+             │                                      │  └─────────────────┘
+             │                                      │
+             │◀═══════════════════ RDMA SEND ═══════│
+             │                                      │
+```
+
+**Source:**
+
+- `lib/daemon/dispatcher/cpu_dispatcher.cpp`,
+- `lib/network/channels/roce/roce_channel.cpp`
+
+### 6.3 Dispatcher Loop
+
+```text
+┌───────────────────────────────────────────────────────────────────┐
+│  CPUDispatcher::polling_worker_thread(core_id)                    │
+├───────────────────────────────────────────────────────────────────┤
+│                                                                   │
+│    while (running_) {                                             │
+│        Buffer* buffers[32];                                       │
+│        n = channel_->receive_burst(buffers, 32);  ◀── poll ring   │
+│                                                                   │
+│        if (n == 0) { yield(); continue; }                         │
+│                                                                   │
+│        for (i = 0; i < n; i++) {                                  │
+│            process_packet(buffers[i]);                            │
+│        }                                                          │
+│    }                                                              │
+│                                                                   │
+├───────────────────────────────────────────────────────────────────┤
+│  process_packet(buffer):                                          │
+│                                                                   │
+│    header = (RPCHeader*) buffer->get_data()                       │
+│    func   = registry_->lookup(header->function_id)                │
+│                                                                   │
+│    InputStream  in(args_ptr, header->arg_len)    ← zero-copy      │
+│    OutputStream out(buffer, capacity)            ← same buffer    │
+│                                                                   │
+│    status = func->cpu_function(in, out)          ← user code      │
+│                                                                   │
+│    response = buffer->prepend(sizeof(RPCResponse))                │
+│    response->status = status                                      │
+│    response->result_len = out.bytes_written()                     │
+│                                                                   │
+│    channel_->send_burst(&buffer, 1)              ← RDMA SEND      │
+│                                                                   │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+**Source:** `lib/daemon/dispatcher/cpu_dispatcher.cpp`
+
+### 6.4 Ring Buffer Memory Layout
+
+The server exposes a ring buffer for clients to write into via RDMA.
+
+```text
+vaddr (exported to client)
+    │
+    ▼
+    ┌─────────────────────────────────────────────────────────────┐
+    │  Header (64 bytes)                                          │
+    │    magic, version, num_slots, slot_size                     │
+    ├─────────────────────────────────────────────────────────────┤
+    │  Slot 0                                                     │
+    │  ┌─────────┬─────────┬─────────┬───────────────────────────┐│
+    │  │ seq# 8B │ len 4B  │ pad 4B  │ payload (up to 2032B)     ││
+    │  └─────────┴─────────┴─────────┴───────────────────────────┘│
+    ├─────────────────────────────────────────────────────────────┤
+    │  Slot 1                                                     │
+    │  ┌─────────┬─────────┬─────────┬───────────────────────────┐│
+    │  │ seq# 8B │ len 4B  │ pad 4B  │ payload                   ││
+    │  └─────────┴─────────┴─────────┴───────────────────────────┘│
+    ├─────────────────────────────────────────────────────────────┤
+    │  ...                                                        │
+    ├─────────────────────────────────────────────────────────────┤
+    │  Slot N-1                                                   │
+    └─────────────────────────────────────────────────────────────┘
+
+Detection mechanism:
+────────────────────
+  Server polls: slot[current].seq# == expected_seq# ?
+  
+  • No  → no data, return NULL
+  • Yes → data ready, return pointer to payload (zero-copy)
+          advance: current_slot++, expected_seq++
+
+Why this works:
+───────────────
+  • Client writes payload first, then seq# (memory barrier)
+  • Server sees seq# update → payload is guaranteed visible
+  • No interrupts, no CQ polling, no CPU notification needed
+```
+
+**Source:**
+
+- `include/cudaq/nvqlink/network/channels/roce/roce_ring_buffer.h`,
+- `examples/roce/roce_daemon_client.cpp`
+
+## 7. Deployment View
+
+### 7.1 Infrastructure Overview
+
+WIP
+
+### 7.2 Hardware Requirements
+
+| Component | Production | Development |
+|-----------|------------|-------------|
+| **NIC** | Mellanox ConnectX (RoCE v2) | Any NIC with Soft-RoCE (rxe) support |
+| **CPU** | Multi-core with RT capabilities | Any x86_64 |
+| **GPU** | NVIDIA GPU with GPUDirect RDMA | Optional (can use CPU mode) |
+| **Network** | Lossless Ethernet (PFC/ECN) | Standard Ethernet |
+
+### 7.3 Software Requirements
+
+| Component | Requirement |
+|-----------|-------------|
+| **OS** | Linux (kernel 5.x+) |
+| **RDMA Stack** | rdma-core, libibverbs |
+| **Compiler** | GCC 9+ or Clang 10+ (C++17) |
+| **CUDA** | CUDA 12+ (optional, for GPU mode) |
+
+## 8. Cross-cutting Concepts
+
+### 8.1 Unified Streams
+
+**Location:** `include/cudaq/nvqlink/network/serialization/`
+
+Streams provide type-safe, zero-copy serialization with dual-mode operation:
+
+**CPU Streams:**
+
+```cpp
+// Mode 1: Channel (persistent, auto packet management)
+InputStream in(channel);
+OutputStream out(channel);
+
+// Mode 2: Buffer (temporary, for Daemon RPC handlers)
+int rpc_handler(InputStream& in, OutputStream& out) {
+  int a = in.read<int>();
+  float b = in.read<float>();
+  out.write(a * b);
+  return 0;
+}
+```
+
+**GPU Streams:**
+
+```cpp
+// Mode 1: GPUChannel (persistent, in CUDA kernel)
+__global__ void my_kernel(GPUChannel* gpu_chan) {
+  GPUInputStream in(*gpu_chan);
+  GPUOutputStream out(*gpu_chan);
+  
+  while (gpu_chan->is_running()) {
+    if (in.available()) {
+      int data = in.read<int>();
+      out.write(data * 2);
+      out.flush();
+    }
+  }
+}
+
+// Mode 2: Buffer (temporary, for GPU Daemon functions)
+__global__ void gpu_rpc(char* packet_data, size_t size) {
+  GPUInputStream in(packet_data, size);
+  int value = in.read<int>();
+  // Process...
+}
+```
+
+**Design:**
+
+- Non-polymorphic (constructor determines mode for zero overhead)
+- Zero-copy via pointer arithmetic on DMA buffers
+- CPU and GPU variants share conceptual API
+- GPU version is header-only for device code
+
+### 8.2 Buffer Management
+
+**Location:** `include/cudaq/nvqlink/network/memory/`
+
+```cpp
+class Buffer {
+public:
+  Buffer(void* base_addr, size_t total_size, size_t headroom, size_t tailroom);
+  
+  void* get_data() const;
+  size_t get_data_length() const;
+  void set_data_length(size_t len);
+  void* prepend(size_t bytes);  // Add header
+  
+  void* get_base_address() const;
+  size_t get_total_size() const;
+};
+```
+
+**Memory Layout:**
+
+```text
+[Headroom | Data | Tailroom]
+ ^         ^
+ base      data_ptr
+```
+
+**Key Features:**
+
+- Pre-allocated pools (no allocation in hot path)
+- Headroom/tailroom for protocol headers
+- Direct NIC DMA buffer wrapping
+- Zero-copy via `reset()` method for backend-specific memory
+
+### 8.3 RoCE/RDMA Backend
+
+**Location:** `include/cudaq/nvqlink/network/channels/roce/`
+
+The RoCE backend implements RDMA communication using Unreliable Connection (UC) mode with memory polling:
+
+**Components:**
+
+- **RoCEChannel**: UC queue pairs, self-contained IB resources
+- **RingBuffer**: Fixed-size slots for RDMA WRITE targets
+- **VerbsContext**: Optional shared IB context and PD
+- **VerbsFlowSwitch**: Hardware flow steering via `ibv_create_flow()`
+
+**Key Features:**
+
+- UC mode: Connection-oriented, no ACKs (low latency)
+- Memory polling: Direct sequence number checks (no CQ overhead)
+- Zero-copy: Direct memory access, no packet copies
+- Soft-RoCE (rxe) supported for development
+- Hardware RoCE NICs supported for production
+
+### 8.4 Configuration
+
+**Location:** `include/cudaq/nvqlink/config.h` (umbrella header)
+
+```cpp
+// Network Config (network/config.h)
+struct ChannelConfig {
+  std::string nic_device;
+  uint32_t queue_id;
+  size_t pool_size_bytes{64 * 1024 * 1024};
+  size_t buffer_size_bytes{2048};
+  size_t headroom_bytes{256};
+  size_t tailroom_bytes{64};
+};
+
+// Daemon Config (daemon/config.h)
+enum class DatapathMode { CPU, GPU };
+
+struct DaemonConfig {
+  std::string id;
+  DatapathMode datapath_mode;
+  ComputeConfig compute;
+  bool is_valid() const;
+};
+
+// QCS Config (qcs/config.h)
+struct QCSDeviceConfig {
+  std::string name;
+  uint16_t control_port{9999};
+  bool is_valid() const;
+};
+```
+
+## 9. Architecture Decisions
+
+### 9.1 UC Mode over RC Mode
+
+**Context:** RDMA offers Reliable Connection (RC) and Unreliable Connection
+(UC) modes.
+
+**Decision:** Use UC mode for data plane communication.
+
+**Rationale:** UC mode eliminates ACK overhead, providing lower latency at the
+cost of reliability. For our use case, the application-level protocol handles
+retries if needed, and the lossless Ethernet fabric prevents packet loss.
+
+### 9.2 Memory Polling over CQ Polling
+
+**Context:** RDMA completions can be detected via Completion Queue (CQ) polling
+or direct memory polling.
+
+**Decision:** Use memory polling with sequence numbers in the ring buffer.
+
+**Rationale:** Memory polling reduces latency by avoiding CQ overhead and
+enables direct integration with GPU polling loops.
+
+### 9.3 Non-Polymorphic Streams
+
+**Context:** Stream classes could use virtual inheritance for flexibility or
+templates for performance.
+
+**Decision:** Use non-polymorphic streams with constructor-based mode selection.
+
+**Rationale:** Eliminates virtual dispatch overhead in the hot path while
+maintaining flexibility through dual-mode construction.
+
+## 10. Quality Requirements
+
+### 10.1 Quality Tree
+
+*Note: The (1), (2), (3), (4), (5) references correspond to the top-level quality goals from section 1.2.*
+
+| Quality Category | Quality | Description | Scenario |
+|------------------|---------|-------------|----------|
+| Performance | Ultra-Low Latency (1) | RPC round-trip must complete within strict timing budgets to prevent logical errors | SC1 |
+|  | Throughput | System must sustain high packet processing rates during peak syndrome streaming | SC2 |
+|  | Zero Overhead (4) | No memory allocation, exception handling, or virtual dispatch in the packet processing path |  |
+| Flexibility | Extensibility (2) | QCS vendors can integrate proprietary hardware without exposing instruction set details or requiring core changes | SC3, SC4 |
+|  | Productivity (5) | Researchers can develop and test QEC protocols without physical hardware access | SC5 |
+| Maintainability | Testability | Core components must be testable in isolation without hardware dependencies | SC6 |
+|  | Code Quality | Codebase follows modern C++ patterns with RAII resource management and no hot path allocations |  |
+| Scalability | Linear Scaling (3) | Adding GPUs increases throughput linearly for parallel window processing |  |
+
+### 10.2 Quality Scenarios
+
+| ID | Scenario |
+|----|----------|
+| SC1 | A QEC decoder receives syndrome data and returns corrections with < 10 µs round-trip latency (p99) under sustained load |
+| SC2 | During peak syndrome streaming at 1 MHz, the system processes > 1M packets/second without dropping data |
+| SC3 | A developer implements a new Channel backend (e.g., for a new network technology) in less than 1 day |
+| SC4 | A QCS vendor integrates their proprietary PPU firmware by implementing a custom Channel; no changes to NVQLink core are required |
+| SC5 | A researcher develops a new AI-based decoder on their laptop using VPPU simulation; the same code deploys to physical hardware by changing only a config flag |
+| SC6 | Unit test coverage exceeds 80% of core components, with all tests runnable without RDMA hardware via mock channels |
+
+### 10.3 Performance Characteristics
+
+#### Zero-Allocation Hot Path
+
+- Buffer pools pre-allocated at initialization
+- No malloc/free during packet processing
+- No exception throwing in critical paths
+- Lock-free where possible (ring buffer polling)
+
+#### Low Latency Design
+
+- **Memory polling**: Direct sequence number checks (no CQ polling overhead)
+- **UC mode RDMA**: No ACKs or flow control
+- **Batch processing**: Receive multiple packets per poll cycle
+- **Direct dispatch**: Minimal indirection from NIC to user function
+
+#### Scalability
+
+- **Multiple queues**: Each `Channel` owns one queue, create multiple `Channels` for parallelism
+- **CPU pinning**: Configure which cores process which queues
+- **GPU offload**: Persistent kernels for GPU-side packet processing
+- **Hardware flow steering**: NIC-level packet routing to queues
+
+## 11. Risks and Technical Debt
+
+WIP
+
+## 12. Glossary
+
+| Term | Definition |
+|------|------------|
+| **CQ** | Completion Queue - RDMA queue for work request completions |
+| **GID** | Global Identifier - 128-bit address for RDMA communication |
+| **HPC** | High-Performance Computing |
+| **libibverbs** | Linux RDMA user-space API library |
+| **PD** | Protection Domain - RDMA security/isolation boundary |
+| **PPU** | Pulse Processing Unit - processor within QCS |
+| **QCS** | Quantum Control System - FPGA/processor controlling the QPU |
+| **QEC** | Quantum Error Correction |
+| **QP** | Queue Pair - RDMA send/receive queue combination |
+| **QPN** | Queue Pair Number - identifier for a QP |
+| **QPU** | Quantum Processing Unit - the physical quantum hardware |
+| **RC** | Reliable Connection - RDMA transport mode with ACKs |
+| **RDMA** | Remote Direct Memory Access |
+| **rkey** | Remote Key - RDMA memory access permission key |
+| **RoCE** | RDMA over Converged Ethernet |
+| **RTH** | Real-time Host - HPC node running NVQLink |
+| **UC** | Unreliable Connection - RDMA transport mode without ACKs |
+| **vaddr** | Virtual Address - memory address for RDMA operations |
+| **VPPU** | Virtual PPU - software emulation of PPU for development |
+
+## Appendix A: Usage Patterns
+
+### A.1 RPC Server (Daemon Mode)
+
+```cpp
+#include "cudaq/nvqlink/daemon/daemon.h"
+#include "cudaq/nvqlink/network/channels/roce/roce_channel.h"
+#include "cudaq/nvqlink/qcs/qcs_device.h"
+
+// Application callbacks
+int process(int input) { return input * 2; }
+void handle_data(const Data& in, Result& out) { /* ... */ }
+
+int main() {
+  // 1. Create Channel (data plane)
+  auto flow_switch = std::make_shared<VerbsFlowSwitch>();
+  auto channel = std::make_unique<RoCEChannel>("mlx5_0", 9000, flow_switch);
+  channel->initialize();
+  
+  // 2. Create QCS control plane (UDP)
+  QCSDeviceConfig qcs_config;
+  qcs_config.control_port = 9999;
+  QCSDevice qcs(qcs_config);
+  
+  // Exchange RDMA parameters over UDP
+  qcs.establish_connection(channel.get());
+  
+  // 3. Create Daemon (owns channel)
+  DaemonConfig daemon_config;
+  daemon_config.id = "my_server";
+  daemon_config.datapath_mode = DatapathMode::CPU;
+  daemon_config.compute.cpu_cores = {0};
+  
+  Daemon daemon(daemon_config, std::move(channel));
+  
+  // 4. Register functions
+  daemon.register_function(NVQLINK_RPC_HANDLE(process));
+  daemon.register_function(NVQLINK_RPC_HANDLE(handle_data));
+  
+  // 5. Start data plane
+  daemon.start();
+  
+  // 6. Trigger program execution (control plane)
+  qcs.trigger();  // Sends START command via UDP
+  
+  // 7. Run
+  while (running) {
+    sleep(1);
+    auto stats = daemon.get_stats();
+    std::cout << "RX: " << stats.packets_received << std::endl;
+  }
+  
+  daemon.stop();
+  qcs.disconnect();
+}
+```
+
+### A.2 Direct I/O (Channel Mode)
+
+```cpp
+#include "cudaq/nvqlink/network/channels/roce/roce_channel.h"
+#include "cudaq/nvqlink/network/serialization/input_stream.h"
+#include "cudaq/nvqlink/network/serialization/output_stream.h"
+
+int main() {
+  // Create channel
+  auto channel = std::make_unique<RoCEChannel>("mlx5_0", 9000, flow_switch);
+  channel->initialize();
+  
+  // Create persistent streams
+  InputStream in(*channel);
+  OutputStream out(*channel);
+  
+  // Custom protocol loop
+  while (running) {
+    if (in.available()) {
+      // Read request
+      uint32_t cmd = in.read<uint32_t>();
+      float value = in.read<float>();
+      
+      // Process
+      float result = process(cmd, value);
+      
+      // Write response
+      out.write(result);
+      out.flush();  // Sends packet
+    }
+  }
+  
+  channel->cleanup();
+}
+```
+
+### A.3 GPU Mode
+
+```cpp
+#include "cudaq/nvqlink/network/gpu_channel.h"
+
+__global__ void gpu_processing(GPUChannel* gpu_chan) {
+  GPUInputStream in(*gpu_chan);
+  GPUOutputStream out(*gpu_chan);
+  
+  while (gpu_chan->is_running()) {
+    if (in.available()) {
+      int data = in.read<int>();
+      
+      // GPU processing
+      int result = data * threadIdx.x;
+      
+      out.write(result);
+      out.flush();
+    }
+  }
+}
+
+int main() {
+  auto channel = std::make_unique<RoCEChannel>(...);
+  channel->initialize();
+  
+  GPUChannel gpu_chan(std::move(channel));
+  
+  // Launch persistent kernel
+  gpu_chan.start_kernel(gpu_processing, blocks, threads);
+  
+  // Kernel runs until stopped
+  while (running) { sleep(1); }
+  
+  gpu_chan.stop_kernel();
+}
+```
+
+## Appendix B: Directory Structure
+
+```text
+cudaq-qclink/
+├── include/cudaq/nvqlink/
+│   ├── nvqlink.h                     # Main public API
+│   ├── config.h                      # Umbrella config header
+│   ├── compiler.h                    # CUDA-Q compiler integration
+│   ├── device.h                      # device_ptr struct (legacy)
+│   ├── lqpu.h                        # LQPU configuration
+│   │
+│   ├── daemon/                       # Layer 2: RPC Service
+│   │   ├── daemon.h                  # Main Daemon class
+│   │   ├── config.h                  # DaemonConfig, ComputeConfig
+│   │   ├── dispatcher/
+│   │   │   ├── dispatcher.h          # Abstract dispatcher
+│   │   │   ├── cpu_dispatcher.h      # CPU packet processing
+│   │   │   └── gpu_dispatcher.h      # GPU persistent kernel
+│   │   └── registry/
+│   │       ├── function_registry.h   # Function lookup
+│   │       ├── function_traits.h     # Type inference
+│   │       ├── function_wrapper.h    # Automatic marshalling
+│   │       └── rpc_builder.h         # RPC handle macro
+│   │
+│   ├── network/                      # Layer 1: Transport
+│   │   ├── channel.h                 # Abstract Channel interface
+│   │   ├── config.h                  # ChannelConfig, MemoryConfig
+│   │   ├── gpu_channel.h             # GPU-controlled datapath
+│   │   ├── memory/
+│   │   │   ├── buffer.h              # Buffer abstraction
+│   │   │   ├── buffer_handle.h       # RAII buffer wrapper
+│   │   │   └── memory_pool.h         # Pre-allocated buffer pool
+│   │   ├── roce/                     # RoCE/RDMA backend
+│   │   │   ├── roce_channel.h        # RoCE Channel implementation
+│   │   │   ├── roce_buffer_pool.h    # RoCE-specific buffer pool
+│   │   │   ├── roce_ring_buffer.h    # RDMA ring buffer
+│   │   │   └── verbs_context.h       # Shared ibv resources
+│   │   ├── serialization/            # Type-safe streams
+│   │   │   ├── input_stream.h        # CPU input stream
+│   │   │   ├── output_stream.h       # CPU output stream
+│   │   │   ├── gpu_input_stream.h    # GPU input stream
+│   │   │   └── gpu_output_stream.h   # GPU output stream
+│   │   └── steering/
+│   │       ├── flow_switch.h         # Abstract flow steering
+│   │       └── verbs_flow_switch.h   # libibverbs flow steering
+│   │
+│   ├── qcs/                          # Layer 3: Control Plane
+│   │   ├── config.h                  # QCSDeviceConfig
+│   │   ├── qcs_device.h              # QCS connection management
+│   │   └── control_server.h          # UDP control protocol
+│   │
+│   ├── compilers/                    # CUDA-Q integration
+│   │   └── cudaq/
+│   │       ├── cudaq.h
+│   │       └── cudaq_toolchain.h
+│   │
+│   └── utils/                        # Utilities
+│       ├── extension_point.h
+│       └── instrumentation/
+│           ├── domains.h
+│           ├── logger.h
+│           ├── nvtx.h
+│           ├── profiler.h
+│           ├── quill_logger.h
+│           └── tracy.h
+│
+├── lib/                              # Implementations
+│   ├── nvqlink.cpp
+│   ├── compiler.cpp
+│   ├── daemon/
+│   ├── network/
+│   ├── qcs/
+│   ├── compilers/cudaq/
+│   └── utils/
+│
+├── examples/                         # Example applications
+│   ├── mock/                         # Development examples
+│   └── roce/                         # Production examples
+│
+└── unittests/                        # Unit tests
+    ├── test_daemon.cpp
+    ├── test_streams.cpp
+    └── test_utils/
+```
+
+## Appendix C: Testing
+
+### Unit Tests
+
+**Location:** `unittests/`
+
+- **test_daemon.cpp**: Daemon lifecycle, function registration, configuration
+- **test_streams.cpp**: Serialization/deserialization, type safety
+- **LoopbackChannel**: In-memory channel for hardware-independent testing
+
+All tests use GoogleTest framework and run without hardware dependencies.
+
+### Examples
+
+**Location:** `examples/`
+
+- **mock/**: Development examples using in-memory channels
+- **roce/**: Production examples using RoCE/RDMA
+  - `roce_daemon`: Full RPC server
+  - `roce_channel`: Direct I/O mode
+  - Clients for both modes

--- a/realtime/docs/example.md
+++ b/realtime/docs/example.md
@@ -1,0 +1,222 @@
+# This document is a work in progress, and it is not yet implemented
+
+# End-to-End Example: Quantum Kernel with device_call
+
+This example shows how a QEC decoder callback would work in the new architecture.
+
+## Two Planes: Control vs Data
+
+```text
+RTH (HPC Node)
+┌────────────────────────────────────────────────────────────────────┐
+│                                                                    │
+│  CONTROL PLANE (UDP)                DATA PLANE (RoCE)              │
+│  ───────────────────                ─────────────────              │
+│  ┌────────────────────┐             ┌────────────────────┐         │
+│  │  QCSDevice         │             │  Daemon            │         │
+│  │  ────────────────  │             │  ────────────────  │         │
+│  │  • ControlServer   │             │  • FunctionRegistry│         │
+│  │    (UDP socket)    │ configures  │  • Dispatcher      │         │
+│  │  • upload_program()│────────────►│  • Callbacks       │         │
+│  │  • trigger()       │             │                    │         │
+│  └─────────┬──────────┘             └─────────┬──────────┘         │
+│            │                                  │                    │
+│            │ UDP                              │ owns               │
+│            │                                  ▼                    │
+│            │                    ┌─────────────────────────────┐    │
+│            │                    │     Channel (RoCE)          │    │
+│            │                    │  • Ring buffer for packets  │    │
+│            │                    │  • RDMA WRITE/SEND          │    │
+│            │                    └──────────────┬──────────────┘    │
+└────────────┼───────────────────────────────────┼───────────────────┘
+             │                                   │
+             │ UDP (out-of-band)                 │ RDMA (data path)
+             │ • Exchange QPN, GID, rkey         │ • device_call packets
+             │ • START/STOP commands             │ • Results
+             │ • Program upload (optional)       │
+             ▼                                   ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  QCS (FPGA / Pulse Processor)                                        │
+│  ┌─────────────────────┐    ┌──────────────────────────────────────┐ │
+│  │  UDP Client         │    │  RDMA Engine (HoloLink)              │ │
+│  │  • Receives params  │    │  • RDMA WRITE for device_call        │ │
+│  │  • Receives START   │    │  • Receives RDMA SEND results        │ │
+│  └─────────────────────┘    └──────────────────────────────────────┘ │
+│                                                                      │
+│  Pulse Processor: executes quantum gates, triggers device_call       │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The Control Plane uses simple **UDP sockets** to exchange RDMA connection
+parameters (QPN, GID, vaddr, rkey) and send commands. This configures the Data
+Plane's **RoCE Channel** before data transfer begins.
+
+## The Quantum Kernel (CUDA-Q side)
+
+```cpp
+// qec_kernel.cpp - Compiled for the QSC/FPGA
+#include "cudaq.h"
+
+// Declare device callbacks (implemented on RTH)
+extern "C" void decoder_enqueue(uint64_t syndrome);
+extern "C" bool decoder_get_correction();
+
+__qpu__ void qec_cycle(cudaq::qvector<>& data, cudaq::qvector<>& ancilla, int rounds) {
+  for (int r = 0; r < rounds; ++r) {
+    // Stabilizer measurement circuit
+    // ... (gates on data and ancilla)
+    
+    auto syndrome = mz(ancilla);
+    
+    // Send syndrome to RTH for decoding
+    cudaq::device_call(/*device_id=*/0, decoder_enqueue, cudaq::to_integer(syndrome));
+  }
+  
+  // Get final correction from decoder
+  bool need_correction = cudaq::device_call(/*device_id=*/0, decoder_get_correction);
+  
+  if (need_correction) {
+    x(data[0]);  // Apply correction
+  }
+}
+```
+
+The compiler lowers `cudaq::device_call` to RDMA operations that send packets
+to the RTH.
+
+## The RTH Server
+
+```cpp
+// rth_qec_server.cpp - Complete RTH setup
+#include "cudaq/nvqlink/daemon/daemon.h"
+#include "cudaq/nvqlink/channel/roce/roce_channel.h"
+#include "cudaq/nvqlink/qcs/qcs_device.h"        // NEW: QCS control plane
+#include "cudaq/nvqlink/qcs/control_server.h"    // NEW: RDMA handshake
+
+using namespace cudaq::nvqlink;
+
+//=============================================================================
+// CALLBACKS (registered with Daemon - data plane)
+//=============================================================================
+
+class Decoder {
+  std::vector<uint64_t> syndromes_;
+public:
+  void enqueue(uint64_t syndrome) { syndromes_.push_back(syndrome); }
+  bool get_correction() { return decode_syndromes(syndromes_); }
+};
+
+Decoder decoder;
+
+void decoder_enqueue(uint64_t syndrome) { decoder.enqueue(syndrome); }
+bool decoder_get_correction() { return decoder.get_correction(); }
+
+//=============================================================================
+// MAIN
+//=============================================================================
+
+int main() {
+  //===========================================================================
+  // STEP 1: Create RoCE Channel (DATA PLANE transport)
+  // Channel is NOT initialized yet - needs RDMA params from control plane
+  //===========================================================================
+  auto flow_switch = std::make_shared<VerbsFlowSwitch>();
+  auto channel = std::make_unique<RoCEChannel>("mlx5_0", 9000, flow_switch);
+  
+  // Initialize local resources (QP, buffers) but not connected yet
+  channel->initialize();
+  
+  //===========================================================================
+  // STEP 2: Create QCS Device (CONTROL PLANE - uses UDP, not RoCE)
+  // This handles: RDMA parameter exchange, program upload, execution trigger
+  //===========================================================================
+  QCSDeviceConfig qcs_config;
+  qcs_config.control_port = 9999;        // UDP port for out-of-band signaling
+  
+  QCSDevice qcs_device(qcs_config);      // Uses its own UDP socket
+  
+  // Start UDP control server and wait for QCS to connect
+  std::cout << "Waiting for QCS connection on UDP port 9999...\n";
+  
+  // This does the RDMA handshake over UDP:
+  // 1. QCS sends DISCOVER packet
+  // 2. RTH sends: {QPN, GID, vaddr, rkey} (channel's connection params)
+  // 3. QCS sends: {QPN, GID} (its connection params)
+  // 4. RTH configures channel with remote QP info
+  qcs_device.establish_connection(channel.get());  // Configures the channel!
+  
+  std::cout << "QCS connected! RDMA data path ready.\n";
+  
+  //===========================================================================
+  // STEP 3: Create Daemon (DATA PLANE - uses the now-configured RoCE channel)
+  //===========================================================================
+  DaemonConfig daemon_config;
+  daemon_config.id = "qec_decoder";
+  daemon_config.mode = DatapathMode::CPU;
+  daemon_config.cpu_cores = {0};
+  
+  // Daemon takes ownership of the configured channel
+  Daemon daemon(daemon_config, std::move(channel));
+  
+  // Register callbacks
+  daemon.register_function(NVQLINK_RPC_HANDLE(decoder_enqueue));
+  daemon.register_function(NVQLINK_RPC_HANDLE(decoder_get_correction));
+  
+  // Start data plane (begins polling for RDMA packets)
+  daemon.start();
+  
+  //===========================================================================
+  // STEP 4: Upload program and trigger (via UDP control plane)
+  //===========================================================================
+  
+  // Load compiled kernel (from nvq++ compilation)
+  auto kernel = load_compiled_kernel("qec_kernel.o");
+  
+  // Upload to QCS (over UDP or separate channel - NOT the RoCE data path)
+  qcs_device.upload_program(kernel);
+  
+  std::cout << "Program uploaded. Triggering execution...\n";
+  
+  // Send START command over UDP
+  // QCS begins running quantum gates; device_call packets arrive via RDMA
+  qcs_device.trigger();
+  
+  //===========================================================================
+  // STEP 5: Run until completion or interrupt
+  //===========================================================================
+  std::cout << "QEC running. Press Ctrl+C to stop.\n";
+  
+  while (running && !qcs_device.is_complete()) {
+    sleep(1);
+    auto stats = daemon.stats();
+    std::cout << "Packets: rx=" << stats.rx << " tx=" << stats.tx << "\n";
+  }
+  
+  // Cleanup
+  daemon.stop();
+  qcs_device.disconnect();  // Sends STOP over UDP
+  
+  return 0;
+}
+```
+
+## What Happens Under the Hood
+
+1. **Compilation**: `cudaq::device_call(0, decoder_enqueue, syndrome)` becomes:
+   - Serialize: `[function_id=hash("decoder_enqueue"), args=[syndrome]]`
+   - Network op: RDMA WRITE to RTH ring buffer
+
+2. **RTH receives packet**:
+   - Daemon's dispatcher polls Channel
+   - Looks up `function_id` in FunctionRegistry
+   - Creates `InputStream` from packet buffer
+   - Calls wrapper: `decoder_enqueue_wrapper(in, out)`
+   - Wrapper auto-deserializes: `uint64_t syndrome = in.read<uint64_t>()`
+   - Calls actual function: `decoder_enqueue(syndrome)`
+   - For functions with return value: `out.write(result)`
+   - Sends response via RDMA SEND
+
+3. **FPGA receives response**:
+   - Polls for RDMA SEND completion
+   - Deserializes result
+   - Continues quantum execution

--- a/realtime/examples/doca/CMakeLists.txt
+++ b/realtime/examples/doca/CMakeLists.txt
@@ -1,0 +1,63 @@
+# DOCA Channel Examples
+# Requires NVQLINK_ENABLE_DOCA=ON
+
+if(NOT NVQLINK_ENABLE_DOCA)
+  message(STATUS "DOCA examples disabled (requires -DNVQLINK_ENABLE_DOCA=ON)")
+  return()
+endif()
+
+# Fetch nlohmann_json for UDP control server
+include(FetchContent)
+FetchContent_Declare(json
+  URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+)
+FetchContent_MakeAvailable(json)
+
+# DOCA Daemon Example (from Plan Phase 5)
+# The main file is .cpp for C++20 compatibility with daemon headers.
+# GPU functions are in a separate .cu file compiled with nvcc.
+add_executable(doca_daemon_example
+  doca_daemon_example.cpp
+  gpu_functions.cu
+)
+
+# CRITICAL: Enable CUDA separable compilation for device function pointers
+# to work across compilation units (gpu_functions.cu <-> doca_rpc_kernel.cu)
+set_target_properties(doca_daemon_example PROPERTIES
+  CUDA_SEPARABLE_COMPILATION ON
+  CUDA_RESOLVE_DEVICE_SYMBOLS ON
+)
+
+target_link_libraries(doca_daemon_example
+  PRIVATE
+    nvqlink_daemon
+    nvqlink_network
+    nlohmann_json::nlohmann_json
+)
+
+target_include_directories(doca_daemon_example
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# DOCA Client (ibverbs-based, adapted from roce_daemon_client)
+add_executable(doca_client
+  doca_client.cpp
+)
+
+target_link_libraries(doca_client
+  PRIVATE
+    ibverbs
+    nlohmann_json::nlohmann_json
+)
+
+target_include_directories(doca_client
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/examples/roce  # For roce_client_common.h
+)
+
+message(STATUS "DOCA examples enabled:")
+message(STATUS "  - doca_daemon_example")
+message(STATUS "  - doca_client")

--- a/realtime/examples/doca/doca_client.cpp
+++ b/realtime/examples/doca/doca_client.cpp
@@ -1,0 +1,436 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "roce_client_common.h"
+
+class RoCEDaemonClient : public RoCEClientBase {
+public:
+  RoCEDaemonClient(const std::string &device_name)
+      : RoCEClientBase(device_name) {
+    // Override GID index for DOCA (use RoCEv2 IPv4-mapped GID)
+    // GID index 3 = RoCEv2 with IPv4-mapped address (::ffff:192.168.100.1)
+    // This matches what DOCAChannel uses on the server side
+    gid_index_ = 3;
+  }
+
+  ~RoCEDaemonClient() {
+    if (qp_)
+      ibv_destroy_qp(qp_);
+  }
+
+  bool connect_to_server(const std::string &server_ip, uint16_t port) {
+    std::cout << "\n[CONNECT] Connecting to server " << server_ip << ":" << port
+              << " (UDP)...\n";
+
+    // Create UDP socket
+    int sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock < 0) {
+      std::cerr << "Failed to create UDP socket\n";
+      return false;
+    }
+
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    struct sockaddr_in server_addr;
+    std::memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(port);
+    inet_pton(AF_INET, server_ip.c_str(), &server_addr.sin_addr);
+
+    // Send DISCOVER
+    std::cout << "[UDP] Sending DISCOVER...\n";
+    const char *discover = "DISCOVER";
+    ssize_t sent = sendto(sock, discover, strlen(discover), 0,
+                          (struct sockaddr *)&server_addr, sizeof(server_addr));
+    if (sent < 0) {
+      std::cerr << "Failed to send DISCOVER\n";
+      close(sock);
+      return false;
+    }
+
+    // Receive channel parameters (single channel for Daemon mode)
+    char buffer[4096];
+    socklen_t addr_len = sizeof(server_addr);
+    ssize_t n = recvfrom(sock, buffer, sizeof(buffer), 0,
+                         (struct sockaddr *)&server_addr, &addr_len);
+    if (n <= 0) {
+      std::cerr << "Failed to receive channel parameters\n";
+      close(sock);
+      return false;
+    }
+
+    try {
+      nlohmann::json msg = nlohmann::json::parse(std::string(buffer, n));
+
+      remote_qpn_ = msg["qpn"];
+      remote_gid_ = string_to_gid(msg["gid"].get<std::string>());
+      server_vaddr_ = msg["vaddr"];
+      server_rkey_ = msg["rkey"];
+      num_slots_ = msg.value("num_slots", 1024);
+      slot_size_ = msg.value("slot_size", 2048);
+
+      std::cout << "[UDP] Received server params:\n";
+      std::cout << "  QPN: " << remote_qpn_ << "\n";
+      std::cout << "  GID: " << msg["gid"].get<std::string>() << "\n";
+      std::cout << "  vaddr: " << server_vaddr_ << "\n";
+      std::cout << "  rkey: " << server_rkey_ << "\n";
+      std::cout << "  Ring buffer: " << num_slots_ << " slots x " << slot_size_
+                << " bytes\n";
+
+    } catch (const std::exception &e) {
+      std::cerr << "Failed to parse server message: " << e.what() << "\n";
+      close(sock);
+      return false;
+    }
+
+    // Create QP
+    struct ibv_qp_init_attr qp_init_attr = {};
+    qp_init_attr.send_cq = send_cq_;
+    qp_init_attr.recv_cq = recv_cq_;
+    qp_init_attr.qp_type = IBV_QPT_UC;
+    qp_init_attr.cap.max_send_wr = 16;
+    qp_init_attr.cap.max_recv_wr = 16;
+    qp_init_attr.cap.max_send_sge = 1;
+    qp_init_attr.cap.max_recv_sge = 1;
+
+    qp_ = ibv_create_qp(pd_, &qp_init_attr);
+    if (!qp_) {
+      std::cerr << "Failed to create QP\n";
+      close(sock);
+      return false;
+    }
+
+    local_qpn_ = qp_->qp_num;
+
+    // Send ACK with client params
+    nlohmann::json client_params;
+    client_params["channel_idx"] = 0; // Single channel for Daemon
+    client_params["qpn"] = local_qpn_;
+    client_params["gid"] = gid_to_string(local_gid_);
+
+    std::string json_str = client_params.dump();
+    sent = sendto(sock, json_str.c_str(), json_str.length(), 0,
+                  (struct sockaddr *)&server_addr, sizeof(server_addr));
+    if (sent < 0) {
+      std::cerr << "Failed to send ACK\n";
+      close(sock);
+      return false;
+    }
+
+    std::cout << "[UDP] Sent ACK with QPN: " << local_qpn_ << "\n";
+
+    // Wait for START message
+    n = recvfrom(sock, buffer, sizeof(buffer), 0,
+                 (struct sockaddr *)&server_addr, &addr_len);
+    if (n > 0) {
+      try {
+        nlohmann::json msg = nlohmann::json::parse(std::string(buffer, n));
+        if (msg.contains("cmd") && msg["cmd"] == "START") {
+          std::cout << "[UDP] Received START from server\n";
+        }
+      } catch (const std::exception &e) {
+        // Ignore if not a valid START message
+      }
+    }
+
+    close(sock);
+
+    // Transition QP to RTS
+    std::cout << "\n[QP] Transitioning QP to RTS...\n";
+    if (!transition_qp_to_rts(qp_, remote_qpn_, remote_gid_)) {
+      return false;
+    }
+    std::cout << "QP ready (QPN: " << local_qpn_ << ")\n";
+
+    // Post receive buffers
+    for (int i = 0; i < 4; i++) {
+      if (!post_recv_buffer(qp_)) {
+        return false;
+      }
+    }
+
+    std::cout << "✓ Configuration complete!\n";
+    return true;
+  }
+
+  bool send_rpc_request(uint32_t function_id, const std::vector<uint8_t> &args,
+                        std::vector<uint8_t> &response) {
+    // Build RPC request in kernel's expected format (RPCHeader + payload):
+    // RPCHeader: [seq_num (8) | function_id (4) | payload_length (4)]
+    // Payload:   [args...]
+    //
+    // This matches the RPCHeader struct in doca_rpc_kernel.cu:
+    //   struct RPCHeader { uint64_t sequence_number; uint32_t function_id;
+    //   uint32_t payload_length; };
+    constexpr size_t RPC_HEADER_SIZE = 16; // sizeof(RPCHeader)
+    std::vector<uint8_t> slot_data(RPC_HEADER_SIZE + args.size());
+    *(uint64_t *)&slot_data[0] = seq_num_;               // sequence_number
+    *(uint32_t *)&slot_data[8] = function_id;            // function_id
+    *(uint32_t *)&slot_data[12] = (uint32_t)args.size(); // payload_length
+    if (!args.empty()) {
+      std::memcpy(&slot_data[16], args.data(), args.size()); // payload
+    }
+
+    std::cout << "\n[SEND] RPC Request (function_id=" << function_id
+              << ", payload=" << args.size() << " bytes)" << std::endl;
+
+    // Calculate target address in server's buffer
+    // NOTE: For DOCA channel, we use direct page-based addressing without a
+    // ring header. The kernel expects data at (page * page_size), where page
+    // comes from immediate data. This differs from the RoCE ring buffer model
+    // which has a 128-byte header.
+    uint32_t slot_idx = head_ % num_slots_;
+    uint64_t slot_offset =
+        slot_idx * slot_size_; // No RING_HEADER_SIZE for DOCA
+    uint64_t target_vaddr = server_vaddr_ + slot_offset;
+
+    // Allocate and register local buffer
+    void *local_buf = malloc(slot_data.size());
+    std::memcpy(local_buf, slot_data.data(), slot_data.size());
+
+    struct ibv_mr *local_mr =
+        ibv_reg_mr(pd_, local_buf, slot_data.size(),
+                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+    if (!local_mr) {
+      std::cerr << "Failed to register send buffer\n";
+      free(local_buf);
+      return false;
+    }
+
+    // Post RDMA WRITE WITH IMMEDIATE (required for DOCA GPUNetIO)
+    // The immediate data generates a CQE that the GPU kernel can poll
+    struct ibv_sge sge = {};
+    sge.addr = (uint64_t)local_buf;
+    sge.length = slot_data.size();
+    sge.lkey = local_mr->lkey;
+
+    struct ibv_send_wr wr = {};
+    wr.wr_id = send_wr_id_++;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM; // Changed from IBV_WR_RDMA_WRITE
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = target_vaddr;
+    wr.wr.rdma.rkey = server_rkey_;
+    // Immediate data: slot index in lower 12 bits (matches Python client and
+    // DOCA kernel)
+    wr.imm_data = htonl(slot_idx & 0xFFF);
+
+    struct ibv_send_wr *bad_wr = nullptr;
+    if (ibv_post_send(qp_, &wr, &bad_wr) != 0) {
+      std::cerr << "Failed to post RDMA WRITE WITH IMMEDIATE\n";
+      ibv_dereg_mr(local_mr);
+      free(local_buf);
+      return false;
+    }
+
+    // Poll for send completion
+    struct ibv_wc wc;
+    int ret;
+    do {
+      ret = ibv_poll_cq(send_cq_, 1, &wc);
+    } while (ret == 0);
+
+    if (ret < 0 || wc.status != IBV_WC_SUCCESS) {
+      std::cerr << "Send completion error: " << ibv_wc_status_str(wc.status)
+                << "\n";
+      ibv_dereg_mr(local_mr);
+      free(local_buf);
+      return false;
+    }
+
+    std::cout << "[SEND] RDMA WRITE WITH IMMEDIATE sent (seq=" << seq_num_
+              << ", slot=" << slot_idx << ", imm_data=" << (slot_idx & 0xFFF)
+              << ")\n";
+
+    // Cleanup send buffer
+    ibv_dereg_mr(local_mr);
+    free(local_buf);
+
+    // Advance ring buffer state
+    head_++;
+    seq_num_++;
+
+    // Wait for response
+    std::cout << "[RECV] Waiting for response...\n";
+
+    ret = 0;
+    int poll_count = 0;
+    const int max_polls = 5000;
+
+    while (ret == 0 && poll_count < max_polls) {
+      ret = ibv_poll_cq(recv_cq_, 1, &wc);
+      if (ret == 0) {
+        usleep(1000);
+        poll_count++;
+      }
+    }
+
+    if (ret < 0 || poll_count >= max_polls) {
+      std::cerr << "[TIMEOUT] No response received\n";
+      return false;
+    }
+
+    if (wc.status != IBV_WC_SUCCESS) {
+      std::cerr << "Receive completion error: " << ibv_wc_status_str(wc.status)
+                << "\n";
+      return false;
+    }
+
+    std::cout << "[RECV] Response received (" << wc.byte_len << " bytes)"
+              << "\n";
+
+    // Parse response matching kernel's RPCResponse struct:
+    // struct RPCResponse { uint64_t seq; int32_t status; uint32_t result_len;
+    // }; Layout: [seq_num (8) | status (4) | result_len (4) | result_data...]
+    constexpr size_t RPC_RESPONSE_HEADER_SIZE = 16; // sizeof(RPCResponse)
+    if (wc.byte_len < RPC_RESPONSE_HEADER_SIZE) {
+      std::cerr << "Response too short: " << wc.byte_len << " bytes\n";
+      return false;
+    }
+
+    uint8_t *buf = (uint8_t *)recv_buffer_;
+    uint64_t resp_seq = *(uint64_t *)&buf[0];
+    int32_t status = *(int32_t *)&buf[8];
+    uint32_t result_len = *(uint32_t *)&buf[12];
+
+    std::cout << "  Response: seq=" << resp_seq << ", status=" << status
+              << ", result_len=" << result_len << "\n";
+
+    if (status != 0) {
+      std::cerr << "RPC error: status=" << status << "\n";
+      return false;
+    }
+
+    response.assign(buf + RPC_RESPONSE_HEADER_SIZE,
+                    buf + RPC_RESPONSE_HEADER_SIZE + result_len);
+
+    // Repost receive buffer
+    post_recv_buffer(qp_);
+
+    return true;
+  }
+
+private:
+  struct ibv_qp *qp_ = nullptr;
+  uint32_t local_qpn_ = 0;
+  uint32_t remote_qpn_ = 0;
+  union ibv_gid remote_gid_ = {};
+  uint64_t server_vaddr_ = 0;
+  uint32_t server_rkey_ = 0;
+  uint32_t num_slots_ = 0;
+  uint32_t slot_size_ = 0;
+
+  // Ring buffer state
+  uint64_t seq_num_ = 1;
+  uint32_t head_ = 0;
+};
+
+// Test functions
+static bool test_add(RoCEDaemonClient &client) {
+  std::cout << "\n" << std::string(60, '=') << "\n";
+  std::cout << "TEST: Add Function (GPU)\n";
+  std::cout << std::string(60, '=') << "\n";
+
+  int32_t a = 42, b = 58;
+  int32_t expected = a + b;
+
+  std::vector<uint8_t> args(8);
+  *(int32_t *)&args[0] = a;
+  *(int32_t *)&args[4] = b;
+
+  std::cout << "  Computing: " << a << " + " << b << " = ?" << "\n";
+
+  std::vector<uint8_t> response;
+  // Function ID 2 matches daemon's gpu_add_numbers registration
+  if (!client.send_rpc_request(2, args, response)) {
+    std::cout << "FAIL: No response\n";
+    return false;
+  }
+
+  if (response.size() < 4) {
+    std::cout << "FAIL: Response too short\n";
+    return false;
+  }
+
+  int32_t result = *(int32_t *)&response[0];
+
+  std::cout << "  Server returned: " << result << "\n";
+
+  if (result == expected) {
+    std::cout << "SUCCESS: " << a << " + " << b << " = " << result
+              << " (correct!)" << "\n";
+    return true;
+  } else {
+    std::cout << "FAIL: Expected " << expected << ", got " << result << "\n";
+    return false;
+  }
+}
+
+int main(int argc, char **argv) {
+  std::cout << std::string(60, '=') << "\n";
+  std::cout << " DOCA Daemon Client (libibverbs)" << "\n";
+  std::cout << " Tests GPU RPC function via real RDMA QP" << "\n";
+  std::cout << std::string(60, '=') << "\n";
+
+  std::string device_name = "mlx5_1";
+  std::string server_ip = "192.168.100.1";
+  uint16_t server_port = 9999;
+
+  if (argc > 1)
+    device_name = argv[1];
+  if (argc > 2)
+    server_ip = argv[2];
+
+  std::cout << "\nConfiguration:\n";
+  std::cout << "  Device: " << device_name << "\n";
+  std::cout << "  Server: " << server_ip << ":" << server_port << "\n\n";
+
+  try {
+    RoCEDaemonClient client(device_name);
+
+    if (!client.initialize()) {
+      return 1;
+    }
+
+    if (!client.connect_to_server(server_ip, server_port)) {
+      return 1;
+    }
+
+    // Run test
+    int success_count = 0;
+    int total_tests = 1;
+
+    if (test_add(client)) {
+      success_count++;
+    }
+
+    // Summary
+    std::cout << "\n" << std::string(60, '=') << "\n";
+    std::cout << "TEST SUMMARY: " << success_count << "/" << total_tests
+              << " tests passed" << "\n";
+    std::cout << std::string(60, '=') << "\n";
+
+    if (success_count == total_tests) {
+      std::cout << "Test passed! DOCA daemon GPU RPC working!\n";
+      return 0;
+    } else {
+      std::cout << "/!\\ Test failed.\n";
+      return 1;
+    }
+
+  } catch (const std::exception &e) {
+    std::cerr << "\nError: " << e.what() << "\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/realtime/examples/doca/doca_daemon_example.cpp
+++ b/realtime/examples/doca/doca_daemon_example.cpp
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "doca_udp_control.h"
+#include "cudaq/nvqlink/daemon/config.h"
+#include "cudaq/nvqlink/daemon/daemon.h"
+#include "cudaq/nvqlink/network/channels/doca/doca_channel.h"
+#include "cudaq/nvqlink/network/channels/doca/doca_channel_config.h"
+
+#include <chrono>
+#include <csignal>
+#include <iostream>
+#include <string>
+#include <thread>
+
+using namespace cudaq::nvqlink;
+
+//==============================================================================
+// Example RPC Function: Add Two Numbers
+//==============================================================================
+
+// GPU function is defined in gpu_functions.cu (compiled with nvcc)
+// This external function retrieves the proper device function pointer
+extern "C" void *get_gpu_add_function_ptr();
+
+//==============================================================================
+// Signal Handling
+//==============================================================================
+
+static volatile bool running = true;
+
+void signal_handler(int signal) {
+  std::cout << "\nReceived signal " << signal << ", shutting down...\n";
+  running = false;
+}
+
+//==============================================================================
+// Main Example
+//==============================================================================
+
+int main(int argc, char *argv[]) {
+  std::cout << "=================================================\n"
+            << "NVQLink DOCA Daemon Example\n"
+            << "=================================================\n"
+            << std::endl;
+
+  // Set up signal handling
+  std::signal(SIGINT, signal_handler);
+  std::signal(SIGTERM, signal_handler);
+
+  // Parse simple arguments
+  std::string nic_device = "mlx5_1";
+  std::string peer_ip;
+
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--nic" && i + 1 < argc)
+      nic_device = argv[++i];
+    else if (arg == "--peer" && i + 1 < argc)
+      peer_ip = argv[++i];
+  }
+
+  try {
+    std::cout << "Step 1: Creating DOCA channel..." << std::endl;
+
+    // Create DOCA channel (from Plan lines 975-980)
+    DOCAChannelConfig doca_config;
+    doca_config.nic_device = nic_device;
+    doca_config.peer_ip = peer_ip;
+    doca_config.page_size = 4096;
+    doca_config.num_pages = 1024;
+    doca_config.max_rpc_size =
+        4096; // Must be non-zero for RDMA WRITE WITH IMMEDIATE
+
+    auto channel = std::make_unique<DOCAChannel>(doca_config);
+    channel->initialize();
+
+    std::cout << "  ✓ Channel initialized" << std::endl;
+
+    //===--------------------------------------------------------------------===
+    // Exchange connection parameters via UDP control plane
+    //===--------------------------------------------------------------------===
+
+    std::cout << "\nStep 2: Exchanging connection parameters..." << std::endl;
+
+    DOCAUDPControlServer control_server(9999);
+    control_server.start();
+
+    if (!control_server.exchange_params(channel.get(), &running)) {
+      std::cerr << "Failed to exchange connection parameters\n";
+      return 1;
+    }
+
+    std::cout << "Connection parameters exchanged\n";
+
+    // Verify QP is connected
+    if (!channel->is_connected()) {
+      std::cerr << "Channel not connected after parameter exchange!\n";
+      return 1;
+    }
+    std::cout << "QP is in connected state (RTS)\n";
+
+    //===--------------------------------------------------------------------===
+    // Create daemon with GPU datapath
+    //===--------------------------------------------------------------------===
+
+    std::cout << "\nStep 3: Creating daemon with GPU datapath...\n";
+
+    DaemonConfig daemon_config;
+    daemon_config.id = "qec_decoder";
+    daemon_config.datapath_mode = DatapathMode::GPU;
+    daemon_config.compute.gpu_device_id = 0;
+
+    std::cout << "  Daemon ID:   " << daemon_config.id << "\n";
+    std::cout << "  Datapath:    GPU\n";
+
+    Daemon daemon(daemon_config, std::move(channel));
+
+    //===--------------------------------------------------------------------===
+    // Register functions (from Plan lines 992)
+    //===--------------------------------------------------------------------===
+
+    std::cout << "\nStep 4: Registering RPC functions...\n";
+
+    // Register GPU function
+    // Function ID must match client's FUNCTION_ADD = 2
+    //
+    // CRITICAL: Use get_gpu_add_function_ptr() to get the DEVICE function
+    // pointer! The GPU function is defined in gpu_functions.cu and compiled
+    // with nvcc. Taking &device_function directly from host code gives a HOST
+    // address, which causes undefined behavior when the GPU tries to call it.
+    void *device_func_ptr = get_gpu_add_function_ptr();
+    if (!device_func_ptr) {
+      throw std::runtime_error("Failed to get GPU function pointer");
+    }
+
+    FunctionMetadata gpu_add_meta;
+    gpu_add_meta.function_id = 2; // Must match client's FUNCTION_ADD
+    gpu_add_meta.name = "gpu_add_numbers";
+    gpu_add_meta.type = FunctionType::GPU;
+    gpu_add_meta.max_result_size = 128;
+    gpu_add_meta.gpu_function = device_func_ptr;
+
+    daemon.register_function(gpu_add_meta);
+    std::cout << "Registered: gpu_add_numbers (GPU, function_id=2)\n";
+
+    //===--------------------------------------------------------------------===
+    // Start daemon
+    //===--------------------------------------------------------------------===
+
+    std::cout << "\nStep 5: Starting daemon...\n";
+    daemon.start();
+
+    std::cout << "\n=================================================\n"
+              << "Daemon is running!\n"
+              << "=================================================\n\n";
+
+    std::cout << "The GPU kernel is now polling for RPC requests.\n"
+              << "GPU has direct control of the NIC (zero CPU involvement).\n\n"
+              << "Press Ctrl+C to stop the daemon.\n\n";
+
+    //===--------------------------------------------------------------------===
+    // Run Until Interrupted
+    //===--------------------------------------------------------------------===
+
+    while (running) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    //===--------------------------------------------------------------------===
+    // Shutdown
+    //===--------------------------------------------------------------------===
+
+    std::cout << "\nShutting down daemon...\n";
+    daemon.stop();
+    std::cout << "Daemon stopped\n";
+
+    std::cout << "\n=================================================\n"
+              << "Example completed successfully!\n"
+              << "=================================================\n\n";
+
+    return 0;
+
+  } catch (const std::exception &e) {
+    std::cerr << "\nError: " << e.what() << "\n";
+    return 1;
+  }
+}

--- a/realtime/examples/doca/doca_udp_control.h
+++ b/realtime/examples/doca/doca_udp_control.h
@@ -1,0 +1,262 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/channels/doca/doca_channel.h"
+
+#include <arpa/inet.h>
+#include <cstdint>
+#include <cstring>
+#include <errno.h>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <nlohmann/json.hpp>
+
+/// @brief UDP Control Server for DOCA Channel connection setup
+///
+/// Adapted from RoCE UDPControlServer for DOCAChannel.
+/// Server-driven protocol: Server sends channel params, waits for client ACK.
+///
+/// Protocol flow:
+///   1. Client → Server: Discovery packet (UDP)
+///   2. Server → Client: Connection params (JSON)
+///   3. Client → Server: ACK with client params (JSON)
+///   4. Server → Client: START message (JSON)
+///
+class DOCAUDPControlServer {
+public:
+  DOCAUDPControlServer(uint16_t port)
+      : port_(port), sock_fd_(-1), client_connected_(false) {
+    std::memset(&client_addr_, 0, sizeof(client_addr_));
+  }
+
+  ~DOCAUDPControlServer() {
+    if (sock_fd_ >= 0)
+      close(sock_fd_);
+  }
+
+  /// @brief Start listening on the control port (UDP)
+  void start() {
+    // Create UDP socket
+    sock_fd_ = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock_fd_ < 0)
+      throw std::runtime_error("Failed to create UDP socket");
+
+    // Allow address reuse
+    int opt = 1;
+    setsockopt(sock_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    // Bind to port
+    struct sockaddr_in addr = {};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons(port_);
+
+    if (bind(sock_fd_, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+      throw std::runtime_error("Failed to bind UDP socket");
+
+    std::cout << "[UDP] Control server listening on port " << port_ << "\n";
+  }
+
+  /// @brief Exchange connection parameters with client
+  ///
+  /// Protocol:
+  ///   1. Wait for client discovery packet
+  ///   2. Send server params (QPN, GID, vaddr, rkey, num_slots, slot_size)
+  ///   3. Wait for client ACK with client params (QPN, GID)
+  ///   4. Configure QP with client params
+  ///   5. Send START message
+  ///
+  /// @param channel DOCA channel to configure
+  /// @param running_flag Pointer to flag for checking if server should keep
+  /// running
+  /// @return true if exchange succeeded, false otherwise
+  bool exchange_params(cudaq::nvqlink::DOCAChannel *channel,
+                       volatile bool *running_flag) {
+    std::cout << "[UDP] Waiting for client...\n";
+
+    // Set receive timeout to allow checking running flag
+    struct timeval tv;
+    tv.tv_sec = 1;
+    tv.tv_usec = 0;
+    setsockopt(sock_fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    try {
+      // Step 1: Wait for client discovery packet
+      if (!client_connected_) {
+        char buf[4096];
+        socklen_t len = sizeof(client_addr_);
+
+        std::cout << "  [WAIT] Waiting for client discovery packet..."
+                  << std::endl;
+
+        while (*running_flag) {
+          ssize_t n = recvfrom(sock_fd_, buf, sizeof(buf), 0,
+                               (struct sockaddr *)&client_addr_, &len);
+
+          if (n < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+              continue; // Timeout, check running flag
+            throw std::runtime_error("Failed to receive discovery packet");
+          }
+
+          // Got discovery packet
+          std::cout << "  ✓ Client discovered: "
+                    << inet_ntoa(client_addr_.sin_addr) << ":"
+                    << ntohs(client_addr_.sin_port) << "\n";
+          client_connected_ = true;
+          break;
+        }
+
+        if (!client_connected_)
+          return false;
+      }
+
+      // Step 2: Send server's connection params
+      auto params = channel->get_connection_params();
+      nlohmann::json j;
+      j["qpn"] = params.qpn;
+      j["gid"] = gid_to_string(params.gid);
+      j["vaddr"] = params.buffer_addr;
+      j["rkey"] = params.rkey;
+      j["num_slots"] = params.num_slots;
+      j["slot_size"] = params.slot_size;
+
+      std::string msg = j.dump();
+
+      ssize_t sent =
+          sendto(sock_fd_, msg.c_str(), msg.length(), 0,
+                 (struct sockaddr *)&client_addr_, sizeof(client_addr_));
+
+      if (sent < 0)
+        throw std::runtime_error("Failed to send channel params");
+
+      std::cout << "  Server → Client: Connection params sent\n";
+      std::cout << "    QPN: " << params.qpn << "\n";
+      std::cout << "    GID: " << gid_to_string(params.gid) << "\n";
+      std::cout << "    vaddr: 0x" << std::hex << params.buffer_addr << std::dec
+                << "\n";
+      std::cout << "    rkey: 0x" << std::hex << params.rkey << std::dec
+                << "\n";
+      std::cout << "    Ring buffer: " << params.num_slots << " slots x "
+                << params.slot_size << " bytes\n";
+
+      // Step 3: Wait for client ACK with client params
+      bool ack_received = false;
+      int retry_count = 0;
+      const int max_retries = 5;
+
+      while (!ack_received && retry_count < max_retries && *running_flag) {
+        char buf[4096];
+        socklen_t len = sizeof(client_addr_);
+
+        ssize_t n = recvfrom(sock_fd_, buf, sizeof(buf), 0,
+                             (struct sockaddr *)&client_addr_, &len);
+
+        if (n < 0) {
+          if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            // Timeout, retry sending params
+            retry_count++;
+            std::cout << "  [RETRY] No ACK, retrying (" << retry_count << "/"
+                      << max_retries << ")...\n";
+            sendto(sock_fd_, msg.c_str(), msg.length(), 0,
+                   (struct sockaddr *)&client_addr_, sizeof(client_addr_));
+            continue;
+          }
+          throw std::runtime_error("Failed to receive ACK");
+        }
+
+        // Parse ACK
+        try {
+          std::string ack_str(buf, n);
+          auto client_j = nlohmann::json::parse(ack_str);
+
+          uint32_t client_qpn = client_j["qpn"];
+          std::string client_gid_str = client_j["gid"];
+
+          std::cout << "  Client → Server: ACK received\n";
+          std::cout << "    QPN: " << client_qpn << "\n";
+          std::cout << "    GID: " << client_gid_str << "\n";
+
+          // Configure QP with client params
+          auto client_gid = string_to_gid(client_gid_str);
+
+          std::cout << "  [DEBUG] Calling set_remote_qp()...\n";
+          try {
+            channel->set_remote_qp(client_qpn, client_gid);
+            std::cout << "  [DEBUG] set_remote_qp() completed\n";
+          } catch (const std::exception &e) {
+            std::cerr << "  [ERROR] set_remote_qp() failed: " << e.what()
+                      << "\n";
+            throw;
+          }
+
+          std::cout << "  ✓ QP setup complete\n";
+
+          ack_received = true;
+
+        } catch (const std::exception &e) {
+          std::cerr << "  [WARN] Failed to parse ACK: " << e.what() << "\n";
+          retry_count++;
+          continue;
+        }
+      }
+
+      if (!ack_received) {
+        std::cerr << "[UDP] Failed to receive ACK after " << max_retries
+                  << " retries\n";
+        return false;
+      }
+
+      // Step 4: Send START message
+      std::cout << "[UDP] Sending START message to client...\n";
+      nlohmann::json start_msg;
+      start_msg["cmd"] = "START";
+
+      std::string start_str = start_msg.dump();
+      sent = sendto(sock_fd_, start_str.c_str(), start_str.length(), 0,
+                    (struct sockaddr *)&client_addr_, sizeof(client_addr_));
+
+      if (sent < 0) {
+        std::cerr << "[UDP] Warning: Failed to send START message\n";
+        return false;
+      }
+
+      std::cout << "[UDP] ✓ START message sent - client can begin RDMA\n";
+
+      return true;
+
+    } catch (const std::exception &e) {
+      std::cerr << "[UDP] Error: " << e.what() << "\n";
+      return false;
+    }
+  }
+
+private:
+  uint16_t port_;
+  int sock_fd_;
+  struct sockaddr_in client_addr_;
+  bool client_connected_;
+
+  std::string gid_to_string(const std::array<uint8_t, 16> &gid) {
+    char buf[64];
+    inet_ntop(AF_INET6, gid.data(), buf, sizeof(buf));
+    return buf;
+  }
+
+  std::array<uint8_t, 16> string_to_gid(const std::string &gid_str) {
+    std::array<uint8_t, 16> gid;
+    inet_pton(AF_INET6, gid_str.c_str(), gid.data());
+    return gid;
+  }
+};

--- a/realtime/examples/doca/gpu_functions.cu
+++ b/realtime/examples/doca/gpu_functions.cu
@@ -1,0 +1,88 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// This file must be compiled with nvcc to properly handle device function
+/// pointers. The main daemon example (.cpp) calls get_gpu_add_function_ptr()
+/// to get the proper device function pointer.
+
+#include "cudaq/nvqlink/network/serialization/gpu_input_stream.h"
+#include "cudaq/nvqlink/network/serialization/gpu_output_stream.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cuda_runtime.h>
+#include <stdexcept>
+#include <string>
+
+using namespace cudaq::nvqlink;
+
+//===------------------------------------------------------------------------===
+// GPU RPC Function: Add Two Numbers
+//===------------------------------------------------------------------------===
+
+/// @brief Simple GPU-callable RPC function for testing
+///
+/// This function demonstrates the NVQLink GPU RPC interface:
+/// - Uses GPUInputStream to deserialize arguments
+/// - Uses GPUOutputStream to serialize results
+/// - Runs entirely on GPU with zero CPU involvement
+///
+__device__ std::int32_t gpu_add_numbers(GPUInputStream &in,
+                                        GPUOutputStream &out) {
+  // Read arguments from input stream
+  std::int32_t a = in.read<std::int32_t>();
+  std::int32_t b = in.read<std::int32_t>();
+
+  // Compute result
+  std::int32_t result = a + b;
+
+  // Debug: print what we're computing
+  printf("GPU: gpu_add_numbers called: %d + %d = %d\n", a, b, result);
+
+  // Write result to output stream
+  out.write(result);
+
+  return 0; // Success
+}
+
+//===------------------------------------------------------------------------===
+// Device Function Pointer Management
+//===------------------------------------------------------------------------===
+
+// Device function pointer type
+using GPUFuncPtr = std::int32_t (*)(GPUInputStream &, GPUOutputStream &);
+
+// Device variable holding the function pointer
+// This is CRITICAL for proper CUDA function pointer semantics!
+// Taking &gpu_add_numbers from host code gives a HOST address, not device
+// address.
+__device__ GPUFuncPtr d_gpu_add_numbers_ptr = gpu_add_numbers;
+
+/// @brief Get the device function pointer from host code
+///
+/// This function uses cudaMemcpyFromSymbol to retrieve the actual device
+/// function pointer stored in the __device__ variable.
+///
+/// @return Device function pointer suitable for use in GPU kernels
+///
+extern "C" void *get_gpu_add_function_ptr() {
+  GPUFuncPtr host_ptr = nullptr;
+  cudaError_t err = cudaMemcpyFromSymbol(&host_ptr, d_gpu_add_numbers_ptr,
+                                         sizeof(GPUFuncPtr));
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Failed to get device function pointer: %s\n",
+            cudaGetErrorString(err));
+    return nullptr;
+  }
+
+  // Debug: print the retrieved pointer
+  printf("[GPU_FUNC] Retrieved device function pointer: %p\n",
+         (void *)host_ptr);
+
+  return reinterpret_cast<void *>(host_ptr);
+}

--- a/realtime/examples/fake_fpga_to_gpu_rdma.cu
+++ b/realtime/examples/fake_fpga_to_gpu_rdma.cu
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include <cassert>
+#include <stdio.h>
+
+#include "cudaq/nvqlink/devices/extensible_rdma_device.cuh"
+#include "cudaq/nvqlink/nvqlink.h"
+
+// Mock the FPGA on the CPU. Write to "Fake FPGA memory" to trigger RDMA
+// data transfer to persistent CUDA kernel on RDMA device
+
+// clang-format off
+// Compile with 
+//
+// nvcc -forward-unknown-to-host-compiler -gencode arch=compute_90,code=sm_90 -gencode arch=compute_90,code=compute_90 --compiler-options -fPIC -O3 -DNDEBUG fake_fpga_to_gpu_rdma.cu -I /path/to/libs/nvqlink/include/ -L /path/to/nvqlink/lib -lcudaq-nvqlink -Wl,-rpath,$PWD/lib 
+// ./a.out
+//
+// clang-format on
+
+// ------ Example of Internal Library Code for Device Functions and Devices ----
+
+__device__ void add_op(void *args, void *res) {
+  // printf("Test here\n");
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int *a = reinterpret_cast<int *>(args);
+  int *b = reinterpret_cast<int *>((char *)args + sizeof(int));
+  if (tid == 0) {
+    *reinterpret_cast<int *>(res) = *a + *b;
+    printf("adding numbers %d + %d = %d\n", *a, *b,
+           *reinterpret_cast<int *>(res));
+  }
+
+  // All threads synchronize before returning
+  __syncthreads();
+}
+
+using namespace cudaq::nvqlink;
+
+__device__ dispatch_func_t d_add_ptr = add_op;
+
+class concrete_rdma_test : public cpu_gpu_rdma_device {
+protected:
+  void build_device_function_table() override {
+    host_func_table.resize(1);
+    cudaMemcpyFromSymbol(&host_func_table[0], d_add_ptr,
+                         sizeof(dispatch_func_t));
+    cudaMalloc(&device_func_table,
+               host_func_table.size() * sizeof(dispatch_func_t));
+    cudaMemcpy(device_func_table, host_func_table.data(),
+               sizeof(dispatch_func_t), cudaMemcpyHostToDevice);
+  }
+};
+// ------------------------------------------------------------------------------
+
+// --- Example for user code -----
+
+using namespace cudaq::nvqlink;
+
+int main() {
+  // Create the rdma device
+  concrete_rdma_test dev;
+  // connect to it
+  dev.connect();
+
+  // Get the internal RDMA connection details
+  auto &rdma_details = dev.get_rdma_connection_data();
+  char *args_ptr = static_cast<char *>(rdma_details.get_raw_source()) +
+                   sizeof(rdma_message_header);
+
+  // Set some rdma device add_op() function arguments
+  int arg1 = 42, arg2 = 24;
+
+  {
+    // Test automatic RDMA by writing to the CPU buffer
+    // The monitoring thread should automatically detect this and transfer to
+    // GPU
+
+    // Prepare a function call message
+    rdma_message_header msg = {
+        .magic = 0xDEADBEEF,
+        .message_type = 0, // function call
+        .function_id = 0,  // add function
+        .num_args = 2,
+        .total_size = sizeof(rdma_message_header) + 2 * sizeof(int) +
+                      sizeof(int), // header + args + result
+        .result_offset = sizeof(rdma_message_header) + 2 * sizeof(int),
+        .result_size = sizeof(int),
+        .reserved = 0};
+
+    std::memcpy(args_ptr, &arg1, sizeof(int));
+    std::memcpy(args_ptr + sizeof(int), &arg2, sizeof(int));
+
+    // Write message to CPU buffer (this should trigger automatic RDMA)
+    std::memcpy(rdma_details.get_raw_source(), &msg, sizeof(msg));
+
+    // Give the monitoring thread time to detect and process the change
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+
+  // The result should be automatically computed and available in the result
+  // buffer
+  int *result_ptr = reinterpret_cast<int *>(args_ptr + 2 * sizeof(int));
+  printf("Result: %d (expected: %d)\n", *result_ptr, arg1 + arg2);
+  assert(*result_ptr == arg1 + arg2 && "result not correct");
+  dev.disconnect();
+}
+// ------------------------------

--- a/realtime/examples/roce/CMakeLists.txt
+++ b/realtime/examples/roce/CMakeLists.txt
@@ -1,0 +1,85 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+if(NVQLINK_ENABLE_ROCE)
+  include(FetchContent)
+  FetchContent_Declare(json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+  )
+  FetchContent_MakeAvailable(json)
+
+  # UDP Control Server (shared by RoCE examples)
+  add_library(udp_control_server STATIC udp_control_server.cpp)
+  target_link_libraries(udp_control_server
+    PUBLIC
+      nvqlink_network
+      nvqlink_daemon
+      nvqlink_utils
+      nlohmann_json::nlohmann_json
+  )
+  target_include_directories(udp_control_server 
+    PUBLIC 
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CUDAQ_NVQLINK_INCLUDE_DIR}
+  )
+  
+  # RoCE Daemon - Full RDMA daemon with UDP control
+  add_executable(roce_daemon roce_daemon.cpp)
+  target_link_libraries(roce_daemon
+    PRIVATE
+      nvqlink_daemon
+      nvqlink_network
+      nvqlink_utils
+      udp_control_server
+      nlohmann_json::nlohmann_json
+  )
+  
+  # RoCE Channel - Worker threads with Channel API
+  add_executable(roce_channel roce_channel.cpp)
+  target_link_libraries(roce_channel
+    PRIVATE
+      nvqlink_daemon
+      nvqlink_network
+      nvqlink_utils
+      udp_control_server
+      nlohmann_json::nlohmann_json
+  )
+  
+  # RoCE Daemon Client (single QP, function_id-based routing)
+  add_executable(roce_daemon_client roce_daemon_client.cpp)
+  target_link_libraries(roce_daemon_client
+    PRIVATE
+      ibverbs
+      nlohmann_json::nlohmann_json
+  )
+  target_include_directories(roce_daemon_client 
+    PRIVATE 
+      ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+  
+  # RoCE Channel Client (multi-QP, queue-based routing)
+  add_executable(roce_channel_client roce_channel_client.cpp)
+  target_link_libraries(roce_channel_client
+    PRIVATE
+      ibverbs
+      nlohmann_json::nlohmann_json
+  )
+  target_include_directories(roce_channel_client 
+    PRIVATE 
+      ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+  
+  message(STATUS "RoCE examples enabled:")
+  message(STATUS "  - roce_daemon (full RDMA daemon)")
+  message(STATUS "  - roce_channel (Channel API with workers)")
+  message(STATUS "  - roce_daemon_client (client for Daemon mode)")
+  message(STATUS "  - roce_channel_client (client for Channel mode)")
+else()
+  message(STATUS "RoCE examples disabled (requires -DNVQLINK_ENABLE_ROCE=ON)")
+  message(STATUS "  Note: RoCE requires libibverbs library")
+endif()

--- a/realtime/examples/roce/roce_channel.cpp
+++ b/realtime/examples/roce/roce_channel.cpp
@@ -1,0 +1,337 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/channels/roce/roce_channel.h"
+#include "udp_control_server.h"
+#include "utils.h"
+#include "cudaq/nvqlink/network/serialization/input_stream.h"
+#include "cudaq/nvqlink/network/serialization/output_stream.h"
+#include "cudaq/nvqlink/network/steering/verbs_flow_switch.h"
+#include "cudaq/nvqlink/utils/instrumentation/profiler.h"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <iostream>
+#include <thread>
+
+using namespace cudaq::nvqlink;
+
+// Atomic flag to control worker threads
+static std::atomic<bool> g_running{true};
+
+// Signal handler for clean shutdown
+static void signal_handler(int) {
+  g_running.store(false);
+  std::cout << "\n[SIGNAL] Shutdown requested..." << std::endl;
+}
+
+//===----------------------------------------------------------------------===//
+// Worker thread functions
+//===----------------------------------------------------------------------===//
+
+static void add_worker_thread(Channel *channel) {
+  std::cout << "[ADD Worker] Thread started (queue-based routing)\n";
+
+  // Create persistent streams for this thread
+  InputStream in(*channel);
+  OutputStream out(*channel);
+
+  while (g_running.load()) {
+    NVQLINK_TRACE_USER_RANGE("add_worker_poll");
+
+    // Check if input is available
+    if (in.available()) {
+      try {
+        NVQLINK_TRACE_USER_RANGE("add_function_processing");
+
+        // Read payload header: [arg_len]
+        uint32_t arg_len = in.read<uint32_t>();
+
+        // Read the two integers
+        int32_t a = in.read<int32_t>();
+        int32_t b = in.read<int32_t>();
+
+        std::cout << "[ADD Worker] Processing: " << a << " + " << b << " = "
+                  << (a + b) << std::endl;
+
+        // Compute the result
+        int32_t result = a + b;
+
+        // Write result back
+        out.write(result);
+        out.flush(); // Send the response packet
+
+      } catch (const std::exception &e) {
+        std::cerr << "[ADD Worker] Error: " << e.what() << std::endl;
+        NVQLINK_TRACE_MARK_ERROR(DOMAIN_USER, "ADD_WORKER_ERROR");
+      }
+    }
+
+    // Small sleep to avoid busy-waiting (can be removed for production)
+    std::this_thread::sleep_for(std::chrono::microseconds(10));
+  }
+
+  std::cout << "[ADD Worker] Thread stopped\n";
+}
+
+static void multiply_worker_thread(Channel *channel) {
+  std::cout << "[MULTIPLY Worker] Thread started (queue-based routing)\n";
+
+  // Create persistent streams for this thread
+  InputStream in(*channel);
+  OutputStream out(*channel);
+
+  while (g_running.load()) {
+    NVQLINK_TRACE_USER_RANGE("multiply_worker_poll");
+
+    // Check if input is available
+    if (in.available()) {
+      try {
+        NVQLINK_TRACE_USER_RANGE("multiply_function_processing");
+
+        // Read payload header: [arg_len]
+        uint32_t arg_len = in.read<uint32_t>();
+
+        // Read the two integers
+        int32_t a = in.read<int32_t>();
+        int32_t b = in.read<int32_t>();
+
+        std::cout << "[MULTIPLY Worker] Processing: " << a << " * " << b
+                  << " = " << (a * b) << std::endl;
+
+        // Compute the result
+        int32_t result = a * b;
+
+        // Write result back
+        out.write(result);
+        out.flush(); // Send the response packet
+
+      } catch (const std::exception &e) {
+        std::cerr << "[MULTIPLY Worker] Error: " << e.what() << std::endl;
+        NVQLINK_TRACE_MARK_ERROR(DOMAIN_USER, "MULTIPLY_WORKER_ERROR");
+      }
+    }
+
+    // Small sleep to avoid busy-waiting
+    std::this_thread::sleep_for(std::chrono::microseconds(10));
+  }
+
+  std::cout << "[MULTIPLY Worker] Thread stopped\n";
+}
+
+static void echo_worker_thread(Channel *channel) {
+  std::cout << "[ECHO Worker] Thread started (queue-based routing)\n";
+
+  // Create persistent streams for this thread
+  InputStream in(*channel);
+  OutputStream out(*channel);
+
+  while (g_running.load()) {
+    NVQLINK_TRACE_USER_RANGE("echo_worker_poll");
+
+    // Check if input is available
+    if (in.available()) {
+      try {
+        NVQLINK_TRACE_USER_RANGE("echo_function_processing");
+
+        // No function_id needed - queue selection IS the routing!
+        // Read the string length first (client must send length prefix)
+        uint32_t str_len = in.read<uint32_t>();
+
+        // Read the string data
+        std::vector<uint8_t> data(str_len);
+        in.read_bytes(data.data(), str_len);
+        std::string msg(data.begin(), data.end());
+
+        std::cout << "[ECHO Worker] Processing: \"" << msg << "\"" << std::endl;
+
+        // Echo back the data
+        out.write_bytes(data.data(), data.size());
+        out.flush();
+
+      } catch (const std::exception &e) {
+        std::cerr << "[ECHO Worker] Error: " << e.what() << std::endl;
+        NVQLINK_TRACE_MARK_ERROR(DOMAIN_USER, "ECHO_WORKER_ERROR");
+      }
+    }
+
+    // Small sleep to avoid busy-waiting
+    std::this_thread::sleep_for(std::chrono::microseconds(10));
+  }
+
+  std::cout << "[ECHO Worker] Thread stopped\n";
+}
+
+//===----------------------------------------------------------------------===//
+
+int main(int argc, char **argv) {
+  std::cout << "============================================================\n";
+  std::cout << "       RoCE Channel Example with Worker Threads\n";
+  std::cout << "============================================================\n";
+  std::cout << "This example demonstrates using Channel API with RoCE\n";
+  std::cout << "backend and multiple worker threads polling for data.\n";
+  std::cout << "============================================================\n";
+
+  // Setup signal handler
+  signal(SIGINT, signal_handler);
+  signal(SIGTERM, signal_handler);
+
+  try {
+    // Parse command line arguments
+    std::string nic_device = "rxe0"; // Default to rxe0 (Soft-RoCE)
+    if (argc > 1)
+      nic_device = argv[1];
+
+    std::string roce_iface = get_interface_name(nic_device);
+    std::string server_mac = get_interface_mac(roce_iface);
+
+    std::cout << "\n========================================================\n";
+    std::cout << "  Network Configuration\n";
+    std::cout << "========================================================\n";
+    std::cout << "RoCE device:  " << nic_device << std::endl;
+    std::cout << "RoCE iface:   " << roce_iface << std::endl;
+    std::cout << "RoCE MAC:     " << server_mac << std::endl;
+    std::cout << "========================================================\n";
+
+    // Build backend configuration - one Channel per worker thread
+    std::cout
+        << "\n[1] Creating RoCE channels (one per worker, shared NIC)...\n";
+
+    // Create FlowSwitch for traffic steering
+    auto flow_switch = std::make_shared<VerbsFlowSwitch>();
+
+    // Create channels with independent contexts
+    // Each channel listens on a different UDP port for flow steering
+    auto add_channel =
+        std::make_unique<RoCEChannel>(nic_device, 9000, flow_switch);
+    auto mult_channel =
+        std::make_unique<RoCEChannel>(nic_device, 9001, flow_switch);
+    auto echo_channel =
+        std::make_unique<RoCEChannel>(nic_device, 9002, flow_switch);
+
+    auto *add_channel_raw = add_channel.get();
+    auto *mult_channel_raw = mult_channel.get();
+    auto *echo_channel_raw = echo_channel.get();
+
+    // Initialize all channels (sets up InfiniBand resources)
+    add_channel_raw->initialize();
+    mult_channel_raw->initialize();
+    echo_channel_raw->initialize();
+
+    std::cout << "    ✓ Three RoCE channels created (independent contexts)\n";
+    std::cout << "    ✓ ADD channel: UDP port 9000\n";
+    std::cout << "    ✓ MULTIPLY channel: UDP port 9001\n";
+    std::cout << "    ✓ ECHO channel: UDP port 9002\n";
+
+    // Start UDP control server
+    std::cout << "\n[3] Starting UDP control server...\n";
+    UDPControlServer control_server(9999);
+    control_server.start();
+
+    std::cout << "    ✓ UDP control server listening on port 9999\n";
+
+    // Wait for client connection and exchange params
+    std::cout << "\n========================================================\n";
+    std::cout << "  Waiting for Client Connection\n";
+    std::cout << "========================================================\n";
+    std::cout << "TCP Control Port: 9999\n\n";
+    std::cout << "Press Ctrl+C to cancel...\n\n";
+
+    std::cout << "To connect from client:\n";
+    std::cout << "  sudo ./roce_full_client " << nic_device << " <server_ip>\n";
+    std::cout << "========================================================\n";
+
+    volatile bool running_for_udp = true;
+
+    // Use multi-channel handler to set up all three channels
+    std::vector<RoCEChannel *> all_channels = {
+        add_channel_raw, mult_channel_raw, echo_channel_raw};
+
+    if (!control_server.exchange_multi_channel(all_channels,
+                                               &running_for_udp)) {
+      std::cout << "\nFailed to exchange channel parameters.\n";
+      return 1;
+    }
+
+    std::cout << "\n✅ All 3 UC QPs ready for data path.\n";
+
+    // Start worker threads - each with dedicated Channel
+    std::cout << "\n[4] Starting worker threads...\n";
+    g_running.store(true);
+
+    std::thread add_thread(add_worker_thread, add_channel_raw);
+    std::thread multiply_thread(multiply_worker_thread, mult_channel_raw);
+    std::thread echo_thread(echo_worker_thread, echo_channel_raw);
+
+    std::cout << "    ✓ ADD worker thread started (queue 0) [ACTIVE]\n";
+    std::cout << "    ✓ MULTIPLY worker thread started (queue 1) [ACTIVE]\n";
+    std::cout << "    ✓ ECHO worker thread started (queue 2) [ACTIVE]\n";
+
+    // Give threads time to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::cout << "\n========================================================\n";
+    std::cout << "  RoCE Channel Ready!\n";
+    std::cout << "========================================================\n\n";
+    std::cout << "Channel-to-Function mapping:\n";
+    std::cout << "  Channel 0 (queue 0): ADD\n";
+    std::cout << "  Channel 1 (queue 1): MULTIPLY\n";
+    std::cout << "  Channel 2 (queue 2): ECHO\n\n";
+
+    std::cout << "Press Ctrl+C to stop\n";
+    std::cout << "========================================================\n";
+
+    // Main loop - print periodic status
+    auto last_print = std::chrono::steady_clock::now();
+    int status_count = 0;
+    while (g_running.load()) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+
+      auto now = std::chrono::steady_clock::now();
+      if (std::chrono::duration_cast<std::chrono::seconds>(now - last_print)
+              .count() >= 10) {
+        status_count++;
+        std::cout << "[Status] Workers running (" << (status_count * 10)
+                  << "s elapsed)..." << std::endl;
+        last_print = now;
+      }
+    }
+
+    // Stop worker threads
+    std::cout << "\n[5] Stopping worker threads...\n";
+    g_running.store(false);
+
+    add_thread.join();
+    multiply_thread.join();
+    echo_thread.join();
+
+    std::cout << "    ✓ All worker threads stopped\n";
+
+    std::cout << "\n[6] Cleaning up...\n";
+    add_channel.reset();
+    mult_channel.reset();
+    echo_channel.reset();
+    std::cout << "    ✓ All channels destroyed\n";
+
+    std::cout << "\n========================================================\n";
+    std::cout << "RoCE Channel Example completed successfully!\n";
+    std::cout << "========================================================\n";
+
+  } catch (const std::exception &e) {
+    std::cerr << "\n❌ Error: " << e.what() << std::endl;
+    std::cerr << "\nTroubleshooting:\n";
+    std::cerr << "  1. Check if Soft-RoCE is installed: rdma link show\n";
+    std::cerr << "  2. Create RoCE device if needed:\n";
+    std::cerr << "     sudo rdma link add rxe0 type rxe netdev lo\n";
+    std::cerr << "  3. Check device status: ibv_devices\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/realtime/examples/roce/roce_channel_client.cpp
+++ b/realtime/examples/roce/roce_channel_client.cpp
@@ -1,0 +1,771 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <infiniband/verbs.h>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+// RPC Function IDs (for routing to correct channel)
+constexpr uint32_t FUNCTION_ECHO = 1;
+constexpr uint32_t FUNCTION_ADD = 2;
+constexpr uint32_t FUNCTION_MULTIPLY = 3;
+
+// Ring buffer layout (must match server)
+constexpr size_t RING_HEADER_SIZE = 128;
+constexpr size_t SLOT_HEADER_SIZE = 16;
+
+/**
+ * RoCE Full Client - Two-way RDMA communication using libibverbs
+ *
+ * This client properly creates QPs and CQs to send RDMA WRITE requests
+ * and receive RDMA SEND responses from the server.
+ */
+class RoCEFullClient {
+public:
+  RoCEFullClient(const std::string &device_name) : device_name_(device_name) {}
+
+  ~RoCEFullClient() { cleanup(); }
+
+  bool initialize() {
+    std::cout << "\n[INIT] Initializing InfiniBand Verbs..." << std::endl;
+
+    // Get device list
+    int num_devices;
+    dev_list_ = ibv_get_device_list(&num_devices);
+    if (!dev_list_ || num_devices == 0) {
+      std::cerr << "No InfiniBand devices found" << std::endl;
+      return false;
+    }
+
+    // Find the specified device
+    ibv_device *device = nullptr;
+    for (int i = 0; i < num_devices; i++) {
+      if (device_name_ == ibv_get_device_name(dev_list_[i])) {
+        device = dev_list_[i];
+        break;
+      }
+    }
+
+    if (!device) {
+      std::cerr << "Device " << device_name_ << " not found" << std::endl;
+      return false;
+    }
+
+    // Open device
+    context_ = ibv_open_device(device);
+    if (!context_) {
+      std::cerr << "Failed to open device" << std::endl;
+      return false;
+    }
+
+    // Query port attributes
+    if (ibv_query_port(context_, port_num_, &port_attr_) != 0) {
+      std::cerr << "Failed to query port" << std::endl;
+      return false;
+    }
+
+    // Allocate protection domain
+    pd_ = ibv_alloc_pd(context_);
+    if (!pd_) {
+      std::cerr << "Failed to allocate protection domain" << std::endl;
+      return false;
+    }
+
+    // Create completion queues
+    send_cq_ = ibv_create_cq(context_, 16, nullptr, nullptr, 0);
+    recv_cq_ = ibv_create_cq(context_, 16, nullptr, nullptr, 0);
+    if (!send_cq_ || !recv_cq_) {
+      std::cerr << "Failed to create completion queues" << std::endl;
+      return false;
+    }
+
+    // Note: QPs will be created dynamically per channel during connection
+
+    // Get local GID
+    if (ibv_query_gid(context_, port_num_, gid_index_, &local_gid_) != 0) {
+      std::cerr << "Failed to query GID" << std::endl;
+      return false;
+    }
+
+    // Allocate receive buffers
+    recv_buffer_size_ = 4096;
+    recv_buffer_ = malloc(recv_buffer_size_);
+    if (!recv_buffer_) {
+      std::cerr << "Failed to allocate receive buffer" << std::endl;
+      return false;
+    }
+
+    recv_mr_ = ibv_reg_mr(pd_, recv_buffer_, recv_buffer_size_,
+                          IBV_ACCESS_LOCAL_WRITE);
+    if (!recv_mr_) {
+      std::cerr << "Failed to register receive buffer" << std::endl;
+      return false;
+    }
+
+    std::cout << "✓ InfiniBand Verbs initialized" << std::endl;
+    std::cout << "  Device: " << device_name_ << std::endl;
+    std::cout << "  Local GID: " << gid_to_string(local_gid_) << std::endl;
+
+    return true;
+  }
+
+  bool connect_to_server(const std::string &server_ip, uint16_t port) {
+    std::cout << "\n[CONNECT] Connecting to server " << server_ip << ":" << port
+              << " (UDP)..." << std::endl;
+
+    // Create UDP socket for control channel
+    int sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock < 0) {
+      std::cerr << "Failed to create UDP socket" << std::endl;
+      return false;
+    }
+
+    // Set receive timeout
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    struct sockaddr_in server_addr;
+    std::memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(port);
+    inet_pton(AF_INET, server_ip.c_str(), &server_addr.sin_addr);
+
+    // Step 1: Send DISCOVER to announce presence
+    std::cout << "[UDP] Sending DISCOVER..." << std::endl;
+    const char *discover = "DISCOVER";
+    ssize_t sent = sendto(sock, discover, strlen(discover), 0,
+                          (struct sockaddr *)&server_addr, sizeof(server_addr));
+    if (sent < 0) {
+      std::cerr << "Failed to send DISCOVER" << std::endl;
+      close(sock);
+      return false;
+    }
+
+    // Step 2: Stay in configuration state until server sends START
+    char buffer[4096];
+    socklen_t addr_len = sizeof(server_addr);
+    uint32_t channels_configured = 0;
+    bool start_received = false;
+
+    std::cout << "\n[UDP] === Configuration State ===" << std::endl;
+    std::cout << "Waiting for server to send channel parameters..."
+              << std::endl;
+
+    while (!start_received) {
+      // Receive message from server
+      ssize_t n = recvfrom(sock, buffer, sizeof(buffer), 0,
+                           (struct sockaddr *)&server_addr, &addr_len);
+      if (n <= 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+          std::cerr << "[UDP] Timeout waiting for server" << std::endl;
+          close(sock);
+          return false;
+        }
+        std::cerr << "Failed to receive from server" << std::endl;
+        close(sock);
+        return false;
+      }
+
+      try {
+        nlohmann::json msg = nlohmann::json::parse(std::string(buffer, n));
+
+        // Check if this is a START message
+        if (msg.contains("cmd") && msg["cmd"] == "START") {
+          std::cout << "\n[UDP] ✅ Received START from server" << std::endl;
+          uint32_t num_channels = msg.value("num_channels", 0);
+          std::cout << "  Server has " << num_channels << " channel(s)"
+                    << std::endl;
+          std::cout << "  Client configured " << channels_configured
+                    << " channel(s)" << std::endl;
+
+          // Parse function routing
+          if (msg.contains("function_routing")) {
+            auto routing = msg["function_routing"];
+            std::cout << "  Function routing:" << std::endl;
+            for (auto &[func_id_str, chan_idx] : routing.items()) {
+              uint32_t func_id = std::stoi(func_id_str);
+              uint32_t channel_idx = chan_idx;
+              function_routing_[func_id] = channel_idx;
+              std::cout << "    Function " << func_id << " → channel "
+                        << channel_idx << std::endl;
+            }
+          }
+
+          start_received = true;
+          break;
+        }
+
+        // Otherwise, this is a channel params message
+        if (!msg.contains("channel_idx")) {
+          std::cerr << "Warning: Received message without channel_idx"
+                    << std::endl;
+          continue;
+        }
+
+        uint32_t channel_idx = msg["channel_idx"];
+        std::cout << "\n[UDP] === Channel " << channel_idx
+                  << " exchange ===" << std::endl;
+
+        // Create a new channel entry
+        ChannelParams channel;
+
+        // Create QP for this channel
+        struct ibv_qp_init_attr qp_init_attr = {};
+        qp_init_attr.send_cq = send_cq_;
+        qp_init_attr.recv_cq = recv_cq_;
+        qp_init_attr.qp_type = IBV_QPT_UC;
+        qp_init_attr.cap.max_send_wr = 16;
+        qp_init_attr.cap.max_recv_wr = 16;
+        qp_init_attr.cap.max_send_sge = 1;
+        qp_init_attr.cap.max_recv_sge = 1;
+
+        channel.qp = ibv_create_qp(pd_, &qp_init_attr);
+        if (!channel.qp) {
+          std::cerr << "Failed to create QP for channel " << channel_idx
+                    << std::endl;
+          close(sock);
+          return false;
+        }
+
+        channel.local_qpn = channel.qp->qp_num;
+
+        // Parse server params
+        channel.remote_qpn = msg["qpn"];
+        channel.remote_gid = string_to_gid(msg["gid"].get<std::string>());
+        channel.server_vaddr = msg["vaddr"];
+        channel.server_rkey = msg["rkey"];
+        channel.num_slots = msg.value("num_slots", 1024);
+        channel.slot_size = msg.value("slot_size", 2048);
+
+        std::cout << "  Server → Client:" << std::endl;
+        std::cout << "    QPN: " << channel.remote_qpn << std::endl;
+        std::cout << "    GID: " << msg["gid"].get<std::string>() << std::endl;
+        std::cout << "    Ring buffer: " << channel.num_slots << " slots x "
+                  << channel.slot_size << " bytes" << std::endl;
+
+        // Send ACK with client params
+        nlohmann::json client_params;
+        client_params["channel_idx"] = channel_idx;
+        client_params["qpn"] = channel.local_qpn;
+        client_params["gid"] = gid_to_string(local_gid_);
+
+        std::string json_str = client_params.dump();
+        sent = sendto(sock, json_str.c_str(), json_str.length(), 0,
+                      (struct sockaddr *)&server_addr, sizeof(server_addr));
+        if (sent < 0) {
+          std::cerr << "Failed to send ACK" << std::endl;
+          close(sock);
+          return false;
+        }
+
+        std::cout << "  Client → Server: ACK sent" << std::endl;
+        std::cout << "    QPN: " << channel.local_qpn << std::endl;
+        std::cout << "    GID: " << gid_to_string(local_gid_) << std::endl;
+
+        channels_.push_back(channel);
+        channels_configured++;
+
+      } catch (const std::exception &e) {
+        std::cerr << "Failed to parse server message: " << e.what()
+                  << std::endl;
+        close(sock);
+        return false;
+      }
+    }
+
+    if (!start_received) {
+      std::cerr << "Failed to receive START from server" << std::endl;
+      close(sock);
+      return false;
+    }
+
+    close(sock);
+
+    std::cout << "\n[QP] Transitioning all " << channels_.size()
+              << " QPs to RTS..." << std::endl;
+
+    // Transition all QPs to RTS
+    for (size_t i = 0; i < channels_.size(); i++) {
+      std::cout << "  Channel " << i << ": QPN " << channels_[i].local_qpn
+                << " → RTS..." << std::endl;
+      if (!transition_qp_to_rts(i)) {
+        return false;
+      }
+      std::cout << "    ✓ Channel " << i << " ready" << std::endl;
+    }
+
+    // Post receive buffers for RDMA SEND responses
+    if (!post_recv_buffers(4)) {
+      return false;
+    }
+
+    std::cout << "\n✓ Configuration complete! Transitioning to RPC state..."
+              << std::endl;
+    return true;
+  }
+
+  bool send_rpc_request(uint32_t function_id, const std::vector<uint8_t> &args,
+                        std::vector<uint8_t> &response) {
+    // Route to correct channel based on function_id
+    auto it = function_routing_.find(function_id);
+    if (it == function_routing_.end()) {
+      std::cerr << "No routing for function_id " << function_id << std::endl;
+      return false;
+    }
+
+    uint32_t channel_idx = it->second;
+    if (channel_idx >= channels_.size()) {
+      std::cerr << "Channel index " << channel_idx << " out of range (have "
+                << channels_.size() << " channels)" << std::endl;
+      return false;
+    }
+
+    auto &ch = channels_[channel_idx];
+
+    std::cout << "  [ROUTE] Function " << function_id << " → channel "
+              << channel_idx << std::endl;
+
+    // Build payload: [arg_len | args]
+    // No function_id in payload - queue selection IS the routing!
+    std::vector<uint8_t> payload(4 + args.size());
+    *(uint32_t *)&payload[0] = (uint32_t)args.size();
+    if (!args.empty()) {
+      std::memcpy(&payload[4], args.data(), args.size());
+    }
+
+    std::cout << "\n[SEND] RPC Request to channel " << channel_idx
+              << " (payload=" << payload.size() << " bytes)" << std::endl;
+
+    // Build slot data for ring buffer
+    std::vector<uint8_t> slot_data(SLOT_HEADER_SIZE + payload.size());
+    *(uint64_t *)&slot_data[0] = ch.seq_num; // seq_num (per-channel)
+    *(uint32_t *)&slot_data[8] = (uint32_t)payload.size(); // payload_len
+    *(uint32_t *)&slot_data[12] = 0;                       // reserved
+    std::memcpy(&slot_data[16], payload.data(), payload.size());
+
+    // Calculate target address in server's ring buffer (per-channel head)
+    uint32_t slot_idx = ch.head % ch.num_slots;
+    uint64_t slot_offset = RING_HEADER_SIZE + (slot_idx * ch.slot_size);
+    uint64_t target_vaddr = ch.server_vaddr + slot_offset;
+
+    // We need to allocate local memory for the slot data
+    void *local_buf = malloc(slot_data.size());
+    std::memcpy(local_buf, slot_data.data(), slot_data.size());
+
+    struct ibv_mr *local_mr =
+        ibv_reg_mr(pd_, local_buf, slot_data.size(),
+                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+    if (!local_mr) {
+      std::cerr << "Failed to register send buffer" << std::endl;
+      free(local_buf);
+      return false;
+    }
+
+    // Post RDMA WRITE
+    struct ibv_sge sge = {};
+    sge.addr = (uint64_t)local_buf;
+    sge.length = slot_data.size();
+    sge.lkey = local_mr->lkey;
+
+    struct ibv_send_wr wr = {};
+    wr.wr_id = send_wr_id_++;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_WRITE;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = target_vaddr;
+    wr.wr.rdma.rkey = ch.server_rkey;
+
+    struct ibv_send_wr *bad_wr = nullptr;
+    if (ibv_post_send(ch.qp, &wr, &bad_wr) != 0) {
+      std::cerr << "Failed to post RDMA WRITE" << std::endl;
+      ibv_dereg_mr(local_mr);
+      free(local_buf);
+      return false;
+    }
+
+    // Poll for send completion
+    struct ibv_wc wc;
+    int ret;
+    do {
+      ret = ibv_poll_cq(send_cq_, 1, &wc);
+    } while (ret == 0);
+
+    if (ret < 0 || wc.status != IBV_WC_SUCCESS) {
+      std::cerr << "Send completion error: " << ibv_wc_status_str(wc.status)
+                << std::endl;
+      ibv_dereg_mr(local_mr);
+      free(local_buf);
+      return false;
+    }
+
+    std::cout << "[SEND] ✓ RDMA WRITE sent (seq=" << ch.seq_num
+              << ", slot=" << slot_idx << ", channel=" << channel_idx << ")"
+              << std::endl;
+
+    // Cleanup send buffer
+    ibv_dereg_mr(local_mr);
+    free(local_buf);
+
+    // Advance ring buffer state (per-channel)
+    ch.head++;
+    ch.seq_num++;
+
+    // Wait for response (RDMA SEND from server)
+    std::cout << "[RECV] Waiting for response..." << std::endl;
+
+    ret = 0;
+    int poll_count = 0;
+    const int max_polls = 5000; // 5 second timeout (1ms per poll)
+
+    while (ret == 0 && poll_count < max_polls) {
+      ret = ibv_poll_cq(recv_cq_, 1, &wc);
+      if (ret == 0) {
+        usleep(1000); // 1ms
+        poll_count++;
+      }
+    }
+
+    if (ret < 0 || poll_count >= max_polls) {
+      std::cerr << "[TIMEOUT] No response received" << std::endl;
+      return false;
+    }
+
+    if (wc.status != IBV_WC_SUCCESS) {
+      std::cerr << "Receive completion error: " << ibv_wc_status_str(wc.status)
+                << std::endl;
+      return false;
+    }
+
+    std::cout << "[RECV] ✓ Response received (" << wc.byte_len << " bytes)"
+              << std::endl;
+
+    // Parse response
+    response.assign((uint8_t *)recv_buffer_,
+                    (uint8_t *)recv_buffer_ + wc.byte_len);
+
+    // Repost receive buffer to the channel that just received
+    // (In this simple client, we just repost to all - could be optimized)
+    post_recv_buffers(1);
+
+    return true;
+  }
+
+private:
+  void cleanup() {
+    for (auto &ch : channels_) {
+      if (ch.qp)
+        ibv_destroy_qp(ch.qp);
+    }
+    channels_.clear();
+    if (send_cq_)
+      ibv_destroy_cq(send_cq_);
+    if (recv_cq_)
+      ibv_destroy_cq(recv_cq_);
+    if (recv_mr_)
+      ibv_dereg_mr(recv_mr_);
+    if (recv_buffer_)
+      free(recv_buffer_);
+    if (pd_)
+      ibv_dealloc_pd(pd_);
+    if (context_)
+      ibv_close_device(context_);
+    if (dev_list_)
+      ibv_free_device_list(dev_list_);
+  }
+
+  bool transition_qp_to_rts(size_t channel_idx) {
+    if (channel_idx >= channels_.size()) {
+      std::cerr << "Invalid channel index: " << channel_idx << std::endl;
+      return false;
+    }
+
+    auto &ch = channels_[channel_idx];
+
+    // RESET -> INIT
+    struct ibv_qp_attr attr = {};
+    attr.qp_state = IBV_QPS_INIT;
+    attr.pkey_index = 0;
+    attr.port_num = port_num_;
+    attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE;
+
+    int mask =
+        IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+    if (ibv_modify_qp(ch.qp, &attr, mask) != 0) {
+      std::cerr << "Failed to transition QP to INIT" << std::endl;
+      return false;
+    }
+
+    // INIT -> RTR
+    std::memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTR;
+    attr.path_mtu = IBV_MTU_1024;
+    attr.dest_qp_num = ch.remote_qpn;
+    attr.rq_psn = 0;
+
+    // Address vector
+    attr.ah_attr.dlid = 0;
+    attr.ah_attr.sl = 0;
+    attr.ah_attr.src_path_bits = 0;
+    attr.ah_attr.port_num = port_num_;
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.grh.dgid = ch.remote_gid;
+    attr.ah_attr.grh.sgid_index = gid_index_;
+    attr.ah_attr.grh.hop_limit = 64;
+
+    mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+           IBV_QP_RQ_PSN;
+    if (ibv_modify_qp(ch.qp, &attr, mask) != 0) {
+      std::cerr << "Failed to transition QP to RTR" << std::endl;
+      return false;
+    }
+
+    // RTR -> RTS
+    std::memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTS;
+    attr.sq_psn = 0;
+
+    mask = IBV_QP_STATE | IBV_QP_SQ_PSN;
+    if (ibv_modify_qp(ch.qp, &attr, mask) != 0) {
+      std::cerr << "Failed to transition QP to RTS" << std::endl;
+      return false;
+    }
+
+    return true;
+  }
+
+  bool post_recv_buffers(int count) {
+    // Post recv buffers to ALL QPs (responses can come from any channel)
+    for (auto &ch : channels_) {
+      for (int i = 0; i < count; i++) {
+        struct ibv_sge sge = {};
+        sge.addr = (uint64_t)recv_buffer_;
+        sge.length = recv_buffer_size_;
+        sge.lkey = recv_mr_->lkey;
+
+        struct ibv_recv_wr wr = {};
+        wr.wr_id = recv_wr_id_++;
+        wr.sg_list = &sge;
+        wr.num_sge = 1;
+
+        struct ibv_recv_wr *bad_wr = nullptr;
+        if (ibv_post_recv(ch.qp, &wr, &bad_wr) != 0) {
+          std::cerr << "Failed to post receive buffer to QP " << ch.local_qpn
+                    << std::endl;
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  std::string gid_to_string(const union ibv_gid &gid) {
+    char buf[64];
+    inet_ntop(AF_INET6, gid.raw, buf, sizeof(buf));
+    return buf;
+  }
+
+  union ibv_gid string_to_gid(const std::string &gid_str) {
+    union ibv_gid gid;
+    inet_pton(AF_INET6, gid_str.c_str(), gid.raw);
+    return gid;
+  }
+
+  std::string device_name_;
+  uint8_t port_num_ = 1;
+  uint8_t gid_index_ = 1; // Use GID index 1 for Soft-RoCE
+
+  // IB Verbs resources
+  struct ibv_device **dev_list_ = nullptr;
+  struct ibv_context *context_ = nullptr;
+  struct ibv_pd *pd_ = nullptr;
+  struct ibv_cq *send_cq_ = nullptr;
+  struct ibv_cq *recv_cq_ = nullptr;
+  struct ibv_qp *qp_ = nullptr;
+  struct ibv_port_attr port_attr_ = {};
+
+  // Connection params per channel
+  struct ChannelParams {
+    uint32_t local_qpn;
+    uint32_t remote_qpn;
+    union ibv_gid remote_gid;
+    uint64_t server_vaddr;
+    uint32_t server_rkey;
+    uint32_t num_slots;
+    uint32_t slot_size;
+    struct ibv_qp *qp;
+
+    // Per-channel ring buffer state
+    uint64_t seq_num = 1;
+    uint32_t head = 0;
+  };
+
+  std::vector<ChannelParams> channels_;
+  union ibv_gid local_gid_ = {};
+  std::map<uint32_t, uint32_t> function_routing_; // function_id → channel_idx
+
+  // Receive buffers
+  void *recv_buffer_ = nullptr;
+  size_t recv_buffer_size_ = 0;
+  struct ibv_mr *recv_mr_ = nullptr;
+
+  // Ring buffer state is now per-channel (in ChannelParams)
+
+  // Work request IDs
+  uint64_t send_wr_id_ = 0;
+  uint64_t recv_wr_id_ = 0;
+};
+
+// Test functions
+static bool test_echo(RoCEFullClient &client) {
+  std::cout << "\n" << std::string(60, '=') << std::endl;
+  std::cout << "TEST 1: Echo Function" << std::endl;
+  std::cout << std::string(60, '=') << std::endl;
+
+  std::string message = "Hello from RoCE full client!";
+  std::vector<uint8_t> args(message.begin(), message.end());
+  std::vector<uint8_t> response;
+
+  if (!client.send_rpc_request(FUNCTION_ECHO, args, response)) {
+    std::cout << "❌ FAIL: No response" << std::endl;
+    return false;
+  }
+
+  // Parse response: [result_data] (Channel mode - no RPC headers)
+  std::string result(response.begin(), response.end());
+
+  if (result == message) {
+    std::cout << "✅ SUCCESS: Echo returned correct message!" << std::endl;
+    std::cout << "  Sent: '" << message << "'" << std::endl;
+    std::cout << "  Received: '" << result << "'" << std::endl;
+    return true;
+  } else {
+    std::cout << "❌ FAIL: Sent '" << message << "', got '" << result << "'"
+              << std::endl;
+    return false;
+  }
+}
+
+static bool test_add(RoCEFullClient &client) {
+  std::cout << "\n" << std::string(60, '=') << std::endl;
+  std::cout << "TEST 2: Add Function" << std::endl;
+  std::cout << std::string(60, '=') << std::endl;
+
+  int32_t a = 42, b = 58;
+  int32_t expected = a + b;
+
+  std::vector<uint8_t> args(8);
+  *(int32_t *)&args[0] = a;
+  *(int32_t *)&args[4] = b;
+
+  std::cout << "  Computing: " << a << " + " << b << " = ?" << std::endl;
+
+  std::vector<uint8_t> response;
+  if (!client.send_rpc_request(FUNCTION_ADD, args, response)) {
+    std::cout << "❌ FAIL: No response" << std::endl;
+    return false;
+  }
+
+  if (response.size() < 4) {
+    std::cout << "❌ FAIL: Response too short (got " << response.size()
+              << " bytes, expected 4)" << std::endl;
+    return false;
+  }
+
+  // Parse response: [result] (Channel mode - no RPC headers)
+  int32_t result = *(int32_t *)&response[0];
+
+  std::cout << "  Server returned: " << result << std::endl;
+
+  if (result == expected) {
+    std::cout << "✅ SUCCESS: " << a << " + " << b << " = " << result
+              << " (correct!)" << std::endl;
+    return true;
+  } else {
+    std::cout << "❌ FAIL: Expected " << expected << ", got " << result
+              << std::endl;
+    return false;
+  }
+}
+
+int main(int argc, char **argv) {
+  std::cout << std::string(60, '=') << std::endl;
+  std::cout << " RoCEv2 Full Client (Linux + libibverbs)" << std::endl;
+  std::cout << " Two-way RDMA communication with proper QP setup" << std::endl;
+  std::cout << std::string(60, '=') << std::endl;
+
+  std::string device_name = "rxe0";
+  std::string server_ip = "127.0.0.1";
+  uint16_t server_port = 9999;
+
+  if (argc > 1)
+    device_name = argv[1];
+  if (argc > 2)
+    server_ip = argv[2];
+
+  std::cout << "\nConfiguration:" << std::endl;
+  std::cout << "  Device: " << device_name << std::endl;
+  std::cout << "  Server: " << server_ip << ":" << server_port << std::endl;
+  std::cout << std::endl;
+
+  try {
+    RoCEFullClient client(device_name);
+
+    if (!client.initialize()) {
+      return 1;
+    }
+
+    if (!client.connect_to_server(server_ip, server_port)) {
+      return 1;
+    }
+
+    // Run tests
+    int success_count = 0;
+    int total_tests = 2;
+
+    if (test_echo(client)) {
+      success_count++;
+    }
+
+    sleep(1);
+
+    if (test_add(client)) {
+      success_count++;
+    }
+
+    // Summary
+    std::cout << "\n" << std::string(60, '=') << std::endl;
+    std::cout << "TEST SUMMARY: " << success_count << "/" << total_tests
+              << " tests passed" << std::endl;
+    std::cout << std::string(60, '=') << std::endl;
+
+    if (success_count == total_tests) {
+      std::cout << "🎉 All tests passed! RoCEv2 two-way communication working!"
+                << std::endl;
+      return 0;
+    } else {
+      std::cout << "⚠️  Some tests failed." << std::endl;
+      return 1;
+    }
+
+  } catch (const std::exception &e) {
+    std::cerr << "\n❌ Error: " << e.what() << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/realtime/examples/roce/roce_client_common.h
+++ b/realtime/examples/roce/roce_client_common.h
@@ -1,0 +1,361 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <fstream>
+#include <ifaddrs.h>
+#include <infiniband/verbs.h>
+#include <iostream>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
+#include <netinet/tcp.h>
+#include <netinet/udp.h>
+#include <nlohmann/json.hpp>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+// Ring buffer layout (must match server)
+constexpr size_t RING_HEADER_SIZE = 128;
+constexpr size_t SLOT_HEADER_SIZE = 16;
+
+// RPC Function IDs
+constexpr uint32_t FUNCTION_ECHO = 1;
+constexpr uint32_t FUNCTION_ADD = 2;
+constexpr uint32_t FUNCTION_MULTIPLY = 3;
+
+/**
+ * Base class for RoCE clients with common IB Verbs setup
+ */
+class RoCEClientBase {
+public:
+  RoCEClientBase(const std::string &device_name) : device_name_(device_name) {}
+
+  virtual ~RoCEClientBase() { cleanup(); }
+
+  bool initialize() {
+    std::cout << "\n[INIT] Initializing InfiniBand Verbs..." << std::endl;
+
+    // Get device list
+    int num_devices;
+    dev_list_ = ibv_get_device_list(&num_devices);
+    if (!dev_list_ || num_devices == 0) {
+      std::cerr << "No InfiniBand devices found" << std::endl;
+      return false;
+    }
+
+    // Find the specified device
+    ibv_device *device = nullptr;
+    for (int i = 0; i < num_devices; i++) {
+      if (device_name_ == ibv_get_device_name(dev_list_[i])) {
+        device = dev_list_[i];
+        break;
+      }
+    }
+
+    if (!device) {
+      std::cerr << "Device " << device_name_ << " not found" << std::endl;
+      return false;
+    }
+
+    // Open device
+    context_ = ibv_open_device(device);
+    if (!context_) {
+      std::cerr << "Failed to open device" << std::endl;
+      return false;
+    }
+
+    // Query port attributes
+    if (ibv_query_port(context_, port_num_, &port_attr_) != 0) {
+      std::cerr << "Failed to query port" << std::endl;
+      return false;
+    }
+
+    // Allocate protection domain
+    pd_ = ibv_alloc_pd(context_);
+    if (!pd_) {
+      std::cerr << "Failed to allocate protection domain" << std::endl;
+      return false;
+    }
+
+    // Create completion queues
+    send_cq_ = ibv_create_cq(context_, 16, nullptr, nullptr, 0);
+    recv_cq_ = ibv_create_cq(context_, 16, nullptr, nullptr, 0);
+    if (!send_cq_ || !recv_cq_) {
+      std::cerr << "Failed to create completion queues" << std::endl;
+      return false;
+    }
+
+    // Get local GID
+    if (ibv_query_gid(context_, port_num_, gid_index_, &local_gid_) != 0) {
+      std::cerr << "Failed to query GID" << std::endl;
+      return false;
+    }
+
+    // Allocate receive buffers
+    recv_buffer_size_ = 4096;
+    recv_buffer_ = malloc(recv_buffer_size_);
+    if (!recv_buffer_) {
+      std::cerr << "Failed to allocate receive buffer" << std::endl;
+      return false;
+    }
+
+    recv_mr_ = ibv_reg_mr(pd_, recv_buffer_, recv_buffer_size_,
+                          IBV_ACCESS_LOCAL_WRITE);
+    if (!recv_mr_) {
+      std::cerr << "Failed to register receive buffer" << std::endl;
+      return false;
+    }
+
+    std::cout << "✓ InfiniBand Verbs initialized" << std::endl;
+    std::cout << "  Device: " << device_name_ << std::endl;
+    std::cout << "  Local GID: " << gid_to_string(local_gid_) << std::endl;
+
+    return true;
+  }
+
+protected:
+  void cleanup() {
+    if (recv_mr_)
+      ibv_dereg_mr(recv_mr_);
+    if (recv_buffer_)
+      free(recv_buffer_);
+    if (send_cq_)
+      ibv_destroy_cq(send_cq_);
+    if (recv_cq_)
+      ibv_destroy_cq(recv_cq_);
+    if (pd_)
+      ibv_dealloc_pd(pd_);
+    if (context_)
+      ibv_close_device(context_);
+    if (dev_list_)
+      ibv_free_device_list(dev_list_);
+  }
+
+  bool transition_qp_to_rts(struct ibv_qp *qp, uint32_t remote_qpn,
+                            const union ibv_gid &remote_gid) {
+    // RESET -> INIT
+    struct ibv_qp_attr attr = {};
+    attr.qp_state = IBV_QPS_INIT;
+    attr.pkey_index = 0;
+    attr.port_num = port_num_;
+    attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE;
+
+    int mask =
+        IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+    if (ibv_modify_qp(qp, &attr, mask) != 0) {
+      std::cerr << "Failed to transition QP to INIT" << std::endl;
+      return false;
+    }
+
+    // INIT -> RTR
+    std::memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTR;
+    attr.path_mtu = IBV_MTU_1024;
+    attr.dest_qp_num = remote_qpn;
+    attr.rq_psn = 0;
+
+    // Address vector
+    attr.ah_attr.dlid = 0;
+    attr.ah_attr.sl = 0;
+    attr.ah_attr.src_path_bits = 0;
+    attr.ah_attr.port_num = port_num_;
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.grh.dgid = remote_gid;
+    attr.ah_attr.grh.sgid_index = gid_index_;
+    attr.ah_attr.grh.hop_limit = 64;
+
+    mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+           IBV_QP_RQ_PSN;
+    if (ibv_modify_qp(qp, &attr, mask) != 0) {
+      std::cerr << "Failed to transition QP to RTR" << std::endl;
+      return false;
+    }
+
+    // RTR -> RTS
+    std::memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTS;
+    attr.sq_psn = 0;
+
+    mask = IBV_QP_STATE | IBV_QP_SQ_PSN;
+    if (ibv_modify_qp(qp, &attr, mask) != 0) {
+      std::cerr << "Failed to transition QP to RTS" << std::endl;
+      return false;
+    }
+
+    return true;
+  }
+
+  bool post_recv_buffer(struct ibv_qp *qp) {
+    struct ibv_sge sge = {};
+    sge.addr = (uint64_t)recv_buffer_;
+    sge.length = recv_buffer_size_;
+    sge.lkey = recv_mr_->lkey;
+
+    struct ibv_recv_wr wr = {};
+    wr.wr_id = recv_wr_id_++;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+
+    struct ibv_recv_wr *bad_wr = nullptr;
+    if (ibv_post_recv(qp, &wr, &bad_wr) != 0) {
+      std::cerr << "Failed to post receive buffer" << std::endl;
+      return false;
+    }
+    return true;
+  }
+
+  std::string gid_to_string(const union ibv_gid &gid) {
+    char buf[64];
+    inet_ntop(AF_INET6, gid.raw, buf, sizeof(buf));
+    return buf;
+  }
+
+  union ibv_gid string_to_gid(const std::string &gid_str) {
+    union ibv_gid gid;
+    inet_pton(AF_INET6, gid_str.c_str(), gid.raw);
+    return gid;
+  }
+
+  std::string device_name_;
+  uint8_t port_num_ = 1;
+  uint8_t gid_index_ = 1; // Use GID index 1 for Soft-RoCE
+
+  // IB Verbs resources
+  struct ibv_device **dev_list_ = nullptr;
+  struct ibv_context *context_ = nullptr;
+  struct ibv_pd *pd_ = nullptr;
+  struct ibv_cq *send_cq_ = nullptr;
+  struct ibv_cq *recv_cq_ = nullptr;
+  struct ibv_port_attr port_attr_ = {};
+
+  union ibv_gid local_gid_ = {};
+
+  // Receive buffers
+  void *recv_buffer_ = nullptr;
+  size_t recv_buffer_size_ = 0;
+  struct ibv_mr *recv_mr_ = nullptr;
+
+  // Work request IDs
+  uint64_t send_wr_id_ = 0;
+  uint64_t recv_wr_id_ = 0;
+};
+
+//===----------------------------------------------------------------------===//
+// Utility Functions
+//===----------------------------------------------------------------------===//
+
+inline std::string get_interface_name(const std::string &roce_device) {
+  // Map RoCE device to network interface by reading sysfs parent file
+  std::string sysfs_path = "/sys/class/infiniband/" + roce_device + "/parent";
+
+  std::ifstream parent_file(sysfs_path);
+  if (parent_file.is_open()) {
+    std::string iface_name;
+    std::getline(parent_file, iface_name);
+    parent_file.close();
+
+    // Trim whitespace
+    iface_name.erase(0, iface_name.find_first_not_of(" \t\r\n"));
+    iface_name.erase(iface_name.find_last_not_of(" \t\r\n") + 1);
+
+    if (!iface_name.empty()) {
+      return iface_name;
+    }
+  }
+
+  return "unknown";
+}
+
+inline std::string get_interface_ip(const std::string &iface_name) {
+  struct ifaddrs *ifaddr, *ifa;
+  std::string ip;
+
+  if (getifaddrs(&ifaddr) == -1) {
+    return ip;
+  }
+
+  for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr)
+      continue;
+
+    if (ifa->ifa_addr->sa_family == AF_INET &&
+        std::string(ifa->ifa_name) == iface_name) {
+      char addr_buf[INET_ADDRSTRLEN];
+      struct sockaddr_in *addr = (struct sockaddr_in *)ifa->ifa_addr;
+      inet_ntop(AF_INET, &addr->sin_addr, addr_buf, INET_ADDRSTRLEN);
+      ip = addr_buf;
+      break;
+    }
+  }
+
+  freeifaddrs(ifaddr);
+  return ip;
+}
+
+inline std::string get_primary_ip() {
+  // Find the first non-loopback, non-docker IPv4 address
+  struct ifaddrs *ifaddr, *ifa;
+  std::string ip;
+
+  if (getifaddrs(&ifaddr) == -1) {
+    return ip;
+  }
+
+  for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr)
+      continue;
+
+    if (ifa->ifa_addr->sa_family == AF_INET) {
+      std::string iface_name = ifa->ifa_name;
+
+      // Skip loopback and docker interfaces
+      if (iface_name == "lo" || iface_name.find("docker") == 0) {
+        continue;
+      }
+
+      char addr_buf[INET_ADDRSTRLEN];
+      struct sockaddr_in *addr = (struct sockaddr_in *)ifa->ifa_addr;
+      inet_ntop(AF_INET, &addr->sin_addr, addr_buf, INET_ADDRSTRLEN);
+      ip = addr_buf;
+      break; // Use the first valid IP found
+    }
+  }
+
+  freeifaddrs(ifaddr);
+  return ip;
+}
+
+inline std::string get_interface_mac(const std::string &iface_name) {
+  int sock = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    return "unknown";
+  }
+
+  struct ifreq ifr;
+  strncpy(ifr.ifr_name, iface_name.c_str(), IFNAMSIZ - 1);
+
+  if (ioctl(sock, SIOCGIFHWADDR, &ifr) < 0) {
+    close(sock);
+    return "unknown";
+  }
+
+  close(sock);
+
+  unsigned char *mac = (unsigned char *)ifr.ifr_hwaddr.sa_data;
+  char mac_str[18];
+  snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0],
+           mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+  return mac_str;
+}

--- a/realtime/examples/roce/roce_daemon.cpp
+++ b/realtime/examples/roce/roce_daemon.cpp
@@ -1,0 +1,206 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "udp_control_server.h"
+#include "utils.h"
+#include "cudaq/nvqlink/daemon/daemon.h"
+#include "cudaq/nvqlink/daemon/registry/function_traits.h"
+#include "cudaq/nvqlink/daemon/registry/function_wrapper.h"
+#include "cudaq/nvqlink/network/config.h"
+#include "cudaq/nvqlink/network/channels/roce/roce_channel.h"
+#include "cudaq/nvqlink/network/steering/verbs_flow_switch.h"
+
+#include <csignal>
+#include <iostream>
+#include <unistd.h>
+
+using namespace cudaq::nvqlink;
+
+//===----------------------------------------------------------------------===//
+// Utility
+//===----------------------------------------------------------------------===//
+
+// Global flag for clean shutdown
+static volatile bool running = true;
+
+static void signal_handler(int) { running = false; }
+
+static void print_network_config(const ChannelConfig &cfg) {
+  // Get network interface info
+  std::string roce_iface = get_interface_name(cfg.nic_device);
+  std::string roce_iface_ip = get_interface_ip(roce_iface);
+  std::string server_mac = get_interface_mac(roce_iface);
+  std::string udp_ip = roce_iface_ip.empty() ? get_primary_ip() : roce_iface_ip;
+
+  std::cout << "\n========================================================\n";
+  std::cout << "  Network Configuration\n";
+  std::cout << "========================================================\n";
+  std::cout << "RoCE device:  " << cfg.nic_device << "\n";
+  std::cout << "RoCE iface:   " << roce_iface << "\n";
+  std::cout << "RoCE MAC:     " << server_mac << "\n";
+  if (!roce_iface_ip.empty()) {
+    std::cout << "RoCE IP:      " << roce_iface_ip << "\n";
+    std::cout << "UDP IP:       " << roce_iface_ip << " (same as RoCE)\n";
+  } else {
+    std::cout << "RoCE IP:      (none - layer 2 only)\n";
+    std::cout << "UDP IP:       " << udp_ip << " (primary system IP)\n";
+  }
+  std::cout << "ROCE_PORT:    4791\n";
+  std::cout << "========================================================\n\n";
+}
+
+//===----------------------------------------------------------------------===//
+// RPC Functions
+//===----------------------------------------------------------------------===//
+
+namespace rpc {
+
+static int32_t add(int32_t a, int32_t b) {
+  int32_t result = a + b;
+  std::cout << "[RPC] Add: " << a << " + " << b << " = " << result << std::endl;
+  return result;
+}
+
+/// Echo function - demonstrates variable-length data handling.
+/// Note: This uses the stream-based API since it needs dynamic sizing.
+static int echo_function(InputStream &in, OutputStream &out) {
+  // Read entire input
+  std::vector<char> data;
+  while (in.available() > 0) {
+    data.push_back(in.read<char>());
+  }
+
+  // Echo back
+  out.write_bytes(data.data(), data.size());
+
+  std::cout << "[RPC] Echo: " << std::string(data.begin(), data.end())
+            << std::endl;
+  return 0;
+}
+
+} // namespace rpc
+
+//===----------------------------------------------------------------------===//
+
+int main(int argc, char **argv) {
+  std::cout << "\n========================================================\n";
+  std::cout << "  NVQLink Daemon Example " << std::endl;
+  std::cout << "========================================================\n";
+
+  // Setup signal handler
+  signal(SIGINT, signal_handler);
+  signal(SIGTERM, signal_handler);
+
+  try {
+    // 1. Configure backend (Soft-RoCE device)
+    ChannelConfig backend_cfg;
+    backend_cfg.nic_device = (argc > 1) ? argv[1] : "rxe0";
+    backend_cfg.queue_id = 0;
+    backend_cfg.pool_size_bytes = 64 * 1024 * 1024;
+
+    print_network_config(backend_cfg);
+
+    // 2. Create RoCE backend in UC mode
+    std::cout << "\nCreating RoCE backend (UC mode)...\n";
+
+    // Create FlowSwitch for traffic steering
+    auto flow_switch = std::make_shared<VerbsFlowSwitch>();
+
+    // Create channel (independent context, listens on UDP port 9000)
+    auto channel = std::make_unique<RoCEChannel>(backend_cfg.nic_device, 9000,
+                                                 flow_switch);
+
+    // Initialize the channel (sets up InfiniBand resources)
+    channel->initialize();
+    std::cout << "RoCE channel initialized successfully\n";
+
+    // 3. Start UDP control server
+    std::cout << "\nStarting UDP control server...\n";
+    UDPControlServer control_server(9999);
+    control_server.start();
+
+    // 4. Wait for client and exchange params
+    std::cout << "\n========================================================\n";
+    std::cout << "  Waiting for Client Connection\n";
+    std::cout << "========================================================\n";
+    std::cout << "UDP Control Port: 9999\n";
+    std::cout << "Press Ctrl+C to cancel...\n";
+
+    // Single channel exchange
+    auto *channel_raw = channel.get();
+    std::vector<RoCEChannel *> channels = {channel_raw};
+    if (!control_server.exchange_multi_channel(channels, &running)) {
+      std::cout << "\nFailed to exchange channel parameters.\n";
+      return 1;
+    }
+    std::cout << "\nUC QP ready for data path.\n";
+
+    // 5. Create Daemon with RPC functions
+    std::cout << "\nCreating Daemon...\n";
+    DaemonConfig daemon_config = DaemonConfigBuilder()
+                                     .set_id("roce_daemon_0")
+                                     .set_datapath_mode(DatapathMode::CPU)
+                                     .set_cpu_cores({0})
+                                     .build();
+
+    auto daemon = std::make_unique<Daemon>(daemon_config, std::move(channel));
+
+    // Register RPC functions
+    //   - Method 1: Supports variable-length data
+    FunctionMetadata echo_meta = {.function_id = 1,
+                                  .name = "echo",
+                                  .type = FunctionType::CPU,
+                                  .max_result_size = 1024,
+                                  .cpu_function = rpc::echo_function};
+    daemon->register_function(echo_meta);
+
+    //   - Method 2: Just pass the function. The `NVQLINK_RPC_HANDLE` macro
+    //               extracts the function name automatically and generates a
+    //               stable hash-based ID.
+    daemon->register_function(NVQLINK_RPC_HANDLE(rpc::add));
+
+    std::cout << "Registered RPC functions:\n";
+    std::cout << "  ID 1: echo\n";
+    std::cout << "  ID 0x" << std::hex << hash_name("rpc::add") << std::dec
+              << ": rpc::add\n";
+
+    daemon->start();
+
+    // Run until interrupted
+    std::cout << "\n========================================================\n";
+    std::cout << "  Server running. Press Ctrl+C to stop.\n";
+    std::cout << "========================================================\n";
+
+    while (running) {
+      sleep(1);
+
+      // Periodically print stats
+      static int counter = 0;
+      if (++counter % 10 == 0) {
+        auto stats = daemon->get_stats();
+        std::cout << "[Stats] Packets received: " << stats.packets_received
+                  << ", sent: " << stats.packets_sent << "\n";
+      }
+    }
+
+    std::cout << "\nShutting down...\n";
+    daemon->stop();
+
+    auto stats = daemon->get_stats();
+    std::cout << "\nFinal stats:\n";
+    std::cout << "  Packets received: " << stats.packets_received << "\n";
+    std::cout << "  Packets sent: " << stats.packets_sent << "\n";
+
+    return 0;
+
+  } catch (const std::exception &e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return 1;
+  }
+  return 0;
+}

--- a/realtime/examples/roce/roce_daemon_client.cpp
+++ b/realtime/examples/roce/roce_daemon_client.cpp
@@ -1,0 +1,446 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "roce_client_common.h"
+
+class RoCEDaemonClient : public RoCEClientBase {
+public:
+  RoCEDaemonClient(const std::string &device_name)
+      : RoCEClientBase(device_name) {}
+
+  ~RoCEDaemonClient() {
+    if (qp_)
+      ibv_destroy_qp(qp_);
+  }
+
+  bool connect_to_server(const std::string &server_ip, uint16_t port) {
+    std::cout << "\n[CONNECT] Connecting to server " << server_ip << ":" << port
+              << " (UDP)..." << std::endl;
+
+    // Create UDP socket
+    int sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock < 0) {
+      std::cerr << "Failed to create UDP socket" << std::endl;
+      return false;
+    }
+
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    struct sockaddr_in server_addr;
+    std::memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(port);
+    inet_pton(AF_INET, server_ip.c_str(), &server_addr.sin_addr);
+
+    // Send DISCOVER
+    std::cout << "[UDP] Sending DISCOVER..." << std::endl;
+    const char *discover = "DISCOVER";
+    ssize_t sent = sendto(sock, discover, strlen(discover), 0,
+                          (struct sockaddr *)&server_addr, sizeof(server_addr));
+    if (sent < 0) {
+      std::cerr << "Failed to send DISCOVER" << std::endl;
+      close(sock);
+      return false;
+    }
+
+    // Receive channel parameters (single channel for Daemon mode)
+    char buffer[4096];
+    socklen_t addr_len = sizeof(server_addr);
+    ssize_t n = recvfrom(sock, buffer, sizeof(buffer), 0,
+                         (struct sockaddr *)&server_addr, &addr_len);
+    if (n <= 0) {
+      std::cerr << "Failed to receive channel parameters" << std::endl;
+      close(sock);
+      return false;
+    }
+
+    try {
+      nlohmann::json msg = nlohmann::json::parse(std::string(buffer, n));
+
+      remote_qpn_ = msg["qpn"];
+      remote_gid_ = string_to_gid(msg["gid"].get<std::string>());
+      server_vaddr_ = msg["vaddr"];
+      server_rkey_ = msg["rkey"];
+      num_slots_ = msg.value("num_slots", 1024);
+      slot_size_ = msg.value("slot_size", 2048);
+
+      std::cout << "[UDP] Received server params:" << std::endl;
+      std::cout << "  QPN: " << remote_qpn_ << std::endl;
+      std::cout << "  GID: " << msg["gid"].get<std::string>() << std::endl;
+      std::cout << "  Ring buffer: " << num_slots_ << " slots x " << slot_size_
+                << " bytes" << std::endl;
+
+    } catch (const std::exception &e) {
+      std::cerr << "Failed to parse server message: " << e.what() << std::endl;
+      close(sock);
+      return false;
+    }
+
+    // Create QP
+    struct ibv_qp_init_attr qp_init_attr = {};
+    qp_init_attr.send_cq = send_cq_;
+    qp_init_attr.recv_cq = recv_cq_;
+    qp_init_attr.qp_type = IBV_QPT_UC;
+    qp_init_attr.cap.max_send_wr = 16;
+    qp_init_attr.cap.max_recv_wr = 16;
+    qp_init_attr.cap.max_send_sge = 1;
+    qp_init_attr.cap.max_recv_sge = 1;
+
+    qp_ = ibv_create_qp(pd_, &qp_init_attr);
+    if (!qp_) {
+      std::cerr << "Failed to create QP" << std::endl;
+      close(sock);
+      return false;
+    }
+
+    local_qpn_ = qp_->qp_num;
+
+    // Send ACK with client params
+    nlohmann::json client_params;
+    client_params["channel_idx"] = 0; // Single channel for Daemon
+    client_params["qpn"] = local_qpn_;
+    client_params["gid"] = gid_to_string(local_gid_);
+
+    std::string json_str = client_params.dump();
+    sent = sendto(sock, json_str.c_str(), json_str.length(), 0,
+                  (struct sockaddr *)&server_addr, sizeof(server_addr));
+    if (sent < 0) {
+      std::cerr << "Failed to send ACK" << std::endl;
+      close(sock);
+      return false;
+    }
+
+    std::cout << "[UDP] Sent ACK with QPN: " << local_qpn_ << std::endl;
+
+    // Wait for START message
+    n = recvfrom(sock, buffer, sizeof(buffer), 0,
+                 (struct sockaddr *)&server_addr, &addr_len);
+    if (n > 0) {
+      try {
+        nlohmann::json msg = nlohmann::json::parse(std::string(buffer, n));
+        if (msg.contains("cmd") && msg["cmd"] == "START") {
+          std::cout << "[UDP] ✅ Received START from server" << std::endl;
+        }
+      } catch (const std::exception &e) {
+        // Ignore if not a valid START message
+      }
+    }
+
+    close(sock);
+
+    // Transition QP to RTS
+    std::cout << "\n[QP] Transitioning QP to RTS..." << std::endl;
+    if (!transition_qp_to_rts(qp_, remote_qpn_, remote_gid_)) {
+      return false;
+    }
+    std::cout << "✓ QP ready (QPN: " << local_qpn_ << ")" << std::endl;
+
+    // Post receive buffers
+    for (int i = 0; i < 4; i++) {
+      if (!post_recv_buffer(qp_)) {
+        return false;
+      }
+    }
+
+    std::cout << "✓ Configuration complete!" << std::endl;
+    return true;
+  }
+
+  bool send_rpc_request(uint32_t function_id, const std::vector<uint8_t> &args,
+                        std::vector<uint8_t> &response) {
+    // Build RPC payload: [function_id | arg_len | args]
+    std::vector<uint8_t> payload(8 + args.size());
+    *(uint32_t *)&payload[0] = function_id;
+    *(uint32_t *)&payload[4] = (uint32_t)args.size();
+    if (!args.empty()) {
+      std::memcpy(&payload[8], args.data(), args.size());
+    }
+
+    std::cout << "\n[SEND] RPC Request (function_id=" << function_id
+              << ", payload=" << payload.size() << " bytes)" << std::endl;
+
+    // Build slot data for ring buffer
+    std::vector<uint8_t> slot_data(SLOT_HEADER_SIZE + payload.size());
+    *(uint64_t *)&slot_data[0] = seq_num_;
+    *(uint32_t *)&slot_data[8] = (uint32_t)payload.size();
+    *(uint32_t *)&slot_data[12] = 0;
+    std::memcpy(&slot_data[16], payload.data(), payload.size());
+
+    // Calculate target address in server's ring buffer
+    uint32_t slot_idx = head_ % num_slots_;
+    uint64_t slot_offset = RING_HEADER_SIZE + (slot_idx * slot_size_);
+    uint64_t target_vaddr = server_vaddr_ + slot_offset;
+
+    // Allocate and register local buffer
+    void *local_buf = malloc(slot_data.size());
+    std::memcpy(local_buf, slot_data.data(), slot_data.size());
+
+    struct ibv_mr *local_mr =
+        ibv_reg_mr(pd_, local_buf, slot_data.size(),
+                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+    if (!local_mr) {
+      std::cerr << "Failed to register send buffer" << std::endl;
+      free(local_buf);
+      return false;
+    }
+
+    // Post RDMA WRITE
+    struct ibv_sge sge = {};
+    sge.addr = (uint64_t)local_buf;
+    sge.length = slot_data.size();
+    sge.lkey = local_mr->lkey;
+
+    struct ibv_send_wr wr = {};
+    wr.wr_id = send_wr_id_++;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_WRITE;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = target_vaddr;
+    wr.wr.rdma.rkey = server_rkey_;
+
+    struct ibv_send_wr *bad_wr = nullptr;
+    if (ibv_post_send(qp_, &wr, &bad_wr) != 0) {
+      std::cerr << "Failed to post RDMA WRITE" << std::endl;
+      ibv_dereg_mr(local_mr);
+      free(local_buf);
+      return false;
+    }
+
+    // Poll for send completion
+    struct ibv_wc wc;
+    int ret;
+    do {
+      ret = ibv_poll_cq(send_cq_, 1, &wc);
+    } while (ret == 0);
+
+    if (ret < 0 || wc.status != IBV_WC_SUCCESS) {
+      std::cerr << "Send completion error: " << ibv_wc_status_str(wc.status)
+                << std::endl;
+      ibv_dereg_mr(local_mr);
+      free(local_buf);
+      return false;
+    }
+
+    std::cout << "[SEND] ✓ RDMA WRITE sent (seq=" << seq_num_
+              << ", slot=" << slot_idx << ")" << std::endl;
+
+    // Cleanup send buffer
+    ibv_dereg_mr(local_mr);
+    free(local_buf);
+
+    // Advance ring buffer state
+    head_++;
+    seq_num_++;
+
+    // Wait for response
+    std::cout << "[RECV] Waiting for response..." << std::endl;
+
+    ret = 0;
+    int poll_count = 0;
+    const int max_polls = 5000;
+
+    while (ret == 0 && poll_count < max_polls) {
+      ret = ibv_poll_cq(recv_cq_, 1, &wc);
+      if (ret == 0) {
+        usleep(1000);
+        poll_count++;
+      }
+    }
+
+    if (ret < 0 || poll_count >= max_polls) {
+      std::cerr << "[TIMEOUT] No response received" << std::endl;
+      return false;
+    }
+
+    if (wc.status != IBV_WC_SUCCESS) {
+      std::cerr << "Receive completion error: " << ibv_wc_status_str(wc.status)
+                << std::endl;
+      return false;
+    }
+
+    std::cout << "[RECV] ✓ Response received (" << wc.byte_len << " bytes)"
+              << std::endl;
+
+    // Parse response: [status | result_len | result_data]
+    if (wc.byte_len < 8) {
+      std::cerr << "Response too short" << std::endl;
+      return false;
+    }
+
+    uint8_t *buf = (uint8_t *)recv_buffer_;
+    uint32_t status = *(uint32_t *)&buf[0];
+    uint32_t result_len = *(uint32_t *)&buf[4];
+
+    if (status != 0) {
+      std::cerr << "RPC error: status=" << status << std::endl;
+      return false;
+    }
+
+    response.assign(buf + 8, buf + 8 + result_len);
+
+    // Repost receive buffer
+    post_recv_buffer(qp_);
+
+    return true;
+  }
+
+private:
+  struct ibv_qp *qp_ = nullptr;
+  uint32_t local_qpn_ = 0;
+  uint32_t remote_qpn_ = 0;
+  union ibv_gid remote_gid_ = {};
+  uint64_t server_vaddr_ = 0;
+  uint32_t server_rkey_ = 0;
+  uint32_t num_slots_ = 0;
+  uint32_t slot_size_ = 0;
+
+  // Ring buffer state
+  uint64_t seq_num_ = 1;
+  uint32_t head_ = 0;
+};
+
+// Test functions
+static bool test_echo(RoCEDaemonClient &client) {
+  std::cout << "\n" << std::string(60, '=') << std::endl;
+  std::cout << "TEST 1: Echo Function" << std::endl;
+  std::cout << std::string(60, '=') << std::endl;
+
+  std::string message = "Hello from Daemon client!";
+  std::vector<uint8_t> args(message.begin(), message.end());
+  std::vector<uint8_t> response;
+
+  if (!client.send_rpc_request(FUNCTION_ECHO, args, response)) {
+    std::cout << "❌ FAIL: No response" << std::endl;
+    return false;
+  }
+
+  std::string result(response.begin(), response.end());
+
+  if (result == message) {
+    std::cout << "✅ SUCCESS: Echo returned correct message!" << std::endl;
+    std::cout << "  Sent: '" << message << "'" << std::endl;
+    std::cout << "  Received: '" << result << "'" << std::endl;
+    return true;
+  } else {
+    std::cout << "❌ FAIL: Sent '" << message << "', got '" << result << "'"
+              << std::endl;
+    return false;
+  }
+}
+
+static bool test_add(RoCEDaemonClient &client) {
+  std::cout << "\n" << std::string(60, '=') << std::endl;
+  std::cout << "TEST 2: Add Function" << std::endl;
+  std::cout << std::string(60, '=') << std::endl;
+
+  int32_t a = 42, b = 58;
+  int32_t expected = a + b;
+
+  std::vector<uint8_t> args(8);
+  *(int32_t *)&args[0] = a;
+  *(int32_t *)&args[4] = b;
+
+  std::cout << "  Computing: " << a << " + " << b << " = ?" << std::endl;
+
+  std::vector<uint8_t> response;
+  // TODO: Fix the magic function ID, which is the hash of "rpc::add"
+  if (!client.send_rpc_request(0x6a98bf13, args, response)) {
+    std::cout << "❌ FAIL: No response" << std::endl;
+    return false;
+  }
+
+  if (response.size() < 4) {
+    std::cout << "❌ FAIL: Response too short" << std::endl;
+    return false;
+  }
+
+  int32_t result = *(int32_t *)&response[0];
+
+  std::cout << "  Server returned: " << result << std::endl;
+
+  if (result == expected) {
+    std::cout << "✅ SUCCESS: " << a << " + " << b << " = " << result
+              << " (correct!)" << std::endl;
+    return true;
+  } else {
+    std::cout << "❌ FAIL: Expected " << expected << ", got " << result
+              << std::endl;
+    return false;
+  }
+}
+
+int main(int argc, char **argv) {
+  std::cout << std::string(60, '=') << std::endl;
+  std::cout << " RoCE Daemon Client (libibverbs)" << std::endl;
+  std::cout << " Single QP with function_id-based routing" << std::endl;
+  std::cout << std::string(60, '=') << std::endl;
+
+  std::string device_name = "rxe0";
+  std::string server_ip = "127.0.0.1";
+  uint16_t server_port = 9999;
+
+  if (argc > 1)
+    device_name = argv[1];
+  if (argc > 2)
+    server_ip = argv[2];
+
+  std::cout << "\nConfiguration:" << std::endl;
+  std::cout << "  Device: " << device_name << std::endl;
+  std::cout << "  Server: " << server_ip << ":" << server_port << std::endl;
+  std::cout << std::endl;
+
+  try {
+    RoCEDaemonClient client(device_name);
+
+    if (!client.initialize()) {
+      return 1;
+    }
+
+    if (!client.connect_to_server(server_ip, server_port)) {
+      return 1;
+    }
+
+    // Run tests
+    int success_count = 0;
+    int total_tests = 2;
+
+    if (test_echo(client)) {
+      success_count++;
+    }
+
+    sleep(1);
+
+    if (test_add(client)) {
+      success_count++;
+    }
+
+    // Summary
+    std::cout << "\n" << std::string(60, '=') << std::endl;
+    std::cout << "TEST SUMMARY: " << success_count << "/" << total_tests
+              << " tests passed" << std::endl;
+    std::cout << std::string(60, '=') << std::endl;
+
+    if (success_count == total_tests) {
+      std::cout << "All tests passed! Daemon mode working!\n";
+      return 0;
+    } else {
+      std::cout << "️ /!\\ Some tests failed.\n";
+      return 1;
+    }
+
+  } catch (const std::exception &e) {
+    std::cerr << "\n❌ Error: " << e.what() << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/realtime/examples/roce/udp_control_server.cpp
+++ b/realtime/examples/roce/udp_control_server.cpp
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "udp_control_server.h"
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <errno.h>
+#include <iostream>
+#include <stdexcept>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <nlohmann/json.hpp>
+
+UDPControlServer::UDPControlServer(uint16_t port)
+    : port_(port), sock_fd_(-1), client_connected_(false) {
+  std::memset(&client_addr_, 0, sizeof(client_addr_));
+}
+
+UDPControlServer::~UDPControlServer() {
+  if (sock_fd_ >= 0)
+    close(sock_fd_);
+}
+
+void UDPControlServer::start() {
+  // Create UDP socket
+  sock_fd_ = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock_fd_ < 0)
+    throw std::runtime_error("Failed to create UDP socket");
+
+  // Allow address reuse
+  int opt = 1;
+  setsockopt(sock_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+  // Bind to port
+  struct sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(port_);
+
+  if (bind(sock_fd_, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+    throw std::runtime_error("Failed to bind UDP socket");
+
+  std::cout << "[UDP] Control server listening on port " << port_ << "\n";
+}
+
+bool UDPControlServer::exchange_multi_channel(
+    const std::vector<cudaq::nvqlink::RoCEChannel *> &channels,
+    volatile bool *running_flag) {
+
+  std::cout << "[UDP] Waiting for client...\n";
+
+  // Set receive timeout to allow checking running flag
+  struct timeval tv;
+  tv.tv_sec = 1;
+  tv.tv_usec = 0;
+  setsockopt(sock_fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+  try {
+    // Exchange parameters for each channel
+    for (std::size_t i = 0; i < channels.size(); i++) {
+      std::cout << "\n[UDP] === Channel " << i << " exchange ===\n";
+
+      auto *channel = channels[i];
+
+      // Build server's connection params
+      auto params = channel->get_connection_params();
+      nlohmann::json j;
+      j["channel_idx"] = i;
+      j["qpn"] = params.qpn;
+      j["psn"] = params.psn;
+      j["gid"] = gid_to_string(params.gid);
+      j["vaddr"] = params.vaddr;
+      j["rkey"] = params.rkey;
+      j["lid"] = params.lid;
+      j["num_slots"] = params.num_slots;
+      j["slot_size"] = params.slot_size;
+
+      std::string msg = j.dump();
+
+      // Send channel params to client (retry until ACK received)
+      bool ack_received = false;
+      int retry_count = 0;
+      const int max_retries = 5;
+
+      while (!ack_received && retry_count < max_retries && *running_flag) {
+        // If first channel, we don't know client address yet
+        // Send to broadcast or wait for client to send first packet
+        if (i == 0 && !client_connected_) {
+          // Wait for initial packet from client (discovery)
+          char buf[4096];
+          socklen_t len = sizeof(client_addr_);
+
+          std::cout << "  [WAIT] Waiting for client discovery packet..."
+                    << std::endl;
+
+          ssize_t n = recvfrom(sock_fd_, buf, sizeof(buf), 0,
+                               (struct sockaddr *)&client_addr_, &len);
+
+          if (n < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+              continue; // Timeout, check running flag
+            throw std::runtime_error("Failed to receive discovery packet");
+          }
+
+          // Got discovery packet
+          std::cout << "  ✓ Client discovered: "
+                    << inet_ntoa(client_addr_.sin_addr) << ":"
+                    << ntohs(client_addr_.sin_port) << "\n";
+          client_connected_ = true;
+        }
+
+        // Send params to client
+        ssize_t sent =
+            sendto(sock_fd_, msg.c_str(), msg.length(), 0,
+                   (struct sockaddr *)&client_addr_, sizeof(client_addr_));
+
+        if (sent < 0)
+          throw std::runtime_error("Failed to send channel params");
+
+        std::cout << "  Server → Client: Channel " << i << " params sent\n";
+        std::cout << "    QPN: " << params.qpn << "\n";
+        std::cout << "    GID: " << gid_to_string(params.gid) << "\n";
+        std::cout << "    vaddr: 0x" << std::hex << params.vaddr << std::dec
+                  << "\n";
+        std::cout << "    rkey: 0x" << std::hex << params.rkey << std::dec
+                  << "\n";
+
+        // Wait for ACK with client params
+        char buf[4096];
+        socklen_t len = sizeof(client_addr_);
+
+        ssize_t n = recvfrom(sock_fd_, buf, sizeof(buf), 0,
+                             (struct sockaddr *)&client_addr_, &len);
+
+        if (n < 0) {
+          if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            // Timeout, retry
+            retry_count++;
+            std::cout << "  [RETRY] No ACK, retrying (" << retry_count << "/"
+                      << max_retries << ")...\n";
+            continue;
+          }
+          throw std::runtime_error("Failed to receive ACK");
+        }
+
+        // Parse ACK
+        try {
+          std::string ack_str(buf, n);
+          auto client_j = nlohmann::json::parse(ack_str);
+
+          uint32_t ack_channel_idx = client_j["channel_idx"];
+          if (ack_channel_idx != i) {
+            std::cerr << "  [WARN] ACK for wrong channel (expected " << i
+                      << ", got " << ack_channel_idx << ")\n";
+            continue;
+          }
+
+          uint32_t client_qpn = client_j["qpn"];
+          std::string client_gid_str = client_j["gid"];
+
+          std::cout << "  Client → Server: ACK received\n";
+          std::cout << "    QPN: " << client_qpn << "\n";
+          std::cout << "    GID: " << client_gid_str << "\n";
+
+          // Configure QP with client params
+          union ibv_gid client_gid = string_to_gid(client_gid_str);
+          channel->set_remote_qp(client_qpn, client_gid);
+
+          std::cout << "  ✓ Channel " << i << " UC QP setup complete\n";
+
+          ack_received = true;
+
+        } catch (const std::exception &e) {
+          std::cerr << "  [WARN] Failed to parse ACK: " << e.what() << "\n";
+          retry_count++;
+          continue;
+        }
+      }
+
+      if (!ack_received) {
+        std::cerr << "[UDP] Failed to receive ACK for channel " << i
+                  << " after " << max_retries << " retries\n";
+        return false;
+      }
+    }
+
+    std::cout << "\n[UDP] All " << channels.size() << " channels exchanged!\n";
+
+    // Step 3: Send START message with function routing
+    // In Channel mode, routing is done by queue selection (no function_id
+    // needed)
+    std::cout << "[UDP] Sending START message to client...\n";
+    nlohmann::json start_msg;
+    start_msg["cmd"] = "START";
+    start_msg["num_channels"] = channels.size();
+
+    // Function routing: map function_id → channel_idx
+    // This tells the client which queue to send each function to
+    nlohmann::json routing;
+    routing["1"] = 2; // ECHO (function_id=1) → channel 2
+    routing["2"] = 0; // ADD (function_id=2) → channel 0
+    routing["3"] = 1; // MULTIPLY (function_id=3) → channel 1
+    start_msg["function_routing"] = routing;
+
+    std::string msg = start_msg.dump();
+    ssize_t sent =
+        sendto(sock_fd_, msg.c_str(), msg.length(), 0,
+               (struct sockaddr *)&client_addr_, sizeof(client_addr_));
+
+    if (sent < 0) {
+      std::cerr << "[UDP] Warning: Failed to send START message\n";
+    } else {
+      std::cout << "[UDP] ✓ START message sent - client can begin RPC\n";
+      std::cout << "       Function routing:\n";
+      std::cout << "         ECHO (1) → channel 2\n";
+      std::cout << "         ADD (2) → channel 0\n";
+      std::cout << "         MULTIPLY (3) → channel 1\n";
+    }
+
+    return true;
+
+  } catch (const std::exception &e) {
+    std::cerr << "[UDP] Error: " << e.what() << "\n";
+    return false;
+  }
+}
+
+std::string UDPControlServer::gid_to_string(const union ibv_gid &gid) {
+  char buf[64];
+  inet_ntop(AF_INET6, gid.raw, buf, sizeof(buf));
+  return buf;
+}
+
+union ibv_gid UDPControlServer::string_to_gid(const std::string &gid_str) {
+  union ibv_gid gid;
+  inet_pton(AF_INET6, gid_str.c_str(), gid.raw);
+  return gid;
+}

--- a/realtime/examples/roce/udp_control_server.h
+++ b/realtime/examples/roce/udp_control_server.h
@@ -1,0 +1,54 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/channels/roce/roce_channel.h"
+
+#include <arpa/inet.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/// @brief UDP Control Server for RoCE connection setup
+///
+/// Server-driven protocol: Server sends channel params, waits for client ACK.
+/// No initial handshake - server drives by sending params for each channel.
+///
+class UDPControlServer {
+public:
+  UDPControlServer(uint16_t port);
+  ~UDPControlServer();
+
+  /// @brief Start listening on the control port (UDP)
+  void start();
+
+  /// @brief Exchange connection parameters for multiple channels
+  ///
+  /// For each channel:
+  ///   1. Server → Client: Channel params (JSON)
+  ///   2. Client → Server: ACK with client params (JSON)
+  ///   3. Server configures QP
+  ///
+  /// @param channels Vector of RoCE channels to configure
+  /// @param running_flag Pointer to flag for checking if server should keep
+  /// running
+  /// @return true if all channels setup succeeded, false otherwise
+  bool exchange_multi_channel(
+      const std::vector<cudaq::nvqlink::RoCEChannel *> &channels,
+      volatile bool *running_flag);
+
+private:
+  uint16_t port_;
+  int sock_fd_;
+  struct sockaddr_in client_addr_;
+  bool client_connected_;
+
+  std::string gid_to_string(const union ibv_gid &gid);
+  union ibv_gid string_to_gid(const std::string &gid_str);
+};

--- a/realtime/examples/roce/utils.h
+++ b/realtime/examples/roce/utils.h
@@ -1,0 +1,159 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <dirent.h>
+#include <fstream>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+inline std::string get_interface_name(const std::string &roce_device) {
+  // Try multiple methods to map RoCE device to network interface
+  
+  // Method 1: Read parent file (works for soft-RoCE)
+  std::string sysfs_path = "/sys/class/infiniband/" + roce_device + "/parent";
+  std::ifstream parent_file(sysfs_path);
+  if (parent_file.is_open()) {
+    std::string iface_name;
+    std::getline(parent_file, iface_name);
+    parent_file.close();
+    
+    // Trim whitespace
+    iface_name.erase(0, iface_name.find_first_not_of(" \t\r\n"));
+    iface_name.erase(iface_name.find_last_not_of(" \t\r\n") + 1);
+    
+    if (!iface_name.empty()) {
+      return iface_name;
+    }
+  }
+
+  // Method 2: Check device/net/ directory (works for hardware NICs like mlx5)
+  std::string net_dir = "/sys/class/infiniband/" + roce_device + "/device/net/";
+  DIR *dir = opendir(net_dir.c_str());
+  if (dir) {
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != nullptr) {
+      std::string name = entry->d_name;
+      if (name != "." && name != "..") {
+        closedir(dir);
+        return name; // Return first interface found
+      }
+    }
+    closedir(dir);
+  }
+
+  // Method 3: Check ports/1/gid_attrs/ndevs/0 (another common location)
+  std::string port_path = "/sys/class/infiniband/" + roce_device + 
+                          "/ports/1/gid_attrs/ndevs/0";
+  std::ifstream port_file(port_path);
+  if (port_file.is_open()) {
+    std::string iface_name;
+    std::getline(port_file, iface_name);
+    port_file.close();
+    
+    // Trim whitespace
+    iface_name.erase(0, iface_name.find_first_not_of(" \t\r\n"));
+    iface_name.erase(iface_name.find_last_not_of(" \t\r\n") + 1);
+    
+    if (!iface_name.empty()) {
+      return iface_name;
+    }
+  }
+
+  return "unknown";
+}
+
+inline std::string get_interface_ip(const std::string &iface_name) {
+  struct ifaddrs *ifaddr, *ifa;
+  std::string ip;
+
+  if (getifaddrs(&ifaddr) == -1) {
+    return ip;
+  }
+
+  for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr)
+      continue;
+
+    if (ifa->ifa_addr->sa_family == AF_INET &&
+        std::string(ifa->ifa_name) == iface_name) {
+      char addr_buf[INET_ADDRSTRLEN];
+      struct sockaddr_in *addr = (struct sockaddr_in *)ifa->ifa_addr;
+      inet_ntop(AF_INET, &addr->sin_addr, addr_buf, INET_ADDRSTRLEN);
+      ip = addr_buf;
+      break;
+    }
+  }
+
+  freeifaddrs(ifaddr);
+  return ip;
+}
+
+inline std::string get_primary_ip() {
+  // Find the first non-loopback, non-docker IPv4 address
+  struct ifaddrs *ifaddr, *ifa;
+  std::string ip;
+
+  if (getifaddrs(&ifaddr) == -1) {
+    return ip;
+  }
+
+  for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr)
+      continue;
+
+    if (ifa->ifa_addr->sa_family == AF_INET) {
+      std::string iface_name = ifa->ifa_name;
+
+      // Skip loopback and docker interfaces
+      if (iface_name == "lo" || iface_name.find("docker") == 0) {
+        continue;
+      }
+
+      char addr_buf[INET_ADDRSTRLEN];
+      struct sockaddr_in *addr = (struct sockaddr_in *)ifa->ifa_addr;
+      inet_ntop(AF_INET, &addr->sin_addr, addr_buf, INET_ADDRSTRLEN);
+      ip = addr_buf;
+      break; // Use the first valid IP found
+    }
+  }
+
+  freeifaddrs(ifaddr);
+  return ip;
+}
+
+inline std::string get_interface_mac(const std::string &iface_name) {
+  int sock = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    return "unknown";
+  }
+
+  struct ifreq ifr;
+  strncpy(ifr.ifr_name, iface_name.c_str(), IFNAMSIZ - 1);
+
+  if (ioctl(sock, SIOCGIFHWADDR, &ifr) < 0) {
+    close(sock);
+    return "unknown";
+  }
+
+  close(sock);
+
+  unsigned char *mac = (unsigned char *)ifr.ifr_hwaddr.sa_data;
+  char mac_str[18];
+  snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0],
+           mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+  return mac_str;
+}

--- a/realtime/include/cudaq/nvqlink.h
+++ b/realtime/include/cudaq/nvqlink.h
@@ -1,0 +1,11 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "nvqlink/nvqlink.h"

--- a/realtime/include/cudaq/nvqlink/compiler.h
+++ b/realtime/include/cudaq/nvqlink/compiler.h
@@ -1,0 +1,164 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+/// @file
+/// @brief CUDA-Q quantum compiler interface and kernel compilation system
+/// @details Provides interfaces for compiling quantum kernels into
+/// device-specific control programs for quantum processing units. Supports
+/// multiple quantum devices and resource management for compiled kernels.
+
+#pragma once
+
+#include "utils/extension_point.h"
+
+#include "device.h"
+
+/// @brief CUDA-Q quantum compiler and kernel management namespace
+/// @details Contains interfaces and implementations for compiling quantum
+/// kernels into executable control programs for quantum processing units.
+namespace cudaq::nvqlink {
+
+/// @brief Internal implementation details for quantum kernel compilation
+namespace details {
+/// @brief Removes non-entrypoint functions from MLIR code manually
+/// @param mlirCode The input MLIR code string to process
+/// @return Processed MLIR code with non-entrypoint functions removed
+/// @details This function manually parses and filters MLIR code to retain only
+/// the quantum kernel entrypoint functions, removing auxiliary functions that
+/// are not needed for device execution.
+std::string removeNonEntrypointFunctionsManual(const std::string &mlirCode);
+} // namespace details
+
+/// @brief Binary program representation for quantum control systems
+/// @details Encapsulates a compiled quantum program as binary data along with
+/// the target quantum device identifier. Used to store device-specific compiled
+/// quantum kernels ready for execution.
+struct qcontrol_program {
+  /// @brief Compiled binary program data
+  /// @details Raw binary representation of the quantum program compiled for
+  /// the specific quantum control system architecture.
+  std::vector<std::byte> binary;
+
+  /// @brief Target quantum device identifier
+  /// @details Specifies which quantum processing unit this program is compiled
+  /// for. Must match the device ID when executing the program.
+  std::size_t qdevice_id;
+};
+
+/// @brief Compiled quantum kernel with associated control programs and
+/// resources
+/// @details Represents a fully compiled quantum kernel that can be executed on
+/// one or more quantum devices. Manages compiled binary programs and tracks
+/// associated resources that need cleanup when the kernel is destroyed.
+class compiled_kernel {
+protected:
+  /// @brief Name of the original quantum kernel
+  /// @details Stores the kernel identifier used during compilation for
+  /// debugging and identification purposes.
+  std::string kernel_name;
+
+  /// @brief Collection of device-specific control programs
+  /// @details Each program in this vector corresponds to a different quantum
+  /// device or quantum control system that can execute this kernel.
+  std::vector<qcontrol_program> control_programs;
+
+  /// @brief Resource tracking for automatic cleanup
+  /// @details Maps resource pointers to their corresponding deleter functions.
+  /// When the compiled_kernel is destroyed, all tracked resources are properly
+  /// cleaned up using their associated deleter functions.
+  std::unordered_map<void *, std::function<void(void *)>> tracked_resources;
+
+public:
+  /// @brief Constructs a compiled kernel with programs and tracked resources
+  /// @param name The name of the quantum kernel
+  /// @param programs Vector of compiled control programs for different devices
+  /// @param tr Map of resources to their deleter functions for cleanup
+  /// @details Creates a compiled kernel instance with all necessary data for
+  /// execution on quantum devices. Takes ownership of the tracked resources.
+  compiled_kernel(
+      std::string name, std::vector<qcontrol_program> programs,
+      const std::unordered_map<void *, std::function<void(void *)>> &tr)
+      : kernel_name(name), control_programs(programs), tracked_resources(tr) {}
+
+  /// @brief Destructor that cleans up all tracked resources
+  /// @details Automatically calls the deleter function for each tracked
+  /// resource to ensure proper cleanup when the compiled kernel goes out of
+  /// scope.
+  ~compiled_kernel() {
+    for (auto &[resource, deleter] : tracked_resources)
+      deleter(resource);
+  }
+
+  /// @brief Gets the kernel name
+  /// @return Const reference to the kernel name string
+  /// @details Returns the identifier of the original quantum kernel that was
+  /// compiled.
+  const std::string &name() const { return kernel_name; }
+
+  /// @brief Gets the compiled control programs
+  /// @return Const reference to the vector of control programs
+  /// @details Returns all device-specific binary programs that were generated
+  /// during compilation of this quantum kernel.
+  const std::vector<qcontrol_program> &get_programs() const {
+    return control_programs;
+  };
+};
+
+/// @brief Abstract base class for quantum kernel compilers
+/// @details Defines the interface that all quantum compiler implementations
+/// must provide. Uses the extension point pattern to allow pluggable compiler
+/// backends for different quantum architectures and programming models.
+class compiler : public cudaqx::extension_point<compiler> {
+public:
+  /// @brief Virtual destructor for proper cleanup of derived classes
+  virtual ~compiler() = default;
+
+  /// @brief Determines if this compiler can handle the given code
+  /// @param code The quantum kernel code to analyze
+  /// @return True if this compiler understands and can compile the code, false
+  /// otherwise
+  /// @details Each compiler implementation should examine the code format,
+  /// language, or other characteristics to determine compatibility. This
+  /// enables automatic selection of the appropriate compiler for different code
+  /// types.
+  virtual bool understands_code(const std::string &code) const = 0;
+
+  /// @brief Compiles quantum kernel code into device-specific control programs
+  /// @param code The source code of the quantum kernel to compile
+  /// @param kernel_name The name identifier for the kernel
+  /// @param num_qcs_devices The number of quantum control system devices to
+  /// target
+  /// @return Unique pointer to the compiled kernel with all control programs
+  /// @details Performs the full compilation pipeline from source code to
+  /// executable binary programs for the specified number of quantum devices.
+  /// The returned compiled_kernel contains all necessary data for execution.
+  virtual std::unique_ptr<compiled_kernel>
+  compile(const std::string &code, const std::string &kernel_name,
+          std::size_t num_qcs_devices) = 0;
+};
+
+/// @brief Extracts MLIR code and kernel name from a quantum kernel callable
+/// @tparam QuantumKernel Type of the quantum kernel callable object
+/// @param kernel The quantum kernel object to extract information from
+/// @return Tuple containing the processed MLIR code and kernel name
+/// @details This template function works with any quantum kernel type to
+/// extract the underlying MLIR representation and kernel identifier. The MLIR
+/// code is processed to remove non-entrypoint functions, preparing it for
+/// compilation.
+/// @note The kernel parameter is forwarded to preserve value category and
+/// enable perfect forwarding for both lvalue and rvalue kernel objects.
+// template <typename QuantumKernel>
+// std::tuple<std::string, std::string> extract_code(QuantumKernel &&kernel) {
+//   std::string kernelName{
+//       cudaq::details::getKernelName(std::forward<QuantumKernel>(kernel))};
+//   auto code = details::removeNonEntrypointFunctionsManual(
+//       cudaq::get_quake_by_name(kernelName));
+//   return std::make_tuple(code, kernelName);
+// }
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/compilers/cudaq/cudaq.h
+++ b/realtime/include/cudaq/nvqlink/compilers/cudaq/cudaq.h
@@ -1,0 +1,32 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq_toolchain.h"
+#include "cudaq/nvqlink/compiler.h"
+#include "cudaq/nvqlink/device.h"
+
+namespace cudaq::nvqlink {
+
+// Subclasses need to fill the passes vector at
+// construction, can also provide the -load pluginlib.so here
+class cudaq_compiler : public compiler {
+protected:
+  std::vector<std::string> passes;
+
+public:
+  cudaq_compiler() {}
+  bool understands_code(const std::string &code) const override;
+
+  std::unique_ptr<compiled_kernel>
+  compile(const std::string &code, const std::string &kernel_name,
+          std::size_t num_qcs_devices) override;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/compilers/cudaq/cudaq_toolchain.h
+++ b/realtime/include/cudaq/nvqlink/compilers/cudaq/cudaq_toolchain.h
@@ -1,0 +1,174 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <dlfcn.h>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+struct toolchain_options {
+  std::string tempDir = "/tmp";
+  std::string optimizationLevel = "-O3";
+  std::vector<std::string> cudaqOptPasses = {"--canonicalize"};
+  std::string qirTarget = "qir"; // or "qir-base"
+  bool keepTempFiles = true;
+  std::string targetTriple = "x86_64-unknown-linux-gnu";
+};
+
+// Base class for all command line tools
+class command_line_tool {
+public:
+  struct tool_result {
+    std::string outputFile;
+    std::string content;
+    int exitCode = 0;
+    std::string errorMessage;
+
+    explicit operator bool() const { return exitCode == 0; }
+  };
+
+  command_line_tool(const std::string &toolName) : toolName_(toolName) {}
+  virtual ~command_line_tool() = default;
+
+  virtual tool_result execute(const std::string &inputFile) = 0;
+  virtual tool_result executeWithContent(const std::string &content) = 0;
+
+protected:
+  std::string toolName_;
+  std::string tempDir_ = "/tmp";
+  std::vector<std::string> tempFiles_;
+
+  std::string executeCommand(const std::string &command);
+  std::string generateUniqueId();
+  std::string createTempFile(const std::string &content,
+                             const std::string &suffix);
+  void addTempFile(const std::string &file) { tempFiles_.push_back(file); }
+
+public:
+  void setTempDir(const std::string &tempDir) { tempDir_ = tempDir; }
+  const std::vector<std::string> &getTempFiles() const { return tempFiles_; }
+};
+} // namespace cudaq::nvqlink
+
+namespace cudaq {
+using namespace nvqlink;
+
+// cudaq-opt tool
+class opt : public command_line_tool {
+private:
+  std::vector<std::string> passes_;
+
+public:
+  opt(const std::vector<std::string> &passes = {"--canonicalize"})
+      : command_line_tool("cudaq-opt"), passes_(passes) {}
+
+  tool_result execute(const std::string &inputFile) override;
+  tool_result executeWithContent(const std::string &content) override;
+
+  opt &addPass(const std::string &pass) {
+    passes_.push_back(pass);
+    return *this;
+  }
+};
+
+// cudaq-translate tool
+class translate : public command_line_tool {
+private:
+  std::string target_;
+
+public:
+  translate(const std::string &target = "qir")
+      : command_line_tool("cudaq-translate"), target_(target) {}
+
+  tool_result execute(const std::string &inputFile) override;
+  tool_result executeWithContent(const std::string &content) override;
+
+  translate &setTarget(const std::string &target) {
+    target_ = target;
+    return *this;
+  }
+};
+} // namespace cudaq
+using namespace cudaq::nvqlink;
+
+namespace llvm {
+// LLC tool
+class llc : public command_line_tool {
+private:
+  std::string targetTriple_;
+
+public:
+  llc(const std::string &targetTriple = "x86_64-unknown-linux-gnu")
+      : command_line_tool("llc"), targetTriple_(targetTriple) {}
+
+  tool_result execute(const std::string &inputFile) override;
+  tool_result executeWithContent(const std::string &content) override;
+
+  llc &setTargetTriple(const std::string &targetTriple) {
+    targetTriple_ = targetTriple;
+    return *this;
+  }
+};
+} // namespace llvm
+
+namespace clang {
+// Clang tool
+class linker : public command_line_tool {
+private:
+  std::string cudaqLibraryPath;
+  std::string optimizationLevel_;
+  bool shared_;
+  bool pic_;
+
+public:
+  linker(const std::string &cudaq, const std::string &optimizationLevel = "-O3",
+         bool shared = true, bool pic = true)
+      : command_line_tool("clang"), cudaqLibraryPath(cudaq),
+        optimizationLevel_(optimizationLevel), shared_(shared), pic_(pic) {}
+
+  tool_result execute(const std::string &inputFile) override;
+  tool_result executeWithContent(const std::string &content) override;
+  tool_result linkMultiple(const std::vector<std::string> &objectFiles);
+
+  linker &setOptimizationLevel(const std::string &level) {
+    optimizationLevel_ = level;
+    return *this;
+  }
+};
+} // namespace clang
+
+using namespace cudaq::nvqlink;
+// Pipe operator overloads for chaining tools
+command_line_tool::tool_result
+operator|(const command_line_tool::tool_result &input, cudaq::opt &tool);
+command_line_tool::tool_result
+operator|(const command_line_tool::tool_result &input,
+          const cudaq::translate &tool);
+command_line_tool::tool_result
+operator|(const command_line_tool::tool_result &input, const llvm::llc &tool);
+command_line_tool::tool_result
+operator|(const command_line_tool::tool_result &input, clang::linker &tool);
+
+namespace cudaq {
+// Helper class to start a pipeline with content
+class pipeline {
+private:
+  std::string content_;
+  std::string tempDir_;
+
+public:
+  pipeline(const std::string &content, const std::string &tempDir = "/tmp")
+      : content_(content), tempDir_(tempDir) {}
+
+  command_line_tool::tool_result operator|(const cudaq::opt &tool);
+};
+} // namespace cudaq

--- a/realtime/include/cudaq/nvqlink/config.h
+++ b/realtime/include/cudaq/nvqlink/config.h
@@ -1,0 +1,15 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+// Convenience umbrella header - includes all configuration headers
+
+#include "cudaq/nvqlink/daemon/config.h"
+#include "cudaq/nvqlink/network/config.h"
+#include "cudaq/nvqlink/qcs/config.h"

--- a/realtime/include/cudaq/nvqlink/daemon/config.h
+++ b/realtime/include/cudaq/nvqlink/daemon/config.h
@@ -1,0 +1,58 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+/// Datapath execution mode
+enum class DatapathMode { CPU, GPU };
+
+/// Compute resource configuration for daemon execution
+struct ComputeConfig {
+  // CPU mode
+  std::vector<uint32_t> cpu_cores;
+
+  // GPU mode
+  std::optional<uint32_t> gpu_device_id;
+  uint32_t gpu_blocks{0};
+  uint32_t gpu_threads_per_block{0};
+};
+
+/// Daemon configuration (Layer 3 - RPC server)
+/// Daemon-specific settings for function dispatch and execution
+struct DaemonConfig {
+  std::string id;
+  DatapathMode datapath_mode;
+  ComputeConfig compute;
+
+  // Validation
+  bool is_valid() const;
+};
+
+/// Builder for DaemonConfig
+class DaemonConfigBuilder {
+public:
+  DaemonConfigBuilder &set_id(const std::string &id);
+  DaemonConfigBuilder &set_datapath_mode(DatapathMode mode);
+  DaemonConfigBuilder &set_cpu_cores(const std::vector<uint32_t> &cores);
+  DaemonConfigBuilder &set_gpu_device(uint32_t device_id, uint32_t blocks,
+                                      uint32_t threads);
+
+  DaemonConfig build() const;
+
+private:
+  DaemonConfig config_;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/daemon/daemon.h
+++ b/realtime/include/cudaq/nvqlink/daemon/daemon.h
@@ -1,0 +1,101 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/daemon/config.h"
+#include "cudaq/nvqlink/daemon/dispatcher/dispatcher.h"
+#include "cudaq/nvqlink/daemon/registry/function_registry.h"
+#include "cudaq/nvqlink/daemon/registry/function_traits.h"
+#include "cudaq/nvqlink/daemon/registry/function_wrapper.h"
+#include "cudaq/nvqlink/network/channel.h"
+
+#include <atomic>
+#include <memory>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+/// Main daemon class representing an RPC server instance.
+/// Configuration is immutable after construction.
+class Daemon {
+public:
+  explicit Daemon(const DaemonConfig &config, std::unique_ptr<Channel> channel);
+  ~Daemon();
+
+  // Delete copy/move to prevent configuration changes
+  Daemon(const Daemon &) = delete;
+  Daemon &operator=(const Daemon &) = delete;
+  Daemon(Daemon &&) = delete;
+  Daemon &operator=(Daemon &&) = delete;
+
+  // Lifecycle management
+  void start();
+  void stop();
+  bool is_running() const { return running_.load(); }
+
+  // Function registration (must be done before start())
+  void register_function(const FunctionMetadata &metadata);
+
+  /// Register a normal C++ function as an RPC handler (new intuitive API).
+  ///
+  /// Use with NVQLINK_RPC_HANDLE macro for automatic name extraction:
+  /// @example
+  /// ```cpp
+  /// daemon->register_function(NVQLINK_RPC_HANDLE(namespace::function));
+  /// ```
+  ///
+  /// @tparam F Function type (deduced)
+  /// @param func Function to register
+  /// @param name Fully-qualified function name (used for ID generation)
+  /// @throws std::runtime_error if daemon is running or hash collision detected
+  ///
+  template <typename F>
+  void register_function(F &&func, std::string_view name) {
+    using Traits = function_traits<std::remove_cvref_t<F>>;
+    using Return = typename Traits::return_type;
+
+    FunctionMetadata meta{.function_id = hash_name(name),
+                          .name = std::string(name),
+                          .type = FunctionType::CPU,
+                          .max_result_size = serialized_size<Return>(),
+                          .cpu_function = make_wrapper(std::forward<F>(func)),
+                          .gpu_function = nullptr};
+
+    register_function(meta); // Calls existing method, checks collision
+  }
+
+  // Statistics
+  struct Stats {
+    uint64_t packets_received{0};
+    uint64_t packets_sent{0};
+    uint64_t errors{0};
+  };
+  Stats get_stats() const;
+
+  // Access to backend (for advanced usage)
+  Channel *channel() { return channel_.get(); }
+
+private:
+  void validate_config() const;
+  void initialize_dispatcher();
+
+  DaemonConfig config_;
+  std::atomic<bool> running_{false};
+
+  std::unique_ptr<Channel> channel_;
+  std::unique_ptr<FunctionRegistry> function_registry_;
+  std::unique_ptr<Dispatcher> dispatcher_;
+
+  std::vector<std::thread> worker_threads_;
+  Stats stats_;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/daemon/dispatcher/cpu_dispatcher.h
+++ b/realtime/include/cudaq/nvqlink/daemon/dispatcher/cpu_dispatcher.h
@@ -1,0 +1,67 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/daemon/dispatcher/dispatcher.h"
+#include "cudaq/nvqlink/network/channel.h"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+/// CPU-mode dispatcher supporting both polling and event-driven backends.
+/// - Polling backends: Calls receive_burst()
+/// - Event-driven backends: Registers callback, calls process_events()
+///
+class CPUDispatcher : public Dispatcher {
+public:
+  CPUDispatcher(Channel *channel, FunctionRegistry *registry,
+                const ComputeConfig &config);
+  ~CPUDispatcher() override;
+
+  void start() override;
+  void stop() override;
+  std::uint64_t get_packets_processed() const override;
+  std::uint64_t get_packets_sent() const override;
+
+private:
+  void polling_worker_thread(std::uint32_t core_id);
+
+  void event_driven_worker_thread(std::uint32_t core_id);
+
+  /// Packet processing (common to both models)
+  ///
+  /// @param buffer Packet buffer
+  ///
+  void process_packet(Buffer *buffer);
+
+  /// Callback for event-driven backends
+  ///
+  /// @param buffers Array of packet buffers
+  /// @param count Number of buffers
+  /// @param user_data User data
+  ///
+  static void packet_received_callback(Buffer **buffers, std::uint32_t count,
+                                       void *user_data);
+
+  Channel *channel_;
+  FunctionRegistry *registry_;
+  ComputeConfig config_;
+
+  ChannelModel model_;
+
+  std::atomic<bool> running_{false};
+  std::atomic<std::uint64_t> packets_processed_{0};
+  std::atomic<std::uint64_t> packets_sent_{0};
+  std::vector<std::thread> threads_;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/daemon/dispatcher/dispatcher.h
+++ b/realtime/include/cudaq/nvqlink/daemon/dispatcher/dispatcher.h
@@ -1,0 +1,48 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/daemon/config.h"
+#include "cudaq/nvqlink/network/channel.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace cudaq::nvqlink {
+
+class FunctionRegistry;
+
+/// Abstract dispatcher interface.
+/// CPU and GPU modes have different implementations.
+///
+class Dispatcher {
+public:
+  virtual ~Dispatcher() = default;
+
+  virtual void start() = 0;
+  virtual void stop() = 0;
+
+  virtual std::uint64_t get_packets_processed() const = 0;
+  virtual std::uint64_t get_packets_sent() const = 0;
+};
+
+/// Factory
+///
+/// @param mode Datapath mode
+/// @param backend Backend providing I/O and buffer management
+/// @param registry Function registry
+/// @param compute_config Compute config
+/// @return Dispatcher
+///
+std::unique_ptr<Dispatcher>
+create_dispatcher(DatapathMode mode, Channel *channel,
+                  FunctionRegistry *registry,
+                  const ComputeConfig &compute_config);
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/daemon/dispatcher/gpu_dispatcher.h
+++ b/realtime/include/cudaq/nvqlink/daemon/dispatcher/gpu_dispatcher.h
@@ -1,0 +1,66 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/daemon/dispatcher/dispatcher.h"
+
+#include <atomic>
+#include <cuda_runtime.h>
+
+namespace cudaq::nvqlink {
+
+/// GPU-mode dispatcher using persistent CUDA kernel.
+///
+class GPUDispatcher : public Dispatcher {
+public:
+  GPUDispatcher(Channel *channel, FunctionRegistry *registry,
+                const ComputeConfig &config);
+  ~GPUDispatcher() override;
+
+  void start() override;
+  void stop() override;
+  uint64_t get_packets_processed() const override;
+  uint64_t get_packets_sent() const override;
+
+private:
+  void launch_persistent_kernel();
+
+  Channel *channel_;
+  FunctionRegistry *registry_;
+  ComputeConfig config_;
+
+  // GPU resources
+  cudaStream_t stream_{nullptr};
+  void *device_shutdown_flag_{nullptr};
+  void *device_stats_{nullptr};
+
+  std::atomic<bool> running_{false};
+};
+
+/// CUDA kernel declaration
+///
+/// @param rx_queue RX queue
+/// @param tx_queue TX queue
+/// @param buffer_pool Buffer pool
+/// @param function_table Function table
+/// @param function_ids Function IDs
+/// @param func_count Function count
+/// @param shutdown_flag Shutdown flag
+/// @param stats Stats
+/// @param num_blocks Number of blocks
+/// @param threads_per_block Threads per block
+/// @param stream Stream
+///
+void launch_daemon_kernel(void *rx_queue, void *tx_queue, void *buffer_pool,
+                          void **function_table, uint32_t *function_ids,
+                          size_t func_count, volatile int *shutdown_flag,
+                          uint64_t *stats, uint32_t num_blocks,
+                          uint32_t threads_per_block, cudaStream_t stream);
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/daemon/registry/function_registry.h
+++ b/realtime/include/cudaq/nvqlink/daemon/registry/function_registry.h
@@ -1,0 +1,103 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/serialization/input_stream.h"
+#include "cudaq/nvqlink/network/serialization/output_stream.h"
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+namespace cudaq::nvqlink {
+
+/// CPU function signature: type-safe streaming interface.
+///
+/// User functions receive an InputStream for reading arguments and
+/// an OutputStream for writing results. Both streams operate on the
+/// same underlying buffer (zero-copy), but provide separate, type-safe
+/// interfaces for reading and writing.
+///
+/// @param in Input stream for reading function arguments
+/// @param out Output stream for writing function results
+/// @return Status code (0 = success, non-zero = error)
+///
+/// @example
+/// ```cpp
+/// int add_function(InputStream& in, OutputStream& out) {
+///   int a = in.read<int>();
+///   int b = in.read<int>();
+///   out.write(a + b);
+///   return 0;
+/// }
+/// ```
+using CPUFunction = std::function<int(InputStream &in, OutputStream &out)>;
+
+// GPU function signature (device function pointer)
+using GPUFunction = void *; // Actually: __device__ function pointer
+
+enum class FunctionType { CPU, GPU };
+
+struct FunctionMetadata {
+  std::uint32_t function_id;
+  std::string name;
+  FunctionType type;
+  std::size_t max_result_size;
+
+  // CPU mode
+  CPUFunction cpu_function;
+
+  // GPU mode
+  GPUFunction gpu_function;
+};
+
+/// Registry for user-defined RPC functions.
+/// Functions must be registered before daemon starts.
+///
+class FunctionRegistry {
+public:
+  FunctionRegistry() = default;
+
+  void register_function(const FunctionMetadata &metadata);
+
+  const FunctionMetadata *lookup(std::uint32_t function_id) const;
+
+  //===--------------------------------------------------------------------===//
+  // GPU mode
+  //===--------------------------------------------------------------------===//
+
+  // For GPU mode: get device-side function table
+  struct GPUFunctionTable {
+    void **device_function_ptrs; // Array of device function pointers
+    std::uint32_t *function_ids; // Corresponding function IDs
+    std::size_t count;
+  };
+  GPUFunctionTable get_gpu_function_table() const;
+
+  /// Get GPU function registry for NVQLink streaming interface
+  /// 
+  /// Converts registered functions to GPUFunctionRegistry format
+  /// for use with GPU kernels that use GPUInputStream/GPUOutputStream.
+  /// Returns device pointer.
+  /// 
+  /// This is the standard NVQLink GPU function dispatch format,
+  /// used by DOCA kernels and any future GPU kernels using the
+  /// streaming interface.
+  /// 
+  /// @return Device pointer to GPUFunctionRegistry (device memory)
+  void* get_gpu_registry() const;
+
+private:
+  std::unordered_map<std::uint32_t, FunctionMetadata> functions_;
+  mutable GPUFunctionTable gpu_table_; // Cached GPU function table (legacy format)
+  mutable void* device_gpu_registry_ = nullptr; // Cached GPUFunctionRegistry (NVQLink format)
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/daemon/registry/function_traits.h
+++ b/realtime/include/cudaq/nvqlink/daemon/registry/function_traits.h
@@ -1,0 +1,120 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+
+namespace cudaq::nvqlink {
+
+//===----------------------------------------------------------------------===//
+// Serialization Concepts
+//===----------------------------------------------------------------------===//
+
+/// Enforces POD (Plain Old Data) requirement for RPC serialization. Types must
+// be trivially copyable and standard layout for zero-copy transfer.
+template <typename T>
+concept Serializable =
+    std::is_trivially_copyable_v<T> && std::is_standard_layout_v<T>;
+
+/// Validates return types for RPC (POD or void)
+template <typename T>
+concept SerializableReturn = std::is_void_v<T> || Serializable<T>;
+
+//===----------------------------------------------------------------------===//
+// Function Traits for Signature Introspection
+//===----------------------------------------------------------------------===//
+
+/// Primary template (undefined - will cause compile error for unsupported
+/// types)
+template <typename T>
+struct function_traits;
+
+/// Specialization for function types (e.g., int(int, int))
+template <typename R, typename... Args>
+struct function_traits<R(Args...)> {
+  using return_type = R;
+  using arg_tuple = std::tuple<std::remove_cvref_t<Args>...>;
+  static constexpr std::size_t arity = sizeof...(Args);
+
+  // Compile-time validation: all arguments must be Serializable
+  static_assert((Serializable<std::remove_cvref_t<Args>> && ...),
+                "All function arguments must be POD types (trivially copyable "
+                "and standard layout)");
+  static_assert(SerializableReturn<R>, "Return type must be void or POD type");
+};
+
+/// Specialization for function pointers (e.g., int(*)(int, int))
+template <typename R, typename... Args>
+struct function_traits<R (*)(Args...)> : function_traits<R(Args...)> {};
+
+/// Specialization for member function pointers (non-const)
+template <typename C, typename R, typename... Args>
+struct function_traits<R (C::*)(Args...)> : function_traits<R(Args...)> {};
+
+/// Specialization for member function pointers (const)
+template <typename C, typename R, typename... Args>
+struct function_traits<R (C::*)(Args...) const> : function_traits<R(Args...)> {
+};
+
+/// Specialization for functors and lambdas (via operator())
+/// This uses SFINAE to only match types that have an operator()
+template <typename F>
+struct function_traits : function_traits<decltype(&F::operator())> {};
+
+//===----------------------------------------------------------------------===//
+// Compile-Time Size Calculation
+//===----------------------------------------------------------------------===//
+
+/// Calculate serialized size of a type
+template <typename T>
+constexpr std::size_t serialized_size() noexcept {
+  if constexpr (std::is_void_v<T>) {
+    return 0;
+  } else {
+    static_assert(Serializable<T>, "Type must be serializable (POD)");
+    return sizeof(T);
+  }
+}
+
+/// Calculate max result size for a function's return type
+template <typename F>
+constexpr std::size_t result_size() noexcept {
+  using Traits = function_traits<std::remove_cvref_t<F>>;
+  using Return = typename Traits::return_type;
+  return serialized_size<Return>();
+}
+
+//===----------------------------------------------------------------------===//
+// FNV-1a Hash for Automatic ID Generation
+//===----------------------------------------------------------------------===//
+
+/// FNV-1a hash algorithm for generating stable function IDs from names.
+/// This is a constexpr-friendly hash with good distribution properties.
+///
+/// @param name Fully-qualified function name (e.g., "namespace::function")
+/// @return 32-bit hash value
+///
+constexpr std::uint32_t hash_name(std::string_view name) noexcept {
+  // FNV-1a constants
+  constexpr std::uint32_t FNV_OFFSET_BASIS = 2166136261u;
+  constexpr std::uint32_t FNV_PRIME = 16777619u;
+
+  std::uint32_t hash = FNV_OFFSET_BASIS;
+  for (char c : name) {
+    hash ^= static_cast<std::uint32_t>(static_cast<unsigned char>(c));
+    hash *= FNV_PRIME;
+  }
+  return hash;
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/daemon/registry/function_wrapper.h
+++ b/realtime/include/cudaq/nvqlink/daemon/registry/function_wrapper.h
@@ -1,0 +1,130 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/daemon/registry/function_registry.h"
+#include "cudaq/nvqlink/daemon/registry/function_traits.h"
+#include "cudaq/nvqlink/network/serialization/input_stream.h"
+#include "cudaq/nvqlink/network/serialization/output_stream.h"
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace cudaq::nvqlink {
+
+/// Macro to capture both function pointer and its name as a string.
+/// Expands to: function_pointer, "namespace::function_name"
+///
+/// @example
+/// ```cpp
+/// daemon->register_function(NVQLINK_RPC_HANDLE(math::add));
+/// // Expands to: daemon->register_function(math::add, "math::add")
+/// ```
+#define NVQLINK_RPC_HANDLE(f) f, #f
+
+//===----------------------------------------------------------------------===//
+// Argument Deserialization
+//===----------------------------------------------------------------------===//
+
+/// Deserialize arguments from InputStream into a tuple.
+/// Uses fold expressions and index_sequence for compile-time iteration.
+///
+/// @tparam Tuple Tuple type containing argument types
+/// @tparam Is Index sequence (0, 1, 2, ...)
+/// @param in Input stream to read from
+/// @return Tuple containing deserialized arguments
+///
+template <typename Tuple, std::size_t... Is>
+Tuple deserialize_args_impl(InputStream &in, std::index_sequence<Is...>) {
+  // Read each argument in sequence using fold expression
+  return Tuple{in.read<std::tuple_element_t<Is, Tuple>>()...};
+}
+
+/// Deserialize all function arguments from stream.
+///
+/// @tparam Args Variadic template of argument types
+/// @param in Input stream to read from
+/// @return Tuple containing all deserialized arguments
+///
+template <typename... Args>
+std::tuple<Args...> deserialize_args(InputStream &in) {
+  return deserialize_args_impl<std::tuple<Args...>>(
+      in, std::index_sequence_for<Args...>{});
+}
+
+//===----------------------------------------------------------------------===//
+// Result Serialization
+//===----------------------------------------------------------------------===//
+
+/// Serialize function result to OutputStream.
+/// Handles both void and non-void return types.
+///
+/// @tparam R Return type
+/// @param out Output stream to write to
+/// @param result Result value to serialize
+///
+template <typename R>
+void serialize_result(OutputStream &out, R &&result) {
+  if constexpr (!std::is_void_v<R>)
+    out.write(std::forward<R>(result));
+  // For void, do nothing
+}
+
+//===----------------------------------------------------------------------===//
+// Function Wrapper Generator
+//===----------------------------------------------------------------------===//
+
+/// Generate a CPUFunction wrapper from a normal C++ function.
+///
+/// This is the core of the magic - it takes a regular function like:
+///   `int32_t add(int32_t a, int32_t b)`
+///
+/// And generates a wrapper compatible with the RPC system:
+///   `int wrapper(InputStream& in, OutputStream& out)`
+///
+/// All template work happens at registration time (control path).
+/// The generated lambda has zero overhead on the hot path.
+///
+/// @tparam F Function type (deduced)
+/// @param func Function to wrap
+/// @return CPUFunction compatible with the dispatcher
+///
+template <typename F>
+CPUFunction make_wrapper(F &&func) {
+  using Traits = function_traits<std::remove_cvref_t<F>>;
+  using Args = typename Traits::arg_tuple;
+  using Return = typename Traits::return_type;
+
+  // The wrapper lambda captures the function and performs serialization
+  return [func = std::forward<F>(func)](InputStream &in,
+                                        OutputStream &out) -> int {
+    try {
+      // Deserialize arguments from input stream into tuple
+      auto args = deserialize_args_impl<Args>(
+          in, std::make_index_sequence<std::tuple_size_v<Args>>{});
+
+      // Call the function with unpacked arguments
+      if constexpr (std::is_void_v<Return>) {
+        std::apply(func, std::move(args));
+        // No result to serialize
+      } else {
+        auto result = std::apply(func, std::move(args));
+        serialize_result(out, std::move(result));
+      }
+
+      return 0; // Success
+    } catch (const std::exception &e) {
+      // TODO: Consider logging the error
+      return -1; // Error
+    }
+  };
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/daemon/registry/gpu_function_registry.h
+++ b/realtime/include/cudaq/nvqlink/daemon/registry/gpu_function_registry.h
@@ -1,0 +1,66 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// NEW: NVQLink-specific component (not adapted from Hololink)
+// PURPOSE: Device-side function registry for RPC dispatch in GPU kernels
+
+#pragma once
+
+#include "cudaq/nvqlink/network/serialization/gpu_input_stream.h"
+#include "cudaq/nvqlink/network/serialization/gpu_output_stream.h"
+
+#include <cstdint>
+
+namespace cudaq::nvqlink {
+
+/**
+ * @brief Device-side function wrapper for GPU RPC dispatch
+ * 
+ * Wraps a GPU-callable function that processes RPC requests.
+ * The function receives serialized arguments via GPUInputStream
+ * and writes results via GPUOutputStream.
+ */
+struct GPUFunctionWrapper {
+    using InvokeFunc = std::int32_t (*)(GPUInputStream&, GPUOutputStream&);
+    
+    InvokeFunc invoke;
+    std::uint32_t function_id;
+};
+
+/**
+ * @brief Device-side function registry (GPU-accessible)
+ * 
+ * Simple linear search registry for GPU kernels. Optimized for
+ * small function counts (< 256 functions). For larger registries,
+ * consider hash table or binary search.
+ */
+struct GPUFunctionRegistry {
+    static constexpr std::uint32_t MAX_FUNCTIONS = 256;
+    
+    GPUFunctionWrapper functions[MAX_FUNCTIONS];
+    std::uint32_t num_functions;
+    
+    /**
+     * @brief Look up function by ID (device-side)
+     * 
+     * @param function_id RPC function ID
+     * @return Function wrapper or nullptr if not found
+     */
+    __device__ GPUFunctionWrapper* lookup(std::uint32_t function_id) {
+        // Linear search - sufficient for small registries
+        for (std::uint32_t i = 0; i < num_functions; ++i) {
+            if (functions[i].function_id == function_id) {
+                return &functions[i];
+            }
+        }
+        return nullptr;
+    }
+};
+
+} // namespace cudaq::nvqlink
+

--- a/realtime/include/cudaq/nvqlink/daemon/registry/rpc_builder.h
+++ b/realtime/include/cudaq/nvqlink/daemon/registry/rpc_builder.h
@@ -1,0 +1,92 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/daemon/registry/function_registry.h"
+#include "cudaq/nvqlink/daemon/registry/function_traits.h"
+#include "cudaq/nvqlink/daemon/registry/function_wrapper.h"
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+// Forward declaration
+class Daemon;
+
+/// Fluent builder API for bulk RPC function registration.
+///
+/// Allows registering multiple functions with a clean, chainable syntax:
+/// @example
+/// ```cpp
+/// RPCBuilder()
+///     .add(NVQLINK_RPC_HANDLE(rpc::add))
+///     .add(NVQLINK_RPC_HANDLE(rpc::multiply))
+///     .add(NVQLINK_RPC_HANDLE(rpc::echo))
+///     .register_all(*daemon);
+/// ```
+///
+class RPCBuilder {
+public:
+  RPCBuilder() = default;
+
+  /// Add a function to the builder.
+  ///
+  /// Use with NVQLINK_RPC_HANDLE macro for automatic name extraction:
+  /// ```cpp
+  /// builder.add(NVQLINK_RPC_HANDLE(namespace::function));
+  /// ```
+  ///
+  /// @tparam F Function type (deduced)
+  /// @param func Function to register
+  /// @param name Fully-qualified function name
+  /// @return Reference to this builder (for chaining)
+  ///
+  template <typename F>
+  RPCBuilder &add(F &&func, std::string_view name) {
+    using Traits = function_traits<std::remove_cvref_t<F>>;
+    using Return = typename Traits::return_type;
+
+    FunctionMetadata meta{.function_id = hash_name(name),
+                          .name = std::string(name),
+                          .type = FunctionType::CPU,
+                          .max_result_size = serialized_size<Return>(),
+                          .cpu_function = make_wrapper(std::forward<F>(func)),
+                          .gpu_function = nullptr};
+
+    entries_.push_back(std::move(meta));
+    return *this;
+  }
+
+  /// Register all accumulated functions with a daemon.
+  ///
+  /// @param daemon Daemon instance to register functions with
+  /// @throws std::runtime_error if hash collision is detected
+  ///
+  void register_all(Daemon &daemon) const;
+
+  /// Get the number of functions in the builder.
+  ///
+  /// @return Number of functions accumulated
+  ///
+  std::size_t size() const { return entries_.size(); }
+
+  /// Check if the builder is empty.
+  ///
+  /// @return true if no functions have been added
+  ///
+  bool empty() const { return entries_.empty(); }
+
+private:
+  std::vector<FunctionMetadata> entries_;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/device.h
+++ b/realtime/include/cudaq/nvqlink/device.h
@@ -1,0 +1,60 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+namespace cudaq::nvqlink {
+
+/// @brief Memory pointer abstraction (kept for reference, not used by new
+/// architecture)
+/// @details Represents a pointer to memory allocated on a quantum processing
+/// unit (controller or classical device). Encapsulates device memory management
+/// details including location and size.
+///
+/// NOTE: This struct is kept for backward compatibility and reference,
+/// but is not actively used by the new Daemon-based architecture.
+/// New code should use native C++ types with automatic serialization.
+struct device_ptr {
+
+  /// @brief Opaque handle to device memory block
+  std::size_t handle = std::numeric_limits<std::size_t>::max();
+
+  /// @brief Size of allocated memory in bytes
+  std::size_t size = 0;
+
+  /// @brief Physical device identifier
+  std::size_t device_id = std::numeric_limits<std::size_t>::max();
+
+  /// @brief Pointer to host memory when referencing local memory
+  void *host_shadow = nullptr;
+
+  /// @brief Default constructor
+  device_ptr() = default;
+
+  /// @brief Constructor with handle and size
+  device_ptr(std::size_t h, std::size_t s) : handle(h), size(s) {}
+
+  /// @brief Constructor with handle, size, and device ID
+  device_ptr(std::size_t h, std::size_t s, std::size_t dev)
+      : handle(h), size(s), device_id(dev) {}
+
+  /// @brief Check if this device_ptr is valid
+  bool is_valid() const {
+    return handle != std::numeric_limits<std::size_t>::max();
+  }
+
+  /// @brief Check if this represents local/host memory
+  bool is_local() const {
+    return device_id == std::numeric_limits<std::size_t>::max();
+  }
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/lqpu.h
+++ b/realtime/include/cudaq/nvqlink/lqpu.h
@@ -1,0 +1,25 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <string>
+
+namespace cudaq::nvqlink {
+
+/// @brief LQPU configuration
+/// @details Logical Quantum Processing Unit configuration.
+/// In the new architecture, LQPU is just configuration data,
+/// not a device container. Actual runtime components (Daemon, QCSDevice,
+/// Channel) are managed explicitly.
+struct LQPUConfig {
+  std::string name;
+  // Future: add connection/deployment info as needed
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channel.h
+++ b/realtime/include/cudaq/nvqlink/network/channel.h
@@ -1,0 +1,160 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/memory/buffer.h"
+
+#include <cstdint>
+#include <functional>
+#include <stdexcept>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+// Channel execution model determines how packets are delivered to the daemon.
+enum class ChannelModel : std::uint8_t {
+  POLLING,     // Application polls the channel for packets
+  EVENT_DRIVEN // Channel invokes callbacks
+};
+
+/// Callback invoked by event-driven channels when packets arrive.
+///
+/// @param buffers Array of packet buffers
+/// @param count Number of buffers
+/// @param user_data User context passed during registration
+///
+using PacketReceivedCallback =
+    std::function<void(Buffer **buffers, std::uint32_t count, void *user_data)>;
+
+/// Abstract channel interface for network I/O.
+///
+/// Channel instances are _NOT_ shareable. That is, multiple threads must not
+/// access the same channel instance concurrently.
+///
+/// Each `Daemon` must create its own `Channel` instance. Multiple channels can
+/// share the same physical NIC through the `NetworkDevice` (managed via
+/// `NetworkDeviceRegistry`), but each channel owns exclusive access to its
+/// allocated queues.
+///
+/// Example:
+/// ```cpp
+///   auto channel1 = std::make_unique<ConcreteChannel>(config1);  // Daemon 1
+///   auto channel2 = std::make_unique<ConcreteChannel>(config2);  // Daemon 2
+///   // channel1 and channel2 share device (via registry), own different queues
+/// ```
+class Channel {
+public:
+  Channel(const Channel &) = delete;
+  Channel &operator=(const Channel &) = delete;
+
+  virtual ~Channel() = default;
+
+  // Initialization
+  virtual void initialize() = 0;
+  virtual void cleanup() = 0;
+
+  // Get execution model
+  virtual ChannelModel get_execution_model() const = 0;
+
+  // Memory management
+  virtual void register_memory(void *addr, std::size_t size) = 0;
+
+  /// Acquire a buffer from the channel's pool (zero allocation on hot path).
+  ///
+  /// @return Buffer, or nullptr if pool exhausted
+  ///
+  /// **OWNERSHIP**: Caller acquires ownership of the buffer and MUST either:
+  ///   1. Pass to send_burst() (transfers ownership), OR
+  ///   2. Call release_buffer() when done
+  ///
+  /// @note Returns pointer to pre-allocated memory - zero malloc on hot path
+  virtual Buffer *acquire_buffer() = 0;
+
+  /// Release a buffer back to the pool.
+  ///
+  /// @param buffer Buffer to release
+  ///
+  /// **OWNERSHIP**: Caller must own the buffer. After this call, buffer is
+  /// invalid.
+  ///
+  /// @note Only call if you still own the buffer (didn't pass to send_burst)
+  virtual void release_buffer(Buffer *buffer) = 0;
+
+  /// Receive a burst of packets (zero-copy, zero allocation).
+  ///
+  /// @param buffers Output array for received buffers
+  /// @param max_count Maximum buffers to receive
+  /// @return Number of buffers received
+  ///
+  /// **OWNERSHIP**: Channel transfers ownership of buffers to caller.
+  ///                Caller MUST call release_buffer() for each buffer when
+  ///                done.
+  ///
+  /// @note Zero-copy: buffers point to pre-allocated ring buffer memory
+  virtual std::uint32_t receive_burst(Buffer **buffers,
+                                      std::uint32_t max_count) {
+    throw std::runtime_error("Polling not supported by this channel");
+  }
+
+  /// Send a burst of packets (zero-copy, takes ownership).
+  ///
+  /// @param buffers Array of buffers to send
+  /// @param count Number of buffers to send
+  /// @return Number of buffers successfully queued for transmission
+  ///
+  /// **OWNERSHIP**: Channel takes ownership of ALL buffers (success or
+  /// failure).
+  ///                Caller MUST NOT touch buffers after this call.
+  ///                Channel will release buffers after transmission completes.
+  ///
+  /// @note Zero-copy: sends directly from pre-allocated memory (no copy)
+  virtual std::uint32_t send_burst(Buffer **buffers, std::uint32_t count) {
+    throw std::runtime_error("Polling not supported by this channel");
+  }
+
+  // Register callback that channel will invoke when packets arrive
+  virtual void register_packet_callback(PacketReceivedCallback callback,
+                                        void *user_data) {
+    throw std::runtime_error("Event-driven mode not supported by this channel");
+  }
+
+  // Application must call this to allow channel to process events
+  // For DOCA: this calls doca_pe_progress() which invokes callbacks
+  virtual void process_events() {
+    throw std::runtime_error("Event-driven mode not supported by this channel");
+  }
+
+  // GPU mode - returns GPU memory handles for persistent kernel
+  struct GPUMemoryHandles {
+    void *rx_queue_addr;       // QP handle (RoCE) or doca_gpu_dev_verbs_qp* (DOCA)
+    void *tx_queue_addr;       // Same as rx_queue_addr for bidirectional
+    void *buffer_pool_addr;    // GPU buffer address
+    std::size_t buffer_pool_size;
+    
+    // DOCA-specific fields (null/zero for non-DOCA channels)
+    void *cq_rq_addr;          // doca_gpu_dev_verbs_cq* (DOCA receive CQ)
+    std::uint32_t buffer_mkey; // Memory key for RDMA operations
+    std::uint32_t *exit_flag;  // CPU-side exit flag (for host writes)
+    std::uint32_t *gpu_exit_flag; // GPU-side exit flag (for kernel reads)
+    std::size_t page_size;     // Buffer page/slot size
+    unsigned num_pages;        // Number of buffer pages/slots
+  };
+  virtual GPUMemoryHandles get_gpu_memory_handles() {
+    return {}; // Only implemented by GPU channels
+  }
+
+  // Configuration
+  virtual void
+  configure_queues(const std::vector<std::uint32_t> &queue_ids) = 0;
+
+protected:
+  Channel() = default;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/doca/doca_buffer_pool.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/doca/doca_buffer_pool.h
@@ -1,0 +1,83 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/memory/buffer.h"
+
+#include <cuda.h>
+#include <doca_dev.h>
+#include <doca_gpunetio.h>
+#include <infiniband/verbs.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+/// @brief GPU-registered buffer pool for DOCA Channel
+///
+/// Key features
+/// - Allocates GPU memory via doca_gpu_mem_alloc()
+/// - dmabuf registration: doca_gpu_dmabuf_fd() + ibv_reg_dmabuf_mr()
+/// - Fallback: ibv_reg_mr_iova() if dmabuf registration fails
+///
+class DOCABufferPool {
+public:
+  DOCABufferPool(doca_gpu *gpu_device, doca_dev *nic_device,
+                 ibv_pd *protection_domain, std::size_t total_size,
+                 std::size_t page_size, unsigned num_pages);
+
+  ~DOCABufferPool();
+
+  DOCABufferPool(const DOCABufferPool &) = delete;
+  DOCABufferPool &operator=(const DOCABufferPool &) = delete;
+
+  /// @brief Initialize the buffer pool
+  bool initialize();
+
+  std::uint8_t *get_gpu_buffer() const { return gpu_buffer_; }
+  std::uint32_t get_rkey() const { return mr_ ? mr_->rkey : 0; }
+  std::uint32_t get_lkey() const { return mr_ ? mr_->lkey : 0; }
+
+  /// @brief Get memory key in big-endian format for DOCA WQEs
+  std::uint32_t get_mkey_be() const;
+
+  std::uint64_t get_external_address() const { return external_addr_; }
+
+  // For Channel interface compatibility
+  Buffer *acquire();
+  void release(Buffer *buffer);
+
+  std::size_t get_page_size() const { return page_size_; }
+  unsigned get_num_pages() const { return num_pages_; }
+
+private:
+  doca_gpu *gpu_device_;
+  doca_dev *nic_device_;
+  ibv_pd *protection_domain_;
+
+  std::size_t total_size_;
+  std::size_t page_size_;
+  unsigned num_pages_;
+
+  std::uint8_t *gpu_buffer_ = nullptr;
+  ibv_mr *mr_ = nullptr;
+  std::uint64_t external_addr_ = 0;
+  int dmabuf_fd_ = -1;
+
+  std::vector<std::unique_ptr<Buffer>> buffers_;
+  std::queue<Buffer *> free_list_;
+  std::mutex mutex_;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/doca/doca_channel.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/doca/doca_channel.h
@@ -1,0 +1,144 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/channel.h"
+#include "cudaq/nvqlink/network/channels/doca/doca_channel_config.h"
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <doca_dev.h>
+#include <doca_gpunetio.h>
+#include <doca_verbs.h>
+#include <infiniband/verbs.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+// Forward declarations
+class DOCACompletionQueue;
+class DOCAQueuePair;
+class DOCABufferPool;
+
+/// @brief DOCA-based channel with GPU-controlled NIC access
+///
+/// This channel uses NVIDIA DOCA GPUNetIO to give the GPU direct control
+/// over NIC queue pairs, enabling ultra-low latency RPC processing where
+/// the GPU polls CQs, processes requests, and submits responses without
+/// CPU involvement in the hot path.
+///
+/// Key differences from RoCEChannel:
+/// - CQ polling happens on GPU, not CPU
+/// - Work requests submitted via GPU SM doorbell
+/// - Zero CPU involvement in steady-state operation
+///
+class DOCAChannel : public Channel {
+public:
+  explicit DOCAChannel(const DOCAChannelConfig &config);
+  ~DOCAChannel() override;
+
+  // Disable copy/move (owns hardware resources)
+  DOCAChannel(const DOCAChannel &) = delete;
+  DOCAChannel &operator=(const DOCAChannel &) = delete;
+  DOCAChannel(DOCAChannel &&) = delete;
+  DOCAChannel &operator=(DOCAChannel &&) = delete;
+
+  // Channel interface implementation
+
+  /// @brief Initialize DOCA resources
+  void initialize() override;
+
+  /// @brief Cleanup DOCA resources
+  void cleanup() override;
+
+  // Note: These are NOT used in GPU mode - GPU kernel handles I/O directly
+  // Kept for interface compatibility and potential fallback/testing modes
+  std::uint32_t receive_burst(Buffer **buffers, std::uint32_t max) override;
+  std::uint32_t send_burst(Buffer **buffers, std::uint32_t count) override;
+
+  Buffer *acquire_buffer() override;
+  void release_buffer(Buffer *buffer) override;
+
+  void register_memory(void *addr, std::size_t size) override;
+  void configure_queues(const std::vector<std::uint32_t> &queue_ids) override;
+
+  // GPU-based polling is still polling (just done by GPU)
+  ChannelModel get_execution_model() const override {
+    return ChannelModel::POLLING;
+  }
+
+  /// @brief Get GPU memory handles for GPUDispatcher integration
+  ///
+  /// Returns DOCA-specific handles including:
+  /// - rx_queue_addr: doca_gpu_dev_verbs_qp* (device-side QP)
+  /// - cq_rq_addr: doca_gpu_dev_verbs_cq* (receive CQ)
+  /// - buffer_mkey: Memory key for RDMA
+  /// - exit_flag: GPU-accessible exit flag
+  ///
+  GPUMemoryHandles get_gpu_memory_handles() override;
+
+  // Connection management (adapted from DocaRoceReceiver methods)
+
+  /// @brief Get connection parameters for control plane exchange
+  DOCAConnectionParams get_connection_params() const;
+
+  /// @brief Configure remote peer after control plane exchange
+  void set_remote_qp(std::uint32_t remote_qpn,
+                     const std::array<std::uint8_t, 16> &remote_gid);
+
+  /// @brief Signal kernel to exit gracefully
+  void signal_exit();
+
+  /// @brief Check if channel is in RTS (Ready to Send) state
+  bool is_connected() const { return connected_; }
+
+private:
+  void init_doca_device();
+  void init_gpu_device();
+  void init_protection_domain();
+  void init_uar();
+  void init_completion_queues();
+  void init_queue_pair();
+  void init_buffer_pool();
+  void init_exit_flag();
+  void find_roce_gid();
+
+  // Configuration
+  DOCAChannelConfig config_;
+
+  // DOCA core resources
+  doca_dev *doca_device_ = nullptr;
+  doca_gpu *doca_gpu_device_ = nullptr;
+  doca_verbs_context *verbs_ctx_ = nullptr;
+  doca_verbs_pd *verbs_pd_ = nullptr;
+  doca_uar *uar_ = nullptr;
+  ibv_pd *ibv_pd_ = nullptr; // Needed for buffer registration
+
+  // Queue resources
+  std::unique_ptr<DOCACompletionQueue> cq_rq_;
+  std::unique_ptr<DOCACompletionQueue> cq_sq_;
+  std::unique_ptr<DOCAQueuePair> qp_;
+
+  // Buffer management
+  std::unique_ptr<DOCABufferPool> buffer_pool_;
+
+  // GPU resources
+  std::uint32_t *gpu_exit_flag_ = nullptr;
+  std::uint32_t *cpu_exit_flag_ = nullptr;
+  cudaStream_t cuda_stream_ = nullptr;
+
+  // Connection state
+  std::uint32_t gid_index_ = 0;
+  bool connected_ = false;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/doca/doca_channel_config.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/doca/doca_channel_config.h
@@ -1,0 +1,77 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace cudaq::nvqlink {
+
+/// @brief Number of Work Queue Entries
+/// 
+/// Must be power of 2. Higher values increase throughput capacity
+/// but also memory usage. 64 is a good balance for RPC workloads.
+/// 
+constexpr std::uint32_t DOCA_WQE_NUM = 64;
+
+/// @brief Maximum inline send size in WQE
+///
+/// Payloads smaller than this can be embedded directly in the WQE,
+/// avoiding an extra DMA read. Optimizes small RPC responses.
+///
+constexpr std::size_t DOCA_MAX_INLINE_SIZE = 44;
+
+/// @brief Configuration for DOCA Channel
+///
+struct DOCAChannelConfig {
+  // Network device (from ibv_name, ibv_port parameters)
+  std::string nic_device{"mlx5_0"};
+  std::uint32_t nic_port{1};
+
+  // GPU configuration
+  int gpu_device_id{0};
+
+  // Buffer configuration (from cu_buffer_size, cu_page_size, pages)
+  std::size_t buffer_size{64 * 1024 * 1024};
+  std::size_t page_size{4096};
+  unsigned num_pages{1024};
+
+  // Queue configuration
+  std::uint32_t wqe_num{DOCA_WQE_NUM};
+
+  // RPC configuration (from cu_frame_size)
+  std::size_t max_rpc_size{2048};
+
+  // Remote peer (from peer_ip parameter)
+  std::string peer_ip;
+  std::uint32_t remote_qpn{0};
+
+  bool is_valid() const {
+    return !nic_device.empty() && buffer_size > 0 && page_size > 0 &&
+           num_pages > 0 && wqe_num > 0;
+  }
+};
+
+/// @brief Connection parameters exchanged via control plane
+///
+/// Uses std::array for GID to avoid DOCA header dependency in public API.
+/// Can be converted to/from doca_verbs_gid internally.
+///
+struct DOCAConnectionParams {
+  std::uint32_t qpn;                // Queue pair number
+  std::array<std::uint8_t, 16> gid; // Global identifier (128-bit)
+  std::uint64_t buffer_addr;        // Virtual address of buffer
+  std::uint32_t rkey;               // Remote memory key
+  std::uint32_t num_slots;          // Number of buffer slots
+  std::size_t slot_size;            // Size of each slot
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/doca/doca_completion_queue.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/doca/doca_completion_queue.h
@@ -1,0 +1,61 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <doca_dev.h>
+#include <doca_error.h>
+#include <doca_gpunetio.h>
+#include <doca_uar.h>
+#include <doca_umem.h>
+#include <doca_verbs.h>
+
+#include <cstdint>
+
+namespace cudaq::nvqlink {
+
+/// @brief DOCA Completion Queue wrapper with GPU-external datapath
+///
+/// Manages:
+/// - GPU memory for CQ entries (via doca_gpu_mem_alloc)
+/// - DOCA UMEM registration
+/// - CQ creation with external datapath enabled
+///
+/// RAII: Cleans up resources in destructor.
+///
+class DOCACompletionQueue {
+public:
+  DOCACompletionQueue(std::uint32_t cqe_num, doca_gpu *gdev, doca_dev *ndev,
+                      doca_uar *uar, doca_verbs_context *vctx);
+
+  ~DOCACompletionQueue();
+
+  // Disable copy/move
+  DOCACompletionQueue(const DOCACompletionQueue &) = delete;
+  DOCACompletionQueue &operator=(const DOCACompletionQueue &) = delete;
+
+  /// @brief Create and initialize the CQ
+  /// @return DOCA_SUCCESS or error code
+  doca_error_t create();
+
+  /// @brief Get the DOCA Verbs CQ handle
+  doca_verbs_cq *get() const { return cq_; }
+
+private:
+  doca_gpu *gdev_;
+  doca_dev *ndev_;
+  doca_uar *uar_;
+  doca_verbs_context *vctx_;
+  std::uint32_t cqe_num_;
+
+  doca_verbs_cq *cq_ = nullptr;
+  void *umem_dev_ptr_ = nullptr;
+  doca_umem *umem_ = nullptr;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/doca/doca_queue_pair.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/doca/doca_queue_pair.h
@@ -1,0 +1,102 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <doca_dev.h>
+#include <doca_error.h>
+#include <doca_gpunetio.h>
+#include <doca_uar.h>
+#include <doca_umem.h>
+#include <doca_verbs.h>
+
+#include <array>
+#include <cstdint>
+
+namespace cudaq::nvqlink {
+
+//===------------------------------------------------------------------------===
+// QP state transition masks
+//===------------------------------------------------------------------------===
+
+constexpr std::uint32_t DOCA_UC_QP_RST2INIT_REQ_ATTR_MASK =
+    DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE |
+    DOCA_VERBS_QP_ATTR_PKEY_INDEX | DOCA_VERBS_QP_ATTR_PORT_NUM;
+
+constexpr std::uint32_t DOCA_UC_QP_INIT2RTR_REQ_ATTR_MASK =
+    DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_RQ_PSN |
+    DOCA_VERBS_QP_ATTR_DEST_QP_NUM | DOCA_VERBS_QP_ATTR_PATH_MTU |
+    DOCA_VERBS_QP_ATTR_AH_ATTR;
+
+constexpr std::uint32_t DOCA_UC_QP_RTR2RTS_REQ_ATTR_MASK =
+    DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_SQ_PSN;
+
+/// @brief DOCA Queue Pair wrapper with GPU-external datapath
+///
+/// Manages:
+/// - QP creation with external datapath
+/// - GPU memory for WQE ring and doorbell records
+/// - QP state transitions (RST → INIT → RTR → RTS)
+/// - GPU export for kernel access
+///
+/// RAII: Cleans up resources in destructor.
+///
+class DOCAQueuePair {
+public:
+  DOCAQueuePair(std::uint32_t wqe_num, doca_gpu *gdev, doca_dev *ndev,
+                doca_uar *uar, doca_verbs_context *vctx, doca_verbs_pd *vpd,
+                doca_verbs_cq *cq_rq, doca_verbs_cq *cq_sq);
+
+  ~DOCAQueuePair();
+
+  // Disable copy/move
+  DOCAQueuePair(const DOCAQueuePair &) = delete;
+  DOCAQueuePair &operator=(const DOCAQueuePair &) = delete;
+
+  /// @brief Create and initialize the QP
+  doca_error_t create();
+
+  /// @brief Transition QP to RTS (Ready to Send) state
+  ///
+  /// Performs UC QP state transitions:
+  /// 1. RST → INIT
+  /// 2. INIT → RTR (Ready to Receive)
+  /// 3. RTR → RTS (Ready to Send)
+  ///
+  doca_error_t connect(const doca_verbs_gid &remote_gid,
+                       std::uint32_t gid_index, std::uint32_t dest_qp_num);
+
+  /// @brief Get the DOCA Verbs QP handle (host-side)
+  doca_verbs_qp *get() const { return qp_; }
+
+  /// @brief Get the GPU Verbs QP handle (host-side)
+  doca_gpu_verbs_qp *get_gpu() const { return gpu_qp_; }
+
+  /// @brief Get the GPU device QP handle (device-side accessible)
+  doca_gpu_dev_verbs_qp *get_gpu_dev() const { return gpu_dev_qp_; }
+
+private:
+  std::uint32_t wqe_num_;
+  doca_gpu *gdev_;
+  doca_dev *ndev_;
+  doca_uar *uar_;
+  doca_verbs_context *vctx_;
+  doca_verbs_pd *vpd_;
+  doca_verbs_cq *cq_rq_;
+  doca_verbs_cq *cq_sq_;
+
+  doca_verbs_qp *qp_ = nullptr;
+  void *umem_dev_ptr_ = nullptr;
+  doca_umem *umem_ = nullptr;
+  doca_umem *umem_dbr_ = nullptr;
+  void *umem_dbr_dev_ptr_ = nullptr;
+  doca_gpu_verbs_qp *gpu_qp_ = nullptr;
+  doca_gpu_dev_verbs_qp *gpu_dev_qp_ = nullptr;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/doca/doca_rpc_kernel.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/doca/doca_rpc_kernel.h
@@ -1,0 +1,73 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <doca_error.h>
+#include <doca_gpunetio_verbs_def.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace cudaq::nvqlink {
+
+// Forward declaration
+struct GPUFunctionRegistry;
+
+extern "C" {
+
+/// @brief Prepare receive and send WQEs before starting main loop
+///
+/// Must be called once before launching the main RPC kernel to initialize
+/// WQE entries and post initial receive work requests.
+///
+/// @param stream CUDA stream for async execution
+/// @param qp GPU device queue pair handle
+/// @param max_rpc_size Maximum size of RPC request/response
+/// @param buffer_mkey Memory key for RDMA buffer
+/// @param num_wqes Number of WQEs to prepare (should match WQE_NUM)
+/// @return DOCA_SUCCESS or error code
+doca_error_t doca_prepare_wqes(cudaStream_t stream, doca_gpu_dev_verbs_qp *qp,
+                               std::uint32_t max_rpc_size,
+                               std::uint32_t buffer_mkey,
+                               std::uint32_t num_wqes);
+
+/// @brief Main RPC processing kernel launcher
+///
+/// Launches a persistent kernel that:
+/// 1. Polls CQ for incoming RPC requests
+/// 2. Dispatches to registered GPU functions
+/// 3. Sends responses back
+/// 4. Reposts receive WQEs
+///
+/// The kernel runs until exit_flag is set to non-zero.
+///
+/// @param stream CUDA stream for kernel launch
+/// @param qp GPU device queue pair handle
+/// @param exit_flag GPU-accessible flag for graceful shutdown
+/// @param buffer GPU buffer for RPC data
+/// @param page_size Size of each buffer page
+/// @param buffer_mkey Memory key for buffer
+/// @param num_pages Number of buffer pages
+/// @param registry Device-side function registry
+/// @param cuda_blocks Number of thread blocks
+/// @param cuda_threads Number of threads per block
+/// @return DOCA_SUCCESS or error code
+///
+doca_error_t doca_rpc_kernel(cudaStream_t stream, doca_gpu_dev_verbs_qp *qp,
+                             std::uint32_t *exit_flag, std::uint8_t *buffer,
+                             std::uint32_t page_size, std::uint32_t buffer_mkey,
+                             unsigned num_pages, GPUFunctionRegistry *registry,
+                             std::uint32_t cuda_blocks,
+                             std::uint32_t cuda_threads);
+
+} // extern "C"
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/roce/roce_buffer_pool.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/roce/roce_buffer_pool.h
@@ -1,0 +1,62 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/memory/buffer.h"
+
+#include <cstdint>
+#include <infiniband/verbs.h>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+/// Buffer pool for RoCE/RDMA buffer management.
+///
+/// Manages Buffer wrappers for RDMA buffers using memory polling architecture.
+///
+/// Used exclusively with UC (Unreliable Connection) mode with RDMA WRITE
+/// and memory polling .
+///
+class RoCEBufferPool {
+public:
+  explicit RoCEBufferPool(std::size_t pool_size);
+  ~RoCEBufferPool();
+
+  /// Wrap data from ring buffer (memory polling).
+  ///
+  /// @param addr Base address of RPC payload (no Ethernet header)
+  /// @param length Length of RPC data
+  /// @param slot_id Slot ID for tracking
+  /// @return Buffer wrapper pointing to the data
+  Buffer *wrap_ring_buffer_data(void *addr, std::uint32_t length,
+                                std::uint64_t slot_id);
+
+  /// Return buffer to pool after processing.
+  void return_buffer(Buffer *buffer);
+
+  /// Get Work Request ID for a buffer (slot ID for ring buffer tracking).
+  std::uint64_t get_wr_id(Buffer *buffer) const;
+
+  /// Set Work Request ID for a buffer (for TX slot tracking).
+  void set_wr_id(Buffer *buffer, std::uint64_t wr_id);
+
+  /// Get a free buffer wrapper for TX allocation (no memory allocation!).
+  Buffer *get_free_buffer();
+
+private:
+  std::vector<std::unique_ptr<Buffer>> buffer_pool_;
+  std::vector<Buffer *> free_buffers_;
+
+  // Map buffer to Work Request ID (slot ID for ring buffer)
+  std::unordered_map<Buffer *, std::uint64_t> wr_id_map_;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/roce/roce_channel.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/roce/roce_channel.h
@@ -1,0 +1,223 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/channel.h"
+#include "cudaq/nvqlink/network/channels/roce/roce_buffer_pool.h"
+#include "cudaq/nvqlink/network/channels/roce/roce_ring_buffer.h"
+#include "cudaq/nvqlink/network/channels/roce/verbs_context.h"
+#include "cudaq/nvqlink/network/steering/flow_switch.h"
+
+#include <infiniband/verbs.h>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+/// RoCE channel for RDMA-based packet I/O.
+///
+/// Implements Channel interface using InfiniBand Verbs for zero-copy RDMA.
+/// Only supports UC (Unreliable Connection) mode with memory polling.
+///
+/// UC Mode: Connection-oriented, requires QP pairing with remote client.
+/// Uses RDMA WRITE for incoming packets (memory polling) and RDMA SEND for
+/// responses.
+///
+/// Each RoCEChannel is self-sufficient and manages its own Queue Pairs.
+/// Can operate independently or share resources via VerbsContext.
+///
+class RoCEChannel : public Channel {
+public:
+  /// Create an independent RoCE channel (no memory sharing).
+  ///
+  /// The channel creates its own `ibv_context` and `ibv_pd`, fully isolated
+  /// from other channels. Use this mode when channels don't need to share
+  /// memory registrations.
+  ///
+  /// @param device_name Device name (e.g., "mlx5_0") or index (e.g., "0")
+  /// @param listen_port UDP port for receiving packets (used by FlowSwitch)
+  /// @param flow_switch Traffic coordinator for steering packets to this
+  /// channel
+  ///
+  RoCEChannel(const std::string &device_name, std::uint16_t listen_port,
+              std::shared_ptr<FlowSwitch> flow_switch);
+
+  /// Create a RoCE channel with shared memory resources.
+  ///
+  /// The channel shares `ibv_context` and `ibv_pd` with other channels via
+  /// `VerbsContext`. Use this mode when multiple channels need to access
+  /// the same memory registrations for zero-copy data sharing.
+  ///
+  /// @param shared_ctx Shared verbs context for memory sharing
+  /// @param listen_port UDP port for receiving packets (used by FlowSwitch)
+  /// @param flow_switch Traffic coordinator for steering packets to this
+  /// channel
+  ///
+  RoCEChannel(std::shared_ptr<VerbsContext> shared_ctx,
+              std::uint16_t listen_port,
+              std::shared_ptr<FlowSwitch> flow_switch);
+
+  ~RoCEChannel() override;
+
+  /// Connection parameters
+  struct ConnectionParams {
+    std::uint32_t qpn;   // Queue Pair Number
+    std::uint32_t psn;   // Packet Sequence Number
+    union ibv_gid gid;   // Global ID (16 bytes)
+    std::uint64_t vaddr; // Virtual address of ring buffer base
+    std::uint32_t rkey;  // Remote key for RDMA WRITE
+    std::uint16_t lid;   // Local ID (for IB, 0 for RoCE)
+    // Ring buffer configuration
+    std::uint32_t num_slots; // Number of ring buffer slots
+    std::uint32_t slot_size; // Size of each slot in bytes
+  };
+
+  /// Export connection parameters for lite clients
+  ConnectionParams get_connection_params() const;
+
+  /// Set remote QP info (must be called before QP transitions to RTR)
+  void set_remote_qp(std::uint32_t remote_qpn, const union ibv_gid &remote_gid);
+
+  //===--------------------------------------------------------------------===//
+  // Channel interface
+  //===--------------------------------------------------------------------===//
+
+  void initialize() override;
+  void cleanup() override;
+  ChannelModel get_execution_model() const override {
+    return ChannelModel::POLLING;
+  }
+
+  void register_memory(void *addr, std::size_t size) override;
+
+  // Buffer management - RoCE uses RoCEBufferPool
+  Buffer *acquire_buffer() override;
+  void release_buffer(Buffer *buffer) override;
+
+  std::uint32_t receive_burst(Buffer **buffers,
+                              std::uint32_t max_count) override;
+  std::uint32_t send_burst(Buffer **buffers, std::uint32_t count) override;
+
+  void configure_queues(const std::vector<std::uint32_t> &queue_ids) override;
+
+private:
+  // Pre-allocated receive buffer with registered memory
+  struct RecvBuffer {
+    void *addr{nullptr};
+    struct ibv_mr *mr{nullptr};
+    std::uint64_t buffer_id{0}; // Unique ID used as WR ID
+  };
+
+  //===--------------------------------------------------------------------===//
+  // Initialization helpers
+  //===--------------------------------------------------------------------===//
+
+  void init_independent(const std::string &device_name);
+  void init_shared(std::shared_ptr<VerbsContext> shared_ctx);
+
+  //===--------------------------------------------------------------------===//
+  // Resource access (handles both independent and shared modes)
+  //===--------------------------------------------------------------------===//
+
+  struct ibv_context *get_context() const;
+  struct ibv_pd *get_pd() const;
+  std::uint8_t get_port_num() const;
+
+  //===--------------------------------------------------------------------===//
+  // Queue Pair management
+  //===--------------------------------------------------------------------===//
+
+  void create_queue_pair();
+  void transition_qp_to_rts(struct ibv_qp *qp);
+  void create_completion_queues();
+
+  //===--------------------------------------------------------------------===//
+  // Buffer management
+  //===--------------------------------------------------------------------===//
+
+  void preallocate_recv_buffers(std::uint32_t count);
+  void initial_post_recv_buffers(struct ibv_qp *qp);
+  void repost_recv_buffer(struct ibv_qp *qp, RecvBuffer *rb);
+
+  // Poll completion queue
+  std::uint32_t poll_completions(struct ibv_cq *cq, struct ibv_wc *wc_array,
+                                 std::uint32_t max_count);
+
+  //===--------------------------------------------------------------------===//
+  // Receive implementation
+  //===--------------------------------------------------------------------===//
+
+  // Initialize ring buffers
+  void initialize_rx_ring_buffer(); // For receiving (RDMA WRITE target)
+  void initialize_tx_ring_buffer(); // For sending (pre-allocated TX slots)
+
+  // Common ring buffer allocation helper
+  void *allocate_and_register_ring_buffer(std::size_t size, int access_flags,
+                                          struct ibv_mr **out_mr,
+                                          const char *buffer_name);
+
+  //===--------------------------------------------------------------------===//
+  // Member variables
+  //===--------------------------------------------------------------------===//
+
+  // Configuration
+  std::uint16_t listen_port_;
+  std::shared_ptr<FlowSwitch> flow_switch_;
+
+  // Shared context (null if independent mode)
+  std::shared_ptr<VerbsContext> shared_ctx_;
+
+  // Independent mode resources (owned if shared_ctx_ is null)
+  struct ibv_context *owned_context_{nullptr};
+  struct ibv_pd *owned_pd_{nullptr};
+  std::uint8_t port_num_{1};
+  bool owns_context_{false};
+
+  // Verbs resources per channel
+  struct ibv_cq *send_cq_{nullptr};
+  struct ibv_cq *recv_cq_{nullptr};
+  struct ibv_qp *qp_{nullptr};
+
+  // Remote QP info
+  std::uint32_t remote_qpn_{0};
+  union ibv_gid remote_gid_{};
+  bool remote_qp_set_{false};
+
+  // Buffer management (pre-allocated, NEVER allocated in hot path)
+  std::unique_ptr<RoCEBufferPool> buffer_pool_;
+  // Pre-allocated receive buffers with MRs
+  std::vector<RecvBuffer> recv_buffers_;
+  // Fast lookup by WR ID
+  std::unordered_map<std::uint64_t, RecvBuffer *> buffer_id_map_;
+
+  // RX Ring buffer for RDMA WRITE memory polling (client → server)
+  std::unique_ptr<RingBufferPoller> rx_ring_buffer_poller_;
+  void *rx_ring_buffer_base_{nullptr};
+  struct ibv_mr *rx_ring_buffer_mr_{nullptr};
+  RingBufferConfig rx_ring_buffer_config_;
+
+  // TX Ring buffer for sending responses (server → client)
+  // Pre-allocated slots, NO allocation on hot path
+  void *tx_ring_buffer_base_{nullptr};
+  struct ibv_mr *tx_ring_buffer_mr_{nullptr};
+  std::uint32_t tx_num_slots_{1024};
+  std::uint32_t tx_slot_size_{2048};
+  std::vector<bool> tx_slot_free_; // Pre-allocated slot tracking
+  std::size_t tx_next_slot_{0};    // Round-robin hint for allocation
+
+  // Configuration constants
+  static constexpr std::uint32_t RECV_RING_SIZE = 1024;
+  static constexpr std::uint32_t SEND_RING_SIZE = 1024;
+  static constexpr std::uint32_t CQ_SIZE = 2048;
+  static constexpr std::uint32_t RECV_BUFFER_SIZE = 2048;
+  static constexpr std::uint32_t MAX_INLINE_DATA = 64;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/roce/roce_ring_buffer.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/roce/roce_ring_buffer.h
@@ -1,0 +1,180 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace cudaq::nvqlink {
+
+/// @brief Shared memory ring buffer layout for RDMA WRITE operations
+///
+/// This implements a lock-free, single-producer single-consumer ring buffer
+/// optimized for RDMA WRITE operations.
+///
+/// Memory Layout:
+/// ┌────────────────────────────────────┐
+/// │ RingBufferHeader (metadata)        │
+/// ├────────────────────────────────────┤
+/// │ Slot 0: [seqn | len | payload]     │
+/// │ Slot 1: [seqn | len | payload]     │
+/// │ ...                                │
+/// │ Slot N-1: [seqn | len | payload]   │
+/// └────────────────────────────────────┘
+///
+/// Producer (RDMA WRITE client):
+/// - Writes to slots in circular order
+/// - Increments sequence number for each write
+/// - Updates head pointer after write
+///
+/// Consumer (Server memory polling):
+/// - Polls tail slot's sequence number
+/// - When seq_num changes → new packet available
+/// - Advances tail pointer after processing
+///
+
+/// Ring buffer control structure (at start of registered memory)
+struct alignas(64) RingBufferHeader {
+  std::atomic<std::uint64_t> head; ///< Next slot to write (producer)
+  std::atomic<std::uint64_t> tail; ///< Next slot to read (consumer)
+  std::uint32_t num_slots;         ///< Total number of slots
+  std::uint32_t slot_size;         ///< Size of each slot in bytes
+  std::uint64_t padding[6];        ///< Cache line padding
+};
+
+/// Per-slot header (at start of each slot)
+struct alignas(16) SlotHeader {
+  std::atomic<std::uint64_t> seqn; ///< Sequence number (0 = empty)
+  std::uint32_t payload_len;       ///< Payload length in bytes
+  std::uint32_t reserved;          ///< Reserved for future use
+};
+
+/// Configuration for ring buffer
+struct RingBufferConfig {
+  std::uint32_t num_slots = 1024; ///< Number of slots (must be power of 2)
+  std::uint32_t slot_size = 2048; ///< Size per slot (including header)
+
+  std::size_t total_size() const {
+    return sizeof(RingBufferHeader) + (num_slots * slot_size);
+  }
+
+  std::size_t get_slot_offset(std::uint32_t index) const {
+    return sizeof(RingBufferHeader) + (index * slot_size);
+  }
+
+  std::uint32_t get_max_payload_size() const {
+    return slot_size - sizeof(SlotHeader);
+  }
+};
+
+/// Helper class for managing ring buffer on server side
+class RingBufferPoller {
+public:
+  RingBufferPoller(void *base_addr, const RingBufferConfig &config)
+      : base_addr_(static_cast<char *>(base_addr)), config_(config),
+        header_(reinterpret_cast<RingBufferHeader *>(base_addr)) {
+    // Initialize header
+    header_->head.store(0, std::memory_order_relaxed);
+    header_->tail.store(0, std::memory_order_relaxed);
+    header_->num_slots = config.num_slots;
+    header_->slot_size = config.slot_size;
+
+    // Clear all slot sequence numbers
+    for (std::uint32_t i = 0; i < config.num_slots; i++) {
+      SlotHeader *slot = get_slot_header(i);
+      slot->seqn.store(0, std::memory_order_relaxed);
+    }
+  }
+
+  /// @brief Poll for next packet (non-blocking)
+  /// @param[out] data Pointer to packet data (if available)
+  /// @param[out] len Length of packet data
+  /// @return true if packet available, false otherwise
+  ///
+  bool poll_next(char **data, std::uint32_t *len) {
+    std::uint64_t tail = header_->tail.load(std::memory_order_acquire);
+    std::uint32_t slot_idx = tail % config_.num_slots;
+
+    SlotHeader *slot = get_slot_header(slot_idx);
+    std::uint64_t seq = slot->seqn.load(std::memory_order_acquire);
+
+    // Check if new packet is available
+    if (seq != expected_seqn_)
+      return false; // No new packet
+
+    // Packet available!
+    *len = slot->payload_len;
+    *data = base_addr_ + config_.get_slot_offset(slot_idx) + sizeof(SlotHeader);
+
+    // Advance tail and expected sequence
+    header_->tail.store(tail + 1, std::memory_order_release);
+    expected_seqn_++;
+
+    // Mark slot as consumed (optional, for debugging)
+    slot->seqn.store(0, std::memory_order_release);
+
+    return true;
+  }
+
+  /// @brief Poll for next burst of packets (non-blocking)
+  /// @param[out] data Array of pointers to packet data (if available)
+  /// @param[out] lens Array of lengths of packet data
+  /// @param[in] max_count Maximum number of packets to poll
+  /// @return Number of packets polled
+  ///
+  std::uint32_t poll_burst(char **data, std::uint32_t *lens,
+                           std::uint32_t max_count) {
+    std::uint64_t tail = header_->tail.load(std::memory_order_acquire);
+    std::uint32_t count = 0;
+
+    for (std::uint32_t i = 0; i < max_count; i++) {
+      std::uint32_t slot_idx = (tail + i) % config_.num_slots;
+      SlotHeader *slot = get_slot_header(slot_idx);
+
+      // Check if packet is available
+      std::uint64_t seqn = slot->seqn.load(std::memory_order_acquire);
+      if (seqn != expected_seqn_ + i)
+        break; // No more packets
+
+      // Extract packet data
+      lens[i] = slot->payload_len;
+      data[i] =
+          base_addr_ + config_.get_slot_offset(slot_idx) + sizeof(SlotHeader);
+
+      // Mark slot as consumed (optional, for debugging)
+      slot->seqn.store(0, std::memory_order_release);
+
+      count++;
+    }
+
+    // Update tail pointer once for entire burst
+    if (count > 0) {
+      header_->tail.store(tail + count, std::memory_order_release);
+      expected_seqn_ += count;
+    }
+
+    return count;
+  }
+
+  std::uint64_t get_packets_received() const { return expected_seqn_ - 1; }
+
+private:
+  SlotHeader *get_slot_header(std::uint32_t index) {
+    char *slot_addr = base_addr_ + config_.get_slot_offset(index);
+    return reinterpret_cast<SlotHeader *>(slot_addr);
+  }
+
+  char *base_addr_;
+  RingBufferConfig config_;
+  RingBufferHeader *header_;
+  std::uint64_t expected_seqn_{1}; // Start from 1 (0 means empty)
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/channels/roce/verbs_context.h
+++ b/realtime/include/cudaq/nvqlink/network/channels/roce/verbs_context.h
@@ -1,0 +1,64 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <infiniband/verbs.h>
+#include <string>
+
+namespace cudaq::nvqlink {
+
+/// Shared InfiniBand Verbs context for memory sharing across channels.
+///
+/// Holds a shared `ibv_context` and `ibv_pd` that can be used by multiple
+/// `RoCEChannel` instances to enable zero-copy data sharing. When multiple
+/// channels share the same `VerbsContext`, they can register memory once
+/// and access it across all channels.
+///
+/// Optional: Only needed when data sharing between channels is required.
+/// Channels can also operate independently with their own contexts.
+///
+class VerbsContext {
+public:
+  /// Create a shared verbs context for the specified device.
+  ///
+  /// @param device_name Device name (e.g., "mlx5_0") or index (e.g., "0")
+  /// @throws std::runtime_error if device not found or initialization fails
+  ///
+  explicit VerbsContext(const std::string &device_name);
+
+  ~VerbsContext();
+
+  // Non-copyable, non-movable
+  VerbsContext(const VerbsContext &) = delete;
+  VerbsContext &operator=(const VerbsContext &) = delete;
+
+  /// Get the InfiniBand Verbs context
+  struct ibv_context *get_context() const { return context_; }
+
+  /// Get the Protection Domain (for memory registration and QP creation)
+  struct ibv_pd *get_protection_domain() const { return pd_; }
+
+  /// Get the device name
+  const std::string &get_device_name() const { return device_name_; }
+
+  /// Get the port number (default: 1)
+  std::uint8_t get_port_num() const { return port_num_; }
+
+private:
+  void open_device();
+  void create_protection_domain();
+
+  std::string device_name_;
+  struct ibv_context *context_{nullptr};
+  struct ibv_pd *pd_{nullptr};
+  std::uint8_t port_num_{1};
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/config.h
+++ b/realtime/include/cudaq/nvqlink/network/config.h
@@ -1,0 +1,37 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace cudaq::nvqlink {
+
+/// Channel configuration (Layer 1 - Hardware abstraction)
+/// Each channel is 1:1 with a queue
+struct ChannelConfig {
+  std::string nic_device; // PCIe address or device name
+  uint32_t queue_id;      // Single queue (1:1 with channel)
+
+  // Buffer pool settings
+  size_t pool_size_bytes{64 * 1024 * 1024}; // 64MB default
+  size_t buffer_size_bytes{2048};           // 2KB default
+  size_t headroom_bytes{256};
+  size_t tailroom_bytes{64};
+};
+
+/// Memory pool configuration (helper for MemoryPool construction)
+struct MemoryConfig {
+  size_t pool_size_bytes{64 * 1024 * 1024};
+  size_t buffer_size_bytes{2048};
+  size_t headroom_bytes{256};
+  size_t tailroom_bytes{64};
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/gpu_channel.h
+++ b/realtime/include/cudaq/nvqlink/network/gpu_channel.h
@@ -1,0 +1,141 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/channel.h"
+
+#include <cuda_runtime.h>
+
+namespace cudaq::nvqlink {
+
+/// Device-side packet queue handles for GPU direct access.
+///
+/// Contains raw pointers to NIC queue data structures that
+/// the GPU can directly access for packet polling and sending.
+struct GPUQueueHandles {
+  void *rx_queue_base;       ///< RX queue descriptor ring (device ptr)
+  void *tx_queue_base;       ///< TX queue descriptor ring (device ptr)
+  std::uint32_t *rx_head;    ///< RX queue head index (device ptr)
+  std::uint32_t *rx_tail;    ///< RX queue tail index (device ptr)
+  std::uint32_t *tx_head;    ///< TX queue head index (device ptr)
+  std::uint32_t *tx_tail;    ///< TX queue tail index (device ptr)
+  std::uint32_t queue_size;  ///< Queue size (number of descriptors)
+  void **packet_buffers;     ///< Array of packet buffer pointers (device ptr)
+  std::size_t *packet_sizes; ///< Array of packet sizes (device ptr)
+  volatile bool *running;    ///< Kernel running flag (device ptr)
+};
+
+/// GPU Channel for device-side NIC control.
+///
+/// Enables CUDA kernels to directly poll NIC queues and send packets
+/// without CPU involvement. Requires GPUDirect RDMA or unified memory.
+///
+/// @example Persistent GPU kernel:
+/// ```cuda
+/// __global__ void gpu_network_kernel(GPUChannel* channel) {
+///   GPUInputStream in(*channel);
+///   GPUOutputStream out(*channel);
+///
+///   while (channel->is_running()) {
+///     if (in.available()) {
+///       int a = in.read<int>();
+///       int b = in.read<int>();
+///       out.write<int>(a + b);
+///       out.flush();
+///     }
+///   }
+/// }
+/// ```
+///
+/// @note This is an advanced feature requiring hardware support:
+///       - GPUDirect RDMA for NIC memory access
+///       - Unified memory for queue synchronization
+///       - Compatible NIC (DPDK with GPU support, DOCA, etc.)
+///
+class GPUChannel {
+public:
+  /// Construct GPUChannel from backend (wraps for GPU kernel use).
+  ///
+  /// @param channel Channel providing NIC access
+  GPUChannel(Channel *channel);
+
+  ~GPUChannel();
+
+  /// Start persistent GPU kernel.
+  ///
+  /// Launches a long-running CUDA kernel that continuously polls
+  /// the NIC and processes packets.
+  ///
+  /// @param kernel_func User kernel function pointer
+  /// @param blocks Number of blocks
+  /// @param threads Threads per block
+  void start_kernel(void (*kernel_func)(GPUChannel *), dim3 blocks,
+                    dim3 threads);
+
+  /// Stop persistent GPU kernel.
+  void stop_kernel();
+
+  /// Check if kernel is running.
+  ///
+  /// @return true if kernel should continue running
+  __host__ __device__ bool is_running() const;
+
+  /// Get device-side queue handles.
+  ///
+  /// @return Pointer to GPU queue handles (device memory)
+  __host__ __device__ GPUQueueHandles *get_queue_handles() {
+    return d_queue_handles_;
+  }
+
+  /// Device-side: Receive a packet (non-blocking).
+  ///
+  /// Polls the RX queue for a new packet. Returns nullptr if no packet.
+  ///
+  /// @param packet_data Output: pointer to packet data (device memory)
+  /// @param packet_size Output: size of packet
+  /// @return true if packet received
+  __device__ bool receive_packet(void **packet_data, std::size_t *packet_size);
+
+  /// Device-side: Send a packet.
+  ///
+  /// @param packet_data Pointer to packet data (device memory)
+  /// @param packet_size Size of packet
+  /// @return true if packet sent successfully
+  __device__ bool send_packet(void *packet_data, std::size_t packet_size);
+
+  /// Device-side: Allocate a buffer for sending.
+  ///
+  /// @param size Requested buffer size
+  /// @return Pointer to buffer (device memory), or nullptr on failure
+  __device__ void *allocate_buffer(std::size_t size);
+
+  /// Device-side: Release a received packet buffer.
+  ///
+  /// @param packet_data Pointer to packet buffer
+  __device__ void release_buffer(void *packet_data);
+
+  /// Get backend pointer (host-side only).
+  Channel *channel() { return channel_; }
+
+private:
+  Channel *channel_;                 ///< Channel for NIC access
+  GPUQueueHandles *d_queue_handles_; ///< Device-side queue handles
+  GPUQueueHandles *h_queue_handles_; ///< Host-side queue handles
+  volatile bool *d_running_;         ///< Device flag for kernel control
+  bool *h_running_;                  ///< Host flag for kernel control
+  cudaStream_t stream_;              ///< CUDA stream for kernel
+
+  /// Initialize device-side queue handles
+  void initialize_queue_handles();
+
+  /// Cleanup device resources
+  void cleanup();
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/memory/buffer.h
+++ b/realtime/include/cudaq/nvqlink/network/memory/buffer.h
@@ -1,0 +1,74 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace cudaq::nvqlink {
+
+/// Zero-copy packet buffer with headroom/tailroom for header manipulation.
+/// Layout: [Headroom | Data | Tailroom]
+///
+class Buffer {
+public:
+  Buffer(void *base_addr, std::size_t total_size, std::size_t headroom,
+         std::size_t tailroom);
+
+  //===--------------------------------------------------------------------===//
+  // Data access
+  //===--------------------------------------------------------------------===//
+
+  void *get_data() const { return data_ptr_; }
+
+  std::size_t get_data_length() const { return data_len_; }
+
+  void set_data_length(std::size_t len) { data_len_ = len; }
+
+  /// Reset buffer to point to new memory (used by buffer pools for zero-copy).
+  ///
+  /// @param base Base address of buffer
+  /// @param data Data pointer (may be offset from base for headroom)
+  /// @param total Total buffer size
+  /// @param datalen Current data length
+  /// @param headroom_size Available headroom
+  /// @param tailroom_size Available tailroom
+  void reset(void *base, void *data, std::size_t total, std::size_t datalen,
+             std::size_t headroom_size, std::size_t tailroom_size) {
+    base_addr_ = base;
+    data_ptr_ = data;
+    total_size_ = total;
+    data_len_ = datalen;
+    headroom_ = headroom_size;
+    tailroom_ = tailroom_size;
+  }
+
+  // Headroom manipulation (for prepending headers)
+  void *prepend(std::size_t bytes);
+
+  // Raw buffer info
+  void *get_base_address() const { return base_addr_; }
+  std::size_t get_total_size() const { return total_size_; }
+  std::size_t get_headroom() const { return headroom_; }
+  std::size_t get_tailroom() const { return tailroom_; }
+
+  // Metadata for NIC
+  std::uint64_t dma_addr{0}; // Physical/device address for NIC
+  std::uint32_t queue_id{0};
+
+private:
+  void *base_addr_;        // Start of entire buffer
+  void *data_ptr_;         // Start of actual packet data
+  std::size_t total_size_; // Total buffer size
+  std::size_t headroom_;
+  std::size_t tailroom_;
+  std::size_t data_len_; // Current data length
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/memory/buffer_handle.h
+++ b/realtime/include/cudaq/nvqlink/network/memory/buffer_handle.h
@@ -1,0 +1,91 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/memory/buffer.h"
+
+namespace cudaq::nvqlink {
+
+// Forward declaration
+class Channel;
+
+/// @brief RAII wrapper for Buffer ownership (optional convenience wrapper)
+///
+/// Enforces ownership semantics:
+/// - Non-copyable (ownership is exclusive)
+/// - Move-only (ownership transfer is explicit)
+/// - Auto-releases on destruction (unless released to send)
+///
+/// Example:
+/// ```cpp
+/// BufferHandle buf(channel, channel->acquire_buffer());
+/// write_to(buf.get());
+/// channel->send(buf.release());  // Ownership transferred
+/// ```
+///
+/// @note For hot path, use raw Buffer* directly. This is for convenience.
+///
+class BufferHandle {
+public:
+  BufferHandle() = default;
+
+  explicit BufferHandle(Channel *channel, Buffer *buffer)
+      : channel_(channel), buffer_(buffer) {}
+
+  ~BufferHandle() {
+    if (buffer_ && channel_) {
+      channel_->release_buffer(buffer_);
+    }
+  }
+
+  // Non-copyable (exclusive ownership)
+  BufferHandle(const BufferHandle &) = delete;
+  BufferHandle &operator=(const BufferHandle &) = delete;
+
+  // Move-only (explicit ownership transfer)
+  BufferHandle(BufferHandle &&other) noexcept
+      : channel_(other.channel_), buffer_(other.buffer_) {
+    other.buffer_ = nullptr;
+    other.channel_ = nullptr;
+  }
+
+  BufferHandle &operator=(BufferHandle &&other) noexcept {
+    if (this != &other) {
+      // Release current buffer
+      if (buffer_ && channel_) {
+        channel_->release_buffer(buffer_);
+      }
+      // Transfer ownership
+      channel_ = other.channel_;
+      buffer_ = other.buffer_;
+      other.buffer_ = nullptr;
+      other.channel_ = nullptr;
+    }
+    return *this;
+  }
+
+  /// Get raw pointer (does NOT transfer ownership)
+  Buffer *get() const { return buffer_; }
+
+  /// Release ownership (caller takes ownership of raw pointer)
+  Buffer *release() {
+    Buffer *buf = buffer_;
+    buffer_ = nullptr;
+    return buf;
+  }
+
+  /// Check if valid
+  explicit operator bool() const { return buffer_ != nullptr; }
+
+private:
+  Channel *channel_{nullptr};
+  Buffer *buffer_{nullptr};
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/memory/memory_pool.h
+++ b/realtime/include/cudaq/nvqlink/network/memory/memory_pool.h
@@ -1,0 +1,57 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/daemon/config.h"
+#include "cudaq/nvqlink/network/config.h"
+#include "cudaq/nvqlink/network/memory/buffer.h"
+
+#include <mutex>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+/// Zero-copy memory pool for packet buffers.
+/// CPU mode: Uses hugepage-backed memory
+/// GPU mode: Uses GPU device memory
+///
+class MemoryPool {
+public:
+  explicit MemoryPool(const MemoryConfig &config, DatapathMode mode);
+  ~MemoryPool();
+
+  // Buffer allocation
+  Buffer *allocate();
+  void deallocate(Buffer *buffer);
+
+  // Statistics
+  std::size_t get_total_buffers() const { return total_buffers_; }
+  std::size_t get_available_buffers() const;
+
+  // Memory base address getters
+  void *get_cpu_base_address() const { return base_addr_; }
+  void *get_gpu_base_address() const { return gpu_base_addr_; }
+
+private:
+  void allocate_cpu_memory();
+  void allocate_gpu_memory();
+
+  MemoryConfig config_;
+  DatapathMode mode_;
+
+  void *base_addr_{nullptr};
+  void *gpu_base_addr_{nullptr}; // For GPU mode
+  bool using_hugepages_{false};  // Track allocation type for proper cleanup
+
+  std::size_t total_buffers_{0};
+  std::vector<Buffer *> free_buffers_;
+  mutable std::mutex mutex_;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/serialization/gpu_input_stream.h
+++ b/realtime/include/cudaq/nvqlink/network/serialization/gpu_input_stream.h
@@ -1,0 +1,205 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <cuda_runtime.h>
+
+namespace cudaq::nvqlink {
+
+// Forward declaration
+class GPUChannel;
+
+/// GPU-side input stream for deserializing data in CUDA kernels.
+///
+/// Works in two modes:
+/// 1. Bound to raw device memory (buffer mode)
+/// 2. Bound to GPU channel (channel mode - persistent)
+///
+/// @example Buffer mode:
+/// ```cuda
+/// __global__ void process_packets(
+///     const char* packet_data,
+///     size_t packet_size,
+///     int* results) {
+///
+///   GPUInputStream in(packet_data, packet_size);
+///
+///   int a = in.read<int>();
+///   int b = in.read<int>();
+///
+///   results[threadIdx.x] = a + b;
+/// }
+/// ```
+///
+/// @example Channel mode:
+/// ```cuda
+/// __global__ void persistent_kernel(GPUChannel* channel) {
+///   GPUInputStream in(*channel);
+///
+///   while (channel->is_running()) {
+///     if (in.available()) {
+///       int a = in.read<int>();
+///       process(a);
+///     }
+///   }
+/// }
+/// ```
+///
+/// @note All methods are __device__ only - this class is for GPU use only.
+/// @note This is a lightweight, header-only implementation for zero overhead.
+///
+class GPUInputStream {
+public:
+  /// Construct from GPUChannel (persistent mode).
+  ///
+  /// Stream will automatically fetch packets from the channel.
+  ///
+  /// @param channel GPU channel to receive packets from
+  __device__ GPUInputStream(GPUChannel &channel);
+
+  /// Construct from raw device memory (buffer mode).
+  ///
+  /// @param data Pointer to device memory
+  /// @param size Size of buffer in bytes
+  __device__ GPUInputStream(const void *data, std::size_t size)
+      : channel_(nullptr), current_packet_(nullptr),
+        read_ptr_(static_cast<const char *>(data)), read_end_(read_ptr_ + size),
+        bytes_read_(0) {}
+
+  /// Read a value of type T from the stream.
+  ///
+  /// @tparam T Type to read (must be trivially copyable)
+  /// @return The read value
+  template <typename T>
+  __device__ T read() {
+    // Check bounds
+    if (read_ptr_ + sizeof(T) > read_end_) {
+      // In device code, we can't throw exceptions
+      // Return zero-initialized value and set error flag
+      error_ = true;
+      return T{};
+    }
+
+    T value;
+    // Use direct memory access (no memcpy in device code)
+    const T *ptr = reinterpret_cast<const T *>(read_ptr_);
+    value = *ptr;
+
+    read_ptr_ += sizeof(T);
+    bytes_read_ += sizeof(T);
+    return value;
+  }
+
+  /// Read raw bytes from the stream.
+  ///
+  /// @param dest Destination buffer (device memory)
+  /// @param len Number of bytes to read
+  __device__ void read_bytes(void *dest, std::size_t len) {
+    if (read_ptr_ + len > read_end_) {
+      error_ = true;
+      return;
+    }
+
+    // Manual copy in device code
+    char *dst = static_cast<char *>(dest);
+    for (std::size_t i = 0; i < len; ++i) {
+      dst[i] = read_ptr_[i];
+    }
+
+    read_ptr_ += len;
+    bytes_read_ += len;
+  }
+
+  /// Peek at the next value without consuming it.
+  ///
+  /// @tparam T Type to peek at
+  /// @return The peeked value
+  template <typename T>
+  __device__ T peek() const {
+    if (read_ptr_ + sizeof(T) > read_end_) {
+      return T{};
+    }
+
+    const T *ptr = reinterpret_cast<const T *>(read_ptr_);
+    return *ptr;
+  }
+
+  /// Skip bytes in the stream.
+  ///
+  /// @param len Number of bytes to skip
+  __device__ void skip(std::size_t len) {
+    if (read_ptr_ + len > read_end_) {
+      error_ = true;
+      return;
+    }
+    read_ptr_ += len;
+    bytes_read_ += len;
+  }
+
+  /// Get number of bytes remaining.
+  ///
+  /// @return Bytes remaining
+  __device__ std::size_t remaining() const {
+    if (read_ptr_ >= read_end_) {
+      return 0;
+    }
+    return static_cast<std::size_t>(read_end_ - read_ptr_);
+  }
+
+  /// Check if at end of stream.
+  ///
+  /// @return true if at end
+  __device__ bool at_end() const { return read_ptr_ >= read_end_; }
+
+  /// Get total bytes read.
+  ///
+  /// @return Total bytes read
+  __device__ std::size_t bytes_read() const { return bytes_read_; }
+
+  /// Check if an error occurred (bounds check failure).
+  ///
+  /// @return true if error
+  __device__ bool has_error() const { return error_; }
+
+  /// Reset error flag.
+  __device__ void clear_error() { error_ = false; }
+
+  /// Check if data is available (non-blocking).
+  ///
+  /// In channel mode, tries to fetch next packet.
+  /// In buffer mode, checks if more data exists.
+  ///
+  /// @return true if data can be read
+  __device__ bool available();
+
+  /// Get pointer to current read position.
+  ///
+  /// @return Pointer to current position (device memory)
+  __device__ const void *current_position() const { return read_ptr_; }
+
+private:
+  /// Fetch next packet from channel (channel mode only)
+  __device__ void fetch_next_packet();
+
+  /// Ensure sufficient data is available
+  __device__ void ensure_data(std::size_t needed);
+
+  // Channel mode (persistent)
+  GPUChannel *channel_;
+  void *current_packet_;
+
+  // Both modes
+  const char *read_ptr_;
+  const char *read_end_;
+  std::size_t bytes_read_;
+  bool error_{false};
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/serialization/gpu_output_stream.h
+++ b/realtime/include/cudaq/nvqlink/network/serialization/gpu_output_stream.h
@@ -1,0 +1,170 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace cudaq::nvqlink {
+
+// Forward declaration
+class GPUChannel;
+
+/// GPU-side output stream for serializing data in CUDA kernels.
+///
+/// Works in two modes:
+/// 1. Bound to raw device memory (buffer mode)
+/// 2. Bound to GPU channel (channel mode - persistent)
+///
+/// @example Buffer mode:
+/// ```cuda
+/// __global__ void generate_response(
+///     char* output_buffer,
+///     size_t buffer_capacity,
+///     int result) {
+///
+///   GPUOutputStream out(output_buffer, buffer_capacity);
+///
+///   out.write<int>(result);
+///   out.write<int>(42);
+///
+///   // bytes_written() can be used to set packet length
+/// }
+/// ```
+///
+/// @example Channel mode:
+/// ```cuda
+/// __global__ void persistent_kernel(GPUChannel* channel) {
+///   GPUOutputStream out(*channel);
+///
+///   out.write<int>(42);
+///   out.flush();  // Send packet
+/// }
+/// ```
+///
+/// @note All methods are __device__ only - this class is for GPU use only.
+/// @note This is a lightweight, header-only implementation for zero overhead.
+///
+class GPUOutputStream {
+public:
+  /// Construct from GPUChannel (persistent mode).
+  ///
+  /// Stream will automatically allocate buffers and send packets.
+  ///
+  /// @param channel GPU channel to send packets to
+  __device__ GPUOutputStream(GPUChannel &channel);
+
+  /// Construct from raw device memory (buffer mode).
+  ///
+  /// @param data Pointer to writable device memory
+  /// @param capacity Buffer capacity in bytes
+  __device__ GPUOutputStream(void *data, size_t capacity)
+      : channel_(nullptr), current_buffer_(nullptr),
+        buffer_start_(static_cast<char *>(data)), write_ptr_(buffer_start_),
+        write_end_(write_ptr_ + capacity), bytes_written_(0) {}
+
+  /// Write a value of type T to the stream.
+  ///
+  /// @tparam T Type to write (must be trivially copyable)
+  /// @param value Value to write
+  template <typename T>
+  __device__ void write(const T &value) {
+    // Check bounds
+    if (write_ptr_ + sizeof(T) > write_end_) {
+      error_ = true;
+      return;
+    }
+
+    // Use direct memory access
+    T *ptr = reinterpret_cast<T *>(write_ptr_);
+    *ptr = value;
+
+    write_ptr_ += sizeof(T);
+    bytes_written_ += sizeof(T);
+  }
+
+  /// Write raw bytes to the stream.
+  ///
+  /// @param src Source buffer (device memory)
+  /// @param len Number of bytes to write
+  __device__ void write_bytes(const void *src, std::size_t len);
+
+  /// Flush the current buffer (send packet).
+  ///
+  /// Only meaningful in Channel mode. In buffer mode, this is a no-op.
+  __device__ void flush();
+
+  /// Get bytes written to buffer.
+  ///
+  /// @return Bytes written
+  __device__ std::uint32_t bytes_written() const { return bytes_written_; }
+
+  /// Get remaining capacity in buffer.
+  ///
+  /// @return Remaining bytes available
+  __device__ std::size_t remaining_capacity() const {
+    if (write_ptr_ >= write_end_) {
+      return 0;
+    }
+    return static_cast<std::size_t>(write_end_ - write_ptr_);
+  }
+
+  /// Check if buffer is full.
+  ///
+  /// @return true if no space remaining
+  __device__ bool is_full() const { return write_ptr_ >= write_end_; }
+
+  /// Check if an error occurred (bounds check failure).
+  ///
+  /// @return true if error
+  __device__ bool has_error() const { return error_; }
+
+  /// Reset error flag.
+  __device__ void clear_error() { error_ = false; }
+
+  /// Get pointer to start of written data.
+  ///
+  /// @return Pointer to buffer start (device memory)
+  __device__ const void *data() const { return buffer_start_; }
+
+  /// Get pointer to current write position.
+  ///
+  /// @return Pointer to current position (device memory)
+  __device__ void *current_position() const { return write_ptr_; }
+
+  /// Reset stream to write from beginning.
+  ///
+  /// Useful for reusing the same buffer.
+  __device__ void reset() {
+    write_ptr_ = buffer_start_;
+    bytes_written_ = 0;
+    error_ = false;
+  }
+
+private:
+  /// Allocate a new buffer (channel mode only)
+  __device__ void allocate_buffer();
+
+  /// Ensure sufficient space is available
+  __device__ void ensure_space(std::size_t needed);
+
+  // Channel mode (persistent)
+  GPUChannel *channel_;
+  void *current_buffer_;
+
+  // Both modes
+  char *buffer_start_;
+  char *write_ptr_;
+  const char *write_end_;
+  std::uint32_t bytes_written_;
+  bool error_{false};
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/serialization/input_stream.h
+++ b/realtime/include/cudaq/nvqlink/network/serialization/input_stream.h
@@ -1,0 +1,168 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/memory/buffer.h"
+
+#include <cstddef>
+#include <cstring>
+#include <string>
+
+namespace cudaq::nvqlink {
+
+// Forward declaration
+class Channel;
+
+/// Unified input stream for deserializing data.
+///
+/// Works in two modes:
+/// 1. Bound to Channel (persistent, manages packet lifecycle)
+/// 2. Bound to raw buffer (temporary, for Daemon RPC functions)
+///
+/// @example Backend mode (persistent):
+/// ```cpp
+/// Backend* backend = create_backend(...);
+/// InputStream in(channel);
+///
+/// while (running) {
+///   if (in.available()) {
+///     int a = in.read<int>();
+///     process(a);
+///   }
+/// }
+/// ```
+///
+/// @example Daemon mode (temporary):
+/// ```cpp
+/// int rpc_function(InputStream& in, OutputStream& out) {
+///   int a = in.read<int>();  // Works the same!
+///   return 0;
+/// }
+/// ```
+///
+class InputStream {
+public:
+  /// Construct from Backend (persistent mode).
+  ///
+  /// Stream manages packet lifecycle, fetching new packets as needed.
+  ///
+  /// @param backend Backend to receive packets from
+  explicit InputStream(Channel &channel);
+
+  /// Construct from raw buffer (temporary mode).
+  ///
+  /// Stream wraps existing buffer, does not manage lifecycle.
+  /// Used by Daemon dispatcher for RPC functions.
+  ///
+  /// @param data Pointer to buffer data
+  /// @param size Size of buffer in bytes
+  InputStream(const void *data, std::size_t size);
+
+  ~InputStream();
+
+  // Disable copy/move
+  InputStream(const InputStream &) = delete;
+  InputStream &operator=(const InputStream &) = delete;
+  InputStream(InputStream &&) = delete;
+  InputStream &operator=(InputStream &&) = delete;
+
+  /// Check if data is available (non-blocking).
+  ///
+  /// Only meaningful in Backend mode. In buffer mode, returns true if not at
+  /// end.
+  ///
+  /// @return true if data can be read
+  bool available();
+
+  /// Read a value of type T from the stream.
+  ///
+  /// @tparam T Type to read (must be trivially copyable)
+  /// @return The read value
+  /// @throws std::runtime_error if insufficient data
+  template <typename T>
+  T read() {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Type must be trivially copyable");
+
+    ensure_data(sizeof(T));
+
+    T value;
+    std::memcpy(&value, read_ptr_, sizeof(T));
+    read_ptr_ += sizeof(T);
+    bytes_read_ += sizeof(T);
+    return value;
+  }
+
+  /// Read raw bytes from the stream.
+  ///
+  /// @param dest Destination buffer
+  /// @param len Number of bytes to read
+  void read_bytes(void *dest, std::size_t len);
+
+  /// Read a length-prefixed string.
+  ///
+  /// @return The read string
+  std::string read_string();
+
+  /// Peek at the next value without consuming it.
+  ///
+  /// @tparam T Type to peek at
+  /// @return The peeked value
+  template <typename T>
+  T peek() {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Type must be trivially copyable");
+
+    ensure_data(sizeof(T));
+
+    T value;
+    std::memcpy(&value, read_ptr_, sizeof(T));
+    return value;
+  }
+
+  /// Skip bytes in the stream.
+  ///
+  /// @param len Number of bytes to skip
+  void skip(std::size_t len);
+
+  /// Get number of bytes remaining in current packet/buffer.
+  ///
+  /// @return Bytes remaining
+  std::size_t remaining() const;
+
+  /// Check if current packet/buffer is fully consumed.
+  ///
+  /// @return true if at end
+  bool at_end() const;
+
+  /// Get total bytes read.
+  ///
+  /// @return Total bytes read
+  std::size_t bytes_read() const { return bytes_read_; }
+
+  /// Get pointer to current read position (advanced usage).
+  ///
+  /// @return Pointer to current position
+  const void *current_position() const { return read_ptr_; }
+
+private:
+  void fetch_next_packet();
+  void ensure_data(std::size_t needed);
+
+  // Backend mode (persistent)
+  Channel *channel_{nullptr};
+  Buffer *current_packet_{nullptr};
+
+  // Both modes
+  const char *read_ptr_{nullptr};
+  const char *read_end_{nullptr};
+  std::size_t bytes_read_{0};
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/serialization/output_stream.h
+++ b/realtime/include/cudaq/nvqlink/network/serialization/output_stream.h
@@ -1,0 +1,145 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/memory/buffer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace cudaq::nvqlink {
+
+// Forward declaration
+class Channel;
+
+/// Unified output stream for serializing data.
+///
+/// Works in two modes:
+/// 1. Bound to Channel (persistent, manages buffer lifecycle)
+/// 2. Bound to raw buffer (temporary, for Daemon RPC functions)
+///
+/// @example Channel mode (persistent):
+/// ```cpp
+/// Channel channel(std::move(backend));
+/// OutputStream out(channel);
+///
+/// out.write<int>(42);
+/// out.flush();  // Send packet
+/// ```
+///
+/// @example Daemon mode (temporary):
+/// ```cpp
+/// int rpc_function(InputStream& in, OutputStream& out) {
+///   out.write<int>(100);  // Works the same!
+///   return 0;
+/// }
+/// ```
+///
+class OutputStream {
+public:
+  /// Construct from Backend (persistent mode).
+  ///
+  /// Stream manages buffer lifecycle, allocating new buffers as needed.
+  ///
+  /// @param backend Backend to send packets to
+  explicit OutputStream(Channel &channel);
+
+  /// Construct from raw buffer (temporary mode).
+  ///
+  /// Stream wraps existing buffer, does not manage lifecycle.
+  /// Used by Daemon dispatcher for RPC functions.
+  ///
+  /// @param data Pointer to writable buffer
+  /// @param capacity Buffer capacity in bytes
+  OutputStream(void *data, size_t capacity);
+
+  ~OutputStream();
+
+  // Disable copy/move
+  OutputStream(const OutputStream &) = delete;
+  OutputStream &operator=(const OutputStream &) = delete;
+  OutputStream(OutputStream &&) = delete;
+  OutputStream &operator=(OutputStream &&) = delete;
+
+  /// Write a value of type T to the stream.
+  ///
+  /// @tparam T Type to write (must be trivially copyable)
+  /// @param value Value to write
+  template <typename T>
+  void write(const T &value) {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Type must be trivially copyable");
+
+    ensure_space(sizeof(T));
+
+    std::memcpy(write_ptr_, &value, sizeof(T));
+    write_ptr_ += sizeof(T);
+    bytes_written_ += sizeof(T);
+  }
+
+  /// Write raw bytes to the stream.
+  ///
+  /// @param src Source buffer
+  /// @param len Number of bytes to write
+  void write_bytes(const void *src, size_t len);
+
+  /// Write a length-prefixed string.
+  ///
+  /// @param str String to write
+  void write_string(const std::string &str);
+
+  /// Flush the current buffer (send packet).
+  ///
+  /// Only meaningful in Channel mode. In buffer mode, this is a no-op.
+  void flush();
+
+  /// Get bytes written to current buffer.
+  ///
+  /// @return Bytes written
+  uint32_t bytes_written() const { return bytes_written_; }
+
+  /// Get remaining capacity in current buffer.
+  ///
+  /// @return Remaining bytes available
+  size_t remaining_capacity() const;
+
+  /// Check if buffer is full.
+  ///
+  /// @return true if no space remaining
+  bool is_full() const;
+
+  /// Get pointer to start of written data (advanced usage).
+  ///
+  /// @return Pointer to buffer start
+  const void *data() const { return buffer_start_; }
+
+  /// Get pointer to current write position (advanced usage).
+  ///
+  /// @return Pointer to current position
+  void *current_position() const { return write_ptr_; }
+
+private:
+  void acquire_buffer();
+  void ensure_space(size_t needed);
+
+  // Backend mode (persistent)
+  Channel *channel_{nullptr};
+  Buffer *current_buffer_{nullptr};
+
+  // Both modes (buffer_start_ must be before write_ptr_ and write_end_ due to
+  // initialization order)
+  char *buffer_start_{nullptr};
+  char *write_ptr_{nullptr};
+  const char *write_end_{nullptr};
+  uint32_t bytes_written_{0};
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/steering/flow_switch.h
+++ b/realtime/include/cudaq/nvqlink/network/steering/flow_switch.h
@@ -1,0 +1,40 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+namespace cudaq::nvqlink {
+
+/// @brief Abstract interface for traffic steering/flow control
+///
+/// FlowSwitch coordinates packet routing to different channels based on
+/// flow rules (e.g., UDP port matching). Implementations use hardware
+/// flow steering when available (e.g., ibv_create_flow for InfiniBand).
+///
+class FlowSwitch {
+public:
+  virtual ~FlowSwitch() = default;
+
+  /// @brief Add a steering rule to route traffic to a specific channel
+  ///
+  /// @param udp_port UDP destination port to match
+  /// @param channel_handle Opaque handle identifying the target channel
+  ///                       (implementation-specific, e.g., ibv_qp* for Verbs)
+  ///
+  virtual void add_steering_rule(uint16_t udp_port, void *channel_handle) = 0;
+
+  /// @brief Remove a steering rule
+  ///
+  /// @param udp_port UDP destination port to stop matching
+  ///
+  virtual void remove_steering_rule(uint16_t udp_port) = 0;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/network/steering/verbs_flow_switch.h
+++ b/realtime/include/cudaq/nvqlink/network/steering/verbs_flow_switch.h
@@ -1,0 +1,39 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/steering/flow_switch.h"
+
+#include <cstdint>
+#include <infiniband/verbs.h>
+#include <map>
+#include <mutex>
+
+namespace cudaq::nvqlink {
+
+/// @brief InfiniBand Verbs implementation of FlowSwitch
+///
+/// Uses `ibv_create_flow()` to program hardware flow steering rules.
+/// Does not own any InfiniBand context - uses the QP's context.
+///
+class VerbsFlowSwitch : public FlowSwitch {
+public:
+  VerbsFlowSwitch() = default;
+  ~VerbsFlowSwitch() override;
+
+  void add_steering_rule(uint16_t udp_port, void *channel_handle) override;
+  void remove_steering_rule(uint16_t udp_port) override;
+
+private:
+  // Map: udp_port -> ibv_flow*
+  std::map<uint16_t, struct ibv_flow *> flow_handles_;
+  std::mutex mutex_;
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/nvqlink.h
+++ b/realtime/include/cudaq/nvqlink/nvqlink.h
@@ -1,0 +1,22 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "lqpu.h"
+
+namespace cudaq::nvqlink {
+
+/// @brief Initialize NVQLink runtime
+/// @param cfg LQPU configuration
+void initialize(const LQPUConfig &cfg);
+
+/// @brief Shutdown NVQLink runtime
+void shutdown();
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/qcs/config.h
+++ b/realtime/include/cudaq/nvqlink/qcs/config.h
@@ -1,0 +1,28 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace cudaq::nvqlink {
+
+/// Configuration for QCS (Quantum Control System) device connection
+/// QCS control plane uses UDP for out-of-band communication:
+/// - RDMA parameter exchange (QPN, GID, vaddr, rkey)
+/// - Program upload
+/// - Execution control (START/STOP/ABORT commands)
+struct QCSDeviceConfig {
+  std::string name;
+  uint16_t control_port{9999}; // UDP port for control plane
+
+  bool is_valid() const { return !name.empty() && control_port > 0; }
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/qcs/control_server.h
+++ b/realtime/include/cudaq/nvqlink/qcs/control_server.h
@@ -1,0 +1,93 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <arpa/inet.h>
+#include <chrono>
+#include <cstdint>
+#include <infiniband/verbs.h>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace cudaq::nvqlink {
+
+class RoCEChannel;
+
+/// @brief UDP server for out-of-band control communication with QCS
+///
+/// Handles the control plane protocol between RTH (Real-time Host) and QCS
+/// (Quantum Control System) for RDMA connection setup and execution control.
+///
+/// Protocol:
+/// 1. QCS → RTH: DISCOVER packet
+/// 2. RTH → QCS: RDMA params {qpn, gid, vaddr, rkey, num_slots, slot_size}
+/// 3. QCS → RTH: ACK with {qpn, gid}
+/// 4. RTH → QCS: START command (triggers quantum program execution)
+/// 5. ... data flows over RDMA (data plane) ...
+/// 6. RTH → QCS: STOP command (or QCS → RTH: COMPLETE)
+class ControlServer {
+public:
+  /// @brief Create a control server listening on the specified UDP port
+  /// @param port UDP port number for control plane communication
+  explicit ControlServer(uint16_t port);
+  ~ControlServer();
+
+  // Delete copy/move
+  ControlServer(const ControlServer &) = delete;
+  ControlServer &operator=(const ControlServer &) = delete;
+  ControlServer(ControlServer &&) = delete;
+  ControlServer &operator=(ControlServer &&) = delete;
+
+  /// @brief Start listening on UDP port
+  void start();
+
+  /// @brief Stop server and close socket
+  void stop();
+
+  /// @brief Wait for QCS to send DISCOVER, exchange RDMA params, configure
+  /// channel
+  ///
+  /// This performs the RDMA handshake:
+  /// 1. Wait for QCS DISCOVER packet
+  /// 2. Send channel's connection params (QPN, GID, vaddr, rkey)
+  /// 3. Receive QCS's connection params (QPN, GID)
+  /// 4. Configure the channel with remote QP info
+  ///
+  /// @param channel The RoCE channel to configure with remote QP info
+  /// @return true if connection established successfully
+  bool exchange_connection_params(RoCEChannel *channel);
+
+  /// @brief Send a command to QCS
+  /// @param cmd Command string (e.g., "START", "STOP", "ABORT")
+  /// @param params Optional JSON parameters
+  void send_command(const std::string &cmd, const nlohmann::json &params = {});
+
+  /// @brief Wait for response from QCS
+  /// @param timeout Maximum time to wait for response
+  /// @return JSON response from QCS
+  nlohmann::json wait_for_response(std::chrono::milliseconds timeout);
+
+  /// @brief Check if QCS client is connected
+  bool is_client_connected() const { return client_connected_; }
+
+  /// @brief Get client address (for diagnostics)
+  std::string get_client_address() const;
+
+private:
+  uint16_t port_;
+  int sock_fd_{-1};
+  struct sockaddr_in client_addr_;
+  bool client_connected_{false};
+
+  // Helper methods
+  std::string gid_to_string(const union ibv_gid &gid);
+  union ibv_gid string_to_gid(const std::string &gid_str);
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/qcs/qcs_device.h
+++ b/realtime/include/cudaq/nvqlink/qcs/qcs_device.h
@@ -1,0 +1,121 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/qcs/config.h"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace cudaq::nvqlink {
+
+class ControlServer;
+class RoCEChannel;
+
+/// @brief Represents a connection to a Quantum Control System (QCS/FPGA)
+///
+/// Handles the CONTROL PLANE via UDP (out-of-band communication):
+/// - Exchange RDMA connection parameters (QPN, GID, vaddr, rkey)
+/// - Program upload
+/// - Execution trigger (START/STOP commands)
+///
+/// The DATA PLANE (device_call handling) is managed by Daemon + Channel.
+/// QCSDevice CONFIGURES the Channel but does NOT own it - ownership is
+/// transferred to the Daemon for data plane operations.
+///
+/// Architecture:
+/// ```
+/// QCSDevice (UDP control)  ──configures──>  Channel (RoCE data)
+///                                              │
+///                                              │ owned by
+///                                              ▼
+///                                           Daemon (RPC server)
+/// ```
+class QCSDevice {
+public:
+  /// @brief Create QCSDevice with its own UDP control socket
+  /// @param config QCS device configuration (name, control port)
+  explicit QCSDevice(const QCSDeviceConfig &config);
+  ~QCSDevice();
+
+  // Delete copy/move
+  QCSDevice(const QCSDevice &) = delete;
+  QCSDevice &operator=(const QCSDevice &) = delete;
+  QCSDevice(QCSDevice &&) = delete;
+  QCSDevice &operator=(QCSDevice &&) = delete;
+
+  //--- Connection Management (UDP) ---
+
+  /// @brief Start UDP control server and wait for QCS to connect
+  ///
+  /// Performs RDMA parameter exchange:
+  /// 1. Waits for QCS DISCOVER packet
+  /// 2. Sends channel's connection params (QPN, GID, vaddr, rkey)
+  /// 3. Receives QCS's connection params (QPN, GID)
+  /// 4. Configures the channel with remote QP info
+  ///
+  /// @param channel The RoCE channel to configure (not owned by QCSDevice)
+  /// @throws std::runtime_error if connection fails
+  void establish_connection(RoCEChannel *channel);
+
+  /// @brief Check if QCS is connected
+  bool is_connected() const { return connected_; }
+
+  /// @brief Disconnect from QCS (sends STOP command)
+  void disconnect();
+
+  /// @brief Get connection parameters (for diagnostics)
+  struct ConnectionInfo {
+    uint32_t local_qpn{0};
+    uint32_t remote_qpn{0};
+    std::array<uint8_t, 16> local_gid{};
+    std::array<uint8_t, 16> remote_gid{};
+    uint64_t ring_buffer_addr{0};
+    uint32_t rkey{0};
+  };
+  ConnectionInfo get_connection_info() const { return connection_info_; }
+
+  //--- Program Management (via UDP) ---
+
+  /// @brief Upload compiled quantum program to QCS
+  ///
+  /// Note: Currently a stub - actual implementation depends on:
+  /// - Program format (LLVM IR, custom ISA, etc.)
+  /// - Transfer mechanism (UDP chunks, separate channel, etc.)
+  ///
+  /// @param binary Compiled program binary
+  void upload_program(const std::vector<std::byte> &binary);
+
+  //--- Execution Control (UDP commands) ---
+
+  /// @brief Send START command to QCS - begins quantum program execution
+  ///
+  /// After this call, the QCS will start executing the uploaded program.
+  /// device_call packets will start arriving via the RDMA data plane.
+  void trigger();
+
+  /// @brief Check if program execution is complete
+  ///
+  /// Note: Currently a stub - actual implementation would poll QCS
+  /// status or wait for COMPLETE message over UDP.
+  bool is_complete() const;
+
+  /// @brief Send ABORT command to QCS - stops program execution
+  void abort();
+
+private:
+  QCSDeviceConfig config_;
+  std::unique_ptr<ControlServer> control_server_;
+  ConnectionInfo connection_info_;
+  bool connected_{false};
+};
+
+} // namespace cudaq::nvqlink

--- a/realtime/include/cudaq/nvqlink/utils/extension_point.h
+++ b/realtime/include/cudaq/nvqlink/utils/extension_point.h
@@ -1,0 +1,202 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace cudaqx {
+
+/// @brief A template class for implementing an extension point mechanism.
+///
+/// This class provides a framework for registering and retrieving plugin-like
+/// extensions. It allows dynamic creation of objects based on registered types.
+///
+/// @tparam T The base type of the extensions.
+/// @tparam CtorArgs Variadic template parameters for constructor arguments.
+///
+/// How to use the extension_point class
+///
+/// The extension_point class provides a mechanism for creating extensible
+/// frameworks with plugin-like functionality. Here's how to use it:
+///
+/// 1. Define your extension point:
+///    Create a new class that inherits from cudaq::extension_point<YourClass>.
+///    This class should declare pure virtual methods that extensions will
+///    implement.
+///
+/// @code
+/// class MyExtensionPoint : public cudaq::extension_point<MyExtensionPoint> {
+/// public:
+///   virtual std::string parrotBack(const std::string &msg) const = 0;
+/// };
+/// @endcode
+///
+/// 2. Implement concrete extensions:
+///    Create classes that inherit from your extension point and implement its
+///    methods. Use the CUDAQ_EXTENSION_CREATOR_FUNCTION macro to define a
+///    creator function.
+///
+/// @code
+/// class RepeatBackOne : public MyExtensionPoint {
+/// public:
+///   std::string parrotBack(const std::string &msg) const override {
+///     return msg + " from RepeatBackOne.";
+///   }
+///
+///   CUDAQ_EXTENSION_CREATOR_FUNCTION(MyExtensionPoint, RepeatBackOne)
+/// };
+/// @endcode
+///
+/// 3. Register your extensions:
+///    Use the CUDAQ_REGISTER_TYPE macro to register each extension.
+///
+/// @code
+/// CUDAQ_REGISTER_TYPE(RepeatBackOne)
+/// @endcode
+///
+/// 4. Use your extensions:
+///    You can now create instances of your extensions, check registrations, and
+///    more.
+///
+/// @code
+/// auto extension = MyExtensionPoint::get("RepeatBackOne");
+/// std::cout << extension->parrotBack("Hello") << std::endl;
+///
+/// auto registeredTypes = MyExtensionPoint::get_registered();
+/// bool isRegistered = MyExtensionPoint::is_registered("RepeatBackOne");
+/// @endcode
+///
+/// This approach allows for a flexible, extensible design where new
+/// functionality can be added without modifying existing code.
+template <typename T, typename... CtorArgs>
+class extension_point {
+
+  /// Type alias for the creator function.
+  using CreatorFunction = std::function<std::unique_ptr<T>(CtorArgs...)>;
+
+protected:
+  /// @brief Get the registry of creator functions.
+  /// @return A reference to the static registry map.
+  /// See INSTANTIATE_REGISTRY() macros below for sample implementations that
+  /// need to be included in C++ source files.
+  static std::unordered_map<std::string, CreatorFunction> &get_registry();
+
+public:
+  /// @brief Create an instance of a registered extension.
+  /// @param name The identifier of the registered extension.
+  /// @param args Constructor arguments for the extension.
+  /// @return A unique pointer to the created instance.
+  /// @throws std::runtime_error if the extension is not found.
+  static std::unique_ptr<T> get(const std::string &name, CtorArgs... args) {
+    auto &registry = get_registry();
+    auto iter = registry.find(name);
+    if (iter == registry.end())
+      throw std::runtime_error("Cannot find extension with name = " + name);
+
+    return iter->second(std::forward<CtorArgs>(args)...);
+  }
+
+  /// @brief Get a list of all registered extension names.
+  /// @return A vector of registered extension names.
+  static std::vector<std::string> get_registered() {
+    std::vector<std::string> names;
+    auto &registry = get_registry();
+    for (auto &[k, v] : registry)
+      names.push_back(k);
+    return names;
+  }
+
+  /// @brief Check if an extension is registered.
+  /// @param name The identifier of the extension to check.
+  /// @return True if the extension is registered, false otherwise.
+  static bool is_registered(const std::string &name) {
+    auto &registry = get_registry();
+    return registry.find(name) != registry.end();
+  }
+};
+
+/// @brief Macro for defining a creator function for an extension.
+/// @param BASE The base class of the extension.
+/// @param TYPE The derived class implementing the extension.
+#define CUDAQ_EXTENSION_CREATOR_FUNCTION(BASE, TYPE)                           \
+  static inline bool register_type() {                                         \
+    auto &registry = get_registry();                                           \
+    registry[TYPE::class_identifier] = TYPE::create;                           \
+    return true;                                                               \
+  }                                                                            \
+  static const bool registered_;                                               \
+  static inline const std::string class_identifier = #TYPE;                    \
+  static std::unique_ptr<BASE> create() { return std::make_unique<TYPE>(); }
+
+/// @brief Macro for defining a custom creator function for an extension.
+/// @param TYPE The class implementing the extension.
+/// @param ... Custom implementation of the create function.
+#define CUDAQ_EXTENSION_CUSTOM_CREATOR_FUNCTION(TYPE, ...)                     \
+  static inline bool register_type() {                                         \
+    auto &registry = get_registry();                                           \
+    registry[TYPE::class_identifier] = TYPE::create;                           \
+    return true;                                                               \
+  }                                                                            \
+  static const bool registered_;                                               \
+  static inline const std::string class_identifier = #TYPE;                    \
+  __VA_ARGS__
+
+#define CUDAQ_EXTENSION_CUSTOM_CREATOR_FUNCTION_WITH_NAME(TYPE, NAME, ...)     \
+  static inline bool register_type() {                                         \
+    auto &registry = TYPE::get_registry();                                     \
+    registry.insert({NAME, TYPE::create});                                     \
+    return true;                                                               \
+  }                                                                            \
+  static const bool registered_;                                               \
+  static inline const std::string class_identifier = #TYPE;                    \
+  __VA_ARGS__
+
+/// @brief Macro for registering an extension type.
+/// @param TYPE The class to be registered as an extension.
+#define CUDAQ_REGISTER_TYPE(TYPE)                                              \
+  const bool TYPE::registered_ = TYPE::register_type();
+
+/// In order to support building CUDA-QX libraries with g++ and building
+/// application code with nvq++ (which uses clang++ under the hood), you must
+/// implement the templated get_registry() function for every set of
+/// extension_point<Args..>. This *must* be done in a C++ file that is built
+/// with the CUDA-QX libraries.
+///
+/// Use this version of the helper macro if the only template argument to
+/// extension_point<> is the derived class (with no additional creator args).
+#define INSTANTIATE_REGISTRY_NO_ARGS(FULL_TYPE_NAME)                           \
+  template <>                                                                  \
+  std::unordered_map<std::string,                                              \
+                     std::function<std::unique_ptr<FULL_TYPE_NAME>()>> &       \
+  cudaqx::extension_point<FULL_TYPE_NAME>::get_registry() {                    \
+    static std::unordered_map<                                                 \
+        std::string, std::function<std::unique_ptr<FULL_TYPE_NAME>()>>         \
+        registry;                                                              \
+    return registry;                                                           \
+  }
+
+/// Use this variadic version of the helper macro if there are additional
+/// arguments for the creator function.
+#define INSTANTIATE_REGISTRY(FULL_TYPE_NAME, ...)                              \
+  template <>                                                                  \
+  std::unordered_map<                                                          \
+      std::string,                                                             \
+      std::function<std::unique_ptr<FULL_TYPE_NAME>(__VA_ARGS__)>> &           \
+  cudaqx::extension_point<FULL_TYPE_NAME, __VA_ARGS__>::get_registry() {       \
+    static std::unordered_map<                                                 \
+        std::string,                                                           \
+        std::function<std::unique_ptr<FULL_TYPE_NAME>(__VA_ARGS__)>>           \
+        registry;                                                              \
+    return registry;                                                           \
+  }
+
+} // namespace cudaqx

--- a/realtime/include/cudaq/nvqlink/utils/instrumentation/domains.h
+++ b/realtime/include/cudaq/nvqlink/utils/instrumentation/domains.h
@@ -1,0 +1,26 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+/// @file domains.hpp
+/// @brief Domain identifiers for logical component grouping
+///
+/// This header provides domain identifiers for logical component grouping.
+/// These are macro identifiers for zero-overhead preprocessor-based dispatch.
+///
+/// Usage:
+///   NVQLINK_TRACE_FULL(DOMAIN_DAEMON, "Something happened")
+///   NVQLINK_LOG_INFO(DOMAIN_DAEMON, "Log message")
+
+#define DOMAIN_DAEMON daemon
+#define DOMAIN_DISPATCHER dispatcher
+#define DOMAIN_MEMORY memory
+#define DOMAIN_CHANNEL channel
+#define DOMAIN_USER user
+#define DOMAIN_GPU gpu

--- a/realtime/include/cudaq/nvqlink/utils/instrumentation/logger.h
+++ b/realtime/include/cudaq/nvqlink/utils/instrumentation/logger.h
@@ -1,0 +1,62 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+/// @file logger.hpp
+/// @brief Unified logging API supporting multiple backends (Quill, NONE)
+///
+/// This header provides a backend-agnostic logging interface. The backend
+/// is selected at compile time via -DLOGGING_BACKEND=<QUILL|NONE>
+///
+/// All backends share common domain definitions (reusing profiler domains)
+/// to ensure consistent logging semantics across the codebase.
+
+namespace cudaq::nvqlink::logger {
+
+//===----------------------------------------------------------------------===//
+// Log Levels
+//===----------------------------------------------------------------------===//
+
+/// @brief Log levels
+///
+/// @note These levels are used to filter log messages at compile time. Hot path
+/// safe logs are compiled out in production.
+enum class Level {
+  TRACE,   ///< Per-packet/operation details (hot path safe)
+  DEBUG,   ///< Diagnostic information (hot path safe)
+  INFO,    ///< Informational messages (control path only)
+  WARNING, ///< Recoverable issues (control path only)
+  ERROR    ///< Failures requiring attention (control path only)
+};
+
+} // namespace cudaq::nvqlink::logger
+
+//===----------------------------------------------------------------------===//
+// Backend Selection
+//===----------------------------------------------------------------------===//
+
+#if defined(LOGGING_BACKEND_QUILL)
+  // Quill backend
+#include "cudaq/nvqlink/utils/instrumentation/quill_logger.h"
+
+#else
+  // No logging - all macros are no-ops
+
+#define NVQLINK_LOG_TRACE(domain, fmt, ...)
+#define NVQLINK_LOG_DEBUG(domain, fmt, ...)
+#define NVQLINK_LOG_INFO(domain, fmt, ...)
+#define NVQLINK_LOG_WARNING(domain, fmt, ...)
+#define NVQLINK_LOG_ERROR(domain, fmt, ...)
+
+namespace cudaq::nvqlink::logger {
+inline void initialize() {}
+inline void shutdown() {}
+} // namespace cudaq::nvqlink::logger
+
+#endif // Backend selection

--- a/realtime/include/cudaq/nvqlink/utils/instrumentation/nvtx.h
+++ b/realtime/include/cudaq/nvqlink/utils/instrumentation/nvtx.h
@@ -1,0 +1,169 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+/// @file nvtx.hpp
+/// @brief NVTX/Nsight profiler backend implementation
+///
+/// This file should only be included via profiler.hpp when
+/// PROFILER_BACKEND_NVTX is defined. It implements the unified profiling API
+/// using NVIDIA NVTX3.
+
+#include <cstdint>
+#include <nvtx3/nvToolsExt.h>
+
+// Note: profiler constants are defined in profiler.hpp
+// This file assumes profiler.hpp has already been included
+
+namespace cudaq::nvqlink::nvtx {
+
+// NVTX domain handles (defined in nvtx.cpp)
+extern nvtxDomainHandle_t domain_daemon;
+extern nvtxDomainHandle_t domain_dispatcher;
+extern nvtxDomainHandle_t domain_memory;
+extern nvtxDomainHandle_t domain_channel;
+extern nvtxDomainHandle_t domain_user;
+extern nvtxDomainHandle_t domain_gpu;
+
+/// Minimal overhead RAII range (no virtual, inlined destructor)
+class ScopedRange {
+  nvtxDomainHandle_t d_;
+
+public:
+  inline ScopedRange(nvtxDomainHandle_t d, const char *name, uint32_t cat,
+                     uint32_t color)
+      : d_(d) {
+    nvtxEventAttributes_t a = {0};
+    a.version = NVTX_VERSION;
+    a.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    a.category = cat;
+    a.colorType = NVTX_COLOR_ARGB;
+    a.color = color;
+    a.messageType = NVTX_MESSAGE_TYPE_ASCII;
+    a.message.ascii = name;
+    nvtxDomainRangePushEx(d_, &a);
+  }
+
+  inline ScopedRange(nvtxDomainHandle_t d, const char *name, uint32_t cat,
+                     uint32_t color, uint64_t payload)
+      : d_(d) {
+    nvtxEventAttributes_t a = {0};
+    a.version = NVTX_VERSION;
+    a.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    a.category = cat;
+    a.colorType = NVTX_COLOR_ARGB;
+    a.color = color;
+    a.messageType = NVTX_MESSAGE_TYPE_ASCII;
+    a.message.ascii = name;
+    a.payloadType = NVTX_PAYLOAD_TYPE_UNSIGNED_INT64;
+    a.payload.ullValue = payload;
+    nvtxDomainRangePushEx(d_, &a);
+  }
+
+  inline ~ScopedRange() {
+    if (d_)
+      nvtxDomainRangePop(d_);
+  }
+};
+
+inline void mark(nvtxDomainHandle_t d, const char *msg) {
+  nvtxEventAttributes_t a = {0};
+  a.version = NVTX_VERSION;
+  a.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  a.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  a.message.ascii = msg;
+  a.colorType = NVTX_COLOR_ARGB;
+  a.color = profiler::COLOR_ERROR;
+  nvtxDomainMarkEx(d, &a);
+}
+
+inline void counter(nvtxDomainHandle_t d, const char *name, uint64_t value) {
+  nvtxEventAttributes_t a = {0};
+  a.version = NVTX_VERSION;
+  a.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  a.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  a.message.ascii = name;
+  a.payloadType = NVTX_PAYLOAD_TYPE_UNSIGNED_INT64;
+  a.payload.ullValue = value;
+  a.colorType = NVTX_COLOR_ARGB;
+  a.color = profiler::COLOR_METRICS;
+  nvtxDomainMarkEx(d, &a);
+}
+} // namespace cudaq::nvqlink::nvtx
+
+// Profiler namespace implementation (forward declared in nvtx.cpp)
+namespace cudaq::nvqlink::profiler {
+void initialize();
+void shutdown();
+} // namespace cudaq::nvqlink::profiler
+
+//===----------------------------------------------------------------------===//
+// Preprocessor-based domain resolution
+//===----------------------------------------------------------------------===//
+
+/// Helper for token pasting to directly map domain identifiers to handles at
+/// compile-time.
+#define _NVQLINK_NVTX_DOMAIN(domain) nvqlink::nvtx::domain_##domain
+
+//===----------------------------------------------------------------------===//
+// Unified API Macros (NVTX Implementation)
+//===----------------------------------------------------------------------===//
+
+#define NVQLINK_TRACE_SCOPE(domain, name)                                      \
+  nvqlink::nvtx::ScopedRange _nvtx_s##__LINE__(                                \
+      _NVQLINK_NVTX_DOMAIN(domain), name, nvqlink::profiler::CAT_FULL,         \
+      nvqlink::profiler::COLOR_FULL)
+
+#define NVQLINK_TRACE_SCOPE_COLOR(domain, name, color)                         \
+  nvqlink::nvtx::ScopedRange _nvtx_sc##__LINE__(                               \
+      _NVQLINK_NVTX_DOMAIN(domain), name, nvqlink::profiler::CAT_FULL, color)
+
+#define NVQLINK_TRACE_HOTPATH(domain, name)                                    \
+  nvqlink::nvtx::ScopedRange _nvtx_h##__LINE__(                                \
+      _NVQLINK_NVTX_DOMAIN(domain), name, nvqlink::profiler::CAT_HOT_PATH,     \
+      nvqlink::profiler::COLOR_HOTPATH)
+
+#define NVQLINK_TRACE_HOTPATH_PAYLOAD(domain, name, payload)                   \
+  nvqlink::nvtx::ScopedRange _nvtx_hp##__LINE__(                               \
+      _NVQLINK_NVTX_DOMAIN(domain), name, nvqlink::profiler::CAT_HOT_PATH,     \
+      nvqlink::profiler::COLOR_HOTPATH, payload)
+
+#define NVQLINK_TRACE_FULL(domain, name)                                       \
+  nvqlink::nvtx::ScopedRange _nvtx_f##__LINE__(                                \
+      _NVQLINK_NVTX_DOMAIN(domain), name, nvqlink::profiler::CAT_FULL,         \
+      nvqlink::profiler::COLOR_FULL)
+
+#define NVQLINK_TRACE_MEMORY(name)                                             \
+  nvqlink::nvtx::ScopedRange _nvtx_m##__LINE__(                                \
+      nvqlink::nvtx::domain_memory, name, nvqlink::profiler::CAT_HOT_PATH,     \
+      nvqlink::profiler::COLOR_MEMORY)
+
+#define NVQLINK_TRACE_USER_RANGE(name)                                         \
+  nvqlink::nvtx::ScopedRange _nvtx_u##__LINE__(                                \
+      nvqlink::nvtx::domain_user, name, nvqlink::profiler::CAT_HOT_PATH,       \
+      nvqlink::profiler::COLOR_USER)
+
+#define NVQLINK_TRACE_COUNTER(name, value)                                     \
+  nvqlink::nvtx::counter(nvqlink::nvtx::domain_memory, name, value)
+
+#define NVQLINK_TRACE_MARK(domain, msg)                                        \
+  nvqlink::nvtx::mark(_NVQLINK_NVTX_DOMAIN(domain), msg)
+
+#define NVQLINK_TRACE_MARK_ERROR(domain, msg)                                  \
+  nvqlink::nvtx::mark(_NVQLINK_NVTX_DOMAIN(domain), msg)
+
+#define NVQLINK_TRACE_NAME_THREAD(name) nvtxNameOsThreadA(pthread_self(), name)
+
+//===----------------------------------------------------------------------===//
+// Tracy-specific features (no-op for NVTX)
+//===----------------------------------------------------------------------===//
+
+#define NVQLINK_ALLOC(ptr, size)
+#define NVQLINK_FREE(ptr)
+#define NVQLINK_TRACE_FRAME_MARK

--- a/realtime/include/cudaq/nvqlink/utils/instrumentation/profiler.h
+++ b/realtime/include/cudaq/nvqlink/utils/instrumentation/profiler.h
@@ -1,0 +1,103 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/utils/instrumentation/domains.h"
+
+#include <cstdint>
+
+/// @file profiler.hpp
+/// @brief Unified profiling API supporting multiple backends (NVTX, Tracy)
+///
+/// This header provides a backend-agnostic profiling interface. The backend
+/// is selected at compile time via -DPROFILER_BACKEND=<NVTX|TRACY|NONE>
+///
+/// All backends share common domain and category definitions to ensure
+/// consistent profiling semantics across tools.
+
+namespace cudaq::nvqlink::profiler {
+
+//===----------------------------------------------------------------------===//
+// Shared Constants (used by all backends)
+//===----------------------------------------------------------------------===//
+
+/// Domain identifiers for logical component grouping
+/// These are macro identifiers for zero-overhead preprocessor-based dispatch
+/// Usage: NVQLINK_TRACE_FULL(DOMAIN_DAEMON, "operation")
+
+constexpr const char *DOMAIN_DAEMON_STR = "daemon";
+constexpr const char *DOMAIN_DISPATCHER_STR = "dispatcher";
+constexpr const char *DOMAIN_MEMORY_STR = "memory";
+constexpr const char *DOMAIN_CHANNEL_STR = "channel";
+constexpr const char *DOMAIN_USER_STR = "user";
+constexpr const char *DOMAIN_GPU_STR = "gpu";
+
+//===----------------------------------------------------------------------===//
+// Category identifiers for operation classification
+//===----------------------------------------------------------------------===//
+
+/// Datapath operations (critical performance)
+constexpr uint32_t CAT_HOT_PATH = 1;
+
+/// Control path operations (initialization, etc.)
+constexpr uint32_t CAT_FULL = 2;
+
+/// Performance counters and metrics
+constexpr uint32_t CAT_METRICS = 3;
+
+//===----------------------------------------------------------------------===//
+// Standard colors (ARGB format) for visual consistency
+//===----------------------------------------------------------------------===//
+
+constexpr uint32_t COLOR_HOTPATH = 0xFF00FF00; ///< Green - hot path operations
+constexpr uint32_t COLOR_FULL = 0xFF0000FF; ///< Blue - control/init operations
+constexpr uint32_t COLOR_USER = 0xFFFFFF00; ///< Yellow - user functions
+constexpr uint32_t COLOR_MEMORY = 0xFFFF8000;  ///< Orange - memory operations
+constexpr uint32_t COLOR_ERROR = 0xFFFF0000;   ///< Red - errors
+constexpr uint32_t COLOR_METRICS = 0xFF00FFFF; ///< Cyan - metrics/counters
+
+} // namespace cudaq::nvqlink::profiler
+
+//===----------------------------------------------------------------------===//
+// Backend Selection
+//===----------------------------------------------------------------------===//
+
+#if defined(PROFILER_BACKEND_NVTX)
+  // NVTX/Nsight backend
+#include "nvqlink/instrumentation/nvtx.h"
+
+#elif defined(PROFILER_BACKEND_TRACY)
+  // Tracy profiler backend
+#include "nvqlink/instrumentation/tracy.h"
+
+#else
+  // No profiling - all macros are no-ops
+
+#define NVQLINK_TRACE_SCOPE(domain, name)
+#define NVQLINK_TRACE_SCOPE_COLOR(domain, name, color)
+#define NVQLINK_TRACE_HOTPATH(domain, name)
+#define NVQLINK_TRACE_HOTPATH_PAYLOAD(domain, name, payload)
+#define NVQLINK_TRACE_FULL(domain, name)
+#define NVQLINK_TRACE_MEMORY(name)
+#define NVQLINK_TRACE_USER_RANGE(name)
+#define NVQLINK_TRACE_COUNTER(name, value)
+#define NVQLINK_TRACE_MARK(domain, msg)
+#define NVQLINK_TRACE_MARK_ERROR(domain, msg)
+#define NVQLINK_TRACE_NAME_THREAD(name)
+
+#define NVQLINK_ALLOC(ptr, size)
+#define NVQLINK_FREE(ptr)
+#define NVQLINK_TRACE_FRAME_MARK
+
+namespace cudaq::nvqlink::profiler {
+inline void initialize() {}
+inline void shutdown() {}
+} // namespace cudaq::nvqlink::profiler
+
+#endif // Backend selection

--- a/realtime/include/cudaq/nvqlink/utils/instrumentation/quill_logger.h
+++ b/realtime/include/cudaq/nvqlink/utils/instrumentation/quill_logger.h
@@ -1,0 +1,150 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+/// @file quill_logger.hpp
+/// @brief Quill logger backend implementation
+///
+/// This file should only be included via logger.hpp when
+/// LOGGING_BACKEND_QUILL is defined. It implements the unified logging API
+/// using Quill v11.0.2.
+///
+/// Quill provides low-latency asynchronous logging with:
+///
+///   - Lock-free SPSC queues (~20-30ns hot path overhead)
+///   - Asynchronous formatting and I/O on dedicated backend thread
+///   - BoundedDropping queue that never blocks the hot path
+///   - Compile-time log level filtering via QUILL_ACTIVE_LOG_LEVEL
+
+#include <quill/Backend.h>
+#include <quill/Frontend.h>
+#include <quill/LogMacros.h>
+#include <quill/Logger.h>
+#include <quill/sinks/ConsoleSink.h>
+#include <quill/std/Vector.h>
+
+// Need profiler.hpp for domain macro definitions (DOMAIN_DAEMON, etc.)
+#include "cudaq/nvqlink/utils/instrumentation/domains.h"
+
+namespace cudaq::nvqlink::quill_backend {
+
+//===----------------------------------------------------------------------===//
+// Custom Frontend Options (following recommended_usage pattern)
+//===----------------------------------------------------------------------===//
+
+/// CustomFrontendOptions optimized for low-latency daemon workloads
+struct CustomFrontendOptions {
+  /// BoundedDropping: NEVER blocks, drops messages if queue is full
+  /// This is critical for hot path safety - we never want logging to stall
+  /// the hot path, even under extreme load
+  static constexpr quill::QueueType queue_type =
+      quill::QueueType::BoundedDropping;
+
+  /// Initial per-thread queue capacity (128KB)
+  static constexpr size_t initial_queue_capacity = 131'072;
+
+  /// Retry interval for blocking queues (not used with BoundedDropping)
+  static constexpr uint32_t blocking_queue_retry_interval_ns = 800;
+
+  /// Maximum capacity for unbounded queues (not used with BoundedDropping)
+  static constexpr size_t unbounded_queue_max_capacity =
+      2ull * 1024u * 1024u * 1024u;
+
+  /// Huge pages policy (disabled for now)
+  static constexpr quill::HugePagesPolicy huge_pages_policy =
+      quill::HugePagesPolicy::Never;
+};
+
+//===----------------------------------------------------------------------===//
+// Using Declarations
+//===----------------------------------------------------------------------===//
+
+using CustomFrontend = quill::FrontendImpl<CustomFrontendOptions>;
+using CustomLogger = quill::LoggerImpl<CustomFrontendOptions>;
+
+//===----------------------------------------------------------------------===//
+// Domain Logger Handles (defined in quill_logger.cpp)
+//===----------------------------------------------------------------------===//
+
+extern CustomLogger *logger_daemon;
+extern CustomLogger *logger_dispatcher;
+extern CustomLogger *logger_memory;
+extern CustomLogger *logger_channel;
+extern CustomLogger *logger_user;
+extern CustomLogger *logger_gpu;
+
+} // namespace cudaq::nvqlink::quill_backend
+
+//===----------------------------------------------------------------------===//
+// Namespace Implementation (forward declared in quill_logger.cpp)
+//===----------------------------------------------------------------------===//
+
+namespace cudaq::nvqlink::logger {
+void initialize();
+void shutdown();
+} // namespace cudaq::nvqlink::logger
+
+//===----------------------------------------------------------------------===//
+// Preprocessor-based domain resolution
+//===----------------------------------------------------------------------===//
+
+/// Helper for token pasting to directly map domain identifiers to logger
+/// handles at compile-time (zero-overhead dispatch) Requires two-level
+/// expansion: domain macro must expand before token pasting
+#define _NVQLINK_LOGGER_IMPL(domain) nvqlink::quill_backend::logger_##domain
+#define _NVQLINK_LOGGER(domain) _NVQLINK_LOGGER_IMPL(domain)
+
+//===----------------------------------------------------------------------===//
+// Unified API Macros (Quill Implementation)
+//===----------------------------------------------------------------------===//
+
+// These macros map to Quill's LOG_* macros while adding domain context.
+// Quill will compile out lower-level logs based on QUILL_ACTIVE_LOG_LEVEL.
+//
+// Note: Includes null-pointer checks for safety during early initialization.
+
+#define NVQLINK_LOG_TRACE(domain, fmt, ...)                                    \
+  do {                                                                         \
+    auto *_logger_ptr = _NVQLINK_LOGGER(domain);                               \
+    if (_logger_ptr) {                                                         \
+      LOG_TRACE_L3(_logger_ptr, fmt, ##__VA_ARGS__);                           \
+    }                                                                          \
+  } while (0)
+
+#define NVQLINK_LOG_DEBUG(domain, fmt, ...)                                    \
+  do {                                                                         \
+    auto *_logger_ptr = _NVQLINK_LOGGER(domain);                               \
+    if (_logger_ptr) {                                                         \
+      LOG_DEBUG(_logger_ptr, fmt, ##__VA_ARGS__);                              \
+    }                                                                          \
+  } while (0)
+
+#define NVQLINK_LOG_INFO(domain, fmt, ...)                                     \
+  do {                                                                         \
+    auto *_logger_ptr = _NVQLINK_LOGGER(domain);                               \
+    if (_logger_ptr) {                                                         \
+      LOG_INFO(_logger_ptr, fmt, ##__VA_ARGS__);                               \
+    }                                                                          \
+  } while (0)
+
+#define NVQLINK_LOG_WARNING(domain, fmt, ...)                                  \
+  do {                                                                         \
+    auto *_logger_ptr = _NVQLINK_LOGGER(domain);                               \
+    if (_logger_ptr) {                                                         \
+      LOG_WARNING(_logger_ptr, fmt, ##__VA_ARGS__);                            \
+    }                                                                          \
+  } while (0)
+
+#define NVQLINK_LOG_ERROR(domain, fmt, ...)                                    \
+  do {                                                                         \
+    auto *_logger_ptr = _NVQLINK_LOGGER(domain);                               \
+    if (_logger_ptr) {                                                         \
+      LOG_ERROR(_logger_ptr, fmt, ##__VA_ARGS__);                              \
+    }                                                                          \
+  } while (0)

--- a/realtime/include/cudaq/nvqlink/utils/instrumentation/tracy.h
+++ b/realtime/include/cudaq/nvqlink/utils/instrumentation/tracy.h
@@ -1,0 +1,133 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+/// @file tracy.hpp
+/// @brief Tracy profiler backend implementation
+///
+/// This file should only be included via profiler.hpp when
+/// PROFILER_BACKEND_TRACY is defined. It implements the unified profiling API
+/// using Tracy profiler.
+///
+/// Tracy provides real-time visualization and low-overhead profiling with:
+/// - Automatic memory tracking
+/// - Lock contention analysis
+/// - Frame markers for game/graphics applications
+/// - Cross-platform support
+
+#include <cstdint>
+#include <tracy/Tracy.hpp>
+
+namespace cudaq::nvqlink::profiler {
+
+// Tracy auto-initializes, so these are no-ops
+inline void initialize() {}
+inline void shutdown() {}
+
+} // namespace cudaq::nvqlink::profiler
+
+//===----------------------------------------------------------------------===//
+// Helper Macros
+//===----------------------------------------------------------------------===//
+
+/// Compile-time string concatenation for "domain::name" format
+/// Uses preprocessor stringification and concatenation
+#define _NVQLINK_STRINGIFY(x) #x
+#define _NVQLINK_TRACY_NAME_IMPL(domain, name)                                 \
+  _NVQLINK_STRINGIFY(domain) "::" name
+#define NVQLINK_TRACY_NAME(domain, name) _NVQLINK_TRACY_NAME_IMPL(domain, name)
+
+//===----------------------------------------------------------------------===//
+// Unified API Macros (Tracy Implementation)
+//===----------------------------------------------------------------------===//
+
+/// Basic scoped range with domain context
+#define NVQLINK_TRACE_SCOPE(domain, name)                                      \
+  ZoneScopedN(NVQLINK_TRACY_NAME(domain, name))
+
+/// Scoped range with custom color
+#define NVQLINK_TRACE_SCOPE_COLOR(domain, name, color)                         \
+  ZoneNamedNC(_tracy_zone_##__LINE__, NVQLINK_TRACY_NAME(domain, name), color, \
+              true)
+
+/// Hot path instrumentation (green)
+#define NVQLINK_TRACE_HOTPATH(domain, name)                                    \
+  NVQLINK_TRACE_SCOPE_COLOR(domain, name, nvqlink::profiler::COLOR_HOTPATH)
+
+/// Hot path with payload (Tracy doesn't support payloads in zone names,
+/// but we can use TracyMessageL to log the value)
+#define NVQLINK_TRACE_HOTPATH_PAYLOAD(domain, name, payload)                   \
+  ZoneNamedNC(_tracy_zone_##__LINE__, NVQLINK_TRACY_NAME(domain, name),        \
+              nvqlink::profiler::COLOR_HOTPATH, true);                         \
+  ZoneValue(_tracy_zone_##__LINE__, payload)
+
+/// Full/control path instrumentation (blue)
+#define NVQLINK_TRACE_FULL(domain, name)                                       \
+  NVQLINK_TRACE_SCOPE_COLOR(domain, name, nvqlink::profiler::COLOR_FULL)
+
+/// Memory operation instrumentation (orange)
+#define NVQLINK_TRACE_MEMORY(name)                                             \
+  ZoneNamedNC(_tracy_zone_mem_##__LINE__, NVQLINK_TRACY_NAME(memory, name),    \
+              nvqlink::profiler::COLOR_MEMORY, true)
+
+/// User function instrumentation (yellow)
+#define NVQLINK_TRACE_USER_RANGE(name)                                         \
+  ZoneNamedNC(_tracy_zone_user_##__LINE__, NVQLINK_TRACY_NAME(user, name),     \
+              nvqlink::profiler::COLOR_USER, true)
+
+/// Performance counter/plot
+/// Tracy has native plot support for visualizing metrics over time
+#define NVQLINK_TRACE_COUNTER(name, value) TracyPlot(name, (int64_t)(value))
+
+/// Point marker
+#define NVQLINK_TRACE_MARK(domain, msg) TracyMessageL(msg)
+
+/// Error marker (red color)
+#define NVQLINK_TRACE_MARK_ERROR(domain, msg)                                  \
+  TracyMessageLC(msg, nvqlink::profiler::COLOR_ERROR)
+
+/// Thread naming for better visualization
+#define NVQLINK_TRACE_NAME_THREAD(name) tracy::SetThreadName(name)
+
+//===----------------------------------------------------------------------===//
+// Tracy-Specific Features
+//===----------------------------------------------------------------------===//
+
+/// Memory allocation tracking
+/// Allows Tracy to build memory usage graphs and detect leaks
+#define NVQLINK_ALLOC(ptr, size) TracyAlloc(ptr, size)
+
+/// Memory free tracking
+#define NVQLINK_FREE(ptr) TracyFree(ptr)
+
+/// Frame boundary marker
+/// Useful for graphics/game applications to measure frame time
+#define NVQLINK_TRACE_FRAME_MARK FrameMark
+
+//===----------------------------------------------------------------------===//
+// Additional Tracy Utilities (optional, not part of unified API)
+//===----------------------------------------------------------------------===//
+
+/// Lockable wrapper for mutex contention tracking
+/// Usage: NVQLINK_LOCKABLE(std::mutex, my_mutex);
+#define NVQLINK_LOCKABLE(type, name) tracy::Lockable<type> name
+
+/// Scoped lock with contention tracking
+/// Usage: NVQLINK_LOCK_GUARD(my_mutex);
+#define NVQLINK_LOCK_GUARD(lockable)                                           \
+  std::lock_guard<decltype(lockable)::LockableBase> _tracy_lock_##__LINE__(    \
+      lockable)
+
+/// Manual zone text annotation
+/// Adds runtime text to the current zone
+#define NVQLINK_ZONE_TEXT(text, len) ZoneText(text, len)
+
+/// Manual zone value annotation
+/// Adds numeric value to the current zone
+#define NVQLINK_ZONE_VALUE(value) ZoneValue(value)

--- a/realtime/lib/CMakeLists.txt
+++ b/realtime/lib/CMakeLists.txt
@@ -1,0 +1,59 @@
+# ============================================================================ #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Fetch spdlog from its GitHub repository
+FetchContent_Declare(
+  spdlog
+  GIT_REPOSITORY https://github.com/gabime/spdlog.git
+  GIT_TAG        v1.15.0           # Update the tag to the version you want
+)
+FetchContent_MakeAvailable(spdlog)
+
+set(LIBRARY_NAME cudaq-nvqlink)
+
+add_compile_options(-Wno-attributes) 
+
+# FIXME?: This must be a shared library. Trying to build a static one will fail.
+add_library(${LIBRARY_NAME} SHARED
+  nvqlink.cpp
+  compiler.cpp
+  utils/logger.cpp
+)
+
+add_subdirectory(compilers)
+
+target_include_directories(${LIBRARY_NAME}
+  PUBLIC 
+    $<BUILD_INTERFACE:${CUDAQ_NVQLINK_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${spdlog_SOURCE_DIR}/include/spdlog>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(${LIBRARY_NAME} PRIVATE spdlog::spdlog)
+
+set_target_properties(${LIBRARY_NAME} PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+install(TARGETS ${LIBRARY_NAME}
+  COMPONENT nvqlink-lib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+    
+install(DIRECTORY ${CUDAQ_NVQLINK_INCLUDE_DIR}/cudaq
+  COMPONENT nvqlink-headers
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN "*.h"
+)
+
+add_subdirectory(daemon)
+add_subdirectory(network)
+add_subdirectory(qcs)
+add_subdirectory(utils)
+
+# FIXME:
+# add_subdirectory(plugins)

--- a/realtime/lib/compiler.cpp
+++ b/realtime/lib/compiler.cpp
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/compiler.h"
+
+#include <regex>
+#include <sstream>
+#include <string>
+
+INSTANTIATE_REGISTRY_NO_ARGS(cudaq::nvqlink::compiler);
+
+namespace cudaq::nvqlink::details {
+
+std::string removeNonEntrypointFunctions(const std::string &mlirCode) {
+  std::string result = mlirCode;
+
+  // Pattern to match func.func or llvm.func operations
+  // This handles both single-line declarations and multi-line definitions
+  std::regex funcPattern(
+      R"(((?:func\.func|llvm\.func)\s+[^{]*(?:\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}|(?:\s*\n|$)))");
+
+  std::sregex_iterator iter(result.begin(), result.end(), funcPattern);
+  std::sregex_iterator end;
+
+  std::vector<std::pair<size_t, size_t>> toRemove;
+
+  // Find all function matches and identify which ones to remove
+  for (auto it = iter; it != end; ++it) {
+    std::string match = it->str();
+
+    // Skip if this is the entrypoint function (contains "cudaq-entrypoint")
+    if (match.find("\"cudaq-entrypoint\"") != std::string::npos) {
+      continue;
+    }
+
+    // Mark this function for removal
+    toRemove.push_back({it->position(), it->position() + it->length()});
+  }
+
+  // Remove functions in reverse order to maintain valid positions
+  for (auto rit = toRemove.rbegin(); rit != toRemove.rend(); ++rit) {
+    result.erase(rit->first, rit->second - rit->first);
+  }
+
+  // Clean up any extra newlines that might be left
+  result = std::regex_replace(result, std::regex(R"(\n\s*\n\s*\n)"), "\n\n");
+
+  return result;
+}
+
+// Alternative approach using manual parsing for more control
+std::string removeNonEntrypointFunctionsManual(const std::string &mlirCode) {
+  std::istringstream iss(mlirCode);
+  std::ostringstream result;
+  std::string line;
+  bool inEntrypointFunction = false;
+  bool inOtherFunction = false;
+  int braceLevel = 0;
+  std::string currentFunction;
+
+  while (std::getline(iss, line)) {
+    // Check if this line starts a function
+    if (line.find("func.func") == 0 || line.find("llvm.func") == 0) {
+      // Check if this is the entrypoint function
+      if (line.find("\"cudaq-entrypoint\"") != std::string::npos) {
+        inEntrypointFunction = true;
+        result << line << "\n";
+        braceLevel = 0;
+        // Count braces in the current line
+        for (char c : line) {
+          if (c == '{')
+            braceLevel++;
+          else if (c == '}')
+            braceLevel--;
+        }
+      } else {
+        // This is a function we want to remove
+        inOtherFunction = true;
+        braceLevel = 0;
+        // Count braces in the current line
+        for (char c : line) {
+          if (c == '{')
+            braceLevel++;
+          else if (c == '}')
+            braceLevel--;
+        }
+        // If it's a single-line declaration (braceLevel == 0), skip it entirely
+        if (braceLevel == 0) {
+          inOtherFunction = false;
+        }
+      }
+    }
+    // Handle lines within functions
+    else if (inEntrypointFunction) {
+      result << line << "\n";
+      // Count braces to know when function ends
+      for (char c : line) {
+        if (c == '{')
+          braceLevel++;
+        else if (c == '}')
+          braceLevel--;
+      }
+      if (braceLevel == 0) {
+        inEntrypointFunction = false;
+      }
+    } else if (inOtherFunction) {
+      // Count braces to know when function ends
+      for (char c : line) {
+        if (c == '{')
+          braceLevel++;
+        else if (c == '}')
+          braceLevel--;
+      }
+      if (braceLevel == 0) {
+        inOtherFunction = false;
+      }
+      // Don't add this line to result
+    }
+    // Handle lines outside functions (module attributes, etc.)
+    else {
+      result << line << "\n";
+    }
+  }
+
+  return result.str();
+}
+
+} // namespace cudaq::nvqlink::details

--- a/realtime/lib/compilers/CMakeLists.txt
+++ b/realtime/lib/compilers/CMakeLists.txt
@@ -1,0 +1,16 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+set(CUDAQ_LIBRARY_MODE ON)
+find_package(CUDAQ QUIET)
+if (CUDAQ_FOUND)
+  message(STATUS "CUDA-Q found: Enabling CUDA-Q compiler support")
+  add_subdirectory(cudaq)
+else()
+  message(STATUS "CUDA-Q not found: Disabling CUDA-Q compiler support (optional)")
+endif()

--- a/realtime/lib/compilers/cudaq/CMakeLists.txt
+++ b/realtime/lib/compilers/cudaq/CMakeLists.txt
@@ -1,0 +1,13 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cudaq_config.h.in"
+               "${CMAKE_BINARY_DIR}/include/compilers/cudaq/cudaq_config.h"
+               @ONLY)
+target_include_directories(cudaq-nvqlink PRIVATE ${CMAKE_BINARY_DIR}/include/compilers/cudaq)
+target_sources(cudaq-nvqlink PRIVATE cudaq.cpp cudaq_toolchain.cpp)

--- a/realtime/lib/compilers/cudaq/cudaq.cpp
+++ b/realtime/lib/compilers/cudaq/cudaq.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/compilers/cudaq/cudaq.h"
+#include "../../utils/logger.h"
+
+#include "cudaq_config.h"
+
+#include <cassert>
+#include <dlfcn.h>
+
+namespace cudaq::nvqlink {
+
+bool cudaq_compiler::understands_code(const std::string &code) const {
+  // FIXME make this better
+  return code.find("module") != std::string::npos &&
+         code.find("func.func") != std::string::npos;
+}
+
+std::unique_ptr<compiled_kernel>
+cudaq_compiler::compile(const std::string &code, const std::string &kernelName,
+                        std::size_t num_qcs_devices) {
+
+  assert(num_qcs_devices == 1 && "only support 1 qcs device for now.");
+
+  // Use the cuda-q toolchain to compile to object code
+  auto result = cudaq::pipeline(code, "/tmp") | cudaq::opt(passes) |
+                cudaq::translate("qir") | llvm::llc("x86_64-unknown-linux-gnu");
+
+  // FIXME Need to input where CUDA-Q libraries are...
+  auto linkResult = clang::linker(CUDAQ_LIBRARY_DIR).linkMultiple({result.outputFile});
+
+  // Open the compiled result
+  void *handle = dlopen(linkResult.outputFile.c_str(), RTLD_LAZY | RTLD_LOCAL);
+  if (!handle)
+    throw std::runtime_error("Failed to load shared library: " +
+                             std::string(dlerror()));
+  // Need to track the allocated resources, i.e. dlclose when we are done
+  std::unordered_map<void *, std::function<void(void *)>> tracked_resources(
+      {{handle, [](void *hdl) -> void { dlclose(hdl); }}});
+
+  // Get the quantum device id
+  auto qid = 0;
+  Logger::log("Compiling {} on device {}", kernelName, qid);
+
+  // FIXME how do we get these symbol strings generically?
+  auto *argsCreator = static_cast<std::byte *>(
+      dlsym(handle, fmt::format("{}.argsCreator", kernelName).c_str()));
+  if (auto *err = dlerror())
+    throw std::runtime_error("could not extract argsCreator function.");
+  auto *thunk = static_cast<std::byte *>(
+      dlsym(handle, fmt::format("{}.thunk", kernelName).c_str()));
+  if (auto *err = dlerror())
+    throw std::runtime_error("could not extract thunk function.");
+
+  // build up the compiled kernel instance
+  qcontrol_program program;
+  program.qdevice_id = qid;
+  program.binary.resize(2 * sizeof(void *));
+  std::memcpy(program.binary.data(), &argsCreator, sizeof(void *));
+  std::memcpy(program.binary.data() + sizeof(void *), &thunk, sizeof(void *));
+  return std::make_unique<compiled_kernel>(
+      kernelName, std::vector<qcontrol_program>{program}, tracked_resources);
+}
+
+class default_cudaq_compiler : public cudaq_compiler {
+public:
+  default_cudaq_compiler() : cudaq_compiler() {
+    passes = {
+        "--add-dealloc",        "--memtoreg=quantum=0",      "--cse",
+        "--canonicalize",       "--apply-op-specialization", "--canonicalize",
+        "--device-code-loader", "--kernel-execution"};
+  }
+
+  CUDAQ_EXTENSION_CUSTOM_CREATOR_FUNCTION_WITH_NAME(
+      default_cudaq_compiler, "cudaq",
+      static std::unique_ptr<compiler> create() {
+        return std::make_unique<default_cudaq_compiler>();
+      })
+};
+
+CUDAQ_REGISTER_TYPE(default_cudaq_compiler)
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/compilers/cudaq/cudaq_config.h.in
+++ b/realtime/lib/compilers/cudaq/cudaq_config.h.in
@@ -1,0 +1,11 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#define CUDAQ_LIBRARY_DIR "@CUDAQ_INSTALL_DIR@/lib"

--- a/realtime/lib/compilers/cudaq/cudaq_toolchain.cpp
+++ b/realtime/lib/compilers/cudaq/cudaq_toolchain.cpp
@@ -1,0 +1,350 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/compilers/cudaq/cudaq_toolchain.h"
+#include "../../utils/logger.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <regex>
+#include <sstream>
+#include <sys/wait.h>
+#include <unistd.h>
+
+using namespace cudaq::nvqlink;
+
+// command_line_tool base implementation
+std::string command_line_tool::executeCommand(const std::string &command) {
+  std::array<char, 128> buffer;
+  std::string result;
+
+  Logger::log("[exec cmd] {}", command);
+  FILE *pipe = popen((command + " 2>&1").c_str(), "r");
+  if (!pipe) {
+    throw std::runtime_error("Failed to execute command: " + command);
+  }
+
+  while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
+    result += buffer.data();
+  }
+
+  int exitCode = pclose(pipe);
+  if (exitCode != 0) {
+    throw std::runtime_error("Command failed with exit code " +
+                             std::to_string(exitCode) + ": " + command +
+                             "\nOutput: " + result);
+  }
+
+  return result;
+}
+
+std::string command_line_tool::generateUniqueId() {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(1000000, 9999999);
+  return std::to_string(dis(gen));
+}
+
+std::string command_line_tool::createTempFile(const std::string &content,
+                                              const std::string &suffix) {
+  std::string filename =
+      tempDir_ + "/" + toolName_ + "_" + generateUniqueId() + suffix;
+  std::ofstream file(filename);
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to create temporary file: " + filename);
+  }
+  file << content;
+  file.close();
+  addTempFile(filename);
+  return filename;
+}
+
+// cudaq::opt implementation
+command_line_tool::tool_result
+cudaq::opt::execute(const std::string &inputFile) {
+  std::string outputFile =
+      tempDir_ + "/optimized_" + generateUniqueId() + ".qke";
+  addTempFile(outputFile);
+
+  std::stringstream cmd;
+  cmd << toolName_;
+  for (const auto &pass : passes_) {
+    cmd << " " << pass;
+  }
+  cmd << " " << inputFile << " -o " << outputFile;
+
+  tool_result result;
+  try {
+    executeCommand(cmd.str());
+    if (std::filesystem::exists(outputFile)) {
+      result.outputFile = outputFile;
+      result.exitCode = 0;
+
+      // Read content for potential piping
+      std::ifstream file(outputFile);
+      if (file.is_open()) {
+        std::ostringstream content;
+        content << file.rdbuf();
+        result.content = content.str();
+      }
+    } else {
+      result.exitCode = 1;
+      result.errorMessage = "Output file not generated";
+    }
+  } catch (const std::exception &e) {
+    result.exitCode = 1;
+    result.errorMessage = e.what();
+  }
+
+  if (result.content.empty())
+    throw std::runtime_error("cudaq::opt error - output is empty.");
+  return result;
+}
+
+command_line_tool::tool_result
+cudaq::opt::executeWithContent(const std::string &content) {
+  std::string inputFile = createTempFile(content, ".qke");
+  return execute(inputFile);
+}
+
+// cudaq::translate implementation
+command_line_tool::tool_result
+cudaq::translate::execute(const std::string &inputFile) {
+  std::string outputFile =
+      tempDir_ + "/translated_" + generateUniqueId() + ".ll";
+  addTempFile(outputFile);
+
+  std::stringstream cmd;
+  cmd << toolName_ << " --convert-to=" << target_ << " " << inputFile << " -o "
+      << outputFile;
+
+  tool_result result;
+  try {
+    executeCommand(cmd.str());
+    if (std::filesystem::exists(outputFile)) {
+      result.outputFile = outputFile;
+      result.exitCode = 0;
+
+      // Read content for potential piping
+      std::ifstream file(outputFile);
+      if (file.is_open()) {
+        std::ostringstream content;
+        content << file.rdbuf();
+        result.content = content.str();
+      }
+    } else {
+      result.exitCode = 1;
+      result.errorMessage = "Output file not generated";
+    }
+  } catch (const std::exception &e) {
+    result.exitCode = 1;
+    result.errorMessage = e.what();
+  }
+
+  return result;
+}
+
+command_line_tool::tool_result
+cudaq::translate::executeWithContent(const std::string &content) {
+  std::string inputFile = createTempFile(content, ".qke");
+  return execute(inputFile);
+}
+
+// llvm::llc implementation
+command_line_tool::tool_result
+llvm::llc::execute(const std::string &inputFile) {
+  std::string outputFile = tempDir_ + "/compiled_" + generateUniqueId() + ".o";
+  addTempFile(outputFile);
+
+  std::stringstream cmd;
+  cmd << toolName_ << " -filetype=obj --relocation-model=pic";
+  if (!targetTriple_.empty()) {
+    cmd << " -mtriple=" << targetTriple_;
+  }
+  cmd << " " << inputFile << " -o " << outputFile;
+
+  tool_result result;
+  try {
+    executeCommand(cmd.str());
+    if (std::filesystem::exists(outputFile)) {
+      result.outputFile = outputFile;
+      result.exitCode = 0;
+      // Object files are binary, so we don't read content
+    } else {
+      result.exitCode = 1;
+      result.errorMessage = "Output file not generated";
+    }
+  } catch (const std::exception &e) {
+    result.exitCode = 1;
+    result.errorMessage = e.what();
+  }
+
+  return result;
+}
+
+command_line_tool::tool_result
+llvm::llc::executeWithContent(const std::string &content) {
+  std::string inputFile = createTempFile(content, ".ll");
+  return execute(inputFile);
+}
+
+// clang::linker implementation
+command_line_tool::tool_result
+clang::linker::execute(const std::string &inputFile) {
+  std::string outputFile = tempDir_ + "/linked_" + generateUniqueId() + ".so";
+
+  std::stringstream cmd;
+  cmd << toolName_;
+  if (shared_)
+    cmd << " -shared";
+  if (pic_)
+    cmd << " -fPIC";
+  cmd << " " << optimizationLevel_ << " " << inputFile << " -o " << outputFile;
+
+  tool_result result;
+  try {
+    executeCommand(cmd.str());
+    if (std::filesystem::exists(outputFile)) {
+      result.outputFile = outputFile;
+      result.exitCode = 0;
+    } else {
+      result.exitCode = 1;
+      result.errorMessage = "Output file not generated";
+    }
+  } catch (const std::exception &e) {
+    result.exitCode = 1;
+    result.errorMessage = e.what();
+  }
+
+  return result;
+}
+
+command_line_tool::tool_result
+clang::linker::executeWithContent(const std::string &content) {
+  std::string inputFile = createTempFile(content, ".o");
+  return execute(inputFile);
+}
+
+command_line_tool::tool_result
+clang::linker::linkMultiple(const std::vector<std::string> &objectFiles) {
+  std::string outputFile = tempDir_ + "/linked_" + generateUniqueId() + ".so";
+
+  std::stringstream cmd;
+  cmd << toolName_;
+  if (shared_)
+    cmd << " -shared";
+  if (pic_)
+    cmd << " -fPIC";
+  cmd << " " << optimizationLevel_ << "  -L " << cudaqLibraryPath
+      << " -lcudaq -Wl,-rpath," << cudaqLibraryPath;
+
+  for (const auto &objFile : objectFiles) {
+    cmd << " " << objFile;
+  }
+  cmd << " -o " << outputFile;
+
+  tool_result result;
+  try {
+    executeCommand(cmd.str());
+    if (std::filesystem::exists(outputFile)) {
+      result.outputFile = outputFile;
+      result.exitCode = 0;
+    } else {
+      result.exitCode = 1;
+      result.errorMessage = "Output file not generated";
+    }
+  } catch (const std::exception &e) {
+    result.exitCode = 1;
+    result.errorMessage = e.what();
+  }
+
+  return result;
+}
+
+// Pipe operator implementations
+command_line_tool::tool_result
+operator|(const command_line_tool::tool_result &input, cudaq::opt &tool) {
+  if (!input) {
+    return input; // Propagate error
+  }
+
+  if (!input.content.empty()) {
+    return tool.executeWithContent(input.content);
+  } else if (!input.outputFile.empty()) {
+    return tool.execute(input.outputFile);
+  }
+
+  command_line_tool::tool_result error;
+  error.exitCode = 1;
+  error.errorMessage = "No valid input for cudaq::opt";
+  return error;
+}
+
+command_line_tool::tool_result
+operator|(const command_line_tool::tool_result &input,
+          const cudaq::translate &tool) {
+  if (!input) {
+    return input; // Propagate error
+  }
+
+  if (!input.content.empty()) {
+    return const_cast<cudaq::translate &>(tool).executeWithContent(
+        input.content);
+  } else if (!input.outputFile.empty()) {
+    return const_cast<cudaq::translate &>(tool).execute(input.outputFile);
+  }
+
+  command_line_tool::tool_result error;
+  error.exitCode = 1;
+  error.errorMessage = "No valid input for cudaq::translate";
+  return error;
+}
+
+command_line_tool::tool_result
+operator|(const command_line_tool::tool_result &input, const llvm::llc &tool) {
+  if (!input) {
+    return input; // Propagate error
+  }
+
+  if (!input.content.empty()) {
+    return const_cast<llvm::llc &>(tool).executeWithContent(input.content);
+  } else if (!input.outputFile.empty()) {
+    return const_cast<llvm::llc &>(tool).execute(input.outputFile);
+  }
+
+  command_line_tool::tool_result error;
+  error.exitCode = 1;
+  error.errorMessage = "No valid input for llvm::llc";
+  return error;
+}
+
+command_line_tool::tool_result
+operator|(const command_line_tool::tool_result &input, clang::linker &tool) {
+  if (!input) {
+    return input; // Propagate error
+  }
+
+  if (!input.outputFile.empty()) {
+    return tool.execute(input.outputFile);
+  }
+
+  command_line_tool::tool_result error;
+  error.exitCode = 1;
+  error.errorMessage = "No valid input for clang::linker";
+  return error;
+}
+
+// cudaq::pipeline implementation
+command_line_tool::tool_result
+cudaq::pipeline::operator|(const cudaq::opt &tool) {
+  auto &cc = const_cast<cudaq::opt &>(tool);
+  cc.setTempDir(tempDir_);
+  return cc.executeWithContent(content_);
+}

--- a/realtime/lib/daemon/CMakeLists.txt
+++ b/realtime/lib/daemon/CMakeLists.txt
@@ -1,0 +1,48 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+set(NVQLINK_DAEMON_SOURCES
+  config.cpp
+  daemon.cpp
+  dispatcher/cpu_dispatcher.cpp
+  dispatcher/dispatcher_factory.cpp
+  registry/function_registry.cpp
+  registry/rpc_builder.cpp
+)
+
+# Add CUDA/GPU sources if CUDA is available
+if(CUDA_FOUND)
+  list(APPEND NVQLINK_DAEMON_SOURCES
+    dispatcher/gpu_dispatcher.cu
+  )
+endif()
+
+add_library(nvqlink_daemon STATIC ${NVQLINK_DAEMON_SOURCES})
+
+target_include_directories(nvqlink_daemon
+  PUBLIC
+    $<BUILD_INTERFACE:${CUDAQ_NVQLINK_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Link dependencies
+target_link_libraries(nvqlink_daemon 
+  PUBLIC 
+    nvqlink_network
+    nvqlink_utils
+)
+
+if(CUDA_FOUND)
+  target_link_libraries(nvqlink_daemon PUBLIC CUDA::cudart)
+  target_compile_definitions(nvqlink_daemon PUBLIC NVQLINK_HAVE_CUDA)
+endif()
+
+# Add DOCA support if enabled
+if(NVQLINK_ENABLE_DOCA)
+  target_compile_definitions(nvqlink_daemon PUBLIC NVQLINK_ENABLE_DOCA)
+endif()

--- a/realtime/lib/daemon/config.cpp
+++ b/realtime/lib/daemon/config.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/daemon/config.h"
+
+using namespace cudaq::nvqlink;
+
+bool DaemonConfig::is_valid() const {
+  if (id.empty())
+    return false;
+  // Validation for datapath-specific config
+  if (datapath_mode == DatapathMode::CPU && compute.cpu_cores.empty())
+    return false;
+  if (datapath_mode == DatapathMode::GPU && !compute.gpu_device_id.has_value())
+    return false;
+  return true;
+}
+
+DaemonConfigBuilder &DaemonConfigBuilder::set_id(const std::string &id) {
+  config_.id = id;
+  return *this;
+}
+
+DaemonConfigBuilder &DaemonConfigBuilder::set_datapath_mode(DatapathMode mode) {
+  config_.datapath_mode = mode;
+  return *this;
+}
+
+DaemonConfigBuilder &
+DaemonConfigBuilder::set_cpu_cores(const std::vector<std::uint32_t> &cores) {
+  config_.compute.cpu_cores = cores;
+  return *this;
+}
+
+DaemonConfigBuilder &DaemonConfigBuilder::set_gpu_device(
+    std::uint32_t device_id, std::uint32_t blocks, std::uint32_t threads) {
+  config_.compute.gpu_device_id = device_id;
+  config_.compute.gpu_blocks = blocks;
+  config_.compute.gpu_threads_per_block = threads;
+  return *this;
+}
+
+DaemonConfig DaemonConfigBuilder::build() const { return config_; }

--- a/realtime/lib/daemon/daemon.cpp
+++ b/realtime/lib/daemon/daemon.cpp
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/daemon/daemon.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+#include "cudaq/nvqlink/utils/instrumentation/profiler.h"
+
+#include <stdexcept>
+
+using namespace cudaq::nvqlink;
+
+Daemon::Daemon(const DaemonConfig &config, std::unique_ptr<Channel> channel)
+    : config_(config), channel_(std::move(channel)) {
+  nvqlink::logger::initialize();
+  nvqlink::profiler::initialize();
+  NVQLINK_TRACE_FULL(DOMAIN_DAEMON, "ctor");
+
+  if (!channel_)
+    throw std::invalid_argument("Daemon: channel cannot be null");
+
+  validate_config();
+  function_registry_ = std::make_unique<FunctionRegistry>();
+
+  NVQLINK_LOG_INFO(DOMAIN_DAEMON, "Daemon {} initialized with provided channel",
+                   config_.id);
+}
+
+Daemon::~Daemon() {
+  NVQLINK_TRACE_FULL(DOMAIN_DAEMON, "dtor");
+  if (running_)
+    stop();
+
+  nvqlink::profiler::shutdown();
+  nvqlink::logger::shutdown();
+}
+
+void Daemon::start() {
+  NVQLINK_TRACE_FULL(DOMAIN_DAEMON, "start");
+  if (running_.exchange(true)) {
+    NVQLINK_LOG_INFO(DOMAIN_DAEMON, "Daemon already running");
+    return;
+  }
+
+  initialize_dispatcher();
+  dispatcher_->start();
+
+  NVQLINK_LOG_INFO(DOMAIN_DAEMON, "Daemon {} started successfully", config_.id);
+}
+
+void Daemon::stop() {
+  NVQLINK_TRACE_FULL(DOMAIN_DAEMON, "stop");
+  if (!running_.exchange(false))
+    return;
+
+  NVQLINK_LOG_INFO(DOMAIN_DAEMON, "Stopping daemon {}...", config_.id);
+
+  if (dispatcher_)
+    dispatcher_->stop();
+
+  NVQLINK_LOG_INFO(DOMAIN_DAEMON, "Daemon {} stopped", config_.id);
+}
+
+void Daemon::register_function(const FunctionMetadata &metadata) {
+  if (running_)
+    throw std::runtime_error(
+        "Cannot register functions while daemon is running");
+
+  if (!function_registry_)
+    function_registry_ = std::make_unique<FunctionRegistry>();
+
+  function_registry_->register_function(metadata);
+}
+
+Daemon::Stats Daemon::get_stats() const {
+  Stats stats = stats_;
+  if (dispatcher_) {
+    stats.packets_received = dispatcher_->get_packets_processed();
+    stats.packets_sent = dispatcher_->get_packets_sent();
+  }
+  return stats;
+}
+
+void Daemon::validate_config() const {
+  // Validate datapath-backend compatibility
+  if (config_.datapath_mode == DatapathMode::GPU) {
+    // TODO: Somewhere, probably not here, we need to validate whether the
+    // backend supports GPU datapath.
+    if (!config_.compute.gpu_device_id.has_value())
+      throw std::invalid_argument(
+          "GPU datapath requires GPU device configuration");
+  }
+
+  if (config_.datapath_mode == DatapathMode::CPU) {
+    if (config_.compute.cpu_cores.empty())
+      throw std::invalid_argument(
+          "CPU datapath requires CPU core configuration");
+  }
+}
+
+void Daemon::initialize_dispatcher() {
+  dispatcher_ = create_dispatcher(config_.datapath_mode, channel_.get(),
+                                  function_registry_.get(), config_.compute);
+  dispatcher_->start();
+}

--- a/realtime/lib/daemon/dispatcher/cpu_dispatcher.cpp
+++ b/realtime/lib/daemon/dispatcher/cpu_dispatcher.cpp
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/daemon/dispatcher/cpu_dispatcher.h"
+#include "cudaq/nvqlink/daemon/registry/function_registry.h"
+#include "cudaq/nvqlink/network/serialization/input_stream.h"
+#include "cudaq/nvqlink/network/serialization/output_stream.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+#include "cudaq/nvqlink/utils/instrumentation/profiler.h"
+
+#include <cstring>
+
+using namespace cudaq::nvqlink;
+
+// Simple RPC header format
+struct __attribute__((packed)) RPCHeader {
+  std::uint32_t function_id;
+  std::uint32_t arg_len;
+};
+
+struct __attribute__((packed)) RPCResponse {
+  int32_t status;
+  std::uint32_t result_len;
+};
+
+CPUDispatcher::CPUDispatcher(Channel *channel, FunctionRegistry *registry,
+                             const ComputeConfig &config)
+    : channel_(channel), registry_(registry), config_(config) {
+  // Detect backend execution model
+  model_ = channel_->get_execution_model();
+}
+
+CPUDispatcher::~CPUDispatcher() { stop(); }
+
+void CPUDispatcher::start() {
+  NVQLINK_TRACE_FULL(DOMAIN_DISPATCHER, "CPUDispatcher::start");
+  if (running_.exchange(true)) {
+    return;
+  }
+
+  NVQLINK_LOG_INFO(
+      DOMAIN_DISPATCHER, "Starting CPU dispatcher with {} cores in {} mode",
+      config_.cpu_cores.size(),
+      (model_ == ChannelModel::POLLING ? "POLLING" : "EVENT-DRIVEN"));
+
+  // For event-driven model, register our callback with backend
+  if (model_ == ChannelModel::EVENT_DRIVEN)
+    channel_->register_packet_callback(packet_received_callback, this);
+
+  // Launch worker threads
+  for (auto core : config_.cpu_cores) {
+    if (model_ == ChannelModel::POLLING)
+      threads_.emplace_back(&CPUDispatcher::polling_worker_thread, this, core);
+    else
+      threads_.emplace_back(&CPUDispatcher::event_driven_worker_thread, this,
+                            core);
+  }
+}
+
+void CPUDispatcher::stop() {
+  if (!running_.exchange(false))
+    return;
+
+  for (auto &thread : threads_) {
+    if (thread.joinable())
+      thread.join();
+  }
+  threads_.clear();
+
+  NVQLINK_LOG_INFO(DOMAIN_DISPATCHER,
+                   "CPU dispatcher stopped. Processed {} packets",
+                   packets_processed_.load());
+}
+
+std::uint64_t CPUDispatcher::get_packets_processed() const {
+  return packets_processed_.load();
+}
+
+std::uint64_t CPUDispatcher::get_packets_sent() const {
+  return packets_sent_.load();
+}
+
+void CPUDispatcher::polling_worker_thread(std::uint32_t core_id) {
+  NVQLINK_TRACE_FULL(DOMAIN_DISPATCHER, "worker_thread_init");
+  NVQLINK_TRACE_NAME_THREAD(("Dispatcher-" + std::to_string(core_id)).c_str());
+
+  // TODO: set CPU affinity to core_id
+
+  constexpr std::uint32_t BURST_SIZE = 32;
+  Buffer *rx_buffers[BURST_SIZE];
+
+  while (running_.load()) {
+    // Poll for packets (batch-level instrumentation)
+    std::uint32_t received;
+    {
+      NVQLINK_TRACE_HOTPATH(DOMAIN_DISPATCHER, "rx_batch");
+      received = channel_->receive_burst(rx_buffers, BURST_SIZE);
+    }
+
+    if (received == 0) {
+      // No packets, yield
+      std::this_thread::yield();
+      continue;
+    }
+
+    // Process batch (one range for entire batch)
+    {
+      NVQLINK_TRACE_HOTPATH(DOMAIN_DISPATCHER, "process_batch");
+      for (std::uint32_t i = 0; i < received; ++i) {
+        process_packet(rx_buffers[i]);
+        packets_processed_.fetch_add(1);
+      }
+    }
+  }
+}
+
+void CPUDispatcher::event_driven_worker_thread(std::uint32_t core_id) {
+  // TODO: set CPU affinity to core_id
+
+  while (running_.load()) {
+    channel_->process_events();
+
+    // Brief yield to prevent tight loop
+    std::this_thread::yield();
+  }
+}
+
+void CPUDispatcher::packet_received_callback(Buffer **buffers,
+                                             std::uint32_t count,
+                                             void *user_data) {
+  auto *dispatcher = static_cast<CPUDispatcher *>(user_data);
+
+  // Backend pushed packets to us via callback
+  for (std::uint32_t i = 0; i < count; i++) {
+    dispatcher->process_packet(buffers[i]);
+    dispatcher->packets_processed_.fetch_add(1);
+  }
+}
+
+void CPUDispatcher::process_packet(Buffer *buffer) {
+  // Parse RPC header (zero-copy: read directly from buffer)
+  auto *header = reinterpret_cast<RPCHeader *>(buffer->get_data());
+
+  // Lookup function
+  const auto *func_meta = registry_->lookup(header->function_id);
+  if (!func_meta) {
+    // Unknown function, drop packet
+    // Copy packed field to avoid binding issue
+    std::uint32_t fid = header->function_id;
+    NVQLINK_LOG_ERROR(DOMAIN_DISPATCHER,
+                      "CPUDispatcher: Unknown function_id={}", fid);
+    channel_->release_buffer(buffer); // Release buffer (we still own it)
+    return;
+  }
+
+  // Create type-safe streams for the user function
+  // Both streams point to the same buffer (zero-copy)
+  std::uint32_t arg_offset = sizeof(RPCHeader);
+  void *arg_start = static_cast<char *>(buffer->get_data()) + arg_offset;
+
+  // Input stream: read arguments from buffer
+  InputStream input_stream(arg_start, header->arg_len);
+
+  // Output stream: write results at BEGINNING of buffer
+  // (will overwrite RPCHeader + arguments, which is fine - we're done reading
+  // them)
+  OutputStream output_stream(buffer->get_data(), func_meta->max_result_size);
+
+  // Execute user function with type-safe streams
+  int status = func_meta->cpu_function(input_stream, output_stream);
+
+  // Update buffer length to reflect result data (overwrote RPCHeader + args)
+  buffer->set_data_length(output_stream.bytes_written());
+
+  // Prepare response (reuse buffer, prepend response header)
+  auto *response =
+      reinterpret_cast<RPCResponse *>(buffer->prepend(sizeof(RPCResponse)));
+  response->status = status;
+  response->result_len = output_stream.bytes_written();
+
+  // Final length: RPCResponse + result
+  buffer->set_data_length(sizeof(RPCResponse) + output_stream.bytes_written());
+
+  // Send response (backend takes ownership and will deallocate after TX)
+  uint32_t sent = channel_->send_burst(&buffer, 1);
+  packets_sent_.fetch_add(sent);
+
+  if (sent == 0)
+    NVQLINK_TRACE_MARK_ERROR(DOMAIN_DISPATCHER, "TX_FAIL");
+}

--- a/realtime/lib/daemon/dispatcher/dispatcher_factory.cpp
+++ b/realtime/lib/daemon/dispatcher/dispatcher_factory.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/daemon/dispatcher/cpu_dispatcher.h"
+#ifdef NVQLINK_HAVE_CUDA
+#include "cudaq/nvqlink/daemon/dispatcher/gpu_dispatcher.h"
+#endif
+
+#include <stdexcept>
+
+using namespace cudaq::nvqlink;
+
+std::unique_ptr<Dispatcher>
+cudaq::nvqlink::create_dispatcher(DatapathMode mode, Channel *channel,
+                                  FunctionRegistry *registry,
+                                  const ComputeConfig &compute_config) {
+  switch (mode) {
+  case DatapathMode::CPU:
+    return std::make_unique<CPUDispatcher>(channel, registry, compute_config);
+  case DatapathMode::GPU:
+#ifdef NVQLINK_HAVE_CUDA
+    return std::make_unique<GPUDispatcher>(channel, registry, compute_config);
+#else
+    throw std::runtime_error("GPU mode requested but CUDA is not available");
+#endif
+  default:
+    throw std::invalid_argument("Unknown datapath mode");
+  }
+}

--- a/realtime/lib/daemon/dispatcher/gpu_dispatcher.cu
+++ b/realtime/lib/daemon/dispatcher/gpu_dispatcher.cu
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ *                                                                             *
+ * All rights reserved.                                                        *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/daemon/dispatcher/gpu_dispatcher.h"
+#include "cudaq/nvqlink/daemon/registry/function_registry.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+#include "cudaq/nvqlink/utils/instrumentation/profiler.h"
+
+#ifdef NVQLINK_ENABLE_DOCA
+#include "cudaq/nvqlink/network/channels/doca/doca_rpc_kernel.h"
+#include "cudaq/nvqlink/daemon/registry/gpu_function_registry.h"
+#endif
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+using namespace cudaq::nvqlink;
+
+// RPC protocol structures (same as CPU)
+struct __attribute__((packed)) RPCHeader {
+  std::uint32_t function_id;
+  std::uint32_t arg_len;
+};
+
+struct __attribute__((packed)) RPCResponse {
+  std::int32_t status;
+  std::uint32_t result_len;
+};
+
+// Device function type signature
+using DeviceRPCFunction = int (*)(void *, std::uint32_t, std::uint32_t,
+                                  std::uint32_t *);
+
+// Persistent kernel implementation - MUST NOT BLOCK INDEFINITELY
+__global__ void
+daemon_persistent_kernel(void *rx_queue, void *tx_queue, void *buffer_pool,
+                         void **function_table, std::uint32_t *function_ids,
+                         std::size_t func_count, volatile int *shutdown_flag,
+                         std::uint64_t *stats) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  std::uint64_t local_packet_count = 0;
+
+  // For PoC: Don't run infinite loop, just do limited iterations
+  // In production: this would be while(!*shutdown_flag)
+  const std::uint64_t MAX_ITERATIONS = 100000; // Limit iterations for PoC
+
+  for (std::uint64_t iter = 0; iter < MAX_ITERATIONS && !(*shutdown_flag);
+       iter++) {
+    // In production: call backend->poll_rx_queue()
+    // For PoC: simulate packet processing
+
+    local_packet_count++;
+
+    // Periodic cooperative yielding
+    if (iter % 1000 == 0) {
+      __threadfence_system(); // Ensure memory visibility
+    }
+  }
+
+  // Write stats back (only thread 0)
+  if (tid == 0) {
+    atomicAdd((unsigned long long *)stats, local_packet_count);
+  }
+}
+
+GPUDispatcher::GPUDispatcher(Channel *channel, FunctionRegistry *registry,
+                             const ComputeConfig &config)
+    : channel_(channel), registry_(registry), config_(config) {}
+
+GPUDispatcher::~GPUDispatcher() {
+  stop();
+
+  if (device_shutdown_flag_)
+    cudaFree(device_shutdown_flag_);
+  if (device_stats_)
+    cudaFree(device_stats_);
+  if (stream_)
+    cudaStreamDestroy(stream_);
+}
+
+void GPUDispatcher::start() {
+  NVQLINK_TRACE_FULL(DOMAIN_GPU, "GPUDispatcher::start");
+  NVQLINK_TRACE_NAME_THREAD("GPU-Host");
+
+  if (running_.exchange(true)) {
+    return;
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_DISPATCHER, "Starting GPU dispatcher on device {}",
+                   config_.gpu_device_id.value_or(0));
+
+  // Set GPU device
+  cudaSetDevice(config_.gpu_device_id.value_or(0));
+
+  // Create stream
+  cudaStreamCreate(&stream_);
+
+  // Allocate device memory for control
+  cudaMalloc(&device_shutdown_flag_, sizeof(int));
+  cudaMalloc(&device_stats_, sizeof(std::uint64_t));
+
+  int zero = 0;
+  cudaMemcpy(device_shutdown_flag_, &zero, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemset(device_stats_, 0, sizeof(std::uint64_t));
+
+  // Launch persistent kernel
+  launch_persistent_kernel();
+
+  // Check that launch succeeded (non-blocking check)
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("Kernel launch failed: ") +
+                             cudaGetErrorString(err));
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_GPU,
+                   "GPU persistent kernel launched (running asynchronously)");
+}
+
+void GPUDispatcher::stop() {
+  if (!running_.exchange(false)) {
+    return;
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_DISPATCHER, "Signaling GPU kernel to shutdown...");
+
+  // Signal kernel to exit (standard RoCE path)
+  int shutdown = 1;
+  cudaMemcpy(device_shutdown_flag_, &shutdown, sizeof(int),
+             cudaMemcpyHostToDevice);
+
+  // For DOCA channels, signal via channel's exit flag
+  // This matches Hololink's pattern: cpu_exit_flag[0] = 1
+  auto gpu_handles = channel_->get_gpu_memory_handles();
+  if (gpu_handles.exit_flag != nullptr) {
+    // Direct write to GPU_CPU mapped memory (same as Hololink destructor)
+    *gpu_handles.exit_flag = 1;
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_DISPATCHER, "Waiting for GPU kernel to complete...");
+
+  // Wait for kernel completion
+  // NOTE: DOCA kernel may be blocked in receive() waiting for packets.
+  // Like Hololink, we just wait - the kernel exits when a packet arrives
+  // and it checks the exit flag, or when the stream is destroyed.
+  cudaError_t err = cudaStreamSynchronize(stream_);
+  if (err != cudaSuccess) {
+    NVQLINK_LOG_WARNING(DOMAIN_DISPATCHER, "Warning: GPU kernel error: {}",
+                        cudaGetErrorString(err));
+  }
+
+  // Read stats
+  std::uint64_t total_packets = 0;
+  cudaMemcpy(&total_packets, device_stats_, sizeof(std::uint64_t),
+             cudaMemcpyDeviceToHost);
+
+  NVQLINK_LOG_INFO(
+      DOMAIN_DISPATCHER,
+      "GPU dispatcher stopped. Processed {} iterations (PoC simulation)",
+      total_packets);
+}
+
+std::uint64_t GPUDispatcher::get_packets_processed() const {
+  if (!device_stats_ || !running_.load())
+    return 0;
+
+  std::uint64_t packets = 0;
+  cudaError_t err = cudaMemcpy(&packets, device_stats_, sizeof(std::uint64_t),
+                               cudaMemcpyDeviceToHost);
+  if (err != cudaSuccess) {
+    return 0;
+  }
+  return packets;
+}
+
+std::uint64_t GPUDispatcher::get_packets_sent() const {
+  // TODO: Implement GPU packet sent tracking
+  return 0;
+}
+
+void GPUDispatcher::launch_persistent_kernel() {
+  NVQLINK_TRACE_FULL(DOMAIN_GPU, "launch_persistent_kernel");
+
+  // Get GPU memory handles from backend
+  auto gpu_handles = channel_->get_gpu_memory_handles();
+
+  // Get function table from registry
+  auto func_table = registry_->get_gpu_function_table();
+
+  // Launch kernel with minimal resources for PoC
+  std::uint32_t blocks = config_.gpu_blocks > 0 ? config_.gpu_blocks : 1;
+  std::uint32_t threads =
+      config_.gpu_threads_per_block > 0 ? config_.gpu_threads_per_block : 32;
+
+  NVQLINK_LOG_INFO(DOMAIN_DISPATCHER,
+                   "Launching kernel with {} blocks, {} threads per block",
+                   blocks, threads);
+
+#ifdef NVQLINK_ENABLE_DOCA
+  // Detect DOCA channel via cq_rq_addr (polymorphic detection)
+  if (gpu_handles.cq_rq_addr != nullptr) {
+    NVQLINK_LOG_INFO(DOMAIN_DISPATCHER, "Detected DOCA channel, launching DOCA RPC kernel");
+    
+    // Get GPU function registry (NVQLink streaming interface format)
+    auto* gpu_registry = static_cast<GPUFunctionRegistry*>(
+        registry_->get_gpu_registry());
+    
+    // Launch DOCA RPC kernel
+    // Pass gpu_exit_flag for kernel to read (host writes to exit_flag)
+    doca_error_t result = doca_rpc_kernel(
+        stream_,
+        static_cast<doca_gpu_dev_verbs_qp*>(gpu_handles.rx_queue_addr),
+        gpu_handles.gpu_exit_flag,
+        static_cast<std::uint8_t*>(gpu_handles.buffer_pool_addr),
+        gpu_handles.page_size,
+        gpu_handles.buffer_mkey,
+        gpu_handles.num_pages,
+        gpu_registry,
+        blocks,
+        threads);
+    
+    if (result != DOCA_SUCCESS) {
+      throw std::runtime_error("DOCA RPC kernel launch failed");
+    }
+    return;
+  }
+#endif
+
+  // Launch standard RoCE kernel ASYNCHRONOUSLY on the stream
+  daemon_persistent_kernel<<<blocks, threads, 0, stream_>>>(
+      gpu_handles.rx_queue_addr, gpu_handles.tx_queue_addr,
+      gpu_handles.buffer_pool_addr, func_table.device_function_ptrs,
+      func_table.function_ids, func_table.count,
+      (volatile int *)device_shutdown_flag_, (std::uint64_t *)device_stats_);
+
+  // DON'T synchronize here - let kernel run asynchronously
+  // Just check for launch errors
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("Kernel launch failed: ") +
+                             cudaGetErrorString(err));
+  }
+}
+
+void launch_daemon_kernel(void *rx_queue, void *tx_queue, void *buffer_pool,
+                          void **function_table, std::uint32_t *function_ids,
+                          std::size_t func_count, volatile int *shutdown_flag,
+                          std::uint64_t *stats, std::uint32_t num_blocks,
+                          std::uint32_t threads_per_block,
+                          cudaStream_t stream) {
+  daemon_persistent_kernel<<<num_blocks, threads_per_block, 0, stream>>>(
+      rx_queue, tx_queue, buffer_pool, function_table, function_ids, func_count,
+      shutdown_flag, stats);
+}

--- a/realtime/lib/daemon/registry/function_registry.cpp
+++ b/realtime/lib/daemon/registry/function_registry.cpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/daemon/registry/function_registry.h"
+
+#ifdef NVQLINK_HAVE_CUDA
+#include <cuda_runtime.h>
+#include "cudaq/nvqlink/daemon/registry/gpu_function_registry.h"
+#endif
+
+#include <stdexcept>
+
+using namespace cudaq::nvqlink;
+
+void FunctionRegistry::register_function(const FunctionMetadata &metadata) {
+  auto it = functions_.find(metadata.function_id);
+  if (it != functions_.end()) {
+    // Hash collision detected - provide detailed error message
+    throw std::runtime_error(
+        "Hash collision detected: Function '" + metadata.name + "' (ID: 0x" +
+        std::to_string(metadata.function_id) + ") collides with '" +
+        it->second.name + "'. Consider renaming one of the functions.");
+  }
+  functions_[metadata.function_id] = metadata;
+}
+
+const FunctionMetadata *
+FunctionRegistry::lookup(std::uint32_t function_id) const {
+  auto it = functions_.find(function_id);
+  return (it != functions_.end()) ? &it->second : nullptr;
+}
+
+#ifdef NVQLINK_HAVE_CUDA
+FunctionRegistry::GPUFunctionTable
+FunctionRegistry::get_gpu_function_table() const {
+  // Allocate device memory for function table
+  std::size_t count = functions_.size();
+
+  void **host_func_ptrs = new void *[count];
+  std::uint32_t *host_func_ids = new std::uint32_t[count];
+
+  std::size_t idx = 0;
+  for (const auto &[id, metadata] : functions_) {
+    if (metadata.type == FunctionType::GPU) {
+      host_func_ptrs[idx] = metadata.gpu_function;
+      host_func_ids[idx] = id;
+      ++idx;
+    }
+  }
+
+  // Copy to device
+  void **device_func_ptrs = nullptr;
+  std::uint32_t *device_func_ids = nullptr;
+
+  cudaMalloc(&device_func_ptrs, sizeof(void *) * count);
+  cudaMalloc(&device_func_ids, sizeof(std::uint32_t) * count);
+
+  cudaMemcpy(device_func_ptrs, host_func_ptrs, sizeof(void *) * count,
+             cudaMemcpyHostToDevice);
+  cudaMemcpy(device_func_ids, host_func_ids, sizeof(std::uint32_t) * count,
+             cudaMemcpyHostToDevice);
+
+  delete[] host_func_ptrs;
+  delete[] host_func_ids;
+
+  gpu_table_.device_function_ptrs = device_func_ptrs;
+  gpu_table_.function_ids = device_func_ids;
+  gpu_table_.count = count;
+
+  return gpu_table_;
+}
+
+void* FunctionRegistry::get_gpu_registry() const {
+  // Build GPU function registry for NVQLink streaming interface
+  // This converts from FunctionRegistry format to GPUFunctionRegistry format
+  // Used by any GPU kernel using GPUInputStream/GPUOutputStream (e.g., DOCA kernel)
+  
+  if (device_gpu_registry_) {
+    return device_gpu_registry_; // Return cached registry
+  }
+  
+  // Count GPU functions
+  std::size_t gpu_func_count = 0;
+  for (const auto& [id, metadata] : functions_) {
+    if (metadata.type == FunctionType::GPU) {
+      ++gpu_func_count;
+    }
+  }
+  
+  if (gpu_func_count == 0) {
+    return nullptr; // No GPU functions registered
+  }
+  
+  if (gpu_func_count > GPUFunctionRegistry::MAX_FUNCTIONS) {
+    throw std::runtime_error(
+        "Too many GPU functions: " + std::to_string(gpu_func_count) +
+        " exceeds maximum " + std::to_string(GPUFunctionRegistry::MAX_FUNCTIONS));
+  }
+  
+  // Build host-side registry
+  GPUFunctionRegistry host_registry;
+  host_registry.num_functions = 0;
+  
+  for (const auto& [id, metadata] : functions_) {
+    if (metadata.type == FunctionType::GPU) {
+      GPUFunctionWrapper wrapper;
+      wrapper.invoke = reinterpret_cast<GPUFunctionWrapper::InvokeFunc>(metadata.gpu_function);
+      wrapper.function_id = id;
+      
+      host_registry.functions[host_registry.num_functions++] = wrapper;
+    }
+  }
+  
+  // Allocate device memory and copy
+  GPUFunctionRegistry* device_registry = nullptr;
+  cudaError_t err = cudaMalloc(&device_registry, sizeof(GPUFunctionRegistry));
+  if (err != cudaSuccess) {
+    throw std::runtime_error("Failed to allocate device memory for GPU registry: " +
+                           std::string(cudaGetErrorString(err)));
+  }
+  
+  err = cudaMemcpy(device_registry, &host_registry, sizeof(GPUFunctionRegistry),
+                   cudaMemcpyHostToDevice);
+  if (err != cudaSuccess) {
+    cudaFree(device_registry);
+    throw std::runtime_error("Failed to copy GPU registry to device: " +
+                           std::string(cudaGetErrorString(err)));
+  }
+  
+  device_gpu_registry_ = device_registry;
+  return device_gpu_registry_;
+}
+
+#endif // NVQLINK_HAVE_CUDA

--- a/realtime/lib/daemon/registry/rpc_builder.cpp
+++ b/realtime/lib/daemon/registry/rpc_builder.cpp
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/daemon/registry/rpc_builder.h"
+#include "cudaq/nvqlink/daemon/daemon.h"
+
+using namespace cudaq::nvqlink;
+
+void RPCBuilder::register_all(Daemon &daemon) const {
+  for (const auto &metadata : entries_) {
+    daemon.register_function(metadata);
+  }
+}

--- a/realtime/lib/network/CMakeLists.txt
+++ b/realtime/lib/network/CMakeLists.txt
@@ -1,0 +1,115 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+set(NVQLINK_NETWORK_SOURCES
+  memory/buffer.cpp
+  memory/memory_pool.cpp
+  serialization/input_stream.cpp
+  serialization/output_stream.cpp
+)
+
+# Add CUDA/GPU sources if CUDA is available
+if(CUDA_FOUND)
+  list(APPEND NVQLINK_NETWORK_SOURCES
+    channels/gpu_channel.cu
+    serialization/gpu_input_stream.cu
+    serialization/gpu_output_stream.cu
+  )
+endif()
+
+# Add RoCE sources if enabled
+if(NVQLINK_ENABLE_ROCE)
+  find_library(IBVERBS_LIB ibverbs REQUIRED)
+  
+  message(STATUS "RoCE channel enabled")
+  message(STATUS "  libibverbs library: ${IBVERBS_LIB}")
+
+  list(APPEND NVQLINK_NETWORK_SOURCES 
+    channels/roce/roce_channel.cpp
+    channels/roce/roce_buffer_pool.cpp
+    channels/roce/verbs_context.cpp
+    steering/verbs_flow_switch.cpp
+  )
+endif()
+
+# Add DOCA sources if enabled
+if(NVQLINK_ENABLE_DOCA)
+  # Require CUDA for DOCA
+  if(NOT CUDA_FOUND)
+    message(FATAL_ERROR "DOCA channel requires CUDA support. Enable CUDA or disable DOCA.")
+  endif()
+  
+  # Find DOCA libraries using pkg-config
+  find_package(PkgConfig REQUIRED)
+  
+  pkg_check_modules(DOCA_COMMON REQUIRED IMPORTED_TARGET doca-common)
+  pkg_check_modules(DOCA_GPUNETIO REQUIRED IMPORTED_TARGET doca-gpunetio)
+  pkg_check_modules(DOCA_VERBS REQUIRED IMPORTED_TARGET doca-verbs)
+  pkg_check_modules(DOCA_RDMA REQUIRED IMPORTED_TARGET doca-rdma)
+  
+  # Also need libibverbs and libmlx5
+  if(NOT IBVERBS_LIB)
+    find_library(IBVERBS_LIB ibverbs REQUIRED)
+  endif()
+  find_library(MLX5_LIB mlx5 REQUIRED)
+  
+  message(STATUS "DOCA GPUNetIO channel enabled")
+  message(STATUS "  doca-common: ${DOCA_COMMON_LIBRARIES}")
+  message(STATUS "  doca-gpunetio: ${DOCA_GPUNETIO_LIBRARIES} (includes doca_gpu types)")
+  message(STATUS "  doca-verbs: ${DOCA_VERBS_LIBRARIES}")
+  message(STATUS "  doca-rdma: ${DOCA_RDMA_LIBRARIES}")
+  message(STATUS "  ibverbs: ${IBVERBS_LIB}")
+  message(STATUS "  mlx5: ${MLX5_LIB}")
+  
+  list(APPEND NVQLINK_NETWORK_SOURCES
+    channels/doca/doca_channel.cpp
+    channels/doca/doca_completion_queue.cpp
+    channels/doca/doca_queue_pair.cpp
+    channels/doca/doca_buffer_pool.cpp
+    channels/doca/doca_rpc_kernel.cu
+  )
+endif()
+
+add_library(nvqlink_network STATIC ${NVQLINK_NETWORK_SOURCES})
+
+# Enable CUDA separable compilation for device function pointers
+# to work across compilation units (e.g., gpu_functions.cu <-> doca_rpc_kernel.cu)
+if(CUDA_FOUND)
+  set_target_properties(nvqlink_network PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+  )
+endif()
+
+target_include_directories(nvqlink_network
+  PUBLIC
+    $<BUILD_INTERFACE:${CUDAQ_NVQLINK_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Link dependencies
+target_link_libraries(nvqlink_network PUBLIC nvqlink_utils)
+
+if(CUDA_FOUND)
+  target_link_libraries(nvqlink_network PUBLIC CUDA::cudart)
+endif()
+
+if(NVQLINK_ENABLE_ROCE)
+  target_link_libraries(nvqlink_network PUBLIC ${IBVERBS_LIB})
+endif()
+
+if(NVQLINK_ENABLE_DOCA)
+  target_link_libraries(nvqlink_network PUBLIC
+    PkgConfig::DOCA_COMMON
+    PkgConfig::DOCA_GPUNETIO
+    PkgConfig::DOCA_VERBS
+    PkgConfig::DOCA_RDMA
+    ${IBVERBS_LIB}
+    ${MLX5_LIB}
+  )
+endif()

--- a/realtime/lib/network/channels/doca/doca_buffer_pool.cpp
+++ b/realtime/lib/network/channels/doca/doca_buffer_pool.cpp
@@ -1,0 +1,138 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/channels/doca/doca_buffer_pool.h"
+#include "cudaq/nvqlink/utils/instrumentation/domains.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+
+#include <cerrno>
+#include <cstring>
+#include <unistd.h>
+
+namespace cudaq::nvqlink {
+
+static std::size_t get_page_size() {
+  long ret = sysconf(_SC_PAGESIZE);
+  if (ret == -1)
+    return 4096;
+  return static_cast<std::size_t>(ret);
+}
+
+static std::uint32_t doca_gpu_dev_verbs_bswap32(std::uint32_t x) {
+  return __builtin_bswap32(x);
+}
+
+DOCABufferPool::DOCABufferPool(doca_gpu *gpu_device, doca_dev *nic_device,
+                               ibv_pd *protection_domain,
+                               std::size_t total_size, std::size_t page_size,
+                               unsigned num_pages)
+    : gpu_device_(gpu_device), nic_device_(nic_device),
+      protection_domain_(protection_domain), total_size_(total_size),
+      page_size_(page_size), num_pages_(num_pages) {}
+
+DOCABufferPool::~DOCABufferPool() {
+  if (mr_)
+    ibv_dereg_mr(mr_);
+  if (dmabuf_fd_ >= 0)
+    close(dmabuf_fd_);
+  if (gpu_buffer_)
+    doca_gpu_mem_free(gpu_device_, gpu_buffer_);
+}
+
+bool DOCABufferPool::initialize() {
+  doca_error_t result;
+
+  // Allocate GPU memory
+  result = doca_gpu_mem_alloc(gpu_device_, total_size_, get_page_size(),
+                              DOCA_GPU_MEM_TYPE_GPU,
+                              reinterpret_cast<void **>(&gpu_buffer_), nullptr);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to allocate GPU buffer: {}",
+                      doca_error_get_descr(result));
+    return false;
+  }
+
+  // CRITICAL: The external address must be 0 because we register the memory
+  // with ibv_reg_mr_iova(..., iova=0, ...) or ibv_reg_dmabuf_mr(..., iova=0,
+  // ...). The rkey is only valid for addresses starting at 0, not the GPU
+  // virtual address. Clients write to offsets from 0, and the NIC translates
+  // 0+offset to gpu_buffer_+offset.
+  external_addr_ = 0;
+
+  // Try dmabuf registration first
+  result = doca_gpu_dmabuf_fd(gpu_device_, static_cast<void *>(gpu_buffer_),
+                              total_size_, &dmabuf_fd_);
+  if (result == DOCA_SUCCESS) {
+    // To use ibv_reg_dmabuf_mr() we must ensure application provides
+    // address and size aligned with the system page size
+    mr_ = ibv_reg_dmabuf_mr(protection_domain_, 0, total_size_,
+                            0, // Use offset 0
+                            dmabuf_fd_,
+                            IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+                                IBV_ACCESS_REMOTE_READ |
+                                IBV_ACCESS_RELAXED_ORDERING);
+
+    if (mr_) {
+      NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Buffer registered via dmabuf, rkey={}",
+                       mr_->rkey);
+    }
+  }
+
+  // Fallback to iova registration
+  if (mr_ == nullptr) {
+    mr_ = ibv_reg_mr_iova(protection_domain_, static_cast<void *>(gpu_buffer_),
+                          total_size_, 0,
+                          IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+    if (mr_ == nullptr) {
+      NVQLINK_LOG_ERROR(
+          DOMAIN_CHANNEL,
+          "Cannot register memory region ptr={} size={}, errno={}",
+          reinterpret_cast<std::uint64_t>(gpu_buffer_), total_size_, errno);
+      return false;
+    }
+
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Buffer registered via iova, rkey={}",
+                     mr_->rkey);
+  }
+
+  // Initialize buffer free list
+  // Buffer constructor: (base_addr, total_size, headroom, tailroom)
+  // For DOCA GPU buffers, we use the full page with no headroom/tailroom
+  buffers_.reserve(num_pages_);
+  for (unsigned i = 0; i < num_pages_; ++i) {
+    auto buffer =
+        std::make_unique<Buffer>(gpu_buffer_ + i * page_size_, page_size_,
+                                 0,  // headroom
+                                 0); // tailroom
+    free_list_.push(buffer.get());
+    buffers_.push_back(std::move(buffer));
+  }
+
+  return true;
+}
+
+std::uint32_t DOCABufferPool::get_mkey_be() const {
+  return mr_ ? doca_gpu_dev_verbs_bswap32(mr_->lkey) : 0;
+}
+
+Buffer *DOCABufferPool::acquire() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (free_list_.empty())
+    return nullptr;
+
+  Buffer *buffer = free_list_.front();
+  free_list_.pop();
+  return buffer;
+}
+
+void DOCABufferPool::release(Buffer *buffer) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  free_list_.push(buffer);
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/channels/doca/doca_channel.cpp
+++ b/realtime/lib/network/channels/doca/doca_channel.cpp
@@ -1,0 +1,490 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/channels/doca/doca_channel.h"
+#include "cudaq/nvqlink/network/channels/doca/doca_buffer_pool.h"
+#include "cudaq/nvqlink/network/channels/doca/doca_completion_queue.h"
+#include "cudaq/nvqlink/network/channels/doca/doca_queue_pair.h"
+#include "cudaq/nvqlink/network/channels/doca/doca_rpc_kernel.h"
+#include "cudaq/nvqlink/utils/instrumentation/domains.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+
+#include <arpa/inet.h>
+#include <cuda_runtime.h>
+#include <doca_log.h>
+#include <doca_rdma_bridge.h>
+#include <doca_verbs_bridge.h>
+#include <infiniband/verbs.h>
+
+#include <cerrno>
+#include <cstring>
+#include <unistd.h>
+
+namespace cudaq::nvqlink {
+
+// Utility functions
+static std::size_t get_page_size() {
+  long ret = sysconf(_SC_PAGESIZE);
+  if (ret == -1)
+    return 4096;
+  return static_cast<std::size_t>(ret);
+}
+
+static doca_verbs_context *open_ib_device(const std::string &dev_name) {
+  int nb_ibdevs = 0;
+  ibv_device **ibdev_list = ibv_get_device_list(&nb_ibdevs);
+  doca_verbs_context *context = nullptr;
+
+  if (ibdev_list == nullptr || nb_ibdevs == 0) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to get RDMA devices list");
+    return nullptr;
+  }
+
+  for (int i = 0; i < nb_ibdevs; i++) {
+    if (strncmp(ibv_get_device_name(ibdev_list[i]), dev_name.c_str(),
+                dev_name.length()) == 0) {
+      ibv_device *dev_handle = ibdev_list[i];
+      ibv_free_device_list(ibdev_list);
+
+      // Pass ibv_device* (NOT ibv_context*) per DOCA 3.x API
+      if (doca_verbs_bridge_verbs_context_create(
+              dev_handle, DOCA_VERBS_CONTEXT_CREATE_FLAGS_NONE, &context) !=
+          DOCA_SUCCESS) {
+        NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                          "Failed to create DOCA Verbs context");
+        return nullptr;
+      }
+
+      return context;
+    }
+  }
+
+  ibv_free_device_list(ibdev_list);
+  NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "IB device not found: {}", dev_name);
+  return nullptr;
+}
+
+DOCAChannel::DOCAChannel(const DOCAChannelConfig &config) : config_(config) {
+  if (!config_.is_valid()) {
+    throw std::invalid_argument("Invalid DOCA channel configuration");
+  }
+}
+
+DOCAChannel::~DOCAChannel() { cleanup(); }
+
+void DOCAChannel::initialize() {
+  try {
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Initializing DOCA channel");
+
+    doca_log_backend *sdk_backend = nullptr;
+    doca_error_t result =
+        doca_log_backend_create_with_file_sdk(stderr, &sdk_backend);
+    if (result != DOCA_SUCCESS) {
+      NVQLINK_LOG_WARNING(DOMAIN_CHANNEL,
+                          "Failed to create DOCA SDK log backend");
+    } else {
+      // Enable verbose DOCA logging for debugging
+      doca_log_level_set_global_sdk_limit(DOCA_LOG_LEVEL_DEBUG);
+    }
+
+    init_doca_device();
+    init_gpu_device();
+    init_protection_domain();
+    find_roce_gid();
+    init_uar();
+    init_completion_queues();
+    init_buffer_pool();
+    init_queue_pair();
+    init_exit_flag();
+
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "DOCA channel initialized successfully");
+
+  } catch (const std::exception &e) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "DOCA channel initialization failed: {}",
+                      e.what());
+    cleanup();
+    throw;
+  }
+}
+
+void DOCAChannel::init_doca_device() {
+  NVQLINK_LOG_DEBUG(DOMAIN_CHANNEL, "Opening DOCA device: {}",
+                    config_.nic_device);
+  verbs_ctx_ = open_ib_device(config_.nic_device);
+  if (!verbs_ctx_) {
+    throw std::runtime_error("Failed to open DOCA device: " +
+                             config_.nic_device);
+  }
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "DOCA device opened successfully");
+}
+
+void DOCAChannel::init_gpu_device() {
+  cudaError_t result_cuda;
+  int gpu_id = config_.gpu_device_id;
+
+  result_cuda = cudaSetDevice(gpu_id);
+  if (result_cuda != cudaSuccess) {
+    throw std::runtime_error("cudaSetDevice failed");
+  }
+
+  char gpu_bus_id[256];
+  result_cuda = cudaDeviceGetPCIBusId(gpu_bus_id, sizeof(gpu_bus_id), gpu_id);
+  if (result_cuda != cudaSuccess) {
+    throw std::runtime_error("cudaDeviceGetPCIBusId failed");
+  }
+
+  doca_error_t result = doca_gpu_create(gpu_bus_id, &doca_gpu_device_);
+  if (result != DOCA_SUCCESS) {
+    throw std::runtime_error("Failed to create DOCA GPU device: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Created GPU device successfully");
+}
+
+void DOCAChannel::init_protection_domain() {
+  doca_error_t result = doca_verbs_pd_create(verbs_ctx_, &verbs_pd_);
+  if (result != DOCA_SUCCESS) {
+    throw std::runtime_error("Failed to create DOCA Verbs PD: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+
+  ibv_pd_ = doca_verbs_bridge_verbs_pd_get_ibv_pd(verbs_pd_);
+  if (!ibv_pd_) {
+    throw std::runtime_error("Failed to get ibv_pd");
+  }
+
+  result = doca_rdma_bridge_open_dev_from_pd(ibv_pd_, &doca_device_);
+  if (result != DOCA_SUCCESS) {
+    throw std::runtime_error("Failed to open DOCA device from PD: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+}
+
+void DOCAChannel::find_roce_gid() {
+  ibv_gid_entry ib_gid_entry;
+  bool gid_found = false;
+
+  for (gid_index_ = 0; gid_index_ < 256; gid_index_++) {
+    std::uint32_t flags = 0;
+    int ret = ibv_query_gid_ex(ibv_pd_->context, config_.nic_port, gid_index_,
+                               &ib_gid_entry, flags);
+    if (ret != 0 && errno != ENODATA) {
+      break;
+    }
+
+    NVQLINK_LOG_DEBUG(DOMAIN_CHANNEL,
+                      "gid_index={} port_num={} gid_type={} subnet_prefix={} "
+                      "interface_id={:#x}",
+                      gid_index_, ib_gid_entry.port_num, ib_gid_entry.gid_type,
+                      ib_gid_entry.gid.global.subnet_prefix,
+                      ib_gid_entry.gid.global.interface_id);
+
+    // Check for RoCE v2 GID characteristics
+    if (ib_gid_entry.gid_type == IBV_GID_TYPE_ROCE_V2 &&
+        ib_gid_entry.gid.global.subnet_prefix == 0 &&
+        (ib_gid_entry.gid.global.interface_id & 0xFFFFFFFF) == 0xFFFF0000) {
+      gid_found = true;
+      NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Found RoCE v2 GID at index {}",
+                       gid_index_);
+      break;
+    }
+  }
+
+  if (!gid_found) {
+    throw std::runtime_error("Cannot find GID for RoCE v2");
+  }
+}
+
+void DOCAChannel::init_uar() {
+  doca_error_t result =
+      doca_uar_create(doca_device_, DOCA_UAR_ALLOCATION_TYPE_NONCACHE, &uar_);
+  if (result != DOCA_SUCCESS) {
+    throw std::runtime_error("Failed to create UAR: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+}
+
+void DOCAChannel::init_completion_queues() {
+  doca_error_t result;
+
+  cq_rq_ = std::make_unique<DOCACompletionQueue>(
+      config_.wqe_num, doca_gpu_device_, doca_device_, uar_, verbs_ctx_);
+  result = cq_rq_->create();
+  if (result != DOCA_SUCCESS) {
+    throw std::runtime_error("Failed to create RQ CQ: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+
+  cq_sq_ = std::make_unique<DOCACompletionQueue>(
+      config_.wqe_num, doca_gpu_device_, doca_device_, uar_, verbs_ctx_);
+  result = cq_sq_->create();
+  if (result != DOCA_SUCCESS) {
+    throw std::runtime_error("Failed to create SQ CQ: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Created CQs successfully");
+}
+
+void DOCAChannel::init_buffer_pool() {
+  buffer_pool_ = std::make_unique<DOCABufferPool>(
+      doca_gpu_device_, doca_device_, ibv_pd_, config_.buffer_size,
+      config_.page_size, config_.num_pages);
+
+  if (!buffer_pool_->initialize()) {
+    throw std::runtime_error("Failed to initialize buffer pool");
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Buffer pool initialized, rkey={:#x}",
+                   buffer_pool_->get_rkey());
+}
+
+void DOCAChannel::init_queue_pair() {
+  doca_error_t result;
+
+  qp_ = std::make_unique<DOCAQueuePair>(
+      config_.wqe_num, doca_gpu_device_, doca_device_, uar_, verbs_ctx_,
+      verbs_pd_, cq_rq_->get(), cq_sq_->get());
+
+  result = qp_->create();
+  if (result != DOCA_SUCCESS) {
+    throw std::runtime_error("Failed to create QP: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+
+  std::uint32_t qp_number = doca_verbs_qp_get_qpn(qp_->get());
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Created QP with number: {:#x}", qp_number);
+
+  // If remote QP is already configured, connect now
+  if (!config_.peer_ip.empty() && config_.remote_qpn != 0) {
+    // Convert peer IP to GID
+    unsigned long client_ip = 0;
+    if (inet_pton(AF_INET, config_.peer_ip.c_str(), &client_ip) != 1) {
+      throw std::runtime_error("Unable to convert peer IP: " + config_.peer_ip);
+    }
+
+    std::uint64_t client_interface_id = client_ip;
+    client_interface_id <<= 32;
+    client_interface_id |= 0xFFFF0000;
+
+    doca_verbs_gid doca_rgid;
+    std::memset(&doca_rgid, 0, sizeof(doca_rgid));
+    std::memcpy(&doca_rgid.raw[8], &client_interface_id, 8);
+
+    result = qp_->connect(doca_rgid, gid_index_, config_.remote_qpn);
+    if (result != DOCA_SUCCESS) {
+      throw std::runtime_error("Failed to connect QP: " +
+                               std::string(doca_error_get_descr(result)));
+    }
+
+    connected_ = true;
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "QP connected to remote peer");
+  }
+}
+
+void DOCAChannel::init_exit_flag() {
+  doca_error_t result;
+
+  // Create CUDA stream for kernel launch
+  cudaError_t result_cuda =
+      cudaStreamCreateWithFlags(&cuda_stream_, cudaStreamNonBlocking);
+  if (result_cuda != cudaSuccess) {
+    throw std::runtime_error("Failed to create CUDA stream");
+  }
+
+  // Allocate exit flag (lines 905-914)
+  result = doca_gpu_mem_alloc(doca_gpu_device_, sizeof(std::uint32_t),
+                              get_page_size(), DOCA_GPU_MEM_TYPE_GPU_CPU,
+                              reinterpret_cast<void **>(&gpu_exit_flag_),
+                              reinterpret_cast<void **>(&cpu_exit_flag_));
+
+  if (result != DOCA_SUCCESS || !gpu_exit_flag_ || !cpu_exit_flag_) {
+    throw std::runtime_error("Failed to allocate exit flag: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+
+  *cpu_exit_flag_ = 0;
+}
+
+void DOCAChannel::cleanup() {
+  // DOCA resource cleanup requires careful ordering:
+  // 1. Signal exit and wait for GPU kernel to stop
+  // 2. Free GPU exit flag
+  // 3. Destroy QP (releases references to CQs and UMEMs)
+  // 4. Destroy CQs (releases references to UMEMs)
+  // 5. Destroy buffer pool
+  // 6. Destroy GPU device, UAR, PD, verbs context, DOCA device
+
+  signal_exit();
+
+  if (cuda_stream_) {
+    cudaStreamSynchronize(cuda_stream_);
+    cudaStreamDestroy(cuda_stream_);
+    cuda_stream_ = nullptr;
+  }
+
+  // Ensure all GPU operations are complete before destroying DOCA resources
+  // cudaDeviceSynchronize();
+
+  if (gpu_exit_flag_) {
+    doca_gpu_mem_free(doca_gpu_device_, gpu_exit_flag_);
+    gpu_exit_flag_ = nullptr;
+    cpu_exit_flag_ = nullptr;
+  }
+
+  // QP must be destroyed before CQs.
+  // QP holds references to the CQs, so destroying CQs first causes errors.
+  qp_.reset();
+  cq_rq_.reset();
+  cq_sq_.reset();
+  buffer_pool_.reset();
+
+  if (doca_gpu_device_) {
+    doca_gpu_destroy(doca_gpu_device_);
+    doca_gpu_device_ = nullptr;
+  }
+
+  if (uar_) {
+    doca_uar_destroy(uar_);
+    uar_ = nullptr;
+  }
+
+  if (verbs_pd_) {
+    doca_verbs_pd_destroy(verbs_pd_);
+    verbs_pd_ = nullptr;
+  }
+
+  if (verbs_ctx_) {
+    doca_verbs_context_destroy(verbs_ctx_);
+    verbs_ctx_ = nullptr;
+  }
+
+  if (doca_device_) {
+    doca_dev_close(doca_device_);
+    doca_device_ = nullptr;
+  }
+}
+
+DOCAConnectionParams DOCAChannel::get_connection_params() const {
+  if (!qp_) {
+    throw std::runtime_error("QP not initialized");
+  }
+
+  DOCAConnectionParams params;
+  params.qpn = doca_verbs_qp_get_qpn(qp_->get());
+  params.buffer_addr = buffer_pool_->get_external_address();
+  params.rkey = buffer_pool_->get_rkey();
+  params.num_slots = buffer_pool_->get_num_pages();
+  params.slot_size = buffer_pool_->get_page_size();
+
+  ibv_gid_entry ib_gid_entry;
+  int ret = ibv_query_gid_ex(ibv_pd_->context, config_.nic_port, gid_index_,
+                             &ib_gid_entry, 0);
+  if (ret == 0) {
+    std::memcpy(params.gid.data(), ib_gid_entry.gid.raw, 16);
+  }
+
+  return params;
+}
+
+void DOCAChannel::set_remote_qp(
+    std::uint32_t remote_qpn, const std::array<std::uint8_t, 16> &remote_gid) {
+  doca_verbs_gid doca_rgid;
+  std::memcpy(doca_rgid.raw, remote_gid.data(), 16);
+
+  doca_error_t result = qp_->connect(doca_rgid, gid_index_, remote_qpn);
+  if (result != DOCA_SUCCESS) {
+    throw std::runtime_error("Failed to connect to remote QP: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Connected to remote QP {:#x}", remote_qpn);
+
+  // CRITICAL: Prepare WQEs AFTER QP is connected
+  // This must happen after connect() because the NIC needs the QP in RTR/RTS
+  // state to process receive WQEs
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "Preparing receive WQEs after QP connection...");
+  result = doca_prepare_wqes(nullptr, // Use default stream
+                             qp_->get_gpu_dev(), config_.max_rpc_size,
+                             buffer_pool_->get_mkey_be(), config_.wqe_num);
+
+  if (result != DOCA_SUCCESS) {
+    throw std::runtime_error("Failed to prepare WQEs after connection: " +
+                             std::string(doca_error_get_descr(result)));
+  }
+  cudaStreamSynchronize(nullptr);
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Receive WQEs prepared successfully");
+
+  connected_ = true;
+}
+
+void DOCAChannel::signal_exit() {
+  if (cpu_exit_flag_) {
+    *cpu_exit_flag_ = 1;
+  }
+}
+
+Channel::GPUMemoryHandles DOCAChannel::get_gpu_memory_handles() {
+  if (!qp_ || !buffer_pool_) {
+    throw std::runtime_error("Channel not initialized");
+  }
+
+  Channel::GPUMemoryHandles handles{};
+  handles.rx_queue_addr = qp_->get_gpu_dev();
+  handles.tx_queue_addr = qp_->get_gpu_dev(); // Same QP for bidirectional
+  handles.buffer_pool_addr = buffer_pool_->get_gpu_buffer();
+  handles.buffer_pool_size = config_.buffer_size;
+
+  // DOCA-specific fields
+  // NOTE: CQ is obtained from QP in kernel via
+  // doca_gpu_dev_verbs_qp_get_cq_rq()
+  handles.cq_rq_addr = qp_->get_gpu_dev(); // Kernel extracts CQ from QP
+  handles.buffer_mkey = buffer_pool_->get_mkey_be();
+  // For DOCA_GPU_MEM_TYPE_GPU_CPU memory, we have two pointers:
+  // - cpu_exit_flag_: for host writes
+  // - gpu_exit_flag_: for kernel reads
+  handles.exit_flag = cpu_exit_flag_;
+  handles.gpu_exit_flag = gpu_exit_flag_;
+  handles.page_size = config_.page_size;
+  handles.num_pages = config_.num_pages;
+
+  return handles;
+}
+
+// Interface methods (minimal implementation for GPU datapath)
+std::uint32_t DOCAChannel::receive_burst(Buffer **buffers, std::uint32_t max) {
+  // Not used in GPU datapath - GPU kernel handles receive directly
+  return 0;
+}
+
+std::uint32_t DOCAChannel::send_burst(Buffer **buffers, std::uint32_t count) {
+  // Not used in GPU datapath - GPU kernel handles send directly
+  return 0;
+}
+
+Buffer *DOCAChannel::acquire_buffer() {
+  return buffer_pool_ ? buffer_pool_->acquire() : nullptr;
+}
+
+void DOCAChannel::release_buffer(Buffer *buffer) {
+  if (buffer_pool_)
+    buffer_pool_->release(buffer);
+}
+
+void DOCAChannel::register_memory(void *addr, std::size_t size) {
+  // Memory registration handled in init_buffer_pool()
+}
+
+void DOCAChannel::configure_queues(
+    const std::vector<std::uint32_t> &queue_ids) {
+  // Queue configuration handled in initialization
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/channels/doca/doca_completion_queue.cpp
+++ b/realtime/lib/network/channels/doca/doca_completion_queue.cpp
@@ -1,0 +1,185 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/channels/doca/doca_completion_queue.h"
+#include "cudaq/nvqlink/utils/instrumentation/domains.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+
+#include <cuda_runtime.h>
+#include <infiniband/mlx5dv.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+
+namespace cudaq::nvqlink {
+
+static std::size_t get_page_size() {
+  long ret = sysconf(_SC_PAGESIZE);
+  if (ret == -1)
+    return 4096; // 4KB, default Linux page size
+  return static_cast<std::size_t>(ret);
+}
+
+static std::uint32_t align_up_uint32(std::uint32_t value,
+                                     std::uint32_t alignment) {
+  std::uint64_t remainder = (value % alignment);
+  if (remainder == 0)
+    return value;
+  return static_cast<std::uint32_t>(value + (alignment - remainder));
+}
+
+static std::uint32_t calc_cq_external_umem_size(std::uint32_t queue_size) {
+  constexpr std::uint32_t VERBS_TEST_DBR_SIZE = 8;
+  std::uint32_t cqe_buf_size = 0;
+
+  if (queue_size != 0)
+    cqe_buf_size = static_cast<std::uint32_t>(queue_size * sizeof(mlx5_cqe64));
+
+  return align_up_uint32(cqe_buf_size + VERBS_TEST_DBR_SIZE, get_page_size());
+}
+
+static void mlx5_init_cqes(mlx5_cqe64 *cqes, std::uint32_t nb_cqes) {
+  for (std::uint32_t cqe_idx = 0; cqe_idx < nb_cqes; cqe_idx++)
+    cqes[cqe_idx].op_own =
+        (MLX5_CQE_INVALID << DOCA_GPUNETIO_VERBS_MLX5_CQE_OPCODE_SHIFT) |
+        MLX5_CQE_OWNER_MASK;
+}
+
+DOCACompletionQueue::DOCACompletionQueue(std::uint32_t cqe_num, doca_gpu *gdev,
+                                         doca_dev *ndev, doca_uar *uar,
+                                         doca_verbs_context *vctx)
+    : cqe_num_(cqe_num), gdev_(gdev), ndev_(ndev), uar_(uar), vctx_(vctx) {}
+
+DOCACompletionQueue::~DOCACompletionQueue() {
+  // Correct DOCA resource cleanup order:
+  // 1. Destroy CQ (releases reference to external UMEM)
+  // 2. Destroy UMEM (memory registration)
+  // 3. Free GPU memory (underlying buffer)
+  if (cq_ != nullptr)
+    doca_verbs_cq_destroy(cq_);
+  if (umem_)
+    doca_umem_destroy(umem_);
+  if (umem_dev_ptr_)
+    doca_gpu_mem_free(gdev_, umem_dev_ptr_);
+}
+
+doca_error_t DOCACompletionQueue::create() {
+  doca_verbs_cq_attr *cq_attr = nullptr;
+  std::uint32_t external_umem_size;
+  mlx5_cqe64 *cq_ring_haddr = nullptr;
+  doca_error_t result = DOCA_SUCCESS;
+  cudaError_t result_cuda;
+
+  result = doca_verbs_cq_attr_create(&cq_attr);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to create CQ attributes: {}",
+                      doca_error_get_descr(result));
+    return result;
+  }
+
+  result = doca_verbs_cq_attr_set_external_uar(cq_attr, uar_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set external UAR: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_cq_attr_set_cq_size(cq_attr, cqe_num_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set CQ size: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_cq_attr_set_external_datapath_en(cq_attr, 1);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "Failed to set external datapath enable: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result =
+      doca_verbs_cq_attr_set_entry_size(cq_attr, DOCA_VERBS_CQ_ENTRY_SIZE_64);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set CQ entry size: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_cq_attr_set_cq_overrun(cq_attr, 1);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set CQ overrun: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // Allocate and initialize CQ ring buffer
+  external_umem_size = calc_cq_external_umem_size(cqe_num_);
+
+  cq_ring_haddr = static_cast<mlx5_cqe64 *>(
+      std::calloc(external_umem_size, sizeof(std::uint8_t)));
+  if (cq_ring_haddr == nullptr) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to allocate CQ host ring buffer");
+    goto exit;
+  }
+
+  mlx5_init_cqes(cq_ring_haddr, cqe_num_);
+
+  result = doca_gpu_mem_alloc(gdev_, external_umem_size, get_page_size(),
+                              DOCA_GPU_MEM_TYPE_GPU, &umem_dev_ptr_, nullptr);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "Failed to allocate GPU memory for CQ: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result_cuda = cudaMemcpy(umem_dev_ptr_, cq_ring_haddr, external_umem_size,
+                           cudaMemcpyDefault);
+  if (result_cuda != cudaSuccess) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to copy CQ ring buffer to GPU");
+    result = DOCA_ERROR_DRIVER;
+    goto exit;
+  }
+
+  // Create UMEM
+  result = doca_umem_gpu_create(
+      gdev_, ndev_, umem_dev_ptr_, external_umem_size,
+      DOCA_ACCESS_FLAG_LOCAL_READ_WRITE | DOCA_ACCESS_FLAG_RDMA_WRITE |
+          DOCA_ACCESS_FLAG_RDMA_READ | DOCA_ACCESS_FLAG_RDMA_ATOMIC,
+      &umem_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to create GPU UMEM: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_cq_attr_set_external_umem(cq_attr, umem_, 0);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set CQ external UMEM");
+    goto exit;
+  }
+
+  // Create the CQ
+  result = doca_verbs_cq_create(vctx_, cq_attr, &cq_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to create CQ: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+exit:
+  doca_verbs_cq_attr_destroy(cq_attr);
+  if (cq_ring_haddr)
+    std::free(cq_ring_haddr);
+  return result;
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/channels/doca/doca_queue_pair.cpp
+++ b/realtime/lib/network/channels/doca/doca_queue_pair.cpp
@@ -1,0 +1,471 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/channels/doca/doca_queue_pair.h"
+#include "cudaq/nvqlink/utils/instrumentation/domains.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+
+#include <cuda_runtime.h>
+#include <doca_gpunetio_verbs_def.h>
+#include <infiniband/mlx5dv.h>
+
+#include <cstdlib>
+#include <unistd.h>
+
+namespace cudaq::nvqlink {
+
+static std::size_t get_page_size() {
+  long ret = sysconf(_SC_PAGESIZE);
+  if (ret == -1)
+    return 4096; // 4KB, default Linux page size
+  return static_cast<std::size_t>(ret);
+}
+
+static std::uint32_t align_up_uint32(std::uint32_t value,
+                                     std::uint32_t alignment) {
+  std::uint64_t remainder = (value % alignment);
+  if (remainder == 0)
+    return value;
+  return static_cast<std::uint32_t>(value + (alignment - remainder));
+}
+
+#define ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
+
+constexpr std::uint32_t VERBS_TEST_DBR_SIZE = 8;
+
+static std::uint32_t calc_qp_external_umem_size(std::uint32_t rq_nwqes,
+                                                std::uint32_t sq_nwqes) {
+  std::uint32_t rq_ring_size = 0;
+  std::uint32_t sq_ring_size = 0;
+
+  if (rq_nwqes != 0)
+    rq_ring_size =
+        static_cast<std::uint32_t>(rq_nwqes * sizeof(mlx5_wqe_data_seg));
+  if (sq_nwqes != 0)
+    sq_ring_size =
+        static_cast<std::uint32_t>(sq_nwqes * sizeof(doca_gpu_dev_verbs_wqe));
+
+  return align_up_uint32(rq_ring_size + sq_ring_size, get_page_size());
+}
+
+DOCAQueuePair::DOCAQueuePair(std::uint32_t wqe_num, doca_gpu *gdev,
+                             doca_dev *ndev, doca_uar *uar,
+                             doca_verbs_context *vctx, doca_verbs_pd *vpd,
+                             doca_verbs_cq *cq_rq, doca_verbs_cq *cq_sq)
+    : wqe_num_(wqe_num), gdev_(gdev), ndev_(ndev), uar_(uar), vctx_(vctx),
+      vpd_(vpd), cq_rq_(cq_rq), cq_sq_(cq_sq) {}
+
+DOCAQueuePair::~DOCAQueuePair() {
+  // Correct DOCA resource cleanup order:
+  // 1. Destroy QP (releases references to external UMEMs)
+  // 2. Destroy UMEMs (memory registrations)
+  // 3. Free GPU memory (underlying buffers)
+  //
+  // Note: gpu_qp_ is managed by DOCA internally, we only destroy the verbs QP
+  if (qp_)
+    doca_verbs_qp_destroy(qp_);
+  if (umem_)
+    doca_umem_destroy(umem_);
+  if (umem_dbr_)
+    doca_umem_destroy(umem_dbr_);
+  if (umem_dev_ptr_)
+    doca_gpu_mem_free(gdev_, umem_dev_ptr_);
+  if (umem_dbr_dev_ptr_)
+    doca_gpu_mem_free(gdev_, umem_dbr_dev_ptr_);
+}
+
+doca_error_t DOCAQueuePair::create() {
+  std::size_t dbr_umem_align_sz;
+  doca_verbs_qp_init_attr *qp_init_attr = nullptr;
+  doca_error_t result = DOCA_SUCCESS;
+  std::uint32_t external_umem_size;
+
+  result = doca_verbs_qp_init_attr_create(&qp_init_attr);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to create QP init attributes: {}",
+                      doca_error_get_descr(result));
+    return result;
+  }
+
+  // Set QP attributes
+  result = doca_verbs_qp_init_attr_set_external_uar(qp_init_attr, uar_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set external UAR for QP: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_init_attr_set_pd(qp_init_attr, vpd_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set PD for QP: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_init_attr_set_external_datapath_en(qp_init_attr, 1);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "Failed to set external datapath for QP: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // Set send/receive CQs
+  result = doca_verbs_qp_init_attr_set_receive_cq(qp_init_attr, cq_rq_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set receive CQ: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_init_attr_set_send_cq(qp_init_attr, cq_sq_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set send CQ: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // Set WR capacities
+  result = doca_verbs_qp_init_attr_set_sq_wr(qp_init_attr, wqe_num_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set SQ WR: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_init_attr_set_rq_wr(qp_init_attr, wqe_num_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set RQ WR: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // Send sge and recv sge
+  result = doca_verbs_qp_init_attr_set_send_max_sges(qp_init_attr, 1);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set send max sges: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_init_attr_set_receive_max_sges(qp_init_attr, 1);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set receive max sges: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // Set QP type to UC (Unreliable Connected)
+  result =
+      doca_verbs_qp_init_attr_set_qp_type(qp_init_attr, DOCA_VERBS_QP_TYPE_UC);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set QP type: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // Set sq_sig_all to 0
+  result = doca_verbs_qp_init_attr_set_sq_sig_all(qp_init_attr, 0);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set sq sig all: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // Allocate external UMEM for WQE ring
+  external_umem_size = calc_qp_external_umem_size(wqe_num_, wqe_num_);
+
+  result = doca_gpu_mem_alloc(gdev_, external_umem_size, get_page_size(),
+                              DOCA_GPU_MEM_TYPE_GPU, &umem_dev_ptr_, nullptr);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "Failed to alloc GPU memory for external UMEM QP");
+    goto exit;
+  }
+
+  result = doca_umem_gpu_create(
+      gdev_, ndev_, umem_dev_ptr_, external_umem_size,
+      DOCA_ACCESS_FLAG_LOCAL_READ_WRITE | DOCA_ACCESS_FLAG_RDMA_WRITE |
+          DOCA_ACCESS_FLAG_RDMA_READ | DOCA_ACCESS_FLAG_RDMA_ATOMIC,
+      &umem_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to create GPU UMEM: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_init_attr_set_external_umem(qp_init_attr, umem_, 0);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "Failed to set DOCA Verbs QP external UMEM");
+    goto exit;
+  }
+
+  // Allocate doorbell record UMEM
+  dbr_umem_align_sz = ROUND_UP(VERBS_TEST_DBR_SIZE, get_page_size());
+  result =
+      doca_gpu_mem_alloc(gdev_, dbr_umem_align_sz, get_page_size(),
+                         DOCA_GPU_MEM_TYPE_GPU, &umem_dbr_dev_ptr_, nullptr);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "Failed to alloc GPU memory for DBR UMEM");
+    goto exit;
+  }
+
+  result = doca_umem_gpu_create(
+      gdev_, ndev_, umem_dbr_dev_ptr_, dbr_umem_align_sz,
+      DOCA_ACCESS_FLAG_LOCAL_READ_WRITE | DOCA_ACCESS_FLAG_RDMA_WRITE |
+          DOCA_ACCESS_FLAG_RDMA_READ | DOCA_ACCESS_FLAG_RDMA_ATOMIC,
+      &umem_dbr_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to create GPU UMEM for DBR: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result =
+      doca_verbs_qp_init_attr_set_external_dbr_umem(qp_init_attr, umem_dbr_, 0);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "Failed to set DOCA Verbs QP external DBR UMEM");
+    goto exit;
+  }
+
+  // Create the QP
+  result = doca_verbs_qp_create(vctx_, qp_init_attr, &qp_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to create QP: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // Export to GPU
+  result = doca_gpu_verbs_export_qp(
+      gdev_, ndev_, qp_, DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_DB,
+      umem_dbr_dev_ptr_, cq_sq_, cq_rq_, &gpu_qp_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to export GPU Verbs QP");
+    goto exit;
+  }
+
+  result = doca_gpu_verbs_get_qp_dev(gpu_qp_, &gpu_dev_qp_);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to get QP device handle");
+    goto exit;
+  }
+
+exit:
+  doca_verbs_qp_init_attr_destroy(qp_init_attr);
+  return result;
+}
+
+doca_error_t DOCAQueuePair::connect(const doca_verbs_gid &remote_gid,
+                                    std::uint32_t gid_index,
+                                    std::uint32_t dest_qp_num) {
+  doca_error_t result;
+  doca_verbs_qp_attr *verbs_qp_attr = nullptr;
+  doca_verbs_ah_attr *ah_attr = nullptr;
+  std::uint32_t rst2init_mask = DOCA_UC_QP_RST2INIT_REQ_ATTR_MASK;
+  std::uint32_t init2rtr_mask = DOCA_UC_QP_INIT2RTR_REQ_ATTR_MASK;
+  std::uint32_t rtr2rts_mask = DOCA_UC_QP_RTR2RTS_REQ_ATTR_MASK;
+
+  // Create AH and QP attributes
+  result = doca_verbs_ah_attr_create(vctx_, &ah_attr);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to create AH attributes: {}",
+                      doca_error_get_descr(result));
+    return result;
+  }
+
+  result = doca_verbs_qp_attr_create(&verbs_qp_attr);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to create QP attributes: {}",
+                      doca_error_get_descr(result));
+    doca_verbs_ah_attr_destroy(ah_attr);
+    return result;
+  }
+
+  // Set AH attributes
+  result = doca_verbs_ah_attr_set_gid(ah_attr, remote_gid);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set remote GID: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_ah_attr_set_dlid(ah_attr, 0); // IB only parameter
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set dlid: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_ah_attr_set_addr_type(ah_attr, DOCA_VERBS_ADDR_TYPE_IPv4);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set address type: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_ah_attr_set_sgid_index(ah_attr, gid_index);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set SGID index: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_ah_attr_set_hop_limit(ah_attr, 0xFF);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set hop limit: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // Set QP attributes
+  result =
+      doca_verbs_qp_attr_set_path_mtu(verbs_qp_attr, DOCA_MTU_SIZE_4K_BYTES);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set path MTU: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_rq_psn(verbs_qp_attr, 0);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set RQ PSN: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_sq_psn(verbs_qp_attr, 0);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set SQ PSN: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_ah_attr(verbs_qp_attr, ah_attr);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set AH attr: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_port_num(verbs_qp_attr, 1);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set port num: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_ack_timeout(verbs_qp_attr, 14);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set ACK timeout: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_retry_cnt(verbs_qp_attr, 7);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set retry count: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_rnr_retry(verbs_qp_attr, 6);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set RNR retry: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_min_rnr_timer(verbs_qp_attr, 12);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set min RNR timer: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_allow_remote_write(verbs_qp_attr, 1);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set allow remote write: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_allow_remote_read(verbs_qp_attr, 1);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set allow remote read: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_attr_set_dest_qp_num(verbs_qp_attr, dest_qp_num);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set dest QP num: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // QP State Transitions
+
+  // RST → INIT
+  result = doca_verbs_qp_attr_set_next_state(verbs_qp_attr,
+                                             DOCA_VERBS_QP_STATE_INIT);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set next state INIT: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_modify(qp_, verbs_qp_attr, rst2init_mask);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to modify QP RST→INIT: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // INIT → RTR
+  result =
+      doca_verbs_qp_attr_set_next_state(verbs_qp_attr, DOCA_VERBS_QP_STATE_RTR);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set next state RTR: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_modify(qp_, verbs_qp_attr, init2rtr_mask);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to modify QP INIT→RTR: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  // RTR → RTS
+  result =
+      doca_verbs_qp_attr_set_next_state(verbs_qp_attr, DOCA_VERBS_QP_STATE_RTS);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to set next state RTS: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+  result = doca_verbs_qp_modify(qp_, verbs_qp_attr, rtr2rts_mask);
+  if (result != DOCA_SUCCESS) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Failed to modify QP RTR→RTS: {}",
+                      doca_error_get_descr(result));
+    goto exit;
+  }
+
+exit:
+  doca_verbs_qp_attr_destroy(verbs_qp_attr);
+  doca_verbs_ah_attr_destroy(ah_attr);
+  return result;
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/channels/doca/doca_rpc_kernel.cu
+++ b/realtime/lib/network/channels/doca/doca_rpc_kernel.cu
@@ -1,0 +1,333 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/daemon/registry/gpu_function_registry.h"
+#include "cudaq/nvqlink/network/serialization/gpu_input_stream.h"
+#include "cudaq/nvqlink/network/serialization/gpu_output_stream.h"
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <doca_error.h>
+#include <doca_gpunetio_dev_verbs_twosided.cuh>
+
+#include <cstdint>
+
+namespace cudaq::nvqlink {
+
+constexpr std::uint32_t RWQE_TERMINATE_KEY = 0x100;
+// TODO: We always use non-inline sends. Add inline send variants if needed.
+
+struct __align__(8) RPCHeader {
+  std::uint64_t sequence_number;
+  std::uint32_t function_id;
+  std::uint32_t payload_length;
+};
+
+struct __align__(8) RPCResponse {
+  std::uint64_t sequence_number;
+  std::int32_t status;
+  std::uint32_t result_length;
+};
+
+/// @brief Receive a single packet from CQ
+///
+__device__ inline std::uint32_t
+receive_packet(doca_gpu_dev_verbs_cq *cq_rq, std::uint8_t *cqe_buffer,
+               const std::uint32_t cqe_mask,
+               const doca_gpu_dev_verbs_ticket_t out_ticket) {
+  doca_gpu_dev_verbs_poll_cq_at<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+                                DOCA_GPUNETIO_VERBS_QP_RQ>(cq_rq, out_ticket);
+
+  mlx5_cqe64 *cqe64 = reinterpret_cast<mlx5_cqe64 *>(
+      cqe_buffer + ((out_ticket & cqe_mask) * DOCA_GPUNETIO_VERBS_CQE_SIZE));
+
+  return doca_gpu_dev_verbs_bswap32(cqe64->imm_inval_pkey) & 0xFFF;
+}
+
+/// @brief Build and submit response WQE
+///
+__device__ inline void
+send_response(doca_gpu_dev_verbs_qp *qp, std::uint64_t wqe_idx,
+              std::uint8_t *buffer, const std::uint32_t page_size,
+              const std::uint32_t buffer_mkey, const unsigned page,
+              const std::uint32_t response_size) {
+  // Debug: Print send parameters
+  printf("DOCA send_response: wqe_idx=%lu, page=%u, page_size=%u, "
+         "response_size=%u, mkey=0x%x\n",
+         (unsigned long)wqe_idx, page, page_size, response_size, buffer_mkey);
+  printf("DOCA send_response: addr=0x%x (page*page_size)\n", page * page_size);
+
+  // COPY FROM HOLOLINK: Lines 84-91 (WQE pointer and index setup)
+  std::uint16_t wqe_idx_16 = static_cast<std::uint16_t>(wqe_idx);
+  doca_gpu_dev_verbs_wqe *wqe_ptr = doca_gpu_dev_verbs_get_wqe_ptr(qp, wqe_idx);
+
+  wqe_ptr->snd_cseg.opmod_idx_opcode =
+      doca_gpu_dev_verbs_bswap32((static_cast<std::uint32_t>(wqe_idx_16)
+                                  << DOCA_GPUNETIO_VERBS_WQE_IDX_SHIFT) |
+                                 DOCA_GPUNETIO_MLX5_OPCODE_SEND);
+
+  // CRITICAL: Use iova-relative address, NOT GPU virtual address!
+  // Memory is registered with iova=0, so addr should be (page * page_size)
+  // offset from 0. This matches Hololink: wqe_ptr->dseg1.addr =
+  // bswap64(cu_page_size * page)
+  wqe_ptr->dseg1.addr =
+      doca_gpu_dev_verbs_bswap64(static_cast<std::uint64_t>(page) * page_size);
+  wqe_ptr->dseg1.byte_count = doca_gpu_dev_verbs_bswap32(
+      static_cast<std::uint32_t>(sizeof(RPCResponse) + response_size));
+  wqe_ptr->dseg1.lkey = buffer_mkey;
+
+  printf("DOCA send_response: WQE prepared - byte_count=%u, submitting...\n",
+         static_cast<std::uint32_t>(sizeof(RPCResponse) + response_size));
+
+  doca_gpu_dev_verbs_mark_wqes_ready<
+      DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, wqe_idx, wqe_idx);
+
+  doca_gpu_dev_verbs_submit<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+                            DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+                            DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_DB>(
+      qp, wqe_idx + 1);
+
+  printf("DOCA send_response: SEND submitted to NIC\n");
+}
+
+/// @brief Repost receive WQE after processing
+///
+__device__ inline std::uint64_t repost_receive(doca_gpu_dev_verbs_qp *qp,
+                                               std::uint64_t rwqe_idx) {
+  // COPY FROM HOLOLINK: Lines 132-136
+  doca_gpu_dev_verbs_submit<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+                            DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+                            DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_DB,
+                            DOCA_GPUNETIO_VERBS_QP_RQ>(qp, rwqe_idx + 1);
+
+  return rwqe_idx;
+}
+
+/// @brief Main RPC processing kernel
+///
+__global__ void
+rpc_dispatch_kernel(doca_gpu_dev_verbs_qp *qp, std::uint32_t *exit_flag,
+                    std::uint8_t *buffer, const std::uint32_t page_size,
+                    const std::uint32_t buffer_mkey, const unsigned num_pages,
+                    GPUFunctionRegistry *registry) {
+  doca_gpu_dev_verbs_cq *cq_rq = doca_gpu_dev_verbs_qp_get_cq_rq(qp);
+  std::uint8_t *cqe_buffer = reinterpret_cast<std::uint8_t *>(
+      __ldg(reinterpret_cast<uintptr_t *>(&cq_rq->cqe_daddr)));
+  const std::uint32_t cqe_mask = (__ldg(&cq_rq->cqe_num) - 1);
+
+  doca_gpu_dev_verbs_ticket_t out_ticket = threadIdx.x;
+  std::uint64_t wqe_idx = threadIdx.x;
+
+  // Debug: Print kernel start (only once per block)
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    printf(
+        "DOCA RPC Kernel: Started, exit_flag=%u, num_pages=%u, registry=%p\n",
+        *exit_flag, num_pages, registry);
+    printf("DOCA RPC Kernel: page_size=%u, buffer_mkey=0x%x, buffer=%p\n",
+           page_size, buffer_mkey, buffer);
+  }
+
+  // Kernel exits when exit_flag is set AND a packet arrives
+  while (DOCA_GPUNETIO_VOLATILE(*exit_flag) == 0) {
+    unsigned page = receive_packet(cq_rq, cqe_buffer, cqe_mask, out_ticket);
+
+    if (page < num_pages) {
+      // Parse RPC header from received data
+      std::uint8_t *page_ptr = buffer + page * page_size;
+      RPCHeader *header = reinterpret_cast<RPCHeader *>(page_ptr);
+      std::uint8_t *payload = page_ptr + sizeof(RPCHeader);
+
+      // Debug: Print received packet info
+      if (threadIdx.x == 0) {
+        printf("DOCA RPC: Received packet - page=%u, seq=%lu, func_id=%u, "
+               "payload_len=%u\n",
+               page, header->sequence_number, header->function_id,
+               header->payload_length);
+      }
+
+      // Create streams for function dispatch
+      GPUInputStream in(payload, header->payload_length);
+      std::uint8_t *response_payload = page_ptr + sizeof(RPCResponse);
+      std::size_t response_capacity = page_size - sizeof(RPCResponse);
+      GPUOutputStream out(response_payload, response_capacity);
+
+      // Dispatch to registered function
+      std::int32_t status = 0;
+      if (registry != nullptr) {
+        GPUFunctionWrapper *func = registry->lookup(header->function_id);
+        if (func != nullptr) {
+          if (threadIdx.x == 0) {
+            printf("DOCA RPC: Found function wrapper at %p\n", (void *)func);
+            printf("DOCA RPC: Function pointer = %p\n", (void *)func->invoke);
+            printf("DOCA RPC: Invoking function %u...\n", header->function_id);
+          }
+
+          // Call the function - if this crashes or hangs, the pointer is
+          // invalid
+          if (func->invoke != nullptr) {
+            status = func->invoke(in, out);
+            if (threadIdx.x == 0) {
+              printf(
+                  "DOCA RPC: Function returned status=%d, bytes_written=%zu\n",
+                  status, out.bytes_written());
+            }
+          } else {
+            status = -3;
+            if (threadIdx.x == 0) {
+              printf("DOCA RPC: ERROR - Function pointer is NULL!\n");
+            }
+          }
+        } else {
+          status = -1;
+          printf("DOCA RPC: Function %u not found\n", header->function_id);
+        }
+      } else {
+        status = -2;
+        printf("DOCA RPC: Registry is null\n");
+      }
+
+      // Build response header
+      RPCResponse response{.sequence_number = header->sequence_number,
+                           .status = status,
+                           .result_length =
+                               static_cast<std::uint32_t>(out.bytes_written())};
+      *reinterpret_cast<RPCResponse *>(page_ptr) = response;
+
+      if (threadIdx.x == 0) {
+        printf("DOCA RPC: Response built - seq=%lu, status=%d, result_len=%u\n",
+               response.sequence_number, response.status,
+               response.result_length);
+      }
+
+      // Only thread 0 sends (to avoid duplicate sends)
+      if (threadIdx.x == 0) {
+        // Debug: print values before call
+        std::uint32_t bytes_written =
+            static_cast<std::uint32_t>(out.bytes_written());
+        printf("DOCA RPC: About to call send_response with page_size=%u, "
+               "bytes_written=%u\n",
+               page_size, bytes_written);
+        send_response(qp, wqe_idx, buffer, page_size, buffer_mkey, page,
+                      bytes_written);
+      }
+    } else {
+      printf("DOCA RPC: Invalid page %u, ignoring\n", page);
+    }
+    wqe_idx += blockDim.x * gridDim.x;
+    out_ticket = repost_receive(qp, wqe_idx);
+  }
+}
+
+/// @brief Prepare WQEs kernel
+///
+__global__ void prepare_wqes_kernel(doca_gpu_dev_verbs_qp *qp,
+                                    const std::uint32_t max_rpc_size,
+                                    const std::uint32_t buffer_mkey) {
+  // Debug: Log kernel execution
+  if (threadIdx.x == 0) {
+    printf("DOCA prepare_wqes_kernel: Starting with %d threads, "
+           "max_rpc_size=%u, mkey=0x%x\n",
+           blockDim.x, max_rpc_size, buffer_mkey);
+  }
+
+  doca_gpu_dev_verbs_ticket_t out_ticket;
+  doca_gpu_dev_verbs_wqe *wqe_ptr;
+  doca_gpu_dev_verbs_wqe_ctrl_seg cseg;
+
+  doca_gpu_dev_verbs_recv(
+      qp,
+      doca_gpu_dev_verbs_addr{
+          .addr = 0, .key = doca_gpu_dev_verbs_bswap32(RWQE_TERMINATE_KEY)},
+      0, &out_ticket);
+
+  wqe_ptr = doca_gpu_dev_verbs_get_wqe_ptr(qp, threadIdx.x);
+  cseg.opmod_idx_opcode =
+      doca_gpu_dev_verbs_bswap32((static_cast<std::uint32_t>(threadIdx.x)
+                                  << DOCA_GPUNETIO_VERBS_WQE_IDX_SHIFT) |
+                                 DOCA_GPUNETIO_MLX5_OPCODE_SEND);
+  cseg.fm_ce_se = DOCA_GPUNETIO_MLX5_WQE_CTRL_CQ_ERROR_UPDATE;
+
+  cseg.qpn_ds = doca_gpu_dev_verbs_bswap32(__ldg(&qp->sq_num_shift8) | 2);
+  wqe_ptr->dseg1.byte_count =
+      doca_gpu_dev_verbs_bswap32(static_cast<std::uint32_t>(max_rpc_size));
+  wqe_ptr->dseg1.lkey = buffer_mkey;
+
+  doca_gpu_dev_verbs_store_wqe_seg(
+      reinterpret_cast<std::uint64_t *>(&wqe_ptr->dseg0),
+      reinterpret_cast<std::uint64_t *>(&cseg));
+
+  __syncthreads(); // Ensure all threads have finished preparing their WQEs
+  if (threadIdx.x == blockDim.x - 1) {
+    printf("DOCA prepare_wqes_kernel: Submitting %d receive WQEs to NIC "
+           "(out_ticket=%lu)\n",
+           blockDim.x, (unsigned long)out_ticket);
+    // Last thread submits all WQEs (0 to blockDim.x)
+    doca_gpu_dev_verbs_submit<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+                              DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+                              DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_DB,
+                              DOCA_GPUNETIO_VERBS_QP_RQ>(qp, blockDim.x);
+    printf("DOCA prepare_wqes_kernel: WQEs submitted successfully\n");
+  }
+}
+
+extern "C" {
+
+doca_error_t doca_prepare_wqes(cudaStream_t stream, doca_gpu_dev_verbs_qp *qp,
+                               std::uint32_t max_rpc_size,
+                               std::uint32_t buffer_mkey,
+                               std::uint32_t num_wqes) {
+  cudaError_t result = cudaGetLastError();
+  if (result != cudaSuccess) {
+    fprintf(stderr, "[%s:%d] CUDA failed with %s\n", __FILE__, __LINE__,
+            cudaGetErrorString(result));
+    return DOCA_ERROR_BAD_STATE;
+  }
+
+  prepare_wqes_kernel<<<1, num_wqes, 0, stream>>>(qp, max_rpc_size,
+                                                  buffer_mkey);
+
+  result = cudaGetLastError();
+  if (result != cudaSuccess) {
+    fprintf(stderr, "[%s:%d] CUDA failed with %s\n", __FILE__, __LINE__,
+            cudaGetErrorString(result));
+    return DOCA_ERROR_BAD_STATE;
+  }
+
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_rpc_kernel(cudaStream_t stream, doca_gpu_dev_verbs_qp *qp,
+                             std::uint32_t *exit_flag, std::uint8_t *buffer,
+                             std::uint32_t page_size, std::uint32_t buffer_mkey,
+                             unsigned num_pages, GPUFunctionRegistry *registry,
+                             std::uint32_t cuda_blocks,
+                             std::uint32_t cuda_threads) {
+  cudaError_t result = cudaGetLastError();
+  if (result != cudaSuccess) {
+    fprintf(stderr, "[%s:%d] CUDA failed with %s\n", __FILE__, __LINE__,
+            cudaGetErrorString(result));
+    return DOCA_ERROR_BAD_STATE;
+  }
+
+  // Launch RPC dispatch kernel
+  rpc_dispatch_kernel<<<cuda_blocks, cuda_threads, 0, stream>>>(
+      qp, exit_flag, buffer, page_size, buffer_mkey, num_pages, registry);
+
+  result = cudaGetLastError();
+  if (result != cudaSuccess) {
+    fprintf(stderr, "[%s:%d] CUDA failed with %s\n", __FILE__, __LINE__,
+            cudaGetErrorString(result));
+    return DOCA_ERROR_BAD_STATE;
+  }
+
+  return DOCA_SUCCESS;
+}
+
+} // extern "C"
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/channels/gpu_channel.cu
+++ b/realtime/lib/network/channels/gpu_channel.cu
@@ -1,0 +1,222 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/gpu_channel.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+#include "cudaq/nvqlink/utils/instrumentation/profiler.h"
+
+#include <cuda_runtime.h>
+#include <stdexcept>
+
+namespace cudaq::nvqlink {
+
+GPUChannel::GPUChannel(Channel *channel)
+    : channel_(channel), d_queue_handles_(nullptr), h_queue_handles_(nullptr),
+      d_running_(nullptr), h_running_(nullptr), stream_(nullptr) {
+  NVQLINK_TRACE_FULL(DOMAIN_GPU, "GPUChannel::constructor");
+
+  if (!channel_) {
+    throw std::invalid_argument("GPUChannel: channel cannot be null");
+  }
+
+  // Create CUDA stream for kernel
+  cudaStreamCreate(&stream_);
+
+  // Allocate device-side queue handles
+  cudaMalloc(&d_queue_handles_, sizeof(GPUQueueHandles));
+
+  // Allocate host-side queue handles
+  h_queue_handles_ = new GPUQueueHandles();
+
+  // Allocate running flag (managed memory for easy access from both sides)
+  volatile bool *temp_running;
+  cudaMallocManaged(&temp_running, sizeof(bool));
+  d_running_ = temp_running;
+  h_running_ =
+      const_cast<bool *>(temp_running); // Remove volatile for host access
+  *h_running_ = false;
+
+  // Initialize queue handles from backend
+  initialize_queue_handles();
+}
+
+GPUChannel::~GPUChannel() {
+  NVQLINK_TRACE_FULL(DOMAIN_GPU, "GPUChannel::destructor");
+  cleanup();
+}
+
+void GPUChannel::start_kernel(void (*kernel_func)(GPUChannel *), dim3 blocks,
+                              dim3 threads) {
+  NVQLINK_TRACE_FULL(DOMAIN_GPU, "GPUChannel::start_kernel");
+
+  *h_running_ = true;
+
+  // Launch persistent kernel
+  kernel_func<<<blocks, threads, 0, stream_>>>(this);
+
+  // Check for launch errors
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "GPUChannel: Kernel launch failed: {}",
+                      cudaGetErrorString(err));
+    *h_running_ = false;
+    throw std::runtime_error("Failed to launch GPU kernel");
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "[GPUChannel] Persistent kernel started");
+}
+
+void GPUChannel::stop_kernel() {
+  NVQLINK_TRACE_FULL(DOMAIN_GPU, "GPUChannel::stop_kernel");
+
+  if (*h_running_) {
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                     "[GPUChannel] Stopping persistent kernel...");
+
+    // Signal kernel to stop
+    *h_running_ = false;
+
+    // Wait for kernel to finish
+    cudaStreamSynchronize(stream_);
+
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "[GPUChannel] Persistent kernel stopped");
+  }
+}
+
+__host__ __device__ bool GPUChannel::is_running() const {
+#ifdef __CUDA_ARCH__
+  // Device code
+  return d_queue_handles_->running ? *d_queue_handles_->running : false;
+#else
+  // Host code
+  return h_running_ ? *h_running_ : false;
+#endif
+}
+
+__device__ bool GPUChannel::receive_packet(void **packet_data,
+                                           std::size_t *packet_size) {
+  GPUQueueHandles *handles = d_queue_handles_;
+
+  // Load queue head/tail (volatile to prevent caching)
+  std::uint32_t head = *handles->rx_head;
+  std::uint32_t tail = *handles->rx_tail;
+
+  // Check if queue has packets
+  if (head == tail) {
+    return false; // No packets available
+  }
+
+  // Get packet index
+  std::uint32_t idx = head % handles->queue_size;
+
+  // Get packet data and size
+  *packet_data = handles->packet_buffers[idx];
+  *packet_size = handles->packet_sizes[idx];
+
+  // Advance head (only one GPU thread should do this!)
+  // For simplicity, we assume single-threaded or proper synchronization
+  atomicAdd((unsigned int *)handles->rx_head, 1);
+
+  return true;
+}
+
+__device__ bool GPUChannel::send_packet(void *packet_data,
+                                        std::size_t packet_size) {
+  GPUQueueHandles *handles = d_queue_handles_;
+
+  // Load queue head/tail
+  std::uint32_t head = *handles->tx_head;
+  std::uint32_t tail = *handles->tx_tail;
+
+  // Check if queue has space
+  if ((tail + 1) % handles->queue_size == head) {
+    return false; // Queue full
+  }
+
+  // Get slot index
+  std::uint32_t idx = tail % handles->queue_size;
+
+  // Set packet data and size
+  handles->packet_buffers[idx] = packet_data;
+  handles->packet_sizes[idx] = packet_size;
+
+  // Advance tail
+  atomicAdd((unsigned int *)handles->tx_tail, 1);
+
+  return true;
+}
+
+__device__ void *GPUChannel::allocate_buffer(std::size_t size) {
+  // Simplified allocation - in real implementation, this would
+  // come from a pre-allocated pool or use device-side malloc
+  // For now, return nullptr to indicate feature not yet implemented
+  return nullptr;
+}
+
+__device__ void GPUChannel::release_buffer(void *packet_data) {
+  // Release packet buffer back to pool
+  // Implementation depends on memory management strategy
+}
+
+void GPUChannel::initialize_queue_handles() {
+  // NOTE: This is a simplified initialization.
+  // In a real implementation, the backend would provide
+  // device-accessible pointers to NIC queue structures.
+
+  // For now, initialize with nullptr - backends need to
+  // implement get_gpu_queue_handles() method
+  h_queue_handles_->rx_queue_base = nullptr;
+  h_queue_handles_->tx_queue_base = nullptr;
+  h_queue_handles_->rx_head = nullptr;
+  h_queue_handles_->rx_tail = nullptr;
+  h_queue_handles_->tx_head = nullptr;
+  h_queue_handles_->tx_tail = nullptr;
+  h_queue_handles_->queue_size = 1024;
+  h_queue_handles_->packet_buffers = nullptr;
+  h_queue_handles_->packet_sizes = nullptr;
+  h_queue_handles_->running = d_running_;
+
+  // Copy to device
+  cudaMemcpy(d_queue_handles_, h_queue_handles_, sizeof(GPUQueueHandles),
+             cudaMemcpyHostToDevice);
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "[GPUChannel] Queue handles initialized");
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "[GPUChannel] Note: Backend must provide GPU-accessible "
+                   "queue pointers for full functionality");
+}
+
+void GPUChannel::cleanup() {
+  // Stop kernel if running
+  stop_kernel();
+
+  // Free CUDA resources
+  if (d_queue_handles_) {
+    cudaFree(d_queue_handles_);
+    d_queue_handles_ = nullptr;
+  }
+
+  if (d_running_) {
+    cudaFree(const_cast<bool *>(d_running_));
+    d_running_ = nullptr;
+    h_running_ = nullptr;
+  }
+
+  if (stream_) {
+    cudaStreamDestroy(stream_);
+    stream_ = nullptr;
+  }
+
+  // Free host resources
+  if (h_queue_handles_) {
+    delete h_queue_handles_;
+    h_queue_handles_ = nullptr;
+  }
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/channels/roce/roce_buffer_pool.cpp
+++ b/realtime/lib/network/channels/roce/roce_buffer_pool.cpp
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/channels/roce/roce_buffer_pool.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+
+#include <cstring>
+#include <stdexcept>
+
+namespace cudaq::nvqlink {
+
+RoCEBufferPool::RoCEBufferPool(std::size_t pool_size) {
+  // Pre-allocate Buffer wrapper objects
+  buffer_pool_.reserve(pool_size);
+  free_buffers_.reserve(pool_size);
+
+  for (std::size_t i = 0; i < pool_size; i++) {
+    // Create Buffer with dummy parameters (will be reset when wrapping received
+    // data)
+    auto buffer = std::make_unique<Buffer>(nullptr, 0, 0, 0);
+    free_buffers_.push_back(buffer.get());
+    buffer_pool_.push_back(std::move(buffer));
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "RoCEBufferPool: Created pool with {} buffer wrappers",
+                   pool_size);
+}
+
+RoCEBufferPool::~RoCEBufferPool() { wr_id_map_.clear(); }
+
+Buffer *RoCEBufferPool::wrap_ring_buffer_data(void *addr, std::uint32_t length,
+                                              std::uint64_t slot_id) {
+  if (free_buffers_.empty())
+    throw std::runtime_error("RoCEBufferPool: No free buffer wrappers");
+
+  // Get a free buffer wrapper
+  Buffer *buf = free_buffers_.back();
+  free_buffers_.pop_back();
+
+  // Ring buffer slot layout:
+  // [SlotHeader (16 bytes)] [Payload (RPC data)]
+  //                         ^ addr points here
+  //
+  // The poller already skipped the SlotHeader, but we need to tell Buffer
+  // that there IS headroom available (for prepending RPCResponse header)
+
+  constexpr std::size_t SLOT_HEADER_SIZE = 16; // sizeof(SlotHeader)
+
+  char *payload_start = static_cast<char *>(addr);
+  char *slot_start = payload_start - SLOT_HEADER_SIZE; // Back up to SlotHeader
+
+  // Reset buffer:
+  // - base_ptr: slot start (includes SlotHeader)
+  // - data_ptr: payload start (after SlotHeader)
+  // - headroom: SLOT_HEADER_SIZE (so prepend() can use it)
+  buf->reset(slot_start,                // base pointer (slot start)
+             payload_start,             // data pointer (RPC payload)
+             length + SLOT_HEADER_SIZE, // total size (includes SlotHeader)
+             length,           // current data length (RPC payload only)
+             SLOT_HEADER_SIZE, // headroom available
+             0);               // no tailroom
+
+  // Store slot ID (for tracking)
+  wr_id_map_[buf] = slot_id;
+
+  return buf;
+}
+
+void RoCEBufferPool::return_buffer(Buffer *buffer) {
+  if (!buffer)
+    return;
+
+  // Clean up mappings
+  wr_id_map_.erase(buffer);
+
+  // Return to free pool
+  free_buffers_.push_back(buffer);
+}
+
+std::uint64_t RoCEBufferPool::get_wr_id(Buffer *buffer) const {
+  auto it = wr_id_map_.find(buffer);
+  if (it == wr_id_map_.end())
+    throw std::runtime_error("RoCEBufferPool: Buffer has no WR ID");
+  return it->second;
+}
+
+void RoCEBufferPool::set_wr_id(Buffer *buffer, std::uint64_t wr_id) {
+  wr_id_map_[buffer] = wr_id;
+}
+
+Buffer *RoCEBufferPool::get_free_buffer() {
+  // NO allocation - just return a pre-allocated buffer wrapper
+  if (free_buffers_.empty())
+    return nullptr;
+
+  Buffer *buf = free_buffers_.back();
+  free_buffers_.pop_back();
+  return buf;
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/channels/roce/roce_channel.cpp
+++ b/realtime/lib/network/channels/roce/roce_channel.cpp
@@ -1,0 +1,776 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/channels/roce/roce_channel.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+#include "cudaq/nvqlink/utils/instrumentation/profiler.h"
+
+#include <cstring>
+#include <stdexcept>
+#include <sys/mman.h>
+
+namespace cudaq::nvqlink {
+
+//===----------------------------------------------------------------------===//
+// Constructors
+//===----------------------------------------------------------------------===//
+
+RoCEChannel::RoCEChannel(const std::string &device_name,
+                         std::uint16_t listen_port,
+                         std::shared_ptr<FlowSwitch> flow_switch)
+    : listen_port_(listen_port), flow_switch_(std::move(flow_switch)) {
+  init_independent(device_name);
+  buffer_pool_ = std::make_unique<RoCEBufferPool>(RECV_RING_SIZE);
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "RoCEChannel: Created (independent mode, device: {}, port: "
+                   "{}, UC mode with memory polling)",
+                   device_name, listen_port_);
+}
+
+RoCEChannel::RoCEChannel(std::shared_ptr<VerbsContext> shared_ctx,
+                         std::uint16_t listen_port,
+                         std::shared_ptr<FlowSwitch> flow_switch)
+    : listen_port_(listen_port), flow_switch_(std::move(flow_switch)) {
+  init_shared(std::move(shared_ctx));
+  buffer_pool_ = std::make_unique<RoCEBufferPool>(RECV_RING_SIZE);
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "RoCEChannel: Created (shared mode, device: {}, port: {}, "
+                   "UC mode with memory polling)",
+                   shared_ctx_->get_device_name(), listen_port_);
+}
+
+RoCEChannel::~RoCEChannel() {
+  cleanup();
+
+  // Deregister and free RX ring buffer memory
+  if (rx_ring_buffer_mr_ != nullptr) {
+    ibv_dereg_mr(rx_ring_buffer_mr_);
+    rx_ring_buffer_mr_ = nullptr;
+  }
+  if (rx_ring_buffer_base_ != nullptr) {
+    munmap(rx_ring_buffer_base_, rx_ring_buffer_config_.total_size());
+    rx_ring_buffer_base_ = nullptr;
+  }
+
+  // Deregister and free TX ring buffer memory
+  if (tx_ring_buffer_mr_ != nullptr) {
+    ibv_dereg_mr(tx_ring_buffer_mr_);
+    tx_ring_buffer_mr_ = nullptr;
+  }
+  if (tx_ring_buffer_base_ != nullptr) {
+    munmap(tx_ring_buffer_base_, tx_num_slots_ * tx_slot_size_);
+    tx_ring_buffer_base_ = nullptr;
+  }
+
+  // Cleanup independent mode resources
+  if (owns_context_) {
+    if (owned_pd_) {
+      ibv_dealloc_pd(owned_pd_);
+      owned_pd_ = nullptr;
+    }
+    if (owned_context_) {
+      ibv_close_device(owned_context_);
+      owned_context_ = nullptr;
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Initialization helpers
+//===----------------------------------------------------------------------===//
+
+void RoCEChannel::init_independent(const std::string &device_name) {
+  // Open device and create protection domain ourselves
+  int num_devices;
+  struct ibv_device **dev_list = ibv_get_device_list(&num_devices);
+  if (!dev_list || num_devices == 0)
+    throw std::runtime_error("No InfiniBand devices found");
+
+  // Find device by name
+  struct ibv_device *device = nullptr;
+  for (int i = 0; i < num_devices; i++) {
+    const char *dev_name = ibv_get_device_name(dev_list[i]);
+    if (device_name == dev_name) {
+      device = dev_list[i];
+      break;
+    }
+  }
+
+  // If not found by name, try using index
+  if (!device) {
+    try {
+      int dev_idx = std::stoi(device_name);
+      if (dev_idx >= 0 && dev_idx < num_devices)
+        device = dev_list[dev_idx];
+    } catch (const std::invalid_argument &) {
+      // Not a number
+    }
+  }
+
+  if (!device) {
+    ibv_free_device_list(dev_list);
+    throw std::runtime_error("Device '" + device_name + "' not found");
+  }
+
+  // Open device context
+  owned_context_ = ibv_open_device(device);
+  if (!owned_context_) {
+    ibv_free_device_list(dev_list);
+    throw std::runtime_error("Failed to open device '" + device_name + "'");
+  }
+
+  // Free device list immediately after opening device - no longer needed
+  ibv_free_device_list(dev_list);
+  dev_list = nullptr;
+
+  // Create protection domain
+  owned_pd_ = ibv_alloc_pd(owned_context_);
+  if (!owned_pd_) {
+    ibv_close_device(owned_context_);
+    owned_context_ = nullptr;
+    throw std::runtime_error("Failed to allocate Protection Domain");
+  }
+
+  owns_context_ = true;
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "RoCEChannel: Initialized independent context for device {}",
+                   device_name);
+}
+
+void RoCEChannel::init_shared(std::shared_ptr<VerbsContext> shared_ctx) {
+  if (!shared_ctx)
+    throw std::runtime_error("Shared VerbsContext cannot be null");
+
+  shared_ctx_ = std::move(shared_ctx);
+  owns_context_ = false;
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "RoCEChannel: Using shared context for device {}",
+                   shared_ctx_->get_device_name());
+}
+
+//===----------------------------------------------------------------------===//
+// Resource access helpers
+//===----------------------------------------------------------------------===//
+
+struct ibv_context *RoCEChannel::get_context() const {
+  if (shared_ctx_)
+    return shared_ctx_->get_context();
+  return owned_context_;
+}
+
+struct ibv_pd *RoCEChannel::get_pd() const {
+  if (shared_ctx_)
+    return shared_ctx_->get_protection_domain();
+  return owned_pd_;
+}
+
+std::uint8_t RoCEChannel::get_port_num() const {
+  if (shared_ctx_)
+    return shared_ctx_->get_port_num();
+  return port_num_;
+}
+
+//===----------------------------------------------------------------------===//
+// Channel interface implementation
+//===----------------------------------------------------------------------===//
+
+void RoCEChannel::initialize() {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "RoCEChannel::initialize");
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "RoCEChannel: Initializing");
+
+  // Create completion queues
+  create_completion_queues();
+
+  // Preallocate receive buffers
+  preallocate_recv_buffers(RECV_RING_SIZE);
+
+  // Create Queue Pair
+  create_queue_pair();
+
+  // Initialize ring buffers (pre-allocated, NO allocation on hot path)
+  initialize_rx_ring_buffer(); // For receiving RDMA WRITEs
+  initialize_tx_ring_buffer(); // For sending responses
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "RoCEChannel: Initialization complete");
+}
+
+void RoCEChannel::cleanup() {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "RoCEChannel::cleanup");
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "RoCEChannel: Cleaning up");
+
+  // Unregister from flow switch
+  if (flow_switch_ && qp_) {
+    flow_switch_->remove_steering_rule(listen_port_);
+  }
+
+  // Destroy Queue Pair
+  if (qp_) {
+    ibv_destroy_qp(qp_);
+    qp_ = nullptr;
+  }
+
+  // Destroy Completion Queues
+  if (recv_cq_) {
+    ibv_destroy_cq(recv_cq_);
+    recv_cq_ = nullptr;
+  }
+
+  if (send_cq_) {
+    ibv_destroy_cq(send_cq_);
+    send_cq_ = nullptr;
+  }
+
+  // Free pre-allocated receive buffers and deregister MRs
+  for (RecvBuffer &rb : recv_buffers_) {
+    if (rb.mr)
+      ibv_dereg_mr(rb.mr);
+    if (rb.addr)
+      free(rb.addr);
+  }
+  recv_buffers_.clear();
+  buffer_id_map_.clear();
+}
+
+Buffer *RoCEChannel::acquire_buffer() {
+  // Acquire from pre-allocated TX ring buffer
+  if (!buffer_pool_ || !tx_ring_buffer_base_)
+    return nullptr;
+
+  // Find a free slot using round-robin search (O(1) amortized)
+  for (std::uint32_t i = 0; i < tx_num_slots_; ++i) {
+    std::size_t slot_idx = (tx_next_slot_ + i) % tx_num_slots_;
+    if (tx_slot_free_[slot_idx]) {
+      tx_slot_free_[slot_idx] = false; // Mark as allocated
+      tx_next_slot_ = (slot_idx + 1) % tx_num_slots_;
+
+      // Get a pre-allocated buffer wrapper from pool
+      Buffer *buffer = buffer_pool_->get_free_buffer();
+      if (!buffer) {
+        tx_slot_free_[slot_idx] = true; // Release slot
+        return nullptr;
+      }
+
+      // Point buffer wrapper to TX slot (zero-copy, just pointer assignment)
+      char *slot_addr = static_cast<char *>(tx_ring_buffer_base_) +
+                        (slot_idx * tx_slot_size_);
+      buffer->reset(slot_addr, slot_addr, tx_slot_size_, 0, 0, tx_slot_size_);
+
+      // Store slot_idx for deallocation
+      buffer_pool_->set_wr_id(buffer, slot_idx);
+
+      return buffer;
+    }
+  }
+
+  return nullptr; // No free slots
+}
+
+void RoCEChannel::release_buffer(Buffer *buffer) {
+  if (!buffer || !buffer_pool_)
+    return;
+
+  // Check if this buffer is from TX ring buffer
+  void *data = buffer->get_base_address();
+  uintptr_t addr = reinterpret_cast<uintptr_t>(data);
+  uintptr_t tx_start = reinterpret_cast<uintptr_t>(tx_ring_buffer_base_);
+  uintptr_t tx_end = tx_start + (tx_num_slots_ * tx_slot_size_);
+
+  if (tx_ring_buffer_base_ && addr >= tx_start && addr < tx_end) {
+    // TX buffer - try to free the slot (may already be freed if double-dealloc)
+    try {
+      std::uint64_t slot_idx = buffer_pool_->get_wr_id(buffer);
+      if (slot_idx < tx_num_slots_) {
+        tx_slot_free_[slot_idx] = true;
+      }
+    } catch (const std::exception &) {
+      // Buffer already deallocated or RX buffer in TX range (shouldn't happen)
+      // Just ignore - the slot may already be freed
+    }
+  }
+  // RX buffers are managed by ring buffer poller, not freed here
+
+  // Return buffer wrapper to pool (idempotent - safe to call multiple times)
+  buffer_pool_->return_buffer(buffer);
+}
+
+void RoCEChannel::create_completion_queues() {
+  auto *context = get_context();
+
+  // Create send completion queue
+  send_cq_ = ibv_create_cq(context, CQ_SIZE, nullptr, nullptr, 0);
+  if (!send_cq_)
+    throw std::runtime_error("Failed to create send CQ");
+
+  // Create receive completion queue
+  recv_cq_ = ibv_create_cq(context, CQ_SIZE, nullptr, nullptr, 0);
+  if (!recv_cq_) {
+    ibv_destroy_cq(send_cq_);
+    throw std::runtime_error("Failed to create receive CQ");
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "RoCEChannel: Created completion queues (size={})", CQ_SIZE);
+}
+
+void RoCEChannel::configure_queues(const std::vector<std::uint32_t> &) {
+  // No-op: Queue configuration is now handled via FlowSwitch
+  // This method is kept for Channel interface compatibility
+}
+
+void RoCEChannel::create_queue_pair() {
+  struct ibv_pd *pd = get_pd();
+
+  // Create Queue Pair (UC mode only)
+  struct ibv_qp_init_attr qp_attr = {};
+  qp_attr.send_cq = send_cq_;
+  qp_attr.recv_cq = recv_cq_;
+  qp_attr.qp_type = IBV_QPT_UC;
+  qp_attr.cap.max_send_wr = SEND_RING_SIZE;
+  qp_attr.cap.max_recv_wr = RECV_RING_SIZE;
+  qp_attr.cap.max_send_sge = 1;
+  qp_attr.cap.max_recv_sge = 1;
+  qp_attr.cap.max_inline_data = MAX_INLINE_DATA;
+
+  qp_ = ibv_create_qp(pd, &qp_attr);
+  if (!qp_)
+    throw std::runtime_error("Failed to create QP");
+
+  // UC mode: Wait for remote QP info before transitioning
+  // Will be done in set_remote_qp()
+  NVQLINK_LOG_INFO(
+      DOMAIN_CHANNEL,
+      "RoCEChannel: Created UC QP (qpn={}) - waiting for remote QP info",
+      qp_->qp_num);
+
+  // Register with flow switch for traffic steering
+  if (flow_switch_) {
+    flow_switch_->add_steering_rule(listen_port_, static_cast<void *>(qp_));
+  }
+}
+
+void RoCEChannel::preallocate_recv_buffers(std::uint32_t count) {
+  struct ibv_pd *pd = get_pd();
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "RoCEChannel: Pre-allocating {} receive buffers...", count);
+
+  recv_buffers_.reserve(count);
+  for (std::uint32_t i = 0; i < count; i++) {
+    RecvBuffer rb;
+
+    rb.addr = aligned_alloc(64, RECV_BUFFER_SIZE);
+    if (!rb.addr)
+      throw std::runtime_error("Failed to allocate receive buffer");
+
+    rb.mr = ibv_reg_mr(pd, rb.addr, RECV_BUFFER_SIZE, IBV_ACCESS_LOCAL_WRITE);
+    if (!rb.mr) {
+      free(rb.addr);
+      throw std::runtime_error("Failed to register receive buffer MR");
+    }
+
+    // Assign unique buffer ID
+    rb.buffer_id = i;
+
+    recv_buffers_.push_back(rb);
+    buffer_id_map_[rb.buffer_id] = &recv_buffers_[i];
+  }
+}
+
+void RoCEChannel::initial_post_recv_buffers(struct ibv_qp *qp) {
+  // Post all pre-allocated buffers to the QP
+  for (RecvBuffer &rb : recv_buffers_)
+    repost_recv_buffer(qp, &rb);
+}
+
+void RoCEChannel::repost_recv_buffer(struct ibv_qp *qp, RecvBuffer *rb) {
+  // Just post WR for existing buffer
+  struct ibv_sge sge = {};
+  sge.addr = reinterpret_cast<std::uint64_t>(rb->addr);
+  sge.length = RECV_BUFFER_SIZE;
+  sge.lkey = rb->mr->lkey;
+
+  struct ibv_recv_wr wr = {};
+  wr.wr_id = rb->buffer_id;
+  wr.sg_list = &sge;
+  wr.num_sge = 1;
+
+  struct ibv_recv_wr *bad_wr = nullptr;
+  int ret = ibv_post_recv(qp, &wr, &bad_wr);
+  if (ret != 0)
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "RoCEChannel: Failed to repost receive buffer: {}",
+                      strerror(errno));
+}
+
+void *RoCEChannel::allocate_and_register_ring_buffer(std::size_t size,
+                                                     int access_flags,
+                                                     struct ibv_mr **out_mr,
+                                                     const char *buffer_name) {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL,
+                     "RoCEChannel::allocate_and_register_ring_buffer");
+
+  // Step 1: Try to allocate with hugepages
+  void *buffer_base = mmap(nullptr, size, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
+
+  if (buffer_base == MAP_FAILED) {
+    NVQLINK_LOG_WARNING(DOMAIN_CHANNEL,
+                        "Warning: Failed to allocate hugepages for {} ring "
+                        "buffer, using regular pages",
+                        buffer_name);
+
+    // Step 2: Fallback to regular pages
+    buffer_base = mmap(nullptr, size, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    if (buffer_base == MAP_FAILED) {
+      throw std::runtime_error(std::string("Failed to allocate memory for ") +
+                               buffer_name + " ring buffer");
+    }
+  }
+
+  // Step 3: Register memory with RDMA
+  *out_mr = ibv_reg_mr(get_pd(), buffer_base, size, access_flags);
+
+  if (!*out_mr) {
+    munmap(buffer_base, size);
+    throw std::runtime_error(
+        std::string("Failed to register ") + buffer_name +
+        " ring buffer memory region: " + std::string(strerror(errno)));
+  }
+
+  return buffer_base;
+}
+
+void RoCEChannel::initialize_rx_ring_buffer() {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "RoCEChannel::initialize_rx_ring_buffer");
+
+  if (rx_ring_buffer_poller_)
+    return; // Already initialized
+
+  // Configure RX ring buffer
+  rx_ring_buffer_config_.num_slots = 1024;
+  rx_ring_buffer_config_.slot_size = 2048;
+  std::size_t ring_buffer_size = rx_ring_buffer_config_.total_size();
+
+  // Allocate and register RX ring buffer
+  // Needs REMOTE_WRITE for client to write to us via RDMA WRITE
+  rx_ring_buffer_base_ = allocate_and_register_ring_buffer(
+      ring_buffer_size, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE,
+      &rx_ring_buffer_mr_, "RX");
+
+  // Initialize RX ring buffer poller
+  rx_ring_buffer_poller_ = std::make_unique<RingBufferPoller>(
+      rx_ring_buffer_base_, rx_ring_buffer_config_);
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "✓ Initialized RX ring buffer:");
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "  Base: {}, Slots: {}, Size: {} MB",
+                   rx_ring_buffer_base_, rx_ring_buffer_config_.num_slots,
+                   ring_buffer_size / (1024 * 1024));
+}
+
+void RoCEChannel::initialize_tx_ring_buffer() {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "RoCEChannel::initialize_tx_ring_buffer");
+
+  if (tx_ring_buffer_base_)
+    return; // Already initialized
+
+  // Pre-allocate TX ring buffer (NO allocation on hot path!)
+  std::size_t tx_buffer_size = tx_num_slots_ * tx_slot_size_;
+
+  // Allocate and register TX ring buffer
+  // Only LOCAL_WRITE needed for TX (we write, then send via RDMA SEND)
+  tx_ring_buffer_base_ = allocate_and_register_ring_buffer(
+      tx_buffer_size, IBV_ACCESS_LOCAL_WRITE, &tx_ring_buffer_mr_, "TX");
+
+  // Pre-allocate slot tracking (all slots start free)
+  tx_slot_free_.resize(tx_num_slots_, true);
+  tx_next_slot_ = 0;
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "✓ Initialized TX ring buffer:");
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "  Base: {}, Slots: {}, Size: {} MB",
+                   tx_ring_buffer_base_, tx_num_slots_,
+                   tx_buffer_size / (1024 * 1024));
+}
+
+void RoCEChannel::register_memory(void *addr, std::size_t size) {
+  // Register memory with our protection domain
+  struct ibv_pd *pd = get_pd();
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "RoCEChannel: Registering memory: {} size {} MB", addr,
+                   size / (1024 * 1024));
+
+  struct ibv_mr *mr =
+      ibv_reg_mr(pd, addr, size,
+                 IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+                     IBV_ACCESS_REMOTE_READ);
+
+  if (!mr)
+    throw std::runtime_error("Failed to register memory region: " +
+                             std::string(strerror(errno)));
+
+  NVQLINK_LOG_INFO(
+      DOMAIN_CHANNEL,
+      "✓ Successfully registered {} MB memory with RoCE (lkey={}, rkey={})",
+      size / (1024 * 1024), mr->lkey, mr->rkey);
+}
+
+std::uint32_t RoCEChannel::receive_burst(Buffer **buffers,
+                                         std::uint32_t max_count) {
+  NVQLINK_TRACE_HOTPATH(DOMAIN_CHANNEL, "receive_burst");
+
+  std::uint32_t count = 0;
+  while (count < max_count) {
+    char *data = nullptr;
+    std::uint32_t len = 0;
+
+    // Poll for next packet from RX ring buffer (non-blocking)
+    if (!rx_ring_buffer_poller_->poll_next(&data, &len))
+      break; // No more packets available
+
+    // Wrap packet data into Buffer (zero-copy, just pointer)
+    // Use wrap_ring_buffer_data() because RDMA WRITE delivers raw payload
+    try {
+      buffers[count] = buffer_pool_->wrap_ring_buffer_data(data, len, count);
+      count++;
+    } catch (const std::exception &e) {
+      NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                        "RoCEChannel: Failed to wrap buffer: {}", e.what());
+      break;
+    }
+  }
+
+  return count;
+}
+
+std::uint32_t RoCEChannel::send_burst(Buffer **buffers, std::uint32_t count) {
+  NVQLINK_TRACE_HOTPATH(DOMAIN_CHANNEL, "send_burst");
+
+  if (!qp_) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "RoCEChannel: No QP configured");
+    return 0;
+  }
+
+  if (!remote_qp_set_) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "RoCEChannel: Cannot send - remote QP not configured");
+    return 0;
+  }
+
+  if (!tx_ring_buffer_mr_ && !rx_ring_buffer_mr_) {
+    NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                      "RoCEChannel: No ring buffers registered");
+    return 0;
+  }
+
+  std::uint32_t sent = 0;
+
+  for (std::uint32_t i = 0; i < count; i++) {
+    void *response_data = buffers[i]->get_data();
+    std::size_t response_len = buffers[i]->get_data_length();
+
+    // Determine which ring buffer this data is in and use correct lkey
+    // TX ring buffer: for buffers allocated via allocate_buffer()
+    // RX ring buffer: for buffers received and reused (Daemon pattern)
+    uintptr_t addr = reinterpret_cast<uintptr_t>(response_data);
+    uintptr_t tx_start = reinterpret_cast<uintptr_t>(tx_ring_buffer_base_);
+    uintptr_t tx_end = tx_start + (tx_num_slots_ * tx_slot_size_);
+    uintptr_t rx_start = reinterpret_cast<uintptr_t>(rx_ring_buffer_base_);
+    uintptr_t rx_end = rx_start + rx_ring_buffer_config_.total_size();
+
+    uint32_t lkey;
+    if (tx_ring_buffer_base_ && addr >= tx_start && addr < tx_end) {
+      lkey = tx_ring_buffer_mr_->lkey; // TX buffer (Channel/Stream mode)
+    } else if (rx_ring_buffer_base_ && addr >= rx_start && addr < rx_end) {
+      lkey = rx_ring_buffer_mr_->lkey; // RX buffer reuse (Daemon mode)
+    } else {
+      NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                        "RoCEChannel: Buffer not in any ring buffer");
+      continue;
+    }
+
+    // Post RDMA SEND with correct lkey
+    struct ibv_sge sge = {};
+    sge.addr = reinterpret_cast<uint64_t>(response_data);
+    sge.length = response_len;
+    sge.lkey = lkey;
+
+    struct ibv_send_wr wr = {};
+    wr.wr_id = i; // Simple ID for tracking
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_SEND;
+    wr.send_flags = IBV_SEND_SIGNALED; // Request completion notification
+
+    struct ibv_send_wr *bad_wr = nullptr;
+    int ret = ibv_post_send(qp_, &wr, &bad_wr);
+    if (ret != 0) {
+      NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                        "RoCEChannel: Failed to post RDMA SEND: {}",
+                        strerror(errno));
+      // Ownership semantics: send_burst takes ownership even on failure
+      release_buffer(buffers[i]);
+      continue;
+    }
+
+    NVQLINK_LOG_DEBUG(DOMAIN_CHANNEL,
+                      "[RoCE TX] Sent RDMA SEND: {} bytes (qpn={})",
+                      response_len, qp_->qp_num);
+    sent++;
+
+    // Poll for send completion immediately (blocking)
+    struct ibv_wc wc;
+    int n = 0;
+    while (n == 0)
+      n = ibv_poll_cq(send_cq_, 1, &wc);
+
+    if (n < 0 || wc.status != IBV_WC_SUCCESS) {
+      NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                        "RoCEChannel: Send completion failed: {}",
+                        (n < 0 ? "poll error" : ibv_wc_status_str(wc.status)));
+    }
+
+    // Ownership semantics: send_burst owns buffer, releases after TX completes
+    release_buffer(buffers[i]);
+  }
+
+  return sent;
+}
+
+void RoCEChannel::transition_qp_to_rts(struct ibv_qp *qp) {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "RoCEChannel::transition_qp_to_rts");
+
+  if (!remote_qp_set_)
+    throw std::runtime_error(
+        "Cannot transition UC QP to RTS: remote QP not set");
+
+  auto port_num = get_port_num();
+
+  // Step 1: RESET → INIT
+  struct ibv_qp_attr attr = {};
+  attr.qp_state = IBV_QPS_INIT;
+  attr.pkey_index = 0;
+  attr.port_num = port_num;
+  attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE;
+
+  int mask =
+      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
+  int ret = ibv_modify_qp(qp, &attr, mask);
+  if (ret != 0)
+    throw std::runtime_error("Failed to transition UC QP to INIT");
+
+  // Step 2: INIT → RTR (requires remote QP info for UC!)
+  std::memset(&attr, 0, sizeof(attr));
+  attr.qp_state = IBV_QPS_RTR;
+  attr.path_mtu = IBV_MTU_1024; // Or query from port
+  attr.dest_qp_num = remote_qpn_;
+  attr.rq_psn = 0; // Expected receive PSN
+
+  // Address vector for RoCEv2
+  attr.ah_attr.dlid = 0; // Not used in RoCEv2
+  attr.ah_attr.sl = 0;
+  attr.ah_attr.src_path_bits = 0;
+  attr.ah_attr.port_num = port_num;
+  attr.ah_attr.is_global = 1; // Must be 1 for RoCEv2
+  attr.ah_attr.grh.dgid = remote_gid_;
+  attr.ah_attr.grh.sgid_index = 1; // Use GID index 1 for Soft-RoCE
+  attr.ah_attr.grh.hop_limit = 64;
+
+  mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+         IBV_QP_RQ_PSN;
+  ret = ibv_modify_qp(qp, &attr, mask);
+  if (ret != 0)
+    throw std::runtime_error("Failed to transition UC QP to RTR");
+
+  // Step 3: RTR → RTS
+  std::memset(&attr, 0, sizeof(attr));
+  attr.qp_state = IBV_QPS_RTS;
+  attr.sq_psn = 0; // Starting send PSN
+
+  mask = IBV_QP_STATE | IBV_QP_SQ_PSN;
+  ret = ibv_modify_qp(qp, &attr, mask);
+  if (ret != 0)
+    throw std::runtime_error("Failed to transition UC QP to RTS");
+
+  NVQLINK_LOG_INFO(
+      DOMAIN_CHANNEL,
+      "RoCEChannel: UC QP transitioned to RTS (qpn={}, remote_qpn={})",
+      qp->qp_num, remote_qpn_);
+}
+
+RoCEChannel::ConnectionParams RoCEChannel::get_connection_params() const {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "RoCEChannel::get_connection_params");
+
+  ConnectionParams params = {};
+
+  // QPN from queue pair
+  if (qp_)
+    params.qpn = qp_->qp_num;
+
+  params.psn = 0; // Starting PSN
+  params.lid = 0; // Not used in RoCEv2
+
+  // Get local GID (use index 1 for Soft-RoCE, 0 often doesn't work)
+  int ret = ibv_query_gid(get_context(), get_port_num(),
+                          1, // GID index (use 1 for Soft-RoCE, not 0)
+                          &params.gid);
+  if (ret != 0) {
+    NVQLINK_LOG_WARNING(
+        DOMAIN_CHANNEL,
+        "Warning: Failed to query GID at index 1, trying index 0");
+    // Fallback to index 0 if index 1 fails
+    ret = ibv_query_gid(get_context(), get_port_num(), 0, &params.gid);
+    if (ret != 0)
+      NVQLINK_LOG_ERROR(DOMAIN_CHANNEL, "Error: Failed to query GID");
+  }
+
+  // Memory region info (for RDMA WRITE target - client writes to RX ring
+  // buffer)
+  if (rx_ring_buffer_base_ != nullptr && rx_ring_buffer_mr_ != nullptr) {
+    params.vaddr = reinterpret_cast<std::uint64_t>(rx_ring_buffer_base_);
+    params.rkey = rx_ring_buffer_mr_->rkey;
+    params.num_slots = rx_ring_buffer_config_.num_slots;
+    params.slot_size = rx_ring_buffer_config_.slot_size;
+  } else {
+    throw std::runtime_error(
+        "RX ring buffer not initialized - cannot export connection params");
+  }
+
+  return params;
+}
+
+void RoCEChannel::set_remote_qp(std::uint32_t remote_qpn,
+                                const union ibv_gid &remote_gid) {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "RoCEChannel::set_remote_qp");
+
+  remote_qpn_ = remote_qpn;
+  remote_gid_ = remote_gid;
+  remote_qp_set_ = true;
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "RoCEChannel: Set remote QP (qpn={})",
+                   remote_qpn_);
+
+  // Transition QP to RTS
+  if (qp_)
+    transition_qp_to_rts(qp_);
+
+  // Now that QP is in RTS, post all pre-allocated receive buffers
+  if (qp_)
+    initial_post_recv_buffers(qp_);
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "RoCEChannel: Posted {} receive buffers (after UC "
+                   "connection established)",
+                   RECV_RING_SIZE);
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/channels/roce/verbs_context.cpp
+++ b/realtime/lib/network/channels/roce/verbs_context.cpp
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/channels/roce/verbs_context.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+#include "cudaq/nvqlink/utils/instrumentation/profiler.h"
+
+#include <cstring>
+#include <stdexcept>
+
+namespace cudaq::nvqlink {
+
+VerbsContext::VerbsContext(const std::string &device_name)
+    : device_name_(device_name) {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "VerbsContext::VerbsContext");
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "VerbsContext: Initializing for device {}",
+                   device_name_);
+
+  open_device();
+  create_protection_domain();
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "VerbsContext: Successfully initialized for device {}",
+                   device_name_);
+}
+
+VerbsContext::~VerbsContext() {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "VerbsContext::~VerbsContext");
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "VerbsContext: Cleaning up device {}",
+                   device_name_);
+
+  // Deallocate Protection Domain
+  if (pd_) {
+    ibv_dealloc_pd(pd_);
+    pd_ = nullptr;
+  }
+
+  // Close device context
+  if (context_) {
+    ibv_close_device(context_);
+    context_ = nullptr;
+  }
+}
+
+void VerbsContext::open_device() {
+  // Get list of available InfiniBand devices
+  int num_devices;
+  struct ibv_device **dev_list = ibv_get_device_list(&num_devices);
+  if (!dev_list || num_devices == 0)
+    throw std::runtime_error("No InfiniBand devices found");
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "VerbsContext: Found {} InfiniBand device(s)", num_devices);
+
+  // Find device by name (device_name_)
+  struct ibv_device *device = nullptr;
+  for (int i = 0; i < num_devices; i++) {
+    const char *dev_name = ibv_get_device_name(dev_list[i]);
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "  [{}] {}", i, dev_name);
+
+    if (device_name_ == dev_name) {
+      device = dev_list[i];
+      break;
+    }
+  }
+
+  // If not found by name, try using index
+  if (!device) {
+    try {
+      int dev_idx = std::stoi(device_name_);
+      if (dev_idx >= 0 && dev_idx < num_devices) {
+        device = dev_list[dev_idx];
+        NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                         "VerbsContext: Using device index {}: {}", dev_idx,
+                         ibv_get_device_name(device));
+      }
+    } catch (const std::invalid_argument &) {
+      // Not a number, device not found
+    }
+  }
+
+  if (!device) {
+    ibv_free_device_list(dev_list);
+    throw std::runtime_error("Device '" + device_name_ + "' not found");
+  }
+
+  // Open device context
+  context_ = ibv_open_device(device);
+  if (!context_) {
+    ibv_free_device_list(dev_list);
+    throw std::runtime_error("Failed to open device '" + device_name_ + "'");
+  }
+
+  // Free device list immediately after opening device - no longer needed
+  ibv_free_device_list(dev_list);
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "VerbsContext: Opened device {}",
+                   ibv_get_device_name(context_->device));
+}
+
+void VerbsContext::create_protection_domain() {
+  pd_ = ibv_alloc_pd(context_);
+  if (!pd_)
+    throw std::runtime_error("Failed to allocate Protection Domain");
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "VerbsContext: Created Protection Domain");
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/memory/buffer.cpp
+++ b/realtime/lib/network/memory/buffer.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/memory/buffer.h"
+
+#include <stdexcept>
+
+using namespace cudaq::nvqlink;
+
+Buffer::Buffer(void *base_addr, std::size_t total_size, std::size_t headroom,
+               std::size_t tailroom)
+    : base_addr_(base_addr), total_size_(total_size), headroom_(headroom),
+      tailroom_(tailroom), data_len_(0) {
+
+  // Data starts after headroom
+  data_ptr_ = static_cast<char *>(base_addr_) + headroom_;
+}
+
+void *Buffer::prepend(std::size_t bytes) {
+  if (bytes > headroom_) {
+    throw std::runtime_error("Insufficient headroom for prepend");
+  }
+
+  data_ptr_ = static_cast<char *>(data_ptr_) - bytes;
+  data_len_ += bytes;
+  headroom_ -= bytes;
+
+  return data_ptr_;
+}

--- a/realtime/lib/network/memory/memory_pool.cpp
+++ b/realtime/lib/network/memory/memory_pool.cpp
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/memory/memory_pool.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+#include "cudaq/nvqlink/utils/instrumentation/profiler.h"
+
+#include <cassert>
+#include <cerrno>
+#include <cstring>
+#ifdef __CUDACC__
+#include <cuda_runtime.h>
+#endif
+#include <stdexcept>
+#include <sys/mman.h>
+#include <unistd.h>
+
+using namespace cudaq::nvqlink;
+
+MemoryPool::MemoryPool(const MemoryConfig &config, DatapathMode mode)
+    : config_(config), mode_(mode) {
+  NVQLINK_TRACE_FULL(DOMAIN_MEMORY, "MemoryPool::constructor");
+
+  total_buffers_ = config_.pool_size_bytes / config_.buffer_size_bytes;
+
+  NVQLINK_TRACE_COUNTER("pool_size_bytes", config_.pool_size_bytes);
+  NVQLINK_TRACE_COUNTER("buffer_size_bytes", config_.buffer_size_bytes);
+  NVQLINK_TRACE_COUNTER("total_buffers", total_buffers_);
+
+  if (mode_ == DatapathMode::CPU) {
+    allocate_cpu_memory();
+  } else {
+#ifdef __CUDACC__
+    allocate_gpu_memory();
+#else
+    throw std::runtime_error("GPU mode requested but CUDA is not available");
+#endif
+  }
+}
+
+MemoryPool::~MemoryPool() {
+  NVQLINK_TRACE_FULL(DOMAIN_MEMORY, "MemoryPool::destructor");
+
+  // Delete all Buffer objects first (allocated with 'new')
+  for (Buffer *buffer : free_buffers_)
+    buffer->~Buffer();
+
+  if (mode_ == DatapathMode::CPU) {
+    if (base_addr_) {
+      if (using_hugepages_)
+        munmap(base_addr_, config_.pool_size_bytes);
+      else
+        std::free(base_addr_);
+    }
+    return;
+  }
+
+  assert(mode_ == DatapathMode::GPU);
+#ifdef __CUDACC__
+  if (gpu_base_addr_)
+    cudaFree(gpu_base_addr_);
+#endif
+}
+
+void MemoryPool::allocate_cpu_memory() {
+  // Try to allocate hugepage-backed memory for optimal performance
+  // Hugepages provide:
+  // 1. Better TLB efficiency (fewer page table walks)
+  // 2. Physical memory contiguity (important for DMA)
+  // 3. Reduced page fault overhead
+
+  NVQLINK_LOG_INFO(
+      DOMAIN_MEMORY,
+      "MemoryPool: Attempting to allocate {} MB using hugepages...",
+      config_.pool_size_bytes / (1024 * 1024));
+
+  base_addr_ =
+      mmap(nullptr, config_.pool_size_bytes, PROT_READ | PROT_WRITE,
+           MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, -1, 0);
+
+  if (base_addr_ == MAP_FAILED) {
+    // Hugepage allocation failed, fall back to regular allocation
+    NVQLINK_LOG_WARNING(DOMAIN_MEMORY,
+                        "Warning: Hugepage allocation failed (errno={}). "
+                        "Falling back to regular pages.",
+                        errno);
+    NVQLINK_LOG_WARNING(DOMAIN_MEMORY, "  Possible causes:");
+    NVQLINK_LOG_WARNING(DOMAIN_MEMORY,
+                        "    - Insufficient hugepages configured");
+    NVQLINK_LOG_WARNING(
+        DOMAIN_MEMORY,
+        "    - Run: echo 1024 > "
+        "/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages");
+    NVQLINK_LOG_WARNING(DOMAIN_MEMORY,
+                        "    - Or add 'hugepagesz=2M hugepages=1024' to kernel "
+                        "boot parameters");
+
+    base_addr_ = std::aligned_alloc(4096, config_.pool_size_bytes);
+    if (!base_addr_) {
+      throw std::runtime_error(
+          "Failed to allocate CPU memory pool (regular pages also failed)");
+    }
+    using_hugepages_ = false;
+    NVQLINK_LOG_INFO(
+        DOMAIN_MEMORY,
+        "MemoryPool: Using regular 4KB pages (performance will be reduced)");
+  } else {
+    using_hugepages_ = true;
+    // Advise kernel not to fork this memory (performance optimization)
+    madvise(base_addr_, config_.pool_size_bytes, MADV_DONTFORK);
+    NVQLINK_LOG_INFO(
+        DOMAIN_MEMORY,
+        "MemoryPool: Successfully allocated {} MB using 2MB hugepages",
+        config_.pool_size_bytes / (1024 * 1024));
+  }
+
+  std::memset(base_addr_, 0, config_.pool_size_bytes);
+
+  // Create buffer objects
+  char *ptr = static_cast<char *>(base_addr_);
+  for (std::size_t i = 0; i < total_buffers_; ++i) {
+    auto *buffer = new Buffer(ptr, config_.buffer_size_bytes,
+                              config_.headroom_bytes, config_.tailroom_bytes);
+    free_buffers_.push_back(buffer);
+    ptr += config_.buffer_size_bytes;
+  }
+
+  NVQLINK_LOG_INFO(DOMAIN_MEMORY,
+                   "MemoryPool: Created {} buffers of {} bytes each",
+                   total_buffers_, config_.buffer_size_bytes);
+}
+
+#ifdef __CUDACC__
+void MemoryPool::allocate_gpu_memory() {
+  cudaError_t err = cudaMalloc(&gpu_base_addr_, config_.pool_size_bytes);
+  if (err != cudaSuccess) {
+    throw std::runtime_error("Failed to allocate GPU memory pool");
+  }
+
+  cudaMemset(gpu_base_addr_, 0, config_.pool_size_bytes);
+
+  // Create buffer objects (metadata on host, data on GPU)
+  char *ptr = static_cast<char *>(gpu_base_addr_);
+  for (std::size_t i = 0; i < total_buffers_; ++i) {
+    auto *buffer = new Buffer(ptr, config_.buffer_size_bytes,
+                              config_.headroom_bytes, config_.tailroom_bytes);
+    free_buffers_.push_back(buffer);
+    ptr += config_.buffer_size_bytes;
+  }
+}
+#endif
+
+Buffer *MemoryPool::allocate() {
+  NVQLINK_TRACE_MEMORY("allocate");
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (free_buffers_.empty()) {
+    NVQLINK_TRACE_MARK_ERROR(DOMAIN_MEMORY, "POOL_EXHAUSTED");
+    return nullptr; // Pool exhausted
+  }
+  Buffer *buffer = free_buffers_.back();
+  free_buffers_.pop_back();
+  return buffer;
+}
+
+void MemoryPool::deallocate(Buffer *buffer) {
+  NVQLINK_TRACE_MEMORY("deallocate");
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  free_buffers_.push_back(buffer);
+
+  // Track pool pressure: low availability = high pressure
+  size_t available = free_buffers_.size();
+  uint64_t pressure = (total_buffers_ - available) * 100 / total_buffers_;
+  NVQLINK_TRACE_COUNTER("pool_pressure_percent", pressure);
+}
+
+std::size_t MemoryPool::get_available_buffers() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return free_buffers_.size();
+}

--- a/realtime/lib/network/serialization/gpu_input_stream.cu
+++ b/realtime/lib/network/serialization/gpu_input_stream.cu
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/gpu_channel.h"
+#include "cudaq/nvqlink/network/serialization/gpu_input_stream.h"
+
+namespace cudaq::nvqlink {
+
+// Channel mode constructor
+__device__ GPUInputStream::GPUInputStream(GPUChannel &channel)
+    : channel_(&channel), current_packet_(nullptr), read_ptr_(nullptr),
+      read_end_(nullptr), bytes_read_(0), error_(false) {
+  // Don't fetch packet yet - lazy initialization
+}
+
+__device__ bool GPUInputStream::available() {
+  // Buffer mode: check if we have data
+  if (!channel_) {
+    return read_ptr_ < read_end_;
+  }
+
+  // Channel mode: check if we have data in current packet
+  if (current_packet_ && read_ptr_ < read_end_) {
+    return true;
+  }
+
+  // Try to get a new packet (non-blocking)
+  fetch_next_packet();
+
+  return current_packet_ != nullptr;
+}
+
+__device__ void GPUInputStream::fetch_next_packet() {
+  if (!channel_) {
+    return; // Buffer mode - no fetching
+  }
+
+  // Release old packet if any
+  if (current_packet_) {
+    channel_->release_buffer(current_packet_);
+    current_packet_ = nullptr;
+    read_ptr_ = nullptr;
+    read_end_ = nullptr;
+  }
+
+  // Try to receive new packet (non-blocking)
+  void *packet_data = nullptr;
+  size_t packet_size = 0;
+
+  if (channel_->receive_packet(&packet_data, &packet_size)) {
+    current_packet_ = packet_data;
+    read_ptr_ = static_cast<const char *>(packet_data);
+    read_end_ = read_ptr_ + packet_size;
+  }
+}
+
+__device__ void GPUInputStream::ensure_data(size_t needed) {
+  // Check if we have enough data in current buffer/packet
+  if (read_ptr_ && read_ptr_ + needed <= read_end_) {
+    return; // Have enough data
+  }
+
+  // In Channel mode, try to fetch next packet if at end
+  if (channel_ && (!current_packet_ || read_ptr_ >= read_end_)) {
+    fetch_next_packet();
+  }
+
+  // Check again after fetching
+  if (!read_ptr_ || read_ptr_ + needed > read_end_) {
+    error_ = true; // Not enough data
+  }
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/serialization/gpu_output_stream.cu
+++ b/realtime/lib/network/serialization/gpu_output_stream.cu
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/gpu_channel.h"
+#include "cudaq/nvqlink/network/serialization/gpu_output_stream.h"
+
+namespace cudaq::nvqlink {
+
+// Channel mode constructor
+__device__ GPUOutputStream::GPUOutputStream(GPUChannel &channel)
+    : channel_(&channel), current_buffer_(nullptr), buffer_start_(nullptr),
+      write_ptr_(nullptr), write_end_(nullptr), bytes_written_(0),
+      error_(false) {
+  // Allocate first buffer
+  allocate_buffer();
+}
+
+__device__ void GPUOutputStream::write_bytes(const void *src, size_t len) {
+  ensure_space(len);
+
+  if (error_) {
+    return;
+  }
+
+  // Manual copy in device code
+  const char *s = static_cast<const char *>(src);
+  for (size_t i = 0; i < len; ++i) {
+    write_ptr_[i] = s[i];
+  }
+
+  write_ptr_ += len;
+  bytes_written_ += len;
+}
+
+__device__ void GPUOutputStream::flush() {
+  if (!channel_) {
+    return; // Buffer mode - no flushing
+  }
+
+  if (!current_buffer_ || bytes_written_ == 0) {
+    return; // Nothing to flush
+  }
+
+  // Send packet via channel
+  bool sent = channel_->send_packet(current_buffer_, bytes_written_);
+
+  if (!sent) {
+    error_ = true;
+    return;
+  }
+
+  // Reset state (buffer is now owned by channel)
+  current_buffer_ = nullptr;
+  write_ptr_ = nullptr;
+  write_end_ = nullptr;
+  buffer_start_ = nullptr;
+  bytes_written_ = 0;
+
+  // Allocate new buffer for next write
+  allocate_buffer();
+}
+
+__device__ void GPUOutputStream::allocate_buffer() {
+  if (!channel_) {
+    return; // Buffer mode - no allocation
+  }
+
+  // Request buffer from channel
+  current_buffer_ = channel_->allocate_buffer(2048); // Default size
+
+  if (!current_buffer_) {
+    error_ = true;
+    return;
+  }
+
+  buffer_start_ = static_cast<char *>(current_buffer_);
+  write_ptr_ = buffer_start_;
+  write_end_ = write_ptr_ + 2048; // TODO: Get actual capacity from channel
+  bytes_written_ = 0;
+}
+
+__device__ void GPUOutputStream::ensure_space(size_t needed) {
+  // Check if we have enough space in current buffer
+  if (write_ptr_ && write_ptr_ + needed <= write_end_) {
+    return; // Have enough space
+  }
+
+  // In Channel mode, flush and get new buffer
+  if (channel_ && bytes_written_ > 0) {
+    flush(); // This allocates a new buffer
+  }
+
+  // Check again after flushing
+  if (!write_ptr_ || write_ptr_ + needed > write_end_) {
+    error_ = true;
+  }
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/serialization/input_stream.cpp
+++ b/realtime/lib/network/serialization/input_stream.cpp
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/serialization/input_stream.h"
+#include "cudaq/nvqlink/network/channel.h"
+
+#include <cstring>
+
+namespace cudaq::nvqlink {
+
+// Backend mode constructor (persistent)
+InputStream::InputStream(Channel &channel) : channel_(&channel) {
+  // Don't fetch packet yet - lazy initialization
+}
+
+// Buffer mode constructor (temporary, for Daemon RPC)
+InputStream::InputStream(const void *data, std::size_t size)
+    : read_ptr_(static_cast<const char *>(data)), read_end_(read_ptr_ + size) {}
+
+InputStream::~InputStream() {
+  // Release current packet if in Backend mode
+  if (channel_ && current_packet_)
+    channel_->release_buffer(current_packet_);
+}
+
+bool InputStream::available() {
+  // Buffer mode: check if we have data
+  if (!channel_)
+    return read_ptr_ < read_end_;
+
+  // Backend mode: check if we have data in current packet
+  if (current_packet_ && read_ptr_ < read_end_)
+    return true;
+
+  // Try to get a new packet (non-blocking)
+  fetch_next_packet();
+
+  return current_packet_ != nullptr;
+}
+
+void InputStream::read_bytes(void *dest, std::size_t len) {
+  ensure_data(len);
+
+  std::memcpy(dest, read_ptr_, len);
+  read_ptr_ += len;
+  bytes_read_ += len;
+}
+
+std::string InputStream::read_string() {
+  // Read length prefix
+  std::uint32_t len = read<std::uint32_t>();
+
+  if (len == 0)
+    return std::string();
+
+  ensure_data(len);
+
+  std::string result(read_ptr_, read_ptr_ + len);
+  read_ptr_ += len;
+  bytes_read_ += len;
+
+  return result;
+}
+
+void InputStream::skip(std::size_t len) {
+  ensure_data(len);
+  read_ptr_ += len;
+  bytes_read_ += len;
+}
+
+std::size_t InputStream::remaining() const {
+  if (!read_ptr_ || read_ptr_ >= read_end_)
+    return 0;
+  return static_cast<std::size_t>(read_end_ - read_ptr_);
+}
+
+bool InputStream::at_end() const {
+  return !read_ptr_ || read_ptr_ >= read_end_;
+}
+
+void InputStream::fetch_next_packet() {
+  if (!channel_)
+    return; // Buffer mode - no fetching
+
+  // Release old packet if any
+  if (current_packet_) {
+    channel_->release_buffer(current_packet_);
+    current_packet_ = nullptr;
+    read_ptr_ = nullptr;
+    read_end_ = nullptr;
+  }
+
+  // Try to receive new packet (non-blocking)
+  Buffer *buffers[1];
+  uint32_t received = channel_->receive_burst(buffers, 1);
+  current_packet_ = (received > 0) ? buffers[0] : nullptr;
+
+  if (current_packet_) {
+    read_ptr_ = static_cast<const char *>(current_packet_->get_data());
+    read_end_ = read_ptr_ + current_packet_->get_data_length();
+  }
+}
+
+void InputStream::ensure_data(std::size_t needed) {
+  // Check if we have enough data in current buffer/packet
+  if (read_ptr_ && read_ptr_ + needed <= read_end_)
+    return; // Have enough data
+
+  // In Backend mode, try to fetch next packet if at end
+  if (channel_ && (!current_packet_ || read_ptr_ >= read_end_))
+    fetch_next_packet();
+
+  // Check again after fetching
+  if (!read_ptr_ || read_ptr_ + needed > read_end_) {
+    throw std::runtime_error("InputStream: insufficient data (need " +
+                             std::to_string(needed) + " bytes, have " +
+                             std::to_string(remaining()) + ")");
+  }
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/serialization/output_stream.cpp
+++ b/realtime/lib/network/serialization/output_stream.cpp
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/serialization/output_stream.h"
+#include "cudaq/nvqlink/network/channel.h"
+
+#include <cstring>
+
+namespace cudaq::nvqlink {
+
+// Backend mode constructor (persistent)
+OutputStream::OutputStream(Channel &channel) : channel_(&channel) {
+  // Lazy buffer acquisition - only acquire when writing
+  // acquire_buffer() will be called on first write
+}
+
+// Buffer mode constructor (temporary, for Daemon RPC)
+OutputStream::OutputStream(void *data, std::size_t capacity)
+    : buffer_start_(static_cast<char *>(data)), write_ptr_(buffer_start_),
+      write_end_(write_ptr_ + capacity) {}
+
+OutputStream::~OutputStream() {
+  // Flush any pending data in Backend mode
+  if (channel_) {
+    try {
+      if (current_buffer_ && bytes_written_ > 0)
+        flush();
+    } catch (...) {
+      // Ignore exceptions in destructor
+    }
+
+    // Release buffer if still held (we still own it)
+    if (current_buffer_)
+      channel_->release_buffer(current_buffer_);
+  }
+}
+
+void OutputStream::write_bytes(const void *src, std::size_t len) {
+  ensure_space(len);
+
+  std::memcpy(write_ptr_, src, len);
+  write_ptr_ += len;
+  bytes_written_ += len;
+}
+
+void OutputStream::write_string(const std::string &str) {
+  // Write length prefix
+  std::uint32_t len = static_cast<std::uint32_t>(str.size());
+  write(len);
+
+  // Write string data
+  if (len > 0) {
+    ensure_space(len);
+    std::memcpy(write_ptr_, str.data(), len);
+    write_ptr_ += len;
+    bytes_written_ += len;
+  }
+}
+
+void OutputStream::flush() {
+  if (!channel_)
+    return; // Buffer mode - no flushing
+
+  if (!current_buffer_ || bytes_written_ == 0)
+    return; // Nothing to flush
+
+  // Set buffer length
+  current_buffer_->set_data_length(bytes_written_);
+
+  // Send packet - send_burst takes ownership of buffer (always)
+  channel_->send_burst(&current_buffer_, 1);
+
+  // Reset state (buffer ownership transferred to send_burst)
+  current_buffer_ = nullptr;
+  write_ptr_ = nullptr;
+  write_end_ = nullptr;
+  buffer_start_ = nullptr;
+  bytes_written_ = 0;
+
+  // Acquire new buffer for next write
+  acquire_buffer();
+}
+
+std::size_t OutputStream::remaining_capacity() const {
+  if (!write_ptr_ || !write_end_)
+    return 0;
+  return static_cast<std::size_t>(write_end_ - write_ptr_);
+}
+
+bool OutputStream::is_full() const { return remaining_capacity() == 0; }
+
+void OutputStream::acquire_buffer() {
+  if (!channel_)
+    return; // Buffer mode - no acquisition
+
+  current_buffer_ = channel_->acquire_buffer();
+
+  if (!current_buffer_)
+    throw std::runtime_error("OutputStream: failed to acquire buffer");
+
+  buffer_start_ = static_cast<char *>(current_buffer_->get_data());
+  write_ptr_ = buffer_start_;
+  write_end_ = write_ptr_ + current_buffer_->get_total_size();
+  bytes_written_ = 0;
+}
+
+void OutputStream::ensure_space(std::size_t needed) {
+  // Check if we have enough space in current buffer
+  if (write_ptr_ && write_ptr_ + needed <= write_end_)
+    return; // Have enough space
+
+  // In Channel mode, acquire buffer if we don't have one yet
+  if (channel_ && !current_buffer_) {
+    acquire_buffer();
+    if (write_ptr_ && write_ptr_ + needed <= write_end_)
+      return; // Now have enough space
+  }
+
+  // In Channel mode, flush and get new buffer if current is full
+  if (channel_ && bytes_written_ > 0)
+    flush(); // This acquires a new buffer
+
+  // Check again after flushing
+  if (!write_ptr_ || write_ptr_ + needed > write_end_) {
+    throw std::runtime_error("OutputStream: insufficient space (need " +
+                             std::to_string(needed) + " bytes, have " +
+                             std::to_string(remaining_capacity()) + ")");
+  }
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/network/steering/verbs_flow_switch.cpp
+++ b/realtime/lib/network/steering/verbs_flow_switch.cpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/steering/verbs_flow_switch.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+#include "cudaq/nvqlink/utils/instrumentation/profiler.h"
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <stdexcept>
+
+namespace cudaq::nvqlink {
+
+VerbsFlowSwitch::~VerbsFlowSwitch() {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "VerbsFlowSwitch::~VerbsFlowSwitch");
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Destroy all flow rules
+  for (auto &[port, flow] : flow_handles_) {
+    if (flow) {
+      ibv_destroy_flow(flow);
+      NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                       "VerbsFlowSwitch: Destroyed flow rule for UDP port {}",
+                       port);
+    }
+  }
+  flow_handles_.clear();
+}
+
+void VerbsFlowSwitch::add_steering_rule(uint16_t udp_port,
+                                        void *channel_handle) {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "VerbsFlowSwitch::add_steering_rule");
+
+  if (!channel_handle) {
+    throw std::invalid_argument("channel_handle cannot be null");
+  }
+
+  struct ibv_qp *qp = static_cast<struct ibv_qp *>(channel_handle);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Check if rule already exists
+  if (flow_handles_.find(udp_port) != flow_handles_.end()) {
+    throw std::runtime_error("Flow steering rule for UDP port " +
+                             std::to_string(udp_port) + " already exists");
+  }
+
+  // Query QP attributes to get port number
+  struct ibv_qp_attr qp_attr;
+  struct ibv_qp_init_attr init_attr;
+
+  int ret = ibv_query_qp(qp, &qp_attr, IBV_QP_PORT, &init_attr);
+  if (ret != 0) {
+    throw std::runtime_error("Failed to query QP attributes");
+  }
+
+  uint8_t port_num = qp_attr.port_num;
+
+  // Create flow specification for UDP port matching
+  // Structure: Ethernet -> IPv4 -> UDP
+  struct {
+    struct ibv_flow_attr attr;
+    struct ibv_flow_spec_eth eth;
+    struct ibv_flow_spec_ipv4 ipv4;
+    struct ibv_flow_spec_tcp_udp udp;
+  } __attribute__((packed)) flow_rule;
+
+  std::memset(&flow_rule, 0, sizeof(flow_rule));
+
+  // Flow attributes
+  flow_rule.attr.type = IBV_FLOW_ATTR_NORMAL;
+  flow_rule.attr.size = sizeof(flow_rule);
+  flow_rule.attr.priority = 0;
+  flow_rule.attr.num_of_specs = 3; // eth + ipv4 + udp
+  flow_rule.attr.port = port_num;
+  flow_rule.attr.flags = 0;
+
+  // Ethernet spec (match all)
+  flow_rule.eth.type = IBV_FLOW_SPEC_ETH;
+  flow_rule.eth.size = sizeof(struct ibv_flow_spec_eth);
+
+  // IPv4 spec (match all)
+  flow_rule.ipv4.type = IBV_FLOW_SPEC_IPV4;
+  flow_rule.ipv4.size = sizeof(struct ibv_flow_spec_ipv4);
+
+  // UDP spec (match destination port)
+  flow_rule.udp.type = IBV_FLOW_SPEC_UDP;
+  flow_rule.udp.size = sizeof(struct ibv_flow_spec_tcp_udp);
+  flow_rule.udp.val.dst_port = htons(udp_port); // Network byte order
+  flow_rule.udp.mask.dst_port = 0xFFFF;         // Match all 16 bits
+
+  // Create flow rule
+  struct ibv_flow *flow = ibv_create_flow(qp, &flow_rule.attr);
+
+  if (!flow) {
+    NVQLINK_LOG_WARNING(
+        DOMAIN_CHANNEL,
+        "VerbsFlowSwitch: Failed to create hardware flow rule for UDP port {} "
+        "(hardware steering may not be supported, traffic will use default QP)",
+        udp_port);
+    // Don't throw - hardware flow steering may not be supported
+    // Packets will be delivered to default QP and software can filter
+    return;
+  }
+
+  flow_handles_[udp_port] = flow;
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "VerbsFlowSwitch: Created flow rule: UDP port {} -> QP",
+                   udp_port);
+}
+
+void VerbsFlowSwitch::remove_steering_rule(uint16_t udp_port) {
+  NVQLINK_TRACE_FULL(DOMAIN_CHANNEL, "VerbsFlowSwitch::remove_steering_rule");
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = flow_handles_.find(udp_port);
+  if (it == flow_handles_.end()) {
+    NVQLINK_LOG_WARNING(DOMAIN_CHANNEL,
+                        "VerbsFlowSwitch: No flow rule found for UDP port {}",
+                        udp_port);
+    return;
+  }
+
+  if (it->second) {
+    ibv_destroy_flow(it->second);
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                     "VerbsFlowSwitch: Removed flow rule for UDP port {}",
+                     udp_port);
+  }
+
+  flow_handles_.erase(it);
+}
+
+} // namespace cudaq::nvqlink

--- a/realtime/lib/nvqlink.cpp
+++ b/realtime/lib/nvqlink.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/nvqlink.h"
+
+namespace cudaq::nvqlink {
+
+void initialize(const LQPUConfig &cfg) {
+  // TODO: Initialize based on new architecture
+  // Stub implementation for Phase 1
+}
+
+void shutdown() {
+  // TODO: Clean shutdown of all components
+  // Stub implementation for Phase 1
+}
+
+} // namespace cudaq::nvqlink
+
+extern "C" {
+
+// Old dispatch function removed - will be replaced by Daemon's FunctionRegistry
+// When needed, device_call will be routed through the Daemon
+}

--- a/realtime/lib/plugins/CMakeLists.txt
+++ b/realtime/lib/plugins/CMakeLists.txt
@@ -1,0 +1,54 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Find MLIR installation
+find_package(MLIR REQUIRED CONFIG)
+
+# Find CUDA-Q installation  
+set(CUDAQ_LIBRARY_MODE ON)
+find_package(CUDAQ REQUIRED CONFIG)
+
+message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+message(STATUS "Using CUDAQConfig.cmake in: ${CUDAQ_DIR}")
+
+# Set up CMake module paths
+set(CMAKE_MODULE_PATH
+  ${LLVM_CMAKE_DIR}
+  ${MLIR_CMAKE_DIR}
+  ${CUDAQ_CMAKE_DIR}
+  ${CMAKE_MODULE_PATH}
+)
+
+# Include necessary MLIR/LLVM modules
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+include(HandleLLVMOptions)
+
+# Set up include directories
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS}) 
+include_directories(${CUDAQ_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+# Add LLVM/MLIR definitions
+add_definitions(${LLVM_DEFINITIONS})
+
+# Get dialect and conversion libraries
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
+link_directories(${CUDAQ_INSTALL_DIR}/lib)
+
+include(HandleLLVMOptions)
+add_llvm_pass_plugin(DeviceCallShmem DeviceCallShmem.cpp)
+target_link_libraries(DeviceCallShmem PRIVATE CCDialect)
+
+set_target_properties(DeviceCallShmem PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+)

--- a/realtime/lib/plugins/DeviceCallShmem.cpp
+++ b/realtime/lib/plugins/DeviceCallShmem.cpp
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Support/Plugin.h"
+
+using namespace mlir;
+using namespace cudaq;
+
+namespace {
+
+struct ReplaceDeviceCall : public OpRewritePattern<cc::DeviceCallOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(cc::DeviceCallOp deviceCallOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = deviceCallOp.getLoc();
+    auto *ctx = rewriter.getContext();
+
+    auto parentModule = deviceCallOp->getParentOfType<ModuleOp>();
+
+    // Declare the intrinsic function if it doesn't exist
+    func::FuncOp intrinsicFunc = parentModule.lookupSymbol<func::FuncOp>(
+        "__nvqlink_device_call_dispatch");
+    if (!intrinsicFunc) {
+      // Create function type for the intrinsic
+      auto i64Type = rewriter.getI64Type();
+      auto i8Type = rewriter.getI8Type();
+      auto voidPtrType = cc::PointerType::get(i8Type);
+      auto charPtrType = cc::PointerType::get(i8Type);
+      auto voidPtrPtrType = cc::PointerType::get(voidPtrType);
+      auto i64PtrType = cc::PointerType::get(i64Type);
+
+      auto intrinsicFuncType = rewriter.getFunctionType(
+          {i64Type, charPtrType, i64Type, voidPtrPtrType, i64PtrType,
+           voidPtrType, i64Type},
+          {});
+
+      // Insert the function declaration at the module level
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(parentModule.getBody());
+
+      intrinsicFunc = rewriter.create<func::FuncOp>(
+          loc, "__nvqlink_device_call_dispatch", intrinsicFuncType);
+      intrinsicFunc.setPrivate();
+    }
+
+    // Get the original arguments and result type
+    ValueRange args = deviceCallOp.getArgs();
+    Type resultType = deviceCallOp.getResultTypes()[0];
+
+    // Get function symbol name
+    StringRef callbackName = deviceCallOp.getCallee();
+    std::size_t stringLength = callbackName.size() + 1;
+
+    // Get device ID (default to 0 if not specified)
+    Value deviceId;
+    if (deviceCallOp.getDevice()) {
+      deviceId = deviceCallOp.getDevice();
+    } else {
+      deviceId = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(0));
+    }
+
+    // Create types needed for the intrinsic function
+    auto i64Type = rewriter.getI64Type();
+    auto i8Type = rewriter.getI8Type();
+    auto voidPtrType = cc::PointerType::get(i8Type);
+    auto charPtrType = cc::PointerType::get(i8Type);
+    auto stringArrayType = cc::ArrayType::get(ctx, i8Type, stringLength);
+    auto stringPtrType = cc::PointerType::get(stringArrayType);
+
+    // Create string literal for callback name
+    Value callbackNameLiteral = rewriter.create<cc::CreateStringLiteralOp>(
+        loc, stringPtrType, rewriter.getStringAttr(callbackName));
+    Value callbackNameStr =
+        rewriter.create<cc::CastOp>(loc, charPtrType, callbackNameLiteral);
+
+    // Create number of arguments constant
+    Value numArgs = rewriter.create<arith::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(args.size()));
+
+    // Allocate arrays for argument pointers and sizes
+    auto voidPtrArrayType = cc::ArrayType::get(ctx, voidPtrType, args.size());
+    auto i64ArrayType = cc::ArrayType::get(ctx, i64Type, args.size());
+
+    Value argsPtrArray = rewriter.create<cc::AllocaOp>(loc, voidPtrArrayType);
+    Value argsSizeArray = rewriter.create<cc::AllocaOp>(loc, i64ArrayType);
+
+    // Allocate storage for each argument and populate arrays
+    for (size_t i = 0; i < args.size(); ++i) {
+      Value arg = args[i];
+      Type argType = arg.getType();
+
+      // Allocate storage for this argument
+      Value argAlloca = rewriter.create<cc::AllocaOp>(loc, argType);
+      rewriter.create<cc::StoreOp>(loc, arg, argAlloca);
+
+      // Cast to void pointer
+      Value argPtr = rewriter.create<cc::CastOp>(loc, voidPtrType, argAlloca);
+
+      // Compute pointer to array element for storing pointer
+      Value ptrIndex = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(i));
+      Value argsPtrArrayIdx = rewriter.create<cc::ComputePtrOp>(
+          loc, cc::PointerType::get(voidPtrType), argsPtrArray,
+          ValueRange{ptrIndex});
+      rewriter.create<cc::StoreOp>(loc, argPtr, argsPtrArrayIdx);
+
+      // Get size of argument type
+      Value argSize = rewriter.create<cc::SizeOfOp>(loc, i64Type, argType);
+
+      // Compute pointer to array element for storing size
+      Value argsSizeArrayIdx = rewriter.create<cc::ComputePtrOp>(
+          loc, cc::PointerType::get(i64Type), argsSizeArray,
+          ValueRange{ptrIndex});
+      rewriter.create<cc::StoreOp>(loc, argSize, argsSizeArrayIdx);
+    }
+
+    // Allocate result storage
+    Value resultAlloca = rewriter.create<cc::AllocaOp>(loc, resultType);
+    Value resultPtr =
+        rewriter.create<cc::CastOp>(loc, voidPtrType, resultAlloca);
+    Value resultSize = rewriter.create<cc::SizeOfOp>(loc, i64Type, resultType);
+
+    // Get pointers to the arrays (cast to void**)
+    Value argsPtrArrayPtr = rewriter.create<cc::CastOp>(
+        loc, cc::PointerType::get(voidPtrType), argsPtrArray);
+    Value argsSizeArrayPtr = rewriter.create<cc::CastOp>(
+        loc, cc::PointerType::get(i64Type), argsSizeArray);
+
+    // Create the intrinsic function call
+    // void __nvqlink_device_call_dispatch(std::size_t device_id,
+    //                                    const char *callbackName,
+    //                                    std::size_t num_args, void **args_vec,
+    //                                    std::size_t *args_sizes, void *result,
+    //                                    std::size_t result_size)
+    rewriter.create<func::CallOp>(
+        loc, "__nvqlink_device_call_dispatch", TypeRange{},
+        ValueRange{deviceId, callbackNameStr, numArgs, argsPtrArrayPtr,
+                   argsSizeArrayPtr, resultPtr, resultSize});
+
+    // Replace the original operation
+    rewriter.replaceOpWithNewOp<cc::LoadOp>(deviceCallOp, resultAlloca);
+    parentModule.dump();
+    return success();
+  }
+};
+
+/// Custom pass implementation
+class DeviceCallShmem
+    : public PassWrapper<DeviceCallShmem, OperationPass<func::FuncOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DeviceCallShmem)
+
+  StringRef getArgument() const override { return "device-call-shmem"; }
+
+  StringRef getDescription() const override { return ""; }
+
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+    auto ctx = funcOp.getContext();
+
+    RewritePatternSet patterns(ctx);
+    patterns.insert<ReplaceDeviceCall>(ctx);
+
+    ConversionTarget target(*ctx);
+    target.addLegalDialect<cc::CCDialect, func::FuncDialect,
+                           arith::ArithDialect>();
+    target.addIllegalOp<cc::DeviceCallOp>();
+
+    if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
+      funcOp.emitOpError("device call simple failed");
+      signalPassFailure();
+    }
+  }
+};
+
+} // anonymous namespace
+
+// Register the plugin with CUDA-Q
+CUDAQ_REGISTER_MLIR_PASS(DeviceCallShmem)

--- a/realtime/lib/qcs/CMakeLists.txt
+++ b/realtime/lib/qcs/CMakeLists.txt
@@ -1,0 +1,38 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+set(NVQLINK_QCS_SOURCES
+  qcs_device.cpp
+  control_server.cpp
+)
+
+add_library(nvqlink_qcs STATIC ${NVQLINK_QCS_SOURCES})
+
+target_include_directories(nvqlink_qcs
+  PUBLIC
+    $<BUILD_INTERFACE:${CUDAQ_NVQLINK_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Link dependencies
+target_link_libraries(nvqlink_qcs
+  PUBLIC
+    nvqlink_network  # For RoCEChannel
+    nvqlink_utils    # For logging
+)
+
+# QCS control plane requires nlohmann/json for UDP protocol
+# Fetch it if not already available
+include(FetchContent)
+FetchContent_Declare(json
+  URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+)
+FetchContent_MakeAvailable(json)
+
+target_link_libraries(nvqlink_qcs PUBLIC nlohmann_json::nlohmann_json)
+

--- a/realtime/lib/qcs/control_server.cpp
+++ b/realtime/lib/qcs/control_server.cpp
@@ -1,0 +1,258 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/qcs/control_server.h"
+#include "cudaq/nvqlink/network/channels/roce/roce_channel.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <errno.h>
+#include <stdexcept>
+#include <sys/socket.h>
+#include <unistd.h>
+
+using namespace cudaq::nvqlink;
+
+ControlServer::ControlServer(uint16_t port)
+    : port_(port), sock_fd_(-1), client_connected_(false) {
+  std::memset(&client_addr_, 0, sizeof(client_addr_));
+}
+
+ControlServer::~ControlServer() { stop(); }
+
+void ControlServer::start() {
+  if (sock_fd_ >= 0)
+    return; // Already started
+
+  // Create UDP socket
+  sock_fd_ = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock_fd_ < 0)
+    throw std::runtime_error("Failed to create UDP socket");
+
+  // Allow address reuse
+  int opt = 1;
+  setsockopt(sock_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+  // Bind to port
+  struct sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(port_);
+
+  if (bind(sock_fd_, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    int err = errno;
+    close(sock_fd_);
+    sock_fd_ = -1;
+    throw std::runtime_error("Failed to bind UDP socket to port " +
+                             std::to_string(port_) + ": " + strerror(err));
+  }
+
+  // Set receive timeout (1 second)
+  struct timeval tv;
+  tv.tv_sec = 1;
+  tv.tv_usec = 0;
+  setsockopt(sock_fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Control server listening on UDP port {}",
+                   port_);
+}
+
+void ControlServer::stop() {
+  if (sock_fd_ >= 0) {
+    close(sock_fd_);
+    sock_fd_ = -1;
+  }
+  client_connected_ = false;
+}
+
+bool ControlServer::exchange_connection_params(RoCEChannel *channel) {
+  if (!channel)
+    throw std::invalid_argument("Channel cannot be null");
+
+  if (sock_fd_ < 0)
+    throw std::runtime_error("Control server not started");
+
+  // Wait for DISCOVER packet from client
+  if (!client_connected_) {
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Waiting for QCS discovery packet...");
+
+    char buf[4096];
+    socklen_t len = sizeof(client_addr_);
+
+    // Poll with timeout to allow for cancellation
+    int max_attempts = 60; // 60 seconds max wait
+    for (int attempt = 0; attempt < max_attempts; ++attempt) {
+      ssize_t n = recvfrom(sock_fd_, buf, sizeof(buf), 0,
+                           (struct sockaddr *)&client_addr_, &len);
+
+      if (n < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+          continue; // Timeout, retry
+        throw std::runtime_error("Failed to receive discovery packet");
+      }
+
+      // Got discovery packet
+      NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "QCS discovered: {}:{}",
+                       inet_ntoa(client_addr_.sin_addr),
+                       ntohs(client_addr_.sin_port));
+      client_connected_ = true;
+      break;
+    }
+
+    if (!client_connected_) {
+      throw std::runtime_error("Timeout waiting for QCS discovery");
+    }
+  }
+
+  // Build server's connection params
+  auto params = channel->get_connection_params();
+  nlohmann::json j;
+  j["qpn"] = params.qpn;
+  j["psn"] = params.psn;
+  j["gid"] = gid_to_string(params.gid);
+  j["vaddr"] = params.vaddr;
+  j["rkey"] = params.rkey;
+  j["lid"] = params.lid;
+  j["num_slots"] = params.num_slots;
+  j["slot_size"] = params.slot_size;
+
+  std::string msg = j.dump();
+
+  // Send params to client (with retries)
+  const int max_retries = 5;
+  for (int retry = 0; retry < max_retries; ++retry) {
+    ssize_t sent =
+        sendto(sock_fd_, msg.c_str(), msg.length(), 0,
+               (struct sockaddr *)&client_addr_, sizeof(client_addr_));
+
+    if (sent < 0)
+      throw std::runtime_error("Failed to send channel params");
+
+    NVQLINK_LOG_INFO(
+        DOMAIN_CHANNEL,
+        "Sent channel params: QPN={}, GID={}, vaddr=0x{:x}, rkey=0x{:x}",
+        params.qpn, gid_to_string(params.gid), params.vaddr, params.rkey);
+
+    // Wait for ACK with client params
+    char buf[4096];
+    socklen_t len = sizeof(client_addr_);
+
+    ssize_t n = recvfrom(sock_fd_, buf, sizeof(buf), 0,
+                         (struct sockaddr *)&client_addr_, &len);
+
+    if (n < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        NVQLINK_LOG_WARNING(DOMAIN_CHANNEL, "No ACK received, retrying ({}/{})",
+                            retry + 1, max_retries);
+        continue;
+      }
+      throw std::runtime_error("Failed to receive ACK");
+    }
+
+    // Parse ACK
+    try {
+      std::string ack_str(buf, n);
+      auto client_j = nlohmann::json::parse(ack_str);
+
+      uint32_t client_qpn = client_j["qpn"];
+      std::string client_gid_str = client_j["gid"];
+
+      NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Received ACK: QPN={}, GID={}",
+                       client_qpn, client_gid_str);
+
+      // Configure QP with client params
+      union ibv_gid client_gid = string_to_gid(client_gid_str);
+      channel->set_remote_qp(client_qpn, client_gid);
+
+      NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                       "RDMA connection established successfully");
+      return true;
+
+    } catch (const std::exception &e) {
+      NVQLINK_LOG_WARNING(DOMAIN_CHANNEL, "Failed to parse ACK: {}", e.what());
+      continue;
+    }
+  }
+
+  NVQLINK_LOG_ERROR(DOMAIN_CHANNEL,
+                    "Failed to establish connection after {} retries",
+                    max_retries);
+  return false;
+}
+
+void ControlServer::send_command(const std::string &cmd,
+                                 const nlohmann::json &params) {
+  if (sock_fd_ < 0)
+    throw std::runtime_error("Control server not started");
+
+  if (!client_connected_)
+    throw std::runtime_error("No client connected");
+
+  nlohmann::json msg;
+  msg["cmd"] = cmd;
+  if (!params.empty())
+    msg["params"] = params;
+
+  std::string msg_str = msg.dump();
+  ssize_t sent = sendto(sock_fd_, msg_str.c_str(), msg_str.length(), 0,
+                        (struct sockaddr *)&client_addr_, sizeof(client_addr_));
+
+  if (sent < 0)
+    throw std::runtime_error("Failed to send command: " + cmd);
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Sent command: {}", cmd);
+}
+
+nlohmann::json
+ControlServer::wait_for_response(std::chrono::milliseconds timeout) {
+  if (sock_fd_ < 0)
+    throw std::runtime_error("Control server not started");
+
+  // Set timeout
+  struct timeval tv;
+  tv.tv_sec = timeout.count() / 1000;
+  tv.tv_usec = (timeout.count() % 1000) * 1000;
+  setsockopt(sock_fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+  char buf[4096];
+  socklen_t len = sizeof(client_addr_);
+
+  ssize_t n = recvfrom(sock_fd_, buf, sizeof(buf), 0,
+                       (struct sockaddr *)&client_addr_, &len);
+
+  if (n < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK)
+      throw std::runtime_error("Timeout waiting for response");
+    throw std::runtime_error("Failed to receive response");
+  }
+
+  std::string response_str(buf, n);
+  return nlohmann::json::parse(response_str);
+}
+
+std::string ControlServer::get_client_address() const {
+  if (!client_connected_)
+    return "not connected";
+
+  char buf[INET_ADDRSTRLEN];
+  inet_ntop(AF_INET, &client_addr_.sin_addr, buf, sizeof(buf));
+  return std::string(buf) + ":" + std::to_string(ntohs(client_addr_.sin_port));
+}
+
+std::string ControlServer::gid_to_string(const union ibv_gid &gid) {
+  char buf[64];
+  inet_ntop(AF_INET6, gid.raw, buf, sizeof(buf));
+  return buf;
+}
+
+union ibv_gid ControlServer::string_to_gid(const std::string &gid_str) {
+  union ibv_gid gid;
+  inet_pton(AF_INET6, gid_str.c_str(), gid.raw);
+  return gid;
+}

--- a/realtime/lib/qcs/qcs_device.cpp
+++ b/realtime/lib/qcs/qcs_device.cpp
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/qcs/qcs_device.h"
+#include "cudaq/nvqlink/network/channels/roce/roce_channel.h"
+#include "cudaq/nvqlink/qcs/control_server.h"
+#include "cudaq/nvqlink/utils/instrumentation/logger.h"
+
+#include <stdexcept>
+
+using namespace cudaq::nvqlink;
+
+QCSDevice::QCSDevice(const QCSDeviceConfig &config) : config_(config) {
+  if (!config_.is_valid())
+    throw std::invalid_argument("Invalid QCSDeviceConfig");
+
+  // Create control server with UDP socket
+  control_server_ = std::make_unique<ControlServer>(config_.control_port);
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "QCSDevice created: name={}, control_port={}", config_.name,
+                   config_.control_port);
+}
+
+QCSDevice::~QCSDevice() {
+  if (connected_) {
+    try {
+      disconnect();
+    } catch (...) {
+      // Don't throw from destructor
+    }
+  }
+}
+
+void QCSDevice::establish_connection(RoCEChannel *channel) {
+  if (!channel)
+    throw std::invalid_argument("Channel cannot be null");
+
+  if (connected_)
+    throw std::runtime_error("Already connected");
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Establishing connection to QCS '{}'...",
+                   config_.name);
+
+  // Start UDP control server
+  control_server_->start();
+
+  // Exchange RDMA connection parameters
+  bool success = control_server_->exchange_connection_params(channel);
+  if (!success)
+    throw std::runtime_error("Failed to exchange RDMA parameters with QCS");
+
+  // Save connection info from channel
+  auto params = channel->get_connection_params();
+  connection_info_.local_qpn = params.qpn;
+  connection_info_.ring_buffer_addr = params.vaddr;
+  connection_info_.rkey = params.rkey;
+
+  // Copy GID
+  std::memcpy(connection_info_.local_gid.data(), params.gid.raw,
+              sizeof(params.gid.raw));
+
+  connected_ = true;
+
+  NVQLINK_LOG_INFO(
+      DOMAIN_CHANNEL, "QCS connection established: QPN={}, vaddr=0x{:x}",
+      connection_info_.local_qpn, connection_info_.ring_buffer_addr);
+}
+
+void QCSDevice::disconnect() {
+  if (!connected_)
+    return;
+
+  try {
+    // Send STOP command to QCS
+    control_server_->send_command("STOP");
+    NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Sent STOP command to QCS");
+  } catch (const std::exception &e) {
+    NVQLINK_LOG_WARNING(DOMAIN_CHANNEL, "Failed to send STOP command: {}",
+                        e.what());
+  }
+
+  control_server_->stop();
+  connected_ = false;
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Disconnected from QCS");
+}
+
+void QCSDevice::upload_program(const std::vector<std::byte> &binary) {
+  if (!connected_)
+    throw std::runtime_error("Not connected to QCS");
+
+  // TODO: Implement program upload
+  // This is a stub - actual implementation depends on:
+  // 1. Program format (LLVM IR, custom ISA, etc.)
+  // 2. Transfer mechanism (UDP chunks, separate channel, etc.)
+  //
+  // Possible approaches:
+  // - Chunk large binaries and send via UDP
+  // - Use separate TCP connection for bulk transfer
+  // - Use RDMA WRITE for direct memory transfer
+  //
+  // For now, just log a warning
+  NVQLINK_LOG_WARNING(DOMAIN_CHANNEL,
+                      "Program upload not yet implemented (size={} bytes)",
+                      binary.size());
+
+  // For a simple implementation, could send metadata via UDP
+  nlohmann::json msg;
+  msg["cmd"] = "UPLOAD_PROGRAM";
+  msg["size"] = binary.size();
+  // In real implementation, would transfer the actual binary here
+
+  control_server_->send_command("UPLOAD_PROGRAM", msg);
+}
+
+void QCSDevice::trigger() {
+  if (!connected_)
+    throw std::runtime_error("Not connected to QCS");
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "Triggering QCS program execution");
+
+  // Send START command
+  control_server_->send_command("START");
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL,
+                   "START command sent - QCS should begin execution");
+}
+
+bool QCSDevice::is_complete() const {
+  if (!connected_)
+    return false;
+
+  // TODO: Implement completion check
+  // This is a stub - actual implementation would:
+  // 1. Poll for COMPLETE message from QCS via UDP
+  // 2. Or check a shared status flag in RDMA memory
+  //
+  // For now, return false (not complete)
+  return false;
+}
+
+void QCSDevice::abort() {
+  if (!connected_)
+    throw std::runtime_error("Not connected to QCS");
+
+  NVQLINK_LOG_WARNING(DOMAIN_CHANNEL, "Aborting QCS program execution");
+
+  control_server_->send_command("ABORT");
+
+  NVQLINK_LOG_INFO(DOMAIN_CHANNEL, "ABORT command sent to QCS");
+}

--- a/realtime/lib/utils/CMakeLists.txt
+++ b/realtime/lib/utils/CMakeLists.txt
@@ -1,0 +1,168 @@
+# ============================================================================ #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Build utils library with conditional instrumentation based on backend selection
+set(NVQLINK_UTILS_SOURCES
+  logger.cpp
+)
+
+# Add profiler backend sources
+if(NVQLINK_PROFILER_BACKEND STREQUAL "TRACY" OR NVQLINK_PROFILER_BACKEND STREQUAL "NVTX")
+  list(APPEND NVQLINK_UTILS_SOURCES instrumentation/nvtx.cpp)
+endif()
+
+# Add logging backend sources
+if(NVQLINK_LOGGING_BACKEND STREQUAL "QUILL")
+  list(APPEND NVQLINK_UTILS_SOURCES instrumentation/quill_logger.cpp)
+endif()
+
+add_library(nvqlink_utils STATIC ${NVQLINK_UTILS_SOURCES})
+
+target_include_directories(nvqlink_utils
+  PUBLIC
+    $<BUILD_INTERFACE:${CUDAQ_NVQLINK_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(nvqlink_utils PUBLIC Threads::Threads spdlog::spdlog)
+
+#===============================================================================
+# Profiler Backend Configuration
+#===============================================================================
+
+if(NVQLINK_PROFILER_BACKEND STREQUAL "TRACY")
+  # Tracy profiler setup via FetchContent
+  include(FetchContent)
+  FetchContent_Declare(tracy
+    GIT_REPOSITORY https://github.com/wolfpld/tracy.git
+    GIT_TAG v0.13.0
+    GIT_SHALLOW TRUE
+  )
+  
+  # Tracy client library options (optimized for low-latency network daemon)
+  set(TRACY_ENABLE ON CACHE BOOL "Enable Tracy profiler" FORCE)
+  set(TRACY_ON_DEMAND ON CACHE BOOL "Enable on-demand profiling (lower overhead when not connected)" FORCE)
+  set(TRACY_NO_FRAME_IMAGE ON CACHE BOOL "Disable frame image capture (games only)" FORCE)
+  set(TRACY_NO_VSYNC_CAPTURE ON CACHE BOOL "Disable vsync capture (games only)" FORCE)
+  set(TRACY_NO_SAMPLING ON CACHE BOOL "Disable statistical sampling (use manual instrumentation)" FORCE)
+  set(TRACY_CALLSTACK 0 CACHE STRING "Callstack depth (0=disabled, adds overhead)" FORCE)
+  
+  FetchContent_MakeAvailable(tracy)
+  
+  # Option to build Tracy profiler GUI
+  option(BUILD_TRACY_PROFILER "Build Tracy profiler GUI (requires OpenSSL, GLFW3, etc.)" OFF)
+  option(TRACY_LEGACY "Use legacy X11 backend for Tracy profiler (recommended for X11 systems)" ON)
+  
+  message(STATUS "Profiler backend: Tracy (v0.13.0)")
+  message(STATUS "  Tracy client library: Built automatically")
+  message(STATUS "  Configuration: On-Demand mode (connect profiler to start)")
+  message(STATUS "  Optimizations: Game features disabled, manual instrumentation only")
+  
+  if(BUILD_TRACY_PROFILER AND NOT CMAKE_CROSSCOMPILING)
+    FetchContent_GetProperties(tracy)
+    if(tracy_POPULATED)
+      # Set Tracy profiler windowing backend
+      if(TRACY_LEGACY)
+        set(LEGACY ON CACHE BOOL "Use legacy X11 backend for Tracy profiler" FORCE)
+        message(STATUS "  Tracy windowing: Legacy X11")
+      else()
+        set(LEGACY OFF CACHE BOOL "Use Wayland backend for Tracy profiler" FORCE)
+        message(STATUS "  Tracy windowing: Wayland")
+      endif()
+      
+      if(EXISTS "${tracy_SOURCE_DIR}/profiler/CMakeLists.txt")
+        add_subdirectory(${tracy_SOURCE_DIR}/profiler ${CMAKE_BINARY_DIR}/tracy-profiler EXCLUDE_FROM_ALL)
+        
+        message(STATUS "  Tracy profiler GUI: Enabled (target: tracy-profiler)")
+        message(STATUS "")
+        message(STATUS "To build Tracy profiler GUI:")
+        message(STATUS "  cmake --build ${CMAKE_BINARY_DIR} --target tracy-profiler")
+        message(STATUS "")
+        if(TRACY_LEGACY)
+          message(STATUS "Dependencies required (Legacy X11):")
+          message(STATUS "  Core: libssl-dev libglfw3-dev libfreetype-dev libcapstone-dev")
+          message(STATUS "  X11:  libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev")
+          message(STATUS "")
+          message(STATUS "Install all (Ubuntu/Debian):")
+          message(STATUS "  sudo apt install libssl-dev libglfw3-dev libfreetype-dev libcapstone-dev \\")
+          message(STATUS "                   libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev")
+        else()
+          message(STATUS "Dependencies required (Wayland): OpenSSL, GLFW3, FreeType, Capstone, xkbcommon, wayland")
+          message(STATUS "  Ubuntu/Debian: sudo apt install libssl-dev libglfw3-dev libfreetype-dev libcapstone-dev libxkbcommon-dev libwayland-dev")
+        endif()
+      else()
+        message(WARNING "Tracy profiler CMakeLists.txt not found")
+        message(WARNING "Tracy profiler GUI will not be available")
+      endif()
+    endif()
+  else()
+    message(STATUS "  Tracy profiler GUI: Disabled (use -DBUILD_TRACY_PROFILER=ON to enable)")
+    message(STATUS "")
+    message(STATUS "Or download pre-built Tracy profiler:")
+    message(STATUS "  https://github.com/wolfpld/tracy/releases/download/v0.13.0/Tracy-0.13.0.7z")
+  endif()
+  
+  # Link Tracy to nvqlink_utils
+  target_link_libraries(nvqlink_utils PUBLIC TracyClient)
+  target_compile_definitions(nvqlink_utils PUBLIC PROFILER_BACKEND_TRACY TRACY_ENABLE)
+  
+elseif(NVQLINK_PROFILER_BACKEND STREQUAL "NVTX")
+  # NVTX profiler setup
+  if(CUDA_FOUND)
+    find_package(CUDAToolkit REQUIRED)
+    target_link_libraries(nvqlink_utils PUBLIC CUDA::nvToolsExt)
+    target_compile_definitions(nvqlink_utils PUBLIC PROFILER_BACKEND_NVTX)
+    message(STATUS "Profiler backend: NVTX/Nsight")
+  else()
+    message(WARNING "NVTX profiler requested but CUDA not found, disabling profiler")
+  endif()
+  
+else()
+  message(STATUS "Profiler backend: NONE (instrumentation disabled)")
+endif()
+
+#===============================================================================
+# Logging Backend Configuration
+#===============================================================================
+
+if(NVQLINK_LOGGING_BACKEND STREQUAL "QUILL")
+  # Quill logger setup via FetchContent
+  include(FetchContent)
+  FetchContent_Declare(quill
+    GIT_REPOSITORY https://github.com/odygrd/quill.git
+    GIT_TAG v11.0.1
+    GIT_SHALLOW TRUE
+  )
+  
+  # Quill library options
+  set(QUILL_BUILD_EXAMPLES OFF CACHE BOOL "Build Quill examples" FORCE)
+  set(QUILL_BUILD_TESTS OFF CACHE BOOL "Build Quill tests" FORCE)
+  
+  FetchContent_MakeAvailable(quill)
+  
+  # Link Quill to nvqlink_utils
+  target_link_libraries(nvqlink_utils PUBLIC quill::quill)
+  target_compile_definitions(nvqlink_utils PUBLIC LOGGING_BACKEND_QUILL)
+  
+  # Compile-time log level filtering
+  if(NVQLINK_LOGGING_LEVEL STREQUAL "TRACE")
+    target_compile_definitions(nvqlink_utils PUBLIC QUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_TRACE_L3)
+  elseif(NVQLINK_LOGGING_LEVEL STREQUAL "DEBUG")
+    target_compile_definitions(nvqlink_utils PUBLIC QUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_DEBUG)
+  elseif(NVQLINK_LOGGING_LEVEL STREQUAL "INFO")
+    target_compile_definitions(nvqlink_utils PUBLIC QUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_INFO)
+  elseif(NVQLINK_LOGGING_LEVEL STREQUAL "WARNING")
+    target_compile_definitions(nvqlink_utils PUBLIC QUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_WARNING)
+  elseif(NVQLINK_LOGGING_LEVEL STREQUAL "ERROR")
+    target_compile_definitions(nvqlink_utils PUBLIC QUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_ERROR)
+  endif()
+  
+  message(STATUS "Logging backend: Quill v11.0.1 (level: ${NVQLINK_LOGGING_LEVEL})")
+else()
+  message(STATUS "Logging backend: NONE (logging disabled)")
+endif()

--- a/realtime/lib/utils/instrumentation/nvtx.cpp
+++ b/realtime/lib/utils/instrumentation/nvtx.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/instrumentation/profiler.h"
+
+#ifdef PROFILER_BACKEND_NVTX
+
+namespace cudaq::nvqlink::nvtx {
+
+// Define domain handles
+nvtxDomainHandle_t domain_daemon = nullptr;
+nvtxDomainHandle_t domain_dispatcher = nullptr;
+nvtxDomainHandle_t domain_memory = nullptr;
+nvtxDomainHandle_t domain_channel = nullptr;
+nvtxDomainHandle_t domain_user = nullptr;
+nvtxDomainHandle_t domain_gpu = nullptr;
+
+void initialize() {
+  domain_daemon = nvtxDomainCreateA("nvqlink::daemon");
+  domain_dispatcher = nvtxDomainCreateA("nvqlink::dispatcher");
+  domain_memory = nvtxDomainCreateA("nvqlink::memory");
+  domain_channel = nvtxDomainCreateA("nvqlink::channel");
+  domain_user = nvtxDomainCreateA("nvqlink::user");
+  domain_gpu = nvtxDomainCreateA("nvqlink::gpu");
+}
+
+void shutdown() {
+  if (domain_daemon)
+    nvtxDomainDestroy(domain_daemon);
+  if (domain_dispatcher)
+    nvtxDomainDestroy(domain_dispatcher);
+  if (domain_memory)
+    nvtxDomainDestroy(domain_memory);
+  if (domain_channel)
+    nvtxDomainDestroy(domain_channel);
+  if (domain_user)
+    nvtxDomainDestroy(domain_user);
+  if (domain_gpu)
+    nvtxDomainDestroy(domain_gpu);
+}
+
+} // namespace cudaq::nvqlink::nvtx
+
+namespace cudaq::nvqlink::profiler {
+
+void initialize() { nvtx::initialize(); }
+
+void shutdown() { nvtx::shutdown(); }
+
+} // namespace cudaq::nvqlink::profiler
+
+#endif // PROFILER_BACKEND_NVTX

--- a/realtime/lib/utils/instrumentation/quill_logger.cpp
+++ b/realtime/lib/utils/instrumentation/quill_logger.cpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/utils/instrumentation/quill_logger.h"
+
+namespace cudaq::nvqlink::quill_backend {
+
+//===----------------------------------------------------------------------===//
+// Domain Logger Instances
+//===----------------------------------------------------------------------===//
+
+// Define logger handles for each domain as global variables. This allows to
+// avoid looking up loggers each time.
+
+CustomLogger *logger_daemon = nullptr;
+CustomLogger *logger_dispatcher = nullptr;
+CustomLogger *logger_memory = nullptr;
+CustomLogger *logger_channel = nullptr;
+CustomLogger *logger_user = nullptr;
+CustomLogger *logger_gpu = nullptr;
+
+} // namespace cudaq::nvqlink::quill_backend
+
+namespace cudaq::nvqlink::logger {
+
+void initialize() {
+  using namespace cudaq::nvqlink::quill_backend;
+
+  //===--------------------------------------------------------------------===//
+  // Start Quill Backend (dedicated logging thread)
+  //===--------------------------------------------------------------------===//
+
+  quill::BackendOptions backend_options;
+  backend_options.thread_name = "nvqlink_log";
+
+  // TODO: Evaluate whether we should pin the backend thread to specific CPU
+  // backend_options.cpu_affinity = ..;
+
+  quill::SignalHandlerOptions signal_handler_options;
+  quill::Backend::start<CustomFrontendOptions>(backend_options,
+                                               signal_handler_options);
+
+  //===--------------------------------------------------------------------===//
+  // Create Console Sink (matches current std::cout behavior)
+  //===--------------------------------------------------------------------===//
+
+  auto console_sink =
+      CustomFrontend::create_or_get_sink<quill::ConsoleSink>("console_sink");
+
+  // Optional: Configure sink pattern
+  // Pattern format: [timestamp] [level] [logger_name] message
+  // Default pattern is already good, but can be customized:
+  // console_sink->set_pattern("[%(time)] [%(log_level)] [%(logger)]
+  // %(message)");
+
+  //===--------------------------------------------------------------------===//
+  // Create Domain Loggers
+  //===--------------------------------------------------------------------===//
+
+  logger_daemon = CustomFrontend::create_or_get_logger("daemon", console_sink);
+  logger_dispatcher =
+      CustomFrontend::create_or_get_logger("dispatcher", console_sink);
+  logger_memory = CustomFrontend::create_or_get_logger("memory", console_sink);
+  logger_channel =
+      CustomFrontend::create_or_get_logger("channel", console_sink);
+  logger_user = CustomFrontend::create_or_get_logger("user", console_sink);
+  logger_gpu = CustomFrontend::create_or_get_logger("gpu", console_sink);
+}
+
+void shutdown() {
+  // Quill backend will automatically flush and stop on program exit, but we can
+  // explicitly stop it here for clean shutdown.
+
+  // Note: This is optional, Quill's destructor handles cleanup
+}
+
+} // namespace cudaq::nvqlink::logger

--- a/realtime/lib/utils/logger.cpp
+++ b/realtime/lib/utils/logger.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "logger.h"
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+namespace cudaq {
+
+__attribute__((constructor)) inline void set_spdlog_handler() {
+  static auto logger = [] {
+    auto sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    auto _logger = std::make_shared<spdlog::logger>("NVQLink Logger", sink);
+    _logger->set_level(spdlog::level::trace);
+    _logger->set_pattern("[%T] [%^%l%$] %v");
+    return _logger;
+  }();
+
+  Logger::set_handler([=](Logger::Level level, const std::string &msg) {
+    switch (level) {
+    case Logger::Level::Info:
+      logger->info(msg);
+      break;
+    case Logger::Level::Debug:
+      logger->debug(msg);
+      break;
+    case Logger::Level::Warn:
+      logger->warn(msg);
+      break;
+    }
+  });
+}
+
+} // namespace cudaq

--- a/realtime/lib/utils/logger.h
+++ b/realtime/lib/utils/logger.h
@@ -1,0 +1,69 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+// spdlog's bundled fmtlib
+#include <spdlog/fmt/fmt.h>
+
+#include <functional>
+#include <mutex>
+#include <string>
+
+namespace cudaq {
+
+class Logger {
+public:
+  enum class Level { Info, Debug, Warn };
+
+  // Sets the actual log handler. Call once at startup, passing a function that
+  // takes a message string and a log level. You may call multiple times.
+  static void
+  set_handler(std::function<void(Level, const std::string &)> handler) {
+    std::lock_guard<std::mutex> lock(handler_mutex());
+    handler_ref() = std::move(handler);
+  }
+
+  // Logging methods with fmt-style formatting.
+  template <typename... Args>
+  static void log(fmt::format_string<Args...> fmt_str, Args &&...args) {
+    log_dispatch(Level::Info,
+                 fmt::format(fmt_str, std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static void debug(fmt::format_string<Args...> fmt_str, Args &&...args) {
+    log_dispatch(Level::Debug,
+                 fmt::format(fmt_str, std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static void warn(fmt::format_string<Args...> fmt_str, Args &&...args) {
+    log_dispatch(Level::Warn,
+                 fmt::format(fmt_str, std::forward<Args>(args)...));
+  }
+
+private:
+  // Mutex and handler storage (function-static to avoid ODR/use issues)
+  static std::mutex &handler_mutex() {
+    static std::mutex mtx;
+    return mtx;
+  }
+  static std::function<void(Level, const std::string &)> &handler_ref() {
+    static std::function<void(Level, const std::string &)> handler{};
+    return handler;
+  }
+
+  static void log_dispatch(Level lvl, const std::string &msg) {
+    std::lock_guard<std::mutex> lock(handler_mutex());
+    if (handler_ref())
+      handler_ref()(lvl, msg);
+  }
+};
+
+} // namespace cudaq

--- a/realtime/unittests/CMakeLists.txt
+++ b/realtime/unittests/CMakeLists.txt
@@ -1,0 +1,85 @@
+# ============================================================================ #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# External Dependencies 
+# ==============================================================================
+
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.17.0
+  EXCLUDE_FROM_ALL
+)
+FetchContent_MakeAvailable(googletest)
+
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Bug in GCC 12 leads to spurious warnings (-Wrestrict)
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+if (CMAKE_COMPILER_IS_GNUCXX 
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0 
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
+  target_compile_options(gtest PUBLIC --param=evrp-mode=legacy)
+endif()
+include(GoogleTest)
+
+
+add_compile_options(-Wno-attributes) 
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/test_config.h.in"
+               "${CMAKE_BINARY_DIR}/include/test_config.h" 
+               @ONLY)
+include_directories(${CMAKE_BINARY_DIR}/include)
+
+# ======= Phase 4: New Test Infrastructure ====================================
+
+# Test utilities library (LoopbackChannel for testing without hardware)
+add_library(test_utils STATIC
+  test_utils/loopback_channel.cpp
+)
+
+target_include_directories(test_utils
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CUDAQ_NVQLINK_INCLUDE_DIR}
+)
+
+target_link_libraries(test_utils
+  PUBLIC
+    nvqlink_network
+)
+
+# Daemon tests
+add_executable(test_daemon test_daemon.cpp)
+target_link_libraries(test_daemon 
+  PRIVATE 
+    GTest::gtest_main
+    cudaq-nvqlink
+    nvqlink_daemon
+    test_utils
+)
+add_dependencies(NVQLINKUnitTests test_daemon)
+gtest_discover_tests(test_daemon)
+
+# Stream tests (serialization/deserialization)
+add_executable(test_streams test_streams.cpp)
+target_link_libraries(test_streams 
+  PRIVATE 
+    GTest::gtest_main
+    nvqlink_network
+)
+add_dependencies(NVQLINKUnitTests test_streams)
+gtest_discover_tests(test_streams)
+
+message(STATUS "Unit tests: Phase 4 - New Daemon-based tests added")
+message(STATUS "  - test_daemon (with LoopbackChannel)")
+message(STATUS "  - test_streams (serialization)")
+
+# ==============================================================================
+
+

--- a/realtime/unittests/test_config.h.in
+++ b/realtime/unittests/test_config.h.in
@@ -1,0 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once 
+
+#define CUDAQ_TEST_BINARY_DIR "@CMAKE_BINARY_DIR@"

--- a/realtime/unittests/test_daemon.cpp
+++ b/realtime/unittests/test_daemon.cpp
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "test_utils/loopback_channel.h"
+#include "cudaq/nvqlink/daemon/daemon.h"
+#include "cudaq/nvqlink/daemon/registry/rpc_builder.h"
+#include "cudaq/nvqlink/network/serialization/input_stream.h"
+#include "cudaq/nvqlink/network/serialization/output_stream.h"
+
+#include <gtest/gtest.h>
+#include <thread>
+
+using namespace cudaq::nvqlink;
+using namespace cudaq::nvqlink::test;
+
+// Simple test functions
+int add(int a, int b) { return a + b; }
+int multiply(int a, int b) { return a * b; }
+void increment(int &value) { value++; }
+
+class DaemonTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Create loopback channel for testing
+    channel = std::make_unique<LoopbackChannel>();
+    channel->initialize();
+  }
+
+  void TearDown() override {
+    if (channel)
+      channel->cleanup();
+  }
+
+  std::unique_ptr<LoopbackChannel> channel;
+};
+
+TEST_F(DaemonTest, Construction) {
+  DaemonConfig config;
+  config.id = "test_daemon";
+  config.datapath_mode = DatapathMode::CPU;
+  config.compute.cpu_cores = {0};
+
+  ASSERT_TRUE(config.is_valid());
+
+  // Create daemon with loopback channel
+  auto daemon = std::make_unique<Daemon>(config, std::move(channel));
+
+  EXPECT_FALSE(daemon->is_running());
+}
+
+TEST_F(DaemonTest, RegisterFunction) {
+  DaemonConfig config;
+  config.id = "test_daemon";
+  config.datapath_mode = DatapathMode::CPU;
+  config.compute.cpu_cores = {0};
+
+  auto daemon = std::make_unique<Daemon>(config, std::move(channel));
+
+  // Register functions using the simplified API
+  EXPECT_NO_THROW(daemon->register_function(NVQLINK_RPC_HANDLE(add)));
+  EXPECT_NO_THROW(daemon->register_function(NVQLINK_RPC_HANDLE(multiply)));
+}
+
+TEST_F(DaemonTest, RegisterDuplicateFunction) {
+  DaemonConfig config;
+  config.id = "test_daemon";
+  config.datapath_mode = DatapathMode::CPU;
+  config.compute.cpu_cores = {0};
+
+  auto daemon = std::make_unique<Daemon>(config, std::move(channel));
+
+  // Register function once
+  daemon->register_function(NVQLINK_RPC_HANDLE(add));
+
+  // Registering the same function again should throw (hash collision)
+  EXPECT_THROW(daemon->register_function(NVQLINK_RPC_HANDLE(add)),
+               std::runtime_error);
+}
+
+TEST_F(DaemonTest, StartStop) {
+  DaemonConfig config;
+  config.id = "test_daemon";
+  config.datapath_mode = DatapathMode::CPU;
+  config.compute.cpu_cores = {0};
+
+  auto daemon = std::make_unique<Daemon>(config, std::move(channel));
+  daemon->register_function(NVQLINK_RPC_HANDLE(add));
+
+  EXPECT_FALSE(daemon->is_running());
+
+  daemon->start();
+  EXPECT_TRUE(daemon->is_running());
+
+  // Give it a moment to actually start
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  daemon->stop();
+  EXPECT_FALSE(daemon->is_running());
+}
+
+TEST_F(DaemonTest, InvalidConfig) {
+  DaemonConfig config;
+  // Invalid: empty id
+  config.datapath_mode = DatapathMode::CPU;
+  config.compute.cpu_cores = {0};
+
+  EXPECT_FALSE(config.is_valid());
+
+  // Note: Daemon constructor may or may not validate config strictly
+  // The is_valid() check is advisory - implementation may allow invalid configs
+  // for testing or graceful degradation
+}
+
+TEST_F(DaemonTest, CPUModeNoCores) {
+  DaemonConfig config;
+  config.id = "test";
+  config.datapath_mode = DatapathMode::CPU;
+  // Invalid: no CPU cores specified for CPU mode
+
+  EXPECT_FALSE(config.is_valid());
+}
+
+TEST_F(DaemonTest, DaemonConfigBuilder) {
+  auto config = DaemonConfigBuilder()
+                    .set_id("test_builder")
+                    .set_datapath_mode(DatapathMode::CPU)
+                    .set_cpu_cores({0, 1})
+                    .build();
+
+  EXPECT_EQ(config.id, "test_builder");
+  EXPECT_EQ(config.datapath_mode, DatapathMode::CPU);
+  EXPECT_EQ(config.compute.cpu_cores.size(), 2);
+  EXPECT_TRUE(config.is_valid());
+}
+
+TEST_F(DaemonTest, GetStats) {
+  DaemonConfig config;
+  config.id = "test_daemon";
+  config.datapath_mode = DatapathMode::CPU;
+  config.compute.cpu_cores = {0};
+
+  auto daemon = std::make_unique<Daemon>(config, std::move(channel));
+  daemon->register_function(NVQLINK_RPC_HANDLE(add));
+
+  // Get initial stats
+  auto stats = daemon->get_stats();
+  EXPECT_EQ(stats.packets_received, 0);
+  EXPECT_EQ(stats.packets_sent, 0);
+  EXPECT_EQ(stats.errors, 0);
+}
+
+// Note: Full end-to-end RPC tests would require:
+// 1. Starting the daemon
+// 2. Injecting properly formatted RPC packets via LoopbackChannel
+// 3. Verifying responses
+// These are more complex integration tests and may be added later

--- a/realtime/unittests/test_streams.cpp
+++ b/realtime/unittests/test_streams.cpp
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/nvqlink/network/serialization/input_stream.h"
+#include "cudaq/nvqlink/network/serialization/output_stream.h"
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace cudaq::nvqlink;
+
+// Test with raw buffers (simpler, no Channel dependency)
+class StreamTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Allocate a simple buffer for testing
+    buffer_memory.resize(2048);
+  }
+
+  std::vector<uint8_t> buffer_memory;
+};
+
+TEST_F(StreamTest, OutputStreamBasicTypes) {
+  OutputStream out(buffer_memory.data(), buffer_memory.size());
+
+  // Write various types
+  out.write(static_cast<uint32_t>(42));
+  out.write(static_cast<uint64_t>(12345678901234ULL));
+  out.write(3.14159f);
+  out.write(2.71828);
+
+  // Verify something was written
+  EXPECT_GT(out.bytes_written(), 0);
+}
+
+TEST_F(StreamTest, InputStreamBasicTypes) {
+  // First write data
+  OutputStream out(buffer_memory.data(), buffer_memory.size());
+  out.write(static_cast<uint32_t>(42));
+  out.write(static_cast<uint64_t>(12345678901234ULL));
+  out.write(3.14159f);
+  out.write(2.71828);
+
+  size_t bytes_written = out.bytes_written();
+
+  // Now read it back
+  InputStream in(buffer_memory.data(), bytes_written);
+
+  EXPECT_EQ(in.read<uint32_t>(), 42);
+  EXPECT_EQ(in.read<uint64_t>(), 12345678901234ULL);
+  EXPECT_FLOAT_EQ(in.read<float>(), 3.14159f);
+  EXPECT_DOUBLE_EQ(in.read<double>(), 2.71828);
+}
+
+TEST_F(StreamTest, RoundTripInteger) {
+  OutputStream out(buffer_memory.data(), buffer_memory.size());
+  int value = 123456;
+  out.write(value);
+
+  size_t bytes_written = out.bytes_written();
+
+  InputStream in(buffer_memory.data(), bytes_written);
+  int read_value = in.read<int>();
+
+  EXPECT_EQ(value, read_value);
+}
+
+TEST_F(StreamTest, RoundTripMultipleValues) {
+  OutputStream out(buffer_memory.data(), buffer_memory.size());
+
+  uint8_t u8 = 255;
+  uint16_t u16 = 65535;
+  uint32_t u32 = 4294967295U;
+  int32_t i32 = -12345;
+
+  out.write(u8);
+  out.write(u16);
+  out.write(u32);
+  out.write(i32);
+
+  size_t bytes_written = out.bytes_written();
+  InputStream in(buffer_memory.data(), bytes_written);
+
+  EXPECT_EQ(in.read<uint8_t>(), u8);
+  EXPECT_EQ(in.read<uint16_t>(), u16);
+  EXPECT_EQ(in.read<uint32_t>(), u32);
+  EXPECT_EQ(in.read<int32_t>(), i32);
+}
+
+TEST_F(StreamTest, RoundTripStruct) {
+  struct TestData {
+    uint32_t id;
+    float value;
+    double timestamp;
+  };
+
+  OutputStream out(buffer_memory.data(), buffer_memory.size());
+
+  TestData data{42, 3.14f, 1234567890.0};
+  out.write(data);
+
+  size_t bytes_written = out.bytes_written();
+  InputStream in(buffer_memory.data(), bytes_written);
+  TestData read_data = in.read<TestData>();
+
+  EXPECT_EQ(read_data.id, data.id);
+  EXPECT_FLOAT_EQ(read_data.value, data.value);
+  EXPECT_DOUBLE_EQ(read_data.timestamp, data.timestamp);
+}
+
+TEST_F(StreamTest, RoundTripMultipleStructs) {
+  OutputStream out(buffer_memory.data(), buffer_memory.size());
+
+  // Write multiple values in sequence
+  for (uint32_t i = 0; i < 5; ++i) {
+    out.write(i);
+  }
+
+  size_t bytes_written = out.bytes_written();
+  InputStream in(buffer_memory.data(), bytes_written);
+
+  // Read them back
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(in.read<uint32_t>(), i);
+  }
+}
+
+TEST_F(StreamTest, BytesReadTracking) {
+  OutputStream out(buffer_memory.data(), buffer_memory.size());
+  out.write(static_cast<uint32_t>(42));
+  out.write(static_cast<uint64_t>(100));
+
+  size_t expected_size = sizeof(uint32_t) + sizeof(uint64_t);
+  EXPECT_EQ(out.bytes_written(), expected_size);
+
+  InputStream in(buffer_memory.data(), expected_size);
+  EXPECT_EQ(in.bytes_read(), 0);
+
+  // Read one value
+  in.read<uint32_t>();
+  EXPECT_EQ(in.bytes_read(), sizeof(uint32_t));
+
+  // Read second value
+  in.read<uint64_t>();
+  EXPECT_EQ(in.bytes_read(), expected_size);
+}
+
+TEST_F(StreamTest, RemainingCapacity) {
+  OutputStream out(buffer_memory.data(), buffer_memory.size());
+
+  size_t initial_capacity = out.remaining_capacity();
+  EXPECT_EQ(initial_capacity, buffer_memory.size());
+
+  out.write(static_cast<uint64_t>(42));
+
+  size_t after_write = out.remaining_capacity();
+  EXPECT_EQ(after_write, initial_capacity - sizeof(uint64_t));
+}
+
+TEST_F(StreamTest, WriteToCapacity) {
+  OutputStream out(buffer_memory.data(), buffer_memory.size());
+
+  // Fill buffer with uint64_t values
+  size_t capacity = out.remaining_capacity();
+  size_t num_values = capacity / sizeof(uint64_t);
+
+  for (size_t i = 0; i < num_values; ++i) {
+    out.write(static_cast<uint64_t>(i));
+  }
+
+  EXPECT_LE(out.bytes_written(), buffer_memory.size());
+  EXPECT_GT(out.bytes_written(), 0);
+}

--- a/realtime/unittests/test_utils/loopback_channel.cpp
+++ b/realtime/unittests/test_utils/loopback_channel.cpp
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "loopback_channel.h"
+
+#include <cstring>
+#include <stdexcept>
+
+using namespace cudaq::nvqlink;
+using namespace cudaq::nvqlink::test;
+
+LoopbackChannel::LoopbackChannel(size_t buffer_size, size_t num_buffers)
+    : buffer_size_(buffer_size), num_buffers_(num_buffers) {}
+
+LoopbackChannel::~LoopbackChannel() {
+  if (initialized_)
+    cleanup();
+}
+
+void LoopbackChannel::initialize() {
+  if (initialized_)
+    return;
+
+  // Allocate memory pool
+  size_t total_size = buffer_size_ * num_buffers_;
+  memory_pool_.resize(total_size);
+
+  // Create buffer objects
+  uint8_t *ptr = memory_pool_.data();
+  for (size_t i = 0; i < num_buffers_; ++i) {
+    auto buffer = std::make_unique<Buffer>(ptr, buffer_size_, 256, 64);
+    free_buffers_.push(buffer.get());
+    buffers_.push_back(std::move(buffer));
+    ptr += buffer_size_;
+  }
+
+  initialized_ = true;
+}
+
+void LoopbackChannel::cleanup() {
+  if (!initialized_)
+    return;
+
+  std::lock_guard<std::mutex> lock(buffer_mutex_);
+
+  // Clear all queues
+  {
+    std::lock_guard<std::mutex> rx_lock(rx_mutex_);
+    std::queue<std::vector<uint8_t>>().swap(rx_queue_);
+  }
+  {
+    std::lock_guard<std::mutex> tx_lock(tx_mutex_);
+    std::queue<std::vector<uint8_t>>().swap(tx_queue_);
+  }
+
+  // Return all buffers to free queue
+  std::queue<Buffer *>().swap(free_buffers_);
+  for (auto &buffer : buffers_)
+    free_buffers_.push(buffer.get());
+
+  initialized_ = false;
+}
+
+Buffer *LoopbackChannel::acquire_buffer() {
+  if (!initialized_)
+    throw std::runtime_error("LoopbackChannel not initialized");
+
+  std::lock_guard<std::mutex> lock(buffer_mutex_);
+  if (free_buffers_.empty())
+    return nullptr; // Pool exhausted
+
+  Buffer *buffer = free_buffers_.front();
+  free_buffers_.pop();
+  buffer->set_data_length(0); // Reset data length
+  return buffer;
+}
+
+void LoopbackChannel::release_buffer(Buffer *buffer) {
+  if (!buffer)
+    return;
+
+  std::lock_guard<std::mutex> lock(buffer_mutex_);
+  buffer->set_data_length(0); // Reset data length
+  free_buffers_.push(buffer);
+}
+
+uint32_t LoopbackChannel::receive_burst(Buffer **buffers, uint32_t max) {
+  if (!initialized_)
+    return 0;
+
+  std::lock_guard<std::mutex> rx_lock(rx_mutex_);
+
+  uint32_t received = 0;
+  while (received < max && !rx_queue_.empty()) {
+    auto &packet = rx_queue_.front();
+
+    // Get a buffer
+    Buffer *buffer = acquire_buffer();
+    if (!buffer)
+      break; // No buffers available
+
+    // Copy packet data to buffer
+    size_t capacity = buffer->get_total_size() - buffer->get_headroom() -
+                      buffer->get_tailroom();
+    if (packet.size() > capacity) {
+      release_buffer(buffer);
+      rx_queue_.pop(); // Drop oversized packet
+      continue;
+    }
+
+    std::memcpy(buffer->get_data(), packet.data(), packet.size());
+    buffer->set_data_length(packet.size());
+
+    buffers[received++] = buffer;
+    rx_queue_.pop();
+  }
+
+  return received;
+}
+
+uint32_t LoopbackChannel::send_burst(Buffer **buffers, uint32_t count) {
+  if (!initialized_)
+    return 0;
+
+  std::lock_guard<std::mutex> tx_lock(tx_mutex_);
+
+  for (uint32_t i = 0; i < count; ++i) {
+    Buffer *buffer = buffers[i];
+    if (!buffer)
+      continue;
+
+    // Copy buffer data to TX queue
+    uint8_t *data_start = static_cast<uint8_t *>(buffer->get_data());
+    std::vector<uint8_t> packet(data_start,
+                                data_start + buffer->get_data_length());
+    tx_queue_.push(std::move(packet));
+  }
+
+  return count;
+}
+
+void LoopbackChannel::inject_rx_packet(const void *data, size_t len) {
+  std::lock_guard<std::mutex> lock(rx_mutex_);
+
+  std::vector<uint8_t> packet(static_cast<const uint8_t *>(data),
+                              static_cast<const uint8_t *>(data) + len);
+  rx_queue_.push(std::move(packet));
+}
+
+std::vector<uint8_t> LoopbackChannel::pop_tx_packet() {
+  std::lock_guard<std::mutex> lock(tx_mutex_);
+
+  if (tx_queue_.empty())
+    return {};
+
+  std::vector<uint8_t> packet = std::move(tx_queue_.front());
+  tx_queue_.pop();
+  return packet;
+}
+
+bool LoopbackChannel::has_tx_packets() const {
+  std::lock_guard<std::mutex> lock(tx_mutex_);
+  return !tx_queue_.empty();
+}
+
+size_t LoopbackChannel::rx_queue_size() const {
+  std::lock_guard<std::mutex> lock(rx_mutex_);
+  return rx_queue_.size();
+}
+
+size_t LoopbackChannel::tx_queue_size() const {
+  std::lock_guard<std::mutex> lock(tx_mutex_);
+  return tx_queue_.size();
+}

--- a/realtime/unittests/test_utils/loopback_channel.h
+++ b/realtime/unittests/test_utils/loopback_channel.h
@@ -1,0 +1,87 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 - Present NVIDIA Corporation & Affiliates.               *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/nvqlink/network/channel.h"
+#include "cudaq/nvqlink/network/memory/buffer.h"
+
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+namespace cudaq::nvqlink::test {
+
+/// @brief In-memory channel for unit testing without hardware
+///
+/// Simulates a network channel using in-memory queues.
+/// Useful for testing Daemon, InputStream/OutputStream, and other
+/// components without requiring RDMA hardware.
+///
+/// Features:
+/// - inject_rx_packet(): Simulate incoming packets
+/// - pop_tx_packet(): Read outgoing packets
+/// - Thread-safe queue operations
+class LoopbackChannel : public Channel {
+public:
+  explicit LoopbackChannel(size_t buffer_size = 2048, size_t num_buffers = 16);
+  ~LoopbackChannel() override;
+
+  // Channel interface
+  void initialize() override;
+  void cleanup() override;
+  Buffer *acquire_buffer() override;
+  void release_buffer(Buffer *buffer) override;
+  uint32_t receive_burst(Buffer **buffers, uint32_t max) override;
+  uint32_t send_burst(Buffer **buffers, uint32_t count) override;
+  void register_memory(void *addr, size_t size) override {
+  } // No-op for loopback
+  ChannelModel get_execution_model() const override {
+    return ChannelModel::POLLING;
+  }
+  void configure_queues(const std::vector<uint32_t> &queue_ids) override {
+  } // No-op for loopback
+
+  // Test helpers
+  /// @brief Inject a packet into the RX queue (simulates incoming packet)
+  void inject_rx_packet(const void *data, size_t len);
+
+  /// @brief Pop a packet from the TX queue (reads outgoing packet)
+  /// @return Packet data (empty if no packets available)
+  std::vector<uint8_t> pop_tx_packet();
+
+  /// @brief Check if there are TX packets available
+  bool has_tx_packets() const;
+
+  /// @brief Get number of RX packets waiting
+  size_t rx_queue_size() const;
+
+  /// @brief Get number of TX packets sent
+  size_t tx_queue_size() const;
+
+private:
+  size_t buffer_size_;
+  size_t num_buffers_;
+
+  // Buffer pool
+  std::vector<uint8_t> memory_pool_;
+  std::vector<std::unique_ptr<Buffer>> buffers_;
+  std::queue<Buffer *> free_buffers_;
+  mutable std::mutex buffer_mutex_;
+
+  // Packet queues (simulate network)
+  std::queue<std::vector<uint8_t>> rx_queue_;
+  std::queue<std::vector<uint8_t>> tx_queue_;
+  mutable std::mutex rx_mutex_;
+  mutable std::mutex tx_mutex_;
+
+  bool initialized_{false};
+};
+
+} // namespace cudaq::nvqlink::test


### PR DESCRIPTION
Open sourcing the prototype for `cudaq::realtime` (fka `qclink`).

- [ ] Scrub instances of "qclink" and "nvqlink" strings in favor of "realtime" namespace