### PR TITLE
Fix bug where cleanup code was cleaned up

### DIFF
--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -551,7 +551,7 @@ class PyKernelDecorator(object):
         """
         # Make sure this hasn't already been cleaned up as we're winding down
         if (cudaq_runtime is not None and
-            cudaq_runtime.delete_cache_execution_engine is not None):
+                cudaq_runtime.delete_cache_execution_engine is not None):
             cudaq_runtime.delete_cache_execution_engine(key)
 
     def resolve_decorator_at_callsite(self, callingMod):


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
Looks like, during cleanup, the pybind bound function `cudaq-runtime.delete_cache_execution_engine` is deleted (and thus set to `None`) before it is called when cleaning up some decorators. I just added a check to not perform clean up in this case.