### PR TITLE
Merge launchKernel + launchModule into unifiedLaunchModule

### DIFF
--- a/python/runtime/cudaq/algorithms/py_state.cpp
+++ b/python/runtime/cudaq/algorithms/py_state.cpp
@@ -235,7 +235,7 @@ public:
                   const_cast<void *>(static_cast<const void *>(&kernelMod)));
       cudaq::SourceModule src{kernelName};
       platform.with_execution_context(context, [&]() {
-        [[maybe_unused]] auto r = platform.launchKernel(src, {args});
+        [[maybe_unused]] auto r = platform.unifiedLaunchModule(src, {args});
       });
       state = std::move(context.simulationState);
     }
@@ -255,7 +255,7 @@ public:
 
     cudaq::SourceModule src{kernelName};
     platform.with_execution_context(context, [&]() {
-      [[maybe_unused]] auto r = platform.launchKernel(src, {args});
+      [[maybe_unused]] auto r = platform.unifiedLaunchModule(src, {args});
     });
     assert(context.overlapResult.has_value());
     return context.overlapResult.value();

--- a/python/runtime/utils/PyRemoteSimulatorQPU.cpp
+++ b/python/runtime/utils/PyRemoteSimulatorQPU.cpp
@@ -120,8 +120,13 @@ public:
                     n_params, shots);
   }
 
-  cudaq::KernelThunkResultType launchKernel(const cudaq::SourceModule &src,
-                                            cudaq::KernelArgs args) override {
+  cudaq::KernelThunkResultType
+  unifiedLaunchModule(const cudaq::AnyModule &module,
+                      cudaq::KernelArgs args) override {
+    if (!std::holds_alternative<cudaq::SourceModule>(module))
+      return Base::unifiedLaunchModule(module, args);
+
+    const auto &src = std::get<cudaq::SourceModule>(module);
     const auto &name = src.getName();
     auto rawFn = src.getFunctionPtr();
     cudaq::KernelThunkType kernelFunc = rawFn ? rawFn->getFn() : nullptr;

--- a/runtime/common/AnalogRemoteRESTQPU.h
+++ b/runtime/common/AnalogRemoteRESTQPU.h
@@ -26,8 +26,13 @@ public:
 
   /// @brief Launch a kernel with the given arguments
   /// Only analog Hamiltonian kernels are supported
-  KernelThunkResultType launchKernel(const SourceModule &src,
-                                     KernelArgs args) override {
+  KernelThunkResultType unifiedLaunchModule(const AnyModule &module,
+                                            KernelArgs args) override {
+    if (!std::holds_alternative<SourceModule>(module))
+      throw std::runtime_error(
+          "AnalogRemoteRESTQPU does not support pre-compiled module launch.");
+
+    const auto &src = std::get<SourceModule>(module);
     const auto &kernelName = src.getName();
     auto executionContext = cudaq::getExecutionContext();
 

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -220,41 +220,39 @@ public:
   /// representation required by the targeted backend. Handle all pertinent
   /// modifications for the execution context as well as asynchronous or
   /// synchronous invocation.
-  KernelThunkResultType launchKernel(const SourceModule &src,
-                                     KernelArgs args) override {
-    const auto &kernelName = src.getName();
-    CUDAQ_INFO("launching remote rest kernel ({})", kernelName);
-
-    auto executionContext = cudaq::getExecutionContext();
-
-    // TODO future iterations of this should support non-void return types.
-    if (!executionContext)
-      throw std::runtime_error(
-          "Remote rest execution can only be performed via cudaq::sample(), "
-          "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
-
-    auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
-
-    // Get the Quake code, lowered according to config file.
+  KernelThunkResultType unifiedLaunchModule(const AnyModule &module,
+                                            KernelArgs args) override {
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
-    auto codes =
-        compiler.lowerQuakeCode(executionContext, kernelName, moduleOp, args);
+    std::string kernelName;
+    std::vector<cudaq::KernelExecution> codes;
+
+    if (std::holds_alternative<SourceModule>(module)) {
+      const auto &src = std::get<SourceModule>(module);
+      kernelName = src.getName();
+      CUDAQ_INFO("launching remote rest kernel ({})", kernelName);
+
+      auto executionContext = cudaq::getExecutionContext();
+
+      // TODO future iterations of this should support non-void return types.
+      if (!executionContext)
+        throw std::runtime_error(
+            "Remote rest execution can only be performed via cudaq::sample(), "
+            "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
+
+      auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
+
+      // Get the Quake code, lowered according to config file.
+      codes =
+          compiler.lowerQuakeCode(executionContext, kernelName, moduleOp, args);
+    } else {
+      const auto &compiled = std::get<CompiledModule>(module);
+      kernelName = compiled.getName();
+      CUDAQ_INFO("launching remote rest kernel via module ({})", kernelName);
+      codes = compiler.emitKernelExecutions(compiled);
+    }
+
     completeLaunchKernel(kernelName, std::move(codes));
-
-    // NB: Kernel should/will never return dynamic results.
-    return {};
-  }
-
-  KernelThunkResultType launchModule(const CompiledModule &compiled,
-                                     KernelArgs args) override {
-    CUDAQ_INFO("launching remote rest kernel via module ({})",
-               compiled.getName());
-
-    Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
-                      noiseModel, emulate);
-    auto codes = compiler.emitKernelExecutions(compiled);
-    completeLaunchKernel(compiled.getName(), std::move(codes));
     return {};
   }
 

--- a/runtime/common/BaseRemoteSimulatorQPU.h
+++ b/runtime/common/BaseRemoteSimulatorQPU.h
@@ -122,26 +122,27 @@ public:
       throw std::runtime_error("Failed to launch VQE. Error: " + errorMsg);
   }
 
-  KernelThunkResultType launchKernel(const SourceModule &src,
-                                     KernelArgs args) override {
-    const auto &name = src.getName();
-    auto rawFn = src.getFunctionPtr();
-    KernelThunkType kernelFunc = rawFn ? rawFn->getFn() : nullptr;
-    // Make sure at most one argument representation is present.
-    KernelArgs forwarded;
-    if (kernelFunc) {
-      if (auto packed = args.getPacked())
-        forwarded = KernelArgs{*packed};
-    } else if (auto rawArgs = args.getTypeErased()) {
-      forwarded = KernelArgs{*rawArgs};
+  KernelThunkResultType unifiedLaunchModule(const AnyModule &module,
+                                            KernelArgs args) override {
+    if (std::holds_alternative<SourceModule>(module)) {
+      const auto &src = std::get<SourceModule>(module);
+      const auto &name = src.getName();
+      auto rawFn = src.getFunctionPtr();
+      KernelThunkType kernelFunc = rawFn ? rawFn->getFn() : nullptr;
+      // Make sure at most one argument representation is present.
+      KernelArgs forwarded;
+      if (kernelFunc) {
+        if (auto packed = args.getPacked())
+          forwarded = KernelArgs{*packed};
+      } else if (auto rawArgs = args.getTypeErased()) {
+        forwarded = KernelArgs{*rawArgs};
+      }
+      auto compiled =
+          compileKernelImpl(name, forwarded, mlir::ModuleOp{}, mlir::Type{});
+      return launchKernelImpl(compiled, kernelFunc, forwarded);
     }
-    auto compiled =
-        compileKernelImpl(name, forwarded, mlir::ModuleOp{}, mlir::Type{});
-    return launchKernelImpl(compiled, kernelFunc, forwarded);
-  }
 
-  KernelThunkResultType launchModule(const CompiledModule &compiled,
-                                     KernelArgs args) override {
+    const auto &compiled = std::get<CompiledModule>(module);
     auto rawArgs = args.getTypeErased();
     auto resultInfo = compiled.getResultInfo();
     void *resultBuf = nullptr;
@@ -173,7 +174,7 @@ public:
   }
 
   [[nodiscard]] CompiledModule compileKernelImpl(const std::string &name,
-                                                 const KernelArgs &args,
+                                                 KernelArgs args,
                                                  mlir::ModuleOp prefabMod,
                                                  mlir::Type resTy) {
     CUDAQ_INFO(

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
 
 // This header file and the types defined within are designed to have no
@@ -295,5 +296,11 @@ public:
   /// the `SourceModule` instance.
   SourceModule(std::string kernelName, const void *mlirModuleOpaquePtr);
 };
+
+// TODO: remove once C++ launch can be cleanly split into compilation + launch.
+// Used by unifiedLaunchModule to compile kernels if they have not been compiled
+// before. In the future, unifiedLaunchModule should only accept compiled
+// modules.
+using AnyModule = std::variant<SourceModule, CompiledModule>;
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/DefaultQPU.h
+++ b/runtime/cudaq/platform/default/DefaultQPU.h
@@ -21,8 +21,8 @@ public:
 
   void enqueue(QuantumTask &task) override;
 
-  KernelThunkResultType launchKernel(const cudaq::SourceModule &src,
-                                     cudaq::KernelArgs args) override;
+  KernelThunkResultType unifiedLaunchModule(const cudaq::AnyModule &module,
+                                            cudaq::KernelArgs args) override;
 
   void configureExecutionContext(ExecutionContext &context) const override;
   void beginExecution() override;

--- a/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
+++ b/runtime/cudaq/platform/default/DefaultQuantumPlatform.cpp
@@ -28,14 +28,19 @@ DefaultQPU::~DefaultQPU() = default;
 
 void DefaultQPU::enqueue(QuantumTask &task) { execution_queue->enqueue(task); }
 
-KernelThunkResultType DefaultQPU::launchKernel(const cudaq::SourceModule &src,
-                                               cudaq::KernelArgs args) {
-  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::launchKernel");
+KernelThunkResultType
+DefaultQPU::unifiedLaunchModule(const cudaq::AnyModule &module,
+                                cudaq::KernelArgs args) {
+  if (!std::holds_alternative<cudaq::SourceModule>(module))
+    return runJITCompiledModule(std::get<cudaq::CompiledModule>(module), args);
+
+  const auto &src = std::get<cudaq::SourceModule>(module);
+  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::unifiedLaunchModule");
   auto rawFn = src.getFunctionPtr();
   if (!rawFn)
     throw std::runtime_error(
-        "DefaultQPU::launchKernel requires a raw kernel function pointer "
-        "for kernel '" +
+        "DefaultQPU::unifiedLaunchModule requires a raw kernel function "
+        "pointer for kernel '" +
         src.getName() + "'.");
   auto packed = args.getPacked();
   void *argData = packed ? packed->data.data() : nullptr;

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
@@ -41,25 +41,25 @@ public:
     }
   }
 
-  KernelThunkResultType launchKernel(const SourceModule &src,
-                                     KernelArgs args) override {
-    const auto &kernelName = src.getName();
-    CUDAQ_INFO("FermioniqBaseQPU launching kernel ({})", kernelName);
-    auto [module, context] = Compiler::loadQuakeCodeByName(kernelName);
-    auto compiled =
-        compileImpl(kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
-          return compiler.runPassPipeline(ctx, kernelName, module, args,
-                                          std::move(context));
-        });
-    launchImpl(compiled);
-    return {};
-  }
-
-  KernelThunkResultType launchModule(const CompiledModule &compiled,
-                                     KernelArgs args) override {
-    CUDAQ_INFO("FermioniqBaseQPU launching kernel via module ({})",
-               compiled.getName());
-    launchImpl(compiled);
+  KernelThunkResultType unifiedLaunchModule(const AnyModule &module,
+                                            KernelArgs args) override {
+    if (std::holds_alternative<SourceModule>(module)) {
+      const auto &src = std::get<SourceModule>(module);
+      const auto &kernelName = src.getName();
+      CUDAQ_INFO("FermioniqBaseQPU launching kernel ({})", kernelName);
+      auto [quakeModule, context] = Compiler::loadQuakeCodeByName(kernelName);
+      auto compiled = compileImpl(
+          kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
+            return compiler.runPassPipeline(ctx, kernelName, quakeModule, args,
+                                            std::move(context));
+          });
+      launchImpl(compiled);
+    } else {
+      const auto &compiled = std::get<CompiledModule>(module);
+      CUDAQ_INFO("FermioniqBaseQPU launching kernel via module ({})",
+                 compiled.getName());
+      launchImpl(compiled);
+    }
     return {};
   }
 

--- a/runtime/cudaq/platform/mqpu/custatevec/GPUEmulatedQPU.cpp
+++ b/runtime/cudaq/platform/mqpu/custatevec/GPUEmulatedQPU.cpp
@@ -28,14 +28,18 @@ void GPUEmulatedQPU::enqueue(QuantumTask &task) {
 }
 
 cudaq::KernelThunkResultType
-GPUEmulatedQPU::launchKernel(const cudaq::SourceModule &src,
-                             cudaq::KernelArgs args) {
-  CUDAQ_INFO("QPU::launchKernel GPU {}", qpu_id);
+GPUEmulatedQPU::unifiedLaunchModule(const cudaq::AnyModule &module,
+                                    cudaq::KernelArgs args) {
+  if (!std::holds_alternative<cudaq::SourceModule>(module))
+    return runJITCompiledModule(std::get<cudaq::CompiledModule>(module), args);
+
+  const auto &src = std::get<cudaq::SourceModule>(module);
+  CUDAQ_INFO("QPU::unifiedLaunchModule GPU {}", qpu_id);
   cudaSetDevice(qpu_id);
   auto rawFn = src.getFunctionPtr();
   if (!rawFn)
     throw std::runtime_error(
-        "GPUEmulatedQPU::launchKernel requires a raw kernel function "
+        "GPUEmulatedQPU::unifiedLaunchModule requires a raw kernel function "
         "pointer for kernel '" +
         src.getName() + "'.");
   auto packed = args.getPacked();

--- a/runtime/cudaq/platform/mqpu/custatevec/GPUEmulatedQPU.h
+++ b/runtime/cudaq/platform/mqpu/custatevec/GPUEmulatedQPU.h
@@ -22,8 +22,8 @@ public:
 
   void enqueue(QuantumTask &task) override;
 
-  KernelThunkResultType launchKernel(const cudaq::SourceModule &src,
-                                     cudaq::KernelArgs args) override;
+  KernelThunkResultType unifiedLaunchModule(const cudaq::AnyModule &src,
+                                            cudaq::KernelArgs args) override;
 
   void configureExecutionContext(ExecutionContext &context) const override;
   void beginExecution() override;

--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
@@ -96,8 +96,13 @@ public:
 
   /// @brief Launch the kernel. Handle all pertinent modifications for the
   /// execution context.
-  [[nodiscard]] KernelThunkResultType launchKernel(const SourceModule &src,
-                                                   KernelArgs args) override {
+  [[nodiscard]] KernelThunkResultType
+  unifiedLaunchModule(const AnyModule &module, KernelArgs args) override {
+    if (!std::holds_alternative<SourceModule>(module))
+      throw std::runtime_error(
+          "OrcaRemoteRESTQPU does not support pre-compiled module launch.");
+
+    const auto &src = std::get<SourceModule>(module);
     auto rawFn = src.getFunctionPtr();
     KernelThunkType kernelFunc = rawFn ? rawFn->getFn() : nullptr;
     auto packed = args.getPacked();

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -34,13 +34,22 @@ extern "C" void cudaq_add_module_launcher_node(void *node_ptr) {
       static_cast<Node *>(node_ptr));
 }
 
-/// Execute a JIT-compiled kernel with provided arguments.
-///
-/// Handles argument marshaling via `argsCreator` (if not fully specialized)
-/// and result buffer allocation.
-static cudaq::KernelThunkResultType
-launchCompiledModule(const cudaq::CompiledModule &compiled,
-                     cudaq::KernelArgs args) {
+cudaq::KernelThunkResultType
+cudaq::QPU::unifiedLaunchModule(const AnyModule &module, KernelArgs args) {
+  if (std::holds_alternative<SourceModule>(module))
+    throw std::runtime_error(
+        "This QPU does not support launching uncompiled SourceModule kernels; "
+        "subclasses must override unifiedLaunchModule.");
+
+  const auto &compiled = std::get<CompiledModule>(module);
+  return runJITCompiledModule(compiled, args);
+}
+
+cudaq::KernelThunkResultType
+cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
+                                 KernelArgs args) {
+  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::runJITCompiledModule",
+                         compiled.getName());
   auto rawArgs = args.getTypeErased().value_or(std::span<void *const>{});
   auto funcPtr = compiled.getJit()->getFn();
   const auto &resultInfo = compiled.getResultInfo();
@@ -71,18 +80,6 @@ launchCompiledModule(const cudaq::CompiledModule &compiled,
   // Fully specialized, no result.
   funcPtr();
   return {nullptr, 0};
-}
-
-cudaq::KernelThunkResultType
-cudaq::QPU::launchModule(const CompiledModule &module, KernelArgs args) {
-  auto launcher = registry::get<ModuleLauncher>("default");
-  if (!launcher)
-    throw std::runtime_error(
-        "No ModuleLauncher registered with name 'default'. This may be a "
-        "result of attempting to use `launchModule` outside Python.");
-  ScopedTraceWithContext(cudaq::TIMING_LAUNCH, "QPU::launchModule",
-                         module.getName());
-  return launchCompiledModule(module, args);
 }
 
 cudaq::CompiledModule cudaq::QPU::compileModule(const SourceModule &src,

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -57,6 +57,9 @@ protected:
   /// terms.
   void handleObservation(ExecutionContext &context) const;
 
+  [[nodiscard]] static KernelThunkResultType
+  runJITCompiledModule(const CompiledModule &compiled, KernelArgs args);
+
 public:
   /// The constructor, initializes the execution queue
   QPU() : execution_queue(std::make_unique<QuantumExecutionQueue>()) {}
@@ -139,10 +142,7 @@ public:
                          const std::size_t shots) {}
 
   [[nodiscard]] virtual KernelThunkResultType
-  launchKernel(const SourceModule &src, KernelArgs args) = 0;
-
-  [[nodiscard]] virtual KernelThunkResultType
-  launchModule(const CompiledModule &compiled, KernelArgs args);
+  unifiedLaunchModule(const AnyModule &module, KernelArgs args);
 
   [[nodiscard]] virtual CompiledModule
   compileModule(const SourceModule &src, KernelArgs args, bool isEntryPoint);

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -221,20 +221,12 @@ quantum_platform::get_remote_capabilities(std::size_t qpu_id) const {
   return platformQPUs[qpu_id]->getRemoteCapabilities();
 }
 
-KernelThunkResultType quantum_platform::launchKernel(const SourceModule &src,
-                                                     const KernelArgs &args,
-                                                     std::size_t qpu_id) {
-  validateQpuId(qpu_id);
-  auto &qpu = platformQPUs[qpu_id];
-  return qpu->launchKernel(src, args);
-}
-
 KernelThunkResultType
-quantum_platform::launchModule(const CompiledModule &module,
-                               const KernelArgs &args, std::size_t qpu_id) {
+quantum_platform::unifiedLaunchModule(const AnyModule &module, KernelArgs args,
+                                      std::size_t qpu_id) {
   validateQpuId(qpu_id);
   auto &qpu = platformQPUs[qpu_id];
-  return qpu->launchModule(module, args);
+  return qpu->unifiedLaunchModule(module, args);
 }
 
 CompiledModule quantum_platform::compileModule(const SourceModule &src,
@@ -302,7 +294,7 @@ cudaq::altLaunchKernel(const char *kernelName,
   std::size_t qpu_id = cudaq::getCurrentQpuId();
   KernelArgs args{KernelArgs::PackedArgs{kernelArgs, argsSize, resultOffset}};
   SourceModule src{kernName, kernelFunc};
-  return platform.launchKernel(src, args, qpu_id);
+  return platform.unifiedLaunchModule(src, args, qpu_id);
 }
 
 cudaq::KernelThunkResultType
@@ -315,7 +307,7 @@ cudaq::streamlinedLaunchKernel(const char *kernelName,
   std::size_t qpu_id = cudaq::getCurrentQpuId();
   KernelArgs args{rawArgs};
   SourceModule src{kernName};
-  [[maybe_unused]] auto r = platform.launchKernel(src, args, qpu_id);
+  [[maybe_unused]] auto r = platform.unifiedLaunchModule(src, args, qpu_id);
   // NB: The streamlined launch will never return results. Use alt or hybrid if
   // the kernel returns results.
   return {};
@@ -329,7 +321,7 @@ cudaq::streamlinedLaunchModule(const CompiledModule &compiled,
 
   auto &platform = *getQuantumPlatformInternal();
   std::size_t qpu_id = getCurrentQpuId();
-  return platform.launchModule(compiled, {rawArgs}, qpu_id);
+  return platform.unifiedLaunchModule(compiled, {rawArgs}, qpu_id);
 }
 
 cudaq::CompiledModule cudaq::streamlinedCompileModule(
@@ -356,9 +348,10 @@ cudaq::hybridLaunchKernel(const char *kernelName, cudaq::KernelThunkType kernel,
   SourceModule src{kernName, kernel};
   if (platform.is_remote(qpu_id)) {
     // This path should never call a kernel that returns results.
-    [[maybe_unused]] auto r = platform.launchKernel(src, {rawArgs}, qpu_id);
+    [[maybe_unused]] auto r =
+        platform.unifiedLaunchModule(src, {rawArgs}, qpu_id);
     return {};
   }
   KernelArgs hybrid{{args, argsSize, resultOffset}, rawArgs};
-  return platform.launchKernel(src, hybrid, qpu_id);
+  return platform.unifiedLaunchModule(src, hybrid, qpu_id);
 }

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -192,16 +192,9 @@ public:
                  cudaq::optimizer &optimizer, const int n_params,
                  const std::size_t shots, std::size_t qpu_id = 0);
 
-  // This method is the hook for the kernel rewrites to invoke quantum kernels.
-  [[nodiscard]] KernelThunkResultType launchKernel(const SourceModule &src,
-                                                   const KernelArgs &args,
-                                                   std::size_t qpu_id = 0);
-
-  // This method launches a kernel from a ModuleOp that has already been
-  // created.
-  [[nodiscard]] KernelThunkResultType launchModule(const CompiledModule &module,
-                                                   const KernelArgs &args,
-                                                   std::size_t qpu_id);
+  [[nodiscard]] KernelThunkResultType
+  unifiedLaunchModule(const AnyModule &module, KernelArgs args,
+                      std::size_t qpu_id = 0);
 
   [[nodiscard]] CompiledModule compileModule(const SourceModule &src,
                                              const KernelArgs &args,

--- a/runtime/cudaq/qis/remote_state.cpp
+++ b/runtime/cudaq/qis/remote_state.cpp
@@ -27,8 +27,8 @@ void RemoteSimulationState::execute() const {
     std::ostringstream remoteLogCout;
     platform.setLogStream(remoteLogCout);
     platform.with_execution_context(context, [&]() {
-      [[maybe_unused]] auto r =
-          platform.launchKernel(SourceModule{kernelName}, KernelArgs{args});
+      [[maybe_unused]] auto r = platform.unifiedLaunchModule(
+          SourceModule{kernelName}, KernelArgs{args});
     });
     platform.resetLogStream();
     // Cache the info log if any.
@@ -155,8 +155,8 @@ std::vector<std::complex<double>> RemoteSimulationState::getAmplitudes(
   // Perform the usual pattern set the context,
   // execute and then reset
   platform.with_execution_context(context, [&]() {
-    [[maybe_unused]] auto r =
-        platform.launchKernel(SourceModule{kernelName}, KernelArgs{args});
+    [[maybe_unused]] auto r = platform.unifiedLaunchModule(
+        SourceModule{kernelName}, KernelArgs{args});
   });
   std::vector<std::complex<double>> amplitudes;
   amplitudes.reserve(basisStates.size());
@@ -188,7 +188,7 @@ RemoteSimulationState::overlap(const cudaq::SimulationState &other) {
                      static_cast<const cudaq::SimulationState *>(&otherState));
   platform.with_execution_context(context, [&]() {
     [[maybe_unused]] auto dynamicResult =
-        platform.launchKernel(SourceModule{kernelName}, KernelArgs{});
+        platform.unifiedLaunchModule(SourceModule{kernelName}, KernelArgs{});
   });
   assert(context.overlapResult.has_value());
   return context.overlapResult.value();

--- a/unittests/common/ExecutionContextThreadTester.cpp
+++ b/unittests/common/ExecutionContextThreadTester.cpp
@@ -24,8 +24,9 @@ public:
 
   void enqueue(cudaq::QuantumTask &task) override {}
 
-  cudaq::KernelThunkResultType launchKernel(const cudaq::SourceModule &src,
-                                            cudaq::KernelArgs args) override {
+  cudaq::KernelThunkResultType
+  unifiedLaunchModule(const cudaq::AnyModule &module,
+                      cudaq::KernelArgs args) override {
     return {};
   }
 };


### PR DESCRIPTION
~Stacks on top of #4446~ Done.

This PR unifies the `launchKernel` and `launchModule` endpoints in `quantum_platform`, `QPU` and its derived classes into a single `unifiedLaunchModule`.

This is achieved by moving the differences between the two methods into `if` and `else` branches within the `unifiedLaunchModule` implementation. This in itself reduces code duplication somewhat by removing the identical parts across the two execution paths. More importantly, it unblocks us to proceed from here on in parallel on:

- consolidating and reducing further the differences between the compilation and launch pipelines for different QPUs and host languages. In particular, we will be able to remove `AnyModule` once the C++ path is split into two phases (mlir-opt + launch) that mirror the current Python path
- introducing overloads of the launch endpoint based on execution policies