### PR TITLE
fix concurrency CI Summary issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,12 @@ jobs:
       - python_wheels
       - python_metapackages
       - binaries
-    if: always()
+    # Run on success, failure, or per-job cancellation — but NOT when the
+    # whole workflow is cancelled (e.g. a newer push triggered the
+    # concurrency rule). Otherwise the "fail on cancelled needs" check below
+    # would surface a phantom `CI Summary failed` on the PR rollup for a run
+    # that was actually preempted, not broken.
+    if: ${{ !cancelled() }}
     env:
       GH_TOKEN: ${{ github.token }}
       NEEDS_JSON: ${{ toJSON(needs) }}


### PR DESCRIPTION
This fixes the issue currently seen in https://github.com/NVIDIA/cuda-quantum/pull/4370

Where if you open a PR and then immediately dispatch a `workflow_run`, the CI Summary may fail the checks for the per-PR status when it actually passes.