### PR TITLE
Adding assert in emulation mode to demonstrate that a new thread is not needed

### DIFF
--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -364,6 +364,13 @@ public:
     cudaq::details::future future;
     if (emulate) {
 
+      // TODO: This assert demonstrates that we are never expected to return a
+      // future in emulation mode. We are launching a new thread just to wait
+      // for its execution to finish below. We need to make this work without
+      // the thread as the executionContext is crossing the thread boundary
+      // which is not thread safe in the general case.
+      assert(!executionContext->asyncExec);
+
       // Fetch the thread-specific seed outside and then pass it inside.
       std::size_t seed = cudaq::get_random_seed();
 


### PR DESCRIPTION
I attempted to remove the thread but ran into issues with `run`. It works best without an execution context and since the execution context is thread local, running in a new thread yields a null `cudaq::getExecutionContext()`.

With an execution context, this [TODO](https://github.com/Renaud-K/cuda-quantum/blob/b6026acabdba5b1ec48df62a2bfea7e0cd0ec9a5/runtime/nvqir/CircuitSimulator.h#L934) is hit. 

And the [following test](https://github.com/Renaud-K/cuda-quantum/blob/b6026acabdba5b1ec48df62a2bfea7e0cd0ec9a5/targettests/execution/qir_cond_for_break.cpp#L9) fails from missed qbits deallocations.