### PR TITLE
Fix pre-commit caches to avoid PR duplication

### DIFF
--- a/.github/workflows/repo_checks.yml
+++ b/.github/workflows/repo_checks.yml
@@ -8,6 +8,8 @@
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
   pull_request:
   merge_group:
     types:


### PR DESCRIPTION


### Description
I noticed after #3760 we have caches for each PR. This was becauserepo_checks.yml only triggered on pull_request and merge_group, so pre-commit caches were never populated on `main`. Since GitHub Actions scopes cache access to the current branch and the default branch, every PR created its own isolated copy of each cache instead of sharing one. This should save ~300MB of cache generation per PR.