### PR TITLE
[CI] - retry matrix write

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -456,14 +456,15 @@ jobs:
     needs: [metadata, build]
 
     outputs:
-      image_hash: ${{ fromJson(steps.write_json.outputs.result).image_hash }}
-      cache_key: ${{ fromJson(steps.write_json.outputs.result).cache_key }}
-      tar_archive: ${{ fromJson(steps.write_json.outputs.result).tar_archive }}
-      build_cache: ${{ fromJson(steps.write_json.outputs.result).build_cache }}
+      image_hash: ${{ fromJson(steps.write_json.outputs.result || steps.write_json_retry1.outputs.result).image_hash }}
+      cache_key: ${{ fromJson(steps.write_json.outputs.result || steps.write_json_retry1.outputs.result).cache_key }}
+      tar_archive: ${{ fromJson(steps.write_json.outputs.result || steps.write_json_retry1.outputs.result).tar_archive }}
+      build_cache: ${{ fromJson(steps.write_json.outputs.result || steps.write_json_retry1.outputs.result).build_cache }}
 
     steps:        
       - uses: cloudposse/github-action-matrix-outputs-write@1.0.0
         id: write_json
+        continue-on-error: true
         with:
           matrix-step-name: ${{ inputs.matrix_key && 'dev_environment' }}
           matrix-key: ${{ inputs.matrix_key }}
@@ -473,3 +474,27 @@ jobs:
             tar_archive: ${{ needs.build.outputs.tar_archive }}
             build_cache: ${{ needs.build.outputs.build_cache }}
             image_tag: ${{ needs.metadata.outputs.image_tags }}
+
+      # matrix write has known issues, see
+      # https://github.com/actions/upload-artifact/issues/560
+      - name: Wait before retry
+        if: steps.write_json.outcome == 'failure'
+        run: sleep 15
+
+      - uses: cloudposse/github-action-matrix-outputs-write@1.0.0
+        id: write_json_retry1
+        if: steps.write_json.outcome == 'failure'
+        continue-on-error: true
+        with:
+          matrix-step-name: ${{ inputs.matrix_key && 'dev_environment' }}
+          matrix-key: ${{ inputs.matrix_key }}
+          outputs: |
+            image_hash: ${{ needs.build.outputs.image_hash }}
+            cache_key: ${{ needs.build.outputs.tar_cache }}
+            tar_archive: ${{ needs.build.outputs.tar_archive }}
+            build_cache: ${{ needs.build.outputs.build_cache }}
+            image_tag: ${{ needs.metadata.outputs.image_tags }}
+
+      - name: Fail if matrix write failed after retry
+        if: steps.write_json.outcome == 'failure' && steps.write_json_retry1.outcome != 'success'
+        run: exit 1


### PR DESCRIPTION
We have been seeing sporadic 403 failures, which is a known issue, e.g. https://github.com/actions/download-artifact/issues/294.

This PR adds a retry mechanism, which seems to usually fix these issues.

A recent example of this in our CI is
https://github.com/NVIDIA/cuda-quantum/actions/runs/22102297057/job/63875274648#step:2:19
```
Run cloudposse/github-action-matrix-outputs-write@1.0.0
Artifact name is valid!
Root directory input is valid!
Beginning upload of artifact content to blob storage
Uploaded bytes 426
Finished uploading artifact content to blob storage!
SHA256 hash of uploaded artifact zip is 9d4e2cbbb062a4b02e4e48ccf62db71357f835d949de71b93178dfc741f3dbe6
Finalizing artifact upload
/home/runner/work/_actions/cloudposse/github-action-matrix-outputs-write/1.0.0/node_modules/@actions/artifact/lib/internal/shared/artifact-twirp-client.js:54
                throw new Error(`Failed to ${method}: ${error.message}`);
                      ^

Error: Failed to FinalizeArtifact: Received non-retryable error: Failed request: (403) Forbidden: Error from intermediary with HTTP status code 403 "Forbidden"
    at ArtifactHttpClient.<anonymous> (/home/runner/work/_actions/cloudposse/github-action-matrix-outputs-write/1.0.0/node_modules/@actions/artifact/lib/internal/shared/artifact-twirp-client.js:54:23)
    at Generator.throw (<anonymous>)
    at rejected (/home/runner/work/_actions/cloudposse/github-action-matrix-outputs-write/1.0.0/node_modules/@actions/artifact/lib/internal/shared/artifact-twirp-client.js:6:65)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.19.6
```