### PR TITLE
[Publishing] Adding divisive_clustering_coresets to long running notebooks

### DIFF
--- a/docs/notebook_validation.py
+++ b/docs/notebook_validation.py
@@ -56,6 +56,7 @@ GPU_REQUIRED_NOTEBOOKS = [
 
 # Notebooks for which we set a longer timeout.
 LONG_RUNNING_NOTEBOOKS = [
+    "divisive_clustering_coresets.ipynb",
     "hybrid_quantum_neural_networks.ipynb",
     "unitary_compilation_diffusion_models.ipynb",
     "qm_mm_pe.ipynb",


### PR DESCRIPTION
Adding divisive_clustering_coresets to long running notebooks

Fixes publishing failure: https://github.com/NVIDIA/cuda-quantum/actions/runs/23862162783/job/69586478750#step:5:1824
