### PR TITLE
skip unitary_compilation_diffusion_models.ipynb until fixed

### DIFF
--- a/docs/notebook_validation.py
+++ b/docs/notebook_validation.py
@@ -58,12 +58,17 @@ GPU_REQUIRED_NOTEBOOKS = [
 LONG_RUNNING_NOTEBOOKS = [
     "divisive_clustering_coresets.ipynb",
     "hybrid_quantum_neural_networks.ipynb",
-    "unitary_compilation_diffusion_models.ipynb",
     "qm_mm_pe.ipynb",
     "qsci.ipynb",
     "uccsd_wf_ansatz.ipynb",
-    "unitary_compilation_diffusion_models",
     "vqe_advanced.ipynb",
+]
+
+# TODO: investigate and fix noteook in CI
+EXTERNAL_NETWORK_NOTEBOOKS = [
+    # Downloads `Floki00/qc_unitary_3qubit` from Hugging Face via
+    # DiffusionPipeline.from_pretrained — has timed out at >35 min in CI.
+    "unitary_compilation_diffusion_models.ipynb",
 ]
 
 
@@ -82,6 +87,11 @@ def validate(notebook_filename, available_backends):
     base_name = os.path.basename(notebook_filename)
     has_gpu = 'nvidia' in available_backends
     if not has_gpu and base_name in GPU_REQUIRED_NOTEBOOKS:
+        return False
+
+    # Notebooks that depend on external network services (HF, etc.) are too
+    # flaky for CI and are unconditionally skipped during validation.
+    if base_name in EXTERNAL_NETWORK_NOTEBOOKS:
         return False
 
     # Collect all set_target calls


### PR DESCRIPTION
This is not permanent, and should be immediately fixed upon followup.

This notebook is currently blocking CI from opening after the llvm22 update, so this PR unconditionally skips it with a TODO to open it up later.