### PR TITLE
Removing cuda-mlir-runtime dependency on nvqir.

### DIFF
--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -13,6 +13,7 @@
 #include "cudaq/Support/TargetConfig.h"
 #include "cudaq/host_config.h"
 #include <filesystem>
+#include <functional>
 #include <map>
 #include <string>
 #include <unordered_map>

--- a/runtime/common/AnalogRemoteRESTQPU.h
+++ b/runtime/common/AnalogRemoteRESTQPU.h
@@ -54,7 +54,8 @@ public:
     std::string strArgs = charArgs;
     nlohmann::json j;
     std::vector<std::size_t> mapping_reorder_idx;
-    codes.emplace_back(name, strArgs, std::nullopt, j, mapping_reorder_idx);
+    codes.emplace_back(name, strArgs, std::nullopt, std::nullopt, j,
+                       mapping_reorder_idx);
 
     if (executionContext) {
       executor->setShots(executionContext->shots);

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -32,7 +32,7 @@
 namespace nvqir {
 // QIR helper to retrieve the output log.
 std::string_view getQirOutputLog();
-cudaq::Resources *getResourceCounts();
+void setResourceCounts(cudaq::Resources &&);
 bool isUsingResourceCounterSimulator();
 } // namespace nvqir
 
@@ -342,7 +342,8 @@ public:
     if (executionContext->name == "resource-count") {
       cudaq::ExecutionContext context("resource-count");
       context.executionManager = cudaq::getDefaultExecutionManager();
-      assert(codes.size() == 1 && codes[0].jit);
+      assert(codes.size() == 1 && codes[0].jit && codes[0].resourceCounts);
+      nvqir::setResourceCounts(std::move(codes[0].resourceCounts.value()));
       cudaq::get_platform().with_execution_context(
           context, [&]() { codes[0].jit->run(kernelName); });
       return;

--- a/runtime/common/CMakeLists.txt
+++ b/runtime/common/CMakeLists.txt
@@ -131,8 +131,7 @@ target_include_directories(cudaq-mlir-runtime
     ${CMAKE_SOURCE_DIR}/runtime)
 
 target_link_libraries(cudaq-mlir-runtime
-  PUBLIC
-    nvqir
+  PRIVATE
     CCDialect
     QuakeDialect
     OptCodeGen
@@ -149,7 +148,7 @@ target_link_libraries(cudaq-mlir-runtime
     MLIRTargetLLVMIRExport
     MLIRLLVMCommonConversion
     MLIRLLVMToLLVMIRTranslation
-  PRIVATE
+    cudaq-common
     CUDAQTargetConfigUtil
     cudaq-logger
 )

--- a/runtime/common/Resources.h
+++ b/runtime/common/Resources.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "Trace.h"
 #include <ostream>
 #include <unordered_map>
 #include <vector>
@@ -47,10 +46,6 @@ public:
     /// @brief Return true if this Instruction is equal to the given one.
     bool operator==(const Instruction &other) const;
   };
-
-  Resources() = default;
-  Resources(Resources &) = default;
-  Resources(Resources &&) = default;
 
   /// @brief Return the number of times the given Instruction is
   /// used in the current kernel execution

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -12,6 +12,7 @@
 #include "Future.h"
 #include "JIT.h"
 #include "Registry.h"
+#include "Resources.h"
 #include "RuntimeTarget.h"
 #include "SampleResult.h"
 #include "common/RecordLogParser.h"
@@ -31,17 +32,20 @@ struct KernelExecution {
   std::string name;
   std::string code;
   std::optional<JitEngine> jit;
+  std::optional<Resources> resourceCounts;
   nlohmann::json output_names;
   std::vector<std::size_t> mapping_reorder_idx;
   nlohmann::json user_data;
   KernelExecution(std::string &n, std::string &c, std::optional<JitEngine> jit,
-                  nlohmann::json &o, std::vector<std::size_t> &m)
-      : name(n), code(c), jit(jit), output_names(o), mapping_reorder_idx(m) {}
+                  std::optional<Resources> rc, nlohmann::json &o,
+                  std::vector<std::size_t> &m)
+      : name(n), code(c), jit(jit), resourceCounts(rc), output_names(o),
+        mapping_reorder_idx(m) {}
   KernelExecution(std::string &n, std::string &c, std::optional<JitEngine> jit,
-                  nlohmann::json &o, std::vector<std::size_t> &m,
-                  nlohmann::json &ud)
-      : name(n), code(c), jit(jit), output_names(o), mapping_reorder_idx(m),
-        user_data(ud) {}
+                  std::optional<Resources> rc, nlohmann::json &o,
+                  std::vector<std::size_t> &m, nlohmann::json &ud)
+      : name(n), code(c), jit(jit), resourceCounts(rc), output_names(o),
+        mapping_reorder_idx(m), user_data(ud) {}
 };
 
 /// @brief Responses / Submissions to the Server are modeled via JSON

--- a/runtime/cudaq/algorithms/resource_estimation.h
+++ b/runtime/cudaq/algorithms/resource_estimation.h
@@ -17,6 +17,7 @@ void switchToResourceCounterSimulator();
 void stopUsingResourceCounterSimulator();
 void setChoiceFunction(std::function<bool()> choice);
 cudaq::Resources *getResourceCounts();
+void setResourceCounts(cudaq::Resources &&);
 } // namespace nvqir
 
 namespace cudaq {

--- a/runtime/cudaq/platform/default/rest/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/rest/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(cudaq-rest-qpu
     fmt::fmt-header-only
     cudaq
     cudaq-platform-default
+    nvqir
     ${AWSSDK_LINK_LIBRARIES})
 
 install(TARGETS cudaq-rest-qpu DESTINATION lib)

--- a/runtime/cudaq/platform/fermioniq/CMakeLists.txt
+++ b/runtime/cudaq/platform/fermioniq/CMakeLists.txt
@@ -25,7 +25,9 @@ target_link_libraries(${LIBRARY_NAME}
     cudaq-mlir-runtime 
     fmt::fmt-header-only
     cudaq 
-    cudaq-platform-default)
+    cudaq-platform-default
+    nvqir
+)
 
 install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
 

--- a/runtime/cudaq/platform/pasqal/CMakeLists.txt
+++ b/runtime/cudaq/platform/pasqal/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(${LIBRARY_NAME}
     fmt::fmt-header-only
     cudaq 
     cudaq-platform-default
+    nvqir
 ) 
     
 install(TARGETS ${LIBRARY_NAME} DESTINATION lib)

--- a/runtime/cudaq/platform/quera/CMakeLists.txt
+++ b/runtime/cudaq/platform/quera/CMakeLists.txt
@@ -25,8 +25,10 @@ target_link_libraries(${LIBRARY_NAME}
     pthread
     cudaq-mlir-runtime 
     cudaq-logger
-    cudaq 
-    cudaq-platform-default)
+    cudaq
+    cudaq-platform-default
+    nvqir
+)
 
 install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
 

--- a/runtime/nvqir/resourcecounter/ResourceCounter.cpp
+++ b/runtime/nvqir/resourcecounter/ResourceCounter.cpp
@@ -27,4 +27,10 @@ cudaq::Resources *getResourceCounts() {
   getResourceCounterSimulator()->flushGateQueue();
   return getResourceCounterSimulator()->getResourceCounts();
 }
+
+void setResourceCounts(cudaq::Resources &&rc) {
+  getResourceCounterSimulator()->flushGateQueue();
+  getResourceCounterSimulator()->setResourceCounts(std::move(rc));
+}
+
 } // namespace nvqir

--- a/runtime/nvqir/resourcecounter/ResourceCounter.h
+++ b/runtime/nvqir/resourcecounter/ResourceCounter.h
@@ -80,6 +80,9 @@ public:
   }
 
   cudaq::Resources *getResourceCounts() { return &this->resourceCounts; }
+  void setResourceCounts(cudaq::Resources &&rc) {
+    this->resourceCounts = std::move(rc);
+  }
 
   void setChoiceFunction(std::function<bool()> choice) {
     assert(choice);


### PR DESCRIPTION
There was coupling between the compiler `cuda-mlir-runtime` and the resource count simulator `nvqir` because the compiler was trying to directly update the resource count of the simulator. With these changes the resource counts are passed as a return value of the compiler and the resource count simulator is updated in the QPU.

The `KernelExecution` has now an additional `Resources` field and certainly shows that it is being overloaded as a return value but this will have to be addressed by other refactors when compilation is broken up into different policies which can then have different return types. 

`nvqir` was publicly linking* with `cuda-common` and other libraries and  `cuda-mlir-runtime` was publicly linking `nvqir`. Removing the dependency on `nvqir` means that existing dependencies have to be made explicit. So `cuda-mlir-runtime` still depends on `cudaq-common` for resouce counts, device code registry and other utilities and the dependency between QPUs and `nvqir` is now apparent. 

