### PR TITLE
Moving function definitions of DeviceCodeRegistry.cpp from cudaq.h to DeviceCodeRegistry.h

### DIFF
--- a/python/runtime/cudaq/algorithms/py_sample_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample_async.cpp
@@ -6,8 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#include "common/DeviceCodeRegistry.h"
 #include "cudaq/algorithms/sample.h"
-#include "cudaq/utils/registry.h"
 #include "runtime/cudaq/platform/py_alt_launch_kernel.h"
 #include "utils/OpaqueArguments.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"

--- a/runtime/common/ArgumentConversion.cpp
+++ b/runtime/common/ArgumentConversion.cpp
@@ -7,13 +7,13 @@
  ******************************************************************************/
 
 #include "ArgumentConversion.h"
+#include "common/DeviceCodeRegistry.h"
 #include "cudaq.h"
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Todo.h"
 #include "cudaq/qis/pauli_word.h"
-#include "cudaq/utils/registry.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"

--- a/runtime/common/DeviceCodeRegistry.h
+++ b/runtime/common/DeviceCodeRegistry.h
@@ -7,9 +7,12 @@
  ******************************************************************************/
 
 #pragma once
+#include <cstdint>
+#include <optional>
 #include <string>
 
-namespace cudaq::registry {
+namespace cudaq {
+namespace registry {
 extern "C" {
 void __cudaq_deviceCodeHolderAdd(const char *, const char *);
 void cudaqRegisterKernelName(const char *);
@@ -32,7 +35,7 @@ const char *__cudaq_getLinkableKernelName(std::intptr_t);
 /// Given a kernel key value, return the corresponding device-side kernel
 /// function. If the kernel is not registered, throws a runtime error.
 void *__cudaq_getLinkableKernelDeviceFunction(std::intptr_t);
-}
+} // extern "C"
 
 /// Given a kernel key value, return the name of the kernel. If the kernel is
 /// not registered, runs a `nullptr`. Note this function is not exposed to the
@@ -43,9 +46,28 @@ const char *getLinkableKernelNameOrNull(std::intptr_t);
 /// `runnable` kernel entry point.
 void *getRunnableKernelOrNull(const std::string &kernelName);
 void *__cudaq_getRunnableKernel(const std::string &kernelName);
-} // namespace cudaq::registry
+} // namespace registry
 
-namespace cudaq::detail {
+namespace detail {
 /// Is the kernel `kernelName` registered?
 bool isKernelGenerated(const std::string &kernelName);
-} // namespace cudaq::detail
+} // namespace detail
+
+/// @brief Given a string kernel name, return the corresponding Quake code
+/// This will throw if the kernel name is unknown to the quake code registry.
+std::string get_quake_by_name(const std::string &kernelName);
+
+/// @brief Given a string kernel name, return the corresponding Quake code.
+/// This overload allows one to specify the known mangled arguments string
+/// in order to disambiguate overloaded kernel names.
+/// This will throw if the kernel name is unknown to the quake code registry.
+std::string get_quake_by_name(const std::string &kernelName,
+                              std::optional<std::string> knownMangledArgs);
+
+/// @brief Given a string kernel name, return the corresponding Quake code.
+// If `throwException` is set, it will throw if the kernel name is unknown to
+// the quake code registry. Otherwise, return an empty string in that case.
+std::string
+get_quake_by_name(const std::string &kernelName, bool throwException,
+                  std::optional<std::string> knownMangledArgs = std::nullopt);
+} // namespace cudaq

--- a/runtime/common/KernelWrapper.h
+++ b/runtime/common/KernelWrapper.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include "common/DeviceCodeRegistry.h"
 #include "cudaq/platform.h"
 #include "cudaq/qis/pauli_word.h"
-#include "cudaq/utils/registry.h"
 #include <cstdint>
 #include <cstring>
 #include <string>

--- a/runtime/cudaq.h
+++ b/runtime/cudaq.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "common/DeviceCodeRegistry.h"
 #include "common/NoiseModel.h"
 #include "cudaq/host_config.h"
 #include "cudaq/qis/qubit_qis.h"
@@ -30,24 +31,6 @@ std::string demangle_kernel(const char *);
 bool isLibraryMode(const std::string &);
 extern bool globalFalse;
 } // namespace __internal__
-
-/// @brief Given a string kernel name, return the corresponding Quake code
-/// This will throw if the kernel name is unknown to the quake code registry.
-std::string get_quake_by_name(const std::string &kernelName);
-
-/// @brief Given a string kernel name, return the corresponding Quake code.
-/// This overload allows one to specify the known mangled arguments string
-/// in order to disambiguate overloaded kernel names.
-/// This will throw if the kernel name is unknown to the quake code registry.
-std::string get_quake_by_name(const std::string &kernelName,
-                              std::optional<std::string> knownMangledArgs);
-
-/// @brief Given a string kernel name, return the corresponding Quake code.
-// If `throwException` is set, it will throw if the kernel name is unknown to
-// the quake code registry. Otherwise, return an empty string in that case.
-std::string
-get_quake_by_name(const std::string &kernelName, bool throwException,
-                  std::optional<std::string> knownMangledArgs = std::nullopt);
 
 // Simple test to see if the QuantumKernel template
 // type is a `cudaq::builder` with `operator()(Args...)`

--- a/runtime/cudaq/algorithms/get_state.h
+++ b/runtime/cudaq/algorithms/get_state.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "common/DeviceCodeRegistry.h"
 #include "common/ExecutionContext.h"
 #include "cudaq/concepts.h"
 #include "cudaq/host_config.h"
@@ -18,7 +19,6 @@
 #include "cudaq/qis/qkernel.h"
 #include "cudaq/qis/remote_state.h"
 #include "cudaq/qis/state.h"
-#include "cudaq/utils/registry.h"
 #include <complex>
 #include <vector>
 

--- a/runtime/cudaq/qis/kernel_utils.h
+++ b/runtime/cudaq/qis/kernel_utils.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include "common/DeviceCodeRegistry.h"
 #include "common/ExecutionContext.h"
 #include "cudaq/concepts.h"
-#include "cudaq/utils/registry.h"
 #include "qkernel.h"
 
 namespace cudaq::details {


### PR DESCRIPTION
It is helpful to have the functions defined in DeviceCodeRegistery.cpp be defined in their own header: DeviceCodeRegistry.h.

DeviceCodeRegistry is isolated into its own module which makes it easier to use with the runtime refactor.
