### PR TITLE
[orca] Execution context and lifecycle simplification

### DIFF
--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
@@ -97,25 +97,6 @@ public:
   /// @brief Return true if the current backend is remote
   virtual bool isRemote() override { return !emulate; }
 
-  void
-  configureExecutionContext(cudaq::ExecutionContext &context) const override {
-    context.executionManager = getDefaultExecutionManager();
-    context.executionManager->configureExecutionContext(context);
-  }
-
-  void
-  finalizeExecutionContext(cudaq::ExecutionContext &context) const override {
-    context.executionManager->finalizeExecutionContext(context);
-  }
-
-  void beginExecution() override {
-    getExecutionContext()->executionManager->beginExecution();
-  }
-
-  void endExecution() override {
-    getExecutionContext()->executionManager->endExecution();
-  }
-
   /// @brief This setTargetBackend override is in charge of reading the
   /// specific target backend configuration file.
   void setTargetBackend(const std::string &backend) override;


### PR DESCRIPTION
* No need to override execution context methods used by local simulators since `orca` is a remote target.

* Follow-up to the changes in PR https://github.com/NVIDIA/cuda-quantum/pull/3736 which caused the nightly integration failures seen here: https://github.com/NVIDIA/cuda-quantum/actions/runs/22029239324/job/63651273975

```
 Sampling detected on a kernel with no qubits. Your kernel must have qubits to sample it.
```

* Manually verified that the `orca.cpp` and `orca.py` tests are working.