### PR TITLE
[ci] fix unknown base branch in check links

### DIFF
--- a/.github/actions/check-markdown-links/action.yml
+++ b/.github/actions/check-markdown-links/action.yml
@@ -20,21 +20,34 @@ runs:
     - name: Convert reStructuredText files to Markdown
       shell: bash
       run: |
-        pip install "rst-to-myst[sphinx]==0.4.0"
-
         # Convert either all rst files or only the modified ones
         if [ "${{ inputs.check-modified-files-only }}" == "yes" ]; then
-          readarray -d '' rst_files < <(git diff --name-only --diff-filter=AM -z ${{ inputs.base-branch }} -- 'docs/sphinx/*.rst' 'docs/sphinx/**/*.rst')
+          echo "Checking links in modified files only"
+
+          # Fetch the base branch
+          git config --global --add safe.directory '*'
+          git fetch origin "${{ inputs.base-branch }}" --depth=1 > /dev/null
+
+          readarray -d '' rst_files < <(git diff --name-only --diff-filter=AM -z origin/${{ inputs.base-branch }} -- 'docs/sphinx/*.rst' 'docs/sphinx/**/*.rst')
         else
+          echo "Checking links in all files"
+
           readarray -d '' rst_files < <(find docs/sphinx/ -type f -name "*.rst" -print0)
         fi
 
+
         if [ ${#rst_files[@]} -gt 0 ]; then
+          echo "Found ${#rst_files[@]} rst files to check:"
+          echo "${rst_files[@]}"
+
+          pip install "rst-to-myst[sphinx]==0.4.0"
           rst2myst convert --raise-on-warning "${rst_files[@]}"
 
           # Stage the newly created .md files to git, so that they appear in
           # the git diff of the github-action-markdown-link-check step below
           git add docs/sphinx
+        else
+          echo "No rst files found to check"
         fi
 
     - name: Check links in Markdown files


### PR DESCRIPTION
I've noticed that in some cases this was failing silently when diffing because of a missing "git fetch".

drive-bys:
- added some log outputs for easier debugging
- only `pip install rst-to-myst` if there are files to convert