### PR TITLE
[python] Use separate context for kernel builder

### DIFF
--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -32,10 +32,10 @@ from .common.givens import givens_builder
 from .kernel_decorator import isa_kernel_decorator
 from .quake_value import QuakeValue
 from .utils import (emitFatalError, emitWarning, nvqppPrefix, getMLIRContext,
-                    recover_func_op, mlirTypeToPyType, cudaq__unique_attr_name,
-                    mlirTypeFromPyType, emitErrorIfInvalidPauli,
-                    recover_value_of, globalRegisteredOperations,
-                    recover_calling_module)
+                    createMLIRContext, recover_func_op, mlirTypeToPyType,
+                    cudaq__unique_attr_name, mlirTypeFromPyType,
+                    emitErrorIfInvalidPauli, recover_value_of,
+                    globalRegisteredOperations, recover_calling_module)
 
 kDynamicPtrIndex: int = -2147483648
 
@@ -246,7 +246,7 @@ class PyKernel(object):
     """
 
     def __init__(self, argTypeList):
-        self.ctx = getMLIRContext()
+        self.ctx = createMLIRContext()
 
         self.conditionalOnMeasure = False
         self.regCounter = 0
@@ -589,6 +589,16 @@ class PyKernel(object):
     def __createQuakeValue(self, value):
         return QuakeValue(value, self)
 
+    def __reloadModuleIntoContext(self, otherModule):
+        """
+        If `otherModule` lives in a different MLIR context than this builder,
+        reload it (round-trip through string) into this builder's context so
+        that module-merge operations work correctly.
+        """
+        if otherModule.context is not self.ctx:
+            return cudaq_runtime.reloadModule(otherModule, self.ctx)
+        return otherModule
+
     def __cloneOrGetFunction(self, astName, currentModule, target):
         """
         Get a the function with the given name.
@@ -601,13 +611,13 @@ class PyKernel(object):
         if astName in thisSymbolTable:
             return thisSymbolTable[astName], currentModule
         if isa_kernel_decorator(target):
-            otherModule = target.qkeModule
+            otherModule = self.__reloadModuleIntoContext(target.qkeModule)
             fulluniq = nvqppPrefix + target.uniqName
             cudaq_runtime.updateModule(fulluniq, currentModule, otherModule)
             fn = recover_func_op(currentModule, fulluniq)
             assert fn and "function may not disappear from module"
             return fn, currentModule
-        otherModule = target.module
+        otherModule = self.__reloadModuleIntoContext(target.module)
         cudaq_runtime.updateModule(target.funcName, currentModule, otherModule)
         fn = recover_func_op(currentModule, target.funcName)
         assert fn and "function may not disappear from module"
@@ -1360,7 +1370,8 @@ class PyKernel(object):
         closure here.
         Returns a `CreateLambdaOp` closure.
         """
-        cudaq_runtime.updateModule(self.uniqName, self.module, target.qkeModule)
+        otherModule = self.__reloadModuleIntoContext(target.qkeModule)
+        cudaq_runtime.updateModule(self.uniqName, self.module, otherModule)
         # build the closure to capture the lifted `args`
         thisPyMod = recover_calling_module()
         if target.defModule != thisPyMod:
@@ -1616,8 +1627,9 @@ class PyKernel(object):
         used in a launch scenario. We reify the kernel as-is here.
         """
         if not hasattr(self, 'qkeModule'):
-            self.qkeModule = cudaq_runtime.cloneModule(self.module)
+            # Reload from the builder's private context into the global context
             ctx = getMLIRContext()
+            self.qkeModule = cudaq_runtime.reloadModule(self.module, ctx)
             pm = PassManager.parse("builtin.module(aot-prep-pipeline)",
                                    context=ctx)
             try:
@@ -1736,8 +1748,8 @@ class PyKernel(object):
             else:
                 processedArgs.append(arg)
 
-        retTy = NoneType.get(self.module.context)
         self.compile()
+        retTy = NoneType.get(self.qkeModule.context)
         specialized = cudaq_runtime.cloneModule(self.qkeModule)
         cudaq_runtime.marshal_and_launch_module(self.name, specialized, retTy,
                                                 *processedArgs)

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -666,9 +666,10 @@ def mk_decorator(builder):
     Make a kernel decorator object from a kernel builder object to make any code
     that handles both CUDA-Q kernel object classes more unified.
     """
+    builder.compile()
     return PyKernelDecorator(None,
                              fromBuilder=True,
-                             module=builder.module,
+                             module=builder.qkeModule,
                              kernelName=builder.uniqName)
 
 

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -41,6 +41,18 @@ globalRegisteredOperations = {}
 globalRegisteredTypes = cudaq_runtime.DataClassRegistry
 
 
+def createMLIRContext():
+    """
+    Create a fresh MLIR Context with all CUDA-Q dialects registered.
+    """
+    ctx = Context()
+    register_all_dialects(ctx)
+    quake.register_dialect(context=ctx)
+    cc.register_dialect(context=ctx)
+    cudaq_runtime.registerLLVMDialectTranslation(ctx)
+    return ctx
+
+
 def getMLIRContext():
     """
     This code creates an MLIRContext singleton for this python process. We do
@@ -51,11 +63,7 @@ def getMLIRContext():
     try:
         cudaq__global_mlir_context
     except NameError:
-        cudaq__global_mlir_context = Context()
-        register_all_dialects(cudaq__global_mlir_context)
-        quake.register_dialect(context=cudaq__global_mlir_context)
-        cc.register_dialect(context=cudaq__global_mlir_context)
-        cudaq_runtime.registerLLVMDialectTranslation(cudaq__global_mlir_context)
+        cudaq__global_mlir_context = createMLIRContext()
     return cudaq__global_mlir_context
 
 

--- a/python/tests/builder/test_kernel_builder.py
+++ b/python/tests/builder/test_kernel_builder.py
@@ -1455,6 +1455,20 @@ def test_call_invalid_attribute_on_a_kernel():
     assert "not supported on PyKernel" in str(e.value)
 
 
+def test_builder_survives_decorator_compilation():
+    """kernel builder context must survive @cudaq.kernel compilation."""
+    kernel = cudaq.make_kernel()
+
+    @cudaq.kernel()
+    def kernel2():
+        pass
+
+    kernel2()
+
+    # This should not crash -- the builder has its own context.
+    kernel.qalloc(1)
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)


### PR DESCRIPTION
This PR fixes the following crash

```python
import cudaq

kernel = cudaq.make_kernel()

@cudaq.kernel()
def kernel2():
    pass

kernel.qalloc(1) # this (or any other MLIR modification) crashes
```

Error: `RuntimeError: the operation has been invalidated`

The reason for this is that kernel2 was getting compiled using `compile_to_mlir` in `python/cudaq/kernel/ast_bridge.py`. This calls `context._clear_live_operations()` at the end of the function. However, the context is global, thus it also clears the context for the kernel builder. This invalidates the insertion point stored in the builder, hence any further modifications of the kernel builder fails.

This PR proposes to use a separate context for the kernel builder. When a kernel builder gets invoked and needs to be jitted, we then output the module as string and reload it into the global context. This will come at some performance cost, but only affects kernels defined using the builder and only at the first invocation (as the compiled MLIR module is cached).