### PR TITLE
[python] Support C++ callable in builder

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2680,26 +2680,19 @@ class PyASTBridge(ast.NodeVisitor):
                         self.module, deviceModuleName)
                     if maybeDeviceKernel != None:
                         [kernelName, code] = maybeDeviceKernel
-                        # TODO: Is there a nicer way to get the type from the C++ side?
-                        otherKernel = Module.parse(code, context=self.ctx)
-                        for op in otherKernel.body.operations:
-                            name = str(
-                                op.name).removeprefix('"').removesuffix('"')
-                            if name == kernelName:
-                                funcTy = FunctionType(
-                                    TypeAttr(
-                                        op.attributes['function_type']).value)
-                                callableTy = cc.CallableType.get(
-                                    self.ctx, funcTy.inputs, funcTy.results)
-                                callee = cudaq_runtime.appendKernelArgument(
-                                    self.kernelFuncOp, callableTy)
-                                self.signature.add_linked_kernel_capture(
-                                    deviceModuleName, callableTy)
-                                self.symbolTable[deviceModuleName] = callee
-                                res = processDecoratorCall(deviceModuleName)
-                                if res is not None:
-                                    self.pushValue(res)
-                                return
+                        qkeModule = Module.parse(code, context=self.ctx)
+                        signature = KernelSignature.parse_from_mlir(
+                            qkeModule, kernelName)
+                        callableTy = signature.get_callable_type()
+                        callee = cudaq_runtime.appendKernelArgument(
+                            self.kernelFuncOp, callableTy)
+                        self.signature.add_linked_kernel_capture(
+                            deviceModuleName, callableTy)
+                        self.symbolTable[deviceModuleName] = callee
+                        res = processDecoratorCall(deviceModuleName)
+                        if res is not None:
+                            self.pushValue(res)
+                        return
 
         if isinstance(node.func, ast.Name):
             symName = (node.func.id if node.func.id in self.symbolTable else

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -14,6 +14,7 @@ import weakref
 from functools import partialmethod
 from typing import get_origin
 
+from .kernel_signature import KernelSignature
 import numpy as np
 from cudaq.mlir.ir import (BoolAttr, Block, Context, Module, TypeAttr, UnitAttr,
                            FunctionType, DictAttr, F32Type, F64Type, NoneType,
@@ -29,7 +30,7 @@ from cudaq.mlir._mlir_libs._quakeDialects import (
 from cudaq.kernel_types import qubit, qvector
 from .common.fermionic_swap import fermionic_swap_builder
 from .common.givens import givens_builder
-from .kernel_decorator import DecoratorCapture, isa_kernel_decorator
+from .kernel_decorator import DecoratorCapture, LinkedKernelCapture, isa_kernel_decorator
 from .quake_value import QuakeValue
 from .utils import (emitFatalError, emitWarning, nvqppPrefix, getMLIRContext,
                     recover_func_op, mlirTypeToPyType, cudaq__unique_attr_name,
@@ -1360,7 +1361,8 @@ class PyKernel(object):
                                                DecoratorCapture(target))
         self.__applyControlOrAdjoint(target, False, [], *target_arguments)
 
-    def resolve_callable_arg(self, insPt, target: DecoratorCapture):
+    def resolve_callable_arg(self, insPt,
+                             target: DecoratorCapture | LinkedKernelCapture):
         """
         `target` must be a callable. For a simple callable (a `func.FuncOp`),
         resolution is trivial. If the callable is a decorator with lambda lifted
@@ -1368,28 +1370,39 @@ class PyKernel(object):
         closure here.
         Returns a `CreateLambdaOp` closure.
         """
-        decorator = target.decorator
+        match target:
+            case DecoratorCapture(decorator=decorator, resolved=resolved_args):
+                kernel_name = nvqppPrefix + decorator.uniqName
+                merge_module = decorator.qkeModule
+                signature = decorator.signature
+            case LinkedKernelCapture(linkedKernel=kernel_name,
+                                     qkeModule=merge_module):
+                signature = KernelSignature.parse_from_mlir(
+                    merge_module, kernel_name)
+                resolved_args = []
+            case _:
+                raise ValueError(f"Invalid callable arg: {target}")
+
         # Add the target kernel to the current module.
-        fulluniq = nvqppPrefix + decorator.uniqName
-        cudaq_runtime.updateModule(fulluniq, self.module, decorator.qkeModule)
-        fn = recover_func_op(self.module, fulluniq)
+        cudaq_runtime.updateModule(kernel_name, self.module, merge_module)
+        fn = recover_func_op(self.module, kernel_name)
+        funcTy = signature.get_lifted_type()
+        callableTy = signature.get_callable_type()
+        arg_types = signature.arg_types
 
         # build the closure to capture the lifted `args`
-        funcTy = decorator.signature.get_lifted_type()
-        callableTy = decorator.signature.get_callable_type()
         with insPt, self.loc:
             lamb = cc.CreateLambdaOp(callableTy, loc=self.loc)
             lamb.attributes.__setitem__('function_type', TypeAttr.get(funcTy))
             initRegion = lamb.initRegion
-            initBlock = Block.create_at_start(initRegion, decorator.arg_types())
+            initBlock = Block.create_at_start(initRegion, arg_types)
             inner = InsertionPoint(initBlock)
             with inner:
                 vs = []
                 for ba in initBlock.arguments:
                     vs.append(ba)
-                captured_args = target.resolved
-                for arg in captured_args:
-                    if isinstance(arg, DecoratorCapture):
+                for arg in resolved_args:
+                    if isinstance(arg, (DecoratorCapture, LinkedKernelCapture)):
                         # The recursive step
                         v = self.resolve_callable_arg(inner, arg)
                     else:

--- a/python/cudaq/kernel/kernel_signature.py
+++ b/python/cudaq/kernel/kernel_signature.py
@@ -70,7 +70,9 @@ class KernelSignature:
         of the MLIR `FuncOp` are treated as direct arguments to the kernel and
         `captured_args` is set to `[]`.
         """
-        funcOp = recover_func_op(mlir_module, nvqppPrefix + kernel_name)
+        if not kernel_name.startswith(nvqppPrefix):
+            kernel_name = nvqppPrefix + kernel_name
+        funcOp = recover_func_op(mlir_module, kernel_name)
         fnTy = mlir.FunctionType(
             mlir.TypeAttr(funcOp.attributes['function_type']).value)
         if len(fnTy.results) > 1:

--- a/python/tests/interop/test_interop.py
+++ b/python/tests/interop/test_interop.py
@@ -331,3 +331,24 @@ def test_py_kernel_from_cpp_with_returns():
         return [f, 2.0, 3.0]
 
     cudaq_test_cpp_algo.run6(foo)
+
+
+def test_cpp_kernel_from_builder_apply_call():
+    """Test that a kernel builder can call a decorator that itself calls C++ kernels."""
+    pytest.importorskip('cudaq_test_cpp_algo')
+
+    from cudaq_test_cpp_algo import qstd
+
+    @cudaq.kernel(defer_compilation=False)
+    def cppCaller():
+        q = cudaq.qvector(4)
+        qstd.qft(q)
+        h(q)
+        qstd.another(q, 2)
+
+    kernel = cudaq.make_kernel()
+    kernel.apply_call(cppCaller)
+
+    counts = cudaq.sample(kernel)
+    counts.dump()
+    assert len(counts) == 1 and '0010' in counts


### PR DESCRIPTION
This is a follow up of #4072, where it was requested that we modify the kernel builder to support calling kernels defined from within C++.

The only difference between handling kernel decorators and C++ kernels is that for the latter the kernel signature must be recovered from the MLIR module, rather than stored separately.