### PR TITLE
[PTSBE] Handle default-constructed `sample_result`

### DIFF
--- a/runtime/cudaq/ptsbe/PTSBESampler.cpp
+++ b/runtime/cudaq/ptsbe/PTSBESampler.cpp
@@ -148,7 +148,7 @@ aggregateResults(const std::vector<cudaq::sample_result> &results) {
   cudaq::CountsDictionary aggregatedCounts;
   for (const auto &res : results) {
     // Skip empty results (e.g., trajectories with zero shots).
-    if (res.size() == 0)
+    if (res.get_total_shots() == 0)
       continue;
 
     for (const auto &[bitstring, count] : res.to_map())

--- a/unittests/ptsbe/ExecutePTSBETester.cpp
+++ b/unittests/ptsbe/ExecutePTSBETester.cpp
@@ -70,6 +70,29 @@ CUDAQ_TEST(ExecutePTSBETest, ThrowsWithoutExecutionContext) {
   }
 }
 
+CUDAQ_TEST(ExecutePTSBETest, AggregateResultsTester) {
+  // Default constructed results should be empty
+  std::vector<sample_result> results(10);
+  auto resultEmpty = aggregateResults(results);
+  EXPECT_EQ(resultEmpty.get_total_shots(), 0);
+  EXPECT_EQ(resultEmpty.to_map().size(), 0);
+
+  // Add some counts to the results
+  results[0] = cudaq::ExecutionResult{{{"00", 10}, {"01", 5}}};
+  auto resultWithCounts = aggregateResults(results);
+  EXPECT_EQ(resultWithCounts.get_total_shots(), 15);
+  resultWithCounts.count("00") == 10;
+  resultWithCounts.count("01") == 5;
+
+  // Add more counts to other results
+  results[1] = cudaq::ExecutionResult{{{"00", 20}, {"10", 15}}};
+  auto resultWithMoreCounts = aggregateResults(results);
+  EXPECT_EQ(resultWithMoreCounts.get_total_shots(), 50);
+  resultWithMoreCounts.count("00") == 30;
+  resultWithMoreCounts.count("01") == 5;
+  resultWithMoreCounts.count("10") == 15;
+}
+
 /// Single trajectory Hadamard circuit: execute H|0> and expect 50/50
 CUDAQ_TEST(ExecutePTSBETest, SingleTrajectoryHadamard) {
   QppSimulator sim;


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

The default constructed `sample_result` (`sample_result() = default`), while being equivalent to an empty map, doesn't allow us to call `to_map` (assuming the default register name). Hence, skipping it when aggregating the result.
