### PR TITLE
Fixing Krylov notebook failure

### DIFF
--- a/docs/sphinx/applications/python/krylov.ipynb
+++ b/docs/sphinx/applications/python/krylov.ipynb
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "ba61665c-dc3b-4e43-b1cf-340855ea68fb",
    "metadata": {},
    "outputs": [],
@@ -100,7 +100,7 @@
       "[pyscf] Total number of orbitals =  2\n",
       "[pyscf] Total number of electrons =  2\n",
       "[pyscf] HF energy =  -1.116325564486115\n",
-      "[pyscf] Total R-CCSD energy =  -1.1371758844013342\n",
+      "[pyscf] Total R-CCSD energy =  -1.1371758844013327\n",
       "Ground state energy (classical simulation)=  (-1.1371757102406845+0j) , index=  3\n"
      ]
     }
@@ -167,17 +167,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[(-0.10647701149300526+0j), (0.17028010135220517+0j), (0.17028010135220514+0j), (-0.22004130022421745+0j), (-0.22004130022421745+0j), (0.1683359862516207+0j), (0.12020049071260122+0j), (0.1656068235817425+0j), (0.1656068235817425+0j), (0.12020049071260122+0j), (0.17407289249680213+0j), (-0.04540633286914128+0j), (0.04540633286914128+0j), (0.04540633286914128+0j), (-0.04540633286914128+0j)]\n",
-      "['IIII', 'ZIII', 'IZII', 'IIZI', 'IIIZ', 'ZZII', 'ZIZI', 'ZIIZ', 'IZZI', 'IZIZ', 'IIZZ', 'XXYY', 'XYYX', 'YXXY', 'YYXX']\n"
+      "[(0.17028010135220506+0j), (0.17028010135220503+0j), (-0.2200413002242175+0j), (-0.2200413002242175+0j), (0.1683359862516207+0j), (0.12020049071260122+0j), (0.1656068235817425+0j), (0.1656068235817425+0j), (0.12020049071260122+0j), (0.17407289249680213+0j), (-0.04540633286914128+0j), (0.04540633286914128+0j), (0.04540633286914128+0j), (-0.04540633286914128+0j)]\n",
+      "['ZIII', 'IZII', 'IIZI', 'IIIZ', 'ZZII', 'ZIZI', 'ZIIZ', 'IZZI', 'IZIZ', 'IIZZ', 'XXYY', 'XYYX', 'YXXY', 'YYXX']\n"
      ]
     }
    ],
    "source": [
-    "\n",
-    "# Collect coefficients from a spin operator so we can pass them to a kernel\n",
+    "# Collect coefficients from a spin operator so we can pass them to a kernel.\n",
+    "# The identity term is excluded. Its contribution is added back to the \n",
+    "# Hamiltonian matrix classically below.\n",
     "def term_coefficients(ham: cudaq.SpinOperator) -> list[complex]:\n",
     "    result = []\n",
     "    for term in ham:\n",
+    "        if term.is_identity():\n",
+    "            continue\n",
     "        result.append(term.evaluate_coefficient())\n",
     "    return result\n",
     "\n",
@@ -185,15 +188,23 @@
     "def term_words(ham: cudaq.SpinOperator) -> list[str]:\n",
     "    # Our kernel uses these words to apply exp_pauli to the entire state.\n",
     "    # we hence ensure that each pauli word covers the entire space.\n",
-    "    \n",
     "    result = []\n",
     "    for term in ham:\n",
+    "        if term.is_identity():\n",
+    "            continue\n",
     "        result.append(term.get_pauli_word(qubits_num))\n",
     "    return result\n",
     "\n",
     "# Build the lists of coefficients and Pauli Words from the H2 Hamiltonian\n",
     "coefficient = term_coefficients(hamiltonian)\n",
     "pauli_string = term_words(hamiltonian)\n",
+    "\n",
+    "# Sum of identity-term coefficients\n",
+    "# The identity contributes `identity_coef * S` to the Hamiltonian matrix.\n",
+    "identity_coef = sum(\n",
+    "    term.evaluate_coefficient().real\n",
+    "    for term in hamiltonian\n",
+    "    if term.is_identity())\n",
     "\n",
     "print(coefficient)\n",
     "print(pauli_string)"
@@ -365,7 +376,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "# Create the identity operator\n",
     "identity_op = cudaq.SpinOperator.from_word('I' * qubits_num)\n",
     "# Get the Pauli word and convert it to a list of integers\n",
@@ -423,7 +433,7 @@
     "        # 2 entry array that stores real and imaginary part of matrix element\n",
     "        tot_e = np.zeros(2)\n",
     "\n",
-    "        # Loops over the terms in the Hamiltonian, computing expectation values\n",
+    "        # Loops over the (non-identity) terms in the Hamiltonian, computing expectation values\n",
     "        for coef, word in zip(coefficient, pauli_string):\n",
     "            pauli_list = pauli_str(word, qubits_num)\n",
     "            \n",
@@ -441,8 +451,8 @@
     "            tot_e[0] += temp[0]\n",
     "            tot_e[1] += temp[1]\n",
     "\n",
-    "        # Sums real and imaginary totals to specify Hamiltonian entry\n",
-    "        ham_matrx[m, n] = tot_e[0] + tot_e[1] * 1j\n",
+    "        # Adds back the identity-term contribution.\n",
+    "        ham_matrx[m, n] = tot_e[0] + tot_e[1] * 1j + identity_coef * wf_overlap[m, n]\n",
     "        if n != m:\n",
     "            ham_matrx[n, m] = np.conj(ham_matrx[m, n])"
    ]
@@ -512,7 +522,7 @@
      "output_type": "stream",
      "text": [
       "Energy from QFD:\n",
-      "(-1.137176660753775-1.6945689273261445e-07j)\n"
+      "(-1.1359686811350462-4.497484607599205e-09j)\n"
      ]
     }
    ],


### PR DESCRIPTION
Skipping identity terms when building the Pauli word and coefficient lists passed to the Krylov kernel. Controlled exp_pauli does not handle the identity terms. We add their contribution back when assembling the Hamiltonian matrix.

Fixes https://github.com/NVIDIA/cuda-quantum/actions/runs/24584888146/job/71904057326#step:5:1955
