### PR TITLE
Change device key lookup behavior in python bridge

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2695,7 +2695,10 @@ class PyASTBridge(ast.NodeVisitor):
                     obj = frame.f_locals.get(moduleNames[0])
                 elif moduleNames[0] in frame.f_globals:
                     obj = frame.f_globals.get(moduleNames[0])
-                if obj:
+                if obj is not None:
+                    # In case a module has been imported multiple times, grab the latest
+                    if isinstance(obj, list):
+                        obj = obj[-1]
                     devKey = checkModule(obj, moduleNames)
                     if devKey:
                         return devKey, pyVal.attr


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
The updates to the python bridge changed `resolveQualifiedName` in two subtle ways:
1. The matching behavior was changed - from `endsWith` to strict equality
2. Instead of returning on the first successful match, the last match was returned.

This introduced an `Unknown Function Call` error for aliased kernel names in submodules (e.g., `cudaq_solvers.stateprep.ceo`, which is imported from and therefore an alias for `cudaq_solvers.pycudaqx_solvers_the_suffix_matters_cudaq_solvers.stateprep.ceo`). To resolve this, I've changed the returned device key to get the full module path, rather than the aliased module path.