### PR TITLE
Add `eliminate-dead-heap-copy` pass for early `malloc` elimination

### DIFF
--- a/include/cudaq/Optimizer/CodeGen/Passes.td
+++ b/include/cudaq/Optimizer/CodeGen/Passes.td
@@ -278,5 +278,33 @@ def ReturnToOutputLog : Pass<"return-to-output-log", "mlir::ModuleOp"> {
   ];
 }
 
+def EliminateDeadHeapCopy
+    : Pass<"eliminate-dead-heap-copy", "mlir::func::FuncOp"> {
+  let summary = "Eliminate dead heap copies from return value logging.";
+  let description = [{
+    When a kernel returns a vector (e.g., measurement results), the frontend
+    wraps the return value with `__nvqpp_vectorCopyCtor`, which performs a
+    malloc+memcpy to copy the data from the callee's stack to the heap. This
+    is necessary because the returned data must outlive the callee's stack
+    frame when one kernel calls another. After AggressiveInlining, this
+    intrinsic is expanded into raw malloc and memcpy operations in the caller.
+
+    After ReturnToOutputLog converts return values to QIR output logging
+    calls (e.g., `__quantum__rt__*_record_output`), it reads from the
+    cc.stdvec_init's buffer (the malloc'd pointer) and creates new load ops
+    from it, leaving the cc.stdvec_init with no users. The malloc+memcpy
+    are then only needed to populate the heap buffer that the output logging
+    reads from. This pass redirects those reads to the memcpy source (the
+    original stack data), making the malloc+memcpy dead, and erases them
+    along with the now-unused cc.stdvec_init.
+
+    Note: this pass is only needed on code paths that do not run LLVM's
+    optimization passes (e.g., when emitting MLIR rather than LLVM IR for 
+    a remote backend). When the full LLVM opt pipeline runs, it would eliminate
+    these dead allocations on its own.
+  }];
+  let dependentDialects = ["cudaq::cc::CCDialect", "mlir::func::FuncDialect"];
+}
+
 
 #endif // CUDAQ_OPT_OPTIMIZER_CODEGEN_PASSES

--- a/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -21,6 +21,7 @@ add_cudaq_library(OptCodeGen
   ConvertToQIR.cpp
   ConvertToQIRAPI.cpp
   DelayMeasurements.cpp
+  EliminateDeadHeapCopy.cpp
   OptUtils.cpp
   Passes.cpp
   Pipelines.cpp

--- a/lib/Optimizer/CodeGen/EliminateDeadHeapCopy.cpp
+++ b/lib/Optimizer/CodeGen/EliminateDeadHeapCopy.cpp
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/CodeGen/Passes.h"
+#include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+
+#define DEBUG_TYPE "eliminate-dead-heap-copy"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_ELIMINATEDEADHEAPCOPY
+#include "cudaq/Optimizer/CodeGen/Passes.h.inc"
+} // namespace cudaq::opt
+
+using namespace mlir;
+
+namespace {
+
+/// When a kernel returns a vector, the frontend copies the stack data to the
+/// heap via malloc+memcpy (from __nvqpp_vectorCopyCtor) so the data outlives
+/// the callee's stack frame. After inlining and ReturnToOutputLog, the output
+/// logging reads from the heap buffer through cc.cast ops, and the
+/// cc.stdvec_init that wrapped the malloc becomes dead. This pass redirects
+/// those cc.cast reads to the memcpy source (the original stack buffer) and
+/// erases the now-dead malloc, memcpy, and cc.stdvec_init.
+struct EliminateDeadHeapCopyPass
+    : public cudaq::opt::impl::EliminateDeadHeapCopyBase<
+          EliminateDeadHeapCopyPass> {
+  using EliminateDeadHeapCopyBase::EliminateDeadHeapCopyBase;
+
+  void runOnOperation() override {
+    auto func = getOperation();
+    SmallVector<func::CallOp> mallocCalls;
+    func.walk([&](func::CallOp callOp) {
+      if (callOp.getCallee() == "malloc")
+        mallocCalls.push_back(callOp);
+    });
+
+    for (auto mallocCall : mallocCalls) {
+      // malloc should return exactly one result (the allocated pointer).
+      if (mallocCall->getNumResults() != 1)
+        continue;
+      Value mallocResult = mallocCall.getResult(0);
+
+      // Classify users of the malloc result.
+      func::CallOp memcpyCall;
+      SmallVector<cudaq::cc::StdvecInitOp> deadVecInits;
+      SmallVector<cudaq::cc::CastOp> castUsers;
+      bool hasUnsafeUser = false;
+
+      for (auto *user : mallocResult.getUsers()) {
+        if (auto userCall = dyn_cast<func::CallOp>(user)) {
+          if (userCall.getCallee().starts_with("llvm.memcpy") &&
+              userCall.getOperand(0) == mallocResult) {
+            if (memcpyCall) {
+              // Multiple memcpys to the same malloc dest — bail out.
+              hasUnsafeUser = true;
+              break;
+            }
+            memcpyCall = userCall;
+            continue;
+          }
+        }
+        // A dead stdvec_init (no remaining users) can be safely erased.
+        // One with live users is treated as unsafe.
+        if (auto vecInit = dyn_cast<cudaq::cc::StdvecInitOp>(user)) {
+          if (vecInit->use_empty()) {
+            deadVecInits.push_back(vecInit);
+            continue;
+          }
+        }
+        // A cc.cast is safe to redirect: since the memcpy copies from
+        // source to the malloc buffer, reading through either pointer
+        // yields the same data.
+        if (auto castOp = dyn_cast<cudaq::cc::CastOp>(user)) {
+          castUsers.push_back(castOp);
+          continue;
+        }
+        // Any other user prevents elimination.
+        hasUnsafeUser = true;
+        break;
+      }
+
+      if (!memcpyCall || hasUnsafeUser)
+        continue;
+
+      Value memcpySrc = memcpyCall.getOperand(1);
+
+      // Redirect cc.cast users from the malloc result to the memcpy source.
+      for (auto castOp : castUsers)
+        castOp->replaceUsesOfWith(mallocResult, memcpySrc);
+
+      // Erase dead stdvec_inits.
+      for (auto vecInit : deadVecInits)
+        vecInit->erase();
+
+      // Erase memcpy and malloc.
+      memcpyCall->erase();
+      mallocCall->erase();
+    }
+  }
+};
+
+} // namespace

--- a/test/Transforms/eliminate_dead_heap_copy.qke
+++ b/test/Transforms/eliminate_dead_heap_copy.qke
@@ -1,0 +1,126 @@
+// ========================================================================== //
+// Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                 //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --eliminate-dead-heap-copy %s | FileCheck %s
+
+// After ReturnToOutputLog, the malloc+memcpy used to create a heap copy of
+// stack data for stdvec returns becomes dead. The only remaining users of the
+// malloc result are the memcpy (as dest) and a cc.cast that feeds into
+// record_output calls. This pass should replace the cc.cast's use of the
+// malloc result with the memcpy source and erase the dead malloc+memcpy.
+
+func.func private @malloc(i64) -> !cc.ptr<i8>
+func.func private @llvm.memcpy.p0i8.p0i8.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
+func.func private @__quantum__rt__int_record_output(i64, !cc.ptr<i8>)
+func.func private @__quantum__rt__array_record_output(i64, !cc.ptr<i8>)
+
+// Test basic malloc+memcpy elimination where the malloc result is only used
+// by memcpy (as dest) and a cc.cast.
+func.func @test_basic_elimination() {
+  %c40 = arith.constant 40 : i64
+  %c5 = arith.constant 5 : i64
+  %false = arith.constant false
+  %alloca = cc.alloca !cc.array<i64 x 5>
+  %cast_src = cc.cast %alloca : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<i8>
+  %malloc_res = call @malloc(%c40) : (i64) -> !cc.ptr<i8>
+  call @llvm.memcpy.p0i8.p0i8.i64(%malloc_res, %cast_src, %c40, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+  %cast_dst = cc.cast %malloc_res : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i64 x ?>>
+  %ptr0 = cc.compute_ptr %cast_dst[0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
+  %val0 = cc.load %ptr0 : !cc.ptr<i64>
+  %label = cc.string_literal "[0]" : !cc.ptr<!cc.array<i8 x 4>>
+  %label_cast = cc.cast %label : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+  call @__quantum__rt__int_record_output(%val0, %label_cast) : (i64, !cc.ptr<i8>) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @test_basic_elimination() {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 40 : i64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 5 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant false
+// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.array<i64 x 5>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_8:.*]] = cc.string_literal "[0]" : !cc.ptr<!cc.array<i8 x 4>>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           call @__quantum__rt__int_record_output(%[[VAL_7]], %[[VAL_9]]) : (i64, !cc.ptr<i8>) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// Test that dead cc.stdvec_init ops are also removed.
+func.func @test_dead_stdvec_init() {
+  %c40 = arith.constant 40 : i64
+  %c5 = arith.constant 5 : i64
+  %false = arith.constant false
+  %alloca = cc.alloca !cc.array<i64 x 5>
+  %cast_src = cc.cast %alloca : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<i8>
+  %malloc_res = call @malloc(%c40) : (i64) -> !cc.ptr<i8>
+  call @llvm.memcpy.p0i8.p0i8.i64(%malloc_res, %cast_src, %c40, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+  %dead_vec = cc.stdvec_init %malloc_res, %c5 : (!cc.ptr<i8>, i64) -> !cc.stdvec<i64>
+  %cast_dst = cc.cast %malloc_res : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i64 x ?>>
+  %ptr0 = cc.compute_ptr %cast_dst[0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
+  %val0 = cc.load %ptr0 : !cc.ptr<i64>
+  %label = cc.string_literal "[0]" : !cc.ptr<!cc.array<i8 x 4>>
+  %label_cast = cc.cast %label : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+  call @__quantum__rt__int_record_output(%val0, %label_cast) : (i64, !cc.ptr<i8>) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @test_dead_stdvec_init() {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 40 : i64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 5 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant false
+// CHECK:           %[[VAL_3:.*]] = cc.alloca !cc.array<i64 x 5>
+// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_8:.*]] = cc.string_literal "[0]" : !cc.ptr<!cc.array<i8 x 4>>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           call @__quantum__rt__int_record_output(%[[VAL_7]], %[[VAL_9]]) : (i64, !cc.ptr<i8>) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// Test that malloc is NOT removed when it has non-memcpy, non-stdvec_init
+// users that cannot be redirected (e.g., another call using it as an argument).
+func.func private @use_ptr(!cc.ptr<i8>)
+
+func.func @test_no_elimination_extra_user() {
+  %c40 = arith.constant 40 : i64
+  %false = arith.constant false
+  %alloca = cc.alloca !cc.array<i64 x 5>
+  %cast_src = cc.cast %alloca : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<i8>
+  %malloc_res = call @malloc(%c40) : (i64) -> !cc.ptr<i8>
+  call @llvm.memcpy.p0i8.p0i8.i64(%malloc_res, %cast_src, %c40, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+  call @use_ptr(%malloc_res) : (!cc.ptr<i8>) -> ()
+  %cast_dst = cc.cast %malloc_res : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i64 x ?>>
+  %ptr0 = cc.compute_ptr %cast_dst[0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
+  %val0 = cc.load %ptr0 : !cc.ptr<i64>
+  %label = cc.string_literal "[0]" : !cc.ptr<!cc.array<i8 x 4>>
+  %label_cast = cc.cast %label : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+  call @__quantum__rt__int_record_output(%val0, %label_cast) : (i64, !cc.ptr<i8>) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func @test_no_elimination_extra_user() {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 40 : i64
+// CHECK:           %[[VAL_1:.*]] = arith.constant false
+// CHECK:           %[[VAL_2:.*]] = cc.alloca !cc.array<i64 x 5>
+// CHECK:           %[[VAL_3:.*]] = cc.cast %[[VAL_2]] : (!cc.ptr<!cc.array<i64 x 5>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = call @malloc(%[[VAL_0]]) : (i64) -> !cc.ptr<i8>
+// CHECK:           call @llvm.memcpy.p0i8.p0i8.i64(%[[VAL_4]], %[[VAL_3]], %[[VAL_0]], %[[VAL_1]]) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+// CHECK:           call @use_ptr(%[[VAL_4]]) : (!cc.ptr<i8>) -> ()
+// CHECK:           %[[VAL_5:.*]] = cc.cast %[[VAL_4]] : (!cc.ptr<i8>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[VAL_6:.*]] = cc.compute_ptr %[[VAL_5]][0] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<i64>
+// CHECK:           %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i64>
+// CHECK:           %[[VAL_8:.*]] = cc.string_literal "[0]" : !cc.ptr<!cc.array<i8 x 4>>
+// CHECK:           %[[VAL_9:.*]] = cc.cast %[[VAL_8]] : (!cc.ptr<!cc.array<i8 x 4>>) -> !cc.ptr<i8>
+// CHECK:           call @__quantum__rt__int_record_output(%[[VAL_7]], %[[VAL_9]]) : (i64, !cc.ptr<i8>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/unittests/backends/quake_backend/QuakeStartServerAndTest.sh.in
+++ b/unittests/backends/quake_backend/QuakeStartServerAndTest.sh.in
@@ -80,6 +80,15 @@ else
   fi
 fi
 
+# Run the Python test
+PYTHONPATH=@CMAKE_BINARY_DIR@/python @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/unittests/backends/quake_backend/test_app.py
+if [ $? -ne 0 ]; then
+  echo ":x: Python test_app.py failed"
+  test_err_sum=$((test_err_sum+1))
+else
+  echo ":white_check_mark: Successfully ran Python test_app.py"
+fi
+
 # kill the server
 kill -INT $pid
 # return success / failure

--- a/unittests/backends/quake_backend/mock_server.py
+++ b/unittests/backends/quake_backend/mock_server.py
@@ -39,13 +39,14 @@ async def postJob(request: Request):
     payload = await request.json()
     # Decode base64
     decoded_payload = base64.b64decode(payload["ir"]).decode('utf-8')
-    # Verify that the input MLIR does not contain actual malloc or memcpy calls.
-    # Match @malloc or @llvm.memcpy as function references (calls or declarations).
+    # Verify that the input MLIR does not contain actual `malloc` or `memcpy` calls.
+    # Match `@malloc` or `@llvm.memcpy` as function references (calls or declarations).
     if re.search(r'@malloc\b', decoded_payload) or \
        re.search(r'@(llvm\.)?memcpy\b', decoded_payload):
         raise RuntimeError(
             "Input MLIR contains malloc or memcpy calls. "
-            "These should have been eliminated by the eliminate-dead-heap-copy pass.")
+            "These should have been eliminated by the eliminate-dead-heap-copy pass."
+        )
 
     ctx = getMLIRContext()
     recovered_mod = Module.parse(decoded_payload, context=ctx)

--- a/unittests/backends/quake_backend/mock_server.py
+++ b/unittests/backends/quake_backend/mock_server.py
@@ -9,7 +9,7 @@
 import cudaq
 from fastapi import FastAPI, HTTPException, Header, Request
 from typing import Union
-import uvicorn, uuid, base64, ctypes, sys
+import uvicorn, uuid, base64, ctypes, sys, re
 from pydantic import BaseModel
 from llvmlite import binding as llvm
 from cudaq.mlir.passmanager import PassManager
@@ -39,6 +39,14 @@ async def postJob(request: Request):
     payload = await request.json()
     # Decode base64
     decoded_payload = base64.b64decode(payload["ir"]).decode('utf-8')
+    # Verify that the input MLIR does not contain actual malloc or memcpy calls.
+    # Match @malloc or @llvm.memcpy as function references (calls or declarations).
+    if re.search(r'@malloc\b', decoded_payload) or \
+       re.search(r'@(llvm\.)?memcpy\b', decoded_payload):
+        raise RuntimeError(
+            "Input MLIR contains malloc or memcpy calls. "
+            "These should have been eliminated by the eliminate-dead-heap-copy pass.")
+
     ctx = getMLIRContext()
     recovered_mod = Module.parse(decoded_payload, context=ctx)
     pm = PassManager.parse(

--- a/unittests/backends/quake_backend/quake_fake.yml
+++ b/unittests/backends/quake_backend/quake_fake.yml
@@ -19,6 +19,7 @@ config:
   link-libs: ["-lcudaq-rest-qpu"]
   # Define the JIT lowering pipeline
   jit-high-level-pipeline: "expand-measurements"
+  jit-low-level-pipeline: "return-to-output-log,func.func(eliminate-dead-heap-copy),symbol-dce"
   # Tell the rest-qpu that we are simply dumping CUDA-Q MLIR code.
   codegen-emission: nop
   # Library mode is only for simulators, physical backends must turn this off

--- a/unittests/backends/quake_backend/test_app.py
+++ b/unittests/backends/quake_backend/test_app.py
@@ -1,0 +1,92 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+import cudaq
+import sys
+
+cudaq.set_target("quake_fake")
+
+qubit_count = 5
+
+
+@cudaq.kernel
+def kernel() -> list[int]:
+    qvector = cudaq.qvector(qubit_count)
+
+    for i in range(qubit_count - 1):
+        h(qvector[i])
+
+    s(qvector[0])
+    r1(math.pi / 2, qvector[1])
+    a = mz(qvector)
+    return a
+
+
+@cudaq.kernel
+def all_zeros() -> list[int]:
+    q = cudaq.qvector(4)
+    return mz(q)
+
+
+@cudaq.kernel
+def all_ones() -> list[int]:
+    q = cudaq.qvector(4)
+    x(q)
+    return mz(q)
+
+
+@cudaq.kernel
+def alternating_01() -> list[int]:
+    q = cudaq.qvector(4)
+    x(q[1])
+    x(q[3])
+    return mz(q)
+
+
+@cudaq.kernel
+def single_qubit_flip() -> list[int]:
+    q = cudaq.qvector(1)
+    x(q[0])
+    return mz(q)
+
+
+try:
+    res = cudaq.run(kernel)
+    assert res is not None
+    assert len(res) > 0
+    assert len(res[0]) == qubit_count
+    for shot in res:
+        for val in shot:
+            assert val in (0, 1)
+
+    # Deterministic: all qubits stay |0>.
+    res = cudaq.run(all_zeros)
+    assert len(res) > 0
+    for shot in res:
+        assert list(shot) == [0, 0, 0, 0], f"expected [0,0,0,0], got {list(shot)}"
+
+    # Deterministic: X on all qubits -> all |1>.
+    res = cudaq.run(all_ones)
+    assert len(res) > 0
+    for shot in res:
+        assert list(shot) == [1, 1, 1, 1], f"expected [1,1,1,1], got {list(shot)}"
+
+    # Deterministic: X on qubits 1 and 3 -> [0,1,0,1].
+    res = cudaq.run(alternating_01)
+    assert len(res) > 0
+    for shot in res:
+        assert list(shot) == [0, 1, 0, 1], f"expected [0,1,0,1], got {list(shot)}"
+
+    # Deterministic: single qubit X -> [1].
+    res = cudaq.run(single_qubit_flip)
+    assert len(res) > 0
+    for shot in res:
+        assert list(shot) == [1], f"expected [1], got {list(shot)}"
+
+except Exception as e:
+    print(e)
+    sys.exit(1)

--- a/unittests/backends/quake_backend/test_app.py
+++ b/unittests/backends/quake_backend/test_app.py
@@ -67,19 +67,22 @@ try:
     res = cudaq.run(all_zeros)
     assert len(res) > 0
     for shot in res:
-        assert list(shot) == [0, 0, 0, 0], f"expected [0,0,0,0], got {list(shot)}"
+        assert list(shot) == [0, 0, 0,
+                              0], f"expected [0,0,0,0], got {list(shot)}"
 
     # Deterministic: X on all qubits -> all |1>.
     res = cudaq.run(all_ones)
     assert len(res) > 0
     for shot in res:
-        assert list(shot) == [1, 1, 1, 1], f"expected [1,1,1,1], got {list(shot)}"
+        assert list(shot) == [1, 1, 1,
+                              1], f"expected [1,1,1,1], got {list(shot)}"
 
     # Deterministic: X on qubits 1 and 3 -> [0,1,0,1].
     res = cudaq.run(alternating_01)
     assert len(res) > 0
     for shot in res:
-        assert list(shot) == [0, 1, 0, 1], f"expected [0,1,0,1], got {list(shot)}"
+        assert list(shot) == [0, 1, 0,
+                              1], f"expected [0,1,0,1], got {list(shot)}"
 
     # Deterministic: single qubit X -> [1].
     res = cudaq.run(single_qubit_flip)


### PR DESCRIPTION
When a kernel returns a vector (for `cudaq::run`), we insert `__nvqpp_vectorCopyCtor` which performs a `malloc` + `memcpy` to copy stack data to the heap. After `AggressiveInlining` and `ReturnToOutputLog`, the heap copy becomes dead but remains in the IR. This is normally cleaned up by LLVM's optimization passes, but on code paths that emit MLIR directly (e.g., `nop` for backends that consume `quake`), these dead allocations persist and get sent to the server.

This PR adds a new MLIR pass, `eliminate-dead-heap-copy`, that redirects reads from the `malloc`'d buffer to the original `memcpy` source (the stack `alloca`), then erases the dead `malloc`, `memcpy`, and `cc.stdvec_init` ops.

This can be added on-demand via target yml file. Update the mock server test to demonstrate that.