### PR TITLE
Extract ExecutionContext updates out of lowerQuakeCode

### DIFF
--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -21,6 +21,7 @@
 #include "cudaq/platform/qpu.h"
 #include "cudaq/platform/quantum_platform.h"
 #include "cudaq/runtime/logger/logger.h"
+#include "cudaq_internal/compiler/CompileOptions.h"
 #include "cudaq_internal/compiler/Compiler.h"
 #include "cudaq_internal/compiler/JIT.h"
 #include "llvm/Support/Base64.h"
@@ -259,6 +260,8 @@ public:
           "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
 
     auto [module, context] = Compiler::loadQuakeCodeByName(kernelName);
+    cudaq_internal::compiler::populateContextFromModule(*executionContext,
+                                                        module);
 
     // Get the Quake code, lowered according to config file.
     // FIXME: For python, we reach here with rawArgs being empty and args having
@@ -292,6 +295,8 @@ public:
 
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
+    cudaq_internal::compiler::populateContextFromModule(*executionContext,
+                                                        module);
     completeLaunchKernel(kernelName,
                          compiler.lowerQuakeCode(executionContext, kernelName,
                                                  module, nullptr, rawArgs));

--- a/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
@@ -47,6 +47,7 @@ public:
     CUDAQ_INFO("FermioniqBaseQPU launching kernel ({})", kernelName);
     auto [module, context] = Compiler::loadQuakeCodeByName(kernelName);
     launchImpl(kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
+      cudaq_internal::compiler::populateContextFromModule(*ctx, module);
       return rawArgs.empty()
                  ? compiler.lowerQuakeCode(ctx, kernelName, module, args, {})
                  : compiler.lowerQuakeCode(ctx, kernelName, module, nullptr,
@@ -60,6 +61,7 @@ public:
                const std::vector<void *> &rawArgs) override {
     CUDAQ_INFO("FermioniqBaseQPU launching kernel via module ({})", kernelName);
     launchImpl(kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
+      cudaq_internal::compiler::populateContextFromModule(*ctx, module);
       return compiler.lowerQuakeCode(ctx, kernelName, module, nullptr, rawArgs);
     });
     return {};

--- a/runtime/internal/compiler/CMakeLists.txt
+++ b/runtime/internal/compiler/CMakeLists.txt
@@ -22,6 +22,7 @@ target_include_directories(cudaq-mlir-runtime-headers INTERFACE
 add_library(cudaq-mlir-runtime
   SHARED
     ArgumentConversion.cpp
+    CompileOptions.cpp
     Compiler.cpp
     CompiledModuleHelper.cpp
     JIT.cpp

--- a/runtime/internal/compiler/CompileOptions.cpp
+++ b/runtime/internal/compiler/CompileOptions.cpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#include "cudaq_internal/compiler/CompileOptions.h"
+#include "cudaq/Optimizer/Builder/RuntimeNames.h"
+#include "cudaq/Optimizer/Dialect/Quake/QuakeInterfaces.h"
+#include "cudaq/Optimizer/Transforms/AddMetadata.h"
+#include "cudaq/runtime/logger/logger.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+
+/// Set the conditional measurement flag in the execution context if the module
+/// contains conditional feedback.
+static void setConditionalMeasurementFlag(cudaq::ExecutionContext &ctx,
+                                          mlir::ModuleOp moduleOp) {
+  for (auto &artifact : moduleOp) {
+    quake::detail::QuakeFunctionAnalysis analysis{&artifact};
+    auto info = analysis.getAnalysisInfo();
+    if (info.empty())
+      continue;
+
+    auto result = info[&artifact];
+    if (result.hasConditionalsOnMeasure) {
+      ctx.hasConditionalsOnMeasureResults = true;
+      break;
+    }
+  }
+}
+
+/// Warn the user if the kernel uses named measurement results in sampling mode.
+static void warnNamedMeasurements(cudaq::ExecutionContext &ctx,
+                                  mlir::ModuleOp moduleOp) {
+  if (ctx.name != "sample" || ctx.warnedNamedMeasurements)
+    return;
+
+  auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
+      std::string(cudaq::runtime::cudaqGenPrefixName) + ctx.kernelName);
+  if (!funcOp)
+    return;
+
+  bool hasNamedMeasurements = false;
+  funcOp.walk([&](quake::MeasurementInterface meas) {
+    if (meas.getOptionalRegisterName().has_value()) {
+      hasNamedMeasurements = true;
+      return mlir::WalkResult::interrupt();
+    }
+    return mlir::WalkResult::advance();
+  });
+  if (hasNamedMeasurements) {
+    ctx.warnedNamedMeasurements = true;
+    CUDAQ_WARN("Kernel {} uses named measurement results "
+               "but is invoked in sampling mode. Support for "
+               "sub-registers in `sample_result` is deprecated and will "
+               "be removed in a future release. Use `run` to retrieve "
+               "individual measurement results.",
+               ctx.kernelName);
+  }
+}
+
+void cudaq_internal::compiler::populateContextFromModule(
+    cudaq::ExecutionContext &ctx, mlir::ModuleOp &moduleOp) {
+  setConditionalMeasurementFlag(ctx, moduleOp);
+  warnNamedMeasurements(ctx, moduleOp);
+}

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -409,27 +409,16 @@ cudaq::CompiledModule Compiler::runPassPipeline(
   auto [moduleOp, epFunc] =
       prepareModule(kernelName, m_module, rawArgs, kernelArgs);
 
-  // Populate conditional measurement flag in the context.
   if (emulate && executionContext && executionContext->name == "sample") {
-    for (auto &artifact : moduleOp) {
-      quake::detail::QuakeFunctionAnalysis analysis{&artifact};
-      auto info = analysis.getAnalysisInfo();
-      if (info.empty())
-        continue;
-      auto result = info[&artifact];
-      if (result.hasConditionalsOnMeasure) {
-        throw std::runtime_error(
-            "`cudaq::sample` and `cudaq::sample_async` no longer support "
-            "kernels "
-            "that branch on measurement results. Kernel '" +
-            kernelName +
-            "' uses conditional feedback. Use `cudaq::run` or "
-            "`cudaq::run_async` "
-            "instead. See CUDA-Q documentation for migration guide.");
-      }
+    if (executionContext->hasConditionalsOnMeasureResults) {
+      throw std::runtime_error(
+          "`cudaq::sample` and `cudaq::sample_async` no longer support kernels "
+          "that branch on measurement results. Kernel '" +
+          kernelName +
+          "' uses conditional feedback. Use `cudaq::run` or `cudaq::run_async` "
+          "instead. See CUDA-Q documentation for migration guide.");
     }
   }
-
   bool combineMeasurements = executeMainPipeline(moduleOp, kernelName);
 
   // We need to run resource counting preprocessing after the pass pipeline as
@@ -449,31 +438,6 @@ cudaq::CompiledModule Compiler::runPassPipeline(
   if (executionContext) {
     if (executionContext->name == "sample") {
       executionContext->reorderIdx = mapping_reorder_idx;
-      // Warn if kernel has named measurement registers (sub-registers).
-      if (!executionContext->warnedNamedMeasurements) {
-        auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
-            std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
-        if (funcOp) {
-          bool hasNamedMeasurements = false;
-          funcOp.walk([&](quake::MeasurementInterface meas) {
-            if (meas.getOptionalRegisterName().has_value()) {
-              hasNamedMeasurements = true;
-              return mlir::WalkResult::interrupt();
-            }
-            return mlir::WalkResult::advance();
-          });
-          if (hasNamedMeasurements) {
-            executionContext->warnedNamedMeasurements = true;
-            std::cerr
-                << "WARNING: Kernel \"" << kernelName
-                << "\" uses named measurement results "
-                << "but is invoked in sampling mode. Support for "
-                << "sub-registers in `sample_result` is deprecated and will "
-                << "be removed in a future release. Use `run` to retrieve "
-                << "individual measurement results." << std::endl;
-          }
-        }
-      }
       // No need to add measurements only to remove them eventually
       if (postCodeGenPasses.find("remove-measurements") == std::string::npos)
         applyPipeline("func.func(add-measurements)", moduleOp, kernelName);

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/CompileOptions.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/CompileOptions.h
@@ -1,0 +1,22 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+#include "common/ExecutionContext.h"
+
+namespace mlir {
+class ModuleOp;
+}
+
+namespace cudaq_internal::compiler {
+
+/// Update the execution context with information extracted from the module.
+void populateContextFromModule(cudaq::ExecutionContext &ctx,
+                               mlir::ModuleOp &moduleOp);
+
+} // namespace cudaq_internal::compiler


### PR DESCRIPTION
This is based on top of #4378 (but the diff is already accurate as I am targeting the branch of that PR)

I've put the new `populateContextFromModule` function in new `CompileOptions.{h|cpp}` files, as I am working on further changes that introduce a proper `CompileOptions` struct.

## Open Question

This is strictly speaking not a NFC, because the point in time in which the two checks are made is not longer the same:
- `setConditionalMeasurementFlag` was previously running after `prepareModule`
- `warnNamedMeasurements`was previously running after `prepareModule` and `executeMainPipeline`

I still need to check that this change does not lead to regressions by going through the executed pass pipeline.