### PR TITLE
Factory only dependency of JitEngine on cudaq-mlir-runtime

### DIFF
--- a/include/cudaq/Optimizer/Builder/Runtime.h
+++ b/include/cudaq/Optimizer/Builder/Runtime.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "cudaq/Optimizer/Builder/Factory.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 
 //===----------------------------------------------------------------------===//
 //
@@ -21,77 +22,6 @@
 //===----------------------------------------------------------------------===//
 
 namespace cudaq::runtime {
-
-/// Prefix for all kernel entry functions.
-static constexpr const char cudaqGenPrefixName[] = "__nvqpp__mlirgen__";
-
-/// Convenience constant for the length of the kernel entry prefix.
-static constexpr unsigned cudaqGenPrefixLength = sizeof(cudaqGenPrefixName) - 1;
-
-/// Name of the callback into the runtime.
-/// A kernel entry procedure can either be replaced with a new function at
-/// compile time (see `cudaqGenPrefixName`) or it can be rewritten to call back
-/// to the runtime library (and be handled at runtime).
-static constexpr const char launchKernelFuncName[] = "altLaunchKernel";
-static constexpr const char launchKernelStreamlinedFuncName[] =
-    "streamlinedLaunchKernel";
-static constexpr const char launchKernelHybridFuncName[] = "hybridLaunchKernel";
-
-static constexpr const char mangledNameMap[] = "quake.mangled_name_map";
-
-static constexpr const char deviceCodeHolderAdd[] =
-    "__cudaq_deviceCodeHolderAdd";
-
-static constexpr const char registerLinkableKernel[] =
-    "__cudaq_registerLinkableKernel";
-static constexpr const char registerRunnableKernel[] =
-    "__cudaq_registerRunnableKernel";
-static constexpr const char getLinkableKernelKey[] =
-    "__cudaq_getLinkableKernelKey";
-static constexpr const char getLinkableKernelName[] =
-    "__cudaq_getLinkableKernelName";
-static constexpr const char getLinkableKernelDeviceSide[] =
-    "__cudaq_getLinkableKernelDeviceFunction";
-
-static constexpr const char CudaqRegisterLambdaName[] =
-    "cudaqRegisterLambdaName";
-static constexpr const char CudaqRegisterArgsCreator[] =
-    "cudaqRegisterArgsCreator";
-static constexpr const char CudaqRegisterKernelName[] =
-    "cudaqRegisterKernelName";
-static constexpr const char CudaqRegisterCallbackName[] =
-    "cudaqRegisterCallbackName";
-
-/// Prefix for an analog kernel entry functions.
-static constexpr const char cudaqAHKPrefixName[] =
-    "__analog_hamiltonian_kernel__";
-
-// Host-side helper functions for working with `cudaq::pauli_word` or a
-// `std::string`. These include both fully dynamic and binding time (library
-// build time) helper functions.
-static constexpr const char sizeofStringAttrName[] = "cc.sizeof_string";
-static constexpr const char getPauliWordSize[] =
-    "_ZNK5cudaq10pauli_word11_nvqpp_sizeEv";
-static constexpr const char getPauliWordData[] =
-    "_ZNK5cudaq10pauli_word11_nvqpp_dataEv";
-static constexpr const char bindingGetStringData[] = "__nvqpp_getStringData";
-static constexpr const char bindingGetStringSize[] = "__nvqpp_getStringSize";
-static constexpr const char bindingInitializeString[] =
-    "__nvqpp_initializeStringFromSpan";
-static constexpr const char bindingDeconstructString[] =
-    "__nvqpp_deconstructString";
-static constexpr const char enableCudaqRun[] = "quake.cudaq_run";
-
-// Runtime layer of a `device_call` application.
-static constexpr const char callDeviceCallback[] =
-    "__nvqpp__device_callback_run";
-static constexpr const char extractDevPtr[] =
-    "__nvqpp__device_extract_device_ptr";
-
-// Garbage collection for arrays created during kernel execution.
-static constexpr const char cleanupArrays[] = "__nvqpp_cleanup_arrays";
-
-static constexpr const char pythonUniqueAttrName[] = "cc.python_uniqued";
 
 /// Get the return type of a kernel FuncOp. Returns a null Type if the kernel
 /// returns void or has more than one result (unsupported).

--- a/include/cudaq/Optimizer/Builder/RuntimeNames.h
+++ b/include/cudaq/Optimizer/Builder/RuntimeNames.h
@@ -1,0 +1,83 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+namespace cudaq::runtime {
+
+/// Prefix for all kernel entry functions.
+static constexpr const char cudaqGenPrefixName[] = "__nvqpp__mlirgen__";
+
+/// Convenience constant for the length of the kernel entry prefix.
+static constexpr unsigned cudaqGenPrefixLength = sizeof(cudaqGenPrefixName) - 1;
+
+/// Name of the callback into the runtime.
+/// A kernel entry procedure can either be replaced with a new function at
+/// compile time (see `cudaqGenPrefixName`) or it can be rewritten to call back
+/// to the runtime library (and be handled at runtime).
+static constexpr const char launchKernelFuncName[] = "altLaunchKernel";
+static constexpr const char launchKernelStreamlinedFuncName[] =
+    "streamlinedLaunchKernel";
+static constexpr const char launchKernelHybridFuncName[] = "hybridLaunchKernel";
+
+static constexpr const char mangledNameMap[] = "quake.mangled_name_map";
+
+static constexpr const char deviceCodeHolderAdd[] =
+    "__cudaq_deviceCodeHolderAdd";
+
+static constexpr const char registerLinkableKernel[] =
+    "__cudaq_registerLinkableKernel";
+static constexpr const char registerRunnableKernel[] =
+    "__cudaq_registerRunnableKernel";
+static constexpr const char getLinkableKernelKey[] =
+    "__cudaq_getLinkableKernelKey";
+static constexpr const char getLinkableKernelName[] =
+    "__cudaq_getLinkableKernelName";
+static constexpr const char getLinkableKernelDeviceSide[] =
+    "__cudaq_getLinkableKernelDeviceFunction";
+
+static constexpr const char CudaqRegisterLambdaName[] =
+    "cudaqRegisterLambdaName";
+static constexpr const char CudaqRegisterArgsCreator[] =
+    "cudaqRegisterArgsCreator";
+static constexpr const char CudaqRegisterKernelName[] =
+    "cudaqRegisterKernelName";
+static constexpr const char CudaqRegisterCallbackName[] =
+    "cudaqRegisterCallbackName";
+
+/// Prefix for an analog kernel entry functions.
+static constexpr const char cudaqAHKPrefixName[] =
+    "__analog_hamiltonian_kernel__";
+
+// Host-side helper functions for working with `cudaq::pauli_word` or a
+// `std::string`. These include both fully dynamic and binding time (library
+// build time) helper functions.
+static constexpr const char sizeofStringAttrName[] = "cc.sizeof_string";
+static constexpr const char getPauliWordSize[] =
+    "_ZNK5cudaq10pauli_word11_nvqpp_sizeEv";
+static constexpr const char getPauliWordData[] =
+    "_ZNK5cudaq10pauli_word11_nvqpp_dataEv";
+static constexpr const char bindingGetStringData[] = "__nvqpp_getStringData";
+static constexpr const char bindingGetStringSize[] = "__nvqpp_getStringSize";
+static constexpr const char bindingInitializeString[] =
+    "__nvqpp_initializeStringFromSpan";
+static constexpr const char bindingDeconstructString[] =
+    "__nvqpp_deconstructString";
+static constexpr const char enableCudaqRun[] = "quake.cudaq_run";
+
+// Runtime layer of a `device_call` application.
+static constexpr const char callDeviceCallback[] =
+    "__nvqpp__device_callback_run";
+static constexpr const char extractDevPtr[] =
+    "__nvqpp__device_extract_device_ptr";
+
+// Garbage collection for arrays created during kernel execution.
+static constexpr const char cleanupArrays[] = "__nvqpp_cleanup_arrays";
+
+static constexpr const char pythonUniqueAttrName[] = "cc.python_uniqued";
+
+} // namespace cudaq::runtime

--- a/python/runtime/cudaq/platform/JITExecutionCache.cpp
+++ b/python/runtime/cudaq/platform/JITExecutionCache.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 #include "JITExecutionCache.h"
 
-using namespace cudaq_internal::compiler;
 using namespace mlir;
 
 namespace cudaq {

--- a/python/runtime/cudaq/platform/JITExecutionCache.h
+++ b/python/runtime/cudaq/platform/JITExecutionCache.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "cudaq_internal/compiler/JIT.h"
+#include "common/CompiledKernel.h"
 #include <list>
 #include <mutex>
 #include <unordered_map>
@@ -27,7 +27,7 @@ protected:
   // the execution engine and to the LRU iterator that is used to track which
   // engine is the least recently used.
   struct MapItemType {
-    cudaq_internal::compiler::JitEngine execEngine;
+    cudaq::JitEngine execEngine;
     std::list<std::size_t>::iterator lruListIt;
   };
   std::unordered_map<std::size_t, MapItemType> cacheMap;
@@ -38,10 +38,10 @@ public:
   JITExecutionCache() = default;
   ~JITExecutionCache();
 
-  void cache(std::size_t hash, cudaq_internal::compiler::JitEngine);
+  void cache(std::size_t hash, cudaq::JitEngine);
   bool hasJITEngine(std::size_t hash);
   void deleteJITEngine(std::size_t hash);
-  cudaq_internal::compiler::JitEngine getJITEngine(std::size_t hash);
+  cudaq::JitEngine getJITEngine(std::size_t hash);
   static JITExecutionCache &getJITCache();
 };
 } // namespace cudaq

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -48,6 +48,7 @@
 namespace py = pybind11;
 using namespace mlir;
 using namespace cudaq_internal::compiler;
+using cudaq::JitEngine;
 
 static std::function<std::string()> getTransportLayer = []() -> std::string {
   throw std::runtime_error("binding for kernel launch is incomplete");

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -296,11 +296,10 @@ public:
     return {};
   }
 
-  void *specializeModule(
-      const std::string &kernelName, mlir::ModuleOp module,
-      const std::vector<void *> &rawArgs,
-      std::optional<cudaq_internal::compiler::JitEngine> &cachedEngine,
-      bool isEntryPoint) override {
+  void *specializeModule(const std::string &kernelName, mlir::ModuleOp module,
+                         const std::vector<void *> &rawArgs,
+                         std::optional<cudaq::JitEngine> &cachedEngine,
+                         bool isEntryPoint) override {
     CUDAQ_INFO("specializing remote rest kernel via module ({})", kernelName);
     throw std::runtime_error(
         "NYI: Remote rest execution via Python/C++ interop.");

--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -143,11 +143,10 @@ public:
     return launchKernelImpl(name, nullptr, nullptr, 0, 0, &rawArgs, module);
   }
 
-  void *specializeModule(
-      const std::string &kernelName, mlir::ModuleOp module,
-      const std::vector<void *> &rawArgs,
-      std::optional<cudaq_internal::compiler::JitEngine> &cachedEngine,
-      bool isEntryPoint) override {
+  void *specializeModule(const std::string &kernelName, mlir::ModuleOp module,
+                         const std::vector<void *> &rawArgs,
+                         std::optional<cudaq::JitEngine> &cachedEngine,
+                         bool isEntryPoint) override {
     CUDAQ_INFO("specializing remote simulator kernel via module ({})",
                kernelName);
     throw std::runtime_error(
@@ -190,8 +189,8 @@ public:
                                      0, rawArgs);
       }();
 
-      auto jit = cudaq_internal::compiler::createQIRJITEngine(moduleOp,
-                                                              "qir-adaptive");
+      auto jit =
+          cudaq_internal::compiler::createJITEngine(moduleOp, "qir-adaptive");
 
       ExecutionContext ctx(executionContextPtr->name,
                            executionContextPtr->shots,

--- a/runtime/common/CompiledKernel.cpp
+++ b/runtime/common/CompiledKernel.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "CompiledKernel.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include <memory>
 #include <stdexcept>
 
@@ -68,4 +69,22 @@ void (*cudaq::CompiledKernel::getEntryPoint() const)() {
   return getJit().entryPoint;
 }
 
-JitEngine cudaq::CompiledKernel::getEngine() const { return getJit().engine; }
+cudaq::JitEngine cudaq::CompiledKernel::getEngine() const {
+  return getJit().engine;
+}
+
+void cudaq::CompiledKernel::attachJit(JitEngine engine,
+                                      bool isFullySpecialized) {
+  bool hasResult = resultInfo.hasResult();
+  std::string fullName = cudaq::runtime::cudaqGenPrefixName + name;
+  std::string entryName =
+      (hasResult || !isFullySpecialized) ? name + ".thunk" : fullName;
+  void (*entryPoint)() = engine.lookupRawNameOrFail(entryName);
+  int64_t (*argsCreator)(const void *, void **) = nullptr;
+  if (!isFullySpecialized)
+    argsCreator = reinterpret_cast<int64_t (*)(const void *, void **)>(
+        engine.lookupRawNameOrFail(name + ".argsCreator"));
+
+  jitRepr = cudaq::CompiledKernel::JitRepr{std::move(engine), entryPoint,
+                                           argsCreator};
+}

--- a/runtime/common/CompiledKernel.h
+++ b/runtime/common/CompiledKernel.h
@@ -8,7 +8,10 @@
 #pragma once
 
 #include "common/ThunkInterface.h"
-#include "cudaq_internal/compiler/JIT.h"
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -23,9 +26,48 @@
 namespace mlir {
 class Type;
 class ModuleOp;
+class ExecutionEngine;
 } // namespace mlir
 
 namespace cudaq {
+class ResultInfo;
+} // namespace cudaq
+
+namespace cudaq_internal::compiler {
+cudaq::ResultInfo createResultInfo(mlir::Type resultType, bool isEntryPoint,
+                                   mlir::ModuleOp module);
+} // namespace cudaq_internal::compiler
+
+namespace cudaq {
+
+/// JitEngine is a type-erased class that is wrapping an mlir::ExecutionEngine
+/// without introducing any link time dependency on MLIR for the client of the
+/// class. Memory management for of the mlir::ExecutionEngine is handled
+/// internally.
+class JitEngine {
+  using RawFnPtr = void (*)();
+  using LookupFn = std::function<RawFnPtr(const std::string &)>;
+
+  struct Base {
+    LookupFn lookupFn;
+    std::function<void(const std::string &)> runFn;
+  };
+
+public:
+  JitEngine(std::unique_ptr<mlir::ExecutionEngine>);
+
+  void run(const std::string &kernelName) const { impl->runFn(kernelName); }
+
+  void (*lookupRawNameOrFail(const std::string &kernelName) const)() {
+    return impl->lookupFn(kernelName);
+  }
+
+  std::size_t getKey() const;
+
+private:
+  class Impl;
+  std::shared_ptr<Base> impl;
+};
 
 /// Pre-computed result metadata, set at build time. Used at execution time
 /// for result buffer allocation and type conversion. Construct via
@@ -65,8 +107,6 @@ public:
 /// after construction.
 class CompiledKernel {
 public:
-  using JitEngine = cudaq_internal::compiler::JitEngine;
-
   // --- Construction ---
 
   CompiledKernel(std::string kernelName, ResultInfo resultInfo);
@@ -110,12 +150,14 @@ public:
   void (*getEntryPoint() const)();
   JitEngine getEngine() const;
 
-private:
-  // Friend functions to attach compiled representations after construction.
-  friend void cudaq_internal::compiler::attachJit(CompiledKernel &ck,
-                                                  JitEngine engine,
-                                                  bool isFullySpecialized);
+  /// @brief Populate the JIT representation of a `CompiledKernel`.
+  ///
+  /// Resolves the entry point and (optionally) `argsCreator` symbols from the
+  /// engine, using the kernel's name and result metadata to determine the
+  /// correct mangled symbol names.
+  void attachJit(JitEngine engine, bool isFullySpecialized);
 
+private:
   // --- Compiled representation formats ---
 
   /// JIT-compiled representation of a kernel, used for local execution.

--- a/runtime/common/ExecutionContext.cpp
+++ b/runtime/common/ExecutionContext.cpp
@@ -11,8 +11,6 @@
 #include <cstring>
 #include <string>
 
-using namespace cudaq_internal::compiler;
-
 namespace nvqir {
 bool isUsingResourceCounterSimulator();
 } // namespace nvqir

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -8,13 +8,13 @@
 
 #pragma once
 
+#include "CompiledKernel.h"
 #include "Future.h"
 #include "NoiseModel.h"
 #include "SampleResult.h"
 #include "Trace.h"
 #include "cudaq/algorithms/optimizer.h"
 #include "cudaq/operators.h"
-#include "cudaq_internal/compiler/JIT.h"
 #include <optional>
 #include <string_view>
 
@@ -166,7 +166,7 @@ public:
 
   /// @brief For performance, a launcher may cache the JIT execution engine and
   /// use it for multiple discrete calls.
-  std::optional<cudaq_internal::compiler::JitEngine> jitEng = std::nullopt;
+  std::optional<cudaq::JitEngine> jitEng = std::nullopt;
 
   /// @endcond
 };
@@ -224,11 +224,11 @@ bool isPersistingJITEngine();
 /// `argsCreatorPtr` must point to the `.argsCreator` function from `jit`
 void checkArtifactReuse(const std::string kernelName,
                         const std::vector<void *> &args,
-                        const cudaq_internal::compiler::JitEngine jit,
+                        const cudaq::JitEngine jit,
                         std::function<void *()> argsCreatorThunk);
 
 void saveArtifact(const std::string kernelName, const std::vector<void *> &args,
-                  const cudaq_internal::compiler::JitEngine jit,
+                  const cudaq::JitEngine jit,
                   std::function<void *()> argsCreatorThunk);
 }; // namespace compiler_artifact
 } // namespace cudaq

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "CompiledKernel.h"
 #include "ExecutionContext.h"
 #include "Future.h"
 #include "Registry.h"
@@ -15,7 +16,6 @@
 #include "RuntimeTarget.h"
 #include "SampleResult.h"
 #include "common/RecordLogParser.h"
-#include "cudaq_internal/compiler/JIT.h"
 #include "nlohmann/json.hpp"
 #include <filesystem>
 
@@ -31,19 +31,19 @@ using BackendConfig = std::map<std::string, std::string>;
 struct KernelExecution {
   std::string name;
   std::string code;
-  std::optional<cudaq_internal::compiler::JitEngine> jit;
+  std::optional<cudaq::JitEngine> jit;
   std::optional<Resources> resourceCounts;
   nlohmann::json output_names;
   std::vector<std::size_t> mapping_reorder_idx;
   nlohmann::json user_data;
   KernelExecution(std::string &n, std::string &c,
-                  std::optional<cudaq_internal::compiler::JitEngine> jit,
+                  std::optional<cudaq::JitEngine> jit,
                   std::optional<Resources> rc, nlohmann::json &o,
                   std::vector<std::size_t> &m)
       : name(n), code(c), jit(jit), resourceCounts(rc), output_names(o),
         mapping_reorder_idx(m) {}
   KernelExecution(std::string &n, std::string &c,
-                  std::optional<cudaq_internal::compiler::JitEngine> jit,
+                  std::optional<cudaq::JitEngine> jit,
                   std::optional<Resources> rc, nlohmann::json &o,
                   std::vector<std::size_t> &m, nlohmann::json &ud)
       : name(n), code(c), jit(jit), resourceCounts(rc), output_names(o),

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -30,6 +30,7 @@
 
 using namespace mlir;
 using namespace cudaq_internal::compiler;
+using cudaq::JitEngine;
 
 static void
 specializeKernel(const std::string &name, ModuleOp module,
@@ -265,7 +266,7 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
 
     if (auto jit = alreadyBuiltJITCode(name, rawArgs)) {
       cudaq::CompiledKernel ck(name, resultInfo);
-      attachJit(ck, *jit, isFullySpecialized);
+      ck.attachJit(*jit, isFullySpecialized);
       return ck;
     }
 
@@ -292,7 +293,7 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
                      isEntryPoint, varArgIndices);
 
     // 4. Lower to QIR and JIT compile.
-    auto jit = createQIRJITEngine(module, "qir:");
+    auto jit = createJITEngine(module, "qir:");
     cacheJITForPerformance(jit);
     auto argsCreatorThunk = [&jit, &name]() {
       return (void *)jit.lookupRawNameOrFail(name + ".argsCreator");
@@ -301,7 +302,7 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
                                            argsCreatorThunk);
 
     cudaq::CompiledKernel ck(name, resultInfo);
-    attachJit(ck, jit, isFullySpecialized);
+    ck.attachJit(jit, isFullySpecialized);
     return ck;
   }
 };

--- a/runtime/cudaq/platform/nvqpp_interface.h
+++ b/runtime/cudaq/platform/nvqpp_interface.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
+#include "common/CompiledKernel.h"
 #include "common/ThunkInterface.h"
-#include "cudaq_internal/compiler/JIT.h"
 #include <optional>
 #include <string>
 #include <vector>
@@ -71,7 +71,6 @@ streamlinedLaunchModule(const std::string &kernelName, mlir::ModuleOp moduleOp,
 [[nodiscard]] void *streamlinedSpecializeModule(
     const std::string &kernelName, mlir::ModuleOp moduleOp,
     const std::vector<void *> &rawArgs,
-    std::optional<cudaq_internal::compiler::JitEngine> &cachedEngine,
-    bool isEntryPoint);
+    std::optional<cudaq::JitEngine> &cachedEngine, bool isEntryPoint);
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -197,11 +197,11 @@ public:
   launchModule(const std::string &name, mlir::ModuleOp module,
                const std::vector<void *> &rawArgs);
 
-  [[nodiscard]] virtual void *specializeModule(
-      const std::string &name, mlir::ModuleOp module,
-      const std::vector<void *> &rawArgs,
-      std::optional<cudaq_internal::compiler::JitEngine> &cachedEngine,
-      bool isEntryPoint);
+  [[nodiscard]] virtual void *
+  specializeModule(const std::string &name, mlir::ModuleOp module,
+                   const std::vector<void *> &rawArgs,
+                   std::optional<cudaq::JitEngine> &cachedEngine,
+                   bool isEntryPoint);
 
   /// @brief Notify the QPU that a new random seed value is set.
   /// By default do nothing, let subclasses override.

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -207,11 +207,11 @@ public:
   launchModule(const std::string &kernelName, mlir::ModuleOp module,
                const std::vector<void *> &rawArgs, std::size_t qpu_id);
 
-  [[nodiscard]] void *specializeModule(
-      const std::string &kernelName, mlir::ModuleOp module,
-      const std::vector<void *> &rawArgs,
-      std::optional<cudaq_internal::compiler::JitEngine> &cachedEngine,
-      std::size_t qpu_id, bool isEntryPoint);
+  [[nodiscard]] void *
+  specializeModule(const std::string &kernelName, mlir::ModuleOp module,
+                   const std::vector<void *> &rawArgs,
+                   std::optional<cudaq::JitEngine> &cachedEngine,
+                   std::size_t qpu_id, bool isEntryPoint);
 
   /// List all available platforms
   static std::vector<std::string> list_platforms();

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -22,6 +22,7 @@
 #include "cudaq/Support/TargetConfig.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq_internal/compiler/ArgumentConversion.h"
+#include "cudaq_internal/compiler/JIT.h"
 #include "cudaq_internal/compiler/RuntimeMLIR.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/Bitcode/BitcodeReader.h"
@@ -485,7 +486,7 @@ std::vector<cudaq::KernelExecution> Compiler::lowerQuakeCodePart2(
     for (auto &[name, module] : modules) {
       auto clonedModule = module.clone();
       jitEngines.emplace_back(
-          createQIRJITEngine(clonedModule, codegenTranslation));
+          createJITEngine(clonedModule, codegenTranslation));
     }
   }
 

--- a/runtime/internal/compiler/JIT.cpp
+++ b/runtime/internal/compiler/JIT.cpp
@@ -50,6 +50,7 @@
 
 using namespace mlir;
 using namespace cudaq_internal::compiler;
+using cudaq::JitEngine;
 
 std::tuple<std::unique_ptr<llvm::orc::LLJIT>, std::function<void()>>
 cudaq_internal::compiler::createWrappedKernel(std::string_view irString,
@@ -241,12 +242,12 @@ void insertSetupAndCleanupOperations(Operation *module) {
 }
 } // namespace
 
-JitEngine
-cudaq_internal::compiler::createQIRJITEngine(ModuleOp &moduleOp,
-                                             llvm::StringRef convertTo) {
+cudaq::JitEngine
+cudaq_internal::compiler::createJITEngine(ModuleOp &moduleOp,
+                                          llvm::StringRef convertTo) {
   // The "fast" instruction selection compilation algorithm is actually very
   // slow for large quantum circuits. Disable that here.
-  ScopedTraceWithContext(cudaq::TIMING_JIT, "createQIRJITEngine");
+  ScopedTraceWithContext(cudaq::TIMING_JIT, "createJITEngine");
   const char *argv[] = {"", "-fast-isel=0", nullptr};
   llvm::cl::ParseCommandLineOptions(2, argv);
 
@@ -258,7 +259,7 @@ cudaq_internal::compiler::createQIRJITEngine(ModuleOp &moduleOp,
           Operation *module,
           llvm::LLVMContext &llvmContext) -> std::unique_ptr<llvm::Module> {
     ScopedTraceWithContext(cudaq::TIMING_JIT,
-                           "createQIRJITEngine::llvmModuleBuilder");
+                           "createJITEngine::llvmModuleBuilder");
     llvmContext.setOpaquePointers(false);
 
     auto *context = module->getContext();
@@ -306,14 +307,14 @@ cudaq_internal::compiler::createQIRJITEngine(ModuleOp &moduleOp,
     pm.enableTiming(timingScope);         // do this right before pm.run
     if (failed(pm.run(module))) {
       engine.eraseHandler(handlerId);
-      throw std::runtime_error("[createQIRJITEngine] Lowering to QIR for "
+      throw std::runtime_error("[createJITEngine] Lowering to QIR for "
                                "remote emulation failed.\n" +
                                error_msg);
     }
     if (auto mod = dyn_cast<ModuleOp>(module))
       if (failed(cudaq::verifier::checkQIRLLVMIRDialect(mod, profileName)))
         throw std::runtime_error(
-            "[createQIRJITEngine] QIR verification failed.\n");
+            "[createJITEngine] QIR verification failed.\n");
 
     timingScope.stop();
     engine.eraseHandler(handlerId);
@@ -325,8 +326,7 @@ cudaq_internal::compiler::createQIRJITEngine(ModuleOp &moduleOp,
 
     auto llvmModule = translateModuleToLLVMIR(module, llvmContext);
     if (!llvmModule)
-      throw std::runtime_error(
-          "[createQIRJITEngine] Lowering to LLVM IR failed.");
+      throw std::runtime_error("[createJITEngine] Lowering to LLVM IR failed.");
 
     ExecutionEngine::setupTargetTriple(llvmModule.get());
     return llvmModule;
@@ -335,24 +335,6 @@ cudaq_internal::compiler::createQIRJITEngine(ModuleOp &moduleOp,
   auto jitOrError = ExecutionEngine::create(moduleOp, opts);
   assert(!!jitOrError && "ExecutionEngine creation failed.");
   return JitEngine(std::move(jitOrError.get()));
-}
-
-void cudaq_internal::compiler::attachJit(cudaq::CompiledKernel &ck,
-                                         JitEngine engine,
-                                         bool isFullySpecialized) {
-  const auto &name = ck.name;
-  bool hasResult = ck.resultInfo.hasResult();
-  std::string fullName = cudaq::runtime::cudaqGenPrefixName + name;
-  std::string entryName =
-      (hasResult || !isFullySpecialized) ? name + ".thunk" : fullName;
-  void (*entryPoint)() = engine.lookupRawNameOrFail(entryName);
-  int64_t (*argsCreator)(const void *, void **) = nullptr;
-  if (!isFullySpecialized)
-    argsCreator = reinterpret_cast<int64_t (*)(const void *, void **)>(
-        engine.lookupRawNameOrFail(name + ".argsCreator"));
-
-  ck.jitRepr = cudaq::CompiledKernel::JitRepr{std::move(engine), entryPoint,
-                                              argsCreator};
 }
 
 /// Build a `ResultInfo` from an MLIR return type.
@@ -372,7 +354,7 @@ cudaq::ResultInfo cudaq_internal::compiler::createResultInfo(Type resultTy,
   return info;
 }
 
-class JitEngine::Impl : public JitEngine::Base {
+class cudaq::JitEngine::Impl : public cudaq::JitEngine::Base {
 public:
   Impl(std::unique_ptr<ExecutionEngine> jitEngine)
       : jitEngine(std::move(jitEngine)) {
@@ -397,9 +379,9 @@ private:
   std::unique_ptr<ExecutionEngine> jitEngine;
 };
 
-JitEngine::JitEngine(std::unique_ptr<ExecutionEngine> jitEngine)
+cudaq::JitEngine::JitEngine(std::unique_ptr<ExecutionEngine> jitEngine)
     : impl(std::make_shared<JitEngine::Impl>(std::move(jitEngine))) {}
 
-std::size_t JitEngine::getKey() const {
+std::size_t cudaq::JitEngine::getKey() const {
   return static_cast<const Impl *>(impl.get())->getKey();
 }

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -7,7 +7,7 @@
  ******************************************************************************/
 #pragma once
 
-#include "cudaq_internal/compiler/JIT.h"
+#include "common/CompiledKernel.h"
 #include <map>
 #include <memory>
 #include <string>
@@ -64,7 +64,7 @@ class Compiler {
 
   /// @brief If we are emulating locally, keep track
   /// of JIT engines for invoking the kernels.
-  std::vector<JitEngine> jitEngines;
+  std::vector<cudaq::JitEngine> jitEngines;
 
   /// @brief Flag indicating whether we should emulate execution locally.
   bool emulate = false;

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/JIT.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/JIT.h
@@ -7,7 +7,7 @@
  ******************************************************************************/
 #pragma once
 
-#include <cstddef>
+#include "common/CompiledKernel.h"
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -22,7 +22,6 @@ class LLJIT;
 } // namespace llvm
 
 namespace mlir {
-class ExecutionEngine;
 class ModuleOp;
 class Type;
 } // namespace mlir
@@ -43,46 +42,9 @@ std::tuple<std::unique_ptr<llvm::orc::LLJIT>, std::function<void()>>
 createWrappedKernel(std::string_view llvmIr, const std::string &kernelName,
                     void *args, std::uint64_t argsSize);
 
-/// JitEngine is a type-erased class that is wrapping an mlir::ExecutionEngine
-/// without introducing any link time dependency on MLIR for the client of the
-/// class. Memory management for of the mlir::ExecutionEngine is handled
-/// internally.
-class JitEngine {
-  using RawFnPtr = void (*)();
-  using LookupFn = std::function<RawFnPtr(const std::string &)>;
-
-  struct Base {
-    LookupFn lookupFn;
-    std::function<void(const std::string &)> runFn;
-  };
-
-public:
-  JitEngine(std::unique_ptr<mlir::ExecutionEngine>);
-
-  void run(const std::string &kernelName) const { impl->runFn(kernelName); }
-
-  void (*lookupRawNameOrFail(const std::string &kernelName) const)() {
-    return impl->lookupFn(kernelName);
-  }
-
-  std::size_t getKey() const;
-
-private:
-  class Impl;
-  std::shared_ptr<Base> impl;
-};
-
 /// Lower ModuleOp to QIR/LLVM IR and create a JIT execution engine.
-JitEngine createQIRJITEngine(mlir::ModuleOp &moduleOp,
-                             llvm::StringRef convertTo);
-
-/// @brief Populate the JIT representation of a `CompiledKernel`.
-///
-/// Resolves the entry point and (optionally) `argsCreator` symbols from the
-/// engine, using the kernel's name and result metadata to determine the
-/// correct mangled symbol names.
-void attachJit(cudaq::CompiledKernel &ck, JitEngine engine,
-               bool isFullySpecialized);
+cudaq::JitEngine createJITEngine(mlir::ModuleOp &moduleOp,
+                                 llvm::StringRef convertTo);
 
 /// @brief Create a `ResultInfo` from MLIR type and module.
 ///


### PR DESCRIPTION
Apologies to the extra people that where added to the review. I think I had a dirty branch with many more changed files.

With this [move](https://github.com/NVIDIA/cuda-quantum/pull/4233), we needed to introduce `cudaq-mlir-runtime-headers`. The `cudaq-common` library has a dependency on these headers. This is because the `ExecutionContext` is including the `JITEngine` and almost every file includes the `ExecutionContext`.

This defeats the purpose of reducing the [visibility of module headers](https://github.com/NVIDIA/cuda-quantum/pull/4188) since it forces every part of the runtime to include them. 

This PR addresses this issue by implementing the methods of the `JitEngine` as closures that are defined on the factory side (cudaq-mlir-runtime). This allows us to move the `JitEngine` in a lower level header (`CompiledKernel.h) since any calls from it have no link-time dependency with `cudaq-mlir-runtime`. 