### PR TITLE
[test] Fix variable name in IQM LIT test

### DIFF
--- a/targettests/execution/mapping_test-1.cpp
+++ b/targettests/execution/mapping_test-1.cpp
@@ -8,7 +8,7 @@
 
 // clang-format off
 // RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s &&  FileCheck --check-prefix=QUAKE %s < %t.txt
-// RUN: nvq++ %s -o %t --target iqm --emulate --mapping-file "%iqm_test_src_dir/Crystal_5.txt" && %t | FileCheck %s
+// RUN: nvq++ %s -o %t --target iqm --emulate --mapping-file "%iqm_tests_dir/Crystal_5.txt" && %t | FileCheck %s
 // clang-format on
 // RUN: nvq++ --enable-mlir %s -o %t
 // RUN: rm -f %t.txt


### PR DESCRIPTION
In https://github.com/NVIDIA/cuda-quantum/pull/3298, `iqm_test_src_dir` was renamed to `iqm_tests_dir`. This was never updated in this file, which caused a `Path %iqm_test_src_dir/Crystal_5.txt does not exist` error to be printed out. 

Presumably the runtime was then proceeding by ignoring the non-existent mapping file. LIT tests were still passing as this error output was ignored.