### PR TITLE
increasing validation timeout to 2100 seconds

### DIFF
--- a/docs/notebook_validation.py
+++ b/docs/notebook_validation.py
@@ -113,7 +113,7 @@ def execute(notebook_filename, jupyter_kernel=None, timeout_seconds=300):
                                                       '.nbconvert.ipynb')
     notebook_basename = os.path.basename(notebook_filename)
     if notebook_basename in LONG_RUNNING_NOTEBOOKS:
-        timeout_seconds = 1500
+        timeout_seconds = 2100
 
     try:
         start_time = time.perf_counter()


### PR DESCRIPTION
increasing validation timeout to 2100 seconds for long running notebooks.

Fixes publishing failure: https://github.com/NVIDIA/cuda-quantum/actions/runs/23413997823/job/68109581299#step:5:2043