### PR TITLE
Introduce QPU::compileModule, use it for launch + specialize

### DIFF
--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -18,6 +18,7 @@
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "cudaq/platform.h"
+#include "cudaq/platform/nvqpp_interface.h"
 #include "cudaq/platform/qpu.h"
 #include "cudaq_internal/compiler/ArgumentConversion.h"
 #include "cudaq_internal/compiler/LayoutInfo.h"
@@ -674,7 +675,8 @@ static cudaq::KernelThunkResultType
 pyLaunchModule(const std::string &name, ModuleOp mod,
                const std::vector<void *> &rawArgs) {
   auto clone = mod.clone();
-  auto res = cudaq::streamlinedLaunchModule(name, clone, rawArgs);
+  auto compiled = cudaq::streamlinedCompileModule(name, clone, rawArgs, true);
+  auto res = cudaq::streamlinedLaunchModule(compiled, rawArgs);
   clone.erase();
   return res;
 }
@@ -943,7 +945,7 @@ marshal_and_retain_module(const std::string &name, MlirModule module,
   auto rawArgs = appendResultToArgsVector(args, retTy, mod, name);
   auto clone = mod.clone();
   auto compiled =
-      cudaq::streamlinedSpecializeModule(name, clone, rawArgs, isEntryPoint);
+      cudaq::streamlinedCompileModule(name, clone, rawArgs, isEntryPoint);
   clone.erase();
   return compiled;
 }

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -278,10 +278,23 @@ public:
   }
 
   KernelThunkResultType
-  launchModule(const std::string &kernelName, mlir::ModuleOp module,
+  launchModule(const CompiledModule &compiled,
                const std::vector<void *> &rawArgs) override {
-    CUDAQ_INFO("launching remote rest kernel via module ({})", kernelName);
+    CUDAQ_INFO("launching remote rest kernel via module ({})",
+               compiled.getName());
 
+    Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
+                      noiseModel, emulate);
+    auto codes = compiler.emitKernelExecutions(compiled);
+    completeLaunchKernel(compiled.getName(), std::move(codes));
+    return {};
+  }
+
+  CompiledModule compileModule(const std::string &kernelName,
+                               mlir::ModuleOp module,
+                               const std::vector<void *> &rawArgs,
+                               bool isEntryPoint) override {
+    CUDAQ_INFO("specializing remote rest kernel via module ({})", kernelName);
     auto executionContext = cudaq::getExecutionContext();
 
     // TODO future iterations of this should support non-void return types.
@@ -292,19 +305,8 @@ public:
 
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
-    completeLaunchKernel(kernelName,
-                         compiler.lowerQuakeCode(executionContext, kernelName,
-                                                 module, nullptr, rawArgs));
-    return {};
-  }
-
-  CompiledModule specializeModule(const std::string &kernelName,
-                                  mlir::ModuleOp module,
-                                  const std::vector<void *> &rawArgs,
-                                  bool isEntryPoint) override {
-    CUDAQ_INFO("specializing remote rest kernel via module ({})", kernelName);
-    throw std::runtime_error(
-        "NYI: Remote rest execution via Python/C++ interop.");
+    return compiler.runPassPipeline(executionContext, kernelName, module,
+                                    rawArgs, nullptr);
   }
 
   void completeLaunchKernel(const std::string &kernelName,

--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -134,25 +134,25 @@ public:
   }
 
   KernelThunkResultType
-  launchModule(const std::string &name, mlir::ModuleOp module,
+  launchModule(const CompiledModule &compiled,
                const std::vector<void *> &rawArgs) override {
-    std::string fullName = cudaq::runtime::cudaqGenPrefixName + name;
+    auto resultInfo = compiled.getResultInfo();
+    auto args = resultInfo.hasResult() ? rawArgs.back() : nullptr;
+    return launchKernelImpl(compiled, nullptr, args, 0, 0, &rawArgs);
+  }
+
+  CompiledModule compileModule(const std::string &kernelName,
+                               mlir::ModuleOp module,
+                               const std::vector<void *> &rawArgs,
+                               bool isEntryPoint) override {
+    CUDAQ_INFO("specializing remote simulator kernel via module ({})",
+               kernelName);
+    std::string fullName = cudaq::runtime::cudaqGenPrefixName + kernelName;
     auto funcOp = module.lookupSymbol<mlir::func::FuncOp>(fullName);
     auto resTy = cudaq::runtime::getReturnType(funcOp);
     auto args = resTy ? rawArgs.back() : nullptr;
     // Looks very much like launchKernel(string, vector<ptr>*).
-    auto compiled = compileKernelImpl(name, args, 0, &rawArgs, module, resTy);
-    return launchKernelImpl(compiled, nullptr, args, 0, 0, &rawArgs);
-  }
-
-  CompiledModule specializeModule(const std::string &kernelName,
-                                  mlir::ModuleOp module,
-                                  const std::vector<void *> &rawArgs,
-                                  bool isEntryPoint) override {
-    CUDAQ_INFO("specializing remote simulator kernel via module ({})",
-               kernelName);
-    throw std::runtime_error(
-        "NYI: Remote simulator execution via Python/C++ interop.");
+    return compileKernelImpl(kernelName, args, 0, &rawArgs, module, resTy);
   }
 
   [[nodiscard]] CompiledModule

--- a/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqBaseQPU.h
@@ -46,31 +46,44 @@ public:
                const std::vector<void *> &rawArgs) override {
     CUDAQ_INFO("FermioniqBaseQPU launching kernel ({})", kernelName);
     auto [module, context] = Compiler::loadQuakeCodeByName(kernelName);
-    launchImpl(kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
+    auto compiled = compileImpl(kernelName, [&](Compiler &compiler,
+                                                ExecutionContext *ctx) {
       return rawArgs.empty()
-                 ? compiler.lowerQuakeCode(ctx, kernelName, module, args, {})
-                 : compiler.lowerQuakeCode(ctx, kernelName, module, nullptr,
-                                           rawArgs);
+                 ? compiler.runPassPipeline(ctx, kernelName, module, {}, args,
+                                            std::move(context))
+                 : compiler.runPassPipeline(ctx, kernelName, module, rawArgs,
+                                            nullptr, std::move(context));
     });
+    launchImpl(compiled);
     return {};
   }
 
   KernelThunkResultType
-  launchModule(const std::string &kernelName, mlir::ModuleOp module,
+  launchModule(const CompiledModule &compiled,
                const std::vector<void *> &rawArgs) override {
-    CUDAQ_INFO("FermioniqBaseQPU launching kernel via module ({})", kernelName);
-    launchImpl(kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
-      return compiler.lowerQuakeCode(ctx, kernelName, module, nullptr, rawArgs);
-    });
+    CUDAQ_INFO("FermioniqBaseQPU launching kernel via module ({})",
+               compiled.getName());
+    launchImpl(compiled);
     return {};
   }
 
+  CompiledModule compileModule(const std::string &kernelName,
+                               mlir::ModuleOp module,
+                               const std::vector<void *> &rawArgs,
+                               bool isEntryPoint) override {
+    CUDAQ_INFO("FermioniqBaseQPU compiling kernel via module ({})", kernelName);
+    return compileImpl(kernelName,
+                       [&](Compiler &compiler, ExecutionContext *ctx) {
+                         return compiler.runPassPipeline(
+                             ctx, kernelName, module, rawArgs, nullptr);
+                       });
+  }
+
 private:
-  void
-  launchImpl(const std::string &kernelName,
-             std::function<std::vector<KernelExecution>(Compiler &,
-                                                        ExecutionContext *)>
-                 lower) {
+  CompiledModule
+  compileImpl(const std::string &kernelName,
+              std::function<CompiledModule(Compiler &, ExecutionContext *)>
+                  runPassPipeline) {
     auto *executionContext = getExecutionContext();
     // TODO future iterations of this should support non-void return types.
     if (!executionContext)
@@ -90,7 +103,20 @@ private:
 
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
-    auto codes = lower(compiler, compileCtx);
+    return runPassPipeline(compiler, compileCtx);
+  }
+
+  void launchImpl(const CompiledModule &compiled) {
+    Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
+                      noiseModel, emulate);
+    auto *executionContext = getExecutionContext();
+    // TODO future iterations of this should support non-void return types.
+    if (!executionContext)
+      throw std::runtime_error(
+          "Remote rest execution can only be performed via cudaq::sample(), "
+          "cudaq::observe(), or cudaq::contrib::draw().");
+
+    auto codes = compiler.emitKernelExecutions(compiled);
 
     if (codes.size() != 1)
       throw std::runtime_error("Provider only allows 1 circuit at a time.");
@@ -113,7 +139,7 @@ private:
       codes[0].user_data = user_data;
     }
 
-    completeLaunchKernel(kernelName, std::move(codes));
+    completeLaunchKernel(compiled.getName(), std::move(codes));
   }
 };
 } // namespace cudaq

--- a/runtime/cudaq/platform/nvqpp_interface.h
+++ b/runtime/cudaq/platform/nvqpp_interface.h
@@ -43,6 +43,7 @@ streamlinedLaunchKernel(const char *kernelName,
 hybridLaunchKernel(const char *kernelName, KernelThunkType kernel, void *args,
                    std::uint64_t argsSize, std::uint64_t resultOffset,
                    const std::vector<void *> &rawArgs);
+} // extern "C"
 
 //===----------------------------------------------------------------------===//
 // Launch module entry points.
@@ -53,23 +54,13 @@ hybridLaunchKernel(const char *kernelName, KernelThunkType kernel, void *args,
 // directly.
 //===----------------------------------------------------------------------===//
 
-// Streamlined interface for launching kernels. Argument synthesis and JIT
-// compilation *must* happen on the local machine. The caller must provide an
-// mlir::ModuleOp and the short name of the entry point kernel function to be
-// called,
+// Streamlined interface for launching kernels.
 [[nodiscard]] KernelThunkResultType
-streamlinedLaunchModule(const char *kernelName, mlir::ModuleOp moduleOp,
+streamlinedLaunchModule(const CompiledModule &compiled,
                         const std::vector<void *> &rawArgs);
 
-} // extern "C"
-
-// Convenience overload.
-[[nodiscard]] KernelThunkResultType
-streamlinedLaunchModule(const std::string &kernelName, mlir::ModuleOp moduleOp,
-                        const std::vector<void *> &rawArgs);
-
-[[nodiscard]] CompiledModule streamlinedSpecializeModule(
-    const std::string &kernelName, mlir::ModuleOp moduleOp,
-    const std::vector<void *> &rawArgs, bool isEntryPoint);
+[[nodiscard]] CompiledModule
+streamlinedCompileModule(const std::string &kernelName, mlir::ModuleOp moduleOp,
+                         const std::vector<void *> &rawArgs, bool isEntryPoint);
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "qpu.h"
+#include "common/CompiledModule.h"
 #include "mlir/IR/BuiltinOps.h"
 #include <cstring>
 
@@ -53,27 +54,27 @@ launchCompiledModule(const cudaq::CompiledModule &compiled,
 }
 
 cudaq::KernelThunkResultType
-cudaq::QPU::launchModule(const std::string &name, mlir::ModuleOp module,
+cudaq::QPU::launchModule(const CompiledModule &module,
                          const std::vector<void *> &rawArgs) {
   auto launcher = registry::get<ModuleLauncher>("default");
   if (!launcher)
     throw std::runtime_error(
         "No ModuleLauncher registered with name 'default'. This may be a "
         "result of attempting to use `launchModule` outside Python.");
-  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::launchModule", name);
-  auto compiled = launcher->compileModule(name, module, rawArgs, true);
-  return launchCompiledModule(compiled, rawArgs);
+  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::launchModule",
+                         module.getName());
+  return launchCompiledModule(module, rawArgs);
 }
 
 cudaq::CompiledModule
-cudaq::QPU::specializeModule(const std::string &name, mlir::ModuleOp module,
-                             const std::vector<void *> &rawArgs,
-                             bool isEntryPoint) {
+cudaq::QPU::compileModule(const std::string &name, mlir::ModuleOp module,
+                          const std::vector<void *> &rawArgs,
+                          bool isEntryPoint) {
   auto launcher = registry::get<ModuleLauncher>("default");
   if (!launcher)
     throw std::runtime_error(
         "No ModuleLauncher registered with name 'default'. This may be a "
-        "result of attempting to use `specializeModule` outside Python.");
-  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::specializeModule", name);
+        "result of attempting to use `compileModule` outside Python.");
+  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::compileModule", name);
   return launcher->compileModule(name, module, rawArgs, isEntryPoint);
 }

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -194,12 +194,12 @@ public:
                const std::vector<void *> &rawArgs) = 0;
 
   [[nodiscard]] virtual KernelThunkResultType
-  launchModule(const std::string &name, mlir::ModuleOp module,
+  launchModule(const CompiledModule &compiled,
                const std::vector<void *> &rawArgs);
 
   [[nodiscard]] virtual CompiledModule
-  specializeModule(const std::string &name, mlir::ModuleOp module,
-                   const std::vector<void *> &rawArgs, bool isEntryPoint);
+  compileModule(const std::string &name, mlir::ModuleOp module,
+                const std::vector<void *> &rawArgs, bool isEntryPoint);
 
   /// @brief Notify the QPU that a new random seed value is set.
   /// By default do nothing, let subclasses override.

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/platform/quantum_platform.h"
+#include "common/CompiledModule.h"
 #include "common/ExecutionContext.h"
 #include "common/PluginUtils.h"
 #include "common/RuntimeTarget.h"
@@ -223,20 +224,21 @@ KernelThunkResultType quantum_platform::launchKernel(
                            resultOffset, rawArgs);
 }
 
-KernelThunkResultType quantum_platform::launchModule(
-    const std::string &kernelName, mlir::ModuleOp module,
-    const std::vector<void *> &rawArgs, std::size_t qpu_id) {
+KernelThunkResultType
+quantum_platform::launchModule(const CompiledModule &module,
+                               const std::vector<void *> &rawArgs,
+                               std::size_t qpu_id) {
   validateQpuId(qpu_id);
   auto &qpu = platformQPUs[qpu_id];
-  return qpu->launchModule(kernelName, module, rawArgs);
+  return qpu->launchModule(module, rawArgs);
 }
 
-CompiledModule quantum_platform::specializeModule(
+CompiledModule quantum_platform::compileModule(
     const std::string &kernelName, mlir::ModuleOp module,
     const std::vector<void *> &rawArgs, std::size_t qpu_id, bool isEntryPoint) {
   validateQpuId(qpu_id);
   auto &qpu = platformQPUs[qpu_id];
-  return qpu->specializeModule(kernelName, module, rawArgs, isEntryPoint);
+  return qpu->compileModule(kernelName, module, rawArgs, isEntryPoint);
 }
 
 void quantum_platform::onRandomSeedSet(std::size_t seed) {
@@ -312,36 +314,27 @@ cudaq::streamlinedLaunchKernel(const char *kernelName,
   return {};
 }
 
-// FIXME: make this an inline function in nvqpp_interface.h. Requires ModuleOp
-// definition be available in that .h file though.
 cudaq::KernelThunkResultType
-cudaq::streamlinedLaunchModule(const char *kernelName, mlir::ModuleOp moduleOp,
+cudaq::streamlinedLaunchModule(const CompiledModule &compiled,
                                const std::vector<void *> &rawArgs) {
-  std::string name = kernelName;
-  return streamlinedLaunchModule(name, moduleOp, rawArgs);
-}
-
-cudaq::KernelThunkResultType
-cudaq::streamlinedLaunchModule(const std::string &kernelName,
-                               mlir::ModuleOp moduleOp,
-                               const std::vector<void *> &rawArgs) {
-  ScopedTraceWithContext("streamlinedLaunchModule", kernelName, rawArgs.size());
-
-  auto &platform = *getQuantumPlatformInternal();
-  std::size_t qpu_id = getCurrentQpuId();
-  return platform.launchModule(kernelName, moduleOp, rawArgs, qpu_id);
-}
-
-cudaq::CompiledModule cudaq::streamlinedSpecializeModule(
-    const std::string &kernelName, mlir::ModuleOp moduleOp,
-    const std::vector<void *> &rawArgs, bool isEntryPoint) {
-  ScopedTraceWithContext("streamlinedSpecializeModule", kernelName,
+  ScopedTraceWithContext("streamlinedLaunchModule", compiled.getName(),
                          rawArgs.size());
 
   auto &platform = *getQuantumPlatformInternal();
   std::size_t qpu_id = getCurrentQpuId();
-  return platform.specializeModule(kernelName, moduleOp, rawArgs, qpu_id,
-                                   isEntryPoint);
+  return platform.launchModule(compiled, rawArgs, qpu_id);
+}
+
+cudaq::CompiledModule cudaq::streamlinedCompileModule(
+    const std::string &kernelName, mlir::ModuleOp moduleOp,
+    const std::vector<void *> &rawArgs, bool isEntryPoint) {
+  ScopedTraceWithContext("streamlinedCompileModule", kernelName,
+                         rawArgs.size());
+
+  auto &platform = *getQuantumPlatformInternal();
+  std::size_t qpu_id = getCurrentQpuId();
+  return platform.compileModule(kernelName, moduleOp, rawArgs, qpu_id,
+                                isEntryPoint);
 }
 
 cudaq::KernelThunkResultType

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "common/CodeGenConfig.h"
+#include "common/CompiledModule.h"
 #include "common/ExecutionContext.h"
 #include "common/NoiseModel.h"
 #include "common/ObserveResult.h"
@@ -204,13 +205,14 @@ public:
   // This method launches a kernel from a ModuleOp that has already been
   // created.
   [[nodiscard]] KernelThunkResultType
-  launchModule(const std::string &kernelName, mlir::ModuleOp module,
-               const std::vector<void *> &rawArgs, std::size_t qpu_id);
+  launchModule(const CompiledModule &module, const std::vector<void *> &rawArgs,
+               std::size_t qpu_id);
 
-  [[nodiscard]] CompiledModule
-  specializeModule(const std::string &kernelName, mlir::ModuleOp module,
-                   const std::vector<void *> &rawArgs, std::size_t qpu_id,
-                   bool isEntryPoint);
+  [[nodiscard]] CompiledModule compileModule(const std::string &kernelName,
+                                             mlir::ModuleOp module,
+                                             const std::vector<void *> &rawArgs,
+                                             std::size_t qpu_id,
+                                             bool isEntryPoint);
 
   /// List all available platforms
   static std::vector<std::string> list_platforms();


### PR DESCRIPTION
This removes `specializeModule` within `QPU` and `quantum_platform`. Instead, both when specializing and launching a kernel from Python, `QPU::compileModule` is called.