### PR TITLE
Fix source build cache invalidation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
         base_image=${{ fromJson(needs.metadata.outputs.platform_config)[format('{0}', matrix.platform)].minimal_base_image }}
         cuda_version=${{ matrix.cuda_version }}
         toolchain=llvm
+        llvm_commit=${{ needs.metadata.outputs.llvm_commit }}
+        pybind11_commit=${{ needs.metadata.outputs.pybind11_commit }}
       registry_cache_from: ${{ inputs.cache_base || needs.metadata.outputs.cache_base }}
       checkout_submodules: true
       environment: ghcr-ci

--- a/.github/workflows/create_cache_command.yml
+++ b/.github/workflows/create_cache_command.yml
@@ -156,6 +156,8 @@ jobs:
         base_image=${{ fromJson(needs.metadata.outputs.platform_config)[format('{0}', matrix.platform)].minimal_base_image }}
         cuda_version=${{ matrix.cuda_version }}
         toolchain=llvm
+        llvm_commit=${{ needs.metadata.outputs.llvm_commit }}
+        pybind11_commit=${{ needs.metadata.outputs.pybind11_commit }}
       registry_cache_from: ${{ needs.pr_info.outputs.target_branch }}
       checkout_submodules: true
       # needed only for the cloudposse GitHub action

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -264,6 +264,8 @@ jobs:
         base_image=${{ fromJson(needs.metadata.outputs.platforms)[format('{0}', matrix.platform)].minimal_base_image }}
         cuda_version=${{ matrix.cuda_version }}
         toolchain=llvm
+        llvm_commit=${{ needs.metadata.outputs.llvm_commit }}
+        pybind11_commit=${{ needs.metadata.outputs.pybind11_commit }}
       registry_cache_from: ${{ needs.metadata.outputs.cache_base }}
       update_registry_cache: ${{ needs.metadata.outputs.cache_target }}
       pull_request_number: ${{ needs.metadata.outputs.pull_request_number }}

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Configure build
         id: config
         run: |
+          echo "llvm_commit=$(git rev-parse @:./tpls/llvm)" >> $GITHUB_OUTPUT
+          echo "pybind11_commit=$(git rev-parse @:./tpls/pybind11)" >> $GITHUB_OUTPUT
+
           platform_tag=`echo ${{ inputs.platform }} | sed 's/linux\///g' | tr -d ' '`
           is_versioned=${{ github.ref_type == 'tag' || startsWith(github.ref_name, 'releases/') || startsWith(github.ref_name, 'staging/') }}
           if ${is_versioned}; then
@@ -165,6 +168,8 @@ jobs:
             release_version=${{ steps.config.outputs.cudaq_version }}
             base_image=${{ inputs.platform_base_image }}
             cuda_version=${{ inputs.cuda_version }}
+            llvm_commit=${{ steps.config.outputs.llvm_commit }}
+            pybind11_commit=${{ steps.config.outputs.pybind11_commit }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: ${{ inputs.platform }}

--- a/docker/build/assets.Dockerfile
+++ b/docker/build/assets.Dockerfile
@@ -43,6 +43,8 @@ RUN source /cuda-quantum/scripts/configure_build.sh install-cuda
 RUN source /cuda-quantum/scripts/configure_build.sh install-gcc
 
 # [CUDA-Q Dependencies]
+ARG llvm_commit
+ARG pybind11_commit
 ADD scripts/install_prerequisites.sh /cuda-quantum/scripts/install_prerequisites.sh
 ADD scripts/set_env_defaults.sh /cuda-quantum/scripts/set_env_defaults.sh
 ADD scripts/install_toolchain.sh /cuda-quantum/scripts/install_toolchain.sh
@@ -50,8 +52,12 @@ ADD scripts/build_llvm.sh /cuda-quantum/scripts/build_llvm.sh
 ADD cmake/caches/LLVM.cmake /cuda-quantum/cmake/caches/LLVM.cmake
 ADD tpls/customizations/llvm /cuda-quantum/tpls/customizations/llvm
 ADD .gitmodules /cuda-quantum/.gitmodules
-ADD .git/modules/tpls/pybind11/HEAD /.git_modules/tpls/pybind11/HEAD
-ADD .git/modules/tpls/llvm/HEAD /.git_modules/tpls/llvm/HEAD
+
+# Pin submodule commits via build args so the prereqs layer caches across
+# CUDA-Q commits when llvm/pybind11 refs are unchanged.
+RUN mkdir -p /.git_modules/tpls/llvm /.git_modules/tpls/pybind11 && \
+    echo "${llvm_commit}" > /.git_modules/tpls/llvm/HEAD && \
+    echo "${pybind11_commit}" > /.git_modules/tpls/pybind11/HEAD
 
 # This is a hack so that we do not need to rebuild the prerequisites 
 # whenever we pick up a new CUDA-Q commit (which is always in CI).


### PR DESCRIPTION
## Fix source build cache invalidation in CI

### Problem
The "Load source build cache" job (`source_build` / prereqs stage) was rebuilding almost every run because the prereqs layers were invalidated on nearly every commit.

The cause was `ADD .git/modules/tpls/llvm/HEAD` and `ADD .git/modules/tpls/pybind11/HEAD` in `assets.Dockerfile`. These files depend on the current checkout, so they change whenever:
- A different PR runs (different merge commit or submodule refs)
- Submodule pins change on main or the PR base

When that `ADD` layer changes, BuildKit invalidates all later layers (git init, LLVM build, GCC `ldd` check), so the expensive prereqs stage was rarely cached.

### Solution
Use build args `llvm_commit` and `pybind11_commit` instead of adding `.git/modules/` HEAD files from the build context. The prereqs layer cache is now driven by submodule commit hashes instead of the current checkout.

- Same `llvm_commit`/`pybind11_commit` → cache hit (e.g. PRs based on main that don’t change submodules)
- Different submodule refs → full rebuild, as expected

### Changes
- **`docker/build/assets.Dockerfile`**: Add `ARG llvm_commit` and `ARG pybind11_commit`; replace `ADD` of submodule HEAD files with a `RUN` that creates them from these args.
- **`ci.yml`**: Pass `llvm_commit` and `pybind11_commit` into the `source_build` job.
- **`create_cache_command.yml`**: Pass submodule commits into the `source_build_caches` job.
- **`deployments.yml`**: Pass submodule commits into the `source_build` job.
- **`prebuilt_binaries.yml`**: Compute and pass `llvm_commit` and `pybind11_commit` for builds where the cache may be cold.