### PR TITLE
Clean up ghcr-ci deployments in clean_up workflow

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -144,6 +144,8 @@ jobs:
   # Since we use the same workflows during CI, a default environment that defines
   # the necessary variables is used instead. Unfortunately, this automatically
   # also creates an (unwanted) deployment, which we delete with this job.
+  # The ghcr-ci environment similarly produces unwanted deployment entries
+  # from the dev_environment workflow during CI runs on pull requests.
   # See also https://github.com/actions/runner/issues/2120
   deployments:
     name: Deployments
@@ -155,26 +157,28 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const deployments = await github.rest.repos.listDeployments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              environment: 'default'
-            });
-            await Promise.all(
-              deployments.data.map(async (deployment) => {
-                await github.rest.repos.createDeploymentStatus({ 
-                owner: context.repo.owner, 
-                repo: context.repo.repo, 
-                deployment_id: deployment.id, 
-                state: 'inactive' 
-                });
-                return github.rest.repos.deleteDeployment({
+            for (const environment of ['default', 'ghcr-ci']) {
+              const deployments = await github.rest.repos.listDeployments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                deployment_id: deployment.id
-                });
-              })
-            );
+                environment: environment
+              });
+              await Promise.all(
+                deployments.data.map(async (deployment) => {
+                  await github.rest.repos.createDeploymentStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: deployment.id,
+                  state: 'inactive'
+                  });
+                  return github.rest.repos.deleteDeployment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: deployment.id
+                  });
+                })
+              );
+            }
 
   pr_cleanup:
     name: Clean up documentation previews


### PR DESCRIPTION
The deployments cleanup job only removes `default` environment deployments                
but not `ghcr-ci` ones. Every CI run creates multiple ghcr-ci deployments 
via dev_environment.yml, leaving "copy-pr-bot temporarily deployed to                     
ghcr-ci — Inactive" entries cluttering PR timelines.                                      
                                                                                          
Extend the existing cleanup loop to also delete ghcr-ci deployments.                      
The production `ghcr-deployment` environment used by deployments.yml                      
is not affected.                                                                          