### PR TITLE
Create executeKernel function in PythonLauncher

### DIFF
--- a/runtime/common/ExecutionContext.cpp
+++ b/runtime/common/ExecutionContext.cpp
@@ -27,18 +27,29 @@ thread_local bool reuseArtifact = false;
 
 class SavedCompilerArtifact {
 public:
+  void saveArtifact(const std::string &kernelName,
+                    const std::vector<void *> &args,
+                    const cudaq::JitEngine &engine,
+                    std::function<void *()> argsCreatorThunk) {
+    if (jitEng.has_value()) {
+      throw std::runtime_error(
+          "Attempted to overwrite saved compiler artifact.");
+    }
+    jitEng = engine;
+    argsCreator = reinterpret_cast<int64_t (*)(const void *, void **)>(
+        argsCreatorThunk());
+    this->kernelName = kernelName;
+    auto [resSize, scopedArgBuffer] = processArgs(args);
+    argSize = resSize;
+    argBuff = std::move(scopedArgBuffer);
+  }
+
   void checkArtifactReuse(const std::string &kernelName,
                           const std::vector<void *> &args,
                           const cudaq::JitEngine &engine,
                           std::function<void *()> argsCreatorThunk) {
     if (!jitEng.has_value()) {
-      jitEng = engine;
-      this->argsCreator = reinterpret_cast<int64_t (*)(const void *, void **)>(
-          argsCreatorThunk());
-      this->kernelName = kernelName;
-      auto [resSize, scopedArgBuffer] = processArgs(args);
-      this->argSize = resSize;
-      this->argBuff = std::move(scopedArgBuffer);
+      saveArtifact(kernelName, args, engine, argsCreatorThunk);
       return;
     }
 
@@ -125,6 +136,15 @@ void checkArtifactReuse(const std::string kernelName,
     return;
 
   savedArtifact.checkArtifactReuse(kernelName, args, jit, argsCreatorThunk);
+}
+
+void saveArtifact(const std::string kernelName, const std::vector<void *> &args,
+                  const JitEngine jit,
+                  std::function<void *()> argsCreatorThunk) {
+  if (!reuseArtifact)
+    return;
+
+  savedArtifact.saveArtifact(kernelName, args, jit, argsCreatorThunk);
 }
 } // namespace compiler_artifact
 

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -225,5 +225,9 @@ bool isPersistingJITEngine();
 void checkArtifactReuse(const std::string kernelName,
                         const std::vector<void *> &args, const JitEngine jit,
                         std::function<void *()> argsCreatorThunk);
+
+void saveArtifact(const std::string kernelName, const std::vector<void *> &args,
+                  const JitEngine jit,
+                  std::function<void *()> argsCreatorThunk);
 }; // namespace compiler_artifact
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -327,6 +327,11 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
 
     auto jit = cudaq::createQIRJITEngine(module, "qir:");
     cacheJITForPerformance(jit);
+    auto argsCreatorThunk = [&jit, &name]() {
+      return (void *)jit.lookupRawNameOrFail(name + ".argsCreator");
+    };
+    cudaq::compiler_artifact::saveArtifact(name, rawArgs, jit,
+                                           argsCreatorThunk);
 
     // FIXME: actually handle results
     // 4. Execute the code right here, right now.


### PR DESCRIPTION
I was resolving merge conflicts for https://github.com/NVIDIA/cuda-quantum/pull/4052 and wanted to make sure I got it right. I am opening this PR as an in-between step.

This PR does not change any code logic, it just refactors the "execute kernel" part of `PythonLauncher::launchModule` into a separate function. Actually, no, there is one change: the message "Loading previously compiled JIT engine for {}" etc is only printed when `isPersistingJITEngine` is true. I am pretty sure that's the desired behaviour.

Finally, I've noticed that when `hasVariationalArgs` is true, the argument buffer as a whole is passed to the thunk function, whereas otherwise it is only its last argument. Is it because there can never be arguments passed when `hasVariationalArgs` is true?