### PR TITLE
[python] Remove GlobalAstRegistry

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -134,8 +134,7 @@ except Exception:
 from .display import display_trace
 from .kernel.kernel_decorator import kernel, PyKernelDecorator
 from .kernel.kernel_builder import (make_kernel, QuakeValue, PyKernel)
-from .kernel.ast_bridge import (globalAstRegistry, globalRegisteredOperations,
-                                PyASTBridge)
+from .kernel.ast_bridge import (globalRegisteredOperations, PyASTBridge)
 from .runtime.sample import sample
 from .runtime.sample import sample_async, AsyncSampleResult
 from .runtime.observe import observe
@@ -288,8 +287,7 @@ def amplitudes(array_data):
 
 
 def __clearKernelRegistries():
-    global globalAstRegistry, globalRegisteredOperations
-    globalAstRegistry.clear()
+    global globalRegisteredOperations
     globalRegisteredOperations.clear()
 
 

--- a/python/cudaq/kernel/analysis.py
+++ b/python/cudaq/kernel/analysis.py
@@ -13,7 +13,7 @@ import textwrap
 
 from cudaq.mlir._mlir_libs._quakeDialects import cudaq_runtime
 from cudaq.mlir.dialects import cc
-from .utils import (globalAstRegistry, mlirTypeFromAnnotation)
+from .utils import mlirTypeFromAnnotation
 
 
 class HasReturnNodeVisitor(ast.NodeVisitor):

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -29,12 +29,12 @@ from cudaq.mlir.ir import (BoolAttr, Block, BlockArgument, Context, ComplexType,
 from cudaq.mlir.passmanager import PassManager
 from .analysis import ValidateArgumentAnnotations, ValidateReturnStatements
 from .captured_data import CapturedDataStorage
-from .utils import (Color, globalAstRegistry, globalRegisteredOperations,
-                    globalRegisteredTypes, nvqppPrefix, mlirTypeFromAnnotation,
-                    mlirTypeFromPyType, mlirTypeToPyType, getMLIRContext,
-                    recover_func_op, is_recovered_value_ok,
-                    recover_value_of_or_none, cudaq__unique_attr_name,
-                    mlirTryCreateStructType, resolve_qualified_symbol)
+from .utils import (Color, globalRegisteredOperations, globalRegisteredTypes,
+                    nvqppPrefix, mlirTypeFromAnnotation, mlirTypeFromPyType,
+                    mlirTypeToPyType, getMLIRContext, recover_func_op,
+                    is_recovered_value_ok, recover_value_of_or_none,
+                    cudaq__unique_attr_name, mlirTryCreateStructType,
+                    resolve_qualified_symbol)
 
 State = cudaq_runtime.State
 
@@ -5361,7 +5361,6 @@ def compile_to_mlir(uniqueId, astModule,
     potential dependent kernel lookups.
     """
 
-    global globalAstRegistry
     verbose = 'verbose' in kwargs and kwargs['verbose']
     returnType = kwargs['returnType'] if 'returnType' in kwargs else None
     lineNumberOffset = kwargs['location'] if 'location' in kwargs else ('', 0)

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -23,7 +23,7 @@ from cudaq.mlir.ir import (Block, ComplexType, F32Type, F64Type, FunctionType,
 from .analysis import HasReturnNodeVisitor
 from .ast_bridge import (compile_to_mlir, PyASTBridge)
 from .captured_data import CapturedDataStorage
-from .utils import (emitFatalError, emitErrorIfInvalidPauli, globalAstRegistry,
+from .utils import (emitFatalError, emitErrorIfInvalidPauli,
                     globalRegisteredTypes, mlirTypeFromPyType, mlirTypeToPyType,
                     nvqppPrefix, getMLIRContext, recover_func_op,
                     recover_value_of, recover_calling_module)
@@ -252,11 +252,6 @@ class PyKernelDecorator(object):
             emitFatalError('CUDA-Q kernel has return statement '
                            'but no return type annotation.')
 
-        if not fromBuilder:
-            # Store the AST for this kernel, it is needed for building up call
-            # graphs. We also must retain the source code location for error
-            # diagnostics
-            globalAstRegistry[self.name] = (self.astModule, self.location)
         self.pre_compile()
 
     def __del__(self):

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -36,11 +36,6 @@ nvqppPrefix = '__nvqpp__mlirgen__'
 
 ahkPrefix = '__analog_hamiltonian_kernel__'
 
-# Keep a global registry of all kernel Python AST modules keyed on their name
-# (without `__nvqpp__mlirgen__` prefix). The values in this dictionary are a
-# tuple of the AST module and the source code location for the kernel.
-globalAstRegistry = {}
-
 # Keep a global registry of all registered custom operations.
 globalRegisteredOperations = {}
 


### PR DESCRIPTION
Before the large Python refactor, we had to keep track of all registered kernels manually. Now this is no longer used anywhere and should be removed.