### PR TITLE
bump mgpu commit to fix c++20 builds

### DIFF
--- a/.github/workflows/config/gitlab_commits.txt
+++ b/.github/workflows/config/gitlab_commits.txt
@@ -1,2 +1,2 @@
 nvidia-mgpu-repo: cuda-quantum/cuquantum-mgpu.git
-nvidia-mgpu-commit: 7fcf926ca043440c72c5cf844c5b7030a0f69a3a
+nvidia-mgpu-commit: 7f4b197923b5b77d17edee56e1a5f1aadee7d837


### PR DESCRIPTION
Bump the mgpu commit to fix c++20 builds.