### PR TITLE
cmake: scope --param=evrp-mode=legacy to CXX compiles only

### DIFF
--- a/realtime/unittests/CMakeLists.txt
+++ b/realtime/unittests/CMakeLists.txt
@@ -23,10 +23,16 @@ FetchContent_MakeAvailable(googletest)
 
 # Bug in GCC 12 leads to spurious warnings (-Wrestrict)
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+# Scope to CXX-language compiles via a generator expression so the flag
+# does NOT propagate through cmake's PUBLIC interface options into nvcc
+# command lines for consumer CUDA targets. nvcc forwards host options to
+# its own host compiler, which can be a different gcc than CMAKE_CXX_COMPILER
+# (e.g. CMAKE_CXX_COMPILER=gcc-12 but CMAKE_CUDA_HOST_COMPILER=gcc-13, where
+# gcc-13 has removed --param=evrp-mode= and would error on it).
 if (CMAKE_COMPILER_IS_GNUCXX 
   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0 
   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
-  target_compile_options(gtest PUBLIC --param=evrp-mode=legacy)
+  target_compile_options(gtest PUBLIC $<$<COMPILE_LANGUAGE:CXX>:--param=evrp-mode=legacy>)
 endif()
 include(GoogleTest)
 

--- a/runtime/common/CMakeLists.txt
+++ b/runtime/common/CMakeLists.txt
@@ -57,10 +57,16 @@ target_link_libraries(${LIBRARY_NAME}
 
 # Bug in GCC 12 leads to spurious warnings (-Wrestrict)
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+# Scope to CXX-language compiles via a generator expression so the flag
+# does NOT propagate through cmake's PUBLIC interface options into nvcc
+# command lines for consumer CUDA targets. nvcc forwards host options to
+# its own host compiler, which can be a different gcc than CMAKE_CXX_COMPILER
+# (e.g. CMAKE_CXX_COMPILER=gcc-12 but CMAKE_CUDA_HOST_COMPILER=gcc-13, where
+# gcc-13 has removed --param=evrp-mode= and would error on it).
 if (CMAKE_COMPILER_IS_GNUCXX
   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0
   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
-  target_compile_options(${LIBRARY_NAME} PUBLIC --param=evrp-mode=legacy)
+  target_compile_options(${LIBRARY_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:--param=evrp-mode=legacy>)
 endif()
 
 # We can only build the RestClient support if we have OpenSSL


### PR DESCRIPTION
The gcc-12 -Wrestrict workaround in runtime/common/CMakeLists.txt and realtime/unittests/CMakeLists.txt was added as a PUBLIC compile option, so cmake propagates it through interface inheritance into nvcc command lines on consumer CUDA targets. nvcc forwards it to its host gcc, which may be a different gcc than CMAKE_CXX_COMPILER (e.g. gcc-12 vs gcc-13) and may not recognize the flag. Wrap it in a $<$<COMPILE_LANGUAGE:CXX>:..> generator expression so it only appears on CXX command lines.