### PR TITLE
Increasing the number of colors

### DIFF
--- a/docs/sphinx/applications/python/divisive_clustering_coresets.ipynb
+++ b/docs/sphinx/applications/python/divisive_clustering_coresets.ipynb
@@ -651,7 +651,7 @@
    "source": [
     "threshold_height = 1\n",
     "clusters = dendo.get_clusters_using_height(threshold_height)\n",
-    "colors = [\"red\", \"blue\", \"green\", \"black\", \"purple\", \"orange\", \"yellow\"]\n",
+    "colors = [\"red\", \"blue\", \"green\", \"black\", \"purple\", \"orange\", \"yellow\", \"cyan\", \"magenta\", \"brown\"]\n",
     "dendo.plot_dendrogram(\n",
     "    plot_title=\"Dendrogram of Coreset using VQE\",\n",
     "    colors=colors,\n",


### PR DESCRIPTION
Increasing the number of colors in the palette so VQE runs producing upto 10 flat clusters at threshold height of 1.

Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/24686493909/job/72220359142#step:5:1914