### PR TITLE
[Python] AST bridge: reject cudaq.dbg.ast aliases and reorderings (#2342)

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2672,11 +2672,32 @@ class PyASTBridge(ast.NodeVisitor):
                     node.func.value.id) and node.func.attr == 'kernel':
                 return
 
+            def isExactCudaqDbgAstCall(func_node):
+                """Return True iff `func_node` is exactly ``<cudaq_alias>.dbg.ast.<name>``.
+
+                Module resolution can follow lazy aliases (e.g. ``cudaq.ast``
+                resolves to ``cudaq.dbg.ast`` via ``_LAZY_SUBMODULES``), so
+                `devKey` alone is not a reliable guard. This check validates
+                the literal AST structure."""
+                if not isinstance(func_node, ast.Attribute):
+                    return False
+                if not isinstance(
+                        func_node.value,
+                        ast.Attribute) or func_node.value.attr != 'ast':
+                    return False
+                if not isinstance(
+                        func_node.value.value,
+                        ast.Attribute) or func_node.value.value.attr != 'dbg':
+                    return False
+                root = func_node.value.value.value
+                return isinstance(root, ast.Name) and self.isCudaqName(root.id)
+
             devKey, name = resolveQualifiedName(node.func)
             if devKey:
 
                 # Handle debug functions
-                if devKey == 'cudaq.dbg.ast':
+                if devKey == 'cudaq.dbg.ast' and isExactCudaqDbgAstCall(
+                        node.func):
                     # Handle a debug print statement
                     arg = self.__groupValues(node.args, [1])
                     self.__insertDbgStmt(arg, name)

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -2672,13 +2672,14 @@ class PyASTBridge(ast.NodeVisitor):
                     node.func.value.id) and node.func.attr == 'kernel':
                 return
 
-            def isExactCudaqDbgAstCall(func_node):
-                """Return True iff `func_node` is exactly ``<cudaq_alias>.dbg.ast.<name>``.
+            def isExactCudaqDbgAstCall(func_node: ast.AST) -> bool:
+                """Return True iff `func_node` is the exact AST shape for
+                ``<cudaq_alias>.dbg.ast.<name>``.
 
-                Module resolution can follow lazy aliases (e.g. ``cudaq.ast``
+                Runtime attribute lookup follows lazy aliases (e.g. ``cudaq.ast``
                 resolves to ``cudaq.dbg.ast`` via ``_LAZY_SUBMODULES``), so
-                `devKey` alone is not a reliable guard. This check validates
-                the literal AST structure."""
+                `devKey` is not a sufficient check. Walk the literal node
+                structure instead."""
                 if not isinstance(func_node, ast.Attribute):
                     return False
                 if not isinstance(

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -571,27 +571,28 @@ def test_decrementing_range():
 
 
 def test_dbg_ast_strict_path():
-    """Only the exact cudaq.dbg.ast.print_i64/f64 form is valid.
+    """Only cudaq.dbg.ast.print_i64/f64 is valid inside a kernel.
 
-    Lazy module aliases (cudaq.ast resolves to cudaq.dbg.ast via
-    _LAZY_SUBMODULES) and component reorderings must all be rejected
-    with a compile-time RuntimeError.
+    cudaq.ast is a lazy alias for cudaq.dbg.ast (via _LAZY_SUBMODULES), so
+    without an explicit AST structure check it would pass the devKey guard.
+    Component reorderings like dbg.cudaq.ast are also rejected.
 
     See https://github.com/NVIDIA/cuda-quantum/issues/2342
     """
 
     @cudaq.kernel
-    def valid_kernel(n: int):
+    def valid_kernel(n: int, f: float):
         q = cudaq.qvector(n)
         h(q[0])
         cudaq.dbg.ast.print_i64(n)
+        cudaq.dbg.ast.print_f64(f)
         mz(q)
 
-    counts = cudaq.sample(valid_kernel, 2)
+    counts = cudaq.sample(valid_kernel, 2, 2.0)
     assert len(counts) > 0
 
-    # https://github.com/NVIDIA/cuda-quantum/issues/2342 - cudaq.ast is a lazy
-    # alias for cudaq.dbg.ast but must not be accepted as a debug call
+    # cudaq.ast resolves to cudaq.dbg.ast at runtime via _LAZY_SUBMODULES;
+    # isExactCudaqDbgAstCall rejects it because the AST node chain is wrong.
     with pytest.raises(RuntimeError):
 
         @cudaq.kernel
@@ -603,7 +604,8 @@ def test_dbg_ast_strict_path():
 
         cudaq.sample(invalid_cudaq_ast, 2)
 
-    # https://github.com/NVIDIA/cuda-quantum/issues/2342 - wrong component order
+    # dbg.cudaq.ast - resolveQualifiedName returns 'dbg.cudaq.ast', which
+    # never matches the devKey guard.
     with pytest.raises(RuntimeError):
 
         @cudaq.kernel
@@ -615,7 +617,7 @@ def test_dbg_ast_strict_path():
 
         cudaq.sample(invalid_dbg_cudaq_ast, 2)
 
-    # https://github.com/NVIDIA/cuda-quantum/issues/2342 - wrong component order
+    # ast.cudaq.dbg - same: resolveQualifiedName returns 'ast.cudaq.dbg'.
     with pytest.raises(RuntimeError):
 
         @cudaq.kernel

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -570,6 +570,64 @@ def test_decrementing_range():
     assert '1010' in counts
 
 
+def test_dbg_ast_strict_path():
+    """Only the exact cudaq.dbg.ast.print_i64/f64 form is valid.
+
+    Lazy module aliases (cudaq.ast resolves to cudaq.dbg.ast via
+    _LAZY_SUBMODULES) and component reorderings must all be rejected
+    with a compile-time RuntimeError.
+
+    See https://github.com/NVIDIA/cuda-quantum/issues/2342
+    """
+
+    @cudaq.kernel
+    def valid_kernel(n: int):
+        q = cudaq.qvector(n)
+        h(q[0])
+        cudaq.dbg.ast.print_i64(n)
+        mz(q)
+
+    counts = cudaq.sample(valid_kernel, 2)
+    assert len(counts) > 0
+
+    # https://github.com/NVIDIA/cuda-quantum/issues/2342 - cudaq.ast is a lazy
+    # alias for cudaq.dbg.ast but must not be accepted as a debug call
+    with pytest.raises(RuntimeError):
+
+        @cudaq.kernel
+        def invalid_cudaq_ast(n: int):
+            q = cudaq.qvector(n)
+            h(q[0])
+            cudaq.ast.print_i64(n)
+            mz(q)
+
+        cudaq.sample(invalid_cudaq_ast, 2)
+
+    # https://github.com/NVIDIA/cuda-quantum/issues/2342 - wrong component order
+    with pytest.raises(RuntimeError):
+
+        @cudaq.kernel
+        def invalid_dbg_cudaq_ast(n: int):
+            q = cudaq.qvector(n)
+            h(q[0])
+            dbg.cudaq.ast.print_i64(n)
+            mz(q)
+
+        cudaq.sample(invalid_dbg_cudaq_ast, 2)
+
+    # https://github.com/NVIDIA/cuda-quantum/issues/2342 - wrong component order
+    with pytest.raises(RuntimeError):
+
+        @cudaq.kernel
+        def invalid_ast_cudaq_dbg(n: int):
+            q = cudaq.qvector(n)
+            h(q[0])
+            ast.cudaq.dbg.print_i64(n)
+            mz(q)
+
+        cudaq.sample(invalid_ast_cudaq_dbg, 2)
+
+
 def test_no_dynamic_Lists():
     with pytest.raises(RuntimeError) as error:
 


### PR DESCRIPTION
  ## Description:                                                                                                                                                                                                                                                                           
  `cudaq.ast` is defined as a lazy alias for `cudaq.dbg.ast` in
  `_LAZY_SUBMODULES`. Because `resolveQualifiedName` returns `obj.__name__`                                                                                                                                                                                                              
  after traversing the attribute chain, `cudaq.ast.print_i64(n)` was                                                                                                                                                                                                                     
  silently accepted inside kernels — `cudaq.ast` resolves to `cudaq.dbg.ast`                                                                                                                                                                                                             
  at runtime, so `obj.__name__` comes back as `'cudaq.dbg.ast'` and passes                                                                                                                                                                                                               
  the `devKey` guard.                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                         
  Fix: add `isExactCudaqDbgAstCall` which walks the literal AST node                                                                                                                                                                                                                     
  structure and requires the chain to be exactly `<cudaq_alias>.dbg.ast.<name>`.                                                                                                                                                                                                         
  The `devKey` check is now conjunctive with this AST check.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                         
  Tests cover:                                                                                                                                                                                                                                                                           
  - valid `cudaq.dbg.ast.print_i64` and `print_f64` calls still work                                                                                                                                                                                                                     
  - `cudaq.ast.print_i64` (lazy alias, the specific bug) is now rejected                                                                                                                                                                                                                 
  - `dbg.cudaq.ast` and `ast.cudaq.dbg` reorderings are rejected                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                         
  Fixes #2342                                                                                                                                                                                                                                                                            
