### PR TITLE
Allow building prerequisites as an unprivileged user.

### DIFF
--- a/scripts/configure_build.sh
+++ b/scripts/configure_build.sh
@@ -11,15 +11,15 @@
 trap '(return 0 2>/dev/null) && return 1 || exit 1' ERR
 
 # [>InstallLocations]
-export CUDAQ_INSTALL_PREFIX=/usr/local/cudaq
-export CUQUANTUM_INSTALL_PREFIX=/usr/local/cuquantum
-export CUTENSOR_INSTALL_PREFIX=/usr/local/cutensor
-export LLVM_INSTALL_PREFIX=/usr/local/llvm
-export BLAS_INSTALL_PREFIX=/usr/local/blas
-export ZLIB_INSTALL_PREFIX=/usr/local/zlib
-export OPENSSL_INSTALL_PREFIX=/usr/local/openssl
-export CURL_INSTALL_PREFIX=/usr/local/curl
-export AWS_INSTALL_PREFIX=/usr/local/aws
+export CUDAQ_INSTALL_PREFIX=${CUDAQ_INSTALL_PREFIX:-/usr/local/cudaq}
+export CUQUANTUM_INSTALL_PREFIX=${CUQUANTUM_INSTALL_PREFIX:-/usr/local/cuquantum}
+export CUTENSOR_INSTALL_PREFIX=${CUTENSOR_INSTALL_PREFIX:-/usr/local/cutensor}
+export LLVM_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX:-/usr/local/llvm}  
+export BLAS_INSTALL_PREFIX=${BLAS_INSTALL_PREFIX:-/usr/local/blas}
+export ZLIB_INSTALL_PREFIX=${ZLIB_INSTALL_PREFIX:-/usr/local/zlib}
+export OPENSSL_INSTALL_PREFIX=${OPENSSL_INSTALL_PREFIX:-/usr/local/openssl}
+export CURL_INSTALL_PREFIX=${CURL_INSTALL_PREFIX:-/usr/local/curl}
+export AWS_INSTALL_PREFIX=${AWS_INSTALL_PREFIX:-/usr/local/aws}
 
 # [<InstallLocations]
 


### PR DESCRIPTION
To help with non-containerized builds. It is useful to build prerequisites as an unprivileged user.