### PR TITLE
[PTSBE] Warn experimental ptsbe trajectory data

### DIFF
--- a/runtime/cudaq/ptsbe/PTSBESampleResult.cpp
+++ b/runtime/cudaq/ptsbe/PTSBESampleResult.cpp
@@ -7,9 +7,22 @@
  ******************************************************************************/
 
 #include "PTSBESampleResult.h"
+#include "cudaq/runtime/logger/logger.h"
+#include <mutex>
 #include <stdexcept>
 
 namespace cudaq::ptsbe {
+namespace {
+std::once_flag ptsbeExecutionDataWarningOnce;
+
+void warnExperimentalExecutionData() {
+  std::call_once(ptsbeExecutionDataWarningOnce, []() {
+    CUDAQ_WARN(
+        "PTSBE execution data API is experimental and may change in a future "
+        "release.");
+  });
+}
+} // namespace
 
 sample_result::sample_result(cudaq::sample_result &&base)
     : cudaq::sample_result(std::move(base)) {}
@@ -27,6 +40,7 @@ const PTSBEExecutionData &sample_result::execution_data() const {
   if (!executionData_.has_value())
     throw std::runtime_error("PTSBE execution data not available. Enable with "
                              "return_execution_data=true.");
+  warnExperimentalExecutionData();
   return executionData_.value();
 }
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
Add warning on accessing of PTSBE experimental/trajectory data about experimental nature.