### PR TITLE
Stop printing MLIR on default

### DIFF
--- a/python/runtime/cudaq/algorithms/py_observe_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe_async.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "py_observe_async.h"
+#include "common/Environment.h"
 #include "cudaq.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Todo.h"
@@ -77,7 +78,8 @@ static async_observe_result pyObserveAsync(const std::string &shortName,
   return details::runObservationAsync(
       detail::make_copyable_function([opaques = std::move(opaques), shortName,
                                       mod = mod.clone(), retTy]() mutable {
-        mod.dump();
+        if (cudaq::getEnvBool("CUDAQ_DUMP_JIT_IR", false))
+          mod.dump();
         [[maybe_unused]] auto result =
             clean_launch_module(shortName, mod, retTy, opaques);
       }),


### PR DESCRIPTION
Dump the kernel in quake format based on `CUDAQ_DUMP_JIT_IR` value, now turned off by default.

Fixes #3901, Fixes #3969 