### PR TITLE
Slim down CompiledModule, move out execution logic

### DIFF
--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -1143,8 +1143,7 @@ void cudaq::bindAltLaunchKernel(nanobind::module_ &mod,
       .def_prop_ro(
           "entry_point",
           [](const cudaq::CompiledModule &ck) {
-            return reinterpret_cast<std::uintptr_t>(
-                ck.getJit().getEntryPoint());
+            return reinterpret_cast<std::uintptr_t>(ck.getJit()->getFn());
           },
           "The address of the JIT-compiled entry point.")
       .def_prop_ro("is_fully_specialized",

--- a/runtime/common/CompiledModule.cpp
+++ b/runtime/common/CompiledModule.cpp
@@ -7,47 +7,58 @@
  ******************************************************************************/
 
 #include "CompiledModule.h"
-#include <cstring>
-#include <memory>
 #include <stdexcept>
 
 cudaq::CompiledModule::CompiledModule(std::string kernelName)
     : name(std::move(kernelName)) {}
 
-const cudaq::CompiledModule::JitArtifact &
-cudaq::CompiledModule::getJit() const {
-  for (auto &[key, artifact] : artifacts)
-    if (auto *jit = std::get_if<JitArtifact>(&artifact))
-      return *jit;
-  throw std::runtime_error("CompiledModule has no JIT artifact.");
+std::optional<cudaq::CompiledModule::JitArtifact>
+cudaq::CompiledModule::getJit(std::optional<std::string> jitName) const {
+  auto name = jitName.value_or(this->name);
+  auto it = artifacts.find(name);
+  if (it == artifacts.end())
+    return std::nullopt;
+  const auto *jit = std::get_if<JitArtifact>(&it->second);
+  return jit ? std::optional(*jit) : std::nullopt;
 }
 
-const cudaq::CompiledModule::MlirArtifact &
-cudaq::CompiledModule::getMlir() const {
-  for (auto &[key, artifact] : artifacts)
-    if (auto *mlir = std::get_if<MlirArtifact>(&artifact))
-      return *mlir;
-  throw std::runtime_error("CompiledModule has no MLIR artifact.");
-}
-
-bool cudaq::CompiledModule::hasJit() const {
-  for (auto &[key, artifact] : artifacts)
-    if (std::holds_alternative<JitArtifact>(artifact))
-      return true;
-  return false;
-}
-
-bool cudaq::CompiledModule::hasMlir() const {
-  for (auto &[key, artifact] : artifacts)
-    if (std::holds_alternative<MlirArtifact>(artifact))
-      return true;
-  return false;
+std::optional<cudaq::CompiledModule::MlirArtifact>
+cudaq::CompiledModule::getMlir(std::optional<std::string> mlirName) const {
+  auto name = mlirName.value_or(this->name + ".mlir");
+  auto it = artifacts.find(name);
+  if (it == artifacts.end())
+    return std::nullopt;
+  const auto *mlir = std::get_if<MlirArtifact>(&it->second);
+  return mlir ? std::optional(*mlir) : std::nullopt;
 }
 
 bool cudaq::CompiledModule::isFullySpecialized() const {
-  if (!hasJit())
-    return true; // No JIT artifact → fully specialized.
-  return getJit().argsCreator == nullptr;
+  return getArgsCreator() == nullptr;
+}
+
+int64_t (*cudaq::CompiledModule::getArgsCreator() const)(const void *,
+                                                         void **) {
+  auto jit = getJit(name + ".argsCreator");
+  return jit ? reinterpret_cast<int64_t (*)(const void *, void **)>(jit->fn)
+             : nullptr;
+}
+
+std::optional<std::int64_t> cudaq::CompiledModule::getReturnOffset() const {
+  auto jit = getJit(name + ".returnOffset");
+  if (!jit)
+    return std::nullopt;
+  auto fn = reinterpret_cast<std::int64_t (*)()>(jit->fn);
+  return fn();
+}
+
+const cudaq::Resources *cudaq::CompiledModule::getResources(
+    std::optional<std::string> resourcesName) const {
+  auto name = resourcesName.value_or(this->name + ".resources");
+  auto it = artifacts.find(name);
+  if (it == artifacts.end())
+    return nullptr;
+  const auto *resources = std::get_if<ResourcesArtifact>(&it->second);
+  return resources ? &resources->getResources() : nullptr;
 }
 
 void cudaq::CompiledModule::addArtifact(std::string name,
@@ -57,62 +68,8 @@ void cudaq::CompiledModule::addArtifact(std::string name,
   artifacts.emplace(std::move(name), std::move(artifact));
 }
 
-cudaq::KernelThunkResultType
-cudaq::CompiledModule::execute(const std::vector<void *> &rawArgs) const {
-  auto &jit = getJit();
-  auto funcPtr = jit.entryPoint;
-  if (!isFullySpecialized()) {
-    // Pack args at runtime via argsCreator, then call the thunk.
-    void *buff = nullptr;
-    jit.argsCreator(static_cast<const void *>(rawArgs.data()), &buff);
-    reinterpret_cast<KernelThunkResultType (*)(void *, bool)>(funcPtr)(
-        buff, /*client_server=*/false);
-    // If the kernel has a result, copy it from the packed buffer into
-    // rawArgs.back() (where the caller expects to find it).
-    if (resultInfo.hasResult()) {
-      auto offset = jit.returnOffset();
-      std::memcpy(rawArgs.back(), static_cast<char *>(buff) + offset,
-                  resultInfo.bufferSize);
-    }
-    std::free(buff);
-    return {nullptr, 0};
-  }
-  if (resultInfo.hasResult()) {
-    // Fully specialized with result: rawArgs.back() is the pre-allocated
-    // result buffer; pass it directly to the thunk.
-    void *buff = const_cast<void *>(rawArgs.back());
-    return reinterpret_cast<KernelThunkResultType (*)(void *, bool)>(funcPtr)(
-        buff, /*client_server=*/false);
-  }
-  // Fully specialized, no result.
-  jit.entryPoint();
-  return {nullptr, 0};
-}
-
-cudaq::KernelThunkResultType cudaq::CompiledModule::execute() const {
-  if (!isFullySpecialized())
-    throw std::runtime_error(
-        "Kernel has unspecialized parameters; call execute(rawArgs) instead.");
-  if (!resultInfo.hasResult()) {
-    getJit().entryPoint();
-    return {nullptr, 0};
-  }
-  // Allocate a result buffer on-the-fly.
-  auto buf = std::make_unique<char[]>(resultInfo.bufferSize);
-  std::vector<void *> rawArgs = {buf.get()};
-  execute(rawArgs);
-  return {buf.release(), resultInfo.bufferSize};
-}
-
-void (*cudaq::CompiledModule::JitArtifact::getEntryPoint() const)() {
-  return entryPoint;
-}
+void (*cudaq::CompiledModule::JitArtifact::getFn() const)() { return fn; }
 
 cudaq::JitEngine cudaq::CompiledModule::JitArtifact::getEngine() const {
   return engine;
-}
-
-std::optional<cudaq::Resources>
-cudaq::CompiledModule::JitArtifact::getResourceCounts() const {
-  return resourceCounts;
 }

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -87,13 +87,15 @@ class ResultInfo {
 public:
   /// Whether this kernel has a result that must be marshaled.
   bool hasResult() const { return typeOpaquePtr != nullptr; }
+  /// Get the size (in bytes) of the buffer needed to hold the result value.
+  std::size_t getBufferSize() const { return bufferSize; }
 };
 
 /// @brief A compiled MLIR module, ready for execution or code generation.
 ///
 /// Contains any number of named compilation artifacts (we currently support
-/// JIT binaries and optimized MLIR modules) that result from the compilation
-/// of a Quake MLIR module.
+/// JIT binaries, optimized MLIR modules, and pre-computed resource metrics)
+/// that result from the compilation of a Quake MLIR module.
 ///
 /// This type does not depend on MLIR/LLVM — it only keeps type-erased / opaque
 /// pointers. Build instances with
@@ -105,46 +107,18 @@ public:
   /// JIT-compiled artifact, ready for local execution.
   class JitArtifact {
     JitEngine engine;
-    void (*entryPoint)() = nullptr;
-    std::int64_t (*argsCreator)(const void *, void **) = nullptr;
-    /// Offset (in bytes) of the result field within the argsCreator-packed
-    /// buffer. Only valid when argsCreator is non-null and the kernel has a
-    /// result. Use resultInfo.bufferSize to know how many bytes to copy.
-    std::int64_t (*returnOffset)() = nullptr;
-    std::optional<Resources> resourceCounts;
+    void (*fn)() = nullptr;
 
-    JitArtifact(JitEngine engine, void (*entryPoint)(),
-                int64_t (*argsCreator)(const void *, void **),
-                int64_t (*returnOffset)(),
-                std::optional<Resources> resourceCounts)
-        : engine(engine), entryPoint(entryPoint), argsCreator(argsCreator),
-          returnOffset(returnOffset),
-          resourceCounts(std::move(resourceCounts)) {}
+    JitArtifact(JitEngine engine, void (*fn)())
+        : engine(std::move(engine)), fn(fn) {}
 
     friend class CompiledModule;
     friend class cudaq_internal::compiler::CompiledModuleHelper;
 
   public:
-    // TODO: remove the following two methods once the `CompiledModule` instance
-    // is returned to Python.
-
-    /// @brief Get the entry point of the kernel as a function pointer.
-    ///
-    /// Assumes that there is (exactly one) compiled JIT artifact.
-    ///
-    /// The returned function pointer will expect different arguments depending
-    /// on the kernel:
-    ///  - if the kernel returns a value and/or is not fully specialized, the
-    ///    entry point will expect a pointer to a buffer storing the packed
-    ///    arguments and result.
-    ///  - otherwise, the entry point will not expect any arguments.
-    ///
-    /// Prefer using `CompiledModule::execute` instead of calling this function
-    /// as it will handle the buffer and argument packing automatically.
-    void (*getEntryPoint() const)();
+    /// Get the raw function pointer stored in this artifact.
+    void (*getFn() const)();
     JitEngine getEngine() const;
-
-    std::optional<Resources> getResourceCounts() const;
   };
 
   /// Optimized MLIR module artifact, for deferred code generation or
@@ -165,8 +139,22 @@ public:
     friend class cudaq_internal::compiler::CompiledModuleHelper;
   };
 
-  /// A compiled artifact is either a JIT binary or an MLIR module.
-  using CompiledArtifact = std::variant<JitArtifact, MlirArtifact>;
+  /// Pre-computed resource metrics (gate counts, depth) from IR analysis.
+  class ResourcesArtifact {
+    Resources resources;
+
+    ResourcesArtifact(Resources resources) : resources(std::move(resources)) {}
+
+    friend class CompiledModule;
+    friend class cudaq_internal::compiler::CompiledModuleHelper;
+
+  public:
+    const Resources &getResources() const { return resources; }
+  };
+
+  /// A compiled artifact is a JIT binary, an MLIR module, or resource metrics.
+  using CompiledArtifact =
+      std::variant<JitArtifact, MlirArtifact, ResourcesArtifact>;
 
   // --- Compilation metadata ---
 
@@ -178,47 +166,51 @@ public:
 
   // --- Queries ---
 
-  /// Whether any artifact in the map is a JitArtifact.
-  bool hasJit() const;
-
-  /// Whether any artifact in the map is an MlirArtifact.
-  bool hasMlir() const;
-
-  /// Get the compiled JIT artifact. Returns the first one found.
+  /// Get the JIT artifact with the given name.
   ///
-  /// Throws if none exists.
-  const JitArtifact &getJit() const;
+  /// If no name is provided, defaults to the kernel name.
+  std::optional<JitArtifact>
+  getJit(std::optional<std::string> jitName = std::nullopt) const;
 
-  /// Get the optimized MLIR artifact. Returns the first one found.
+  /// Get the MLIR artifact with the given name.
   ///
-  /// Throws if none exists.
-  const MlirArtifact &getMlir() const;
+  /// If no name is provided, defaults to `kernel_name + ".mlir"`.
+  std::optional<MlirArtifact>
+  getMlir(std::optional<std::string> mlirName = std::nullopt) const;
+
+  /// Get the pre-computed resource counts, or `nullptr` if it does not exist.
+  ///
+  /// If no name is provided, defaults to `kernel_name + ".resources"`.
+  const Resources *
+  getResources(std::optional<std::string> resourcesName = std::nullopt) const;
 
   /// Get all compiled artifacts.
   const std::map<std::string, CompiledArtifact> &getArtifacts() const {
     return artifacts;
   }
 
-  /// Whether the kernel is fully specialized (all arguments inlined). For JIT
-  /// kernels this means `argsCreator` is null.
-  /// Kernels without a JIT artifact are considered fully specialized.
+  /// Whether the kernel is fully specialized (all arguments inlined).
+  ///
+  /// Currently, kernels are considered fully specialized if and only if they do
+  /// not have an `argsCreator` artifact.
   bool isFullySpecialized() const;
+
+  /// Get the argument-marshaling function, or `nullptr` if it does not exist.
+  ///
+  /// Assumes the artifact is named `kernelName + ".argsCreator"`.
+  int64_t (*getArgsCreator() const)(const void *, void **);
+
+  /// Get the offset (in bytes) of the result field within the
+  /// `argsCreator`-packed buffer, evaluating the stored JIT function.
+  /// Returns `std::nullopt` if no `.returnOffset` artifact was emitted
+  /// (e.g. the kernel has no result or is fully specialized).
+  ///
+  /// Assumes the artifact is named `kernelName + ".returnOffset"`.
+  std::optional<std::int64_t> getReturnOffset() const;
 
   const std::string &getName() const { return name; }
   const ResultInfo &getResultInfo() const { return resultInfo; }
   const CompilationMetadata &getMetadata() const { return metadata; }
-
-  // --- Execution (local JIT path) ---
-
-  /// @brief Execute a fully specialized kernel (no external arguments needed).
-  ///
-  /// Assumes that there is (exactly one) compiled JIT artifact.
-  KernelThunkResultType execute() const;
-
-  /// @brief Execute the JIT-ed kernel with caller-provided arguments.
-  ///
-  /// Assumes that there is (exactly one) compiled JIT artifact.
-  KernelThunkResultType execute(const std::vector<void *> &rawArgs) const;
 
 private:
   friend class cudaq_internal::compiler::CompiledModuleHelper;

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -8,10 +8,49 @@
 
 #include "qpu.h"
 #include "mlir/IR/BuiltinOps.h"
+#include <cstring>
 
 using namespace cudaq_internal::compiler;
 
 LLVM_INSTANTIATE_REGISTRY(cudaq::ModuleLauncher::RegistryType)
+
+/// Execute a JIT-compiled kernel with provided arguments.
+///
+/// Handles argument marshaling via `argsCreator` (if not fully specialized) and
+/// result buffer allocation.
+cudaq::KernelThunkResultType
+launchCompiledModule(const cudaq::CompiledModule &compiled,
+                     const std::vector<void *> &rawArgs) {
+  auto funcPtr = compiled.getJit()->getFn();
+  const auto &resultInfo = compiled.getResultInfo();
+  if (!compiled.isFullySpecialized()) {
+    // Pack args at runtime via argsCreator, then call the thunk.
+    auto argsCreator = compiled.getArgsCreator();
+    void *buff = nullptr;
+    argsCreator(static_cast<const void *>(rawArgs.data()), &buff);
+    reinterpret_cast<cudaq::KernelThunkResultType (*)(void *, bool)>(funcPtr)(
+        buff, /*client_server=*/false);
+    // If the kernel has a result, copy it from the packed buffer into
+    // rawArgs.back() (where the caller expects to find it).
+    if (resultInfo.hasResult()) {
+      auto offset = compiled.getReturnOffset().value();
+      std::memcpy(rawArgs.back(), static_cast<char *>(buff) + offset,
+                  resultInfo.getBufferSize());
+    }
+    std::free(buff);
+    return {nullptr, 0};
+  }
+  if (resultInfo.hasResult()) {
+    // Fully specialized with result: rawArgs.back() is the pre-allocated
+    // result buffer; pass it directly to the thunk.
+    void *buff = const_cast<void *>(rawArgs.back());
+    return reinterpret_cast<cudaq::KernelThunkResultType (*)(void *, bool)>(
+        funcPtr)(buff, /*client_server=*/false);
+  }
+  // Fully specialized, no result.
+  funcPtr();
+  return {nullptr, 0};
+}
 
 cudaq::KernelThunkResultType
 cudaq::QPU::launchModule(const std::string &name, mlir::ModuleOp module,
@@ -23,7 +62,7 @@ cudaq::QPU::launchModule(const std::string &name, mlir::ModuleOp module,
         "result of attempting to use `launchModule` outside Python.");
   ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::launchModule", name);
   auto compiled = launcher->compileModule(name, module, rawArgs, true);
-  return compiled.execute(rawArgs);
+  return launchCompiledModule(compiled, rawArgs);
 }
 
 cudaq::CompiledModule

--- a/runtime/internal/compiler/CompiledModuleHelper.cpp
+++ b/runtime/internal/compiler/CompiledModuleHelper.cpp
@@ -15,6 +15,7 @@
 #include "mlir/IR/Types.h"
 
 using namespace mlir;
+using cudaq::CompiledModule;
 
 namespace cudaq_internal::compiler {
 
@@ -32,75 +33,64 @@ cudaq::ResultInfo CompiledModuleHelper::createResultInfo(Type resultTy,
   return info;
 }
 
-std::vector<CompiledModuleHelper::NamedJitArtifact>
-CompiledModuleHelper::createJitArtifacts(
-    const std::string &kernelName, cudaq::JitEngine engine,
-    const cudaq::ResultInfo &resultInfo, bool isFullySpecialized,
-    std::optional<cudaq::Resources> resourceCounts) {
+std::vector<CompiledModuleHelper::NamedCompiledArtifact>
+CompiledModuleHelper::createJitArtifacts(const std::string &kernelName,
+                                         cudaq::JitEngine engine,
+                                         const cudaq::ResultInfo &resultInfo,
+                                         bool isFullySpecialized) {
   bool hasResult = resultInfo.hasResult();
   std::string fullName =
       std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName;
   std::string entryName =
       (hasResult || !isFullySpecialized) ? kernelName + ".thunk" : fullName;
   void (*entryPoint)() = engine.lookupRawNameOrFail(entryName);
-  int64_t (*argsCreator)(const void *, void **) = nullptr;
-  int64_t (*returnOffset)() = nullptr;
-  if (!isFullySpecialized) {
-    argsCreator = reinterpret_cast<int64_t (*)(const void *, void **)>(
-        engine.lookupRawNameOrFail(kernelName + ".argsCreator"));
-    if (hasResult)
-      returnOffset = reinterpret_cast<int64_t (*)()>(
-          engine.lookupRawNameOrFail(kernelName + ".returnOffset"));
-  }
 
-  std::vector<NamedJitArtifact> artifacts;
+  std::vector<NamedCompiledArtifact> artifacts;
   artifacts.emplace_back(kernelName,
-                         cudaq::CompiledModule::JitArtifact{
-                             std::move(engine), entryPoint, argsCreator,
-                             returnOffset, std::move(resourceCounts)});
+                         CompiledModule::JitArtifact{engine, entryPoint});
+  if (!isFullySpecialized) {
+    void (*argsCreatorFn)() =
+        engine.lookupRawNameOrFail(kernelName + ".argsCreator");
+    artifacts.emplace_back(kernelName + ".argsCreator",
+                           CompiledModule::JitArtifact{engine, argsCreatorFn});
+    if (hasResult) {
+      void (*returnOffsetFn)() =
+          engine.lookupRawNameOrFail(kernelName + ".returnOffset");
+      artifacts.emplace_back(
+          kernelName + ".returnOffset",
+          CompiledModule::JitArtifact{engine, returnOffsetFn});
+    }
+  }
   return artifacts;
 }
 
-CompiledModuleHelper::NamedMlirArtifact
+CompiledModuleHelper::NamedCompiledArtifact
+CompiledModuleHelper::createResourcesArtifact(std::string name,
+                                              cudaq::Resources rc) {
+  return {std::move(name), CompiledModule::ResourcesArtifact{std::move(rc)}};
+}
+
+CompiledModuleHelper::NamedCompiledArtifact
 CompiledModuleHelper::createMlirArtifact(std::string name, ModuleOp module,
                                          std::shared_ptr<MLIRContext> context) {
   const void *ptr = module.getAsOpaquePointer();
   return {std::move(name),
-          cudaq::CompiledModule::MlirArtifact{ptr, std::move(context)}};
+          CompiledModule::MlirArtifact{ptr, std::move(context)}};
 }
 
 ModuleOp CompiledModuleHelper::getMlirModuleOp(
-    const cudaq::CompiledModule::MlirArtifact &artifact) {
+    const CompiledModule::MlirArtifact &artifact) {
   return ModuleOp::getFromOpaquePointer(artifact.modulePtr);
 }
 
-cudaq::CompiledModule CompiledModuleHelper::createCompiledModule(
+CompiledModule CompiledModuleHelper::createCompiledModule(
     std::string name, cudaq::ResultInfo resultInfo,
-    std::vector<NamedJitArtifact> jitArtifacts,
-    cudaq::CompiledModule::CompilationMetadata metadata) {
-  return createCompiledModule(std::move(name), std::move(resultInfo),
-                              std::move(jitArtifacts), {}, std::move(metadata));
-}
-
-cudaq::CompiledModule CompiledModuleHelper::createCompiledModule(
-    std::string name, cudaq::ResultInfo resultInfo,
-    std::vector<NamedMlirArtifact> mlirArtifacts,
-    cudaq::CompiledModule::CompilationMetadata metadata) {
-  return createCompiledModule(std::move(name), std::move(resultInfo), {},
-                              std::move(mlirArtifacts), std::move(metadata));
-}
-
-cudaq::CompiledModule CompiledModuleHelper::createCompiledModule(
-    std::string name, cudaq::ResultInfo resultInfo,
-    std::vector<NamedJitArtifact> jitArtifacts,
-    std::vector<NamedMlirArtifact> mlirArtifacts,
-    cudaq::CompiledModule::CompilationMetadata metadata) {
-  cudaq::CompiledModule compiled(std::move(name));
+    std::vector<NamedCompiledArtifact> compiledArtifacts,
+    CompiledModule::CompilationMetadata metadata) {
+  CompiledModule compiled(std::move(name));
   compiled.resultInfo = std::move(resultInfo);
   compiled.metadata = std::move(metadata);
-  for (auto &[artName, artifact] : jitArtifacts)
-    compiled.addArtifact(std::move(artName), std::move(artifact));
-  for (auto &[artName, artifact] : mlirArtifacts)
+  for (auto &[artName, artifact] : compiledArtifacts)
     compiled.addArtifact(std::move(artName), std::move(artifact));
   return compiled;
 }

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -470,17 +470,20 @@ cudaq::CompiledModule Compiler::runPassPipeline(
 
   // For emulation or resource counting: create JIT artifacts before
   // applying combine-measurements (so the JIT sees un-combined measurements).
-  std::vector<CompiledModuleHelper::NamedJitArtifact> jitArtifacts;
+  std::vector<CompiledModuleHelper::NamedCompiledArtifact> artifacts;
   if (emulate ||
       (executionContext && executionContext->name == "resource-count")) {
     for (auto &[name, module] : modules) {
       auto clonedModule = module.clone();
-      auto artifacts = CompiledModuleHelper::createJitArtifacts(
+      auto jitArtifacts = CompiledModuleHelper::createJitArtifacts(
           kernelName, createJITEngine(clonedModule, codegenTranslation), {},
-          /*isFullySpecialized=*/true, std::move(resourceCounts));
-      assert(artifacts.size() == 1);
-      artifacts[0].first = name;
-      jitArtifacts.push_back(std::move(artifacts[0]));
+          /*isFullySpecialized=*/true);
+      assert(jitArtifacts.size() == 1);
+      jitArtifacts[0].first = name;
+      artifacts.push_back(std::move(jitArtifacts[0]));
+      if (resourceCounts)
+        artifacts.push_back(CompiledModuleHelper::createResourcesArtifact(
+            name + ".resources", std::move(*resourceCounts)));
     }
   }
 
@@ -488,15 +491,14 @@ cudaq::CompiledModule Compiler::runPassPipeline(
     for (auto &[name, module] : modules)
       runPassPipeline("func.func(combine-measurements)", module);
 
-  std::vector<CompiledModuleHelper::NamedMlirArtifact> mlirArtifacts;
   for (auto &[name, module] : modules) {
     auto mlirName = name + ".mlir"; // distinguish MLIR and JIT artifacts
-    mlirArtifacts.push_back(
+    artifacts.push_back(
         CompiledModuleHelper::createMlirArtifact(mlirName, module, context));
   }
 
   return CompiledModuleHelper::createCompiledModule(
-      kernelName, {}, std::move(jitArtifacts), std::move(mlirArtifacts),
+      kernelName, {}, std::move(artifacts),
       {.reorderIdx = mapping_reorder_idx});
 }
 
@@ -538,13 +540,12 @@ Compiler::emitKernelExecutions(const cudaq::CompiledModule &compiled) {
     std::optional<cudaq::JitEngine> optionalJit;
     std::optional<cudaq::Resources> optionalResourceCounts;
     auto kernelName = name.substr(0, name.length() - 5);
-    auto it = compiled.getArtifacts().find(kernelName);
-    if (it != compiled.getArtifacts().end()) {
-      const auto &jit =
-          std::get<cudaq::CompiledModule::JitArtifact>(it->second);
-      optionalJit = jit.getEngine();
-      optionalResourceCounts = jit.getResourceCounts();
-    }
+    auto jit = compiled.getJit(kernelName);
+    if (jit)
+      optionalJit = jit->getEngine();
+    auto resourceCounts = compiled.getResources(kernelName + ".resources");
+    if (resourceCounts)
+      optionalResourceCounts = *resourceCounts;
 
     auto mapping_reorder_idx = compiled.getMetadata().reorderIdx;
     codes.emplace_back(kernelName, codeStr, optionalJit, optionalResourceCounts,

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/CompiledModuleHelper.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/CompiledModuleHelper.h
@@ -25,10 +25,8 @@ class CompiledModuleHelper {
 public:
   // --- Named artifact aliases ---
 
-  using NamedJitArtifact =
-      std::pair<std::string, cudaq::CompiledModule::JitArtifact>;
-  using NamedMlirArtifact =
-      std::pair<std::string, cudaq::CompiledModule::MlirArtifact>;
+  using NamedCompiledArtifact =
+      std::pair<std::string, cudaq::CompiledModule::CompiledArtifact>;
 
   CompiledModuleHelper() = delete;
 
@@ -48,18 +46,22 @@ public:
   /// engine.
   ///
   /// Uses the kernel's name and result metadata to determine the correct
-  /// mangled symbol names. Currently returns one artifact.
-  ///
-  /// Optionally, a \p resourceCounts can be attached to the returned artifact.
-  static std::vector<NamedJitArtifact> createJitArtifacts(
-      const std::string &kernelName, cudaq::JitEngine engine,
-      const cudaq::ResultInfo &resultInfo, bool isFullySpecialized,
-      std::optional<cudaq::Resources> resourceCounts = std::nullopt);
+  /// mangled symbol names.
+  static std::vector<NamedCompiledArtifact>
+  createJitArtifacts(const std::string &kernelName, cudaq::JitEngine engine,
+                     const cudaq::ResultInfo &resultInfo,
+                     bool isFullySpecialized);
+
+  // --- ResourcesArtifact construction ---
+
+  /// Construct a named `ResourcesArtifact` from pre-computed resource counts.
+  static NamedCompiledArtifact createResourcesArtifact(std::string name,
+                                                       cudaq::Resources rc);
 
   // --- MlirArtifact construction and access ---
 
   /// Construct a named `MlirArtifact` from a `ModuleOp`.
-  static NamedMlirArtifact
+  static NamedCompiledArtifact
   createMlirArtifact(std::string name, mlir::ModuleOp module,
                      std::shared_ptr<mlir::MLIRContext> context = nullptr);
 
@@ -69,23 +71,10 @@ public:
 
   // --- CompiledModule construction ---
 
-  /// Create a `CompiledModule` containing only JIT artifacts.
+  /// Create a `CompiledModule` containing the given compiled artifacts.
   static cudaq::CompiledModule createCompiledModule(
       std::string name, cudaq::ResultInfo resultInfo,
-      std::vector<NamedJitArtifact> jitArtifacts,
-      cudaq::CompiledModule::CompilationMetadata metadata = {});
-
-  /// Create a `CompiledModule` containing only MLIR artifacts.
-  static cudaq::CompiledModule createCompiledModule(
-      std::string name, cudaq::ResultInfo resultInfo,
-      std::vector<NamedMlirArtifact> mlirArtifacts,
-      cudaq::CompiledModule::CompilationMetadata metadata = {});
-
-  /// Create a `CompiledModule` containing both JIT and MLIR artifacts.
-  static cudaq::CompiledModule createCompiledModule(
-      std::string name, cudaq::ResultInfo resultInfo,
-      std::vector<NamedJitArtifact> jitArtifacts,
-      std::vector<NamedMlirArtifact> mlirArtifacts,
+      std::vector<NamedCompiledArtifact> compiledArtifacts,
       cudaq::CompiledModule::CompilationMetadata metadata = {});
 };
 


### PR DESCRIPTION
This is the second follow up after #4322 from our discussion last week.

This PR 'dumbs down' the `CompiledModule` type in the following sense
- it does not make any assumptions anymore on what the compilation artifacts contain (e.g. before `JitArtifact` kept track of the various named entrypoints according to some naming convention)
- it does not know what 'executing' a `CompiledModule` means

The result is a pretty clean 'container' type that just knows how to store artifacts of different kinds. The only methods that still rely on some naming conventions are `getArgsCreator` and `getReturnOffset`, which exist purely for convenience (can be removed if you wish).

This logic (which is dependent on conventions), now lives outside of the type. The naming conventions and entrypoint resolution was fully moved to construction (in `runtime/internal/compiler/include/cudaq_internal/compiler/CompiledModuleHelper.h`). The execution logic on the other hand was moved to the only placed it is currently used in (`runtime/cudaq/platform/qpu.cpp`). We might need to move this further as we unify kernel execution for C++ and Python, but wasn't sure where it would eventually land (and in what form).