### PR TITLE
Enabling the qpp_H2MoleculeTester tests to run unprivileged

### DIFF
--- a/python/cudaq/domains/chemistry/__init__.py
+++ b/python/cudaq/domains/chemistry/__init__.py
@@ -6,6 +6,8 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
+DATA_DIRECTORY = '.'
+
 
 def tryImport():
     """Import `openfermion` and `openfermionpyscf`."""
@@ -22,8 +24,7 @@ def create_molecular_hamiltonian(geometry: list,
                                  multiplicity=1,
                                  charge=0,
                                  n_active_electrons=None,
-                                 n_active_orbitals=None,
-                                 data_directory='.'):
+                                 n_active_orbitals=None):
     '''
     Create the molecular Hamiltonian corresponding to the provided 
     geometry, basis set, multiplicity, and charge.  One can also specify the 
@@ -48,7 +49,7 @@ def create_molecular_hamiltonian(geometry: list,
     '''
     of, ofpyscf = tryImport()
     molecule = ofpyscf.run_pyscf(of.MolecularData(
-        geometry, basis, multiplicity, charge, data_directory=data_directory),
+        geometry, basis, multiplicity, charge, data_directory=DATA_DIRECTORY),
                                  run_fci=True)
     if n_active_electrons is None:
         n_core_orbitals = 0
@@ -74,8 +75,7 @@ def __internal_cpp_create_molecular_hamiltonian(geometry: list,
                                                 multiplicity=1,
                                                 charge=0,
                                                 n_active_electrons=None,
-                                                n_active_orbitals=None,
-                                                data_directory='.'):
+                                                n_active_orbitals=None):
     '''
     Internal function meant for integration with CUDA-Q C++. 
     (Does not require `import cudaq`)
@@ -103,7 +103,7 @@ def __internal_cpp_create_molecular_hamiltonian(geometry: list,
     '''
     of, ofpyscf = tryImport()
     molecule = ofpyscf.run_pyscf(of.MolecularData(
-        geometry, basis, multiplicity, charge, data_directory=data_directory),
+        geometry, basis, multiplicity, charge, data_directory=DATA_DIRECTORY),
                                  run_fci=True)
     if n_active_electrons is None:
         n_core_orbitals = 0


### PR DESCRIPTION
I would like to be able to run these tests as an unprivileged user. If you do so, you will hit the following error:
```
C++ exception with description "PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.12/dist-packages/openfermion/testing/data/H2_sto-3g_singlet.hdf5'
```
Bu default `MolecularData` save `.hdf5` at the above location. Providing the `data_directory` argument allows for this file to be saved in the working directory.