### PR TITLE
Passing the execution context as an argument to the compiler.

### DIFF
--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -252,7 +252,7 @@ public:
     // Get the Quake code, lowered according to config file.
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
-    auto codes = compiler.lowerQuakeCode(kernelName, rawArgs);
+    auto codes = compiler.lowerQuakeCode(executionContext, kernelName, rawArgs);
     completeLaunchKernel(kernelName, std::move(codes));
   }
 
@@ -281,8 +281,10 @@ public:
     // but apparently it isn't. This works around that bug.
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
-    auto codes = rawArgs.empty() ? compiler.lowerQuakeCode(kernelName, args)
-                                 : compiler.lowerQuakeCode(kernelName, rawArgs);
+    auto codes =
+        rawArgs.empty()
+            ? compiler.lowerQuakeCode(executionContext, kernelName, args)
+            : compiler.lowerQuakeCode(executionContext, kernelName, rawArgs);
     completeLaunchKernel(kernelName, std::move(codes));
 
     // NB: Kernel should/will never return dynamic results.
@@ -305,8 +307,9 @@ public:
 
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
-    completeLaunchKernel(kernelName,
-                         compiler.lowerQuakeCode(kernelName, module, rawArgs));
+    completeLaunchKernel(
+        kernelName,
+        compiler.lowerQuakeCode(executionContext, kernelName, module, rawArgs));
     return {};
   }
 

--- a/runtime/common/Compiler.cpp
+++ b/runtime/common/Compiler.cpp
@@ -224,11 +224,9 @@ Compiler::Compiler(ServerHelper *serverHelper,
 Compiler::~Compiler() = default;
 
 std::vector<cudaq::KernelExecution> Compiler::lowerQuakeCodePart2(
-    const std::string &kernelName, void *kernelArgs,
-    const std::vector<void *> &rawArgs, mlir::ModuleOp m_module,
-    mlir::MLIRContext *contextPtr, void *updatedArgs) {
-  auto executionContext = cudaq::getExecutionContext();
-
+    ExecutionContext *executionContext, const std::string &kernelName,
+    void *kernelArgs, const std::vector<void *> &rawArgs,
+    mlir::ModuleOp m_module, mlir::MLIRContext *contextPtr, void *updatedArgs) {
   // Extract the kernel name
   auto origFn = m_module.template lookupSymbol<mlir::func::FuncOp>(
       std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
@@ -533,31 +531,35 @@ std::vector<cudaq::KernelExecution> Compiler::lowerQuakeCodePart2(
 /// lowering process is controllable via the configuration file in the
 /// platform directory for the targeted backend.
 std::vector<cudaq::KernelExecution>
-Compiler::lowerQuakeCode(const std::string &kernelName, void *kernelArgs,
+Compiler::lowerQuakeCode(ExecutionContext *executionContext,
+                         const std::string &kernelName, void *kernelArgs,
                          const std::vector<void *> &rawArgs) {
 
   auto [m_module, contextPtr, updatedArgs] =
       extractQuakeCodeAndContext(kernelName, kernelArgs);
-  return lowerQuakeCodePart2(kernelName, kernelArgs, rawArgs, m_module,
-                             contextPtr.get(), updatedArgs);
+  return lowerQuakeCodePart2(executionContext, kernelName, kernelArgs, rawArgs,
+                             m_module, contextPtr.get(), updatedArgs);
 }
 
 std::vector<cudaq::KernelExecution>
-Compiler::lowerQuakeCode(const std::string &kernelName, void *kernelArgs) {
-  return lowerQuakeCode(kernelName, kernelArgs, {});
+Compiler::lowerQuakeCode(ExecutionContext *executionContext,
+                         const std::string &kernelName, void *kernelArgs) {
+  return lowerQuakeCode(executionContext, kernelName, kernelArgs, {});
 }
 
 std::vector<cudaq::KernelExecution>
-Compiler::lowerQuakeCode(const std::string &kernelName,
+Compiler::lowerQuakeCode(ExecutionContext *executionContext,
+                         const std::string &kernelName,
                          const std::vector<void *> &rawArgs) {
-  return lowerQuakeCode(kernelName, nullptr, rawArgs);
+  return lowerQuakeCode(executionContext, kernelName, nullptr, rawArgs);
 }
 
 std::vector<cudaq::KernelExecution>
-Compiler::lowerQuakeCode(const std::string &kernelName, mlir::ModuleOp module,
+Compiler::lowerQuakeCode(ExecutionContext *executionContext,
+                         const std::string &kernelName, mlir::ModuleOp module,
                          const std::vector<void *> &rawArgs) {
-  return lowerQuakeCodePart2(kernelName, nullptr, rawArgs, module,
-                             module.getContext(), nullptr);
+  return lowerQuakeCodePart2(executionContext, kernelName, nullptr, rawArgs,
+                             module, module.getContext(), nullptr);
 }
 
 mlir::ModuleOp Compiler::lowerQuakeCodeBuildModule(

--- a/runtime/common/Compiler.h
+++ b/runtime/common/Compiler.h
@@ -73,7 +73,8 @@ class Compiler {
   bool printIR = false;
 
   std::vector<cudaq::KernelExecution>
-  lowerQuakeCodePart2(const std::string &kernelName, void *kernelArgs,
+  lowerQuakeCodePart2(ExecutionContext *executionContext,
+                      const std::string &kernelName, void *kernelArgs,
                       const std::vector<void *> &rawArgs,
                       mlir::ModuleOp m_module, mlir::MLIRContext *contextPtr,
                       void *updatedArgs);
@@ -98,14 +99,17 @@ public:
   /// lowering process is controllable via the configuration file in the
   /// platform directory for the targeted backend.
   std::vector<cudaq::KernelExecution>
-  lowerQuakeCode(const std::string &kernelName, void *kernelArgs,
+  lowerQuakeCode(ExecutionContext *executionContext,
+                 const std::string &kernelName, void *kernelArgs,
                  const std::vector<void *> &rawArgs);
 
   std::vector<cudaq::KernelExecution>
-  lowerQuakeCode(const std::string &kernelName, void *kernelArgs);
+  lowerQuakeCode(ExecutionContext *executionContext,
+                 const std::string &kernelName, void *kernelArgs);
 
   std::vector<cudaq::KernelExecution>
-  lowerQuakeCode(const std::string &kernelName,
+  lowerQuakeCode(ExecutionContext *executionContext,
+                 const std::string &kernelName,
                  const std::vector<void *> &rawArgs);
 
   // Here the quake code is passed to us (via a ModuleOp), so unlike the other
@@ -117,7 +121,8 @@ public:
   // of this launch instance) and disposable. It can be modified by this call in
   // any way necessary without breaking some other kernel launch.
   std::vector<cudaq::KernelExecution>
-  lowerQuakeCode(const std::string &kernelName, mlir::ModuleOp module,
+  lowerQuakeCode(ExecutionContext *executionContext,
+                 const std::string &kernelName, mlir::ModuleOp module,
                  const std::vector<void *> &rawArgs);
 };
 } // namespace cudaq

--- a/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
@@ -67,9 +67,11 @@ public:
 
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
-    auto codes = rawArgs.empty()
-                     ? compiler.lowerQuakeCode(kernelName, args, {})
-                     : compiler.lowerQuakeCode(kernelName, nullptr, rawArgs);
+    auto codes =
+        rawArgs.empty()
+            ? compiler.lowerQuakeCode(executionContext, kernelName, args, {})
+            : compiler.lowerQuakeCode(executionContext, kernelName, nullptr,
+                                      rawArgs);
     if (codes.size() != 1) {
       throw std::runtime_error("Provider only allows 1 circuit at a time.");
     }


### PR DESCRIPTION
To avoid having to modify and restore global state when the compiler needs a different execution context, these changes pass it as an argument. 