### PR TITLE
[Quake] Add a type for collection of measurements

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -1155,6 +1155,64 @@ def quake_DiscriminateOp : QuakeOp<"discriminate", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// GetMeasureOp
+//===----------------------------------------------------------------------===//
+
+def quake_GetMeasureOp : QuakeOp<"get_measure", [Pure]> {
+  let summary =
+    "Extract a single measurement from a measurements collection.";
+  let description = [{
+    Extracts a single `!quake.measure` value from a `!quake.measurements<N>`
+    collection by index. This is analogous to `quake.extract_ref` for qubits.
+
+    Example:
+    ```mlir
+      %m = quake.get_measure %ms[0] : (!quake.measurements<4>) -> !quake.measure
+    ```
+  }];
+
+  let arguments = (ins
+    MeasurementsType:$measurements,
+    Optional<AnySignlessIntegerOrIndex>:$index,
+    I64Attr:$rawIndex
+  );
+  let results = (outs MeasureType:$measure);
+
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$measurements, "mlir::Value":$index,
+                   "mlir::IntegerAttr":$rawIndex), [{
+      return build($_builder, $_state, $_builder.getType<MeasureType>(),
+                   measurements, index, rawIndex);
+    }]>,
+    OpBuilder<(ins "mlir::Value":$measurements, "mlir::Value":$index), [{
+      return build($_builder, $_state, $_builder.getType<MeasureType>(),
+                   measurements, index, GetMeasureOp::kDynamicIndex);
+    }]>,
+    OpBuilder<(ins "mlir::Value":$measurements, "std::size_t":$rawIndex), [{
+      auto i64Ty = $_builder.getI64Type();
+      return build($_builder, $_state, $_builder.getType<MeasureType>(),
+                   measurements, mlir::Value{},
+                   mlir::IntegerAttr::get(i64Ty, rawIndex));
+    }]>
+  ];
+
+  let assemblyFormat = [{
+    $measurements `[` custom<RawIndex>($index, $rawIndex) `]` `:`
+      functional-type(operands, results) attr-dict
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    static constexpr std::size_t kDynamicIndex =
+      std::numeric_limits<std::size_t>::max();
+
+    bool hasConstantIndex() { return !getIndex(); }
+    std::size_t getConstantIndex() { return getRawIndex(); }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Quantum gates
 //===----------------------------------------------------------------------===//
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -31,7 +31,8 @@ inline bool isQuantumType(mlir::Type ty) {
 /// \returns true if \p `ty` is a Quake type.
 inline bool isQuakeType(mlir::Type ty) {
   // This should correspond to the registered types in QuakeTypes.cpp.
-  return isQuantumType(ty) || mlir::isa<quake::MeasureType>(ty);
+  return isQuantumType(ty) ||
+         mlir::isa<quake::MeasureType, quake::MeasurementsType>(ty);
 }
 
 /// \returns true if \p ty is a quantum reference type, excluding `struq`.

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.td
@@ -252,6 +252,41 @@ def MeasureType : QuakeType<"Measure", "measure"> {
 }
 
 //===----------------------------------------------------------------------===//
+// MeasurementsType: classical data type for a collection of measurements
+//===----------------------------------------------------------------------===//
+
+def MeasurementsType : QuakeType<"Measurements", "measurements"> {
+  let summary = "a sequence of measurement results";
+  let description = [{
+    A value of type `measurements` is a collection of values of type `measure`.
+    This is the natural result type of measuring multiple qubits. Like `veq` is
+    to `ref`, `measurements` is to `measure`.
+
+    ```mlir
+      %ms = quake.mz %qubits : (!quake.veq<4>) -> !quake.measurements<4>
+      %m0 = quake.get_measure %ms[0] : (!quake.measurements<4>) -> !quake.measure
+    ```
+  }];
+
+  let parameters = (ins "std::size_t":$size);
+
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    static constexpr std::size_t kDynamicSize =
+      std::numeric_limits<std::size_t>::max();
+    
+    bool hasSpecifiedSize() const { return getSize() != kDynamicSize; }
+    bool hasNonZeroSpecifiedSize() const {
+      return hasSpecifiedSize() && getSize();
+    }
+    static MeasurementsType getUnsized(mlir::MLIRContext *ctx) {
+      return MeasurementsType::get(ctx, kDynamicSize);
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // StateType
 //===----------------------------------------------------------------------===//
 

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -576,6 +576,30 @@ void quake::GetMemberOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
+// GetMeasureOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult quake::GetMeasureOp::verify() {
+  if (getIndex()) {
+    if (getRawIndex() != kDynamicIndex)
+      return emitOpError(
+          "must not have both a constant index and an index argument.");
+  } else {
+    if (getRawIndex() == kDynamicIndex) {
+      return emitOpError("invalid constant index value");
+    } else {
+      auto msSize = getMeasurements().getType().getSize();
+      if (getMeasurements().getType().hasSpecifiedSize() &&
+          getRawIndex() >= msSize)
+        return emitOpError("invalid index [" + std::to_string(getRawIndex()) +
+                           "] because >= size [" + std::to_string(msSize) +
+                           "]");
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // InitializeStateOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -50,6 +50,34 @@ Type quake::VeqType::parse(AsmParser &parser) {
 }
 
 //===----------------------------------------------------------------------===//
+// Measurements' custom parser and pretty printing.
+//
+// measurements `<` (`?` | int) `>`
+//===----------------------------------------------------------------------===//
+
+void quake::MeasurementsType::print(AsmPrinter &os) const {
+  os << '<';
+  if (hasSpecifiedSize())
+    os << getSize();
+  else
+    os << '?';
+  os << '>';
+}
+
+Type quake::MeasurementsType::parse(AsmParser &parser) {
+  if (parser.parseLess())
+    return {};
+  std::size_t size = kDynamicSize;
+  if (succeeded(parser.parseOptionalQuestion()))
+    size = kDynamicSize;
+  else if (parser.parseInteger(size))
+    return {};
+  if (parser.parseGreater())
+    return {};
+  return get(parser.getContext(), size);
+}
+
+//===----------------------------------------------------------------------===//
 
 Type quake::StruqType::parse(AsmParser &parser) {
   if (parser.parseLess())
@@ -157,6 +185,6 @@ std::size_t quake::getAllocationSize(Type ty) {
 //===----------------------------------------------------------------------===//
 
 void quake::QuakeDialect::registerTypes() {
-  addTypes<CableType, ControlType, MeasureType, RefType, StateType, StruqType,
-           VeqType, WireType>();
+  addTypes<CableType, ControlType, MeasureType, MeasurementsType, RefType,
+           StateType, StruqType, VeqType, WireType>();
 }

--- a/test/Transforms/quake-errors.qke
+++ b/test/Transforms/quake-errors.qke
@@ -493,3 +493,11 @@ func.func @test(%0: !quake.veq<3>, %1: !quake.veq<2>, %2: !quake.ref) {
   %4 = quake.concat %0, %1, %2 : (!quake.veq<3>, !quake.veq<2>, !quake.ref) -> !quake.veq<34>
   return
 }
+
+// -----
+
+func.func @test(%ms : !quake.measurements<4>) -> !quake.measure {
+  // expected-error @+1 {{'quake.get_measure' op invalid index [4] because >= size [4]}}
+  %m = quake.get_measure %ms[4] : (!quake.measurements<4>) -> !quake.measure
+  return %m : !quake.measure
+}

--- a/test/Transforms/roundtrip-ops.qke
+++ b/test/Transforms/roundtrip-ops.qke
@@ -975,3 +975,24 @@ func.func @integrated_device() {
 // CHECK:           %[[VAL_14:.*]] = cc.device_call @integrated_device_callback<%[[VAL_2]], %[[VAL_10]], %[[VAL_11]] * %[[VAL_3]], %[[VAL_12]], %[[VAL_13]]> on %[[VAL_5]](%[[VAL_0]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK:           return
 // CHECK:         }
+
+func.func @measurements_ops(%ms4 : !quake.measurements<4>,
+                            %msd : !quake.measurements<?>,
+                            %idx : index) {
+  %m0 = quake.get_measure %ms4[0] : (!quake.measurements<4>) -> !quake.measure
+  %m_dyn = quake.get_measure %ms4[%idx] : (!quake.measurements<4>, index) -> !quake.measure
+  %c2 = arith.constant 2 : i64
+  %m_unsized = quake.get_measure %msd[%c2] : (!quake.measurements<?>, i64) -> !quake.measure
+  return
+}
+
+// CHECK-LABEL:   func.func @measurements_ops(
+// CHECK-SAME:                                %[[VAL_0:.*]]: !quake.measurements<4>,
+// CHECK-SAME:                                %[[VAL_1:.*]]: !quake.measurements<?>,
+// CHECK-SAME:                                %[[VAL_2:.*]]: index) {
+// CHECK:           %[[VAL_3:.*]] = quake.get_measure %[[VAL_0]][0] : (!quake.measurements<4>) -> !quake.measure
+// CHECK:           %[[VAL_4:.*]] = quake.get_measure %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!quake.measurements<4>, index) -> !quake.measure
+// CHECK:           %[[VAL_5:.*]] = arith.constant 2 : i64
+// CHECK:           %[[VAL_6:.*]] = quake.get_measure %[[VAL_1]]{{\[}}%[[VAL_5]]] : (!quake.measurements<?>, i64) -> !quake.measure
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
This PR introduces support for handling collections of quantum measurement results in the Quake dialect. 
Following have been added:
- a new `!quake.measurements<N>` type,
-  an operation to extract individual measurements from such collections, 
- associated parsing, verification, and testing

