### PR TITLE
 [CMake] Add FindMinizip module

### DIFF
--- a/cmake/modules/FindMinizip.cmake
+++ b/cmake/modules/FindMinizip.cmake
@@ -1,0 +1,63 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Minizip is an addon library bundled with zlib (contrib/minizip) but not
+# installed by default.  This project's install_prerequisites.sh builds it.
+# The module tries pkg-config first, then falls back to manual search.
+
+set(_minizip_hints
+  "${ZLIB_ROOT}"
+  "$ENV{ZLIB_INSTALL_PREFIX}"
+  "${ZLIB_INCLUDE_DIR}/.."
+)
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  find_path(_minizip_pc_dir NAMES minizip.pc
+    HINTS ${_minizip_hints}
+    PATH_SUFFIXES lib/pkgconfig
+  )
+  if(_minizip_pc_dir)
+    set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${_minizip_pc_dir}")
+  endif()
+  pkg_check_modules(_minizip_pkg QUIET minizip)
+endif()
+
+find_library(Minizip_LIBRARY NAMES minizip
+  HINTS
+    ${_minizip_pkg_LIBRARY_DIRS}
+    ${_minizip_hints}
+  PATH_SUFFIXES lib
+)
+
+find_path(Minizip_INCLUDE_DIR NAMES unzip.h
+  HINTS
+    ${_minizip_pkg_INCLUDE_DIRS}
+    ${_minizip_hints}
+  PATH_SUFFIXES include include/minizip
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Minizip
+  REQUIRED_VARS Minizip_LIBRARY Minizip_INCLUDE_DIR
+)
+
+if(Minizip_FOUND AND NOT TARGET Minizip::Minizip)
+  add_library(Minizip::Minizip UNKNOWN IMPORTED)
+  set_target_properties(Minizip::Minizip PROPERTIES
+    IMPORTED_LOCATION "${Minizip_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${Minizip_INCLUDE_DIR}"
+  )
+  # Minizip depends on zlib
+  find_package(ZLIB QUIET)
+  if(TARGET ZLIB::ZLIB)
+    set_property(TARGET Minizip::Minizip APPEND PROPERTY
+      INTERFACE_LINK_LIBRARIES ZLIB::ZLIB
+    )
+  endif()
+endif()

--- a/runtime/cudaq/platform/default/rest_server/CMakeLists.txt
+++ b/runtime/cudaq/platform/default/rest_server/CMakeLists.txt
@@ -6,61 +6,11 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-# Unzip utility based on libz.
-# Minizip is an addon library, not included by default in the official libz distribution.
-# Hence, we require libz installation via the `install_prerequisites.sh` script, which does install minizip.
+# Minizip is a zlib addon installed by install_prerequisites.sh.
+find_package(Minizip REQUIRED)
 add_library(unzip_util STATIC helpers/UnzipUtils.cpp)
-target_link_libraries(unzip_util PRIVATE fmt::fmt-header-only)
+target_link_libraries(unzip_util PRIVATE fmt::fmt-header-only Minizip::Minizip)
 target_include_directories(unzip_util PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/runtime>)
-find_package(PkgConfig)
-# By default, Minizip has package config (.pc) file.
-# If CMake can find PkgConfig, use it to find minizip
-
-find_path(MINIZIP_PKG_CONFIG_DIR NAMES minizip.pc
-  HINTS 
-    ${ZLIB_ROOT}/lib/pkgconfig
-    $ENV{ZLIB_INSTALL_PREFIX}/lib/pkgconfig
-    ${ZLIB_INCLUDE_DIR}/../lib/pkgconfig
-)
-if (PkgConfig_FOUND AND MINIZIP_PKG_CONFIG_DIR) 
-  set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${MINIZIP_PKG_CONFIG_DIR}")
-  pkg_check_modules(MINI_ZIP IMPORTED_TARGET minizip)
-  # Make sure that we link to minizip static library
-  if (MINI_ZIP_FOUND)
-    find_library(MINI_ZIP_LIB NAMES libminizip.a
-      HINTS 
-        ${MINI_ZIP_LIBRARY_DIRS}
-    )
-    target_link_libraries(unzip_util PRIVATE ${MINI_ZIP_LIB})
-    target_include_directories(unzip_util PRIVATE ${ZLIB_INCLUDE_DIR} ${MINI_ZIP_INCLUDE_DIRS})  
-  endif()
-else()
-  # No PkgConfig, locate the lib manually
-  # Make sure that we find minizip static library
-  find_library(MINI_ZIP_LIB NAMES libminizip.a
-    HINTS 
-      ${ZLIB_ROOT}/lib
-      $ENV{ZLIB_INSTALL_PREFIX}/lib
-      ${ZLIB_INCLUDE_DIR}/../lib
-  )
-  get_filename_component(MINI_LIB_DIR ${MINI_ZIP_LIB} DIRECTORY)
-  find_file(MINI_UNZIP_INC NAMES unzip.h 
-    HINTS 
-      ${MINI_LIB_DIR}/../include
-      ${MINI_LIB_DIR}/../include/minizip
-  )
-  if (MINI_ZIP_LIB AND MINI_UNZIP_INC)
-    message(STATUS "Minizip found: ${MINI_ZIP_LIB} and ${MINI_UNZIP_INC}")
-    target_link_libraries(unzip_util PRIVATE ${MINI_ZIP_LIB} ZLIB::ZLIB)
-    get_filename_component(MINI_INCLUDE_DIR ${MINI_UNZIP_INC} DIRECTORY)
-    target_include_directories(unzip_util PRIVATE ${MINI_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})  
-    set(MINI_ZIP_FOUND TRUE)
-  endif()
-endif()
-
-if (NOT MINI_ZIP_FOUND)
-  message(FATAL_ERROR "Minizip from zLib NOT found. Please run the 'install_prerequisites.sh' script to install zLib with Minizip")
-endif()
 
 set(LIBRARY_NAME rest-remote-platform-client)
 add_library(${LIBRARY_NAME}


### PR DESCRIPTION
PR chain:
- #4238 
- #4240
- \>\> #4297 \<\< (This)

Introduced a new CMake module to find and configure the Minizip library,
which is an addon for zlib.
