### PR TITLE
Adding uccsd_wf_ansatz notebook to long running notebooks group

### DIFF
--- a/docs/notebook_validation.py
+++ b/docs/notebook_validation.py
@@ -60,6 +60,7 @@ LONG_RUNNING_NOTEBOOKS = [
     "unitary_compilation_diffusion_models.ipynb",
     "qm_mm_pe.ipynb",
     "qsci.ipynb",
+    "uccsd_wf_ansatz.ipynb",
     "vqe_advanced.ipynb",
 ]
 


### PR DESCRIPTION
Adding uccsd_wf_ansatz notebook to long running notebooks group

Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/23753409670/job/69210489698#step:7:1189