### PR TITLE
Simplifying slightly launch interface

### DIFF
--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -98,8 +98,10 @@ public:
       auto args = argsData->getArgs();
       args.insert(args.begin(),
                   const_cast<void *>(static_cast<const void *>(&kernelMod)));
-      platform.with_execution_context(
-          context, [&]() { platform.launchKernel(kernelName, args); });
+      platform.with_execution_context(context, [&]() {
+        [[maybe_unused]] auto r =
+            platform.launchKernel(kernelName, nullptr, nullptr, 0, 0, args);
+      });
       state = std::move(context.simulationState);
     }
   }
@@ -116,8 +118,10 @@ public:
     args.insert(args.begin(),
                 const_cast<void *>(static_cast<const void *>(&kernelMod)));
 
-    platform.with_execution_context(
-        context, [&]() { platform.launchKernel(kernelName, args); });
+    platform.with_execution_context(context, [&]() {
+      [[maybe_unused]] auto r =
+          platform.launchKernel(kernelName, nullptr, nullptr, 0, 0, args);
+    });
     assert(context.overlapResult.has_value());
     return context.overlapResult.value();
   }

--- a/python/runtime/utils/PyRemoteSimulatorQPU.cpp
+++ b/python/runtime/utils/PyRemoteSimulatorQPU.cpp
@@ -133,23 +133,21 @@ public:
                void *args, std::uint64_t voidStarSize,
                std::uint64_t resultOffset,
                const std::vector<void *> &rawArgs) override {
-    CUDAQ_INFO("{}: Launch kernel named '{}' remote QPU {} (simulator = {})",
-               Derived::class_name, name, this->qpu_id, this->m_simName);
-    ::launchKernelImpl(cudaq::getExecutionContext(), this->m_client,
-                       this->m_simName, name,
-                       make_degenerate_kernel_type(kernelFunc), args,
-                       voidStarSize, resultOffset, rawArgs);
-    // TODO: Python should probably support return values too.
+    if (kernelFunc) {
+      CUDAQ_INFO("{}: Launch kernel named '{}' remote QPU {} (simulator = {})",
+                 Derived::class_name, name, this->qpu_id, this->m_simName);
+      ::launchKernelImpl(cudaq::getExecutionContext(), this->m_client,
+                         this->m_simName, name,
+                         make_degenerate_kernel_type(kernelFunc), args,
+                         voidStarSize, resultOffset, rawArgs);
+    } else {
+      CUDAQ_INFO("{}: Streamline launch kernel named '{}' remote QPU {} "
+                 "(simulator = {})",
+                 Derived::class_name, name, this->qpu_id, this->m_simName);
+      ::launchKernelStreamlineImpl(cudaq::getExecutionContext(), this->m_client,
+                                   this->m_simName, name, rawArgs);
+    }
     return {};
-  }
-
-  void launchKernel(const std::string &name,
-                    const std::vector<void *> &rawArgs) override {
-    CUDAQ_INFO("{}: Streamline launch kernel named '{}' remote QPU {} "
-               "(simulator = {})",
-               Derived::class_name, name, this->qpu_id, this->m_simName);
-    ::launchKernelStreamlineImpl(cudaq::getExecutionContext(), this->m_client,
-                                 this->m_simName, name, rawArgs);
   }
 };
 

--- a/runtime/common/AnalogRemoteRESTQPU.h
+++ b/runtime/common/AnalogRemoteRESTQPU.h
@@ -24,13 +24,6 @@ public:
   virtual bool isEmulated() override { return false; }
 
   /// @brief Launch a kernel with the given arguments
-  void launchKernel(const std::string &kernelName,
-                    const std::vector<void *> &rawArgs) override {
-    throw std::runtime_error(
-        "Arbitrary kernel execution is not supported on this target.");
-  }
-
-  /// @brief Launch a kernel with the given arguments
   /// Only analog Hamiltonian kernels are supported
   KernelThunkResultType
   launchKernel(const std::string &kernelName, KernelThunkType kernelFunc,

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -239,25 +239,6 @@ public:
     serverHelper->setRuntimeTarget(runtimeTarget);
   }
 
-  void launchKernel(const std::string &kernelName,
-                    const std::vector<void *> &rawArgs) override {
-    CUDAQ_INFO("launching remote rest kernel ({})", kernelName);
-
-    auto executionContext = cudaq::getExecutionContext();
-
-    // TODO future iterations of this should support non-void return types.
-    if (!executionContext)
-      throw std::runtime_error(
-          "Remote rest execution can only be performed via cudaq::sample(), "
-          "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
-
-    // Get the Quake code, lowered according to config file.
-    Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
-                      noiseModel, emulate);
-    auto codes = compiler.lowerQuakeCode(executionContext, kernelName, rawArgs);
-    completeLaunchKernel(kernelName, std::move(codes));
-  }
-
   /// @brief Launch the kernel. Extract the Quake code and lower to the
   /// representation required by the targeted backend. Handle all pertinent
   /// modifications for the execution context as well as asynchronous or
@@ -285,8 +266,9 @@ public:
                       noiseModel, emulate);
     auto codes =
         rawArgs.empty()
-            ? compiler.lowerQuakeCode(executionContext, kernelName, args)
-            : compiler.lowerQuakeCode(executionContext, kernelName, rawArgs);
+            ? compiler.lowerQuakeCode(executionContext, kernelName, args, {})
+            : compiler.lowerQuakeCode(executionContext, kernelName, nullptr,
+                                      rawArgs);
     completeLaunchKernel(kernelName, std::move(codes));
 
     // NB: Kernel should/will never return dynamic results.

--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -120,19 +120,12 @@ public:
       throw std::runtime_error("Failed to launch VQE. Error: " + errorMsg);
   }
 
-  void launchKernel(const std::string &name,
-                    const std::vector<void *> &rawArgs) override {
-    [[maybe_unused]] auto dynamicResult = launchKernelImpl(
-        name, nullptr, nullptr, 0, 0, &rawArgs, mlir::ModuleOp{});
-  }
-
   KernelThunkResultType
   launchKernel(const std::string &name, KernelThunkType kernelFunc, void *args,
                std::uint64_t voidStarSize, std::uint64_t resultOffset,
                const std::vector<void *> &rawArgs) override {
-    // Remote simulation cannot deal with rawArgs. Drop them on the floor.
     return launchKernelImpl(name, kernelFunc, args, voidStarSize, resultOffset,
-                            nullptr, mlir::ModuleOp{});
+                            kernelFunc ? nullptr : &rawArgs, mlir::ModuleOp{});
   }
 
   KernelThunkResultType

--- a/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
@@ -53,11 +53,6 @@ public:
     return {};
   }
 
-  void launchKernel(const std::string &kernelName,
-                    const std::vector<void *> &rawArgs) override {
-    launchKernel(kernelName, nullptr, nullptr, 0, 0, rawArgs);
-  }
-
   KernelThunkResultType
   launchModule(const std::string &kernelName, mlir::ModuleOp module,
                const std::vector<void *> &rawArgs) override {

--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.cpp
@@ -93,9 +93,4 @@ KernelThunkResultType cudaq::OrcaRemoteRESTQPU::launchKernelCommon(
   return {};
 }
 
-void cudaq::OrcaRemoteRESTQPU::launchKernel(const std::string &,
-                                            const std::vector<void *> &) {
-  throw std::runtime_error("launch kernel on raw args not implemented");
-}
-
 CUDAQ_REGISTER_TYPE(QPU, OrcaRemoteRESTQPU, orca)

--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
@@ -111,8 +111,5 @@ public:
                const std::vector<void *> &rawArgs) override {
     return launchKernelCommon(kernelName, kernelFunc, args);
   }
-
-  void launchKernel(const std::string &kernelName,
-                    const std::vector<void *> &rawArgs) override;
 };
 } // namespace cudaq

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -193,17 +193,6 @@ public:
                std::uint64_t, std::uint64_t,
                const std::vector<void *> &rawArgs) = 0;
 
-  /// Launch the kernel with given name and argument arrays.
-  // This is intended for any QPUs whereby we need to JIT-compile the kernel
-  // with argument synthesis. The QPU implementation must override this.
-  virtual void launchKernel(const std::string &name,
-                            const std::vector<void *> &rawArgs) {
-    if (!isRemote())
-      throw std::runtime_error("Wrong kernel launch point: Attempt to launch "
-                               "kernel in streamlined for JIT mode on local "
-                               "simulated QPU. This is not supported.");
-  }
-
   [[nodiscard]] virtual KernelThunkResultType
   launchModule(const std::string &name, mlir::ModuleOp module,
                const std::vector<void *> &rawArgs);

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -208,14 +208,6 @@ KernelThunkResultType quantum_platform::launchKernel(
                            resultOffset, rawArgs);
 }
 
-void quantum_platform::launchKernel(const std::string &kernelName,
-                                    const std::vector<void *> &rawArgs,
-                                    std::size_t qpu_id) {
-  validateQpuId(qpu_id);
-  auto &qpu = platformQPUs[qpu_id];
-  qpu->launchKernel(kernelName, rawArgs);
-}
-
 KernelThunkResultType quantum_platform::launchModule(
     const std::string &kernelName, mlir::ModuleOp module,
     const std::vector<void *> &rawArgs, std::size_t qpu_id) {
@@ -302,7 +294,8 @@ cudaq::streamlinedLaunchKernel(const char *kernelName,
   auto &platform = *getQuantumPlatformInternal();
   std::string kernName = kernelName;
   std::size_t qpu_id = cudaq::getCurrentQpuId();
-  platform.launchKernel(kernName, rawArgs, qpu_id);
+  [[maybe_unused]] auto r =
+      platform.launchKernel(kernName, nullptr, nullptr, 0, 0, rawArgs, qpu_id);
   // NB: The streamlined launch will never return results. Use alt or hybrid if
   // the kernel returns results.
   return {};
@@ -353,7 +346,8 @@ cudaq::hybridLaunchKernel(const char *kernelName, cudaq::KernelThunkType kernel,
   std::size_t qpu_id = cudaq::getCurrentQpuId();
   if (platform.is_remote(qpu_id)) {
     // This path should never call a kernel that returns results.
-    platform.launchKernel(kernName, rawArgs, qpu_id);
+    [[maybe_unused]] auto r = platform.launchKernel(kernName, nullptr, nullptr,
+                                                    0, 0, rawArgs, qpu_id);
     return {};
   }
   return platform.launchKernel(kernName, kernel, args, argsSize, resultOffset,

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -200,8 +200,6 @@ public:
                void *args, std::uint64_t voidStarSize,
                std::uint64_t resultOffset, const std::vector<void *> &rawArgs,
                std::size_t qpu_id = 0);
-  void launchKernel(const std::string &kernelName, const std::vector<void *> &,
-                    std::size_t qpu_id = 0);
 
   // This method launches a kernel from a ModuleOp that has already been
   // created.

--- a/runtime/cudaq/qis/remote_state.cpp
+++ b/runtime/cudaq/qis/remote_state.cpp
@@ -24,8 +24,10 @@ void RemoteSimulationState::execute() const {
     // potential logging of the result of the API call.
     std::ostringstream remoteLogCout;
     platform.setLogStream(remoteLogCout);
-    platform.with_execution_context(
-        context, [&]() { platform.launchKernel(kernelName, args); });
+    platform.with_execution_context(context, [&]() {
+      [[maybe_unused]] auto r =
+          platform.launchKernel(kernelName, nullptr, nullptr, 0, 0, args);
+    });
     platform.resetLogStream();
     // Cache the info log if any.
     platformExecutionLog = remoteLogCout.str();
@@ -150,8 +152,10 @@ std::vector<std::complex<double>> RemoteSimulationState::getAmplitudes(
   context.amplitudeMaps = std::move(amplitudeMaps);
   // Perform the usual pattern set the context,
   // execute and then reset
-  platform.with_execution_context(
-      context, [&]() { platform.launchKernel(kernelName, args); });
+  platform.with_execution_context(context, [&]() {
+    [[maybe_unused]] auto r =
+        platform.launchKernel(kernelName, nullptr, nullptr, 0, 0, args);
+  });
   std::vector<std::complex<double>> amplitudes;
   amplitudes.reserve(basisStates.size());
   for (const auto &basisState : basisStates)

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -543,19 +543,6 @@ Compiler::lowerQuakeCode(cudaq::ExecutionContext *executionContext,
 
 std::vector<cudaq::KernelExecution>
 Compiler::lowerQuakeCode(cudaq::ExecutionContext *executionContext,
-                         const std::string &kernelName, void *kernelArgs) {
-  return lowerQuakeCode(executionContext, kernelName, kernelArgs, {});
-}
-
-std::vector<cudaq::KernelExecution>
-Compiler::lowerQuakeCode(cudaq::ExecutionContext *executionContext,
-                         const std::string &kernelName,
-                         const std::vector<void *> &rawArgs) {
-  return lowerQuakeCode(executionContext, kernelName, nullptr, rawArgs);
-}
-
-std::vector<cudaq::KernelExecution>
-Compiler::lowerQuakeCode(cudaq::ExecutionContext *executionContext,
                          const std::string &kernelName, mlir::ModuleOp module,
                          const std::vector<void *> &rawArgs) {
   return lowerQuakeCodePart2(executionContext, kernelName, nullptr, rawArgs,

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -82,17 +82,17 @@ class Compiler {
   std::tuple<mlir::ModuleOp, std::unique_ptr<mlir::MLIRContext>, void *>
   extractQuakeCodeAndContext(const std::string &kernelName, void *data);
 
+  mlir::ModuleOp lowerQuakeCodeBuildModule(const std::string &,
+                                           mlir::ModuleOp module,
+                                           mlir::MLIRContext *,
+                                           mlir::func::FuncOp);
+
 public:
   Compiler(cudaq::ServerHelper *,
            const std::map<std::string, std::string> &backendConfig,
            cudaq::config::TargetConfig &config,
            const cudaq::noise_model *noiseModel, bool emulate);
   ~Compiler();
-
-  mlir::ModuleOp lowerQuakeCodeBuildModule(const std::string &,
-                                           mlir::ModuleOp module,
-                                           mlir::MLIRContext *,
-                                           mlir::func::FuncOp);
 
   /// @brief Extract the Quake representation for the given kernel name and
   /// lower it to the code format required for the specific backend. The
@@ -101,15 +101,6 @@ public:
   std::vector<cudaq::KernelExecution>
   lowerQuakeCode(cudaq::ExecutionContext *executionContext,
                  const std::string &kernelName, void *kernelArgs,
-                 const std::vector<void *> &rawArgs);
-
-  std::vector<cudaq::KernelExecution>
-  lowerQuakeCode(cudaq::ExecutionContext *executionContext,
-                 const std::string &kernelName, void *kernelArgs);
-
-  std::vector<cudaq::KernelExecution>
-  lowerQuakeCode(cudaq::ExecutionContext *executionContext,
-                 const std::string &kernelName,
                  const std::vector<void *> &rawArgs);
 
   // Here the quake code is passed to us (via a ModuleOp), so unlike the other


### PR DESCRIPTION
To allow the launches to be split by policy, we need to unify them first to avoid an explosion of launches in the API. 

I was experimenting with this which went well until I hit `launchModule`. Still, I am guessing that this is the direction we are moving towards with the `CompiledKernel` which would ultimately allow us to have a unique launch function on the QPU side. 

It is a small change but maybe still useful if this is a step in the right direction. In the meantime I will spent some more time on `launchModule`.