### PR TITLE
[unittest] Update the unittest to conform to new API contracts.

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -197,7 +197,7 @@ if (cuStateVec_FOUND)
   )
   target_include_directories(test_custatevec_observe_from_sampling PRIVATE .)
   target_compile_definitions(test_custatevec_observe_from_sampling
-                             PRIVATE -DNVQIR_BACKEND_NAME=custatevec_fp32)
+    PRIVATE -DNVQIR_BACKEND_NAME=custatevec_fp32 -DCUDAQ_SIMULATION_SCALAR_FP32)
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
     target_link_options(test_custatevec_observe_from_sampling PRIVATE ${CUDAQ_FORCE_LINK_FLAG})
   endif()

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -1382,7 +1382,7 @@ TEST(BuilderTester, checkFromStateVector) {
   }
 
   {
-    auto [kernel, initState] = cudaq::make_kernel<cudaq::state*>();
+    auto [kernel, initState] = cudaq::make_kernel<cudaq::state *>();
     auto qubits = kernel.qalloc(initState);
     std::cout << kernel << "\n";
     auto counts = cudaq::sample(kernel, &st0);
@@ -1400,7 +1400,7 @@ TEST(BuilderTester, checkFromStateVector) {
     // 2 qubit 11 state
     std::vector<cudaq::complex> vec{0., 0., 0., 1.};
     cudaq::state st1{vec};
-    auto [kernel, initState] = cudaq::make_kernel<cudaq::state*>();
+    auto [kernel, initState] = cudaq::make_kernel<cudaq::state *>();
     auto qubits = kernel.qalloc(initState);
     // induce the need for a kron prod between [0,0,0,1] and [1, 0, 0, 0]
     auto anotherOne = kernel.qalloc(2);
@@ -1415,7 +1415,7 @@ TEST(BuilderTester, checkFromStateVector) {
     // 2 qubit 11 state
     std::vector<cudaq::complex> vec{0., 0., 0., 1.};
     cudaq::state st2{std::move(vec)};
-    auto [kernel, initState] = cudaq::make_kernel<cudaq::state*>();
+    auto [kernel, initState] = cudaq::make_kernel<cudaq::state *>();
     auto qubits = kernel.qalloc(initState);
     // induce the need for a kron prod between [0,0,0,1] and [1, 0]
     auto anotherOne = kernel.qalloc();

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -1365,9 +1365,10 @@ CUDAQ_TEST(BuilderTester, checkControlledRotations) {
 
 TEST(BuilderTester, checkFromStateVector) {
   std::vector<cudaq::complex> vec{M_SQRT1_2, 0., 0., M_SQRT1_2};
+  cudaq::state st0{vec};
   {
     auto kernel = cudaq::make_kernel();
-    auto qubits = kernel.qalloc(vec);
+    auto qubits = kernel.qalloc(st0);
     std::cout << kernel << "\n";
     auto counts = cudaq::sample(kernel);
     counts.dump();
@@ -1381,11 +1382,10 @@ TEST(BuilderTester, checkFromStateVector) {
   }
 
   {
-    auto [kernel, initState] =
-        cudaq::make_kernel<std::vector<cudaq::complex>>();
+    auto [kernel, initState] = cudaq::make_kernel<cudaq::state*>();
     auto qubits = kernel.qalloc(initState);
     std::cout << kernel << "\n";
-    auto counts = cudaq::sample(kernel, vec);
+    auto counts = cudaq::sample(kernel, &st0);
     counts.dump();
     EXPECT_EQ(counts.size(), 2);
     std::size_t counter = 0;
@@ -1399,14 +1399,14 @@ TEST(BuilderTester, checkFromStateVector) {
   {
     // 2 qubit 11 state
     std::vector<cudaq::complex> vec{0., 0., 0., 1.};
-    auto [kernel, initState] =
-        cudaq::make_kernel<std::vector<cudaq::complex>>();
+    cudaq::state st1{vec};
+    auto [kernel, initState] = cudaq::make_kernel<cudaq::state*>();
     auto qubits = kernel.qalloc(initState);
     // induce the need for a kron prod between
     // [0,0,0,1] and [1, 0, 0, 0]
     auto anotherOne = kernel.qalloc(2);
     std::cout << kernel << "\n";
-    auto counts = cudaq::sample(kernel, vec);
+    auto counts = cudaq::sample(kernel, &st1);
     counts.dump();
     EXPECT_EQ(counts.size(), 1);
     EXPECT_EQ(counts.count("1100"), 1000);
@@ -1415,14 +1415,14 @@ TEST(BuilderTester, checkFromStateVector) {
   {
     // 2 qubit 11 state
     std::vector<cudaq::complex> vec{0., 0., 0., 1.};
-    auto [kernel, initState] =
-        cudaq::make_kernel<std::vector<cudaq::complex>>();
+    cudaq::state st2{vec};
+    auto [kernel, initState] = cudaq::make_kernel<cudaq::state*>();
     auto qubits = kernel.qalloc(initState);
     // induce the need for a kron prod between
     // [0,0,0,1] and [1, 0]
     auto anotherOne = kernel.qalloc();
     std::cout << kernel << "\n";
-    auto counts = cudaq::sample(kernel, vec);
+    auto counts = cudaq::sample(kernel, &st2);
     counts.dump();
     EXPECT_EQ(counts.size(), 1);
     EXPECT_EQ(counts.count("110"), 1000);

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -1402,8 +1402,7 @@ TEST(BuilderTester, checkFromStateVector) {
     cudaq::state st1{vec};
     auto [kernel, initState] = cudaq::make_kernel<cudaq::state*>();
     auto qubits = kernel.qalloc(initState);
-    // induce the need for a kron prod between
-    // [0,0,0,1] and [1, 0, 0, 0]
+    // induce the need for a kron prod between [0,0,0,1] and [1, 0, 0, 0]
     auto anotherOne = kernel.qalloc(2);
     std::cout << kernel << "\n";
     auto counts = cudaq::sample(kernel, &st1);
@@ -1415,11 +1414,10 @@ TEST(BuilderTester, checkFromStateVector) {
   {
     // 2 qubit 11 state
     std::vector<cudaq::complex> vec{0., 0., 0., 1.};
-    cudaq::state st2{vec};
+    cudaq::state st2{std::move(vec)};
     auto [kernel, initState] = cudaq::make_kernel<cudaq::state*>();
     auto qubits = kernel.qalloc(initState);
-    // induce the need for a kron prod between
-    // [0,0,0,1] and [1, 0]
+    // induce the need for a kron prod between [0,0,0,1] and [1, 0]
     auto anotherOne = kernel.qalloc();
     std::cout << kernel << "\n";
     auto counts = cudaq::sample(kernel, &st2);


### PR DESCRIPTION
This updates the unittest so that cudaq::state objects are used to capture and pass state information (amplitude vectors) into kernels. The new API contract is that this sort of state information shall be passed into CUDA-Q kernels as state objects and not raw vectors.