### PR TITLE
[docs] [fix] Incorrect tag in C++ `run` example

### DIFF
--- a/docs/sphinx/using/examples/measuring_kernels.rst
+++ b/docs/sphinx/using/examples/measuring_kernels.rst
@@ -65,8 +65,8 @@ The results show qubit 0 is one, indicating the reset worked, and qubit 1 has a 
 
     .. literalinclude:: ../../examples/cpp/measuring_kernels.cpp
         :language: cpp
-        :start-after: [Begin Run1]
-        :end-before: [End Run1]
+        :start-after: [Begin Run0]
+        :end-before: [End Run0]
 
 Output
 


### PR DESCRIPTION
* Fix the rendering in https://nvidia.github.io/cuda-quantum/latest/using/examples/measuring_kernels.html
* The first snippet should be of the code