### PR TITLE
[testing] Apply the work-around for issue#3708 to an example in docs

### DIFF
--- a/docs/sphinx/targets/cpp/qci.cpp
+++ b/docs/sphinx/targets/cpp/qci.cpp
@@ -67,9 +67,9 @@ int main() {
     return static_cast<double>(ones[q]) / num_shots;
   };
 
-  // mz[0] and mz[1] are Bell measurement outcomes, so each is ~50%.
-  // mz[2] is the teleported qubit. Its P(1) is determined by the
-  // prepared state: P(mz[2]=1) ~4.6% for the angles above.
+  // `mz[0]` and `mz[1]` are Bell measurement outcomes, so each is ~50%.
+  // Probability of measuring`mz[2]` in 1 is determined by the prepared state,
+  // which is ~4.6% for the angles above.
   std::cout << "Results over " << num_shots << " shots:\n";
   for (std::size_t q = 0; q < 3; ++q)
     std::cout << "  mz[" << q << "] = 1:  " << ones[q] << " / " << num_shots


### PR DESCRIPTION
* Follow-up to PR https://github.com/NVIDIA/cuda-quantum/pull/3957
* Same work-around for issue https://github.com/NVIDIA/cuda-quantum/issues/3708 should be applied to this example
* Note that the probabilities depend on the shots count, higher is better, but to keep the test fast, we limit the number of shots