### PR TITLE
Skip MPI invalid batch size test when running with single rank

### DIFF
--- a/python/tests/parallel/test_mpi_dynamics.py
+++ b/python/tests/parallel/test_mpi_dynamics.py
@@ -340,6 +340,12 @@ def testMpiBatchedStatesInvalidBatchSize():
 
     num_ranks = cudaq.mpi.num_ranks()
 
+    # Skip if running with a single MPI rank, since any batch size is divisible by 1
+    if num_ranks == 1:
+        pytest.skip(
+            "This test requires at least 2 MPI ranks to test invalid batch size"
+        )
+
     # Simple single-qubit Hamiltonian
     hamiltonian = 2 * np.pi * 0.1 * spin.x(0)
     dimensions = {0: 2}


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

The testMpiBatchedStatesInvalidBatchSize test expects a RuntimeError when batch size is not divisible by the number of MPI ranks. However, when running with a single rank (num_ranks=1, two gpus), any batch size is divisible by 1, making this test scenario impossible to validate.

This error was discovered while generating code coverage on a 2-GPU machine:
```
python/tests/parallel/test_mpi_dynamics.py::testMpiTwoQubitBatched PASSED [ 96%]
python/tests/parallel/test_mpi_dynamics.py::testMpiBatchedStatesInvalidBatchSize FAILED [ 96%]
....
python/tests/visualization/test_draw.py::test_draw_hw_target PASSED      [100%]

=================================== FAILURES ===================================
_____________________ testMpiBatchedStatesInvalidBatchSize _____________________

    @skipIfUnsupported
    def testMpiBatchedStatesInvalidBatchSize():
        """
        Test invalid batch size for distributed batched evolution. This should raise a runtime error when the batch size
        is not evenly divisible by the number of MPI ranks.
        """
        import cupy as cp

        num_ranks = cudaq.mpi.num_ranks()

        # Simple single-qubit Hamiltonian
        hamiltonian = 2 * np.pi * 0.1 * spin.x(0)
        dimensions = {0: 2}

        # Create (num_ranks + 1) distinct initial states to ensure invalid batch size
        initial_states = []
        for i in range(num_ranks + 1):
            theta = i * np.pi / 8
            state_data = cp.array([np.cos(theta), np.sin(theta)],
                                  dtype=cp.complex128)
            initial_states.append(cudaq.State.from_data(state_data))

        batch_size = len(initial_states)
        steps = np.linspace(0, 1, 11)
        schedule = Schedule(steps, ['time'])

        # This should raise a runtime error due to invalid batch size
>       with pytest.raises(RuntimeError) as excinfo:
E       Failed: DID NOT RAISE <class 'RuntimeError'>

python/tests/parallel/test_mpi_dynamics.py:360: Failed

```