### PR TITLE
[python] Use pybind for kernel argument type casting

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -258,8 +258,10 @@ orca = cudaq_runtime.orca
 
 
 def synthesize(kernel, *args):
+    processed_args = kernel.process_call_arguments(*args)
     return PyKernelDecorator(None,
-                             module=cudaq_runtime.synthesize(kernel, *args),
+                             module=cudaq_runtime.synthesize(
+                                 kernel, processed_args),
                              kernelName=kernel.name,
                              decorator=kernel)
 

--- a/python/cudaq/kernel/kernel_args.py
+++ b/python/cudaq/kernel/kernel_args.py
@@ -1,0 +1,175 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+"""
+Typed argument wrappers for CUDA-Q kernel arguments.
+
+Each wrapper represents a Python value that can be passed to a kernel and
+corresponds to a supported MLIR type. These types will be marshaled into
+OpaqueArguments by the C++ type caster in `python/utils/OpaqueArgumentsCaster.h`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Union
+
+
+@dataclass(slots=True)
+class Float64Arg:
+    """A float value destined for an MLIR Float64Type parameter."""
+    value: float
+
+
+@dataclass(slots=True)
+class Float32Arg:
+    """A float value destined for an MLIR Float32Type parameter."""
+    value: float
+
+
+@dataclass(slots=True)
+class IntArg:
+    """An integer value destined for an MLIR IntegerType (width != 1)."""
+    value: int
+
+
+@dataclass(slots=True)
+class BoolArg:
+    """A boolean value destined for an MLIR IntegerType(1)."""
+    value: bool
+
+
+@dataclass(slots=True)
+class ComplexF64Arg:
+    """A complex value destined for an MLIR ComplexType(f64)."""
+    value: complex
+
+
+@dataclass(slots=True)
+class ComplexF32Arg:
+    """A complex value destined for an MLIR ComplexType(f32)."""
+    value: complex
+
+
+@dataclass(slots=True)
+class PauliWordArg:
+    """A cudaq.pauli_word destined for an MLIR cc::CharspanType."""
+    value: Any
+
+
+@dataclass(slots=True)
+class StateArg:
+    """A cudaq.State destined for an MLIR cc::PointerType(StateType)."""
+    value: Any
+
+
+@dataclass(slots=True)
+class StructArg:
+    """A structured value destined for an MLIR cc::StructType.
+
+    Carries the opaque MLIR type and module handles so the C++ type caster
+    can compute the target layout.
+    """
+    value: Any
+    mlir_type: Any  # MlirType (opaque handle)
+    module: Any  # MlirModule (opaque handle)
+
+
+@dataclass(slots=True)
+class VecArg:
+    """A list value destined for an MLIR cc::StdvecType.
+
+    Carries the opaque MLIR type so the C++ type caster can determine the
+    element type for nested vector handling.
+    """
+    value: list
+    mlir_type: Any  # MlirType (opaque handle)
+
+
+@dataclass(slots=True)
+class DecoratorCapture:
+    """A captured kernel decorator (Python-defined kernel passed as argument).
+
+    Attributes:
+        decorator: The PyKernelDecorator instance.
+        resolved: The resolved captured arguments (list of ArgWrapper values).
+    """
+    decorator: Any
+    resolved: list
+
+    def __str__(self) -> str:
+        return self.decorator.name + " -> " + str(self.resolved)
+
+    def __repr__(self) -> str:
+        return "name: " + self.decorator.name + ", resolved: " + str(
+            self.resolved)
+
+
+@dataclass(slots=True)
+class LinkedKernelCapture:
+    """A captured C++ kernel linked into the current module.
+
+    Attributes:
+        linkedKernel: The mangled name of the linked C++ kernel.
+        qkeModule: The parsed MLIR module containing the kernel's Quake code.
+    """
+    linkedKernel: str
+    qkeModule: Any  # MlirModule
+
+    def __str__(self) -> str:
+        return self.linkedKernel
+
+    def __repr__(self) -> str:
+        return "name: " + self.linkedKernel
+
+
+KernelArg = Union[Float64Arg, Float32Arg, IntArg, BoolArg, ComplexF64Arg,
+                  ComplexF32Arg, PauliWordArg, StateArg, StructArg, VecArg,
+                  DecoratorCapture, LinkedKernelCapture]
+
+
+def wrap_for_mlir_type(arg: Any,
+                       arg_type: Any,
+                       module: Any = None) -> KernelArg:
+    """Wrap a Python value in the appropriate typed wrapper based on the
+    expected MLIR type.
+
+    Args:
+        arg: The Python value to wrap.
+        arg_type: The expected MLIR type (from the kernel signature).
+        module: The MLIR module (needed for StructArg).
+    """
+    from cudaq.mlir.ir import ComplexType, F32Type, F64Type, IntegerType
+    from cudaq.mlir.dialects import cc
+
+    if F64Type.isinstance(arg_type):
+        return Float64Arg(float(arg))
+    if F32Type.isinstance(arg_type):
+        return Float32Arg(float(arg))
+    if IntegerType.isinstance(arg_type):
+        if IntegerType(arg_type).width == 1:
+            return BoolArg(bool(arg))
+        return IntArg(int(arg))
+    if ComplexType.isinstance(arg_type):
+        element_type = ComplexType(arg_type).element_type
+        if F64Type.isinstance(element_type):
+            return ComplexF64Arg(complex(arg))
+        return ComplexF32Arg(complex(arg))
+    if cc.CharspanType.isinstance(arg_type):
+        return PauliWordArg(arg)
+    if cc.PointerType.isinstance(arg_type):
+        element_type = cc.PointerType.getElementType(arg_type)
+        if cc.StateType.isinstance(element_type):
+            return StateArg(arg)
+    if cc.StructType.isinstance(arg_type):
+        return StructArg(arg, arg_type, module)
+    if cc.StdvecType.isinstance(arg_type):
+        return VecArg(arg if isinstance(arg, list) else list(arg), arg_type)
+    if cc.CallableType.isinstance(arg_type):
+        raise RuntimeError(
+            f"Unexpected callable type for non-decorator argument: {arg}")
+    raise RuntimeError(f"Unsupported MLIR type for argument: {arg_type}")

--- a/python/cudaq/runtime/draw.py
+++ b/python/cudaq/runtime/draw.py
@@ -25,7 +25,7 @@ def _detail_draw(format, decorator, *args):
     # Arguments are resolved, so go ahead and do the draw functionality, which
     # performs a kernel launch.
     return cudaq_runtime.draw_impl(format, decorator.uniqName, module, retTy,
-                                   *processedArgs)
+                                   processedArgs)
 
 
 def draw(decoratorOrFormat, *args):

--- a/python/cudaq/runtime/observe.py
+++ b/python/cudaq/runtime/observe.py
@@ -267,7 +267,7 @@ def observe_async(kernel, spin_operator, *args, qpu_id=0, shots_count=-1):
     returnTy = decorator.get_none_type()
     return cudaq_runtime.observe_async_impl(shortName, module, returnTy,
                                             spin_operator, qpu_id, shots_count,
-                                            *processedArgs)
+                                            processedArgs)
 
 
 def observe_parallel(kernel,
@@ -333,4 +333,4 @@ def observe_parallel(kernel,
     return cudaq_runtime.observe_parallel_impl(shortName, module, returnTy,
                                                execution, spin_operator,
                                                shots_count, noise_model,
-                                               *processedArgs)
+                                               processedArgs)

--- a/python/cudaq/runtime/resource_count.py
+++ b/python/cudaq/runtime/resource_count.py
@@ -40,4 +40,4 @@ def estimate_resources(kernel, *args, **kwargs):
     choice = kwargs.get("choice", None)
     return cudaq_runtime.estimate_resources_impl(decorator.uniqName, module,
                                                  returnTy, choice,
-                                                 *processedArgs)
+                                                 processedArgs)

--- a/python/cudaq/runtime/run.py
+++ b/python/cudaq/runtime/run.py
@@ -63,7 +63,7 @@ def run(decorator, *args, shots_count=100, noise_model=None, qpu_id=0):
     retTy = decorator.get_none_type()
     return cudaq_runtime.run_impl(decorator.uniqName + ".run", module, retTy,
                                   shots_count, noise_model, qpu_id,
-                                  *processedArgs)
+                                  processedArgs)
 
 
 def run_async(decorator, *args, shots_count=100, noise_model=None, qpu_id=0):
@@ -121,5 +121,5 @@ Returns:
     async_results = cudaq_runtime.run_async_impl(decorator.uniqName + ".run",
                                                  module, retTy, shots_count,
                                                  noise_model, qpu_id,
-                                                 *processedArgs)
+                                                 processedArgs)
     return AsyncRunResult(async_results, module)

--- a/python/cudaq/runtime/sample.py
+++ b/python/cudaq/runtime/sample.py
@@ -272,5 +272,5 @@ def sample_async(decorator,
                                                      retTy, shots_count,
                                                      noise_model,
                                                      explicit_measurements,
-                                                     qpu_id, *processedArgs)
+                                                     qpu_id, processedArgs)
     return AsyncSampleResult(sample_results, module)

--- a/python/cudaq/runtime/state.py
+++ b/python/cudaq/runtime/state.py
@@ -47,7 +47,7 @@ def get_state(kernel, *args):
     returnTy = (decorator.return_type
                 if decorator.return_type else decorator.get_none_type())
     return cudaq_runtime.get_state_impl(decorator.uniqName, module, returnTy,
-                                        *processedArgs)
+                                        processedArgs)
 
 
 def get_state_async(kernel, *args, qpu_id=0):
@@ -76,7 +76,7 @@ def get_state_async(kernel, *args, qpu_id=0):
     returnTy = (decorator.return_type
                 if decorator.return_type else decorator.get_none_type())
     return cudaq_runtime.get_state_async_impl(decorator.uniqName, module,
-                                              returnTy, qpu_id, *processedArgs)
+                                              returnTy, qpu_id, processedArgs)
 
 
 def to_cupy(state, dtype=None):

--- a/python/cudaq/runtime/translate.py
+++ b/python/cudaq/runtime/translate.py
@@ -88,4 +88,4 @@ def translate(kernel, *args, format="qir:0.1"):
     # Arguments are resolved. Specialize this kernel and translate to the
     # selected transport layer.
     return cudaq_runtime.translate_impl(decorator.uniqName, module, retTy,
-                                        format, *processedArgs)
+                                        format, processedArgs)

--- a/python/cudaq/runtime/unitary.py
+++ b/python/cudaq/runtime/unitary.py
@@ -40,4 +40,4 @@ def get_unitary(kernel, *args):
     returnTy = (decorator.return_type
                 if decorator.return_type else decorator.get_none_type())
     return cudaq_runtime.get_unitary_impl(decorator.uniqName, module, returnTy,
-                                          *processedArgs)
+                                          processedArgs)

--- a/python/runtime/cudaq/algorithms/py_unitary.cpp
+++ b/python/runtime/cudaq/algorithms/py_unitary.cpp
@@ -10,7 +10,6 @@
 #include "cudaq/algorithms/unitary.h"
 #include "runtime/cudaq/operators/py_helpers.h"
 #include "runtime/cudaq/platform/py_alt_launch_kernel.h"
-#include "mlir/Bindings/Python/PybindAdaptors.h"
 
 namespace py = pybind11;
 
@@ -19,10 +18,11 @@ using namespace cudaq;
 /// Compute the unitary of this kernel module.
 static py::array get_unitary_impl(const std::string &shortName,
                                   MlirModule module, MlirType returnTy,
-                                  py::args args) {
+                                  cudaq::OpaqueArguments args) {
   // Uses the same pattern as py_draw.
-  auto f = [=]() {
-    return cudaq::marshal_and_launch_module(shortName, module, returnTy, args);
+  auto f = [shortName, module, returnTy, args = std::move(args)]() mutable {
+    return cudaq::marshal_and_launch_module(shortName, module, returnTy,
+                                            std::move(args));
   };
 
   // Return as numpy array (dim, dim), complex128

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.h
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.h
@@ -11,6 +11,7 @@
 #include "cudaq/Optimizer/Builder/Factory.h"
 #include "cudaq/algorithms/run.h"
 #include "utils/OpaqueArguments.h"
+#include "utils/OpaqueArgumentsCaster.h"
 #include "utils/PyTypes.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include <pybind11/complex.h>
@@ -25,11 +26,6 @@ namespace cudaq {
 
 /// @brief Set current architecture's data layout attribute on a module.
 void setDataLayout(MlirModule module);
-
-/// @brief Create a new OpaqueArguments pointer and pack the
-/// python arguments in it. Clients must delete the memory.
-OpaqueArguments *toOpaqueArgs(py::args &args, MlirModule mod,
-                              const std::string &name);
 
 // FIXME: Document!
 std::size_t byteSize(mlir::Type ty);
@@ -47,16 +43,12 @@ void bindAltLaunchKernel(py::module &mod, std::function<std::string()> &&);
 /// has a result, it has type \p returnType. \p module must be modifiable.
 py::object marshal_and_launch_module(const std::string &kernelName,
                                      MlirModule module, MlirType returnType,
-                                     py::args runtimeArgs);
+                                     OpaqueArguments runtimeArgs);
 
 /// Pure C++ code that launches a kernel. Argument marshaling and result
 /// unmarshalling is \e not performed.
 KernelThunkResultType clean_launch_module(const std::string &kernelName,
                                           mlir::ModuleOp mod, mlir::Type retTy,
                                           OpaqueArguments &args);
-
-OpaqueArguments
-marshal_arguments_for_module_launch(mlir::ModuleOp mod, py::args runtimeArgs,
-                                    mlir::func::FuncOp kernelFunc);
 
 } // namespace cudaq

--- a/python/utils/OpaqueArguments.h
+++ b/python/utils/OpaqueArguments.h
@@ -38,12 +38,6 @@ namespace cudaq {
 // runtime, so it can be used to launch kernels. See ArgumentWrapper.h.
 class OpaqueArguments;
 
-/// This function modifies input arguments to convert them into valid CUDA-Q
-/// argument types. Future work should make this function perform more checks,
-/// we probably want to take the kernel MLIR argument types as input and use
-/// that to validate that the passed arguments are good to go.
-py::args simplifiedValidateInputArguments(py::args &args);
-
 /// @brief Search the given Module for the function with provided name.
 template <bool noThrow = false>
 mlir::func::FuncOp getKernelFuncOp(mlir::ModuleOp mod,
@@ -123,23 +117,6 @@ void handleStructMemberVariable(void *data, std::size_t offset,
 /// For the current vector element type, insert the value into the dynamically
 /// constructed vector.
 void *handleVectorElements(mlir::Type eleTy, py::list list);
-
-/// Take a list of python objects (the arguments) and convert them to C++
-/// objects on the heap. The results are returned in \p argData and include
-/// special `deletors` so that the argument data is cleaned up correctly.
-void packArgs(OpaqueArguments &argData, py::list args,
-              mlir::ArrayRef<mlir::Type> mlirTys,
-              const std::function<bool(OpaqueArguments &, py::object &,
-                                       unsigned)> &backupHandler,
-              mlir::func::FuncOp kernelFuncOp);
-
-/// This overload handles dropping the front \p startingArgIdx arguments on the
-/// floor. They are not packed in \p argData and are simply ignored.
-void packArgs(OpaqueArguments &argData, py::args args,
-              mlir::func::FuncOp kernelFuncOp,
-              const std::function<bool(OpaqueArguments &, py::object &,
-                                       unsigned)> &backupHandler,
-              std::size_t startingArgIdx = 0);
 
 /// Return `true` if the given \p args represents a request for broadcasting
 /// sample or observe over all argument sets. \p args types can be `int`,

--- a/python/utils/OpaqueArgumentsCaster.h
+++ b/python/utils/OpaqueArgumentsCaster.h
@@ -1,0 +1,185 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "OpaqueArguments.h"
+#include "cudaq/qis/state.h"
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+namespace cudaq {
+
+/// Pack a list of Python typed-wrapper objects into an OpaqueArguments.
+/// Each element in \p args must be one of the wrapper types defined in
+/// python/cudaq/kernel/kernel_args.py.
+inline bool packWrappedArgs(OpaqueArguments &argData, py::list args) {
+  for (auto item : args) {
+    auto obj = py::reinterpret_borrow<py::object>(item);
+    std::string cls =
+        obj.attr("__class__").attr("__name__").cast<std::string>();
+
+    if (cls == "Float64Arg") {
+      addArgument(argData, obj.attr("value").cast<double>());
+
+    } else if (cls == "Float32Arg") {
+      addArgument(argData, obj.attr("value").cast<float>());
+
+    } else if (cls == "IntArg") {
+      addArgument(argData, obj.attr("value").cast<std::int64_t>());
+
+    } else if (cls == "BoolArg") {
+      addArgument(argData, static_cast<char>(obj.attr("value").cast<bool>()));
+
+    } else if (cls == "ComplexF64Arg") {
+      addArgument(argData, obj.attr("value").cast<std::complex<double>>());
+
+    } else if (cls == "ComplexF32Arg") {
+      addArgument(argData, obj.attr("value").cast<std::complex<float>>());
+
+    } else if (cls == "PauliWordArg") {
+      addArgument(argData, obj.attr("value").cast<pauli_word>().str());
+
+    } else if (cls == "StateArg") {
+      auto *stateArg = obj.attr("value").cast<state *>();
+      if (stateArg == nullptr)
+        throw std::runtime_error("Null cudaq::state* argument passed.");
+      auto simState =
+          state_helper::getSimulationState(const_cast<state *>(stateArg));
+      if (!simState)
+        throw std::runtime_error(
+            "Error: Unable to retrieve simulation state from cudaq::state. "
+            "The state contains no simulation state.");
+      if (simState->getKernelInfo().has_value()) {
+        state *copyState = new state(*stateArg);
+        argData.emplace_back(
+            copyState, [](void *ptr) { delete static_cast<state *>(ptr); });
+      } else {
+        argData.emplace_back(stateArg, [](void *) {});
+      }
+
+    } else if (cls == "StructArg") {
+      auto mlirTy = obj.attr("mlir_type");
+      auto mlirMod = obj.attr("module");
+      auto mod = unwrap(mlirMod.cast<MlirModule>());
+      auto ty =
+          mlir::cast<cudaq::cc::StructType>(unwrap(mlirTy.cast<MlirType>()));
+      auto [size, offsets] = getTargetLayout(mod, ty);
+      auto memberTys = ty.getMembers();
+      auto allocatedArg = std::malloc(size);
+      py::object value = obj.attr("value");
+      if (ty.getName() == "tuple") {
+        auto elements = value.cast<py::tuple>();
+        for (std::size_t i = 0; i < offsets.size(); i++)
+          handleStructMemberVariable(allocatedArg, offsets[i], memberTys[i],
+                                     elements[i]);
+      } else {
+        py::dict attributes = value.attr("__annotations__").cast<py::dict>();
+        for (std::size_t i = 0; const auto &[attr_name, unused] : attributes) {
+          py::object attr_value =
+              value.attr(attr_name.cast<std::string>().c_str());
+          handleStructMemberVariable(allocatedArg, offsets[i], memberTys[i],
+                                     attr_value);
+          i++;
+        }
+      }
+      argData.emplace_back(allocatedArg, [](void *ptr) { std::free(ptr); });
+
+    } else if (cls == "VecArg") {
+      auto mlirTy = obj.attr("mlir_type");
+      auto ty =
+          mlir::cast<cudaq::cc::StdvecType>(unwrap(mlirTy.cast<MlirType>()));
+      auto list = obj.attr("value").cast<py::list>();
+      auto eleTy = ty.getElementType();
+
+      auto appendVectorValue = [&argData]<typename T>(mlir::Type eleTy,
+                                                      py::list list) {
+        auto allocatedArg = handleVectorElements(eleTy, list);
+        argData.emplace_back(allocatedArg, [](void *ptr) {
+          delete static_cast<std::vector<T> *>(ptr);
+        });
+      };
+
+      if (eleTy.isInteger(1)) {
+        appendVectorValue.template operator()<char>(eleTy, list);
+      } else {
+        appendVectorValue.template operator()<std::int64_t>(eleTy, list);
+      }
+
+    } else if (cls == "LinkedKernelCapture") {
+      auto kernelName = obj.attr("linkedKernel").cast<std::string>();
+      kernelName.erase(0, strlen(runtime::cudaqGenPrefixName));
+      auto kernelModule = unwrap(obj.attr("qkeModule").cast<MlirModule>());
+      OpaqueArguments resolvedArgs;
+      argData.emplace_back(
+          new runtime::CallableClosureArgument(
+              kernelName, kernelModule, std::nullopt, std::move(resolvedArgs)),
+          [](void *that) {
+            delete static_cast<runtime::CallableClosureArgument *>(that);
+          });
+
+    } else if (cls == "DecoratorCapture") {
+      py::object decorator = obj.attr("decorator");
+      auto kernelName = decorator.attr("uniqName").cast<std::string>();
+      auto kernelModule =
+          unwrap(decorator.attr("qkeModule").cast<MlirModule>());
+      // auto calledFuncOp =
+      //     kernelModule.lookupSymbol<mlir::func::FuncOp>(
+      //         runtime::cudaqGenPrefixName + kernelName);
+      py::list arguments = obj.attr("resolved");
+      auto startLiftedArgs = [&]() -> std::optional<unsigned> {
+        if (!arguments.empty())
+          return decorator.attr("formal_arity")().cast<unsigned>();
+        return std::nullopt;
+      }();
+      OpaqueArguments resolvedArgs;
+      if (startLiftedArgs) {
+        packWrappedArgs(resolvedArgs, arguments);
+      }
+      auto *closure = new runtime::CallableClosureArgument(
+          kernelName, kernelModule, std::move(startLiftedArgs),
+          std::move(resolvedArgs));
+      argData.emplace_back(closure, [](void *that) {
+        delete static_cast<runtime::CallableClosureArgument *>(that);
+      });
+
+    } else {
+      throw std::runtime_error(
+          "Unknown argument wrapper type: " + cls +
+          " for value: " + py::str(obj).cast<std::string>());
+    }
+  }
+  return true;
+}
+
+} // namespace cudaq
+
+namespace pybind11 {
+namespace detail {
+
+template <>
+struct type_caster<cudaq::OpaqueArguments> {
+  PYBIND11_TYPE_CASTER(cudaq::OpaqueArguments, const_name("OpaqueArguments"));
+
+  bool load(handle src, bool /*convert*/) {
+    if (!isinstance<py::list>(src))
+      return false;
+    return cudaq::packWrappedArgs(value, reinterpret_borrow<py::list>(src));
+  }
+
+  // C++ -> Python direction is not needed.
+  static handle cast(cudaq::OpaqueArguments &&, return_value_policy, handle) {
+    throw std::runtime_error("OpaqueArguments cannot be converted to Python.");
+  }
+};
+
+} // namespace detail
+} // namespace pybind11


### PR DESCRIPTION
Previously, kernel arguments passed to `PyKernelDecorator` were passed as-is to the C++ bindings and then cast to the appropriate types within C++. This is hard to maintain as inspecting python objects from C++ is cumbersome, especially if we want to keep some of the python "duck typing" (e.g. handling both np.array and lists seamlessly).

This PR cleans this up as follows:
1. Define in Python a clear list of kernel argument types that are supported as 