### PR TITLE
Further deployment cleanup to drain all ghcr-ci entries

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -158,40 +158,38 @@ jobs:
         with:
           script: |
             const BATCH = 50;
+            const MAX_PER_RUN = 200;
             for (const environment of ['default', 'ghcr-ci']) {
               let deleted = 0;
-              for await (const response of github.paginate.iterator(
-                github.rest.repos.listDeployments,
-                {
+              while (deleted < MAX_PER_RUN) {
+                const {data: deployments} = await github.rest.repos.listDeployments({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   environment: environment,
-                  per_page: 100
-                }
-              )) {
-                for (let i = 0; i < response.data.length; i += BATCH) {
-                  const batch = response.data.slice(i, i + BATCH);
-                  const results = await Promise.allSettled(
-                    batch.map(async (deployment) => {
-                      await github.rest.repos.createDeploymentStatus({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        deployment_id: deployment.id,
-                        state: 'inactive'
-                      });
-                      return github.rest.repos.deleteDeployment({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        deployment_id: deployment.id
-                      });
-                    })
-                  );
-                  const fulfilled = results.filter(r => r.status === 'fulfilled').length;
-                  deleted += fulfilled;
-                  if (fulfilled < batch.length) {
-                    console.log(`${environment}: ${batch.length - fulfilled} failures in batch, stopping.`);
-                    break;
-                  }
+                  per_page: Math.min(BATCH, MAX_PER_RUN - deleted)
+                });
+                if (deployments.length === 0) break;
+
+                const results = await Promise.allSettled(
+                  deployments.map(async (deployment) => {
+                    await github.rest.repos.createDeploymentStatus({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      deployment_id: deployment.id,
+                      state: 'inactive'
+                    });
+                    return github.rest.repos.deleteDeployment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      deployment_id: deployment.id
+                    });
+                  })
+                );
+                const fulfilled = results.filter(r => r.status === 'fulfilled').length;
+                deleted += fulfilled;
+                if (fulfilled < deployments.length) {
+                  console.log(`${environment}: ${deployments.length - fulfilled} failures, stopping.`);
+                  break;
                 }
               }
               console.log(`${environment}: deleted ${deleted} deployments this run`);

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -157,6 +157,7 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
+            const BATCH = 100;
             for (const environment of ['default', 'ghcr-ci']) {
               const deployments = await github.paginate(
                 github.rest.repos.listDeployments,
@@ -167,21 +168,28 @@ jobs:
                   per_page: 100
                 }
               );
-              await Promise.all(
-                deployments.map(async (deployment) => {
-                  await github.rest.repos.createDeploymentStatus({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  deployment_id: deployment.id,
-                  state: 'inactive'
-                  });
-                  return github.rest.repos.deleteDeployment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  deployment_id: deployment.id
-                  });
-                })
-              );
+              console.log(`${environment}: ${deployments.length} deployments to delete`);
+              let deleted = 0;
+              for (let i = 0; i < deployments.length; i += BATCH) {
+                const batch = deployments.slice(i, i + BATCH);
+                await Promise.all(
+                  batch.map(async (deployment) => {
+                    await github.rest.repos.createDeploymentStatus({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    deployment_id: deployment.id,
+                    state: 'inactive'
+                    });
+                    return github.rest.repos.deleteDeployment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    deployment_id: deployment.id
+                    });
+                  })
+                );
+                deleted += batch.length;
+                console.log(`${environment}: deleted ${deleted}/${deployments.length}`);
+              }
             }
 
   pr_cleanup:

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -158,13 +158,17 @@ jobs:
         with:
           script: |
             for (const environment of ['default', 'ghcr-ci']) {
-              const deployments = await github.rest.repos.listDeployments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                environment: environment
-              });
+              const deployments = await github.paginate(
+                github.rest.repos.listDeployments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  environment: environment,
+                  per_page: 100
+                }
+              );
               await Promise.all(
-                deployments.data.map(async (deployment) => {
+                deployments.map(async (deployment) => {
                   await github.rest.repos.createDeploymentStatus({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -158,38 +158,43 @@ jobs:
         with:
           script: |
             const BATCH = 50;
-            const MAX_PER_RUN = 200;
+            const MAX_PER_RUN = 500;
             for (const environment of ['default', 'ghcr-ci']) {
               let deleted = 0;
-              while (deleted < MAX_PER_RUN) {
-                const {data: deployments} = await github.rest.repos.listDeployments({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  environment: environment,
-                  per_page: Math.min(BATCH, MAX_PER_RUN - deleted)
-                });
-                if (deployments.length === 0) break;
+              try {
+                while (deleted < MAX_PER_RUN) {
+                  const {data: deployments} = await github.rest.repos.listDeployments({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    environment: environment,
+                    per_page: Math.min(BATCH, MAX_PER_RUN - deleted)
+                  });
+                  if (deployments.length === 0) break;
 
-                const results = await Promise.allSettled(
-                  deployments.map(async (deployment) => {
-                    await github.rest.repos.createDeploymentStatus({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      deployment_id: deployment.id,
-                      state: 'inactive'
-                    });
-                    return github.rest.repos.deleteDeployment({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      deployment_id: deployment.id
-                    });
-                  })
-                );
-                const fulfilled = results.filter(r => r.status === 'fulfilled').length;
-                deleted += fulfilled;
-                if (fulfilled < deployments.length) {
-                  console.log(`${environment}: ${deployments.length - fulfilled} failures, stopping.`);
-                  break;
+                  const results = await Promise.allSettled(
+                    deployments.map(async (deployment) => {
+                      await github.rest.repos.createDeploymentStatus({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        deployment_id: deployment.id,
+                        state: 'inactive'
+                      });
+                      return github.rest.repos.deleteDeployment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        deployment_id: deployment.id
+                      });
+                    })
+                  );
+                  const fulfilled = results.filter(r => r.status === 'fulfilled').length;
+                  deleted += fulfilled;
+                  if (fulfilled < deployments.length) break;
+                }
+              } catch (e) {
+                if (e.status === 403) {
+                  console.log(`${environment}: rate limited, will continue next run.`);
+                } else {
+                  throw e;
                 }
               }
               console.log(`${environment}: deleted ${deleted} deployments this run`);

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -157,9 +157,10 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const BATCH = 100;
+            const BATCH = 50;
             for (const environment of ['default', 'ghcr-ci']) {
-              const deployments = await github.paginate(
+              let deleted = 0;
+              for await (const response of github.paginate.iterator(
                 github.rest.repos.listDeployments,
                 {
                   owner: context.repo.owner,
@@ -167,29 +168,33 @@ jobs:
                   environment: environment,
                   per_page: 100
                 }
-              );
-              console.log(`${environment}: ${deployments.length} deployments to delete`);
-              let deleted = 0;
-              for (let i = 0; i < deployments.length; i += BATCH) {
-                const batch = deployments.slice(i, i + BATCH);
-                await Promise.all(
-                  batch.map(async (deployment) => {
-                    await github.rest.repos.createDeploymentStatus({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    deployment_id: deployment.id,
-                    state: 'inactive'
-                    });
-                    return github.rest.repos.deleteDeployment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    deployment_id: deployment.id
-                    });
-                  })
-                );
-                deleted += batch.length;
-                console.log(`${environment}: deleted ${deleted}/${deployments.length}`);
+              )) {
+                for (let i = 0; i < response.data.length; i += BATCH) {
+                  const batch = response.data.slice(i, i + BATCH);
+                  const results = await Promise.allSettled(
+                    batch.map(async (deployment) => {
+                      await github.rest.repos.createDeploymentStatus({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        deployment_id: deployment.id,
+                        state: 'inactive'
+                      });
+                      return github.rest.repos.deleteDeployment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        deployment_id: deployment.id
+                      });
+                    })
+                  );
+                  const fulfilled = results.filter(r => r.status === 'fulfilled').length;
+                  deleted += fulfilled;
+                  if (fulfilled < batch.length) {
+                    console.log(`${environment}: ${batch.length - fulfilled} failures in batch, stopping.`);
+                    break;
+                  }
+                }
               }
+              console.log(`${environment}: deleted ${deleted} deployments this run`);
             }
 
   pr_cleanup:


### PR DESCRIPTION
`listDeployments` returns 30 results by default. The cleanup job
deleted one page per cron tick, but ghcr-ci deployments accumulate
faster than that (~14 per CI run). Old deployments were never fully
drained, leaving "temporarily deployed to ghcr-ci" entries on PR
timelines indefinitely.
