### PR TITLE
Add `distributed-device-call` pass to the default simulation pipeline

### DIFF
--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -58,6 +58,7 @@ static void specializeKernel(const std::string &name, ModuleOp module,
   pm.addPass(
       cudaq::opt::createApplySpecialization({.constantPropagation = true}));
   cudaq::opt::addAggressiveInlining(pm);
+  pm.addPass(cudaq::opt::createDistributedDeviceCall());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   if (resultTy) {
     // If we're expecting a result, then we want to call the .thunk function so


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

We accidentally dropped this pass; hence, `device_call` is not properly lowered to a pure function call.
