### PR TITLE
[tii] Bump up the default client version

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/tii/TiiServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/tii/TiiServerHelper.cpp
@@ -48,7 +48,7 @@ namespace cudaq {
 /// retrieving quantum computation jobs.
 class TiiServerHelper : public ServerHelper {
   static constexpr const char *DEFAULT_URL = "https://q-cloud.tii.ae";
-  static constexpr const char *DEFAULT_VERSION = "0.2.2";
+  static constexpr const char *DEFAULT_VERSION = "0.2.4";
 
 public:
   const std::string name() const override { return "tii"; }


### PR DESCRIPTION
## Summary
- Bump `DEFAULT_VERSION` in `TiiServerHelper.cpp` from `0.2.2` to `0.2.4`

## Motivation
- The TII server (`q-cloud.tii.ae`) now enforces a minimum `qibo-client` version of 0.2.3, returning HTTP 426 (Upgrade Required) for older clients. 
- This breaks both C++ and Python TII targets with:
```
    {"detail":"Outdated client version: 0.2.2. Please upgrade to qibo-client >= 0.2.3."}
```
## Testing
- Verified locally against `q-cloud.tii.ae` that requests succeed with version `0.2.4`.