### PR TITLE
Fix bug with calling registered C++ kernels multiple times in python kernels

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2681,6 +2681,9 @@ class PyASTBridge(ast.NodeVisitor):
                 # Handle registered C++ kernels
                 elif cudaq_runtime.isRegisteredDeviceModule(devKey):
                     deviceModuleName = devKey + '.' + name
+                    if deviceModuleName in self.symbolTable:
+                        processDecoratorCall(deviceModuleName)
+                        return
                     maybeDeviceKernel = cudaq_runtime.checkRegisteredCppDeviceKernel(
                         self.module, deviceModuleName)
                     if maybeDeviceKernel != None:

--- a/python/tests/interop/test_interop.py
+++ b/python/tests/interop/test_interop.py
@@ -178,6 +178,24 @@ def test_cpp_kernel_from_python_2():
         e.value)
 
 
+def test_cpp_kernel_from_python_3():
+    pytest.importorskip('cudaq_test_cpp_algo')
+
+    import cudaq_test_cpp_algo
+
+    @cudaq.kernel
+    def call_c_twice():
+        q = cudaq.qvector(4)
+        cudaq_test_cpp_algo.qstd.uccsd(q, 2)
+        cudaq_test_cpp_algo.qstd.uccsd(q, 2)
+
+    @cudaq.kernel
+    def call_call_c_twice():
+        call_c_twice()
+
+    call_call_c_twice()
+
+
 def test_callbacks():
     pytest.importorskip('cudaq_test_cpp_algo')
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
Looks like when a C++ kernel is called multiple times from a python kernel, it will add the argument to the kernel function multiple times instead of checking if it's already been added. However, `add_linked_kernel_capture` is smarter so it will only get added to the signature once, creating a mismatch and eventual error in `mergeAllCallableClosures`. This PR adds a check to see if the C++ kernel has already been added to prevent this.