### PR TITLE
Add classic quantum algorithm examples in Python and C++

### DIFF
--- a/docs/sphinx/examples/cpp/basics/bernstein_vazirani.cpp
+++ b/docs/sphinx/examples/cpp/basics/bernstein_vazirani.cpp
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
 #include <cudaq.h>
 #include <iostream>
 
@@ -24,13 +32,13 @@ std::vector<int> random_bitstring(int qubit_count) {
   return vector_of_bits;
 }
 
-__qpu__ void oracle(cudaq::qview<> qvector, cudaq::qubit &auxillary_qubit,
+__qpu__ void oracle(cudaq::qview<> qvector, cudaq::qubit &auxiliary_qubit,
                     std::vector<int> &hidden_bitstring) {
   for (auto i = 0; i < hidden_bitstring.size(); i++) {
     if (hidden_bitstring[i] == 1)
       // Apply a `cx` gate with the current qubit as
-      // the control and the auxillary qubit as the target.
-      x<cudaq::ctrl>(qvector[i], auxillary_qubit);
+      // the control and the auxiliary qubit as the target.
+      x<cudaq::ctrl>(qvector[i], auxiliary_qubit);
   }
 }
 
@@ -38,24 +46,24 @@ __qpu__ void bernstein_vazirani(std::vector<int> &hidden_bitstring) {
   // Allocate the specified number of qubits - this
   // corresponds to the length of the hidden bitstring.
   cudaq::qvector qvector(hidden_bitstring.size());
-  // Allocate an extra auxillary qubit.
-  cudaq::qubit auxillary_qubit;
+  // Allocate an extra auxiliary qubit.
+  cudaq::qubit auxiliary_qubit;
 
-  // Prepare the auxillary qubit.
-  h(auxillary_qubit);
-  z(auxillary_qubit);
+  // Prepare the auxiliary qubit.
+  h(auxiliary_qubit);
+  z(auxiliary_qubit);
 
   // Place the rest of the qubits in a superposition state.
   h(qvector);
 
   // Query the oracle.
-  oracle(qvector, auxillary_qubit, hidden_bitstring);
+  oracle(qvector, auxiliary_qubit, hidden_bitstring);
 
   // Apply another set of Hadamards to the qubits.
   h(qvector);
 
   // Apply measurement gates to just the `qubits`
-  // (excludes the auxillary qubit).
+  // (excludes the auxiliary qubit).
   mz(qvector);
 }
 

--- a/docs/sphinx/examples/cpp/basics/grover.cpp
+++ b/docs/sphinx/examples/cpp/basics/grover.cpp
@@ -1,0 +1,104 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
+# All rights reserved.                                                        #
+#                                                                             #
+# This source code and the accompanying materials are made available under    #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+
+#include <cudaq.h>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+
+/*
+ * Grover's algorithm is a quantum algorithm that finds with high probability 
+ * the unique input to a black box function that produces a particular output 
+ * value, using just O(sqrt(N)) evaluations of the function, where N is the 
+ * size of the function's domain.
+ * 
+ * This example demonstrates:
+ * 1. Multi-controlled Z gates.
+ * 2. The `cudaq::compute_action` primitive for automatic un-computation.
+ * 3. Kernel composition and template kernels.
+ */
+
+// Reflection about the uniform superposition state.
+__qpu__ void reflect_about_uniform(cudaq::qvector<> &qs) {
+  auto ctrlQubits = qs.front(qs.size() - 1);
+  auto &lastQubit = qs.back();
+
+  // Compute (U) Action (V) produces: U V U::Adjoint
+  cudaq::compute_action(
+      [&]() {
+        h(qs);
+        x(qs);
+      },
+      [&]() { z<cudaq::ctrl>(ctrlQubits, lastQubit); });
+}
+
+// The oracle marks the target state by flipping its phase.
+struct oracle {
+  void operator()(const long target_state, cudaq::qvector<> &qs) __qpu__ {
+    cudaq::compute_action(
+        [&]() {
+          for (int i = 0; i < qs.size(); ++i) {
+            // If the bit in target_state is 0, apply X to that qubit
+            // so that the multi-controlled Z applies to the |0> state.
+            bool target_bit_set = (target_state >> (qs.size() - i - 1)) & 1;
+            if (!target_bit_set)
+              x(qs[i]);
+          }
+        },
+        [&]() {
+          auto ctrlQubits = qs.front(qs.size() - 1);
+          z<cudaq::ctrl>(ctrlQubits, qs.back());
+        });
+  }
+};
+
+// The main Grover algorithm kernel.
+struct run_grover {
+  template <typename CallableKernel>
+  __qpu__ auto operator()(const int n_qubits, const long target_state,
+                          CallableKernel &&oracle_kernel) {
+    // Calculate the optimal number of iterations: floor(pi/4 * sqrt(N))
+    int n_iterations = std::round(0.25 * M_PI * std::sqrt(1 << n_qubits));
+
+    cudaq::qvector qs(n_qubits);
+
+    // Start in uniform superposition.
+    h(qs);
+
+    // Iteratively apply oracle and diffusion operator.
+    for (int i = 0; i < n_iterations; i++) {
+      oracle_kernel(target_state, qs);
+      reflect_about_uniform(qs);
+    }
+
+    // Measure to find the target state.
+    mz(qs);
+  }
+};
+
+int main() {
+  const int n_qubits = 4;
+  const long target_state = 0b1011; // We are searching for 11
+
+  std::cout << "Searching for target state: 1011\n";
+
+  // Sample the kernel.
+  auto counts = cudaq::sample(run_grover{}, n_qubits, target_state, oracle{});
+
+  // Output results.
+  std::cout << "Found string: " << counts.most_probable() << "\n";
+
+  // Validation.
+  if (counts.most_probable() == "1011") {
+      std::cout << "Success!\n";
+  } else {
+      std::cout << "Failure.\n";
+  }
+
+  return 0;
+}

--- a/docs/sphinx/examples/cpp/basics/grover.cpp
+++ b/docs/sphinx/examples/cpp/basics/grover.cpp
@@ -1,22 +1,22 @@
-# ============================================================================ #
-# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
-# All rights reserved.                                                        #
-#                                                                             #
-# This source code and the accompanying materials are made available under    #
-# the terms of the Apache License 2.0 which accompanies this distribution.    #
-# ============================================================================ #
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
 
-#include <cudaq.h>
 #include <cmath>
 #include <cstdio>
+#include <cudaq.h>
 #include <iostream>
 
 /*
- * Grover's algorithm is a quantum algorithm that finds with high probability 
- * the unique input to a black box function that produces a particular output 
- * value, using just O(sqrt(N)) evaluations of the function, where N is the 
+ * Grover's algorithm is a quantum algorithm that finds with high probability
+ * the unique input to a black box function that produces a particular output
+ * value, using just O(sqrt(N)) evaluations of the function, where N is the
  * size of the function's domain.
- * 
+ *
  * This example demonstrates:
  * 1. Multi-controlled Z gates.
  * 2. The `cudaq::compute_action` primitive for automatic un-computation.
@@ -95,9 +95,9 @@ int main() {
 
   // Validation.
   if (counts.most_probable() == "1011") {
-      std::cout << "Success!\n";
+    std::cout << "Success!\n";
   } else {
-      std::cout << "Failure.\n";
+    std::cout << "Failure.\n";
   }
 
   return 0;

--- a/docs/sphinx/examples/cpp/basics/teleportation.cpp
+++ b/docs/sphinx/examples/cpp/basics/teleportation.cpp
@@ -1,0 +1,85 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
+# All rights reserved.                                                        #
+#                                                                             #
+# This source code and the accompanying materials are made available under    #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+
+#include <cudaq.h>
+#include <iostream>
+
+/*
+ * Quantum Teleportation allows for the transfer of a quantum state from one 
+ * qubit to another, using a shared entangled pair and classical communication.
+ * 
+ * This example demonstrates:
+ * 1. Mid-circuit measurements (`mz`).
+ * 2. Conditional operations based on classical measurement results.
+ * 3. Use of `cudaq::run` to execute kernels and process results.
+ */
+
+struct teleportation {
+  auto operator()() __qpu__ {
+    // Allocate 3 qubits:
+    // q[0]: The qubit to be teleported (Alice's data)
+    // q[1]: Alice's half of the Bell pair
+    // q[2]: Bob's half of the Bell pair
+    cudaq::qarray<3> q;
+
+    // 1. Prepare the state to be teleported on q[0].
+    // For this example, let's prepare the |1> state by applying X.
+    x(q[0]);
+
+    // 2. Create a Bell pair between q[1] and q[2].
+    h(q[1]);
+    x<cudaq::ctrl>(q[1], q[2]);
+
+    // 3. Alice performs a Bell measurement on q[0] and q[1].
+    x<cudaq::ctrl>(q[0], q[1]);
+    h(q[0]);
+
+    // Mid-circuit measurement
+    auto b0 = mz(q[0]);
+    auto b1 = mz(q[1]);
+
+    // 4. Bob applies conditional gates based on Alice's measurements.
+    if (b1)
+      x(q[2]);
+    if (b0)
+      z(q[2]);
+
+    // 5. Measure Bob's qubit to verify the state was teleported.
+    // It should be in the |1> state.
+    return mz(q[2]);
+  }
+};
+
+int main() {
+  std::cout << "Executing Quantum Teleportation...\n";
+
+  // Since teleportation is a probabilistic process that requires 
+  // classical feedback, we use `cudaq::run` instead of `cudaq::sample`.
+  // `cudaq::sample` does not support kernels with conditional feedback.
+  int n_shots = 100;
+  auto results = cudaq::run(n_shots, teleportation{});
+
+  // Extract counts for the last qubit (Bob's qubit)
+  std::size_t n_ones = 0;
+  for (auto r : results) {
+    if (r) {
+        n_ones++;
+    }
+  }
+
+  std::cout << "Measured '1' on target qubit " << n_ones << " times out of " << n_shots << " shots.\n";
+
+  // Validation
+  if (n_ones == n_shots) {
+      std::cout << "Success! The |1> state was teleported perfectly.\n";
+  } else {
+      std::cout << "Failure.\n";
+  }
+
+  return 0;
+}

--- a/docs/sphinx/examples/cpp/basics/teleportation.cpp
+++ b/docs/sphinx/examples/cpp/basics/teleportation.cpp
@@ -1,18 +1,18 @@
-# ============================================================================ #
-# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
-# All rights reserved.                                                        #
-#                                                                             #
-# This source code and the accompanying materials are made available under    #
-# the terms of the Apache License 2.0 which accompanies this distribution.    #
-# ============================================================================ #
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
 
 #include <cudaq.h>
 #include <iostream>
 
 /*
- * Quantum Teleportation allows for the transfer of a quantum state from one 
+ * Quantum Teleportation allows for the transfer of a quantum state from one
  * qubit to another, using a shared entangled pair and classical communication.
- * 
+ *
  * This example demonstrates:
  * 1. Mid-circuit measurements (`mz`).
  * 2. Conditional operations based on classical measurement results.
@@ -58,7 +58,7 @@ struct teleportation {
 int main() {
   std::cout << "Executing Quantum Teleportation...\n";
 
-  // Since teleportation is a probabilistic process that requires 
+  // Since teleportation is a probabilistic process that requires
   // classical feedback, we use `cudaq::run` instead of `cudaq::sample`.
   // `cudaq::sample` does not support kernels with conditional feedback.
   int n_shots = 100;
@@ -68,17 +68,18 @@ int main() {
   std::size_t n_ones = 0;
   for (auto r : results) {
     if (r) {
-        n_ones++;
+      n_ones++;
     }
   }
 
-  std::cout << "Measured '1' on target qubit " << n_ones << " times out of " << n_shots << " shots.\n";
+  std::cout << "Measured '1' on target qubit " << n_ones << " times out of "
+            << n_shots << " shots.\n";
 
   // Validation
   if (n_ones == n_shots) {
-      std::cout << "Success! The |1> state was teleported perfectly.\n";
+    std::cout << "Success! The |1> state was teleported perfectly.\n";
   } else {
-      std::cout << "Failure.\n";
+    std::cout << "Failure.\n";
   }
 
   return 0;

--- a/docs/sphinx/examples/python/bernstein_vazirani.py
+++ b/docs/sphinx/examples/python/bernstein_vazirani.py
@@ -1,0 +1,68 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
+# All rights reserved.                                                        #
+#                                                                             #
+# This source code and the accompanying materials are made available under    #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+
+import cudaq
+import random
+
+# The Bernstein-Vazirani algorithm allows us to find a hidden bitstring
+# `s` in a single query to an oracle that computes f(x) = s · x (mod 2).
+
+def generate_random_bitstring(length):
+    return [random.randint(0, 1) for _ in range(length)]
+
+@cudaq.kernel
+def oracle(qvector: cudaq.qview, auxillary_qubit: cudaq.qubit, hidden_bitstring: list[int]):
+    for i, bit in enumerate(hidden_bitstring):
+        if bit == 1:
+            # Apply a `cx` gate with the current qubit as
+            # the control and the auxillary qubit as the target.
+            x.ctrl(qvector[i], auxillary_qubit)
+
+@cudaq.kernel
+def bernstein_vazirani(hidden_bitstring: list[int]):
+    # Allocate the specified number of qubits - this
+    # corresponds to the length of the hidden bitstring.
+    qvector = cudaq.qreg(len(hidden_bitstring))
+    
+    # Allocate an extra auxillary qubit.
+    auxillary_qubit = cudaq.qubit()
+
+    # Prepare the auxillary qubit in the |-> state.
+    x(auxillary_qubit)
+    h(auxillary_qubit)
+
+    # Place the rest of the qubits in a superposition state.
+    h(qvector)
+
+    # Query the oracle.
+    oracle(qvector, auxillary_qubit, hidden_bitstring)
+
+    # Apply another set of Hadamards to the qubits to 
+    # extract the hidden bitstring.
+    h(qvector)
+
+    # Measure the qubits.
+    mz(qvector)
+
+# Setup the experiment
+qubit_count = 5
+hidden_bitstring = generate_random_bitstring(qubit_count)
+print(f"Encoded bitstring  = {''.join(map(str, hidden_bitstring))}")
+
+# Sample the kernel
+result = cudaq.sample(bernstein_vazirani, hidden_bitstring)
+
+# Output the results
+measured_bitstring = result.most_probable()
+print(f"Measured bitstring = {measured_bitstring}")
+
+# Validation
+if measured_bitstring == ''.join(map(str, hidden_bitstring)):
+    print("Success!")
+else:
+    print("Failure.")

--- a/docs/sphinx/examples/python/bernstein_vazirani.py
+++ b/docs/sphinx/examples/python/bernstein_vazirani.py
@@ -1,9 +1,9 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
-# All rights reserved.                                                        #
-#                                                                             #
-# This source code and the accompanying materials are made available under    #
-# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under      #
+# the terms of the Apache License 2.0 which accompanies this distribution.      #
 # ============================================================================ #
 
 import cudaq
@@ -16,12 +16,12 @@ def generate_random_bitstring(length):
     return [random.randint(0, 1) for _ in range(length)]
 
 @cudaq.kernel
-def oracle(qvector: cudaq.qview, auxillary_qubit: cudaq.qubit, hidden_bitstring: list[int]):
+def oracle(qvector: cudaq.qview, auxiliary_qubit: cudaq.qubit, hidden_bitstring: list[int]):
     for i, bit in enumerate(hidden_bitstring):
         if bit == 1:
             # Apply a `cx` gate with the current qubit as
-            # the control and the auxillary qubit as the target.
-            x.ctrl(qvector[i], auxillary_qubit)
+            # the control and the auxiliary qubit as the target.
+            x.ctrl(qvector[i], auxiliary_qubit)
 
 @cudaq.kernel
 def bernstein_vazirani(hidden_bitstring: list[int]):
@@ -29,18 +29,18 @@ def bernstein_vazirani(hidden_bitstring: list[int]):
     # corresponds to the length of the hidden bitstring.
     qvector = cudaq.qreg(len(hidden_bitstring))
     
-    # Allocate an extra auxillary qubit.
-    auxillary_qubit = cudaq.qubit()
+    # Allocate an extra auxiliary qubit.
+    auxiliary_qubit = cudaq.qubit()
 
-    # Prepare the auxillary qubit in the |-> state.
-    x(auxillary_qubit)
-    h(auxillary_qubit)
+    # Prepare the auxiliary qubit in the |-> state.
+    x(auxiliary_qubit)
+    h(auxiliary_qubit)
 
     # Place the rest of the qubits in a superposition state.
     h(qvector)
 
     # Query the oracle.
-    oracle(qvector, auxillary_qubit, hidden_bitstring)
+    oracle(qvector, auxiliary_qubit, hidden_bitstring)
 
     # Apply another set of Hadamards to the qubits to 
     # extract the hidden bitstring.

--- a/docs/sphinx/examples/python/grover.py
+++ b/docs/sphinx/examples/python/grover.py
@@ -1,9 +1,9 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
-# All rights reserved.                                                        #
-#                                                                             #
-# This source code and the accompanying materials are made available under    #
-# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under      #
+# the terms of the Apache License 2.0 which accompanies this distribution.      #
 # ============================================================================ #
 
 import cudaq

--- a/docs/sphinx/examples/python/grover.py
+++ b/docs/sphinx/examples/python/grover.py
@@ -1,0 +1,83 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
+# All rights reserved.                                                        #
+#                                                                             #
+# This source code and the accompanying materials are made available under    #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+
+import cudaq
+import numpy as np
+
+# Grover's algorithm is a quantum algorithm that finds with high probability 
+# the unique input to a black box function that produces a particular output 
+# value, using just O(sqrt(N)) evaluations of the function, where N is the 
+# size of the function's domain.
+
+@cudaq.kernel
+def reflect_about_uniform(qs: cudaq.qview):
+    """
+    Reflection about the uniform superposition state.
+    This is also known as the Grover diffusion operator.
+    """
+    ctrlQubits = qs.front(qs.size() - 1)
+    lastQubit = qs.back()
+
+    # compute_action(U, V) performs U V U_adjoint
+    cudaq.compute_action(lambda: (h(qs), x(qs)), 
+                         lambda: z.ctrl(ctrlQubits, lastQubit))
+
+@cudaq.kernel
+def oracle(qs: cudaq.qview, target_state: int):
+    """
+    The oracle marks the target state by flipping its phase.
+    """
+    def prepare_oracle():
+        for i in range(qs.size()):
+            # If the bit in target_state is 0, apply X to that qubit
+            # so that the multi-controlled Z applies to the |0> state.
+            if not ((target_state >> (qs.size() - i - 1)) & 1):
+                x(qs[i])
+
+    ctrlQubits = qs.front(qs.size() - 1)
+    cudaq.compute_action(prepare_oracle, 
+                         lambda: z.ctrl(ctrlQubits, qs.back()))
+
+@cudaq.kernel
+def grover(n_qubits: int, target_state: int):
+    # Allocate the qubits
+    qs = cudaq.qreg(n_qubits)
+
+    # Calculate the number of iterations
+    n_iterations = int(np.round(0.25 * np.pi * np.sqrt(2**n_qubits)))
+
+    # Start in uniform superposition
+    h(qs)
+
+    # Iteratively apply oracle and diffusion operator
+    for _ in range(n_iterations):
+        oracle(qs, target_state)
+        reflect_about_uniform(qs)
+
+    # Measure to find the target state
+    mz(qs)
+
+# --- Execution ---
+
+n_qubits = 4
+target_state = 0b1011  # We are searching for 11
+
+print(f"Searching for target state: {bin(target_state)}")
+
+# Sample the kernel
+result = cudaq.sample(grover, n_qubits, target_state)
+
+# Output the results
+measured_state = result.most_probable()
+print(f"Measured state: {measured_state}")
+
+# Validation
+if int(measured_state, 2) == target_state:
+    print("Success!")
+else:
+    print("Failure.")

--- a/docs/sphinx/examples/python/teleportation.py
+++ b/docs/sphinx/examples/python/teleportation.py
@@ -1,0 +1,69 @@
+# ============================================================================ #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
+# All rights reserved.                                                        #
+#                                                                             #
+# This source code and the accompanying materials are made available under    #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+
+import cudaq
+
+# Quantum Teleportation allows for the transfer of a quantum state from one 
+# qubit to another, using a shared entangled pair and classical communication.
+
+@cudaq.kernel
+def teleportation():
+    # Allocate 3 qubits:
+    # q[0]: The qubit to be teleported (Alice's data)
+    # q[1]: Alice's half of the Bell pair
+    # q[2]: Bob's half of the Bell pair
+    q = cudaq.qreg(3)
+
+    # 1. Prepare the state to be teleported on q[0].
+    # For this example, let's prepare the |1> state by applying X.
+    x(q[0])
+
+    # 2. Create a Bell pair between q[1] and q[2].
+    h(q[1])
+    x.ctrl(q[1], q[2])
+
+    # 3. Alice performs a Bell measurement on q[0] and q[1].
+    x.ctrl(q[0], q[1])
+    h(q[0])
+
+    # Mid-circuit measurement
+    b0 = mz(q[0])
+    b1 = mz(q[1])
+
+    # 4. Bob applies conditional gates based on Alice's measurements.
+    # In CUDA-Q, we can use if-statements on measurement results.
+    if b1:
+        x(q[2])
+    if b0:
+        z(q[2])
+
+    # 5. Measure Bob's qubit to verify the state was teleported.
+    # It should be in the |1> state.
+    return mz(q[2])
+
+# --- Execution ---
+
+print("Executing Quantum Teleportation...")
+
+# Since teleportation is a probabilistic process that requires 
+# classical feedback, we use `cudaq.run` instead of `cudaq.sample`.
+# `cudaq.sample` does not support kernels with conditional feedback.
+shots_count = 100
+results = cudaq.run(teleportation, shots_count=shots_count)
+
+# Extract counts for the teleported qubit state
+ones_count = sum(results)
+
+print(f"Teleportation Results (Target Qubit):")
+print(f"Measured '1': {ones_count} times out of {shots_count} shots.")
+
+# Validation
+if ones_count == shots_count:
+    print("Success! The |1> state was teleported perfectly.")
+else:
+    print(f"Failure. Expected {shots_count} but got {ones_count}.")

--- a/docs/sphinx/examples/python/teleportation.py
+++ b/docs/sphinx/examples/python/teleportation.py
@@ -1,9 +1,9 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates and Contributors. #
-# All rights reserved.                                                        #
-#                                                                             #
-# This source code and the accompanying materials are made available under    #
-# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under      #
+# the terms of the Apache License 2.0 which accompanies this distribution.      #
 # ============================================================================ #
 
 import cudaq


### PR DESCRIPTION
This commit adds high-quality, well-documented examples for:
- Grover's Search (Python & C++)
- Quantum Teleportation (Python & C++)
- Bernstein-Vazirani (Python)

These examples demonstrate key CUDA-Q features like compute_action, mid-circuit measurements, and conditional feedback using the run API. The Grover example is promoted from internal tests for better visibility.