### PR TITLE
Add workflow for migrating container images

### DIFF
--- a/.github/workflows/migrate_image.yml
+++ b/.github/workflows/migrate_image.yml
@@ -1,0 +1,159 @@
+on:
+  workflow_dispatch:
+    inputs:
+      source_image:
+        type: string
+        required: true
+        description: The full name of the image to migrate, including repository and tag.
+      target_image:
+        type: string
+        required: true
+        description: The full destination name of the image, including repository and tag.
+      ngc_api_key:
+        type: string
+        required: false
+        description: The API key to use when authenticating with NGC.
+      sign_image:
+        type: boolean
+        required: false
+        default: true
+
+name: Migrate image
+
+jobs:
+  migrate:
+    name: Copying image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    environment:
+      name: production
+      url: ${{ vars.deployment_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: "${{ github.ref }}"
+
+      - name: Configure registries
+        id: config
+        run: |  
+          NGC_API_KEY=$(jq -r '.inputs.ngc_api_key' $GITHUB_EVENT_PATH)
+          echo "::add-mask::$NGC_API_KEY"
+          if echo "${{ inputs.target_image }}" | grep -q "^nvcr.io"; then 
+            echo "push_to_ngc=true" >> $GITHUB_OUTPUT
+            ngc_org=`echo "${{ inputs.target_image }}" | cut -d / -f2`
+            ngc_team=`echo "${{ inputs.target_image }}" | cut -d / -f3`
+            echo "ngc_org=$ngc_org" >> $GITHUB_OUTPUT
+            echo "ngc_team=$ngc_team" >> $GITHUB_OUTPUT
+          fi
+          if echo "${{ inputs.source_image }}" | grep -q "^nvcr.io"; then 
+            echo "pull_from_ngc=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Log in to NGC registry
+        if: steps.config.outputs.pull_from_ngc == 'true' || steps.config.outputs.push_to_ngc == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: 'nvcr.io'
+          username: '$oauthtoken'
+          password: ${{ inputs.ngc_api_key || secrets.NGC_CREDENTIALS }}
+
+      - name: Log in to the container registry
+        if: vars.registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.registry }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Prepare image
+        id: setup
+        run: |
+          echo "FROM ${{ inputs.source_image }}" >> ngc.Dockerfile
+          target_image_name=`echo ${{ inputs.target_image }} | cut -d : -f1`
+          target_image_tag=`echo ${{ inputs.target_image }} | cut -d : -f2`
+
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends curl
+          curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
+          chmod 755 regctl
+
+          manifest=`./regctl image manifest ${{ inputs.source_image }} --format "{{ json . }}"`
+          platforms=`echo $manifest | jq -r '.manifests | map("\(.platform.os)/\(.platform.architecture)") | .[]'`
+          echo "platforms=$(echo $platforms | tr ' ' ,)" >> $GITHUB_OUTPUT
+
+          ./regctl image inspect ${{ inputs.source_image }} \
+          | jq -r '.config.Labels | to_entries | map("\(.key)=\(.value|tostring)") | .[]' \
+          > labels.txt
+
+          {
+            echo 'labels<<multiline'
+            cat labels.txt
+            echo multiline
+          } >> $GITHUB_OUTPUT
+          echo "target_image_name=$target_image_name" >> $GITHUB_OUTPUT
+          echo "target_image_tag=$target_image_tag" >> $GITHUB_OUTPUT
+
+      - name: Set up buildx runner
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.19.0
+          driver-opts: |
+            image=moby/buildkit:v0.19.0
+
+      - name: Update cuda-quantum metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.setup.outputs.target_image_name }}
+          flavor: latest=false
+          tags: type=raw,value=${{ steps.setup.outputs.target_image_tag }}
+          labels: |
+            ${{ steps.setup.outputs.labels }}
+
+      - name: Copy cuda-quantum NGC image
+        id: copy_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ngc.Dockerfile
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          platforms: ${{ steps.setup.outputs.platforms }}
+          push: false # FIXME
+
+      - name: Install Cosign
+        if: inputs.sign_image && steps.config.outputs.push_to_ngc != 'true'
+        uses: sigstore/cosign-installer@v3.3.0
+        with:
+          cosign-release: 'v2.2.2'
+
+      - name: Sign image with GitHub OIDC Token
+        if: inputs.sign_image && steps.config.outputs.push_to_ngc != 'true'
+        env:
+          DIGEST: ${{ steps.copy_build.outputs.digest }}
+          TAGS: ${{ steps.metadata.outputs.tags }}
+        run: cosign sign --yes --recursive "${TAGS}@${DIGEST}"
+
+      - name: Install NGC CLI
+        if: inputs.sign_image && steps.config.outputs.push_to_ngc == 'true'
+        uses: ./.github/actions/install-ngc-cli
+        with:
+          version: 3.31.0
+          checksum: b715e503e2c0b44814a51f330eafd605f5d240ea0987bf615700d359c993f138
+
+      - name: Sign image with NGC CLI
+        if: inputs.sign_image && steps.config.outputs.push_to_ngc == 'true'
+        env:
+          TAGS: ${{ steps.metadata.outputs.tags }}
+          NGC_CLI_API_KEY: ${{ inputs.ngc_api_key || secrets.NGC_CREDENTIALS }}
+          NGC_CLI_ORG: ${{ steps.config.outputs.ngc_org }}
+          NGC_CLI_TEAM: ${{ steps.config.outputs.ngc_team }}
+        run: |
+          echo "Signing ${TAGS}"
+          ngc-cli/ngc registry image publish --source ${TAGS} ${TAGS} --sign
+


### PR DESCRIPTION
This workflow automates the migration of container images between registries, including optional signing with NGC CLI or Cosign.

This is just a more general modification of the release_stable.yml workflow.