### PR TITLE
[Realtime] Explicitly specify `roce_receiver` as a Hololink target to build

### DIFF
--- a/realtime/docs/building.md
+++ b/realtime/docs/building.md
@@ -67,7 +67,7 @@ cmake -G Ninja -S "$HOLOLINK_DIR" -B build \
         -DHOLOLINK_BUILD_EMULATOR=OFF
 
 cmake --build build \
-        --target gpu_roce_transceiver hololink_core
+        --target roce_receiver gpu_roce_transceiver hololink_core
 ```
 
 > **_NOTE:_**  In order to compile Holoscan Sensor Bridge from source,

--- a/realtime/unittests/utils/hololink_test.sh
+++ b/realtime/unittests/utils/hololink_test.sh
@@ -233,7 +233,7 @@ do_build() {
         -DHOLOLINK_BUILD_EXAMPLES=OFF \
         -DHOLOLINK_BUILD_EMULATOR=OFF
     cmake --build "$hololink_build" -j"$JOBS" \
-        --target gpu_roce_transceiver hololink_core
+        --target roce_receiver gpu_roce_transceiver hololink_core
 
     # Build cuda-quantum/realtime with hololink tools enabled
     echo "--- Building cuda-quantum/realtime ---"


### PR DESCRIPTION
Currently, we rely on the fact that `gpu_roce_transceiver` depends on `roce_receiver`. Hence, the latter will be built.

We're explicitly looking for `ROCE_RECEIVER_LIB` in the build script, thus making `roce_receiver` an explicit target.
