### PR TITLE
Fixes a miscompile of cc.loop while-loop

### DIFF
--- a/lib/Optimizer/Transforms/LoopAnalysis.cpp
+++ b/lib/Optimizer/Transforms/LoopAnalysis.cpp
@@ -75,8 +75,11 @@ static bool isaConstantOf(Value v, std::int64_t hasVal) {
 }
 
 static bool isClosedIntervalForm(arith::CmpIPredicate p) {
-  return p == arith::CmpIPredicate::ule || p == arith::CmpIPredicate::sle ||
-         p == arith::CmpIPredicate::uge || p == arith::CmpIPredicate::sge;
+  return p == arith::CmpIPredicate::ule || p == arith::CmpIPredicate::sle;
+}
+
+static bool isClosedIntervalDownForm(arith::CmpIPredicate p) {
+  return p == arith::CmpIPredicate::uge || p == arith::CmpIPredicate::sge;
 }
 
 static bool isSemiOpenIntervalForm(arith::CmpIPredicate p) {
@@ -333,8 +336,8 @@ bool opt::LoopComponents::shouldCommuteStepOp() const {
 }
 
 bool opt::LoopComponents::isClosedIntervalForm() const {
-  auto cmp = cast<arith::CmpIOp>(compareOp);
-  return ::isClosedIntervalForm(cmp.getPredicate());
+  auto p = cast<arith::CmpIOp>(compareOp).getPredicate();
+  return ::isClosedIntervalForm(p) || ::isClosedIntervalDownForm(p);
 }
 
 bool opt::LoopComponents::isLinearExpr() const {

--- a/lib/Optimizer/Transforms/LoopAnalysis.cpp
+++ b/lib/Optimizer/Transforms/LoopAnalysis.cpp
@@ -75,7 +75,8 @@ static bool isaConstantOf(Value v, std::int64_t hasVal) {
 }
 
 static bool isClosedIntervalForm(arith::CmpIPredicate p) {
-  return p == arith::CmpIPredicate::ule || p == arith::CmpIPredicate::sle;
+  return p == arith::CmpIPredicate::ule || p == arith::CmpIPredicate::sle ||
+         p == arith::CmpIPredicate::uge || p == arith::CmpIPredicate::sge;
 }
 
 static bool isSemiOpenIntervalForm(arith::CmpIPredicate p) {

--- a/lib/Optimizer/Transforms/LoopNormalizePatterns.inc
+++ b/lib/Optimizer/Transforms/LoopNormalizePatterns.inc
@@ -156,6 +156,24 @@ public:
                !isa<cudaq::cc::ContinueOp>(op);
       });
     }
+
+    // 5) Back-convert the loop's induction-position result for external uses
+    if (c.induction < loop.getNumResults()) {
+      Value loopResult = loop.getResult(c.induction);
+      if (!loopResult.use_empty()) {
+        rewriter.setInsertionPointAfter(loop);
+        auto mulRes =
+            rewriter.create<arith::MulIOp>(loc, loopResult, c.stepValue);
+        Value recovered;
+        if (c.stepIsAnAddOp())
+          recovered =
+              rewriter.create<arith::AddIOp>(loc, c.initialValue, mulRes);
+        else
+          recovered =
+              rewriter.create<arith::SubIOp>(loc, c.initialValue, mulRes);
+        loopResult.replaceAllUsesExcept(recovered, mulRes.getOperation());
+      }
+    }
     loop->setAttr(cudaq::opt::NormalizedLoopAttr, rewriter.getUnitAttr());
 
     rewriter.finalizeRootUpdate(loop);

--- a/python/tests/kernel/test_run_kernel.py
+++ b/python/tests/kernel/test_run_kernel.py
@@ -1619,6 +1619,66 @@ def test_return_with_false_condition_with_variable_defined_outside_the_loop():
     assert results[0] == 0
 
 
+def test_while_loop_countdown_sge():
+
+    @cudaq.kernel
+    def kernel() -> int:
+        val = 3
+        while val >= 0:
+            val -= 1
+        return val
+
+    results = cudaq.run(kernel, shots_count=1)
+    assert len(results) == 1
+    assert results[0] == -1
+
+
+def test_while_loop_countup_sle():
+
+    @cudaq.kernel
+    def kernel() -> int:
+        val = 5
+        while val <= 10:
+            val += 1
+        return val
+
+    results = cudaq.run(kernel, shots_count=1)
+    assert len(results) == 1
+    assert results[0] == 11
+
+
+def test_while_loop_sge_with_quantum_gates():
+
+    @cudaq.kernel
+    def kernel() -> int:
+        q = cudaq.qvector(3)
+        val = 2
+        while val >= 0:
+            x(q[val])
+            val -= 1
+        return mz(q[0])
+
+    results = cudaq.run(kernel, shots_count=1)
+    assert len(results) == 1
+    assert results[0] == 1
+
+
+def test_while_loop_sgt_workaround_still_works():
+
+    @cudaq.kernel
+    def kernel() -> int:
+        q = cudaq.qvector(3)
+        val = 2
+        while val > -1:
+            x(q[val])
+            val -= 1
+        return mz(q[0])
+
+    results = cudaq.run(kernel, shots_count=1)
+    assert len(results) == 1
+    assert results[0] == 1
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     loc = os.path.abspath(__file__)

--- a/test/Transforms/loop_normal_closed_interval.qke
+++ b/test/Transforms/loop_normal_closed_interval.qke
@@ -59,3 +59,43 @@ func.func @countup_sle() -> i64 {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 11 : i64
 // CHECK:           return %[[VAL_0]] : i64
 // CHECK:         }
+
+func.func @countdown_sgt() -> i64 {
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i64 = arith.constant 0 : i64
+  %c3_i64 = arith.constant 3 : i64
+  %0 = cc.loop while ((%arg0 = %c3_i64) -> (i64)) {
+    %1 = arith.cmpi sgt, %arg0, %c0_i64 : i64
+    cc.condition %1(%arg0 : i64)
+  } do {
+  ^bb0(%arg0: i64):
+    %1 = arith.subi %arg0, %c1_i64 : i64
+    cc.continue %1 : i64
+  }
+  return %0 : i64
+}
+
+// CHECK-LABEL:   func.func @countdown_sgt() -> i64 {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i64
+// CHECK:           return %[[VAL_0]] : i64
+// CHECK:         }
+
+func.func @countup_slt() -> i64 {
+  %c1_i64 = arith.constant 1 : i64
+  %c10_i64 = arith.constant 10 : i64
+  %c5_i64 = arith.constant 5 : i64
+  %0 = cc.loop while ((%arg0 = %c5_i64) -> (i64)) {
+    %1 = arith.cmpi slt, %arg0, %c10_i64 : i64
+    cc.condition %1(%arg0 : i64)
+  } do {
+  ^bb0(%arg0: i64):
+    %1 = arith.addi %arg0, %c1_i64 : i64
+    cc.continue %1 : i64
+  }
+  return %0 : i64
+}
+
+// CHECK-LABEL:   func.func @countup_slt() -> i64 {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 10 : i64
+// CHECK:           return %[[VAL_0]] : i64
+// CHECK:         }

--- a/test/Transforms/loop_normal_closed_interval.qke
+++ b/test/Transforms/loop_normal_closed_interval.qke
@@ -1,0 +1,61 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --cc-loop-normalize --canonicalize --cc-loop-unroll --canonicalize %s | FileCheck %s
+
+// Regression test: a `while val >= 0: val -= 1` loop starting at 3 must run 4
+// iterations (closed interval) and yield val = -1.
+
+func.func @countdown_sge() -> i64 {
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i64 = arith.constant 0 : i64
+  %c3_i64 = arith.constant 3 : i64
+  %0 = cc.loop while ((%arg0 = %c3_i64) -> (i64)) {
+    %1 = arith.cmpi sge, %arg0, %c0_i64 : i64
+    cc.condition %1(%arg0 : i64)
+  } do {
+  ^bb0(%arg0: i64):
+    %1 = arith.subi %arg0, %c1_i64 : i64
+    cc.continue %1 : i64
+  } step {
+  ^bb0(%arg0: i64):
+    cc.continue %arg0 : i64
+  }
+  return %0 : i64
+}
+
+// CHECK-LABEL:   func.func @countdown_sge() -> i64 {
+// CHECK:           %[[VAL_0:.*]] = arith.constant -1 : i64
+// CHECK:           return %[[VAL_0]] : i64
+// CHECK:         }
+
+// Regression test: a `while val <= 10: val += 1` loop starting at 5 must run 6
+// iterations (closed interval) and yield val = 11.
+
+func.func @countup_sle() -> i64 {
+  %c1_i64 = arith.constant 1 : i64
+  %c10_i64 = arith.constant 10 : i64
+  %c5_i64 = arith.constant 5 : i64
+  %0 = cc.loop while ((%arg0 = %c5_i64) -> (i64)) {
+    %1 = arith.cmpi sle, %arg0, %c10_i64 : i64
+    cc.condition %1(%arg0 : i64)
+  } do {
+  ^bb0(%arg0: i64):
+    %1 = arith.addi %arg0, %c1_i64 : i64
+    cc.continue %1 : i64
+  } step {
+  ^bb0(%arg0: i64):
+    cc.continue %arg0 : i64
+  }
+  return %0 : i64
+}
+
+// CHECK-LABEL:   func.func @countup_sle() -> i64 {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 11 : i64
+// CHECK:           return %[[VAL_0]] : i64
+// CHECK:         }


### PR DESCRIPTION
Fixes a miscompile of cc.loop while-loop with closed-interval comparisons (>=, <=).

- Adding uge/sge to isClosedIntervalForm.
- After the loop, replacing external uses of the induction-position result

Fixes #4401 