### PR TITLE
[PTSBE] Add missing seed to ptsbe unit tests

### DIFF
--- a/unittests/ptsbe/PTSSamplingStrategyTester.cpp
+++ b/unittests/ptsbe/PTSSamplingStrategyTester.cpp
@@ -579,7 +579,7 @@ TEST(ConditionalSamplingStrategyTest, FilterByErrorCount) {
     return traj.countErrors() == 1;
   };
 
-  ConditionalSamplingStrategy strategy(predicate);
+  ConditionalSamplingStrategy strategy(predicate, /*seed=*/42);
   auto trajectories = strategy.generateTrajectories(noise_points, 10);
 
   EXPECT_EQ(trajectories.size(), 2);
@@ -598,7 +598,7 @@ TEST(ConditionalSamplingStrategyTest, FilterByNoErrors) {
     return traj.countErrors() == 0;
   };
 
-  ConditionalSamplingStrategy strategy(predicate);
+  ConditionalSamplingStrategy strategy(predicate, /*seed=*/42);
   auto trajectories = strategy.generateTrajectories(noise_points, 10);
 
   EXPECT_EQ(trajectories.size(), 1);
@@ -613,7 +613,7 @@ TEST(ConditionalSamplingStrategyTest, FilterByProbabilityThreshold) {
     return traj.probability > 0.1;
   };
 
-  ConditionalSamplingStrategy strategy(predicate);
+  ConditionalSamplingStrategy strategy(predicate, /*seed=*/42);
   auto trajectories = strategy.generateTrajectories(noise_points, 10);
 
   EXPECT_EQ(trajectories.size(), 2);
@@ -630,7 +630,7 @@ TEST(ConditionalSamplingStrategyTest, FilterNonePass) {
     return traj.probability > 1.0;
   };
 
-  ConditionalSamplingStrategy strategy(predicate);
+  ConditionalSamplingStrategy strategy(predicate, /*seed=*/42);
   auto trajectories = strategy.generateTrajectories(noise_points, 10);
 
   EXPECT_EQ(trajectories.size(), 0);
@@ -641,7 +641,7 @@ TEST(ConditionalSamplingStrategyTest, FilterAllPass) {
 
   auto predicate = [](const cudaq::KrausTrajectory &) { return true; };
 
-  ConditionalSamplingStrategy strategy(predicate);
+  ConditionalSamplingStrategy strategy(predicate, /*seed=*/42);
   auto trajectories = strategy.generateTrajectories(noise_points, 10);
 
   EXPECT_EQ(trajectories.size(), 4);
@@ -652,7 +652,7 @@ TEST(ConditionalSamplingStrategyTest, EarlyExit) {
 
   auto predicate = [](const cudaq::KrausTrajectory &) { return true; };
 
-  ConditionalSamplingStrategy strategy(predicate);
+  ConditionalSamplingStrategy strategy(predicate, /*seed=*/42);
   auto trajectories = strategy.generateTrajectories(noise_points, 2);
 
   EXPECT_EQ(trajectories.size(), 2);
@@ -770,7 +770,7 @@ TEST(PTSSamplingStrategyTest, PolymorphicUsage) {
   strategies.push_back(std::make_unique<ExhaustiveSamplingStrategy>());
   strategies.push_back(std::make_unique<OrderedSamplingStrategy>());
   strategies.push_back(std::make_unique<ConditionalSamplingStrategy>(
-      [](const cudaq::KrausTrajectory &) { return true; }));
+      [](const cudaq::KrausTrajectory &) { return true; }, /*seed=*/42));
 
   for (auto &strategy : strategies) {
     auto trajectories = strategy->generateTrajectories(noise_points, 5);


### PR DESCRIPTION
I noticed another [failure](https://github.com/NVIDIA/cuda-quantum/actions/runs/22823665164/job/66200369920?pr=4115#step:9:1595) related to stochastic PTSBE unit tests. They were missing seed.