### PR TITLE
Skipping full Mottonen decomposition

### DIFF
--- a/runtime/cudaq/builder/kernels.h
+++ b/runtime/cudaq/builder/kernels.h
@@ -80,13 +80,17 @@ void from_state(Kernel &&kernel, QuakeValue &qubits,
         break;
     }
   }
-  if (nonZeroCount <= 1) {
+  if (nonZeroCount == 0)
+    throw std::invalid_argument(
+        "[from_state] input state vector is all zeros; a quantum state "
+        "must have unit norm.");
+  if (nonZeroCount == 1) {
     // Möttönen ordering: state-vector index MSB maps to qubits[0], LSB to
-    // qubits[numQubits-1]
-    if (nonZeroCount == 1)
-      for (std::make_signed_t<std::size_t> q = 0; q < numQubits; ++q)
-        if ((nonZeroIdx >> (numQubits - 1 - q)) & 1)
-          kernel.x(qubits[q]);
+    // qubits[numQubits-1].
+    auto nq = static_cast<std::size_t>(numQubits);
+    for (std::size_t q = 0; q < nq; ++q)
+      if ((nonZeroIdx >> (nq - 1 - q)) & 1)
+        kernel.x(qubits[q]);
     return;
   }
 

--- a/runtime/cudaq/builder/kernels.h
+++ b/runtime/cudaq/builder/kernels.h
@@ -69,6 +69,27 @@ void from_state(Kernel &&kernel, QuakeValue &qubits,
         "[from_state] cannot infer size of input quantum register, please "
         "specify the number of qubits via the from_state() final argument.");
 
+  constexpr double basisTol = 1e-12;
+  std::size_t nonZeroCount = 0;
+  std::size_t nonZeroIdx = 0;
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    if (std::abs(data[i]) > basisTol) {
+      ++nonZeroCount;
+      nonZeroIdx = i;
+      if (nonZeroCount > 1)
+        break;
+    }
+  }
+  if (nonZeroCount <= 1) {
+    // Möttönen ordering: state-vector index MSB maps to qubits[0], LSB to
+    // qubits[numQubits-1]
+    if (nonZeroCount == 1)
+      for (std::make_signed_t<std::size_t> q = 0; q < numQubits; ++q)
+        if ((nonZeroIdx >> (numQubits - 1 - q)) & 1)
+          kernel.x(qubits[q]);
+    return;
+  }
+
   auto mutableQubits = cudaq::range(numQubits);
   std::reverse(mutableQubits.begin(), mutableQubits.end());
   bool omegaNonZero = false;

--- a/unittests/integration/kernels_tester.cpp
+++ b/unittests/integration/kernels_tester.cpp
@@ -204,11 +204,8 @@ CUDAQ_TEST(KernelsTester, checkFromStateBasis) {
     std::vector<std::complex<double>> zero(8, 0.0);
     auto kernel = cudaq::make_kernel();
     auto qubits = kernel.qalloc(3);
-    cudaq::from_state(kernel, qubits, zero);
-    auto ss = cudaq::get_state(kernel);
-    EXPECT_NEAR(std::abs(ss[0] - std::complex<double>(1.0, 0.0)), 0.0, 1e-6);
-    for (std::size_t i = 1; i < 8; i++)
-      EXPECT_NEAR(std::abs(ss[i]), 0.0, 1e-6);
+    EXPECT_THROW(cudaq::from_state(kernel, qubits, zero),
+                 std::invalid_argument);
   }
 
   {

--- a/unittests/integration/kernels_tester.cpp
+++ b/unittests/integration/kernels_tester.cpp
@@ -181,6 +181,49 @@ CUDAQ_TEST(KernelsTester, checkFromState) {
   }
 }
 
+CUDAQ_TEST(KernelsTester, checkFromStateBasis) {
+  auto verifyBasis = [](std::size_t numQubits, std::size_t idx) {
+    std::vector<std::complex<double>> state(1ULL << numQubits, 0.0);
+    state[idx] = 1.0;
+    auto kernel = cudaq::make_kernel();
+    auto qubits = kernel.qalloc(numQubits);
+    cudaq::from_state(kernel, qubits, state);
+    auto ss = cudaq::get_state(kernel);
+    for (std::size_t i = 0; i < state.size(); i++)
+      EXPECT_NEAR(std::abs(ss[i] - state[i]), 0.0, 1e-6);
+  };
+
+  for (std::size_t idx = 0; idx < 8; idx++)
+    verifyBasis(3, idx);
+
+  verifyBasis(4, 0);
+  verifyBasis(4, 5);
+  verifyBasis(4, 15);
+
+  {
+    std::vector<std::complex<double>> zero(8, 0.0);
+    auto kernel = cudaq::make_kernel();
+    auto qubits = kernel.qalloc(3);
+    cudaq::from_state(kernel, qubits, zero);
+    auto ss = cudaq::get_state(kernel);
+    EXPECT_NEAR(std::abs(ss[0] - std::complex<double>(1.0, 0.0)), 0.0, 1e-6);
+    for (std::size_t i = 1; i < 8; i++)
+      EXPECT_NEAR(std::abs(ss[i]), 0.0, 1e-6);
+  }
+
+  {
+    constexpr std::size_t numQubits = 16;
+    std::vector<std::complex<double>> state(1ULL << numQubits, 0.0);
+    state[0] = 1.0;
+    auto kernel = cudaq::make_kernel();
+    auto qubits = kernel.qalloc(numQubits);
+    cudaq::from_state(kernel, qubits, state);
+    auto counts = cudaq::sample(kernel);
+    EXPECT_EQ(counts.size(), 1u);
+    EXPECT_EQ(counts.begin()->first, std::string(numQubits, '0'));
+  }
+}
+
 CUDAQ_TEST(KernelsTester, checkSampleBug2937) {
   constexpr int qubit_count = 20;
   auto kernel = cudaq::make_kernel();


### PR DESCRIPTION
Before this change, a 16-qubit basis state input emitted `2^n controlled rotations` and took `29 seconds` to build and sample. Here we are adding a path that detects input with one non-zero amplitude and emit `X` gates on the set bits of that index.

Result: This has sped up the execution time by **289x** (For 16 qubits, 29 s -> 100 ms).

Fixes #765 