### PR TITLE
Fix macOS xdist crash in GHZ noise validation test

### DIFF
--- a/python/tests/kernel/test_run_kernel.py
+++ b/python/tests/kernel/test_run_kernel.py
@@ -73,18 +73,19 @@ def test_simple_run_ghz_with_noise():
     depol = cudaq.Depolarization2(.5)
     noise = cudaq.NoiseModel()
     noise.add_all_qubit_channel("cx", depol)
-    results = cudaq.run(simple,
-                        qubitCount,
-                        shots_count=shots,
-                        noise_model=noise)
-    print(results)
-    assert len(results) == shots
-    noisy_count = 0
-    for result in results:
-        if result != 0 and result != qubitCount:
-            noisy_count += 1
-    assert noisy_count > 0
-    cudaq.reset_target()
+    try:
+        # Materialize results before resetting the simulation target.
+        results = list(
+            cudaq.run(simple, qubitCount, shots_count=shots, noise_model=noise))
+        print(results)
+        assert len(results) == shots
+        noisy_count = 0
+        for result in results:
+            if result != 0 and result != qubitCount:
+                noisy_count += 1
+        assert noisy_count > 0
+    finally:
+        cudaq.reset_target()
 
 
 def test_return_bool():

--- a/scripts/validate_pycudaq.sh
+++ b/scripts/validate_pycudaq.sh
@@ -333,15 +333,47 @@ fi
 
 # Run core tests
 echo "Running core tests."
-python3 -m pytest -v -n auto "$root_folder/tests" \
-    --ignore "$root_folder/tests/backends" \
-    --ignore "$root_folder/tests/dynamics/integrators" \
-    --ignore "$root_folder/tests/parallel" \
-    --ignore "$root_folder/tests/domains"
+core_test_args=(
+    -v
+    -n
+    auto
+    "$root_folder/tests"
+    --ignore
+    "$root_folder/tests/backends"
+    --ignore
+    "$root_folder/tests/dynamics/integrators"
+    --ignore
+    "$root_folder/tests/parallel"
+    --ignore
+    "$root_folder/tests/domains"
+)
+
+macos_serial_core_tests=()
+if $is_macos; then
+    ghz_noise_test="test_simple_run_ghz_with_noise"
+    ghz_noise_nodeid="$root_folder/tests/kernel/test_run_kernel.py::${ghz_noise_test}"
+    core_test_args+=(
+        -k
+        "not ${ghz_noise_test}"
+    )
+    macos_serial_core_tests+=("$ghz_noise_nodeid")
+    echo "macOS xdist workaround: excluding ${ghz_noise_test} from parallel core run; it will run serially."
+fi
+
+python3 -m pytest "${core_test_args[@]}"
 if [ ! $? -eq 0 ]; then
     echo -e "\e[01;31mPython tests failed.\e[0m" >&2
     status_sum=$((status_sum + 1))
 fi
+
+for serial_test in "${macos_serial_core_tests[@]}"; do
+    echo "Running serial core test: $serial_test"
+    python3 -m pytest -v --rootdir "$root_folder/tests" "$serial_test"
+    if [ ! $? -eq 0 ]; then
+        echo -e "\e[01;31mPython serial core test failed: $serial_test\e[0m" >&2
+        status_sum=$((status_sum + 1))
+    fi
+done
 
 # If this is a quick test, we return here.
 if $quick_test; then


### PR DESCRIPTION
Fixes #4281.

- This PR addresses an intermittent macOS CI crash where an xdist worker dies while running test_simple_run_ghz_with_noise.
- The change is intentionally minimal and limited to test/validation flow, without touching product runtime code.

Root cause addressed
- The failing path uses global target state in a noisy kernel test, and this can be fragile under parallel test execution in macOS CI.
- The failure mode is a worker crash, not a deterministic assertion failure.

What changed
- Hardened target lifecycle in test_run_kernel.py:
- test_simple_run_ghz_with_noise now guarantees target reset via try/finally.
- Results are materialized before resetting target to avoid teardown/lifecycle races.
- Updated macOS validation strategy in validate_pycudaq.sh:
- Keep core tests parallel with xdist.
- Exclude test_simple_run_ghz_with_noise from the parallel core batch on macOS.
- Run that single test serially immediately after core tests.

Why this approach
- Keeps maximum parallel coverage for the rest of the suite.
- Isolates only the unstable test in macOS CI.
- Minimizes blast radius and avoids broad skips or module-wide serialization.

Validation
- Target test passed in serial and xdist locally.
- Stress runs of the target test in xdist were stable across repeated iterations.
- Adjacent GHZ tests remained green in serial and xdist after the change.
- Script syntax validated and change scope confirmed to the two intended files only.

Impact
- Reduces flaky macOS worker crashes for the validation pipeline.
- Preserves test coverage while improving CI reliability.