### PR TITLE
Adding set_target and reset_target calls in dynamic tests

### DIFF
--- a/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
+++ b/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
@@ -11,13 +11,12 @@ import os
 
 torch = pytest.importorskip("torch")
 
-# Note: the test model may create state, hence need to set the target to "dynamics"
-cudaq.set_target("dynamics")
-
 if cudaq.num_available_gpus() == 0:
     pytest.skip("Skipping GPU tests", allow_module_level=True)
 else:
+    cudaq.set_target("dynamics")
     from system_models import *
+    cudaq.reset_target()
 
 
 @pytest.fixture(autouse=True)

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -15,6 +15,7 @@ else:
     # Note: the test model may create state, hence need to set the target to "dynamics"
     cudaq.set_target("dynamics")
     from system_models import *
+    cudaq.reset_target()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Seems like the workers inherit the active dynamics target in the failing tests below. As we don't have any reset mechanism in the tests it just used the one used in the test before.

Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/23778592009/job/69290539828#step:7:52661

Fixes #4226 