### PR TITLE
remove on push for new workflow

### DIFF
--- a/.github/workflows/build_package_sources.yml
+++ b/.github/workflows/build_package_sources.yml
@@ -16,7 +16,6 @@
 #     The environment to build the source image for.
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       push_to_NGC:


### PR DESCRIPTION
Accidentally kept on push: for the new workflow for debugging purposes. Let's disable that.