### PR TITLE
Bump qutip>5

### DIFF
--- a/docker/release/cudaq.Dockerfile
+++ b/docker/release/cudaq.Dockerfile
@@ -61,8 +61,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && python3 -m pip install --no-cache-dir --break-system-packages numpy scipy \
     && ln -s /bin/python3 /bin/python
 RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ python3-dev \
-    # Ref: https://github.com/qutip/qutip/issues/2412
-    && python3 -m pip install --no-cache-dir --break-system-packages notebook==7.3.2 "qutip<5" matplotlib \
+    && python3 -m pip install --no-cache-dir --break-system-packages notebook==7.3.2 "qutip>5" matplotlib \
     && apt-get remove -y gcc g++ python3-dev \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docs/sphinx/examples/python/visualization.ipynb
+++ b/docs/sphinx/examples/python/visualization.ipynb
@@ -58,7 +58,7 @@
     "\n",
     "except ImportError:\n",
     "    print(\"Tools not found, please install and restart your kernel after this is done.\")\n",
-    "    #!{sys.executable} -m pip install qutip\\<5 matplotlib\\>=3.5\n"
+    "    #!{sys.executable} -m pip install qutip\\>5 matplotlib\\>=3.5\n"
    ]
   },
   {

--- a/pyproject.toml.cu12
+++ b/pyproject.toml.cu12
@@ -56,7 +56,7 @@ Releases = "https://nvidia.github.io/cuda-quantum/latest/releases.html"
 # https://github.com/h5py/h5py/issues/2408
 [project.optional-dependencies]
 chemistry = [ "openfermionpyscf==0.5", "h5py<3.11"  ]
-visualization = [ "qutip<5" , "matplotlib>=3.5" ]
+visualization = [ "qutip>5" , "matplotlib>=3.5" ]
 # Additional torch-based integrator
 integrators = [ "torchdiffeq" ]
 

--- a/pyproject.toml.cu13
+++ b/pyproject.toml.cu13
@@ -57,7 +57,7 @@ Releases = "https://nvidia.github.io/cuda-quantum/latest/releases.html"
 # https://github.com/h5py/h5py/issues/2408
 [project.optional-dependencies]
 chemistry = [ "openfermionpyscf==0.5", "h5py<3.11"  ]
-visualization = [ "qutip<5" , "matplotlib>=3.5" ]
+visualization = [ "qutip>5" , "matplotlib>=3.5" ]
 # Additional torch-based integrator
 integrators = [ "torchdiffeq" ]
 

--- a/python/metapackages/pyproject.toml
+++ b/python/metapackages/pyproject.toml
@@ -39,7 +39,7 @@ Releases = "https://nvidia.github.io/cuda-quantum/latest/releases.html"
 
 [project.optional-dependencies]
 chemistry = [ "scipy==1.10.1", "openfermionpyscf==0.5", "h5py==3.12.1"  ]
-visualization = [ "qutip<5" , "matplotlib>=3.5" ]
+visualization = [ "qutip>5" , "matplotlib>=3.5" ]
 
 [build-system]
 requires = ["setuptools", "nvidia-ml-py"]


### PR DESCRIPTION
Bump qutip. It was held back for older python versions that we no longer support. This is causing issues in CI, and should be bumped anyways.