### PR TITLE
[remote sim] Allow compiler generated LLVM memory functions and dynamic memory allocation functions

### DIFF
--- a/scripts/validate_installation.sh
+++ b/scripts/validate_installation.sh
@@ -261,8 +261,7 @@ do
             # Skipped long-running tests (variational optimization loops) for the "remote-mqpu" target to keep CI runtime manageable.
             # A simplified test for these use cases is included in the 'test/Remote-Sim/' test suite. 
             # Skipped tests that require passing kernel callables to entry-point kernels for the "remote-mqpu" target.
-            # Also see issue: https://github.com/NVIDIA/cuda-quantum/issues/3792
-            if [[ "$ex" == *"vqe_h2"* || "$ex" == *"qaoa_maxcut"* || "$ex" == *"gradients"* || "$ex" == *"grover"* || "$ex" == *"phase_estimation"* || "$ex" == *"trotter_kernel_mode"* || "$ex" == *"builder.cpp"* || "$ex" == *"iterative_qpe"* || "$ex" == *"measuring_kernels"* ]];
+            if [[ "$ex" == *"vqe_h2"* || "$ex" == *"qaoa_maxcut"* || "$ex" == *"gradients"* || "$ex" == *"grover"* || "$ex" == *"phase_estimation"* || "$ex" == *"trotter_kernel_mode"* || "$ex" == *"builder.cpp"* ]];
             then
                 let "skipped+=1"
                 echo "Skipping $t target.";


### PR DESCRIPTION
This PR relaxes the NVQIR verification logic by including LLVM memory intrinsics (`llvm.memcpy`, `llvm.memmove`, `llvm.memset`) and common host runtime functions (`malloc`, `free`, `memcpy`, `memset`) in the allowed functions list.

* Fixes the issue #3792 
* Makes the remote simulator's behavior closer to that of local simulator.
