### PR TITLE
Fix run_async crash on shots_count=0 and leak in async_run_result

### DIFF
--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -14,6 +14,7 @@
 #include "utils/OpaqueArguments.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include <future>
+#include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/complex.h>
@@ -135,10 +136,13 @@ run_impl(const std::string &shortName, MlirModule module,
 namespace {
 // Internal struct representing buffer to be filled asynchronously.
 // When the `ready` future is set, the content of the buffer is filled.
+// `results` and `error` are owned by the struct; the deferred future captures
+// non-owning raw pointers to them, which stay valid for the future's lifetime
+// because the future is destroyed before these members.
 struct async_run_result {
+  std::unique_ptr<std::vector<nanobind::object>> results;
+  std::unique_ptr<std::string> error;
   std::future<void> ready;
-  std::vector<nanobind::object> *results;
-  std::string *error;
 };
 } // namespace
 
@@ -163,8 +167,8 @@ run_async_impl(const std::string &shortName, MlirModule module,
         "Noise model is not supported on remote platforms.");
 
   async_run_result result;
-  result.results = new std::vector<nanobind::object>();
-  result.error = new std::string();
+  result.results = std::make_unique<std::vector<nanobind::object>>();
+  result.error = std::make_unique<std::string>();
 
   if (shots_count == 0) {
     std::promise<void> promise;
@@ -216,21 +220,20 @@ run_async_impl(const std::string &shortName, MlirModule module,
     // Release GIL to allow c++ threads, re-acquire for conversion of the
     // results to python objects.
     nanobind::gil_scoped_release gil_release{};
-    auto resultFuture =
-        std::async(std::launch::deferred,
-                   [sf = std::move(spanFuture), ef = std::move(errorFuture),
-                    errorPtr = result.error, resultsPtr = result.results, mod,
-                    shots_count, shortName]() mutable {
-                     auto error = ef.get();
-                     std::swap(*errorPtr, error);
-                     if (error.empty()) {
-                       auto span = sf.get();
-                       nanobind::gil_scoped_acquire gil{};
-                       auto results =
-                           pyReadResults(span, mod, shots_count, shortName);
-                       std::swap(*resultsPtr, results);
-                     }
-                   });
+    auto resultFuture = std::async(
+        std::launch::deferred,
+        [sf = std::move(spanFuture), ef = std::move(errorFuture),
+         errorPtr = result.error.get(), resultsPtr = result.results.get(), mod,
+         shots_count, shortName]() mutable {
+          auto error = ef.get();
+          std::swap(*errorPtr, error);
+          if (error.empty()) {
+            auto span = sf.get();
+            nanobind::gil_scoped_acquire gil{};
+            auto results = pyReadResults(span, mod, shots_count, shortName);
+            std::swap(*resultsPtr, results);
+          }
+        });
     result.ready = std::move(resultFuture);
   }
 
@@ -269,14 +272,9 @@ void cudaq::bindPyRunAsync(nanobind::module_ &mod) {
               nanobind::gil_scoped_release release;
               self.ready.get();
             }
-            auto err = *self.error;
-            if (!err.empty()) {
-              delete self.error;
-              throw std::runtime_error(err);
-            }
-            auto ret = *self.results;
-            delete self.results;
-            return ret;
+            if (!self.error->empty())
+              throw std::runtime_error(*self.error);
+            return std::move(*self.results);
           },
           "FIXME: documentation goes here");
 

--- a/python/runtime/cudaq/algorithms/py_run.cpp
+++ b/python/runtime/cudaq/algorithms/py_run.cpp
@@ -147,9 +147,6 @@ static async_run_result
 run_async_impl(const std::string &shortName, MlirModule module,
                std::size_t shots_count, std::optional<noise_model> noise_model,
                std::size_t qpu_id, nanobind::args runtimeArgs) {
-  if (!shots_count)
-    return {};
-
   auto &platform = get_platform();
   auto numQPUs = platform.num_qpus();
   if (qpu_id >= numQPUs)

--- a/python/tests/kernel/test_run_async_kernel.py
+++ b/python/tests/kernel/test_run_async_kernel.py
@@ -70,6 +70,17 @@ def test_run_async():
         assert non_zero_count > 0
 
 
+def test_run_async_shots_zero():
+    # `shots_count=0` is a valid input (docs require non-negative). The async
+    # path must match the sync path and return an empty list rather than
+    # crashing on `.get()`.
+    handle = cudaq.run_async(simple, 2, shots_count=0)
+    results = handle.get()
+    assert results == []
+    # Sync `cudaq.run` already returns []; asserting the contract is identical.
+    assert cudaq.run(simple, 2, shots_count=0) == results
+
+
 @pytest.mark.skip(reason="Skipping test due to issue #3193")
 def test_run_async_with_noise():
     cudaq.set_target("density-matrix-cpu")


### PR DESCRIPTION
  ## Summary

  Two small fixes in `python/runtime/cudaq/algorithms/py_run.cpp`,
  split into two commits.

  ### 1. `run_async(..., shots_count=0).get()` no longer crashes

  `run_async_impl` had an early `if (!shots_count) return {};` that produced a
  value-initialized `async_run_result` whose `std::future` had no shared state.
  The follow-up `.get()` then threw `std::future_error: No associated state`.

  The function already had a `shots_count == 0` branch further down that
  allocates the buffers and returns a ready future — the early return was
  short-circuiting it. Drop the early return.

  This restores parity with the synchronous `cudaq.run(..., shots_count=0)`
  (which returns `[]`) and matches the documented contract that `shots_count`
  is non-negative and the result list length equals `shots_count`.

  ### 2. `async_run_result` no longer leaks memory

  `async_run_result` held `std::vector<nb::object>*` and `std::string*` as raw
  pointers with no destructor. Cleanup lived only in `AsyncRunResultImpl.get()`,
  and was asymmetric — the success path freed only `results`, the error path
  freed only `error`. The mismatched buffer leaked on every call. If `.get()`
  was never invoked, both leaked.

  Switch ownership to `std::unique_ptr` so the struct destructor cleans up on
  every path. The deferred future captures non-owning raw pointers obtained via
  `.get()` on the unique_ptrs; ordering of struct members guarantees the future
  is destroyed before the unique_ptrs, so the captures are valid for the
  future's lifetime.

  `get()` is also simplified: throw straight from `*self.error`, and `std::move`
  the results vector out instead of `copy + delete`. This removes per-element
  Python refcount churn for large `shots_count`, and the success path becomes
  `noexcept`.

  ## Reproducer (before this PR)

  ```python
  import cudaq

  @cudaq.kernel
  def bell() -> int:
      q = cudaq.qubit()
      h(q)
      return mz(q)

  # Bug 1: crashes with "std::future_error: No associated state"
  cudaq.run_async(bell, shots_count=0).get()

  # Bug 2: heap-allocated string/vector leaked on every call
  for _ in range(10000):
      cudaq.run_async(bell, shots_count=10).get()
