### PR TITLE
Upgrade assets build runner for better performance

### DIFF
--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -35,7 +35,7 @@ name: Pre-built binaries
 jobs:
   build_installer:
     name: Build CUDA Quantum assets
-    runs-on: ${{ (contains(inputs.platform, 'arm') && 'linux-arm64-cpu8') || 'linux-amd64-cpu8' }}
+    runs-on: ${{ (contains(inputs.platform, 'arm') && 'linux-arm64-cpu32') || 'linux-amd64-cpu32' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
The current assets build takes ~1h 15m to complete ([example run](https://github.com/NVIDIA/cuda-quantum/actions/runs/21874755484/job/63144837346)￼).

With the new runners, the same build completes in ~41 minutes ([example run](https://github.com/NVIDIA/cuda-quantum/actions/runs/21879464248/job/63168279666?pr=3916)￼).

Note: After merging, we should monitor runner utilization. If this CPU group becomes oversubscribed, queue times could offset the performance gains. This change is straightforward to revert if needed.