### PR TITLE
Adding fetch_depth as 0 to get the full history

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -189,6 +189,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ vars.preview_branch }}
+          fetch-depth: 0
 
       - name: Delete preview folder for closed PR
         if: github.event_name == 'pull_request_target'


### PR DESCRIPTION
With fetch_depth as 0, the full history is available and so the command returns the actual last modified date for each `pr-*/ ` folder. The default value of 1 was just returning the last commit.