### PR TITLE
[NFC] Breaking up Compiler.cpp to isolate common code from policy specific code.

### DIFF
--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -90,6 +90,22 @@ nlohmann::json formOutputNames(const std::string &codegenTranslation,
   }
   return output_names;
 }
+/// Extract qubit-mapping reorder indices from the entry-point attributes.
+std::vector<std::size_t> extractMappingReorderIdx(mlir::ModuleOp moduleOp,
+                                                  mlir::func::FuncOp epFunc) {
+  assert(moduleOp.template lookupSymbol<mlir::func::FuncOp>(epFunc.getName()) &&
+         "Entry point function must survive the lowering pipeline.");
+  std::vector<std::size_t> mapping_reorder_idx;
+  if (auto mappingAttr = dyn_cast_if_present<mlir::ArrayAttr>(
+          epFunc->getAttr("mapping_reorder_idx"))) {
+    mapping_reorder_idx.resize(mappingAttr.size());
+    std::transform(mappingAttr.begin(), mappingAttr.end(),
+                   mapping_reorder_idx.begin(), [](mlir::Attribute attr) {
+                     return mlir::cast<mlir::IntegerAttr>(attr).getInt();
+                   });
+  }
+  return mapping_reorder_idx;
+}
 } // namespace
 
 std::pair<mlir::ModuleOp, std::unique_ptr<mlir::MLIRContext>>
@@ -337,23 +353,6 @@ bool Compiler::executeMainPipeline(mlir::ModuleOp moduleOp,
   }
   applyPipeline(passPipelineConfig, moduleOp, kernelName);
   return combineMeasurements;
-}
-
-std::vector<std::size_t>
-Compiler::extractMappingReorderIdx(mlir::ModuleOp moduleOp,
-                                   mlir::func::FuncOp epFunc) {
-  assert(moduleOp.template lookupSymbol<mlir::func::FuncOp>(epFunc.getName()) &&
-         "Entry point function must survive the lowering pipeline.");
-  std::vector<std::size_t> mapping_reorder_idx;
-  if (auto mappingAttr = dyn_cast_if_present<mlir::ArrayAttr>(
-          epFunc->getAttr("mapping_reorder_idx"))) {
-    mapping_reorder_idx.resize(mappingAttr.size());
-    std::transform(mappingAttr.begin(), mappingAttr.end(),
-                   mapping_reorder_idx.begin(), [](mlir::Attribute attr) {
-                     return mlir::cast<mlir::IntegerAttr>(attr).getInt();
-                   });
-  }
-  return mapping_reorder_idx;
 }
 
 cudaq::CompiledModule Compiler::assembleCompiledModule(

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -224,38 +224,40 @@ Compiler::Compiler(cudaq::ServerHelper *serverHelper,
 
 Compiler::~Compiler() = default;
 
-cudaq::CompiledModule Compiler::runPassPipeline(
-    cudaq::ExecutionContext *executionContext, const std::string &kernelName,
-    mlir::ModuleOp m_module, const std::vector<void *> &rawArgs,
-    void *kernelArgs, std::shared_ptr<mlir::MLIRContext> context) {
-  auto contextPtr = m_module.getContext();
-  assert(!context || context.get() == contextPtr);
+// =============================================================================
+// Common helpers for policy-specific runPassPipeline overloads
+// =============================================================================
 
-  // Extract the kernel name
+void Compiler::applyPipeline(const std::string &pipeline,
+                             mlir::ModuleOp moduleOp,
+                             const std::string &kernelName) {
+  auto *contextPtr = moduleOp.getContext();
+  mlir::PassManager pm(contextPtr);
+  std::string errMsg;
+  llvm::raw_string_ostream os(errMsg);
+  CUDAQ_INFO("Pass pipeline for {} = {}", kernelName, pipeline);
+  if (failed(parsePassPipeline(pipeline, pm, os)))
+    throw std::runtime_error(
+        "Remote rest platform failed to add passes to pipeline (" + errMsg +
+        ").");
+  if (disableMLIRthreading || enablePrintMLIREachPass)
+    contextPtr->disableMultithreading();
+  if (enablePrintMLIREachPass)
+    pm.enableIRPrinting();
+  if (failed(pm.run(moduleOp)))
+    throw std::runtime_error("Remote rest platform Quake lowering failed.");
+}
+
+std::pair<mlir::ModuleOp, mlir::func::FuncOp>
+Compiler::prepareModule(const std::string &kernelName, mlir::ModuleOp m_module,
+                        const std::vector<void *> &rawArgs, void *kernelArgs) {
+  auto *contextPtr = m_module.getContext();
+
   auto origFn = m_module.template lookupSymbol<mlir::func::FuncOp>(
       std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
 
   auto moduleOp =
       lowerQuakeCodeBuildModule(kernelName, m_module, contextPtr, origFn);
-
-  // Lambda to apply a specific pipeline to the given ModuleOp
-  auto runPassPipeline = [&](const std::string &pipeline,
-                             mlir::ModuleOp moduleOpIn) {
-    mlir::PassManager pm(contextPtr);
-    std::string errMsg;
-    llvm::raw_string_ostream os(errMsg);
-    CUDAQ_INFO("Pass pipeline for {} = {}", kernelName, pipeline);
-    if (failed(parsePassPipeline(pipeline, pm, os)))
-      throw std::runtime_error(
-          "Remote rest platform failed to add passes to pipeline (" + errMsg +
-          ").");
-    if (disableMLIRthreading || enablePrintMLIREachPass)
-      moduleOpIn.getContext()->disableMultithreading();
-    if (enablePrintMLIREachPass)
-      pm.enableIRPrinting();
-    if (failed(pm.run(moduleOpIn)))
-      throw std::runtime_error("Remote rest platform Quake lowering failed.");
-  };
 
   auto epFunc =
       moduleOp.template lookupSymbol<mlir::func::FuncOp>(origFn.getName());
@@ -265,7 +267,6 @@ cudaq::CompiledModule Compiler::runPassPipeline(
     if (isPython)
       mergeAllCallableClosures(moduleOp, kernelName, rawArgs);
 
-    // Mark all newly merged kernels private, and leave the entry point alone.
     for (auto &op : moduleOp)
       if (auto f = dyn_cast<mlir::func::FuncOp>(op))
         if (f != epFunc)
@@ -273,14 +274,9 @@ cudaq::CompiledModule Compiler::runPassPipeline(
 
     if (!rawArgs.empty()) {
       CUDAQ_INFO("Run Argument Synth.\n");
-      // For quantum devices, we generate a collection of `init` and
-      // `num_qubits` functions and their substitutions created
-      // from a kernel and arguments that generated a state argument.
       ArgumentConverter argCon(kernelName, moduleOp);
       argCon.gen(rawArgs);
 
-      // Store kernel and substitution strings on the stack.
-      // We pass string references to the `createArgumentSynthesisPass`.
       mlir::SmallVector<std::string> kernels;
       mlir::SmallVector<std::string> substs;
       for (auto *kInfo : argCon.getKernelSubstitutions()) {
@@ -293,7 +289,6 @@ cudaq::CompiledModule Compiler::runPassPipeline(
         substs.emplace_back(substBuff);
       }
 
-      // Collect references for the argument synthesis.
       mlir::SmallVector<mlir::StringRef> kernelRefs{kernels.begin(),
                                                     kernels.end()};
       mlir::SmallVector<mlir::StringRef> substRefs{substs.begin(),
@@ -303,9 +298,6 @@ cudaq::CompiledModule Compiler::runPassPipeline(
       pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
       pm.addPass(
           cudaq::opt::createLambdaLifting({.constantPropagation = true}));
-      // We must inline these lambda calls before apply specialization as it
-      // does not perform control/adjoint specialization across function call
-      // boundary.
       cudaq::opt::addAggressiveInlining(pm);
       pm.addPass(
           cudaq::opt::createApplySpecialization({.constantPropagation = true}));
@@ -327,8 +319,88 @@ cudaq::CompiledModule Compiler::runPassPipeline(
       throw std::runtime_error("Could not successfully apply quake-synth.");
   }
 
+  return {moduleOp, epFunc};
+}
+
+bool Compiler::executeMainPipeline(mlir::ModuleOp moduleOp,
+                                   const std::string &kernelName) {
+  auto combineMeasurements =
+      passPipelineConfig.find("combine-measurements") != std::string::npos;
+  if (emulate && combineMeasurements) {
+    std::regex combine("(.*),([ ]*)combine-measurements(.*)");
+    std::string replacement("$1$3");
+    passPipelineConfig =
+        std::regex_replace(passPipelineConfig, combine, replacement);
+    CUDAQ_INFO("Delaying combine-measurements pass due to emulation. "
+               "Updating pipeline to {}",
+               passPipelineConfig);
+  }
+  applyPipeline(passPipelineConfig, moduleOp, kernelName);
+  return combineMeasurements;
+}
+
+std::vector<std::size_t>
+Compiler::extractMappingReorderIdx(mlir::ModuleOp moduleOp,
+                                   mlir::func::FuncOp epFunc) {
+  assert(moduleOp.template lookupSymbol<mlir::func::FuncOp>(epFunc.getName()) &&
+         "Entry point function must survive the lowering pipeline.");
+  std::vector<std::size_t> mapping_reorder_idx;
+  if (auto mappingAttr = dyn_cast_if_present<mlir::ArrayAttr>(
+          epFunc->getAttr("mapping_reorder_idx"))) {
+    mapping_reorder_idx.resize(mappingAttr.size());
+    std::transform(mappingAttr.begin(), mappingAttr.end(),
+                   mapping_reorder_idx.begin(), [](mlir::Attribute attr) {
+                     return mlir::cast<mlir::IntegerAttr>(attr).getInt();
+                   });
+  }
+  return mapping_reorder_idx;
+}
+
+cudaq::CompiledModule Compiler::assembleCompiledModule(
+    const std::string &kernelName,
+    std::vector<std::pair<std::string, mlir::ModuleOp>> &modules, bool needJit,
+    bool runCombineMeasurements, std::optional<cudaq::Resources> resourceCounts,
+    const std::vector<std::size_t> &mappingReorderIdx,
+    std::shared_ptr<mlir::MLIRContext> context) {
+  std::vector<CompiledModuleHelper::NamedCompiledArtifact> artifacts;
+  if (needJit) {
+    for (auto &[name, module] : modules) {
+      auto clonedModule = module.clone();
+      auto jitArtifacts = CompiledModuleHelper::createJitArtifacts(
+          kernelName, createJITEngine(clonedModule, codegenTranslation), {},
+          /*isFullySpecialized=*/true);
+      assert(jitArtifacts.size() == 1);
+      jitArtifacts[0].first = name;
+      artifacts.push_back(std::move(jitArtifacts[0]));
+      if (resourceCounts)
+        artifacts.push_back(CompiledModuleHelper::createResourcesArtifact(
+            name + ".resources", std::move(*resourceCounts)));
+    }
+  }
+
+  if (runCombineMeasurements)
+    for (auto &[name, module] : modules)
+      applyPipeline("func.func(combine-measurements)", module, kernelName);
+
+  for (auto &[name, module] : modules) {
+    auto mlirName = name + ".mlir";
+    artifacts.push_back(
+        CompiledModuleHelper::createMlirArtifact(mlirName, module, context));
+  }
+
+  return CompiledModuleHelper::createCompiledModule(
+      kernelName, {}, std::move(artifacts), {.reorderIdx = mappingReorderIdx});
+}
+
+cudaq::CompiledModule Compiler::runPassPipeline(
+    cudaq::ExecutionContext *executionContext, const std::string &kernelName,
+    mlir::ModuleOp m_module, const std::vector<void *> &rawArgs,
+    void *kernelArgs, std::shared_ptr<mlir::MLIRContext> context) {
+  assert(!context || context.get() == m_module.getContext());
+  auto [moduleOp, epFunc] =
+      prepareModule(kernelName, m_module, rawArgs, kernelArgs);
+
   if (emulate && executionContext && executionContext->name == "sample") {
-    // Populate conditional measurement flag in the context.
     for (auto &artifact : moduleOp) {
       quake::detail::QuakeFunctionAnalysis analysis{&artifact};
       auto info = analysis.getAnalysisInfo();
@@ -347,24 +419,9 @@ cudaq::CompiledModule Compiler::runPassPipeline(
       }
     }
   }
-  // Delay combining measurements for backends that cannot handle
-  // subveqs and multiple measurements until we created the emulation code.
-  auto combineMeasurements =
-      passPipelineConfig.find("combine-measurements") != std::string::npos;
-  if (emulate && combineMeasurements) {
-    std::regex combine("(.*),([ ]*)combine-measurements(.*)");
-    std::string replacement("$1$3");
-    passPipelineConfig =
-        std::regex_replace(passPipelineConfig, combine, replacement);
-    CUDAQ_INFO("Delaying combine-measurements pass due to emulation. "
-               "Updating pipeline to {}",
-               passPipelineConfig);
-  }
 
-  runPassPipeline(passPipelineConfig, moduleOp);
-  // We need to run resource counting preprocessing after the pass pipeline as
-  // the pre-processing might change the IR structure (may interfere with
-  // other passes).
+  bool combineMeasurements = executeMainPipeline(moduleOp, kernelName);
+
   std::optional<cudaq::Resources> resourceCounts;
   if (executionContext && executionContext->name == "resource-count") {
     auto result = cudaq::opt::countResourcesFromIR(moduleOp);
@@ -374,22 +431,11 @@ cudaq::CompiledModule Compiler::runPassPipeline(
     resourceCounts = std::move(*result);
   }
 
-  assert(moduleOp.template lookupSymbol<mlir::func::FuncOp>(epFunc.getName()) &&
-         "Entry point function must survive the lowering pipeline.");
-  std::vector<std::size_t> mapping_reorder_idx;
-  if (auto mappingAttr = dyn_cast_if_present<mlir::ArrayAttr>(
-          epFunc->getAttr("mapping_reorder_idx"))) {
-    mapping_reorder_idx.resize(mappingAttr.size());
-    std::transform(mappingAttr.begin(), mappingAttr.end(),
-                   mapping_reorder_idx.begin(), [](mlir::Attribute attr) {
-                     return mlir::cast<mlir::IntegerAttr>(attr).getInt();
-                   });
-  }
+  auto mapping_reorder_idx = extractMappingReorderIdx(moduleOp, epFunc);
 
   if (executionContext) {
     if (executionContext->name == "sample") {
       executionContext->reorderIdx = mapping_reorder_idx;
-      // Warn if kernel has named measurement registers (sub-registers).
       if (!executionContext->warnedNamedMeasurements) {
         auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
             std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
@@ -414,35 +460,30 @@ cudaq::CompiledModule Compiler::runPassPipeline(
           }
         }
       }
-      // No need to add measurements only to remove them eventually
       if (postCodeGenPasses.find("remove-measurements") == std::string::npos)
-        runPassPipeline("func.func(add-measurements)", moduleOp);
+        applyPipeline("func.func(add-measurements)", moduleOp, kernelName);
     } else {
       executionContext->reorderIdx.clear();
     }
   }
 
   std::vector<std::pair<std::string, mlir::ModuleOp>> modules;
-  // Apply observations if necessary
   if (executionContext && executionContext->name == "observe") {
     mapping_reorder_idx.clear();
-    runPassPipeline("canonicalize,cse", moduleOp);
+    applyPipeline("canonicalize,cse", moduleOp, kernelName);
     cudaq::spin_op &spin = executionContext->spin.value();
     for (const auto &term : spin) {
       if (term.is_identity())
         continue;
 
-      // Get the ansatz
       [[maybe_unused]] auto ansatz =
           moduleOp.template lookupSymbol<mlir::func::FuncOp>(
               cudaq::runtime::cudaqGenPrefixName + kernelName);
       assert(ansatz && "could not find the ansatz kernel");
 
-      // Create a new Module to clone the ansatz into it
       auto tmpModuleOp = moduleOp.clone();
 
-      // Create the pass manager, add the quake observe ansatz pass and run it
-      // followed by the canonicalizer
+      auto *contextPtr = moduleOp.getContext();
       mlir::PassManager pm(contextPtr);
       pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createObserveAnsatzPass(
           term.get_binary_symplectic_form()));
@@ -452,54 +493,24 @@ cudaq::CompiledModule Compiler::runPassPipeline(
         pm.enableIRPrinting();
       if (failed(pm.run(tmpModuleOp)))
         throw std::runtime_error("Could not apply measurements to ansatz.");
-      // The full pass pipeline was run above, but the ansatz pass can
-      // introduce gates that aren't supported by the backend, so we need to
-      // re-run the gate set mapping if that existed in the original pass
-      // pipeline.
       auto csvSplit = cudaq::split(passPipelineConfig, ',');
       for (auto &pass : csvSplit)
         if (pass.ends_with("-gate-set-mapping"))
-          runPassPipeline(pass, tmpModuleOp);
+          applyPipeline(pass, tmpModuleOp, kernelName);
       if (!emulate && combineMeasurements)
-        runPassPipeline("func.func(combine-measurements)", tmpModuleOp);
+        applyPipeline("func.func(combine-measurements)", tmpModuleOp,
+                      kernelName);
       modules.emplace_back(term.get_term_id(), tmpModuleOp);
     }
   } else {
     modules.emplace_back(kernelName, moduleOp);
   }
 
-  // For emulation or resource counting: create JIT artifacts before
-  // applying combine-measurements (so the JIT sees un-combined measurements).
-  std::vector<CompiledModuleHelper::NamedCompiledArtifact> artifacts;
-  if (emulate ||
-      (executionContext && executionContext->name == "resource-count")) {
-    for (auto &[name, module] : modules) {
-      auto clonedModule = module.clone();
-      auto jitArtifacts = CompiledModuleHelper::createJitArtifacts(
-          kernelName, createJITEngine(clonedModule, codegenTranslation), {},
-          /*isFullySpecialized=*/true);
-      assert(jitArtifacts.size() == 1);
-      jitArtifacts[0].first = name;
-      artifacts.push_back(std::move(jitArtifacts[0]));
-      if (resourceCounts)
-        artifacts.push_back(CompiledModuleHelper::createResourcesArtifact(
-            name + ".resources", std::move(*resourceCounts)));
-    }
-  }
-
-  if (emulate && combineMeasurements)
-    for (auto &[name, module] : modules)
-      runPassPipeline("func.func(combine-measurements)", module);
-
-  for (auto &[name, module] : modules) {
-    auto mlirName = name + ".mlir"; // distinguish MLIR and JIT artifacts
-    artifacts.push_back(
-        CompiledModuleHelper::createMlirArtifact(mlirName, module, context));
-  }
-
-  return CompiledModuleHelper::createCompiledModule(
-      kernelName, {}, std::move(artifacts),
-      {.reorderIdx = mapping_reorder_idx});
+  bool needJit = emulate || (executionContext &&
+                             executionContext->name == "resource-count");
+  return assembleCompiledModule(
+      kernelName, modules, needJit, emulate && combineMeasurements,
+      std::move(resourceCounts), mapping_reorder_idx, context);
 }
 
 std::vector<cudaq::KernelExecution>

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -283,6 +283,7 @@ Compiler::prepareModule(const std::string &kernelName, mlir::ModuleOp m_module,
     if (isPython)
       mergeAllCallableClosures(moduleOp, kernelName, rawArgs);
 
+    // Mark all newly merged kernels private, and leave the entry point alone.
     for (auto &op : moduleOp)
       if (auto f = dyn_cast<mlir::func::FuncOp>(op))
         if (f != epFunc)
@@ -290,9 +291,14 @@ Compiler::prepareModule(const std::string &kernelName, mlir::ModuleOp m_module,
 
     if (!rawArgs.empty()) {
       CUDAQ_INFO("Run Argument Synth.\n");
+      // For quantum devices, we generate a collection of `init` and
+      // `num_qubits` functions and their substitutions created
+      // from a kernel and arguments that generated a state argument.
       ArgumentConverter argCon(kernelName, moduleOp);
       argCon.gen(rawArgs);
 
+      // Store kernel and substitution strings on the stack.
+      // We pass string references to the `createArgumentSynthesisPass`.
       mlir::SmallVector<std::string> kernels;
       mlir::SmallVector<std::string> substs;
       for (auto *kInfo : argCon.getKernelSubstitutions()) {
@@ -305,6 +311,7 @@ Compiler::prepareModule(const std::string &kernelName, mlir::ModuleOp m_module,
         substs.emplace_back(substBuff);
       }
 
+      // Collect references for the argument synthesis.
       mlir::SmallVector<mlir::StringRef> kernelRefs{kernels.begin(),
                                                     kernels.end()};
       mlir::SmallVector<mlir::StringRef> substRefs{substs.begin(),
@@ -314,6 +321,9 @@ Compiler::prepareModule(const std::string &kernelName, mlir::ModuleOp m_module,
       pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
       pm.addPass(
           cudaq::opt::createLambdaLifting({.constantPropagation = true}));
+      // We must inline these lambda calls before apply specialization as it
+      // does not perform control/adjoint specialization across function call
+      // boundary.
       cudaq::opt::addAggressiveInlining(pm);
       pm.addPass(
           cudaq::opt::createApplySpecialization({.constantPropagation = true}));
@@ -399,6 +409,7 @@ cudaq::CompiledModule Compiler::runPassPipeline(
   auto [moduleOp, epFunc] =
       prepareModule(kernelName, m_module, rawArgs, kernelArgs);
 
+  // Populate conditional measurement flag in the context.
   if (emulate && executionContext && executionContext->name == "sample") {
     for (auto &artifact : moduleOp) {
       quake::detail::QuakeFunctionAnalysis analysis{&artifact};
@@ -421,6 +432,9 @@ cudaq::CompiledModule Compiler::runPassPipeline(
 
   bool combineMeasurements = executeMainPipeline(moduleOp, kernelName);
 
+  // We need to run resource counting preprocessing after the pass pipeline as
+  // the pre-processing might change the IR structure (may interfere with
+  // other passes).
   std::optional<cudaq::Resources> resourceCounts;
   if (executionContext && executionContext->name == "resource-count") {
     auto result = cudaq::opt::countResourcesFromIR(moduleOp);
@@ -435,6 +449,7 @@ cudaq::CompiledModule Compiler::runPassPipeline(
   if (executionContext) {
     if (executionContext->name == "sample") {
       executionContext->reorderIdx = mapping_reorder_idx;
+      // Warn if kernel has named measurement registers (sub-registers).
       if (!executionContext->warnedNamedMeasurements) {
         auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
             std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
@@ -459,6 +474,7 @@ cudaq::CompiledModule Compiler::runPassPipeline(
           }
         }
       }
+      // No need to add measurements only to remove them eventually
       if (postCodeGenPasses.find("remove-measurements") == std::string::npos)
         applyPipeline("func.func(add-measurements)", moduleOp, kernelName);
     } else {
@@ -466,6 +482,7 @@ cudaq::CompiledModule Compiler::runPassPipeline(
     }
   }
 
+  // Apply observations if necessary
   std::vector<std::pair<std::string, mlir::ModuleOp>> modules;
   if (executionContext && executionContext->name == "observe") {
     mapping_reorder_idx.clear();
@@ -475,13 +492,17 @@ cudaq::CompiledModule Compiler::runPassPipeline(
       if (term.is_identity())
         continue;
 
+      // Get the ansatz
       [[maybe_unused]] auto ansatz =
           moduleOp.template lookupSymbol<mlir::func::FuncOp>(
               cudaq::runtime::cudaqGenPrefixName + kernelName);
       assert(ansatz && "could not find the ansatz kernel");
 
+      // Create a new Module to clone the ansatz into it
       auto tmpModuleOp = moduleOp.clone();
 
+      // Create the pass manager, add the quake observe ansatz pass and run it
+      // followed by the canonicalizer
       auto *contextPtr = moduleOp.getContext();
       mlir::PassManager pm(contextPtr);
       pm.addNestedPass<mlir::func::FuncOp>(cudaq::opt::createObserveAnsatzPass(
@@ -492,6 +513,10 @@ cudaq::CompiledModule Compiler::runPassPipeline(
         pm.enableIRPrinting();
       if (failed(pm.run(tmpModuleOp)))
         throw std::runtime_error("Could not apply measurements to ansatz.");
+      // The full pass pipeline was run above, but the ansatz pass can
+      // introduce gates that aren't supported by the backend, so we need to
+      // re-run the gate set mapping if that existed in the original pass
+      // pipeline.
       auto csvSplit = cudaq::split(passPipelineConfig, ',');
       for (auto &pass : csvSplit)
         if (pass.ends_with("-gate-set-mapping"))

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -93,10 +93,6 @@ class Compiler {
   bool executeMainPipeline(mlir::ModuleOp moduleOp,
                            const std::string &kernelName);
 
-  /// Extract qubit-mapping reorder indices from the entry-point attributes.
-  std::vector<std::size_t> extractMappingReorderIdx(mlir::ModuleOp moduleOp,
-                                                    mlir::func::FuncOp epFunc);
-
   /// Create JIT and MLIR artifacts and assemble a CompiledModule.
   cudaq::CompiledModule assembleCompiledModule(
       const std::string &kernelName,

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -77,6 +77,35 @@ class Compiler {
                                            mlir::MLIRContext *,
                                            mlir::func::FuncOp);
 
+  // ---- Common helpers used by runPassPipeline ----
+
+  /// Run an arbitrary MLIR pass pipeline string on a module.
+  void applyPipeline(const std::string &pipeline, mlir::ModuleOp moduleOp,
+                     const std::string &kernelName);
+
+  /// Build the module, merge closures, and synthesize arguments.
+  std::pair<mlir::ModuleOp, mlir::func::FuncOp>
+  prepareModule(const std::string &kernelName, mlir::ModuleOp m_module,
+                const std::vector<void *> &rawArgs, void *kernelArgs);
+
+  /// Delay combine-measurements for emulation, then run the main pass
+  /// pipeline.  Returns true when combine-measurements was delayed.
+  bool executeMainPipeline(mlir::ModuleOp moduleOp,
+                           const std::string &kernelName);
+
+  /// Extract qubit-mapping reorder indices from the entry-point attributes.
+  std::vector<std::size_t> extractMappingReorderIdx(mlir::ModuleOp moduleOp,
+                                                    mlir::func::FuncOp epFunc);
+
+  /// Create JIT and MLIR artifacts and assemble a CompiledModule.
+  cudaq::CompiledModule assembleCompiledModule(
+      const std::string &kernelName,
+      std::vector<std::pair<std::string, mlir::ModuleOp>> &modules,
+      bool needJit, bool runCombineMeasurements,
+      std::optional<cudaq::Resources> resourceCounts,
+      const std::vector<std::size_t> &mappingReorderIdx,
+      std::shared_ptr<mlir::MLIRContext> context);
+
 public:
   Compiler(cudaq::ServerHelper *,
            const std::map<std::string, std::string> &backendConfig,


### PR DESCRIPTION
The goal of this PR is to prepare `lowerQuakeCode` and `runPassPipeline` to be overloaded based on the policies introduced in #4339. Practically speaking, the code located between `ctx->name == "..."` has been moved into utility methods which do not depend on the `executionContext`.

5 private helper methods have been extracted.
1. The lambda `runPassPipeline` has been renamed to `applyPipeline` as to not be confused with the new `runPassPipeline` method and is now a method as it is being called from several other methods
2. `prepareModule` builds the module via lowerQuakeCodeBuildModule, merges closures, performs argument/quake synthesis.

3. `executeMainPipeline` handles the combine-measurements delay for emulation, then runs the main pass pipeline. Returns whether combine-measurements was delayed.

4. `extractMappingReorderIdx` extracts qubit-mapping reorder indices from entry-point attributes. Moved into the anonymous namespace.

5. `assembleCompiledModule` creates JIT artifacts (when needed), runs deferred combine-measurements, creates MLIR artifacts, and assembles the final CompiledModule.