### PR TITLE
[DO NOT MERGE] Set the kernel reuse flag for broadcast observe.

### DIFF
--- a/python/cudaq/runtime/observe.py
+++ b/python/cudaq/runtime/observe.py
@@ -35,12 +35,14 @@ def __broadcastObserve(kernel, spin_operator, *args, shots_count=0, qpu_id=0):
         ctx.totalIterations = N
         ctx.batchIteration = i
         ctx.setSpinOperator(spin_operator)
+        ctx.allowJitEngineCaching = True
         with ctx:
             kernel(*a)
         res = ctx.result
         results.append(
             cudaq_runtime.ObserveResult(ctx.getExpectationValue(),
                                         spin_operator, res))
+        ctx.unset_jit_engine()
     return results
 
 


### PR DESCRIPTION
This is meant to improve performance for the broadcast observe launcher code path.