### PR TITLE
[ci] Fix Mock QPU tests and ensure CI runs them

### DIFF
--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -250,7 +250,7 @@ jobs:
               exit 1
             fi
             for backendTest in python/tests/backends/*.py; do
-              python -m pytest -v --durations=0  $backendTest
+              MOCK_NO_SKIP=true python -m pytest -v --durations=0  $backendTest
               pytest_status=$?
 
               # Exit code 5 indicates that no tests were collected,

--- a/python/tests/backends/test_IQM.py
+++ b/python/tests/backends/test_IQM.py
@@ -22,14 +22,16 @@ import pytest
 iqm_client = pytest.importorskip("iqm.iqm_client")
 
 try:
-    from utils.mock_qpu.iqm import startServer
+    from utils.mock_qpu import start_server, get_backend_port
     from utils.mock_qpu.iqm.mock_iqm_cortex_cli import write_a_mock_tokens_file
-except:
+except Exception as e:
+    if os.environ.get("MOCK_NO_SKIP", "").lower() == "true":
+        raise e
     pytest.skip("Mock qpu not available, skipping IQM tests.",
                 allow_module_level=True)
 
-# Define the port for the mock server
-port = 62443
+TARGET_QPU = "iqm"
+port = get_backend_port(TARGET_QPU)
 
 
 def assert_close(want, got, tolerance=1.0e-5) -> bool:
@@ -43,7 +45,7 @@ def startUpMockServer():
         write_a_mock_tokens_file(tmp_tokens_file.name)
 
     # Launch the Mock Server
-    p = Process(target=startServer, args=(port,))
+    p = Process(target=start_server, args=(TARGET_QPU,))
     p.start()
 
     if not check_server_connection(port):

--- a/python/tests/backends/test_IonQ.py
+++ b/python/tests/backends/test_IonQ.py
@@ -13,13 +13,15 @@ from typing import List
 from multiprocessing import Process
 from network_utils import check_server_connection
 try:
-    from utils.mock_qpu.ionq import startServer
-except:
+    from utils.mock_qpu import start_server, get_backend_port
+except Exception as e:
+    if os.environ.get("MOCK_NO_SKIP", "").lower() == "true":
+        raise e
     print("Mock qpu not available, skipping IonQ tests.")
     pytest.skip("Mock qpu not available.", allow_module_level=True)
 
-# Define the port for the mock server
-port = 62441
+TARGET_QPU = "ionq"
+port = get_backend_port(TARGET_QPU)
 
 
 def assert_close(got) -> bool:
@@ -31,10 +33,10 @@ def startUpMockServer():
     os.environ["IONQ_API_KEY"] = "00000000000000000000000000000000"
 
     # Set the targeted QPU
-    cudaq.set_target("ionq", url="http://localhost:{}".format(port))
+    cudaq.set_target(TARGET_QPU, url="http://localhost:{}".format(port))
 
     # Launch the Mock Server
-    p = Process(target=startServer, args=(port,))
+    p = Process(target=start_server, args=(TARGET_QPU,))
     p.start()
 
     if not check_server_connection(port):

--- a/python/tests/backends/test_Quantinuum_kernel.py
+++ b/python/tests/backends/test_Quantinuum_kernel.py
@@ -13,13 +13,15 @@ from multiprocessing import Process
 from typing import List
 from network_utils import check_server_connection
 try:
-    from utils.mock_qpu.quantinuum import startServer
-except:
+    from utils.mock_qpu import start_server, get_backend_port
+except Exception as e:
+    if os.environ.get("MOCK_NO_SKIP", "").lower() == "true":
+        raise e
     print("Mock qpu not available, skipping Quantinuum tests.")
     pytest.skip("Mock qpu not available.", allow_module_level=True)
 
-# Define the port for the mock server
-port = 62440
+TARGET_QPU = "quantinuum"
+port = get_backend_port(TARGET_QPU)
 
 
 def assert_close(got) -> bool:
@@ -39,7 +41,7 @@ def startUpMockServer():
     cudaq.set_random_seed(13)
 
     # Launch the Mock Server
-    p = Process(target=startServer, args=(port,))
+    p = Process(target=start_server, args=(TARGET_QPU,))
     p.start()
 
     if not check_server_connection(port):
@@ -60,7 +62,7 @@ def startUpMockServer():
 @pytest.fixture(scope="function", autouse=True)
 def configureTarget(startUpMockServer):
     # Set the target
-    cudaq.set_target('quantinuum',
+    cudaq.set_target(TARGET_QPU,
                      url='http://localhost:{}'.format(port),
                      credentials=startUpMockServer,
                      project='mock_project_id')

--- a/python/tests/backends/test_Quantinuum_ng_kernel.py
+++ b/python/tests/backends/test_Quantinuum_ng_kernel.py
@@ -13,13 +13,15 @@ from multiprocessing import Process
 from typing import List
 from network_utils import check_server_connection
 try:
-    from utils.mock_qpu.quantinuum import startServer
-except:
+    from utils.mock_qpu import start_server, get_backend_port
+except Exception as e:
+    if os.environ.get("MOCK_NO_SKIP", "").lower() == "true":
+        raise e
     print("Mock qpu not available, skipping Quantinuum tests.")
     pytest.skip("Mock qpu not available.", allow_module_level=True)
 
-# Define the port for the mock server
-port = 62440
+TARGET_QPU = "quantinuum"
+port = get_backend_port(TARGET_QPU)
 
 
 def assert_close(got) -> bool:
@@ -39,7 +41,7 @@ def startUpMockServer():
     cudaq.set_random_seed(13)
 
     # Launch the Mock Server
-    p = Process(target=startServer, args=(port,))
+    p = Process(target=start_server, args=(TARGET_QPU,))
     p.start()
 
     if not check_server_connection(port):
@@ -60,7 +62,7 @@ def startUpMockServer():
 @pytest.fixture(scope="function", autouse=True)
 def configureTarget(startUpMockServer):
     # Set the target, using the next generation `Helios` device.
-    cudaq.set_target('quantinuum',
+    cudaq.set_target(TARGET_QPU,
                      url='http://localhost:{}'.format(port),
                      credentials=startUpMockServer,
                      project='mock_project_id',

--- a/utils/mock_qpu/__init__.py
+++ b/utils/mock_qpu/__init__.py
@@ -28,3 +28,41 @@ def get_backend_port(backend: str) -> int:
 
 def all_backend_names() -> list[str]:
     return list(MOCK_QPU_PORTS.keys())
+
+
+def start_server(backend: str):
+    """Start the mock QPU backend server."""
+
+    import cudaq
+    import uvicorn
+
+    port = get_backend_port(backend)
+
+    match backend:
+        case "anyon":
+            from .anyon import app
+        case "braket":
+            from .braket import app
+        case "infleqtion":
+            from .infleqtion import app
+        case "ionq":
+            from .ionq import app
+        case "iqm":
+            from .iqm import app
+        case "oqc":
+            from .oqc import app
+        case "qci":
+            from .qci import app
+        case "quantinuum":
+            from .quantinuum import app
+        case "quantum_machines":
+            from .quantum_machines import app
+        case _:
+            # <backend> is in all_backend_names() but not handled!
+            raise ValueError(
+                f"case '{backend}' is not handled in start_mock_qpu.py")
+
+    cudaq.set_random_seed(13)
+
+    print(f"Starting {backend} server on port {port}")
+    uvicorn.run(app, port=port, host='0.0.0.0', log_level="info")

--- a/utils/start_mock_qpu.py
+++ b/utils/start_mock_qpu.py
@@ -10,46 +10,7 @@
 
 import argparse
 
-from mock_qpu import get_backend_port, all_backend_names
-
-
-def start_server(backend: str):
-    """Start the mock QPU backend server."""
-
-    import cudaq
-    import uvicorn
-
-    port = get_backend_port(backend)
-
-    match backend:
-        case "anyon":
-            from mock_qpu.anyon import app
-        case "braket":
-            from mock_qpu.braket import app
-        case "infleqtion":
-            from mock_qpu.infleqtion import app
-        case "ionq":
-            from mock_qpu.ionq import app
-        case "iqm":
-            from mock_qpu.iqm import app
-        case "oqc":
-            from mock_qpu.oqc import app
-        case "qci":
-            from mock_qpu.qci import app
-        case "quantinuum":
-            from mock_qpu.quantinuum import app
-        case "quantum_machines":
-            from mock_qpu.quantum_machines import app
-        case _:
-            # <backend> is in all_backend_names() but not handled!
-            raise ValueError(
-                f"case '{backend}' is not handled in start_mock_qpu.py")
-
-    cudaq.set_random_seed(13)
-
-    print(f"Starting {backend} server on port {port}")
-    uvicorn.run(app, port=port, host='0.0.0.0', log_level="info")
-
+from mock_qpu import start_server, all_backend_names
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Spotted by @amccaskey: our python backend tests that relied on mock QPUs where broken and not being run since https://github.com/NVIDIA/cuda-quantum/pull/3747.

This wasn't caught because the `ImportError` that was raised was silenced and the tests were subsequently skipped. This PR fixes this.

I have also added a `MOCK_NO_SKIP` env variable that can be used as a flag by CI to disallow test skipping on import failure, so that such an issue does not get missed again.