### PR TITLE
[core] Use less electric terms.

### DIFF
--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -784,7 +784,7 @@ def quake_SplitCableOp : QuakeOp<"split_cable", [Pure]> {
   let hasVerifier = 1;
 }
 
-def quake_LeftTeeOp : QuakeOp<"left_tee", [Pure]> {
+def quake_DetachWireOp : QuakeOp<"detach_wire", [Pure]> {
   let summary = "Split a cable exposing a single wire and a new cable.";
   let description = [{
     This operation can be used as syntactic sugar for extracting a single wire
@@ -800,13 +800,13 @@ def quake_LeftTeeOp : QuakeOp<"left_tee", [Pure]> {
     ```mlir
       // create a cable with 3 wires: 0, 1, and 2
       %20 = quake.null_cable !quake.cable<3>
-      %21:2 = quake.left_tee %20[1] : (!quake.cable<3>) -> (!quake.wire,
+      %21:2 = quake.detach_wire %20[1] : (!quake.cable<3>) -> (!quake.wire,
                                                             !quake.cable<2>)
       // %21#0 contains wire 1 previously at position 1 in %20
       // %21#1 contains wire 0 at position 0, and wire 2 at position 1
     ```
 
-    See also `quake.right_tee`.
+    See also `quake.attach_wire`.
   }];
 
   let arguments = (ins
@@ -824,7 +824,7 @@ def quake_LeftTeeOp : QuakeOp<"left_tee", [Pure]> {
   let hasVerifier = 1;
 }
 
-def quake_RightTeeOp : QuakeOp<"right_tee", [Pure]> {
+def quake_AttachWireOp : QuakeOp<"attach_wire", [Pure]> {
   let summary = "Compose a cable from a single wire and an existing cable.";
   let description = [{
     This operation can be used as syntactic sugar for inserting a single wire
@@ -842,15 +842,15 @@ def quake_RightTeeOp : QuakeOp<"right_tee", [Pure]> {
     ```mlir
       // create a cable with 3 wires: 0, 1, and 2
       %20 = quake.null_cable !quake.cable<3>
-      %21:2 = quake.left_tee %20[1] : (!cable<3>) -> (!wire, !cable<2>)
+      %21:2 = quake.detach_wire %20[1] : (!cable<3>) -> (!wire, !cable<2>)
       // %21#0 contains wire 1 previous at position 1 in %20
       // %21#1 contains wire 0 at position 0, and wire 2 at position 1
-      %22 = quake.right_tee %21#0, %21#1[2] : (!wire, !cable<2>) -> (!cable<3>)
+      %22 = quake.attach_wire %21#0, %21#1[2] : (!wire, !cable<2>) -> (!cable<3>)
       // %22 contains wire 0 at position 0, wire 2 at position 1,
       // and wire 1 at position 2 as they were originally created in %20
     ```
 
-    See also `quake.left_tee`.
+    See also `quake.detach_wire`.
   }];
 
   let arguments = (ins

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -948,7 +948,7 @@ LogicalResult quake::SplitCableOp::verify() {
   return success();
 }
 
-LogicalResult quake::LeftTeeOp::verify() {
+LogicalResult quake::DetachWireOp::verify() {
   if (!getCable().getType().getSize())
     return emitOpError("cannot remove a wire from an empty bundle.");
   if (getIndex() >= getCable().getType().getSize())
@@ -959,7 +959,7 @@ LogicalResult quake::LeftTeeOp::verify() {
   return success();
 }
 
-LogicalResult quake::RightTeeOp::verify() {
+LogicalResult quake::AttachWireOp::verify() {
   if (getIndex() > getCable().getType().getSize())
     return emitOpError("index into the bundle is out of bounds.");
   if (getCableOut().getType().getSize() != getCable().getType().getSize() + 1)

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -938,33 +938,33 @@ LogicalResult quake::DiscriminateOp::verify() {
 LogicalResult quake::BundleCableOp::verify() {
   auto ty = cast<quake::CableType>(getResult().getType());
   if (getWires().size() != ty.getSize())
-    return emitOpError("the bundle type size must equal the arity.");
+    return emitOpError("the cable type size must equal the arity.");
   return success();
 }
 
 LogicalResult quake::SplitCableOp::verify() {
   if (getResults().size() != getCable().getType().getSize())
-    return emitOpError("the bundle type size must equal the coarity.");
+    return emitOpError("the cable type size must equal the coarity.");
   return success();
 }
 
 LogicalResult quake::DetachWireOp::verify() {
   if (!getCable().getType().getSize())
-    return emitOpError("cannot remove a wire from an empty bundle.");
+    return emitOpError("cannot remove a wire from an empty cable.");
   if (getIndex() >= getCable().getType().getSize())
-    return emitOpError("index into the bundle is out of bounds.");
+    return emitOpError("index into the cable is out of bounds.");
   if (getCableOut().getType().getSize() != getCable().getType().getSize() - 1)
-    return emitOpError("the bundle result type size must equal the size of the "
-                       "bundle argument - 1.");
+    return emitOpError("the cable result type size must equal the size of the "
+                       "cable argument - 1.");
   return success();
 }
 
 LogicalResult quake::AttachWireOp::verify() {
   if (getIndex() > getCable().getType().getSize())
-    return emitOpError("index into the bundle is out of bounds.");
+    return emitOpError("index into the cable is out of bounds.");
   if (getCableOut().getType().getSize() != getCable().getType().getSize() + 1)
-    return emitOpError("the bundle result type size must equal the size of "
-                       "the bundle argument + 1.");
+    return emitOpError("the cable result type size must equal the size of "
+                       "the cable argument + 1.");
   return success();
 }
 

--- a/test/Transforms/roundtrip-ops.qke
+++ b/test/Transforms/roundtrip-ops.qke
@@ -918,9 +918,9 @@ func.func @cable() {
   %0 = quake.null_cable !quake.cable<4>
   %1:4 = quake.split_cable %0 : (!quake.cable<4>) -> (!quake.wire, !quake.wire, !quake.wire, !quake.wire)
   %2 = quake.bundle_cable %1#0, %1#3, %1#1, %1#2 : (!quake.wire, !quake.wire, !quake.wire, !quake.wire) -> !quake.cable<4>
-  %3:2 = quake.left_tee %2[1] : (!quake.cable<4>) -> (!quake.wire, !quake.cable<3>)
+  %3:2 = quake.detach_wire %2[1] : (!quake.cable<4>) -> (!quake.wire, !quake.cable<3>)
   %4 = quake.x %3#0 : (!quake.wire) -> !quake.wire
-  %5 = quake.right_tee %4, %3#1[3] : (!quake.wire, !quake.cable<3>) -> !quake.cable<4>
+  %5 = quake.attach_wire %4, %3#1[3] : (!quake.wire, !quake.cable<3>) -> !quake.cable<4>
   %6 = quake.call_by_ref @external_struq_call(%5) : (!quake.cable<4>) -> !quake.cable<4>
   quake.sink %6 : !quake.cable<4>
   return
@@ -930,9 +930,9 @@ func.func @cable() {
 // CHECK:           %[[VAL_0:.*]] = quake.null_cable <4>
 // CHECK:           %[[VAL_1:.*]]:4 = quake.split_cable %[[VAL_0]] : (!quake.cable<4>) -> (!quake.wire, !quake.wire, !quake.wire, !quake.wire)
 // CHECK:           %[[VAL_2:.*]] = quake.bundle_cable %[[VAL_1]]#0, %[[VAL_1]]#3, %[[VAL_1]]#1, %[[VAL_1]]#2 : (!quake.wire, !quake.wire, !quake.wire, !quake.wire) -> !quake.cable<4>
-// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = quake.left_tee %[[VAL_2]][1] : (!quake.cable<4>) -> (!quake.wire, !quake.cable<3>)
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = quake.detach_wire %[[VAL_2]][1] : (!quake.cable<4>) -> (!quake.wire, !quake.cable<3>)
 // CHECK:           %[[VAL_5:.*]] = quake.x %[[VAL_3]] : (!quake.wire) -> !quake.wire
-// CHECK:           %[[VAL_6:.*]] = quake.right_tee %[[VAL_5]], %[[VAL_4]][3] : (!quake.wire, !quake.cable<3>) -> !quake.cable<4>
+// CHECK:           %[[VAL_6:.*]] = quake.attach_wire %[[VAL_5]], %[[VAL_4]][3] : (!quake.wire, !quake.cable<3>) -> !quake.cable<4>
 // CHECK:           %[[VAL_8:.*]] = quake.call_by_ref @external_struq_call(%[[VAL_6]]) : (!quake.cable<4>) -> !quake.cable<4>
 // CHECK:           quake.sink %[[VAL_8]] : !quake.cable<4>
 // CHECK:           return


### PR DESCRIPTION
Replace left_tee/right_tee ops with detach_wire/attach_wire for clarity.