### PR TITLE
[bug-fix] Validate the simulation data used to create state from data

### DIFF
--- a/runtime/common/JsonConvert.h
+++ b/runtime/common/JsonConvert.h
@@ -190,6 +190,9 @@ inline void from_json(const json &j, ExecutionContext &context) {
     // flat pair of dimensions and data, whereby an empty dimension array
     // represents no state data in the context.
     if (!stateDim.empty()) {
+      if (stateDim[0] != stateData.size())
+        throw std::runtime_error(
+            "[from_json] `simulationData` dimension mismatch");
       // Create the simulation specific SimulationState
       auto *simulator = cudaq::get_simulator();
       if (simulator->isSinglePrecision()) {
@@ -203,6 +206,9 @@ inline void from_json(const json &j, ExecutionContext &context) {
         context.simulationState = simulator->createStateFromData(
             std::make_pair(stateData.data(), stateDim[0]));
       }
+    } else if (!stateData.empty()) {
+      throw std::runtime_error(
+          "[from_json] `simulationData` dimension mismatch");
     }
   }
 

--- a/runtime/common/SimulationState.h
+++ b/runtime/common/SimulationState.h
@@ -86,6 +86,11 @@ protected:
     else
       throw std::runtime_error("unsupported data type for state vector.");
 
+    auto &[size, ptr] = sizeAndPtr;
+    if (!ptr || size == 0)
+      throw std::runtime_error(
+          "[getSizeAndPtr] invalid null pointer or zero size");
+
     return sizeAndPtr;
   }
 

--- a/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatState.cpp
@@ -116,6 +116,9 @@ CuDensityMatState::createFromData(const state_data &data) {
 std::unique_ptr<SimulationState>
 CuDensityMatState::createFromSizeAndPtr(std::size_t size, void *dataPtr,
                                         std::size_t type) {
+  if (!dataPtr || size == 0)
+    throw std::runtime_error(
+        "[createFromSizeAndPtr] invalid null pointer or zero size");
   bool isDm = false;
   if (type == cudaq::detail::variant_index<cudaq::state_data,
                                            cudaq::TensorStateData>()) {

--- a/runtime/nvqir/custatevec/CuStateVecState.h
+++ b/runtime/nvqir/custatevec/CuStateVecState.h
@@ -209,6 +209,9 @@ public:
 
   std::unique_ptr<SimulationState>
   createFromSizeAndPtr(std::size_t size, void *ptr, std::size_t type) override {
+    if (!ptr || size == 0)
+      throw std::runtime_error(
+          "[createFromSizeAndPtr] invalid null pointer or zero size");
     // If the data is provided as a pointer / size, then
     // we assume we do not own it.
     bool weOwnTheData = type < 2 ? true : false;

--- a/runtime/nvqir/cutensornet/mps_simulation_state.inc
+++ b/runtime/nvqir/cutensornet/mps_simulation_state.inc
@@ -543,6 +543,8 @@ std::unique_ptr<cudaq::SimulationState>
 MPSSimulationState<ScalarType>::createFromSizeAndPtr(std::size_t size,
                                                      void *ptr,
                                                      std::size_t dataType) {
+  if (!ptr || size == 0)
+    throw std::runtime_error("[createFromSizeAndPtr] invalid null pointer or zero size");
   if (dataType == cudaq::detail::variant_index<cudaq::state_data,
                                                cudaq::TensorStateData>()) {
     std::vector<MPSTensor> mpsTensors;

--- a/runtime/nvqir/cutensornet/tn_simulation_state.inc
+++ b/runtime/nvqir/cutensornet/tn_simulation_state.inc
@@ -288,6 +288,8 @@ template <typename ScalarType>
 std::unique_ptr<cudaq::SimulationState>
 TensorNetSimulationState<ScalarType>::createFromSizeAndPtr(
     std::size_t size, void *ptr, std::size_t dataType) {
+  if (!ptr || size == 0)
+    throw std::runtime_error("[createFromSizeAndPtr] invalid null pointer or zero size");
   if (dataType == cudaq::detail::variant_index<cudaq::state_data,
                                                cudaq::TensorStateData>()) {
     throw std::runtime_error(

--- a/runtime/nvqir/qpp/QppCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppCircuitSimulator.cpp
@@ -104,6 +104,9 @@ struct QppState : public cudaq::SimulationState {
 
   std::unique_ptr<SimulationState>
   createFromSizeAndPtr(std::size_t size, void *ptr, std::size_t) override {
+    if (!ptr || size == 0)
+      throw std::runtime_error(
+          "[createFromSizeAndPtr] invalid null pointer or zero size");
     return std::make_unique<QppState>(Eigen::Map<qpp::ket>(
         reinterpret_cast<std::complex<double> *>(ptr), size));
   }

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -135,6 +135,9 @@ struct QppDmState : public cudaq::SimulationState {
 
   std::unique_ptr<SimulationState>
   createFromSizeAndPtr(std::size_t size, void *ptr, std::size_t type) override {
+    if (!ptr || size == 0)
+      throw std::runtime_error(
+          "[createFromSizeAndPtr] invalid null pointer or zero size");
     // This is state vector data (1D array), convert it to density matrix: rho =
     // |psi><psi|
     auto *stateData =

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -494,6 +494,19 @@ target_link_libraries(test_utils
   gtest_main)
 gtest_discover_tests(test_utils DISCOVERY_TIMEOUT 120)
 
+add_executable(test_json_convert main.cpp common/JsonConvertTester.cpp)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
+  target_link_options(test_json_convert PRIVATE ${CUDAQ_FORCE_LINK_FLAG})
+endif()
+target_link_libraries(test_json_convert
+  PRIVATE
+  cudaq
+  cudaq-platform-default
+  nvqir
+  nvqir-qpp
+  gtest_main)
+gtest_discover_tests(test_json_convert DISCOVERY_TIMEOUT 120)
+
 add_executable(test_ptsbe main.cpp
   ptsbe/KrausSelectionTester.cpp
   ptsbe/KrausTrajectoryTester.cpp

--- a/unittests/common/JsonConvertTester.cpp
+++ b/unittests/common/JsonConvertTester.cpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "common/JsonConvert.h"
+#include "nvqir/CircuitSimulator.h"
+#include <gtest/gtest.h>
+
+TEST(JsonConvertTester, CreateFromSizeAndPtrNullPtr) {
+  auto *sim = cudaq::get_simulator();
+  ASSERT_NE(sim, nullptr);
+  cudaq::state_data data =
+      std::make_pair(static_cast<std::complex<double> *>(nullptr),
+                     static_cast<std::size_t>(4));
+  EXPECT_ANY_THROW(sim->createStateFromData(data));
+}
+
+TEST(JsonConvertTester, CreateFromSizeAndPtrZeroSize) {
+  auto *sim = cudaq::get_simulator();
+  ASSERT_NE(sim, nullptr);
+  std::complex<double> dummy{1.0, 0.0};
+  cudaq::state_data data = std::make_pair(&dummy, static_cast<std::size_t>(0));
+  EXPECT_ANY_THROW(sim->createStateFromData(data));
+}
+
+TEST(JsonConvertTester, CreateFromSizeAndPtrValid) {
+  auto *sim = cudaq::get_simulator();
+  ASSERT_NE(sim, nullptr);
+  std::vector<std::complex<double>> stateVec = {{1.0, 0.0}, {0.0, 0.0}};
+  cudaq::state_data data = std::make_pair(stateVec.data(), stateVec.size());
+  std::unique_ptr<cudaq::SimulationState> state;
+  EXPECT_NO_THROW(state = sim->createStateFromData(data));
+  ASSERT_NE(state, nullptr);
+  EXPECT_EQ(state->getNumQubits(), 1);
+  EXPECT_EQ(state->getNumElements(), 2u);
+}
+
+namespace {
+/// Build a "minimal" `ExecutionContext` JSON with the given `simulationData`
+static json makeExecContextJson(const json &simData = json()) {
+  json j;
+  j["name"] = "extract-state";
+  j["shots"] = -1;
+  j["hasConditionalsOnMeasureResults"] = false;
+  j["result"] = json::array();
+  j["registerNames"] = json::array();
+  if (!simData.is_null())
+    j["simulationData"] = simData;
+  return j;
+}
+} // namespace
+
+TEST(JsonConvertTester, SimDataDimMismatch0) {
+  json simData;
+  simData["dim"] = {1024};
+  simData["data"] = {{1.0, 0.0}};
+  json j = makeExecContextJson(simData);
+  cudaq::ExecutionContext ctx("extract-state");
+  EXPECT_ANY_THROW(cudaq::from_json(j, ctx));
+}
+
+TEST(JsonConvertTester, SimDataDimMismatch1) {
+  json simData;
+  simData["dim"] = {4};
+  simData["data"] = json::array();
+  json j = makeExecContextJson(simData);
+  cudaq::ExecutionContext ctx("extract-state");
+  EXPECT_ANY_THROW(cudaq::from_json(j, ctx));
+}
+
+TEST(JsonConvertTester, SimDataDimMismatch2) {
+  json simData;
+  simData["dim"] = json::array();
+  simData["data"] = {{1.0, 0.0}};
+  json j = makeExecContextJson(simData);
+  cudaq::ExecutionContext ctx("extract-state");
+  EXPECT_ANY_THROW(cudaq::from_json(j, ctx));
+}


### PR DESCRIPTION
This PR improves the error handling and validation for simulation state creation from raw data
 -  Enforce stricter checks for pointer validity and size, 
 - Throw a runtime error if the dimensions and data size in `simulationData` do not match, or if data is provided without dimensions, ensuring only well-formed simulation states are deserialized.