### PR TITLE
Revert "[nvq++] Remove kernel bodies in fixup-linkage (#3874)"

### DIFF
--- a/tools/fixup-linkage/CMakeLists.txt
+++ b/tools/fixup-linkage/CMakeLists.txt
@@ -6,14 +6,6 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-set(LLVM_LINK_COMPONENTS
-  Core
-  IRReader
-  Support
-)
-
 add_llvm_executable(fixup-linkage fixup-linkage.cpp)
-
-llvm_update_compile_flags(fixup-linkage)
 
 install(TARGETS fixup-linkage DESTINATION bin)


### PR DESCRIPTION
This reverts commit 912bdaeac1a6da4a492542ff351db71a1425cdd2.

This is causing an odd failure in cudaqx: https://github.com/NVIDIA/cudaqx/actions/runs/21840326207/job/63023080859?pr=416#step:14:123

Given that it is unclear what is causing this and what the fix will look like, let's temporarily revert the change until the issue is resolved.