### PR TITLE
[python] Validate callable arg signature at call site

### DIFF
--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -650,6 +650,7 @@ class PyKernelDecorator(object):
 
     def process_argument(self, arg, arg_type):
         if isa_kernel_decorator(arg):
+            _validate_kernel_callable_arg(arg, arg_type)
             return DecoratorCapture(arg)
 
         arg = self.convertStringsToPauli(arg)
@@ -775,3 +776,48 @@ def _parse_ast(funcSrc: str, verbose: bool = False):
         except ImportError:
             pass
     return astModule
+
+
+def _validate_kernel_callable_arg(kernel, arg_type):
+    """
+    Validate that `kernel` matches the `arg_type` callable signature.
+    """
+    if not cc.CallableType.isinstance(arg_type):
+        emitFatalError(
+            f"Expected argument of type `{arg_type}`, got callable kernel `{kernel.name}`"
+        )
+
+    expectedFnTy = FunctionType(cc.CallableType.getFunctionType(arg_type))
+    expectedInputs = list(expectedFnTy.inputs)
+    expectedResults = list(expectedFnTy.results)
+
+    actualInputs = list(kernel.signature.arg_types)
+    actualReturn = kernel.signature.return_type
+    actualResults = [actualReturn] if actualReturn is not None else []
+
+    def _format(inputs, results):
+        inputs_str = ", ".join(str(t) for t in inputs)
+        results_str = ", ".join(str(t) for t in results) or "None"
+        return f"({inputs_str}) -> {results_str}"
+
+    if len(expectedInputs) != len(actualInputs):
+        emitFatalError(
+            f"Expected callable with signature {_format(expectedInputs, expectedResults)}, "
+            f"got callable kernel `{kernel.name}` with signature {_format(actualInputs, actualResults)}"
+        )
+
+    mismatches = [(i, exp, act)
+                  for i, (exp,
+                          act) in enumerate(zip(expectedInputs, actualInputs))
+                  if exp != act]
+    if mismatches or expectedResults != actualResults:
+        details = "; ".join(f"argument {i}: expected `{exp}`, got `{act}`"
+                            for i, exp, act in mismatches)
+        if expectedResults != actualResults:
+            ret_detail = (f"return: expected `{_format([], expectedResults)}`, "
+                          f"got `{_format([], actualResults)}`")
+            details = f"{details}; {ret_detail}" if details else ret_detail
+        emitFatalError(
+            f"Expected callable with signature {_format(expectedInputs, expectedResults)}, "
+            f"got callable kernel `{kernel.name}` with signature {_format(actualInputs, actualResults)}"
+        )

--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -787,37 +787,22 @@ def _validate_kernel_callable_arg(kernel, arg_type):
             f"Expected argument of type `{arg_type}`, got callable kernel `{kernel.name}`"
         )
 
-    expectedFnTy = FunctionType(cc.CallableType.getFunctionType(arg_type))
-    expectedInputs = list(expectedFnTy.inputs)
-    expectedResults = list(expectedFnTy.results)
+    expectedFnTy = cc.CallableType.getFunctionType(arg_type)
+    actualFnTy = cc.CallableType.getFunctionType(
+        kernel.signature.get_callable_type())
 
-    actualInputs = list(kernel.signature.arg_types)
-    actualReturn = kernel.signature.return_type
-    actualResults = [actualReturn] if actualReturn is not None else []
+    if expectedFnTy == actualFnTy:
+        return
 
-    def _format(inputs, results):
-        inputs_str = ", ".join(str(t) for t in inputs)
-        results_str = ", ".join(str(t) for t in results) or "None"
-        return f"({inputs_str}) -> {results_str}"
+    def _format(fnTy):
+        inputs_str = ", ".join(str(t) for t in fnTy.inputs)
+        results = fnTy.results
+        if results:
+            return f"({inputs_str}) -> {results[0]}"
+        else:
+            return inputs_str
 
-    if len(expectedInputs) != len(actualInputs):
-        emitFatalError(
-            f"Expected callable with signature {_format(expectedInputs, expectedResults)}, "
-            f"got callable kernel `{kernel.name}` with signature {_format(actualInputs, actualResults)}"
-        )
-
-    mismatches = [(i, exp, act)
-                  for i, (exp,
-                          act) in enumerate(zip(expectedInputs, actualInputs))
-                  if exp != act]
-    if mismatches or expectedResults != actualResults:
-        details = "; ".join(f"argument {i}: expected `{exp}`, got `{act}`"
-                            for i, exp, act in mismatches)
-        if expectedResults != actualResults:
-            ret_detail = (f"return: expected `{_format([], expectedResults)}`, "
-                          f"got `{_format([], actualResults)}`")
-            details = f"{details}; {ret_detail}" if details else ret_detail
-        emitFatalError(
-            f"Expected callable with signature {_format(expectedInputs, expectedResults)}, "
-            f"got callable kernel `{kernel.name}` with signature {_format(actualInputs, actualResults)}"
-        )
+    emitFatalError(
+        f"Expected callable with signature {_format(expectedFnTy)}, "
+        f"got callable kernel `{kernel.name}` with signature {_format(actualFnTy)}"
+    )

--- a/python/tests/kernel/test_kernel_features.py
+++ b/python/tests/kernel/test_kernel_features.py
@@ -339,6 +339,40 @@ def test_2grover_compute_action():
     assert '011' in counts
 
 
+def test_callable_kernel_arg_signature_mismatch_arg_type():
+
+    @cudaq.kernel
+    def k1(fct: Callable[[int, cudaq.qubit], None]):
+        qubit = cudaq.qubit()
+        fct(0, qubit)
+
+    @cudaq.kernel
+    def k2(cond: bool, q: cudaq.qubit):
+        if cond:
+            x(q)
+
+    with pytest.raises(RuntimeError, match="Expected callable with signature"):
+        k1(k2)
+
+    with pytest.raises(RuntimeError, match="Expected argument of type"):
+        k2(True, k1)
+
+
+def test_callable_kernel_arg_signature_mismatch_arity():
+
+    @cudaq.kernel
+    def caller(fct: Callable[[cudaq.qubit], None]):
+        qubit = cudaq.qubit()
+        fct(qubit)
+
+    @cudaq.kernel
+    def callee(a: int, q: cudaq.qubit):
+        pass
+
+    with pytest.raises(RuntimeError, match="Expected callable with signature"):
+        caller(callee)
+
+
 def test_observe():
 
     @cudaq.kernel


### PR DESCRIPTION
Previously, the following

```python
import cudaq
from cudaq.qis import qis
from typing import Callable
@cudaq.kernel
def k1(fct: Callable[[int, cudaq.qubit], None]):
    qubit = cudaq.qubit()
    fct(0,qubit)
@cudaq.kernel
def k2(cond: bool, q: cudaq.qubit):
    if cond:
        x(q)
print(k1(k2))
```
 
was raising a very cryptic error:

```
loc("-":5:7): error: 'func.call' op operand type mismatch: expected operand type 'i1', but provided 'i64' for operand number 0
error: substitution module must have been created
RuntimeError: Could not successfully apply argument synth.
```

This PR cleans up the error message by checking the type of the callable.