### PR TITLE
Fixing memory leak in async API

### DIFF
--- a/python/runtime/cudaq/algorithms/py_observe_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe_async.cpp
@@ -76,14 +76,19 @@ static async_observe_result pyObserveAsync(const std::string &shortName,
 
   // Launch the asynchronous execution.
   nanobind::gil_scoped_release release;
+  auto clonedMod = std::shared_ptr<mlir::ModuleOp>(
+      new mlir::ModuleOp(mod.clone()), [](mlir::ModuleOp *p) {
+        p->erase();
+        delete p;
+      });
   return details::runObservationAsync(
-      detail::make_copyable_function([opaques = std::move(opaques), shortName,
-                                      mod = mod.clone()]() mutable {
-        if (cudaq::getEnvBool("CUDAQ_DUMP_JIT_IR", false))
-          mod.dump();
-        [[maybe_unused]] auto result =
-            clean_launch_module(shortName, mod, opaques);
-      }),
+      detail::make_copyable_function(
+          [opaques = std::move(opaques), shortName, clonedMod]() mutable {
+            if (cudaq::getEnvBool("CUDAQ_DUMP_JIT_IR", false))
+              clonedMod->dump();
+            [[maybe_unused]] auto result =
+                clean_launch_module(shortName, *clonedMod, opaques);
+          }),
       spin_operator, platform, shots, shortName, qpu_id);
 }
 

--- a/python/runtime/cudaq/algorithms/py_sample_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample_async.cpp
@@ -42,6 +42,12 @@ static async_sample_result sample_async_impl(
   // Should only have C++ going on here, safe to release the GIL
   nanobind::gil_scoped_release release;
 
+  auto clonedMod = std::shared_ptr<mlir::ModuleOp>(
+      new mlir::ModuleOp(mod.clone()), [](mlir::ModuleOp *p) {
+        p->erase();
+        delete p;
+      });
+
   // Use runSamplingAsync with noise model support.
   // The noise_model is passed by value to runSamplingAsync, which captures
   // it in the async task to ensure proper lifetime and handles setting/
@@ -51,11 +57,11 @@ static async_sample_result sample_async_impl(
       // (1) no Python data access is allowed in this lambda body.
       // (2) This lambda might be executed multiple times, e.g, when
       // the kernel contains measurement feedback.
-      detail::make_copyable_function([opaques = std::move(opaques), kernelName,
-                                      mod = mod.clone()]() mutable {
-        [[maybe_unused]] auto result =
-            clean_launch_module(kernelName, mod, opaques);
-      }),
+      detail::make_copyable_function(
+          [opaques = std::move(opaques), kernelName, clonedMod]() mutable {
+            [[maybe_unused]] auto result =
+                clean_launch_module(kernelName, *clonedMod, opaques);
+          }),
       platform, kernelName, shots_count, explicit_measurements, qpu_id,
       std::move(noise_model));
 }

--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -199,12 +199,17 @@ static std::future<state> get_state_async_impl(const std::string &shortName,
   auto opaques = marshal_arguments_for_module_launch(mod, args, fnOp);
 
   nanobind::gil_scoped_release release;
+  auto clonedMod = std::shared_ptr<mlir::ModuleOp>(
+      new mlir::ModuleOp(mod.clone()), [](mlir::ModuleOp *p) {
+        p->erase();
+        delete p;
+      });
   return details::runGetStateAsync(
-      detail::make_copyable_function([opaques = std::move(opaques), kernelName,
-                                      mod = mod.clone()]() mutable {
-        [[maybe_unused]] auto result =
-            clean_launch_module(kernelName, mod, opaques);
-      }),
+      detail::make_copyable_function(
+          [opaques = std::move(opaques), kernelName, clonedMod]() mutable {
+            [[maybe_unused]] auto result =
+                clean_launch_module(kernelName, *clonedMod, opaques);
+          }),
       platform, qpu_id);
 }
 


### PR DESCRIPTION
The clone captured into the async task lambda was never erased. That left the operation in the MLIR context. Now we are wrapping it in a shared pointer with an erasing deleter that ties cleanup to lambda destruction. Similar solution as how we already handled it in [pyLaunchModule](https://github.com/NVIDIA/cuda-quantum/blob/main/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp#L682).

The memory leak of around 15 KB per call is no more. 

Fixes #3355 