### PR TITLE
C++ API doc

### DIFF
--- a/CppAPICodingStyle.md
+++ b/CppAPICodingStyle.md
@@ -6,14 +6,12 @@ toolchain.
 
 ## 1. Goals
 
-1. Make it obvious which APIs are supported for **end users** versus **internal
-development**.
-2. Preserve long-term stability for the **User API** (backward compatibility +
- deprecation schedule).
-3. Allow **Hardware vendors** and **core developers** to access internal
-interfaces without accidentally turning them into user-facing commitments.
-4. Ensure `cudaq` can discover headers needed to compile user code (including
- internal headers that user headers must include).
+1. Provide definitions for the different levels of APIs developers or end users
+may encounter.
+2. Provide definitions for developer categories and how each category may
+interact with the above APIs.
+3. Make it obvious which APIs are supported for end users versus internal
+development.
 
 ---
 
@@ -21,8 +19,9 @@ interfaces without accidentally turning them into user-facing commitments.
 
 ### 2.1 Users (e.g, Quantum algorithm developers)
 
+- Do not contribute to changes to the `cudaq` codebase.
 - Use only the **User API** shipped with the product.
-- Compile with `cudaq` and link to shipped runtime libraries.
+- Compile and link to shipped runtime libraries with `nvq++`
 - Must not rely on internal headers/namespaces.
 
 ### 2.2 Library developers (e.g., `cudaqx`)
@@ -33,17 +32,17 @@ their own CMake project.
 
 ### 2.3 Hardware vendors and core developers
 
+- Do contribute to changes to the `cudaq` codebase.
 - May use:
   - **User API**
   - **Internal public module APIs**
   - **Module private APIs**
-- Contribute changes to the codebase and/or add backends, modules, extensions.
 
 ---
 
 ## 3. API Layers and Rules
 
-We define a three API layers as illustrated below:
+We define three API layers as illustrated below:
 
 1. **User API**
 2. **Internal public module APIs**
@@ -67,7 +66,7 @@ We define a three API layers as illustrated below:
 ├────────────────────────────────────────────────────────────────────┤
 │ Audience:   Hardware vendors + core developers                     │
 │            (NOT for users / external libs to depend on)            │
-│ Headers:    "cudaq_internals/<module>/<hdr>.h"  (or cudaq_dev/...) │
+│ Headers:    "cudaq_internal/<module>/<hdr>.h"  (or cudaq_dev/...)  │
 │ Namespace:  cudaq::<module>::...  (module lowercase)               │
 │             cudaq::<module>::detail = NON-public                   │
 │ Naming:     CamelCase (or consistent module convention)            │
@@ -153,22 +152,17 @@ avoid confusion with the User API.
 
 **Proposed convention:**
 
-- `#include "cudaq_internals/<module_name>/<header_name>.h"`
-or
-- `#include "cudaq_dev/<module_name>/<header_name>.h"`
-or
-- `#include "cudaq_<module_name>/<header_name>.h"`
+- `#include "cudaq_internal/<module_name>/<header_name>.h"`
 
 Rationale:
 
 - clearly signals “not for users”
-- stable and grep-friendly
 - avoids collision with user include hierarchy
 
 #### 3.2.3 Shipping and visibility
 
 - These headers **are shipped** with the product if they are reachable from
-shipped user headers or required by `nvq++` compilation.
+shipped user headers as required by `nvq++` compilation.
 - They **must be discoverable** by `nvq++` through configured include paths.
 
 #### 3.2.4 Namespaces
@@ -210,16 +204,13 @@ not be consumed outside the module.
 
 #### 3.3.3 Shipping
 
-- Private headers are **not shipped** with the product.
+- Private headers are **not shipped** with the product with the exception of
+header based implementation such as template meta-programming. In which case,
+private APIs shall be in the `detail` namespace.
 
 #### 3.3.4 Include rules
 
 - Private headers are included using **relative paths** from within the module.
-- Exception: template-heavy code sometimes requires headers to be included
-transitively.
-  - If a shipped header must include a private header, the included declarations
-  must be placed the private `detail` namespace.
-  - This remains non-public and subject to change.
 
 ---
 
@@ -237,15 +228,8 @@ transitively.
 Internal developer code (allowed for hardware vendors/core developers):
 
 ```cpp
-#include "cudaq_internals/compiler/lower.h"
-#include "cudaq_internals/cudaq_fmt/Formatting.h"
-```
-
-or
-
-```cpp
-#include "cudaq_dev/compiler/lower.h"
-#include "cudaq_dev/cudaq_fmt/Formatting.h"
+#include "cudaq_internal/compiler/lower.h"
+#include "cudaq_internal/cudaq_fmt/Formatting.h"
 ```
 
 Module private include (module-only):


### PR DESCRIPTION
This is a proposal to formalize the coding style of our C++ APIs. (Which can later be consolidated with python).
The main ideas is that we define 3 types of interfaces:

- user API
- internal public APIs
- private APIs

To clearly distinguish between the user API and internal APIs. I propose headers under a different root directory.
User API is under `cudaq/`
Internal APIs would be under `cudaq_dev/`, `cudaq_internals/` or `cudaq_<module_name>/` . TBD.

Another significant change is that module APIs are all under a <module_name> namespace.
Example: `cudaq::compiler::lowerQuake`

