### PR TITLE
[NFC] Split out CompiledModule container into class

### DIFF
--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -206,7 +206,7 @@ public:
               name, jit, {}, true);
       auto mlirArtifact =
           cudaq_internal::compiler::CompiledModuleHelper::createMlirArtifact(
-              name + ".mlir", moduleOp);
+              name, moduleOp);
       artifacts.push_back(mlirArtifact);
       return cudaq_internal::compiler::CompiledModuleHelper::
           createCompiledModule(name, resultInfo, std::move(artifacts));
@@ -214,7 +214,7 @@ public:
 
     auto mlirArtifact =
         cudaq_internal::compiler::CompiledModuleHelper::createMlirArtifact(
-            name + ".mlir", prefabMod);
+            name, prefabMod);
 
     return cudaq_internal::compiler::CompiledModuleHelper::createCompiledModule(
         name, resultInfo, {mlirArtifact});

--- a/runtime/common/CompiledModule.cpp
+++ b/runtime/common/CompiledModule.cpp
@@ -7,29 +7,31 @@
  ******************************************************************************/
 
 #include "CompiledModule.h"
-#include <stdexcept>
+#include <string_view>
 
 cudaq::CompiledModule::CompiledModule(std::string kernelName)
     : name(std::move(kernelName)) {}
 
 std::optional<cudaq::CompiledModule::JitArtifact>
-cudaq::CompiledModule::getJit(std::optional<std::string> jitName) const {
-  auto name = jitName.value_or(this->name);
-  auto it = artifacts.find(name);
-  if (it == artifacts.end())
-    return std::nullopt;
-  const auto *jit = std::get_if<JitArtifact>(&it->second);
-  return jit ? std::optional(*jit) : std::nullopt;
+cudaq::CompiledModule::getJit() const {
+  return getJit(name);
+}
+
+std::optional<cudaq::CompiledModule::JitArtifact>
+cudaq::CompiledModule::getJit(std::string_view jitName) const {
+  auto *jit = artifacts.get<JitArtifact>(jitName);
+  return jit ? std::optional<JitArtifact>{*jit} : std::nullopt;
 }
 
 std::optional<cudaq::CompiledModule::MlirArtifact>
-cudaq::CompiledModule::getMlir(std::optional<std::string> mlirName) const {
-  auto name = mlirName.value_or(this->name + ".mlir");
-  auto it = artifacts.find(name);
-  if (it == artifacts.end())
-    return std::nullopt;
-  const auto *mlir = std::get_if<MlirArtifact>(&it->second);
-  return mlir ? std::optional(*mlir) : std::nullopt;
+cudaq::CompiledModule::getMlir() const {
+  return getMlir(name);
+}
+
+std::optional<cudaq::CompiledModule::MlirArtifact>
+cudaq::CompiledModule::getMlir(std::string_view mlirName) const {
+  auto *mlir = artifacts.get<MlirArtifact>(mlirName);
+  return mlir ? std::optional<MlirArtifact>{*mlir} : std::nullopt;
 }
 
 bool cudaq::CompiledModule::isFullySpecialized() const {
@@ -51,21 +53,19 @@ std::optional<std::int64_t> cudaq::CompiledModule::getReturnOffset() const {
   return fn();
 }
 
-const cudaq::Resources *cudaq::CompiledModule::getResources(
-    std::optional<std::string> resourcesName) const {
-  auto name = resourcesName.value_or(this->name + ".resources");
-  auto it = artifacts.find(name);
-  if (it == artifacts.end())
-    return nullptr;
-  const auto *resources = std::get_if<ResourcesArtifact>(&it->second);
-  return resources ? &resources->getResources() : nullptr;
+const cudaq::Resources *cudaq::CompiledModule::getResources() const {
+  return getResources(name);
+}
+
+const cudaq::Resources *
+cudaq::CompiledModule::getResources(std::string_view resourcesName) const {
+  auto *res = artifacts.get<ResourcesArtifact>(resourcesName);
+  return res ? &res->getResources() : nullptr;
 }
 
 void cudaq::CompiledModule::addArtifact(std::string name,
                                         CompiledArtifact artifact) {
-  if (artifacts.contains(name))
-    throw std::runtime_error("Artifact with name " + name + " already exists");
-  artifacts.emplace(std::move(name), std::move(artifact));
+  artifacts.add(std::move(name), std::move(artifact));
 }
 
 void (*cudaq::CompiledModule::JitArtifact::getFn() const)() { return fn; }

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -7,16 +7,16 @@
  ******************************************************************************/
 #pragma once
 
+#include "common/NamedVariantStore.h"
 #include "common/Resources.h"
 #include "common/ThunkInterface.h"
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <map>
 #include <memory>
 #include <optional>
 #include <string>
-#include <variant>
+#include <string_view>
 #include <vector>
 
 // This header file and the types defined within are designed to have no
@@ -153,8 +153,9 @@ public:
   };
 
   /// A compiled artifact is a JIT binary, an MLIR module, or resource metrics.
-  using CompiledArtifact =
-      std::variant<JitArtifact, MlirArtifact, ResourcesArtifact>;
+  using ArtifactsStore =
+      detail::NamedVariantStore<JitArtifact, MlirArtifact, ResourcesArtifact>;
+  using CompiledArtifact = ArtifactsStore::Value;
 
   // --- Compilation metadata ---
 
@@ -169,24 +170,27 @@ public:
   /// Get the JIT artifact with the given name.
   ///
   /// If no name is provided, defaults to the kernel name.
-  std::optional<JitArtifact>
-  getJit(std::optional<std::string> jitName = std::nullopt) const;
+  std::optional<JitArtifact> getJit() const;
+  std::optional<JitArtifact> getJit(std::string_view jitName) const;
 
   /// Get the MLIR artifact with the given name.
   ///
-  /// If no name is provided, defaults to `kernel_name + ".mlir"`.
-  std::optional<MlirArtifact>
-  getMlir(std::optional<std::string> mlirName = std::nullopt) const;
+  /// If no name is provided, defaults to the kernel name.
+  std::optional<MlirArtifact> getMlir() const;
+  std::optional<MlirArtifact> getMlir(std::string_view mlirName) const;
 
   /// Get the pre-computed resource counts, or `nullptr` if it does not exist.
   ///
-  /// If no name is provided, defaults to `kernel_name + ".resources"`.
-  const Resources *
-  getResources(std::optional<std::string> resourcesName = std::nullopt) const;
+  /// If no name is provided, defaults to the kernel name.
+  const Resources *getResources() const;
+  const Resources *getResources(std::string_view resourcesName) const;
 
-  /// Get all compiled artifacts.
-  const std::map<std::string, CompiledArtifact> &getArtifacts() const {
-    return artifacts;
+  /// Get all compiled artifacts in insertion order.
+  const ArtifactsStore &getArtifacts() const { return artifacts; }
+
+  /// Get all MLIR artifacts in insertion order.
+  auto getMlirArtifacts() const {
+    return artifacts.getAllOfType<MlirArtifact>();
   }
 
   /// Whether the kernel is fully specialized (all arguments inlined).
@@ -225,7 +229,7 @@ private:
                          // signature here. Though I'm not sure what MLIR
                          // agnostic information is worth storing.
   CompilationMetadata metadata;
-  std::map<std::string, CompiledArtifact> artifacts;
+  ArtifactsStore artifacts;
 };
 
 } // namespace cudaq

--- a/runtime/common/NamedVariantStore.h
+++ b/runtime/common/NamedVariantStore.h
@@ -1,0 +1,79 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+#include <algorithm>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace cudaq::detail {
+
+/// A container of named heterogeneous name-value pairs, retrievable by name and
+/// value type.
+template <typename... Ts>
+class NamedVariantStore {
+public:
+  using Value = std::variant<Ts...>;
+  using Entry = std::pair<std::string, Value>;
+  using Storage = std::vector<Entry>;
+  using const_iterator = Storage::const_iterator;
+
+  /// Get the value with the given name and type `T`.
+  template <typename T>
+  const T *get(std::string_view name) const {
+    for (const auto &[valName, val] : entries) {
+      if (valName != name)
+        continue;
+      if (const auto *typedVal = std::get_if<T>(&val))
+        return typedVal;
+    }
+    return nullptr;
+  }
+
+  /// Range over all entries of type `T` in insertion order.
+  template <typename T>
+  auto getAllOfType() const {
+    return std::views::all(entries) |
+           std::views::filter([](const Entry &entry) {
+             return std::holds_alternative<T>(entry.second);
+           }) |
+           std::views::transform(
+               [](const Entry &entry)
+                   -> std::pair<const std::string &, const T &> {
+                 return {entry.first, *std::get_if<T>(&entry.second)};
+               });
+  }
+
+  /// Add an entry with the given name and value.
+  ///
+  /// Throws a `std::runtime_error` if an entry with the same name and type
+  /// already exists.
+  void add(std::string name, Value value) {
+    const auto duplicate =
+        std::ranges::any_of(entries, [&](const Entry &entry) {
+          return entry.first == name && entry.second.index() == value.index();
+        });
+    if (duplicate)
+      throw std::runtime_error("Value with same type and name '" + name +
+                               "' already exists");
+    entries.emplace_back(std::move(name), std::move(value));
+  }
+
+  const_iterator begin() const { return entries.begin(); }
+  const_iterator end() const { return entries.end(); }
+
+private:
+  Storage entries;
+};
+
+} // namespace cudaq::detail

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -36,13 +36,13 @@ struct KernelExecution {
   nlohmann::json output_names;
   std::vector<std::size_t> mapping_reorder_idx;
   nlohmann::json user_data;
-  KernelExecution(std::string &n, std::string &c,
+  KernelExecution(const std::string &n, const std::string &c,
                   std::optional<cudaq::JitEngine> jit,
                   std::optional<Resources> rc, nlohmann::json &o,
                   std::vector<std::size_t> &m)
       : name(n), code(c), jit(jit), resourceCounts(rc), output_names(o),
         mapping_reorder_idx(m) {}
-  KernelExecution(std::string &n, std::string &c,
+  KernelExecution(const std::string &n, const std::string &c,
                   std::optional<cudaq::JitEngine> jit,
                   std::optional<Resources> rc, nlohmann::json &o,
                   std::vector<std::size_t> &m, nlohmann::json &ud)

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -385,7 +385,7 @@ cudaq::CompiledModule Compiler::assembleCompiledModule(
       artifacts.push_back(std::move(jitArtifacts[0]));
       if (resourceCounts)
         artifacts.push_back(CompiledModuleHelper::createResourcesArtifact(
-            name + ".resources", std::move(*resourceCounts)));
+            name, std::move(*resourceCounts)));
     }
   }
 
@@ -394,9 +394,8 @@ cudaq::CompiledModule Compiler::assembleCompiledModule(
       applyPipeline("func.func(combine-measurements)", module, kernelName);
 
   for (auto &[name, module] : modules) {
-    auto mlirName = name + ".mlir";
     artifacts.push_back(
-        CompiledModuleHelper::createMlirArtifact(mlirName, module, context));
+        CompiledModuleHelper::createMlirArtifact(name, module, context));
   }
 
   return CompiledModuleHelper::createCompiledModule(
@@ -547,11 +546,7 @@ Compiler::emitKernelExecutions(const cudaq::CompiledModule &compiled) {
 
   // Apply user-specified codegen
   std::vector<cudaq::KernelExecution> codes;
-  for (auto &[name, artifact] : compiled.getArtifacts()) {
-    if (!name.ends_with(".mlir"))
-      continue;
-    auto &mlirArtifact =
-        std::get<cudaq::CompiledModule::MlirArtifact>(artifact);
+  for (const auto &[name, mlirArtifact] : compiled.getMlirArtifacts()) {
     auto moduleOpI = CompiledModuleHelper::getMlirModuleOp(mlirArtifact);
 
     std::string codeStr;
@@ -577,17 +572,16 @@ Compiler::emitKernelExecutions(const cudaq::CompiledModule &compiled) {
     // Retrieve pre-computed JIT engine and resource counts (if any).
     std::optional<cudaq::JitEngine> optionalJit;
     std::optional<cudaq::Resources> optionalResourceCounts;
-    auto kernelName = name.substr(0, name.length() - 5);
-    auto jit = compiled.getJit(kernelName);
+    auto jit = compiled.getJit(name);
     if (jit)
       optionalJit = jit->getEngine();
-    auto resourceCounts = compiled.getResources(kernelName + ".resources");
+    auto resourceCounts = compiled.getResources(name);
     if (resourceCounts)
       optionalResourceCounts = *resourceCounts;
 
     auto mapping_reorder_idx = compiled.getMetadata().reorderIdx;
-    codes.emplace_back(kernelName, codeStr, optionalJit, optionalResourceCounts,
-                       j, mapping_reorder_idx);
+    codes.emplace_back(name, codeStr, optionalJit, optionalResourceCounts, j,
+                       mapping_reorder_idx);
   }
 
   return codes;

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -51,6 +51,7 @@ set(CUDAQ_RUNTIME_TEST_SOURCES
   integration/kernels_tester.cpp
   common/MeasureCountsTester.cpp
   common/NoiseModelTester.cpp
+  common/CompiledModuleTester.cpp
   common/ExecutionContextThreadTester.cpp
   ptsbe/PTSBESampleTester.cpp
   ptsbe/PTSBEMultiBackendTester.cpp

--- a/unittests/common/CompiledModuleTester.cpp
+++ b/unittests/common/CompiledModuleTester.cpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "common/NamedVariantStore.h"
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+using Store = cudaq::detail::NamedVariantStore<int, double, std::string>;
+
+TEST(NamedVariantStoreTester, GetFindsMatchingTypeAfterSameNamedEntry) {
+  Store store;
+  store.add("artifact", 3.14);
+  store.add("artifact", std::string("payload"));
+  store.add("other", 7);
+
+  const auto *stringValue = store.get<std::string>("artifact");
+  ASSERT_NE(stringValue, nullptr);
+  EXPECT_EQ(*stringValue, "payload");
+
+  const auto *doubleValue = store.get<double>("artifact");
+  ASSERT_NE(doubleValue, nullptr);
+  EXPECT_DOUBLE_EQ(*doubleValue, 3.14);
+
+  EXPECT_EQ(store.get<int>("artifact"), nullptr);
+}
+
+TEST(NamedVariantStoreTester, RejectsDuplicateNameAndTypeButAllowsOthers) {
+  Store store;
+  store.add("artifact", 7);
+
+  try {
+    store.add("artifact", 9);
+    FAIL() << "Expected duplicate name/type insertion to throw.";
+  } catch (const std::runtime_error &err) {
+    EXPECT_NE(std::string(err.what()).find("artifact"), std::string::npos);
+  }
+
+  EXPECT_NO_THROW(store.add("artifact", 2.5));
+  EXPECT_NO_THROW(store.add("other", 9));
+}
+
+TEST(NamedVariantStoreTester, GetAllOfTypePreservesInsertionOrder) {
+  Store store;
+  store.add("alpha", std::string("a"));
+  store.add("skip", 1);
+  store.add("beta", std::string("b"));
+  store.add("skip-again", 2.0);
+  store.add("gamma", std::string("c"));
+
+  std::vector<std::string> names;
+  std::vector<std::string> values;
+  for (const auto &[name, value] : store.getAllOfType<std::string>()) {
+    names.push_back(name);
+    values.push_back(value);
+  }
+
+  EXPECT_EQ(names, (std::vector<std::string>{"alpha", "beta", "gamma"}));
+  EXPECT_EQ(values, (std::vector<std::string>{"a", "b", "c"}));
+}


### PR DESCRIPTION
NOTE: This is a re-post of #4392, which I merged into the wrong branch! It's already been reviewed, discussed and approved.

---

This PR splits out the container that is used in CompiledModule into its own type. This is so that it can be re-used by other upcoming types that look very similar, e.g. KernelArgs.

I took the opportunity to change to using a vector of pairs instead of a std::map to store the artifacts. This should be faster (most of the time, there will be <5 artifacts) and means that several artifacts of different types can share the same name. This removes the need to adopt some naming convention to differentiate multiple artifact types for the same kernel, as they can share the same name.
