### PR TITLE
Fix zero() and identity() scalar fallback

### DIFF
--- a/python/cudaq/operators/custom/backwards_compatibility.py
+++ b/python/cudaq/operators/custom/backwards_compatibility.py
@@ -35,7 +35,7 @@ def const(constant_value: NumericType) -> ScalarOperator:
 def zero(
         degrees: Sequence[int] | int = []
 ) -> ScalarOperator | MatrixOperatorTerm:
-    if hasattr(degrees, "len") and len(degrees) == 0:
+    if hasattr(degrees, "__len__") and len(degrees) == 0:
         return ScalarOperator.const(0)
     zero_op = MatrixOperatorTerm(0.)
     if isinstance(degrees, int):
@@ -49,7 +49,7 @@ def zero(
 def identity(
         degrees: Sequence[int] | int = []
 ) -> ScalarOperator | MatrixOperatorTerm:
-    if hasattr(degrees, "len") and len(degrees) == 0:
+    if hasattr(degrees, "__len__") and len(degrees) == 0:
         return ScalarOperator.const(1)
     id_op = MatrixOperatorTerm()
     if isinstance(degrees, int):

--- a/python/tests/operator/test_matrix_op.py
+++ b/python/tests/operator/test_matrix_op.py
@@ -731,6 +731,10 @@ def test_backwards_compatibility():
     scalar = const(3)
     assert type(scalar) == ScalarOperator
     assert scalar.evaluate() == 3
+    assert type(zero()) == ScalarOperator
+    assert zero().evaluate() == 0
+    assert type(identity()) == ScalarOperator
+    assert identity().evaluate() == 1
     with pytest.raises(ValueError):
         const(lambda: 5)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- fix the empty-sequence check in `cudaq.operators.zero()` and `cudaq.operators.identity()`
- replace `hasattr(degrees, "len")` with `hasattr(degrees, "__len__")`
- add a regression test for no-argument calls

## Root cause
`zero()` and `identity()` used `hasattr(degrees, "len")` to detect an empty sequence.

That check is incorrect in Python: standard containers expose `__len__`, not `len`. Because of that, the empty-input branch never triggered, and no-argument calls fell through to the `MatrixOperatorTerm` path instead of returning the documented `ScalarOperator`.

## User-visible behavior
Before this change:
- `operators.zero()` returned `MatrixOperatorTerm`
- `operators.identity()` returned `MatrixOperatorTerm`

After this change:
- `operators.zero()` returns `ScalarOperator.const(0)`
- `operators.identity()` returns `ScalarOperator.const(1)`

