### PR TITLE
[PTSBE] fully qualify names and drop `using namespace` directives

### DIFF
--- a/unittests/ptsbe/ExecutePTSBETester.cpp
+++ b/unittests/ptsbe/ExecutePTSBETester.cpp
@@ -15,23 +15,21 @@
 #include <numeric>
 
 using namespace cudaq;
-using namespace cudaq::ptsbe;
-using namespace cudaq::ptsbe::detail;
 
 // Use QPP simulator for testing samplePTSBE
 using QppSimulator =
     QppCircuitSimulatorTester<nvqir::QppCircuitSimulator<qpp::ket>>;
 
-const PTSBETrace kHadamardTrace = {
+const ptsbe::PTSBETrace kHadamardTrace = {
     {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}}};
-const PTSBETrace kXTrace = {
+const ptsbe::PTSBETrace kXTrace = {
     {ptsbe::TraceInstructionType::Gate, "x", {0}, {}, {}}};
 
 /// samplePTSBEGeneric throws without ExecutionContext
 CUDAQ_TEST(ExecutePTSBETest, ThrowsWithoutExecutionContext) {
   QppSimulator sim;
 
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = kHadamardTrace;
   batch.measureQubits = {0};
 
@@ -39,7 +37,7 @@ CUDAQ_TEST(ExecutePTSBETest, ThrowsWithoutExecutionContext) {
   batch.trajectories.push_back(traj);
 
   try {
-    samplePTSBEGeneric(sim, batch);
+    ptsbe::detail::samplePTSBEGeneric(sim, batch);
     FAIL() << "Expected an exception without ExecutionContext";
   } catch (...) {
   }
@@ -48,20 +46,20 @@ CUDAQ_TEST(ExecutePTSBETest, ThrowsWithoutExecutionContext) {
 CUDAQ_TEST(ExecutePTSBETest, AggregateResultsTester) {
   // Default constructed results should be empty
   std::vector<sample_result> results(10);
-  auto resultEmpty = aggregateResults(results);
+  auto resultEmpty = ptsbe::detail::aggregateResults(results);
   EXPECT_EQ(resultEmpty.get_total_shots(), 0);
   EXPECT_EQ(resultEmpty.to_map().size(), 0);
 
   // Add some counts to the results
   results[0] = cudaq::ExecutionResult{{{"00", 10}, {"01", 5}}};
-  auto resultWithCounts = aggregateResults(results);
+  auto resultWithCounts = ptsbe::detail::aggregateResults(results);
   EXPECT_EQ(resultWithCounts.get_total_shots(), 15);
   EXPECT_EQ(resultWithCounts.count("00"), 10);
   EXPECT_EQ(resultWithCounts.count("01"), 5);
 
   // Add more counts to other results
   results[1] = cudaq::ExecutionResult{{{"00", 20}, {"10", 15}}};
-  auto resultWithMoreCounts = aggregateResults(results);
+  auto resultWithMoreCounts = ptsbe::detail::aggregateResults(results);
   EXPECT_EQ(resultWithMoreCounts.get_total_shots(), 50);
   EXPECT_EQ(resultWithMoreCounts.count("00"), 30);
   EXPECT_EQ(resultWithMoreCounts.count("01"), 5);
@@ -72,15 +70,15 @@ CUDAQ_TEST(ExecutePTSBETest, AggregateResultsTester) {
 CUDAQ_TEST(ExecutePTSBETest, SingleTrajectoryHadamard) {
   cudaq::set_random_seed(42);
 
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = kHadamardTrace;
   batch.measureQubits = {0};
 
   KrausTrajectory traj(0, {}, 1.0, 100);
   batch.trajectories.push_back(traj);
 
-  auto results = samplePTSBEWithLifecycle(batch);
-  auto result = aggregateResults(results);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
+  auto result = ptsbe::detail::aggregateResults(results);
 
   std::size_t count0 = result.count("0");
   std::size_t count1 = result.count("1");
@@ -92,7 +90,7 @@ CUDAQ_TEST(ExecutePTSBETest, SingleTrajectoryHadamard) {
 /// Multiple trajectories: verify counts from all trajectories are aggregated
 CUDAQ_TEST(ExecutePTSBETest, MultipleTrajectoryAggregation) {
 
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = kXTrace;
   batch.measureQubits = {0};
 
@@ -101,13 +99,13 @@ CUDAQ_TEST(ExecutePTSBETest, MultipleTrajectoryAggregation) {
   batch.trajectories.push_back(traj1);
   batch.trajectories.push_back(traj2);
 
-  auto results = samplePTSBEWithLifecycle(batch);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
 
   EXPECT_EQ(results.size(), 2u);
   EXPECT_EQ(results[0].count("1"), 7u);
   EXPECT_EQ(results[1].count("1"), 3u);
 
-  auto result = aggregateResults(results);
+  auto result = ptsbe::detail::aggregateResults(results);
   EXPECT_EQ(result.count("1"), 10u);
   EXPECT_EQ(result.count("0"), 0u);
 }
@@ -115,7 +113,7 @@ CUDAQ_TEST(ExecutePTSBETest, MultipleTrajectoryAggregation) {
 /// Zero-shot trajectories return empty result to maintain index correspondence
 CUDAQ_TEST(ExecutePTSBETest, ZeroShotTrajectoryReturnsEmptyResult) {
 
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = {{ptsbe::TraceInstructionType::Gate, "y", {0}, {}, {}}};
   batch.measureQubits = {0};
 
@@ -124,14 +122,14 @@ CUDAQ_TEST(ExecutePTSBETest, ZeroShotTrajectoryReturnsEmptyResult) {
   batch.trajectories.push_back(zeroShot);
   batch.trajectories.push_back(normalShot);
 
-  auto results = samplePTSBEWithLifecycle(batch);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
 
   EXPECT_EQ(results.size(), 2u);
   EXPECT_EQ(results[0].count("0"), 0u);
   EXPECT_EQ(results[0].count("1"), 0u);
   EXPECT_EQ(results[1].count("1"), 10u);
 
-  auto result = aggregateResults(results);
+  auto result = ptsbe::detail::aggregateResults(results);
   EXPECT_EQ(result.count("1"), 10u);
 }
 
@@ -140,24 +138,24 @@ CUDAQ_TEST(ExecutePTSBETest, EmptyInputsReturnEmpty) {
 
   // Test 1: Empty trajectories vector
   {
-    PTSBatch batch;
+    ptsbe::PTSBatch batch;
     batch.trace = kHadamardTrace;
     batch.measureQubits = {0};
 
-    auto results = samplePTSBEWithLifecycle(batch);
+    auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
     EXPECT_TRUE(results.empty());
   }
 
   // Test 2: Empty measureQubits
   {
-    PTSBatch batch;
+    ptsbe::PTSBatch batch;
     batch.trace = kHadamardTrace;
     batch.measureQubits = {};
 
     KrausTrajectory traj(0, {}, 1.0, 10);
     batch.trajectories.push_back(traj);
 
-    auto results = samplePTSBEWithLifecycle(batch);
+    auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
     EXPECT_TRUE(results.empty());
   }
 }
@@ -166,7 +164,7 @@ CUDAQ_TEST(ExecutePTSBETest, EmptyInputsReturnEmpty) {
 CUDAQ_TEST(ExecutePTSBETest, BellStateDistribution) {
   cudaq::set_random_seed(42);
 
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Gate, "x", {1}, {0}, {}},
@@ -176,8 +174,8 @@ CUDAQ_TEST(ExecutePTSBETest, BellStateDistribution) {
   KrausTrajectory traj(0, {}, 1.0, 100);
   batch.trajectories.push_back(traj);
 
-  auto results = samplePTSBEWithLifecycle(batch);
-  auto result = aggregateResults(results);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
+  auto result = ptsbe::detail::aggregateResults(results);
 
   std::size_t count00 = result.count("00");
   std::size_t count11 = result.count("11");
@@ -193,7 +191,7 @@ CUDAQ_TEST(ExecutePTSBETest, BellStateDistribution) {
 CUDAQ_TEST(ExecutePTSBETest, TrajectoryWithNoiseInsertion) {
 
   // Trace: [0] id gate on q0, [1] Noise(depol) on q0
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = {
       {ptsbe::TraceInstructionType::Gate, "id", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
@@ -211,8 +209,8 @@ CUDAQ_TEST(ExecutePTSBETest, TrajectoryWithNoiseInsertion) {
   KrausTrajectory traj(0, selections, 1.0, 10);
   batch.trajectories.push_back(traj);
 
-  auto results = samplePTSBEWithLifecycle(batch);
-  auto result = aggregateResults(results);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
+  auto result = ptsbe::detail::aggregateResults(results);
 
   // I|0> with X error = X|0> = |1>
   EXPECT_EQ(result.count("1"), 10u);
@@ -222,7 +220,7 @@ CUDAQ_TEST(ExecutePTSBETest, TrajectoryWithNoiseInsertion) {
 CUDAQ_TEST(ExecutePTSBETest, MultiQubitWithSelectiveNoise) {
 
   // Trace: [0] X q0, [1] Noise q0, [2] X q1
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = {
       {ptsbe::TraceInstructionType::Gate, "x", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
@@ -247,8 +245,8 @@ CUDAQ_TEST(ExecutePTSBETest, MultiQubitWithSelectiveNoise) {
   batch.trajectories.push_back(traj1);
   batch.trajectories.push_back(traj2);
 
-  auto results = samplePTSBEWithLifecycle(batch);
-  auto result = aggregateResults(results);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
+  auto result = ptsbe::detail::aggregateResults(results);
 
   EXPECT_EQ(result.count("11"), 10u);
   EXPECT_EQ(result.count("01"), 10u);
@@ -259,7 +257,7 @@ CUDAQ_TEST(ExecutePTSBETest, PartialMeasurement) {
   cudaq::set_random_seed(42);
 
   // Bell state
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Gate, "x", {1}, {0}, {}},
@@ -269,8 +267,8 @@ CUDAQ_TEST(ExecutePTSBETest, PartialMeasurement) {
   KrausTrajectory traj(0, {}, 1.0, 100);
   batch.trajectories.push_back(traj);
 
-  auto results = samplePTSBEWithLifecycle(batch);
-  auto result = aggregateResults(results);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
+  auto result = ptsbe::detail::aggregateResults(results);
 
   std::size_t count0 = result.count("0");
   std::size_t count1 = result.count("1");
@@ -283,36 +281,36 @@ CUDAQ_TEST(ExecutePTSBETest, PartialMeasurement) {
 CUDAQ_TEST(ExecutePTSBETest, MeasurementOrderAffectsBitstring) {
 
   // q0=1, q1=0
-  std::vector<TraceInstruction> trace = {
+  std::vector<ptsbe::TraceInstruction> trace = {
       {ptsbe::TraceInstructionType::Gate, "x", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Gate, "id", {1}, {}, {}},
   };
 
   // First test: measure in order {0, 1}
   {
-    PTSBatch batch;
+    ptsbe::PTSBatch batch;
     batch.trace = trace;
     batch.measureQubits = {0, 1};
 
     KrausTrajectory traj(0, {}, 1.0, 10);
     batch.trajectories.push_back(traj);
 
-    auto results = samplePTSBEWithLifecycle(batch);
-    auto result = aggregateResults(results);
+    auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
+    auto result = ptsbe::detail::aggregateResults(results);
     EXPECT_EQ(result.count("10"), 10u);
   }
 
   // Second test: measure in order {1, 0}
   {
-    PTSBatch batch;
+    ptsbe::PTSBatch batch;
     batch.trace = trace;
     batch.measureQubits = {1, 0};
 
     KrausTrajectory traj(0, {}, 1.0, 10);
     batch.trajectories.push_back(traj);
 
-    auto results = samplePTSBEWithLifecycle(batch);
-    auto result = aggregateResults(results);
+    auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
+    auto result = ptsbe::detail::aggregateResults(results);
     EXPECT_EQ(result.count("01"), 10u);
   }
 }
@@ -321,7 +319,7 @@ CUDAQ_TEST(ExecutePTSBETest, MeasurementOrderAffectsBitstring) {
 CUDAQ_TEST(ExecutePTSBETest, MultipleTrajectoryStateReset) {
 
   // Trace: [0] id gate q0, [1] Noise q0
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = {
       {ptsbe::TraceInstructionType::Gate, "id", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
@@ -345,13 +343,13 @@ CUDAQ_TEST(ExecutePTSBETest, MultipleTrajectoryStateReset) {
   batch.trajectories.push_back(trajWithError);
   batch.trajectories.push_back(trajNoError);
 
-  auto results = samplePTSBEWithLifecycle(batch);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
 
   EXPECT_EQ(results.size(), 2u);
   EXPECT_EQ(results[0].count("1"), 10u);
   EXPECT_EQ(results[1].count("0"), 10u);
 
-  auto result = aggregateResults(results);
+  auto result = ptsbe::detail::aggregateResults(results);
   EXPECT_EQ(result.count("1"), 10u);
   EXPECT_EQ(result.count("0"), 10u);
 }
@@ -359,7 +357,7 @@ CUDAQ_TEST(ExecutePTSBETest, MultipleTrajectoryStateReset) {
 /// Readout noise: bit flip applied after measurement flips X|0>=|1> to |0>
 CUDAQ_TEST(ExecutePTSBETest, ReadoutNoiseBitFlipFlipsOutcome) {
 
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = {
       {ptsbe::TraceInstructionType::Gate, "x", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Measurement, "mz", {0}, {}, {}},
@@ -379,8 +377,8 @@ CUDAQ_TEST(ExecutePTSBETest, ReadoutNoiseBitFlipFlipsOutcome) {
   KrausTrajectory traj(0, selections, 1.0, 10);
   batch.trajectories.push_back(traj);
 
-  auto results = samplePTSBEWithLifecycle(batch);
-  auto result = aggregateResults(results);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
+  auto result = ptsbe::detail::aggregateResults(results);
 
   EXPECT_EQ(result.count("0"), 10u);
   EXPECT_EQ(result.count("1"), 0u);
@@ -389,14 +387,14 @@ CUDAQ_TEST(ExecutePTSBETest, ReadoutNoiseBitFlipFlipsOutcome) {
 /// Verify samplePTSBEWithLifecycle produces correct results via production
 /// dispatch path (runtime precision dispatch + concept check).
 CUDAQ_TEST(ExecutePTSBETest, LifecycleDispatchProducesCorrectResults) {
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.trace = kXTrace;
   batch.measureQubits = {0};
 
   KrausTrajectory traj(0, {}, 1.0, 10);
   batch.trajectories.push_back(traj);
 
-  auto results = samplePTSBEWithLifecycle(batch);
+  auto results = ptsbe::detail::samplePTSBEWithLifecycle(batch);
 
   EXPECT_EQ(results.size(), 1u);
   EXPECT_EQ(results[0].count("1"), 10u);

--- a/unittests/ptsbe/MergeTasksWithTrajectoryTester.cpp
+++ b/unittests/ptsbe/MergeTasksWithTrajectoryTester.cpp
@@ -12,11 +12,10 @@
 #include <cmath>
 
 using namespace cudaq;
-using namespace cudaq::ptsbe;
 
 /// Verify convertTrace handles multi-gate PTSBE trace correctly
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, ConvertTraceMultiGate) {
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Gate, "x", {1}, {}, {}},
       {ptsbe::TraceInstructionType::Gate, "x", {1}, {0}, {}},
@@ -45,7 +44,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, ConvertTraceMultiGate) {
 
 /// Verify convertTrace preserves gate parameters
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, ConvertTracePreservesParameters) {
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "rx", {0}, {}, {M_PI / 2}},
       {ptsbe::TraceInstructionType::Gate, "rz", {1}, {}, {M_PI / 4}},
   };
@@ -61,7 +60,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, ConvertTracePreservesParameters) {
 
 /// Verify convertTrace skips Noise and Measurement entries
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, ConvertTraceSkipsNoiseAndMeasurement) {
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
        "depolarization",
@@ -82,14 +81,14 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, ConvertTraceSkipsNoiseAndMeasurement) {
 
 /// Verify mergeTasksWithTrajectory returns gate tasks unchanged when no noise
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, NoNoiseInsertions) {
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Gate, "x", {1}, {}, {}},
   };
 
   KrausTrajectory trajectory(0, {}, 1.0, 100);
 
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
 
   ASSERT_EQ(merged.size(), 2u);
   EXPECT_EQ(merged[0].operationName, "h");
@@ -99,7 +98,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, NoNoiseInsertions) {
 /// Verify single noise insertion at its trace position
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, SingleNoiseInsertion) {
   // Trace: [0] H on q0, [1] Noise(depol) on q0, [2] X on q1
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
        "depolarization",
@@ -115,7 +114,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, SingleNoiseInsertion) {
       KrausSelection(1, {0}, "h", 3, true)};
   KrausTrajectory trajectory(0, selections, 0.1, 10);
 
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
 
   // Should be: H, noise(Z), X
   ASSERT_EQ(merged.size(), 3u);
@@ -128,7 +127,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, SingleNoiseInsertion) {
 /// Verify two consecutive noise entries at the same gate
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, MultipleNoiseEntriesAfterGate) {
   // Trace: [0] H on q0, [1] Noise on q0, [2] Noise on q1
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
        "depolarization",
@@ -150,7 +149,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, MultipleNoiseEntriesAfterGate) {
       KrausSelection(2, {1}, "h", 3, true)};
   KrausTrajectory trajectory(0, selections, 0.05, 5);
 
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
 
   ASSERT_EQ(merged.size(), 3u);
   EXPECT_EQ(merged[0].operationName, "h");
@@ -162,7 +161,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, MultipleNoiseEntriesAfterGate) {
 
 /// Verify invalid circuit_location throws error
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, InvalidCircuitLocationThrows) {
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
   };
 
@@ -172,7 +171,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, InvalidCircuitLocationThrows) {
   KrausTrajectory trajectory(0, selections, 0.1, 10);
 
   try {
-    mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+    ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
     FAIL() << "Expected an exception for invalid circuit_location";
   } catch (...) {
   }
@@ -181,7 +180,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, InvalidCircuitLocationThrows) {
 /// Verify noise at the last trace position works
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, NoiseAtLastPosition) {
   // Trace: [0] H on q0, [1] X on q1, [2] Noise on q1
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Gate, "x", {1}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
@@ -197,7 +196,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, NoiseAtLastPosition) {
       KrausSelection(2, {1}, "x", 3, true)};
   KrausTrajectory trajectory(0, selections, 0.1, 10);
 
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
 
   // Should be: H, X, noise(Z)
   ASSERT_EQ(merged.size(), 3u);
@@ -209,7 +208,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, NoiseAtLastPosition) {
 /// Verify identity noise is skipped (not inserted into merged output)
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, IdentityNoiseSkipped) {
   // Trace: [0] H on q0, [1] Noise on q0, [2] X on q1
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
        "depolarization",
@@ -224,7 +223,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, IdentityNoiseSkipped) {
   std::vector<KrausSelection> selections = {KrausSelection(1, {0}, "h", 0)};
   KrausTrajectory trajectory(0, selections, 0.9, 90);
 
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
 
   // Identity is skipped, so only H and X remain
   ASSERT_EQ(merged.size(), 2u);
@@ -235,7 +234,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, IdentityNoiseSkipped) {
 /// Verify mixed identity and error noise insertions
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, MixedIdentityAndErrorNoise) {
   // Trace: [0] H q0, [1] Noise q0, [2] X q1, [3] Noise q1, [4] Z q0
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
        "depolarization",
@@ -258,7 +257,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, MixedIdentityAndErrorNoise) {
       KrausSelection(1, {0}, "h", 0), KrausSelection(3, {1}, "x", 2, true)};
   KrausTrajectory trajectory(0, selections, 0.2, 20);
 
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
 
   // H, (identity skipped), X, noise(Y), Z
   ASSERT_EQ(merged.size(), 4u);
@@ -271,20 +270,20 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, MixedIdentityAndErrorNoise) {
 
 /// Verify empty trace produces empty task list
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, EmptyTrace) {
-  std::vector<TraceInstruction> ptsbeTrace;
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace;
 
   auto tasks = cudaq::ptsbe::detail::convertTrace<double>(ptsbeTrace);
   EXPECT_TRUE(tasks.empty());
 
   KrausTrajectory trajectory(0, {}, 1.0, 100);
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
   EXPECT_TRUE(merged.empty());
 }
 
 /// Verify noise after every gate in the circuit
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, NoiseOnEveryGate) {
   // Trace: [0] H q0, [1] Noise q0, [2] X q1, [3] Noise q1
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
        "depolarization",
@@ -306,7 +305,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, NoiseOnEveryGate) {
       KrausSelection(3, {1}, "x", 1, true)};
   KrausTrajectory trajectory(0, selections, 0.01, 1);
 
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
 
   // H, noise(Z), X, noise(X)
   ASSERT_EQ(merged.size(), 4u);
@@ -319,13 +318,13 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, NoiseOnEveryGate) {
 /// Verify measurement entries are skipped during merge
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, MeasurementsSkipped) {
   // Trace: [0] H q0, [1] Measurement mz q0
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Measurement, "mz", {0}, {}, {}},
   };
 
   KrausTrajectory trajectory(0, {}, 1.0, 100);
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
 
   ASSERT_EQ(merged.size(), 1u);
   EXPECT_EQ(merged[0].operationName, "h");
@@ -334,7 +333,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, MeasurementsSkipped) {
 /// Verify all-identity trajectory produces only circuit gate tasks (no noise)
 CUDAQ_TEST(MergeTasksWithTrajectoryTest, AllIdentitySkipsAllNoise) {
   // Trace: [0] H q0, [1] Noise q0, [2] X q1, [3] Noise q1
-  std::vector<TraceInstruction> ptsbeTrace = {
+  std::vector<ptsbe::TraceInstruction> ptsbeTrace = {
       {ptsbe::TraceInstructionType::Gate, "h", {0}, {}, {}},
       {ptsbe::TraceInstructionType::Noise,
        "depolarization",
@@ -356,7 +355,7 @@ CUDAQ_TEST(MergeTasksWithTrajectoryTest, AllIdentitySkipsAllNoise) {
                                             KrausSelection(3, {1}, "x", 0)};
   KrausTrajectory trajectory(0, selections, 0.81, 81);
 
-  auto merged = mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
+  auto merged = ptsbe::mergeTasksWithTrajectory<double>(ptsbeTrace, trajectory);
 
   // Only circuit gates remain
   ASSERT_EQ(merged.size(), 2u);

--- a/unittests/ptsbe/PTSBEInterfaceTester.cpp
+++ b/unittests/ptsbe/PTSBEInterfaceTester.cpp
@@ -12,40 +12,41 @@
 #include <type_traits>
 
 using namespace cudaq;
-using namespace cudaq::ptsbe;
 
 namespace {
 
 struct MockPTSBESimulator {
   mutable bool sampleWithPTSBE_called = false;
 
-  std::vector<cudaq::sample_result> sampleWithPTSBE(const PTSBatch &batch) {
+  std::vector<cudaq::sample_result>
+  sampleWithPTSBE(const ptsbe::PTSBatch &batch) {
     sampleWithPTSBE_called = true;
     return {};
   }
 };
 
-struct MockBatchSimulator : BatchSimulator {
+struct MockBatchSimulator : ptsbe::BatchSimulator {
   mutable bool sampleWithPTSBE_called = false;
 
-  std::vector<cudaq::sample_result> sampleWithPTSBE(const PTSBatch &batch) {
+  std::vector<cudaq::sample_result>
+  sampleWithPTSBE(const ptsbe::PTSBatch &batch) {
     sampleWithPTSBE_called = true;
     return {};
   }
 };
 
 struct NonPTSBESimulator {
-  void execute(const PTSBatch &) {}
+  void execute(const ptsbe::PTSBatch &) {}
 };
 
-static_assert(std::is_base_of_v<BatchSimulator, MockBatchSimulator>);
-static_assert(!std::is_base_of_v<BatchSimulator, MockPTSBESimulator>);
+static_assert(std::is_base_of_v<ptsbe::BatchSimulator, MockBatchSimulator>);
+static_assert(!std::is_base_of_v<ptsbe::BatchSimulator, MockPTSBESimulator>);
 
 } // namespace
 
-/// Test: PTSBatch compiles and can hold trajectory data
+/// Test: ptsbe::PTSBatch compiles and can hold trajectory data
 CUDAQ_TEST(PTSBEInterfaceTest, PTSBatchWithTrajectories) {
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
 
   for (size_t i = 0; i < 5; ++i) {
     KrausTrajectory traj;
@@ -79,7 +80,7 @@ CUDAQ_TEST(PTSBEInterfaceTest, TrajectoryWithNoise) {
 
 /// Test: Shot allocation across multiple trajectories
 CUDAQ_TEST(PTSBEInterfaceTest, ShotAllocation) {
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
 
   // Different shot counts per trajectory
   std::vector<size_t> shot_counts = {500, 300, 150, 50};
@@ -100,7 +101,7 @@ CUDAQ_TEST(PTSBEInterfaceTest, ShotAllocation) {
 
 /// Test: Zero-shot trajectory (probability thresholding edge case)
 CUDAQ_TEST(PTSBEInterfaceTest, ZeroShotTrajectory) {
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
 
   KrausTrajectory zero_traj;
   zero_traj.trajectory_id = 0;
@@ -118,7 +119,7 @@ CUDAQ_TEST(PTSBEInterfaceTest, ZeroShotTrajectory) {
 
 /// Test: Empty batch (validation edge case)
 CUDAQ_TEST(PTSBEInterfaceTest, EmptyBatch) {
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
 
   EXPECT_TRUE(batch.trajectories.empty());
   EXPECT_TRUE(batch.measureQubits.empty());
@@ -134,26 +135,27 @@ CUDAQ_TEST(PTSBEInterfaceTest, CleanTrajectory) {
   EXPECT_EQ(traj.num_shots, 500);
 }
 
-/// Test: Runtime dispatch calls sampleWithPTSBE for BatchSimulator implementers
+/// Test: Runtime dispatch calls sampleWithPTSBE for ptsbe::BatchSimulator
+/// implementers
 CUDAQ_TEST(PTSBEInterfaceTest, RuntimeDispatchCallsMock) {
   MockBatchSimulator ptsbe_sim;
-  PTSBatch batch;
+  ptsbe::PTSBatch batch;
   batch.measureQubits = {0, 1};
 
   ptsbe_sim.sampleWithPTSBE(batch);
   EXPECT_TRUE(ptsbe_sim.sampleWithPTSBE_called);
 
   constexpr bool nonPtsbeIsBatchSimulator =
-      std::is_base_of_v<BatchSimulator, NonPTSBESimulator>;
+      std::is_base_of_v<ptsbe::BatchSimulator, NonPTSBESimulator>;
   EXPECT_FALSE(nonPtsbeIsBatchSimulator);
 }
 
-/// Test: BatchSimulator inheritance is the dispatch contract
+/// Test: ptsbe::BatchSimulator inheritance is the dispatch contract
 CUDAQ_TEST(PTSBEInterfaceTest, BatchSimulatorDispatchContract) {
   constexpr bool mockBatchIsBatchSimulator =
-      std::is_base_of_v<BatchSimulator, MockBatchSimulator>;
+      std::is_base_of_v<ptsbe::BatchSimulator, MockBatchSimulator>;
   constexpr bool mockPtsbeIsBatchSimulator =
-      std::is_base_of_v<BatchSimulator, MockPTSBESimulator>;
+      std::is_base_of_v<ptsbe::BatchSimulator, MockPTSBESimulator>;
   EXPECT_TRUE(mockBatchIsBatchSimulator);
   EXPECT_FALSE(mockPtsbeIsBatchSimulator);
 }

--- a/unittests/ptsbe/PTSBESampleTester.cpp
+++ b/unittests/ptsbe/PTSBESampleTester.cpp
@@ -23,7 +23,6 @@
 #include "cudaq/ptsbe/strategies/ExhaustiveSamplingStrategy.h"
 
 using namespace cudaq::ptsbe;
-using namespace cudaq::ptsbe::detail;
 
 namespace {
 
@@ -81,13 +80,13 @@ auto inlineNoiseKernel = []() __qpu__ {
 // ============================================================================
 
 CUDAQ_TEST(PTSBESampleTest, TracePTSBatchCapturesBellCircuit) {
-  auto batch = tracePTSBatch(bellKernel);
+  auto batch = detail::tracePTSBatch(bellKernel);
   // Bell circuit: h, x gates + mz measurements
   EXPECT_EQ(countInstructions(batch.trace, TraceInstructionType::Gate), 2);
 }
 
 CUDAQ_TEST(PTSBESampleTest, TracePTSBatchPreservesGateNames) {
-  auto batch = tracePTSBatch(bellKernel);
+  auto batch = detail::tracePTSBatch(bellKernel);
 
   // Find Gate instructions
   std::vector<const TraceInstruction *> gates;
@@ -101,7 +100,7 @@ CUDAQ_TEST(PTSBESampleTest, TracePTSBatchPreservesGateNames) {
 }
 
 CUDAQ_TEST(PTSBESampleTest, TracePTSBatchHandlesKernelArgs) {
-  auto batch = tracePTSBatch(rotationKernel, 1.57);
+  auto batch = detail::tracePTSBatch(rotationKernel, 1.57);
 
   ASSERT_FALSE(batch.trace.empty());
   EXPECT_EQ(batch.trace[0].name, "rx");
@@ -109,7 +108,7 @@ CUDAQ_TEST(PTSBESampleTest, TracePTSBatchHandlesKernelArgs) {
 }
 
 CUDAQ_TEST(PTSBESampleTest, TracePTSBatchHandlesEmptyKernel) {
-  auto batch = tracePTSBatch(emptyKernel);
+  auto batch = detail::tracePTSBatch(emptyKernel);
   EXPECT_TRUE(batch.trace.empty());
 }
 
@@ -132,7 +131,7 @@ CUDAQ_TEST(PTSBESampleTest, ValidateKernelThrowsForMCMContext) {
   cudaq::ExecutionContext ctx("tracer");
   ctx.registerNames.push_back("mcm_result");
   try {
-    validatePTSBEKernel("testKernel", ctx);
+    detail::validatePTSBEKernel("testKernel", ctx);
     FAIL() << "Expected an exception for MCM context";
   } catch (...) {
   }
@@ -140,24 +139,24 @@ CUDAQ_TEST(PTSBESampleTest, ValidateKernelThrowsForMCMContext) {
 
 CUDAQ_TEST(PTSBESampleTest, ValidateKernelNoThrowForValidContext) {
   cudaq::ExecutionContext ctx("tracer");
-  EXPECT_NO_THROW(validatePTSBEKernel("testKernel", ctx));
+  EXPECT_NO_THROW(detail::validatePTSBEKernel("testKernel", ctx));
 }
 
 CUDAQ_TEST(PTSBESampleTest, WarnNamedRegisters) {
   // __global__ only: no warning
   cudaq::ExecutionContext globalCtx("tracer");
   globalCtx.kernelTrace.appendMeasurement("mz", {{2, 0}}, "__global__");
-  warnNamedRegisters("testKernel", globalCtx);
+  detail::warnNamedRegisters("testKernel", globalCtx);
   EXPECT_FALSE(globalCtx.warnedNamedMeasurements);
 
   // Named register: sets flag
   cudaq::ExecutionContext namedCtx("tracer");
   namedCtx.kernelTrace.appendMeasurement("mz", {{2, 0}}, "my_register");
-  warnNamedRegisters("testKernel", namedCtx);
+  detail::warnNamedRegisters("testKernel", namedCtx);
   EXPECT_TRUE(namedCtx.warnedNamedMeasurements);
 
   // Second call is a no-op (flag already set)
-  warnNamedRegisters("testKernel", namedCtx);
+  detail::warnNamedRegisters("testKernel", namedCtx);
   EXPECT_TRUE(namedCtx.warnedNamedMeasurements);
 }
 
@@ -166,20 +165,20 @@ CUDAQ_TEST(PTSBESampleTest, WarnNamedRegisters) {
 // ============================================================================
 
 CUDAQ_TEST(PTSBESampleTest, PTSBatchHasCorrectMeasureQubits) {
-  auto batch = tracePTSBatch(bellKernel);
+  auto batch = detail::tracePTSBatch(bellKernel);
   EXPECT_EQ(batch.measureQubits.size(), 2);
   EXPECT_EQ(batch.measureQubits[0], 0);
   EXPECT_EQ(batch.measureQubits[1], 1);
 }
 
 CUDAQ_TEST(PTSBESampleTest, PTSBatchFromGHZHas3Qubits) {
-  auto batch = tracePTSBatch(ghzKernel);
+  auto batch = detail::tracePTSBatch(ghzKernel);
   EXPECT_EQ(numQubits(batch.trace), 3);
   EXPECT_EQ(batch.measureQubits.size(), 3);
 }
 
 CUDAQ_TEST(PTSBESampleTest, PTSBatchTrajectoriesEmptyForPOC) {
-  auto batch = tracePTSBatch(bellKernel);
+  auto batch = detail::tracePTSBatch(bellKernel);
   EXPECT_TRUE(batch.trajectories.empty());
 }
 
@@ -187,14 +186,14 @@ CUDAQ_TEST(PTSBESampleTest, PTSBatchTrajectoriesEmptyForPOC) {
 // extractMeasureQubits derives the list from Measurement entries,
 // so only the actually-measured qubits appear, in kernel order.
 CUDAQ_TEST(PTSBESampleTest, PTSBatchSeparatedMeasureQubits) {
-  auto batch = tracePTSBatch(separatedMeasureKernel);
+  auto batch = detail::tracePTSBatch(separatedMeasureKernel);
   EXPECT_EQ(batch.measureQubits.size(), 2);
   EXPECT_EQ(batch.measureQubits[0], 0);
   EXPECT_EQ(batch.measureQubits[1], 2);
 }
 
 CUDAQ_TEST(PTSBESampleTest, PTSBatchQubitInfoPreserved) {
-  auto batch = tracePTSBatch(bellKernel);
+  auto batch = detail::tracePTSBatch(bellKernel);
 
   // Find Gate instructions
   std::vector<const TraceInstruction *> gates;
@@ -242,22 +241,22 @@ CUDAQ_TEST(PTSBESampleTest, SampleImplicitMeasureAllQubits) {
 // Test that a batch with valid trace but no trajectories returns empty results
 CUDAQ_TEST(PTSBESampleTest, ExecuteWithEmptyTrajectoriesReturnsEmpty) {
   // Capture a valid trace first
-  auto batch = tracePTSBatch(bellKernel);
+  auto batch = detail::tracePTSBatch(bellKernel);
   // Clear trajectories (they're already empty from tracePTSBatch)
   EXPECT_TRUE(batch.trajectories.empty());
 
   // No trajectories - should return empty results
-  auto results = samplePTSBEWithLifecycle(batch);
+  auto results = detail::samplePTSBEWithLifecycle(batch);
   EXPECT_TRUE(results.empty());
 }
 
 CUDAQ_TEST(PTSBESampleTest, FullInterceptFlowCapturesTrace) {
-  auto batch = tracePTSBatch(bellKernel);
+  auto batch = detail::tracePTSBatch(bellKernel);
   EXPECT_FALSE(batch.trace.empty());
   EXPECT_FALSE(batch.measureQubits.empty());
 
   // With no trajectories, should return empty (not throw)
-  auto results = samplePTSBEWithLifecycle(batch);
+  auto results = detail::samplePTSBEWithLifecycle(batch);
   EXPECT_TRUE(results.empty());
 }
 
@@ -275,9 +274,9 @@ CUDAQ_TEST(PTSBESampleTest, RunSamplingPTSBEAcceptsShotAllocationStrategy) {
   PTSBEOptions ptsbe_opts;
   ptsbe_opts.shot_allocation =
       ShotAllocationStrategy(ShotAllocationStrategy::Type::UNIFORM);
-  auto result =
-      runSamplingPTSBE([]() { bellKernel(); }, platform,
-                       cudaq::getKernelName(bellKernel), 50, ptsbe_opts);
+  auto result = detail::runSamplingPTSBE([]() { bellKernel(); }, platform,
+                                         cudaq::getKernelName(bellKernel), 50,
+                                         ptsbe_opts);
 
   platform.reset_noise();
   (void)result;
@@ -299,7 +298,7 @@ CUDAQ_TEST(PTSBESampleTest, PTSBESampleWithShotAllocationOption) {
 
 // Test that tracePTSBatch correctly captures GHZ circuit structure
 CUDAQ_TEST(PTSBESampleTest, TracePTSBatchCapturesGHZCircuit) {
-  auto batch = tracePTSBatch(ghzKernel);
+  auto batch = detail::tracePTSBatch(ghzKernel);
   // GHZ has 3 gates (h, cx, cx)
   EXPECT_EQ(countInstructions(batch.trace, TraceInstructionType::Gate), 3);
   // 3 qubits
@@ -308,7 +307,7 @@ CUDAQ_TEST(PTSBESampleTest, TracePTSBatchCapturesGHZCircuit) {
 
 // Test that tracePTSBatch correctly handles parameterized kernels
 CUDAQ_TEST(PTSBESampleTest, TracePTSBatchHandlesParameterizedKernel) {
-  auto batch = tracePTSBatch(rotationKernel, 1.57);
+  auto batch = detail::tracePTSBatch(rotationKernel, 1.57);
   // rotationKernel has 2 gates (rx, ry)
   EXPECT_EQ(countInstructions(batch.trace, TraceInstructionType::Gate), 2);
   // 2 qubits
@@ -334,16 +333,16 @@ CUDAQ_TEST(PTSBESampleTest, E2E_GenerateTrajectoriesAllocateShotsRunSample) {
   cudaq::ExecutionContext traceCtx("tracer");
   auto &platform = cudaq::get_platform();
   platform.with_execution_context(traceCtx, [&]() { bellKernel(); });
-  cleanupTracerQubits(traceCtx.kernelTrace);
+  detail::cleanupTracerQubits(traceCtx.kernelTrace);
 
   // Build PTSBE trace with noise model and extract noise sites
   PTSBatch batch;
-  batch.trace = buildPTSBETrace(traceCtx.kernelTrace, noise);
-  batch.measureQubits = extractMeasureQubits(batch.trace);
+  batch.trace = detail::buildPTSBETrace(traceCtx.kernelTrace, noise);
+  batch.measureQubits = detail::extractMeasureQubits(batch.trace);
   EXPECT_FALSE(batch.trace.empty());
   EXPECT_FALSE(batch.measureQubits.empty());
 
-  auto extraction = extractNoiseSites(batch.trace);
+  auto extraction = detail::extractNoiseSites(batch.trace);
   ASSERT_GT(extraction.noise_sites.size(), 0)
       << "Expected at least one noise site for h gate";
   EXPECT_TRUE(extraction.all_unitary_mixtures);
@@ -371,10 +370,10 @@ CUDAQ_TEST(PTSBESampleTest, E2E_GenerateTrajectoriesAllocateShotsRunSample) {
   EXPECT_EQ(sum_shots, total_shots);
 
   // Execute PTSBE and aggregate
-  auto results = samplePTSBEWithLifecycle(batch);
+  auto results = detail::samplePTSBEWithLifecycle(batch);
   EXPECT_EQ(results.size(), batch.trajectories.size());
 
-  auto result = aggregateResults(results);
+  auto result = detail::aggregateResults(results);
 
   // Total counts should equal total shots
   EXPECT_EQ(result.get_total_shots(), total_shots);
@@ -599,7 +598,7 @@ CUDAQ_TEST(PTSBESampleTest, SampleAsyncPropagatesException) {
 
   auto &platform = cudaq::get_platform();
 
-  auto future = runSamplingAsyncPTSBE(
+  auto future = detail::runSamplingAsyncPTSBE(
       []() { throw std::runtime_error("injected async failure"); }, platform,
       "test_kernel", 10, PTSBEOptions{}, /*qpu_id=*/0, noise);
 
@@ -742,8 +741,8 @@ CUDAQ_TEST(PTSBESampleTest, PopulateExecutionDataFiltersZeroShotTrajectories) {
       cudaq::sample_result{cudaq::ExecutionResult{cudaq::CountsDictionary{}}});
   results.push_back(cudaq::sample_result{cudaq::ExecutionResult{counts2}});
 
-  populateExecutionDataTrajectories(executionData, std::move(trajectories),
-                                    std::move(results));
+  detail::populateExecutionDataTrajectories(
+      executionData, std::move(trajectories), std::move(results));
 
   EXPECT_EQ(executionData.trajectories.size(), 2u);
   EXPECT_EQ(executionData.trajectories[0].trajectory_id, 0u);

--- a/unittests/ptsbe/ShotAllocationTester.cpp
+++ b/unittests/ptsbe/ShotAllocationTester.cpp
@@ -11,7 +11,6 @@
 #include <array>
 
 using namespace cudaq;
-using namespace cudaq::ptsbe;
 
 // A simple trajectory for testing
 static KrausTrajectory makeTrajectory(std::size_t id, double prob,
@@ -35,9 +34,9 @@ CUDAQ_TEST(ShotAllocationTest, ProportionalBasic) {
 
   // Multinomial sampling with weights 5:3:2.
   // Tolerance is ~4*sigma (sigma = sqrt(n*p*(1-p))).
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 1000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 1000, strategy);
 
   EXPECT_NEAR(trajectories[0].num_shots, 500, 65);
   EXPECT_NEAR(trajectories[1].num_shots, 300, 60);
@@ -55,9 +54,9 @@ CUDAQ_TEST(ShotAllocationTest, ProportionalWithEqualMultiplicity) {
                                                makeTrajectory(2, 0.334, 0, 1)};
 
   // Each trajectory gets ~333 shots; sigma ~14.9, tolerance is ~4*sigma.
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 1000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 1000, strategy);
 
   std::size_t total = trajectories[0].num_shots + trajectories[1].num_shots +
                       trajectories[2].num_shots;
@@ -71,9 +70,9 @@ CUDAQ_TEST(ShotAllocationTest, ProportionalWithEqualMultiplicity) {
 CUDAQ_TEST(ShotAllocationTest, ProportionalSingleTrajectory) {
   std::vector<KrausTrajectory> trajectories = {makeTrajectory(0, 1.0)};
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 5000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 5000, strategy);
 
   EXPECT_EQ(trajectories[0].num_shots, 5000);
 }
@@ -82,8 +81,9 @@ CUDAQ_TEST(ShotAllocationTest, UniformBasic) {
   std::vector<KrausTrajectory> trajectories = {
       makeTrajectory(0, 0.8), makeTrajectory(1, 0.1), makeTrajectory(2, 0.1)};
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::UNIFORM);
-  allocateShots(trajectories, 3000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::UNIFORM);
+  ptsbe::allocateShots(trajectories, 3000, strategy);
 
   // All get equal shots (ignoring probability)
   EXPECT_EQ(trajectories[0].num_shots, 1000);
@@ -95,8 +95,9 @@ CUDAQ_TEST(ShotAllocationTest, UniformWithRemainder) {
   std::vector<KrausTrajectory> trajectories = {makeTrajectory(0, 0.5),
                                                makeTrajectory(1, 0.5)};
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::UNIFORM);
-  allocateShots(trajectories, 1001, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::UNIFORM);
+  ptsbe::allocateShots(trajectories, 1001, strategy);
 
   // Total must equal 1001
   std::size_t total = trajectories[0].num_shots + trajectories[1].num_shots;
@@ -114,9 +115,9 @@ CUDAQ_TEST(ShotAllocationTest, LowWeightBiasBasic) {
       makeTrajectory(2, 0.3, 2, 3)  // 2 errors, mult=3
   };
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 1000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 1000, strategy);
 
   // Trajectory 0 (no errors) should get most shots
   EXPECT_GT(trajectories[0].num_shots, trajectories[1].num_shots);
@@ -133,14 +134,14 @@ CUDAQ_TEST(ShotAllocationTest, LowWeightBiasStrength) {
   std::vector<KrausTrajectory> trajectories2 = trajectories1;
 
   // Weak bias (strength = 1.0)
-  ShotAllocationStrategy weak_bias(
-      ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 1.0, /*seed=*/42);
-  allocateShots(trajectories1, 1000, weak_bias);
+  ptsbe::ShotAllocationStrategy weak_bias(
+      ptsbe::ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 1.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories1, 1000, weak_bias);
 
   // Strong bias (strength = 3.0)
-  ShotAllocationStrategy strong_bias(
-      ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 3.0, /*seed=*/42);
-  allocateShots(trajectories2, 1000, strong_bias);
+  ptsbe::ShotAllocationStrategy strong_bias(
+      ptsbe::ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 3.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories2, 1000, strong_bias);
 
   // Strong bias should give even more shots to low-weight trajectory
   EXPECT_GT(trajectories2[0].num_shots, trajectories1[0].num_shots);
@@ -154,9 +155,9 @@ CUDAQ_TEST(ShotAllocationTest, HighWeightBiasBasic) {
       makeTrajectory(2, 0.3, 2, 3)  // 2 errors, mult=3
   };
 
-  ShotAllocationStrategy strategy(
-      ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS, 2.0, /*seed=*/42);
-  allocateShots(trajectories, 1000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 1000, strategy);
 
   // Trajectory 2 (most errors) should get most shots
   EXPECT_LT(trajectories[0].num_shots, trajectories[1].num_shots);
@@ -169,10 +170,10 @@ CUDAQ_TEST(ShotAllocationTest, HighWeightBiasBasic) {
 
 CUDAQ_TEST(ShotAllocationTest, EmptyTrajectoryList) {
   std::vector<KrausTrajectory> trajectories;
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
 
-  EXPECT_ANY_THROW({ allocateShots(trajectories, 1000, strategy); });
+  EXPECT_ANY_THROW({ ptsbe::allocateShots(trajectories, 1000, strategy); });
 }
 
 CUDAQ_TEST(ShotAllocationTest, ProportionalThrowsOnZeroWeights) {
@@ -182,18 +183,18 @@ CUDAQ_TEST(ShotAllocationTest, ProportionalThrowsOnZeroWeights) {
   trajectories.push_back(KrausTrajectory(0, {}, 0.0, 0));
   trajectories.push_back(KrausTrajectory(1, {}, 0.0, 0));
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  EXPECT_ANY_THROW({ allocateShots(trajectories, 100, strategy); });
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  EXPECT_ANY_THROW({ ptsbe::allocateShots(trajectories, 100, strategy); });
 }
 
 CUDAQ_TEST(ShotAllocationTest, SingleShotDistribution) {
   std::vector<KrausTrajectory> trajectories = {makeTrajectory(0, 0.5),
                                                makeTrajectory(1, 0.5)};
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 1, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 1, strategy);
 
   // One trajectory gets 1 shot, other gets 0
   std::size_t total = trajectories[0].num_shots + trajectories[1].num_shots;
@@ -206,9 +207,9 @@ CUDAQ_TEST(ShotAllocationTest, LargeNumberOfTrajectories) {
     trajectories.push_back(makeTrajectory(i, 0.001));
   }
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 100000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 100000, strategy);
 
   std::size_t total = 0;
   for (const auto &traj : trajectories) {
@@ -230,12 +231,13 @@ CUDAQ_TEST(ShotAllocationTest, CompareProportionalVsUniform) {
   std::vector<KrausTrajectory> traj_unif = {makeTrajectory(0, 0.5, 0, 9),
                                             makeTrajectory(1, 0.5, 0, 1)};
 
-  ShotAllocationStrategy proportional(
-      ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
-  ShotAllocationStrategy uniform(ShotAllocationStrategy::Type::UNIFORM);
+  ptsbe::ShotAllocationStrategy proportional(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::ShotAllocationStrategy uniform(
+      ptsbe::ShotAllocationStrategy::Type::UNIFORM);
 
-  allocateShots(traj_prop, 1000, proportional);
-  allocateShots(traj_unif, 1000, uniform);
+  ptsbe::allocateShots(traj_prop, 1000, proportional);
+  ptsbe::allocateShots(traj_unif, 1000, uniform);
 
   // Proportional: high-multiplicity trajectory gets significantly more shots.
   EXPECT_GT(traj_prop[0].num_shots, traj_prop[1].num_shots);
@@ -254,13 +256,13 @@ CUDAQ_TEST(ShotAllocationTest, CompareLowVsHighWeightBias) {
   };
   std::vector<KrausTrajectory> high_bias = low_bias;
 
-  ShotAllocationStrategy low_strategy(
-      ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 2.0, /*seed=*/42);
-  ShotAllocationStrategy high_strategy(
-      ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS, 2.0, /*seed=*/42);
+  ptsbe::ShotAllocationStrategy low_strategy(
+      ptsbe::ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 2.0, /*seed=*/42);
+  ptsbe::ShotAllocationStrategy high_strategy(
+      ptsbe::ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS, 2.0, /*seed=*/42);
 
-  allocateShots(low_bias, 1000, low_strategy);
-  allocateShots(high_bias, 1000, high_strategy);
+  ptsbe::allocateShots(low_bias, 1000, low_strategy);
+  ptsbe::allocateShots(high_bias, 1000, high_strategy);
 
   // Low-weight bias: trajectory 0 gets more
   EXPECT_GT(low_bias[0].num_shots, low_bias[1].num_shots);
@@ -303,9 +305,9 @@ CUDAQ_TEST(ShotAllocationTest, VerySmallProbabilities) {
     trajectories.push_back(makeTrajectory(i, 1e-6));
   }
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 1000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 1000, strategy);
 
   std::size_t total = 0;
   for (const auto &traj : trajectories) {
@@ -320,9 +322,9 @@ CUDAQ_TEST(ShotAllocationTest, ExtremelyUnequalMultiplicities) {
       makeTrajectory(1, 0.001, 0, 1)    // Rare trajectory
   };
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 10000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 10000, strategy);
 
   EXPECT_GE(trajectories[0].num_shots, 9980);
   EXPECT_LE(trajectories[1].num_shots, 20);
@@ -336,8 +338,9 @@ CUDAQ_TEST(ShotAllocationTest, ManyTrajectoriesFewShots) {
     trajectories.push_back(makeTrajectory(i, 0.01));
   }
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::UNIFORM);
-  allocateShots(trajectories, 50, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::UNIFORM);
+  ptsbe::allocateShots(trajectories, 50, strategy);
 
   std::size_t total = 0;
   for (const auto &traj : trajectories) {
@@ -359,16 +362,16 @@ CUDAQ_TEST(ShotAllocationTest, TotalShotsInvariant) {
       makeTrajectory(0, 0.4, 0, 4), makeTrajectory(1, 0.3, 1, 3),
       makeTrajectory(2, 0.2, 2, 2), makeTrajectory(3, 0.1, 3, 1)};
 
-  std::vector<ShotAllocationStrategy::Type> strategies = {
-      ShotAllocationStrategy::Type::PROPORTIONAL,
-      ShotAllocationStrategy::Type::UNIFORM,
-      ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS,
-      ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS};
+  std::vector<ptsbe::ShotAllocationStrategy::Type> strategies = {
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL,
+      ptsbe::ShotAllocationStrategy::Type::UNIFORM,
+      ptsbe::ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS,
+      ptsbe::ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS};
 
   for (auto strat_type : strategies) {
     auto traj_copy = trajectories;
-    ShotAllocationStrategy strategy(strat_type, 2.0, /*seed=*/42);
-    allocateShots(traj_copy, 1000, strategy);
+    ptsbe::ShotAllocationStrategy strategy(strat_type, 2.0, /*seed=*/42);
+    ptsbe::allocateShots(traj_copy, 1000, strategy);
 
     std::size_t total = 0;
     for (const auto &traj : traj_copy) {
@@ -383,9 +386,9 @@ CUDAQ_TEST(ShotAllocationTest, NonNegativeShots) {
   std::vector<KrausTrajectory> trajectories = {makeTrajectory(0, 0.5),
                                                makeTrajectory(1, 0.5)};
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 1000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 1000, strategy);
 
   for (const auto &traj : trajectories) {
     // Always non-negative
@@ -398,9 +401,9 @@ CUDAQ_TEST(ShotAllocationTest, SpanWithArray) {
       {makeTrajectory(0, 0.5, 0, 5), makeTrajectory(1, 0.3, 0, 3),
        makeTrajectory(2, 0.2, 0, 2)}};
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 1000, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 1000, strategy);
 
   std::size_t total = trajectories[0].num_shots + trajectories[1].num_shots +
                       trajectories[2].num_shots;
@@ -416,8 +419,9 @@ CUDAQ_TEST(ShotAllocationTest, SpanWithSubrange) {
       makeTrajectory(3, 0.25)};
 
   std::span<KrausTrajectory> first_two(all_trajectories.data(), 2);
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::UNIFORM);
-  allocateShots(first_two, 600, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::UNIFORM);
+  ptsbe::allocateShots(first_two, 600, strategy);
 
   EXPECT_EQ(all_trajectories[0].num_shots, 300);
   EXPECT_EQ(all_trajectories[1].num_shots, 300);
@@ -454,12 +458,14 @@ CUDAQ_TEST(ShotAllocationTest, ProportionalReproducibility) {
                                      makeTrajectory(2, 0.2, 0, 2)};
   std::vector<KrausTrajectory> t2 = t1;
 
-  ShotAllocationStrategy s1(ShotAllocationStrategy::Type::PROPORTIONAL, 2.0,
-                            /*seed=*/42);
-  ShotAllocationStrategy s2(ShotAllocationStrategy::Type::PROPORTIONAL, 2.0,
-                            /*seed=*/42);
-  allocateShots(t1, 1000, s1);
-  allocateShots(t2, 1000, s2);
+  ptsbe::ShotAllocationStrategy s1(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0,
+      /*seed=*/42);
+  ptsbe::ShotAllocationStrategy s2(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0,
+      /*seed=*/42);
+  ptsbe::allocateShots(t1, 1000, s1);
+  ptsbe::allocateShots(t2, 1000, s2);
 
   EXPECT_EQ(t1[0].num_shots, t2[0].num_shots);
   EXPECT_EQ(t1[1].num_shots, t2[1].num_shots);
@@ -471,12 +477,14 @@ CUDAQ_TEST(ShotAllocationTest, LowWeightBiasReproducibility) {
                                      makeTrajectory(1, 0.5, 2, 5)};
   std::vector<KrausTrajectory> t2 = t1;
 
-  ShotAllocationStrategy s1(ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 2.0,
-                            /*seed=*/99);
-  ShotAllocationStrategy s2(ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 2.0,
-                            /*seed=*/99);
-  allocateShots(t1, 500, s1);
-  allocateShots(t2, 500, s2);
+  ptsbe::ShotAllocationStrategy s1(
+      ptsbe::ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 2.0,
+      /*seed=*/99);
+  ptsbe::ShotAllocationStrategy s2(
+      ptsbe::ShotAllocationStrategy::Type::LOW_WEIGHT_BIAS, 2.0,
+      /*seed=*/99);
+  ptsbe::allocateShots(t1, 500, s1);
+  ptsbe::allocateShots(t2, 500, s2);
 
   EXPECT_EQ(t1[0].num_shots, t2[0].num_shots);
   EXPECT_EQ(t1[1].num_shots, t2[1].num_shots);
@@ -487,12 +495,14 @@ CUDAQ_TEST(ShotAllocationTest, HighWeightBiasReproducibility) {
                                      makeTrajectory(1, 0.5, 2, 5)};
   std::vector<KrausTrajectory> t2 = t1;
 
-  ShotAllocationStrategy s1(ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS, 2.0,
-                            /*seed=*/77);
-  ShotAllocationStrategy s2(ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS, 2.0,
-                            /*seed=*/77);
-  allocateShots(t1, 500, s1);
-  allocateShots(t2, 500, s2);
+  ptsbe::ShotAllocationStrategy s1(
+      ptsbe::ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS, 2.0,
+      /*seed=*/77);
+  ptsbe::ShotAllocationStrategy s2(
+      ptsbe::ShotAllocationStrategy::Type::HIGH_WEIGHT_BIAS, 2.0,
+      /*seed=*/77);
+  ptsbe::allocateShots(t1, 500, s1);
+  ptsbe::allocateShots(t2, 500, s2);
 
   EXPECT_EQ(t1[0].num_shots, t2[0].num_shots);
   EXPECT_EQ(t1[1].num_shots, t2[1].num_shots);
@@ -503,9 +513,9 @@ CUDAQ_TEST(ShotAllocationTest, ProportionalNoTruncationZeroShots) {
   for (std::size_t i = 0; i < 100; ++i)
     trajectories.push_back(makeTrajectory(i, 0.01));
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/1234);
-  allocateShots(trajectories, 50, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/1234);
+  ptsbe::allocateShots(trajectories, 50, strategy);
 
   std::size_t total = 0;
   for (const auto &traj : trajectories)
@@ -527,9 +537,9 @@ CUDAQ_TEST(ShotAllocationTest, ProportionalExactTotal) {
 
   for (std::size_t shots : {1, 3, 7, 100, 999, 10000}) {
     auto traj_copy = trajectories;
-    ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                    2.0, /*seed=*/42);
-    allocateShots(traj_copy, shots, strategy);
+    ptsbe::ShotAllocationStrategy strategy(
+        ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+    ptsbe::allocateShots(traj_copy, shots, strategy);
 
     std::size_t total = 0;
     for (const auto &t : traj_copy)
@@ -543,10 +553,10 @@ CUDAQ_TEST(ShotAllocationTest, DoubleAllocationDoesNotAccumulate) {
   std::vector<KrausTrajectory> trajectories = {makeTrajectory(0, 0.7, 0, 7),
                                                makeTrajectory(1, 0.3, 0, 3)};
 
-  ShotAllocationStrategy strategy(ShotAllocationStrategy::Type::PROPORTIONAL,
-                                  2.0, /*seed=*/42);
-  allocateShots(trajectories, 100, strategy);
-  allocateShots(trajectories, 100, strategy);
+  ptsbe::ShotAllocationStrategy strategy(
+      ptsbe::ShotAllocationStrategy::Type::PROPORTIONAL, 2.0, /*seed=*/42);
+  ptsbe::allocateShots(trajectories, 100, strategy);
+  ptsbe::allocateShots(trajectories, 100, strategy);
 
   std::size_t total = 0;
   for (const auto &t : trajectories)

--- a/unittests/ptsbe/TraceConversionTester.cpp
+++ b/unittests/ptsbe/TraceConversionTester.cpp
@@ -12,11 +12,11 @@
 #include <cmath>
 
 using namespace cudaq;
-using namespace cudaq::ptsbe;
 
 /// Verify basic conversion: gate name, matrix populated, qubit IDs extracted
 CUDAQ_TEST(TraceConversionTest, BasicConversion) {
-  TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "h", {5}, {}, {});
+  ptsbe::TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "h", {5}, {},
+                               {});
   auto task = cudaq::ptsbe::detail::convertToSimulatorTask<double>(inst);
 
   EXPECT_EQ(task.operationName, "h");
@@ -30,8 +30,8 @@ CUDAQ_TEST(TraceConversionTest, BasicConversion) {
 /// Verify parameterized gate: parameters passed through and cast to ScalarType
 CUDAQ_TEST(TraceConversionTest, ParameterizedGate) {
   double angle = M_PI / 3;
-  TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "rx", {0}, {},
-                        {angle});
+  ptsbe::TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "rx", {0}, {},
+                               {angle});
   auto task = cudaq::ptsbe::detail::convertToSimulatorTask<double>(inst);
 
   EXPECT_EQ(task.operationName, "rx");
@@ -41,8 +41,8 @@ CUDAQ_TEST(TraceConversionTest, ParameterizedGate) {
 
 /// Verify controlled gate: controls and targets extracted correctly
 CUDAQ_TEST(TraceConversionTest, ControlledGate) {
-  TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "x", {2}, {0, 1},
-                        {});
+  ptsbe::TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "x", {2},
+                               {0, 1}, {});
   auto task = cudaq::ptsbe::detail::convertToSimulatorTask<double>(inst);
 
   EXPECT_EQ(task.controls.size(), 2u);
@@ -54,8 +54,8 @@ CUDAQ_TEST(TraceConversionTest, ControlledGate) {
 
 /// Verify unknown gate throws with descriptive error
 CUDAQ_TEST(TraceConversionTest, UnknownGateThrows) {
-  TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "invalid_gate_xyz",
-                        {0}, {}, {});
+  ptsbe::TraceInstruction inst(ptsbe::TraceInstructionType::Gate,
+                               "invalid_gate_xyz", {0}, {}, {});
   try {
     cudaq::ptsbe::detail::convertToSimulatorTask<double>(inst);
     FAIL() << "Expected an exception for unknown gate";
@@ -65,8 +65,8 @@ CUDAQ_TEST(TraceConversionTest, UnknownGateThrows) {
 
 /// Verify float precision: parameters cast to float
 CUDAQ_TEST(TraceConversionTest, FloatPrecision) {
-  TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "rx", {0}, {},
-                        {M_PI / 4});
+  ptsbe::TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "rx", {0}, {},
+                               {M_PI / 4});
   auto task = cudaq::ptsbe::detail::convertToSimulatorTask<float>(inst);
 
   EXPECT_EQ(task.parameters.size(), 1u);
@@ -75,8 +75,8 @@ CUDAQ_TEST(TraceConversionTest, FloatPrecision) {
 
 /// Verify multi-target gate (swap)
 CUDAQ_TEST(TraceConversionTest, MultiTargetGate) {
-  TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "swap", {3, 7}, {},
-                        {});
+  ptsbe::TraceInstruction inst(ptsbe::TraceInstructionType::Gate, "swap",
+                               {3, 7}, {}, {});
   auto task = cudaq::ptsbe::detail::convertToSimulatorTask<double>(inst);
 
   EXPECT_EQ(task.targets.size(), 2u);

--- a/unittests/ptsbe/TrajectoryDeduplicationTester.cpp
+++ b/unittests/ptsbe/TrajectoryDeduplicationTester.cpp
@@ -13,7 +13,6 @@
 #include <vector>
 
 using namespace cudaq;
-using namespace cudaq::ptsbe;
 
 static KrausTrajectory createTrajectory(std::size_t id, double prob,
                                         std::size_t errors = 0) {
@@ -32,24 +31,24 @@ static KrausTrajectory createTrajectoryWithSelections(
 TEST(TrajectoryDeduplicationTest, HashSameContentEqual) {
   KrausTrajectory a = createTrajectory(0, 0.5, 1);
   KrausTrajectory b = createTrajectory(1, 0.6, 1);
-  EXPECT_EQ(hashTrajectoryContent(a), hashTrajectoryContent(b));
+  EXPECT_EQ(ptsbe::hashTrajectoryContent(a), ptsbe::hashTrajectoryContent(b));
 }
 
 TEST(TrajectoryDeduplicationTest, HashDifferentContentDifferent) {
   KrausTrajectory a = createTrajectory(0, 0.5, 0);
   KrausTrajectory b = createTrajectory(0, 0.5, 1);
-  EXPECT_NE(hashTrajectoryContent(a), hashTrajectoryContent(b));
+  EXPECT_NE(ptsbe::hashTrajectoryContent(a), ptsbe::hashTrajectoryContent(b));
 }
 
 TEST(TrajectoryDeduplicationTest, EmptyInput) {
   std::vector<KrausTrajectory> empty;
-  auto result = deduplicateTrajectories(empty);
+  auto result = ptsbe::deduplicateTrajectories(empty);
   EXPECT_TRUE(result.empty());
 }
 
 TEST(TrajectoryDeduplicationTest, SingleTrajectory) {
   std::vector<KrausTrajectory> input = {createTrajectory(0, 0.5, 1)};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].multiplicity, 1);
   EXPECT_EQ(result[0].kraus_selections.size(), 1);
@@ -59,7 +58,7 @@ TEST(TrajectoryDeduplicationTest, SingleTrajectory) {
 TEST(TrajectoryDeduplicationTest, TwoIdenticalMergeToOne) {
   KrausTrajectory t = createTrajectory(0, 0.5, 1);
   std::vector<KrausTrajectory> input = {t, t};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].multiplicity, 2);
   EXPECT_EQ(result[0].kraus_selections.size(), 1);
@@ -68,7 +67,7 @@ TEST(TrajectoryDeduplicationTest, TwoIdenticalMergeToOne) {
 TEST(TrajectoryDeduplicationTest, TwoDistinctNoMerge) {
   std::vector<KrausTrajectory> input = {createTrajectory(0, 0.5, 0),
                                         createTrajectory(1, 0.5, 1)};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   ASSERT_EQ(result.size(), 2);
   EXPECT_EQ(result[0].multiplicity, 1);
   EXPECT_EQ(result[1].multiplicity, 1);
@@ -77,7 +76,7 @@ TEST(TrajectoryDeduplicationTest, TwoDistinctNoMerge) {
 TEST(TrajectoryDeduplicationTest, ThreeIdenticalMergeToOne) {
   KrausTrajectory t = createTrajectory(0, 0.25, 2);
   std::vector<KrausTrajectory> input = {t, t, t};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].multiplicity, 3);
   EXPECT_EQ(result[0].kraus_selections.size(), 2);
@@ -87,7 +86,7 @@ TEST(TrajectoryDeduplicationTest, TwoPairsTwoUnique) {
   KrausTrajectory a = createTrajectory(0, 0.5, 0);
   KrausTrajectory b = createTrajectory(1, 0.5, 1);
   std::vector<KrausTrajectory> input = {a, b, a, b};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   ASSERT_EQ(result.size(), 2);
   EXPECT_EQ(result[0].multiplicity, 2);
   EXPECT_EQ(result[1].multiplicity, 2);
@@ -97,7 +96,7 @@ TEST(TrajectoryDeduplicationTest, RepresentativeKeepsFirstProbability) {
   KrausTrajectory t1 = createTrajectory(10, 0.4, 1);
   KrausTrajectory t2 = createTrajectory(20, 0.6, 1);
   std::vector<KrausTrajectory> input = {t1, t2};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   ASSERT_EQ(result.size(), 1);
   EXPECT_NEAR(result[0].probability, 0.4, PROBABILITY_EPSILON);
   EXPECT_EQ(result[0].trajectory_id, 10);
@@ -107,7 +106,7 @@ TEST(TrajectoryDeduplicationTest, MultiplicitySumPreserved) {
   KrausTrajectory a = createTrajectory(0, 0.5, 0);
   KrausTrajectory b = createTrajectory(1, 0.5, 1);
   std::vector<KrausTrajectory> input = {a, a, a, b, b};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   ASSERT_EQ(result.size(), 2);
   std::size_t total_multiplicity = 0;
   for (const auto &trajectory : result)
@@ -117,7 +116,7 @@ TEST(TrajectoryDeduplicationTest, MultiplicitySumPreserved) {
 
 TEST(TrajectoryDeduplicationTest, MultiplicityAlwaysAtLeastOne) {
   std::vector<KrausTrajectory> input = {createTrajectory(0, 0.5, 1)};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   ASSERT_EQ(result.size(), 1);
   EXPECT_GE(result[0].multiplicity, 1);
 }
@@ -130,7 +129,7 @@ TEST(TrajectoryDeduplicationTest, DifferentOrderDifferentContent) {
   std::vector<KrausTrajectory> input = {
       createTrajectoryWithSelections(0, sel1, 0.25),
       createTrajectoryWithSelections(1, sel2, 0.25)};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   EXPECT_EQ(result.size(), 2);
 }
 
@@ -140,7 +139,7 @@ TEST(TrajectoryDeduplicationTest, SameContentDifferentIdAndShots) {
   KrausTrajectory t2 = createTrajectory(99, 0.5, 1);
   t2.num_shots = 200;
   std::vector<KrausTrajectory> input = {t1, t2};
-  auto result = deduplicateTrajectories(input);
+  auto result = ptsbe::deduplicateTrajectories(input);
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].multiplicity, 2);
   EXPECT_EQ(result[0].trajectory_id, 0);


### PR DESCRIPTION
Address comments from @schweitzpgi that pointed out the style did not match the existing codebase.