### PR TITLE
[CI] Fix sporadic dynamics target leak in parallel test execution

### DIFF
--- a/python/tests/dynamics/conftest.py
+++ b/python/tests/dynamics/conftest.py
@@ -1,0 +1,23 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""
+Safety-net fixture: guarantee target reset after every dynamics test so that
+a failed teardown in a per-test fixture cannot leak the dynamics target to
+other tests on the same pytest-xdist worker.
+"""
+import pytest
+import cudaq
+
+
+@pytest.fixture(autouse=True)
+def ensure_target_reset():
+    yield
+    try:
+        cudaq.reset_target()
+    except Exception:
+        pass

--- a/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
+++ b/python/tests/dynamics/integrators/test_evolve_dynamics_torch_integrators.py
@@ -15,8 +15,10 @@ if cudaq.num_available_gpus() == 0:
     pytest.skip("Skipping GPU tests", allow_module_level=True)
 else:
     cudaq.set_target("dynamics")
-    from system_models import *
-    cudaq.reset_target()
+    try:
+        from system_models import *
+    finally:
+        cudaq.reset_target()
 
 
 @pytest.fixture(autouse=True)

--- a/python/tests/dynamics/test_evolve_dynamics.py
+++ b/python/tests/dynamics/test_evolve_dynamics.py
@@ -14,8 +14,10 @@ if cudaq.num_available_gpus() == 0:
 else:
     # Note: the test model may create state, hence need to set the target to "dynamics"
     cudaq.set_target("dynamics")
-    from system_models import *
-    cudaq.reset_target()
+    try:
+        from system_models import *
+    finally:
+        cudaq.reset_target()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
 Fixes #4248. The publishing CI runs pytest -n auto (pytest-xdist), which distributes individual test functions across worker processes. When a dynamics test and a non-dynamics test land on the same worker, the dynamics target can leak if cleanup fails, causing subsequent tests to fail with:

```
Silencing runtime error: [dynamics target] Execution context 'sample' is not supported.
```
Two failure modes cause the leak:

  1. Module-level import crash: test_evolve_dynamics.py calls set_target("dynamics") then from system_models import * then reset_target() at module scope. If the import fails (e.g., missing
   cupy), reset_target() never runs because there is no try/finally.
  2. Fixture teardown failure: The per-test set_up_target fixture calls reset_target() after yield. If the GPU is in a bad state after a failed test, reset_target() can throw, leaking the
  dynamics target to the next test on that worker.

  Changes

  - Wrap module-level imports in try/finally in test_evolve_dynamics.py and test_evolve_dynamics_torch_integrators.py so reset_target() always runs even if the import fails.
  - Add dynamics/conftest.py with a safety-net autouse fixture that calls reset_target() after every dynamics test (swallowing exceptions to prevent cascade failures). Follows the existing pattern in ptsbe/conftest.py.

  Test plan

  - All 50 test_evolve_dynamics.py tests pass
  - All 7 test_evolve_simulators.py tests pass
  - Full parallel suite (pytest -v -n auto python/tests/ --ignore .../backends --ignore .../dynamics/integrators --ignore .../parallel --ignore .../domains): 1155 passed, no dynamics target leak errors
  - Verified import failure path: reset_target() runs via finally, target resets to default
  - CI publishing workflow passes