### PR TITLE
[llvm22] Fixes the cross-DSO TypeID split

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -297,14 +297,6 @@ jobs:
           name: pycudaq-${{ matrix.python_version }}-darwin-arm64
           path: dist/
 
-      - name: Diagnose wheel import
-        run: |
-          DIAG_VENV="$RUNNER_TEMP/cudaq-import-diag"
-          python${{ matrix.python_version }} -m venv "$DIAG_VENV"
-          source "$DIAG_VENV/bin/activate"
-          pip install --find-links dist "cuda-quantum-cu13==${{ needs.wheel.outputs.cudaq_version }}"
-          python -X faulthandler -c "import cudaq; print('IMPORT_OK')" 2>&1 || true
-
       - name: Validate wheel
         run: |
           # Validates wheel: core tests, examples, snippets, backends.

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -358,6 +358,23 @@ jobs:
             python -X faulthandler -c "import cudaq; print('import ok')" 2>&1 | tee /tmp/import_cudaq.log || true
             echo "::endgroup::"
 
+            echo "::group::TypeID DSO diagnostic (BuiltinDialect)"
+            site_pkgs=$(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])" 2>/dev/null || true)
+            if [ -n "$site_pkgs" ]; then
+              find "$site_pkgs" \( -name 'libCUDAQuantumPythonCAPI.so' \
+                                -o -name '_quakeDialects*.so' \
+                                -o -name 'libcudaq-mlir-runtime.so' \) -print 2>/dev/null \
+              | while read f; do
+                  echo "--- $f ---"
+                  nm -D --defined-only "$f" 2>/dev/null | grep TypeIDResolverINS_14BuiltinDialect \
+                    || echo "(no defined BuiltinDialect TypeID symbol)"
+                  echo "(undefined refs:)"
+                  nm -D --undefined-only "$f" 2>/dev/null | grep TypeIDResolverINS_14BuiltinDialect | head -5 \
+                    || echo "(none)"
+                done
+            fi
+            echo "::endgroup::"
+
             python -m pip install pytest pytest-xdist
             python -m pytest -v --durations=0 -n auto python/tests/ \
               --ignore python/tests/backends \

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -354,27 +354,6 @@ jobs:
               exit 1
             fi
 
-            echo "::group::cudaq import smoke-test"
-            python -X faulthandler -c "import cudaq; print('import ok')" 2>&1 | tee /tmp/import_cudaq.log || true
-            echo "::endgroup::"
-
-            echo "::group::TypeID DSO diagnostic (BuiltinDialect)"
-            site_pkgs=$(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])" 2>/dev/null || true)
-            if [ -n "$site_pkgs" ]; then
-              find "$site_pkgs" \( -name 'libCUDAQuantumPythonCAPI.so' \
-                                -o -name '_quakeDialects*.so' \
-                                -o -name 'libcudaq-mlir-runtime.so' \) -print 2>/dev/null \
-              | while read f; do
-                  echo "--- $f ---"
-                  nm -D --defined-only "$f" 2>/dev/null | grep TypeIDResolverINS_14BuiltinDialect \
-                    || echo "(no defined BuiltinDialect TypeID symbol)"
-                  echo "(undefined refs:)"
-                  nm -D --undefined-only "$f" 2>/dev/null | grep TypeIDResolverINS_14BuiltinDialect | head -5 \
-                    || echo "(none)"
-                done
-            fi
-            echo "::endgroup::"
-
             python -m pip install pytest pytest-xdist
             python -m pytest -v --durations=0 -n auto python/tests/ \
               --ignore python/tests/backends \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,7 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 if(APPLE)
   SET(CMAKE_INSTALL_RPATH "@loader_path;@loader_path/lib;@loader_path/lib/plugins;@loader_path/../lib;@loader_path/../lib/plugins;@executable_path;@executable_path/lib;@executable_path/lib/plugins;@executable_path/../lib;@executable_path/../lib/plugins")
 else()
-  SET(CMAKE_INSTALL_RPATH "$ORIGIN:$ORIGIN/lib:$ORIGIN/lib/plugins:$ORIGIN/../lib:$ORIGIN/../lib/plugins")
+  SET(CMAKE_INSTALL_RPATH "$ORIGIN:$ORIGIN/lib:$ORIGIN/lib/plugins:$ORIGIN/../lib:$ORIGIN/../lib/plugins:$ORIGIN/../cudaq/mlir/_mlir_libs:$ORIGIN/../python/cudaq/mlir/_mlir_libs")
 endif()
 
 SET(BLA_STATIC ON)

--- a/pyproject.toml.cu12
+++ b/pyproject.toml.cu12
@@ -87,5 +87,16 @@ if.platform-machine = "x86_64"
 inherit.cmake.args = "append"
 cmake.args = ["-DCUDAQ_ENABLE_PASQAL_QRMI_CONNECTOR=ON"]
 
+# Linux: use LLD as the linker
+[[tool.scikit-build.overrides]]
+if.platform-system = "linux"
+inherit.cmake.args = "append"
+cmake.args = [
+    "-DLLVM_USE_LINKER=lld",
+    "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -B/usr/local/llvm/bin",
+    "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld -B/usr/local/llvm/bin",
+    "-DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld -B/usr/local/llvm/bin",
+]
+
 [tool.setuptools_scm]
 write_to = "_version.py"

--- a/pyproject.toml.cu13
+++ b/pyproject.toml.cu13
@@ -89,6 +89,17 @@ if.platform-machine = "x86_64"
 inherit.cmake.args = "append"
 cmake.args = ["-DCUDAQ_ENABLE_PASQAL_QRMI_CONNECTOR=ON"]
 
+# Linux: use LLD as the linker
+[[tool.scikit-build.overrides]]
+if.platform-system = "linux"
+inherit.cmake.args = "append"
+cmake.args = [
+    "-DLLVM_USE_LINKER=lld",
+    "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -B/usr/local/llvm/bin",
+    "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld -B/usr/local/llvm/bin",
+    "-DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld -B/usr/local/llvm/bin",
+]
+
 # macOS: Disable symbol stripping. LLVM's JIT relies on local symbols for
 # internal data structures (eg., PassRegistry). On macOS
 # with it's two-level namespace they are removed by stripping which

--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -289,28 +289,6 @@ if(TARGET cudaq-mlir-runtime AND TARGET CUDAQuantumPythonCAPI)
   add_dependencies(cudaq-mlir-runtime CUDAQuantumPythonCAPI)
 endif()
 
-if(APPLE AND TARGET CUDAQuantumPythonModules.extension._quakeDialects.dso)
-  set(_darwin_typeid_diag_script
-    "${CMAKE_CURRENT_BINARY_DIR}/darwin_typeid_diag.sh")
-  file(GENERATE OUTPUT "${_darwin_typeid_diag_script}" CONTENT
-"#!/bin/sh
-echo '--- CAPI: TypeIDResolver BuiltinDialect symbol ---'
-nm -g '$<TARGET_FILE:CUDAQuantumPythonCAPI>' | grep TypeIDResolverINS_14BuiltinDialect || echo '(no match in CAPI)'
-echo '--- _quakeDialects: TypeIDResolver BuiltinDialect symbol ---'
-nm -gm '$<TARGET_FILE:CUDAQuantumPythonModules.extension._quakeDialects.dso>' | grep TypeIDResolverINS_14BuiltinDialect || echo '(no match in _quakeDialects)'
-echo '--- cudaq-mlir-runtime: TypeIDResolver BuiltinDialect symbol ---'
-nm -g '$<TARGET_FILE:cudaq-mlir-runtime>' | grep TypeIDResolverINS_14BuiltinDialect || echo '(no match in cudaq-mlir-runtime)'
-echo '--- _quakeDialects: namespace flag (should be flat) ---'
-otool -hv '$<TARGET_FILE:CUDAQuantumPythonModules.extension._quakeDialects.dso>' 2>/dev/null | grep -E 'TWOLEVEL|flags' || echo '(otool unavailable)'
-exit 0
-")
-  add_custom_command(
-    TARGET CUDAQuantumPythonModules.extension._quakeDialects.dso POST_BUILD
-    COMMENT "Darwin diag: BuiltinDialect TypeID symbol distribution"
-    COMMAND sh "${_darwin_typeid_diag_script}"
-  )
-endif()
-
 ## The Python bindings module for Quake dialect depends on CUDAQ libraries
 ## which it can't locate since they are in "../../lib" and the 'rpath' is set
 ## to '$ORIGIN' by default.

--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -266,7 +266,7 @@ if(TARGET CUDAQuantumPythonModules.extension._quakeDialects.dso)
   endif()
 endif()
 
-if(APPLE AND TARGET cudaq-mlir-runtime AND TARGET CUDAQuantumPythonCAPI)
+if(TARGET cudaq-mlir-runtime AND TARGET CUDAQuantumPythonCAPI)
   get_target_property(_mr_link_options cudaq-mlir-runtime LINK_OPTIONS)
   if(_mr_link_options)
     list(REMOVE_ITEM _mr_link_options
@@ -277,8 +277,13 @@ if(APPLE AND TARGET cudaq-mlir-runtime AND TARGET CUDAQuantumPythonCAPI)
       PROPERTIES LINK_OPTIONS "${_mr_link_options}")
   endif()
   target_link_options(cudaq-mlir-runtime BEFORE PRIVATE
-    "$<TARGET_FILE:CUDAQuantumPythonCAPI>"
-    "LINKER:-undefined,dynamic_lookup")
+    "$<TARGET_FILE:CUDAQuantumPythonCAPI>")
+  target_link_libraries(cudaq-mlir-runtime INTERFACE
+    $<BUILD_INTERFACE:CUDAQuantumPythonCAPI>)
+  if(APPLE)
+    target_link_options(cudaq-mlir-runtime PRIVATE
+      "LINKER:-undefined,dynamic_lookup")
+  endif()
   set_property(TARGET cudaq-mlir-runtime APPEND PROPERTY
     BUILD_RPATH "$<TARGET_FILE_DIR:CUDAQuantumPythonCAPI>")
   add_dependencies(cudaq-mlir-runtime CUDAQuantumPythonCAPI)


### PR DESCRIPTION
LLVM ERROR: can't create Attribute 'mlir::StringAttr' because storage uniquer isn't initialized: the dialect was likely not loaded.

- Root cause
  - `libcudaq-mlir-runtime.so` had its own TypeID copies on Linux.The Apple-only CAPI-prepend block was never extended to Linux.
  - Appended `$ORIGIN/../cudaq/mlir/_mlir_libs` (wheel/install layout) and `$ORIGIN/../python/cudaq/mlir/_mlir_libs` (build tree) to the global Linux `CMAKE_INSTALL_RPATH`
  - Wheel build used BFD ld, not LLD, on Linux. `build_cudaq.sh` passes `-DLLVM_USE_LINKER=lld` but scikit-build-core didn't. Under BFD, the CAPI-prepend trick fails for `_quakeDialects.so`. Added a Linux-only override in `pyproject.toml`, `pyproject.toml.cu12`, `pyproject.toml.cu13`.














