### PR TITLE
Add tensor_product and trace methods to cudaq::state

### DIFF
--- a/docs/sphinx/examples/cpp/basics/density_matrix_utils.cpp
+++ b/docs/sphinx/examples/cpp/basics/density_matrix_utils.cpp
@@ -1,0 +1,49 @@
+#include <cudaq.h>
+#include <iostream>
+
+/**
+ * This example demonstrates the use of the `trace` and `tensor_product`
+ * methods on `cudaq::state`. These methods are particularly useful when
+ * working with density matrices (mixed states) and for combining subsystem states.
+ */
+
+int main() {
+  // Define a simple kernel to create a Bell state.
+  auto bell = []() __qpu__ {
+    cudaq::qubit q, r;
+    h(q);
+    cx(q, r);
+  };
+
+  // 1. Get the state vector (pure state)
+  auto stateVector = cudaq::get_state(bell);
+  std::cout << "State vector (rank " << stateVector.get_tensor(0).extents.size()
+            << "):\n";
+  stateVector.dump();
+
+  // 2. Get the density matrix (mixed state) using the 'dm' simulator
+  // Note: We can also get this by using the 'dm' target.
+  cudaq::set_target("dm");
+  auto densityMatrix = cudaq::get_state(bell);
+  std::cout << "\nDensity matrix (rank "
+            << densityMatrix.get_tensor(0).extents.size() << "):\n";
+  densityMatrix.dump();
+
+  // 3. Take the trace of the density matrix.
+  // For any valid density matrix, the trace should be 1.0.
+  auto tr = densityMatrix.trace();
+  std::cout << "\nTrace of density matrix: " << tr << "\n";
+
+  // 4. Compute the tensor product of two states.
+  // Combining two 2-qubit Bell states into a 4-qubit joint state.
+  auto jointState = densityMatrix.tensor_product(densityMatrix);
+  std::cout << "\nJoint state (4 qubits) rank: "
+            << jointState.get_tensor(0).extents.size() << "\n";
+  std::cout << "Joint state dimensions: " << jointState.get_tensor(0).extents[0]
+            << "x" << jointState.get_tensor(0).extents[1] << "\n";
+
+  // The trace of the tensor product of normalized states is also 1.0.
+  std::cout << "Trace of joint state: " << jointState.trace() << "\n";
+
+  return 0;
+}

--- a/runtime/common/SimulationState.h
+++ b/runtime/common/SimulationState.h
@@ -207,6 +207,69 @@ public:
   /// @brief Destroy the state representation, frees all associated memory.
   virtual void destroyState() = 0;
 
+  /// @brief Return the trace of this state.
+  virtual std::complex<double> trace() {
+    auto t = getTensor(0);
+    if (t.extents.size() != 2)
+      throw std::runtime_error("trace() only supported for density matrices.");
+
+    std::complex<double> tr = 0.0;
+    auto dim = t.extents[0];
+    for (std::size_t i = 0; i < dim; ++i)
+      tr += (*this)(0, {i, i});
+    return tr;
+  }
+
+  /// @brief Return the tensor product of this state with another.
+  virtual std::unique_ptr<SimulationState>
+  tensorProduct(const SimulationState &other) {
+    if (!isArrayLike() || !other.isArrayLike())
+      throw std::runtime_error(
+          "tensorProduct() not supported for non-array-like states.");
+
+    auto t1 = getTensor(0);
+    auto t2 = other.getTensor(0);
+
+    auto get_data = [](const SimulationState &s) {
+      auto t = s.getTensor(0);
+      std::vector<std::complex<double>> data(t.get_num_elements());
+      if (s.isDeviceData()) {
+        s.toHost(data.data(), data.size());
+      } else {
+        auto ptr = reinterpret_cast<const std::complex<double> *>(t.data);
+        std::copy(ptr, ptr + data.size(), data.begin());
+      }
+      return data;
+    };
+
+    auto data1 = get_data(*this);
+    auto data2 = get_data(other);
+
+    if (t1.extents.size() == 1 && t2.extents.size() == 1) {
+      // Vector-Vector
+      std::vector<std::complex<double>> res(data1.size() * data2.size());
+      for (std::size_t i = 0; i < data1.size(); ++i)
+        for (std::size_t j = 0; j < data2.size(); ++j)
+          res[i * data2.size() + j] = data1[i] * data2[j];
+      return createFromData(res);
+    }
+
+    // DM cases
+    auto m1 = (t1.extents.size() == 2)
+                  ? complex_matrix(data1, {t1.extents[0], t1.extents[1]})
+                  : complex_matrix(data1, {t1.extents[0], 1});
+    if (t1.extents.size() == 1)
+      m1 = m1 * m1.adjoint();
+
+    auto m2 = (t2.extents.size() == 2)
+                  ? complex_matrix(data2, {t2.extents[0], t2.extents[1]})
+                  : complex_matrix(data2, {t2.extents[0], 1});
+    if (t2.extents.size() == 1)
+      m2 = m2 * m2.adjoint();
+
+    return createFromData(kronecker(m1, m2));
+  }
+
   /// @brief Return the element from the tensor at the
   /// given tensor index and at the given indices.
   virtual std::complex<double>

--- a/runtime/cudaq/qis/state.cpp
+++ b/runtime/cudaq/qis/state.cpp
@@ -8,6 +8,7 @@
 
 #include "state.h"
 #include "common/EigenDense.h"
+#include "cudaq/operators/matrix.h"
 #include "cudaq/simulators.h"
 #include <iostream>
 
@@ -109,6 +110,12 @@ std::complex<double> state::operator()(std::size_t idx, std::size_t jdx) const {
 std::complex<double> state::overlap(const state &other) {
   return internal->overlap(*other.internal.get());
 }
+
+state state::tensor_product(const state &other) const {
+  return state(internal->tensorProduct(*other.internal).release());
+}
+
+std::complex<double> state::trace() const { return internal->trace(); }
 
 std::complex<double> state::amplitude(const std::vector<int> &basisState) {
   return internal->getAmplitude(basisState);

--- a/runtime/cudaq/qis/state.h
+++ b/runtime/cudaq/qis/state.h
@@ -153,6 +153,13 @@ public:
   /// For state vectors (pure states), it is computed as `|<this | other>|`.
   std::complex<double> overlap(const state &other);
 
+  /// @brief Return the tensor product of this state with another.
+  state tensor_product(const state &other) const;
+
+  /// @brief Return the trace of this state.
+  /// Note: Only valid for density matrices (rank 2 states).
+  std::complex<double> trace() const;
+
   /// @brief Return the amplitude of the given computational basis state
   std::complex<double> amplitude(const std::vector<int> &basisState);
 

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -108,6 +108,8 @@ struct QppDmState : public cudaq::SimulationState {
     return state(indices[0], indices[1]);
   }
 
+  std::complex<double> trace() override { return state.trace(); }
+
   std::unique_ptr<cudaq::SimulationState>
   createFromData(const state_data &data) override {
     if (std::holds_alternative<cudaq::complex_matrix>(data)) {

--- a/unittests/integration/get_state_tester.cpp
+++ b/unittests/integration/get_state_tester.cpp
@@ -152,6 +152,39 @@ CUDAQ_TEST(GetStateTester, checkSimple) {
 #endif
 }
 
+CUDAQ_TEST(GetStateTester, checkTraceAndTensorProduct) {
+  auto bell = []() __qpu__ {
+    cudaq::qubit q, r;
+    h(q);
+    cx(q, r);
+  };
+
+  // 1. Trace of density matrix
+#ifdef CUDAQ_BACKEND_DM
+  auto dm = cudaq::get_state(bell);
+  EXPECT_NEAR(1.0, dm.trace().real(), 1e-6);
+  EXPECT_NEAR(0.0, dm.trace().imag(), 1e-6);
+
+  // 2. Tensor product of density matrices
+  auto jointDm = dm.tensor_product(dm);
+  EXPECT_EQ(jointDm.get_tensor(0).extents.size(), 2);
+  EXPECT_EQ(jointDm.get_tensor(0).extents[0], 16);
+  EXPECT_EQ(jointDm.get_tensor(0).extents[1], 16);
+  EXPECT_NEAR(1.0, jointDm.trace().real(), 1e-6);
+#else
+  auto stateVector = cudaq::get_state(bell);
+  // Trace should throw for state vector
+  EXPECT_THROW(stateVector.trace(), std::runtime_error);
+
+  // Tensor product of state vectors
+  auto jointVec = stateVector.tensor_product(stateVector);
+  EXPECT_EQ(jointVec.get_tensor(0).extents.size(), 1);
+  EXPECT_EQ(jointVec.get_tensor(0).extents[0], 16);
+  // Overlap of |joint> with |bell> x |bell> should be 1
+  EXPECT_NEAR(1.0, jointVec.overlap(jointVec).real(), 1e-6);
+#endif
+}
+
 #ifdef CUDAQ_BACKEND_TENSORNET
 __qpu__ void bell() {
   cudaq::qubit q, r;


### PR DESCRIPTION
Fixes #4269

Summary of changes:
- Added `trace()` and `tensor_product()` to `cudaq::state`.
- - Added default implementations in `SimulationState`.
- - Optimized `trace()` for QPP DM simulator.
- - Added new example and unit tests.