### PR TITLE
Update cmake constraint for wheel build (for upstream change)

### DIFF
--- a/pyproject.toml.cu12
+++ b/pyproject.toml.cu12
@@ -69,7 +69,7 @@ build-backend = "scikit_build_core.build"
 wheel.packages = ["python/cudaq"]
 build-dir = "_skbuild"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-cmake.minimum-version = "3.27"
+cmake.version = ">=3.27,<3.29"
 cmake.build-type = "Release"
 cmake.verbose = false
 cmake.args = [

--- a/pyproject.toml.cu13
+++ b/pyproject.toml.cu13
@@ -71,7 +71,7 @@ build-backend = "scikit_build_core.build"
 wheel.packages = ["python/cudaq"]
 build-dir = "_skbuild"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-cmake.minimum-version = "3.27"
+cmake.version = ">=3.27,<3.29"
 cmake.build-type = "Release"
 cmake.verbose = false
 cmake.args = [


### PR DESCRIPTION
This is needed due to the recent release of `build` 1.4.4

* https://pypi.org/project/build/1.4.4/
* https://github.com/pypa/build/releases/tag/1.4.4

More specifically, the `build` package now adds `--ignore-installed` during part of the build process, and since our cmake version pinnings weren't consistent across `[build-system]` and `[tool.scikit-build]`, cmake got updated to be >4 halfway through the build. CUDA-Q does not support cmake>4.