### PR TITLE
[Publishing fix] Using xdist_group

### DIFF
--- a/scripts/validate_pycudaq.sh
+++ b/scripts/validate_pycudaq.sh
@@ -333,9 +333,14 @@ else
     done
 fi
 
+xdist_flags=""
+if $is_macos; then
+    xdist_flags="--dist=loadgroup"
+fi
+
 # Run core tests
 echo "Running core tests."
-python3 -m pytest -v -n "$pytest_workers" "$root_folder/tests" \
+python3 -m pytest -v -n "$pytest_workers" $xdist_flags "$root_folder/tests" \
     --ignore "$root_folder/tests/backends" \
     --ignore "$root_folder/tests/dynamics/integrators" \
     --ignore "$root_folder/tests/parallel" \
@@ -355,7 +360,7 @@ fi
 
 # Run backend tests (single invocation with xdist; --rootdir matches upstream import layout)
 echo "Running backend tests."
-python3 -m pytest -v -n "$pytest_workers" --rootdir "$root_folder/tests" "$root_folder/tests/backends"
+python3 -m pytest -v -n "$pytest_workers" $xdist_flags --rootdir "$root_folder/tests" "$root_folder/tests/backends"
 status=$?
 # Exit code 5 indicates that no tests were collected.
 if [ ! $status -eq 0 ] && [ ! $status -eq 5 ]; then


### PR DESCRIPTION
The remote platform test module sets pytest.mark.xdist_group to keep its tests on one worker, but pytest-xdist only honors that marker under --dist=loadgroup.

Fixes: https://github.com/NVIDIA/cuda-quantum/actions/runs/24750269888/job/72426003995#step:7:2816