### PR TITLE
chore: use deployment: false to avoid creating deployment objects

### DIFF
--- a/.github/workflows/build_package_sources.yml
+++ b/.github/workflows/build_package_sources.yml
@@ -231,6 +231,7 @@ jobs:
 
     environment:
       name: ${{ inputs.environment || 'default' }}
+      deployment: ${{ inputs.environment != '' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -140,42 +140,6 @@ jobs:
           package-type: 'container'
           package-version-ids: '${{ steps.packages.outputs.versions_to_remove }}'
 
-  # We use environments to deploy to a public registry after PRs are merged.
-  # Since we use the same workflows during CI, a default environment that defines
-  # the necessary variables is used instead. Unfortunately, this automatically
-  # also creates an (unwanted) deployment, which we delete with this job.
-  # See also https://github.com/actions/runner/issues/2120
-  deployments:
-    name: Deployments
-    runs-on: ubuntu-latest
-    permissions:
-      deployments: write
-
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            const deployments = await github.rest.repos.listDeployments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              environment: 'default'
-            });
-            await Promise.all(
-              deployments.data.map(async (deployment) => {
-                await github.rest.repos.createDeploymentStatus({ 
-                owner: context.repo.owner, 
-                repo: context.repo.repo, 
-                deployment_id: deployment.id, 
-                state: 'inactive' 
-                });
-                return github.rest.repos.deleteDeployment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                deployment_id: deployment.id
-                });
-              })
-            );
-
   pr_cleanup:
     name: Clean up documentation previews
     if: github.event_name == 'pull_request_target' || github.event.schedule == '0 0 * * *'

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -110,6 +110,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != '' }}
 
     steps:
       - name: Checkout repository
@@ -210,6 +211,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != '' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/dev_environment_macos.yml
+++ b/.github/workflows/dev_environment_macos.yml
@@ -56,6 +56,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != '' }}
 
     steps:
       - name: Checkout repository
@@ -127,6 +128,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != '' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -55,6 +55,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != '' }}
 
     steps:
       - id: info
@@ -98,6 +99,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != '' }}
   
     steps:
       - name: Checkout repository
@@ -227,6 +229,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != '' }}
 
     # Needed for making local images available to the docker/build-push-action.
     # See also https://stackoverflow.com/a/63927832.
@@ -405,6 +408,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != '' }}
 
     # Needed for making local images available to the docker/build-push-action.
     # See also https://stackoverflow.com/a/63927832.

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -47,6 +47,7 @@ jobs:
     environment:
       name: ${{ (github.event.workflow_run.name == 'CI' && 'default') || 'github-pages' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ github.event.workflow_run.name != 'CI' }}
   
     steps:
       - name: Checkout repository

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -48,6 +48,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'default' }}
       url: ${{ vars.deployment_url || format('https://github.com/{0}', github.repository) }}
+      deployment: ${{ inputs.environment != '' }}
 
     # Needed for making local images available to the docker/build-push-action.
     # See also https://stackoverflow.com/a/63927832.


### PR DESCRIPTION
The `deployment: false` environment option was recently released (see https://github.com/orgs/community/discussions/36919#discussioncomment-16214515), which prevents GitHub from creating deployment objects when a job references an environment. This removes the need for the `deployments` cleanup job in `clean_up.yml`, which was running every 5 minutes purely to delete unwanted `default` deployment objects created during CI.

**Changes:**
- Add `deployment: ${{ inputs.environment != '' }}` to all job environment blocks in `docker_images.yml`, `dev_environment.yml`, `dev_environment_macos.yml`, `build_package_sources.yml`, and `prebuilt_binaries.yml` — suppressing deployment creation when the workflow is called from CI (no explicit environment), while preserving it for real publishing runs
- Add `deployment: ${{ github.event.workflow_run.name != 'CI' }}` to `documentation.yml` — no deployment for CI doc previews, but keeps the `github-pages` deployment tracked for actual releases
- Remove the `deployments` job from `clean_up.yml` (along with its comment referencing the runner issue)

Closes the workaround described in the comment referencing https://github.com/actions/runner/issues/2120.
