### PR TITLE
pin AlmaLinux mirrors to 8.9

### DIFF
--- a/docker/build/devdeps.manylinux.Dockerfile
+++ b/docker/build/devdeps.manylinux.Dockerfile
@@ -69,7 +69,8 @@ ENV CXX="$LLVM_INSTALL_PREFIX/bootstrap/cxx"
 # Build pybind11 - 
 # we should be able to use the same pybind version independent on what Python version we generate bindings for.
 ENV PYBIND11_INSTALL_PREFIX=/usr/local/pybind11
-RUN dnf install -y --nobest --setopt=install_weak_deps=False \
+# Using releasever=8.9: cmake packages missing from 8.10 mirrors for aarch64
+RUN dnf install -y --nobest --setopt=install_weak_deps=False --releasever=8.9\
         ninja-build cmake python3-devel \
     && mkdir /pybind11-project && cd /pybind11-project && git init \
     && git remote add origin https://github.com/pybind/pybind11 \
@@ -102,7 +103,8 @@ ENV CUDA_VERSION=${cuda_version}
 RUN arch_folder=$([ "$(uname -m)" == "aarch64" ] && echo sbsa || echo x86_64) \
     && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/$distro/$arch_folder/cuda-$distro.repo \
     && dnf clean expire-cache \
-    && dnf install -y --nobest --setopt=install_weak_deps=False wget \
+    # Using releasever=8.9: cmake packages missing from 8.10 mirrors for aarch64
+    && dnf install -y --nobest --setopt=install_weak_deps=False --releasever=8.9 wget \
         cuda-compiler-$(echo ${CUDA_VERSION} | tr . -) \
         cuda-cudart-devel-$(echo ${CUDA_VERSION} | tr . -) \
         libcublas-devel-$(echo ${CUDA_VERSION} | tr . -) \


### PR DESCRIPTION
This helps alleviate an issue where boost libraries were not found for the arm64 images, causing failures when building the wheels[0].

This should ideally not be permanent, and Almalinux should fix the mirrors.

[0] - https://github.com/NVIDIA/cuda-quantum/actions/runs/21368765817/job/61512365389#step:10:595