### PR TITLE
Fix RuntimeError typo and duplicate test function name

### DIFF
--- a/python/cudaq/runtime/observe.py
+++ b/python/cudaq/runtime/observe.py
@@ -137,7 +137,7 @@ def observe(kernel,
     elif isa_dynamic_kernel(kernel):
         decorator = mk_decorator(kernel)
     else:
-        raise RuntimeRrror(
+        raise RuntimeError(
             "unrecognized kernel - did you forget the @kernel attribute?")
     if (decorator.launch_args_required() != 0) and (decorator.formal_arity()
                                                     != len(args)):
@@ -254,7 +254,7 @@ def observe_async(kernel, spin_operator, *args, qpu_id=0, shots_count=-1):
     elif isa_dynamic_kernel(kernel):
         decorator = mk_decorator(kernel)
     else:
-        raise RuntimeRrror(
+        raise RuntimeError(
             "unrecognized kernel - did you forget the @kernel attribute?")
     if (decorator.launch_args_required() != 0) and (decorator.formal_arity()
                                                     != len(args)):
@@ -325,7 +325,7 @@ def observe_parallel(kernel,
     elif isa_dynamic_kernel(kernel):
         decorator = mk_decorator(kernel)
     else:
-        raise RuntimeRrror(
+        raise RuntimeError(
             "unrecognized kernel - did you forget the @kernel attribute?")
     shortName = decorator.uniqName
     processedArgs, module = decorator.prepare_call(*args)

--- a/python/tests/builder/test_qalloc_init_state.py
+++ b/python/tests/builder/test_qalloc_init_state.py
@@ -192,7 +192,7 @@ def test_kernel_complex128_capture_f64():
 
 
 @skipIfNvidiaFP64NotInstalled
-def test_kernel_complex128_capture_f64():
+def test_kernel_complex64_invalid_precision_f64():
     cudaq.reset_target()
     cudaq.set_target('nvidia', option='fp64')
 


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->

- Fix `RuntimeRrror` typo to `RuntimeError` in observe.py (3 occurrences)
- Rename duplicate `test_kernel_complex128_capture_f64` to `test_kernel_complex64_invalid_precision_f64` to avoid shadowing

