### PR TITLE
[PTSBE] Fix "sample" context bug

### DIFF
--- a/runtime/cudaq/ptsbe/PTSBESampler.h
+++ b/runtime/cudaq/ptsbe/PTSBESampler.h
@@ -78,11 +78,11 @@ std::vector<cudaq::sample_result> samplePTSBE(const PTSBatch &batch);
 /// 5. Deallocates qubits and resets context
 ///
 /// @param batch PTSBE specification
-/// @param contextType ExecutionContext type (default: "sample")
+/// @param contextType ExecutionContext type (default: "ptsbe_sample").
 /// @return Per-trajectory sample results
 /// @throws std::runtime_error if simulator cast fails or gate conversion fails
 std::vector<cudaq::sample_result>
 samplePTSBEWithLifecycle(const PTSBatch &batch,
-                         const std::string &contextType = "sample");
+                         const std::string &contextType = "ptsbe_sample");
 
 } // namespace cudaq::ptsbe

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -157,7 +157,9 @@ protected:
     // Default to single shot
     std::size_t batch_size = 1;
     auto *executionContext = getExecutionContext();
-    if (executionContext && executionContext->name == "sample" &&
+    if (executionContext &&
+        (executionContext->name == "sample" ||
+         executionContext->name == "ptsbe_sample") &&
         !executionContext->hasConditionalsOnMeasureResults)
       batch_size = executionContext->shots;
     else if (executionContext && executionContext->name == "msm")

--- a/unittests/ptsbe/PTSBESampleTester.cpp
+++ b/unittests/ptsbe/PTSBESampleTester.cpp
@@ -345,7 +345,7 @@ CUDAQ_TEST(PTSBESampleTest, E2E_GenerateTrajectoriesAllocateShotsRunSample) {
   EXPECT_EQ(sum_shots, total_shots);
 
   // Execute PTSBE and aggregate
-  auto results = samplePTSBEWithLifecycle(batch, "sample");
+  auto results = samplePTSBEWithLifecycle(batch);
   EXPECT_EQ(results.size(), batch.trajectories.size());
 
   auto result = aggregateResults(results);


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
@1tnguyen noticed `sample` context was causing issues with redundant sampling and PTSBE as it triggered redundant sampling of the zero state using the full shot count at the end of PTSBE execution. The context type is changed to `ptsbe_sample` to skip the base class sampling branch. Had to update stim's `getBatchSize()` to recognize the new context name for correct FrameSimulator initialization.