### PR TITLE
[ci] Fix bash syntax bug - missing `fi`

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -776,6 +776,7 @@ jobs:
                   echo "::warning::Unsupported file type: $filename"
                   echo ":warning: Test skipped (unsupported file type): $filename" >> $GITHUB_STEP_SUMMARY
                   test_skip_sum=$((test_skip_sum+1))
+                fi
                 ;;
             esac
           done


### PR DESCRIPTION
Somehow got missed while resolving merge conflicts.

Should fix the following error seen in nightly integration tests:
```
/__w/_temp/file_name.sh: line 343: syntax error near unexpected token `;;'
/__w/_temp/file_name.sh: line 343: `      ;;'
```