### PR TITLE
Fix merge-group cache tag for Create CUDA Quantum installer job

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -283,7 +283,7 @@ jobs:
           elif ${{ github.event_name == 'merge_group' }}; then
             # for merge queues, also push buildkit cache to the registry to speed up subsequent builds
             cache_to="type=registry,ref=${registry_cache}-${cache_id}-${platform_id}:merge-group-$registry_cache_base"
-            build_cache="type=registry,ref=${registry_cache}-${cache_id}-${platform_id}:$registry_cache_base"
+            build_cache="type=registry,ref=${registry_cache}-${cache_id}-${platform_id}:merge-group-$registry_cache_base"
           else 
             build_cache="type=registry,ref=${registry_cache}-${cache_id}-${platform_id}:$registry_cache_base"
           fi


### PR DESCRIPTION
## Fix Create CUDA Quantum installer cache for merge-group runs

### Problem
During merge-queue CI runs, the **Create CUDA Quantum installer** job was using the wrong cache tag. It was pulling from: 
```
ghcr.io/nvidia/buildcache-cuda-quantum-merge-group-assets-prereqs-cu13-0-llvm-amd64:main
```

but the cache is actually published under: 
```
ghcr.io/nvidia/buildcache-cuda-quantum-merge-group-assets-prereqs-cu13-0-llvm-amd64:merge-group-main
```

So the installer job was resolving the wrong tag and missing the merge-group cache.

### Cause
In `.github/workflows/dev_environment.yml`, for `merge_group` events we **push** the build cache with tag `merge-group-$registry_cache_base` (e.g. `merge-group-main`) via `cache_to`, but we **expose** that cache to downstream jobs via the `build_cache` output, which was still set to `$registry_cache_base` (e.g. `main`). So the tag used for publishing and the tag passed to the installer job were inconsistent.

### Fix
For `merge_group`, the `build_cache` output is now set to use the same tag as `cache_to`: `merge-group-$registry_cache_base`. The installer job therefore receives a `build_cache` value that points at the correct image tag (e.g. `...:merge-group-main`) and uses the merge-queue cache as intended.