### PR TITLE
fixing GIL deadlock in mqpu async kernel compilation

### DIFF
--- a/python/runtime/cudaq/platform/PythonSignalCheck.cpp
+++ b/python/runtime/cudaq/platform/PythonSignalCheck.cpp
@@ -41,6 +41,8 @@ public:
 
 namespace cudaq {
 void addPythonSignalInstrumentation(mlir::PassManager &pm) {
+  if (!PyGILState_Check())
+    return;
   pm.addInstrumentation(std::make_unique<PythonSignalCheckInstrumentation>());
 }
 


### PR DESCRIPTION
The test `test_mpi_mqpu.py` was hanging where PyGILState_Ensure() on the worker waits for the main thread to release the GIL, but the main thread is in `asyncResult.get()` holding the GIL.

`addPythonSignalInstrumentation` now skips installing the per-pass PyGILState_Ensure based instrumentation when called from a thread that doesn't currently hold the GIL.
