### PR TITLE
[python] Simplify PyKernelDecorator __init__

### DIFF
--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -153,7 +153,6 @@ class PyKernelDecorator(object):
             self._parse_signature_from_python()
             self.pre_compile()
 
-
     def __del__(self):
         # explicitly call `del` on the MLIR `ModuleOp` wrappers.
         if self.qkeModule:


### PR DESCRIPTION
In the process of familiarizing myself with the code, I reorganized the logic a bit.

I find the refactored version much easier to read and parse. I've been quite careful to keep it equivalent to the old code (go through the branches one by one, you should see that it does the same thing).

I am opening this PR as I think it is a net positive so we might as well  merge it in, but feel free to disagree. If you think this is an unnecessary change, I'll happily close the PR.