### PR TITLE
Cache cudaq-dev to GHCR instead of GHA cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,7 @@ jobs:
       devdeps_image: ${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-gcc11', matrix.platform)] }}
       devdeps_cache: ${{ fromJson(needs.config.outputs.json).cache_key[format('{0}-gcc11', matrix.platform)] }}
       devdeps_archive: ${{ fromJson(needs.config.outputs.json).tar_archive[format('{0}-gcc11', matrix.platform)] }}
+      environment: ghcr-ci
 
   python_wheels:
     name: Create Python wheels


### PR DESCRIPTION
# cache cudaq-dev to GHCR

This PR enables caching of the cudaq-dev image in GHCR to ease storage burden on GHA cache.

## Example: Cache Push
From this test run:
https://github.com/NVIDIA/cuda-quantum/actions/runs/21890621205/job/63202525987?pr=3919#step:14:2267
```
#11 pushing manifest for ghcr.io/nvidia/cuda-quantum-dev:arm64-pr-3919-base@sha256:60fbbfd2eb27c1ef55d2e6f88dcd2b8919d2a2754b99883233f76da9e4927477

```
## Example: Cache Reuse

Later in the same workflow, the image is reused via its digest:

https://github.com/NVIDIA/cuda-quantum/actions/runs/21890621205/job/63202525987?pr=3919#step:20:5
```
    build-args: cudaqdev_image=ghcr.io/nvidia/cuda-quantum-dev@sha256:60fbbfd2eb27c1ef55d2e6f88dcd2b8919d2a2754b99883233f76da9e4927477

```