### PR TITLE
Jit target compilation pipeline unification

### DIFF
--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -64,6 +64,7 @@ else()
     ../../runtime/internal/compiler/RuntimeMLIR.cpp
     ../../runtime/internal/compiler/JIT.cpp
     ../../runtime/internal/compiler/Compiler.cpp
+    ../../runtime/internal/compiler/JITTargetPipeline.cpp
     ../../runtime/internal/compiler/TracePassInstrumentation.cpp
   )
   set(_quakeDialects_extra_link_libs "")

--- a/python/tests/backends/test_circuit_opt_bench.py
+++ b/python/tests/backends/test_circuit_opt_bench.py
@@ -50,11 +50,8 @@ def test_swap_no_decomposition_default_target():
 def test_custom_unitary_produces_2q_gates():
     """Registered SU(4) unitary must produce entangling gates after synthesis.
 
-    This validates handling of registered random SU(4) operations through the
-    target pipeline. The target pipeline must inline the KAK-decomposed helper
-    function into the main kernel (apply-op-specialization +
-    aggressive-inlining). Without those passes, resource counting sees only 1Q
-    gates for this case.
+    This validates SU(4) handling through the target pipeline. Without helper
+    inlining, resource counting sees only 1Q gates for this case.
     """
     cudaq.set_target('circuit-opt-bench')
 

--- a/python/tests/backends/test_circuit_opt_bench.py
+++ b/python/tests/backends/test_circuit_opt_bench.py
@@ -48,12 +48,13 @@ def test_swap_no_decomposition_default_target():
 
 
 def test_custom_unitary_produces_2q_gates():
-    """Custom SU(4) unitary must produce entangling gates after synthesis.
+    """Registered SU(4) unitary must produce entangling gates after synthesis.
 
-    The pipeline must inline the KAK-decomposed helper function into the
-    main kernel (apply-op-specialization + aggressive-inlining). Without
-    these passes, the helper is removed by symbol-dce and 0 2Q gates
-    appear in the output.
+    This is the minimal reproducer for the Benchpress QV construction path,
+    which registers random SU(4) operations via cudaq.register_operation().
+    The target pipeline must inline the KAK-decomposed helper function into
+    the main kernel (apply-op-specialization + aggressive-inlining). Without
+    those passes, resource counting sees only 1Q gates for this case.
     """
     cudaq.set_target('circuit-opt-bench')
 

--- a/python/tests/backends/test_circuit_opt_bench.py
+++ b/python/tests/backends/test_circuit_opt_bench.py
@@ -50,11 +50,11 @@ def test_swap_no_decomposition_default_target():
 def test_custom_unitary_produces_2q_gates():
     """Registered SU(4) unitary must produce entangling gates after synthesis.
 
-    This is the minimal reproducer for the Benchpress QV construction path,
-    which registers random SU(4) operations via cudaq.register_operation().
-    The target pipeline must inline the KAK-decomposed helper function into
-    the main kernel (apply-op-specialization + aggressive-inlining). Without
-    those passes, resource counting sees only 1Q gates for this case.
+    This validates handling of registered random SU(4) operations through the
+    target pipeline. The target pipeline must inline the KAK-decomposed helper
+    function into the main kernel (apply-op-specialization +
+    aggressive-inlining). Without those passes, resource counting sees only 1Q
+    gates for this case.
     """
     cudaq.set_target('circuit-opt-bench')
 

--- a/runtime/cudaq/platform/default/circuit-opt-bench.yml
+++ b/runtime/cudaq/platform/default/circuit-opt-bench.yml
@@ -17,13 +17,8 @@ target-arguments:
 
 config:
   nvqir-simulation-backend: qpp
-  # Target high-level stage: materialize registered custom-op matrices and
-  # synthesize them to gates before target lowering.
-  jit-high-level-pipeline: "get-concrete-matrix,unitary-synthesis"
-  # Target mid-level stage: inline synthesized helper calls, decompose to a CX
-  # routing basis, prepare wire metadata, optionally route, then lower routed
-  # two-qubit work to CZ. With no device argument, routing is bypassed.
-  jit-mid-level-pipeline: "apply-op-specialization,aggressive-inlining,decomposition{basis=h,rx,ry,rz,x,x(1)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=%DEVICE:bypass%},func.func(delay-measurements,regtomem),decomposition{basis=h,rx,ry,rz,x,z(1)}"
-  # Target low-level cleanup stage: remove wire-set symbols left by routing prep.
-  jit-low-level-pipeline: "symbol-dce"
+  # Target mid-level stage: decompose to a CX routing basis, prepare wire
+  # metadata, optionally route, then lower routed two-qubit work to CZ. With no
+  # device argument, routing is bypassed.
+  jit-mid-level-pipeline: "decomposition{basis=h,rx,ry,rz,x,x(1)},func.func(add-dealloc,combine-quantum-alloc,canonicalize,factor-quantum-alloc,memtoreg),add-wireset,func.func(assign-wire-indices),qubit-mapping{device=%DEVICE:bypass%},func.func(regtomem),decomposition{basis=h,rx,ry,rz,x,z(1)}"
   library-mode: false

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -26,6 +26,7 @@
 #include "cudaq_internal/compiler/ArgumentConversion.h"
 #include "cudaq_internal/compiler/CompiledModuleHelper.h"
 #include "cudaq_internal/compiler/JIT.h"
+#include "cudaq_internal/compiler/JITTargetPipeline.h"
 #include "cudaq_internal/compiler/RuntimeMLIR.h"
 #include "cudaq_internal/compiler/TracePassInstrumentation.h"
 #include "runtime/cudaq/platform/PythonSignalCheck.h"
@@ -101,104 +102,16 @@ static void specializeKernel(const std::string &name, ModuleOp module,
     throw std::runtime_error("Pass pipeline failed.");
 }
 
-/// Replace %KEY% and %KEY:default% placeholders in a pipeline string with
-/// values from the runtime config map. If the key is in runtimeConfig, use
-/// that value. Otherwise use the inline default if provided (%KEY:val%).
-/// Keys in the pipeline are uppercase; runtimeConfig keys are lowercase.
-/// This is the Python JIT equivalent of ServerHelper::updatePassPipeline().
-static void substitutePipelinePlaceholders(
-    std::string &pipeline,
-    const std::map<std::string, std::string> &runtimeConfig) {
-  std::string::size_type pos = 0;
-  while (pos < pipeline.size()) {
-    auto start = pipeline.find('%', pos);
-    if (start == std::string::npos)
-      break;
-    auto end = pipeline.find('%', start + 1);
-    if (end == std::string::npos)
-      break;
-    auto token = pipeline.substr(start + 1, end - start - 1);
-    auto colon = token.find(':');
-    auto key = (colon != std::string::npos) ? token.substr(0, colon) : token;
-
-    // Lowercase the key to match runtimeConfig convention.
-    std::string lower;
-    for (char c : key)
-      lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-    auto it = runtimeConfig.find(lower);
-
-    if (it != runtimeConfig.end()) {
-      pipeline.replace(start, end - start + 1, it->second);
-      pos = start + it->second.size();
-    } else if (colon != std::string::npos) {
-      auto defaultVal = token.substr(colon + 1);
-      pipeline.replace(start, end - start + 1, defaultVal);
-      pos = start + defaultVal.size();
-    } else {
-      pos = end + 1;
-    }
-  }
-}
-
-static void appendPipelineStage(std::string &pipeline,
-                                const std::string &stage) {
-  if (stage.empty())
-    return;
-  if (!pipeline.empty())
-    pipeline += ",";
-  pipeline += stage;
-}
-
-static bool buildTargetPassPipeline(std::string &pipeline,
-                                    bool &runsStandardFinalize) {
-  runsStandardFinalize = false;
+/// Run the target compilation pipeline for Python MLIR kernels. Local Python
+/// targets only enter this path when they configure target pass-pipeline
+/// fields.
+static bool runTargetPassPipeline(mlir::ModuleOp module) {
   auto *rt = cudaq::get_platform().get_runtime_target();
   if (!rt)
     return false;
-  auto &cfg = rt->config;
-  if (!cfg.BackendConfig.has_value() || !cfg.BackendConfig->hasPassPipeline())
-    return false;
-
-  if (!cfg.BackendConfig->TargetPassPipeline.empty()) {
-    pipeline = cfg.BackendConfig->TargetPassPipeline;
-    substitutePipelinePlaceholders(pipeline, rt->runtimeConfig);
-    return true;
-  }
-
-  appendPipelineStage(pipeline, "canonicalize");
-
-  const bool emulate = cudaq::is_emulated_platform();
-  auto codegenTranslation = cfg.getCodeGenSpec(rt->runtimeConfig);
-  const std::string allowEarlyExit =
-      codegenTranslation.starts_with("qir-adaptive") ? "true" : "false";
-
-  if (emulate)
-    appendPipelineStage(pipeline, "emul-jit-prep-pipeline{erase-noise=true "
-                                  "allow-early-exit=" +
-                                      allowEarlyExit + "}");
-  else
-    appendPipelineStage(pipeline, "hw-jit-prep-pipeline{allow-early-exit=" +
-                                      allowEarlyExit + "}");
-
-  const std::string lowerDeviceCalls =
-      (codegenTranslation == "nop" && !emulate) ? "false" : "true";
-  appendPipelineStage(
-      pipeline,
-      cfg.BackendConfig->getPassPipeline(
-          "jit-deploy-pipeline", "jit-finalize-pipeline{lower-device-calls=" +
-                                     lowerDeviceCalls + "}"));
-  substitutePipelinePlaceholders(pipeline, rt->runtimeConfig);
-  runsStandardFinalize = true;
-  return true;
-}
-
-/// Run the target compilation pipeline for Python MLIR kernels. This mirrors
-/// the staged target flow in Compiler.cpp for targets that define pass-pipeline
-/// fields, while preserving target-pass-pipeline as an exact override.
-static bool runTargetPassPipeline(mlir::ModuleOp module) {
-  std::string pipeline;
-  bool runsStandardFinalize = false;
-  if (!buildTargetPassPipeline(pipeline, runsStandardFinalize))
+  auto pipelineConfig = cudaq_internal::compiler::buildJITTargetPipelineConfig(
+      rt->config, rt->runtimeConfig, cudaq::is_emulated_platform());
+  if (!pipelineConfig.hasConfiguredPassPipeline)
     return false;
 
   auto *ctx = module.getContext();
@@ -207,11 +120,12 @@ static bool runTargetPassPipeline(mlir::ModuleOp module) {
   pm.addInstrumentation(std::make_unique<cudaq::TracePassInstrumentation>());
   std::string errMsg;
   llvm::raw_string_ostream errOS(errMsg);
-  if (mlir::failed(mlir::parsePassPipeline(pipeline, pm, errOS)))
+  if (mlir::failed(mlir::parsePassPipeline(pipelineConfig.passPipelineConfig,
+                                           pm, errOS)))
     throw std::runtime_error("Failed to parse target pipeline: " + errMsg);
   if (failed(cudaq::runPassManagerReleasingGIL(pm, module)))
     throw std::runtime_error("Pass pipeline failed.");
-  return runsStandardFinalize;
+  return pipelineConfig.runsStandardFinalize;
 }
 
 /// Lowers \p module to LLVM code. The LLVM code will use "full QIR" as the

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -140,22 +140,67 @@ static void substitutePipelinePlaceholders(
   }
 }
 
-/// Run target-specific passes if the active target config defines a pipeline.
-/// Interleaves jit-deploy-pipeline between high and mid-level stages.
-/// specializeKernel() covers what hw-jit-prep-pipeline and
-/// jit-finalize-pipeline do (inlining, specialization, DistributedDeviceCall),
-/// so those are not interleaved here. Targets needing passes from those stages
-/// (e.g., apply-control-negations) should include them in their own config
-/// fields. Only reads top-level config:, not configuration-matrix entries.
-static void runTargetPassPipeline(mlir::ModuleOp module) {
+static void appendPipelineStage(std::string &pipeline,
+                                const std::string &stage) {
+  if (stage.empty())
+    return;
+  if (!pipeline.empty())
+    pipeline += ",";
+  pipeline += stage;
+}
+
+static bool buildTargetPassPipeline(std::string &pipeline,
+                                    bool &runsStandardFinalize) {
+  runsStandardFinalize = false;
   auto *rt = cudaq::get_platform().get_runtime_target();
   if (!rt)
-    return;
+    return false;
   auto &cfg = rt->config;
   if (!cfg.BackendConfig.has_value() || !cfg.BackendConfig->hasPassPipeline())
-    return;
-  auto pipeline = cfg.BackendConfig->getPassPipeline("jit-deploy-pipeline", "");
+    return false;
+
+  if (!cfg.BackendConfig->TargetPassPipeline.empty()) {
+    pipeline = cfg.BackendConfig->TargetPassPipeline;
+    substitutePipelinePlaceholders(pipeline, rt->runtimeConfig);
+    return true;
+  }
+
+  appendPipelineStage(pipeline, "canonicalize");
+
+  const bool emulate = cudaq::is_emulated_platform();
+  auto codegenTranslation = cfg.getCodeGenSpec(rt->runtimeConfig);
+  const std::string allowEarlyExit =
+      codegenTranslation.starts_with("qir-adaptive") ? "true" : "false";
+
+  if (emulate)
+    appendPipelineStage(pipeline, "emul-jit-prep-pipeline{erase-noise=true "
+                                  "allow-early-exit=" +
+                                      allowEarlyExit + "}");
+  else
+    appendPipelineStage(pipeline, "hw-jit-prep-pipeline{allow-early-exit=" +
+                                      allowEarlyExit + "}");
+
+  const std::string lowerDeviceCalls =
+      (codegenTranslation == "nop" && !emulate) ? "false" : "true";
+  appendPipelineStage(
+      pipeline,
+      cfg.BackendConfig->getPassPipeline(
+          "jit-deploy-pipeline", "jit-finalize-pipeline{lower-device-calls=" +
+                                     lowerDeviceCalls + "}"));
   substitutePipelinePlaceholders(pipeline, rt->runtimeConfig);
+  runsStandardFinalize = true;
+  return true;
+}
+
+/// Run the target compilation pipeline for Python MLIR kernels. This mirrors
+/// the staged target flow in Compiler.cpp for targets that define pass-pipeline
+/// fields, while preserving target-pass-pipeline as an exact override.
+static bool runTargetPassPipeline(mlir::ModuleOp module) {
+  std::string pipeline;
+  bool runsStandardFinalize = false;
+  if (!buildTargetPassPipeline(pipeline, runsStandardFinalize))
+    return false;
+
   auto *ctx = module.getContext();
   PassManager pm(ctx);
   cudaq::addPythonSignalInstrumentation(pm);
@@ -166,6 +211,7 @@ static void runTargetPassPipeline(mlir::ModuleOp module) {
     throw std::runtime_error("Failed to parse target pipeline: " + errMsg);
   if (failed(cudaq::runPassManagerReleasingGIL(pm, module)))
     throw std::runtime_error("Pass pipeline failed.");
+  return runsStandardFinalize;
 }
 
 /// Lowers \p module to LLVM code. The LLVM code will use "full QIR" as the
@@ -180,12 +226,14 @@ std::string cudaq::detail::lower_to_qir_llvm(const std::string &name,
   cudaq_internal::compiler::mergeAllCallableClosures(module, name,
                                                      args.getArgs());
   specializeKernel(name, module, args.getArgs());
-  runTargetPassPipeline(module);
+  const bool finalizedByTargetPipeline = runTargetPassPipeline(module);
   PassManager pm(module.getContext());
   cudaq::addPythonSignalInstrumentation(pm);
   pm.addInstrumentation(std::make_unique<cudaq::TracePassInstrumentation>());
-  cudaq::opt::addAggressiveInlining(pm);
-  cudaq::opt::createTargetFinalizePipeline(pm);
+  if (!finalizedByTargetPipeline) {
+    cudaq::opt::addAggressiveInlining(pm);
+    cudaq::opt::createTargetFinalizePipeline(pm);
+  }
   cudaq::opt::addAOTPipelineConvertToQIR(pm, format);
   if (failed(cudaq::runPassManagerReleasingGIL(pm, module)))
     throw std::runtime_error("Pass pipeline failed.");
@@ -214,12 +262,13 @@ std::string cudaq::detail::lower_to_openqasm(const std::string &name,
   cudaq_internal::compiler::mergeAllCallableClosures(module, name,
                                                      args.getArgs());
   specializeKernel(name, module, args.getArgs());
-  runTargetPassPipeline(module);
+  const bool finalizedByTargetPipeline = runTargetPassPipeline(module);
   auto *ctx = module.getContext();
   PassManager pm(ctx);
   cudaq::addPythonSignalInstrumentation(pm);
   pm.addInstrumentation(std::make_unique<cudaq::TracePassInstrumentation>());
-  cudaq::opt::createTargetFinalizePipeline(pm);
+  if (!finalizedByTargetPipeline)
+    cudaq::opt::createTargetFinalizePipeline(pm);
   cudaq::opt::createPipelineTransformsForPythonToOpenQASM(pm);
   cudaq::opt::addPipelineTranslateToOpenQASM(pm);
   const bool enablePrintMLIRBeforeAndAfterEachPass =

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -102,9 +102,8 @@ static void specializeKernel(const std::string &name, ModuleOp module,
     throw std::runtime_error("Pass pipeline failed.");
 }
 
-/// Run the target compilation pipeline for Python MLIR kernels. Local Python
-/// targets only enter this path when they configure target pass-pipeline
-/// fields.
+/// Run the target compilation pipeline for Python MLIR kernels. Returns true
+/// when the target pipeline already ran standard finalization.
 static bool runTargetPassPipeline(mlir::ModuleOp module) {
   auto *rt = cudaq::get_platform().get_runtime_target();
   if (!rt)

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -108,8 +108,9 @@ static bool runTargetPassPipeline(mlir::ModuleOp module) {
   auto *rt = cudaq::get_platform().get_runtime_target();
   if (!rt)
     return false;
-  auto pipelineConfig = cudaq_internal::compiler::buildJITTargetPipelineConfig(
-      rt->config, rt->runtimeConfig, cudaq::is_emulated_platform());
+  auto pipelineConfig =
+      cudaq_internal::compiler::JITTargetPipelineConfig::createFromTargetConfig(
+          rt->config, rt->runtimeConfig, cudaq::is_emulated_platform());
   if (!pipelineConfig.hasConfiguredPassPipeline)
     return false;
 

--- a/runtime/internal/compiler/CMakeLists.txt
+++ b/runtime/internal/compiler/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(cudaq-mlir-runtime
     ArgumentConversion.cpp
     Compiler.cpp
     CompiledModuleHelper.cpp
+    JITTargetPipeline.cpp
     JIT.cpp
     RuntimeMLIR.cpp
     RuntimeCppMLIR.cpp

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -152,9 +152,8 @@ cudaq_internal::compiler::Compiler::Compiler(
   }
 
   if (config.BackendConfig.has_value()) {
-    auto pipelineConfig =
-        cudaq_internal::compiler::buildJITTargetPipelineConfig(
-            config, backendConfig, emulate);
+    auto pipelineConfig = cudaq_internal::compiler::JITTargetPipelineConfig::
+        createFromTargetConfig(config, backendConfig, emulate);
     passPipelineConfig = pipelineConfig.passPipelineConfig;
     codegenTranslation = pipelineConfig.codegenTranslation;
     postCodeGenPasses = pipelineConfig.postCodeGenPasses;

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -25,6 +25,7 @@
 #include "cudaq/runtime/logger/logger.h"
 #include "cudaq_internal/compiler/ArgumentConversion.h"
 #include "cudaq_internal/compiler/JIT.h"
+#include "cudaq_internal/compiler/JITTargetPipeline.h"
 #include "cudaq_internal/compiler/RuntimeMLIR.h"
 #include "nlohmann/json.hpp"
 #include "llvm/ADT/SmallSet.h"
@@ -151,72 +152,41 @@ cudaq_internal::compiler::Compiler::Compiler(
   }
 
   if (config.BackendConfig.has_value()) {
-    const auto codeGenSpec = config.getCodeGenSpec(backendConfig);
-    if (!codeGenSpec.empty()) {
-      CUDAQ_INFO("Set codegen translation: {}", codeGenSpec);
-      codegenTranslation = codeGenSpec;
+    auto pipelineConfig =
+        cudaq_internal::compiler::buildJITTargetPipelineConfig(
+            config, backendConfig, emulate);
+    passPipelineConfig = pipelineConfig.passPipelineConfig;
+    codegenTranslation = pipelineConfig.codegenTranslation;
+    postCodeGenPasses = pipelineConfig.postCodeGenPasses;
+
+    if (!codegenTranslation.empty()) {
+      CUDAQ_INFO("Set codegen translation: {}", codegenTranslation);
       // Validate codegen configuration.
       cudaq::parseCodeGenTranslation(codegenTranslation);
     }
 
-    const std::string allowEarlyExitSetting =
-        codegenTranslation.starts_with("qir-adaptive") ? "true" : "false";
-
-    // 1. Apply all the target-agnostic high-level passes. If this is an
-    // emulation and a noise model has been set, do not erase the noise
-    // callbacks.
-    if (emulate)
-      // FIXME: Noise should eventually be enabled for emulated hardware targets
-      passPipelineConfig += ",emul-jit-prep-pipeline{erase-noise=true"
-                            " allow-early-exit=" +
-                            allowEarlyExitSetting + "}";
-    else
-      passPipelineConfig +=
-          ",hw-jit-prep-pipeline{allow-early-exit=" + allowEarlyExitSetting +
-          "}";
-
-    // 2. Apply target-specific high-level passes from the .yml file, if any.
-    if (!config.BackendConfig->JITHighLevelPipeline.empty()) {
+    if (pipelineConfig.usesTargetPassPipelineOverride) {
+      CUDAQ_INFO("Using target pass pipeline: {}", passPipelineConfig);
+    } else if (!config.BackendConfig->JITHighLevelPipeline.empty()) {
       CUDAQ_INFO("Appending JIT high level pipeline: {}",
                  config.BackendConfig->JITHighLevelPipeline);
-      passPipelineConfig += "," + config.BackendConfig->JITHighLevelPipeline;
     }
 
-    // 3. Appply the target-agnostic deployment passes. Any additional
-    // restructuring to get ready for decomposition.
-    passPipelineConfig += ",jit-deploy-pipeline";
-
-    // 4. Apply the target-specific mid-level passes. This decomposed quantum
-    // gates for a specific target machine, etc.
-    if (!config.BackendConfig->JITMidLevelPipeline.empty()) {
+    if (!pipelineConfig.usesTargetPassPipelineOverride &&
+        !config.BackendConfig->JITMidLevelPipeline.empty()) {
       CUDAQ_INFO("Appending JIT mid level pipeline: {}",
                  config.BackendConfig->JITMidLevelPipeline);
-      passPipelineConfig += "," + config.BackendConfig->JITMidLevelPipeline;
     }
 
-    // 5. Apply the target-agnostic finalization passes. This lowers the IR to
-    // CFG form.
-    // If this is not emulation, and the codegen translation is nop (dumping
-    // CUDA-Q MLIR), then we want to keep device calls as-is, to be submitted to
-    // the server for lowering and execution.
-    passPipelineConfig +=
-        ",jit-finalize-pipeline{lower-device-calls=" +
-        std::string{(codegenTranslation == "nop" && !emulate) ? "false"
-                                                              : "true"} +
-        "}";
-
-    // 6. Apply the target-specific low-level passes.
-    if (!config.BackendConfig->JITLowLevelPipeline.empty()) {
+    if (!pipelineConfig.usesTargetPassPipelineOverride &&
+        !config.BackendConfig->JITLowLevelPipeline.empty()) {
       CUDAQ_INFO("Appending JIT low level pipeline: {}",
                  config.BackendConfig->JITLowLevelPipeline);
-      passPipelineConfig += "," + config.BackendConfig->JITLowLevelPipeline;
     }
 
-    if (!config.BackendConfig->PostCodeGenPasses.empty()) {
+    if (!postCodeGenPasses.empty())
       CUDAQ_INFO("Adding post-codegen lowering pipeline: {}",
-                 config.BackendConfig->PostCodeGenPasses);
-      postCodeGenPasses = config.BackendConfig->PostCodeGenPasses;
-    }
+                 postCodeGenPasses);
   }
 
   auto disableQM = backendConfig.find("disable_qubit_mapping");
@@ -225,11 +195,7 @@ cudaq_internal::compiler::Compiler::Compiler(
     // qubit-mapping{device=bypass} to effectively disable the qubit-mapping
     // pass. Use $1 - $4 to make sure any other pass options are left
     // untouched.
-    std::regex qubitMapping(
-        "(.*)qubit-mapping\\{(.*)device=[^,\\}]+(.*)\\}(.*)");
-    std::string replacement("$1qubit-mapping{$2device=bypass$3}$4");
-    passPipelineConfig =
-        std::regex_replace(passPipelineConfig, qubitMapping, replacement);
+    cudaq_internal::compiler::setQubitMappingBypass(passPipelineConfig);
     CUDAQ_INFO("disable_qubit_mapping option found, so updated lowering "
                "pipeline to {}",
                passPipelineConfig);

--- a/runtime/internal/compiler/JITTargetPipeline.cpp
+++ b/runtime/internal/compiler/JITTargetPipeline.cpp
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq_internal/compiler/JITTargetPipeline.h"
+#include "cudaq/Support/TargetConfig.h"
+#include <cctype>
+#include <regex>
+
+static void appendPipelineStage(std::string &pipeline,
+                                const std::string &stage) {
+  if (stage.empty())
+    return;
+  if (!pipeline.empty())
+    pipeline += ",";
+  pipeline += stage;
+}
+
+void cudaq_internal::compiler::substitutePipelinePlaceholders(
+    std::string &pipeline,
+    const std::map<std::string, std::string> &runtimeConfig) {
+  std::string::size_type pos = 0;
+  while (pos < pipeline.size()) {
+    auto start = pipeline.find('%', pos);
+    if (start == std::string::npos)
+      break;
+    auto end = pipeline.find('%', start + 1);
+    if (end == std::string::npos)
+      break;
+    auto token = pipeline.substr(start + 1, end - start - 1);
+    auto colon = token.find(':');
+    auto key = (colon != std::string::npos) ? token.substr(0, colon) : token;
+
+    std::string lower;
+    for (char c : key)
+      lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    auto it = runtimeConfig.find(lower);
+
+    if (it != runtimeConfig.end()) {
+      pipeline.replace(start, end - start + 1, it->second);
+      pos = start + it->second.size();
+    } else if (colon != std::string::npos) {
+      auto defaultVal = token.substr(colon + 1);
+      pipeline.replace(start, end - start + 1, defaultVal);
+      pos = start + defaultVal.size();
+    } else {
+      pos = end + 1;
+    }
+  }
+}
+
+void cudaq_internal::compiler::setQubitMappingBypass(std::string &pipeline) {
+  std::regex qubitMapping("(.*)qubit-mapping\\{(.*)device=[^,\\}]+(.*)\\}(.*)");
+  std::string replacement("$1qubit-mapping{$2device=bypass$3}$4");
+  pipeline = std::regex_replace(pipeline, qubitMapping, replacement);
+}
+
+cudaq_internal::compiler::JITTargetPipelineConfig
+cudaq_internal::compiler::buildJITTargetPipelineConfig(
+    const cudaq::config::TargetConfig &config,
+    const std::map<std::string, std::string> &runtimeConfig, bool emulate) {
+  JITTargetPipelineConfig pipelineConfig;
+  if (!config.BackendConfig.has_value())
+    return pipelineConfig;
+
+  pipelineConfig.hasBackendConfig = true;
+  const auto &backendConfig = *config.BackendConfig;
+  pipelineConfig.hasConfiguredPassPipeline = backendConfig.hasPassPipeline();
+  pipelineConfig.codegenTranslation = config.getCodeGenSpec(runtimeConfig);
+  pipelineConfig.postCodeGenPasses = backendConfig.PostCodeGenPasses;
+
+  if (!backendConfig.TargetPassPipeline.empty()) {
+    pipelineConfig.passPipelineConfig = backendConfig.TargetPassPipeline;
+    pipelineConfig.usesTargetPassPipelineOverride = true;
+    substitutePipelinePlaceholders(pipelineConfig.passPipelineConfig,
+                                   runtimeConfig);
+    return pipelineConfig;
+  }
+
+  const std::string allowEarlyExit =
+      pipelineConfig.codegenTranslation.starts_with("qir-adaptive") ? "true"
+                                                                    : "false";
+
+  if (emulate)
+    appendPipelineStage(pipelineConfig.passPipelineConfig,
+                        "emul-jit-prep-pipeline{erase-noise=true "
+                        "allow-early-exit=" +
+                            allowEarlyExit + "}");
+  else
+    appendPipelineStage(
+        pipelineConfig.passPipelineConfig,
+        "hw-jit-prep-pipeline{allow-early-exit=" + allowEarlyExit + "}");
+
+  const std::string lowerDeviceCalls =
+      (pipelineConfig.codegenTranslation == "nop" && !emulate) ? "false"
+                                                               : "true";
+  appendPipelineStage(
+      pipelineConfig.passPipelineConfig,
+      backendConfig.getPassPipeline(
+          "jit-deploy-pipeline", "jit-finalize-pipeline{lower-device-calls=" +
+                                     lowerDeviceCalls + "}"));
+  substitutePipelinePlaceholders(pipelineConfig.passPipelineConfig,
+                                 runtimeConfig);
+  pipelineConfig.runsStandardFinalize = true;
+  return pipelineConfig;
+}

--- a/runtime/internal/compiler/JITTargetPipeline.cpp
+++ b/runtime/internal/compiler/JITTargetPipeline.cpp
@@ -60,7 +60,7 @@ void cudaq_internal::compiler::setQubitMappingBypass(std::string &pipeline) {
 }
 
 cudaq_internal::compiler::JITTargetPipelineConfig
-cudaq_internal::compiler::buildJITTargetPipelineConfig(
+cudaq_internal::compiler::JITTargetPipelineConfig::createFromTargetConfig(
     const cudaq::config::TargetConfig &config,
     const std::map<std::string, std::string> &runtimeConfig, bool emulate) {
   JITTargetPipelineConfig pipelineConfig;

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
@@ -16,55 +16,35 @@ class TargetConfig;
 
 namespace cudaq_internal::compiler {
 
-/// Materialized target JIT pipeline settings derived from a target YAML config
-/// and runtime target arguments.
+/// Target JIT pipeline settings resolved from target config and runtime args.
 struct JITTargetPipelineConfig {
-  /// MLIR pass-pipeline string to run. Defaults to the compiler's baseline
-  /// canonicalization-only pipeline when the target has no backend config.
+  /// MLIR pass pipeline to run.
   std::string passPipelineConfig = "canonicalize";
-  /// Codegen emission selected by the target config and runtime args, e.g.
-  /// "qir-adaptive", "qir-base", "qasm2", or "nop".
+  /// Codegen emission selected by the target config.
   std::string codegenTranslation;
-  /// Optional pass-pipeline string to run after codegen translation.
+  /// Optional pass pipeline to run after codegen.
   std::string postCodeGenPasses;
-  /// True when the target has a top-level backend `config:` entry.
+  /// Target has a top-level backend `config:` entry.
   bool hasBackendConfig = false;
-  /// True when the backend config provides any target pass-pipeline fields.
-  /// Python local targets use this to avoid adding default JIT stages to
-  /// simulator targets that never requested target pipeline handling.
+  /// Backend config provides target pass pipeline fields.
   bool hasConfiguredPassPipeline = false;
-  /// True when `target-pass-pipeline` is set. In this mode the target-provided
-  /// pipeline is used exactly, with no standard prep/deploy/finalize stages
-  /// interleaved.
+  /// `target-pass-pipeline` is an exact pipeline override.
   bool usesTargetPassPipelineOverride = false;
-  /// True when `passPipelineConfig` includes the standard
-  /// `jit-finalize-pipeline`. Python translate paths use this to avoid running
-  /// target finalization twice.
+  /// Standard `jit-finalize-pipeline` is part of `passPipelineConfig`.
   bool runsStandardFinalize = false;
 };
 
-/// Build the standard staged JIT target pipeline:
-///
-///   canonicalize, {hw|emul}-jit-prep-pipeline,
-///   jit-high-level-pipeline, jit-deploy-pipeline,
-///   jit-mid-level-pipeline, jit-finalize-pipeline,
-///   jit-low-level-pipeline
-///
-/// `target-pass-pipeline` remains an exact override. `%KEY%` and
-/// `%KEY:default%` placeholders are substituted from `runtimeConfig`.
+/// Build the staged JIT target pipeline or exact target override.
 JITTargetPipelineConfig buildJITTargetPipelineConfig(
     const cudaq::config::TargetConfig &config,
     const std::map<std::string, std::string> &runtimeConfig, bool emulate);
 
-/// Replace `%KEY%` and `%KEY:default%` placeholders in `pipeline` using
-/// lowercase keys from `runtimeConfig`. Unresolved placeholders without a
-/// default are left unchanged for provider-specific rewriting.
+/// Replace `%KEY%` and `%KEY:default%` placeholders from runtime config.
 void substitutePipelinePlaceholders(
     std::string &pipeline,
     const std::map<std::string, std::string> &runtimeConfig);
 
-/// Rewrite any `qubit-mapping{...device=...}` stage in `pipeline` to
-/// `device=bypass`, preserving the other pass options.
+/// Rewrite `qubit-mapping{...device=...}` to use `device=bypass`.
 void setQubitMappingBypass(std::string &pipeline);
 
 } // namespace cudaq_internal::compiler

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
@@ -1,0 +1,39 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace cudaq::config {
+class TargetConfig;
+}
+
+namespace cudaq_internal::compiler {
+
+struct JITTargetPipelineConfig {
+  std::string passPipelineConfig = "canonicalize";
+  std::string codegenTranslation;
+  std::string postCodeGenPasses;
+  bool hasBackendConfig = false;
+  bool hasConfiguredPassPipeline = false;
+  bool usesTargetPassPipelineOverride = false;
+  bool runsStandardFinalize = false;
+};
+
+JITTargetPipelineConfig buildJITTargetPipelineConfig(
+    const cudaq::config::TargetConfig &config,
+    const std::map<std::string, std::string> &runtimeConfig, bool emulate);
+
+void substitutePipelinePlaceholders(
+    std::string &pipeline,
+    const std::map<std::string, std::string> &runtimeConfig);
+
+void setQubitMappingBypass(std::string &pipeline);
+
+} // namespace cudaq_internal::compiler

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
@@ -16,17 +16,17 @@ class TargetConfig;
 
 namespace cudaq_internal::compiler {
 
-/// Target JIT pipeline settings resolved from target config and runtime args.
+/// Target JIT pipeline settings resolved from target data and runtime options.
 struct JITTargetPipelineConfig {
   /// MLIR pass pipeline to run.
   std::string passPipelineConfig = "canonicalize";
-  /// Codegen emission selected by the target config.
+  /// Code generation emission selected by the target.
   std::string codegenTranslation;
-  /// Optional pass pipeline to run after codegen.
+  /// Optional pass pipeline to run after code generation.
   std::string postCodeGenPasses;
-  /// Target has a top-level backend `config:` entry.
+  /// Target has a top-level backend entry.
   bool hasBackendConfig = false;
-  /// Backend config provides target pass pipeline fields.
+  /// Backend data provides target pass pipeline fields.
   bool hasConfiguredPassPipeline = false;
   /// `target-pass-pipeline` is an exact pipeline override.
   bool usesTargetPassPipelineOverride = false;
@@ -39,7 +39,7 @@ JITTargetPipelineConfig buildJITTargetPipelineConfig(
     const cudaq::config::TargetConfig &config,
     const std::map<std::string, std::string> &runtimeConfig, bool emulate);
 
-/// Replace `%KEY%` and `%KEY:default%` placeholders from runtime config.
+/// Replace `%KEY%` and `%KEY:default%` placeholders from runtime options.
 void substitutePipelinePlaceholders(
     std::string &pipeline,
     const std::map<std::string, std::string> &runtimeConfig);

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
@@ -18,6 +18,11 @@ namespace cudaq_internal::compiler {
 
 /// Target JIT pipeline settings resolved from target data and runtime options.
 struct JITTargetPipelineConfig {
+  /// Build the staged JIT target pipeline or exact target override.
+  static JITTargetPipelineConfig createFromTargetConfig(
+      const cudaq::config::TargetConfig &config,
+      const std::map<std::string, std::string> &runtimeConfig, bool emulate);
+
   /// MLIR pass pipeline to run.
   std::string passPipelineConfig = "canonicalize";
   /// Code generation emission selected by the target.
@@ -33,11 +38,6 @@ struct JITTargetPipelineConfig {
   /// Standard `jit-finalize-pipeline` is part of `passPipelineConfig`.
   bool runsStandardFinalize = false;
 };
-
-/// Build the staged JIT target pipeline or exact target override.
-JITTargetPipelineConfig buildJITTargetPipelineConfig(
-    const cudaq::config::TargetConfig &config,
-    const std::map<std::string, std::string> &runtimeConfig, bool emulate);
 
 /// Replace `%KEY%` and `%KEY:default%` placeholders from runtime options.
 void substitutePipelinePlaceholders(

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/JITTargetPipeline.h
@@ -16,24 +16,55 @@ class TargetConfig;
 
 namespace cudaq_internal::compiler {
 
+/// Materialized target JIT pipeline settings derived from a target YAML config
+/// and runtime target arguments.
 struct JITTargetPipelineConfig {
+  /// MLIR pass-pipeline string to run. Defaults to the compiler's baseline
+  /// canonicalization-only pipeline when the target has no backend config.
   std::string passPipelineConfig = "canonicalize";
+  /// Codegen emission selected by the target config and runtime args, e.g.
+  /// "qir-adaptive", "qir-base", "qasm2", or "nop".
   std::string codegenTranslation;
+  /// Optional pass-pipeline string to run after codegen translation.
   std::string postCodeGenPasses;
+  /// True when the target has a top-level backend `config:` entry.
   bool hasBackendConfig = false;
+  /// True when the backend config provides any target pass-pipeline fields.
+  /// Python local targets use this to avoid adding default JIT stages to
+  /// simulator targets that never requested target pipeline handling.
   bool hasConfiguredPassPipeline = false;
+  /// True when `target-pass-pipeline` is set. In this mode the target-provided
+  /// pipeline is used exactly, with no standard prep/deploy/finalize stages
+  /// interleaved.
   bool usesTargetPassPipelineOverride = false;
+  /// True when `passPipelineConfig` includes the standard
+  /// `jit-finalize-pipeline`. Python translate paths use this to avoid running
+  /// target finalization twice.
   bool runsStandardFinalize = false;
 };
 
+/// Build the standard staged JIT target pipeline:
+///
+///   canonicalize, {hw|emul}-jit-prep-pipeline,
+///   jit-high-level-pipeline, jit-deploy-pipeline,
+///   jit-mid-level-pipeline, jit-finalize-pipeline,
+///   jit-low-level-pipeline
+///
+/// `target-pass-pipeline` remains an exact override. `%KEY%` and
+/// `%KEY:default%` placeholders are substituted from `runtimeConfig`.
 JITTargetPipelineConfig buildJITTargetPipelineConfig(
     const cudaq::config::TargetConfig &config,
     const std::map<std::string, std::string> &runtimeConfig, bool emulate);
 
+/// Replace `%KEY%` and `%KEY:default%` placeholders in `pipeline` using
+/// lowercase keys from `runtimeConfig`. Unresolved placeholders without a
+/// default are left unchanged for provider-specific rewriting.
 void substitutePipelinePlaceholders(
     std::string &pipeline,
     const std::map<std::string, std::string> &runtimeConfig);
 
+/// Rewrite any `qubit-mapping{...device=...}` stage in `pipeline` to
+/// `device=bypass`, preserving the other pass options.
 void setQubitMappingBypass(std::string &pipeline);
 
 } // namespace cudaq_internal::compiler


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Description
This is based on #4432 and should only be looked at after merging.

Python target lowering was not running the same target JIT pipeline stages as the normal compiler flow. This broke targets that rely on custom operation synthesis, especially registered SU(4) operations used with `estimate_resources`. The synthesis created helper functions, but the Python path was missing the specialization and inlining stages needed to expose the synthesized two-qubit gates, so resource counting saw only one-qubit gates. We fixed this by sharing the JIT target pipeline assembly between the compiler path and the Python local QPU path. Python local targets now use the shared target pipeline only when the target explicitly configures target pass-pipeline fields, which preserves the existing behavior for local simulator targets that do not override these pipelines (which is what happened already, just incorrectly). This centralizes the target YAML pipeline behavior while keeping Python lowering aligned with the standard compiler flow. 

Note the test `test_custom_unitary_produces_2q_gates` would fail if we just removed the passes from the target without this unification.

This allows me to remove the passes that in https://github.com/NVIDIA/cuda-quantum/pull/4432 @schweitzpgi noted shouldn't be required.

One possible follow-up question is whether the local Python QPU path should eventually delegate more of its module specialization and target-pipeline execution to `Compiler.cpp`, similar to the REST path, while preserving Python-specific JIT caching, resource counting, and result-handling behavior.