### PR TITLE
bump moby/buildkit:v0.19.0 -> moby/buildkit:v0.27.1

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -226,7 +226,7 @@ jobs:
           buildkitd-config: ${{ needs.metadata.outputs.runner != 'ubuntu-latest' && '/etc/buildkit/buildkitd.toml' || null }}
           driver-opts: |
             network=host
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -165,7 +165,7 @@ jobs:
           buildkitd-config: ${{ needs.metadata.outputs.runner != 'ubuntu-latest' && '/etc/buildkit/buildkitd.toml' || null }}
           driver-opts: |
             network=host
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
    
       - name: Build Open MPI
         id: docker_build
@@ -316,7 +316,7 @@ jobs:
           buildkitd-config: ${{ needs.metadata.outputs.runner != 'ubuntu-latest' && '/etc/buildkit/buildkitd.toml' || null }}
           driver-opts: |
             network=host
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Extract metadata
         id: metadata
@@ -535,7 +535,7 @@ jobs:
           buildkitd-config: ${{ needs.metadata.outputs.runner != 'ubuntu-latest' && '/etc/buildkit/buildkitd.toml' || null }}
           driver-opts: |
             network=host
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Extract cuda-quantum-dev metadata
         id: cudaqdev_metadata

--- a/.github/workflows/generate_cc.yml
+++ b/.github/workflows/generate_cc.yml
@@ -63,7 +63,7 @@ jobs:
           version: v0.19.0
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Build CUDA Quantum
         id: cudaq_build

--- a/.github/workflows/gh_registry.yml
+++ b/.github/workflows/gh_registry.yml
@@ -123,7 +123,7 @@ jobs:
           endpoint: builder_context
           version: v0.19.0
           driver-opts: |
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Prepare push
         id: metadata

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -127,7 +127,7 @@ jobs:
           endpoint: builder_context
           version: v0.19.0
           driver-opts: |
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Extract metadata
         id: metadata

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -131,7 +131,7 @@ jobs:
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             network=host
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Extract metadata
         id: metadata
@@ -232,7 +232,7 @@ jobs:
           version: v0.19.0
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -440,7 +440,7 @@ jobs:
           version: v0.19.0
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Extract cuda-quantum metadata
         id: metadata
@@ -601,7 +601,7 @@ jobs:
           version: v0.19.0
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Build installer
         uses: docker/build-push-action@v5
@@ -716,7 +716,7 @@ jobs:
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             network=host
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Build cuda-quantum wheel
         id: build_wheel

--- a/.github/workflows/publishing_stable.yml
+++ b/.github/workflows/publishing_stable.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           version: v0.19.0
           driver-opts: |
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Update cuda-quantum metadata
         id: metadata

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -133,7 +133,7 @@ jobs:
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
             network=host
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Build wheel
         id: wheel_build

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -64,7 +64,7 @@ jobs:
           version: v0.19.0
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Build CUDA Quantum
         run: |
@@ -187,7 +187,7 @@ jobs:
           version: v0.19.0
           buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
           driver-opts: |
-            image=moby/buildkit:v0.19.0
+            image=moby/buildkit:v0.27.1
 
       - name: Set up dev environment
         id: dev_env


### PR DESCRIPTION
# Bump moby/buildkit v0.19.0 -> v0.27.1

There is no specific fix that has been identified, this bump is for general improvements and to stay up to date.

## EDIT:


I have been queueing a lot of PRs, but we got rate limited when this one was running. Could be a coincidence, but maybe bumping this changed how requests are handled.

https://github.com/NVIDIA/cuda-quantum/actions/runs/21897940887/job/63219510155#step:11:344

`ERROR: failed to solve: failed to compute cache key: failed to copy: httpReadSeeker: failed open: unexpected status code https://ghcr.io/v2/nvidia/buildcache-cuda-quantum-merge-group-assets-prereqs-cu12-6-llvm-amd64/blobs/sha256:48cd7e7a31ae01535923054e565c405c5b36f0992c7f9232deb9103e89d5ce6e: 429 Too Many Requests - Server message: toomanyrequests: retry-after: 316.890478ms`


The only thing I can think of is a change to how the following works with the updated reusable workflows:
```
          buildkitd-config: /etc/buildkit/buildkitd.toml # hard-coded to run on our runners
```