### PR TITLE
Fix density matrix indexing bug for dynamics backend

### DIFF
--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -160,9 +160,12 @@ CuDensityMatState::operator()(std::size_t tensorIdx,
     if (indices.size() != 2)
       throw std::runtime_error("CuDensityMatState holding a density matrix "
                                "supports only 2-dimensional indices");
-    if (indices[0] >= dimension || indices[1] >= dimension)
+    // For density matrix, dimension is the total size (dim*dim), so we need
+    // to compute the single-side dimension for bounds checking.
+    const std::size_t dim = static_cast<std::size_t>(std::sqrt(dimension));
+    if (indices[0] >= dim || indices[1] >= dim)
       throw std::runtime_error("CuDensityMatState indices out of range");
-    return extractValue(indices[0] * dimension + indices[1]);
+    return extractValue(indices[0] * dim + indices[1]);
   }
   if (indices.size() != 1)
     throw std::runtime_error(

--- a/unittests/dynamics/test_CuDensityMatState.cpp
+++ b/unittests/dynamics/test_CuDensityMatState.cpp
@@ -210,3 +210,71 @@ TEST_F(CuDensityMatStateTest, InitialStateEnum) {
     }
   }
 }
+
+// Regression test for density matrix indexing bug.
+// The bug was that operator() used the total dimension (dim*dim) instead of
+// single-side dimension (dim) for bounds checking and linear index calculation.
+TEST_F(CuDensityMatStateTest, DensityMatrixIndexing) {
+  // Create a 2-qubit density matrix (4x4 = 16 elements)
+  // For |00><00| state
+  CuDensityMatState state(densityMatrixData.size(),
+                          cudaq::dynamics::createArrayGpu(densityMatrixData));
+  state.initialize_cudm(handle, hilbertSpaceDims, /*batchSize=*/1);
+  EXPECT_TRUE(state.is_density_matrix());
+
+  // Valid indices for 4x4 density matrix are 0, 1, 2, 3
+  // The bug would compute linear index as i * 16 + j instead of i * 4 + j
+
+  // Test (0,0) - this worked even with the bug because 0*16+0 == 0*4+0
+  auto val00 = state(0, {0, 0});
+  EXPECT_NEAR(val00.real(), 1.0, 1e-12);
+  EXPECT_NEAR(val00.imag(), 0.0, 1e-12);
+
+  // Test (1,1) - this would fail with the bug: 1*16+1=17 > 16 elements
+  auto val11 = state(0, {1, 1});
+  EXPECT_NEAR(val11.real(), 0.0, 1e-12);
+  EXPECT_NEAR(val11.imag(), 0.0, 1e-12);
+
+  // Test (2,2) - this would fail with the bug: 2*16+2=34 > 16 elements
+  auto val22 = state(0, {2, 2});
+  EXPECT_NEAR(val22.real(), 0.0, 1e-12);
+  EXPECT_NEAR(val22.imag(), 0.0, 1e-12);
+
+  // Test (3,3) - this would fail with the bug: 3*16+3=51 > 16 elements
+  auto val33 = state(0, {3, 3});
+  EXPECT_NEAR(val33.real(), 0.0, 1e-12);
+  EXPECT_NEAR(val33.imag(), 0.0, 1e-12);
+
+  // Test off-diagonal elements
+  auto val03 = state(0, {0, 3});
+  EXPECT_NEAR(val03.real(), 0.0, 1e-12);
+  auto val30 = state(0, {3, 0});
+  EXPECT_NEAR(val30.real(), 0.0, 1e-12);
+
+  // Test out-of-bounds access is rejected
+  EXPECT_THROW(state(0, {4, 0}), std::runtime_error);
+  EXPECT_THROW(state(0, {0, 4}), std::runtime_error);
+  EXPECT_THROW(state(0, {4, 4}), std::runtime_error);
+}
+
+// Test indexing for single-qubit density matrix
+TEST_F(CuDensityMatStateTest, SingleQubitDensityMatrixIndexing) {
+  // 1-qubit system: 2x2 density matrix (4 elements)
+  std::vector<std::complex<double>> singleQubitDm = {
+      {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}};
+  CuDensityMatState state(singleQubitDm.size(),
+                          cudaq::dynamics::createArrayGpu(singleQubitDm));
+  state.initialize_cudm(handle, {2}, /*batchSize=*/1);
+  EXPECT_TRUE(state.is_density_matrix());
+
+  // Valid indices are 0, 1
+  auto val00 = state(0, {0, 0});
+  EXPECT_NEAR(val00.real(), 1.0, 1e-12);
+
+  auto val11 = state(0, {1, 1});
+  EXPECT_NEAR(val11.real(), 0.0, 1e-12);
+
+  // Out-of-bounds
+  EXPECT_THROW(state(0, {2, 0}), std::runtime_error);
+  EXPECT_THROW(state(0, {0, 2}), std::runtime_error);
+}


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
This PR fixes a critical bug in `CuDensityMatState::operator()` where density matrix element access used incorrect dimension for bounds checking and linear index calculation.

### Problem
The `operator()` function used the total dimension (`dim*dim`) instead of single-side dimension (`dim`) when accessing density matrix elements:
```
// Before (buggy)
if (indices[0] >= dimension || indices[1] >= dimension)  // dimension = 16 for 4x4 matrix
    throw std::runtime_error("CuDensityMatState indices out of range");
return extractValue(indices[0] * dimension + indices[1]);  // Wrong linear index
```
For a 2-qubit system (4×4 density matrix with dimension=16):
Valid indices should be 0, 1, 2, 3
rho[1,1] computed index 1*16+1=17, causing CUDA memory access error
rho[0,4] passed bounds check (4 < 16) but accessed wrong memory location
Only rho[0,0] worked by coincidence (0*16+0 == 0*4+0)

How to repro:
```
import cudaq
import numpy as np
import cupy as cp
from cudaq import spin
from cudaq.dynamics import Schedule

cudaq.set_target("dynamics")

psi0 = cudaq.State.from_data(cp.array([1.0, 0.0, 0.0, 0.0], dtype=cp.complex128))
hamiltonian = 0.0 * spin.z(0) + 0.0 * spin.z(1)
schedule = Schedule(np.linspace(0.0, 0.1, 2), ["t"])

result = cudaq.evolve(
    hamiltonian, {0: 2, 1: 2}, schedule, psi0,
    collapse_operators=[spin.z(0)],
    store_intermediate_results=cudaq.IntermediateResultSave.ALL,
)

rho = result.final_state()
print(rho[0, 0])  # Works
print(rho[1, 1])  # Before: CUDA crash | After: 0j ✓
```
