### PR TITLE
Enable external backend integration via entry points and CUDAQ_BACKEND_PATH

### DIFF
--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -127,6 +127,17 @@ except Exception:
         print("Could not find a suitable cuQuantum Python package.")
     pass
 
+# Discover external backends
+try:
+    from importlib.metadata import entry_points as _entry_points
+    for _ep in _entry_points(group='cudaq.backends'):
+        try:
+            _ep.load()()
+        except Exception:
+            pass
+except Exception:
+    pass
+
 # ============================================================================ #
 # Module Imports
 # ============================================================================ #

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -202,6 +202,27 @@ LinkedLibraryHolder::LinkedLibraryHolder() : availablePlatforms{"default"} {
   auto targetPath = cudaqLibPath.parent_path() / "targets";
   findAvailableTargets(targetPath, targets, simulationTargets);
 
+  const char *backendPathVar = std::getenv("CUDAQ_BACKEND_PATH");
+  if (backendPathVar) {
+    std::string entry;
+    std::stringstream ss(backendPathVar);
+    while (std::getline(ss, entry, ':')) {
+      if (entry.empty())
+        continue;
+      std::filesystem::path pkgRoot(entry);
+      auto extTargetPath = pkgRoot / "targets";
+      auto extLibDir = pkgRoot / "lib";
+      if (!std::filesystem::is_directory(extTargetPath)) {
+        CUDAQ_INFO("CUDAQ_BACKEND_PATH entry '{}': no targets/ dir, skipping.",
+                   entry);
+        continue;
+      }
+      CUDAQ_INFO("Loading external backends from '{}'.", entry);
+      findAvailableTargets(extTargetPath, targets, simulationTargets,
+                           extLibDir);
+    }
+  }
+
   CUDAQ_INFO("Init: Library Path is {}.", cudaqLibPath.string());
 
   // We have to ensure that nvqir and cudaq are loaded

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -487,6 +487,13 @@ void LinkedLibraryHolder::setTarget(
   for (auto &[key, value] : extraConfig)
     backendConfigStr += fmt::format(";{};{}", key, value);
 
+  if (!target.serverHelperLibDir.empty()) {
+    auto ymlPath =
+        std::filesystem::path(target.serverHelperLibDir).parent_path() /
+        "targets" / (targetName + ".yml");
+    backendConfigStr += fmt::format(";__yml_path;{}", ymlPath.string());
+  }
+
   platform->setTargetBackend(backendConfigStr);
   setQuantumPlatformInternal(platform);
   currentTarget = targetName;

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -532,18 +532,6 @@ Resources *python::detail::getResourceCounts() {
   return nvqir::getResourceCounts();
 }
 
-void LinkedLibraryHolder::registerBackend(const std::string &configPath,
-                                          const std::string &libDir) {
-  std::filesystem::path ymlPath(configPath);
-  if (!std::filesystem::exists(ymlPath))
-    throw std::runtime_error("Backend config file not found: " + configPath);
-
-  CUDAQ_INFO("Registering external backend from {} (lib={})", configPath,
-             libDir);
-  findAvailableTargets(ymlPath.parent_path(), targets, simulationTargets,
-                       std::filesystem::path(libDir));
-}
-
 std::string python::getTransportLayer(LinkedLibraryHolder *holder) {
   if (holder && cudaq::__internal__::canModifyTarget()) {
     auto runtimeTarget = holder->getTarget();

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -469,9 +469,13 @@ void LinkedLibraryHolder::setTarget(
 
   // Pack the config into the backend string name
   std::string backendConfigStr = targetName;
-  auto potentialServerHelperPath =
-      cudaqLibPath /
+  auto soName =
       fmt::format("libcudaq-serverhelper-{}.{}", targetName, libSuffix);
+  auto potentialServerHelperPath = cudaqLibPath / soName;
+  if (!std::filesystem::exists(potentialServerHelperPath) &&
+      !target.serverHelperLibDir.empty())
+    potentialServerHelperPath =
+        std::filesystem::path(target.serverHelperLibDir) / soName;
   if (std::filesystem::exists(potentialServerHelperPath) &&
       !libHandles.count(potentialServerHelperPath.string())) {
     void *serverHelperHandle = dlopen(

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -123,7 +123,8 @@ void parseRuntimeTarget(const std::filesystem::path &cudaqLibPath,
 void findAvailableTargets(
     const std::filesystem::path &targetPath,
     std::unordered_map<std::string, RuntimeTarget> &targets,
-    std::unordered_map<std::string, RuntimeTarget> &simulationTargets) {
+    std::unordered_map<std::string, RuntimeTarget> &simulationTargets,
+    const std::filesystem::path &libDir) {
 
   // directory_iterator ordering is unspecified, so sort it to make it
   // repeatable and consistent.
@@ -160,8 +161,11 @@ void findAvailableTargets(
       target.config = config;
       target.name = targetName;
       target.description = config.Description;
-      auto cudaqLibPath = targetPath.parent_path() / "lib";
-      parseRuntimeTarget(cudaqLibPath, target, defaultTargetConfigStr);
+      auto resolvedLibDir =
+          libDir.empty() ? targetPath.parent_path() / "lib" : libDir;
+      if (!libDir.empty())
+        target.serverHelperLibDir = libDir.string();
+      parseRuntimeTarget(resolvedLibDir, target, defaultTargetConfigStr);
       CUDAQ_INFO("Found Target: {} -> (sim={}, platform={})", targetName,
                  target.simulatorName, target.platformName);
       // Add the target.

--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -532,6 +532,18 @@ Resources *python::detail::getResourceCounts() {
   return nvqir::getResourceCounts();
 }
 
+void LinkedLibraryHolder::registerBackend(const std::string &configPath,
+                                          const std::string &libDir) {
+  std::filesystem::path ymlPath(configPath);
+  if (!std::filesystem::exists(ymlPath))
+    throw std::runtime_error("Backend config file not found: " + configPath);
+
+  CUDAQ_INFO("Registering external backend from {} (lib={})", configPath,
+             libDir);
+  findAvailableTargets(ymlPath.parent_path(), targets, simulationTargets,
+                       std::filesystem::path(libDir));
+}
+
 std::string python::getTransportLayer(LinkedLibraryHolder *holder) {
   if (holder && cudaq::__internal__::canModifyTarget()) {
     auto runtimeTarget = holder->getTarget();

--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -31,6 +31,14 @@ namespace cudaq {
 
 class quantum_platform;
 
+/// @brief Search a targets directory for available targets, registering each
+/// with the provided maps.
+void findAvailableTargets(
+    const std::filesystem::path &targetPath,
+    std::unordered_map<std::string, RuntimeTarget> &targets,
+    std::unordered_map<std::string, RuntimeTarget> &simulationTargets,
+    const std::filesystem::path &libDir = {});
+
 /// @brief The LinkedLibraryHolder provides a mechanism for
 /// dynamically loading and storing the required plugin libraries
 /// for the CUDA-Q runtime within the Python runtime.

--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -100,11 +100,6 @@ public:
 
   /// @brief Reset the target back to the default.
   void resetTarget();
-
-  /// @brief Register an external backend from a YAML config file and a
-  /// directory containing its server-helper shared library.
-  void registerBackend(const std::string &configPath,
-                       const std::string &libDir);
 };
 
 namespace python {

--- a/python/utils/LinkedLibraryHolder.h
+++ b/python/utils/LinkedLibraryHolder.h
@@ -100,6 +100,11 @@ public:
 
   /// @brief Reset the target back to the default.
   void resetTarget();
+
+  /// @brief Register an external backend from a YAML config file and a
+  /// directory containing its server-helper shared library.
+  void registerBackend(const std::string &configPath,
+                       const std::string &libDir);
 };
 
 namespace python {

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -196,7 +196,14 @@ public:
     /// Once we know the backend, we should search for the configuration file
     /// from there we can get the URL/PORT and the required MLIR pass pipeline.
     std::string fileName = mutableBackend + std::string(".yml");
-    auto configFilePath = platformPath / fileName;
+    std::filesystem::path configFilePath;
+    auto ymlPathIter = backendConfig.find("__yml_path");
+    if (ymlPathIter != backendConfig.end()) {
+      configFilePath = ymlPathIter->second;
+      backendConfig.erase(ymlPathIter);
+    } else {
+      configFilePath = platformPath / fileName;
+    }
     CUDAQ_INFO("Config file path = {}", configFilePath.string());
     std::ifstream configFile(configFilePath.string());
     std::string configYmlContents((std::istreambuf_iterator<char>(configFile)),

--- a/runtime/common/RuntimeTarget.h
+++ b/runtime/common/RuntimeTarget.h
@@ -37,6 +37,9 @@ struct RuntimeTarget {
   // key-value pairs for the backend configuration specified in the command-line
   // (C++) or the set_target call (Python).
   std::map<std::string, std::string> runtimeConfig;
+  // Directory containing libcudaq-serverhelper-<name>.so for this target.
+  // If empty, use the default CUDA-Q library directory.
+  std::string serverHelperLibDir;
   // Helper to generate the help string for the extra target arguments
   // (specified in the target config YAML file).
   std::string get_target_args_help_string() const;

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -44,6 +44,7 @@ set(CUDAQ_RUNTIME_TEST_SOURCES
   common/MeasureCountsTester.cpp
   common/NoiseModelTester.cpp
   common/ExecutionContextThreadTester.cpp
+  common/RuntimeTargetTester.cpp
   ptsbe/PTSBESampleTester.cpp
   ptsbe/PTSBEMultiBackendTester.cpp
   integration/tracer_tester.cpp

--- a/unittests/common/RuntimeTargetTester.cpp
+++ b/unittests/common/RuntimeTargetTester.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "common/RuntimeTarget.h"
+#include <gtest/gtest.h>
+
+TEST(RuntimeTargetTester, defaultServerHelperLibDirIsEmpty) {
+  cudaq::RuntimeTarget target;
+  EXPECT_TRUE(target.serverHelperLibDir.empty());
+}
+
+TEST(RuntimeTargetTester, serverHelperLibDirCanBeSet) {
+  cudaq::RuntimeTarget target;
+  target.serverHelperLibDir = "/opt/my-backend/lib";
+  EXPECT_EQ(target.serverHelperLibDir, "/opt/my-backend/lib");
+}
+
+TEST(RuntimeTargetTester, serverHelperLibDirIsIndependentOfName) {
+  cudaq::RuntimeTarget target;
+  target.name = "my-backend";
+  target.serverHelperLibDir = "/opt/my-backend/lib";
+  EXPECT_EQ(target.name, "my-backend");
+  EXPECT_EQ(target.serverHelperLibDir, "/opt/my-backend/lib");
+}

--- a/unittests/target_config/CMakeLists.txt
+++ b/unittests/target_config/CMakeLists.txt
@@ -11,9 +11,13 @@ add_executable(test_target_config TargetConfigTester.cpp)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
   target_link_options(test_target_config PRIVATE ${CUDAQ_FORCE_LINK_FLAG})
 endif()
+target_include_directories(test_target_config PRIVATE
+  ${CMAKE_SOURCE_DIR}/python/utils
+)
 target_link_libraries(test_target_config
   PRIVATE
     CUDAQTargetConfigUtil
+    cudaq-py-utils
     gtest_main
 )
 

--- a/unittests/target_config/CMakeLists.txt
+++ b/unittests/target_config/CMakeLists.txt
@@ -11,14 +11,18 @@ add_executable(test_target_config TargetConfigTester.cpp)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
   target_link_options(test_target_config PRIVATE ${CUDAQ_FORCE_LINK_FLAG})
 endif()
-target_include_directories(test_target_config PRIVATE
-  ${CMAKE_SOURCE_DIR}/python/utils
-)
 target_link_libraries(test_target_config
   PRIVATE
     CUDAQTargetConfigUtil
-    cudaq-py-utils
     gtest_main
 )
+
+if(CUDAQ_ENABLE_PYTHON)
+  target_include_directories(test_target_config PRIVATE
+    ${CMAKE_SOURCE_DIR}/python/utils
+  )
+  target_link_libraries(test_target_config PRIVATE cudaq-py-utils)
+  target_compile_definitions(test_target_config PRIVATE CUDAQ_ENABLE_PYTHON)
+endif()
 
 gtest_discover_tests(test_target_config)

--- a/unittests/target_config/TargetConfigTester.cpp
+++ b/unittests/target_config/TargetConfigTester.cpp
@@ -147,7 +147,7 @@ TEST_F(ExternalBackendTester, setsServerHelperLibDir) {
   cudaq::findAvailableTargets(root / "targets", targets, simTargets,
                               root / "lib");
 
-  ASSERT_EQ(targets.count("my-backend"), 1u);
+  ASSERT_EQ(targets.count("my-backend"), 1);
   EXPECT_EQ(targets.at("my-backend").serverHelperLibDir,
             (root / "lib").string());
   EXPECT_EQ(targets.at("my-backend").name, "my-backend");
@@ -162,8 +162,8 @@ TEST_F(ExternalBackendTester, backendPathMultipleEntries) {
     cudaq::findAvailableTargets(root / "targets", targets, simTargets,
                                 root / "lib");
 
-  ASSERT_EQ(targets.count("backend-a"), 1u);
-  ASSERT_EQ(targets.count("backend-b"), 1u);
+  ASSERT_EQ(targets.count("backend-a"), 1);
+  ASSERT_EQ(targets.count("backend-b"), 1);
   EXPECT_EQ(targets.at("backend-a").serverHelperLibDir,
             (rootA / "lib").string());
   EXPECT_EQ(targets.at("backend-b").serverHelperLibDir,
@@ -177,9 +177,26 @@ TEST_F(ExternalBackendTester, serverHelperPathResolvesToLibDir) {
   cudaq::findAvailableTargets(root / "targets", targets, simTargets,
                               root / "lib");
 
-  ASSERT_EQ(targets.count("my-backend"), 1u);
+  ASSERT_EQ(targets.count("my-backend"), 1);
   const auto &target = targets.at("my-backend");
   auto resolvedPath = std::filesystem::path(target.serverHelperLibDir) /
                       ("libcudaq-serverhelper-" + target.name + ".so");
   EXPECT_TRUE(std::filesystem::exists(resolvedPath));
+}
+
+TEST_F(ExternalBackendTester, reconstructYmlPathFromServerHelperLibDir) {
+  auto root = createBackendPackage("my-backend");
+
+  std::unordered_map<std::string, cudaq::RuntimeTarget> targets, simTargets;
+  cudaq::findAvailableTargets(root / "targets", targets, simTargets,
+                              root / "lib");
+
+  ASSERT_EQ(targets.count("my-backend"), 1);
+  const auto &target = targets.at("my-backend");
+  ASSERT_FALSE(target.serverHelperLibDir.empty());
+
+  auto ymlPath =
+      std::filesystem::path(target.serverHelperLibDir).parent_path() /
+      "targets" / (target.name + ".yml");
+  EXPECT_TRUE(std::filesystem::exists(ymlPath));
 }

--- a/unittests/target_config/TargetConfigTester.cpp
+++ b/unittests/target_config/TargetConfigTester.cpp
@@ -6,12 +6,15 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#ifdef CUDAQ_ENABLE_PYTHON
 #include "LinkedLibraryHolder.h"
+#endif
 #include "cudaq/Support/TargetConfigYaml.h"
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
 
+#ifdef CUDAQ_ENABLE_PYTHON
 class ExternalBackendTester : public ::testing::Test {
 protected:
   std::filesystem::path tmpRoot;
@@ -200,3 +203,4 @@ TEST_F(ExternalBackendTester, reconstructYmlPathFromServerHelperLibDir) {
       "targets" / (target.name + ".yml");
   EXPECT_TRUE(std::filesystem::exists(ymlPath));
 }
+#endif // CUDAQ_ENABLE_PYTHON

--- a/unittests/target_config/TargetConfigTester.cpp
+++ b/unittests/target_config/TargetConfigTester.cpp
@@ -17,11 +17,11 @@ protected:
   std::filesystem::path tmpRoot;
 
   void SetUp() override {
-    tmpRoot = std::filesystem::temp_directory_path() /
-              ("cudaq_test_" + std::string(
-                                   ::testing::UnitTest::GetInstance()
-                                       ->current_test_info()
-                                       ->name()));
+    tmpRoot =
+        std::filesystem::temp_directory_path() /
+        ("cudaq_test_" +
+         std::string(
+             ::testing::UnitTest::GetInstance()->current_test_info()->name()));
     std::filesystem::create_directories(tmpRoot);
   }
 

--- a/unittests/target_config/TargetConfigTester.cpp
+++ b/unittests/target_config/TargetConfigTester.cpp
@@ -12,6 +12,40 @@
 #include <fstream>
 #include <gtest/gtest.h>
 
+class ExternalBackendTester : public ::testing::Test {
+protected:
+  std::filesystem::path tmpRoot;
+
+  void SetUp() override {
+    tmpRoot = std::filesystem::temp_directory_path() /
+              ("cudaq_test_" + std::string(
+                                   ::testing::UnitTest::GetInstance()
+                                       ->current_test_info()
+                                       ->name()));
+    std::filesystem::create_directories(tmpRoot);
+  }
+
+  void TearDown() override { std::filesystem::remove_all(tmpRoot); }
+
+  std::filesystem::path createBackendPackage(const std::string &name,
+                                             bool createSo = false) {
+    auto root = tmpRoot / name;
+    auto targetsDir = root / "targets";
+    auto libDir = root / "lib";
+    std::filesystem::create_directories(targetsDir);
+    std::filesystem::create_directories(libDir);
+
+    std::ofstream(targetsDir / (name + ".yml"))
+        << "name: " << name << "\ndescription: \"Test backend.\"\nconfig:\n"
+        << "  platform-qpu: remote_rest\n  library-mode: false\n";
+
+    if (createSo)
+      std::ofstream(libDir / ("libcudaq-serverhelper-" + name + ".so")).close();
+
+    return root;
+  }
+};
+
 TEST(TargetConfigTester, checkMachineList) {
   const std::string configYmlContents = R"(
 name: test
@@ -106,61 +140,46 @@ target-arguments:
             "qir-adaptive:1.0:int_computations,float_computations");
 }
 
-TEST(TargetConfigTester, setsServerHelperLibDir) {
-  auto tmpDir = std::filesystem::temp_directory_path() /
-                "cudaq_test_find_available_targets";
-  auto targetsDir = tmpDir / "targets";
-  auto libDir = tmpDir / "lib";
-  std::filesystem::create_directories(targetsDir);
-  std::filesystem::create_directories(libDir);
-
-  const std::string ymlContent = R"(
-name: my-backend
-description: "Test backend."
-config:
-  platform-qpu: remote_rest
-  library-mode: false
-)";
-  std::ofstream(targetsDir / "my-backend.yml") << ymlContent;
+TEST_F(ExternalBackendTester, setsServerHelperLibDir) {
+  auto root = createBackendPackage("my-backend");
 
   std::unordered_map<std::string, cudaq::RuntimeTarget> targets, simTargets;
-  cudaq::findAvailableTargets(targetsDir, targets, simTargets, libDir);
+  cudaq::findAvailableTargets(root / "targets", targets, simTargets,
+                              root / "lib");
 
-  ASSERT_EQ(targets.count("my-backend"), 1);
-  EXPECT_EQ(targets.at("my-backend").serverHelperLibDir, libDir.string());
+  ASSERT_EQ(targets.count("my-backend"), 1u);
+  EXPECT_EQ(targets.at("my-backend").serverHelperLibDir,
+            (root / "lib").string());
   EXPECT_EQ(targets.at("my-backend").name, "my-backend");
-
-  std::filesystem::remove_all(tmpDir);
 }
 
-TEST(TargetConfigTester, backendPathMultipleEntries) {
-  auto tmpDir =
-      std::filesystem::temp_directory_path() / "cudaq_test_backend_path";
-
-  auto createBackend = [&](const std::string &name) {
-    auto root = tmpDir / name;
-    std::filesystem::create_directories(root / "targets");
-    std::filesystem::create_directories(root / "lib");
-    std::ofstream(root / "targets" / (name + ".yml"))
-        << "name: " << name << "\ndescription: \"Test.\"\nconfig:\n"
-        << "  platform-qpu: remote_rest\n  library-mode: false\n";
-    return root;
-  };
-
-  auto rootA = createBackend("backend-a");
-  auto rootB = createBackend("backend-b");
+TEST_F(ExternalBackendTester, backendPathMultipleEntries) {
+  auto rootA = createBackendPackage("backend-a");
+  auto rootB = createBackendPackage("backend-b");
 
   std::unordered_map<std::string, cudaq::RuntimeTarget> targets, simTargets;
   for (auto &root : {rootA, rootB})
     cudaq::findAvailableTargets(root / "targets", targets, simTargets,
                                 root / "lib");
 
-  ASSERT_EQ(targets.count("backend-a"), 1);
-  ASSERT_EQ(targets.count("backend-b"), 1);
+  ASSERT_EQ(targets.count("backend-a"), 1u);
+  ASSERT_EQ(targets.count("backend-b"), 1u);
   EXPECT_EQ(targets.at("backend-a").serverHelperLibDir,
             (rootA / "lib").string());
   EXPECT_EQ(targets.at("backend-b").serverHelperLibDir,
             (rootB / "lib").string());
+}
 
-  std::filesystem::remove_all(tmpDir);
+TEST_F(ExternalBackendTester, serverHelperPathResolvesToLibDir) {
+  auto root = createBackendPackage("my-backend", /*createSo=*/true);
+
+  std::unordered_map<std::string, cudaq::RuntimeTarget> targets, simTargets;
+  cudaq::findAvailableTargets(root / "targets", targets, simTargets,
+                              root / "lib");
+
+  ASSERT_EQ(targets.count("my-backend"), 1u);
+  const auto &target = targets.at("my-backend");
+  auto resolvedPath = std::filesystem::path(target.serverHelperLibDir) /
+                      ("libcudaq-serverhelper-" + target.name + ".so");
+  EXPECT_TRUE(std::filesystem::exists(resolvedPath));
 }

--- a/unittests/target_config/TargetConfigTester.cpp
+++ b/unittests/target_config/TargetConfigTester.cpp
@@ -6,7 +6,10 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#include "LinkedLibraryHolder.h"
 #include "cudaq/Support/TargetConfigYaml.h"
+#include <filesystem>
+#include <fstream>
 #include <gtest/gtest.h>
 
 TEST(TargetConfigTester, checkMachineList) {
@@ -101,4 +104,31 @@ target-arguments:
             "qir-adaptive:1.0:int_computations,float_computations");
   EXPECT_EQ(config.getCodeGenSpec({{"machine", "Helios-1E"}}),
             "qir-adaptive:1.0:int_computations,float_computations");
+}
+
+TEST(TargetConfigTester, setsServerHelperLibDir) {
+  auto tmpDir = std::filesystem::temp_directory_path() /
+                "cudaq_test_find_available_targets";
+  auto targetsDir = tmpDir / "targets";
+  auto libDir = tmpDir / "lib";
+  std::filesystem::create_directories(targetsDir);
+  std::filesystem::create_directories(libDir);
+
+  const std::string ymlContent = R"(
+name: my-backend
+description: "Test backend."
+config:
+  platform-qpu: remote_rest
+  library-mode: false
+)";
+  std::ofstream(targetsDir / "my-backend.yml") << ymlContent;
+
+  std::unordered_map<std::string, cudaq::RuntimeTarget> targets, simTargets;
+  cudaq::findAvailableTargets(targetsDir, targets, simTargets, libDir);
+
+  ASSERT_EQ(targets.count("my-backend"), 1);
+  EXPECT_EQ(targets.at("my-backend").serverHelperLibDir, libDir.string());
+  EXPECT_EQ(targets.at("my-backend").name, "my-backend");
+
+  std::filesystem::remove_all(tmpDir);
 }

--- a/unittests/target_config/TargetConfigTester.cpp
+++ b/unittests/target_config/TargetConfigTester.cpp
@@ -132,3 +132,35 @@ config:
 
   std::filesystem::remove_all(tmpDir);
 }
+
+TEST(TargetConfigTester, backendPathMultipleEntries) {
+  auto tmpDir =
+      std::filesystem::temp_directory_path() / "cudaq_test_backend_path";
+
+  auto createBackend = [&](const std::string &name) {
+    auto root = tmpDir / name;
+    std::filesystem::create_directories(root / "targets");
+    std::filesystem::create_directories(root / "lib");
+    std::ofstream(root / "targets" / (name + ".yml"))
+        << "name: " << name << "\ndescription: \"Test.\"\nconfig:\n"
+        << "  platform-qpu: remote_rest\n  library-mode: false\n";
+    return root;
+  };
+
+  auto rootA = createBackend("backend-a");
+  auto rootB = createBackend("backend-b");
+
+  std::unordered_map<std::string, cudaq::RuntimeTarget> targets, simTargets;
+  for (auto &root : {rootA, rootB})
+    cudaq::findAvailableTargets(root / "targets", targets, simTargets,
+                                root / "lib");
+
+  ASSERT_EQ(targets.count("backend-a"), 1);
+  ASSERT_EQ(targets.count("backend-b"), 1);
+  EXPECT_EQ(targets.at("backend-a").serverHelperLibDir,
+            (rootA / "lib").string());
+  EXPECT_EQ(targets.at("backend-b").serverHelperLibDir,
+            (rootB / "lib").string());
+
+  std::filesystem::remove_all(tmpDir);
+}


### PR DESCRIPTION
A new hardware integration strategy that enables external backend packages to be discovered and used by CUDA-Q at runtime without requiring their code to be merged in CUDA-Q repository.

### What we need from hardware provider in a wheel
   - .so file
   - .yml file (for configuration)

- The hardware provider's `pyproject.toml` should have the following entry point
```toml
[project]
name = "<hw-provider>"
...

[project.entry-points."cudaq.backends"]
<hw-provider> = "<hw-provider>:register"
```

- Inside `<hw-provider>/__init__.py`
  - This sets the env var before the C extension is initialized

```python
import os

_pkg_dir = os.path.dirname(os.path.abspath(__file__))

def register():
    existing = os.environ.get('CUDAQ_BACKEND_PATH', '')
    os.environ['CUDAQ_BACKEND_PATH'] = _pkg_dir + (':' + existing if existing else '')
```

### How it will work is
   - User just needs to `pip install <hw-provider>`, which will install a wheel with <hw-provider>/targets/<hw-provider>.yml and <hw-provider>/lib/libcudaq-serverhelper-<hw-provider>.so and a register() entry point in group `cudaq.backends`
   - Issuing `import cudaq` will trigger a entry point discovery
      - It will run `register()` method
      - `register()` appends its package root to CUDAQ_BACKEND_PATH
      - LinkedLibraryHolder scans CUDAQ_BACKEND_PATH, then calls `findAvailableTargets()` through which `RuntimeTarget` gets serverHelperLibDir
      - When a user sets a target using `cudaq.set_target("<hw-provider>")`
         - set_target() will open the .so file from serverHelperLibDir using dlopen
         - Then it will put `__yml_path` in the backend config string
         - Now, `BaseRemoteRESTQPU::setTargetBackend()` reads the above YAML file
   
**Note:** `<hw-provider>` is hardware provider like TII, IQNQ, Quantinuum etc.
 
This PR will be followed by the docs PR.