### PR TITLE
[unittests] Build unit tests in library mode

### DIFF
--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -51,7 +51,7 @@ private:
   int result = 0;
 
   /// Unique integer for measure result identification
-  std::size_t uniqueId = 0;
+  [[maybe_unused]] std::size_t uniqueId = 0;
 
 public:
   measure_result(int res, std::size_t id) : result(res), uniqueId(id) {}

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -13,6 +13,20 @@ set (CMAKE_CXX_FLAGS
 SET(CMAKE_EXE_LINKER_FLAGS "")
 SET(CMAKE_SHARED_LINKER_FLAGS "")
 
+# These unit test executables instantiate `__qpu__` kernel functor structs and
+# call `cudaq::sample(myKernel)` directly from C++ test code, with no `nvq++`
+# / `cudaq-quake` step. The AST bridge never runs, so measurement and gate
+# calls reach the inline bodies in `runtime/cudaq/qis/qubit_qis.h` on the
+# host. That is the same execution model as library mode, but without the
+# `CUDAQ_LIBRARY_MODE` macro the headers' MLIR-mode branches are selected
+# and any future trap on host invocation breaks the test binaries silently.
+#
+# This is a temporary workaround until library mode is removed and a proper
+# runtime-isolation harness replaces it. Defining the macro at directory
+# scope routes every target below this point through the library-mode
+# inline bodies that work on host today.
+add_compile_definitions(CUDAQ_LIBRARY_MODE)
+
 # ctest's PROCESSORS property tells the scheduler how many CPU slots each test
 # occupies. Without it, `ctest -j N` launches N OpenMP-parallel tests at once
 # (2N threads competing for N cores). This value is only applied to tests that


### PR DESCRIPTION
## Summary

Set `CUDAQ_LIBRARY_MODE` at directory scope in `unittests/CMakeLists.txt` so every unit-test binary in the tree compiles against the library-mode inline implementations of the runtime headers.

## Motivation

The unit-test binaries instantiate `__qpu__` functor structs and invoke `cudaq::sample(myKernel)` directly from C++ test code, with no `nvq++` / `cudaq-quake` step in between. The AST bridge never runs, so measurement and gate calls reach the inline bodies in `runtime/cudaq/qis/qubit_qis.h` on the host. That is exactly the library-mode execution model.

Today this happens to work because the historic inline `mz` / `mx` / `my` bodies execute on host. Future runtime header changes can make this implicit dependency explicit by trapping host invocation of the MLIR-mode entry points (e.g., `std::abort()` stubs); pre-emptively setting the macro keeps these test binaries on the supported execution path.
