### PR TITLE
Add apply-op-specialization and inlining to circuit-opt-bench pipeline

### DIFF
--- a/python/tests/backends/test_circuit_opt_bench.py
+++ b/python/tests/backends/test_circuit_opt_bench.py
@@ -10,6 +10,7 @@
 # optional SABRE routing on a specified device topology.
 
 import cudaq
+import numpy as np
 import pytest
 
 
@@ -44,6 +45,35 @@ def test_swap_no_decomposition_default_target():
     resources = cudaq.estimate_resources(kernel)
     assert resources.gate_count_for_arity(2) == 1
     assert resources.depth_for_arity(2) == 1
+
+
+def test_custom_unitary_produces_2q_gates():
+    """Custom SU(4) unitary must produce entangling gates after synthesis.
+
+    The pipeline must inline the KAK-decomposed helper function into the
+    main kernel (apply-op-specialization + aggressive-inlining). Without
+    these passes, the helper is removed by symbol-dce and 0 2Q gates
+    appear in the output.
+    """
+    cudaq.set_target('circuit-opt-bench')
+
+    rng = np.random.default_rng(42)
+    z = rng.standard_normal((4, 4)) + 1j * rng.standard_normal((4, 4))
+    q_mat, r = np.linalg.qr(z)
+    d = np.diag(r)
+    mat = q_mat * (d / np.abs(d))
+
+    kernel = cudaq.make_kernel()
+    q = kernel.qalloc(2)
+    cudaq.register_operation("test_su4_pipeline", mat.flatten().tolist())
+    kernel.test_su4_pipeline(q[0], q[1])
+
+    resources = cudaq.estimate_resources(kernel)
+    two_q = resources.gate_count_for_arity(2)
+    assert two_q >= 1, (
+        f"Random SU(4) produced 0 2Q gates. Gates: {resources.to_dict()}")
+    assert two_q <= 6, (
+        f"KAK produces at most 3 CX (6 CZ after basis change), got {two_q}")
 
 
 def _make_nonlocal_cx_kernel():

--- a/runtime/cudaq/platform/default/circuit-opt-bench.yml
+++ b/runtime/cudaq/platform/default/circuit-opt-bench.yml
@@ -24,7 +24,9 @@ config:
   # %DEVICE:bypass% defaults to bypass (no routing) when device is not set.
   # Post-routing decomposition converts router-inserted SWAPs and remaining
   # CX gates to CZ as the final 2Q gate.
-  jit-mid-level-pipeline: "func.func(expand-control-veqs,multicontrol-decomposition),decomposition{basis=h,rx,ry,rz,x,x(1)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=%DEVICE:bypass%},func.func(delay-measurements,regtomem),decomposition{basis=h,rx,ry,rz,x,z(1)}"
+  # Inline KAK-decomposed helper functions before decomposition and routing
+  # so the router sees the individual CX gates, not opaque quake.apply ops.
+  jit-mid-level-pipeline: "apply-op-specialization,aggressive-inlining,func.func(expand-control-veqs,multicontrol-decomposition),decomposition{basis=h,rx,ry,rz,x,x(1)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=%DEVICE:bypass%},func.func(delay-measurements,regtomem),decomposition{basis=h,rx,ry,rz,x,z(1)}"
   # Cleanup: symbol-dce removes wire_set ops left by add-wireset (prevents
   # the JIT from taking the wireset-to-profile QIR path).
   jit-low-level-pipeline: "func.func(apply-control-negations,canonicalize,cse),symbol-dce"


### PR DESCRIPTION
Without these passes, unitary-synthesis creates `quake.apply` ops that call KAK-decomposed helper functions, but the helpers are never inlined into the main kernel. symbol-dce then removes them as dead code, producing 0 2Q gates for any custom unitary operation which breaks resource estimation.