### PR TITLE
Use nvidia proxy cache

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -228,6 +228,12 @@ jobs:
             network=host
             image=moby/buildkit:v0.19.0
 
+      - name: Setup proxy cache
+        if: needs.metadata.outputs.runner != 'ubuntu-latest'
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -166,7 +166,13 @@ jobs:
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0
-   
+
+      - name: Setup proxy cache
+        if: needs.metadata.outputs.runner != 'ubuntu-latest'
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
       - name: Build Open MPI
         id: docker_build
         uses: docker/build-push-action@v5
@@ -317,6 +323,12 @@ jobs:
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0
+
+      - name: Setup proxy cache
+        if: needs.metadata.outputs.runner != 'ubuntu-latest'
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
 
       - name: Extract metadata
         id: metadata
@@ -536,6 +548,12 @@ jobs:
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0
+
+      - name: Setup proxy cache
+        if: needs.metadata.outputs.runner != 'ubuntu-latest'
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
 
       - name: Extract cuda-quantum-dev metadata
         id: cudaqdev_metadata

--- a/.github/workflows/generate_cc.yml
+++ b/.github/workflows/generate_cc.yml
@@ -65,6 +65,11 @@ jobs:
           driver-opts: |
             image=moby/buildkit:v0.19.0
 
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
       - name: Build CUDA Quantum
         id: cudaq_build
         run: |

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -133,6 +133,11 @@ jobs:
             network=host
             image=moby/buildkit:v0.19.0
 
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
       - name: Extract metadata
         id: metadata
         uses: docker/metadata-action@v5
@@ -233,6 +238,11 @@ jobs:
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             image=moby/buildkit:v0.19.0
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -442,6 +442,11 @@ jobs:
           driver-opts: |
             image=moby/buildkit:v0.19.0
 
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
       - name: Extract cuda-quantum metadata
         id: metadata
         uses: docker/metadata-action@v5
@@ -603,6 +608,11 @@ jobs:
           driver-opts: |
             image=moby/buildkit:v0.19.0
 
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
       - name: Build installer
         uses: docker/build-push-action@v5
         with:
@@ -717,6 +727,11 @@ jobs:
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
 
       - name: Build cuda-quantum wheel
         id: build_wheel

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -135,6 +135,11 @@ jobs:
             network=host
             image=moby/buildkit:v0.19.0
 
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
       - name: Build wheel
         id: wheel_build
         uses: docker/build-push-action@v5

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -66,6 +66,11 @@ jobs:
           driver-opts: |
             image=moby/buildkit:v0.19.0
 
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
       - name: Build CUDA Quantum
         run: |
           if ${{ steps.restore_devdeps.outcome != 'skipped' }}; then
@@ -188,6 +193,11 @@ jobs:
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             image=moby/buildkit:v0.19.0
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
 
       - name: Set up dev environment
         id: dev_env


### PR DESCRIPTION
This change uses the [nv-gha-runners/setup-proxy-cache](https://github.com/nv-gha-runners/setup-proxy-cache)￼ workflow to enable the internal APT proxy on our runners.

The pip and conda proxies are enabled by default; APT must be explicitly opted into, which is what this PR configures.