### PR TITLE
custabilizer backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,18 +590,18 @@ if (CUDAQ_ENABLE_PYTHON)
   
   # Apply specific patch to pybind11 for our documentation.
   # Only apply the patch if not already applied.
-  execute_process(COMMAND ${GIT_EXECUTABLE} -C tpls/pybind11/ apply ../customizations/pybind11/pybind.h.diff --ignore-whitespace --reverse --check
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  RESULT_VARIABLE GIT_PATCH_RESULT
-                  ERROR_QUIET)
-  if (NOT GIT_PATCH_RESULT EQUAL "0")
-    execute_process(COMMAND ${GIT_EXECUTABLE} -C tpls/pybind11/ apply ../customizations/pybind11/pybind.h.diff --ignore-whitespace
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE GIT_PATCH_RESULT)
-  endif()
-  if (NOT GIT_PATCH_RESULT EQUAL "0")
-    message(FATAL_ERROR "Applying patch to submodule failed with ${GIT_PATCH_RESULT}, please update patch")
-  endif()
+  #execute_process(COMMAND ${GIT_EXECUTABLE} -C tpls/pybind11/ apply ../customizations/pybind11/pybind.h.diff --ignore-whitespace --reverse --check
+  #                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  #                  RESULT_VARIABLE GIT_PATCH_RESULT
+  #                  ERROR_QUIET)
+  #if (NOT GIT_PATCH_RESULT EQUAL "0")
+  #  execute_process(COMMAND ${GIT_EXECUTABLE} -C tpls/pybind11/ apply ../customizations/pybind11/pybind.h.diff --ignore-whitespace
+  #                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  #                    RESULT_VARIABLE GIT_PATCH_RESULT)
+  #endif()
+  #if (NOT GIT_PATCH_RESULT EQUAL "0")
+  #  message(FATAL_ERROR "Applying patch to submodule failed with ${GIT_PATCH_RESULT}, please update patch")
+  #endif()
   
   # Regarding the use of PyBind, we need to be careful that the same STL is used for any 
   # Python bindings generated as part of the CUDA-Q build and bindings generated for 

--- a/python/tests/backends/test_custabilizer.py
+++ b/python/tests/backends/test_custabilizer.py
@@ -1,0 +1,228 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import os
+from typing import List
+import pytest
+
+import cudaq
+import numpy as np
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setTarget():
+    try:
+        cudaq.set_target('custabilizer')
+    except RuntimeError:
+        pytest.skip("target not available")
+    yield
+    cudaq.reset_target()
+
+
+def test_custabilizer_non_clifford():
+    """Custabilizer inherits from Stim, so non-Clifford gates should be rejected."""
+
+    @cudaq.kernel
+    def kernel():
+        qubits = cudaq.qvector(10)
+        rx(0.1, qubits[0])
+
+    with pytest.raises(RuntimeError) as e:
+        cudaq.sample(kernel)
+    assert 'Gate not supported by Stim simulator' in repr(e)
+
+
+def test_custabilizer_toffoli_gates():
+    """Custabilizer inherits from Stim, so multi-control gates should be rejected."""
+
+    @cudaq.kernel
+    def kernel():
+        qubits = cudaq.qvector(10)
+        cx(qubits[0:9], qubits[9])
+
+    with pytest.raises(RuntimeError) as e:
+        cudaq.sample(kernel)
+    assert 'Gates with >1 controls not supported by Stim simulator' in repr(e)
+
+
+def test_custabilizer_sample():
+    """Test basic sampling with large qubit count (custabilizer GPU backend)."""
+
+    @cudaq.kernel
+    def kernel():
+        qubits = cudaq.qvector(250)
+        h(qubits[0])
+        for i in range(1, 250):
+            cx(qubits[i - 1], qubits[i])
+        mz(qubits)
+
+    counts = cudaq.sample(kernel)
+    assert len(counts) == 2
+    assert '0' * 250 in counts
+    assert '1' * 250 in counts
+
+
+def test_custabilizer_all_mz_types():
+    """Test different measurement basis types."""
+
+    @cudaq.kernel
+    def kernel():
+        qubits = cudaq.qvector(10)
+        mx(qubits)
+        my(qubits)
+        mz(qubits)
+
+    counts = cudaq.sample(kernel)
+    assert len(counts) > 1
+
+
+def test_custabilizer_state_preparation():
+    """Custabilizer does not support state initialization."""
+
+    @cudaq.kernel
+    def kernel(vec: List[complex]):
+        qubits = cudaq.qvector(vec)
+
+    with pytest.raises(RuntimeError) as e:
+        state = [1. / np.sqrt(2.), 1. / np.sqrt(2.), 0., 0.]
+        cudaq.sample(kernel, state)
+    assert 'does not support initialization of qubits from state data' in repr(e)
+
+
+def test_custabilizer_state_preparation_builder():
+    """Custabilizer does not support state initialization via builder."""
+    kernel, state = cudaq.make_kernel(List[complex])
+    qubits = kernel.qalloc(state)
+
+    with pytest.raises(RuntimeError) as e:
+        state = [1. / np.sqrt(2.), 1. / np.sqrt(2.), 0., 0.]
+        cudaq.sample(kernel, state)
+    assert 'does not support initialization of qubits from state data' in repr(e)
+
+
+def test_custabilizer_bell_state():
+    """Test Bell state preparation and measurement."""
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(2)
+        h(q[0])
+        cx(q[0], q[1])
+        mz(q)
+
+    cudaq.set_random_seed(13)
+    counts = cudaq.sample(kernel, shots_count=1000)
+    assert len(counts) == 2
+    assert '00' in counts
+    assert '11' in counts
+    assert np.isclose(counts.probability('00'), 0.5, atol=0.2)
+    assert np.isclose(counts.probability('11'), 0.5, atol=0.2)
+
+
+def test_custabilizer_mid_circuit_measurement():
+    """Test mid-circuit measurement with conditionals (exercises measureQubit)."""
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(2)
+        h(q[0])
+        # Mid-circuit measurement that triggers measureQubit call
+        result = mz(q[0])
+        if result:
+            x(q[1])
+        mz(q)
+
+    cudaq.set_random_seed(13)
+    counts = cudaq.sample(kernel, shots_count=1000)
+    # Should see 00 and 11 (when q[0] is 0 or 1, q[1] follows)
+    assert len(counts) == 2
+    assert '00' in counts
+    assert '11' in counts
+    assert np.isclose(counts.probability('00'), 0.5, atol=0.2)
+    assert np.isclose(counts.probability('11'), 0.5, atol=0.2)
+
+
+def test_custabilizer_ghz_state():
+    """Test GHZ state with varying qubit counts."""
+
+    @cudaq.kernel
+    def kernel(n: int):
+        qubits = cudaq.qvector(n)
+        h(qubits[0])
+        for i in range(n - 1):
+            cx(qubits[i], qubits[i + 1])
+        mz(qubits)
+
+    for n in [3, 5, 10]:
+        counts = cudaq.sample(kernel, n, shots_count=100)
+        assert len(counts) == 2
+        assert '0' * n in counts
+        assert '1' * n in counts
+
+
+def test_custabilizer_noise_support():
+    """Test that noise models work with custabilizer."""
+    noise = cudaq.NoiseModel()
+    # Add bit flip noise on X gates
+    noise.add_channel('x', [0], cudaq.BitFlipChannel(0.1))
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(5)
+        x(q)
+        mz(q)
+
+    # Without noise, should always get 11111
+    counts_no_noise = cudaq.sample(kernel)
+    assert counts_no_noise['11111'] == 1000
+
+    # With noise, should see some bit flips
+    counts_with_noise = cudaq.sample(kernel, noise_model=noise, shots_count=1000)
+    # Should have multiple outcomes due to noise
+    assert len(counts_with_noise) > 1
+
+
+def test_custabilizer_explicit_measurements():
+    """Test explicit measurements flag."""
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(3)
+        x(q[0])
+        mz(q[0])
+        mz(q[1])
+        mz(q[2])
+
+    counts = cudaq.sample(kernel)
+    assert counts['100'] == 1000
+    counts = cudaq.sample(kernel, explicit_measurements=True)
+    assert counts['100'] == 1000
+
+
+def test_custabilizer_register_names():
+    """Test named measurement registers."""
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(2)
+        h(q[0])
+        mz(q[0], register_name="first")
+        cx(q[0], q[1])
+        mz(q, register_name="both")
+
+    result = cudaq.sample(kernel, shots_count=100)
+    assert 'first' in result.register_names
+    assert 'both' in result.register_names
+    first_reg = result.get_register_counts('first')
+    assert '0' in first_reg or '1' in first_reg
+
+
+# leave for gdb debugging
+if __name__ == "__main__":
+    loc = os.path.abspath(__file__)
+    pytest.main([loc, "-s"])

--- a/runtime/nvqir/CMakeLists.txt
+++ b/runtime/nvqir/CMakeLists.txt
@@ -41,6 +41,29 @@ install(TARGETS ${LIBRARY_NAME}
 add_subdirectory(qpp)
 add_subdirectory(stim)
 
+find_path(CUSTABILIZER_INCLUDE_DIR
+  NAMES custabilizer.hpp
+  HINTS
+    ${CUSTABILIZER_ROOT}/include
+    ENV CUSTABILIZER_INCLUDE_DIR
+    ENV CUSTABILIZER_ROOT
+  PATH_SUFFIXES include)
+
+find_library(CUSTABILIZER_LIBRARY
+  NAMES custabilizer libcustabilizer.so libcustabilizer.so.0
+  HINTS
+    ${CUSTABILIZER_ROOT}/lib64
+    ${CUSTABILIZER_ROOT}/lib
+    ${CUSTABILIZER_ROOT}/build/lib
+    ENV CUSTABILIZER_LIBRARY
+    ENV CUSTABILIZER_ROOT
+  PATH_SUFFIXES lib lib64 build/lib)
+
+if (CUSTABILIZER_INCLUDE_DIR AND CUSTABILIZER_LIBRARY AND CUDA_FOUND)
+  message(STATUS "CUSTABILIZER_LIBRARY: ${CUSTABILIZER_LIBRARY}")
+  add_subdirectory(custabilizer)
+endif()
+
 if (CUSTATEVEC_ROOT AND CUDA_FOUND) 
   add_subdirectory(custatevec)
 endif() 

--- a/runtime/nvqir/custabilizer/CMakeLists.txt
+++ b/runtime/nvqir/custabilizer/CMakeLists.txt
@@ -1,0 +1,62 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+enable_language(CUDA)
+find_package(CUDAToolkit REQUIRED)
+
+set(LIBRARY_NAME nvqir-custabilizer)
+set(INTERFACE_POSITION_INDEPENDENT_CODE ON)
+
+add_library(${LIBRARY_NAME} SHARED CustabilizerCircuitSimulator.cpp)
+set_property(GLOBAL APPEND PROPERTY CUDAQ_RUNTIME_LIBS ${LIBRARY_NAME})
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/nvqir-custabilizer.map "
+{
+  global:
+    *;
+  local:
+    *4stim*;
+};
+")
+
+target_include_directories(${LIBRARY_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/runtime>
+    $<INSTALL_INTERFACE:include>
+  PRIVATE
+    ${CUSTABILIZER_INCLUDE_DIR})
+
+target_link_libraries(${LIBRARY_NAME}
+  PRIVATE
+    nvqir-stim
+    libstim
+    fmt::fmt-header-only
+    cudaq-common
+    ${CUSTABILIZER_LIBRARY}
+    CUDA::cudart)
+
+target_link_options(${LIBRARY_NAME}
+  PRIVATE
+    "-Wl,--version-script,${CMAKE_CURRENT_BINARY_DIR}/nvqir-custabilizer.map")
+
+get_filename_component(CUSTABILIZER_LIB_DIR ${CUSTABILIZER_LIBRARY} DIRECTORY)
+set_target_properties(${LIBRARY_NAME}
+  PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${LLVM_BINARY_DIR}/lib:${CUSTABILIZER_LIB_DIR}")
+
+add_custom_command(
+  TARGET ${LIBRARY_NAME}
+  POST_BUILD
+  COMMAND bash ${CMAKE_SOURCE_DIR}/runtime/nvqir/stim/verify_linkage.sh $<TARGET_FILE:${LIBRARY_NAME}>
+  VERBATIM
+  COMMENT "Verifying that no stim namespace symbols are exported in ${LIBRARY_NAME}..."
+)
+
+install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
+
+add_target_config(custabilizer)

--- a/runtime/nvqir/custabilizer/CustabilizerCircuitSimulator.cpp
+++ b/runtime/nvqir/custabilizer/CustabilizerCircuitSimulator.cpp
@@ -1,0 +1,328 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "CustabilizerErrorHandling.h"
+#include "../stim/StimCircuitSimulator.h"
+
+using namespace cudaq;
+
+namespace nvqir {
+
+namespace {
+
+struct CustabilizerCircuit {
+  custabilizerHandle_t handle = nullptr;
+  custabilizerCircuit_t circuit = nullptr;
+  void *buffer_d = nullptr;
+  int64_t buffer_size = 0;
+
+  explicit CustabilizerCircuit(const std::string &stim_circuit_str) {
+    HANDLE_CUST_ERROR(custabilizerCreate(&handle));
+    HANDLE_CUST_ERROR(custabilizerCircuitSizeFromString(handle, stim_circuit_str.c_str(),
+                                                &buffer_size));
+    HANDLE_CUDA_ERROR(cudaMalloc(&buffer_d, static_cast<size_t>(buffer_size)));
+    HANDLE_CUST_ERROR(custabilizerCreateCircuitFromString(handle, stim_circuit_str.c_str(),
+                                                  buffer_d, buffer_size,
+                                                  &circuit));
+  }
+
+  ~CustabilizerCircuit() {
+    if (buffer_d)
+      cudaFree(buffer_d);
+    if (circuit)
+      custabilizerDestroyCircuit(circuit);
+    if (handle)
+      custabilizerDestroy(handle);
+  }
+
+  CustabilizerCircuit(const CustabilizerCircuit &) = delete;
+  CustabilizerCircuit &operator=(const CustabilizerCircuit &) = delete;
+};
+
+struct CustabilizerFrameRunner {
+  custabilizerHandle_t handle = nullptr;
+  custabilizerFrameSimulator_t frame_simulator = nullptr;
+  custabilizerBitInt_t *x_table_d = nullptr;
+  custabilizerBitInt_t *z_table_d = nullptr;
+  custabilizerBitInt_t *m_table_d = nullptr;
+  int64_t num_qubits = 0;
+  int64_t allocated_shots = 0;
+  int64_t allocated_measurements = 0;
+  int64_t stride_bytes = 0;
+  stim::Circuit circuitCache;
+  bool cache_executed = false;
+
+  explicit CustabilizerFrameRunner(int64_t num_qubits)
+      : num_qubits(num_qubits) {
+    if (num_qubits <= 0)
+      throw std::runtime_error("cuStabilizer frame simulator requires num_qubits > 0");
+    HANDLE_CUST_ERROR(custabilizerCreate(&handle));
+  }
+
+  ~CustabilizerFrameRunner() {
+    deallocate();
+    if (handle)
+      custabilizerDestroy(handle);
+  }
+
+  CustabilizerFrameRunner(const CustabilizerFrameRunner &) = delete;
+  CustabilizerFrameRunner &operator=(const CustabilizerFrameRunner &) = delete;
+
+  void apply(const stim::Circuit &circuit) {
+    circuitCache += circuit;
+    cache_executed = false;
+  }
+
+  void clear() {
+    circuitCache.clear();
+    cache_executed = false;
+  }
+
+  std::vector<uint32_t> getMeasurementTable(int64_t num_shots,
+                                            bool randomize_after_measurement,
+                                            uint64_t seed) {
+    if (num_shots <= 0)
+      throw std::runtime_error("num_shots must be > 0");
+    int64_t measurement_count = circuitCache.count_measurements();
+
+    if (num_shots > allocated_shots || measurement_count > allocated_measurements) {
+      reallocate(num_shots, measurement_count);
+    }
+
+    if (!cache_executed) {
+      CustabilizerCircuit circuit(circuitCache.str());
+      HANDLE_CUST_ERROR(custabilizerFrameSimulatorApplyCircuit(
+          handle, frame_simulator, circuit.circuit,
+          randomize_after_measurement ? 1 : 0, seed, x_table_d, z_table_d,
+          m_table_d, 0));
+      cache_executed = true;
+    }
+
+    const size_t words_per_row = static_cast<size_t>((num_shots + 31) / 32);
+    const size_t total_words = words_per_row * static_cast<size_t>(measurement_count);
+    std::vector<uint32_t> out(total_words);
+    const size_t total_bytes = total_words * sizeof(uint32_t);
+    if (total_bytes > 0)
+      HANDLE_CUDA_ERROR(cudaMemcpy(out.data(), m_table_d, total_bytes, cudaMemcpyDeviceToHost));
+    return out;
+  }
+
+private:
+  void deallocate() {
+    if (x_table_d) {
+      cudaFree(x_table_d);
+      x_table_d = nullptr;
+    }
+    if (z_table_d) {
+      cudaFree(z_table_d);
+      z_table_d = nullptr;
+    }
+    if (m_table_d) {
+      cudaFree(m_table_d);
+      m_table_d = nullptr;
+    }
+    if (frame_simulator) {
+      custabilizerDestroyFrameSimulator(frame_simulator);
+      frame_simulator = nullptr;
+    }
+    allocated_shots = 0;
+    allocated_measurements = 0;
+  }
+
+  void reallocate(int64_t new_shots, int64_t new_measurements) {
+    deallocate();
+
+    allocated_shots = new_shots;
+    allocated_measurements = new_measurements;
+    stride_bytes = ((new_shots + 31) / 32) * static_cast<int64_t>(sizeof(uint32_t));
+
+    const size_t xz_bytes =
+        static_cast<size_t>(stride_bytes) * static_cast<size_t>(num_qubits);
+    const size_t m_bytes =
+        static_cast<size_t>(stride_bytes) * static_cast<size_t>(new_measurements);
+
+    HANDLE_CUDA_ERROR(cudaMalloc(&x_table_d, xz_bytes));
+    HANDLE_CUDA_ERROR(cudaMalloc(&z_table_d, xz_bytes));
+    HANDLE_CUDA_ERROR(cudaMalloc(&m_table_d, m_bytes));
+    HANDLE_CUDA_ERROR(cudaMemset(x_table_d, 0, xz_bytes));
+    HANDLE_CUDA_ERROR(cudaMemset(z_table_d, 0, xz_bytes));
+    HANDLE_CUDA_ERROR(cudaMemset(m_table_d, 0, m_bytes));
+
+    HANDLE_CUST_ERROR(custabilizerCreateFrameSimulator(handle, num_qubits, new_shots,
+                                               new_measurements, stride_bytes,
+                                               &frame_simulator));
+  }
+};
+
+} // namespace
+
+/// @brief The CustabilizerCircuitSimulator extends StimCircuitSimulator
+/// to use cuStabilizer for GPU-accelerated frame simulation, while keeping
+/// Stim's TableauSimulator for the noiseless reference.
+class CustabilizerCircuitSimulator : public StimCircuitSimulator {
+protected:
+  /// @brief Persistent frame runner for circuit accumulation and execution
+  std::unique_ptr<CustabilizerFrameRunner> frameRunner;
+
+  /// @brief Override: reject MSM mode, initialize frame runner
+  void addQubitsToState(std::size_t qubitCount,
+                        const void *stateDataIn = nullptr) override {
+    if (stateDataIn)
+      throw std::runtime_error(
+          "The cuStabilizer backend does not support initialization of qubits from state data.");
+    if (executionContext && executionContext->name == "msm")
+      throw std::runtime_error("MSM mode is not supported by custabilizer backend.");
+    StimCircuitSimulator::addQubitsToState(qubitCount, stateDataIn);
+    if (nQubitsAllocated > 0 && !frameRunner) {
+      frameRunner = std::make_unique<CustabilizerFrameRunner>(
+          static_cast<int64_t>(nQubitsAllocated));
+    }
+  }
+
+  /// @brief Override: also clear the frame runner
+  void deallocateStateImpl() override {
+    StimCircuitSimulator::deallocateStateImpl();
+    if (frameRunner) {
+      frameRunner->clear();
+      frameRunner.reset();
+    }
+  }
+
+  /// @brief Override: apply to tableau and accumulate in frameRunner
+  void applyOpToSims(const std::string &gate_name,
+                     const std::vector<uint32_t> &targets) override {
+    if (targets.empty())
+      return;
+    stim::Circuit tempCircuit;
+    CUDAQ_INFO("Calling applyOpToSims {} - {}", gate_name, targets);
+    tempCircuit.safe_append_u(gate_name, targets);
+    tableau->safe_do_circuit(tempCircuit);
+    if (frameRunner)
+      frameRunner->apply(tempCircuit);
+  }
+
+  /// @brief Override: accumulate noise in frameRunner
+  void applyNoise(const cudaq::kraus_channel &channel,
+                  const std::vector<std::uint32_t> &qubits) override {
+    CUDAQ_INFO("[custabilizer] apply kraus channel {}, is_msm_mode = {}",
+               channel.get_type_name(), is_msm_mode);
+    if (is_msm_mode)
+      throw std::runtime_error("MSM mode is not supported by custabilizer backend.");
+
+    if (auto res = isValidStimNoiseChannel(channel)) {
+      stim::Circuit noiseOps;
+      noiseOps.safe_append_u(res.value().stim_name, qubits, channel.parameters);
+      if (frameRunner)
+        frameRunner->apply(noiseOps);
+      msm_err_count += res->params.size();
+    }
+  }
+
+  /// @brief Override: use frame runner for mid-circuit measurements
+  bool measureQubit(const std::size_t index) override {
+    applyOpToSims(
+        "M", std::vector<std::uint32_t>{static_cast<std::uint32_t>(index)});
+    num_measurements++;
+
+    const std::vector<bool> &v = tableau->measurement_record.storage;
+    const bool tableauBit = *v.crbegin();
+
+    if (executionContext && executionContext->name == "sample" &&
+        !executionContext->hasConditionalsOnMeasureResults) {
+      return tableauBit;
+    }
+
+    if (!frameRunner)
+      throw std::runtime_error("Frame runner not initialized");
+    const uint64_t seed = randomEngine();
+    const auto m_table = frameRunner->getMeasurementTable(
+        /*num_shots=*/1, /*randomize_after_measurement=*/true, seed);
+    const size_t words_per_row = 1;
+    const size_t last_meas = num_measurements - 1;
+    const bool sampleFlip = (m_table[last_meas * words_per_row] & 0x1u) != 0;
+    return tableauBit ^ sampleFlip;
+  }
+
+  /// @brief Override: use frame runner for batch sampling
+  cudaq::ExecutionResult sample(const std::vector<std::size_t> &qubits,
+                                const int shots) override {
+    if (executionContext->explicitMeasurements && qubits.empty() &&
+        num_measurements == 0)
+      throw std::runtime_error(
+          "The sampling option `explicit_measurements` is not supported on a "
+          "kernel without any measurement operation.");
+
+    bool populateResult = [&]() {
+      if (executionContext->explicitMeasurements)
+        return qubits.empty();
+      return true;
+    }();
+
+    if (nQubitsAllocated == 0)
+      throw std::runtime_error("custabilizer backend state is not initialized.");
+
+    const auto batch_size = static_cast<int64_t>(getBatchSize());
+    if (shots > batch_size)
+      throw std::runtime_error("Requested shots exceed custabilizer batch size.");
+
+    std::vector<std::uint32_t> stimTargetQubits(qubits.begin(), qubits.end());
+    applyOpToSims("M", stimTargetQubits);
+    num_measurements += stimTargetQubits.size();
+
+    if (!populateResult)
+      return cudaq::ExecutionResult();
+
+    const std::vector<bool> &v = tableau->measurement_record.storage;
+    if (v.size() != num_measurements)
+      throw std::runtime_error("Internal error: tableau measurement record size mismatch.");
+
+    if (!frameRunner)
+      throw std::runtime_error("Frame runner not initialized");
+    const uint64_t seed = randomEngine();
+    const auto m_table = frameRunner->getMeasurementTable(
+        batch_size, /*randomize_after_measurement=*/true, seed);
+
+    const size_t words_per_row = static_cast<size_t>((batch_size + 31) / 32);
+    auto get_flip = [&](size_t shot, size_t meas) -> bool {
+      const uint32_t word = m_table[meas * words_per_row + (shot >> 5)];
+      return ((word >> (shot & 31)) & 1u) != 0;
+    };
+
+    const size_t bits_per_sample = num_measurements;
+    assert(bits_per_sample >= qubits.size());
+    const std::size_t first_bit_to_save =
+        executionContext->explicitMeasurements ? 0 : bits_per_sample - qubits.size();
+
+    CountsDictionary counts;
+    std::vector<std::string> sequentialData;
+    sequentialData.reserve(shots);
+    for (std::size_t shot = 0; shot < static_cast<std::size_t>(shots); shot++) {
+      std::string aShot(bits_per_sample - first_bit_to_save, '0');
+      for (std::size_t b = first_bit_to_save; b < bits_per_sample; b++) {
+        const bool bit = get_flip(shot, b) ^ v[b];
+        aShot[b - first_bit_to_save] = bit ? '1' : '0';
+      }
+      counts[aShot]++;
+      sequentialData.push_back(std::move(aShot));
+    }
+
+    ExecutionResult result(counts);
+    result.sequentialData = std::move(sequentialData);
+    return result;
+  }
+
+public:
+  std::string name() const override { return "custabilizer"; }
+  NVQIR_SIMULATOR_CLONE_IMPL(CustabilizerCircuitSimulator)
+};
+
+} // namespace nvqir
+
+#ifndef __NVQIR_QPP_TOGGLE_CREATE
+NVQIR_REGISTER_SIMULATOR(nvqir::CustabilizerCircuitSimulator, custabilizer)
+#endif

--- a/runtime/nvqir/custabilizer/CustabilizerErrorHandling.h
+++ b/runtime/nvqir/custabilizer/CustabilizerErrorHandling.h
@@ -1,0 +1,33 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+#include "common/cudaq_fmt.h"
+#include "cuda_runtime.h"
+#include "custabilizer.h"
+#include <stdexcept>
+
+#define HANDLE_CUDA_ERROR(x)                                                   \
+  {                                                                            \
+    const auto err = x;                                                        \
+    if (err != cudaSuccess) {                                                  \
+      throw std::runtime_error(cudaq_fmt::format("[cuda] %{} in {} (line {})", \
+                                                 cudaq_fmt::underlying(err),   \
+                                                 __FUNCTION__, __LINE__));     \
+    }                                                                          \
+  }
+
+#define HANDLE_CUST_ERROR(x)                                                   \
+  {                                                                            \
+    const auto err = x;                                                        \
+    if (err != CUSTABILIZER_STATUS_SUCCESS) {                                  \
+      throw std::runtime_error(cudaq_fmt::format(                              \
+          "[custabilizer] {} in {} (line {})",                                 \
+          custabilizerGetErrorString(err), __FUNCTION__, __LINE__));           \
+    }                                                                          \
+  }

--- a/runtime/nvqir/custabilizer/custabilizer.yml
+++ b/runtime/nvqir/custabilizer/custabilizer.yml
@@ -1,0 +1,13 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                           #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+name: custabilizer
+description: "cuStabilizer-accelerated backend target"
+config:
+  nvqir-simulation-backend: custabilizer
+  preprocessor-defines: ["-D CUDAQ_SIMULATION_SCALAR_FP64"]

--- a/runtime/nvqir/stim/StimCircuitSimulator.h
+++ b/runtime/nvqir/stim/StimCircuitSimulator.h
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "nvqir/CircuitSimulator.h"
+#include "stim.h"
+#include <random>
+
+namespace nvqir {
+
+/// @brief Collection of information about a noise type in Stim
+struct StimNoiseType {
+  /// The name of the error mechanism in Stim
+  std::string stim_name;
+  /// Whether the error mechanism flips X; one per error mechanism per target
+  std::vector<bool> flips_x;
+  /// Whether the error mechanism flips Z; one per error mechanism per target
+  std::vector<bool> flips_z;
+  /// One probability per error mechanism
+  std::vector<double> params;
+  /// The number of targets for the noise type
+  int num_targets = 1;
+};
+
+/// @brief The StimCircuitSimulator implements the CircuitSimulator
+/// base class to provide a simulator delegating to the Stim library from
+/// https://github.com/quantumlib/Stim.
+class StimCircuitSimulator : public nvqir::CircuitSimulatorBase<double> {
+protected:
+  // Follow Stim naming convention (W) for bit width (required for templates).
+  static constexpr std::size_t W = stim::MAX_BITWORD_WIDTH;
+
+  /// @brief Number of measurements performed so far.
+  std::size_t num_measurements = 0;
+
+  /// @brief Top-level random engine. Stim simulator RNGs are based off of this
+  /// engine.
+  std::mt19937_64 randomEngine;
+
+  /// @brief Stim Tableau simulator (noiseless)
+  std::unique_ptr<stim::TableauSimulator<W>> tableau;
+
+  /// @brief Stim Frame/Flip simulator (used to generate multiple shots)
+  std::unique_ptr<stim::FrameSimulator<W>> sampleSim;
+
+  /// @brief Error counter for MSM generation. This is only used for "msm" and
+  /// "msm_size" execution contexts.
+  std::size_t msm_err_count = 0;
+
+  /// @brief Error ID counter for MSM generation. This is only used for "msm"
+  /// and "msm_size" execution contexts.
+  std::size_t msm_id_counter = 0;
+
+  /// @brief Whether or not the execution context name is "msm" (value is cached
+  /// for speed)
+  bool is_msm_mode = false;
+
+  std::optional<StimNoiseType>
+  isValidStimNoiseChannel(const cudaq::kraus_channel &channel) const;
+
+  /// @brief Grow the state vector by one qubit.
+  void addQubitToState() override;
+
+  /// @brief Get the batch size to use for the Stim simulator.
+  std::size_t getBatchSize();
+
+  /// @brief Return the number of rows and columns needed for a Parity Check
+  /// Matrix
+  std::optional<std::pair<std::size_t, std::size_t>>
+  generateMSMSize() override;
+
+  void generateMSM() override;
+
+  /// @brief Override the default sized allocation of qubits
+  /// here to be a bit more efficient than the default implementation
+  void addQubitsToState(std::size_t qubitCount,
+                        const void *stateDataIn = nullptr) override;
+
+  /// @brief Reset the qubit state.
+  void deallocateStateImpl() override;
+
+  /// @brief Apply operation to all Stim simulators.
+  /// This is the key method that derived classes should override to replace
+  /// the frame simulator execution.
+  virtual void applyOpToSims(const std::string &gate_name,
+                             const std::vector<uint32_t> &targets);
+
+  /// @brief Apply the noise channel on \p qubits
+  void applyNoiseChannel(const std::string_view gateName,
+                         const std::vector<std::size_t> &controls,
+                         const std::vector<std::size_t> &targets,
+                         const std::vector<double> &params) override;
+
+  bool isValidNoiseChannel(const cudaq::noise_model_type &type) const override;
+
+  void applyNoise(const cudaq::kraus_channel &channel,
+                  const std::vector<std::size_t> &qubits) override;
+
+  virtual void applyNoise(const cudaq::kraus_channel &channel,
+                          const std::vector<std::uint32_t> &qubits);
+
+  void applyGate(const GateApplicationTask &task) override;
+
+  /// @brief Set the current state back to the |0> state.
+  void setToZeroState() override;
+
+  /// @brief Override the calculateStateDim because this is not a state vector
+  /// simulator.
+  std::size_t calculateStateDim(const std::size_t numQubits) override;
+
+  /// @brief Measure the qubit and return the result.
+  bool measureQubit(const std::size_t index) override;
+
+  QubitOrdering getQubitOrdering() const override;
+
+public:
+  StimCircuitSimulator();
+  virtual ~StimCircuitSimulator() = default;
+
+  void setRandomSeed(std::size_t seed) override;
+
+  bool canHandleObserve() override;
+
+  /// @brief Reset the qubit
+  /// @param index 0-based index of qubit to reset
+  void resetQubit(const std::size_t index) override;
+
+  /// @brief Sample the multi-qubit state. If \p qubits is empty and
+  /// explicitMeasurements is set, this returns all previously saved
+  /// measurements.
+  cudaq::ExecutionResult sample(const std::vector<std::size_t> &qubits,
+                                const int shots) override;
+
+  bool isStateVectorSimulator() const override;
+
+  std::string name() const override;
+  NVQIR_SIMULATOR_CLONE_IMPL(StimCircuitSimulator)
+};
+
+} // namespace nvqir


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

## Description

This PR adds [cuStabilizer](https://docs.nvidia.com/cuda/cuquantum/latest/custabilizer/index.html) as a backend. It is based on Stim backend, as it accepts the same circuit format and outputs same bit tables.

### Usage

Install custabilizer by downloading cuquantum sdk or from PyPi: `pip install custabilizer-cu12` (for cuda 12.x). 

```bash
# Get install dir of cuStabilizer, assuming wheel installation. Change this directory if you have a different install path
export CUSTABILIZER_ROOT=$(pip show custatevec-cu12 | grep Location | cut -d \  -f 2 )/cuquantum/
./scripts/build_cudaq.sh
```

Then set cudaq target
```python
cudaq.set_target('custabilizer')
```

## Performance notes



I am new to this project, but storing measurement results as a vector of strings seems odd. For one, while actual circuit simulation takes about 0.008 seconds on distance=rounds=6 code with 1M shots, the code below takes about 1.4s (~150 times more).

```cpp
    CountsDictionary counts;
    std::vector<std::string> sequentialData;
    sequentialData.reserve(shots);
    for (std::size_t shot = 0; shot < static_cast<std::size_t>(shots); shot++) {
      std::string aShot(bits_per_sample - first_bit_to_save, '0');
      for (std::size_t b = first_bit_to_save; b < bits_per_sample; b++) {
        const bool bit = get_flip(shot, b) ^ v[b];
        aShot[b - first_bit_to_save] = bit ? '1' : '0';
      }
      counts[aShot]++;
      sequentialData.push_back(std::move(aShot));
    }
```

And if you were ever to calculate, say "how often does qubit Q has an error" or "how many qubits in this shot returned 1", you'd have to loop over strings and calculate number of ones, whereas if results was a numeric dtype, you could just sum over column/row. String presentation ideally should be on the layer closest to the user.