### PR TITLE
Replacing llvm type registry with our own

### DIFF
--- a/lib/Optimizer/Transforms/DecompositionPatternSelection.cpp
+++ b/lib/Optimizer/Transforms/DecompositionPatternSelection.cpp
@@ -183,7 +183,7 @@ public:
   static DecompositionGraph fromRegistry() {
     llvm::StringMap<std::unique_ptr<cudaq::DecompositionPatternType>> patterns;
     for (const auto &patternType :
-         cudaq::DecompositionPatternType::RegistryType::entries()) {
+         cudaq::DecompositionPatternTypeRegistry::entries()) {
       patterns.insert({patternType.getName(), patternType.instantiate()});
     }
     return DecompositionGraph(std::move(patterns));

--- a/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -39,7 +39,7 @@
 
 using namespace mlir;
 
-CUDAQ_INSTANTIATE_REGISTRY(cudaq::DecompositionPatternType::RegistryType)
+LLVM_INSTANTIATE_REGISTRY(cudaq::DecompositionPatternTypeRegistry)
 
 namespace {
 
@@ -309,6 +309,8 @@ LogicalResult checkAndExtractControls(quake::OperatorInterface op,
 }
 
 // From here on, we define the decomposition patterns ==========================
+#define CONCAT(a, b) CONCAT_INNER(a, b)
+#define CONCAT_INNER(a, b) a##b
 
 /// Macro to register a decomposition pattern with its metadata
 /// Usage: REGISTER_DECOMPOSITION_PATTERN(PatternName, "source_op", "target1",
@@ -332,7 +334,8 @@ LogicalResult checkAndExtractControls(quake::OperatorInterface op,
       return pattern;                                                          \
     }                                                                          \
   };                                                                           \
-  CUDAQ_REGISTER_TYPE(cudaq::DecompositionPatternType, PATTERN##Type, PATTERN)
+  static cudaq::DecompositionPatternTypeRegistry::Add<PATTERN##Type> CONCAT(   \
+      TEMPNAME_, PATTERN)(#PATTERN, "");
 
 // NOTE: The patterns SToR1, TToR1, R1ToU3, and U3ToRotations handle arbitrary
 // control counts and are registered with (n) metadata. R1ToRz explicitly
@@ -1831,8 +1834,8 @@ void cudaq::populateWithAllDecompositionPatterns(
         std::map<std::string, std::unique_ptr<cudaq::DecompositionPatternType>>
             map;
         for (auto &patternType :
-             cudaq::DecompositionPatternType::RegistryType::entries()) {
-          map[patternType.getName()] = patternType.instantiate();
+             cudaq::DecompositionPatternTypeRegistry::entries()) {
+          map[patternType.getName().str()] = patternType.instantiate();
         }
         return map;
       }();

--- a/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -39,7 +39,7 @@
 
 using namespace mlir;
 
-LLVM_INSTANTIATE_REGISTRY(cudaq::DecompositionPatternType::RegistryType)
+CUDAQ_INSTANTIATE_REGISTRY(cudaq::DecompositionPatternType::RegistryType)
 
 namespace {
 
@@ -1832,7 +1832,7 @@ void cudaq::populateWithAllDecompositionPatterns(
             map;
         for (auto &patternType :
              cudaq::DecompositionPatternType::RegistryType::entries()) {
-          map[patternType.getName().str()] = patternType.instantiate();
+          map[patternType.getName()] = patternType.instantiate();
         }
         return map;
       }();

--- a/lib/Optimizer/Transforms/DecompositionPatterns.h
+++ b/lib/Optimizer/Transforms/DecompositionPatterns.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "common/Registry.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Registry.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include <string>
@@ -28,12 +28,7 @@ namespace cudaq {
 /// system. Stores the pattern metadata and provides a factory method to create
 /// new instances of the pattern.
 ///
-/// Register decomposition patterns using
-/// CUDAQ_REGISTER_TYPE(cudaq::DecompositionPatternType, MyPatternType,
-/// pattern_name)
-/// where pattern_name is the same as MyPatternType().getPatternName().
-class DecompositionPatternType
-    : public registry::RegisteredType<DecompositionPatternType> {
+class DecompositionPatternType {
 public:
   virtual ~DecompositionPatternType() = default;
 
@@ -104,4 +99,6 @@ std::unique_ptr<mlir::ConversionTarget>
 createBasisTarget(mlir::MLIRContext &context,
                   mlir::ArrayRef<std::string> targetBasis);
 
+using DecompositionPatternTypeRegistry =
+    llvm::Registry<DecompositionPatternType>;
 } // namespace cudaq

--- a/runtime/common/Executor.cpp
+++ b/runtime/common/Executor.cpp
@@ -59,4 +59,4 @@ details::future Executor::execute(std::vector<KernelExecution> &codesToExecute,
 }
 } // namespace cudaq
 
-LLVM_INSTANTIATE_REGISTRY(cudaq::Executor::RegistryType)
+CUDAQ_INSTANTIATE_REGISTRY(cudaq::Executor::RegistryType)

--- a/runtime/common/Registry.h
+++ b/runtime/common/Registry.h
@@ -7,41 +7,154 @@
  ******************************************************************************/
 
 #pragma once
+
+// Suppress the LLVM ABI breaking check for translation units that include this
+// header. Several server helper DSOs transitively include LLVM headers (e.g.
+// llvm/Support/Base64.h) but do not link against LLVM libraries, so the ABI
+// check symbol would be unresolved. This define must be set before any LLVM
+// header is included. TODO: remove once those DSOs stop including LLVM headers.
 #define LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING 1
-#include "llvm/Support/Registry.h"
+
 #include <memory>
+#include <string>
 
 namespace cudaq {
+
+/// A registry entry: name + factory function that constructs a
+/// std::unique_ptr<T>. Modeled after llvm::SimpleRegistryEntry.
+template <typename T>
+class RegistryEntry {
+  const char *Name;
+  std::unique_ptr<T> (*Ctor)();
+
+public:
+  RegistryEntry(const char *N, std::unique_ptr<T> (*C)()) : Name(N), Ctor(C) {}
+
+  const char *getName() const { return Name; }
+  std::unique_ptr<T> instantiate() const { return Ctor(); }
+};
+
+/// A global type registry used with static constructors to make pluggable
+/// components "just work" when linked with an executable or shared library.
+///
+/// This is a drop-in replacement for llvm::Registry<T> that has no LLVM
+/// dependencies. The cross-shared-library mechanism is the same: Head, Tail,
+/// and add_node are defined in exactly one translation unit per registry type
+/// via CUDAQ_INSTANTIATE_REGISTRY, so all DSOs that link against that TU
+/// share a single list.
+template <typename T>
+class Registry {
+public:
+  using type = T;
+  using entry = RegistryEntry<T>;
+
+  class node;
+  class iterator;
+
+private:
+  Registry() = delete;
+
+  friend class node;
+  static node *Head, *Tail;
+
+public:
+  /// Node in the singly-linked list of entries.
+  class node {
+    friend class iterator;
+    friend class Registry<T>;
+
+    node *Next;
+    const entry &Val;
+
+  public:
+    node(const entry &V) : Next(nullptr), Val(V) {}
+  };
+
+  /// Append a node to the list. Defined out-of-line by
+  /// CUDAQ_INSTANTIATE_REGISTRY so that the single definition lives in
+  /// the DSO that owns this registry.
+  static void add_node(node *N);
+
+  /// Forward iterator over registry entries.
+  class iterator {
+    const node *Cur;
+
+  public:
+    using value_type = const entry;
+    using reference = const entry &;
+    using pointer = const entry *;
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::forward_iterator_tag;
+
+    explicit iterator(const node *N) : Cur(N) {}
+
+    bool operator==(const iterator &That) const { return Cur == That.Cur; }
+    bool operator!=(const iterator &That) const { return Cur != That.Cur; }
+    iterator &operator++() {
+      Cur = Cur->Next;
+      return *this;
+    }
+    const entry &operator*() const { return Cur->Val; }
+    const entry *operator->() const { return &Cur->Val; }
+  };
+
+  /// begin() is defined by CUDAQ_INSTANTIATE_REGISTRY (same pattern as LLVM).
+  static iterator begin();
+  static iterator end() { return iterator(nullptr); }
+
+  /// Lightweight range for range-based for loops.
+  struct range {
+    iterator b, e;
+    iterator begin() const { return b; }
+    iterator end() const { return e; }
+  };
+  static range entries() { return {begin(), end()}; }
+
+  /// Static registration helper. Constructed as a global/static object to
+  /// register a concrete subtype V under a string name:
+  ///
+  ///   static Registry<Base>::Add<Derived> reg("name");
+  template <typename V>
+  class Add {
+    entry Entry;
+    node Node;
+
+    static std::unique_ptr<T> CtorFn() { return std::make_unique<V>(); }
+
+  public:
+    Add(const char *Name) : Entry(Name, CtorFn), Node(Entry) {
+      add_node(&Node);
+    }
+  };
+};
+
 namespace registry {
 
-/// @brief RegisteredType allows interface types to declare themselves
-/// as plugin interfaces. Used as follows
-/// class MyInterface : public RegisteredType<MyInterface> {...};
+/// Mixin base class: inherit from this to declare T as a register-able type.
+///   class QPU : public RegisteredType<QPU> { ... };
 template <typename T>
 class RegisteredType {
 public:
-  using RegistryType = llvm::Registry<T>;
+  using RegistryType = ::cudaq::Registry<T>;
 };
 
-/// @brief Retrieve a plugin sub-type of the given template type by name.
+/// Retrieve a registered subtype by name.
 template <typename T>
 std::unique_ptr<T> get(const std::string &name) {
-  for (typename T::RegistryType::iterator it = T::RegistryType::begin(),
-                                          ie = T::RegistryType::end();
+  for (auto it = T::RegistryType::begin(), ie = T::RegistryType::end();
        it != ie; ++it) {
-    if (name == it->getName().str())
+    if (name == it->getName())
       return it->instantiate();
   }
   return nullptr;
 }
 
-/// @brief Return true if the plugin with given name and type is available.
+/// Return true if a subtype with the given name is registered.
 template <typename T>
 bool isRegistered(const std::string &name) {
-  for (typename T::RegistryType::iterator it = T::RegistryType::begin(),
-                                          ie = T::RegistryType::end();
+  for (auto it = T::RegistryType::begin(), ie = T::RegistryType::end();
        it != ie; ++it) {
-    if (name == it->getName().str())
+    if (name == it->getName())
       return true;
   }
   return false;
@@ -50,8 +163,44 @@ bool isRegistered(const std::string &name) {
 } // namespace registry
 } // namespace cudaq
 
+/// Instantiate a registry for a single type. Place this in exactly one `.cpp`
+/// per registry type in the DSO that should own the list.
+///
+/// REGISTRY_CLASS is the Registry typedef, e.g. cudaq::QPU::RegistryType.
+///
+/// This mirrors LLVM_INSTANTIATE_REGISTRY: it provides the template
+/// definitions for Head, Tail, add_node, and begin, then forces explicit
+/// instantiation for the concrete type.
+#define CUDAQ_INSTANTIATE_REGISTRY(REGISTRY_CLASS)                             \
+  namespace cudaq {                                                            \
+  template <typename T>                                                        \
+  typename Registry<T>::node *Registry<T>::Head = nullptr;                     \
+  template <typename T>                                                        \
+  typename Registry<T>::node *Registry<T>::Tail = nullptr;                     \
+  template <typename T>                                                        \
+  void Registry<T>::add_node(typename Registry<T>::node *N) {                  \
+    if (Tail)                                                                  \
+      Tail->Next = N;                                                          \
+    else                                                                       \
+      Head = N;                                                                \
+    Tail = N;                                                                  \
+  }                                                                            \
+  template <typename T>                                                        \
+  typename Registry<T>::iterator Registry<T>::begin() {                        \
+    return iterator(Head);                                                     \
+  }                                                                            \
+  template                                                                     \
+      typename REGISTRY_CLASS::node *Registry<REGISTRY_CLASS::type>::Head;     \
+  template                                                                     \
+      typename REGISTRY_CLASS::node *Registry<REGISTRY_CLASS::type>::Tail;     \
+  template void                                                                \
+  Registry<REGISTRY_CLASS::type>::add_node(typename REGISTRY_CLASS::node *);   \
+  template typename REGISTRY_CLASS::iterator                                   \
+  Registry<REGISTRY_CLASS::type>::begin();                                     \
+  }
+
 #define CONCAT(a, b) CONCAT_INNER(a, b)
 #define CONCAT_INNER(a, b) a##b
 
 #define CUDAQ_REGISTER_TYPE(TYPE, SUBTYPE, NAME)                               \
-  static TYPE::RegistryType::Add<SUBTYPE> CONCAT(TMPNAME_, NAME)(#NAME, "");
+  static TYPE::RegistryType::Add<SUBTYPE> CONCAT(TMPNAME_, NAME)(#NAME);

--- a/runtime/common/ServerHelper.cpp
+++ b/runtime/common/ServerHelper.cpp
@@ -40,4 +40,4 @@ void ServerHelper::parseConfigForCommonParams(const BackendConfig &config) {
 }
 } // namespace cudaq
 
-LLVM_INSTANTIATE_REGISTRY(cudaq::ServerHelper::RegistryType)
+CUDAQ_INSTANTIATE_REGISTRY(cudaq::ServerHelper::RegistryType)

--- a/runtime/cudaq/domains/chemistry/molecule.cpp
+++ b/runtime/cudaq/domains/chemistry/molecule.cpp
@@ -30,7 +30,7 @@ struct rebind_container<
 
 #include <xtensor/xio.hpp>
 
-LLVM_INSTANTIATE_REGISTRY(cudaq::MoleculePackageDriver::RegistryType)
+CUDAQ_INSTANTIATE_REGISTRY(cudaq::MoleculePackageDriver::RegistryType)
 
 namespace cudaq {
 

--- a/runtime/cudaq/platform/default/rest_server/RemoteRuntimeClient.cpp
+++ b/runtime/cudaq/platform/default/rest_server/RemoteRuntimeClient.cpp
@@ -8,4 +8,4 @@
 
 #include "common/RemoteKernelExecutor.h"
 
-LLVM_INSTANTIATE_REGISTRY(cudaq::RemoteRuntimeClient::RegistryType)
+CUDAQ_INSTANTIATE_REGISTRY(cudaq::RemoteRuntimeClient::RegistryType)

--- a/runtime/cudaq/platform/default/rest_server/RemoteRuntimeServer.cpp
+++ b/runtime/cudaq/platform/default/rest_server/RemoteRuntimeServer.cpp
@@ -8,4 +8,4 @@
 
 #include "common/RemoteKernelExecutor.h"
 
-LLVM_INSTANTIATE_REGISTRY(cudaq::RemoteRuntimeServer::RegistryType)
+CUDAQ_INSTANTIATE_REGISTRY(cudaq::RemoteRuntimeServer::RegistryType)

--- a/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
+++ b/runtime/cudaq/platform/mqpu/MultiQPUPlatform.cpp
@@ -21,7 +21,7 @@
 #include <filesystem>
 #include <fstream>
 
-LLVM_INSTANTIATE_REGISTRY(cudaq::QPU::RegistryType)
+CUDAQ_INSTANTIATE_REGISTRY(cudaq::QPU::RegistryType)
 
 namespace {
 class MultiQPUQuantumPlatform : public cudaq::quantum_platform {

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -12,7 +12,7 @@
 
 using namespace cudaq_internal::compiler;
 
-LLVM_INSTANTIATE_REGISTRY(cudaq::ModuleLauncher::RegistryType)
+CUDAQ_INSTANTIATE_REGISTRY(cudaq::ModuleLauncher::RegistryType)
 
 /// Execute a JIT-compiled kernel with provided arguments.
 ///

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -21,7 +21,7 @@
 
 using namespace cudaq_internal::compiler;
 
-LLVM_INSTANTIATE_REGISTRY(cudaq::QPU::RegistryType)
+CUDAQ_INSTANTIATE_REGISTRY(cudaq::QPU::RegistryType)
 
 namespace cudaq {
 

--- a/unittests/Optimizer/DecompositionPatternsTest.cpp
+++ b/unittests/Optimizer/DecompositionPatternsTest.cpp
@@ -244,25 +244,24 @@ TEST_F(DecompositionPatternsTest, PatternNamesMatchDebugNames) {
       cudaq::DecompositionPatternType::RegistryType::entries();
 
   for (auto &entry : patternEntries) {
-    auto patternName = entry.getName();
+    std::string patternName = entry.getName();
     // Create the pattern
-    auto patternType = cudaq::registry::get<cudaq::DecompositionPatternType>(
-        patternName.str());
+    auto patternType =
+        cudaq::registry::get<cudaq::DecompositionPatternType>(patternName);
     ASSERT_NE(patternType, nullptr)
-        << "Failed to recover registered pattern type: " << patternName.str();
+        << "Failed to recover registered pattern type: " << patternName;
 
     auto pattern = patternType->create(context.get());
-    ASSERT_NE(pattern, nullptr)
-        << "Failed to create pattern: " << patternName.str();
+    ASSERT_NE(pattern, nullptr) << "Failed to create pattern: " << patternName;
 
     // Get the debug name
     auto debugName = pattern->getDebugName().str();
     stripNamespace(debugName);
 
     // Verify they match
-    EXPECT_EQ(patternName.str(), debugName)
-        << "Pattern name '" << patternName.str()
-        << "' does not match debug name '" << debugName << "'";
+    EXPECT_EQ(patternName, debugName)
+        << "Pattern name '" << patternName << "' does not match debug name '"
+        << debugName << "'";
   }
 }
 
@@ -272,7 +271,7 @@ TEST_F(DecompositionPatternsTest, MetadataConsistency) {
       cudaq::DecompositionPatternType::RegistryType::entries();
 
   for (auto &entry : patternEntries) {
-    std::string patternName = entry.getName().str();
+    std::string patternName = entry.getName();
     auto patternType = entry.instantiate();
     std::string sourceGate = patternType->getSourceOp().str();
     auto targetGates = patternType->getTargetOps();
@@ -299,7 +298,7 @@ TEST_F(DecompositionPatternsTest, DecompositionProducesOnlyTargetGates) {
       cudaq::DecompositionPatternType::RegistryType::entries();
 
   for (auto &entry : patternEntries) {
-    std::string patternName = entry.getName().str();
+    std::string patternName = entry.getName();
     auto patternType = entry.instantiate();
     std::string sourceGate = patternType->getSourceOp().str();
     auto targetGates = patternType->getTargetOps();

--- a/unittests/Optimizer/DecompositionPatternsTest.cpp
+++ b/unittests/Optimizer/DecompositionPatternsTest.cpp
@@ -230,8 +230,7 @@ void stripNamespace(std::string &debugName) {
 
 // Test 1: Verify the total number of registered decomposition patterns
 TEST_F(DecompositionPatternsTest, TotalPatternCount) {
-  auto patternEntries =
-      cudaq::DecompositionPatternType::RegistryType::entries();
+  auto patternEntries = cudaq::DecompositionPatternTypeRegistry::entries();
   unsigned int size =
       std::distance(patternEntries.begin(), patternEntries.end());
   EXPECT_EQ(size, 31) << "Expected 31 decomposition patterns, but found "
@@ -240,14 +239,12 @@ TEST_F(DecompositionPatternsTest, TotalPatternCount) {
 
 // Test 2: Verify pattern names match getDebugName()
 TEST_F(DecompositionPatternsTest, PatternNamesMatchDebugNames) {
-  auto patternEntries =
-      cudaq::DecompositionPatternType::RegistryType::entries();
+  auto patternEntries = cudaq::DecompositionPatternTypeRegistry::entries();
 
   for (auto &entry : patternEntries) {
-    std::string patternName = entry.getName();
+    std::string patternName = entry.getName().str();
     // Create the pattern
-    auto patternType =
-        cudaq::registry::get<cudaq::DecompositionPatternType>(patternName);
+    auto patternType = entry.instantiate();
     ASSERT_NE(patternType, nullptr)
         << "Failed to recover registered pattern type: " << patternName;
 
@@ -267,11 +264,10 @@ TEST_F(DecompositionPatternsTest, PatternNamesMatchDebugNames) {
 
 // Test 3: Verify metadata is consistent (source and target gates are valid)
 TEST_F(DecompositionPatternsTest, MetadataConsistency) {
-  auto patternEntries =
-      cudaq::DecompositionPatternType::RegistryType::entries();
+  auto patternEntries = cudaq::DecompositionPatternTypeRegistry::entries();
 
   for (auto &entry : patternEntries) {
-    std::string patternName = entry.getName();
+    std::string patternName = entry.getName().str();
     auto patternType = entry.instantiate();
     std::string sourceGate = patternType->getSourceOp().str();
     auto targetGates = patternType->getTargetOps();
@@ -294,11 +290,10 @@ TEST_F(DecompositionPatternsTest, MetadataConsistency) {
 
 // Test 4: Verify pattern decompositions produce only target gates
 TEST_F(DecompositionPatternsTest, DecompositionProducesOnlyTargetGates) {
-  auto patternEntries =
-      cudaq::DecompositionPatternType::RegistryType::entries();
+  auto patternEntries = cudaq::DecompositionPatternTypeRegistry::entries();
 
   for (auto &entry : patternEntries) {
-    std::string patternName = entry.getName();
+    std::string patternName = entry.getName().str();
     auto patternType = entry.instantiate();
     std::string sourceGate = patternType->getSourceOp().str();
     auto targetGates = patternType->getTargetOps();


### PR DESCRIPTION
While exploring and prototyping options for compile-time checks of QPUs, I keep running into the issue that llvm headers bleed into user code. I would like to put an end to this issue once and for all by replacing it with our own registry.

This registry is widely borrowed from LLVM by Claude and reviewed by codex. I have asked it to keep the current model, whereby it is instantiated in one place so that a registration from a shared lib is visible to all shared libs.

I believe, from discussions with Bruno, that this should also help the LLVM update work.