### PR TITLE
Add stateless CompiledModuleHelper

### DIFF
--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -92,6 +92,7 @@ declare_mlir_python_extension(CUDAQuantumPythonSources.Extension
     ../../runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
     ../../runtime/cudaq/platform/default/python/QPU.cpp
     ../../runtime/internal/compiler/ArgumentConversion.cpp
+    ../../runtime/internal/compiler/CompiledModuleHelper.cpp
     ../../runtime/internal/compiler/LayoutInfo.cpp
     ../../runtime/internal/compiler/RuntimeMLIR.cpp
     ../../runtime/internal/compiler/RuntimePyMLIR.cpp

--- a/runtime/common/CompiledModule.cpp
+++ b/runtime/common/CompiledModule.cpp
@@ -7,15 +7,11 @@
  ******************************************************************************/
 
 #include "CompiledModule.h"
-#include "cudaq/Optimizer/Builder/RuntimeNames.h"
 #include <memory>
 #include <stdexcept>
 
-using namespace cudaq_internal::compiler;
-
-cudaq::CompiledModule::CompiledModule(std::string kernelName,
-                                      ResultInfo resultInfo)
-    : name(std::move(kernelName)), resultInfo(std::move(resultInfo)) {}
+cudaq::CompiledModule::CompiledModule(std::string kernelName)
+    : name(std::move(kernelName)) {}
 
 const cudaq::CompiledModule::JitArtifact &
 cudaq::CompiledModule::getJit() const {
@@ -103,20 +99,4 @@ void (*cudaq::CompiledModule::JitArtifact::getEntryPoint() const)() {
 
 cudaq::JitEngine cudaq::CompiledModule::JitArtifact::getEngine() const {
   return engine;
-}
-
-void cudaq::CompiledModule::attachJit(JitEngine engine,
-                                      bool isFullySpecialized) {
-  bool hasResult = resultInfo.hasResult();
-  std::string fullName = cudaq::runtime::cudaqGenPrefixName + name;
-  std::string entryName =
-      (hasResult || !isFullySpecialized) ? name + ".thunk" : fullName;
-  void (*entryPoint)() = engine.lookupRawNameOrFail(entryName);
-  int64_t (*argsCreator)(const void *, void **) = nullptr;
-  if (!isFullySpecialized)
-    argsCreator = reinterpret_cast<int64_t (*)(const void *, void **)>(
-        engine.lookupRawNameOrFail(name + ".argsCreator"));
-
-  addArtifact(name, JitArtifact{std::move(engine), entryPoint, argsCreator,
-                                std::nullopt});
 }

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -20,25 +20,17 @@
 #include <vector>
 
 // This header file and the types defined within are designed to have no
-// dependencies and be useable across the compiler and runtime. However,
-// constructing instances of these types is easiest done within compilation
-// units that do link against MLIR. We provide this functionality via free
-// functions, defined as friends of the types defined here and implemented in
-// the `cudaq-mlir-runtime` library.
+// dependencies and be useable across the compiler and runtime. Constructing
+// `CompiledModule` is supported through
+// `cudaq_internal::compiler::CompiledModuleHelper`, available in
+// `CompiledModuleHelper.h` from `cudaq-mlir-runtime`.
 
 namespace mlir {
-class Type;
-class ModuleOp;
 class ExecutionEngine;
 } // namespace mlir
 
-namespace cudaq {
-class ResultInfo;
-} // namespace cudaq
-
 namespace cudaq_internal::compiler {
-cudaq::ResultInfo createResultInfo(mlir::Type resultType, bool isEntryPoint,
-                                   mlir::ModuleOp module);
+class CompiledModuleHelper;
 } // namespace cudaq_internal::compiler
 
 namespace cudaq {
@@ -73,12 +65,9 @@ private:
 };
 
 /// Pre-computed result metadata, set at build time. Used at execution time
-/// for result buffer allocation and type conversion. Construct via
-/// `createResultInfo` (implemented in `cudaq-mlir-runtime`).
+/// for result buffer allocation and type conversion.
 class ResultInfo {
-  // Friend factory function, to be used for construction.
-  friend cudaq::ResultInfo cudaq_internal::compiler::createResultInfo(
-      mlir::Type resultType, bool isEntryPoint, mlir::ModuleOp module);
+  friend class cudaq_internal::compiler::CompiledModuleHelper;
   friend class CompiledModule;
 
   /// Opaque pointer to the `mlir::Type` of the result. Obtained via
@@ -106,8 +95,8 @@ public:
 /// of a Quake MLIR module.
 ///
 /// This type does not depend on MLIR/LLVM — it only keeps type-erased / opaque
-/// pointers. Use the `attachJit` member function to attach JIT-compiled
-/// artifacts after construction.
+/// pointers. Build instances with
+/// `cudaq_internal::compiler::CompiledModuleHelper`.
 class CompiledModule {
 public:
   // --- Compiled artifact types ---
@@ -126,6 +115,7 @@ public:
           resourceCounts(std::move(resourceCounts)) {}
 
     friend class CompiledModule;
+    friend class cudaq_internal::compiler::CompiledModuleHelper;
 
   public:
     // TODO: remove the following two methods once the `CompiledModule` instance
@@ -166,17 +156,6 @@ public:
 
   /// A compiled artifact is either a JIT binary or an MLIR module.
   using CompiledArtifact = std::variant<JitArtifact, MlirArtifact>;
-
-  // --- Construction ---
-
-  CompiledModule(std::string kernelName, ResultInfo resultInfo);
-
-  /// @brief Populate the JIT representation of a `CompiledModule`.
-  ///
-  /// Resolves the entry point and (optionally) `argsCreator` symbols from the
-  /// engine, using the kernel's name and result metadata to determine the
-  /// correct mangled symbol names.
-  void attachJit(JitEngine engine, bool isFullySpecialized);
 
   // --- Queries ---
 
@@ -222,7 +201,11 @@ public:
   KernelThunkResultType execute(const std::vector<void *> &rawArgs) const;
 
 private:
-  /// Add a compiled artifact to the kernel.
+  friend class cudaq_internal::compiler::CompiledModuleHelper;
+
+  CompiledModule(std::string kernelName);
+
+  /// Add a compiled artifact to the module under the given name.
   void addArtifact(std::string name, CompiledArtifact artifact);
 
   std::string name;

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -23,6 +23,7 @@
 #include "cudaq/Verifier/QIRLLVMIRDialect.h"
 #include "cudaq/platform.h"
 #include "cudaq_internal/compiler/ArgumentConversion.h"
+#include "cudaq_internal/compiler/CompiledModuleHelper.h"
 #include "cudaq_internal/compiler/JIT.h"
 #include "cudaq_internal/compiler/RuntimeMLIR.h"
 #include "mlir/ExecutionEngine/ExecutionEngine.h"
@@ -359,12 +360,14 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
         varArgIndices.clear();
     }
     const bool isFullySpecialized = varArgIndices.empty();
-    auto resultInfo = createResultInfo(resultTy, isEntryPoint, module);
+    auto resultInfo =
+        CompiledModuleHelper::createResultInfo(resultTy, isEntryPoint, module);
 
     if (auto jit = alreadyBuiltJITCode(name, rawArgs)) {
-      cudaq::CompiledModule ck(name, resultInfo);
-      ck.attachJit(*jit, isFullySpecialized);
-      return ck;
+      auto jitArtifacts = CompiledModuleHelper::createJitArtifacts(
+          name, *jit, resultInfo, isFullySpecialized);
+      return CompiledModuleHelper::createCompiledModule(name, resultInfo,
+                                                        jitArtifacts);
     }
 
     // 1. Check that this call is sane.
@@ -404,9 +407,10 @@ struct PythonLauncher : public cudaq::ModuleLauncher {
     cudaq::compiler_artifact::saveArtifact(name, rawArgs, jit,
                                            argsCreatorThunk);
 
-    cudaq::CompiledModule ck(name, resultInfo);
-    ck.attachJit(jit, isFullySpecialized);
-    return ck;
+    auto jitArtifacts = CompiledModuleHelper::createJitArtifacts(
+        name, jit, resultInfo, isFullySpecialized);
+    return CompiledModuleHelper::createCompiledModule(
+        name, std::move(resultInfo), jitArtifacts);
   }
 };
 } // namespace

--- a/runtime/internal/compiler/CMakeLists.txt
+++ b/runtime/internal/compiler/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(cudaq-mlir-runtime
   SHARED
     ArgumentConversion.cpp
     Compiler.cpp
+    CompiledModuleHelper.cpp
     JIT.cpp
     RuntimeMLIR.cpp
     RuntimeCppMLIR.cpp

--- a/runtime/internal/compiler/CompiledModuleHelper.cpp
+++ b/runtime/internal/compiler/CompiledModuleHelper.cpp
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq_internal/compiler/CompiledModuleHelper.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
+#include "cudaq_internal/compiler/LayoutInfo.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Types.h"
+
+using namespace mlir;
+
+namespace cudaq_internal::compiler {
+
+cudaq::ResultInfo CompiledModuleHelper::createResultInfo(Type resultTy,
+                                                         bool isEntryPoint,
+                                                         ModuleOp module) {
+  cudaq::ResultInfo info;
+  if (!resultTy || !isEntryPoint)
+    return info;
+
+  info.typeOpaquePtr = resultTy.getAsOpaquePointer();
+  auto [size, offsets] = getResultBufferLayout(module, resultTy);
+  info.bufferSize = size;
+  info.fieldOffsets = std::move(offsets);
+  return info;
+}
+
+std::vector<CompiledModuleHelper::NamedJitArtifact>
+CompiledModuleHelper::createJitArtifacts(const std::string &kernelName,
+                                         cudaq::JitEngine engine,
+                                         const cudaq::ResultInfo &resultInfo,
+                                         bool isFullySpecialized) {
+  bool hasResult = resultInfo.hasResult();
+  std::string fullName =
+      std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName;
+  std::string entryName =
+      (hasResult || !isFullySpecialized) ? kernelName + ".thunk" : fullName;
+  void (*entryPoint)() = engine.lookupRawNameOrFail(entryName);
+  int64_t (*argsCreator)(const void *, void **) = nullptr;
+  if (!isFullySpecialized)
+    argsCreator = reinterpret_cast<int64_t (*)(const void *, void **)>(
+        engine.lookupRawNameOrFail(kernelName + ".argsCreator"));
+
+  std::vector<NamedJitArtifact> artifacts;
+  artifacts.emplace_back(kernelName, cudaq::CompiledModule::JitArtifact{
+                                         std::move(engine), entryPoint,
+                                         argsCreator, std::nullopt});
+  return artifacts;
+}
+
+cudaq::CompiledModule CompiledModuleHelper::createCompiledModule(
+    std::string name, cudaq::ResultInfo resultInfo,
+    std::vector<NamedJitArtifact> jitArtifacts) {
+  return createCompiledModule(std::move(name), std::move(resultInfo),
+                              std::move(jitArtifacts), {});
+}
+
+cudaq::CompiledModule CompiledModuleHelper::createCompiledModule(
+    std::string name, cudaq::ResultInfo resultInfo,
+    std::vector<NamedMlirArtifact> mlirArtifacts) {
+  return createCompiledModule(std::move(name), std::move(resultInfo), {},
+                              std::move(mlirArtifacts));
+}
+
+cudaq::CompiledModule CompiledModuleHelper::createCompiledModule(
+    std::string name, cudaq::ResultInfo resultInfo,
+    std::vector<NamedJitArtifact> jitArtifacts,
+    std::vector<NamedMlirArtifact> mlirArtifacts) {
+  cudaq::CompiledModule compiled(std::move(name));
+  compiled.resultInfo = std::move(resultInfo);
+  for (auto &[artName, artifact] : jitArtifacts)
+    compiled.addArtifact(std::move(artName), std::move(artifact));
+  for (auto &[artName, artifact] : mlirArtifacts)
+    compiled.addArtifact(std::move(artName), std::move(artifact));
+  return compiled;
+}
+
+} // namespace cudaq_internal::compiler

--- a/runtime/internal/compiler/JIT.cpp
+++ b/runtime/internal/compiler/JIT.cpp
@@ -19,7 +19,6 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Verifier/QIRLLVMIRDialect.h"
 #include "cudaq/runtime/logger/logger.h"
-#include "cudaq_internal/compiler/LayoutInfo.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
@@ -338,23 +337,6 @@ cudaq_internal::compiler::createJITEngine(ModuleOp &moduleOp,
   auto jitOrError = ExecutionEngine::create(moduleOp, opts);
   assert(!!jitOrError && "ExecutionEngine creation failed.");
   return JitEngine(std::move(jitOrError.get()));
-}
-
-/// Build a `ResultInfo` from an MLIR return type.
-/// \p resultTy may be null (no return value). When \p isEntryPoint is false,
-/// the result is not marshaled — returns an empty `ResultInfo`.
-cudaq::ResultInfo cudaq_internal::compiler::createResultInfo(Type resultTy,
-                                                             bool isEntryPoint,
-                                                             ModuleOp module) {
-  cudaq::ResultInfo info;
-  if (!resultTy || !isEntryPoint)
-    return info;
-
-  info.typeOpaquePtr = resultTy.getAsOpaquePointer();
-  auto [size, offsets] = getResultBufferLayout(module, resultTy);
-  info.bufferSize = size;
-  info.fieldOffsets = std::move(offsets);
-  return info;
 }
 
 class cudaq::JitEngine::Impl : public cudaq::JitEngine::Base {

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/CompiledModuleHelper.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/CompiledModuleHelper.h
@@ -1,0 +1,74 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+#include "common/CompiledModule.h"
+
+namespace mlir {
+class Type;
+class ModuleOp;
+} // namespace mlir
+
+namespace cudaq_internal::compiler {
+
+/// Compiler-side helper for `cudaq::CompiledModule`: static factory methods and
+/// utilities that depend on MLIR but pair with the MLIR-free `CompiledModule`
+/// API in `common/CompiledModule.h`.
+class CompiledModuleHelper {
+public:
+  // --- Named artifact aliases ---
+
+  using NamedJitArtifact =
+      std::pair<std::string, cudaq::CompiledModule::JitArtifact>;
+  using NamedMlirArtifact =
+      std::pair<std::string, cudaq::CompiledModule::MlirArtifact>;
+
+  CompiledModuleHelper() = delete;
+
+  // --- ResultInfo construction ---
+
+  /// Create a `ResultInfo` from MLIR type metadata.
+  ///
+  /// When \p resultType is null or \p isEntryPoint is false, returns an empty
+  /// `ResultInfo` (no marshaled return value).
+  static cudaq::ResultInfo createResultInfo(mlir::Type resultType,
+                                            bool isEntryPoint,
+                                            mlir::ModuleOp module);
+
+  // --- JitArtifact construction ---
+
+  /// Construct named JitArtifacts from the compiled functions in the JIT
+  /// engine.
+  ///
+  /// Uses the kernel's name and result metadata to determine the correct
+  /// mangled symbol names. Returns one named artifact per resolved symbol.
+  static std::vector<NamedJitArtifact>
+  createJitArtifacts(const std::string &kernelName, cudaq::JitEngine engine,
+                     const cudaq::ResultInfo &resultInfo,
+                     bool isFullySpecialized);
+
+  // --- CompiledModule construction ---
+
+  /// Create a `CompiledModule` containing only JIT artifacts.
+  static cudaq::CompiledModule
+  createCompiledModule(std::string name, cudaq::ResultInfo resultInfo,
+                       std::vector<NamedJitArtifact> jitArtifacts);
+
+  /// Create a `CompiledModule` containing only MLIR artifacts.
+  static cudaq::CompiledModule
+  createCompiledModule(std::string name, cudaq::ResultInfo resultInfo,
+                       std::vector<NamedMlirArtifact> mlirArtifacts);
+
+  /// Create a `CompiledModule` containing both JIT and MLIR artifacts.
+  static cudaq::CompiledModule
+  createCompiledModule(std::string name, cudaq::ResultInfo resultInfo,
+                       std::vector<NamedJitArtifact> jitArtifacts,
+                       std::vector<NamedMlirArtifact> mlirArtifacts);
+};
+
+} // namespace cudaq_internal::compiler

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/JIT.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/JIT.h
@@ -28,7 +28,6 @@ class Type;
 
 namespace cudaq {
 class CompiledModule;
-class ResultInfo;
 } // namespace cudaq
 
 namespace cudaq_internal::compiler {
@@ -45,12 +44,5 @@ createWrappedKernel(std::string_view llvmIr, const std::string &kernelName,
 /// Lower ModuleOp to QIR/LLVM IR and create a JIT execution engine.
 cudaq::JitEngine createJITEngine(mlir::ModuleOp &moduleOp,
                                  llvm::StringRef convertTo);
-
-/// @brief Create a `ResultInfo` from MLIR type and module.
-///
-/// When `resultType` is null or `isEntryPoint` is false, returns an empty
-/// `ResultInfo`.
-cudaq::ResultInfo createResultInfo(mlir::Type resultType, bool isEntryPoint,
-                                   mlir::ModuleOp module);
 
 } // namespace cudaq_internal::compiler


### PR DESCRIPTION
This is a rewrite of #4329, using a stateless class with static functions rather than a builder pattern.
