### PR TITLE
remove apt proxy cache

### DIFF
--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -239,7 +239,7 @@ jobs:
         if: needs.metadata.outputs.runner != 'ubuntu-latest'
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -171,7 +171,7 @@ jobs:
         if: needs.metadata.outputs.runner != 'ubuntu-latest'
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Build Open MPI
         id: docker_build
@@ -328,7 +328,7 @@ jobs:
         if: needs.metadata.outputs.runner != 'ubuntu-latest'
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Set up ccache and ORAS
         uses: ./.github/actions/ccache-setup
@@ -595,7 +595,7 @@ jobs:
         if: needs.metadata.outputs.runner != 'ubuntu-latest'
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Set up ccache and ORAS
         uses: ./.github/actions/ccache-setup

--- a/.github/workflows/generate_cc.yml
+++ b/.github/workflows/generate_cc.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Build CUDA Quantum
         id: cudaq_build

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Set up ccache and ORAS
         uses: ./.github/actions/ccache-setup
@@ -282,7 +282,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -481,7 +481,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Extract cuda-quantum metadata
         id: metadata
@@ -647,7 +647,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Build installer
         uses: docker/build-push-action@v5
@@ -788,7 +788,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Build cuda-quantum wheel
         id: build_wheel

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Build wheel
         id: wheel_build

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Build CUDA Quantum
         id: build
@@ -250,7 +250,7 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         with:
-          enable-apt: true
+          enable-apt: false
 
       - name: Set up dev environment
         id: dev_env


### PR DESCRIPTION
This will fix the errors we are seeing since the apt proxy cache is getting rate limited. Potentially enable in the future again.