### PR TITLE
Remove unused support_conditional_feedback

### DIFF
--- a/docs/sphinx/specification/cudaq/platform.rst
+++ b/docs/sphinx/specification/cudaq/platform.rst
@@ -39,7 +39,6 @@ The :code:`cudaq::quantum_platform`  should take the following structure
       bool is_simulator(std::size_t qpu_id = 0) const;
       bool is_remote(std::size_t qpu_id = 0) const;
       bool is_emulated(std::size_t qpu_id = 0) const;
-      bool supports_conditional_feedback(std::size_t qpu_id = 0) const;
       bool supports_explicit_measurements(std::size_t qpu_id = 0) const;
       RemoteCapabilities get_remote_capabilities(std::size_t qpu_id = 0) const;
       std::string name() const;

--- a/python/runtime/common/py_ExecutionContext.cpp
+++ b/python/runtime/common/py_ExecutionContext.cpp
@@ -91,10 +91,6 @@ void bindExecutionContext(py::module &mod) {
         }
         return false;
       });
-  mod.def("supportsConditionalFeedback", []() {
-    auto &platform = cudaq::get_platform();
-    return platform.supports_conditional_feedback();
-  });
   mod.def("supportsExplicitMeasurements", []() {
     auto &platform = cudaq::get_platform();
     return platform.supports_explicit_measurements();

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -86,11 +86,6 @@ public:
   /// @return
   bool isSimulator() override { return emulate; }
 
-  /// @brief Return true if the current backend supports conditional feedback
-  bool supportsConditionalFeedback() override {
-    return codegenTranslation == "qir-adaptive";
-  }
-
   /// @brief Return true if the current backend supports explicit measurements
   bool supportsExplicitMeasurements() override { return false; }
 

--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -49,9 +49,6 @@ public:
     return execution_queue->getExecutionThreadId();
   }
 
-  // Conditional feedback is handled by the server side.
-  virtual bool supportsConditionalFeedback() override { return true; }
-
   // Get the capabilities from the client.
   virtual RemoteCapabilities getRemoteCapabilities() const override {
     return m_client->getRemoteCapabilities();

--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
@@ -82,9 +82,6 @@ public:
   /// @brief Return true if the current backend is a simulator
   bool isSimulator() override { return emulate; }
 
-  /// @brief Return true if the current backend supports conditional feedback
-  bool supportsConditionalFeedback() override { return false; }
-
   /// @brief Return true if the current backend supports explicit measurements
   bool supportsExplicitMeasurements() override { return false; }
 

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -136,9 +136,6 @@ public:
   /// Is this QPU a simulator ?
   virtual bool isSimulator() { return true; }
 
-  /// @brief Return whether this QPU has conditional feedback support
-  virtual bool supportsConditionalFeedback() { return false; }
-
   /// @brief Return whether this QPU supports explicit measurements
   virtual bool supportsExplicitMeasurements() { return true; }
 

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -173,11 +173,6 @@ std::size_t quantum_platform::get_num_qubits(std::size_t qpu_id) const {
   return platformQPUs[qpu_id]->getNumQubits();
 }
 
-bool quantum_platform::supports_conditional_feedback(std::size_t qpu_id) const {
-  validateQpuId(qpu_id);
-  return platformQPUs[qpu_id]->supportsConditionalFeedback();
-}
-
 bool quantum_platform::supports_explicit_measurements(
     std::size_t qpu_id) const {
   validateQpuId(qpu_id);

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -131,9 +131,6 @@ public:
   /// Return whether this platform is a simulator.
   bool is_simulator(std::size_t qpu_id = 0) const;
 
-  /// @brief Return whether the QPU has conditional feedback support
-  bool supports_conditional_feedback(std::size_t qpu_id = 0) const;
-
   /// @brief Return whether the QPU supports explicit measurements.
   bool supports_explicit_measurements(std::size_t qpu_id = 0) const;
 


### PR DESCRIPTION
This seems to be unused throughout the code base. Removing it would simplify the runtime refactor.