### PR TITLE
Add operation names to noise model

### DIFF
--- a/python/runtime/common/py_NoiseModel.cpp
+++ b/python/runtime/common/py_NoiseModel.cpp
@@ -287,8 +287,11 @@ void bindNoiseChannels(py::module &mod) {
           py::arg("index"),
           "Return the :class:`KrausOperator` at the given index in this "
           ":class:`KrausChannel`.")
-      .def("append", &kraus_channel::push_back,
-           "Add a :class:`KrausOperator` to this :class:`KrausChannel`.");
+      .def(
+          "append",
+          [](kraus_channel &self, kraus_op op) { self.push_back(op); },
+          py::arg("operator"),
+          "Add a :class:`KrausOperator` to this :class:`KrausChannel`.");
 
   py::class_<depolarization_channel, kraus_channel>(
       mod, "DepolarizationChannel",

--- a/runtime/common/NoiseModel.cpp
+++ b/runtime/common/NoiseModel.cpp
@@ -189,7 +189,7 @@ void generateUnitaryParameters_fp64(
 kraus_channel::kraus_channel(const kraus_channel &other)
     : ops(other.ops), noise_type(other.noise_type),
       parameters(other.parameters), unitary_ops(other.unitary_ops),
-      probabilities(other.probabilities) {}
+      probabilities(other.probabilities), op_names(other.op_names) {}
 
 std::size_t kraus_channel::size() const { return ops.size(); }
 
@@ -205,11 +205,20 @@ kraus_channel &kraus_channel::operator=(const kraus_channel &other) {
   parameters = other.parameters;
   unitary_ops = other.unitary_ops;
   probabilities = other.probabilities;
+  op_names = other.op_names;
   return *this;
 }
 
 std::vector<kraus_op> kraus_channel::get_ops() const { return ops; }
-void kraus_channel::push_back(kraus_op op) { ops.push_back(op); }
+
+void kraus_channel::push_back(kraus_op op, std::optional<std::string> name) {
+  ops.push_back(op);
+  if (name.has_value())
+    op_names.push_back(std::move(*name));
+  else
+    op_names.push_back(get_type_name() + "[" + std::to_string(ops.size() - 1) +
+                       "]");
+}
 
 void noise_model::add_channel(const std::string &quantumOp,
                               const std::vector<std::size_t> &qubits,


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
Adds operation names to the cpp noise model. This is a helper function which for PTSBE allows human readable operation names as well as compatibility with simulators which apply noise/gates by name (eg., Stim). This should be API backward compatible. 

Pulled out from https://github.com/taalexander/cuda-quantum/pull/5