### PR TITLE
restrict ninja to -j8, use larger systems for flang build

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -122,15 +122,15 @@ jobs:
         run: |
           if [ -n "$(echo ${{ inputs.platforms }} | grep ',')" ]; then
             # multi-platform builds get no platform tag
-            echo "runner=linux-amd64-cpu8" >> $GITHUB_OUTPUT
+            echo "runner=linux-amd64-cpu16" >> $GITHUB_OUTPUT
           elif [ -n "$(echo ${{ inputs.platforms }} | grep -i arm)" ]; then
             platform_tag=`echo ${{ inputs.platforms }} | sed 's/linux\///g' | tr -d ' '`
             echo "platform_tag=$platform_tag" >> $GITHUB_OUTPUT
-            echo "runner=linux-arm64-cpu8" >> $GITHUB_OUTPUT
+            echo "runner=linux-arm64-cpu16" >> $GITHUB_OUTPUT
           else
             platform_tag=`echo ${{ inputs.platforms }} | sed 's/linux\///g' | tr -d ' '`
             echo "platform_tag=$platform_tag" >> $GITHUB_OUTPUT
-            echo "runner=linux-amd64-cpu8" >> $GITHUB_OUTPUT
+            echo "runner=linux-amd64-cpu16" >> $GITHUB_OUTPUT
           fi
 
           repo_owner=${{ github.repository_owner }}

--- a/scripts/build_llvm.sh
+++ b/scripts/build_llvm.sh
@@ -40,6 +40,7 @@ Python3_EXECUTABLE=${Python3_EXECUTABLE:-python3}
 # Process command line arguments.
 build_configuration=Release
 verbose=false
+build_concurrency="-j 8"
 
 __optind__=$OPTIND
 OPTIND=1


### PR DESCRIPTION
While building flang in gcc12, potential OOM errors persisted. This update uses beefier runners with 64GB of RAM, and also restricts ninja to 8 concurrent threads.