### PR TITLE
[python] Add IonQ observe broadcast regression test

### DIFF
--- a/python/tests/backends/test_IonQ.py
+++ b/python/tests/backends/test_IonQ.py
@@ -144,6 +144,31 @@ def test_ionq_observe():
     assert assert_close(res.expectation())
 
 
+def test_ionq_observe_broadcast():
+    qubit_count = 5
+    sample_count = 4
+    shots_count = 10000
+    parameters = np.random.default_rng(13).uniform(low=0,
+                                                   high=1,
+                                                   size=(sample_count,
+                                                         qubit_count))
+
+    @cudaq.kernel
+    def kernel(qubit_count: int, parameters: List[float]):
+        qvector = cudaq.qvector(qubit_count)
+        for i in range(qubit_count - 1):
+            rx(parameters[i], qvector[i])
+
+    results = cudaq.observe(kernel,
+                            spin.z(0), [qubit_count] * sample_count,
+                            parameters,
+                            shots_count=shots_count)
+    expected = np.cos(parameters[:, 0])
+
+    assert len(results) == sample_count
+    assert np.allclose([r.expectation() for r in results], expected, atol=0.1)
+
+
 def test_ionq_u3_decomposition():
 
     @cudaq.kernel


### PR DESCRIPTION
## Summary

Follow-up to #4395 (which fixed `cudaq.observe` broadcast on REST QPU targets). That PR added regression tests for OQC and Quantinuum but not IonQ, even though #4363 explicitly listed IonQ as affected. IonQ uses the same `BaseRemoteRESTQPU` path, so an analogous test in `test_IonQ.py` closes the coverage gap.

The new test mirrors `test_OQC_observe_broadcast` / `test_quantinuum_observe_broadcast` exactly: a 4-sample parameter sweep through `cudaq.observe(...)` on `spin.z(0)`, with results compared to the analytical `cos(theta)` answer.

## Verification

I reproduced the original `TypeError` against `target='ionq'` (both `emulate=True` and the real cloud `qpu='simulator'`), applied the fix from #4395, and confirmed the broadcast call now returns correct expectation values within shot noise. The new test passes on the post-#4395 main.

## Test plan

- [x] `yapf --style google` clean
- [x] Manually verified against the real IonQ cloud simulator (broadcast `observe`, 3 parameter sets, 200 shots, results within 0.02 of analytical `cos(theta)`)
- [ ] CI: `python/tests/backends/test_IonQ.py::test_ionq_observe_broadcast`