### PR TITLE
Use basis argument for Decomposition/BasisConversion passes

### DIFF
--- a/lib/Optimizer/CodeGen/Passes.cpp
+++ b/lib/Optimizer/CodeGen/Passes.cpp
@@ -14,8 +14,6 @@
 
 using namespace mlir;
 
-static SmallVector<std::string> z_disabledPatterns = {"R1ToU3"};
-
 static void addAnyonPPipeline(OpPassManager &pm) {
   using namespace cudaq::opt;
   std::string basis[] = {
@@ -23,7 +21,6 @@ static void addAnyonPPipeline(OpPassManager &pm) {
   };
   BasisConversionOptions options;
   options.basis = basis;
-  options.disabledPatterns = z_disabledPatterns;
   pm.addPass(createBasisConversion(options));
 }
 
@@ -34,7 +31,6 @@ static void addAnyonCPipeline(OpPassManager &pm) {
   };
   BasisConversionOptions options;
   options.basis = basis;
-  options.disabledPatterns = z_disabledPatterns;
   pm.addPass(createBasisConversion(options));
 }
 
@@ -46,7 +42,6 @@ static void addOQCPipeline(OpPassManager &pm) {
   };
   BasisConversionOptions options;
   options.basis = basis;
-  options.disabledPatterns = z_disabledPatterns;
   pm.addPass(createBasisConversion(options));
 }
 
@@ -60,7 +55,6 @@ static void addQCIPipeline(OpPassManager &pm) {
   };
   BasisConversionOptions options;
   options.basis = basis;
-  options.disabledPatterns = z_disabledPatterns;
   pm.addPass(createBasisConversion(options));
 }
 
@@ -71,7 +65,6 @@ static void addQuantinuumPipeline(OpPassManager &pm) {
   };
   BasisConversionOptions options;
   options.basis = basis;
-  options.disabledPatterns = z_disabledPatterns;
   pm.addPass(createBasisConversion(options));
 }
 
@@ -83,7 +76,6 @@ static void addIQMPipeline(OpPassManager &pm) {
   };
   BasisConversionOptions options;
   options.basis = basis;
-  options.disabledPatterns = z_disabledPatterns;
   pm.addPass(createBasisConversion(options));
 }
 
@@ -95,7 +87,6 @@ static void addIonQPipeline(OpPassManager &pm) {
   };
   BasisConversionOptions options;
   options.basis = basis;
-  options.disabledPatterns = z_disabledPatterns;
   pm.addPass(createBasisConversion(options));
 }
 
@@ -106,7 +97,6 @@ static void addFermioniqPipeline(OpPassManager &pm) {
   };
   BasisConversionOptions options;
   options.basis = basis;
-  options.disabledPatterns = z_disabledPatterns;
   pm.addPass(createBasisConversion(options));
 }
 

--- a/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -148,10 +148,7 @@ void cudaq::opt::createPipelineTransformsForPythonToOpenQASM(
   pm.addNestedPass<func::FuncOp>(createCSEPass());
   pm.addNestedPass<func::FuncOp>(createMultiControlDecomposition());
   pm.addPass(createDecomposition(
-      {.enabledPatterns = {"SToR1", "TToR1", "R1ToU3", "U3ToRotations",
-                           "CHToCX", "CCZToCX", "CRzToCX", "CRyToCX", "CRxToCX",
-                           "CR1ToCX", "CCZToCX", "RxAdjToRx", "RyAdjToRy",
-                           "RzAdjToRz"}}));
+      {.basis = {"h", "s", "t", "rx", "ry", "rz", "x", "y", "z", "x(1)"}}));
   pm.addPass(createQuakeToCCPrep());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(createExpandControlVeqs());

--- a/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/braket.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{enable-patterns=SToR1,TToR1,R1ToU3,U3ToRotations,CHToCX,CCZToCX,CRzToCX,CRyToCX,CRxToCX,CR1ToCX,RxAdjToRx,RyAdjToRy,RzAdjToRz,ExpPauliDecomposition},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/infleqtion/infleqtion.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/infleqtion/infleqtion.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{enable-patterns=SToR1,TToR1,CCZToCX,CRyToCX,CRxToCX,R1AdjToR1,RxAdjToRx,RyAdjToRy,RzAdjToRz,ExpPauliDecomposition},quake-to-cc-prep,func.func(memtoreg{quantum=0})"
+  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(memtoreg{quantum=0})"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/quantum_machines/quantum_machines.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{enable-patterns=CHToCX,RzAdjToRz,CCZToCX,CR1ToCX,SwapToCX,CRxToCX,CRyToCX,CRzToCX},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating OpenQASM 2.0.
   codegen-emission: qasm2
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/scaleway/scaleway.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/scaleway/scaleway.yml
@@ -19,7 +19,7 @@ config:
   # Add the rest-qpu library to the link list
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the JIT lowering pipeline
-  jit-mid-level-pipeline: "lower-to-cfg,decomposition{enable-patterns=SToR1,TToR1,R1ToU3,U3ToRotations,CHToCX,CCXToCCZ,CCZToCX,CRzToCX,CRyToCX,CRxToCX,CR1ToCX,RxAdjToRx,RyAdjToRy,RzAdjToRz,ExpPauliDecomposition},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
+  jit-mid-level-pipeline: "lower-to-cfg,decomposition{basis=h,s,t,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,combine-quantum-alloc,canonicalize,combine-measurements)"
   # Tell the rest-qpu that we are generating QIR.
   codegen-emission: qasm2
   # Library mode is only for simulators, physical backends must turn this off

--- a/runtime/cudaq/platform/default/rest/helpers/tii/tii.yml
+++ b/runtime/cudaq/platform/default/rest/helpers/tii/tii.yml
@@ -19,7 +19,7 @@ config:
   # Add preprocessor defines to compilation
   preprocessor-defines: ["-D CUDAQ_QUANTUM_DEVICE"]
   # Define the JIT lowering pipelines
-  jit-mid-level-pipeline: "lower-to-cfg,func.func(canonicalize,multicontrol-decomposition),decomposition{enable-patterns=U3ToRotations,SToR1,TToR1,CHToCX,CCZToCX,CRzToCX,CRyToCX,CRxToCX,CR1ToCX,R1AdjToR1,RxAdjToRx,RyAdjToRy,RzAdjToRz,ExpPauliDecomposition},quake-to-cc-prep,func.func(expand-control-veqs,canonicalize),symbol-dce"
+  jit-mid-level-pipeline: "lower-to-cfg,func.func(canonicalize,multicontrol-decomposition),decomposition{basis=h,s,t,r1,rx,ry,rz,x,y,z,x(1)},quake-to-cc-prep,func.func(expand-control-veqs,canonicalize),symbol-dce"
   codegen-emission: qasm2
   # Library mode is only for simulators, physical backends must turn this off
   library-mode: false

--- a/test/Transforms/BasisConversion/all-qir-gates.qke
+++ b/test/Transforms/BasisConversion/all-qir-gates.qke
@@ -6,7 +6,7 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --basis-conversion="basis=h,s,t,rx,ry,rz,x,y,z,x(1) disable-patterns=R1ToU3" %s | FileCheck %s
+// RUN: cudaq-opt --basis-conversion="basis=h,s,t,rx,ry,rz,x,y,z,x(1)" %s | FileCheck %s
 
 /// This test covers all the supported CUDA-Q gates along with control and
 /// adjoint modifiers, similar to the test in `python/tests/backends/test_Infleqtion.py::test_all_gates`

--- a/test/Transforms/BasisConversion/phased_rx-cz.qke
+++ b/test/Transforms/BasisConversion/phased_rx-cz.qke
@@ -6,8 +6,8 @@
 // the terms of the Apache License 2.0 which accompanies this distribution.   //
 // ========================================================================== //
 
-// RUN: cudaq-opt --basis-conversion="basis=z(1),phased_rx disable-patterns=R1ToU3" %s | FileCheck %s
-// RUN: cudaq-opt --basis-conversion="basis=z(1),phased_rx disable-patterns=R1ToU3" %s | CircuitCheck %s --up-to-global-phase
+// RUN: cudaq-opt --basis-conversion="basis=z(1),phased_rx" %s | FileCheck %s
+// RUN: cudaq-opt --basis-conversion="basis=z(1),phased_rx" %s | CircuitCheck %s --up-to-global-phase
 
 
 // CHECK-LABEL: func.func @cx


### PR DESCRIPTION
This was an old outstanding task following https://github.com/NVIDIA/cuda-quantum/pull/3644. There is now a simpler 'declarative' way of defining which basis gates to decompose to, without having to explicitly list all patterns.

- Replace explicit `enable-patterns` lists with the `basis` argument in Decomposition pass usage across 5 target YAML files (braket, scaleway, tii, infleqtion, quantum_machines) and the OpenQASM pipeline
- Remove redundant `disable-patterns=R1ToU3` from all 8 BasisConversion pipeline definitions, as the pattern selection algorithm (introduced in #3644) handles this automatically
- Remove `disable-patterns=R1ToU3` from BasisConversion test RUN lines

The pattern selection algorithm selects decomposition patterns via backward traversal of a decomposition pattern graph, choosing the shortest path to the target basis. This makes manually curating pattern lists unnecessary.
