### PR TITLE
Add Coderabbit configuration for evaluation trial

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,8 +17,6 @@
 # Feedback: post impressions in the dedicated Slack thread. You can also
 # reply directly to CodeRabbit's PR comments (it learns from corrections).
 #
-# See coderabbit-trial.md at the project root for full trial guidelines.
-#
 # TODO: Migrate coding-knowledge path_instructions into per-directory
 #       AGENTS.md files (with a ## Reviewing section). Keep only
 #       review-specific directives (breaking-change flags, etc.) here.


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
Adds a Coderabbit configuration file to trial it's capabilities for the Cuda-Q project. The initial plan is for a one-month trial and to answer the following questions:

- Do we gain a benefit for the tool?
- Opt-in or opt-out long-term?
- Does CodeRabbit actually improve our code-quality? What about development throughput?
  - If so how would we measure this?
- What is the right human/AI review balance?
- Which review categories does AI handle well vs poorly?
- Should CodeRabbit be a required/approving reviewer?
- Link cudaqx for cross-repo breaking change detection?
- Add per-directory AGENTS.md files to replace temporary path_instructions?