### PR TITLE
Add back eager loading of `libcudaq-em-default` on import

### DIFF
--- a/python/utils/LinkedLibraryHolder.cpp
+++ b/python/utils/LinkedLibraryHolder.cpp
@@ -185,10 +185,13 @@ LinkedLibraryHolder::LinkedLibraryHolder() : availablePlatforms{"default"} {
 
   CUDAQ_INFO("Init: Library Path is {}.", cudaqLibPath.string());
 
-  // We have to ensure that nvqir and cudaq are loaded
+  // Load nvqir, cudaq, and the default execution manager. The em cannot
+  // be a needed dep of libcudaq.so (circular dependency), but downstream
+  // libraries like cuda-qx reference its symbols at dlopen time.
   std::vector<std::filesystem::path> libPaths{
       cudaqLibPath / fmt::format("libnvqir.{}", libSuffix),
-      cudaqLibPath / fmt::format("libcudaq.{}", libSuffix)};
+      cudaqLibPath / fmt::format("libcudaq.{}", libSuffix),
+      cudaqLibPath / fmt::format("libcudaq-em-default.{}", libSuffix)};
 
   const char *dynlibs_var = std::getenv("CUDAQ_DYNLIBS");
   if (dynlibs_var != nullptr) {


### PR DESCRIPTION
Downstream libraries like `CUDA-QX` reference
symbols in `libcudaq-em-default.so` at dlopen time via inline functions in `execution_manager.h`. Since this library is neither a simulator nor a platform, the lazy loading from #4225 never loaded it, causing an undefined symbol error on import as noticed by @bmhowe23 in this comment https://github.com/NVIDIA/cuda-quantum/pull/4225#issuecomment-4230312258.

I tried to find a way to achieve this with pure Cmake but due to circular dependencies it was not easy so adding this back. Performance hit will be minimal for import time (most a few ms). 