### PR TITLE
[python] Use resolve_captured_arguments in kernel builder

### DIFF
--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -29,12 +29,12 @@ from cudaq.mlir._mlir_libs._quakeDialects import (
 from cudaq.kernel_types import qubit, qvector
 from .common.fermionic_swap import fermionic_swap_builder
 from .common.givens import givens_builder
-from .kernel_decorator import isa_kernel_decorator
+from .kernel_decorator import DecoratorCapture, isa_kernel_decorator
 from .quake_value import QuakeValue
 from .utils import (emitFatalError, emitWarning, nvqppPrefix, getMLIRContext,
                     recover_func_op, mlirTypeToPyType, cudaq__unique_attr_name,
                     mlirTypeFromPyType, emitErrorIfInvalidPauli,
-                    recover_value_of, globalRegisteredOperations)
+                    globalRegisteredOperations)
 
 kDynamicPtrIndex: int = -2147483648
 
@@ -482,7 +482,7 @@ class PyKernel(object):
 
         return operand
 
-    def __getMLIRValueFromPythonArg(self, arg, argTy):
+    def __getMLIRValueFromPythonArg(self, arg, argTy=None):
         """
         Given a python runtime argument, create and return an equivalent
         constant MLIR Value.
@@ -1356,10 +1356,11 @@ class PyKernel(object):
                     f"or deactivate deferred compilation:\n\n"
                     f"    @cudaq.kernel(defer_compilation=False)\n"
                     f"    def {name}(...): ...\n")
-            target = self.resolve_callable_arg(self.insertPoint, target)
+            target = self.resolve_callable_arg(self.insertPoint,
+                                               DecoratorCapture(target))
         self.__applyControlOrAdjoint(target, False, [], *target_arguments)
 
-    def resolve_callable_arg(self, insPt, target):
+    def resolve_callable_arg(self, insPt, target: DecoratorCapture):
         """
         `target` must be a callable. For a simple callable (a `func.FuncOp`),
         resolution is trivial. If the callable is a decorator with lambda lifted
@@ -1367,31 +1368,32 @@ class PyKernel(object):
         closure here.
         Returns a `CreateLambdaOp` closure.
         """
+        decorator = target.decorator
         # Add the target kernel to the current module.
-        fulluniq = nvqppPrefix + target.uniqName
-        cudaq_runtime.updateModule(fulluniq, self.module, target.qkeModule)
+        fulluniq = nvqppPrefix + decorator.uniqName
+        cudaq_runtime.updateModule(fulluniq, self.module, decorator.qkeModule)
         fn = recover_func_op(self.module, fulluniq)
 
         # build the closure to capture the lifted `args`
-        funcTy = target.signature.get_lifted_type()
-        callableTy = target.signature.get_callable_type()
+        funcTy = decorator.signature.get_lifted_type()
+        callableTy = decorator.signature.get_callable_type()
         with insPt, self.loc:
             lamb = cc.CreateLambdaOp(callableTy, loc=self.loc)
             lamb.attributes.__setitem__('function_type', TypeAttr.get(funcTy))
             initRegion = lamb.initRegion
-            initBlock = Block.create_at_start(initRegion, target.arg_types())
+            initBlock = Block.create_at_start(initRegion, decorator.arg_types())
             inner = InsertionPoint(initBlock)
             with inner:
                 vs = []
                 for ba in initBlock.arguments:
                     vs.append(ba)
-                for var in target.captured_variables():
-                    v = recover_value_of(var.name, target.defFrame)
-                    if isa_kernel_decorator(v):
+                captured_args = target.resolved
+                for arg in captured_args:
+                    if isinstance(arg, DecoratorCapture):
                         # The recursive step
-                        v = self.resolve_callable_arg(inner, v)
+                        v = self.resolve_callable_arg(inner, arg)
                     else:
-                        v = self.__getMLIRValueFromPythonArg(v, var.type)
+                        v = self.__getMLIRValueFromPythonArg(arg)
                     vs.append(v)
                 if funcTy.results:
                     call = func.CallOp(fn, vs).result

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -72,9 +72,9 @@ def ensure_not_recursive(method):
 
 class DecoratorCapture:
 
-    def __init__(self, decorator, values):
+    def __init__(self, decorator):
         self.decorator = decorator
-        self.resolved = values
+        self.resolved = decorator.resolve_captured_arguments()
 
     def __str__(self):
         self.decorator.name + " -> " + str(self.resolved)
@@ -642,8 +642,7 @@ class PyKernelDecorator(object):
 
     def process_argument(self, arg, arg_type):
         if isa_kernel_decorator(arg):
-            captured_args = arg.resolve_captured_arguments()
-            return DecoratorCapture(arg, captured_args)
+            return DecoratorCapture(arg)
 
         arg = self.convertStringsToPauli(arg)
         mlirType = mlirTypeFromPyType(type(arg),


### PR DESCRIPTION
A minor change that reuses the logic of `PyKernelDecorator.resolve_captured_arguments` to resolve the captured arguments of kernel decorators within the builder. Other than making sure the behaviour is consistent, the main benefit of this is that it no longer requires a `.defFrame` attribute to be defined.
