### PR TITLE
[DOCS] Fix typing error in documentation (noisless -> noiseless)

### DIFF
--- a/docs/sphinx/using/applications.rst
+++ b/docs/sphinx/using/applications.rst
@@ -291,7 +291,7 @@ This page contains a number of different applications implemented using CUDA-Q. 
         <img src="../_static/app_title_images/quantum_pagerank_preview.png" alt="Quantum Pagerank Preview" class="notebook-image">
     </div> 
 
-    <div class="notebook-entry" data-tags="chemistry,noisless">
+    <div class="notebook-entry" data-tags="chemistry,noiseless">
         <a href="../applications/python/uccsd_wf_ansatz.html" class="notebook-title">UCCSD Wavefunction Ansatz</a>
         <div class="notebook-content">
             Learn how to implement the UCCSD wavefunction ansatz using CUDA-Q.
@@ -307,7 +307,7 @@ This page contains a number of different applications implemented using CUDA-Q. 
         <img src="../_static/app_title_images/mps_encoding.png" alt="MPS Encoding" class="notebook-image">
     </div>
 
-    <div class="notebook-entry" data-tags="chemistry,noisless">
+    <div class="notebook-entry" data-tags="chemistry,noiseless">
         <a href="../applications/python/qm_mm_pe.html" class="notebook-title">QM/MM simulation: VQE within a Polarizable Embedded Framework.</a>
         <div class="notebook-content">
             Learn how to implement QM/MM with PE framework using CUDA-Q.


### PR DESCRIPTION
This PR fixes a typing error in `docs/sphinx/using/applications.rst` (`noisless `-> `noiseless`).