### PR TITLE
[DOCS] [EXAMPLES] Add missing math import

### DIFF
--- a/docs/sphinx/targets/python/quantum_machines_all_gates.py
+++ b/docs/sphinx/targets/python/quantum_machines_all_gates.py
@@ -1,4 +1,5 @@
 import cudaq
+import math
 
 # Test all gates on the quantum machines target.
 # The default executor is mock, use executor name to run on another backend (real or simulator).


### PR DESCRIPTION
We use (e. g.) `math.pi`, but we didn't import is -> missing import was added.

Contributed by **Benedikt Johannes**