### PR TITLE
[Braket] Remove unnecessary S3 bucket config

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/braket/BraketExecutor.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/braket/BraketExecutor.cpp
@@ -18,8 +18,6 @@
 
 #include <aws/s3-crt/model/CreateBucketRequest.h>
 #include <aws/s3-crt/model/GetObjectRequest.h>
-#include <aws/s3-crt/model/PutBucketPolicyRequest.h>
-#include <aws/s3-crt/model/PutPublicAccessBlockRequest.h>
 
 #include <aws/core/utils/ARN.h>
 
@@ -52,53 +50,7 @@ void tryCreateBucket(Aws::S3Crt::S3CrtClient &client, std::string const &region,
       throw std::runtime_error(error.GetMessage());
     }
   }
-
-  Aws::S3Crt::Model::PutPublicAccessBlockRequest publicReq;
-  publicReq.SetBucket(bucketName);
-  Aws::S3Crt::Model::PublicAccessBlockConfiguration publicConfig;
-  publicConfig.SetBlockPublicAcls(true);
-  publicConfig.SetIgnorePublicAcls(true);
-  publicConfig.SetBlockPublicPolicy(true);
-  publicConfig.SetRestrictPublicBuckets(true);
-  publicReq.SetPublicAccessBlockConfiguration(publicConfig);
-
-  auto publicResponse = client.PutPublicAccessBlock(publicReq);
-  if (!publicResponse.IsSuccess()) {
-    auto error = publicResponse.GetError();
-    throw std::runtime_error(error.GetMessage());
-  }
-
-  std::string policy = fmt::format(R"({{
-    "Version": "2012-10-17",
-    "Statement": [
-        {{
-            "Effect": "Allow",
-            "Principal": {{
-                "Service": [
-                    "braket.amazonaws.com"
-                ]
-            }},
-            "Action": "s3:*",
-            "Resource": [
-                "arn:aws:s3:::{0}",
-                "arn:aws:s3:::{0}/*"
-            ]
-        }}
-    ]
-}})",
-                                   bucketName);
-
-  Aws::S3Crt::Model::PutBucketPolicyRequest policyReq;
-  policyReq.SetBucket(bucketName);
-  policyReq.SetBody(std::make_shared<Aws::StringStream>(policy));
-
-  auto policyResponse = client.PutBucketPolicy(policyReq);
-  if (!policyResponse.IsSuccess()) {
-    auto error = policyResponse.GetError();
-    throw std::runtime_error(error.GetMessage());
-  }
 }
-
 } // namespace
 
 namespace cudaq {


### PR DESCRIPTION
S3 buckets block public access by default, making the `put_public_access_block` call redundant. The bucket policy granting Braket service access is not required for the service to function, so the `put_bucket_policy` call is also removed.

See https://github.com/amazon-braket/amazon-braket-sdk-python/pull/1234