### PR TITLE
Fix issue with uninitialized values for noise channels

### DIFF
--- a/runtime/nvqir/cutensornet/tensornet_state.h
+++ b/runtime/nvqir/cutensornet/tensornet_state.h
@@ -47,8 +47,10 @@ struct AppliedTensorOp {
   std::optional<NoiseChannelData> noiseChannel;
   std::vector<int32_t> targetQubitIds;
   std::vector<int32_t> controlQubitIds;
-  bool isAdjoint;
-  bool isUnitary;
+  bool isAdjoint = false;
+  bool isUnitary = false;
+
+  /// Constructor for gate/projector operations.
   AppliedTensorOp(void *dataPtr, const std::vector<int32_t> &targetQubits,
                   const std::vector<int32_t> &controlQubits, bool adjoint,
                   bool unitary)
@@ -56,6 +58,10 @@ struct AppliedTensorOp {
         controlQubitIds(controlQubits), isAdjoint(adjoint), isUnitary(unitary) {
   }
 
+  /// Constructor for noise channel operations.
+  /// Note: isAdjoint and isUnitary use default initialization (false) and
+  /// should not be read for noise channel ops - check noiseChannel.has_value()
+  /// first.
   AppliedTensorOp(const std::vector<int32_t> &qubits,
                   const std::vector<void *> &krausOps,
                   const std::vector<double> &probabilities)

--- a/runtime/nvqir/cutensornet/tensornet_state.inc
+++ b/runtime/nvqir/cutensornet/tensornet_state.inc
@@ -1077,12 +1077,27 @@ TensorNetState<ScalarType>::createFromOpTensors(
   LOG_API_TIME();
   auto state = std::make_unique<TensorNetState>(numQubits, inScratchPad, handle,
                                                 randomEngine);
-  for (const auto &op : opTensors)
-    if (op.isUnitary)
+  for (const auto &op : opTensors) {
+    // Check for noise channel first (noise channel ops have deviceData ==
+    // nullptr and noiseChannel.has_value() == true)
+    if (op.noiseChannel.has_value()) {
+      const bool isGeneralChannel = op.noiseChannel->tensorData.size() !=
+                                    op.noiseChannel->probabilities.size();
+      if (isGeneralChannel) {
+        state->applyGeneralChannel(op.targetQubitIds,
+                                   op.noiseChannel->tensorData);
+      } else {
+        state->applyUnitaryChannel(op.targetQubitIds,
+                                   op.noiseChannel->tensorData,
+                                   op.noiseChannel->probabilities);
+      }
+    } else if (op.isUnitary) {
       state->applyGate(op.controlQubitIds, op.targetQubitIds, op.deviceData,
                        op.isAdjoint);
-    else
+    } else {
       state->applyQubitProjector(op.deviceData, op.targetQubitIds);
+    }
+  }
 
   return state;
 }


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
* Fix undefined behavior caused by uninitialized isAdjoint and isUnitary members in AppliedTensorOp when using noise channel constructor
* Fix noise channel operations being ignored during state reconstruction

The AppliedTensorOp struct's noise channel constructor did not initialize isAdjoint and isUnitary members. When a simulation state containing noise channel operations was used to initialize new qubits, createFromOpTensors and addQubitsToState would read these uninitialized values, causing undefined behavior and crashes.

**How to repro:**
```
// nvq++ --target tensornet repro.cpp -o repro
#include <cudaq.h>

__qpu__ void bell() {
    cudaq::qvector q(2);
    h(q[0]);
    x<cudaq::ctrl>(q[0], q[1]);
}

struct extend_kernel {
    void operator()(cudaq::state &s) __qpu__ {
        cudaq::qvector q(s);
        cudaq::qubit extra;
        h(extra);
    }
};

int main() {
    cudaq::noise_model noise;
    noise.add_channel<cudaq::types::h>({0}, cudaq::depolarization_channel(0.1));
    cudaq::set_noise(noise);

    cudaq::sample(100, bell);
    auto state = cudaq::get_state(bell);

    extend_kernel kernel;
    cudaq::sample(100, kernel, state);  // Crashes before fix!

    cudaq::unset_noise();
    return 0;
}
```

Error before fix:
```
cuTensorNet error CUTENSORNET_STATUS_INVALID_VALUE in line 100
Aborted (core dumped)
```
