### PR TITLE
bump CUDAQ Test runners cpu8 -> cpu16

### DIFF
--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -27,7 +27,7 @@ name: Run CI within the dev environment container
 jobs:
   build_and_test:
     name: Dev environment (Debug)
-    runs-on: ${{ (contains(inputs.platform, 'arm') && 'linux-arm64-cpu8') || 'linux-amd64-cpu8' }}
+    runs-on: ${{ (contains(inputs.platform, 'arm') && 'linux-arm64-cpu16') || 'linux-amd64-cpu16' }}
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
We are seeing some OOM failures in the test runners. Bumping the runners to cpu16 to go from 32GB RAM to 64GB.
