### PR TITLE
Fix tensornet backend crash on empty spin_op observe

### DIFF
--- a/python/tests/kernel/test_observe_kernel.py
+++ b/python/tests/kernel/test_observe_kernel.py
@@ -15,6 +15,10 @@ from typing import List
 import cudaq
 from cudaq import spin
 
+skipIfNoTensorNet = pytest.mark.skipif(
+    not (cudaq.num_available_gpus() > 0 and cudaq.has_target('tensornet')),
+    reason="tensornet backend not available")
+
 
 @pytest.fixture(autouse=True)
 def run_and_clear_registries():
@@ -271,6 +275,26 @@ def test_empty_spin_op():
     batched = h.distribute_terms(2)
     assert batched[1].term_count == 0
     assert cudaq.observe(circuit, batched[1], .59).expectation() == 0
+
+
+@skipIfNoTensorNet
+def test_empty_spin_op_tensornet():
+
+    @cudaq.kernel
+    def circuit():
+        q = cudaq.qvector(2)
+        h(q[0])
+
+    cudaq.set_target('tensornet')
+    try:
+        empty_op = cudaq.SpinOperator()
+        assert empty_op.term_count == 0
+        assert empty_op.degrees == []
+
+        result = cudaq.observe(circuit, empty_op)
+        assert result.expectation() == 0.0
+    finally:
+        cudaq.reset_target()
 
 
 def test_spec_adherence():

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.inc
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.inc
@@ -491,6 +491,13 @@ SimulatorTensorNetBase<ScalarType>::observe(const cudaq::spin_op &ham) {
 
   assert(cudaq::spin_op::canonicalize(ham) == ham);
   LOG_API_TIME();
+  // Empty observables can arise when terms are distributed across more workers
+  // than the operator contains. Their expectation value is always zero.
+  if (ham.num_terms() == 0) {
+    std::vector<cudaq::ExecutionResult> results;
+    cudaq::sample_result perTermData(0.0, results);
+    return cudaq::observe_result(0.0, ham, perTermData);
+  }
   prepareQubitTensorState();
   if (!m_reuseContractionPathObserve) {
     // If contraction path reuse is disabled, convert spin_op to


### PR DESCRIPTION
## Summary
- The tensornet simulator's `observe` method did not handle empty spin operators (`num_terms() == 0`), which can arise when distributing terms across more workers than the operator contains.
- Add an early return with zero expectation value for this case, matching the behavior of other simulator backends.
- Add a tensornet-specific test for observing an empty `SpinOperator`.