### PR TITLE
Adding coverage for if condition in a list

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -3797,12 +3797,16 @@ class PyASTBridge(ast.NodeVisitor):
         the MLIR.
 
         By simple, we mean expressions like `[expr(iter) for iter in iterable]`
-        or `myList = [exprThatReturns(iter) for iter in iterable]`.
+        or `myList = [exprThatReturns(iter) for iter in iterable]`, optionally
+        with `if` filter clause.
         """
         if len(node.generators) > 1:
             self.emitFatalError(
                 "CUDA-Q only supports single generators for list comprehension.",
                 node)
+
+        if_clauses = node.generators[0].ifs
+        hasFilter = len(if_clauses) > 0
 
         self.visit(node.generators[0].iter)
         iterable = self.popValue()
@@ -3841,6 +3845,15 @@ class PyASTBridge(ast.NodeVisitor):
             # This loop could be marked as invariant if we didn't use
             # `visit_For`, but that would be premature optimization.
             self.visit_For(forNode)
+
+        def evalFilter():
+            cond = None
+            for if_node in if_clauses:
+                self.visit(if_node)
+                this_cond = self.__arithmetic_to_bool(self.popValue())
+                cond = this_cond if cond is None else arith.AndIOp(
+                    cond, this_cond).result
+            return cond
 
         target_types = {}
 
@@ -4040,10 +4053,11 @@ class PyASTBridge(ast.NodeVisitor):
             return
 
         if quake.RefType.isinstance(listElemTy):
-            if quake.VeqType.isinstance(orig_iterable_type):
+            if quake.VeqType.isinstance(orig_iterable_type) and not hasFilter:
                 self.pushValue(iterable)
                 return
-            if cc.StdvecType.isinstance(orig_iterable_type):
+            if (cc.StdvecType.isinstance(orig_iterable_type) or
+                    quake.VeqType.isinstance(orig_iterable_type)):
                 i64Ty = self.getIntegerType()
                 veqTy = self.getVeqType()
                 c0 = self.getConstantInt(0)
@@ -4056,18 +4070,39 @@ class PyASTBridge(ast.NodeVisitor):
 
                 def bodyBuilder(args):
                     i, curr_veq = args[0], args[1]
-                    elem_addr = cc.ComputePtrOp(
-                        cc.PointerType.get(iterTy), iterable, [i],
-                        DenseI32ArrayAttr.get([kDynamicPtrIndex],
-                                              context=self.ctx))
-                    idx_val = cc.LoadOp(elem_addr).result
+                    if quake.VeqType.isinstance(iterable.type):
+                        idx_val = quake.ExtractRefOp(iterTy,
+                                                     iterable,
+                                                     -1,
+                                                     index=i).result
+                    else:
+                        elem_addr = cc.ComputePtrOp(
+                            cc.PointerType.get(iterTy), iterable, [i],
+                            DenseI32ArrayAttr.get([kDynamicPtrIndex],
+                                                  context=self.ctx))
+                        idx_val = cc.LoadOp(elem_addr).result
                     self.symbolTable.beginBlock()
                     self.__deconstructAssignment(node.generators[0].target,
                                                  idx_val)
-                    self.visit(node.elt)
-                    ref = self.popValue()
+                    if hasFilter:
+                        cond = evalFilter()
+                        ifOp = cc.IfOp([veqTy], cond, [])
+                        thenBlock = Block.create_at_start(ifOp.thenRegion, [])
+                        with InsertionPoint(thenBlock):
+                            self.visit(node.elt)
+                            ref = self.popValue()
+                            appended = quake.ConcatOp(veqTy,
+                                                      [curr_veq, ref]).result
+                            cc.ContinueOp([appended])
+                        elseBlock = Block.create_at_start(ifOp.elseRegion, [])
+                        with InsertionPoint(elseBlock):
+                            cc.ContinueOp([curr_veq])
+                        new_veq = ifOp.result
+                    else:
+                        self.visit(node.elt)
+                        ref = self.popValue()
+                        new_veq = quake.ConcatOp(veqTy, [curr_veq, ref]).result
                     self.symbolTable.endBlock()
-                    new_veq = quake.ConcatOp(veqTy, [curr_veq, ref]).result
                     cc.ContinueOp([i, new_veq])
 
                 loop = self.createForLoop(
@@ -4089,47 +4124,72 @@ class PyASTBridge(ast.NodeVisitor):
                                 TypeAttr.get(listElemTy),
                                 seqSize=iterableSize).result
 
-        # General case of
-        # `listVar = [expr(i) for i in iterable]`
-        # Need to think of this as
-        # `listVar = stdvec(iterable.size)`
-        # `for i, r in enumerate(listVar):`
-        # `   listVar[i] = expr(r)`
-        def bodyBuilder(iterVar):
-            self.symbolTable.beginBlock()
+        def extractIterVal(iterVar):
             if quake.VeqType.isinstance(iterable.type):
-                iterVal = quake.ExtractRefOp(iterTy,
-                                             iterable,
-                                             -1,
-                                             index=iterVar).result
-            else:
-                eleAddr = cc.ComputePtrOp(
-                    cc.PointerType.get(iterTy), iterable, [iterVar],
-                    DenseI32ArrayAttr.get([kDynamicPtrIndex], context=self.ctx))
-                iterVal = cc.LoadOp(eleAddr).result
+                return quake.ExtractRefOp(iterTy, iterable, -1,
+                                          index=iterVar).result
+            eleAddr = cc.ComputePtrOp(
+                cc.PointerType.get(iterTy), iterable, [iterVar],
+                DenseI32ArrayAttr.get([kDynamicPtrIndex], context=self.ctx))
+            return cc.LoadOp(eleAddr).result
 
-            # We don't do support anything within list comprehensions that would
-            # require being careful about assigning references, so simply
-            # adding them to the symbol table is enough for list comprehension.
-            self.__deconstructAssignment(node.generators[0].target, iterVal)
+        def storeElementAt(storeIdx):
             self.visit(node.elt)
             element = self.popValue()
-            # We do need to be careful, however, about validating the list
-            # elements.
+            # We do need to be careful about validating the list elements.
             self.__validate_container_entry(element, node.elt)
-
             listValueAddr = cc.ComputePtrOp(
-                cc.PointerType.get(listElemTy), listValue, [iterVar],
+                cc.PointerType.get(listElemTy), listValue, [storeIdx],
                 DenseI32ArrayAttr.get([kDynamicPtrIndex], context=self.ctx))
             element = self.changeOperandToType(listElemTy,
                                                element,
                                                allowDemotion=False)
             cc.StoreOp(element, listValueAddr)
-            self.symbolTable.endBlock()
 
-        self.createInvariantForLoop(bodyBuilder, iterableSize)
-        res = cc.StdvecInitOp(resultVecTy, listValue,
-                              length=iterableSize).result
+        if not hasFilter:
+
+            def bodyBuilder(iterVar):
+                self.symbolTable.beginBlock()
+                iterVal = extractIterVal(iterVar)
+                self.__deconstructAssignment(node.generators[0].target, iterVal)
+                storeElementAt(iterVar)
+                self.symbolTable.endBlock()
+
+            self.createInvariantForLoop(bodyBuilder, iterableSize)
+            res = cc.StdvecInitOp(resultVecTy, listValue,
+                                  length=iterableSize).result
+            self.pushValue(res)
+            return
+
+        i64Ty = self.getIntegerType()
+        c0 = self.getConstantInt(0)
+        c1 = self.getConstantInt(1)
+
+        def filteredBodyBuilder(args):
+            i, count = args[0], args[1]
+            self.symbolTable.beginBlock()
+            iterVal = extractIterVal(i)
+            self.__deconstructAssignment(node.generators[0].target, iterVal)
+            cond = evalFilter()
+            ifOp = cc.IfOp([i64Ty], cond, [])
+            thenBlock = Block.create_at_start(ifOp.thenRegion, [])
+            with InsertionPoint(thenBlock):
+                storeElementAt(count)
+                cc.ContinueOp([arith.AddIOp(count, c1).result])
+            elseBlock = Block.create_at_start(ifOp.elseRegion, [])
+            with InsertionPoint(elseBlock):
+                cc.ContinueOp([count])
+            nextCount = ifOp.result
+            self.symbolTable.endBlock()
+            cc.ContinueOp([i, nextCount])
+
+        loop = self.createForLoop(
+            [i64Ty, i64Ty],
+            filteredBodyBuilder, [c0, c0], lambda args: arith.CmpIOp(
+                IntegerAttr.get(i64Ty, 2), args[0], iterableSize).result,
+            lambda args: [arith.AddIOp(args[0], c1).result, args[1]])
+        finalCount = loop.results[1]
+        res = cc.StdvecInitOp(resultVecTy, listValue, length=finalCount).result
         self.pushValue(res)
         return
 

--- a/python/tests/mlir/ast_list_comprehension.py
+++ b/python/tests/mlir/ast_list_comprehension.py
@@ -1135,6 +1135,97 @@ def test_list_comprehension_qubit_refs():
 # CHECK: return
 
 
+def test_list_comprehension_filter():
+    print("test_list_comprehension_filter:")
+
+    @cudaq.kernel
+    def kernel1() -> list[int]:
+        return [x for x in range(16) if False]
+
+    out = cudaq.run(kernel1, shots_count=1)
+    assert len(out) == 1 and out[0] == []
+    print(kernel1)
+
+    @cudaq.kernel
+    def kernel2(mask: int) -> list[int]:
+        return [x for x in range(8) if ((1 << x) & mask) != 0]
+
+    out = cudaq.run(kernel2, 0b10011, shots_count=1)
+    assert len(out) == 1 and out[0] == [0, 1, 4]
+    print(kernel2)
+
+    @cudaq.kernel
+    def kernel3() -> list[int]:
+        vals = [1, 2, 3, 4, 5]
+        return [v for v in vals if v % 2 == 0]
+
+    out = cudaq.run(kernel3, shots_count=1)
+    assert len(out) == 1 and out[0] == [2, 4]
+    print(kernel3)
+
+    @cudaq.kernel
+    def kernel4() -> list[int]:
+        return [x for x in range(10) if x > 2 if x < 7]
+
+    out = cudaq.run(kernel4, shots_count=1)
+    assert len(out) == 1 and out[0] == [3, 4, 5, 6]
+    print(kernel4)
+
+    @cudaq.kernel
+    def kernel5():
+        qs = cudaq.qvector(4)
+        flips = [qs[i] for i in range(4) if i % 2 == 1]
+        x(flips)
+
+    out = cudaq.sample(kernel5)
+    assert len(out) == 1 and '0101' in out
+    print(kernel5)
+
+    @cudaq.kernel
+    def kernel6(mask: int):
+        qs = cudaq.qvector(4)
+        x(qs)
+        target = cudaq.qubit()
+        x.ctrl([qs[i] for i in range(4) if ((1 << i) & mask) != 0], target)
+
+    out = cudaq.sample(kernel6, 0b1001)
+    assert len(out) == 1 and '11111' in out
+    print(kernel6)
+
+
+# CHECK-LABEL: test_list_comprehension_filter:
+# CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel1..
+# CHECK: cc.loop
+# CHECK: cc.if
+# CHECK: cc.stdvec_init
+# CHECK: return
+# CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel2..
+# CHECK: cc.loop
+# CHECK: cc.if
+# CHECK: cc.stdvec_init
+# CHECK: return
+# CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel3..
+# CHECK: cc.loop
+# CHECK: cc.if
+# CHECK: cc.stdvec_init
+# CHECK: return
+# CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel4..
+# CHECK: cc.loop
+# CHECK: cc.if
+# CHECK: cc.stdvec_init
+# CHECK: return
+# CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel5..
+# CHECK: cc.loop
+# CHECK: cc.if
+# CHECK: quake.concat
+# CHECK: return
+# CHECK-LABEL: func.func @__nvqpp__mlirgen__kernel6..
+# CHECK: cc.loop
+# CHECK: cc.if
+# CHECK: quake.concat
+# CHECK: return
+
+
 def test_list_comprehension_failures():
     print("test_list_comprehension_failures:")
     try:


### PR DESCRIPTION
- Lower if`-filtered list comprehensions (handles chained if) in Python kernel AST bridge
- Works for int/bool element types and qubit-ref results
- Adds `test_list_comprehension_filter` covering constant, variable, captured-list, chained-if, and control-qubit cases

Fixes #4207 