### PR TITLE
[CI] - Implement exponential backoff retry to various network operations

### DIFF
--- a/.github/workflows/build_package_sources.yml
+++ b/.github/workflows/build_package_sources.yml
@@ -78,8 +78,9 @@ jobs:
 
       - name: Pull images
         run: |
-          docker pull "${{ steps.images.outputs.base_image }}"
-          docker pull "${{ steps.images.outputs.target_image }}"
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry docker pull "${{ steps.images.outputs.base_image }}"
+          retry docker pull "${{ steps.images.outputs.target_image }}"
 
       - name: Diff package lists
         run: |
@@ -164,6 +165,7 @@ jobs:
 
       - name: Install wheel
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           whl=$(find wheel -name '*.whl' 2>/dev/null | head -1)
           if [ -z "$whl" ]; then
             echo "No .whl file found under wheel/"
@@ -171,7 +173,7 @@ jobs:
             exit 1
           fi
           echo "Installing $whl"
-          pip install "$whl"
+          retry pip install "$whl"
           # Capture package name (PEP 427: name-version-...); normalize to pip form (dashes)
           installed_pkg=$(basename "$whl" .whl | sed -E 's/-[0-9]+\.[0-9]+(\.[0-9]+)?.*//' | tr '_' '-')
           echo "$installed_pkg" > installed_wheel_package.txt
@@ -356,6 +358,7 @@ jobs:
       - name: Download CUDA-Q prerequisite sources
         run: |
           set -euo pipefail
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           # Generate cudaq_prereqs.lock for the current configuration
           bash scripts/install_prerequisites.sh -l
           cat cudaq_prereqs.lock
@@ -397,24 +400,24 @@ jobs:
                 fname="$(basename "$url")"
                 dest="prereqs/${name}/${fname}"
                 echo "Downloading tar archive for $name from $url -> $dest"
-                curl -L "$url" -o "$dest"
+                retry curl -L "$url" -o "$dest"
                 ;;
               sh)
                 fname="$(basename "$url")"
                 dest="prereqs/${name}/${fname}"
                 echo "Downloading shell installer for $name from $url -> $dest"
-                curl -L "$url" -o "$dest"
+                retry curl -L "$url" -o "$dest"
                 chmod +x "$dest"
                 ;;
               pem)
                 dest="prereqs/${name}/${name}.pem"
                 echo "Downloading PEM bundle for $name from $url -> $dest"
-                curl -L "$url" -o "$dest"
+                retry curl -L "$url" -o "$dest"
                 ;;
               git)
                 dest_dir="prereqs/${name}"
                 echo "Cloning git repo for $name from $url (ref=${ref:-HEAD}) -> $dest_dir"
-                git clone "$url" "$dest_dir"
+                retry git clone "$url" "$dest_dir"
                 if [ -n "${ref:-}" ]; then
                   git -C "$dest_dir" checkout "$ref"
                 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,9 +444,10 @@ jobs:
             esac
           }
 
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           # All sub-jobs (with names + html_url + conclusion). Paginate; this
           # workflow can have hundreds of matrix legs across reusable workflows.
-          gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+          retry gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
             --jq '.jobs[] | {name, html_url, conclusion, status, started_at, completed_at}' \
             | jq -s '.' > /tmp/jobs.json
 
@@ -630,14 +631,15 @@ jobs:
         if: env.PR_NUMBER != ''
         run: |
           set -euo pipefail
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           marker="<!-- ci-summary:${{ github.workflow }}:${EVENT_NAME} -->"
-          existing=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+          existing=$(retry gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -1 || true)
           if [ -n "$existing" ]; then
             jq -Rs '{body: .}' < /tmp/comment.md \
-              | gh api "repos/$REPO/issues/comments/$existing" -X PATCH --input -
+              | retry gh api "repos/$REPO/issues/comments/$existing" -X PATCH --input -
           else
-            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+            retry gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
           fi
         continue-on-error: true
 

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -145,8 +145,9 @@ jobs:
       - name: Restore prerequisites from GHCR
         run: |
           set -e  # Exit on error
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           echo "${{ github.token }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
-          oras pull ${{ needs.devdeps.outputs.image_hash }}
+          retry oras pull ${{ needs.devdeps.outputs.image_hash }}
 
           tar -xzf macos-artifacts.tar.gz -C $HOME
           rm macos-artifacts.tar.gz
@@ -163,7 +164,9 @@ jobs:
           registry-token: ${{ github.token }}
 
       - name: Install Python dependencies
-        run: CCACHE_DISABLE=1 pip install -r requirements-dev.txt
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          CCACHE_DISABLE=1 retry pip install -r requirements-dev.txt
 
       - name: Build MLIR Python bindings
         run: |
@@ -236,8 +239,9 @@ jobs:
       - name: Restore prerequisites from GHCR
         run: |
           set -e  # Exit on error
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           echo "${{ github.token }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
-          oras pull ${{ needs.devdeps.outputs.image_hash }}
+          retry oras pull ${{ needs.devdeps.outputs.image_hash }}
 
           tar -xzf macos-artifacts.tar.gz -C $HOME
           rm macos-artifacts.tar.gz
@@ -250,7 +254,9 @@ jobs:
           registry-token: ${{ github.token }}
 
       - name: Install Python dependencies
-        run: CCACHE_DISABLE=1 pip install -r requirements-dev.txt
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          CCACHE_DISABLE=1 retry pip install -r requirements-dev.txt
 
       - name: Build MLIR Python bindings
         run: |
@@ -387,8 +393,9 @@ jobs:
       - name: Restore prerequisites from GHCR
         run: |
           set -e  # Exit on error
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           echo "${{ github.token }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
-          oras pull ${{ needs.devdeps.outputs.image_hash }}
+          retry oras pull ${{ needs.devdeps.outputs.image_hash }}
 
           tar -xzf macos-artifacts.tar.gz -C $HOME
           rm macos-artifacts.tar.gz
@@ -402,8 +409,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          CCACHE_DISABLE=1 pip install -r requirements-dev.txt
-          brew install makeself pigz
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          CCACHE_DISABLE=1 retry pip install -r requirements-dev.txt
+          retry brew install makeself pigz
 
       - name: Build MLIR Python bindings
         run: |
@@ -498,8 +506,9 @@ jobs:
 
       - name: Install CUDA-Q (Python via wheel)
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           sudo -u cudaqtest -H python3 -m venv /Users/cudaqtest/venv
-          sudo -u cudaqtest -H /Users/cudaqtest/venv/bin/pip install wheel/*.whl
+          retry sudo -u cudaqtest -H /Users/cudaqtest/venv/bin/pip install wheel/*.whl
 
       - name: Validate installation
         run: |

--- a/.github/workflows/clean_caches.yml
+++ b/.github/workflows/clean_caches.yml
@@ -38,14 +38,15 @@ jobs:
       - name: Download cache keys
         id: artifacts
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-          artifacts=$(gh api $artifacts_url -q '.artifacts[] | {name: .name, url: .archive_download_url}')
+          artifacts=$(retry gh api $artifacts_url -q '.artifacts[] | {name: .name, url: .archive_download_url}')
 
           for artifact in `echo "$artifacts"`; do
             name=`echo $artifact | jq -r '.name'`
             if [ "${name#cache_key}" != "${name}" ]; then
               url=`echo $artifact | jq -r '.url'`
-              gh api $url > cache_keys.zip
+              retry gh api $url > cache_keys.zip
               unzip -d cache_keys cache_keys.zip
               for file in `find cache_keys/ -type f`; do
                 keys+=" `cat $file`"

--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -28,19 +28,20 @@ jobs:
 
     steps:
       - run: |
-          branches_to_delete=`gh api --paginate \
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          branches_to_delete=`retry gh api --paginate \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/branches \
             --jq '.[] | select(.name | test("^bot/[0-9]+")).name'`
 
-          for branch in $branches_to_delete; do 
+          for branch in $branches_to_delete; do
             echo "Deleting $branch."
-            gh api \
+            retry gh api \
               --method DELETE \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/nvidia/cuda-quantum/git/refs/heads/$branch 
+              /repos/nvidia/cuda-quantum/git/refs/heads/$branch
           done
         env:
           GH_TOKEN: ${{ secrets.REPO_BOT_ACCESS_TOKEN || github.token }}
@@ -96,7 +97,8 @@ jobs:
       - name: Find matching signatures files
         id: sig_files
         run: |
-          gh api -X GET --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry gh api -X GET --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
             /orgs/${{ github.repository_owner }}/packages/container/${{ matrix.image_name }}/versions >> packages.json
 
           sig_tags=`cat packages.json | jq -r ".[] | select(.metadata.package_type==\"container\").metadata.container.tags[]" | (egrep -o '^sha256-\S+\.sig$' || true)`
@@ -251,12 +253,13 @@ jobs:
 
     steps:
       - run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           pr_number=${{ github.event.pull_request.number }}
           repo_owner=${{ github.repository_owner }}
 
           for package in cuda-quantum-macos-ccache cuda-quantum-linux-ccache; do
             echo "Cleaning up $package for PR #${pr_number}..."
-            versions=`gh api --paginate \
+            versions=`retry gh api --paginate \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               /orgs/${repo_owner}/packages/container/${package}/versions 2>/dev/null || echo "[]"`
@@ -264,7 +267,7 @@ jobs:
             echo "$versions" | jq -r ".[] | select(.metadata.container.tags[] | test(\"pr-${pr_number}$\")).id" | while read version_id; do
               if [ -n "$version_id" ]; then
                 echo "Deleting version $version_id from $package"
-                gh api --method DELETE \
+                retry gh api --method DELETE \
                   -H "Accept: application/vnd.github+json" \
                   -H "X-GitHub-Api-Version: 2022-11-28" \
                   /orgs/${repo_owner}/packages/container/${package}/versions/${version_id} 2>/dev/null || true

--- a/.github/workflows/create_cache_command.yml
+++ b/.github/workflows/create_cache_command.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Download PR info
         id: pr_info
         run: |
-          pr_info=`wget -O - ${{ inputs.pr_url }}`
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          pr_info=`retry wget -O - ${{ inputs.pr_url }}`
           pr_nr=`echo $pr_info | jq -r '.number'`
           head_label=`echo $pr_info | jq -r '.head.label'`
           head_sha=`echo $pr_info | jq -r '.head.sha'`

--- a/.github/workflows/delete_tags.yml
+++ b/.github/workflows/delete_tags.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Gather tags
         id: tags
         run: |
-          gh api -X GET --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry gh api -X GET --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
             /orgs/${{ github.repository_owner }}/packages/container/${{ inputs.ghcr_image }}/versions >> packages.json
 
           existing_image_tags=`cat packages.json | jq -r ".[] | select(.metadata.package_type==\"container\").metadata.container.tags[]" | (egrep --invert-match '^sha256-\S+\.sig$' || true)`
@@ -81,7 +82,8 @@ jobs:
 
       - name: List remaining tags
         run: |
-          gh api -X GET --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry gh api -X GET --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
             /orgs/${{ github.repository_owner }}/packages/container/${{ inputs.ghcr_image }}/versions >> packages.json
 
           existing_image_tags=`cat packages.json | jq -r ".[] | select(.metadata.package_type==\"container\").metadata.container.tags[]" | (egrep --invert-match '^sha256-\S+\.sig$' || true)`

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -91,14 +91,15 @@ jobs:
         if: github.event_name == 'workflow_run'
         id: pr_info
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-          artifacts=$(gh api $artifacts_url -q '.artifacts[] | {name: .name, url: .archive_download_url}')
+          artifacts=$(retry gh api $artifacts_url -q '.artifacts[] | {name: .name, url: .archive_download_url}')
 
           for artifact in `echo "$artifacts"`; do
             name=`echo $artifact | jq -r '.name'`
             if [ "$name" == "metadata_pr" ]; then
               url=`echo $artifact | jq -r '.url'`
-              gh api $url > metadata.zip
+              retry gh api $url > metadata.zip
               unzip -d metadata metadata.zip
               for file in `find metadata/ -type f`; do
                 cat "$file" >> metadata.txt

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -330,7 +330,10 @@ jobs:
           # We want this dispatch to trigger additional workflows.
           github-token: ${{ secrets.REPO_BOT_ACCESS_TOKEN }}
           script: |
-            github.rest.actions.createWorkflowDispatch({
+            // The createWorkflowDispatch call has been observed to hit transient
+            // GitHub API 5xx errors; retry up to 3 times with exponential backoff.
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+            const params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'deployments.yml',
@@ -340,7 +343,18 @@ jobs:
                 cache_base: '${{ needs.metadata.outputs.cache_base }}',
                 devcontainer_only: ${{ github.event_name == 'schedule' }}
               },
-            })
+            };
+            for (let n = 1; n <= 3; n++) {
+              try {
+                await github.rest.actions.createWorkflowDispatch(params);
+                if (n > 1) core.notice(`createWorkflowDispatch succeeded on attempt ${n}`);
+                return;
+              } catch (err) {
+                if (n === 3) throw err;
+                core.warning(`createWorkflowDispatch attempt ${n}/3 failed: ${err.message}; retrying...`);
+                await sleep(15000 * n * n);
+              }
+            }
 
   # This job is needed only when using the cloudposse GitHub action to read
   # the output of a matrix job. This is a workaround due to current GitHub
@@ -863,7 +877,8 @@ jobs:
         with:
           github-token: ${{ secrets.REPO_BOT_ACCESS_TOKEN }}
           script: |
-            await github.rest.actions.createWorkflowDispatch({
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+            const params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'publishing.yml',
@@ -871,4 +886,15 @@ jobs:
               inputs: {
                 deployment_id: context.runId.toString(),
               },
-            });
+            };
+            for (let n = 1; n <= 3; n++) {
+              try {
+                await github.rest.actions.createWorkflowDispatch(params);
+                if (n > 1) core.notice(`createWorkflowDispatch succeeded on attempt ${n}`);
+                return;
+              } catch (err) {
+                if (n === 3) throw err;
+                core.warning(`createWorkflowDispatch attempt ${n}/3 failed: ${err.message}; retrying...`);
+                await sleep(15000 * n * n);
+              }
+            }

--- a/.github/workflows/dev_environment.yml
+++ b/.github/workflows/dev_environment.yml
@@ -400,6 +400,7 @@ jobs:
         id: uploaded_image
         if: inputs.update_registry_cache == '' && inputs.build_target == ''
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           if ${{ inputs.environment != '' }}; then
             image_hash=${{ needs.metadata.outputs.image_name }}@${{ steps.docker_build.outputs.digest }}
             echo "image_hash=$image_hash" >> $GITHUB_OUTPUT
@@ -427,12 +428,12 @@ jobs:
             fi
             remote_tag=${{ needs.metadata.outputs.tag_prefix }}${{ steps.cache.outputs.registry_cache_base }}${{ needs.metadata.outputs.tag_suffix }}
             echo "Trying to pull remote tag $remote_image:$remote_tag."
-            docker pull $remote_image:$remote_tag || true
+            retry docker pull $remote_image:$remote_tag || true
             if [ "$(docker images -q $remote_image:$remote_tag 2> /dev/null)" == "" ]; then
               platform_tag=${{ needs.metadata.outputs.platform_tag }}
               remote_tag=`echo $remote_tag | sed s/"${platform_tag:+$platform_tag-}"//`
               echo "Trying to pull remote tag $remote_image:$remote_tag."
-              docker pull $remote_image:$remote_tag || true
+              retry docker pull $remote_image:$remote_tag || true
             fi
 
             if [ "$(docker images -q $remote_image:$remote_tag 2> /dev/null)" != "" ]; then

--- a/.github/workflows/dev_environment_macos.yml
+++ b/.github/workflows/dev_environment_macos.yml
@@ -138,7 +138,9 @@ jobs:
           submodules: ${{ inputs.checkout_submodules }}
 
       - name: Install ORAS
-        run: brew install oras
+        run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry brew install oras
 
       - name: Log in to GitHub CR
         run: echo "${{ github.token }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -187,12 +189,13 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: '13.0'
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           # Fix CI runner quirk: gcc pre-installed but not linked
           brew unlink gcc 2>/dev/null || true
           brew link gcc --overwrite 2>/dev/null || true
-          
+
           # NumPy is required by MLIR's find_package(Python3 ... NumPy)
-          pip3 install numpy --break-system-packages
+          retry pip3 install numpy --break-system-packages
           
           # Build prerequisites with Python bindings enabled so the cmake
           # cache already has MLIR_ENABLE_BINDINGS_PYTHON=ON.  Downstream
@@ -213,17 +216,18 @@ jobs:
         id: push_image
         if: steps.cache_check.outputs.cache_hit != 'true'
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           # Package artifacts
           echo "Packaging artifacts from ~/.local and ~/.llvm-project..."
           tar -czf macos-artifacts.tar.gz -C $HOME .local .llvm-project
           ls -lh macos-artifacts.tar.gz
-          
+
           # Push directly to GHCR as OCI artifact using ORAS
-          oras push ${{ steps.cache_key.outputs.image_name }} \
+          retry oras push ${{ steps.cache_key.outputs.image_name }} \
             macos-artifacts.tar.gz:application/gzip
-          
+
           # Get digest for signing
-          digest=$(oras manifest fetch ${{ steps.cache_key.outputs.image_name }} --descriptor | jq -r '.digest')
+          digest=$(retry oras manifest fetch ${{ steps.cache_key.outputs.image_name }} --descriptor | jq -r '.digest')
           echo "digest=${{ steps.cache_key.outputs.image_name }}@${digest}" >> $GITHUB_OUTPUT
 
       - name: Install Cosign

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -122,12 +122,13 @@ jobs:
       - name: Determine build arguments
         id: build_info
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           repo_owner=${{ github.repository_owner }}
           registry=${{ vars.registry || 'localhost:5000' }}
           image_name=$registry/${repo_owner,,}/${{ vars.packages_prefix }}open-mpi
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
 
-          docker pull ${{ inputs.ompidev_image }} # to get the tag
+          retry docker pull ${{ inputs.ompidev_image }} # to get the tag
           dev_tag=`docker inspect ${{ inputs.ompidev_image }} --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"'`
           echo "image_tag=${dev_tag#ompi-}" >> $GITHUB_OUTPUT
           docker image rm ${{ inputs.ompidev_image }}
@@ -275,18 +276,19 @@ jobs:
       - name: Load prerequisites
         id: prereqs
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           if ${{ steps.restore.outcome != 'skipped' }}; then
             load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
             base_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
             echo "Base image: $base_image" >> $GITHUB_STEP_SUMMARY
             # Push the image to the local registry to make it available within
             # the containered environment that docker/build-push-action uses.
-            docker push $base_image
+            retry docker push $base_image
             rm -rf "${{ inputs.devdeps_archive }}"
           elif ${{ inputs.devdeps_image != '' }}; then
             base_image=${{ inputs.devdeps_image }}
             echo "Base image: $base_image" >> $GITHUB_STEP_SUMMARY
-            docker pull $base_image
+            retry docker pull $base_image
           else
             echo "::error file=docker_images.yml::Missing configuration for development dependencies. Either specify the image (i.e. provide devdeps_image) or cache (i.e. provide devdeps_cache and devdeps_archive) that should be used for the build."
             exit 1
@@ -816,12 +818,13 @@ jobs:
       - name: Build documentation
         id: docs_build
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           if ${{ steps.restore_cudaq.outcome != 'skipped' }}; then
             load_output=`docker load --input "${{ needs.cudaq_image.outputs.tar_archive }}"`
             cudaq_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
           else
             cudaq_image=${{ needs.cudaq_image.outputs.image_hash }}
-            docker pull $cudaq_image
+            retry docker pull $cudaq_image
           fi
 
           image_tag=`docker inspect $cudaq_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"' | sed -E 's/^(arm64-|amd64-)//'`
@@ -834,7 +837,7 @@ jobs:
             cudaqdev_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
           else
             cudaqdev_image=${{ needs.cudaqdev_image.outputs.image_hash }}
-            docker pull $cudaqdev_image
+            retry docker pull $cudaqdev_image
           fi
 
           docker run --rm -dit --network host --name cuda-quantum-dev $cudaqdev_image
@@ -925,12 +928,13 @@ jobs:
 
       - name: Validate cuda-quantum image
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           if ${{ steps.restore.outcome != 'skipped' }}; then
             load_output=`docker load --input "${{ needs.cudaq_image.outputs.tar_archive }}"`
             cudaq_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
           else
             cudaq_image=${{ needs.cudaq_image.outputs.image_hash }}
-            docker pull $cudaq_image
+            retry docker pull $cudaq_image
           fi
 
           docker run --rm -dit --name cuda-quantum $cudaq_image
@@ -938,7 +942,7 @@ jobs:
           docker cp docs/notebook_validation.py cuda-quantum:"/home/cudaq/notebook_validation.py"
           # In containers without GPU support, UCX does not work properly since it is configured to work with GPU-support.
           # Hence, don't enforce UCX when running these tests.
-          docker exec cuda-quantum bash -c "python3 -m pip install --break-system-packages pandas scipy seaborn h5py contfrac"
+          retry docker exec cuda-quantum bash -c "python3 -m pip install --break-system-packages pandas scipy seaborn h5py contfrac"
           docker exec cuda-quantum bash -c "sudo apt install -y python3-venv"
           (docker exec cuda-quantum bash -c "unset OMPI_MCA_pml && set -o pipefail && bash validate_installation.sh | tee /tmp/validation.out") && passed=true || passed=false
           docker cp cuda-quantum:"/tmp/validation.out" /tmp/validation.out

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -1042,7 +1042,13 @@ jobs:
           keys+=" ${{ needs.cudaq_image.outputs.tar_cache }}"
           keys+=" ${{ needs.ompi_image.outputs.tar_cache }}"
           echo "$keys" >> cache_keys.txt
-          echo "artifact_name=${{ needs.validation.outputs.artifact_id }}_cache_keys" >> $GITHUB_OUTPUT
+          # Fall back to platform/cuda matrix dimensions when validation's
+          # artifact_id is unset (e.g. validation failed before job_summary),
+          # otherwise multiple matrix legs collide on the bare "_cache_keys"
+          # artifact name and `upload-artifact` returns 409 Conflict.
+          artifact_id="${{ needs.validation.outputs.artifact_id }}"
+          fallback="image_${{ needs.metadata.outputs.platform_tag }}_cu$(echo '${{ inputs.cuda_version }}' | cut -d . -f1)"
+          echo "artifact_name=${artifact_id:-$fallback}_cache_keys" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -58,12 +58,13 @@ jobs:
       - name: Download artifacts
         id: artifacts
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           if ${{ github.event_name == 'workflow_dispatch' }}; then
             artifacts_url=https://api.github.com/repos/${{ inputs.github_repository || github.repository }}/actions/runs/${{ inputs.deployment_id }}/artifacts
           else
             artifacts_url=${{ github.event.workflow_run.artifacts_url }}
           fi
-          artifacts=$(gh api --paginate $artifacts_url -q '.artifacts[] | {name: .name, url: .archive_download_url}')
+          artifacts=$(retry gh api --paginate $artifacts_url -q '.artifacts[] | {name: .name, url: .archive_download_url}')
           artifact_name=cuda_quantum_docs
 
           docs_found=${{ github.event.workflow_run.name == 'CI' || false }}
@@ -71,11 +72,11 @@ jobs:
             name=`echo $artifact | jq -r '.name'`
             if [ "$name" == "$artifact_name" ]; then
               url=`echo $artifact | jq -r '.url'`
-              gh api $url > cuda_quantum_docs.zip
+              retry gh api $url > cuda_quantum_docs.zip
               docs_found=true && echo "docs_archive=cuda_quantum_docs.zip" >> $GITHUB_OUTPUT
             elif [ "$name" == "metadata_ci" ]; then
               url=`echo $artifact | jq -r '.url'`
-              gh api $url > metadata.zip
+              retry gh api $url > metadata.zip
               unzip -d metadata metadata.zip
               for file in `find metadata/ -type f`; do
                 cat "$file" >> metadata.txt
@@ -114,7 +115,7 @@ jobs:
             elif ${{ github.event.workflow_run.name != 'CI' }} && [ "$head_branch" != "${head_branch#staging/}" ]; then
               # Only publish docs if no release branch exists for that version.
               version=`echo ${head_branch#staging/} | (egrep -o "^v?([0-9]{1,}\.)+[0-9]{1,}$" || true)`
-              gh api repos/${{ github.repository }}/branches \
+              retry gh api repos/${{ github.repository }}/branches \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 --paginate --jq '.[].name | select(startswith("releases/"))' \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -98,11 +98,13 @@ jobs:
       - name: Set variables
         id: vars
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           cudaq_test_image=${{ inputs.cudaq_test_image || vars.cudaq_test_image }}
           cudaq_nightly_image=ghcr.io/nvidia/${{ vars.packages_prefix }}cuda-quantum
 
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends curl
-          curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
+          retry sudo apt-get update
+          retry sudo apt-get install -y --no-install-recommends curl
+          retry curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
           chmod 755 regctl
 
           manifest=`./regctl image manifest $cudaq_test_image --format "{{ json . }}"`
@@ -281,6 +283,7 @@ jobs:
       # Provider-specific setup steps
       - name: Setup ${{ matrix.provider }} account
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           case "${{ matrix.provider }}" in
             anyon)
               echo "### Setting up Anyon account" >> $GITHUB_STEP_SUMMARY
@@ -349,7 +352,7 @@ jobs:
               ;;
             pasqal)
               echo "### Setting up Pasqal account" >> $GITHUB_STEP_SUMMARY
-              python3 -m pip install pasqal-cloud
+              retry python3 -m pip install pasqal-cloud
               echo "::add-mask::${{ secrets.PASQAL_USERNAME }}"
               echo "::add-mask::${{ secrets.PASQAL_PASSWORD }}"
               echo "::add-mask::${{ secrets.PASQAL_PROJECT_ID }}"

--- a/.github/workflows/migrate_image.yml
+++ b/.github/workflows/migrate_image.yml
@@ -74,12 +74,14 @@ jobs:
       - name: Prepare image
         id: setup
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           echo "FROM ${{ inputs.source_image }}" >> ngc.Dockerfile
           target_image_name=`echo ${{ inputs.target_image }} | cut -d : -f1`
           target_image_tag=`echo ${{ inputs.target_image }} | cut -d : -f2`
 
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends curl
-          curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
+          retry sudo apt-get update
+          retry sudo apt-get install -y --no-install-recommends curl
+          retry curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
           chmod 755 regctl
 
           manifest=`./regctl image manifest ${{ inputs.source_image }} --format "{{ json . }}"`

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -413,13 +413,14 @@ jobs:
           shell: bash -l
           run: |
             retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+            retry_dnf() { local pre=""; [ "$(id -u)" -ne 0 ] && pre=sudo; for n in 1 2 3; do $pre dnf "$@" && return 0; [ $n -lt 3 ] && { $pre dnf clean metadata >/dev/null 2>&1 || true; sleep $((15*n*n)); }; done; return 1; }
             PYTHON="python3.$(ls cuda_quantum*.whl | grep -o cp3[0-9]* | cut -c 4- | head -1)"
             if [ -x "$(command -v apt-get)" ]; then
               retry sudo apt-get update
               retry sudo apt-get install -y --no-install-recommends $PYTHON $PYTHON-venv
               $PYTHON -m venv "$HOME/.venv" && PATH="$HOME/.venv/bin:$PATH"
             elif [ -x "$(command -v dnf)" ]; then
-              retry sudo dnf install -y --nobest --setopt=install_weak_deps=False $(echo $PYTHON | tr -d .)
+              retry_dnf install -y --nobest --setopt=install_weak_deps=False $(echo $PYTHON | tr -d .)
               $PYTHON -m ensurepip --upgrade
             elif [ -x "$(command -v zypper)" ]; then
               retry sudo zypper --non-interactive up --no-recommends
@@ -449,6 +450,7 @@ jobs:
           shell: bash -l
           run: |
             retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+            retry_dnf() { local pre=""; [ "$(id -u)" -ne 0 ] && pre=sudo; for n in 1 2 3; do $pre dnf "$@" && return 0; [ $n -lt 3 ] && { $pre dnf clean metadata >/dev/null 2>&1 || true; sleep $((15*n*n)); }; done; return 1; }
             # Uninstall CUDA Quantum
             install_dir="$CUDA_QUANTUM_PATH"
             sudo bash ${CUDA_QUANTUM_PATH}/uninstall.sh -y
@@ -481,7 +483,7 @@ jobs:
             status_sum=0
 
             if ${{ contains(matrix.os_image, 'redhat' ) }}; then
-              retry sudo dnf install -y --nobest --setopt=install_weak_deps=False gcc-toolset-12
+              retry_dnf install -y --nobest --setopt=install_weak_deps=False gcc-toolset-12
               source /opt/rh/gcc-toolset-12/enable
               export OMPI_CXX=g++
               /usr/local/openmpi/bin/mpic++ mpi_cuda_check.cpp -o check.x && \

--- a/.github/workflows/prebuilt_binaries.yml
+++ b/.github/workflows/prebuilt_binaries.yml
@@ -412,21 +412,23 @@ jobs:
           user: cudaq
           shell: bash -l
           run: |
+            retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
             PYTHON="python3.$(ls cuda_quantum*.whl | grep -o cp3[0-9]* | cut -c 4- | head -1)"
             if [ -x "$(command -v apt-get)" ]; then
-              sudo apt-get update && sudo apt-get install -y --no-install-recommends $PYTHON $PYTHON-venv
+              retry sudo apt-get update
+              retry sudo apt-get install -y --no-install-recommends $PYTHON $PYTHON-venv
               $PYTHON -m venv "$HOME/.venv" && PATH="$HOME/.venv/bin:$PATH"
             elif [ -x "$(command -v dnf)" ]; then
-              sudo dnf install -y --nobest --setopt=install_weak_deps=False $(echo $PYTHON | tr -d .)
+              retry sudo dnf install -y --nobest --setopt=install_weak_deps=False $(echo $PYTHON | tr -d .)
               $PYTHON -m ensurepip --upgrade
             elif [ -x "$(command -v zypper)" ]; then
-              sudo zypper --non-interactive up --no-recommends
-              sudo zypper --non-interactive in --no-recommends $(echo $PYTHON | tr -d .)
-              $PYTHON -m ensurepip --upgrade            
+              retry sudo zypper --non-interactive up --no-recommends
+              retry sudo zypper --non-interactive in --no-recommends $(echo $PYTHON | tr -d .)
+              $PYTHON -m ensurepip --upgrade
             fi
 
-            ${PYTHON} -m pip install cuda_quantum*.whl
-            ${PYTHON} -m pip install pytest numpy psutil
+            retry ${PYTHON} -m pip install cuda_quantum*.whl
+            retry ${PYTHON} -m pip install pytest numpy psutil
             # FIXME: some tests fail when building against libc++
             # https://github.com/NVIDIA/cuda-quantum/issues/1712
             # /home/cudaq/python/kernel/test_kernel_parameters.py
@@ -446,6 +448,7 @@ jobs:
           user: cudaq
           shell: bash -l
           run: |
+            retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
             # Uninstall CUDA Quantum
             install_dir="$CUDA_QUANTUM_PATH"
             sudo bash ${CUDA_QUANTUM_PATH}/uninstall.sh -y
@@ -478,7 +481,7 @@ jobs:
             status_sum=0
 
             if ${{ contains(matrix.os_image, 'redhat' ) }}; then
-              sudo dnf install -y --nobest --setopt=install_weak_deps=False gcc-toolset-12
+              retry sudo dnf install -y --nobest --setopt=install_weak_deps=False gcc-toolset-12
               source /opt/rh/gcc-toolset-12/enable
               export OMPI_CXX=g++
               /usr/local/openmpi/bin/mpic++ mpi_cuda_check.cpp -o check.x && \

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -51,14 +51,15 @@ jobs:
     steps:
       - id: check
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           if [ "$EVENT_NAME" != "workflow_run" ]; then
             echo "run_publishing=true" >> $GITHUB_OUTPUT
           elif [[ "$HEAD_BRANCH" == "main" || "$HEAD_BRANCH" == releases/* || "$HEAD_BRANCH" == staging/* || "$HEAD_BRANCH" == experimental/* ]]; then
             echo "run_publishing=true" >> $GITHUB_OUTPUT
           else
-            artifact_url=$(gh api "$ARTIFACTS_URL" --paginate -q '.artifacts[] | select(.name=="publishing_requested") | .archive_download_url' | head -1)
+            artifact_url=$(retry gh api "$ARTIFACTS_URL" --paginate -q '.artifacts[] | select(.name=="publishing_requested") | .archive_download_url' | head -1)
             if [ -n "$artifact_url" ]; then
-              gh api "$artifact_url" -o publishing_requested.zip
+              retry gh api "$artifact_url" -o publishing_requested.zip
               unzip -o publishing_requested.zip
               content=$(cat publishing_requested.txt 2>/dev/null | tr -d '\n' || echo "true")
             else
@@ -110,16 +111,17 @@ jobs:
       - name: Download build info
         id: artifacts
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           if ${{ inputs.deployment_id != '' }}; then
             artifacts_url=https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ inputs.deployment_id }}/artifacts
           else
             artifacts_url=${{ github.event.workflow_run.artifacts_url }}
             echo "Artifacts downloaded from https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}" >> $GITHUB_STEP_SUMMARY
           fi
-          artifacts=$(gh api $artifacts_url --paginate -q '.artifacts[] | {name: .name, url: .archive_download_url}')
+          artifacts=$(retry gh api $artifacts_url --paginate -q '.artifacts[] | {name: .name, url: .archive_download_url}')
 
           function download {
-            gh api $1 > info.zip
+            retry gh api $1 > info.zip
             unzip -d info info.zip
             for file in `find info/ -type f`; do
               cat "$file" >> $2.txt
@@ -170,7 +172,7 @@ jobs:
               release_version=`cat "$name.txt" | grep -o 'release-version: \S*' | cut -d ' ' -f 2`
             elif [ "$name" == "cuda_quantum_docs" ] && ${{ github.event_name == 'workflow_dispatch' && inputs.include_docs }}; then
               docs_archive="$(pwd)/cuda_quantum_docs.zip"
-              gh api $url > "$docs_archive"
+              retry gh api $url > "$docs_archive"
             fi
           done
 
@@ -415,6 +417,7 @@ jobs:
       - name: Retrieve assets
         id: release_info
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           release_id=${{ fromJson(needs.assets.outputs.docker_images)[format('{0}', matrix.info_file)].release_id }}
           assets_folder=assets && mkdir "$assets_folder" && cd "$assets_folder"
           cp -r /tmp/assets/${{ matrix.info_file }}/. "$(pwd)" && rm -rf /tmp/assets
@@ -429,7 +432,7 @@ jobs:
           cudaqdevdeps_image=`cat $build_info | grep -o 'cuda-quantum-devdeps-image: \S*' | cut -d ' ' -f 2`
           for file in `ls *zip`; do unzip "$file" && rm "$file"; done && cd -
 
-          docker pull $cudaqbase_image
+          retry docker pull $cudaqbase_image
           base_tag=`docker inspect $cudaqbase_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.version"'`
           base_tag=$(echo "$base_tag" | sed -E 's/^(arm64-|amd64-)//')
           image_title=`docker inspect $cudaqbase_image --format='{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.title"'`
@@ -875,6 +878,7 @@ jobs:
       - name: Fetch macOS artifacts from Deployments run
         id: fetch
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           artifacts_url="${{ needs.assets.outputs.artifacts_url }}"
           if [ -z "$artifacts_url" ]; then
             echo "No artifacts URL available."
@@ -883,7 +887,7 @@ jobs:
             exit 0
           fi
 
-          artifacts=$(gh api $artifacts_url --paginate -q '.artifacts[] | {name: .name, url: .archive_download_url}')
+          artifacts=$(retry gh api $artifacts_url --paginate -q '.artifacts[] | {name: .name, url: .archive_download_url}')
 
           has_macos_wheels=false
           has_macos_installer=false
@@ -896,14 +900,14 @@ jobs:
             if [[ "$name" == pycudaq-*-darwin-arm64 ]]; then
               python_version=$(echo "$name" | sed 's/pycudaq-\(.*\)-darwin-arm64/\1/')
               echo "Downloading macOS wheel: $name (Python $python_version)"
-              gh api "$url" > "${name}.zip"
+              retry gh api "$url" > "${name}.zip"
               unzip "${name}.zip" -d wheels/
               rm "${name}.zip"
               has_macos_wheels=true
 
             elif [[ "$name" == cudaq-arm64-darwin-installer-* ]]; then
               echo "Downloading macOS installer: $name"
-              gh api "$url" > "${name}.zip"
+              retry gh api "$url" > "${name}.zip"
               unzip "${name}.zip" -d installer/
               rm "${name}.zip"
               has_macos_installer=true
@@ -994,10 +998,11 @@ jobs:
       - name: Basic validation (GPU backends)
         shell: bash
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           # Seems like we will need to install build-essential for resolving nbconvert issue `RuntimeError: Unsupported compiler -- at least C++11 support is needed!`"
           # Given here: https://github.com/NVIDIA/cuda-quantum/blob/main/docs/sphinx/applications/python/qchem/cppe_lib.py#L18
           # and https://github.com/jupyter/nbconvert/issues/1742
-          sudo apt-get update && sudo apt-get install -y build-essential python3-dev python3-venv python3-pip
+          retry sudo apt-get update && retry sudo apt-get install -y build-essential python3-dev python3-venv python3-pip
 
           backends_to_test=`\
               for file in $(ls $CUDA_QUANTUM_PATH/targets/*.yml); \
@@ -1102,15 +1107,17 @@ jobs:
       - name: Runtime dependencies (apt)
         if: startsWith(matrix.os_image, 'ubuntu')
         run: |
-          apt-get update && apt-get install -y --no-install-recommends \
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry apt-get update
+          retry apt-get install -y --no-install-recommends \
             wget ca-certificates libc6-dev libopenmpi-dev
           distro=`echo ${{ matrix.os_image }} | tr -d . | tr -d :`
           CUDA_DOWNLOAD_URL=https://developer.download.nvidia.com/compute/cuda/repos
-          wget "${CUDA_DOWNLOAD_URL}/$distro/x86_64/cuda-keyring_1.1-1_all.deb"
+          retry wget "${CUDA_DOWNLOAD_URL}/$distro/x86_64/cuda-keyring_1.1-1_all.deb"
           dpkg -i cuda-keyring_1.1-1_all.deb
           cuda_version_suffix="$(echo ${{ matrix.cuda_version }} | tr . -)"
-          apt-get update
-          apt-get install -y --no-install-recommends \
+          retry apt-get update
+          retry apt-get install -y --no-install-recommends \
           cuda-cudart-$cuda_version_suffix \
           cuda-cudart-dev-$cuda_version_suffix \
           cuda-nvrtc-$cuda_version_suffix \
@@ -1123,7 +1130,8 @@ jobs:
       - name: Runtime dependencies (dnf)
         if: startsWith(matrix.os_image, 'redhat')
         run: |
-          dnf install -y --nobest --setopt=install_weak_deps=False \
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry dnf install -y --nobest --setopt=install_weak_deps=False \
             'dnf-command(config-manager)' glibc-devel openssh-clients
           CUDA_VERSION=${{ matrix.cuda_version }}
           DISTRIBUTION=rhel8
@@ -1132,13 +1140,13 @@ jobs:
           # We need to install an MPI implementation, otherwise nothing
           # will be able to run on the nvidia-mgpu backend.
           # Install conda to a shared path so the non-root test user can access MPI.
-          dnf install -y --nobest --setopt=install_weak_deps=False wget
+          retry dnf install -y --nobest --setopt=install_weak_deps=False wget
           conda_prefix=/opt/miniconda3
-          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh -O /tmp/miniconda.sh
+          retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh -O /tmp/miniconda.sh
           bash /tmp/miniconda.sh -b -u -p "$conda_prefix"
           rm -f /tmp/miniconda.sh
           eval "$($conda_prefix/bin/conda shell.bash hook)"
-          conda install -y -c conda-forge openmpi">=5.0.7"
+          retry conda install -y -c conda-forge openmpi">=5.0.7"
           chmod -R a+rX "$conda_prefix"
 
       - name: Install and run sanity checks
@@ -1238,24 +1246,26 @@ jobs:
       - name: Run basic validation
         shell: bash
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           # These simple steps are only expected to work for
           # test cases that don't require MPI.
           # Create clean python3 environment.
-          apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv
+          retry apt-get update
+          retry apt-get install -y --no-install-recommends python3 python3-pip python3-venv
 
           # Make a place for local wheels
           mkdir -p /tmp/packages && mv /tmp/wheels/* /tmp/packages && rmdir /tmp/wheels
-          
+
           # Create and activate virtual environment
           python3 -m venv /opt/cudaq-venv
           source /opt/cudaq-venv/bin/activate
 
           if [ -n "${{ matrix.cuda_major }}" ]; then
-            pip install cuda-quantum-cu${{ matrix.cuda_major }}==${{ needs.assets.outputs.cudaq_version }} -v \
+            retry pip install cuda-quantum-cu${{ matrix.cuda_major }}==${{ needs.assets.outputs.cudaq_version }} -v \
               --find-links "file:///tmp/packages"
           else
-            pip install --upgrade pip
-            pip install cudaq==${{ needs.assets.outputs.cudaq_version }} -v \
+            retry pip install --upgrade pip
+            retry pip install cudaq==${{ needs.assets.outputs.cudaq_version }} -v \
               --find-links "file:///tmp/packages" \
             2>&1 | tee /tmp/install.out
 
@@ -1282,7 +1292,7 @@ jobs:
 
           # Also need to test dynamics
           echo "Running with target dynamics"
-          python3 -m pip install matplotlib
+          retry python3 -m pip install matplotlib
           python3 docs/sphinx/examples/python/dynamics/qubit_dynamics.py
 
           set -e # Re-enable exit code error checking
@@ -1340,7 +1350,9 @@ jobs:
       - name: Run validation
         shell: bash
         run: |
-          apt-get update && apt-get install -y --no-install-recommends \
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry apt-get update
+          retry apt-get install -y --no-install-recommends \
             ca-certificates vim wget unzip openssh-client
           mv /tmp/wheels/* /tmp/packages && rmdir /tmp/wheels
 
@@ -1407,15 +1419,16 @@ jobs:
 
       - name: Validate metapackage install chain
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           mkdir -p /tmp/packages
           mv /tmp/wheels/* /tmp/packages
           mv /tmp/metapackages/* /tmp/packages
 
           python3 -m venv /tmp/metapackage-test
           source /tmp/metapackage-test/bin/activate
-          pip install --upgrade pip
+          retry pip install --upgrade pip
 
-          pip install "cudaq==${{ needs.assets.outputs.cudaq_version }}" \
+          retry pip install "cudaq==${{ needs.assets.outputs.cudaq_version }}" \
             --find-links "file:///tmp/packages"
 
           expected_dependency=cuda-quantum-cu13

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1131,7 +1131,10 @@ jobs:
         if: startsWith(matrix.os_image, 'redhat')
         run: |
           retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
-          retry dnf install -y --nobest --setopt=install_weak_deps=False \
+          # dnf-specific retry: clears cached metadata between attempts so that
+          # a stale 404 from a CDN mirror doesn't poison the cache for retry #2.
+          retry_dnf() { local pre=""; [ "$(id -u)" -ne 0 ] && pre=sudo; for n in 1 2 3; do $pre dnf "$@" && return 0; [ $n -lt 3 ] && { $pre dnf clean metadata >/dev/null 2>&1 || true; sleep $((15*n*n)); }; done; return 1; }
+          retry_dnf install -y --nobest --setopt=install_weak_deps=False \
             'dnf-command(config-manager)' glibc-devel openssh-clients
           CUDA_VERSION=${{ matrix.cuda_version }}
           DISTRIBUTION=rhel8
@@ -1140,7 +1143,7 @@ jobs:
           # We need to install an MPI implementation, otherwise nothing
           # will be able to run on the nvidia-mgpu backend.
           # Install conda to a shared path so the non-root test user can access MPI.
-          retry dnf install -y --nobest --setopt=install_weak_deps=False wget
+          retry_dnf install -y --nobest --setopt=install_weak_deps=False wget
           conda_prefix=/opt/miniconda3
           retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh -O /tmp/miniconda.sh
           bash /tmp/miniconda.sh -b -u -p "$conda_prefix"

--- a/.github/workflows/publishing_stable.yml
+++ b/.github/workflows/publishing_stable.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Prepare image
         id: setup
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           nightly_image=${{ inputs.image_source_location }}/${{ inputs.image_short_name }}:${{ inputs.image_tag }}
           echo "FROM $nightly_image" >> ngc.Dockerfile
           if ! ${{ inputs.allow_arbitrary_tag }} && [ "$(echo ${{ inputs.image_tag }} | egrep -o 'cu[0-9]{1,2}-([0-9]{1,}\.)+[0-9]{1,}')" != "${{ inputs.image_tag }}" ]; then
@@ -96,8 +97,9 @@ jobs:
             exit 1
           fi
 
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends curl
-          curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
+          retry sudo apt-get update
+          retry sudo apt-get install -y --no-install-recommends curl
+          retry curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
           chmod 755 regctl
 
           manifest=`./regctl image manifest $nightly_image --format "{{ json . }}"`

--- a/.github/workflows/python_metapackages.yml
+++ b/.github/workflows/python_metapackages.yml
@@ -53,8 +53,8 @@ jobs:
                 cp $file python/metapackages/$file
             done
 
-            retry apt-get update
-            retry apt-get install -y --no-install-recommends \
+            retry sudo apt-get update
+            retry sudo apt-get install -y --no-install-recommends \
                 python3 python3-pip python3-venv
             retry python3 -m pip install build
 

--- a/.github/workflows/python_metapackages.yml
+++ b/.github/workflows/python_metapackages.yml
@@ -47,14 +47,16 @@ jobs:
       - name: Build metapackages
         id: metapackage_build
         run: |
+            retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
             sed -i "s/README.md.in/README.md/g" python/metapackages/pyproject.toml
             for file in LICENSE NOTICE CITATION.cff; do
                 cp $file python/metapackages/$file
             done
 
-            apt-get update && apt-get install -y --no-install-recommends \
+            retry apt-get update
+            retry apt-get install -y --no-install-recommends \
                 python3 python3-pip python3-venv
-            python3 -m pip install build
+            retry python3 -m pip install build
 
             echo "Creating README.md for cudaq package"
             package_name=cudaq
@@ -134,7 +136,8 @@ jobs:
 
       - name: Test installation
         run: |
-          mkdir -p /tmp/packages 
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          mkdir -p /tmp/packages
           mv /tmp/wheels/* /tmp/packages && mv /tmp/metapackages/* /tmp/packages
           rmdir /tmp/wheels /tmp/metapackages
 
@@ -146,23 +149,23 @@ jobs:
               "${CUDA_DOWNLOAD_URL}/${CUDA_DISTRIBUTION}/${CUDA_ARCH_FOLDER}/cuda-${CUDA_DISTRIBUTION}.repo"
 
             cuda_version_suffix=`echo ${{ matrix.cuda_version }} | tr . -`
-            dnf install -y --nobest --setopt=install_weak_deps=False \
+            retry dnf install -y --nobest --setopt=install_weak_deps=False \
               cuda-cudart-${cuda_version_suffix}
           fi
 
           python=python${{ matrix.python_version }}
-          $python -m pip install pip3-autoremove
+          retry $python -m pip install pip3-autoremove
 
           # autoremove is in an odd location that isn't found unless we search for it...
           autoremove="$python $($python -m pip show pip3-autoremove |  grep -e 'Location: .*$' | cut -d ' ' -f2)/pip_autoremove.py"
 
           package_dep=`echo cuda-quantum${cuda_version_suffix:+-cu$cuda_version_suffix} | cut -d '-' -f1-2`
-          if [ -n "$($python -m pip list | grep $package_dep)" ]; then 
+          if [ -n "$($python -m pip list | grep $package_dep)" ]; then
             echo "::error file=python_metapackages.yml::Unexpected installation of $package_dep package."
             exit 1
           fi
 
-          $python -m pip install "cudaq==${{ inputs.cudaq_version }}" --find-links "file:///tmp/packages"
+          retry $python -m pip install "cudaq==${{ inputs.cudaq_version }}" --find-links "file:///tmp/packages"
 
           if [ -z "$($python -m pip list | grep $package_dep)" ]; then 
             echo "::error file=python_metapackages.yml::Missing installation of $package_dep package."
@@ -179,8 +182,8 @@ jobs:
           fi
 
           if [ "$package_dep" != "cuda-quantum" ]; then
-            $python -m pip install ${package_dep}==${{ inputs.cudaq_version }} --find-links "file:///tmp/packages"
-            $python -m pip install cudaq==${{ inputs.cudaq_version }} --find-links "file:///tmp/packages"
+            retry $python -m pip install ${package_dep}==${{ inputs.cudaq_version }} --find-links "file:///tmp/packages"
+            retry $python -m pip install cudaq==${{ inputs.cudaq_version }} --find-links "file:///tmp/packages"
             $python -c 'import cudaq; print(cudaq.get_target().name)'
             $autoremove -y cudaq
             if [ -z "$($python -m pip list | grep $package_dep)" ]; then 

--- a/.github/workflows/python_metapackages.yml
+++ b/.github/workflows/python_metapackages.yml
@@ -137,6 +137,7 @@ jobs:
       - name: Test installation
         run: |
           retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry_dnf() { local pre=""; [ "$(id -u)" -ne 0 ] && pre=sudo; for n in 1 2 3; do $pre dnf "$@" && return 0; [ $n -lt 3 ] && { $pre dnf clean metadata >/dev/null 2>&1 || true; sleep $((15*n*n)); }; done; return 1; }
           mkdir -p /tmp/packages
           mv /tmp/wheels/* /tmp/packages && mv /tmp/metapackages/* /tmp/packages
           rmdir /tmp/wheels /tmp/metapackages
@@ -149,7 +150,7 @@ jobs:
               "${CUDA_DOWNLOAD_URL}/${CUDA_DISTRIBUTION}/${CUDA_ARCH_FOLDER}/cuda-${CUDA_DISTRIBUTION}.repo"
 
             cuda_version_suffix=`echo ${{ matrix.cuda_version }} | tr . -`
-            retry dnf install -y --nobest --setopt=install_weak_deps=False \
+            retry_dnf install -y --nobest --setopt=install_weak_deps=False \
               cuda-cudart-${cuda_version_suffix}
           fi
 

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -86,18 +86,19 @@ jobs:
       - name: Load prerequisites
         id: prereqs
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           if ${{ steps.restore.outcome != 'skipped' }}; then
             load_output=`docker load --input "${{ inputs.devdeps_archive }}"`
             base_image=`echo "$load_output" | grep -o 'Loaded image: \S*:\S*' | head -1 | cut -d ' ' -f 3`
             echo "Base image: $base_image" >> $GITHUB_STEP_SUMMARY
             # Push the image to the local registry to make it available within
             # the containered environment that docker/build-push-action uses.
-            docker push $base_image
+            retry docker push $base_image
             rm -rf "${{ inputs.devdeps_archive }}"
           elif ${{ inputs.devdeps_image != '' }}; then
             base_image=${{ inputs.devdeps_image }}
             echo "Base image: $base_image" >> $GITHUB_STEP_SUMMARY
-            docker pull $base_image
+            retry docker pull $base_image
           else
             echo "::error file=python_wheels.yml::Missing configuration for development dependencies. Either specify the image (i.e. provide devdeps_image) or cache (i.e. provide devdeps_cache and devdeps_archive) that should be used for the build."
             exit 1
@@ -296,6 +297,7 @@ jobs:
           image: wheel_validation:local
           shell: bash
           run: |
+            retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
             python${{ inputs.python_version }} -m pytest -v /tmp/tests/ \
               --ignore /tmp/tests/backends
             pytest_status=$?
@@ -303,7 +305,7 @@ jobs:
               echo "::error file=python_wheel.yml::Python tests failed with status $pytest_status."
               exit 1
             fi
-            python${{ inputs.python_version }} -m pip install --user fastapi uvicorn llvmlite
+            retry python${{ inputs.python_version }} -m pip install --user fastapi uvicorn llvmlite
             python${{ inputs.python_version }} -m pytest -v /tmp/tests/backends
             pytest_status=$?
             # Exit code 5 indicates that no tests were collected,
@@ -323,16 +325,17 @@ jobs:
           image: wheel_validation:local
           shell: bash
           run: |
+            retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
             # Uninstall pip-installed cuda-quantum in the `wheel_validation:local` image.
-            # In this step, we test the full installation workflow with conda; 
+            # In this step, we test the full installation workflow with conda;
             # hence we don't want to mix conda and pip packages.
             cuda_major=$(echo ${{ inputs.cuda_version }} | cut -d . -f1)
             python${{ inputs.python_version }} -m pip uninstall -y cuda-quantum-cu${cuda_major}
 
             # Install cuda-quantum wheel and all dependencies (including MPI) using conda (README instructions)
-            dnf install -y --nobest --setopt=install_weak_deps=False wget unzip openssh-clients
+            retry dnf install -y --nobest --setopt=install_weak_deps=False wget unzip openssh-clients
             mkdir -p ~/miniconda3
-            wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh -O ~/miniconda3/miniconda.sh
+            retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh -O ~/miniconda3/miniconda.sh
             bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
             ~/miniconda3/bin/conda init bash
             source ~/.bashrc
@@ -360,7 +363,7 @@ jobs:
             done <<< "$ompi_script"
 
             # Run the MPI test
-            python${{ inputs.python_version }} -m pip install pytest numpy
+            retry python${{ inputs.python_version }} -m pip install pytest numpy
             mpirun --allow-run-as-root -np 4 python${{ inputs.python_version }} -m pytest -v /tmp/tests/parallel/test_mpi_api.py
             pytest_mpi_status=$?
             if [ ! $pytest_mpi_status -eq 0 ]; then

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -326,6 +326,7 @@ jobs:
           shell: bash
           run: |
             retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+            retry_dnf() { local pre=""; [ "$(id -u)" -ne 0 ] && pre=sudo; for n in 1 2 3; do $pre dnf "$@" && return 0; [ $n -lt 3 ] && { $pre dnf clean metadata >/dev/null 2>&1 || true; sleep $((15*n*n)); }; done; return 1; }
             # Uninstall pip-installed cuda-quantum in the `wheel_validation:local` image.
             # In this step, we test the full installation workflow with conda;
             # hence we don't want to mix conda and pip packages.
@@ -333,7 +334,7 @@ jobs:
             python${{ inputs.python_version }} -m pip uninstall -y cuda-quantum-cu${cuda_major}
 
             # Install cuda-quantum wheel and all dependencies (including MPI) using conda (README instructions)
-            retry dnf install -y --nobest --setopt=install_weak_deps=False wget unzip openssh-clients
+            retry_dnf install -y --nobest --setopt=install_weak_deps=False wget unzip openssh-clients
             mkdir -p ~/miniconda3
             retry wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh -O ~/miniconda3/miniconda.sh
             bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3

--- a/.github/workflows/realtime_ci.yml
+++ b/.github/workflows/realtime_ci.yml
@@ -81,10 +81,11 @@ jobs:
         shell: bash
         run: |
           retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
+          retry_dnf() { local pre=""; [ "$(id -u)" -ne 0 ] && pre=sudo; for n in 1 2 3; do $pre dnf "$@" && return 0; [ $n -lt 3 ] && { $pre dnf clean metadata >/dev/null 2>&1 || true; sleep $((15*n*n)); }; done; return 1; }
           # Install cmake for building a test example that uses the installed CUDA Quantum Realtime
           # Install cmake depending on distro
           if [[ "${{ matrix.distro }}" == "ubi9" ]]; then
-            retry dnf install -y cmake
+            retry_dnf install -y cmake
           else
             retry apt update
             retry apt install -y --no-install-recommends cmake

--- a/.github/workflows/realtime_ci.yml
+++ b/.github/workflows/realtime_ci.yml
@@ -80,12 +80,14 @@ jobs:
       - name: Test CUDA Quantum Realtime installation
         shell: bash
         run: |
+          retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
           # Install cmake for building a test example that uses the installed CUDA Quantum Realtime
           # Install cmake depending on distro
           if [[ "${{ matrix.distro }}" == "ubi9" ]]; then
-            dnf install -y cmake
+            retry dnf install -y cmake
           else
-            apt update && apt install -y --no-install-recommends cmake 
+            retry apt update
+            retry apt install -y --no-install-recommends cmake
           fi
           # Build the test example that uses the installed CUDA Quantum Realtime
           cd realtime/examples/gpu_dispatch

--- a/.github/workflows/test_in_devenv.yml
+++ b/.github/workflows/test_in_devenv.yml
@@ -281,16 +281,18 @@ jobs:
           image: dev_env:local
           shell: bash
           run: |
+            retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
             cd $CUDAQ_REPO_ROOT
 
             export DEBIAN_FRONTEND=noninteractive
-            apt-get update -y && apt-get install -y python3-venv
+            retry apt-get update -y
+            retry apt-get install -y python3-venv
 
             VENV_DIR="$HOME/.venvs/cudaq"
             python3 -m venv --system-site-packages "$VENV_DIR"
             . "$VENV_DIR/bin/activate"
 
-            pip install -r requirements-tests-backend.txt
+            retry pip install -r requirements-tests-backend.txt
             pip install . -vvv
             pyinstall_status=$?
             if [ ! $pyinstall_status -eq 0 ]; then
@@ -298,7 +300,7 @@ jobs:
               exit 1
             fi
 
-            python -m pip install pytest pytest-xdist
+            retry python -m pip install pytest pytest-xdist
             python -m pytest -v --durations=0 -n auto python/tests/ \
               --ignore python/tests/backends \
               --ignore python/tests/contrib
@@ -328,7 +330,7 @@ jobs:
               exit 1
             fi
 
-            pip install qiskit
+            retry pip install qiskit
             python -m pytest -v --durations=0  python/tests/contrib
             pytest_status=$?
             if [ ! $pytest_status -eq 0 ]; then

--- a/docker/build/devcontainer.Dockerfile
+++ b/docker/build/devcontainer.Dockerfile
@@ -36,9 +36,12 @@ ARG cuda_version
 ENV CUDA_VERSION=${cuda_version}
 
 # When a dialogue box would be needed during install, assume default configurations.
-# Set here to avoid setting it for all install commands. 
+# Set here to avoid setting it for all install commands.
 # Given as arg to make sure that this value is only set during build but not in the launched container.
 ARG DEBIAN_FRONTEND=noninteractive
+# Tolerate transient apt mirror failures.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && echo 'Acquire::Retries::Delay::Maximum "30";' >> /etc/apt/apt.conf.d/80-retries
 RUN apt update && apt-get install -y --no-install-recommends ca-certificates wget build-essential \
     && apt-get upgrade -y libc-bin libcap2 \
     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 

--- a/docker/build/devdeps.Dockerfile
+++ b/docker/build/devdeps.Dockerfile
@@ -30,6 +30,10 @@ ARG toolchain=llvm
 # Set here to avoid setting it for all install commands.
 # Given as arg to make sure that this value is only set during build but not in the launched container.
 ARG DEBIAN_FRONTEND=noninteractive
+# Tolerate transient apt mirror failures (internal NV cache and ubuntu mirrors
+# have been observed to return 502/connection-failed for short intervals).
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && echo 'Acquire::Retries::Delay::Maximum "30";' >> /etc/apt/apt.conf.d/80-retries
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
     apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -115,11 +119,13 @@ FROM ${base_image}
 SHELL ["/bin/bash", "-c"]
 
 # When a dialogue box would be needed during install, assume default configurations.
-# Set here to avoid setting it for all install commands. 
+# Set here to avoid setting it for all install commands.
 # Given as arg to make sure that this value is only set during build but not in the launched container.
 ARG DEBIAN_FRONTEND=noninteractive
 ENV HOME=/home SHELL=/bin/bash LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && echo 'Acquire::Retries::Delay::Maximum "30";' >> /etc/apt/apt.conf.d/80-retries
 
 # Copy over the llvm build dependencies.
 COPY --from=prereqs /usr/local/llvm /usr/local/llvm

--- a/docker/build/devdeps.ompi.Dockerfile
+++ b/docker/build/devdeps.ompi.Dockerfile
@@ -28,6 +28,10 @@ ENV COMMON_COMPILER_FLAGS="-march=x86-64-v3 -mtune=generic -O2 -pipe"
 ENV COMMON_COMPILER_FLAGS_ARM="-march=armv8-a -mtune=generic -O2 -pipe"
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
+# Tolerate transient apt mirror failures.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && echo 'Acquire::Retries::Delay::Maximum "30";' >> /etc/apt/apt.conf.d/80-retries
+
 # 1 - Install basic tools needed for the builds
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/build/package_sources.Dockerfile
+++ b/docker/build/package_sources.Dockerfile
@@ -39,6 +39,10 @@ FROM ${base_image}
 SHELL ["/bin/bash", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Tolerate transient apt mirror failures.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && echo 'Acquire::Retries::Delay::Maximum "30";' >> /etc/apt/apt.conf.d/80-retries
+
 # Install deps for fetching apt source, pip sdists, and cloning tpls
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/docker/test/installer/runtime_dependencies.sh
+++ b/docker/test/installer/runtime_dependencies.sh
@@ -10,11 +10,17 @@
 
 trap '(return 0 2>/dev/null) && return 1 || exit 1' ERR
 
+# Tolerate transient apt/dnf mirror failures.
+if [ -d /etc/apt/apt.conf.d ]; then
+    echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries 2>/dev/null || \
+        sudo sh -c 'echo "Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries' 2>/dev/null || true
+fi
+
 case $1 in
     *ubuntu*)
         pkg_manager=apt-get
     ;;
-    *debian*) 
+    *debian*)
         pkg_manager=apt-get
     ;;
     *almalinux*|*redhat*)

--- a/docker/test/wheels/debian.Dockerfile
+++ b/docker/test/wheels/debian.Dockerfile
@@ -15,6 +15,9 @@ ARG pip_install_flags=""
 ARG preinstalled_modules="numpy pytest nvidia-cublas-cu12"
 
 ARG DEBIAN_FRONTEND=noninteractive
+# Tolerate transient apt mirror failures.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && echo 'Acquire::Retries::Delay::Maximum "30";' >> /etc/apt/apt.conf.d/80-retries
 RUN apt-get update && apt-get install -y --no-install-recommends wget \
         python${python_version} python${python_version}-venv
 

--- a/docker/test/wheels/ubuntu.Dockerfile
+++ b/docker/test/wheels/ubuntu.Dockerfile
@@ -14,6 +14,9 @@ ARG pip_install_flags="--user"
 ARG preinstalled_modules="numpy pytest nvidia-cublas-cu12"
 
 ARG DEBIAN_FRONTEND=noninteractive
+# Tolerate transient apt mirror failures.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && echo 'Acquire::Retries::Delay::Maximum "30";' >> /etc/apt/apt.conf.d/80-retries
 RUN apt-get update && apt-get install -y --no-install-recommends wget \
         python${python_version} python${python_version}-venv
 


### PR DESCRIPTION
Adds exponential backoff retry to various components in our CI pipeline.

Most of these are surgical, and are directly targeting actual failures we have seen in the last month that have been solved by retries.

The retry implementation is relatively surgical because if the failure is due to rate limiting, we do not want to just keep trying as that will compound the issue, yet most of the transient failures are due to network issues.

One thing to note is there are reusable workflows for retry mechanisms - namely `nick-fields/retry@v4` is useful. I chose not to use this reusable worfklow because it runs just a single command, and most of our failures are embedded in scripts and other logic that it doesn't make sense to retry _everything_. If a seg fault during the build fails the job at 2 hours, we do not want to try it 3 times in a row just to seg fault again with the same failure.