### PR TITLE
[NFC] Use std::span in remote client / argument-conversion APIs

### DIFF
--- a/python/runtime/utils/PyRemoteSimulatorQPU.cpp
+++ b/python/runtime/utils/PyRemoteSimulatorQPU.cpp
@@ -102,7 +102,7 @@ static void launchKernelStreamlineImpl(
   const bool requestOkay = remote_client->sendRequest(
       *mlirContext, executionContext,
       /*vqe_gradient=*/nullptr, /*vqe_optimizer=*/nullptr, /*vqe_n_params=*/0,
-      sim_name, name, nullptr, nullptr, 0, &errorMsg, &actualArgs);
+      sim_name, name, nullptr, nullptr, 0, &errorMsg, actualArgs);
   if (!requestOkay)
     throw std::runtime_error("Failed to launch kernel. Error: " + errorMsg);
 }

--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -194,7 +194,9 @@ public:
           return m_client->lowerKernelInPlace(prefabMod, name, *rawArgs);
         }
         return m_client->lowerKernel(*m_mlirContext, name, args, voidStarSize,
-                                     0, rawArgs);
+                                     0,
+                                     rawArgs ? std::span<void *const>{*rawArgs}
+                                             : std::span<void *const>{});
       }();
 
       auto jit =
@@ -274,7 +276,9 @@ public:
         *m_mlirContext, executionContext,
         /*vqe_gradient=*/nullptr, /*vqe_optimizer=*/nullptr, /*vqe_n_params=*/0,
         m_simName, name, make_degenerate_kernel_type(kernelFunc), args,
-        voidStarSize, &errorMsg, rawArgs, moduleOp);
+        voidStarSize, &errorMsg,
+        rawArgs ? std::span<void *const>{*rawArgs} : std::span<void *const>{},
+        moduleOp);
     if (!requestOkay)
       throw std::runtime_error("Failed to launch kernel. Error: " + errorMsg);
     if (isDirectInvocation &&

--- a/runtime/common/BaseRestRemoteClient.h
+++ b/runtime/common/BaseRestRemoteClient.h
@@ -112,7 +112,7 @@ public:
   lowerKernelCommon(mlir::MLIRContext &mlirContext, const std::string &name,
                     const void *args, std::uint64_t argsSize,
                     const std::size_t startingArgIdx,
-                    const std::vector<void *> *rawArgs, mlir::ModuleOp module) {
+                    std::span<void *const> rawArgs, mlir::ModuleOp module) {
     enablePrintMLIREachPass = getEnvBool("CUDAQ_MLIR_PRINT_EACH_PASS", false);
     // Extract the kernel name
     auto func = module.lookupSymbol<mlir::func::FuncOp>(
@@ -122,9 +122,8 @@ public:
       throw std::runtime_error("no kernel named " + name + " found in module");
 
     // Merge other modules (e.g., if there are device kernel calls).
-    if (rawArgs && !rawArgs->empty())
-      cudaq_internal::compiler::mergeAllCallableClosures(module, name,
-                                                         *rawArgs);
+    if (!rawArgs.empty())
+      cudaq_internal::compiler::mergeAllCallableClosures(module, name, rawArgs);
 
     // Create a new Module to clone the function into
     auto location = mlir::FileLineColLoc::get(&mlirContext, "<builder>", 1, 1);
@@ -156,12 +155,12 @@ public:
       return module;
     }();
     std::string passName;
-    if (rawArgs || args) {
+    if (!rawArgs.empty() || args) {
       mlir::PassManager pm(&mlirContext);
-      if (rawArgs && !rawArgs->empty()) {
+      if (!rawArgs.empty()) {
         CUDAQ_INFO("Run Argument Synth.\n");
         cudaq_internal::compiler::ArgumentConverter argCon(name, moduleOp);
-        argCon.gen_drop_front(*rawArgs, startingArgIdx);
+        argCon.gen_drop_front(rawArgs, startingArgIdx);
 
         // Store kernel and substitution strings on the stack.
         // We pass string references to the `createArgumentSynthesisPass`.
@@ -257,16 +256,16 @@ public:
 
   virtual mlir::ModuleOp
   lowerKernelInPlace(mlir::ModuleOp module, const std::string &name,
-                     const std::vector<void *> &rawArgs) override {
+                     std::span<void *const> rawArgs) override {
     return lowerKernelCommon</*cloneAgain=*/false>(
-        *module.getContext(), name, nullptr, 0, 0, &rawArgs, module);
+        *module.getContext(), name, nullptr, 0, 0, rawArgs, module);
   }
 
-  virtual mlir::ModuleOp
-  lowerKernel(mlir::MLIRContext &mlirContext, const std::string &name,
-              const void *args, std::uint64_t argsSize,
-              const std::size_t startingArgIdx,
-              const std::vector<void *> *rawArgs) override {
+  virtual mlir::ModuleOp lowerKernel(mlir::MLIRContext &mlirContext,
+                                     const std::string &name, const void *args,
+                                     std::uint64_t argsSize,
+                                     const std::size_t startingArgIdx,
+                                     std::span<void *const> rawArgs) override {
 
     // Get the quake representation of the kernel
     auto quakeCode = cudaq::get_quake_by_name(name);
@@ -283,7 +282,7 @@ public:
                                      const std::string &name, const void *args,
                                      std::uint64_t voidStarSize,
                                      std::size_t startingArgIdx,
-                                     const std::vector<void *> *rawArgs,
+                                     std::span<void *const> rawArgs,
                                      mlir::Operation *prefabMod) {
     ScopedTraceWithContext(cudaq::TIMING_JIT, "constructKernelPayload");
     mlir::ModuleOp moduleOp;
@@ -291,7 +290,7 @@ public:
     if (prefabMod) {
       ctx = prefabMod->getContext();
       moduleOp = lowerKernelInPlace(mlir::cast<mlir::ModuleOp>(prefabMod), name,
-                                    *rawArgs);
+                                    rawArgs);
     } else {
       ctx = &mlirContext;
       moduleOp = lowerKernel(mlirContext, name, args, voidStarSize,
@@ -314,12 +313,13 @@ public:
     return llvm::encodeBase64(mlirCode);
   }
 
-  cudaq::RestRequest constructVQEJobRequest(
-      mlir::MLIRContext &mlirContext, cudaq::ExecutionContext &io_context,
-      const std::string &backendSimName, const std::string &kernelName,
-      const void *kernelArgs, cudaq::gradient *gradient,
-      cudaq::optimizer &optimizer, const int n_params,
-      const std::vector<void *> *rawArgs) {
+  cudaq::RestRequest
+  constructVQEJobRequest(mlir::MLIRContext &mlirContext,
+                         cudaq::ExecutionContext &io_context,
+                         const std::string &backendSimName,
+                         const std::string &kernelName, const void *kernelArgs,
+                         cudaq::gradient *gradient, cudaq::optimizer &optimizer,
+                         const int n_params, std::span<void *const> rawArgs) {
     cudaq::RestRequest request(io_context, version());
 
     request.opt = RestRequestOptFields();
@@ -360,7 +360,7 @@ public:
       mlir::MLIRContext &mlirContext, cudaq::ExecutionContext &io_context,
       const std::string &backendSimName, const std::string &kernelName,
       void (*kernelFunc)(void *), const void *kernelArgs,
-      std::uint64_t argsSize, const std::vector<void *> *rawArgs,
+      std::uint64_t argsSize, std::span<void *const> rawArgs,
       mlir::Operation *prefabMod) {
 
     cudaq::RestRequest request(io_context, version());
@@ -389,11 +389,11 @@ public:
       stateIrPayload1.entryPoint = kernelName1;
       stateIrPayload1.ir =
           constructKernelPayload(mlirContext, kernelName1, nullptr, 0,
-                                 /*startingArgIdx=*/0, &args1, {});
+                                 /*startingArgIdx=*/0, args1, {});
       stateIrPayload2.entryPoint = kernelName2;
       stateIrPayload2.ir =
           constructKernelPayload(mlirContext, kernelName2, nullptr, 0,
-                                 /*startingArgIdx=*/0, &args2, {});
+                                 /*startingArgIdx=*/0, args2, {});
       // First kernel of the overlap calculation
       request.code = stateIrPayload1.ir;
       request.entryPoint = stateIrPayload1.entryPoint;
@@ -430,7 +430,7 @@ public:
               const int vqe_n_params, const std::string &backendSimName,
               const std::string &kernelName, void (*kernelFunc)(void *),
               const void *kernelArgs, std::uint64_t argsSize,
-              std::string *optionalErrorMsg, const std::vector<void *> *rawArgs,
+              std::string *optionalErrorMsg, std::span<void *const> rawArgs,
               mlir::Operation *prefabMod) override {
     cudaq::RestRequest request = [&]() {
       if (vqe_n_params > 0)

--- a/runtime/common/RemoteKernelExecutor.h
+++ b/runtime/common/RemoteKernelExecutor.h
@@ -17,6 +17,7 @@
 #include "common/Registry.h"
 #include "cudaq/remote_capabilities.h"
 #include <optional>
+#include <span>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
@@ -97,10 +98,10 @@ public:
                                      const void *kernelArgs,
                                      std::uint64_t argsSize,
                                      const std::size_t startingArgIdx,
-                                     const std::vector<void *> *rawArgs) = 0;
-  virtual mlir::ModuleOp
-  lowerKernelInPlace(mlir::ModuleOp module, const std::string &shortName,
-                     const std::vector<void *> &rawArgs) = 0;
+                                     std::span<void *const> rawArgs) = 0;
+  virtual mlir::ModuleOp lowerKernelInPlace(mlir::ModuleOp module,
+                                            const std::string &shortName,
+                                            std::span<void *const> rawArgs) = 0;
 
   // Delegate/send kernel execution to a remote server.
   // Subclass will implement necessary transport-layer serialization and
@@ -113,7 +114,7 @@ public:
               const std::string &kernelName, void (*kernelFunc)(void *),
               const void *kernelArgs, std::uint64_t argsSize,
               std::string *optionalErrorMsg = nullptr,
-              const std::vector<void *> *rawArgs = nullptr,
+              std::span<void *const> rawArgs = {},
               mlir::Operation *prefabMod = nullptr) = 0;
   // Destructor
   virtual ~RemoteRuntimeClient() = default;

--- a/runtime/internal/compiler/ArgumentConversion.cpp
+++ b/runtime/internal/compiler/ArgumentConversion.cpp
@@ -846,12 +846,12 @@ ArgumentConverter::ArgumentConverter(StringRef kernelName,
                                      ModuleOp sourceModule)
     : sourceModule(sourceModule), kernelName(kernelName) {}
 
-void ArgumentConverter::gen(const std::vector<void *> &arguments) {
+void ArgumentConverter::gen(std::span<void *const> arguments) {
   gen(kernelName, sourceModule, arguments);
 }
 
 void ArgumentConverter::gen(StringRef kernelName, ModuleOp sourceModule,
-                            const std::vector<void *> &arguments) {
+                            std::span<void *const> arguments) {
   auto *ctx = sourceModule.getContext();
   OpBuilder builder(ctx);
   ModuleOp substModule =
@@ -961,7 +961,7 @@ void ArgumentConverter::gen(StringRef kernelName, ModuleOp sourceModule,
   }
 }
 
-void ArgumentConverter::gen(const std::vector<void *> &arguments,
+void ArgumentConverter::gen(std::span<void *const> arguments,
                             const std::unordered_set<unsigned> &exclusions) {
   std::vector<void *> partialArgs;
   for (auto iter : llvm::enumerate(arguments)) {
@@ -974,7 +974,7 @@ void ArgumentConverter::gen(const std::vector<void *> &arguments,
   gen(partialArgs);
 }
 
-void ArgumentConverter::gen_drop_front(const std::vector<void *> &arguments,
+void ArgumentConverter::gen_drop_front(std::span<void *const> arguments,
                                        unsigned numDrop) {
   // If we're dropping all the arguments, we're done.
   if (numDrop >= arguments.size())
@@ -994,7 +994,7 @@ void ArgumentConverter::gen_drop_front(const std::vector<void *> &arguments,
 
 bool cudaq_internal::compiler::mergeAllCallableClosures(
     ModuleOp intoModule, const std::string &shortName,
-    const std::vector<void *> &rawArgs, std::optional<unsigned> betaRedux) {
+    std::span<void *const> rawArgs, std::optional<unsigned> betaRedux) {
   if (rawArgs.empty())
     return false;
   auto fullName = cudaq::runtime::cudaqGenPrefixName + shortName;

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/ArgumentConversion.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/ArgumentConversion.h
@@ -13,6 +13,7 @@
 #include "cudaq/qis/state.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Types.h"
+#include <span>
 #include <unordered_set>
 #include <vector>
 
@@ -60,21 +61,21 @@ public:
 
   /// Generate a substitution ModuleOp for the vector of arguments presented.
   /// The arguments are those presented to the kernel, kernelName.
-  void gen(const std::vector<void *> &arguments);
+  void gen(std::span<void *const> arguments);
 
   /// Generate a substitution ModuleOp for the vector of arguments presented.
   /// The arguments are those presented to the kernel, kernelName.
   void gen(mlir::StringRef kernelName, mlir::ModuleOp sourceModule,
-           const std::vector<void *> &arguments);
+           std::span<void *const> arguments);
 
   /// Generate a substitution ModuleOp but include only the arguments that do
   /// not appear in the set of \p exclusions.
-  void gen(const std::vector<void *> &arguments,
+  void gen(std::span<void *const> arguments,
            const std::unordered_set<unsigned> &exclusions);
 
   /// Generate a substitution ModuleOp but drop the first \p numDrop arguments
   /// and thereby exclude them from the substitutions.
-  void gen_drop_front(const std::vector<void *> &arguments, unsigned numDrop);
+  void gen_drop_front(std::span<void *const> arguments, unsigned numDrop);
 
   /// Get the kernel info that were collected by `gen()`.
   mlir::SmallVector<KernelSubstitutionInfo *> &getKernelSubstitutions() {
@@ -123,7 +124,7 @@ private:
 /// Return <code>true</code> if and only if \p intoModule has been modified.
 bool mergeAllCallableClosures(mlir::ModuleOp intoModule,
                               const std::string &shortName,
-                              const std::vector<void *> &rawArgs,
+                              std::span<void *const> rawArgs,
                               std::optional<unsigned> betaRedux = {});
 
 } // namespace cudaq_internal::compiler


### PR DESCRIPTION
Change signatures in `RemoteRuntimeClient`, `ArgumentConverter::gen*` and `mergeAllCallableClosures` to take `std::span`s instead of `const std::vector<void *> *` or `const std::vector<void *> &`.

This is more general and casting from a reference to span is implicit, so most call sites remain unchanged. Note that technically, a pointer to a vector can distinguish the empty vector from no vector (`nullptr`), but this distinction is never made in the code, so using `span`s removes this unnecessary distinction as well.
