### PR TITLE
Fix CMake dependence issue for `scaleway` target

### DIFF
--- a/runtime/cudaq/platform/default/rest/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/rest/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(cudaq-rest-qpu
     cudaq
     cudaq-platform-default
     nvqir
+    ZLIB::ZLIB
     ${AWSSDK_LINK_LIBRARIES})
 
 install(TARGETS cudaq-rest-qpu DESTINATION lib)

--- a/runtime/cudaq/platform/default/rest/helpers/scaleway/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/rest/helpers/scaleway/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(cudaq-serverhelper-scaleway
     cudaq-logger
   PRIVATE
     LLVMSupport
+    ZLIB::ZLIB
 )
 
 install(TARGETS cudaq-serverhelper-scaleway DESTINATION lib)


### PR DESCRIPTION
* This PR fixes the existing bug that was exposed by changes in https://github.com/NVIDIA/cuda-quantum/pull/4238
* Recently we moved `MLIRIR` from `PUBLIC` to `PRIVATE` in the `cudaq` target to avoid leaking MLIR IR dependencies to consumers.
* As a result, `zlib` stopped propagating to `cudaq-rest-qpu` (which is the expected correct behavior)
