### PR TITLE
Rename CompiledKernel to CompiledModule

### DIFF
--- a/python/runtime/cudaq/platform/JITExecutionCache.h
+++ b/python/runtime/cudaq/platform/JITExecutionCache.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "common/CompiledKernel.h"
+#include "common/CompiledModule.h"
 #include <list>
 #include <mutex>
 #include <unordered_map>

--- a/runtime/common/CMakeLists.txt
+++ b/runtime/common/CMakeLists.txt
@@ -26,7 +26,7 @@ set(COMMON_RUNTIME_SRC
   SampleResult.cpp
   ServerHelper.cpp
   Trace.cpp
-  CompiledKernel.cpp
+  CompiledModule.cpp
   "${CMAKE_BINARY_DIR}/runtime/common/Version.cpp"
 )
 

--- a/runtime/common/CompiledModule.cpp
+++ b/runtime/common/CompiledModule.cpp
@@ -6,54 +6,54 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "CompiledKernel.h"
+#include "CompiledModule.h"
 #include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include <memory>
 #include <stdexcept>
 
 using namespace cudaq_internal::compiler;
 
-cudaq::CompiledKernel::CompiledKernel(std::string kernelName,
+cudaq::CompiledModule::CompiledModule(std::string kernelName,
                                       ResultInfo resultInfo)
     : name(std::move(kernelName)), resultInfo(std::move(resultInfo)) {}
 
-const cudaq::CompiledKernel::JitArtifact &
-cudaq::CompiledKernel::getJit() const {
+const cudaq::CompiledModule::JitArtifact &
+cudaq::CompiledModule::getJit() const {
   for (auto &[key, artifact] : artifacts)
     if (auto *jit = std::get_if<JitArtifact>(&artifact))
       return *jit;
   throw std::runtime_error("CompiledKernel has no JIT artifact.");
 }
 
-const cudaq::CompiledKernel::MlirArtifact &
-cudaq::CompiledKernel::getMlir() const {
+const cudaq::CompiledModule::MlirArtifact &
+cudaq::CompiledModule::getMlir() const {
   for (auto &[key, artifact] : artifacts)
     if (auto *mlir = std::get_if<MlirArtifact>(&artifact))
       return *mlir;
   throw std::runtime_error("CompiledKernel has no MLIR artifact.");
 }
 
-bool cudaq::CompiledKernel::hasJit() const {
+bool cudaq::CompiledModule::hasJit() const {
   for (auto &[key, artifact] : artifacts)
     if (std::holds_alternative<JitArtifact>(artifact))
       return true;
   return false;
 }
 
-bool cudaq::CompiledKernel::hasMlir() const {
+bool cudaq::CompiledModule::hasMlir() const {
   for (auto &[key, artifact] : artifacts)
     if (std::holds_alternative<MlirArtifact>(artifact))
       return true;
   return false;
 }
 
-bool cudaq::CompiledKernel::isFullySpecialized() const {
+bool cudaq::CompiledModule::isFullySpecialized() const {
   if (!hasJit())
     return true; // No JIT artifact → fully specialized.
   return getJit().argsCreator == nullptr;
 }
 
-void cudaq::CompiledKernel::addArtifact(std::string name,
+void cudaq::CompiledModule::addArtifact(std::string name,
                                         CompiledArtifact artifact) {
   if (artifacts.contains(name))
     throw std::runtime_error("Artifact with name " + name + " already exists");
@@ -61,7 +61,7 @@ void cudaq::CompiledKernel::addArtifact(std::string name,
 }
 
 cudaq::KernelThunkResultType
-cudaq::CompiledKernel::execute(const std::vector<void *> &rawArgs) const {
+cudaq::CompiledModule::execute(const std::vector<void *> &rawArgs) const {
   auto &jit = getJit();
   auto funcPtr = jit.entryPoint;
   if (resultInfo.hasResult()) {
@@ -82,7 +82,7 @@ cudaq::CompiledKernel::execute(const std::vector<void *> &rawArgs) const {
   return {nullptr, 0};
 }
 
-cudaq::KernelThunkResultType cudaq::CompiledKernel::execute() const {
+cudaq::KernelThunkResultType cudaq::CompiledModule::execute() const {
   if (!isFullySpecialized())
     throw std::runtime_error(
         "Kernel has unspecialized parameters; call execute(rawArgs) instead.");
@@ -97,15 +97,15 @@ cudaq::KernelThunkResultType cudaq::CompiledKernel::execute() const {
   return {buf.release(), resultInfo.bufferSize};
 }
 
-void (*cudaq::CompiledKernel::JitArtifact::getEntryPoint() const)() {
+void (*cudaq::CompiledModule::JitArtifact::getEntryPoint() const)() {
   return entryPoint;
 }
 
-cudaq::JitEngine cudaq::CompiledKernel::JitArtifact::getEngine() const {
+cudaq::JitEngine cudaq::CompiledModule::JitArtifact::getEngine() const {
   return engine;
 }
 
-void cudaq::CompiledKernel::attachJit(JitEngine engine,
+void cudaq::CompiledModule::attachJit(JitEngine engine,
                                       bool isFullySpecialized) {
   bool hasResult = resultInfo.hasResult();
   std::string fullName = cudaq::runtime::cudaqGenPrefixName + name;

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -79,7 +79,7 @@ class ResultInfo {
   // Friend factory function, to be used for construction.
   friend cudaq::ResultInfo cudaq_internal::compiler::createResultInfo(
       mlir::Type resultType, bool isEntryPoint, mlir::ModuleOp module);
-  friend class CompiledKernel;
+  friend class CompiledModule;
 
   /// Opaque pointer to the `mlir::Type` of the result. Obtained via
   /// `mlir::Type::getAsOpaquePointer()`.
@@ -99,19 +99,16 @@ public:
   bool hasResult() const { return typeOpaquePtr != nullptr; }
 };
 
-/// @brief A compiled, ready-to-execute kernel.
+/// @brief A compiled MLIR module, ready for execution or codegen.
 ///
-/// Contains a map of named compiled artifacts (JIT binaries or MLIR modules)
-/// along with metadata needed for execution and result extraction.
-///
-/// For non-observe kernels, the map has a single entry keyed by the kernel
-/// name. For observe mode, there is one entry per Pauli term, keyed by the
-/// term ID.
+/// Contains any number of named compilation artifacts (we currently support
+/// JIT binaries and optimized MLIR modules) that result from the compilation
+/// of a Quake MLIR module.
 ///
 /// This type does not depend on MLIR/LLVM — it only keeps type-erased / opaque
-/// pointers. Use the `attachJit` member function to attach a JIT-compiled
-/// artifact after construction.
-class CompiledKernel {
+/// pointers. Use the `attachJit` member function to attach JIT-compiled
+/// artifacts after construction.
+class CompiledModule {
 public:
   // --- Compiled artifact types ---
 
@@ -128,7 +125,7 @@ public:
         : engine(engine), entryPoint(entryPoint), argsCreator(argsCreator),
           resourceCounts(std::move(resourceCounts)) {}
 
-    friend class CompiledKernel;
+    friend class CompiledModule;
 
   public:
     // TODO: remove the following two methods once the `CompiledKernel` instance
@@ -164,7 +161,7 @@ public:
     [[maybe_unused]] const void *modulePtr = nullptr;
 #pragma GCC diagnostic pop
 
-    friend class CompiledKernel;
+    friend class CompiledModule;
   };
 
   /// A compiled artifact is either a JIT binary or an MLIR module.
@@ -172,7 +169,7 @@ public:
 
   // --- Construction ---
 
-  CompiledKernel(std::string kernelName, ResultInfo resultInfo);
+  CompiledModule(std::string kernelName, ResultInfo resultInfo);
 
   /// @brief Populate the JIT representation of a `CompiledKernel`.
   ///

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "CompiledKernel.h"
+#include "CompiledModule.h"
 #include "Future.h"
 #include "NoiseModel.h"
 #include "SampleResult.h"

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "CompiledKernel.h"
+#include "CompiledModule.h"
 #include "ExecutionContext.h"
 #include "Future.h"
 #include "Registry.h"

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -8,7 +8,7 @@
 
 #include "QPU.h"
 #include "common/ArgumentWrapper.h"
-#include "common/CompiledKernel.h"
+#include "common/CompiledModule.h"
 #include "common/Environment.h"
 #include "common/ExecutionContext.h"
 #include "common/RuntimeTarget.h"
@@ -319,7 +319,7 @@ static void precountResources(ModuleOp module) {
 
 namespace {
 struct PythonLauncher : public cudaq::ModuleLauncher {
-  cudaq::CompiledKernel compileModule(const std::string &name, ModuleOp module,
+  cudaq::CompiledModule compileModule(const std::string &name, ModuleOp module,
                                       const std::vector<void *> &rawArgs,
                                       bool isEntryPoint) override {
 
@@ -362,7 +362,7 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
     auto resultInfo = createResultInfo(resultTy, isEntryPoint, module);
 
     if (auto jit = alreadyBuiltJITCode(name, rawArgs)) {
-      cudaq::CompiledKernel ck(name, resultInfo);
+      cudaq::CompiledModule ck(name, resultInfo);
       ck.attachJit(*jit, isFullySpecialized);
       return ck;
     }
@@ -404,7 +404,7 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
     cudaq::compiler_artifact::saveArtifact(name, rawArgs, jit,
                                            argsCreatorThunk);
 
-    cudaq::CompiledKernel ck(name, resultInfo);
+    cudaq::CompiledModule ck(name, resultInfo);
     ck.attachJit(jit, isFullySpecialized);
     return ck;
   }

--- a/runtime/cudaq/platform/nvqpp_interface.h
+++ b/runtime/cudaq/platform/nvqpp_interface.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "common/CompiledKernel.h"
+#include "common/CompiledModule.h"
 #include "common/ThunkInterface.h"
 #include <optional>
 #include <string>

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "QuantumExecutionQueue.h"
-#include "common/CompiledKernel.h"
+#include "common/CompiledModule.h"
 #include "common/Registry.h"
 #include "common/ThunkInterface.h"
 #include "common/Timing.h"
@@ -212,8 +212,8 @@ struct ModuleLauncher : public registry::RegisteredType<ModuleLauncher> {
   virtual ~ModuleLauncher() = default;
 
   /// Compile (specialize + JIT) a kernel module and return a ready-to-execute
-  /// CompiledKernel.
-  virtual CompiledKernel compileModule(const std::string &name,
+  /// CompiledModule.
+  virtual CompiledModule compileModule(const std::string &name,
                                        mlir::ModuleOp module,
                                        const std::vector<void *> &rawArgs,
                                        bool isEntryPoint) = 0;

--- a/runtime/internal/compiler/JIT.cpp
+++ b/runtime/internal/compiler/JIT.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq_internal/compiler/JIT.h"
-#include "common/CompiledKernel.h"
+#include "common/CompiledModule.h"
 #include "common/Environment.h"
 #include "common/Timing.h"
 #include "cudaq/Frontend/nvqpp/AttributeNames.h"

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -7,7 +7,7 @@
  ******************************************************************************/
 #pragma once
 
-#include "common/CompiledKernel.h"
+#include "common/CompiledModule.h"
 #include <map>
 #include <memory>
 #include <string>

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/JIT.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/JIT.h
@@ -7,7 +7,7 @@
  ******************************************************************************/
 #pragma once
 
-#include "common/CompiledKernel.h"
+#include "common/CompiledModule.h"
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -27,7 +27,7 @@ class Type;
 } // namespace mlir
 
 namespace cudaq {
-class CompiledKernel;
+class CompiledModule;
 class ResultInfo;
 } // namespace cudaq
 


### PR DESCRIPTION
This is a first follow-up from yesterday's conversation. It renames `CompiledKernel` to `CompiledModule`. This is to clarify the exact scope of this type:

> A `CompiledModule` is the collection of artifacts produced by CUDAQ when compiling a Quake MLIR module.

This is slightly different from a "compiled kernel", as it may contain zero, one or multiple entrypoints.

I'm working separately on another PR that will make a clearer distinction between the CompiledModule and its artifacts (e.g. `JitArtifact` come with an entrypoint, whereas `MlirArtifact`s do not). It will also move the logic on how to "execute" `CompiledModule`s out of the type itself.
