### PR TITLE
login to GHCR before pulling image

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -95,6 +95,13 @@ jobs:
       cudaq_test_image: ${{ steps.vars.outputs.cudaq_nightly_image }}@${{ steps.test_image.outputs.digest }}
 
     steps:
+      - name: Log in to GitHub CR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Set variables
         id: vars
         run: |
@@ -111,13 +118,6 @@ jobs:
 
           echo "platforms=$(echo $platforms | tr ' ' ,)" >> $GITHUB_OUTPUT
           echo "cudaq_nightly_image=$cudaq_nightly_image" >> $GITHUB_OUTPUT
-
-      - name: Log in to GitHub CR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
 
       - name: Set up context for buildx
         run: |


### PR DESCRIPTION
This is needed to unblock https://github.com/NVIDIA/cuda-quantum/pull/4328 from testing nightly images.