### PR TITLE
Fixing quake.subveq survival in CCX to CCZ rewrite

### DIFF
--- a/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -947,13 +947,13 @@ struct CCXToCCZ : public cudaq::DecompositionPattern<CCXToCCZType, quake::XOp> {
 
   LogicalResult matchAndRewrite(quake::XOp op,
                                 PatternRewriter &rewriter) const override {
-    if (failed(checkNumControls(op, 2)))
+    SmallVector<Value, 2> controls(2);
+    if (failed(checkAndExtractControls(op, controls, rewriter)))
       return failure();
 
     // Op info
     Location loc = op->getLoc();
     Value target = op.getTarget();
-    SmallVector<Value> controls = op.getControls();
 
     QuakeOperatorCreator qRewriter(rewriter);
     qRewriter.create<quake::HOp>(loc, target);

--- a/python/tests/backends/test_IQM.py
+++ b/python/tests/backends/test_IQM.py
@@ -157,6 +157,22 @@ def test_iqm_u3_ctrl_decomposition():
     result = cudaq.sample(kernel)
 
 
+def test_iqm_ccx_qvec_slice_control():
+
+    @cudaq.kernel
+    def check_mcx():
+        qubits = cudaq.qvector(4)
+        x.ctrl(qubits[1:3], qubits[0])
+
+    @cudaq.kernel
+    def check_mcx1():
+        qubits = cudaq.qvector(4)
+        x.ctrl(qubits[1:4], qubits[0])
+
+    cudaq.sample(check_mcx)
+    cudaq.sample(check_mcx1)
+
+
 def test_IQM_state_preparation():
     shots = 10000
 

--- a/test/Transforms/DecompositionPatterns/CCXToCCZ-subveq.qke
+++ b/test/Transforms/DecompositionPatterns/CCXToCCZ-subveq.qke
@@ -1,0 +1,29 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt -pass-pipeline='builtin.module(decomposition{enable-patterns=CCXToCCZ})' %s | FileCheck %s
+
+// Regression: CCX with a quake.subveq control (size 2) must have the veq
+// control split into individual ref controls. Otherwise the veq control
+// survives onto the rewritten quake.z and reaches backend emitters that
+// don't handle quake.subveq (e.g. translateToIQMJson).
+
+// CHECK-LABEL: func.func @subveq_control
+func.func @subveq_control() attributes {"cudaq-entrypoint"} {
+  %0 = quake.alloca !quake.veq<4>
+  %1 = quake.subveq %0, 1, 2 : (!quake.veq<4>) -> !quake.veq<2>
+  %2 = quake.extract_ref %0[0] : (!quake.veq<4>) -> !quake.ref
+  // CHECK:      quake.extract_ref %{{.*}} : (!quake.veq<2>, i64) -> !quake.ref
+  // CHECK:      quake.extract_ref %{{.*}} : (!quake.veq<2>, i64) -> !quake.ref
+  // CHECK:      quake.h
+  // CHECK-NEXT: quake.z [%{{.*}}, %{{.*}}] %{{.*}} : (!quake.ref, !quake.ref, !quake.ref) -> ()
+  // CHECK-NEXT: quake.h
+  // CHECK-NOT:  quake.x
+  quake.x [%1] %2 : (!quake.veq<2>, !quake.ref) -> ()
+  return
+}


### PR DESCRIPTION
- `x.ctrl(qubits[1:3], qubits[0])` was producing IQM JSON translation errors: 'quake.subveq' op unable to translate op to IQM Json.
- MultiControlDecomposition defers CCX/CCZ to the CCXToCCZ decomposition pattern. But that pattern used checkNumControls and forwarded the original veq/subveq operand straight onto the rewritten quake.z. The subveq then survived into translateToIQMJson, which has no case for it.
- The fix is to switch CCXToCCZ to checkAndExtractControls, which is already used by `CCZToCX`. So any veq/subveq control is split into individual quake.extract_refs before the new quake.z is built.

Fixes #4141 

# CPP example used for testing

```
#include <cudaq.h>

int main()
{
    auto kernel = cudaq::make_kernel();
    auto qubit = kernel.qalloc(4);
    auto ctrl_bits = qubit.slice(1,2);
    kernel.x<cudaq::ctrl>(ctrl_bits, qubit[0]);
    auto counts = cudaq::sample(kernel);
    counts.dump();

    auto kernel1 = cudaq::make_kernel();
    auto qubit1 = kernel1.qalloc(4);
    auto ctrl_bits1 = qubit1.slice(1,3);
    kernel.x<cudaq::ctrl>(ctrl_bits1, qubit1[0]);
    auto counts1 = cudaq::sample(kernel1);
    counts1.dump();
}
```

# Output of testing against IQM server

```
[2026-05-01 22:51:18.045] [info] [IQMServerHelper.cpp:270] postJobResponse: {"counts_batch":[{"counts":{"0000":493,"1111":507},"measurement_keys":["m_QB1","m_QB2","m_QB3","m_QB4"]}],"message":null,"metadata":{"calibration_set_id":"61f8a617-7440-4521-a306-aa2096682706","request":{"circuits":[{"instructions":[{"args":{"key":"m_QB1"},"name":"measure","qubits":["QB1"]},{"args":{"key":"m_QB2"},"name":"measure","qubits":["QB2"]},{"args":{"key":"m_QB3"},"name":"measure","qubits":["QB3"]},{"args":{"key":"m_QB4"},"name":"measure","qubits":["QB4"]}],"name":"__nvqppBuilderKernel_093606261879"}],"qubit_mapping":[{"logical_name":"QB1","physical_name":"QB1"},{"logical_name":"QB2","physical_name":"QB2"},{"logical_name":"QB3","physical_name":"QB3"},{"logical_name":"QB4","physical_name":"QB4"},{"logical_name":"QB5","physical_name":"QB5"}],"shots":1000},"timestamps":{"compilation_ended":"2026-05-01T22:51:17.104693Z","compilation_started":"2026-05-01T22:51:16.919366Z","compile_end":"2026-05-01T22:51:17.104693Z","compile_start":"2026-05-01T22:51:16.919366Z","execution_end":"2026-05-01T22:51:17.312677Z","execution_ended":"2026-05-01T22:51:17.312677Z","execution_start":"2026-05-01T22:51:17.282203Z","execution_started":"2026-05-01T22:51:17.282203Z","post_processing_ended":"2026-05-01T22:51:17.316822Z","post_processing_started":"2026-05-01T22:51:17.313485Z","ready":"2026-05-01T22:51:17.317357Z","received":"2026-05-01T22:51:16.828059Z","validation_ended":"2026-05-01T22:51:16.878544Z","validation_started":"2026-05-01T22:51:16.877568Z"}},"status":"ready","warnings":null}
{ 0000:493 1111:507 }
```