### PR TITLE
[test] Clean up execution tests.

### DIFF
--- a/targettests/execution/angled_gate.cpp
+++ b/targettests/execution/angled_gate.cpp
@@ -30,6 +30,7 @@ int main() {
   for (auto &[bits, count] : counts) {
     printf("%s\n", bits.data());
   }
+  return 0;
 }
 
 // CHECK: 00

--- a/targettests/execution/auto_kernel.cpp
+++ b/targettests/execution/auto_kernel.cpp
@@ -10,11 +10,6 @@
 
 #include <cudaq.h>
 
-// CHECK: size 3
-// CHECK: 0: {{[tf]}}
-// CHECK: 1: {{[tf]}}
-// CHECK: 2: {{[tf]}}
-
 struct ak2 {
   auto operator()() __qpu__ {
     cudaq::qarray<3> q;
@@ -38,3 +33,8 @@ int main() {
   }
   return 0;
 }
+
+// CHECK: size 3
+// CHECK: 0: {{[tf]}}
+// CHECK: 1: {{[tf]}}
+// CHECK: 2: {{[tf]}}

--- a/targettests/execution/bug_qubit.cpp
+++ b/targettests/execution/bug_qubit.cpp
@@ -9,19 +9,19 @@
 // This code is from Issue 251.
 
 // clang-format off
-// RUN: nvq++ --target anyon      --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target infleqtion --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target ionq       --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target anyon      --emulate %s -o %t && %t
+// RUN: nvq++ --target infleqtion --emulate %s -o %t && %t
+// RUN: nvq++ --target ionq       --emulate %s -o %t && %t
 // RUN: nvq++ --target iqm        --emulate %s -o %t
-// RUN: IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s
-// RUN: IQM_QPU_QA=%iqm_tests_dir/Crystal_20.txt %t | FileCheck %s
-// RUN: IQM_QPU_QA=%iqm_tests_dir/Crystal_54.txt %t | FileCheck %s
-// RUN: nvq++ --target oqc        --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
-// RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t
+// RUN: IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t
+// RUN: IQM_QPU_QA=%iqm_tests_dir/Crystal_20.txt %t
+// RUN: IQM_QPU_QA=%iqm_tests_dir/Crystal_54.txt %t
+// RUN: nvq++ --target oqc        --emulate %s -o %t && %t
+// RUN: nvq++ --target quantinuum --emulate %s -o %t && %t
+// RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t; fi
+// RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t; fi
 // RUN: cudaq-quake %s | cudaq-opt --promote-qubit-allocation | FileCheck --check-prefixes=MLIR %s
+// clang-format on
 
 #include <cudaq.h>
 #include <iostream>
@@ -34,20 +34,17 @@ struct simple_x {
   }
 };
 
+// clang-format on
 // MLIR-LABEL:   func.func @__nvqpp__mlirgen__simple_x()
 // MLIR-NOT:       quake.alloca !quake.ref
 // MLIR:           %[[VAL_0:.*]] = quake.alloca !quake.veq<1>
 // MLIR-NEXT:      %[[VAL_1:.*]] = quake.extract_ref %[[VAL_0]][0] : (!quake.veq<1>) -> !quake.ref
+// clang-format off
 
 int main() {
   auto result = cudaq::sample(simple_x{});
 
-#ifndef SYNTAX_CHECK
   std::cout << result.most_probable() << '\n';
-  assert("1" == result.most_probable());
-#endif
-
-  return 0;
+  // Success is "1".
+  return std::string{"1"} != result.most_probable();
 }
-
-// CHECK: 1

--- a/targettests/execution/callable_kernel_arg.cpp
+++ b/targettests/execution/callable_kernel_arg.cpp
@@ -16,7 +16,6 @@
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %quantum_machines_avail; then nvq++ --target quantum_machines --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/cast.cpp
+++ b/targettests/execution/cast.cpp
@@ -6,9 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// clang-format off
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
-// clang-format on
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/complex_vector_synthesis.cpp
+++ b/targettests/execution/complex_vector_synthesis.cpp
@@ -7,10 +7,10 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ --enable-mlir %s -o %t  && %t | FileCheck %s
+// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
 // TODO-FIX-KERNEL-EXEC
 // RUN: nvq++ --target quantinuum --emulate -fkernel-exec-kind=2 %s -o %t  && %t | FileCheck %s
-// RUN: nvq++ --target quantinuum --emulate                      %s -o %t  && %t | FileCheck %s
+// RUN: nvq++ --target quantinuum --emulate %s -o %t  && %t | FileCheck %s
 // clang-format on
 
 #include <complex>

--- a/targettests/execution/conditional_run.cpp
+++ b/targettests/execution/conditional_run.cpp
@@ -6,9 +6,11 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+// clang-format off
 // RUN: nvq++ --target quantinuum --quantinuum-machine Helios-1SC --emulate %s -o %t && %t
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: nvq++ --enable-mlir %s -o %t && %t
+// clang-format on
 
 // The test here is the assert statement.
 

--- a/targettests/execution/custom_operation_adj.cpp
+++ b/targettests/execution/custom_operation_adj.cpp
@@ -8,11 +8,11 @@
 
 // clang-format off
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target anyon      --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target anyon --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target ionq  --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target iqm   --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s
+// RUN: nvq++ --target oqc   --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target infleqtion --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target ionq       --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target iqm        --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s
-// RUN: nvq++ --target oqc        --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
@@ -20,9 +20,11 @@
 
 #include <cudaq.h>
 
-CUDAQ_REGISTER_OPERATION(custom_s, 1, 0, {1, 0, 0, std::complex<double>{0.0, 1.0}})
+CUDAQ_REGISTER_OPERATION(custom_s, 1, 0,
+                         {1, 0, 0, std::complex<double>{0.0, 1.0}})
 
-CUDAQ_REGISTER_OPERATION(custom_s_adj, 1, 0, {1, 0, 0, std::complex<double>{0.0, -1.0}})
+CUDAQ_REGISTER_OPERATION(custom_s_adj, 1, 0,
+                         {1, 0, 0, std::complex<double>{0.0, -1.0}})
 
 __qpu__ void kernel() {
   cudaq::qubit q;
@@ -38,6 +40,7 @@ int main() {
   for (auto &[bits, count] : counts) {
     printf("%s\n", bits.data());
   }
+  return 0;
 }
 
 // CHECK: 1

--- a/targettests/execution/custom_operation_basic.cpp
+++ b/targettests/execution/custom_operation_basic.cpp
@@ -8,11 +8,11 @@
 
 // clang-format off
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target anyon      --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target anyon --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target ionq  --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target iqm   --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s
+// RUN: nvq++ --target oqc   --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target infleqtion --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target ionq       --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target iqm        --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s
-// RUN: nvq++ --target oqc        --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
@@ -38,6 +38,7 @@ int main() {
   for (auto &[bits, count] : counts) {
     printf("%s\n", bits.data());
   }
+  return 0;
 }
 
 // CHECK-DAG: 11

--- a/targettests/execution/custom_operation_ctrl.cpp
+++ b/targettests/execution/custom_operation_ctrl.cpp
@@ -8,10 +8,10 @@
 
 // clang-format off
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target anyon      --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target ionq       --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target iqm        --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s
-// RUN: nvq++ --target oqc        --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target anyon --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target ionq  --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target iqm   --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s
+// RUN: nvq++ --target oqc   --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
 // clang-format on
@@ -34,6 +34,7 @@ int main() {
   for (auto &[bits, count] : counts) {
     printf("%s\n", bits.data());
   }
+  return 0;
 }
 
 // CHECK-DAG: 11

--- a/targettests/execution/custom_operation_toffoli.cpp
+++ b/targettests/execution/custom_operation_toffoli.cpp
@@ -6,8 +6,10 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+// clang-format off
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t %s 2>&1 | FileCheck %s -check-prefix=FAIL
+// clang-format on
 
 #include <cudaq.h>
 
@@ -28,6 +30,7 @@ int main() {
   for (auto &[bits, count] : counts) {
     printf("%s\n", bits.data());
   }
+  return 0;
 }
 
 // CHECK: 110

--- a/targettests/execution/device_code_loaded.cpp
+++ b/targettests/execution/device_code_loaded.cpp
@@ -10,9 +10,6 @@
 
 #include <cudaq.h>
 
-// CHECK: { [[B0:.*]]:[[C0:.*]] [[B1:.*]]:[[C1:.*]] }
-// CHECK-NEXT: module {{.*}} func.func @__nvqpp__mlirgen__ghz{{.*}}(%arg0: i32{{.*}}) attributes {
-
 // Define a quantum kernel
 struct ghz {
   auto operator()(const int N) __qpu__ {
@@ -32,3 +29,8 @@ int main() {
   printf("%s\n", cudaq::get_quake(ghz{}).data());
   return 0;
 }
+
+// clang-format off
+// CHECK: { [[B0:.*]]:[[C0:.*]] [[B1:.*]]:[[C1:.*]] }
+// CHECK-NEXT: module {{.*}} func.func @__nvqpp__mlirgen__ghz{{.*}}(%arg0: i32{{.*}}) attributes {
+// clang-format on

--- a/targettests/execution/global_reg_sample.cpp
+++ b/targettests/execution/global_reg_sample.cpp
@@ -7,10 +7,9 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ -DNO_ADAPTIVE --target iqm        --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s
-// RUN: nvq++               --target quantinuum --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++                                             %s -o %t && %t | FileCheck %s
-// RUN: nvq++ %s --enable-mlir -o %t
+// RUN: nvq++ -DNO_ADAPTIVE --target iqm --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_5.txt  %t | FileCheck %s
+// RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/if_jit.cpp
+++ b/targettests/execution/if_jit.cpp
@@ -17,7 +17,6 @@
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/include.cpp
+++ b/targettests/execution/include.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// What is the following bit of script for precisely?
 // RUN: if [ $(echo | cut -c4- ) -ge 20 ]; then \
 // RUN:   nvq++ --enable-mlir %s -o %t && %t | FileCheck %s; \
 // RUN: fi

--- a/targettests/execution/int8_t.cpp
+++ b/targettests/execution/int8_t.cpp
@@ -15,7 +15,6 @@
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/int8_t_free_func.cpp
+++ b/targettests/execution/int8_t_free_func.cpp
@@ -15,7 +15,6 @@
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/lambda_introspection.cpp
+++ b/targettests/execution/lambda_introspection.cpp
@@ -57,7 +57,9 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: 2: module {{.*}} func.func @__nvqpp__mlirgen__Z4mainE3$_0() attributes {
 // CHECK: 3: module {{.*}} func.func @__nvqpp__mlirgen__Z4mainE3$_1() attributes {
 // CHECK: 4: module {{.*}} func.func @__nvqpp__mlirgen__ghz{{.*}}() attributes {{{.*}}"cudaq-entrypoint"{{.*}}} {
 // CHECK: 5: module {{.*}} func.func @__nvqpp__mlirgen__Z8functionvE3$_0() attributes {
+// clang-format on

--- a/targettests/execution/load_value.cpp
+++ b/targettests/execution/load_value.cpp
@@ -15,7 +15,6 @@
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/mapping_test-1.cpp
+++ b/targettests/execution/mapping_test-1.cpp
@@ -7,11 +7,9 @@
  ******************************************************************************/
 
 // clang-format off
-// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s &&  FileCheck --check-prefix=QUAKE %s < %t.txt
+// RUN: nvq++ %s -o %t --target oqc --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2> %t.txt | FileCheck %s &&  FileCheck --check-prefix=QUAKE %s < %t.txt; status=$?; rm -f %t.txt; exit "$status"
 // RUN: nvq++ %s -o %t --target iqm --emulate --mapping-file "%iqm_tests_dir/Crystal_5.txt" && %t | FileCheck %s
 // clang-format on
-// RUN: nvq++ --enable-mlir %s -o %t
-// RUN: rm -f %t.txt
 
 #include <cudaq.h>
 #include <iostream>
@@ -38,6 +36,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // QUAKE-LABEL: tail call void @__quantum__qis__x__body(%Qubit* null)
 // QUAKE:       tail call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
 // QUAKE:       tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
@@ -52,3 +51,4 @@ int main() {
 // QUAKE:       ret void
 
 // CHECK-LABEL: most_probable "101"
+// clang-format on

--- a/targettests/execution/other_introspection.cpp
+++ b/targettests/execution/other_introspection.cpp
@@ -6,7 +6,6 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t
 // RUN: nvq++ --enable-mlir %s -o %t && %t | grep lookhere | FileCheck %s
 
 #include <iostream>

--- a/targettests/execution/predefined_lib_mode.cpp
+++ b/targettests/execution/predefined_lib_mode.cpp
@@ -5,10 +5,8 @@
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
-// clang-format off
+
 // RUN: nvq++ -DTEST_DEF -DMY_VAR=\"CUDAQ\" %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir -DTEST_DEF -DMY_VAR=\"CUDAQ\" %s -o %t
-// clang-format on
 
 #include <iostream>
 

--- a/targettests/execution/predefined_mlir_mode.cpp
+++ b/targettests/execution/predefined_mlir_mode.cpp
@@ -6,7 +6,6 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 // clang-format off
-// RUN: nvq++ --enable-mlir -DTEST_DEF -DMY_VAR=\"CUDAQ\" %s -o %t
 // RUN: nvq++ --enable-mlir -DTEST_DEF -DMY_VAR=\"CUDAQ\" %s -o %t && %t | FileCheck %s
 // clang-format on
 

--- a/targettests/execution/preprocessor_defines.cpp
+++ b/targettests/execution/preprocessor_defines.cpp
@@ -6,34 +6,37 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+// clang-format off
 // RUN: nvq++ --enable-mlir -DCUDAQ_HELLO_WORLD %s -o %t && %t | FileCheck --check-prefixes=DEFINE_ON %s
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
 // RUN: if [ $(echo | cut -c4- ) -ge 20 ]; then \
 // RUN:   nvq++ --enable-mlir %s -o %t && %t | FileCheck %s; \
 // RUN: fi
+// clang-format on
 
 #include "cudaq.h"
 
 #ifdef CUDAQ_HELLO_WORLD
 struct test {
-    void operator()() __qpu__ {
-        cudaq::qubit q;
-        h(q);
-        mz(q);
-    }
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    h(q);
+    mz(q);
+  }
 };
-#else 
+#else
 struct test {
-    void operator()() __qpu__ {
-        cudaq::qubit q;
-        x(q);
-        mz(q);
-    }
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    x(q);
+    mz(q);
+  }
 };
-#endif 
+#endif
 
 int main() {
-    cudaq::sample(test{}).dump();
+  cudaq::sample(test{}).dump();
+  return 0;
 }
 
 // DEFINE_ON: { [[B0:.*]]:[[C0:.*]] [[B1:.*]]:[[C1:.*]] }

--- a/targettests/execution/qir_if_base.cpp
+++ b/targettests/execution/qir_if_base.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ %s -o %t --target ionq --emulate && %t 2>&1 | FileCheck %s
-// RUN: nvq++ --enable-mlir %s -o %t
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/qir_op1_after_measure.cpp
+++ b/targettests/execution/qir_op1_after_measure.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ -v %s -o %t --target oqc --emulate && %t 2>&1 | FileCheck %s
-// RUN: nvq++ --enable-mlir %s -o %t
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/qir_op2_after_measure.cpp
+++ b/targettests/execution/qir_op2_after_measure.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ -v %s -o %t --target oqc --emulate && %t 2>&1 | FileCheck %s
-// RUN: nvq++ --enable-mlir %s -o %t
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/qir_op3_after_measure.cpp
+++ b/targettests/execution/qir_op3_after_measure.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ -v %s -o %t --target oqc --emulate && %t 2>&1 | FileCheck %s
-// RUN: nvq++ --enable-mlir %s -o %t
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/qir_range_err_runtime.cpp
+++ b/targettests/execution/qir_range_err_runtime.cpp
@@ -8,7 +8,6 @@
 
 // RUN: nvq++ %s -o %t --target quantinuum --emulate && %t 2>&1 | FileCheck %s
 // RUN: nvq++ %s -o %t --target oqc --emulate && %t 2>&1 | FileCheck %s
-// RUN: nvq++ --enable-mlir %s -o %t
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/qir_simple_cond-1.cpp
+++ b/targettests/execution/qir_simple_cond-1.cpp
@@ -9,7 +9,6 @@
 // clang-format off
 // RUN: nvq++ --target stim --enable-mlir %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --quantinuum-machine Helios-1SC --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir %s -o %t
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/qir_simple_cond-2.cpp
+++ b/targettests/execution/qir_simple_cond-2.cpp
@@ -8,7 +8,6 @@
 
 // clang-format off
 // RUN: nvq++ --target quantinuum --quantinuum-machine Helios-1SC --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir %s -o %t
 // XFAIL: *
 // ^^^^^ This is caused by this error: invalid instruction found:   %2 = xor i1 %0, true
 //       This error is reasonable given the current version of the Adaptive

--- a/targettests/execution/qir_string_labels.cpp
+++ b/targettests/execution/qir_string_labels.cpp
@@ -10,7 +10,6 @@
 // RUN: nvq++ -v %s -o %t --target quantinuum --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2>&1 | FileCheck --check-prefixes=CHECK,QIR_ADAPTIVE %s
 // RUN: nvq++ -v %s -o %t --target ionq --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2>&1 | FileCheck --check-prefixes=CHECK,IONQ %s
 // RUN: if %qci_avail; then nvq++ -v %s -o %t --target qci --emulate && CUDAQ_DUMP_JIT_IR=1 %t 2>&1 | FileCheck --check-prefixes=CHECK,QIR_ADAPTIVE %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t
 // clang-format on
 
 // Note: iqm (and others) that don't use QIR should not be included in this test.

--- a/targettests/execution/quantum_struct.cpp
+++ b/targettests/execution/quantum_struct.cpp
@@ -6,9 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// clang-format off
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
-// clang-format on
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/state_init.cpp
+++ b/targettests/execution/state_init.cpp
@@ -6,9 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// clang-format off
 // RUN: nvq++ --enable-mlir %s -o %t  && %t | FileCheck %s
-// clang-format on
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/state_init_large.cpp
+++ b/targettests/execution/state_init_large.cpp
@@ -6,9 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// clang-format off
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
-// clang-format on
+// RUN: nvq++ %s -o %t && %t | FileCheck %s
 
 // Tests qvector initialization from a cudaq::state created in host code with a
 // large number of qubits (19 qubits = 524288 elements).
@@ -44,4 +42,5 @@ int main() {
   // CHECK-LABEL: Large state test
   // CHECK: 0000000000000000000
   // CHECK: 1000000000000000000
+  return 0;
 }

--- a/targettests/execution/state_overlap.cpp
+++ b/targettests/execution/state_overlap.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>
 #include <iomanip>

--- a/targettests/execution/state_preparation_vector_sizes.cpp
+++ b/targettests/execution/state_preparation_vector_sizes.cpp
@@ -62,6 +62,7 @@ int main() {
       std::cout << '\n';
     }
   }
+  return 0;
 }
 
 // CHECK:           state: (size: 2) { (1,0) (0,0) }

--- a/targettests/execution/swap_gate.cpp
+++ b/targettests/execution/swap_gate.cpp
@@ -16,6 +16,7 @@
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
+// clang-format on
 
 #include "cudaq.h"
 #include <iostream>

--- a/targettests/execution/template_introspection.cpp
+++ b/targettests/execution/template_introspection.cpp
@@ -6,7 +6,6 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t
 // RUN: nvq++ --enable-mlir %s -o %t && %t | FileCheck %s
 
 #include <cudaq.h>

--- a/targettests/execution/test-3.cpp
+++ b/targettests/execution/test-3.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 // RUN: nvq++ -v %s -o %t --target quantinuum --emulate && %t | FileCheck %s
-// RUN: nvq++ --enable-mlir %s -o %t
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/uccsd.cpp
+++ b/targettests/execution/uccsd.cpp
@@ -9,9 +9,9 @@
 // clang-format off
 // RUN: nvq++ --target anyon --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s ; fi
-// RUN: nvq++ --target ionq       --emulate %s -o %t && %t | FileCheck %s
-// RUN: nvq++ --target iqm        --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_20.txt %t | FileCheck %s
-// RUN: nvq++ --target oqc        --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target ionq --emulate %s -o %t && %t | FileCheck %s
+// RUN: nvq++ --target iqm  --emulate %s -o %t && IQM_QPU_QA=%iqm_tests_dir/Crystal_20.txt %t | FileCheck %s
+// RUN: nvq++ --target oqc  --emulate %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --target quantinuum --emulate %s -o %t && %t | FileCheck %s
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: nvq++ --enable-mlir %s -o %t

--- a/targettests/execution/variable_size_qreg.cpp
+++ b/targettests/execution/variable_size_qreg.cpp
@@ -16,7 +16,6 @@
 // RUN: if %braket_avail; then nvq++ --target braket --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %qci_avail; then nvq++ --target qci --emulate %s -o %t && %t | FileCheck %s; fi
 // RUN: if %quantum_machines_avail; then nvq++ --target quantum_machines --emulate %s -o %t && %t | FileCheck %s; fi
-// RUN: nvq++ --enable-mlir %s -o %t
 // clang-format on
 
 #include <cudaq.h>

--- a/targettests/execution/vector_int_parameters.cpp
+++ b/targettests/execution/vector_int_parameters.cpp
@@ -6,11 +6,9 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// clang-format off
 // Simulators
 // RUN: nvq++ --enable-mlir  %s -o %t && %t | FileCheck %s
 // RUN: nvq++ --library-mode %s -o %t && %t | FileCheck %s
-// clang-format on
 
 #include <cudaq.h>
 #include <iostream>

--- a/targettests/execution/vector_result.cpp
+++ b/targettests/execution/vector_result.cpp
@@ -6,7 +6,8 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-// RUN: nvq++ --enable-mlir %s -o %t && %t
+// NB: uses internal checks and return code.
+// RUN: nvq++ %s -o %t && %t
 
 #include "cudaq.h"
 #include <cstdio>


### PR DESCRIPTION
Do some cleanup on these tests.

  - eliminate purely redundant command lines, not needed
  - add missing code, like "return 0;" in main()
  - remove FileCheck use from trivial tests that didn't need it
  - other misc.