### PR TITLE
Fix `list[pauli_word]` broadcast detection in sample/observe

### DIFF
--- a/python/cudaq/runtime/utils.py
+++ b/python/cudaq/runtime/utils.py
@@ -83,6 +83,8 @@ def __isBroadcast(kernel, *args):
         checkList.extend([list[float], list[complex], list[int], list[bool]])
         checkList.extend(
             ['list[float]', 'list[complex]', 'list[int]', 'list[bool]'])
+        checkList.extend(
+            [list[cudaq_runtime.pauli_word], 'list[cudaq.pauli_word]'])
         firstArgTypeIsStdvec = argTypes[firstArgType] in checkList
         if (isinstance(firstArg, list) or
                 isinstance(firstArg, List)) and not firstArgTypeIsStdvec:

--- a/python/tests/kernel/test_sample_kernel.py
+++ b/python/tests/kernel/test_sample_kernel.py
@@ -170,6 +170,31 @@ def test_broadcastPy39Plus():
         assert len(c) == 2
 
 
+def test_list_pauli_word_not_broadcast():
+    """
+    Test that list[pauli_word] arguments are not incorrectly detected as 
+    broadcast arguments. This is a regression test for a bug where
+    list[pauli_word] was missing from the broadcast detection whitelist,
+    causing the list elements to be iterated as separate argument sets
+    instead of passing the whole list as a single argument.
+    """
+
+    @cudaq.kernel
+    def kernel_pauli_list(words: list[cudaq.pauli_word]):
+        qreg = cudaq.qvector(2)
+        exp_pauli(0.1, qreg, words[0])
+
+    # Test with list of pauli_word objects
+    words_obj = [cudaq.pauli_word("ZZ"), cudaq.pauli_word("XX")]
+    counts = cudaq.sample(kernel_pauli_list, words_obj)
+    assert len(counts) > 0
+
+    # Test with list of strings (auto-converted to pauli_word)
+    words_str = ["ZZ", "XX"]
+    counts = cudaq.sample(kernel_pauli_list, words_str)
+    assert len(counts) > 0
+
+
 def test_sample_async():
 
     @cudaq.kernel()


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
Add list[cudaq_runtime.pauli_word] to the broadcast detection whitelist in __isBroadcast(). Without this fix, passing a list[pauli_word] argument to sample() or observe() would incorrectly trigger broadcast mode, causing the runtime to iterate over list elements instead of passing the whole list as a single argument. This was blocking the execution of application in #3839.

Includes regression test in test_sample_kernel.py.

