### PR TITLE
[cc] Measure handle type

### DIFF
--- a/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
+++ b/include/cudaq/Optimizer/Dialect/CC/CCTypes.td
@@ -283,6 +283,27 @@ def cc_CharSpanType
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// MeasureHandleType - opaque, word-sized classical value
+//===----------------------------------------------------------------------===//
+
+def cc_MeasureHandleType : CCType<"MeasureHandle", "measure_handle"> {
+  let summary = "An opaque word-sized handle for a measurement event.";
+  let description = [{
+    The IR alias of the C++ `cudaq::measure_handle` class. Semantically an
+    opaque, word-sized classical value (an `i64` payload) whose only meaningful
+    consumer is `quake.discriminate`. The bridge emits this type so that
+    verification passes can reject entry-point kernels that leak handles across
+    the host-device boundary; a late lowering pass replaces it with `i64`
+    before QIR emission.
+
+    ```mlir
+      %mh = quake.mz %q name "mh" : (!quake.ref) -> !cc.measure_handle
+      %b  = quake.discriminate %mh : (!cc.measure_handle) -> i1
+    ```
+  }];
+}
+
 def IsSpanLikePred : CPred<"isa<cudaq::cc::SpanLikeType>($_self)">;
 def SpanningType : Type<IsSpanLikePred, "dynamic length type">;
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -1065,8 +1065,17 @@ class Measurement<string mnemonic> : QuakeOp<mnemonic, [MeasurementInterface,
     Variadic<AnyQTargetType>:$targets,
     OptionalAttr<StrAttr>:$registerName
   );
+  // The classical result of a measurement is one of:
+  //   - !quake.measure                   (the legacy SSA result),
+  //   - !cc.measure_handle               (the cudaq::measure_handle alias),
+  //   - !cc.stdvec<!quake.measure>       (vector of legacy results),
+  //   - !cc.stdvec<!cc.measure_handle>   (vector of handles).
+  // The handle forms are emitted by the bridge for `cudaq::measure_handle`
+  // callers (overloads of `mz`/`mx`/`my`) and are lowered to `i64` by
+  // `--convert-to-qir-api`'s `TypeConverter`.
   let results = (outs
-    AnyTypeOf<[MeasureType, StdvecOf<[MeasureType]>]>:$measOut,
+    AnyTypeOf<[MeasureType, cc_MeasureHandleType,
+               StdvecOf<[MeasureType, cc_MeasureHandleType]>]>:$measOut,
     Variadic<WireType>:$wires
   );
 
@@ -1131,19 +1140,21 @@ def MzOp : Measurement<"mz"> {
 def quake_DiscriminateOp : QuakeOp<"discriminate", [Pure]> {
   let summary = "Converts a measurement to a classical integral value.";
   let description = [{
-    Quake's measurement operators return a value of type `!quake.measure`. The
-    discriminate operation converts a value of type measure to a classical
-    integral value. This value is typically an `i1` type, but might be `i2` for
-    qutrits, or even an `i8` for general qudits.
+    Quake's measurement operators return a value of type `!quake.measure` or,
+    for `cudaq::measure_handle` callers, `!cc.measure_handle`. The
+    discriminate operation converts either form to a classical integral value.
+    The result is typically an `i1`, but might be `i2` for qutrits, or `i8`
+    for general qudits.
 
     While a measurement of a wire changes/corrupts the state of the wire, the
-    model maintains that a `!quake.measure` value is non-volatile. Therefore,
-    multiple applications of discriminate on the same `!quake.measure` value
-    will yield the same result value for a given result type.
+    model maintains that the classical measurement value is non-volatile.
+    Multiple applications of discriminate on the same value will yield the
+    same result for a given result type.
   }];
 
   let arguments = (ins
-    AnyTypeOf<[MeasureType, StdvecOf<[MeasureType]>]>:$measurement
+    AnyTypeOf<[MeasureType, cc_MeasureHandleType,
+               StdvecOf<[MeasureType, cc_MeasureHandleType]>]>:$measurement
   );
   let results = (outs
     AnyTypeOf<[AnySignlessInteger, StdvecOf<[AnySignlessInteger]>]>

--- a/lib/Optimizer/CodeGen/ConvertCCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/ConvertCCToLLVM.cpp
@@ -45,6 +45,9 @@ void cudaq::opt::populateCCTypeConversions(LLVMTypeConverter *converter) {
   converter->addConversion([](cc::IndirectCallableType type) {
     return IntegerType::get(type.getContext(), 64);
   });
+  converter->addConversion([](cc::MeasureHandleType type) {
+    return IntegerType::get(type.getContext(), 64);
+  });
   converter->addConversion([](cc::CallableType type) {
     return lambdaAsPairOfPointers(type.getContext());
   });

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -377,6 +377,11 @@ LogicalResult cudaq::cc::CastOp::verify() {
     } else if (isa<IntegerType>(inTy) && isa<cc::IndirectCallableType>(outTy)) {
       // ok: nop
       // the indirect callable value is an integer key on the device side.
+    } else if (isa<IntegerType>(inTy) && isa<cc::MeasureHandleType>(outTy)) {
+      // ok: nop
+      // the measure handle is an opaque i64 payload.
+    } else if (isa<cc::MeasureHandleType>(inTy) && isa<IntegerType>(outTy)) {
+      // ok: nop
     } else if (isa<IntegerType>(inTy) && isa<cc::PointerType>(outTy)) {
       // ok: inttoptr
     } else if (isa<cc::PointerType>(inTy) && isa<IntegerType>(outTy)) {

--- a/lib/Optimizer/Dialect/CC/CCTypes.cpp
+++ b/lib/Optimizer/Dialect/CC/CCTypes.cpp
@@ -231,7 +231,7 @@ bool isDynamicallySizedType(Type ty) {
 
 void CCDialect::registerTypes() {
   addTypes<ArrayType, CallableType, CharspanType, IndirectCallableType,
-           PointerType, StdvecType, StructType>();
+           MeasureHandleType, PointerType, StdvecType, StructType>();
 }
 
 } // namespace cudaq::cc

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -828,13 +828,19 @@ LogicalResult verifyMeasurements(MEAS op, TypeRange targetsType,
       targetsType.size() > 1 ||
       (targetsType.size() == 1 && isa<quake::VeqType>(targetsType[0]));
   if (mustBeStdvec) {
-    if (!isa<cudaq::cc::StdvecType>(op.getMeasOut().getType()))
-      return op.emitOpError("must return `!cc.stdvec<!quake.measure>`, when "
-                            "measuring a qreg, a series of qubits, or both");
+    auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(op.getMeasOut().getType());
+    if (!stdvecTy || !isa<quake::MeasureType, cudaq::cc::MeasureHandleType>(
+                         stdvecTy.getElementType()))
+      return op.emitOpError(
+          "must return `!cc.stdvec<!quake.measure>` or "
+          "`!cc.stdvec<!cc.measure_handle>` when measuring a qvector, a "
+          "series of qubits, or both");
   } else {
-    if (!isa<quake::MeasureType>(op.getMeasOut().getType()))
+    if (!isa<quake::MeasureType, cudaq::cc::MeasureHandleType>(
+            op.getMeasOut().getType()))
       return op->emitOpError(
-          "must return `!quake.measure` when measuring exactly one qubit");
+          "must return `!quake.measure` or `!cc.measure_handle` when "
+          "measuring exactly one qubit");
   }
   if (op.getRegisterName())
     if (op.getRegisterName()->empty())
@@ -865,11 +871,13 @@ LogicalResult quake::DiscriminateOp::verify() {
   if (isa<cudaq::cc::StdvecType>(getMeasurement().getType())) {
     auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(getResult().getType());
     if (!stdvecTy || !isa<IntegerType>(stdvecTy.getElementType()))
-      return emitOpError("must return a !cc.stdvec<integral> type, when "
-                         "discriminating a qreg, a series of qubits, or both");
+      return emitOpError(
+          "must return a !cc.stdvec<integral> type, when discriminating a "
+          "qvector, a series of qubits, or both");
   } else {
-    auto measTy = isa<quake::MeasureType>(getMeasurement().getType());
-    if (!measTy || !isa<IntegerType>(getResult().getType()))
+    if (!isa<quake::MeasureType, cudaq::cc::MeasureHandleType>(
+            getMeasurement().getType()) ||
+        !isa<IntegerType>(getResult().getType()))
       return emitOpError(
           "must return integral type when discriminating exactly one qubit");
   }

--- a/test/Transforms/invalid.qke
+++ b/test/Transforms/invalid.qke
@@ -226,3 +226,11 @@ func.func private @wonk(!quake.veq<18>, i32) -> f64
 
 // expected-error@+1 {{cannot classically allocate quake abstract type}}
 %0 = cc.alloca !quake.measure
+
+// -----
+
+func.func @mz_handle_register_scalar_result(%v: !quake.veq<?>) {
+  // expected-error@+1 {{must return `!cc.stdvec<!quake.measure>` or `!cc.stdvec<!cc.measure_handle>`}}
+  %m = quake.mz %v : (!quake.veq<?>) -> !cc.measure_handle
+  return
+}

--- a/test/Transforms/roundtrip-ops.qke
+++ b/test/Transforms/roundtrip-ops.qke
@@ -998,3 +998,31 @@ func.func @measure_handle_cast_roundtrip(%i : i64) -> i64 {
 // CHECK:         %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.measure_handle) -> i64
 // CHECK:         return %[[VAL_2]] : i64
 // CHECK:       }
+
+
+func.func @measure_handle_mz_one(%q : !quake.ref) -> i1 {
+  %m = quake.mz %q name "h" : (!quake.ref) -> !cc.measure_handle
+  %b = quake.discriminate %m : (!cc.measure_handle) -> i1
+  return %b : i1
+}
+
+// CHECK-LABEL: func.func @measure_handle_mz_one(
+// CHECK-SAME:    %[[VAL_0:.*]]: !quake.ref) -> i1 {
+// CHECK:         %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "h" : (!quake.ref) -> !cc.measure_handle
+// CHECK:         %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!cc.measure_handle) -> i1
+// CHECK:         return %[[VAL_2]] : i1
+// CHECK:       }
+
+func.func @measure_handle_mx_vec(%v : !quake.veq<?>) -> !cc.stdvec<i1> {
+  %m = quake.mx %v : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+  %b = quake.discriminate %m
+      : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+  return %b : !cc.stdvec<i1>
+}
+
+// CHECK-LABEL: func.func @measure_handle_mx_vec(
+// CHECK-SAME:    %[[VAL_0:.*]]: !quake.veq<?>) -> !cc.stdvec<i1> {
+// CHECK:         %[[VAL_1:.*]] = quake.mx %[[VAL_0]] : (!quake.veq<?>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:         %[[VAL_2:.*]] = quake.discriminate %[[VAL_1]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+// CHECK:         return %[[VAL_2]] : !cc.stdvec<i1>
+// CHECK:       }

--- a/test/Transforms/roundtrip-ops.qke
+++ b/test/Transforms/roundtrip-ops.qke
@@ -975,3 +975,26 @@ func.func @integrated_device() {
 // CHECK:           %[[VAL_14:.*]] = cc.device_call @integrated_device_callback<%[[VAL_2]], %[[VAL_10]], %[[VAL_11]] * %[[VAL_3]], %[[VAL_12]], %[[VAL_13]]> on %[[VAL_5]](%[[VAL_0]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK:           return
 // CHECK:         }
+
+
+func.func @measure_handle_passthrough(%h : !cc.measure_handle) -> !cc.measure_handle {
+  return %h : !cc.measure_handle
+}
+
+// CHECK-LABEL: func.func @measure_handle_passthrough(
+// CHECK-SAME:    %[[VAL_0:.*]]: !cc.measure_handle) -> !cc.measure_handle {
+// CHECK:         return %[[VAL_0]] : !cc.measure_handle
+// CHECK:       }
+
+func.func @measure_handle_cast_roundtrip(%i : i64) -> i64 {
+  %h = cc.cast %i : (i64) -> !cc.measure_handle
+  %r = cc.cast %h : (!cc.measure_handle) -> i64
+  return %r : i64
+}
+
+// CHECK-LABEL: func.func @measure_handle_cast_roundtrip(
+// CHECK-SAME:    %[[VAL_0:.*]]: i64) -> i64 {
+// CHECK:         %[[VAL_1:.*]] = cc.cast %[[VAL_0]] : (i64) -> !cc.measure_handle
+// CHECK:         %[[VAL_2:.*]] = cc.cast %[[VAL_1]] : (!cc.measure_handle) -> i64
+// CHECK:         return %[[VAL_2]] : i64
+// CHECK:       }


### PR DESCRIPTION
## Summary
Introduce `!cc.measure_handle` - the IR alias for the source-language `cudaq::measure_handle` - and widen `quake.mz`/`mx`/`my` and `quake.discriminate` ODS / verifiers to admit it alongside the existing `!quake.measure` form. Pure IR vocabulary: no path yet produces or consumes the new type. This is the prologue of a small stack; lowering through `convert-to-qir-api` lands in a follow-up PR, frontend bindings after that.

## Motivation
`cudaq::measure_handle` is a distinct source-language type from both raw integers and the existing measurement token: integer-shaped at the bit level, but identity-preserving for analyses that need to distinguish a measurement event from arbitrary i64 traffic. Landing the IR vocabulary first gives the QIR conversion PR and the frontend PRs a stable target without forcing the ODS contracts to churn step by step.

## What Changed
- **New type** `!cc.measure_handle` in the CC dialect; i64 payload, opaque to the IR. Registered with the CC dialect, lowered to `i64` in the CC->LLVM type converter, and `cc.cast` admits no-op `i64 <-> !cc.measure_handle`.
- **ODS widening** on `quake.mz`/`mx`/`my` results and `quake.discriminate` operand: now `!cc.measure_handle` or `!cc.stdvec<!cc.measure_handle>` are admitted in addition to the prior `!quake.measure` forms.
- **Verifier widening**: `verifyMeasurements` and `DiscriminateOp::verify` accept the new shape; arity diagnostics mention both spellings so users see why a scalar-typed result is rejected when measuring a register.
- **Tests**: `test/Transforms/roundtrip-ops.qke` (passthrough + `i64 <-> !cc.measure_handle` `cc.cast` round-trip), `test/Transforms/invalid.qke` (verifier negatives).

## Risks
No behavioral change in this PR: no path produces or consumes `!cc.measure_handle` until the follow-up PR lands. Risk is bounded to ODS coverage gaps that would surface in the consumer; the follow-up wires up `--convert-to-qir-api` and tests it.

## Downstream Impact
- CUDA-QX: none.
- Public API: none.
- Stack: lowering through `--convert-to-qir-api` lands in a follow-up PR built on this branch; C++/Python frontend bindings land after that.