### PR TITLE
Move quake namespace.

### DIFF
--- a/docs/sphinx/using/extending/mlir_pass.rst
+++ b/docs/sphinx/using/extending/mlir_pass.rst
@@ -41,11 +41,11 @@ a pass, start with the following template in the :code:`MyCustomPlugin.cpp` file
 
     namespace {
 
-    struct ReplaceH : public OpRewritePattern<quake::HOp> {
+    struct ReplaceH : public OpRewritePattern<cudaq::quake::HOp> {
       using OpRewritePattern::OpRewritePattern;
-      LogicalResult matchAndRewrite(quake::HOp hOp,
+      LogicalResult matchAndRewrite(cudaq::quake::HOp hOp,
                                     PatternRewriter &rewriter) const override {
-        rewriter.replaceOpWithNewOp<quake::SOp>(
+        rewriter.replaceOpWithNewOp<cudaq::quake::SOp>(
             hOp, hOp.isAdj(), hOp.getParameters(), hOp.getControls(),
             hOp.getTargets());
         return success();
@@ -66,8 +66,8 @@ a pass, start with the following template in the :code:`MyCustomPlugin.cpp` file
         RewritePatternSet patterns(ctx);
         patterns.insert<ReplaceH>(ctx);
         ConversionTarget target(*ctx);
-        target.addLegalDialect<quake::QuakeDialect>();
-        target.addIllegalOp<quake::HOp>();
+        target.addLegalDialect<cudaq::quake::QuakeDialect>();
+        target.addIllegalOp<cudaq::quake::HOp>();
         if (failed(applyPartialConversion(circuit, target, std::move(patterns)))) {
           circuit.emitOpError("simple pass failed");
           signalPassFailure();

--- a/include/cudaq/Optimizer/Builder/Factory.h
+++ b/include/cudaq/Optimizer/Builder/Factory.h
@@ -23,7 +23,7 @@ namespace llvm {
 class DataLayout;
 }
 
-namespace quake {
+namespace cudaq::quake {
 class StateType;
 }
 

--- a/include/cudaq/Optimizer/Builder/Marshal.h
+++ b/include/cudaq/Optimizer/Builder/Marshal.h
@@ -30,7 +30,7 @@ inline bool isCodegenArgumentGather(std::size_t kind) {
 
 inline bool isStateType(mlir::Type ty) {
   if (auto ptrTy = dyn_cast<cc::PointerType>(ty))
-    return isa<quake::StateType>(ptrTy.getElementType());
+    return isa<cudaq::quake::StateType>(ptrTy.getElementType());
   return false;
 }
 

--- a/include/cudaq/Optimizer/Dialect/Characteristics.h
+++ b/include/cudaq/Optimizer/Dialect/Characteristics.h
@@ -64,7 +64,7 @@ inline bool hasCallOp(A &op) {
 inline bool hasMeasureOp(mlir::Operation &op) {
   return internal::hasCharacteristic(
       [](mlir::Operation &op) {
-        return mlir::isa<quake::MeasurementInterface>(op);
+        return mlir::isa<cudaq::quake::MeasurementInterface>(op);
       },
       op);
 }

--- a/include/cudaq/Optimizer/Dialect/Common/Traits.h
+++ b/include/cudaq/Optimizer/Dialect/Common/Traits.h
@@ -10,7 +10,7 @@
 
 #include "mlir/IR/OpImplementation.h"
 
-namespace quake {
+namespace cudaq::quake {
 mlir::LogicalResult verifyWireArityAndCoarity(mlir::Operation *op);
 
 /// Returns true iff \p op is a Quantum Operator (unitary), measurement, or a
@@ -31,7 +31,7 @@ mlir::ValueRange getQuantumResults(mlir::Operation *op);
 /// Set the operands from \p op from \p quantumVals.
 mlir::LogicalResult setQuantumOperands(mlir::Operation *op,
                                        mlir::ValueRange quantumVals);
-} // namespace quake
+} // namespace cudaq::quake
 
 namespace cudaq {
 
@@ -49,7 +49,7 @@ template <typename ConcreteType>
 class QuantumGate : public mlir::OpTrait::TraitBase<ConcreteType, QuantumGate> {
 public:
   static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
-    return quake::verifyWireArityAndCoarity(op);
+    return cudaq::quake::verifyWireArityAndCoarity(op);
   }
 };
 
@@ -66,7 +66,7 @@ class QuantumMeasure
     : public mlir::OpTrait::TraitBase<ConcreteType, QuantumMeasure> {
 public:
   static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
-    return quake::verifyWireArityAndCoarity(op);
+    return cudaq::quake::verifyWireArityAndCoarity(op);
   }
 };
 

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeDialect.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeDialect.td
@@ -24,7 +24,7 @@ def QuakeDialect : Dialect {
     language in which one writes programs that build quantum circuits. Quake is 
     not tied to a particular quantum hardware/machine.
   }];
-  let cppNamespace = "::quake";
+  let cppNamespace = "cudaq::quake";
   let useDefaultTypePrinterParser = 1;
   let extraClassDeclaration = [{
     /// Register all Quake types.

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeInterfaces.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeInterfaces.td
@@ -24,7 +24,7 @@ def OperatorInterface : OpInterface<"OperatorInterface"> {
     getting this information without the need of casting an operation to its
     actual type.
   }];
-  let cppNamespace = "::quake";
+  let cppNamespace = "cudaq::quake";
 
   let methods = [
     InterfaceMethod<
@@ -95,7 +95,7 @@ def MeasurementInterface : OpInterface<"MeasurementInterface"> {
     the value of the qubit in the sense the information that the qubit encoded
     in its state is not recoverable.
   }];
-  let cppNamespace = "quake";
+  let cppNamespace = "cudaq::quake";
 
   let methods = [
     InterfaceMethod<

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.h
@@ -25,7 +25,7 @@
 // Canonicalizer functions.
 //===----------------------------------------------------------------------===//
 
-namespace quake {
+namespace cudaq::quake {
 mlir::Value createConstantAlloca(mlir::PatternRewriter &builder,
                                  mlir::Location loc, mlir::OpResult result,
                                  mlir::ValueRange args);
@@ -53,7 +53,7 @@ void genericOpPrinter(mlir::OpAsmPrinter &_odsPrinter, mlir::Operation *op,
                       bool isAdj, mlir::OperandRange params,
                       mlir::OperandRange ctrls, mlir::OperandRange targs,
                       mlir::DenseBoolArrayAttr negatedQubitControlsAttr);
-} // namespace quake
+} // namespace cudaq::quake
 
 //===----------------------------------------------------------------------===//
 // Tablegen generated logic.
@@ -73,7 +73,7 @@ inline bool isQuakeOperation(mlir::Operation *op) {
   return false;
 }
 
-namespace quake {
+namespace cudaq::quake {
 /// Returns true if and only if any quantum operand has type `!quake.ref` or
 /// `!quake.veq`.
 inline bool hasReference(mlir::Operation *op) {
@@ -87,14 +87,15 @@ inline bool hasReference(mlir::Operation *op) {
 /// when the surface type is dynamically sized but the inner value has a known
 /// size.
 inline std::optional<std::size_t> getVeqSize(mlir::Value v) {
-  auto veqTy = mlir::dyn_cast<quake::VeqType>(v.getType());
+  auto veqTy = mlir::dyn_cast<cudaq::quake::VeqType>(v.getType());
   if (!veqTy)
     return std::nullopt;
   if (veqTy.hasSpecifiedSize())
     return veqTy.getSize();
-  if (auto relaxOp = v.getDefiningOp<quake::RelaxSizeOp>()) {
+  if (auto relaxOp = v.getDefiningOp<cudaq::quake::RelaxSizeOp>()) {
     // RelaxSizeOp verifier guarantees input is VeqType when result is VeqType.
-    auto innerTy = mlir::cast<quake::VeqType>(relaxOp.getInputVec().getType());
+    auto innerTy =
+        mlir::cast<cudaq::quake::VeqType>(relaxOp.getInputVec().getType());
     if (innerTy.hasSpecifiedSize())
       return innerTy.getSize();
   }
@@ -104,7 +105,7 @@ inline std::optional<std::size_t> getVeqSize(mlir::Value v) {
 /// Returns true if and only if any quantum operand has type `!quake.ref`.
 inline bool hasNonVectorReference(mlir::Operation *op) {
   for (mlir::Value opnd : op->getOperands())
-    if (isa<quake::RefType>(opnd.getType()))
+    if (isa<cudaq::quake::RefType>(opnd.getType()))
       return true;
   return false;
 }
@@ -131,13 +132,13 @@ inline bool isAllValues(mlir::Operation *op) {
 /// (QLS) form.
 inline bool isWrapped(mlir::Operation *op) {
   for (mlir::Value val : op->getOperands())
-    if (isa<quake::WireType>(val.getType()) &&
-        !val.getDefiningOp<quake::UnwrapOp>())
+    if (isa<cudaq::quake::WireType>(val.getType()) &&
+        !val.getDefiningOp<cudaq::quake::UnwrapOp>())
       return false;
   for (mlir::Value val : op->getResults())
-    if (isa<quake::WireType>(val.getType()))
+    if (isa<cudaq::quake::WireType>(val.getType()))
       for (auto *u : val.getUsers())
-        if (!isa<quake::WrapOp>(u))
+        if (!isa<cudaq::quake::WrapOp>(u))
           return false;
   return true;
 }
@@ -146,7 +147,7 @@ inline bool isWrapped(mlir::Operation *op) {
 /// Linear-value form is defined such that the Op, \p op, is not in full (or
 /// partial) memory-SSA form and is not in the intermediate QLS form.
 inline bool isLinearValueForm(mlir::Operation *op) {
-  return isa<quake::NullWireOp, quake::SinkOp>(op) ||
+  return isa<cudaq::quake::NullWireOp, cudaq::quake::SinkOp>(op) ||
          (isAllValues(op) && !isWrapped(op));
 }
 inline bool isLinearValueForm(mlir::Value val) {
@@ -156,8 +157,8 @@ inline bool isLinearValueForm(mlir::Value val) {
 }
 
 template <typename OP>
-constexpr bool isMeasure =
-    std::is_same_v<OP, quake::MxOp> || std::is_same_v<OP, quake::MyOp> ||
-    std::is_same_v<OP, quake::MzOp>;
+constexpr bool isMeasure = std::is_same_v<OP, cudaq::quake::MxOp> ||
+                           std::is_same_v<OP, cudaq::quake::MyOp> ||
+                           std::is_same_v<OP, cudaq::quake::MzOp>;
 
-} // namespace quake
+} // namespace cudaq::quake

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -101,10 +101,10 @@ def quake_AllocaOp : QuakeOp<"alloca", [MemoryEffects<[MemAlloc, MemWrite]>]> {
     bool hasInitializedState() {
       auto *self = getOperation();
       return self->hasOneUse() &&
-        mlir::isa<quake::InitializeStateOp>(*self->getUsers().begin());
+        mlir::isa<cudaq::quake::InitializeStateOp>(*self->getUsers().begin());
     }
 
-    quake::InitializeStateOp getInitializedState();
+    cudaq::quake::InitializeStateOp getInitializedState();
   }];
 }
 
@@ -329,7 +329,7 @@ def quake_SubVeqOp : QuakeOp<"subveq", [AttrSizedOperandSegments, Pure]> {
     OpBuilder<(ins "mlir::Type":$veqTy, "mlir::Value":$input,
                    "mlir::Value":$lower, "mlir::Value":$upper), [{
       return build($_builder, $_state, veqTy, input, lower, upper,
-        quake::SubVeqOp::kDynamicIndex, quake::SubVeqOp::kDynamicIndex);
+        cudaq::quake::SubVeqOp::kDynamicIndex, cudaq::quake::SubVeqOp::kDynamicIndex);
     }]>,
     OpBuilder<(ins "mlir::Type":$veqTy, "mlir::Value":$input,
                    "std::int64_t":$lower, "std::int64_t":$upper), [{
@@ -1089,7 +1089,7 @@ def quake_ResetOp : QuakeOp<"reset", [QuantumGate,
   let extraClassDeclaration = [{
     void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::
         EffectInstance<mlir::MemoryEffects::Effect>> &effects) {
-      quake::getResetEffectsImpl(effects, getTargetsMutable());
+      cudaq::quake::getResetEffectsImpl(effects, getTargetsMutable());
     }
   }];
 }
@@ -1126,7 +1126,7 @@ class Measurement<string mnemonic> : QuakeOp<mnemonic, [MeasurementInterface,
   code OpBaseDeclaration = [{
     void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::EffectInstance<
       mlir::MemoryEffects::Effect>> &effects) {
-      quake::getMeasurementEffectsImpl(effects, getTargetsMutable());
+      cudaq::quake::getMeasurementEffectsImpl(effects, getTargetsMutable());
     }
   }];
 
@@ -1291,7 +1291,7 @@ class QuakeOperator<string mnemonic, list<Trait> traits = [],
 
     void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::EffectInstance<
       mlir::MemoryEffects::Effect>> &effects) {
-      quake::getOperatorEffectsImpl(effects, getControlsMutable(), getTargetsMutable());
+      cudaq::quake::getOperatorEffectsImpl(effects, getControlsMutable(), getTargetsMutable());
     }
 
     //===------------------------------------------------------------------===//
@@ -1454,7 +1454,7 @@ def quake_ExpPauliOp : QuakeOp<"exp_pauli",
 
     void getEffectsImpl(mlir::SmallVectorImpl<mlir::SideEffects::EffectInstance<
       mlir::MemoryEffects::Effect>> &effects) {
-      quake::getOperatorEffectsImpl(effects, getControlsMutable(), getTargetsMutable());
+      cudaq::quake::getOperatorEffectsImpl(effects, getControlsMutable(), getTargetsMutable());
     }
 
     //===------------------------------------------------------------------===//

--- a/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
+++ b/include/cudaq/Optimizer/Dialect/Quake/QuakeTypes.h
@@ -20,37 +20,38 @@
 #define GET_TYPEDEF_CLASSES
 #include "cudaq/Optimizer/Dialect/Quake/QuakeTypes.h.inc"
 
-namespace quake {
+namespace cudaq::quake {
 /// \returns true if \p `ty` is a quantum value or reference.
 inline bool isQuantumType(mlir::Type ty) {
   // NB: this intentionally excludes MeasureType.
-  return mlir::isa<quake::RefType, quake::VeqType, quake::WireType,
-                   quake::ControlType, quake::StruqType, quake::CableType>(ty);
+  return mlir::isa<cudaq::quake::RefType, cudaq::quake::VeqType,
+                   cudaq::quake::WireType, cudaq::quake::ControlType,
+                   cudaq::quake::StruqType, cudaq::quake::CableType>(ty);
 }
 
 /// \returns true if \p `ty` is a Quake type.
 inline bool isQuakeType(mlir::Type ty) {
   // This should correspond to the registered types in QuakeTypes.cpp.
-  return isQuantumType(ty) || mlir::isa<quake::MeasureType>(ty);
+  return isQuantumType(ty) || mlir::isa<cudaq::quake::MeasureType>(ty);
 }
 
 /// \returns true if \p ty is a quantum reference type, excluding `struq`.
 inline bool isNonStruqReferenceType(mlir::Type ty) {
-  return mlir::isa<quake::RefType, quake::VeqType>(ty);
+  return mlir::isa<cudaq::quake::RefType, cudaq::quake::VeqType>(ty);
 }
 
 /// \returns true if \p ty is a quantum reference type.
 inline bool isQuantumReferenceType(mlir::Type ty) {
-  return isNonStruqReferenceType(ty) || mlir::isa<quake::StruqType>(ty);
+  return isNonStruqReferenceType(ty) || mlir::isa<cudaq::quake::StruqType>(ty);
 }
 
 /// A quake wire type is a linear type.
 inline bool isLinearType(mlir::Type ty) {
-  return mlir::isa<quake::WireType, quake::CableType>(ty);
+  return mlir::isa<cudaq::quake::WireType, cudaq::quake::CableType>(ty);
 }
 
 inline bool isQuantumValueType(mlir::Type ty) {
-  return isLinearType(ty) || mlir::isa<quake::ControlType>(ty);
+  return isLinearType(ty) || mlir::isa<cudaq::quake::ControlType>(ty);
 }
 
 bool isConstantQuantumRefType(mlir::Type ty);
@@ -60,9 +61,9 @@ std::size_t getAllocationSize(mlir::Type ty);
 
 /// Get the number of wires in \p ty. \p ty must be a value type.
 inline std::size_t getWireCount(mlir::Type ty) {
-  if (isa<quake::WireType, quake::ControlType>(ty))
+  if (isa<cudaq::quake::WireType, cudaq::quake::ControlType>(ty))
     return 1;
-  return cast<quake::CableType>(ty).getSize();
+  return cast<cudaq::quake::CableType>(ty).getSize();
 }
 
-} // namespace quake
+} // namespace cudaq::quake

--- a/include/cudaq/Optimizer/InitAllDialects.h
+++ b/include/cudaq/Optimizer/InitAllDialects.h
@@ -33,7 +33,7 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
 
     // CUDA-Q dialects
     cudaq::cc::CCDialect,
-    quake::QuakeDialect
+    cudaq::quake::QuakeDialect
   >();
   // clang-format on
 }

--- a/include/cudaq/Optimizer/Transforms/AddMetadata.h
+++ b/include/cudaq/Optimizer/Transforms/AddMetadata.h
@@ -15,7 +15,7 @@ namespace mlir {
 class Operation;
 }
 
-namespace quake::detail {
+namespace cudaq::quake::detail {
 /// Define a type to contain the Quake Function Metadata
 struct QuakeMetadata {
   bool hasConditionalsOnMeasure = false;
@@ -50,4 +50,4 @@ private:
 
   QuakeFunctionInfo infoMap;
 };
-} // namespace quake::detail
+} // namespace cudaq::quake::detail

--- a/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/include/cudaq/Optimizer/Transforms/Passes.td
@@ -29,7 +29,7 @@ def AddMeasurements : Pass<"add-measurements", "mlir::func::FuncOp"> {
 
   }];
   
-  let dependentDialects = ["quake::QuakeDialect",
+  let dependentDialects = ["cudaq::quake::QuakeDialect",
     "mlir::cf::ControlFlowDialect"];
 }
 
@@ -236,7 +236,7 @@ def CombineMeasurements :
     }
     ```
   }];
-  let dependentDialects = ["cudaq::cc::CCDialect", "quake::QuakeDialect"];
+  let dependentDialects = ["cudaq::cc::CCDialect", "cudaq::quake::QuakeDialect"];
 }
 
 def CombineQuantumAllocations :
@@ -256,7 +256,7 @@ def CombineQuantumAllocations :
     combined deallocation will be added to each exit block.
   }];
 
-  let dependentDialects = ["cudaq::cc::CCDialect", "quake::QuakeDialect"];
+  let dependentDialects = ["cudaq::cc::CCDialect", "cudaq::quake::QuakeDialect"];
 }
 
 def ConstantPropagation : Pass<"constant-propagation", "mlir::func::FuncOp"> {
@@ -365,7 +365,7 @@ def DependencyAnalysis : Pass<"dep-analysis", "mlir::ModuleOp"> {
     when running DependencyAnalysis.
   }];
 
-  let dependentDialects = ["quake::QuakeDialect"];
+  let dependentDialects = ["cudaq::quake::QuakeDialect"];
 
   let statistics = [
     Statistic<"numVirtualQubits", "num-virtual-qubits",
@@ -410,7 +410,7 @@ def DesugarCableOps : Pass<"desugar-cable-ops"> {
     ```
   }];
 
-  let dependentDialects = ["quake::QuakeDialect"];
+  let dependentDialects = ["cudaq::quake::QuakeDialect"];
 }
 
 def DistributedDeviceCall : Pass<"distributed-device-call", "mlir::ModuleOp"> {
@@ -509,7 +509,7 @@ def FactorQuantumAllocations :
     If the function contains deallocations of quantum vectors (`veq`), these
     will be replaced with a series of deallocations.
   }];
-  let dependentDialects = ["quake::QuakeDialect", "cudaq::cc::CCDialect"];
+  let dependentDialects = ["cudaq::quake::QuakeDialect", "cudaq::cc::CCDialect"];
 
   let options = [
     Option<"enableFailures", "enable-failures", "bool", /*default=*/"false",
@@ -967,7 +967,7 @@ def MemToReg : Pass<"memtoreg", "mlir::func::FuncOp"> {
     SSA semantics. A use can destroy the value itself, therefore it is required
     that `wire` values be threads in and out of each and every use.
   }];
-  let dependentDialects = ["cudaq::cc::CCDialect", "quake::QuakeDialect"];
+  let dependentDialects = ["cudaq::cc::CCDialect", "cudaq::quake::QuakeDialect"];
 
   let options = [
     Option<"classicalValues", "classical", "bool",
@@ -1041,7 +1041,7 @@ def PhaseFolding: Pass<"phase-folding", "mlir::func::FuncOp"> {
     "Minimumn percentage of rz ops in subcircuit to run phase folding">,
   ];
 
-  let dependentDialects = ["cudaq::cc::CCDialect", "quake::QuakeDialect"];
+  let dependentDialects = ["cudaq::cc::CCDialect", "cudaq::quake::QuakeDialect"];
 }
 
 def PromoteRefToVeqAlloc : Pass<"promote-qubit-allocation"> {
@@ -1189,7 +1189,7 @@ def RegToMem : Pass<"regtomem", "mlir::func::FuncOp"> {
     use cloning to recover such a finite DAG representation. This pass does not,
     however, attempt to perform such heroics.
   }];
-  let dependentDialects = ["cudaq::cc::CCDialect", "quake::QuakeDialect"];
+  let dependentDialects = ["cudaq::cc::CCDialect", "cudaq::quake::QuakeDialect"];
 }
 
 def ReplaceStateWithKernel : Pass<"replace-state-with-kernel",
@@ -1476,7 +1476,7 @@ def UnwindLowering : Pass<"unwind-lowering", "mlir::func::FuncOp"> {
   }];
 
   let dependentDialects = ["mlir::cf::ControlFlowDialect",
-                           "quake::QuakeDialect", "cudaq::cc::CCDialect"];
+                           "cudaq::quake::QuakeDialect", "cudaq::cc::CCDialect"];
 }
 
 def UpdateRegisterNames : Pass<"update-register-names"> {

--- a/lib/Frontend/nvqpp/ASTBridge.cpp
+++ b/lib/Frontend/nvqpp/ASTBridge.cpp
@@ -53,7 +53,7 @@ listReachableFunctions(clang::CallGraphNode *cgn) {
 // Does `ty` refer to a Quake quantum type? This also checks custom recursive
 // types. It does not check builtin recursive types; e.g., `!llvm.ptr<T>`.
 static bool isQubitType(Type ty) {
-  if (quake::isQuakeType(ty))
+  if (cudaq::quake::isQuakeType(ty))
     return true;
   // FIXME: next if case is a bug.
   if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(ty))

--- a/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -93,8 +93,9 @@ void QuakeBridgeVisitor::addArgumentSymbols(
       auto parmTy = entryBlock->getArgument(index).getType();
       if (isa<FunctionType, cc::CallableType, cc::IndirectCallableType,
               cc::PointerType, cc::SpanLikeType, LLVM::LLVMStructType,
-              quake::ControlType, quake::RefType, quake::StruqType,
-              quake::VeqType, quake::WireType>(parmTy)) {
+              cudaq::quake::ControlType, cudaq::quake::RefType,
+              cudaq::quake::StruqType, cudaq::quake::VeqType,
+              cudaq::quake::WireType>(parmTy)) {
         symbolTable.insert(name, entryBlock->getArgument(index));
       } else {
         auto stackSlot = cc::AllocaOp::create(builder, loc, parmTy);
@@ -133,7 +134,7 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
     // Types from the `cudaq` namespace.
     // A qubit is a qudit<LEVEL=2>.
     if (name == "qudit" || name == "qubit")
-      return pushType(quake::RefType::get(ctx));
+      return pushType(cudaq::quake::RefType::get(ctx));
     // qreg<SIZE,LEVEL>, qarray<SIZE,LEVEL>, qspan<SIZE,LEVEL>
     if (name == "qspan" || name == "qreg" || name == "qarray") {
       // If the first template argument is not `std::dynamic_extent` then we
@@ -150,15 +151,15 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
         };
         std::int64_t size = getExtValueHelper(templArg.getAsIntegral());
         if (size != static_cast<std::int64_t>(std::dynamic_extent))
-          return pushType(quake::VeqType::get(ctx, size));
+          return pushType(cudaq::quake::VeqType::get(ctx, size));
       }
-      return pushType(quake::VeqType::getUnsized(ctx));
+      return pushType(cudaq::quake::VeqType::getUnsized(ctx));
     }
     // qvector<LEVEL>, qview<LEVEL>
     if (name == "qvector" || name == "qview")
-      return pushType(quake::VeqType::getUnsized(ctx));
+      return pushType(cudaq::quake::VeqType::getUnsized(ctx));
     if (name == "state")
-      return pushType(quake::StateType::get(ctx));
+      return pushType(cudaq::quake::StateType::get(ctx));
     if (name == "pauli_word")
       return pushType(cc::CharspanType::get(ctx));
     if (name == "qkernel") {
@@ -181,9 +182,9 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
       if (!cts || !TraverseType(cts->getTemplateArgs()[0].getAsType()))
         return false;
       auto ty = popType();
-      if (quake::isQuantumType(ty)) {
-        if (ty == quake::RefType::get(ctx))
-          return pushType(quake::VeqType::getUnsized(ctx));
+      if (cudaq::quake::isQuantumType(ty)) {
+        if (ty == cudaq::quake::RefType::get(ctx))
+          return pushType(cudaq::quake::VeqType::getUnsized(ctx));
         cudaq::emitFatalError(toLocation(x->getSourceRange()),
                               "std::vector element type is not supported");
         return false;
@@ -228,7 +229,7 @@ bool QuakeBridgeVisitor::interceptRecordDecl(clang::RecordDecl *x) {
       if (!TraverseType(cts->getTemplateArgs()[0].getAsType()))
         return false;
       auto refTy = popType();
-      if (isa<quake::RefType, quake::VeqType>(refTy))
+      if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(refTy))
         return pushType(refTy);
       return pushType(cc::PointerType::get(ctx, refTy));
     }
@@ -685,7 +686,7 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
   assert(type && "variable must have a valid type");
   auto loc = toLocation(x->getSourceRange());
   auto name = x->getName();
-  if (auto qType = dyn_cast<quake::VeqType>(type)) {
+  if (auto qType = dyn_cast<cudaq::quake::VeqType>(type)) {
     // Variable is of !quake.veq type.
     mlir::Value qreg;
     std::size_t qregSize = qType.getSize();
@@ -697,16 +698,16 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
       auto qregSizeVal = mlir::arith::ConstantIntOp::create(
           builder, loc, builder.getIntegerType(64), qregSize);
       if (qregSize != 0)
-        qreg = quake::AllocaOp::create(builder, loc, qType);
+        qreg = cudaq::quake::AllocaOp::create(builder, loc, qType);
       else
-        qreg = quake::AllocaOp::create(builder, loc, qType, qregSizeVal);
+        qreg = cudaq::quake::AllocaOp::create(builder, loc, qType, qregSizeVal);
     }
     symbolTable.insert(name, qreg);
     // allocated_qreg_names.push_back(name);
     return pushValue(qreg);
   }
 
-  if (auto qType = dyn_cast<quake::RefType>(type)) {
+  if (auto qType = dyn_cast<cudaq::quake::RefType>(type)) {
     // Variable is of !quake.ref type.
     if (x->hasInit() && !valueStack.empty()) {
       symbolTable.insert(name, peekValue());
@@ -714,15 +715,15 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     }
     auto zero = mlir::arith::ConstantIntOp::create(
         builder, loc, builder.getIntegerType(64), 0);
-    auto qregSizeOne = quake::AllocaOp::create(
-        builder, loc, quake::VeqType::get(builder.getContext(), 1));
+    auto qregSizeOne = cudaq::quake::AllocaOp::create(
+        builder, loc, cudaq::quake::VeqType::get(builder.getContext(), 1));
     Value addressTheQubit =
-        quake::ExtractRefOp::create(builder, loc, qregSizeOne, zero);
+        cudaq::quake::ExtractRefOp::create(builder, loc, qregSizeOne, zero);
     symbolTable.insert(name, addressTheQubit);
     return pushValue(addressTheQubit);
   }
 
-  if (isa<quake::StruqType>(type)) {
+  if (isa<cudaq::quake::StruqType>(type)) {
     // A pure quantum struct is just passed along by value. It cannot be stored
     // to a variable.
     symbolTable.insert(name, peekValue());
@@ -752,9 +753,10 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
         return true;
 
       // Assign registerName
-      if (auto descr = initVec.getDefiningOp<quake::DiscriminateOp>())
-        if (auto meas = descr.getMeasurement()
-                            .getDefiningOp<quake::MeasurementInterface>())
+      if (auto descr = initVec.getDefiningOp<cudaq::quake::DiscriminateOp>())
+        if (auto meas =
+                descr.getMeasurement()
+                    .getDefiningOp<cudaq::quake::MeasurementInterface>())
           meas.setRegisterName(builder.getStringAttr(x->getName()));
 
       // Did this come from a stdvec init op? If not drop out
@@ -783,9 +785,9 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
         auto firstGepUser = *gepOp->getResult(0).getUsers().begin();
         if (auto storeOp = dyn_cast<cc::StoreOp>(firstGepUser)) {
           auto result = storeOp->getOperand(0);
-          if (auto discr = result.getDefiningOp<quake::DiscriminateOp>())
-            if (auto mzOp =
-                    discr.getMeasurement().getDefiningOp<quake::MzOp>()) {
+          if (auto discr = result.getDefiningOp<cudaq::quake::DiscriminateOp>())
+            if (auto mzOp = discr.getMeasurement()
+                                .getDefiningOp<cudaq::quake::MzOp>()) {
               // Found it, tag it with the name.
               mzOp.setRegisterName(builder.getStringAttr(x->getName()));
               break;
@@ -819,8 +821,8 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
 
   // If this was an auto var = mz(q), then we want to know the
   // var name, as it will serve as the classical bit register name
-  if (auto discr = initValue.getDefiningOp<quake::DiscriminateOp>())
-    if (auto mz = discr.getMeasurement().getDefiningOp<quake::MzOp>())
+  if (auto discr = initValue.getDefiningOp<cudaq::quake::DiscriminateOp>())
+    if (auto mz = discr.getMeasurement().getDefiningOp<cudaq::quake::MzOp>())
       mz.setRegisterName(builder.getStringAttr(x->getName()));
 
   assert(initValue && "initializer value must be lowered");

--- a/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -73,10 +73,10 @@ maybeUnpackOperands(OpBuilder &builder, Location loc, ValueRange operands,
   SmallVector<Value> targets = operands.take_back(targetCount);
   Value last_target = operands.back();
 
-  if (isa<quake::VeqType>(last_target.getType())) {
+  if (isa<cudaq::quake::VeqType>(last_target.getType())) {
     // Split the vector. Last `targetCount` are targets, front `N-targetCount`
     // are controls.
-    auto vecSize = quake::VeqSizeOp::create(
+    auto vecSize = cudaq::quake::VeqSizeOp::create(
         builder, loc, builder.getIntegerType(64), targets);
     auto size =
         cudaq::cc::CastOp::create(builder, loc, builder.getI64Type(), vecSize,
@@ -89,14 +89,14 @@ maybeUnpackOperands(OpBuilder &builder, Location loc, ValueRange operands,
         arith::ConstantIntOp::create(builder, loc, builder.getI64Type(), 0);
     auto last = arith::SubIOp::create(builder, loc, offset, numTargets);
     // The canonicalizer will compute a constant size, if possible.
-    auto unsizedVeqTy = quake::VeqType::getUnsized(builder.getContext());
+    auto unsizedVeqTy = cudaq::quake::VeqType::getUnsized(builder.getContext());
 
     // Get the subvector of all targets
-    Value targetSubveq = quake::SubVeqOp::create(builder, loc, unsizedVeqTy,
-                                                 last_target, zero, offset);
+    Value targetSubveq = cudaq::quake::SubVeqOp::create(
+        builder, loc, unsizedVeqTy, last_target, zero, offset);
     // Get the subvector of all qubits excluding the last one: controls.
-    Value ctrlSubveq = quake::SubVeqOp::create(builder, loc, unsizedVeqTy,
-                                               last_target, zero, last);
+    Value ctrlSubveq = cudaq::quake::SubVeqOp::create(
+        builder, loc, unsizedVeqTy, last_target, zero, last);
     return std::make_pair(SmallVector<Value>{targetSubveq},
                           SmallVector<Value>{ctrlSubveq});
   }
@@ -167,19 +167,20 @@ bool buildOp(OpBuilder &builder, Location loc, ValueRange operands,
     }
   } else {
     assert(operands.size() >= 1 && "must be at least 1 operand");
-    if ((operands.size() == 1) && isa<quake::VeqType>(operands[0].getType())) {
+    if ((operands.size() == 1) &&
+        isa<cudaq::quake::VeqType>(operands[0].getType())) {
       auto target = operands[0];
       if (!negations.empty())
         reportNegateError();
       Type i64Ty = builder.getI64Type();
-      auto size = quake::VeqSizeOp::create(builder, loc,
-                                           builder.getIntegerType(64), target);
+      auto size = cudaq::quake::VeqSizeOp::create(
+          builder, loc, builder.getIntegerType(64), target);
       Value rank = cudaq::cc::CastOp::create(builder, loc, i64Ty, size,
                                              cudaq::cc::CastOpMode::Unsigned);
       auto bodyBuilder = [&](OpBuilder &builder, Location loc, Region &,
                              Block &block) {
-        Value ref = quake::ExtractRefOp::create(builder, loc, target,
-                                                block.getArgument(0));
+        Value ref = cudaq::quake::ExtractRefOp::create(builder, loc, target,
+                                                       block.getArgument(0));
         A::create(builder, loc, ValueRange(), ref);
       };
       cudaq::opt::factory::createInvariantLoop(builder, loc, rank, bodyBuilder);
@@ -549,12 +550,13 @@ SmallVector<Value> QuakeBridgeVisitor::convertKernelArgs(
       result.push_back(castTo);
       continue;
     }
-    if (auto vVecTy = dyn_cast<quake::VeqType>(vTy))
-      if (auto kVecTy = dyn_cast<quake::VeqType>(kTy)) {
+    if (auto vVecTy = dyn_cast<cudaq::quake::VeqType>(vTy))
+      if (auto kVecTy = dyn_cast<cudaq::quake::VeqType>(kTy)) {
         // Both are Veq but the Veq are not identical. If the callee has a
         // dynamic size, we can relax the size from the calling context.
         if (vVecTy.hasSpecifiedSize() && !kVecTy.hasSpecifiedSize()) {
-          auto relax = quake::RelaxSizeOp::create(builder, loc, kVecTy, v);
+          auto relax =
+              cudaq::quake::RelaxSizeOp::create(builder, loc, kVecTy, v);
           result.push_back(relax);
           continue;
         }
@@ -674,16 +676,16 @@ bool QuakeBridgeVisitor::VisitCastExpr(clang::CastExpr *x) {
   }
   case clang::CastKind::CK_ConstructorConversion: {
     // Enable implicit conversion of surface types, which both map to VeqType.
-    if (isa<quake::VeqType>(castToTy))
+    if (isa<cudaq::quake::VeqType>(castToTy))
       if (auto cxxExpr = dyn_cast<clang::CXXConstructExpr>(x->getSubExpr()))
         if (cxxExpr->getNumArgs() == 1 &&
-            isa<quake::VeqType>(peekValue().getType()))
+            isa<cudaq::quake::VeqType>(peekValue().getType()))
           return true;
     // ... or which both map to RefType.
-    if (isa<quake::RefType>(castToTy))
+    if (isa<cudaq::quake::RefType>(castToTy))
       if (auto cxxExpr = dyn_cast<clang::CXXConstructExpr>(x->getSubExpr()))
         if (cxxExpr->getNumArgs() == 1 &&
-            isa<quake::RefType>(peekValue().getType()))
+            isa<cudaq::quake::RefType>(peekValue().getType()))
           return true;
 
     // Enable implicit conversion of lambda -> std::function, which are both
@@ -696,9 +698,9 @@ bool QuakeBridgeVisitor::VisitCastExpr(clang::CastExpr *x) {
     }
     if (isa<ComplexType>(castToTy) && isa<ComplexType>(peekValue().getType()))
       return true;
-    if (isa<quake::StateType>(castToTy))
+    if (isa<cudaq::quake::StateType>(castToTy))
       if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(peekValue().getType()))
-        if (isa<quake::StateType>(ptrTy.getElementType()))
+        if (isa<cudaq::quake::StateType>(ptrTy.getElementType()))
           return pushValue(cudaq::cc::LoadOp::create(builder, loc, popValue()));
     if (auto funcTy = peelPointerFromFunction(castToTy))
       if (auto fromTy = dyn_cast<cc::CallableType>(peekValue().getType())) {
@@ -1018,8 +1020,8 @@ bool QuakeBridgeVisitor::VisitMaterializeTemporaryExpr(
   // The following cases are λ expressions, quantum data, or a std::vector view.
   // In those cases, there is nothing to materialize, so we can just pass the
   // Value on the top of the stack.
-  if (isa<cc::CallableType, quake::VeqType, quake::RefType, cc::SpanLikeType,
-          quake::StateType>(ty))
+  if (isa<cc::CallableType, cudaq::quake::VeqType, cudaq::quake::RefType,
+          cc::SpanLikeType, cudaq::quake::StateType>(ty))
     return true;
 
   // If not one of the above special cases, then materialize the value to a
@@ -1088,9 +1090,9 @@ bool QuakeBridgeVisitor::VisitMemberExpr(clang::MemberExpr *x) {
     auto object = popValue(); // DeclRefExpr
     auto ty = popType();
     std::int32_t offset = field->getFieldIndex();
-    if (isa<quake::StruqType>(object.getType())) {
+    if (isa<cudaq::quake::StruqType>(object.getType())) {
       return pushValue(
-          quake::GetMemberOp::create(builder, loc, ty, object, offset));
+          cudaq::quake::GetMemberOp::create(builder, loc, ty, object, offset));
     }
     if (!isa<cc::PointerType>(object.getType())) {
       reportClangError(x, mangler,
@@ -1446,8 +1448,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           [[maybe_unused]] auto calleeTy = popType();
           assert(isa<FunctionType>(calleeTy));
           auto qregArg = popValue();
-          auto qrSize = quake::VeqSizeOp::create(builder, loc,
-                                                 builder.getI64Type(), qregArg);
+          auto qrSize = cudaq::quake::VeqSizeOp::create(
+              builder, loc, builder.getI64Type(), qregArg);
           return pushValue(qrSize);
         }
 
@@ -1465,13 +1467,13 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
             auto one = getConstantInt(builder, loc, 1, 64);
             auto offset = arith::SubIOp::create(builder, loc, qrSize, one);
             auto unsizedVecTy =
-                quake::VeqType::getUnsized(builder.getContext());
-            return pushValue(quake::SubVeqOp::create(builder, loc, unsizedVecTy,
-                                                     qregArg, zero, offset));
+                cudaq::quake::VeqType::getUnsized(builder.getContext());
+            return pushValue(cudaq::quake::SubVeqOp::create(
+                builder, loc, unsizedVecTy, qregArg, zero, offset));
           }
           assert(actArgs.size() == 0);
           return pushValue(
-              quake::ExtractRefOp::create(builder, loc, qregArg, zero));
+              cudaq::quake::ExtractRefOp::create(builder, loc, qregArg, zero));
         }
 
     if (funcName == "back")
@@ -1481,8 +1483,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           assert(isa<FunctionType>(calleeTy));
           auto actArgs = lastValues(x->getNumArgs());
           auto qregArg = popValue();
-          auto qrSize = quake::VeqSizeOp::create(builder, loc,
-                                                 builder.getI64Type(), qregArg);
+          auto qrSize = cudaq::quake::VeqSizeOp::create(
+              builder, loc, builder.getI64Type(), qregArg);
           auto one = getConstantInt(builder, loc, 1, 64);
           auto endOff = arith::SubIOp::create(builder, loc, qrSize, one);
           if (actArgs.size() == 1) {
@@ -1490,13 +1492,13 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
             auto startOff =
                 arith::SubIOp::create(builder, loc, qrSize, actArgs.front());
             auto unsizedVecTy =
-                quake::VeqType::getUnsized(builder.getContext());
-            return pushValue(quake::SubVeqOp::create(
+                cudaq::quake::VeqType::getUnsized(builder.getContext());
+            return pushValue(cudaq::quake::SubVeqOp::create(
                 builder, loc, unsizedVecTy, qregArg, startOff, endOff));
           }
           assert(actArgs.size() == 0);
-          return pushValue(
-              quake::ExtractRefOp::create(builder, loc, qregArg, endOff));
+          return pushValue(cudaq::quake::ExtractRefOp::create(builder, loc,
+                                                              qregArg, endOff));
         }
 
     if (funcName == "slice") {
@@ -1512,9 +1514,10 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto one = getConstantInt(builder, loc, 1, 64);
           Value offset = arith::AddIOp::create(builder, loc, start, count);
           offset = arith::SubIOp::create(builder, loc, offset, one);
-          auto unsizedVecTy = quake::VeqType::getUnsized(builder.getContext());
-          return pushValue(quake::SubVeqOp::create(builder, loc, unsizedVecTy,
-                                                   qregArg, start, offset));
+          auto unsizedVecTy =
+              cudaq::quake::VeqType::getUnsized(builder.getContext());
+          return pushValue(cudaq::quake::SubVeqOp::create(
+              builder, loc, unsizedVecTy, qregArg, start, offset));
         }
     }
 
@@ -1568,7 +1571,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           reportClangError(x, mangler, "could not determine string argument");
         }
       };
-      if (args.size() == 3 && isa<quake::VeqType>(args[1].getType())) {
+      if (args.size() == 3 && isa<cudaq::quake::VeqType>(args[1].getType())) {
         // Have f64, veq, string
         parameters.push_back(args[0]);
         targets.push_back(args[1]);
@@ -1584,15 +1587,16 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         SmallVector<Value> quantumArgs;
         for (std::size_t i = 2; i < args.size(); i++)
           quantumArgs.push_back(args[i]);
-        targets.push_back(quake::ConcatOp::create(
+        targets.push_back(cudaq::quake::ConcatOp::create(
             builder, loc,
-            quake::VeqType::get(builder.getContext(), quantumArgs.size()),
+            cudaq::quake::VeqType::get(builder.getContext(),
+                                       quantumArgs.size()),
             quantumArgs));
         addTheString(args[1]);
       }
 
-      quake::ExpPauliOp::create(builder, loc, parameters, ValueRange{}, targets,
-                                pauliWord);
+      cudaq::quake::ExpPauliOp::create(builder, loc, parameters, ValueRange{},
+                                       targets, pauliWord);
       return true;
     }
 
@@ -1621,7 +1625,7 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         // The first argument that is not floating-point must be a qubit. If
         // the user has interleaved floating-point and qubit arguments, that's
         // an error.
-        if (isa<quake::RefType, quake::VeqType>(aTy)) {
+        if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(aTy)) {
           qubits.push_back(a);
         } else {
           reportClangError(x, mangler,
@@ -1632,7 +1636,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
 
       if (auto callee = calleeOp.getDefiningOp<func::ConstantOp>()) {
         StringRef calleeName = callee.getValue();
-        quake::ApplyNoiseOp::create(builder, loc, calleeName, params, qubits);
+        cudaq::quake::ApplyNoiseOp::create(builder, loc, calleeName, params,
+                                           qubits);
 
         // Add the declaration of the function to the module.
         SmallVector<Type> argTys;
@@ -1654,22 +1659,25 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       // Measurements always return a bool or a std::vector<bool>.
       bool useStdvec =
           (args.size() > 1) ||
-          (args.size() == 1 && isa<quake::VeqType>(args[0].getType()));
+          (args.size() == 1 && isa<cudaq::quake::VeqType>(args[0].getType()));
       auto measure = [&]() -> Value {
-        Type measTy = quake::MeasureType::get(builder.getContext());
+        Type measTy = cudaq::quake::MeasureType::get(builder.getContext());
         if (useStdvec)
           measTy = cc::StdvecType::get(measTy);
         if (funcName == "mx")
-          return quake::MxOp::create(builder, loc, measTy, args).getMeasOut();
+          return cudaq::quake::MxOp::create(builder, loc, measTy, args)
+              .getMeasOut();
         if (funcName == "my")
-          return quake::MyOp::create(builder, loc, measTy, args).getMeasOut();
-        return quake::MzOp::create(builder, loc, measTy, args).getMeasOut();
+          return cudaq::quake::MyOp::create(builder, loc, measTy, args)
+              .getMeasOut();
+        return cudaq::quake::MzOp::create(builder, loc, measTy, args)
+            .getMeasOut();
       }();
       Type resTy = builder.getI1Type();
       if (useStdvec)
         resTy = cc::StdvecType::get(resTy);
       return pushValue(
-          quake::DiscriminateOp::create(builder, loc, resTy, measure));
+          cudaq::quake::DiscriminateOp::create(builder, loc, resTy, measure));
     }
 
     // Handle the quantum gate set.
@@ -1677,64 +1685,66 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       reportClangError(x, mangler, "target qubit cannot be negated");
     };
     if (funcName == "h")
-      return buildOp<quake::HOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/false,
-                                 isControl);
+      return buildOp<cudaq::quake::HOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/false,
+                                        isControl);
     if (funcName == "ch")
-      return buildOp<quake::HOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/false,
-                                 /*control=*/true);
+      return buildOp<cudaq::quake::HOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/false,
+                                        /*control=*/true);
     if (funcName == "x")
-      return buildOp<quake::XOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/false,
-                                 isControl);
+      return buildOp<cudaq::quake::XOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/false,
+                                        isControl);
     if (funcName == "cnot" || funcName == "cx" || funcName == "ccx")
-      return buildOp<quake::XOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/false,
-                                 /*control=*/true);
+      return buildOp<cudaq::quake::XOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/false,
+                                        /*control=*/true);
     if (funcName == "y")
-      return buildOp<quake::YOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/false,
-                                 isControl);
+      return buildOp<cudaq::quake::YOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/false,
+                                        isControl);
     if (funcName == "cy")
-      return buildOp<quake::YOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/false,
-                                 /*control=*/true);
+      return buildOp<cudaq::quake::YOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/false,
+                                        /*control=*/true);
     if (funcName == "z")
-      return buildOp<quake::ZOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/false,
-                                 isControl);
+      return buildOp<cudaq::quake::ZOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/false,
+                                        isControl);
     if (funcName == "cz")
-      return buildOp<quake::ZOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/false,
-                                 /*control=*/true);
+      return buildOp<cudaq::quake::ZOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/false,
+                                        /*control=*/true);
     if (funcName == "s")
-      return buildOp<quake::SOp>(builder, loc, args, negations,
-                                 reportNegateError, isAdjoint, isControl);
+      return buildOp<cudaq::quake::SOp>(builder, loc, args, negations,
+                                        reportNegateError, isAdjoint,
+                                        isControl);
     if (funcName == "cs")
-      return buildOp<quake::SOp>(builder, loc, args, negations,
-                                 reportNegateError, isAdjoint,
-                                 /*control=*/true);
+      return buildOp<cudaq::quake::SOp>(builder, loc, args, negations,
+                                        reportNegateError, isAdjoint,
+                                        /*control=*/true);
     if (funcName == "sdg")
-      return buildOp<quake::SOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/true,
-                                 isControl);
+      return buildOp<cudaq::quake::SOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/true,
+                                        isControl);
     if (funcName == "t")
-      return buildOp<quake::TOp>(builder, loc, args, negations,
-                                 reportNegateError, isAdjoint, isControl);
+      return buildOp<cudaq::quake::TOp>(builder, loc, args, negations,
+                                        reportNegateError, isAdjoint,
+                                        isControl);
     if (funcName == "ct")
-      return buildOp<quake::TOp>(builder, loc, args, negations,
-                                 reportNegateError, isAdjoint,
-                                 /*control=*/true);
+      return buildOp<cudaq::quake::TOp>(builder, loc, args, negations,
+                                        reportNegateError, isAdjoint,
+                                        /*control=*/true);
     if (funcName == "tdg")
-      return buildOp<quake::TOp>(builder, loc, args, negations,
-                                 reportNegateError, /*adjoint=*/true,
-                                 isControl);
+      return buildOp<cudaq::quake::TOp>(builder, loc, args, negations,
+                                        reportNegateError, /*adjoint=*/true,
+                                        isControl);
 
     if (funcName == "reset") {
       if (!negations.empty())
         reportNegateError();
-      return quake::ResetOp::create(builder, loc, TypeRange{}, args[0]);
+      return cudaq::quake::ResetOp::create(builder, loc, TypeRange{}, args[0]);
     }
     if (funcName == "swap") {
       const auto size = args.size();
@@ -1746,48 +1756,48 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       SmallVector<Value> ctrls(args.begin(), args.begin() + size - 2);
       auto negs =
           negatedControlsAttribute(builder.getContext(), ctrls, negations);
-      auto swap = quake::SwapOp::create(builder, loc, ctrls, targets);
+      auto swap = cudaq::quake::SwapOp::create(builder, loc, ctrls, targets);
       if (negs)
         swap->setAttr("negated_qubit_controls", negs);
       return true;
     }
     if (funcName == "p" || funcName == "r1")
-      return buildOp<quake::R1Op, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint,
-                                         isControl);
+      return buildOp<cudaq::quake::R1Op, Param>(builder, loc, args, negations,
+                                                reportNegateError, isAdjoint,
+                                                isControl);
     if (funcName == "cr1")
-      return buildOp<quake::R1Op, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint,
-                                         /*control=*/true);
+      return buildOp<cudaq::quake::R1Op, Param>(builder, loc, args, negations,
+                                                reportNegateError, isAdjoint,
+                                                /*control=*/true);
     if (funcName == "rx")
-      return buildOp<quake::RxOp, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint,
-                                         isControl);
+      return buildOp<cudaq::quake::RxOp, Param>(builder, loc, args, negations,
+                                                reportNegateError, isAdjoint,
+                                                isControl);
     if (funcName == "crx")
-      return buildOp<quake::RxOp, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint,
-                                         /*control=*/true);
+      return buildOp<cudaq::quake::RxOp, Param>(builder, loc, args, negations,
+                                                reportNegateError, isAdjoint,
+                                                /*control=*/true);
     if (funcName == "ry")
-      return buildOp<quake::RyOp, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint,
-                                         isControl);
+      return buildOp<cudaq::quake::RyOp, Param>(builder, loc, args, negations,
+                                                reportNegateError, isAdjoint,
+                                                isControl);
     if (funcName == "cry")
-      return buildOp<quake::RyOp, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint,
-                                         /*control=*/true);
+      return buildOp<cudaq::quake::RyOp, Param>(builder, loc, args, negations,
+                                                reportNegateError, isAdjoint,
+                                                /*control=*/true);
     if (funcName == "rz")
-      return buildOp<quake::RzOp, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint,
-                                         isControl);
+      return buildOp<cudaq::quake::RzOp, Param>(builder, loc, args, negations,
+                                                reportNegateError, isAdjoint,
+                                                isControl);
     if (funcName == "crz")
-      return buildOp<quake::RzOp, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint,
-                                         /*control=*/true);
+      return buildOp<cudaq::quake::RzOp, Param>(builder, loc, args, negations,
+                                                reportNegateError, isAdjoint,
+                                                /*control=*/true);
 
     if (funcName == "u3")
-      return buildOp<quake::U3Op, Param>(builder, loc, args, negations,
-                                         reportNegateError, isAdjoint,
-                                         isControl, /*paramCount=*/3);
+      return buildOp<cudaq::quake::U3Op, Param>(builder, loc, args, negations,
+                                                reportNegateError, isAdjoint,
+                                                isControl, /*paramCount=*/3);
 
     // See if this is a custom unitary.
     std::string maybeUnitaryGenerator = funcName.str() + "_generator_";
@@ -1823,21 +1833,21 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       ValueRange operands(args);
       assert(operands.size() >= 1 && "must be at least 1 operand");
       if ((operands.size() == 1) &&
-          isa<quake::VeqType>(operands[0].getType())) {
+          isa<cudaq::quake::VeqType>(operands[0].getType())) {
         auto target = operands[0];
         if (!negations.empty())
           reportNegateError();
         Type i64Ty = builder.getI64Type();
-        auto size = quake::VeqSizeOp::create(
+        auto size = cudaq::quake::VeqSizeOp::create(
             builder, loc, builder.getIntegerType(64), target);
         Value rank = cudaq::cc::CastOp::create(builder, loc, i64Ty, size,
                                                cudaq::cc::CastOpMode::Unsigned);
         auto bodyBuilder = [&](OpBuilder &builder, Location loc, Region &,
                                Block &block) {
-          Value ref = quake::ExtractRefOp::create(builder, loc, target,
-                                                  block.getArgument(0));
-          quake::CustomUnitarySymbolOp::create(builder, loc, srefAttr,
-                                               ValueRange(), ref);
+          Value ref = cudaq::quake::ExtractRefOp::create(builder, loc, target,
+                                                         block.getArgument(0));
+          cudaq::quake::CustomUnitarySymbolOp::create(builder, loc, srefAttr,
+                                                      ValueRange(), ref);
         };
         cudaq::opt::factory::createInvariantLoop(builder, loc, rank,
                                                  bodyBuilder);
@@ -1855,8 +1865,8 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         for (auto p : operands.take_front(paramCount))
           if (isa<cudaq::cc::PointerType>(p.getType()))
             params.push_back(cudaq::cc::LoadOp::create(builder, loc, p));
-        quake::CustomUnitarySymbolOp::create(builder, loc, srefAttr, isAdjoint,
-                                             params, ctrls, targets, negs);
+        cudaq::quake::CustomUnitarySymbolOp::create(
+            builder, loc, srefAttr, isAdjoint, params, ctrls, targets, negs);
       }
       return true;
     }
@@ -1876,27 +1886,29 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         if (!negations.empty()) {
           // Loop over the ctrlValues and negate (apply an XOp) those in the
           // negations list.
-          if (auto concat = ctrlValues.getDefiningOp<quake::ConcatOp>()) {
+          if (auto concat =
+                  ctrlValues.getDefiningOp<cudaq::quake::ConcatOp>()) {
             for (auto v : concat.getTargets())
               if (std::find(negations.begin(), negations.end(), v) !=
                   negations.end()) {
-                if (isa<quake::VeqType>(v.getType())) {
+                if (isa<cudaq::quake::VeqType>(v.getType())) {
                   reportClangError(
                       x, mangler, "cannot negate an entire register of qubits");
                 } else {
                   SmallVector<Value> dummy;
-                  buildOp<quake::XOp>(builder, loc, v, dummy, []() {});
+                  buildOp<cudaq::quake::XOp>(builder, loc, v, dummy, []() {});
                 }
               }
-          } else if (isa<quake::VeqType>(ctrlValues.getType())) {
+          } else if (isa<cudaq::quake::VeqType>(ctrlValues.getType())) {
             assert(negations.size() == 1 && negations[0] == ctrlValues);
             reportClangError(x, mangler,
                              "cannot negate an entire register of qubits");
           } else {
-            assert(isa<quake::RefType>(ctrlValues.getType()));
+            assert(isa<cudaq::quake::RefType>(ctrlValues.getType()));
             assert(negations.size() == 1 && negations[0] == ctrlValues);
             SmallVector<Value> dummy;
-            buildOp<quake::XOp>(builder, loc, ctrlValues, dummy, []() {});
+            buildOp<cudaq::quake::XOp>(builder, loc, ctrlValues, dummy,
+                                       []() {});
           }
         }
       };
@@ -1947,8 +1959,9 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         auto kernelArgs =
             convertKernelArgs(loc, 2, args, kernelTy.getInputs(), x);
         inlinedStartControlNegations();
-        quake::ApplyOp::create(builder, loc, TypeRange{}, calleeSymbol,
-                               /*isAdjoint=*/false, ctrlValues, kernelArgs);
+        cudaq::quake::ApplyOp::create(builder, loc, TypeRange{}, calleeSymbol,
+                                      /*isAdjoint=*/false, ctrlValues,
+                                      kernelArgs);
         return inlinedFinishControlNegations();
       }
       if (auto func = calleeValue.getDefiningOp<func::ConstantOp>()) {
@@ -1957,8 +1970,9 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         inlinedStartControlNegations();
         auto kernelArgs =
             convertKernelArgs(loc, 2, args, funcTy.getInputs(), x);
-        quake::ApplyOp::create(builder, loc, funcTy.getResults(), callableSym,
-                               /*isAdjoint=*/false, ctrlValues, kernelArgs);
+        cudaq::quake::ApplyOp::create(
+            builder, loc, funcTy.getResults(), callableSym,
+            /*isAdjoint=*/false, ctrlValues, kernelArgs);
         return inlinedFinishControlNegations();
       }
       if (auto ty = dyn_cast<cc::CallableType>(calleeValue.getType())) {
@@ -1997,13 +2011,13 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto kernelArgs =
               convertKernelArgs(loc, 2, args, funcTy.getInputs(), x);
           if (isKernelEntryPoint(callOperDecl)) {
-            quake::ApplyOp::create(builder, loc, funcTy.getResults(),
-                                   calleeSymbol,
-                                   /*isAdjoint=*/false, ctrlValues, kernelArgs);
+            cudaq::quake::ApplyOp::create(
+                builder, loc, funcTy.getResults(), calleeSymbol,
+                /*isAdjoint=*/false, ctrlValues, kernelArgs);
           } else {
-            quake::ApplyOp::create(builder, loc, funcTy.getResults(),
-                                   calleeValue,
-                                   /*isAdjoint=*/false, ctrlValues, kernelArgs);
+            cudaq::quake::ApplyOp::create(
+                builder, loc, funcTy.getResults(), calleeValue,
+                /*isAdjoint=*/false, ctrlValues, kernelArgs);
           }
           return inlinedFinishControlNegations();
         }
@@ -2057,15 +2071,15 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         assert(kernFunc && "kernel call operator must be present");
         auto kernTy = kernFunc.getFunctionType();
         auto kernArgs = convertKernelArgs(loc, 1, args, kernTy.getInputs(), x);
-        return quake::ApplyOp::create(builder, loc, TypeRange{}, kernelSymbol,
-                                      /*isAdjoint=*/true, ValueRange{},
-                                      kernArgs);
+        return cudaq::quake::ApplyOp::create(
+            builder, loc, TypeRange{}, kernelSymbol,
+            /*isAdjoint=*/true, ValueRange{}, kernArgs);
       }
       if (auto func = kernelValue.getDefiningOp<func::ConstantOp>()) {
         auto kernSym = func.getValueAttr();
         auto funcTy = cast<FunctionType>(func.getType());
         auto kernArgs = convertKernelArgs(loc, 1, args, funcTy.getInputs(), x);
-        return quake::ApplyOp::create(
+        return cudaq::quake::ApplyOp::create(
             builder, loc, funcTy.getResults(), kernSym,
             /*isAdjoint=*/true, ValueRange{}, kernArgs);
       }
@@ -2103,11 +2117,11 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
           auto kernelArgs =
               convertKernelArgs(loc, 1, args, funcTy.getInputs(), x);
           if (isKernelEntryPoint(callOperDecl)) {
-            return quake::ApplyOp::create(
+            return cudaq::quake::ApplyOp::create(
                 builder, loc, funcTy.getResults(), kernelSymbol,
                 /*isAdjoint=*/true, ValueRange{}, kernelArgs);
           }
-          return quake::ApplyOp::create(
+          return cudaq::quake::ApplyOp::create(
               builder, loc, funcTy.getResults(), kernelValue,
               /*isAdjoint=*/true, ValueRange{}, kernelArgs);
         }
@@ -2117,13 +2131,13 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
     }
 
     if (funcName == "compute_action") {
-      quake::ComputeActionOp::create(builder, loc, /*is_dagger=*/false, args[0],
-                                     args[1]);
+      cudaq::quake::ComputeActionOp::create(builder, loc, /*is_dagger=*/false,
+                                            args[0], args[1]);
       return true;
     }
     if (funcName == "compute_dag_action") {
-      quake::ComputeActionOp::create(builder, loc, /*is_dagger=*/true, args[0],
-                                     args[1]);
+      cudaq::quake::ComputeActionOp::create(builder, loc, /*is_dagger=*/true,
+                                            args[0], args[1]);
       return true;
     }
 
@@ -2505,7 +2519,7 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
         // extract `Op` to the symbol table, but always generate a new
         // `quake.extract_ref` `Op` to get the exact qubit (reference) value.
         auto address_qubit =
-            quake::ExtractRefOp::create(builder, loc, qreg_var, idx_var);
+            cudaq::quake::ExtractRefOp::create(builder, loc, qreg_var, idx_var);
         return replaceTOSValue(address_qubit);
       }
       // Get name of the qreg, e.g. qr, and use it to construct a name for the
@@ -2525,7 +2539,7 @@ bool QuakeBridgeVisitor::VisitCXXOperatorCallExpr(
       // in the symbol table, and return the AddressQubit operation's
       // resulting value.
       auto address_qubit =
-          quake::ExtractRefOp::create(builder, loc, qreg_var, idx_var);
+          cudaq::quake::ExtractRefOp::create(builder, loc, qreg_var, idx_var);
 
       // NB: varName is built from the variable name *and* the index value. This
       // front-end optimization is likely unnecessary as the compiler can always
@@ -2717,30 +2731,31 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
           return true;
   auto last = lastValues(size);
   bool allRef = std::all_of(last.begin(), last.end(), [](auto v) {
-    return isa<quake::RefType, quake::VeqType>(v.getType());
+    return isa<cudaq::quake::RefType, cudaq::quake::VeqType>(v.getType());
   });
-  if (allRef && isa<quake::StruqType>(initListTy))
+  if (allRef && isa<cudaq::quake::StruqType>(initListTy))
     return pushValue(
-        quake::MakeStruqOp::create(builder, loc, initListTy, last));
+        cudaq::quake::MakeStruqOp::create(builder, loc, initListTy, last));
 
   if (allRef && !isa<cc::StructType>(initListTy)) {
     // Initializer list contains all quantum reference types. In this case we
     // want to create quake code to concatenate the references into a veq.
     if (size > 1) {
-      auto veqTy = [&]() -> quake::VeqType {
+      auto veqTy = [&]() -> cudaq::quake::VeqType {
         unsigned size = 0;
         for (auto v : last) {
-          if (auto veqTy = dyn_cast<quake::VeqType>(v.getType())) {
+          if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(v.getType())) {
             if (!veqTy.hasSpecifiedSize())
-              return quake::VeqType::getUnsized(builder.getContext());
+              return cudaq::quake::VeqType::getUnsized(builder.getContext());
             size += veqTy.getSize();
           } else {
             ++size;
           }
         }
-        return quake::VeqType::get(builder.getContext(), size);
+        return cudaq::quake::VeqType::get(builder.getContext(), size);
       }();
-      return pushValue(quake::ConcatOp::create(builder, loc, veqTy, last));
+      return pushValue(
+          cudaq::quake::ConcatOp::create(builder, loc, veqTy, last));
     }
     // Pass initialization list with one member as a Ref.
     return pushValue(last[0]);
@@ -2798,8 +2813,9 @@ bool QuakeBridgeVisitor::VisitInitListExpr(clang::InitListExpr *x) {
   }
 
   // If quantum, use value semantics with cc insert / extract value.
-  if (isa<quake::StruqType>(eleTy))
-    return pushValue(quake::MakeStruqOp::create(builder, loc, eleTy, last));
+  if (isa<cudaq::quake::StruqType>(eleTy))
+    return pushValue(
+        cudaq::quake::MakeStruqOp::create(builder, loc, eleTy, last));
 
   Value alloca = (numEles > 1)
                      ? cc::AllocaOp::create(builder, loc, eleTy, arrSize)
@@ -2855,7 +2871,8 @@ bool QuakeBridgeVisitor::TraverseCXXConstructExpr(clang::CXXConstructExpr *x,
     if (!TraverseType(x->getType()))
       return false;
     assert(typeStack.size() == typeStackDepth + 1);
-    if (x->isStdInitListInitialization() && isa<quake::VeqType>(peekType()))
+    if (x->isStdInitListInitialization() &&
+        isa<cudaq::quake::VeqType>(peekType()))
       initializerIsGlobal = true;
   }
   auto *ctor = x->getConstructor();
@@ -2896,12 +2913,13 @@ bool QuakeBridgeVisitor::VisitCXXParenListInitExpr(
   auto ty = peekType();
   assert(ty && "type must be present");
   LLVM_DEBUG(llvm::dbgs() << "paren list type: " << ty << '\n');
-  auto structTy = dyn_cast<quake::StruqType>(ty);
+  auto structTy = dyn_cast<cudaq::quake::StruqType>(ty);
   if (!structTy)
     return true;
   auto loc = toLocation(x);
   auto last = lastValues(structTy.getMembers().size());
-  return pushValue(quake::MakeStruqOp::create(builder, loc, structTy, last));
+  return pushValue(
+      cudaq::quake::MakeStruqOp::create(builder, loc, structTy, last));
 }
 
 bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
@@ -2918,30 +2936,30 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
     if (x->getNumArgs() == 0) {
       if (ctorName == "qudit") {
         // This is a single qubit.
-        assert(isa<quake::RefType>(ctorTy));
-        return pushValue(quake::AllocaOp::create(builder, loc));
+        assert(isa<cudaq::quake::RefType>(ctorTy));
+        return pushValue(cudaq::quake::AllocaOp::create(builder, loc));
       }
       // These classes have template arguments that may give a compile-time
       // constant size. qarray is the only one that requires it, however.
       if (ctorName == "qreg" || ctorName == "qarray" || ctorName == "qspan") {
-        [[maybe_unused]] auto veqTy = cast<quake::VeqType>(ctorTy);
+        [[maybe_unused]] auto veqTy = cast<cudaq::quake::VeqType>(ctorTy);
         assert(veqTy.hasSpecifiedSize());
-        return pushValue(quake::AllocaOp::create(builder, loc, ctorTy));
+        return pushValue(cudaq::quake::AllocaOp::create(builder, loc, ctorTy));
       }
       if (ctorName == "qvector") {
         // The default qvector ctor creates a veq of size 1.
-        assert(isa<quake::VeqType>(ctorTy));
-        auto veq1Ty = quake::VeqType::get(builder.getContext(), 1);
-        return pushValue(quake::AllocaOp::create(builder, loc, veq1Ty));
+        assert(isa<cudaq::quake::VeqType>(ctorTy));
+        auto veq1Ty = cudaq::quake::VeqType::get(builder.getContext(), 1);
+        return pushValue(cudaq::quake::AllocaOp::create(builder, loc, veq1Ty));
       }
     } else if (x->getNumArgs() == 1) {
       if (ctorName == "qreg") {
         // This is a cudaq::qreg(std::size_t).
         auto sizeVal = popValue();
         assert(isa<IntegerType>(sizeVal.getType()));
-        return pushValue(quake::AllocaOp::create(
-            builder, loc, quake::VeqType::getUnsized(builder.getContext()),
-            sizeVal));
+        return pushValue(cudaq::quake::AllocaOp::create(
+            builder, loc,
+            cudaq::quake::VeqType::getUnsized(builder.getContext()), sizeVal));
       }
 
       if (ctorName == "state") {
@@ -2950,7 +2968,7 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
         // to perform the conversion.
         Value stdvec = popValue();
         auto stateTy = cudaq::cc::PointerType::get(
-            quake::StateType::get(builder.getContext()));
+            cudaq::quake::StateType::get(builder.getContext()));
         if (auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(stdvec.getType())) {
           auto dataTy = cudaq::cc::PointerType::get(stdvecTy.getElementType());
           Value data =
@@ -2958,12 +2976,12 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
           auto i64Ty = builder.getI64Type();
           Value size =
               cudaq::cc::StdvecSizeOp::create(builder, loc, i64Ty, stdvec);
-          return pushValue(quake::CreateStateOp::create(
+          return pushValue(cudaq::quake::CreateStateOp::create(
               builder, loc, stateTy, ValueRange{data, size}));
         }
         if (auto alloc = stdvec.getDefiningOp<cudaq::cc::AllocaOp>()) {
           Value size = alloc.getSeqSize();
-          return pushValue(quake::CreateStateOp::create(
+          return pushValue(cudaq::quake::CreateStateOp::create(
               builder, loc, stateTy, ValueRange{alloc, size}));
         }
         TODO_loc(loc, "unhandled state constructor");
@@ -2973,24 +2991,25 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
       // lambda determines: is `t` a cudaq::state* ?
       auto isStateType = [&](Type t) {
         if (auto ptrTy = dyn_cast<cc::PointerType>(t))
-          return isa<quake::StateType>(ptrTy.getElementType());
+          return isa<cudaq::quake::StateType>(ptrTy.getElementType());
         return false;
       };
 
       if (ctorName == "qudit") {
         auto initials = popValue();
-        if (isa<quake::StateType>(initials.getType()))
+        if (isa<cudaq::quake::StateType>(initials.getType()))
           if (auto load = initials.getDefiningOp<cudaq::cc::LoadOp>())
             initials = load.getPtrvalue();
         if (isStateType(initials.getType())) {
-          Value alloca = quake::AllocaOp::create(builder, loc);
-          auto veq1Ty = quake::VeqType::get(builder.getContext(), 1);
-          Value initSt = quake::InitializeStateOp::create(
+          Value alloca = cudaq::quake::AllocaOp::create(builder, loc);
+          auto veq1Ty = cudaq::quake::VeqType::get(builder.getContext(), 1);
+          Value initSt = cudaq::quake::InitializeStateOp::create(
               builder, loc, veq1Ty, ValueRange{alloca, initials});
-          if (auto initOp = initials.getDefiningOp<quake::CreateStateOp>())
-            quake::DeleteStateOp::create(builder, loc, initOp);
+          if (auto initOp =
+                  initials.getDefiningOp<cudaq::quake::CreateStateOp>())
+            cudaq::quake::DeleteStateOp::create(builder, loc, initOp);
           return pushValue(
-              quake::ExtractRefOp::create(builder, loc, initSt, 0));
+              cudaq::quake::ExtractRefOp::create(builder, loc, initSt, 0));
         }
         bool ok = false;
         if (auto ptrTy = dyn_cast<cc::PointerType>(initials.getType()))
@@ -2999,37 +3018,40 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
         if (!ok) {
           // Invalid initializer ignored, but emit an error.
           reportClangError(x, mangler, "invalid qudit initial value");
-          return pushValue(quake::AllocaOp::create(builder, loc));
+          return pushValue(cudaq::quake::AllocaOp::create(builder, loc));
         }
         auto *ctx = builder.getContext();
-        auto veqTy = quake::VeqType::get(ctx, 1);
-        auto alloc = quake::AllocaOp::create(builder, loc, veqTy);
-        auto init = quake::InitializeStateOp::create(builder, loc, veqTy, alloc,
-                                                     initials);
-        return pushValue(quake::ExtractRefOp::create(builder, loc, init, 0));
+        auto veqTy = cudaq::quake::VeqType::get(ctx, 1);
+        auto alloc = cudaq::quake::AllocaOp::create(builder, loc, veqTy);
+        auto init = cudaq::quake::InitializeStateOp::create(builder, loc, veqTy,
+                                                            alloc, initials);
+        return pushValue(
+            cudaq::quake::ExtractRefOp::create(builder, loc, init, 0));
       }
       if (ctorName == "qvector") {
         auto initials = popValue();
         auto *ctx = builder.getContext();
         if (isa<IntegerType>(initials.getType())) {
           // This is the cudaq::qvector(std::size_t) ctor.
-          return pushValue(quake::AllocaOp::create(
-              builder, loc, quake::VeqType::getUnsized(ctx), initials));
+          return pushValue(cudaq::quake::AllocaOp::create(
+              builder, loc, cudaq::quake::VeqType::getUnsized(ctx), initials));
         }
-        if (isa<quake::StateType>(initials.getType()))
+        if (isa<cudaq::quake::StateType>(initials.getType()))
           if (auto load = initials.getDefiningOp<cudaq::cc::LoadOp>())
             initials = load.getPtrvalue();
         if (isStateType(initials.getType())) {
           Value state = initials;
           auto i64Ty = builder.getI64Type();
-          auto numQubits =
-              quake::GetNumberOfQubitsOp::create(builder, loc, i64Ty, state);
-          auto veqTy = quake::VeqType::getUnsized(ctx);
-          Value alloc = quake::AllocaOp::create(builder, loc, veqTy, numQubits);
-          Value initSt = quake::InitializeStateOp::create(builder, loc, veqTy,
-                                                          alloc, state);
-          if (auto initOp = initials.getDefiningOp<quake::CreateStateOp>())
-            quake::DeleteStateOp::create(builder, loc, initOp);
+          auto numQubits = cudaq::quake::GetNumberOfQubitsOp::create(
+              builder, loc, i64Ty, state);
+          auto veqTy = cudaq::quake::VeqType::getUnsized(ctx);
+          Value alloc =
+              cudaq::quake::AllocaOp::create(builder, loc, veqTy, numQubits);
+          Value initSt = cudaq::quake::InitializeStateOp::create(
+              builder, loc, veqTy, alloc, state);
+          if (auto initOp =
+                  initials.getDefiningOp<cudaq::quake::CreateStateOp>())
+            cudaq::quake::DeleteStateOp::create(builder, loc, initOp);
           return pushValue(initSt);
         }
 
@@ -3067,16 +3089,17 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
               "internal error: could not determine the number of qubits");
           return false;
         }
-        auto veqTy = quake::VeqType::getUnsized(ctx);
-        auto alloc = quake::AllocaOp::create(builder, loc, veqTy, numQubits);
-        return pushValue(quake::InitializeStateOp::create(builder, loc, veqTy,
-                                                          alloc, initials));
+        auto veqTy = cudaq::quake::VeqType::getUnsized(ctx);
+        auto alloc =
+            cudaq::quake::AllocaOp::create(builder, loc, veqTy, numQubits);
+        return pushValue(cudaq::quake::InitializeStateOp::create(
+            builder, loc, veqTy, alloc, initials));
       }
       if ((ctorName == "qspan" || ctorName == "qview") &&
-          isa<quake::VeqType>(peekValue().getType())) {
+          isa<cudaq::quake::VeqType>(peekValue().getType())) {
         // One of the qspan ctors, which effectively just makes a copy. Here we
         // omit making a copy and just forward the veq argument.
-        assert(isa<quake::VeqType>(ctorTy));
+        assert(isa<cudaq::quake::VeqType>(ctorTy));
         return true;
       }
     }
@@ -3087,7 +3110,7 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
           if (valueStack.empty())
             return false;
           Value v = peekValue();
-          return v && isa<quake::VeqType>(v.getType());
+          return v && isa<cudaq::quake::VeqType>(v.getType());
         }
       }
       return false;
@@ -3150,7 +3173,7 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
       // The `reference_wrapper` class is used to guide the `qudit&` through a
       // container class (like `std::vector`). It is a NOP at the Quake level.
       [[maybe_unused]] auto tosTy = peekValue().getType();
-      assert((isa<quake::RefType, quake::VeqType>(tosTy)));
+      assert((isa<cudaq::quake::RefType, cudaq::quake::VeqType>(tosTy)));
       return true;
     }
 
@@ -3228,9 +3251,9 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
     }
   }
 
-  if (isa<quake::StruqType>(ctorTy)) {
-    if (quake::isConstantQuantumRefType(ctorTy))
-      return pushValue(quake::AllocaOp::create(builder, loc, ctorTy));
+  if (isa<cudaq::quake::StruqType>(ctorTy)) {
+    if (cudaq::quake::isConstantQuantumRefType(ctorTy))
+      return pushValue(cudaq::quake::AllocaOp::create(builder, loc, ctorTy));
     return true;
   }
 
@@ -3244,7 +3267,7 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
 
   if (ctor->isCopyOrMoveConstructor()) {
     // Just walk through copy constructors for quantum struct types.
-    if (isa<quake::StruqType>(ctorTy))
+    if (isa<cudaq::quake::StruqType>(ctorTy))
       return true;
     if (parent->isPOD()) {
       // Copy or move constructor on a POD struct. The value stack should

--- a/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -246,7 +246,7 @@ bool QuakeBridgeVisitor::TraverseCXXForRangeStmt(clang::CXXForRangeStmt *x,
       opt::factory::createMonotonicLoop(builder, loc, initial, idxIters, stepBy,
                                         bodyBuilder);
     }
-  } else if (auto veqTy = dyn_cast<quake::VeqType>(buffer.getType());
+  } else if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(buffer.getType());
              veqTy && veqTy.hasSpecifiedSize()) {
     Value iters = arith::ConstantIntOp::create(
         builder, loc, i64Ty, static_cast<int64_t>(veqTy.getSize()));
@@ -255,7 +255,8 @@ bool QuakeBridgeVisitor::TraverseCXXForRangeStmt(clang::CXXForRangeStmt *x,
       OpBuilder::InsertionGuard guard(builder);
       builder.setInsertionPointToStart(&block);
       Value index = block.getArgument(0);
-      Value ref = quake::ExtractRefOp::create(builder, loc, buffer, index);
+      Value ref =
+          cudaq::quake::ExtractRefOp::create(builder, loc, buffer, index);
       symbolTable.insert(loopVar->getName(), ref);
       if (!TraverseStmt(static_cast<clang::Stmt *>(body)))
         result = false;

--- a/lib/Frontend/nvqpp/ConvertType.cpp
+++ b/lib/Frontend/nvqpp/ConvertType.cpp
@@ -138,7 +138,7 @@ static bool isKernelResultType(Type t) {
 /// (function), or a string.
 static bool isKernelArgumentType(Type t) {
   return isArithmeticType(t) || isComposedArithmeticType(t) ||
-         quake::isQuantumReferenceType(t) || isKernelCallable(t) ||
+         cudaq::quake::isQuantumReferenceType(t) || isKernelCallable(t) ||
          isFunctionCallable(t) ||
          // TODO: move from pointers to a builtin string type.
          cudaq::isCharPointerType(t);
@@ -248,7 +248,7 @@ bool QuakeBridgeVisitor::VisitRecordDecl(clang::RecordDecl *x) {
   bool isStruq = !fieldTys.empty();
   bool quantumMembers = false;
   for (auto ty : fieldTys) {
-    if (quake::isQuantumType(ty))
+    if (cudaq::quake::isQuantumType(ty))
       quantumMembers = true;
     if (!quake::isQuantumReferenceType(ty))
       isStruq = false;
@@ -261,7 +261,7 @@ bool QuakeBridgeVisitor::VisitRecordDecl(clang::RecordDecl *x) {
 
   auto ty = [&]() -> Type {
     if (isStruq)
-      return quake::StruqType::get(ctx, fieldTys);
+      return cudaq::quake::StruqType::get(ctx, fieldTys);
     if (name.empty())
       return cc::StructType::get(ctx, fieldTys, width, alignInBytes);
     return cc::StructType::get(ctx, name, fieldTys, width, alignInBytes);
@@ -270,7 +270,7 @@ bool QuakeBridgeVisitor::VisitRecordDecl(clang::RecordDecl *x) {
   // Do some error analysis on the product type. Check the following:
 
   // - If this is a struq:
-  if (isa<quake::StruqType>(ty)) {
+  if (isa<cudaq::quake::StruqType>(ty)) {
     // -- does it contain invalid C++ types?
     for (auto *field : x->fields()) {
       auto *ty = field->getType().getTypePtr();
@@ -296,15 +296,15 @@ bool QuakeBridgeVisitor::VisitRecordDecl(clang::RecordDecl *x) {
     }
     // -- does it contain contain a struq member? Not allowed.
     for (auto fieldTy : fieldTys)
-      if (isa<quake::StruqType>(fieldTy))
+      if (isa<cudaq::quake::StruqType>(fieldTy))
         reportClangError(x, mangler,
                          "recursive quantum struct types are not allowed.");
   }
 
   // - Is this a struct does it have quantum types? Not allowed.
-  if (!isa<quake::StruqType>(ty))
+  if (!isa<cudaq::quake::StruqType>(ty))
     for (auto fieldTy : fieldTys)
-      if (quake::isQuakeType(fieldTy))
+      if (cudaq::quake::isQuakeType(fieldTy))
         reportClangError(
             x, mangler,
             "hybrid quantum-classical struct types are not allowed.");
@@ -450,7 +450,8 @@ bool QuakeBridgeVisitor::VisitLValueReferenceType(
     return pushType(cc::PointerType::get(builder.getContext()));
   auto eleTy = popType();
   if (isa<cc::CallableType, cc::IndirectCallableType, cc::SpanLikeType,
-          quake::VeqType, quake::RefType, quake::StruqType>(eleTy))
+          cudaq::quake::VeqType, cudaq::quake::RefType,
+          cudaq::quake::StruqType>(eleTy))
     return pushType(eleTy);
   return pushType(cc::PointerType::get(eleTy));
 }
@@ -462,8 +463,9 @@ bool QuakeBridgeVisitor::VisitRValueReferenceType(
   auto eleTy = popType();
   // FIXME: LLVMStructType is promoted as a temporary workaround.
   if (isa<cc::ArrayType, cc::CallableType, cc::IndirectCallableType,
-          cc::SpanLikeType, cc::StructType, quake::VeqType, quake::RefType,
-          quake::StruqType, LLVM::LLVMStructType>(eleTy))
+          cc::SpanLikeType, cc::StructType, cudaq::quake::VeqType,
+          cudaq::quake::RefType, cudaq::quake::StruqType, LLVM::LLVMStructType>(
+          eleTy))
     return pushType(eleTy);
   return pushType(cc::PointerType::get(eleTy));
 }
@@ -471,10 +473,10 @@ bool QuakeBridgeVisitor::VisitRValueReferenceType(
 bool QuakeBridgeVisitor::VisitConstantArrayType(clang::ConstantArrayType *t) {
   auto size = t->getSize().getZExtValue();
   auto ty = popType();
-  if (quake::isQuantumType(ty)) {
+  if (cudaq::quake::isQuantumType(ty)) {
     auto *ctx = builder.getContext();
-    if (ty == quake::RefType::get(ctx))
-      return pushType(quake::VeqType::getUnsized(ctx));
+    if (ty == cudaq::quake::RefType::get(ctx))
+      return pushType(cudaq::quake::VeqType::getUnsized(ctx));
     emitFatalError(builder.getUnknownLoc(),
                    "array element type is not supported");
     return false;
@@ -512,7 +514,7 @@ SmallVector<Type> QuakeBridgeVisitor::lastTypes(unsigned n) {
 
 static bool isReferenceToCudaqStateType(Type t) {
   if (auto ptrTy = dyn_cast<cc::PointerType>(t))
-    return isa<quake::StateType>(ptrTy.getElementType());
+    return isa<cudaq::quake::StateType>(ptrTy.getElementType());
   return false;
 }
 

--- a/lib/Optimizer/Builder/Factory.cpp
+++ b/lib/Optimizer/Builder/Factory.cpp
@@ -117,7 +117,7 @@ Value factory::packIsArrayAndLengthArray(
     // With opaque pointers, both qubit (RefType) and array (VeqType) convert
     // to the same !llvm.ptr type, so we must check the original quake types
     // to distinguish them.
-    bool isQubit = isa<quake::RefType>(originalControls[i].getType());
+    bool isQubit = isa<cudaq::quake::RefType>(originalControls[i].getType());
     if (isQubit) {
       element = zero;
     } else {
@@ -435,7 +435,7 @@ Type factory::convertToHostSideType(Type ty, ModuleOp mod) {
     return cc::StructType::get(ctx, newMembers, structTy.getBitSize(),
                                structTy.getAlignment(), structTy.getPacked());
   }
-  if (auto memrefTy = dyn_cast<quake::VeqType>(ty)) {
+  if (auto memrefTy = dyn_cast<cudaq::quake::VeqType>(ty)) {
     // Use pointer as these must be pass-by-reference.
     return cc::PointerType::get(factory::stlVectorType(
         IntegerType::get(ctx, /*FIXME sizeof a pointer?*/ 64)));

--- a/lib/Optimizer/Builder/Marshal.cpp
+++ b/lib/Optimizer/Builder/Marshal.cpp
@@ -773,10 +773,10 @@ void cudaq::opt::marshal::populateCallbackBuffer(
 
 bool cudaq::opt::marshal::hasLegalType(FunctionType funTy) {
   for (auto ty : funTy.getInputs())
-    if (quake::isQuantumType(ty))
+    if (cudaq::quake::isQuantumType(ty))
       return false;
   for (auto ty : funTy.getResults())
-    if (quake::isQuantumType(ty))
+    if (cudaq::quake::isQuantumType(ty))
       return false;
   return true;
 }

--- a/lib/Optimizer/CAPI/Dialects.cpp
+++ b/lib/Optimizer/CAPI/Dialects.cpp
@@ -11,12 +11,12 @@
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "mlir/InitAllDialects.h"
 
-MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Quake, quake, quake::QuakeDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Quake, quake, cudaq::quake::QuakeDialect)
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(CC, cc, cudaq::cc::CCDialect)
 
 extern "C" void cudaqRegisterAllDialects(MlirContext context) {
   mlir::DialectRegistry registry;
-  registry.insert<quake::QuakeDialect, cudaq::cc::CCDialect>();
+  registry.insert<cudaq::quake::QuakeDialect, cudaq::cc::CCDialect>();
   mlir::registerAllDialects(registry);
   auto *mlirContext = unwrap(context);
   mlirContext->appendDialectRegistry(registry);

--- a/lib/Optimizer/CodeGen/CCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/CCToLLVM.cpp
@@ -590,7 +590,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto inputTy = sizeOfOp.getInputType();
     auto resultTy = sizeOfOp.getType();
-    if (quake::isQuakeType(inputTy) ||
+    if (cudaq::quake::isQuakeType(inputTy) ||
         cudaq::cc::isDynamicallySizedType(inputTy)) {
       // Types that cannot be reified produce the poison op.
       rewriter.replaceOpWithNewOp<cudaq::cc::PoisonOp>(sizeOfOp, resultTy);

--- a/lib/Optimizer/CodeGen/ConvertCCToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/ConvertCCToLLVM.cpp
@@ -73,8 +73,9 @@ void cudaq::opt::populateCCTypeConversions(LLVMTypeConverter *converter) {
       return type;
     return LLVM::LLVMArrayType::get(eleTy, type.getSize());
   });
-  converter->addConversion(
-      [](quake::StateType type) { return factory::stateImplType(type); });
+  converter->addConversion([](cudaq::quake::StateType type) {
+    return factory::stateImplType(type);
+  });
   converter->addConversion([converter](cc::StructType type) -> Type {
     SmallVector<Type> members;
     for (auto t : type.getMembers())

--- a/lib/Optimizer/CodeGen/ConvertToExecMgr.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToExecMgr.cpp
@@ -30,21 +30,21 @@ namespace {
 struct QuakeTypeConverter : public TypeConverter {
   QuakeTypeConverter() {
     addConversion([](Type ty) { return ty; });
-    addConversion([](quake::VeqType ty) {
+    addConversion([](cudaq::quake::VeqType ty) {
       return cudaq::cc::PointerType::get(
           cudaq::opt::getCudaqQubitSpanType(ty.getContext()));
     });
-    addConversion([](quake::RefType ty) {
+    addConversion([](cudaq::quake::RefType ty) {
       return cudaq::cc::PointerType::get(
           cudaq::opt::getCudaqQubitSpanType(ty.getContext()));
     });
-    addConversion([&](quake::StruqType ty) {
+    addConversion([&](cudaq::quake::StruqType ty) {
       SmallVector<Type> mems;
       for (auto m : ty.getMembers())
         mems.push_back(convertType(m));
       return cudaq::cc::StructType::get(ty.getContext(), mems);
     });
-    addConversion([](quake::MeasureType ty) {
+    addConversion([](cudaq::quake::MeasureType ty) {
       return IntegerType::get(ty.getContext(), 64);
     });
   }
@@ -63,7 +63,7 @@ struct QuakeToCCPass : public cudaq::opt::impl::QuakeToCCBase<QuakeToCCPass> {
     target.addLegalDialect<arith::ArithDialect, cudaq::cc::CCDialect,
                            cf::ControlFlowDialect, func::FuncDialect,
                            LLVM::LLVMDialect>();
-    target.addIllegalDialect<quake::QuakeDialect>();
+    target.addIllegalDialect<cudaq::quake::QuakeDialect>();
 
     LLVM_DEBUG(llvm::dbgs() << "Module before:\n"; op.dump());
     if (failed(applyPartialConversion(op, target, std::move(patterns))))

--- a/lib/Optimizer/CodeGen/ConvertToQIR.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIR.cpp
@@ -193,20 +193,20 @@ public:
 } // namespace
 
 void cudaq::opt::initializeTypeConversions(LLVMTypeConverter &typeConverter) {
-  typeConverter.addConversion([](quake::VeqType type) {
+  typeConverter.addConversion([](cudaq::quake::VeqType type) {
     return cg::getLLVMArrayType(type.getContext());
   });
-  typeConverter.addConversion([](quake::RefType type) {
+  typeConverter.addConversion([](cudaq::quake::RefType type) {
     return cg::getLLVMQubitType(type.getContext());
   });
-  typeConverter.addConversion([&](quake::StruqType type) {
+  typeConverter.addConversion([&](cudaq::quake::StruqType type) {
     SmallVector<Type> mems;
     for (auto m : type.getMembers())
       mems.push_back(typeConverter.convertType(m));
     return LLVM::LLVMStructType::getLiteral(type.getContext(), mems,
                                             /*packed=*/false);
   });
-  typeConverter.addConversion([](quake::MeasureType type) {
+  typeConverter.addConversion([](cudaq::quake::MeasureType type) {
     return IntegerType::get(type.getContext(), 1);
   });
   cudaq::opt::populateCCTypeConversions(&typeConverter);

--- a/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -64,7 +64,7 @@ static SmallVector<Value> filterArgs(Operation *op, ValueRange adaptedArgs) {
   SmallVector<Value> result;
   assert(arrAttr.size() == adaptedArgs.size());
   for (auto [tyAttr, argval] : llvm::zip(arrAttr, adaptedArgs))
-    if (quake::isQuantumValueType(cast<TypeAttr>(tyAttr).getValue()))
+    if (cudaq::quake::isQuantumValueType(cast<TypeAttr>(tyAttr).getValue()))
       result.push_back(argval);
   return result;
 }
@@ -129,19 +129,26 @@ struct QIRAPITypeConverter : public TypeConverter {
       auto newSig = cast<FunctionType>(convertType(ty.getSignature()));
       return cudaq::cc::IndirectCallableType::get(newSig);
     });
+    addConversion([&](cudaq::quake::VeqType ty) {
+      return getArrayType(ty.getContext());
+    });
+    addConversion([&](cudaq::quake::RefType ty) {
+      return getQubitType(ty.getContext());
+    });
+    addConversion([&](cudaq::quake::WireType ty) {
+      return getQubitType(ty.getContext());
+    });
+    addConversion([&](cudaq::quake::ControlType ty) {
+      return getQubitType(ty.getContext());
+    });
+    addConversion([&](cudaq::quake::CableType ty) {
+      return getArrayType(ty.getContext());
+    });
+    addConversion([&](cudaq::quake::MeasureType ty) {
+      return getResultType(ty.getContext());
+    });
     addConversion(
-        [&](quake::VeqType ty) { return getArrayType(ty.getContext()); });
-    addConversion(
-        [&](quake::RefType ty) { return getQubitType(ty.getContext()); });
-    addConversion(
-        [&](quake::WireType ty) { return getQubitType(ty.getContext()); });
-    addConversion(
-        [&](quake::ControlType ty) { return getQubitType(ty.getContext()); });
-    addConversion(
-        [&](quake::CableType ty) { return getArrayType(ty.getContext()); });
-    addConversion(
-        [&](quake::MeasureType ty) { return getResultType(ty.getContext()); });
-    addConversion([&](quake::StruqType ty) { return convertStruqType(ty); });
+        [&](cudaq::quake::StruqType ty) { return convertStruqType(ty); });
     // `!cc.measure_handle` is the IR alias of `cudaq::measure_handle`. The
     // QIR API models classical measurement results as `Result*` (legacy
     // `quake.measure`) or as opaque `i64` payloads (handle form). The
@@ -179,7 +186,7 @@ struct QIRAPITypeConverter : public TypeConverter {
     return FunctionType::get(ty.getContext(), args, res);
   }
 
-  Type convertStruqType(quake::StruqType ty) {
+  Type convertStruqType(cudaq::quake::StruqType ty) {
     SmallVector<Type> mems;
     mems.reserve(ty.getNumMembers());
     if (failed(convertTypes(ty.getMembers(), mems)))
@@ -208,15 +215,16 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 template <typename M>
-struct AllocaOpToCallsRewrite : public OpConversionPattern<quake::AllocaOp> {
+struct AllocaOpToCallsRewrite
+    : public OpConversionPattern<cudaq::quake::AllocaOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::AllocaOp alloc, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::AllocaOp alloc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // If this alloc is just returning a qubit
     if (auto resultType =
-            dyn_cast_if_present<quake::RefType>(alloc.getType())) {
+            dyn_cast_if_present<cudaq::quake::RefType>(alloc.getType())) {
       StringRef qirQubitAllocate = cudaq::opt::QIRQubitAllocate;
       Type qubitTy = M::getQubitType(rewriter.getContext());
 
@@ -234,7 +242,7 @@ struct AllocaOpToCallsRewrite : public OpConversionPattern<quake::AllocaOp> {
     Value sizeOperand;
     auto loc = alloc.getLoc();
     if (adaptor.getOperands().empty()) {
-      auto type = cast<quake::VeqType>(alloc.getType());
+      auto type = cast<cudaq::quake::VeqType>(alloc.getType());
       if (!type.hasSpecifiedSize())
         return failure();
       auto constantSize = type.getSize();
@@ -262,11 +270,11 @@ struct AllocaOpToCallsRewrite : public OpConversionPattern<quake::AllocaOp> {
 
 template <typename M>
 struct NullWireOpToCallsRewrite
-    : public OpConversionPattern<quake::NullWireOp> {
+    : public OpConversionPattern<cudaq::quake::NullWireOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::NullWireOp nullwire, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::NullWireOp nullwire, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     StringRef qirQubitAllocate = cudaq::opt::QIRQubitAllocate;
     Type qubitTy = M::getQubitType(rewriter.getContext());
@@ -279,11 +287,11 @@ struct NullWireOpToCallsRewrite
 
 template <typename M>
 struct NullCableOpToCallsRewrite
-    : public OpConversionPattern<quake::NullCableOp> {
+    : public OpConversionPattern<cudaq::quake::NullCableOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::NullCableOp nullcable, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::NullCableOp nullcable, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Create a QIR call to allocate the qubits.
     StringRef qirQubitArrayAllocate = cudaq::opt::QIRArrayQubitAllocateArray;
@@ -292,7 +300,7 @@ struct NullCableOpToCallsRewrite
     // NullCableOp must have a constant size encoded in the `!quake.cable`
     // return type.
     auto loc = nullcable.getLoc();
-    quake::CableType type = nullcable.getType();
+    cudaq::quake::CableType type = nullcable.getType();
     auto constantSize = type.getSize();
     Value sizeOperand =
         arith::ConstantIntOp::create(rewriter, loc, constantSize, 64);
@@ -306,13 +314,14 @@ struct NullCableOpToCallsRewrite
 };
 
 template <typename M>
-struct AllocaOpToIntRewrite : public OpConversionPattern<quake::AllocaOp> {
+struct AllocaOpToIntRewrite
+    : public OpConversionPattern<cudaq::quake::AllocaOp> {
   using OpConversionPattern::OpConversionPattern;
 
   // Precondition: every allocation must have been annotated with a starting
   // index by the preparation phase.
   LogicalResult
-  matchAndRewrite(quake::AllocaOp alloc, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::AllocaOp alloc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!alloc->hasAttr(cudaq::opt::StartingOffsetAttrName))
       return alloc.emitOpError("allocation must be annotated.");
@@ -329,7 +338,7 @@ struct AllocaOpToIntRewrite : public OpConversionPattern<quake::AllocaOp> {
 
     // In the case this is allocating a single qubit, we can just substitute
     // the startingIndex as the qubit value. Voila!
-    if (auto resultType = dyn_cast<quake::RefType>(ty)) {
+    if (auto resultType = dyn_cast<cudaq::quake::RefType>(ty)) {
       Value index =
           arith::ConstantIntOp::create(rewriter, loc, startingOffset, 64);
       auto qubitTy = M::getQubitType(rewriter.getContext());
@@ -337,7 +346,7 @@ struct AllocaOpToIntRewrite : public OpConversionPattern<quake::AllocaOp> {
       return success();
     }
 
-    auto veqTy = dyn_cast<quake::VeqType>(ty);
+    auto veqTy = dyn_cast<cudaq::quake::VeqType>(ty);
     if (!veqTy)
       return alloc.emitOpError("quake alloca must be a veq");
     if (!veqTy.hasSpecifiedSize())
@@ -362,13 +371,14 @@ struct AllocaOpToIntRewrite : public OpConversionPattern<quake::AllocaOp> {
 };
 
 template <typename M>
-struct NullWireOpToIntRewrite : public OpConversionPattern<quake::NullWireOp> {
+struct NullWireOpToIntRewrite
+    : public OpConversionPattern<cudaq::quake::NullWireOp> {
   using OpConversionPattern::OpConversionPattern;
 
   // Precondition: every allocation must have been annotated with a starting
   // index by the preparation phase.
   LogicalResult
-  matchAndRewrite(quake::NullWireOp nullwire, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::NullWireOp nullwire, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto startingOffsetAttr =
         nullwire->getAttr(cudaq::opt::StartingOffsetAttrName);
@@ -390,13 +400,13 @@ struct NullWireOpToIntRewrite : public OpConversionPattern<quake::NullWireOp> {
 
 template <typename M>
 struct NullCableOpToIntRewrite
-    : public OpConversionPattern<quake::NullCableOp> {
+    : public OpConversionPattern<cudaq::quake::NullCableOp> {
   using OpConversionPattern::OpConversionPattern;
 
   // Precondition: every allocation must have been annotated with a starting
   // index by the preparation phase.
   LogicalResult
-  matchAndRewrite(quake::NullCableOp nullcable, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::NullCableOp nullcable, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto startingOffsetAttr =
         nullcable->getAttr(cudaq::opt::StartingOffsetAttrName);
@@ -406,7 +416,7 @@ struct NullCableOpToIntRewrite
     auto loc = nullcable.getLoc();
     auto startingOffset = cast<IntegerAttr>(startingOffsetAttr).getInt();
 
-    quake::CableType cableTy = nullcable.getType();
+    cudaq::quake::CableType cableTy = nullcable.getType();
     if (!cableTy)
       return nullcable.emitOpError("quake null_cable must be a cable");
 
@@ -439,11 +449,12 @@ Type getInitialType(OP op, unsigned off) {
 }
 
 template <typename M>
-struct ApplyNoiseOpRewrite : public OpConversionPattern<quake::ApplyNoiseOp> {
+struct ApplyNoiseOpRewrite
+    : public OpConversionPattern<cudaq::quake::ApplyNoiseOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ApplyNoiseOp noise, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ApplyNoiseOp noise, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = noise.getLoc();
 
@@ -596,7 +607,7 @@ struct ApplyNoiseOpRewrite : public OpConversionPattern<quake::ApplyNoiseOp> {
       origQubitTys.push_back(getInitialType(
           noise, paramOffset + adaptor.getParameters().size() + i));
     for (auto [qb, oa] : llvm::zip(adaptor.getQubits(), origQubitTys)) {
-      if (isa<quake::VeqType>(oa)) {
+      if (isa<cudaq::quake::VeqType>(oa)) {
         auto svec = func::CallOp::create(rewriter, loc, qirArrTy,
                                          cudaq::opt::QISConvertArrayToStdvec,
                                          ValueRange{qb});
@@ -642,7 +653,7 @@ struct QubitHelperConversionPattern : public OpConversionPattern<OP> {
 
   Value wrapQubitAsArray(Location loc, ConversionPatternRewriter &rewriter,
                          Value val, Type origTy) const {
-    if (isa<quake::VeqType>(origTy))
+    if (isa<cudaq::quake::VeqType>(origTy))
       return val;
 
     // Create a QIR array container of 1 element.
@@ -675,8 +686,8 @@ struct QubitHelperConversionPattern : public OpConversionPattern<OP> {
 
 template <typename M>
 struct ConcatOpRewrite
-    : public QubitHelperConversionPattern<M, quake::ConcatOp> {
-  using Base = QubitHelperConversionPattern<M, quake::ConcatOp>;
+    : public QubitHelperConversionPattern<M, cudaq::quake::ConcatOp> {
+  using Base = QubitHelperConversionPattern<M, cudaq::quake::ConcatOp>;
   using Base::Base;
 
   // For this rewrite, we walk the list of operands (if any) and for each
@@ -687,7 +698,7 @@ struct ConcatOpRewrite
   // This algorithm will generate a linear number of concat calls for the number
   // of operands.
   LogicalResult
-  matchAndRewrite(quake::ConcatOp concat, Base::OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ConcatOp concat, Base::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (adaptor.getOperands().empty()) {
       rewriter.eraseOp(concat);
@@ -718,13 +729,13 @@ struct ConcatOpRewrite
 
 template <typename M>
 struct BundleCableOpRewrite
-    : public QubitHelperConversionPattern<M, quake::BundleCableOp> {
-  using Base = QubitHelperConversionPattern<M, quake::BundleCableOp>;
+    : public QubitHelperConversionPattern<M, cudaq::quake::BundleCableOp> {
+  using Base = QubitHelperConversionPattern<M, cudaq::quake::BundleCableOp>;
   using Base::Base;
 
   // Note that this is the same as quake.concat.
   LogicalResult
-  matchAndRewrite(quake::BundleCableOp bundle, Base::OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::BundleCableOp bundle, Base::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (adaptor.getOperands().empty()) {
       rewriter.eraseOp(bundle);
@@ -750,14 +761,14 @@ struct BundleCableOpRewrite
   }
 };
 
-struct DeallocOpRewrite : public OpConversionPattern<quake::DeallocOp> {
+struct DeallocOpRewrite : public OpConversionPattern<cudaq::quake::DeallocOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::DeallocOp dealloc, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::DeallocOp dealloc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto ty = dealloc.getReference().getType();
-    StringRef qirFuncName = isa<quake::VeqType>(ty)
+    StringRef qirFuncName = isa<cudaq::quake::VeqType>(ty)
                                 ? cudaq::opt::QIRArrayQubitReleaseArray
                                 : cudaq::opt::QIRArrayQubitReleaseQubit;
     rewriter.replaceOpWithNewOp<func::CallOp>(dealloc, TypeRange{}, qirFuncName,
@@ -766,14 +777,14 @@ struct DeallocOpRewrite : public OpConversionPattern<quake::DeallocOp> {
   }
 };
 
-struct SinkOpRewrite : public OpConversionPattern<quake::SinkOp> {
+struct SinkOpRewrite : public OpConversionPattern<cudaq::quake::SinkOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::SinkOp sink, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::SinkOp sink, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto ty = sink.getTarget().getType();
-    StringRef qirFuncName = isa<quake::CableType>(ty)
+    StringRef qirFuncName = isa<cudaq::quake::CableType>(ty)
                                 ? cudaq::opt::QIRArrayQubitReleaseArray
                                 : cudaq::opt::QIRArrayQubitReleaseQubit;
     rewriter.replaceOpWithNewOp<func::CallOp>(sink, TypeRange{}, qirFuncName,
@@ -795,15 +806,15 @@ struct DeallocLikeErase : public OpConversionPattern<OP> {
   }
 };
 
-using DeallocOpErase = DeallocLikeErase<quake::DeallocOp>;
-using SinkOpErase = DeallocLikeErase<quake::SinkOp>;
+using DeallocOpErase = DeallocLikeErase<cudaq::quake::DeallocOp>;
+using SinkOpErase = DeallocLikeErase<cudaq::quake::SinkOp>;
 
 struct DiscriminateOpRewrite
-    : public OpConversionPattern<quake::DiscriminateOp> {
+    : public OpConversionPattern<cudaq::quake::DiscriminateOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::DiscriminateOp disc, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::DiscriminateOp disc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = disc.getLoc();
     Value m = adaptor.getMeasurement();
@@ -819,11 +830,11 @@ enum struct QirVersion { version_0_1, version_1_0 };
 
 template <typename M>
 struct DiscriminateOpToCallRewrite
-    : public OpConversionPattern<quake::DiscriminateOp> {
+    : public OpConversionPattern<cudaq::quake::DiscriminateOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::DiscriminateOp disc, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::DiscriminateOp disc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = disc.getLoc();
     // Handle-form callers feed `quake.discriminate` an `i64` payload (the
@@ -862,7 +873,8 @@ struct DiscriminateOpToCallRewrite
 };
 
 template <typename M>
-struct ExtractRefOpRewrite : public OpConversionPattern<quake::ExtractRefOp> {
+struct ExtractRefOpRewrite
+    : public OpConversionPattern<cudaq::quake::ExtractRefOp> {
   using OpConversionPattern::OpConversionPattern;
 
   // There are two cases depending on which flavor of QIR is being generated.
@@ -871,7 +883,7 @@ struct ExtractRefOpRewrite : public OpConversionPattern<quake::ExtractRefOp> {
   // For the profile QIRs, we replace this with a `cc.extract_value` operation,
   // which will be canonicalized into a constant.
   LogicalResult
-  matchAndRewrite(quake::ExtractRefOp extract, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ExtractRefOp extract, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = extract.getLoc();
     auto veq = adaptor.getVeq();
@@ -912,7 +924,8 @@ struct ExtractRefOpRewrite : public OpConversionPattern<quake::ExtractRefOp> {
 };
 
 template <typename M>
-struct SplitCableOpRewrite : public OpConversionPattern<quake::SplitCableOp> {
+struct SplitCableOpRewrite
+    : public OpConversionPattern<cudaq::quake::SplitCableOp> {
   using OpConversionPattern::OpConversionPattern;
 
   // There are two cases depending on which flavor of QIR is being generated.
@@ -921,7 +934,7 @@ struct SplitCableOpRewrite : public OpConversionPattern<quake::SplitCableOp> {
   // For the profile QIRs, we replace this with a `cc.extract_value` operation,
   // which will be canonicalized into a constant.
   LogicalResult
-  matchAndRewrite(quake::SplitCableOp split, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::SplitCableOp split, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = split.getLoc();
     auto cab = adaptor.getCable();
@@ -929,7 +942,7 @@ struct SplitCableOpRewrite : public OpConversionPattern<quake::SplitCableOp> {
 
     SmallVector<Value> qubits;
     std::uint64_t size =
-        cast<quake::CableType>(getInitialType(split, 0)).getSize();
+        cast<cudaq::quake::CableType>(getInitialType(split, 0)).getSize();
     for (std::uint64_t i = 0; i < size; ++i) {
       Value index = arith::ConstantIntOp::create(rewriter, loc, i, 64);
       auto call = func::CallOp::create(
@@ -943,11 +956,12 @@ struct SplitCableOpRewrite : public OpConversionPattern<quake::SplitCableOp> {
   }
 };
 
-struct GetMemberOpRewrite : public OpConversionPattern<quake::GetMemberOp> {
+struct GetMemberOpRewrite
+    : public OpConversionPattern<cudaq::quake::GetMemberOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::GetMemberOp member, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::GetMemberOp member, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto toTy = getTypeConverter()->convertType(member.getType());
     std::int32_t position = adaptor.getIndex();
@@ -957,11 +971,11 @@ struct GetMemberOpRewrite : public OpConversionPattern<quake::GetMemberOp> {
   }
 };
 
-struct VeqSizeOpRewrite : public OpConversionPattern<quake::VeqSizeOp> {
+struct VeqSizeOpRewrite : public OpConversionPattern<cudaq::quake::VeqSizeOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::VeqSizeOp veqsize, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::VeqSizeOp veqsize, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<func::CallOp>(
         veqsize, TypeRange{veqsize.getType()}, cudaq::opt::QIRArrayGetSize,
@@ -970,11 +984,12 @@ struct VeqSizeOpRewrite : public OpConversionPattern<quake::VeqSizeOp> {
   }
 };
 
-struct MakeStruqOpRewrite : public OpConversionPattern<quake::MakeStruqOp> {
+struct MakeStruqOpRewrite
+    : public OpConversionPattern<cudaq::quake::MakeStruqOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::MakeStruqOp mkstruq, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::MakeStruqOp mkstruq, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = mkstruq.getLoc();
     auto *ctx = rewriter.getContext();
@@ -1021,10 +1036,10 @@ struct QmemRAIIOpRewrite : public OpConversionPattern<cudaq::codegen::RAIIOp> {
     // Cascade to set functionName.
     StringRef functionName;
     Type ptrTy;
-    if (isa<quake::StateType>(eleTy)) {
+    if (isa<cudaq::quake::StateType>(eleTy)) {
       functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithCudaqStatePtr;
       ptrTy = cudaq::cc::PointerType::get(
-          quake::StateType::get(rewriter.getContext()));
+          cudaq::quake::StateType::get(rewriter.getContext()));
     } else if (eleTy == rewriter.getF64Type()) {
       if (fromComplex) {
         functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithStateComplex64;
@@ -1055,7 +1070,7 @@ struct QmemRAIIOpRewrite : public OpConversionPattern<cudaq::codegen::RAIIOp> {
 
     Value sizeOperand;
     if (!adaptor.getAllocSize()) {
-      auto type = dyn_cast<quake::VeqType>(allocTy);
+      auto type = dyn_cast<cudaq::quake::VeqType>(allocTy);
       auto constantSize = type ? type.getSize() : 1;
       sizeOperand =
           arith::ConstantIntOp::create(rewriter, loc, constantSize, 64);
@@ -1078,11 +1093,12 @@ struct QmemRAIIOpRewrite : public OpConversionPattern<cudaq::codegen::RAIIOp> {
   }
 };
 
-struct RelaxSizeOpErase : public OpConversionPattern<quake::RelaxSizeOp> {
+struct RelaxSizeOpErase
+    : public OpConversionPattern<cudaq::quake::RelaxSizeOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::RelaxSizeOp relax, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::RelaxSizeOp relax, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOp(relax, relax.getInputVec());
     return success();
@@ -1090,11 +1106,11 @@ struct RelaxSizeOpErase : public OpConversionPattern<quake::RelaxSizeOp> {
 };
 
 template <typename M>
-struct SubveqOpRewrite : public OpConversionPattern<quake::SubVeqOp> {
+struct SubveqOpRewrite : public OpConversionPattern<cudaq::quake::SubVeqOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::SubVeqOp subveq, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::SubVeqOp subveq, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = subveq.getLoc();
 
@@ -1135,11 +1151,11 @@ struct SubveqOpRewrite : public OpConversionPattern<quake::SubVeqOp> {
   }
 };
 
-struct WrapOpErase : public OpConversionPattern<quake::WrapOp> {
+struct WrapOpErase : public OpConversionPattern<cudaq::quake::WrapOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::WrapOp wrap, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::WrapOp wrap, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // The wire value and the ref value ought to be the same.
     LLVM_DEBUG({
@@ -1152,11 +1168,11 @@ struct WrapOpErase : public OpConversionPattern<quake::WrapOp> {
   }
 };
 
-struct UnwrapOpErase : public OpConversionPattern<quake::UnwrapOp> {
+struct UnwrapOpErase : public OpConversionPattern<cudaq::quake::UnwrapOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::UnwrapOp unwrap, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::UnwrapOp unwrap, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOp(unwrap, adaptor.getRefValue());
     return success();
@@ -1169,12 +1185,15 @@ struct UnwrapOpErase : public OpConversionPattern<quake::UnwrapOp> {
 
 template <typename M>
 struct CustomUnitaryOpPattern
-    : public QubitHelperConversionPattern<M, quake::CustomUnitarySymbolOp> {
-  using Base = QubitHelperConversionPattern<M, quake::CustomUnitarySymbolOp>;
+    : public QubitHelperConversionPattern<M,
+                                          cudaq::quake::CustomUnitarySymbolOp> {
+  using Base =
+      QubitHelperConversionPattern<M, cudaq::quake::CustomUnitarySymbolOp>;
   using Base::Base;
 
   LogicalResult
-  matchAndRewrite(quake::CustomUnitarySymbolOp unitary, Base::OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::CustomUnitarySymbolOp unitary,
+                  Base::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!unitary.getParameters().empty())
       return unitary.emitOpError(
@@ -1272,12 +1291,12 @@ struct CustomUnitaryOpPattern
 
 template <typename M>
 struct ExpPauliOpPattern
-    : public QubitHelperConversionPattern<M, quake::ExpPauliOp> {
-  using Base = QubitHelperConversionPattern<M, quake::ExpPauliOp>;
+    : public QubitHelperConversionPattern<M, cudaq::quake::ExpPauliOp> {
+  using Base = QubitHelperConversionPattern<M, cudaq::quake::ExpPauliOp>;
   using Base::Base;
 
   LogicalResult
-  matchAndRewrite(quake::ExpPauliOp pauli, Base::OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ExpPauliOp pauli, Base::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = pauli.getLoc();
     // Make sure that apply-control-negations pass was run.
@@ -1288,11 +1307,12 @@ struct ExpPauliOpPattern
     if (adaptor.getControls().empty()) {
       // do nothing
     } else if (adaptor.getControls().size() > 1 ||
-               !isa<quake::VeqType>(getInitialType(pauli, firstControlIndex))) {
+               !isa<cudaq::quake::VeqType>(
+                   getInitialType(pauli, firstControlIndex))) {
       // Concat all controls into a single Array.
       Type arrayTy = M::getArrayType(rewriter.getContext());
       auto wrapIfQubit = [&](Value adaptorVal, Type origTy) {
-        if (isa<quake::VeqType>(origTy))
+        if (isa<cudaq::quake::VeqType>(origTy))
           return adaptorVal;
         return Base::wrapQubitAsArray(loc, rewriter, adaptorVal, origTy);
       };
@@ -1318,7 +1338,8 @@ struct ExpPauliOpPattern
     const auto firstTargetIndex =
         firstControlIndex + adaptor.getControls().size();
     Type firstTy = getInitialType(pauli, firstTargetIndex);
-    if (adaptor.getTargets().size() > 1 || !isa<quake::VeqType>(firstTy)) {
+    if (adaptor.getTargets().size() > 1 ||
+        !isa<cudaq::quake::VeqType>(firstTy)) {
       // Concat all targets into a single Array.
       Type arrayTy = M::getArrayType(rewriter.getContext());
       Value firstOperand = adaptor.getTargets().front();
@@ -1451,11 +1472,11 @@ struct ExpPauliOpPattern
 };
 
 template <typename M>
-struct MeasurementOpPattern : public OpConversionPattern<quake::MzOp> {
+struct MeasurementOpPattern : public OpConversionPattern<cudaq::quake::MzOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::MzOp mz, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::MzOp mz, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = mz.getLoc();
     auto regNameAttr = dyn_cast<StringAttr>(mz.getRegisterNameAttr());
@@ -1557,11 +1578,11 @@ struct MeasurementOpPattern : public OpConversionPattern<quake::MzOp> {
 };
 
 template <typename M>
-struct ResetOpPattern : public OpConversionPattern<quake::ResetOp> {
+struct ResetOpPattern : public OpConversionPattern<cudaq::quake::ResetOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ResetOp reset, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ResetOp reset, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Get the reset QIR function name
     auto qirFunctionName = M::getQIRReset();
@@ -1581,14 +1602,14 @@ struct ResetOpPattern : public OpConversionPattern<quake::ResetOp> {
   }
 };
 
-struct ApplyOpTrap : public OpConversionPattern<quake::ApplyOp> {
+struct ApplyOpTrap : public OpConversionPattern<cudaq::quake::ApplyOp> {
   using OpConversionPattern::OpConversionPattern;
 
   // If we see a `quake.apply` operation at this point, something has gone wrong
   // and we were unable to autogenerate the function that we should be calling.
   // So we replace the apply with a trap and the results with poison values.
   LogicalResult
-  matchAndRewrite(quake::ApplyOp apply, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ApplyOp apply, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = apply.getLoc();
     Value zero = arith::ConstantIntOp::create(rewriter, loc, 0, 64);
@@ -1604,11 +1625,12 @@ struct ApplyOpTrap : public OpConversionPattern<quake::ApplyOp> {
   }
 };
 
-struct CallByRefOpRewrite : public OpConversionPattern<quake::CallByRefOp> {
+struct CallByRefOpRewrite
+    : public OpConversionPattern<cudaq::quake::CallByRefOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::CallByRefOp call, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::CallByRefOp call, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Replace this with a func.call, but forward the quantum arguments to the
     // uses.
@@ -1618,7 +1640,7 @@ struct CallByRefOpRewrite : public OpConversionPattern<quake::CallByRefOp> {
 
     SmallVector<Value> quantumArgs;
     for (auto [valarg, qirarg] : llvm::zip(call.getArgs(), adaptor.getArgs()))
-      if (quake::isQuantumValueType(valarg.getType()))
+      if (cudaq::quake::isQuantumValueType(valarg.getType()))
         quantumArgs.push_back(qirarg);
 
     auto refCall =
@@ -1748,14 +1770,14 @@ struct QuantumGatePattern : public OpConversionPattern<OP> {
       if (op.getIsAdj()) {
         for (std::size_t i = 0; i < opParams.size(); ++i)
           opParams[i] = arith::NegFOp::create(rewriter, loc, opParams[i]);
-        if constexpr (std::is_same_v<OP, quake::U2Op>) {
+        if constexpr (std::is_same_v<OP, cudaq::quake::U2Op>) {
           std::swap(opParams[0], opParams[1]);
           auto fltTy = cast<FloatType>(opParams[0].getType());
           Value pi = arith::ConstantFloatOp::create(rewriter, loc, fltTy,
                                                     llvm::APFloat{M_PI});
           opParams[0] = arith::SubFOp::create(rewriter, loc, opParams[0], pi);
           opParams[1] = arith::AddFOp::create(rewriter, loc, opParams[1], pi);
-        } else if constexpr (std::is_same_v<OP, quake::U3Op>) {
+        } else if constexpr (std::is_same_v<OP, cudaq::quake::U3Op>) {
           // swap the 2nd and 3rd parameter for correctness
           std::swap(opParams[1], opParams[2]);
         }
@@ -1875,7 +1897,7 @@ struct QuantumGatePattern : public OpConversionPattern<OP> {
           return strTy.isIdentified() && strTy.getName() == "Array";
       return false;
     };
-    return isa<quake::VeqType>(ty) || alreadyConverted(ty);
+    return isa<cudaq::quake::VeqType>(ty) || alreadyConverted(ty);
   }
 
   static bool conformsToIntendedCall(std::size_t numControls, Type ctrlTy,
@@ -1884,20 +1906,20 @@ struct QuantumGatePattern : public OpConversionPattern<OP> {
       return false;
     auto trivialName = specializeFunctionName(op, qirFunctionName, numControls);
     const bool nameChanged = trivialName != qirFunctionName;
-    if (nameChanged && !isa<quake::VeqType>(ctrlTy))
+    if (nameChanged && !isa<cudaq::quake::VeqType>(ctrlTy))
       return true;
-    return !nameChanged && isa<quake::VeqType>(ctrlTy);
+    return !nameChanged && isa<cudaq::quake::VeqType>(ctrlTy);
   }
 
   static StringRef specializeFunctionName(OP op, StringRef funcName,
                                           std::size_t numCtrls) {
     // Last resort to change the names of particular functions from the
     // general scheme to specialized names under the right conditions.
-    if constexpr (std::is_same_v<OP, quake::XOp> && M::convertToCNot) {
+    if constexpr (std::is_same_v<OP, cudaq::quake::XOp> && M::convertToCNot) {
       if (numCtrls == 1)
         return cudaq::opt::QIRCnot;
     }
-    if constexpr (std::is_same_v<OP, quake::ZOp> && M::convertToCZ) {
+    if constexpr (std::is_same_v<OP, cudaq::quake::ZOp> && M::convertToCZ) {
       if (numCtrls == 1)
         return cudaq::opt::QIRCZ;
     }
@@ -2206,20 +2228,20 @@ struct FullQIR {
         ApplyNoiseOpRewrite<Self>,
 
         /* Regular quantum operators. */
-        QuantumGatePattern<Self, quake::HOp>,
-        QuantumGatePattern<Self, quake::PhasedRxOp>,
-        QuantumGatePattern<Self, quake::R1Op>,
-        QuantumGatePattern<Self, quake::RxOp>,
-        QuantumGatePattern<Self, quake::RyOp>,
-        QuantumGatePattern<Self, quake::RzOp>,
-        QuantumGatePattern<Self, quake::SOp>,
-        QuantumGatePattern<Self, quake::SwapOp>,
-        QuantumGatePattern<Self, quake::TOp>,
-        QuantumGatePattern<Self, quake::U2Op>,
-        QuantumGatePattern<Self, quake::U3Op>,
-        QuantumGatePattern<Self, quake::XOp>,
-        QuantumGatePattern<Self, quake::YOp>,
-        QuantumGatePattern<Self, quake::ZOp>>(typeConverter, ctx);
+        QuantumGatePattern<Self, cudaq::quake::HOp>,
+        QuantumGatePattern<Self, cudaq::quake::PhasedRxOp>,
+        QuantumGatePattern<Self, cudaq::quake::R1Op>,
+        QuantumGatePattern<Self, cudaq::quake::RxOp>,
+        QuantumGatePattern<Self, cudaq::quake::RyOp>,
+        QuantumGatePattern<Self, cudaq::quake::RzOp>,
+        QuantumGatePattern<Self, cudaq::quake::SOp>,
+        QuantumGatePattern<Self, cudaq::quake::SwapOp>,
+        QuantumGatePattern<Self, cudaq::quake::TOp>,
+        QuantumGatePattern<Self, cudaq::quake::U2Op>,
+        QuantumGatePattern<Self, cudaq::quake::U3Op>,
+        QuantumGatePattern<Self, cudaq::quake::XOp>,
+        QuantumGatePattern<Self, cudaq::quake::YOp>,
+        QuantumGatePattern<Self, cudaq::quake::ZOp>>(typeConverter, ctx);
     commonQuakeHandlingPatterns(patterns, typeConverter, ctx);
     commonClassicalHandlingPatterns(patterns, typeConverter, ctx);
   }
@@ -2275,20 +2297,20 @@ struct AnyProfileQIR {
         ResetOpPattern<Self>, ApplyNoiseOpRewrite<Self>,
 
         /* Regular quantum operators. */
-        QuantumGatePattern<Self, quake::HOp>,
-        QuantumGatePattern<Self, quake::PhasedRxOp>,
-        QuantumGatePattern<Self, quake::R1Op>,
-        QuantumGatePattern<Self, quake::RxOp>,
-        QuantumGatePattern<Self, quake::RyOp>,
-        QuantumGatePattern<Self, quake::RzOp>,
-        QuantumGatePattern<Self, quake::SOp>,
-        QuantumGatePattern<Self, quake::SwapOp>,
-        QuantumGatePattern<Self, quake::TOp>,
-        QuantumGatePattern<Self, quake::U2Op>,
-        QuantumGatePattern<Self, quake::U3Op>,
-        QuantumGatePattern<Self, quake::XOp>,
-        QuantumGatePattern<Self, quake::YOp>,
-        QuantumGatePattern<Self, quake::ZOp>>(typeConverter, ctx);
+        QuantumGatePattern<Self, cudaq::quake::HOp>,
+        QuantumGatePattern<Self, cudaq::quake::PhasedRxOp>,
+        QuantumGatePattern<Self, cudaq::quake::R1Op>,
+        QuantumGatePattern<Self, cudaq::quake::RxOp>,
+        QuantumGatePattern<Self, cudaq::quake::RyOp>,
+        QuantumGatePattern<Self, cudaq::quake::RzOp>,
+        QuantumGatePattern<Self, cudaq::quake::SOp>,
+        QuantumGatePattern<Self, cudaq::quake::SwapOp>,
+        QuantumGatePattern<Self, cudaq::quake::TOp>,
+        QuantumGatePattern<Self, cudaq::quake::U2Op>,
+        QuantumGatePattern<Self, cudaq::quake::U3Op>,
+        QuantumGatePattern<Self, cudaq::quake::XOp>,
+        QuantumGatePattern<Self, cudaq::quake::YOp>,
+        QuantumGatePattern<Self, cudaq::quake::ZOp>>(typeConverter, ctx);
     commonQuakeHandlingPatterns(patterns, typeConverter, ctx);
     commonClassicalHandlingPatterns(patterns, typeConverter, ctx);
   }
@@ -2375,7 +2397,7 @@ struct QuakeToQIRAPIPass
     target.addLegalDialect<arith::ArithDialect, cudaq::cc::CCDialect,
                            cf::ControlFlowDialect, func::FuncDialect,
                            LLVM::LLVMDialect>();
-    target.addIllegalDialect<quake::QuakeDialect,
+    target.addIllegalDialect<cudaq::quake::QuakeDialect,
                              cudaq::codegen::CodeGenDialect>();
     target.addLegalOp<cudaq::codegen::MaterializeConstantArrayOp>();
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp fn) {
@@ -2471,7 +2493,8 @@ struct QuakeToQIRAPIPass
           return true;
       return false;
     }
-    return quake::isQuakeType(ty) || isa<cudaq::cc::MeasureHandleType>(ty);
+    return cudaq::quake::isQuakeType(ty) ||
+           isa<cudaq::cc::MeasureHandleType>(ty);
   }
 
   void runOnOperation() override {
@@ -2596,7 +2619,7 @@ struct QuakeToQIRAPIPrepPass
       OpBuilder builder(module);
       module.walk([&](func::FuncOp func) {
         int counter = 0;
-        func.walk([&](quake::MzOp mz) {
+        func.walk([&](cudaq::quake::MzOp mz) {
           guaranteeMzIsLabeled(mz, counter, builder);
         });
       });
@@ -2618,18 +2641,18 @@ struct QuakeToQIRAPIPrepPass
           // value. This ought to handle both reference and value semantics. If
           // the value semantics is using wire sets, no (redundant) annotation
           // is needed.
-          if (auto alloc = dyn_cast<quake::AllocaOp>(op)) {
+          if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(op)) {
             auto allocTy = alloc.getType();
-            if (isa<quake::RefType>(allocTy)) {
+            if (isa<cudaq::quake::RefType>(allocTy)) {
               alloc->setAttr(cudaq::opt::StartingOffsetAttrName,
                              builder.getI64IntegerAttr(totalQubits++));
               return;
             }
-            if (!isa<quake::VeqType>(allocTy)) {
+            if (!isa<cudaq::quake::VeqType>(allocTy)) {
               alloc.emitOpError("must be veq type.");
               return;
             }
-            auto veqTy = cast<quake::VeqType>(allocTy);
+            auto veqTy = cast<cudaq::quake::VeqType>(allocTy);
             if (!veqTy.hasSpecifiedSize()) {
               alloc.emitOpError("must have a constant size.");
               return;
@@ -2639,19 +2662,19 @@ struct QuakeToQIRAPIPrepPass
             totalQubits += veqTy.getSize();
             return;
           }
-          if (auto nw = dyn_cast<quake::NullWireOp>(op)) {
+          if (auto nw = dyn_cast<cudaq::quake::NullWireOp>(op)) {
             nw->setAttr(cudaq::opt::StartingOffsetAttrName,
                         builder.getI64IntegerAttr(totalQubits++));
             return;
           }
-          if (auto nc = dyn_cast<quake::NullCableOp>(op)) {
-            quake::CableType cableTy = nc.getType();
+          if (auto nc = dyn_cast<cudaq::quake::NullCableOp>(op)) {
+            cudaq::quake::CableType cableTy = nc.getType();
             nc->setAttr(cudaq::opt::StartingOffsetAttrName,
                         builder.getI64IntegerAttr(totalQubits));
             totalQubits += cableTy.getSize();
             return;
           }
-          if (auto bw = dyn_cast<quake::BorrowWireOp>(op)) {
+          if (auto bw = dyn_cast<cudaq::quake::BorrowWireOp>(op)) {
             [[maybe_unused]] StringRef name = bw.getSetName();
             [[maybe_unused]] std::int32_t wire = bw.getIdentity();
             bw.emitOpError("not implemented.");
@@ -2659,7 +2682,7 @@ struct QuakeToQIRAPIPrepPass
           }
 
           // For each mz, we want to assign it a result index.
-          if (auto mz = dyn_cast<quake::MzOp>(op)) {
+          if (auto mz = dyn_cast<cudaq::quake::MzOp>(op)) {
             // Verify there is exactly one qubit being measured.
             if (mz.getTargets().empty() ||
                 std::distance(mz.getTargets().begin(), mz.getTargets().end()) !=
@@ -2708,11 +2731,12 @@ struct QuakeToQIRAPIPrepPass
 
     auto *ctx = module.getContext();
     module.walk([&](Operation *op) {
-      if (std::all_of(op->getResultTypes().begin(), op->getResultTypes().end(),
-                      [&](Type ty) { return !quake::isQuantumType(ty); }) &&
-          std::all_of(op->getOperandTypes().begin(),
-                      op->getOperandTypes().end(),
-                      [&](Type ty) { return !quake::isQuantumType(ty); }))
+      if (std::all_of(
+              op->getResultTypes().begin(), op->getResultTypes().end(),
+              [&](Type ty) { return !cudaq::quake::isQuantumType(ty); }) &&
+          std::all_of(
+              op->getOperandTypes().begin(), op->getOperandTypes().end(),
+              [&](Type ty) { return !cudaq::quake::isQuantumType(ty); }))
         return;
       SmallVector<Attribute> typeAttrs;
       typeAttrs.reserve(op->getOperands().size());
@@ -2735,7 +2759,8 @@ struct QuakeToQIRAPIPrepPass
     return cudaq::opt::qir0_1::RequiredResultsAttrName;
   }
 
-  void guaranteeMzIsLabeled(quake::MzOp mz, int &counter, OpBuilder &builder) {
+  void guaranteeMzIsLabeled(cudaq::quake::MzOp mz, int &counter,
+                            OpBuilder &builder) {
     if (mz.getRegisterNameAttr()) {
       mz->setAttr(cudaq::opt::MzAssignedNameAttrName, builder.getUnitAttr());
       return;

--- a/lib/Optimizer/CodeGen/DelayMeasurements.cpp
+++ b/lib/Optimizer/CodeGen/DelayMeasurements.cpp
@@ -86,7 +86,7 @@ struct DelayMeasurementsPass
       }
 
       if (op.hasTrait<cudaq::QuantumMeasure>() || isa<func::ReturnOp>(op) ||
-          isa<quake::DeallocOp>(op)) {
+          isa<cudaq::quake::DeallocOp>(op)) {
         addOpAndUsersToList(&op, opsToMoveToEnd);
         continue;
       }

--- a/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToCodegen.cpp
@@ -22,14 +22,15 @@ namespace {
 // Code generation: converts the Quake IR to Codegen IR.
 //===----------------------------------------------------------------------===//
 
-class CodeGenRAIIPattern : public OpRewritePattern<quake::InitializeStateOp> {
+class CodeGenRAIIPattern
+    : public OpRewritePattern<cudaq::quake::InitializeStateOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::InitializeStateOp init,
+  LogicalResult matchAndRewrite(cudaq::quake::InitializeStateOp init,
                                 PatternRewriter &rewriter) const override {
     Value mem = init.getTargets();
-    auto alloc = mem.getDefiningOp<quake::AllocaOp>();
+    auto alloc = mem.getDefiningOp<cudaq::quake::AllocaOp>();
     if (!alloc)
       return init.emitOpError("init_state must have alloca as input");
     rewriter.replaceOpWithNewOp<cudaq::codegen::RAIIOp>(
@@ -64,11 +65,12 @@ public:
   }
 };
 
-class CreateStateOpPattern : public OpRewritePattern<quake::CreateStateOp> {
+class CreateStateOpPattern
+    : public OpRewritePattern<cudaq::quake::CreateStateOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::CreateStateOp createStateOp,
+  LogicalResult matchAndRewrite(cudaq::quake::CreateStateOp createStateOp,
                                 PatternRewriter &rewriter) const override {
     auto module = createStateOp->getParentOfType<ModuleOp>();
     auto loc = createStateOp.getLoc();
@@ -103,7 +105,7 @@ public:
     auto result = irBuilder.loadIntrinsic(module, createStateFunc);
     assert(succeeded(result) && "loading intrinsic should never fail");
 
-    auto stateTy = quake::StateType::get(ctx);
+    auto stateTy = cudaq::quake::StateType::get(ctx);
     auto statePtrTy = cudaq::cc::PointerType::get(stateTy);
     auto i8PtrTy = cudaq::cc::PointerType::get(rewriter.getI8Type());
     auto cast = cudaq::cc::CastOp::create(rewriter, loc, i8PtrTy, buffer);
@@ -114,11 +116,12 @@ public:
   }
 };
 
-class DeleteStateOpPattern : public OpRewritePattern<quake::DeleteStateOp> {
+class DeleteStateOpPattern
+    : public OpRewritePattern<cudaq::quake::DeleteStateOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::DeleteStateOp deleteStateOp,
+  LogicalResult matchAndRewrite(cudaq::quake::DeleteStateOp deleteStateOp,
                                 PatternRewriter &rewriter) const override {
     auto module = deleteStateOp->getParentOfType<ModuleOp>();
     auto ctx = deleteStateOp.getContext();
@@ -136,12 +139,13 @@ public:
 };
 
 class GetNumberOfQubitsOpPattern
-    : public OpRewritePattern<quake::GetNumberOfQubitsOp> {
+    : public OpRewritePattern<cudaq::quake::GetNumberOfQubitsOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::GetNumberOfQubitsOp getNumQubitsOp,
-                                PatternRewriter &rewriter) const override {
+  LogicalResult
+  matchAndRewrite(cudaq::quake::GetNumberOfQubitsOp getNumQubitsOp,
+                  PatternRewriter &rewriter) const override {
     auto module = getNumQubitsOp->getParentOfType<ModuleOp>();
     auto ctx = getNumQubitsOp.getContext();
     auto state = getNumQubitsOp.getOperand();

--- a/lib/Optimizer/CodeGen/QuakeToExecMgr.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToExecMgr.cpp
@@ -98,18 +98,18 @@ namespace {
 /// span of non-constant size.
 /// All support functions will be declared as intrinsics. Some will be
 /// implemented in C++ and others in the intrinsics table.
-class AllocaOpRewrite : public OpConversionPattern<quake::AllocaOp> {
+class AllocaOpRewrite : public OpConversionPattern<cudaq::quake::AllocaOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::AllocaOp alloca, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::AllocaOp alloca, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = alloca.getLoc();
     auto i64Ty = rewriter.getI64Type();
     auto qspanTy = cudaq::opt::getCudaqQubitSpanType(rewriter.getContext());
     Value qspan = cudaq::cc::AllocaOp::create(rewriter, loc, qspanTy);
-    if (auto resultType = dyn_cast<quake::RefType>(alloca.getType())) {
+    if (auto resultType = dyn_cast<cudaq::quake::RefType>(alloca.getType())) {
       auto one = arith::ConstantIntOp::create(rewriter, loc, 1, 64);
       Value buffer = cudaq::cc::AllocaOp::create(rewriter, loc, i64Ty, one);
       auto call = func::CallOp::create(
@@ -125,7 +125,7 @@ public:
     } else {
       Value sizeOperand;
       if (adaptor.getOperands().empty()) {
-        auto type = cast<quake::VeqType>(alloca.getType());
+        auto type = cast<cudaq::quake::VeqType>(alloca.getType());
         assert(type.hasSpecifiedSize() && "veq must have a constant size");
         auto constantSize = type.getSize();
         sizeOperand =
@@ -155,12 +155,12 @@ public:
   }
 };
 
-class DeallocOpRewrite : public OpConversionPattern<quake::DeallocOp> {
+class DeallocOpRewrite : public OpConversionPattern<cudaq::quake::DeallocOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::DeallocOp dealloc, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::DeallocOp dealloc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<func::CallOp>(
         dealloc, mlir::TypeRange{}, cudaq::opt::CudaqEMReturn,
@@ -169,12 +169,12 @@ public:
   }
 };
 
-class ConcatOpRewrite : public OpConversionPattern<quake::ConcatOp> {
+class ConcatOpRewrite : public OpConversionPattern<cudaq::quake::ConcatOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ConcatOp concat, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ConcatOp concat, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = concat.getLoc();
     auto newspan = packQubitSpans(loc, rewriter, adaptor.getOperands());
@@ -185,12 +185,12 @@ public:
 };
 
 class DiscriminateOpRewrite
-    : public OpConversionPattern<quake::DiscriminateOp> {
+    : public OpConversionPattern<cudaq::quake::DiscriminateOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::DiscriminateOp discr, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::DiscriminateOp discr, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto m = discr.getMeasurement();
     rewriter.replaceOp(discr, m);
@@ -198,12 +198,13 @@ public:
   }
 };
 
-class ExtractRefOpRewrite : public OpConversionPattern<quake::ExtractRefOp> {
+class ExtractRefOpRewrite
+    : public OpConversionPattern<cudaq::quake::ExtractRefOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ExtractRefOp extract, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ExtractRefOp extract, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = extract.getLoc();
     auto offset = [&]() -> Value {
@@ -239,7 +240,7 @@ public:
   }
 };
 
-class SubveqOpRewrite : public OpConversionPattern<quake::SubVeqOp> {
+class SubveqOpRewrite : public OpConversionPattern<cudaq::quake::SubVeqOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
@@ -247,7 +248,7 @@ public:
   // does not make a copy. It simply constructs a new qubit span which is a
   // subspan of the original.
   LogicalResult
-  matchAndRewrite(quake::SubVeqOp subveq, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::SubVeqOp subveq, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = subveq.getLoc();
     auto up = [&]() -> Value {
@@ -288,12 +289,12 @@ public:
   }
 };
 
-class ResetRewrite : public OpConversionPattern<quake::ResetOp> {
+class ResetRewrite : public OpConversionPattern<cudaq::quake::ResetOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ResetOp resetOp, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ResetOp resetOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<func::CallOp>(resetOp, mlir::TypeRange{},
                                               cudaq::opt::CudaqEMReset,
@@ -368,7 +369,7 @@ public:
   }
 };
 
-class MzOpRewrite : public OpConversionPattern<quake::MzOp> {
+class MzOpRewrite : public OpConversionPattern<cudaq::quake::MzOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
@@ -393,7 +394,7 @@ public:
   }
 
   LogicalResult
-  matchAndRewrite(quake::MzOp mzOp, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::MzOp mzOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = mzOp.getLoc();
     auto mod = mzOp->getParentOfType<ModuleOp>();
@@ -414,41 +415,41 @@ public:
 };
 
 /// Convert a MX operation to a sequence H; MZ.
-class MxToMzRewrite : public OpRewritePattern<quake::MxOp> {
+class MxToMzRewrite : public OpRewritePattern<cudaq::quake::MxOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::MxOp mx,
+  LogicalResult matchAndRewrite(cudaq::quake::MxOp mx,
                                 PatternRewriter &rewriter) const override {
-    quake::HOp::create(rewriter, mx.getLoc(), mx.getTargets());
-    rewriter.replaceOpWithNewOp<quake::MzOp>(
+    cudaq::quake::HOp::create(rewriter, mx.getLoc(), mx.getTargets());
+    rewriter.replaceOpWithNewOp<cudaq::quake::MzOp>(
         mx, mx.getResultTypes(), mx.getTargets(), mx.getRegisterNameAttr());
     return success();
   }
 };
 
 /// Convert a MY operation to a sequence S; H; MZ.
-class MyToMzRewrite : public OpRewritePattern<quake::MyOp> {
+class MyToMzRewrite : public OpRewritePattern<cudaq::quake::MyOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::MyOp my,
+  LogicalResult matchAndRewrite(cudaq::quake::MyOp my,
                                 PatternRewriter &rewriter) const override {
-    quake::SOp::create(rewriter, my.getLoc(), true, ValueRange{}, ValueRange{},
-                       my.getTargets());
-    quake::HOp::create(rewriter, my.getLoc(), my.getTargets());
-    rewriter.replaceOpWithNewOp<quake::MzOp>(
+    cudaq::quake::SOp::create(rewriter, my.getLoc(), true, ValueRange{},
+                              ValueRange{}, my.getTargets());
+    cudaq::quake::HOp::create(rewriter, my.getLoc(), my.getTargets());
+    rewriter.replaceOpWithNewOp<cudaq::quake::MzOp>(
         my, my.getResultTypes(), my.getTargets(), my.getRegisterNameAttr());
     return success();
   }
 };
 
-class VeqSizeOpRewrite : public OpConversionPattern<quake::VeqSizeOp> {
+class VeqSizeOpRewrite : public OpConversionPattern<cudaq::quake::VeqSizeOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::VeqSizeOp vecsize, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::VeqSizeOp vecsize, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = vecsize->getLoc();
     auto i64Ty = rewriter.getI64Type();
@@ -466,16 +467,17 @@ public:
 void cudaq::opt::populateQuakeToCCPatterns(TypeConverter &converter,
                                            RewritePatternSet &patterns) {
   auto *context = patterns.getContext();
-  patterns.insert<AllocaOpRewrite, ConcatOpRewrite, DeallocOpRewrite,
-                  DiscriminateOpRewrite, ExtractRefOpRewrite, VeqSizeOpRewrite,
-                  MzOpRewrite, ResetRewrite, SubveqOpRewrite,
-                  GenericRewrite<quake::HOp>, GenericRewrite<quake::PhasedRxOp>,
-                  GenericRewrite<quake::R1Op>, GenericRewrite<quake::RxOp>,
-                  GenericRewrite<quake::RyOp>, GenericRewrite<quake::RzOp>,
-                  GenericRewrite<quake::SOp>, GenericRewrite<quake::SwapOp>,
-                  GenericRewrite<quake::TOp>, GenericRewrite<quake::U2Op>,
-                  GenericRewrite<quake::U3Op>, GenericRewrite<quake::XOp>,
-                  GenericRewrite<quake::YOp>, GenericRewrite<quake::ZOp>>(
+  patterns.insert<
+      AllocaOpRewrite, ConcatOpRewrite, DeallocOpRewrite, DiscriminateOpRewrite,
+      ExtractRefOpRewrite, VeqSizeOpRewrite, MzOpRewrite, ResetRewrite,
+      SubveqOpRewrite, GenericRewrite<cudaq::quake::HOp>,
+      GenericRewrite<cudaq::quake::PhasedRxOp>,
+      GenericRewrite<cudaq::quake::R1Op>, GenericRewrite<cudaq::quake::RxOp>,
+      GenericRewrite<cudaq::quake::RyOp>, GenericRewrite<cudaq::quake::RzOp>,
+      GenericRewrite<cudaq::quake::SOp>, GenericRewrite<cudaq::quake::SwapOp>,
+      GenericRewrite<cudaq::quake::TOp>, GenericRewrite<cudaq::quake::U2Op>,
+      GenericRewrite<cudaq::quake::U3Op>, GenericRewrite<cudaq::quake::XOp>,
+      GenericRewrite<cudaq::quake::YOp>, GenericRewrite<cudaq::quake::ZOp>>(
       converter, context);
 }
 

--- a/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
+++ b/lib/Optimizer/CodeGen/QuakeToLLVM.cpp
@@ -29,20 +29,20 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 /// Lowers Quake AllocaOp to QIR function call in LLVM.
-class AllocaOpRewrite : public ConvertOpToLLVMPattern<quake::AllocaOp> {
+class AllocaOpRewrite : public ConvertOpToLLVMPattern<cudaq::quake::AllocaOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::AllocaOp alloca, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::AllocaOp alloca, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = alloca->getLoc();
     auto parentModule = alloca->getParentOfType<ModuleOp>();
     auto *context = parentModule->getContext();
 
     // If this alloc is just returning a qubit
-    if (auto resultType =
-            dyn_cast_if_present<quake::RefType>(alloca.getResult().getType())) {
+    if (auto resultType = dyn_cast_if_present<cudaq::quake::RefType>(
+            alloca.getResult().getType())) {
 
       StringRef qirQubitAllocate = cudaq::opt::QIRQubitAllocate;
       auto qubitType = cudaq::cg::getLLVMQubitType(context);
@@ -66,7 +66,7 @@ public:
     // be compile time known and encoded in the veq return type.
     Value sizeOperand;
     if (adaptor.getOperands().empty()) {
-      auto type = cast<quake::VeqType>(alloca.getResult().getType());
+      auto type = cast<cudaq::quake::VeqType>(alloca.getResult().getType());
       auto constantSize = type.getSize();
       sizeOperand =
           arith::ConstantIntOp::create(rewriter, loc, constantSize, 64);
@@ -114,7 +114,7 @@ public:
       fromComplex = true;
       eleTy = complexTy.getElementType();
     }
-    if (isa<quake::StateType>(eleTy))
+    if (isa<cudaq::quake::StateType>(eleTy))
       functionName = cudaq::opt::QIRArrayQubitAllocateArrayWithCudaqStatePtr;
     if (eleTy == rewriter.getF64Type())
       functionName =
@@ -141,7 +141,7 @@ public:
       else if (sizeTy.getWidth() > 64)
         sizeOperand = LLVM::TruncOp::create(rewriter, loc, i64Ty, sizeOperand);
     } else {
-      auto type = cast<quake::VeqType>(allocTy);
+      auto type = cast<cudaq::quake::VeqType>(allocTy);
       auto constantSize = type.getSize();
       sizeOperand =
           arith::ConstantIntOp::create(rewriter, loc, constantSize, 64);
@@ -166,12 +166,13 @@ public:
 };
 
 /// Lower Quake Dealloc Ops to QIR function calls.
-class DeallocOpRewrite : public ConvertOpToLLVMPattern<quake::DeallocOp> {
+class DeallocOpRewrite
+    : public ConvertOpToLLVMPattern<cudaq::quake::DeallocOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::DeallocOp dealloc, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::DeallocOp dealloc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto parentModule = dealloc->getParentOfType<ModuleOp>();
     auto context = parentModule->getContext();
@@ -181,7 +182,7 @@ public:
     // Could be a dealloc on a ref or a veq
     StringRef qirQuantumDeallocateFunc;
     Type operandType, qType = dealloc.getOperand().getType();
-    if (isa<quake::VeqType>(qType)) {
+    if (isa<cudaq::quake::VeqType>(qType)) {
       qirQuantumDeallocateFunc = cudaq::opt::QIRArrayQubitReleaseArray;
       operandType = cudaq::cg::getLLVMArrayType(context);
     } else {
@@ -208,12 +209,12 @@ public:
 // for further reallocations, etc. (These opportunities are left as TODOs.) In
 // general, quake.concat does not guarantee that the sizes of the input Veq is
 // a compile-time constant however.
-class ConcatOpRewrite : public ConvertOpToLLVMPattern<quake::ConcatOp> {
+class ConcatOpRewrite : public ConvertOpToLLVMPattern<cudaq::quake::ConcatOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ConcatOp concat, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ConcatOp concat, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto parentModule = concat->getParentOfType<ModuleOp>();
     auto context = parentModule->getContext();
@@ -276,12 +277,12 @@ public:
 };
 
 class DiscriminateOpPattern
-    : public ConvertOpToLLVMPattern<quake::DiscriminateOp> {
+    : public ConvertOpToLLVMPattern<cudaq::quake::DiscriminateOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::DiscriminateOp discr, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::DiscriminateOp discr, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto m = discr.getMeasurement();
     rewriter.replaceOp(discr, m);
@@ -291,12 +292,12 @@ public:
 
 /// Convert a ExtractRefOp to the respective QIR.
 class ExtractQubitOpRewrite
-    : public ConvertOpToLLVMPattern<quake::ExtractRefOp> {
+    : public ConvertOpToLLVMPattern<cudaq::quake::ExtractRefOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ExtractRefOp extract, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ExtractRefOp extract, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = extract.getLoc();
     auto parentModule = extract->getParentOfType<ModuleOp>();
@@ -337,12 +338,13 @@ public:
   }
 };
 
-class GetMemberOpPattern : public ConvertOpToLLVMPattern<quake::GetMemberOp> {
+class GetMemberOpPattern
+    : public ConvertOpToLLVMPattern<cudaq::quake::GetMemberOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::GetMemberOp extract, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::GetMemberOp extract, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto toTy = getTypeConverter()->convertType(extract.getType());
     std::int64_t position = adaptor.getIndex();
@@ -352,12 +354,13 @@ public:
   }
 };
 
-class MakeStruqOpPattern : public ConvertOpToLLVMPattern<quake::MakeStruqOp> {
+class MakeStruqOpPattern
+    : public ConvertOpToLLVMPattern<cudaq::quake::MakeStruqOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::MakeStruqOp mkStruq, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::MakeStruqOp mkStruq, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = mkStruq.getLoc();
     auto *ctx = rewriter.getContext();
@@ -375,12 +378,12 @@ public:
   }
 };
 
-class SubveqOpRewrite : public ConvertOpToLLVMPattern<quake::SubVeqOp> {
+class SubveqOpRewrite : public ConvertOpToLLVMPattern<cudaq::quake::SubVeqOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::SubVeqOp subveq, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::SubVeqOp subveq, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = subveq->getLoc();
     auto parentModule = subveq->getParentOfType<ModuleOp>();
@@ -426,12 +429,12 @@ public:
 };
 
 /// Lower the quake.reset op to QIR
-class ResetRewrite : public ConvertOpToLLVMPattern<quake::ResetOp> {
+class ResetRewrite : public ConvertOpToLLVMPattern<cudaq::quake::ResetOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ResetOp instOp, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ResetOp instOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto parentModule = instOp->getParentOfType<ModuleOp>();
     auto context = parentModule->getContext();
@@ -456,12 +459,13 @@ public:
 };
 
 /// Lower exp_pauli(f64, veq, cc.string) to __quantum__qis__exp_pauli
-class ExpPauliRewrite : public ConvertOpToLLVMPattern<quake::ExpPauliOp> {
+class ExpPauliRewrite
+    : public ConvertOpToLLVMPattern<cudaq::quake::ExpPauliOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ExpPauliOp instOp, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ExpPauliOp instOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = instOp->getLoc();
     auto parentModule = instOp->getParentOfType<ModuleOp>();
@@ -597,7 +601,7 @@ public:
     // Get the first control
     auto control = instOp.getControls().front();
     auto instOperands = adaptor.getOperands();
-    if (numControls == 1 && isa<quake::VeqType>(control.getType())) {
+    if (numControls == 1 && isa<cudaq::quake::VeqType>(control.getType())) {
       // Operands are already an Array* and Qubit*.
       rewriter.replaceOpWithNewOp<LLVM::CallOp>(
           instOp, TypeRange{}, qirFunctionSymbolRef, instOperands);
@@ -622,7 +626,7 @@ public:
     // original quake types to distinguish them.
     auto allControlsAreQubits = [&]() {
       for (auto c : instOp.getControls())
-        if (!isa<quake::RefType>(c.getType()))
+        if (!isa<cudaq::quake::RefType>(c.getType()))
           return false;
       return true;
     }();
@@ -779,7 +783,7 @@ public:
     auto control = *instOp.getControls().begin();
     Type type = control.getType();
     // If type is a VeqType, then we're good, just forward to the call op
-    if (numControls == 1 && isa<quake::VeqType>(type)) {
+    if (numControls == 1 && isa<cudaq::quake::VeqType>(type)) {
 
       // Add the control array to the args.
       funcArgs.push_back(adaptor.getControls().front());
@@ -966,7 +970,7 @@ public:
     auto control = *instOp.getControls().begin();
     Type type = control.getType();
     // If type is a VeqType, then we're good, just forward to the call op
-    if (numControls == 1 && isa<quake::VeqType>(type)) {
+    if (numControls == 1 && isa<cudaq::quake::VeqType>(type)) {
 
       // Add the control array to the args.
       funcArgs.push_back(adaptor.getControls().front());
@@ -1166,12 +1170,13 @@ public:
   }
 };
 
-class GetVeqSizeOpRewrite : public OpConversionPattern<quake::VeqSizeOp> {
+class GetVeqSizeOpRewrite
+    : public OpConversionPattern<cudaq::quake::VeqSizeOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::VeqSizeOp vecsize, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::VeqSizeOp vecsize, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = vecsize->getLoc();
     auto parentModule = vecsize->getParentOfType<ModuleOp>();
@@ -1243,12 +1248,13 @@ public:
 
 /// In case we still have a RelaxSizeOp, we can just remove it, since QIR works
 /// on `Array*` for all sized veqs.
-class RemoveRelaxSizeRewrite : public OpConversionPattern<quake::RelaxSizeOp> {
+class RemoveRelaxSizeRewrite
+    : public OpConversionPattern<cudaq::quake::RelaxSizeOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::RelaxSizeOp relax, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::RelaxSizeOp relax, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOp(relax, relax.getInputVec());
     return success();
@@ -1259,7 +1265,7 @@ public:
 /// the custom operations ought to be decomposed by a separate pass and should
 /// never reach here.
 class CustomUnitaryOpRewrite
-    : public ConvertOpToLLVMPattern<quake::CustomUnitarySymbolOp> {
+    : public ConvertOpToLLVMPattern<cudaq::quake::CustomUnitarySymbolOp> {
 public:
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -1297,7 +1303,7 @@ public:
   }
 
   LogicalResult
-  matchAndRewrite(quake::CustomUnitarySymbolOp op, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::CustomUnitarySymbolOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto parentModule = op->getParentOfType<ModuleOp>();
@@ -1426,21 +1432,22 @@ void cudaq::opt::populateQuakeToLLVMPatterns(LLVMTypeConverter &typeConverter,
   patterns
       .insert<GetVeqSizeOpRewrite, RemoveRelaxSizeRewrite, ReturnBitRewrite>(
           context);
-  patterns
-      .insert<AllocaOpRewrite, ConcatOpRewrite, CustomUnitaryOpRewrite,
-              DeallocOpRewrite, DiscriminateOpPattern, ExtractQubitOpRewrite,
-              ExpPauliRewrite, GetMemberOpPattern, MakeStruqOpPattern,
-              OneTargetRewrite<quake::HOp>, OneTargetRewrite<quake::XOp>,
-              OneTargetRewrite<quake::YOp>, OneTargetRewrite<quake::ZOp>,
-              OneTargetRewrite<quake::SOp>, OneTargetRewrite<quake::TOp>,
-              OneTargetOneParamRewrite<quake::R1Op>,
-              OneTargetTwoParamRewrite<quake::PhasedRxOp>,
-              OneTargetOneParamRewrite<quake::RxOp>,
-              OneTargetOneParamRewrite<quake::RyOp>,
-              OneTargetOneParamRewrite<quake::RzOp>,
-              OneTargetTwoParamRewrite<quake::U2Op>,
-              OneTargetThreeParamRewrite<quake::U3Op>, QmemRAIIOpRewrite,
-              ResetRewrite, SubveqOpRewrite, TwoTargetRewrite<quake::SwapOp>>(
-          typeConverter);
-  patterns.insert<MeasureRewrite<quake::MzOp>>(typeConverter, measureCounter);
+  patterns.insert<
+      AllocaOpRewrite, ConcatOpRewrite, CustomUnitaryOpRewrite,
+      DeallocOpRewrite, DiscriminateOpPattern, ExtractQubitOpRewrite,
+      ExpPauliRewrite, GetMemberOpPattern, MakeStruqOpPattern,
+      OneTargetRewrite<cudaq::quake::HOp>, OneTargetRewrite<cudaq::quake::XOp>,
+      OneTargetRewrite<cudaq::quake::YOp>, OneTargetRewrite<cudaq::quake::ZOp>,
+      OneTargetRewrite<cudaq::quake::SOp>, OneTargetRewrite<cudaq::quake::TOp>,
+      OneTargetOneParamRewrite<cudaq::quake::R1Op>,
+      OneTargetTwoParamRewrite<cudaq::quake::PhasedRxOp>,
+      OneTargetOneParamRewrite<cudaq::quake::RxOp>,
+      OneTargetOneParamRewrite<cudaq::quake::RyOp>,
+      OneTargetOneParamRewrite<cudaq::quake::RzOp>,
+      OneTargetTwoParamRewrite<cudaq::quake::U2Op>,
+      OneTargetThreeParamRewrite<cudaq::quake::U3Op>, QmemRAIIOpRewrite,
+      ResetRewrite, SubveqOpRewrite, TwoTargetRewrite<cudaq::quake::SwapOp>>(
+      typeConverter);
+  patterns.insert<MeasureRewrite<cudaq::quake::MzOp>>(typeConverter,
+                                                      measureCounter);
 }

--- a/lib/Optimizer/CodeGen/TranslateToIQMJson.cpp
+++ b/lib/Optimizer/CodeGen/TranslateToIQMJson.cpp
@@ -59,7 +59,7 @@ static LogicalResult emitOperation(nlohmann::json &json,
 
 static LogicalResult emitOperation(nlohmann::json &json,
                                    cudaq::Emitter &emitter,
-                                   quake::AllocaOp op) {
+                                   cudaq::quake::AllocaOp op) {
   Value refOrVeq = op.getRefOrVec();
   auto name = emitter.createName("QB", 1);
   emitter.getOrAssignName(refOrVeq, name);
@@ -68,7 +68,7 @@ static LogicalResult emitOperation(nlohmann::json &json,
 
 static LogicalResult emitOperation(nlohmann::json &json,
                                    cudaq::Emitter &emitter,
-                                   quake::BorrowWireOp op) {
+                                   cudaq::quake::BorrowWireOp op) {
   auto name = std::string("QB") + std::to_string(op.getIdentity() + 1);
   emitter.getOrAssignName(op.getResult(), name);
   return success();
@@ -76,7 +76,7 @@ static LogicalResult emitOperation(nlohmann::json &json,
 
 static LogicalResult emitOperation(nlohmann::json &json,
                                    cudaq::Emitter &emitter,
-                                   quake::ExtractRefOp op) {
+                                   cudaq::quake::ExtractRefOp op) {
   std::optional<int64_t> index = std::nullopt;
   if (op.hasConstantIndex())
     index = op.getConstantIndex();
@@ -92,7 +92,7 @@ static LogicalResult emitOperation(nlohmann::json &json,
 
 static LogicalResult emitOperation(nlohmann::json &json,
                                    cudaq::Emitter &emitter,
-                                   quake::OperatorInterface optor) {
+                                   cudaq::quake::OperatorInterface optor) {
   auto name = optor->getName().stripDialect();
   std::vector<std::string> validInstructions{"z", "phased_rx"};
   if (std::find(validInstructions.begin(), validInstructions.end(),
@@ -151,7 +151,8 @@ static LogicalResult emitOperation(nlohmann::json &json,
 }
 
 static LogicalResult emitOperation(nlohmann::json &json,
-                                   cudaq::Emitter &emitter, quake::MzOp op) {
+                                   cudaq::Emitter &emitter,
+                                   cudaq::quake::MzOp op) {
   json["name"] = "measure";
   std::vector<std::string> qubits;
   for (auto target : op.getTargets())
@@ -179,20 +180,20 @@ static LogicalResult emitOperation(nlohmann::json &json,
   return llvm::TypeSwitch<Operation *, LogicalResult>(&op)
       .Case<ModuleOp>([&](auto op) { return emitOperation(json, emitter, op); })
       // Quake
-      .Case<quake::AllocaOp>(
+      .Case<cudaq::quake::AllocaOp>(
           [&](auto op) { return emitOperation(json, emitter, op); })
-      .Case<quake::BorrowWireOp>(
+      .Case<cudaq::quake::BorrowWireOp>(
           [&](auto op) { return emitOperation(json, emitter, op); })
-      .Case<quake::ExtractRefOp>(
+      .Case<cudaq::quake::ExtractRefOp>(
           [&](auto op) { return emitOperation(json, emitter, op); })
-      .Case<quake::OperatorInterface>(
+      .Case<cudaq::quake::OperatorInterface>(
           [&](auto op) { return emitOperation(json, emitter, op); })
-      .Case<quake::MzOp>(
+      .Case<cudaq::quake::MzOp>(
           [&](auto op) { return emitOperation(json, emitter, op); })
       // Ignore
-      .Case<quake::DiscriminateOp>([](auto) { return success(); })
-      .Case<quake::DeallocOp>([](auto) { return success(); })
-      .Case<quake::ReturnWireOp>([](auto) { return success(); })
+      .Case<cudaq::quake::DiscriminateOp>([](auto) { return success(); })
+      .Case<cudaq::quake::DeallocOp>([](auto) { return success(); })
+      .Case<cudaq::quake::ReturnWireOp>([](auto) { return success(); })
       .Case<func::ReturnOp>([](auto) { return success(); })
       .Case<arith::ConstantOp>([](auto) { return success(); })
       .Default([&](Operation *) -> LogicalResult {

--- a/lib/Optimizer/CodeGen/TranslateToOpenQASM.cpp
+++ b/lib/Optimizer/CodeGen/TranslateToOpenQASM.cpp
@@ -23,8 +23,8 @@ using namespace mlir;
 //===----------------------------------------------------------------------===//
 
 /// Translates operation names into OpenQASM gate names
-static LogicalResult translateOperatorName(quake::OperatorInterface optor,
-                                           StringRef &name) {
+static LogicalResult
+translateOperatorName(cudaq::quake::OperatorInterface optor, StringRef &name) {
   StringRef qkeName = optor->getName().stripDialect();
   if (optor.getControls().size() == 0) {
     name = StringSwitch<StringRef>(qkeName).Case("r1", "u1").Default(qkeName);
@@ -158,23 +158,24 @@ static LogicalResult emitOperation(cudaq::Emitter &emitter,
 }
 
 static LogicalResult emitOperation(cudaq::Emitter &emitter,
-                                   quake::AllocaOp allocaOp) {
+                                   cudaq::quake::AllocaOp allocaOp) {
   Value refOrVeq = allocaOp.getRefOrVec();
   auto name = emitter.createName();
   auto size = 1;
-  if (auto veq = dyn_cast<quake::VeqType>(refOrVeq.getType())) {
+  if (auto veq = dyn_cast<cudaq::quake::VeqType>(refOrVeq.getType())) {
     if (!veq.hasSpecifiedSize())
       return allocaOp.emitError("allocates unbounded veq");
     size = veq.getSize();
   }
   emitter.os << llvm::formatv("qreg {0}[{1}];\n", name, size);
-  if (isa<quake::RefType>(refOrVeq.getType()))
+  if (isa<cudaq::quake::RefType>(refOrVeq.getType()))
     name.append("[0]");
   emitter.getOrAssignName(refOrVeq, name);
   return success();
 }
 
-static LogicalResult emitOperation(cudaq::Emitter &emitter, quake::ApplyOp op) {
+static LogicalResult emitOperation(cudaq::Emitter &emitter,
+                                   cudaq::quake::ApplyOp op) {
   // In Quake's reference semantics form, kernels only return classical types.
   // Thus, we check whether the numbers of results is zero or not.
   if (op.getNumResults() > 0)
@@ -187,7 +188,7 @@ static LogicalResult emitOperation(cudaq::Emitter &emitter, quake::ApplyOp op) {
   SmallVector<Value> parameters;
   SmallVector<Value> targets;
   for (auto arg : op.getActuals()) {
-    if (isa<quake::RefType, quake::VeqType>(arg.getType()))
+    if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(arg.getType()))
       targets.push_back(arg);
     else
       parameters.push_back(arg);
@@ -235,7 +236,7 @@ static LogicalResult emitOperation(cudaq::Emitter &emitter, func::FuncOp op) {
   SmallVector<Value> parameters;
   SmallVector<Value> targets;
   for (auto arg : op.getArguments()) {
-    if (isa<quake::RefType, quake::VeqType>(arg.getType()))
+    if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(arg.getType()))
       targets.push_back(arg);
     else
       parameters.push_back(arg);
@@ -270,7 +271,7 @@ static LogicalResult emitOperation(cudaq::Emitter &emitter, func::FuncOp op) {
 }
 
 static LogicalResult emitOperation(cudaq::Emitter &emitter,
-                                   quake::ExtractRefOp op) {
+                                   cudaq::quake::ExtractRefOp op) {
   std::optional<int64_t> index = std::nullopt;
   if (op.hasConstantIndex())
     index = op.getConstantIndex();
@@ -296,7 +297,7 @@ static LogicalResult emitOperation(cudaq::Emitter &emitter,
 }
 
 static LogicalResult emitOperation(cudaq::Emitter &emitter,
-                                   quake::OperatorInterface optor) {
+                                   cudaq::quake::OperatorInterface optor) {
   // Handle adjoint for T and S
   StringRef name = "";
   if (failed(translateOperatorName(optor, name)))
@@ -329,13 +330,14 @@ static LogicalResult emitOperation(cudaq::Emitter &emitter,
   return success();
 }
 
-static LogicalResult emitOperation(cudaq::Emitter &emitter, quake::MzOp op) {
+static LogicalResult emitOperation(cudaq::Emitter &emitter,
+                                   cudaq::quake::MzOp op) {
   if (op.getTargets().size() > 1)
     return op.emitError(
         "cannot translate measurements with more than one target");
   auto qrefOrVeq = op.getTargets()[0];
   auto size = 1;
-  if (auto veq = dyn_cast<quake::VeqType>(qrefOrVeq.getType())) {
+  if (auto veq = dyn_cast<cudaq::quake::VeqType>(qrefOrVeq.getType())) {
     if (!veq.hasSpecifiedSize())
       return op.emitError("cannot emmit measure on an unbounded veq");
     size = veq.getSize();
@@ -346,7 +348,8 @@ static LogicalResult emitOperation(cudaq::Emitter &emitter, quake::MzOp op) {
   return success();
 }
 
-static LogicalResult emitOperation(cudaq::Emitter &emitter, quake::ResetOp op) {
+static LogicalResult emitOperation(cudaq::Emitter &emitter,
+                                   cudaq::quake::ResetOp op) {
   emitter.os << "reset " << emitter.getOrAssignName(op.getTargets()) << ";";
   return success();
 }
@@ -358,24 +361,27 @@ static LogicalResult emitOperation(cudaq::Emitter &emitter, Operation &op) {
       .Case<func::FuncOp>([&](auto op) { return emitOperation(emitter, op); })
       .Case<func::CallOp>([&](auto op) { return emitOperation(emitter, op); })
       // Quake
-      .Case<quake::ApplyOp>([&](auto op) { return emitOperation(emitter, op); })
-      .Case<quake::AllocaOp>(
+      .Case<cudaq::quake::ApplyOp>(
           [&](auto op) { return emitOperation(emitter, op); })
-      .Case<quake::ExtractRefOp>(
+      .Case<cudaq::quake::AllocaOp>(
           [&](auto op) { return emitOperation(emitter, op); })
-      .Case<quake::OperatorInterface>(
+      .Case<cudaq::quake::ExtractRefOp>(
+          [&](auto op) { return emitOperation(emitter, op); })
+      .Case<cudaq::quake::OperatorInterface>(
           [&](auto optor) { return emitOperation(emitter, optor); })
-      .Case<quake::MzOp>([&](auto op) { return emitOperation(emitter, op); })
-      .Case<quake::ResetOp>([&](auto op) { return emitOperation(emitter, op); })
+      .Case<cudaq::quake::MzOp>(
+          [&](auto op) { return emitOperation(emitter, op); })
+      .Case<cudaq::quake::ResetOp>(
+          [&](auto op) { return emitOperation(emitter, op); })
       // Ignore
-      .Case<quake::DeallocOp>([&](auto op) { return success(); })
+      .Case<cudaq::quake::DeallocOp>([&](auto op) { return success(); })
       .Case<func::ReturnOp>([&](auto op) { return success(); })
       .Case<arith::ConstantOp>([&](auto op) { return success(); })
       .Case<cudaq::cc::AllocaOp>([&](auto op) { return success(); })
       .Case<cudaq::cc::StoreOp>([&](auto op) { return success(); })
       .Case<cudaq::cc::CastOp>([&](auto op) { return success(); })
       .Case<cudaq::cc::ComputePtrOp>([&](auto op) { return success(); })
-      .Case<quake::DiscriminateOp>([&](auto op) { return success(); })
+      .Case<cudaq::quake::DiscriminateOp>([&](auto op) { return success(); })
       .Case<cudaq::cc::ScopeOp>(
           [&](auto op) { return emitOperation(emitter, op); })
       .Case<cudaq::cc::ContinueOp>([&](auto op) { return success(); })

--- a/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
+++ b/lib/Optimizer/CodeGen/WireSetsToProfileQIR.cpp
@@ -60,10 +60,10 @@ namespace {
 struct QuakeTypeConverter : public TypeConverter {
   QuakeTypeConverter() {
     addConversion([](Type ty) { return ty; });
-    addConversion([](quake::WireType ty) {
+    addConversion([](cudaq::quake::WireType ty) {
       return cudaq::cg::getQubitType(ty.getContext());
     });
-    addConversion([](quake::MeasureType ty) {
+    addConversion([](cudaq::quake::MeasureType ty) {
       return cudaq::cg::getResultType(ty.getContext());
     });
   }
@@ -161,11 +161,11 @@ struct GeneralRewrite : OpConversionPattern<OP> {
 };
 
 namespace {
-struct BorrowWireRewrite : OpConversionPattern<quake::BorrowWireOp> {
+struct BorrowWireRewrite : OpConversionPattern<cudaq::quake::BorrowWireOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::BorrowWireOp borrowWire, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::BorrowWireOp borrowWire, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto id = borrowWire.getIdentity();
     auto loc = borrowWire.getLoc();
@@ -179,11 +179,11 @@ struct BorrowWireRewrite : OpConversionPattern<quake::BorrowWireOp> {
   }
 };
 
-struct ResetRewrite : OpConversionPattern<quake::ResetOp> {
+struct ResetRewrite : OpConversionPattern<cudaq::quake::ResetOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ResetOp reset, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ResetOp reset, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     SmallVector<Value> qubits{adaptor.getTargets()};
     auto loc = reset.getLoc();
@@ -205,10 +205,10 @@ struct BranchRewrite : OpConversionPattern<cf::BranchOp> {
     rewriter.startOpModification(branchOp);
     if (branchOp.getSuccessor())
       for (auto arg : branchOp.getSuccessor()->getArguments())
-        if (isa<quake::WireType>(arg.getType()))
+        if (isa<cudaq::quake::WireType>(arg.getType()))
           arg.setType(qubitTy);
     for (auto operand : branchOp.getOperands())
-      if (isa<quake::WireType>(operand.getType()))
+      if (isa<cudaq::quake::WireType>(operand.getType()))
         operand.setType(qubitTy);
     rewriter.finalizeOpModification(branchOp);
     return success();
@@ -225,39 +225,39 @@ struct CondBranchRewrite : OpConversionPattern<cf::CondBranchOp> {
     rewriter.startOpModification(branchOp);
     for (auto suc : branchOp.getSuccessors())
       for (auto arg : suc->getArguments())
-        if (isa<quake::WireType>(arg.getType()))
+        if (isa<cudaq::quake::WireType>(arg.getType()))
           arg.setType(qubitTy);
     for (auto operand : branchOp.getOperands())
-      if (isa<quake::WireType>(operand.getType()))
+      if (isa<cudaq::quake::WireType>(operand.getType()))
         operand.setType(qubitTy);
     rewriter.finalizeOpModification(branchOp);
     return success();
   }
 };
 
-struct ReturnWireRewrite : OpConversionPattern<quake::ReturnWireOp> {
+struct ReturnWireRewrite : OpConversionPattern<cudaq::quake::ReturnWireOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::ReturnWireOp returnWire, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ReturnWireOp returnWire, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.eraseOp(returnWire);
     return success();
   }
 };
 
-struct WireSetRewrite : OpConversionPattern<quake::WireSetOp> {
+struct WireSetRewrite : OpConversionPattern<cudaq::quake::WireSetOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(quake::WireSetOp wireSetOp, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::WireSetOp wireSetOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.eraseOp(wireSetOp);
     return success();
   }
 };
 
-struct MzRewrite : OpConversionPattern<quake::MzOp> {
+struct MzRewrite : OpConversionPattern<cudaq::quake::MzOp> {
   using Base = OpConversionPattern;
   explicit MzRewrite(TypeConverter &typeConverter, unsigned &counter,
                      OutputNamesType &resultQubitVals, MLIRContext *ctxt,
@@ -266,12 +266,12 @@ struct MzRewrite : OpConversionPattern<quake::MzOp> {
         resultQubitVals(resultQubitVals) {}
 
   LogicalResult
-  matchAndRewrite(quake::MzOp meas, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::MzOp meas, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     bool measureFollowedByDiscriminate = [&]() {
       for (auto user : meas->getResult(0).getUsers())
-        if (isa<quake::DiscriminateOp>(user))
+        if (isa<cudaq::quake::DiscriminateOp>(user))
           return true;
       return false;
     }();
@@ -333,7 +333,7 @@ private:
   OutputNamesType &resultQubitVals;
 };
 
-struct DiscriminateRewrite : OpConversionPattern<quake::DiscriminateOp> {
+struct DiscriminateRewrite : OpConversionPattern<cudaq::quake::DiscriminateOp> {
   using Base = OpConversionPattern;
 
   explicit DiscriminateRewrite(TypeConverter &typeConverter, bool adaptive,
@@ -343,7 +343,7 @@ struct DiscriminateRewrite : OpConversionPattern<quake::DiscriminateOp> {
         regNameMap(nameMap) {}
 
   LogicalResult
-  matchAndRewrite(quake::DiscriminateOp disc, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::DiscriminateOp disc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = disc.getLoc();
 
@@ -394,8 +394,8 @@ struct WireSetToProfileQIRPass
     auto *context = &getContext();
     OpBuilder builder(op);
     DenseMap<Operation *, StringRef> regNameMap;
-    op.walk([&](quake::DiscriminateOp disc) {
-      auto meas = disc.getMeasurement().getDefiningOp<quake::MzOp>();
+    op.walk([&](cudaq::quake::DiscriminateOp disc) {
+      auto meas = disc.getMeasurement().getDefiningOp<cudaq::quake::MzOp>();
       auto name = meas ? meas.getRegisterName() : std::nullopt;
       if (name)
         regNameMap[disc.getOperation()] = *name;
@@ -403,7 +403,7 @@ struct WireSetToProfileQIRPass
         regNameMap[disc.getOperation()] = "?";
     });
     std::optional<std::uint32_t> highestIdentity;
-    op.walk([&](quake::BorrowWireOp op) {
+    op.walk([&](cudaq::quake::BorrowWireOp op) {
       highestIdentity = highestIdentity
                             ? std::max(*highestIdentity, op.getIdentity())
                             : op.getIdentity();
@@ -416,16 +416,16 @@ struct WireSetToProfileQIRPass
     QuakeTypeConverter quakeTypeConverter;
     unsigned resultCounter = 0;
     OutputNamesType resultQubitVals;
-    patterns.insert<BranchRewrite, CondBranchRewrite,
-                    GeneralRewrite<quake::HOp>, GeneralRewrite<quake::XOp>,
-                    GeneralRewrite<quake::YOp>, GeneralRewrite<quake::ZOp>,
-                    GeneralRewrite<quake::SOp>, GeneralRewrite<quake::TOp>,
-                    GeneralRewrite<quake::RxOp>, GeneralRewrite<quake::RyOp>,
-                    GeneralRewrite<quake::RzOp>, GeneralRewrite<quake::R1Op>,
-                    GeneralRewrite<quake::U3Op>, GeneralRewrite<quake::SwapOp>,
-                    GeneralRewrite<quake::PhasedRxOp>, BorrowWireRewrite,
-                    ResetRewrite, ReturnWireRewrite>(quakeTypeConverter,
-                                                     context);
+    patterns.insert<
+        BranchRewrite, CondBranchRewrite, GeneralRewrite<cudaq::quake::HOp>,
+        GeneralRewrite<cudaq::quake::XOp>, GeneralRewrite<cudaq::quake::YOp>,
+        GeneralRewrite<cudaq::quake::ZOp>, GeneralRewrite<cudaq::quake::SOp>,
+        GeneralRewrite<cudaq::quake::TOp>, GeneralRewrite<cudaq::quake::RxOp>,
+        GeneralRewrite<cudaq::quake::RyOp>, GeneralRewrite<cudaq::quake::RzOp>,
+        GeneralRewrite<cudaq::quake::R1Op>, GeneralRewrite<cudaq::quake::U3Op>,
+        GeneralRewrite<cudaq::quake::SwapOp>,
+        GeneralRewrite<cudaq::quake::PhasedRxOp>, BorrowWireRewrite,
+        ResetRewrite, ReturnWireRewrite>(quakeTypeConverter, context);
     patterns.insert<MzRewrite>(quakeTypeConverter, resultCounter,
                                resultQubitVals, context);
     const bool isAdaptiveProfile = convertTo == "qir-adaptive";
@@ -434,8 +434,8 @@ struct WireSetToProfileQIRPass
     ConversionTarget target(*context);
     target.addLegalDialect<arith::ArithDialect, cudaq::cc::CCDialect,
                            func::FuncDialect, LLVM::LLVMDialect>();
-    target.addIllegalDialect<quake::QuakeDialect>();
-    target.addLegalOp<quake::WireSetOp>();
+    target.addIllegalDialect<cudaq::quake::QuakeDialect>();
+    target.addLegalOp<cudaq::quake::WireSetOp>();
 
     LLVM_DEBUG(llvm::dbgs() << "Module before:\n"; op.dump());
     if (failed(applyPartialConversion(op, target, std::move(patterns))))
@@ -552,7 +552,7 @@ struct WireSetToProfileQIRPrepPass
     createNewDecl(cudaq::opt::NVQIRInvokeWithControlBits, invokeCtrlTy);
 
     unsigned counter = 0;
-    op.walk([&](quake::MzOp meas) {
+    op.walk([&](cudaq::quake::MzOp meas) {
       auto optName = meas.getRegisterName();
       std::string name;
       if (optName) {
@@ -651,7 +651,7 @@ struct WireSetToProfileQIRPostPass
     QuakeTypeConverter quakeTypeConverter;
     patterns.insert<WireSetRewrite>(quakeTypeConverter, ctx);
     ConversionTarget target(*ctx);
-    target.addIllegalDialect<quake::QuakeDialect>();
+    target.addIllegalDialect<cudaq::quake::QuakeDialect>();
 
     LLVM_DEBUG(llvm::dbgs() << "Module before:\n"; op.dump());
     if (failed(applyPartialConversion(op, target, std::move(patterns))))

--- a/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -197,7 +197,7 @@ void cudaq::cc::AllocaOp::getCanonicalizationPatterns(
 
 LogicalResult cudaq::cc::AllocaOp::verify() {
   // It is deeply incorrect to allocate storage for quake abstract types.
-  if (quake::isQuakeType(getElementType()))
+  if (cudaq::quake::isQuakeType(getElementType()))
     return emitOpError("cannot classically allocate quake abstract type");
   return success();
 }
@@ -1989,7 +1989,7 @@ bool hasAllocation(Region &region) {
     for (auto &op : block) {
       if (auto mem = dyn_cast<MemoryEffectOpInterface>(op))
         if (mem.hasEffect<MemoryEffects::Allocate>())
-          if (quantumAllocs || !isa<quake::AllocaOp>(op))
+          if (quantumAllocs || !isa<cudaq::quake::AllocaOp>(op))
             return true;
       if (!isa<cudaq::cc::ScopeOp>(op))
         for (auto &opReg : op.getRegions())
@@ -2173,7 +2173,7 @@ ParseResult cudaq::cc::IfOp::parse(OpAsmParser &parser,
     if (parser.parseAssignmentList(regionArgs, linearOperands) ||
         parser.parseRParen())
       return failure();
-    Type wireTy = quake::WireType::get(builder.getContext());
+    Type wireTy = cudaq::quake::WireType::get(builder.getContext());
     for (auto argOperand : llvm::zip(regionArgs, linearOperands)) {
       std::get<0>(argOperand).type = wireTy;
       if (parser.resolveOperand(std::get<1>(argOperand), wireTy,
@@ -2189,7 +2189,7 @@ ParseResult cudaq::cc::IfOp::parse(OpAsmParser &parser,
     // region arguments. (It can have more.)
     std::int64_t numRegionArgs = regionArgs.size();
     std::for_each(result.types.begin(), result.types.end(), [&](Type t) {
-      if (quake::isLinearType(t))
+      if (cudaq::quake::isLinearType(t))
         --numRegionArgs;
     });
     if (numRegionArgs > 0)
@@ -2250,7 +2250,7 @@ void cudaq::cc::IfOp::getEntrySuccessorRegions(
 template <typename A>
 long countLinearArgs(const A &iterable) {
   return std::count_if(iterable.begin(), iterable.end(),
-                       [](Type t) { return quake::isLinearType(t); });
+                       [](Type t) { return cudaq::quake::isLinearType(t); });
 }
 
 LogicalResult cudaq::cc::verifyConvergentLinearTypesInRegions(Operation *op) {

--- a/lib/Optimizer/Dialect/CC/CCTypes.cpp
+++ b/lib/Optimizer/Dialect/CC/CCTypes.cpp
@@ -101,7 +101,7 @@ cc::StructType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
                        mlir::StringAttr, llvm::ArrayRef<mlir::Type> members,
                        bool, bool, std::uint64_t, unsigned int) {
   for (auto ty : members)
-    if (quake::isQuantumType(ty))
+    if (cudaq::quake::isQuantumType(ty))
       return emitError() << "cc.struct may not contain quake types: " << ty;
   return success();
 }
@@ -145,7 +145,7 @@ void cc::ArrayType::print(AsmPrinter &printer) const {
 LogicalResult
 cc::ArrayType::verify(function_ref<InFlightDiagnostic()> emitError, Type eleTy,
                       std::int64_t) {
-  if (quake::isQuantumType(eleTy))
+  if (cudaq::quake::isQuantumType(eleTy))
     return emitError() << "cc.array may not have a quake element type: "
                        << eleTy;
   return success();
@@ -154,7 +154,7 @@ cc::ArrayType::verify(function_ref<InFlightDiagnostic()> emitError, Type eleTy,
 LogicalResult
 cc::StdvecType::verify(function_ref<InFlightDiagnostic()> emitError,
                        Type eleTy) {
-  if (quake::isQuantumType(eleTy))
+  if (cudaq::quake::isQuantumType(eleTy))
     return emitError() << "cc.stdvec may not have a quake element type: "
                        << eleTy;
   return success();

--- a/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
+++ b/lib/Optimizer/Dialect/Quake/CanonicalPatterns.inc
@@ -15,10 +15,11 @@
 
 namespace {
 
-struct AdjustAdjointExpPauliPattern : OpRewritePattern<quake::ExpPauliOp> {
+struct AdjustAdjointExpPauliPattern
+    : OpRewritePattern<cudaq::quake::ExpPauliOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ExpPauliOp pauli,
+  LogicalResult matchAndRewrite(cudaq::quake::ExpPauliOp pauli,
                                 PatternRewriter &rewriter) const override {
     if (!pauli.isAdj())
       return failure();
@@ -26,7 +27,7 @@ struct AdjustAdjointExpPauliPattern : OpRewritePattern<quake::ExpPauliOp> {
     if (!pauli.getParameters().empty())
       negp.push_back(arith::NegFOp::create(rewriter, pauli.getLoc(),
                                            pauli.getParameters()[0]));
-    rewriter.replaceOpWithNewOp<quake::ExpPauliOp>(
+    rewriter.replaceOpWithNewOp<cudaq::quake::ExpPauliOp>(
         pauli, pauli.getResultTypes(), UnitAttr{}, negp, pauli.getControls(),
         pauli.getTargets(), pauli.getNegatedQubitControlsAttr(),
         pauli.getPauli(), pauli.getPauliLiteralAttr());
@@ -55,11 +56,11 @@ struct AdjustAdjointExpPauliPattern : OpRewritePattern<quake::ExpPauliOp> {
 //   %a = cc.string_literal "XX" : !cc.ptr<!cc.array<i8 x 3>>  // DCE?
 //   quake.exp_pauli (%c) %q to "XX" : (f64, !quake.ref) -> ()
 //
-class BindExpPauliWord : public OpRewritePattern<quake::ExpPauliOp> {
+class BindExpPauliWord : public OpRewritePattern<cudaq::quake::ExpPauliOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ExpPauliOp pauli,
+  LogicalResult matchAndRewrite(cudaq::quake::ExpPauliOp pauli,
                                 PatternRewriter &rewriter) const override {
     auto pauliWord = pauli.getPauli();
     if (!pauliWord)
@@ -70,7 +71,7 @@ public:
     if (!buffer)
       return failure();
 
-    rewriter.replaceOpWithNewOp<quake::ExpPauliOp>(
+    rewriter.replaceOpWithNewOp<cudaq::quake::ExpPauliOp>(
         pauli, pauli.getResultTypes(), pauli.getIsAdjAttr(),
         pauli.getParameters(), pauli.getControls(), pauli.getTargets(),
         pauli.getNegatedQubitControlsAttr(), Value{},
@@ -83,12 +84,12 @@ public:
 // ────────────────────────────────────────────────
 // %4 = constant 10 : i64
 struct ForwardConstantVeqSizePattern
-    : public OpRewritePattern<quake::VeqSizeOp> {
+    : public OpRewritePattern<cudaq::quake::VeqSizeOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::VeqSizeOp veqSize,
+  LogicalResult matchAndRewrite(cudaq::quake::VeqSizeOp veqSize,
                                 PatternRewriter &rewriter) const override {
-    auto veqTy = dyn_cast<quake::VeqType>(veqSize.getVeq().getType());
+    auto veqTy = dyn_cast<cudaq::quake::VeqType>(veqSize.getVeq().getType());
     if (!veqTy)
       return failure();
     if (!veqTy.hasSpecifiedSize())
@@ -104,10 +105,11 @@ struct ForwardConstantVeqSizePattern
 // %3 = quake.alloca !quake.veq<?>[%2 : i32]
 // ─────────────────────────────────────────
 // %3 = quake.alloca !quake.veq<10>
-struct FuseConstantToAllocaPattern : public OpRewritePattern<quake::AllocaOp> {
+struct FuseConstantToAllocaPattern
+    : public OpRewritePattern<cudaq::quake::AllocaOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::AllocaOp alloc,
+  LogicalResult matchAndRewrite(cudaq::quake::AllocaOp alloc,
                                 PatternRewriter &rewriter) const override {
     auto size = alloc.getSize();
     if (!size)
@@ -115,16 +117,17 @@ struct FuseConstantToAllocaPattern : public OpRewritePattern<quake::AllocaOp> {
     auto intCon = cudaq::opt::factory::getIntIfConstant(size);
     if (!intCon)
       return failure();
-    auto veqTy = dyn_cast<quake::VeqType>(alloc.getType());
+    auto veqTy = dyn_cast<cudaq::quake::VeqType>(alloc.getType());
     if (!veqTy)
       return failure();
     if (veqTy.hasSpecifiedSize())
       return failure();
     auto loc = alloc.getLoc();
     auto resTy = alloc.getType();
-    auto newAlloc = quake::AllocaOp::create(rewriter, loc,
-                                            static_cast<std::size_t>(*intCon));
-    rewriter.replaceOpWithNewOp<quake::RelaxSizeOp>(alloc, resTy, newAlloc);
+    auto newAlloc = cudaq::quake::AllocaOp::create(
+        rewriter, loc, static_cast<std::size_t>(*intCon));
+    rewriter.replaceOpWithNewOp<cudaq::quake::RelaxSizeOp>(alloc, resTy,
+                                                           newAlloc);
     return success();
   }
 };
@@ -134,10 +137,10 @@ struct FuseConstantToAllocaPattern : public OpRewritePattern<quake::AllocaOp> {
 // ──────────────────────────────────────────────────────────────────
 // %3 = quake.extract_ref %1[10] : (!quake.veq<?>) -> !quake.ref
 struct FuseConstantToExtractRefPattern
-    : public OpRewritePattern<quake::ExtractRefOp> {
+    : public OpRewritePattern<cudaq::quake::ExtractRefOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ExtractRefOp extract,
+  LogicalResult matchAndRewrite(cudaq::quake::ExtractRefOp extract,
                                 PatternRewriter &rewriter) const override {
     auto index = extract.getIndex();
     if (!index)
@@ -145,7 +148,7 @@ struct FuseConstantToExtractRefPattern
     auto intCon = cudaq::opt::factory::getIntIfConstant(index);
     if (!intCon)
       return failure();
-    rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(
+    rewriter.replaceOpWithNewOp<cudaq::quake::ExtractRefOp>(
         extract, extract.getVeq(), static_cast<std::size_t>(*intCon));
     return success();
   }
@@ -156,26 +159,26 @@ struct FuseConstantToExtractRefPattern
 // ───────────────────────────────────────────
 // replace all use with %2
 struct ForwardConcatExtractPattern
-    : public OpRewritePattern<quake::ExtractRefOp> {
+    : public OpRewritePattern<cudaq::quake::ExtractRefOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ExtractRefOp extract,
+  LogicalResult matchAndRewrite(cudaq::quake::ExtractRefOp extract,
                                 PatternRewriter &rewriter) const override {
     auto veq = extract.getVeq();
-    auto concatOp = veq.getDefiningOp<quake::ConcatOp>();
+    auto concatOp = veq.getDefiningOp<cudaq::quake::ConcatOp>();
     if (concatOp && extract.hasConstantIndex()) {
       // Don't run this canonicalization if any of the operands
       // to concat are of type veq.
       auto concatQubits = concatOp.getTargets();
       for (auto qOp : concatQubits)
-        if (isa<quake::VeqType>(qOp.getType()))
+        if (isa<cudaq::quake::VeqType>(qOp.getType()))
           return failure();
 
       // concat only has ref type operands.
       auto index = extract.getConstantIndex();
       if (index < concatQubits.size()) {
         auto qOpValue = concatQubits[index];
-        if (isa<quake::RefType>(qOpValue.getType())) {
+        if (isa<cudaq::quake::RefType>(qOpValue.getType())) {
           rewriter.replaceOp(extract, {qOpValue});
           return success();
         }
@@ -191,12 +194,12 @@ struct ForwardConcatExtractPattern
 // ───────────────────────────────────────────
 // quake.* %1 ...
 struct ForwardConcatExtractSingleton
-    : public OpRewritePattern<quake::ExtractRefOp> {
+    : public OpRewritePattern<cudaq::quake::ExtractRefOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ExtractRefOp extract,
+  LogicalResult matchAndRewrite(cudaq::quake::ExtractRefOp extract,
                                 PatternRewriter &rewriter) const override {
-    if (auto concat = extract.getVeq().getDefiningOp<quake::ConcatOp>())
+    if (auto concat = extract.getVeq().getDefiningOp<cudaq::quake::ConcatOp>())
       if (concat.getType().getSize() == 1 && extract.hasConstantIndex() &&
           extract.getConstantIndex() == 0) {
         assert(concat.getTargets().size() == 1 && concat.getTargets()[0]);
@@ -221,7 +224,7 @@ static Value createCast(PatternRewriter &rewriter, Location loc, Value inVal) {
 }
 
 class ExtractRefFromSubVeqPattern
-    : public OpRewritePattern<quake::ExtractRefOp> {
+    : public OpRewritePattern<cudaq::quake::ExtractRefOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
@@ -237,13 +240,13 @@ public:
   //   %1 = ... : !quake.veq<4>
   //   %3 = quake.extract_ref %1[2] : (!uwake.veq<4>) -> !quake.ref
   // ```
-  LogicalResult matchAndRewrite(quake::ExtractRefOp extract,
+  LogicalResult matchAndRewrite(cudaq::quake::ExtractRefOp extract,
                                 PatternRewriter &rewriter) const override {
-    auto subveq = extract.getVeq().getDefiningOp<quake::SubVeqOp>();
+    auto subveq = extract.getVeq().getDefiningOp<cudaq::quake::SubVeqOp>();
     if (!subveq)
       return failure();
     // Let the combining of back-to-back subveq ops happen first.
-    auto subsub = subveq.getVeq().getDefiningOp<quake::SubVeqOp>();
+    auto subsub = subveq.getVeq().getDefiningOp<cudaq::quake::SubVeqOp>();
     if (subsub)
       return failure();
 
@@ -264,8 +267,8 @@ public:
       auto cast2 = createCast(rewriter, loc, low);
       offset = arith::AddIOp::create(rewriter, loc, cast1, cast2);
     }
-    rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(extract, subveq.getVeq(),
-                                                     offset);
+    rewriter.replaceOpWithNewOp<cudaq::quake::ExtractRefOp>(
+        extract, subveq.getVeq(), offset);
     return success();
   }
 };
@@ -273,10 +276,10 @@ public:
 // %7 = quake.concat %4 : (!quake.veq<2>) -> !quake.veq<2>
 // ───────────────────────────────────────────
 // removed
-struct ConcatNoOpPattern : public OpRewritePattern<quake::ConcatOp> {
+struct ConcatNoOpPattern : public OpRewritePattern<cudaq::quake::ConcatOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ConcatOp concat,
+  LogicalResult matchAndRewrite(cudaq::quake::ConcatOp concat,
                                 PatternRewriter &rewriter) const override {
     // Remove concat veq<N> -> veq<N>
     // or
@@ -286,13 +289,13 @@ struct ConcatNoOpPattern : public OpRewritePattern<quake::ConcatOp> {
       return failure();
 
     // We only want to handle veq -> veq here.
-    if (isa<quake::RefType>(qubitsToConcat.front().getType())) {
+    if (isa<cudaq::quake::RefType>(qubitsToConcat.front().getType())) {
       return failure();
     }
 
     // Do not handle anything where we don't know the sizes.
     auto retTy = concat.getResult().getType();
-    if (auto veqTy = dyn_cast<quake::VeqType>(retTy))
+    if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(retTy))
       if (!veqTy.hasSpecifiedSize())
         // This could be a folded quake.relax_size op.
         return failure();
@@ -308,38 +311,38 @@ struct ConcatNoOpPattern : public OpRewritePattern<quake::ConcatOp> {
 // %.8 = quake.concat %4, %5, %6 : (!quake.ref, !quake.veq<4>,
 //        !quake.veq<2>) -> !quake.veq<7>
 // %8 = quake.relax_size %.8 : (!quake.veq<7>) -> !quake.veq<?>
-struct ConcatSizePattern : public OpRewritePattern<quake::ConcatOp> {
+struct ConcatSizePattern : public OpRewritePattern<cudaq::quake::ConcatOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ConcatOp concat,
+  LogicalResult matchAndRewrite(cudaq::quake::ConcatOp concat,
                                 PatternRewriter &rewriter) const override {
     if (concat.getType().hasSpecifiedSize())
       return failure();
 
     auto *ctx = rewriter.getContext();
     auto loc = concat.getLoc();
-    auto refTy = quake::RefType::get(ctx);
+    auto refTy = cudaq::quake::RefType::get(ctx);
     // Walk the arguments and sum them, if possible.
     std::size_t sum = 0;
     SmallVector<Value> targets;
     for (auto opnd : concat.getTargets()) {
-      if (auto veqTy = dyn_cast<quake::VeqType>(opnd.getType())) {
+      if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(opnd.getType())) {
         if (!veqTy.hasSpecifiedSize())
           return failure();
         sum += veqTy.getSize();
         targets.push_back(opnd);
         continue;
       }
-      if (auto stqTy = dyn_cast<quake::StruqType>(opnd.getType())) {
+      if (auto stqTy = dyn_cast<cudaq::quake::StruqType>(opnd.getType())) {
         if (!stqTy.hasSpecifiedSize())
           return failure();
-        sum += quake::getAllocationSize(stqTy);
+        sum += cudaq::quake::getAllocationSize(stqTy);
         auto arity = stqTy.getArity();
         if (*arity) {
           // Get each member for IR legalization.
           for (auto [i, memTy] : llvm::enumerate(stqTy.getMembers())) {
-            auto mem =
-                quake::GetMemberOp::create(rewriter, loc, memTy, opnd, i);
+            auto mem = cudaq::quake::GetMemberOp::create(rewriter, loc, memTy,
+                                                         opnd, i);
             targets.push_back(mem);
           }
         }
@@ -354,10 +357,11 @@ struct ConcatSizePattern : public OpRewritePattern<quake::ConcatOp> {
     }
 
     // Leans into the relax_size canonicalization pattern.
-    auto newTy = quake::VeqType::get(ctx, sum);
-    Value newOp = quake::ConcatOp::create(rewriter, loc, newTy, targets);
-    auto noSizeTy = quake::VeqType::getUnsized(ctx);
-    rewriter.replaceOpWithNewOp<quake::RelaxSizeOp>(concat, noSizeTy, newOp);
+    auto newTy = cudaq::quake::VeqType::get(ctx, sum);
+    Value newOp = cudaq::quake::ConcatOp::create(rewriter, loc, newTy, targets);
+    auto noSizeTy = cudaq::quake::VeqType::getUnsized(ctx);
+    rewriter.replaceOpWithNewOp<cudaq::quake::RelaxSizeOp>(concat, noSizeTy,
+                                                           newOp);
     return success();
   }
 };
@@ -368,21 +372,22 @@ struct ConcatSizePattern : public OpRewritePattern<quake::ConcatOp> {
 // %3 = quake.concat %1, %2 : (!quake.ref, !quake.ref) -> !quake.veq<2>
 // ────────────────────────────────────────────────────────────────
 // [%0/%3] -- replace uses of %3 with %0
-struct UselessConcatOpPattern : public OpRewritePattern<quake::ConcatOp> {
+struct UselessConcatOpPattern
+    : public OpRewritePattern<cudaq::quake::ConcatOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ConcatOp concat,
+  LogicalResult matchAndRewrite(cudaq::quake::ConcatOp concat,
                                 PatternRewriter &rewriter) const override {
     auto *ctx = rewriter.getContext();
-    auto refTy = quake::RefType::get(ctx);
+    auto refTy = cudaq::quake::RefType::get(ctx);
 
     // Make sure this subgraph matches the pattern.
-    quake::AllocaOp alloc;
+    cudaq::quake::AllocaOp alloc;
     for (auto iter : llvm::enumerate(concat.getTargets())) {
       auto arg = iter.value();
       if (arg.getType() != refTy)
         return failure();
-      auto extract = arg.getDefiningOp<quake::ExtractRefOp>();
+      auto extract = arg.getDefiningOp<cudaq::quake::ExtractRefOp>();
       if (!extract || !extract.hasConstantIndex())
         return failure();
       auto i = iter.index();
@@ -393,13 +398,14 @@ struct UselessConcatOpPattern : public OpRewritePattern<quake::ConcatOp> {
         if (extract.getVeq() != alloc.getResult())
           return failure();
       } else {
-        auto veqAlloc = extract.getVeq().getDefiningOp<quake::AllocaOp>();
+        auto veqAlloc =
+            extract.getVeq().getDefiningOp<cudaq::quake::AllocaOp>();
         if (!veqAlloc || veqAlloc.getSize())
           return failure();
         alloc = veqAlloc;
       }
     }
-    auto allocSize = quake::getAllocationSize(alloc.getType());
+    auto allocSize = cudaq::quake::getAllocationSize(alloc.getType());
     if (concat.getTargets().size() != allocSize)
       return failure();
 
@@ -415,20 +421,22 @@ struct UselessConcatOpPattern : public OpRewritePattern<quake::ConcatOp> {
 //                                !quake.veq<N>>) -> !quake.veq<N>
 // ────────────────────────────────────────────────────────────────
 // [%6/%8] -- replace uses of %8 with %6
-struct BypassMakeStruq : public OpRewritePattern<quake::GetMemberOp> {
+struct BypassMakeStruq : public OpRewritePattern<cudaq::quake::GetMemberOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::GetMemberOp getMem,
+  LogicalResult matchAndRewrite(cudaq::quake::GetMemberOp getMem,
                                 PatternRewriter &rewriter) const override {
-    auto makeStruq = getMem.getStruq().getDefiningOp<quake::MakeStruqOp>();
+    auto makeStruq =
+        getMem.getStruq().getDefiningOp<cudaq::quake::MakeStruqOp>();
     if (!makeStruq)
       return failure();
-    auto toStrTy = cast<quake::StruqType>(getMem.getStruq().getType());
+    auto toStrTy = cast<cudaq::quake::StruqType>(getMem.getStruq().getType());
     std::uint32_t idx = getMem.getIndex();
     Value from = makeStruq.getOperand(idx);
     auto toTy = toStrTy.getMembers()[idx];
     if (from.getType() != toTy)
-      rewriter.replaceOpWithNewOp<quake::RelaxSizeOp>(getMem, toTy, from);
+      rewriter.replaceOpWithNewOp<cudaq::quake::RelaxSizeOp>(getMem, toTy,
+                                                             from);
     else
       rewriter.replaceOp(getMem, from);
     return success();
@@ -440,21 +448,21 @@ struct BypassMakeStruq : public OpRewritePattern<quake::GetMemberOp> {
 // %.22 = quake.init_state %1, %2 : (!quake.veq<k>, T) -> !quake.veq<k>
 // %22 = quake.relax_size %.22 : (!quake.veq<k>) -> !quake.veq<?>
 struct ForwardAllocaTypePattern
-    : public OpRewritePattern<quake::InitializeStateOp> {
+    : public OpRewritePattern<cudaq::quake::InitializeStateOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::InitializeStateOp initState,
+  LogicalResult matchAndRewrite(cudaq::quake::InitializeStateOp initState,
                                 PatternRewriter &rewriter) const override {
-    if (auto isTy = dyn_cast<quake::VeqType>(initState.getType()))
+    if (auto isTy = dyn_cast<cudaq::quake::VeqType>(initState.getType()))
       if (!isTy.hasSpecifiedSize()) {
         auto targ = initState.getTargets();
-        if (auto targTy = dyn_cast<quake::VeqType>(targ.getType()))
+        if (auto targTy = dyn_cast<cudaq::quake::VeqType>(targ.getType()))
           if (targTy.hasSpecifiedSize()) {
-            auto newInit = quake::InitializeStateOp::create(
+            auto newInit = cudaq::quake::InitializeStateOp::create(
                 rewriter, initState.getLoc(), targTy, targ,
                 initState.getState());
-            rewriter.replaceOpWithNewOp<quake::RelaxSizeOp>(initState, isTy,
-                                                            newInit);
+            rewriter.replaceOpWithNewOp<cudaq::quake::RelaxSizeOp>(
+                initState, isTy, newInit);
             return success();
           }
       }
@@ -466,7 +474,7 @@ struct ForwardAllocaTypePattern
         auto eleTy = ptrTy.getElementType();
         if (auto arrTy = dyn_cast<cudaq::cc::ArrayType>(eleTy))
           if (arrTy.isUnknownSize()) {
-            rewriter.replaceOpWithNewOp<quake::InitializeStateOp>(
+            rewriter.replaceOpWithNewOp<cudaq::quake::InitializeStateOp>(
                 initState, initState.getTargets().getType(),
                 initState.getTargets(), stateCast.getValue());
             return success();
@@ -480,12 +488,13 @@ struct ForwardAllocaTypePattern
 // ──────────────────────────────────────────────────────────────────────────
 // %.3 = quake.subveq %0, 4, 10 : (!quake.veq<12>, i64, i64) -> !quake.veq<7>
 // %3 = quake.relax_size %.3 : (!quake.veq<7>) -> !quake.veq<?>
-struct FixUnspecifiedSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
+struct FixUnspecifiedSubveqPattern
+    : public OpRewritePattern<cudaq::quake::SubVeqOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::SubVeqOp subveq,
+  LogicalResult matchAndRewrite(cudaq::quake::SubVeqOp subveq,
                                 PatternRewriter &rewriter) const override {
-    auto veqTy = dyn_cast<quake::VeqType>(subveq.getType());
+    auto veqTy = dyn_cast<cudaq::quake::VeqType>(subveq.getType());
     if (veqTy && veqTy.hasSpecifiedSize())
       return failure();
     if (!(subveq.hasConstantLowerBound() && subveq.hasConstantUpperBound()))
@@ -493,12 +502,12 @@ struct FixUnspecifiedSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
     auto *ctx = rewriter.getContext();
     std::size_t size =
         subveq.getConstantUpperBound() - subveq.getConstantLowerBound() + 1u;
-    auto szVecTy = quake::VeqType::get(ctx, size);
+    auto szVecTy = cudaq::quake::VeqType::get(ctx, size);
     auto loc = subveq.getLoc();
-    auto subv = quake::SubVeqOp::create(
+    auto subv = cudaq::quake::SubVeqOp::create(
         rewriter, loc, szVecTy, subveq.getVeq(), subveq.getLower(),
         subveq.getUpper(), subveq.getRawLower(), subveq.getRawUpper());
-    rewriter.replaceOpWithNewOp<quake::RelaxSizeOp>(subveq, veqTy, subv);
+    rewriter.replaceOpWithNewOp<cudaq::quake::RelaxSizeOp>(subveq, veqTy, subv);
     return success();
   }
 };
@@ -508,19 +517,21 @@ struct FixUnspecifiedSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
 // %3 = quake.subveq %0, %1, %2 : (!quake.veq<12>, i64, i64) -> !quake.veq<?>
 // ──────────────────────────────────────────────────────────────────────────
 // %3 = quake.subveq %0, 4, 10 : (!quake.veq<12>, i64, i64) -> !quake.veq<7>
-struct FuseConstantToSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
+struct FuseConstantToSubveqPattern
+    : public OpRewritePattern<cudaq::quake::SubVeqOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::SubVeqOp subveq,
+  LogicalResult matchAndRewrite(cudaq::quake::SubVeqOp subveq,
                                 PatternRewriter &rewriter) const override {
     if (subveq.hasConstantLowerBound() && subveq.hasConstantUpperBound())
       return failure();
     bool regen = false;
     std::int64_t lo = subveq.getConstantLowerBound();
     auto veqSize = [&]() -> std::int64_t {
-      auto size = cast<quake::VeqType>(subveq.getVeq().getType()).getSize();
+      auto size =
+          cast<cudaq::quake::VeqType>(subveq.getVeq().getType()).getSize();
       // Note: do not support more than 2^32 qubits.
-      if (size == quake::VeqType::kDynamicSize)
+      if (size == cudaq::quake::VeqType::kDynamicSize)
         return std::numeric_limits<std::int32_t>::max();
       return size - 1;
     }();
@@ -551,7 +562,7 @@ struct FuseConstantToSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
           subveq, subveq.getType());
       poison.emitWarning("subrange of qvector is invalid.");
     } else {
-      rewriter.replaceOpWithNewOp<quake::SubVeqOp>(
+      rewriter.replaceOpWithNewOp<cudaq::quake::SubVeqOp>(
           subveq, subveq.getType(), subveq.getVeq(), loVal, hiVal, lo, hi);
     }
     return success();
@@ -560,14 +571,15 @@ struct FuseConstantToSubveqPattern : public OpRewritePattern<quake::SubVeqOp> {
 
 // Replace subveq operations that extract the entire original register with the
 // original register.
-struct RemoveSubVeqNoOpPattern : public OpRewritePattern<quake::SubVeqOp> {
+struct RemoveSubVeqNoOpPattern
+    : public OpRewritePattern<cudaq::quake::SubVeqOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::SubVeqOp subVeqOp,
+  LogicalResult matchAndRewrite(cudaq::quake::SubVeqOp subVeqOp,
                                 PatternRewriter &rewriter) const override {
     auto origVeq = subVeqOp.getVeq();
     // The original veq size must be known
-    auto veqType = dyn_cast<quake::VeqType>(origVeq.getType());
+    auto veqType = dyn_cast<cudaq::quake::VeqType>(origVeq.getType());
     if (!veqType.hasSpecifiedSize())
       return failure();
     if (!(subVeqOp.hasConstantLowerBound() && subVeqOp.hasConstantUpperBound()))
@@ -593,20 +605,20 @@ struct RemoveSubVeqNoOpPattern : public OpRewritePattern<quake::SubVeqOp> {
 // %11 = quake.subveq %10, 0, 2 : (!quake.veq<7>) -> !quake.veq<3>
 // ───────────────────────────────────────────────────────────────
 // %11 = quake.subveq %4, 1, 3 : (!quake.veq<?>) -> !quake.veq<3>
-class CombineSubVeqsPattern : public OpRewritePattern<quake::SubVeqOp> {
+class CombineSubVeqsPattern : public OpRewritePattern<cudaq::quake::SubVeqOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::SubVeqOp subveq,
+  LogicalResult matchAndRewrite(cudaq::quake::SubVeqOp subveq,
                                 PatternRewriter &rewriter) const override {
-    auto prior = subveq.getVeq().getDefiningOp<quake::SubVeqOp>();
+    auto prior = subveq.getVeq().getDefiningOp<cudaq::quake::SubVeqOp>();
     if (!prior)
       return failure();
 
     auto loc = subveq.getLoc();
 
     // Lambda to create a Value for the lower bound of `s`.
-    auto lofunc = [&](quake::SubVeqOp s) -> Value {
+    auto lofunc = [&](cudaq::quake::SubVeqOp s) -> Value {
       if (s.hasConstantLowerBound())
         return arith::ConstantIntOp::create(rewriter, loc,
                                             s.getConstantLowerBound(), 64);
@@ -628,8 +640,8 @@ public:
     Value sum1 = arith::AddIOp::create(rewriter, loc, cast1, cast2);
     Value sum2 = arith::AddIOp::create(rewriter, loc, cast1, cast3);
     auto veqTy = subveq.getType();
-    rewriter.replaceOpWithNewOp<quake::SubVeqOp>(subveq, veqTy, prior.getVeq(),
-                                                 sum1, sum2);
+    rewriter.replaceOpWithNewOp<cudaq::quake::SubVeqOp>(
+        subveq, veqTy, prior.getVeq(), sum1, sum2);
     return success();
   }
 };
@@ -639,15 +651,16 @@ public:
 // ────────────────────────────────────────────────────────────────────
 // %11 = quake.init_state %_, %_ : (!quake.veq<2>, T1) -> !quake.veq<?>
 // %12 = constant 2 : i64
-struct FoldInitStateSizePattern : public OpRewritePattern<quake::VeqSizeOp> {
+struct FoldInitStateSizePattern
+    : public OpRewritePattern<cudaq::quake::VeqSizeOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::VeqSizeOp veqSize,
+  LogicalResult matchAndRewrite(cudaq::quake::VeqSizeOp veqSize,
                                 PatternRewriter &rewriter) const override {
     Value veq = veqSize.getVeq();
-    if (auto initState = veq.getDefiningOp<quake::InitializeStateOp>())
+    if (auto initState = veq.getDefiningOp<cudaq::quake::InitializeStateOp>())
       if (auto veqTy =
-              dyn_cast<quake::VeqType>(initState.getTargets().getType()))
+              dyn_cast<cudaq::quake::VeqType>(initState.getTargets().getType()))
         if (veqTy.hasSpecifiedSize()) {
           std::size_t numQubits = veqTy.getSize();
           rewriter.replaceOpWithNewOp<arith::ConstantIntOp>(
@@ -661,12 +674,13 @@ struct FoldInitStateSizePattern : public OpRewritePattern<quake::VeqSizeOp> {
 // If there is no operation that modifies the wire after it gets unwrapped and
 // before it is wrapped, then the wrap operation is a nop and can be
 // eliminated.
-struct KillDeadWrapPattern : public OpRewritePattern<quake::WrapOp> {
+struct KillDeadWrapPattern : public OpRewritePattern<cudaq::quake::WrapOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::WrapOp wrap,
+  LogicalResult matchAndRewrite(cudaq::quake::WrapOp wrap,
                                 PatternRewriter &rewriter) const override {
-    if (auto unwrap = wrap.getWireValue().getDefiningOp<quake::UnwrapOp>())
+    if (auto unwrap =
+            wrap.getWireValue().getDefiningOp<cudaq::quake::UnwrapOp>())
       rewriter.eraseOp(wrap);
     return success();
   }
@@ -679,7 +693,7 @@ struct MergeRotationPattern : public OpRewritePattern<OP> {
 
   LogicalResult matchAndRewrite(OP rotate,
                                 PatternRewriter &rewriter) const override {
-    auto wireTy = quake::WireType::get(rewriter.getContext());
+    auto wireTy = cudaq::quake::WireType::get(rewriter.getContext());
     if (rotate.getTarget(0).getType() != wireTy ||
         !rotate.getControls().empty())
       return failure();
@@ -721,17 +735,18 @@ struct MergeRotationPattern : public OpRewritePattern<OP> {
 // quake operations. All quake ops that take a sized veq argument are
 // polymorphic on all veq types. If the op is not a quake op, then maintain
 // strong typing.
-struct ForwardRelaxedSizePattern : public OpRewritePattern<quake::RelaxSizeOp> {
+struct ForwardRelaxedSizePattern
+    : public OpRewritePattern<cudaq::quake::RelaxSizeOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::RelaxSizeOp relax,
+  LogicalResult matchAndRewrite(cudaq::quake::RelaxSizeOp relax,
                                 PatternRewriter &rewriter) const override {
     auto inpVec = relax.getInputVec();
     bool replaced = false;
     rewriter.replaceUsesWithIf(relax, inpVec, [&](OpOperand &use) {
       bool res = false;
       if (Operation *user = use.getOwner())
-        res = isQuakeOperation(user) && !isa<quake::ApplyOp>(user);
+        res = isQuakeOperation(user) && !isa<cudaq::quake::ApplyOp>(user);
       replaced = replaced || res;
       return res;
     });

--- a/lib/Optimizer/Dialect/Quake/QuakeDialect.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeDialect.cpp
@@ -21,7 +21,7 @@
 
 //===----------------------------------------------------------------------===//
 
-void quake::QuakeDialect::initialize() {
+void cudaq::quake::QuakeDialect::initialize() {
   registerTypes();
   addOperations<
 #define GET_OP_LIST

--- a/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -27,7 +27,7 @@ using namespace mlir;
 
 static LogicalResult verifyWireResultsAreLinear(Operation *op) {
   for (Value v : op->getOpResults())
-    if (isa<quake::WireType>(v.getType())) {
+    if (isa<cudaq::quake::WireType>(v.getType())) {
       // Terminators can forward wire values, but they are not quantum
       // operations.
       if (v.hasOneUse() || v.use_empty())
@@ -48,18 +48,18 @@ static LogicalResult verifyWireResultsAreLinear(Operation *op) {
 /// When a quake operation is in value form, the number of wire arguments (wire
 /// arity) must be the same as the number of wires returned as results (wire
 /// coarity). This function verifies that this property is true.
-LogicalResult quake::verifyWireArityAndCoarity(Operation *op) {
+LogicalResult cudaq::quake::verifyWireArityAndCoarity(Operation *op) {
   std::size_t arity = 0;
   std::size_t coarity = 0;
   auto getCounts = [&](auto op) {
     for (auto arg : op.getTargets())
-      if (isa<quake::WireType>(arg.getType()))
+      if (isa<cudaq::quake::WireType>(arg.getType()))
         ++arity;
     coarity = op.getWires().size();
   };
   if (auto gate = dyn_cast<OperatorInterface>(op)) {
     for (auto arg : gate.getControls())
-      if (isa<quake::WireType>(arg.getType()))
+      if (isa<cudaq::quake::WireType>(arg.getType()))
         ++arity;
     getCounts(gate);
   } else if (auto meas = dyn_cast<MeasurementInterface>(op)) {
@@ -70,11 +70,11 @@ LogicalResult quake::verifyWireArityAndCoarity(Operation *op) {
   return op->emitOpError("arity does not equal coarity of wires");
 }
 
-bool quake::isSupportedMappingOperation(Operation *op) {
+bool cudaq::quake::isSupportedMappingOperation(Operation *op) {
   return isa<OperatorInterface, MeasurementInterface, SinkOp, ReturnWireOp>(op);
 }
 
-ValueRange quake::getQuantumTypesFromRange(ValueRange range) {
+ValueRange cudaq::quake::getQuantumTypesFromRange(ValueRange range) {
 
   // Skip over classical types at the beginning
   int numClassical = 0;
@@ -95,15 +95,16 @@ ValueRange quake::getQuantumTypesFromRange(ValueRange range) {
   return retVals;
 }
 
-ValueRange quake::getQuantumResults(Operation *op) {
+ValueRange cudaq::quake::getQuantumResults(Operation *op) {
   return getQuantumTypesFromRange(op->getResults());
 }
 
-ValueRange quake::getQuantumOperands(Operation *op) {
+ValueRange cudaq::quake::getQuantumOperands(Operation *op) {
   return getQuantumTypesFromRange(op->getOperands());
 }
 
-LogicalResult quake::setQuantumOperands(Operation *op, ValueRange quantumVals) {
+LogicalResult cudaq::quake::setQuantumOperands(Operation *op,
+                                               ValueRange quantumVals) {
   ValueRange quantumOperands = getQuantumTypesFromRange(op->getOperands());
 
   if (quantumOperands.size() != quantumVals.size())
@@ -122,26 +123,27 @@ LogicalResult quake::setQuantumOperands(Operation *op, ValueRange quantumVals) {
 // AllocaOp
 //===----------------------------------------------------------------------===//
 
-Value quake::createConstantAlloca(PatternRewriter &builder, Location loc,
-                                  OpResult result, ValueRange args) {
+Value cudaq::quake::createConstantAlloca(PatternRewriter &builder, Location loc,
+                                         OpResult result, ValueRange args) {
   auto newAlloca = [&]() {
-    if (isa<quake::VeqType>(result.getType()) &&
-        cast<quake::VeqType>(result.getType()).hasSpecifiedSize()) {
-      return quake::AllocaOp::create(
-          builder, loc, cast<quake::VeqType>(result.getType()).getSize());
+    if (isa<cudaq::quake::VeqType>(result.getType()) &&
+        cast<cudaq::quake::VeqType>(result.getType()).hasSpecifiedSize()) {
+      return cudaq::quake::AllocaOp::create(
+          builder, loc,
+          cast<cudaq::quake::VeqType>(result.getType()).getSize());
     }
     auto constOp = cast<arith::ConstantOp>(args[0].getDefiningOp());
-    return quake::AllocaOp::create(
+    return cudaq::quake::AllocaOp::create(
         builder, loc,
         static_cast<std::size_t>(
             cast<IntegerAttr>(constOp.getValue()).getInt()));
   }();
-  return quake::RelaxSizeOp::create(
-      builder, loc, quake::VeqType::getUnsized(builder.getContext()),
+  return cudaq::quake::RelaxSizeOp::create(
+      builder, loc, cudaq::quake::VeqType::getUnsized(builder.getContext()),
       newAlloca);
 }
 
-LogicalResult quake::AllocaOp::verify() {
+LogicalResult cudaq::quake::AllocaOp::verify() {
   // Result must be RefType or VeqType by construction.
   if (auto resTy = dyn_cast<VeqType>(getResult().getType())) {
     if (resTy.hasSpecifiedSize()) {
@@ -177,24 +179,24 @@ LogicalResult quake::AllocaOp::verify() {
   Operation *self = getOperation();
   if (!self->getUsers().empty() && !self->hasOneUse())
     for (auto *op : self->getUsers())
-      if (isa<quake::InitializeStateOp>(op))
+      if (isa<cudaq::quake::InitializeStateOp>(op))
         return emitOpError("init_state must be the only use");
   return success();
 }
 
-void quake::AllocaOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                                  MLIRContext *context) {
+void cudaq::quake::AllocaOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
   // Use a canonicalization pattern as folding the constant into the veq type
   // changes the type. Uses may still expect a veq with unspecified size.
   // Folding is strictly reductive and doesn't allow the creation of ops.
   patterns.add<FuseConstantToAllocaPattern>(context);
 }
 
-quake::InitializeStateOp quake::AllocaOp::getInitializedState() {
+cudaq::quake::InitializeStateOp cudaq::quake::AllocaOp::getInitializedState() {
   auto *self = getOperation();
   if (self->hasOneUse()) {
     auto x = self->getUsers().begin();
-    return dyn_cast<quake::InitializeStateOp>(*x);
+    return dyn_cast<cudaq::quake::InitializeStateOp>(*x);
   }
   return {};
 }
@@ -203,7 +205,7 @@ quake::InitializeStateOp quake::AllocaOp::getInitializedState() {
 // Apply
 //===----------------------------------------------------------------------===//
 
-LogicalResult quake::ApplyOp::verify() {
+LogicalResult cudaq::quake::ApplyOp::verify() {
   FunctionType asSig;
   if (auto callee = getCallee()) {
     auto fn =
@@ -231,8 +233,9 @@ LogicalResult quake::ApplyOp::verify() {
   // lowering the apply op is required to add a `quake.concat` op to manifest
   // the type conversion.
   auto isRelaxedVeq = [](Type ty1, Type ty2) {
-    if (auto veq2 = dyn_cast<quake::VeqType>(ty2))
-      return quake::isQuantumReferenceType(ty1) && !veq2.hasSpecifiedSize();
+    if (auto veq2 = dyn_cast<cudaq::quake::VeqType>(ty2))
+      return cudaq::quake::isQuantumReferenceType(ty1) &&
+             !veq2.hasSpecifiedSize();
     return false;
   };
 
@@ -252,7 +255,7 @@ LogicalResult quake::ApplyOp::verify() {
   return success();
 }
 
-void quake::ApplyOp::print(OpAsmPrinter &p) {
+void cudaq::quake::ApplyOp::print(OpAsmPrinter &p) {
   if (getIsAdj())
     p << "<adj>";
   p << ' ';
@@ -274,7 +277,8 @@ void quake::ApplyOp::print(OpAsmPrinter &p) {
       {"operand_segment_sizes", "is_adj", getCalleeAttrNameStr()});
 }
 
-ParseResult quake::ApplyOp::parse(OpAsmParser &parser, OperationState &result) {
+ParseResult cudaq::quake::ApplyOp::parse(OpAsmParser &parser,
+                                         OperationState &result) {
   if (succeeded(parser.parseOptionalLess())) {
     if (parser.parseKeyword("adj") || parser.parseGreater())
       return failure();
@@ -343,7 +347,7 @@ ParseResult quake::ApplyOp::parse(OpAsmParser &parser, OperationState &result) {
 // ApplyNoiseOp
 //===----------------------------------------------------------------------===//
 
-void quake::ApplyNoiseOp::print(OpAsmPrinter &p) {
+void cudaq::quake::ApplyNoiseOp::print(OpAsmPrinter &p) {
   // noise_func or key
   p << ' ';
   if (auto fn = getNoiseFuncAttr())
@@ -358,8 +362,8 @@ void quake::ApplyNoiseOp::print(OpAsmPrinter &p) {
                           {"operand_segment_sizes", getNoiseFuncAttrName()});
 }
 
-ParseResult quake::ApplyNoiseOp::parse(OpAsmParser &parser,
-                                       OperationState &result) {
+ParseResult cudaq::quake::ApplyNoiseOp::parse(OpAsmParser &parser,
+                                              OperationState &result) {
   SmallVector<OpAsmParser::UnresolvedOperand> keyOperand;
   if (parser.parseOperandList(keyOperand))
     return failure();
@@ -403,7 +407,7 @@ ParseResult quake::ApplyNoiseOp::parse(OpAsmParser &parser,
   return success();
 }
 
-LogicalResult quake::ApplyNoiseOp::verify() {
+LogicalResult cudaq::quake::ApplyNoiseOp::verify() {
   // Must have either a noise_func or a key and not both.
   if (!getNoiseFuncAttr()) {
     if (!getKey())
@@ -445,12 +449,12 @@ LogicalResult quake::ApplyNoiseOp::verify() {
 // BorrowWire
 //===----------------------------------------------------------------------===//
 
-LogicalResult quake::BorrowWireOp::verify() {
+LogicalResult cudaq::quake::BorrowWireOp::verify() {
   std::int32_t id = getIdentity();
   if (id < 0)
     return emitOpError("id cannot be negative");
   ModuleOp module = getOperation()->getParentOfType<ModuleOp>();
-  auto wires = module.lookupSymbol<quake::WireSetOp>(getSetName());
+  auto wires = module.lookupSymbol<cudaq::quake::WireSetOp>(getSetName());
   if (!wires)
     return emitOpError("wire set could not be found");
   std::int32_t setCardinality = wires.getCardinality();
@@ -463,30 +467,30 @@ LogicalResult quake::BorrowWireOp::verify() {
 // Concat
 //===----------------------------------------------------------------------===//
 
-void quake::ConcatOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                                  MLIRContext *context) {
+void cudaq::quake::ConcatOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<ConcatSizePattern, ConcatNoOpPattern, UselessConcatOpPattern>(
       context);
 }
 
-LogicalResult quake::ConcatOp::verify() {
+LogicalResult cudaq::quake::ConcatOp::verify() {
   bool isUnspecified = false;
   std::size_t size = 0;
   for (auto tq : getTargets()) {
     Type ty = tq.getType();
-    if (auto veq = dyn_cast<quake::VeqType>(ty);
+    if (auto veq = dyn_cast<cudaq::quake::VeqType>(ty);
         veq && !veq.hasSpecifiedSize()) {
       isUnspecified = true;
       break;
     }
-    if (auto struq = dyn_cast<quake::StruqType>(ty);
+    if (auto struq = dyn_cast<cudaq::quake::StruqType>(ty);
         struq && !struq.hasSpecifiedSize()) {
       isUnspecified = true;
       break;
     }
     size += getAllocationSize(ty);
   }
-  auto resTy = cast<quake::VeqType>(getType());
+  auto resTy = cast<cudaq::quake::VeqType>(getType());
   if (isUnspecified && resTy.hasSpecifiedSize())
     return emitOpError("veq size must be non-constant");
   if (resTy.hasSpecifiedSize() && resTy.getSize() != size)
@@ -526,12 +530,12 @@ void printRawString(OpAsmPrinter &printer, OP refOp, Value stringVal,
     printer << rawString;
 }
 
-void quake::ExpPauliOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                                    MLIRContext *context) {
+void cudaq::quake::ExpPauliOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<BindExpPauliWord, AdjustAdjointExpPauliPattern>(context);
 }
 
-LogicalResult quake::ExpPauliOp::verify() {
+LogicalResult cudaq::quake::ExpPauliOp::verify() {
   if (getPauliLiteralAttr()) {
     if (getPauli())
       return emitOpError("cannot have both a literal and a value Pauli word");
@@ -552,7 +556,7 @@ static ParseResult
 parseRawIndex(OpAsmParser &parser,
               std::optional<OpAsmParser::UnresolvedOperand> &index,
               IntegerAttr &rawIndex) {
-  std::size_t constantIndex = quake::ExtractRefOp::kDynamicIndex;
+  std::size_t constantIndex = cudaq::quake::ExtractRefOp::kDynamicIndex;
   OptionalParseResult parsedInteger =
       parser.parseOptionalInteger(constantIndex);
   if (parsedInteger.has_value()) {
@@ -579,14 +583,14 @@ void printRawIndex(OpAsmPrinter &printer, OP refOp, Value index,
     printer << rawIndex.getValue();
 }
 
-void quake::ExtractRefOp::getCanonicalizationPatterns(
+void cudaq::quake::ExtractRefOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<FuseConstantToExtractRefPattern, ForwardConcatExtractSingleton,
                ForwardConcatExtractPattern, ExtractRefFromSubVeqPattern>(
       context);
 }
 
-LogicalResult quake::ExtractRefOp::verify() {
+LogicalResult cudaq::quake::ExtractRefOp::verify() {
   if (getIndex()) {
     if (getRawIndex() != kDynamicIndex)
       return emitOpError(
@@ -609,9 +613,9 @@ LogicalResult quake::ExtractRefOp::verify() {
 // GetMemberOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult quake::GetMemberOp::verify() {
+LogicalResult cudaq::quake::GetMemberOp::verify() {
   std::uint32_t index = getIndex();
-  auto strTy = cast<quake::StruqType>(getStruq().getType());
+  auto strTy = cast<cudaq::quake::StruqType>(getStruq().getType());
   std::uint32_t size = strTy.getNumMembers();
   if (index >= size)
     return emitOpError("invalid index [" + std::to_string(index) +
@@ -622,7 +626,7 @@ LogicalResult quake::GetMemberOp::verify() {
   return success();
 }
 
-void quake::GetMemberOp::getCanonicalizationPatterns(
+void cudaq::quake::GetMemberOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<BypassMakeStruq>(context);
 }
@@ -631,7 +635,7 @@ void quake::GetMemberOp::getCanonicalizationPatterns(
 // InitializeStateOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult quake::InitializeStateOp::verify() {
+LogicalResult cudaq::quake::InitializeStateOp::verify() {
   auto ptrTy = cast<cudaq::cc::PointerType>(getState().getType());
   Type ty = ptrTy.getElementType();
   if (auto arrTy = dyn_cast<cudaq::cc::ArrayType>(ty)) {
@@ -644,13 +648,13 @@ LogicalResult quake::InitializeStateOp::verify() {
     }
     if (!isa<FloatType, ComplexType>(arrTy.getElementType()))
       return emitOpError("invalid data pointer type");
-  } else if (!isa<FloatType, ComplexType, quake::StateType>(ty)) {
+  } else if (!isa<FloatType, ComplexType, cudaq::quake::StateType>(ty)) {
     return emitOpError("invalid data pointer type");
   }
   return success();
 }
 
-void quake::InitializeStateOp::getCanonicalizationPatterns(
+void cudaq::quake::InitializeStateOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<ForwardAllocaTypePattern>(context);
 }
@@ -659,14 +663,14 @@ void quake::InitializeStateOp::getCanonicalizationPatterns(
 // MakeStruqOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult quake::MakeStruqOp::verify() {
+LogicalResult cudaq::quake::MakeStruqOp::verify() {
   if (getType().getNumMembers() != getNumOperands())
     return emitOpError("result type has different member count than operands");
   for (auto [ty, opnd] : llvm::zip(getType().getMembers(), getOperands())) {
     if (ty == opnd.getType())
       continue;
-    auto veqTy = dyn_cast<quake::VeqType>(ty);
-    auto veqOpndTy = dyn_cast<quake::VeqType>(opnd.getType());
+    auto veqTy = dyn_cast<cudaq::quake::VeqType>(ty);
+    auto veqOpndTy = dyn_cast<cudaq::quake::VeqType>(opnd.getType());
     if (veqTy && !veqTy.hasSpecifiedSize() && veqOpndTy &&
         veqOpndTy.hasSpecifiedSize())
       continue;
@@ -679,13 +683,13 @@ LogicalResult quake::MakeStruqOp::verify() {
 // RelaxSizeOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult quake::RelaxSizeOp::verify() {
-  if (cast<quake::VeqType>(getType()).hasSpecifiedSize())
+LogicalResult cudaq::quake::RelaxSizeOp::verify() {
+  if (cast<cudaq::quake::VeqType>(getType()).hasSpecifiedSize())
     emitOpError("return veq type must not specify a size");
   return success();
 }
 
-void quake::RelaxSizeOp::getCanonicalizationPatterns(
+void cudaq::quake::RelaxSizeOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<ForwardRelaxedSizePattern>(context);
 }
@@ -694,7 +698,7 @@ void quake::RelaxSizeOp::getCanonicalizationPatterns(
 // SubVeqOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult quake::SubVeqOp::verify() {
+LogicalResult cudaq::quake::SubVeqOp::verify() {
   if ((hasConstantLowerBound() && getRawLower() == kDynamicIndex) ||
       (!hasConstantLowerBound() && getRawLower() != kDynamicIndex))
     return emitOpError("invalid lower bound specified");
@@ -704,13 +708,13 @@ LogicalResult quake::SubVeqOp::verify() {
   if (hasConstantLowerBound() && hasConstantUpperBound()) {
     if (getRawLower() > getRawUpper())
       return emitOpError("invalid subrange specified");
-    if (auto veqTy = dyn_cast<quake::VeqType>(getVeq().getType()))
+    if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(getVeq().getType()))
       if (veqTy.hasSpecifiedSize())
         if (getRawLower() >= veqTy.getSize() ||
             getRawUpper() >= veqTy.getSize())
           return emitOpError(
               "subveq range does not fully intersect the input veq");
-    if (auto veqTy = dyn_cast<quake::VeqType>(getResult().getType()))
+    if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(getResult().getType()))
       if (veqTy.hasSpecifiedSize())
         if (veqTy.getSize() != getRawUpper() - getRawLower() + 1)
           return emitOpError("incorrect size for result veq type");
@@ -718,8 +722,8 @@ LogicalResult quake::SubVeqOp::verify() {
   return success();
 }
 
-void quake::SubVeqOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                                  MLIRContext *context) {
+void cudaq::quake::SubVeqOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<FixUnspecifiedSubveqPattern, FuseConstantToSubveqPattern,
                RemoveSubVeqNoOpPattern, CombineSubVeqsPattern>(context);
 }
@@ -728,8 +732,8 @@ void quake::SubVeqOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 // VeqSizeOp
 //===----------------------------------------------------------------------===//
 
-void quake::VeqSizeOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                                   MLIRContext *context) {
+void cudaq::quake::VeqSizeOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<FoldInitStateSizePattern, ForwardConstantVeqSizePattern>(
       context);
 }
@@ -738,8 +742,8 @@ void quake::VeqSizeOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 // WrapOp
 //===----------------------------------------------------------------------===//
 
-void quake::WrapOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                                MLIRContext *context) {
+void cudaq::quake::WrapOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add<KillDeadWrapPattern>(context);
 }
 
@@ -747,8 +751,8 @@ void quake::WrapOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 // CallByRefOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult
-quake::CallByRefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+LogicalResult cudaq::quake::CallByRefOp::verifySymbolUses(
+    SymbolTableCollection &symbolTable) {
   auto fn =
       symbolTable.lookupNearestSymbolFrom<func::FuncOp>(*this, getCalleeAttr());
   if (!fn)
@@ -759,10 +763,10 @@ quake::CallByRefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 // This is syntactic sugar for calling a kernel declared with quantum reference
 // types and using "mismatched" arguments of quantum value types. This verify
 // enforces all the restrictions on the call.
-LogicalResult quake::CallByRefOp::verify() {
+LogicalResult cudaq::quake::CallByRefOp::verify() {
   // Arguments must be classical or wire types, not ref types.
   for (auto ty : getOperandTypes())
-    if (quake::isQuantumReferenceType(ty))
+    if (cudaq::quake::isQuantumReferenceType(ty))
       return emitOpError("quantum reference types are not allowed");
 
   auto fn = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(*this,
@@ -777,11 +781,11 @@ LogicalResult quake::CallByRefOp::verify() {
 
   // Signature of callee must not contain quantum value types.
   for (auto ty : asSig.getResults())
-    if (quake::isQuantumValueType(ty))
+    if (cudaq::quake::isQuantumValueType(ty))
       return emitOpError(
           "quantum value types are not allowed in callee results");
   for (auto ty : asSig.getInputs())
-    if (quake::isQuantumValueType(ty))
+    if (cudaq::quake::isQuantumValueType(ty))
       return emitOpError(
           "quantum value types are not allowed in callee inputs");
 
@@ -802,12 +806,13 @@ LogicalResult quake::CallByRefOp::verify() {
        llvm::enumerate(llvm::zip(getOperandTypes(), asSig.getInputs()))) {
     auto i = iter.index();
     auto [operTy, sigTy] = iter.value();
-    if (quake::isQuantumValueType(operTy)) {
+    if (cudaq::quake::isQuantumValueType(operTy)) {
       if (!quake::isQuantumReferenceType(sigTy))
         return emitOpError("argument #" + std::to_string(i) +
                            " must be a quantum type");
-      if (quake::isConstantQuantumRefType(sigTy) &&
-          quake::getWireCount(operTy) != quake::getAllocationSize(sigTy))
+      if (cudaq::quake::isConstantQuantumRefType(sigTy) &&
+          cudaq::quake::getWireCount(operTy) !=
+              cudaq::quake::getAllocationSize(sigTy))
         return emitOpError("argument #" + std::to_string(i) +
                            " must match in size");
       if (operTy != myResultTypes[formalResultsSize + i])
@@ -837,17 +842,18 @@ LogicalResult verifyMeasurements(MEAS op, TypeRange targetsType,
     return failure();
   bool mustBeStdvec =
       targetsType.size() > 1 ||
-      (targetsType.size() == 1 && isa<quake::VeqType>(targetsType[0]));
+      (targetsType.size() == 1 && isa<cudaq::quake::VeqType>(targetsType[0]));
   if (mustBeStdvec) {
     auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(op.getMeasOut().getType());
-    if (!stdvecTy || !isa<quake::MeasureType, cudaq::cc::MeasureHandleType>(
-                         stdvecTy.getElementType()))
+    if (!stdvecTy ||
+        !isa<cudaq::quake::MeasureType, cudaq::cc::MeasureHandleType>(
+            stdvecTy.getElementType()))
       return op.emitOpError(
           "must return `!cc.stdvec<!quake.measure>` or "
           "`!cc.stdvec<!cc.measure_handle>` when measuring a qvector, a "
           "series of qubits, or both");
   } else {
-    if (!isa<quake::MeasureType, cudaq::cc::MeasureHandleType>(
+    if (!isa<cudaq::quake::MeasureType, cudaq::cc::MeasureHandleType>(
             op.getMeasOut().getType()))
       return op->emitOpError(
           "must return `!quake.measure` or `!cc.measure_handle` when "
@@ -859,17 +865,17 @@ LogicalResult verifyMeasurements(MEAS op, TypeRange targetsType,
   return success();
 }
 
-LogicalResult quake::MxOp::verify() {
+LogicalResult cudaq::quake::MxOp::verify() {
   return verifyMeasurements(*this, getTargets().getType(),
                             getMeasOut().getType());
 }
 
-LogicalResult quake::MyOp::verify() {
+LogicalResult cudaq::quake::MyOp::verify() {
   return verifyMeasurements(*this, getTargets().getType(),
                             getMeasOut().getType());
 }
 
-LogicalResult quake::MzOp::verify() {
+LogicalResult cudaq::quake::MzOp::verify() {
   return verifyMeasurements(*this, getTargets().getType(),
                             getMeasOut().getType());
 }
@@ -878,7 +884,7 @@ LogicalResult quake::MzOp::verify() {
 // Discriminate
 //===----------------------------------------------------------------------===//
 
-LogicalResult quake::DiscriminateOp::verify() {
+LogicalResult cudaq::quake::DiscriminateOp::verify() {
   if (isa<cudaq::cc::StdvecType>(getMeasurement().getType())) {
     auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(getResult().getType());
     if (!stdvecTy || !isa<IntegerType>(stdvecTy.getElementType()))
@@ -886,7 +892,7 @@ LogicalResult quake::DiscriminateOp::verify() {
           "must return a !cc.stdvec<integral> type, when discriminating a "
           "qvector, a series of qubits, or both");
   } else {
-    if (!isa<quake::MeasureType, cudaq::cc::MeasureHandleType>(
+    if (!isa<cudaq::quake::MeasureType, cudaq::cc::MeasureHandleType>(
             getMeasurement().getType()) ||
         !isa<IntegerType>(getResult().getType()))
       return emitOpError(
@@ -895,20 +901,20 @@ LogicalResult quake::DiscriminateOp::verify() {
   return success();
 }
 
-LogicalResult quake::BundleCableOp::verify() {
-  auto ty = cast<quake::CableType>(getResult().getType());
+LogicalResult cudaq::quake::BundleCableOp::verify() {
+  auto ty = cast<cudaq::quake::CableType>(getResult().getType());
   if (getWires().size() != ty.getSize())
     return emitOpError("the cable type size must equal the arity.");
   return success();
 }
 
-LogicalResult quake::SplitCableOp::verify() {
+LogicalResult cudaq::quake::SplitCableOp::verify() {
   if (getResults().size() != getCable().getType().getSize())
     return emitOpError("the cable type size must equal the coarity.");
   return success();
 }
 
-LogicalResult quake::DetachWireOp::verify() {
+LogicalResult cudaq::quake::DetachWireOp::verify() {
   if (!getCable().getType().getSize())
     return emitOpError("cannot remove a wire from an empty cable.");
   if (getIndex() >= getCable().getType().getSize())
@@ -919,7 +925,7 @@ LogicalResult quake::DetachWireOp::verify() {
   return success();
 }
 
-LogicalResult quake::AttachWireOp::verify() {
+LogicalResult cudaq::quake::AttachWireOp::verify() {
   if (getIndex() > getCable().getType().getSize())
     return emitOpError("index into the cable is out of bounds.");
   if (getCableOut().getType().getSize() != getCable().getType().getSize() + 1)
@@ -932,8 +938,8 @@ LogicalResult quake::AttachWireOp::verify() {
 // WireSetOp
 //===----------------------------------------------------------------------===//
 
-ParseResult quake::WireSetOp::parse(OpAsmParser &parser,
-                                    OperationState &result) {
+ParseResult cudaq::quake::WireSetOp::parse(OpAsmParser &parser,
+                                           OperationState &result) {
   StringAttr name;
   if (parser.parseSymbolName(name, getSymNameAttrName(result.name),
                              result.attributes))
@@ -954,7 +960,7 @@ ParseResult quake::WireSetOp::parse(OpAsmParser &parser,
   return success();
 }
 
-void quake::WireSetOp::print(OpAsmPrinter &p) {
+void cudaq::quake::WireSetOp::print(OpAsmPrinter &p) {
   p << ' ';
   p.printSymbolName(getSymName());
   p << '[' << getCardinality() << ']';
@@ -992,12 +998,12 @@ static LogicalResult getParameterAsDouble(Value parameter, double &result) {
   return failure();
 }
 
-void quake::HOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::HOp::getOperatorMatrix(Matrix &matrix) {
   using namespace llvm::numbers;
   matrix.assign({inv_sqrt2, inv_sqrt2, inv_sqrt2, -inv_sqrt2});
 }
 
-void quake::PhasedRxOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::PhasedRxOp::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
 
   // Get parameters
@@ -1015,7 +1021,7 @@ void quake::PhasedRxOp::getOperatorMatrix(Matrix &matrix) {
        -1i * std::exp(-1i * phi) * std::sin(theta / 2.), std::cos(theta / 2.)});
 }
 
-void quake::R1Op::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::R1Op::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
   double theta;
   if (failed(getParameterAsDouble(getParameter(), theta)))
@@ -1025,7 +1031,7 @@ void quake::R1Op::getOperatorMatrix(Matrix &matrix) {
   matrix.assign({1, 0, 0, std::exp(theta * 1i)});
 }
 
-void quake::RxOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::RxOp::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
   double theta;
   if (failed(getParameterAsDouble(getParameter(), theta)))
@@ -1036,12 +1042,12 @@ void quake::RxOp::getOperatorMatrix(Matrix &matrix) {
                  -1i * std::sin(theta / 2.), std::cos(theta / 2.)});
 }
 
-void quake::RxOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                              MLIRContext *context) {
-  patterns.add<MergeRotationPattern<quake::RxOp>>(context);
+void cudaq::quake::RxOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<MergeRotationPattern<cudaq::quake::RxOp>>(context);
 }
 
-void quake::RyOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::RyOp::getOperatorMatrix(Matrix &matrix) {
   // Get parameter
   double theta;
   if (failed(getParameterAsDouble(getParameter(), theta)))
@@ -1054,12 +1060,12 @@ void quake::RyOp::getOperatorMatrix(Matrix &matrix) {
                  -std::sin(theta / 2.), std::cos(theta / 2.)});
 }
 
-void quake::RyOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                              MLIRContext *context) {
-  patterns.add<MergeRotationPattern<quake::RyOp>>(context);
+void cudaq::quake::RyOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<MergeRotationPattern<cudaq::quake::RyOp>>(context);
 }
 
-void quake::RzOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::RzOp::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
 
   // Get parameter
@@ -1073,12 +1079,12 @@ void quake::RzOp::getOperatorMatrix(Matrix &matrix) {
   matrix.assign({std::exp(-1i * theta / 2.), 0, 0, std::exp(1i * theta / 2.)});
 }
 
-void quake::RzOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
-                                              MLIRContext *context) {
-  patterns.add<MergeRotationPattern<quake::RzOp>>(context);
+void cudaq::quake::RzOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<MergeRotationPattern<cudaq::quake::RzOp>>(context);
 }
 
-void quake::SOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::SOp::getOperatorMatrix(Matrix &matrix) {
   using namespace llvm::numbers;
   using namespace std::complex_literals;
   if (getIsAdj())
@@ -1087,11 +1093,11 @@ void quake::SOp::getOperatorMatrix(Matrix &matrix) {
     matrix.assign({1, 0, 0, 1i});
 }
 
-void quake::SwapOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::SwapOp::getOperatorMatrix(Matrix &matrix) {
   matrix.assign({1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1});
 }
 
-void quake::TOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::TOp::getOperatorMatrix(Matrix &matrix) {
   using namespace llvm::numbers;
   if (getIsAdj())
     matrix.assign({1, 0, 0, {inv_sqrt2, -inv_sqrt2}});
@@ -1099,7 +1105,7 @@ void quake::TOp::getOperatorMatrix(Matrix &matrix) {
     matrix.assign({1, 0, 0, {inv_sqrt2, inv_sqrt2}});
 }
 
-void quake::U2Op::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::U2Op::getOperatorMatrix(Matrix &matrix) {
   using namespace llvm::numbers;
   using namespace std::complex_literals;
 
@@ -1120,7 +1126,7 @@ void quake::U2Op::getOperatorMatrix(Matrix &matrix) {
                  inv_sqrt2 * std::exp(1i * (phi + lambda))});
 }
 
-void quake::U3Op::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::U3Op::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
 
   // Get parameters
@@ -1145,20 +1151,20 @@ void quake::U3Op::getOperatorMatrix(Matrix &matrix) {
                  std::exp(1i * (phi + lambda)) * std::cos(theta / 2.)});
 }
 
-void quake::XOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::XOp::getOperatorMatrix(Matrix &matrix) {
   matrix.assign({0, 1, 1, 0});
 }
 
-void quake::YOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::YOp::getOperatorMatrix(Matrix &matrix) {
   using namespace std::complex_literals;
   matrix.assign({0, 1i, -1i, 0});
 }
 
-void quake::ZOp::getOperatorMatrix(Matrix &matrix) {
+void cudaq::quake::ZOp::getOperatorMatrix(Matrix &matrix) {
   matrix.assign({1, 0, 0, -1});
 }
 
-void quake::CustomUnitarySymbolOp::getOperatorMatrix(Matrix &matrix) {}
+void cudaq::quake::CustomUnitarySymbolOp::getOperatorMatrix(Matrix &matrix) {}
 
 //===----------------------------------------------------------------------===//
 
@@ -1168,7 +1174,7 @@ void quake::CustomUnitarySymbolOp::getOperatorMatrix(Matrix &matrix) {}
 bool cudaq::EnableInlinerInterface::isLegalToInline(Operation *call,
                                                     Operation *callable,
                                                     bool) const {
-  if (auto applyOp = dyn_cast<quake::ApplyOp>(call))
+  if (auto applyOp = dyn_cast<cudaq::quake::ApplyOp>(call))
     if (applyOp.applyToVariant())
       return false;
   if (auto destFunc = call->getParentOfType<func::FuncOp>())
@@ -1210,11 +1216,11 @@ inline static void getModedEffectsImpl(EffectsVectorImpl &effects,
                                        MutableArrayRef<OpOperand> controls,
                                        MutableArrayRef<OpOperand> targets) {
   for (OpOperand &v : controls)
-    if (isa<quake::RefType, quake::VeqType>(v.get().getType()))
+    if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(v.get().getType()))
       effects.emplace_back(MemoryEffects::Read::get(), &v,
                            SideEffects::DefaultResource::get());
   for (OpOperand &v : targets)
-    if (isa<quake::RefType, quake::VeqType>(v.get().getType())) {
+    if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(v.get().getType())) {
       effects.emplace_back(MemoryEffects::Read::get(), &v,
                            SideEffects::DefaultResource::get());
       effects.emplace_back(MemoryEffects::Write::get(), &v,
@@ -1223,21 +1229,21 @@ inline static void getModedEffectsImpl(EffectsVectorImpl &effects,
 }
 
 /// Quake reset has modeless effects.
-void quake::getResetEffectsImpl(EffectsVectorImpl &effects,
-                                MutableArrayRef<OpOperand> targets) {
+void cudaq::quake::getResetEffectsImpl(EffectsVectorImpl &effects,
+                                       MutableArrayRef<OpOperand> targets) {
   getModedEffectsImpl(effects, {}, targets);
 }
 
 /// Quake measurement operations have moded effects.
-void quake::getMeasurementEffectsImpl(EffectsVectorImpl &effects,
-                                      MutableArrayRef<OpOperand> targets) {
+void cudaq::quake::getMeasurementEffectsImpl(
+    EffectsVectorImpl &effects, MutableArrayRef<OpOperand> targets) {
   getModedEffectsImpl(effects, {}, targets);
 }
 
 /// Quake quantum operators have moded effects.
-void quake::getOperatorEffectsImpl(EffectsVectorImpl &effects,
-                                   MutableArrayRef<OpOperand> controls,
-                                   MutableArrayRef<OpOperand> targets) {
+void cudaq::quake::getOperatorEffectsImpl(EffectsVectorImpl &effects,
+                                          MutableArrayRef<OpOperand> controls,
+                                          MutableArrayRef<OpOperand> targets) {
   getModedEffectsImpl(effects, controls, targets);
 }
 
@@ -1254,7 +1260,7 @@ void quake::getOperatorEffectsImpl(EffectsVectorImpl &effects,
   MACRO(UnwrapOp)
 // clang-format on
 #define INSTANTIATE_CALLBACKS(Op)                                              \
-  void quake::Op::getEffects(                                                  \
+  void cudaq::quake::Op::getEffects(                                           \
       SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>      \
           &effects) {                                                          \
     getEffectsImpl(effects);                                                   \
@@ -1263,7 +1269,7 @@ void quake::getOperatorEffectsImpl(EffectsVectorImpl &effects,
 QUANTUM_OPS(INSTANTIATE_CALLBACKS)
 
 #define INSTANTIATE_LINEAR_TYPE_VERIFY(Op)                                     \
-  LogicalResult quake::Op::verify() {                                          \
+  LogicalResult cudaq::quake::Op::verify() {                                   \
     return verifyWireResultsAreLinear(getOperation());                         \
   }
 

--- a/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
+++ b/lib/Optimizer/Dialect/Quake/QuakeTypes.cpp
@@ -27,7 +27,7 @@ using namespace mlir;
 // veq `<` (`?` | int) `>`
 //===----------------------------------------------------------------------===//
 
-void quake::VeqType::print(AsmPrinter &os) const {
+void cudaq::quake::VeqType::print(AsmPrinter &os) const {
   os << '<';
   if (hasSpecifiedSize())
     os << getSize();
@@ -36,7 +36,7 @@ void quake::VeqType::print(AsmPrinter &os) const {
   os << '>';
 }
 
-Type quake::VeqType::parse(AsmParser &parser) {
+Type cudaq::quake::VeqType::parse(AsmParser &parser) {
   if (parser.parseLess())
     return {};
   std::size_t size = kDynamicSize;
@@ -51,7 +51,7 @@ Type quake::VeqType::parse(AsmParser &parser) {
 
 //===----------------------------------------------------------------------===//
 
-Type quake::StruqType::parse(AsmParser &parser) {
+Type cudaq::quake::StruqType::parse(AsmParser &parser) {
   if (parser.parseLess())
     return {};
   std::string name;
@@ -70,25 +70,25 @@ Type quake::StruqType::parse(AsmParser &parser) {
       break;
     if (!succeeded(*optTy))
       return {};
-    if (!llvm::isa<quake::RefType, quake::VeqType>(member))
+    if (!llvm::isa<cudaq::quake::RefType, cudaq::quake::VeqType>(member))
       parser.emitError(parser.getCurrentLocation(),
                        "invalid struq member type");
     members.push_back(member);
   } while (succeeded(parser.parseOptionalComma()));
   if (parser.parseGreater())
     return {};
-  return quake::StruqType::get(ctx, nameAttr, members);
+  return cudaq::quake::StruqType::get(ctx, nameAttr, members);
 }
 
-bool quake::StruqType::hasSpecifiedSize() const {
+bool cudaq::quake::StruqType::hasSpecifiedSize() const {
   for (auto ty : getMembers())
-    if (auto veqTy = llvm::dyn_cast<quake::VeqType>(ty))
+    if (auto veqTy = llvm::dyn_cast<cudaq::quake::VeqType>(ty))
       if (!veqTy.hasSpecifiedSize())
         return false;
   return true;
 }
 
-std::optional<std::size_t> quake::StruqType::getArity() const {
+std::optional<std::size_t> cudaq::quake::StruqType::getArity() const {
   if (getMembers().empty())
     return {0};
   std::size_t res = 0;
@@ -108,7 +108,7 @@ std::optional<std::size_t> quake::StruqType::getArity() const {
   return {res};
 }
 
-void quake::StruqType::print(AsmPrinter &printer) const {
+void cudaq::quake::StruqType::print(AsmPrinter &printer) const {
   printer << '<';
   if (getName())
     printer << getName() << ": ";
@@ -124,39 +124,41 @@ void quake::StruqType::print(AsmPrinter &printer) const {
 // function returns false for any type not in the set \e R or if the composition
 // of types contains a `veq` of unspecified size.
 static bool isConstQuantumBits(Type ty) {
-  if (isa<quake::RefType>(ty))
+  if (isa<cudaq::quake::RefType>(ty))
     return true;
-  if (auto t = dyn_cast<quake::StruqType>(ty)) {
+  if (auto t = dyn_cast<cudaq::quake::StruqType>(ty)) {
     for (auto m : t.getMembers())
       if (!isConstQuantumBits(m))
         return false;
     return true;
   }
-  if (auto t = dyn_cast<quake::VeqType>(ty))
+  if (auto t = dyn_cast<cudaq::quake::VeqType>(ty))
     if (t.hasSpecifiedSize())
       return true;
   return false;
 }
 
-bool quake::isConstantQuantumRefType(Type ty) { return isConstQuantumBits(ty); }
+bool cudaq::quake::isConstantQuantumRefType(Type ty) {
+  return isConstQuantumBits(ty);
+}
 
-std::size_t quake::getAllocationSize(Type ty) {
-  if (isa<quake::RefType>(ty))
+std::size_t cudaq::quake::getAllocationSize(Type ty) {
+  if (isa<cudaq::quake::RefType>(ty))
     return 1;
-  if (auto stq = dyn_cast<quake::StruqType>(ty)) {
+  if (auto stq = dyn_cast<cudaq::quake::StruqType>(ty)) {
     std::size_t size = 0;
     for (auto m : stq.getMembers())
       size += getAllocationSize(m);
     return size;
   }
-  auto veq = cast<quake::VeqType>(ty);
+  auto veq = cast<cudaq::quake::VeqType>(ty);
   assert(veq.hasSpecifiedSize() && "veq type must have constant size");
   return veq.getSize();
 }
 
 //===----------------------------------------------------------------------===//
 
-void quake::QuakeDialect::registerTypes() {
+void cudaq::quake::QuakeDialect::registerTypes() {
   addTypes<CableType, ControlType, MeasureType, RefType, StateType, StruqType,
            VeqType, WireType>();
 }

--- a/lib/Optimizer/Transforms/AddDeallocs.cpp
+++ b/lib/Optimizer/Transforms/AddDeallocs.cpp
@@ -47,14 +47,14 @@ struct DeallocationAnalysisInfo {
     for (Region &region : op->getRegions())
       for (Block &block : region)
         for (Operation &op : block) {
-          if (auto alloca = dyn_cast<quake::AllocaOp>(op)) {
+          if (auto alloca = dyn_cast<cudaq::quake::AllocaOp>(op)) {
             if (!deallocMap.count(&op))
               deallocMap.insert(std::make_pair(&op, false));
-          } else if (auto dealloc = dyn_cast<quake::DeallocOp>(op)) {
+          } else if (auto dealloc = dyn_cast<cudaq::quake::DeallocOp>(op)) {
             auto val = dealloc.getReference();
             Operation *alloc = val.getDefiningOp();
-            if (!isa<quake::AllocaOp>(alloc)) {
-              auto initState = cast<quake::InitializeStateOp>(alloc);
+            if (!isa<cudaq::quake::AllocaOp>(alloc)) {
+              auto initState = cast<cudaq::quake::InitializeStateOp>(alloc);
               alloc = initState.getTargets().getDefiningOp();
             }
             if (deallocMap.count(alloc))
@@ -96,7 +96,7 @@ private:
               cudaq::cc::UnwindReturnOp>(o)) {
         o->emitError("must run unwind-lowering before add-dealloc.");
         hasErrors = true;
-      } else if (auto alloc = dyn_cast<quake::AllocaOp>(o)) {
+      } else if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(o)) {
         auto *op = alloc.getOperation();
         if (!allocMap.count(op)) {
           allocMap.insert(std::make_pair(op, /*deallocated=*/false));
@@ -104,11 +104,11 @@ private:
           LLVM_DEBUG(llvm::dbgs() << "adding alloca: " << op << " from "
                                   << op->getParentOp() << '\n');
         }
-      } else if (auto dealloc = dyn_cast<quake::DeallocOp>(o)) {
+      } else if (auto dealloc = dyn_cast<cudaq::quake::DeallocOp>(o)) {
         auto val = dealloc.getReference();
-        if (auto init = val.getDefiningOp<quake::InitializeStateOp>())
+        if (auto init = val.getDefiningOp<cudaq::quake::InitializeStateOp>())
           val = init.getTargets();
-        if (auto alloc = val.getDefiningOp<quake::AllocaOp>()) {
+        if (auto alloc = val.getDefiningOp<cudaq::quake::AllocaOp>()) {
           auto *op = alloc.getOperation();
           if (allocMap.count(op))
             allocMap[op] = true;
@@ -131,14 +131,14 @@ private:
 inline void generateDeallocsForSet(PatternRewriter &rewriter,
                                    llvm::DenseSet<Operation *> &allocSet) {
   for (Operation *a : allocSet) {
-    auto alloc = cast<quake::AllocaOp>(a);
+    auto alloc = cast<cudaq::quake::AllocaOp>(a);
     Value v = alloc;
     if (a->hasOneUse()) {
       if (auto initState =
-              dyn_cast<quake::InitializeStateOp>(*a->getUsers().begin()))
+              dyn_cast<cudaq::quake::InitializeStateOp>(*a->getUsers().begin()))
         v = initState;
     }
-    quake::DeallocOp::create(rewriter, a->getLoc(), v);
+    cudaq::quake::DeallocOp::create(rewriter, a->getLoc(), v);
   }
 }
 

--- a/lib/Optimizer/Transforms/AddMeasurements.cpp
+++ b/lib/Optimizer/Transforms/AddMeasurements.cpp
@@ -34,10 +34,10 @@ struct Analysis {
         hasMeasurement = true;
         return WalkResult::interrupt();
       }
-      if (auto alloc = dyn_cast<quake::AllocaOp>(op)) {
+      if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(op)) {
         if (alloc->hasOneUse()) {
           Operation *user = *alloc->getUsers().begin();
-          if (isa<quake::InitializeStateOp>(user))
+          if (isa<cudaq::quake::InitializeStateOp>(user))
             op = user;
         }
         allocations.emplace_back(op);
@@ -88,14 +88,14 @@ addMeasurements(func::FuncOp funcOp, SmallVector<Operation *> &allocations,
 
   // Set insertion point to the new block and add measurements
   builder.setInsertionPointToEnd(newBlock);
-  auto measTy = quake::MeasureType::get(builder.getContext());
+  auto measTy = cudaq::quake::MeasureType::get(builder.getContext());
   for (auto [index, alloca] : llvm::enumerate(allocations)) {
-    if (isa<quake::VeqType>(alloca->getResult(0).getType())) {
+    if (isa<cudaq::quake::VeqType>(alloca->getResult(0).getType())) {
       auto stdvecTy = cudaq::cc::StdvecType::get(measTy);
-      quake::MzOp::create(builder, loc, stdvecTy,
-                          ValueRange{alloca->getResult(0)});
+      cudaq::quake::MzOp::create(builder, loc, stdvecTy,
+                                 ValueRange{alloca->getResult(0)});
     } else {
-      quake::MzOp::create(builder, loc, measTy, alloca->getResult(0));
+      cudaq::quake::MzOp::create(builder, loc, measTy, alloca->getResult(0));
     }
   }
 

--- a/lib/Optimizer/Transforms/AddMetadata.cpp
+++ b/lib/Optimizer/Transforms/AddMetadata.cpp
@@ -49,16 +49,16 @@ static cudaq::cc::AllocaOp seekAllocaFrom(Value v) {
 
 /// If the operation is a Measurement, check if its qubits are used in a
 /// subsequent reset operation, return true if so.
-static bool checkIsMeasureAndReset(quake::MeasurementInterface mxOp) {
+static bool checkIsMeasureAndReset(cudaq::quake::MeasurementInterface mxOp) {
   if (mxOp.getOptionalRegisterName())
     for (Value measuredQubit : mxOp.getTargets())
       for (Operation *user : measuredQubit.getUsers())
-        if (isa_and_present<quake::ResetOp>(user))
+        if (isa_and_present<cudaq::quake::ResetOp>(user))
           return true;
   return false;
 }
 
-void quake::detail::QuakeFunctionAnalysis::performAnalysis(
+void cudaq::quake::detail::QuakeFunctionAnalysis::performAnalysis(
     Operation *operation) {
   auto funcOp = dyn_cast<func::FuncOp>(operation);
   if (!funcOp)
@@ -68,7 +68,7 @@ void quake::detail::QuakeFunctionAnalysis::performAnalysis(
                           << '\n');
   QuakeMetadata data;
   SmallPtrSet<Operation *, 8> dirtySet;
-  funcOp->walk([&](quake::DiscriminateOp disc) {
+  funcOp->walk([&](cudaq::quake::DiscriminateOp disc) {
     dirtySet.insert(disc.getOperation());
   });
 
@@ -99,13 +99,15 @@ void quake::detail::QuakeFunctionAnalysis::performAnalysis(
     auto *op = keys.back();
     keys.pop_back();
     if (isa<cudaq::cc::IfOp, cudaq::cc::ConditionOp, cf::CondBranchOp,
-            quake::MeasurementInterface, quake::OperatorInterface,
-            quake::ApplyOp, CallOpInterface>(op)) {
+            cudaq::quake::MeasurementInterface, cudaq::quake::OperatorInterface,
+            cudaq::quake::ApplyOp, CallOpInterface>(op)) {
       data.hasConditionalsOnMeasure = true;
       data.hasQuantumDataflowViaClassical =
-          isa<quake::MeasurementInterface, quake::OperatorInterface>(op);
-      data.hasUnexpectedCalls = isa<quake::ApplyOp, cudaq::cc::CallCallableOp,
-                                    func::CallOp, func::CallIndirectOp>(op);
+          isa<cudaq::quake::MeasurementInterface,
+              cudaq::quake::OperatorInterface>(op);
+      data.hasUnexpectedCalls =
+          isa<cudaq::quake::ApplyOp, cudaq::cc::CallCallableOp, func::CallOp,
+              func::CallIndirectOp>(op);
       LLVM_DEBUG(llvm::dbgs() << "FOUND: mid-circuit dependence!\n");
       break;
     }
@@ -137,7 +139,7 @@ void quake::detail::QuakeFunctionAnalysis::performAnalysis(
   //   auto reg = mz(q);
   //   reset(q);
   // don't necessarily need conditional statements
-  funcOp->walk([&](quake::MeasurementInterface meas) {
+  funcOp->walk([&](cudaq::quake::MeasurementInterface meas) {
     // NB: checkIsMeasureAndReset does NOT check the order or any control
     // flow. We only know that a measurement and a reset acted on the same
     // SSA-value. This is overly conservative and possibly a lurking bug.
@@ -169,7 +171,8 @@ public:
       return;
 
     // Create the analysis and extract the info
-    const auto &analysis = getAnalysis<quake::detail::QuakeFunctionAnalysis>();
+    const auto &analysis =
+        getAnalysis<cudaq::quake::detail::QuakeFunctionAnalysis>();
     const auto &funcAnalysisInfo = analysis.getAnalysisInfo();
     auto iter = funcAnalysisInfo.find(funcOp);
     assert(iter != funcAnalysisInfo.end());

--- a/lib/Optimizer/Transforms/AggressiveInlining.cpp
+++ b/lib/Optimizer/Transforms/AggressiveInlining.cpp
@@ -74,7 +74,7 @@ public:
 
       // Check that no one misguidedly attempts to add SymbolUserOpInterface to
       // these Ops.
-      if (isa<quake::ApplyOp, cudaq::cc::CallCallableOp,
+      if (isa<cudaq::quake::ApplyOp, cudaq::cc::CallCallableOp,
               cudaq::cc::CallIndirectCallableOp>(op)) {
         op->emitOpError("Internal bug was introduced.");
         return;

--- a/lib/Optimizer/Transforms/ApplyControlNegations.cpp
+++ b/lib/Optimizer/Transforms/ApplyControlNegations.cpp
@@ -38,15 +38,17 @@ public:
 
     for (auto negationIter : llvm::enumerate(negations.value()))
       if (negationIter.value())
-        quake::XOp::create(rewriter, loc, ValueRange(),
-                           ValueRange{op.getControls()[negationIter.index()]});
+        cudaq::quake::XOp::create(
+            rewriter, loc, ValueRange(),
+            ValueRange{op.getControls()[negationIter.index()]});
 
-    if constexpr (std::is_same_v<Op, quake::ExpPauliOp>) {
-      quake::ExpPauliOp::create(
+    if constexpr (std::is_same_v<Op, cudaq::quake::ExpPauliOp>) {
+      cudaq::quake::ExpPauliOp::create(
           rewriter, loc, TypeRange{}, op.getIsAdjAttr(), op.getParameters(),
           op.getControls(), op.getTargets(), op.getNegatedQubitControlsAttr(),
           op.getPauli(), op.getPauliLiteralAttr());
-    } else if constexpr (std::is_same_v<Op, quake::CustomUnitarySymbolOp>) {
+    } else if constexpr (std::is_same_v<Op,
+                                        cudaq::quake::CustomUnitarySymbolOp>) {
       Op::create(rewriter, loc, op.getGeneratorAttr(), op.getIsAdj(),
                  op.getParameters(), op.getControls(), op.getTargets());
     } else {
@@ -56,8 +58,9 @@ public:
 
     for (auto negationIter : llvm::enumerate(negations.value()))
       if (negationIter.value())
-        quake::XOp::create(rewriter, loc, ValueRange(),
-                           ValueRange{op.getControls()[negationIter.index()]});
+        cudaq::quake::XOp::create(
+            rewriter, loc, ValueRange(),
+            ValueRange{op.getControls()[negationIter.index()]});
     rewriter.eraseOp(op);
 
     return success();
@@ -75,36 +78,41 @@ struct ApplyControlNegationsPass
     auto funcOp = getOperation();
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
-    patterns.insert<
-        ReplaceNegativeControl<quake::XOp>, ReplaceNegativeControl<quake::YOp>,
-        ReplaceNegativeControl<quake::ZOp>, ReplaceNegativeControl<quake::HOp>,
-        ReplaceNegativeControl<quake::SOp>, ReplaceNegativeControl<quake::TOp>,
-        ReplaceNegativeControl<quake::RxOp>,
-        ReplaceNegativeControl<quake::RyOp>,
-        ReplaceNegativeControl<quake::RzOp>,
-        ReplaceNegativeControl<quake::R1Op>,
-        ReplaceNegativeControl<quake::U3Op>,
-        ReplaceNegativeControl<quake::SwapOp>,
-        ReplaceNegativeControl<quake::ExpPauliOp>,
-        ReplaceNegativeControl<quake::CustomUnitarySymbolOp>>(ctx);
+    patterns
+        .insert<ReplaceNegativeControl<cudaq::quake::XOp>,
+                ReplaceNegativeControl<cudaq::quake::YOp>,
+                ReplaceNegativeControl<cudaq::quake::ZOp>,
+                ReplaceNegativeControl<cudaq::quake::HOp>,
+                ReplaceNegativeControl<cudaq::quake::SOp>,
+                ReplaceNegativeControl<cudaq::quake::TOp>,
+                ReplaceNegativeControl<cudaq::quake::RxOp>,
+                ReplaceNegativeControl<cudaq::quake::RyOp>,
+                ReplaceNegativeControl<cudaq::quake::RzOp>,
+                ReplaceNegativeControl<cudaq::quake::R1Op>,
+                ReplaceNegativeControl<cudaq::quake::U3Op>,
+                ReplaceNegativeControl<cudaq::quake::SwapOp>,
+                ReplaceNegativeControl<cudaq::quake::ExpPauliOp>,
+                ReplaceNegativeControl<cudaq::quake::CustomUnitarySymbolOp>>(
+            ctx);
     ConversionTarget target(*ctx);
     target.addLegalDialect<cudaq::cc::CCDialect, arith::ArithDialect,
                            LLVM::LLVMDialect>();
-    target.addDynamicallyLegalDialect<quake::QuakeDialect>([](Operation *op) {
-      auto quantumOp = dyn_cast<quake::OperatorInterface>(op);
-      if (!quantumOp)
-        return true;
+    target.addDynamicallyLegalDialect<cudaq::quake::QuakeDialect>(
+        [](Operation *op) {
+          auto quantumOp = dyn_cast<cudaq::quake::OperatorInterface>(op);
+          if (!quantumOp)
+            return true;
 
-      auto negations = quantumOp.getNegatedControls();
-      if (!negations.has_value())
-        return true;
+          auto negations = quantumOp.getNegatedControls();
+          if (!negations.has_value())
+            return true;
 
-      for (auto negation : negations.value())
-        if (negation)
-          return false;
+          for (auto negation : negations.value())
+            if (negation)
+              return false;
 
-      return true;
-    });
+          return true;
+        });
     if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
       funcOp->emitOpError("could not replace negations");
       signalPassFailure();

--- a/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
+++ b/lib/Optimizer/Transforms/ApplyOpSpecialization.cpp
@@ -75,7 +75,7 @@ struct ApplyOpAnalysis {
 
 private:
   void performAnalysis(Operation *op) {
-    op->walk([&](quake::ApplyOp apply) {
+    op->walk([&](cudaq::quake::ApplyOp apply) {
       if (constProp) {
         // If some of the arguments in getActuals() are constants, then
         // materialize those constants in a clone of the variant. The
@@ -99,7 +99,7 @@ private:
               mapper.map(genericFunc.getArgument(idx), newConst);
               LLVM_DEBUG(llvm::dbgs() << "apply has constant arguments.\n");
             } else {
-              if (auto relax = v.getDefiningOp<quake::RelaxSizeOp>()) {
+              if (auto relax = v.getDefiningOp<cudaq::quake::RelaxSizeOp>()) {
                 // Also, specialize any relaxed veq types.
                 v = relax.getInputVec();
                 updateSignature = true;
@@ -130,8 +130,9 @@ private:
                 auto *ctx = newFunc.getContext();
                 OpBuilder builder(ctx);
                 builder.setInsertionPoint(&newFunc.front().front());
-                auto relax = quake::RelaxSizeOp::create(
-                    builder, newFunc.getLoc(), quake::VeqType::getUnsized(ctx),
+                auto relax = cudaq::quake::RelaxSizeOp::create(
+                    builder, newFunc.getLoc(),
+                    cudaq::quake::VeqType::getUnsized(ctx),
                     newFunc.front().getArgument(pos));
                 newFunc.front().getArgument(pos).replaceAllUsesExcept(
                     relax.getResult(), relax.getOperation());
@@ -143,7 +144,7 @@ private:
               entry.push_front(c);
             module.push_back(newFunc);
             OpBuilder builder(apply);
-            auto newApply = quake::ApplyOp::create(
+            auto newApply = cudaq::quake::ApplyOp::create(
                 builder, apply.getLoc(), apply.getResultTypes(),
                 SymbolRefAttr::get(ctx, calleeName), apply.getIsAdj(),
                 apply.getControls(), preservedArgs);
@@ -184,7 +185,7 @@ private:
       for (auto pr : cloneMap) {
         auto &func = pr.first;
         auto &variant = pr.second;
-        func->walk([&](quake::ApplyOp apply) {
+        func->walk([&](cudaq::quake::ApplyOp apply) {
           auto callee = lookupCallee(apply);
           auto iter = infoMap.find(callee);
           if (iter == infoMap.end()) {
@@ -199,7 +200,7 @@ private:
     }
   }
 
-  func::FuncOp lookupCallee(quake::ApplyOp apply) {
+  func::FuncOp lookupCallee(cudaq::quake::ApplyOp apply) {
     auto callee = apply.getCallee();
     if (callee)
       return module.lookupSymbol<func::FuncOp>(*callee);
@@ -225,7 +226,7 @@ static std::string getCtrlVariantFunctionName(const std::string &n) {
   return n + ".ctrl";
 }
 
-static std::string getVariantFunctionName(quake::ApplyOp apply,
+static std::string getVariantFunctionName(cudaq::quake::ApplyOp apply,
                                           const std::string &calleeName) {
   if (apply.getIsAdj() && !apply.getControls().empty())
     return getAdjCtrlVariantFunctionName(calleeName);
@@ -286,13 +287,13 @@ static bool regionHasUnstructuredControlFlow(Region &region) {
 
 namespace {
 /// Replace an apply op with a call to the correct variant function.
-struct ApplyOpPattern : public OpRewritePattern<quake::ApplyOp> {
-  using Base = OpRewritePattern<quake::ApplyOp>;
+struct ApplyOpPattern : public OpRewritePattern<cudaq::quake::ApplyOp> {
+  using Base = OpRewritePattern<cudaq::quake::ApplyOp>;
 
   explicit ApplyOpPattern(MLIRContext *ctx, bool constProp)
       : Base(ctx), constProp(constProp) {}
 
-  LogicalResult matchAndRewrite(quake::ApplyOp apply,
+  LogicalResult matchAndRewrite(cudaq::quake::ApplyOp apply,
                                 PatternRewriter &rewriter) const override {
     std::string calleeOrigName;
     FunctionType calleeSignature;
@@ -315,11 +316,11 @@ struct ApplyOpPattern : public OpRewritePattern<quake::ApplyOp> {
     }
     auto calleeName = getVariantFunctionName(apply, calleeOrigName);
     auto *ctx = apply.getContext();
-    auto unsizedVeqTy = quake::VeqType::getUnsized(ctx);
+    auto unsizedVeqTy = cudaq::quake::VeqType::getUnsized(ctx);
     SmallVector<Value> newArgs;
     if (!apply.getControls().empty()) {
-      auto consOp = quake::ConcatOp::create(rewriter, apply.getLoc(),
-                                            unsizedVeqTy, apply.getControls());
+      auto consOp = cudaq::quake::ConcatOp::create(
+          rewriter, apply.getLoc(), unsizedVeqTy, apply.getControls());
       newArgs.push_back(consOp);
     }
     for (auto [v, toTy] :
@@ -328,8 +329,8 @@ struct ApplyOpPattern : public OpRewritePattern<quake::ApplyOp> {
         continue;
       Value arg = v;
       if (arg.getType() != toTy)
-        arg = quake::ConcatOp::create(rewriter, apply.getLoc(), unsizedVeqTy,
-                                      arg);
+        arg = cudaq::quake::ConcatOp::create(rewriter, apply.getLoc(),
+                                             unsizedVeqTy, arg);
       newArgs.emplace_back(arg);
     }
     LLVM_DEBUG(llvm::dbgs() << "replacing: " << apply << '\n');
@@ -342,10 +343,10 @@ struct ApplyOpPattern : public OpRewritePattern<quake::ApplyOp> {
   const bool constProp;
 };
 
-struct FoldCallable : public OpRewritePattern<quake::ApplyOp> {
+struct FoldCallable : public OpRewritePattern<cudaq::quake::ApplyOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ApplyOp apply,
+  LogicalResult matchAndRewrite(cudaq::quake::ApplyOp apply,
                                 PatternRewriter &rewriter) const override {
     // If we already know the callee function, there's nothing to do.
     if (apply.getCallee())
@@ -359,9 +360,10 @@ struct FoldCallable : public OpRewritePattern<quake::ApplyOp> {
     SmallVector<Value> newArguments = {ind};
     newArguments.append(apply.getActuals().begin(), apply.getActuals().end());
     LLVM_DEBUG(llvm::dbgs() << "replacing " << apply << '\n');
-    [[maybe_unused]] auto result = rewriter.replaceOpWithNewOp<quake::ApplyOp>(
-        apply, apply.getResultTypes(), sym, apply.getIsAdj(),
-        apply.getControls(), newArguments);
+    [[maybe_unused]] auto result =
+        rewriter.replaceOpWithNewOp<cudaq::quake::ApplyOp>(
+            apply, apply.getResultTypes(), sym, apply.getIsAdj(),
+            apply.getControls(), newArguments);
     LLVM_DEBUG(llvm::dbgs() << "as " << result << '\n');
     return success();
   }
@@ -425,7 +427,7 @@ public:
     DenseSet<Operation *> controlNotNeeded;
     if (computeActionOptimization) {
       func->walk([&](Operation *op) {
-        if (auto compAct = dyn_cast<quake::ComputeActionOp>(op)) {
+        if (auto compAct = dyn_cast<cudaq::quake::ComputeActionOp>(op)) {
           // This is clearly a compute action. Mark the compute side.
           if (auto *defOp = compAct.getCompute().getDefiningOp()) {
             controlNotNeeded.insert(defOp);
@@ -433,13 +435,13 @@ public:
             compAct.emitError("compute value not determined");
             signalPassFailure();
           }
-        } else if (auto app0 = dyn_cast<quake::ApplyOp>(op)) {
+        } else if (auto app0 = dyn_cast<cudaq::quake::ApplyOp>(op)) {
           auto next1 = ++app0->getIterator();
           Operation &op1 = *next1;
-          if (auto app1 = dyn_cast<quake::ApplyOp>(op1)) {
+          if (auto app1 = dyn_cast<cudaq::quake::ApplyOp>(op1)) {
             auto next2 = ++next1;
             Operation &op2 = *next2;
-            if (auto app2 = dyn_cast<quake::ApplyOp>(op2);
+            if (auto app2 = dyn_cast<cudaq::quake::ApplyOp>(op2);
                 app2 && (app0.getCalleeAttr() == app2.getCalleeAttr()) &&
                 ((!app0.getIsAdj() && app2.getIsAdj()) ||
                  (app0.getIsAdj() && !app2.getIsAdj())) &&
@@ -466,7 +468,7 @@ public:
     // uncompute kernel) without the controls added.
     auto funcName = getCtrlVariantFunctionName(func.getName().str());
     auto funcTy = func.getFunctionType();
-    auto veqTy = quake::VeqType::getUnsized(ctx);
+    auto veqTy = cudaq::quake::VeqType::getUnsized(ctx);
     auto loc = func.getLoc();
     SmallVector<Type> inTys = {veqTy};
     inTys.append(funcTy.getInputs().begin(), funcTy.getInputs().end());
@@ -480,7 +482,7 @@ public:
     // Helper to check if this is a call to a function taking quantum arguments.
     const auto isQuantumKernelCall = [](Operation *op) -> bool {
       if (auto callOp = dyn_cast<func::CallOp>(op))
-        return !quake::getQuantumOperands(op).empty();
+        return !cudaq::quake::getQuantumOperands(op).empty();
       return false;
     };
 
@@ -511,14 +513,14 @@ public:
         // FIXME: Quake quantum gates do have results.
         builder.create(res);
         op->erase();
-      } else if (auto apply = dyn_cast<quake::ApplyOp>(op)) {
+      } else if (auto apply = dyn_cast<cudaq::quake::ApplyOp>(op)) {
         // If op is an apply and in the set `controlNotNeeded`, then skip it.
         if (controlNotNeeded.count(apply))
           return;
         SmallVector<Value> newControls = {newCond};
         newControls.append(apply.getControls().begin(),
                            apply.getControls().end());
-        auto newApply = quake::ApplyOp::create(
+        auto newApply = cudaq::quake::ApplyOp::create(
             builder, apply.getLoc(), apply.getResultTypes(),
             apply.getCalleeAttr(), apply.getIsAdjAttr(), newControls,
             apply.getActuals());
@@ -549,11 +551,12 @@ public:
           << "cannot make adjoint of kernel: unstructured control flow\n");
       return failure();
     }
-    // quake::ApplyOp implements CallOpInterface but can be handled below by
-    // toggling isAdj. Reject any other call-like op that we cannot invert.
+    // cudaq::quake::ApplyOp implements CallOpInterface but can be handled below
+    // by toggling isAdj. Reject any other call-like op that we cannot invert.
     if (cudaq::opt::internal::hasCharacteristic(
             [](Operation &op) {
-              return isa<mlir::CallOpInterface>(op) && !isa<quake::ApplyOp>(op);
+              return isa<mlir::CallOpInterface>(op) &&
+                     !isa<cudaq::quake::ApplyOp>(op);
             },
             *func.getOperation())) {
       LLVM_DEBUG(llvm::dbgs() << "cannot make adjoint of kernel with calls\n");
@@ -590,7 +593,7 @@ public:
   static SmallVector<Operation *> getOpsToInvert(Block &block) {
     SmallVector<Operation *> ops;
     for (auto &op : block)
-      if (cudaq::opt::hasQuantum(op) || isa<quake::ApplyOp>(op))
+      if (cudaq::opt::hasQuantum(op) || isa<cudaq::quake::ApplyOp>(op))
         ops.push_back(&op);
     return ops;
   }
@@ -784,16 +787,16 @@ public:
         continue;
       }
 
-      if (auto applyOp = dyn_cast<quake::ApplyOp>(op)) {
+      if (auto applyOp = dyn_cast<cudaq::quake::ApplyOp>(op)) {
         LLVM_DEBUG(llvm::dbgs() << "moving apply op: " << *op << ".\n");
         // Adjoint of an ApplyOp: toggles the isAdj flag.
         mlir::UnitAttr newIsAdj =
             applyOp.getIsAdj() ? mlir::UnitAttr{}
                                : mlir::UnitAttr::get(builder.getContext());
-        quake::ApplyOp::create(builder, applyOp.getLoc(),
-                               applyOp.getResultTypes(),
-                               applyOp.getCalleeAttr(), newIsAdj,
-                               applyOp.getControls(), applyOp.getActuals());
+        cudaq::quake::ApplyOp::create(
+            builder, applyOp.getLoc(), applyOp.getResultTypes(),
+            applyOp.getCalleeAttr(), newIsAdj, applyOp.getControls(),
+            applyOp.getActuals());
         applyOp->erase();
         continue;
       }
@@ -814,7 +817,8 @@ public:
 
       // If this is a quantum op that is not self adjoint, we need
       // to adjoint it.
-      if (auto quantumOp = dyn_cast_or_null<quake::OperatorInterface>(op);
+      if (auto quantumOp =
+              dyn_cast_or_null<cudaq::quake::OperatorInterface>(op);
           !quantumOp->hasTrait<cudaq::Hermitian>() && !opWasNegated) {
         if (op->hasAttr("is_adj"))
           op->removeAttr("is_adj");

--- a/lib/Optimizer/Transforms/BasisConversion.cpp
+++ b/lib/Optimizer/Transforms/BasisConversion.cpp
@@ -56,7 +56,8 @@ struct BasisConversion
           return WalkResult::advance();
         }
         for (auto arg : funcOp.getArguments())
-          if (isa<quake::RefType, quake::VeqType>(arg.getType())) {
+          if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(
+                  arg.getType())) {
             kernels.push_back(funcOp);
             return WalkResult::advance();
           }
@@ -64,7 +65,7 @@ struct BasisConversion
         return WalkResult::skip();
       }
       // Check if it is controlled quake.apply
-      if (auto applyOp = dyn_cast<quake::ApplyOp>(op))
+      if (auto applyOp = dyn_cast<cudaq::quake::ApplyOp>(op))
         if (!applyOp.getControls().empty())
           return WalkResult::interrupt();
 

--- a/lib/Optimizer/Transforms/CableRoughIn.cpp
+++ b/lib/Optimizer/Transforms/CableRoughIn.cpp
@@ -54,7 +54,7 @@ public:
                                 PatternRewriter &rewriter) const override {
     bool performRewrite = [&]() {
       for (auto arg : call.getOperands())
-        if (quake::isQuantumReferenceType(arg.getType()))
+        if (cudaq::quake::isQuantumReferenceType(arg.getType()))
           return true;
       return false;
     }();
@@ -65,8 +65,8 @@ public:
 
     auto loc = call.getLoc();
     auto *ctx = rewriter.getContext();
-    auto refTy = quake::RefType::get(ctx);
-    auto wireTy = quake::WireType::get(ctx);
+    auto refTy = cudaq::quake::RefType::get(ctx);
+    auto wireTy = cudaq::quake::WireType::get(ctx);
 
     // Walk arguments and map them to value types and keep track of the new wire
     // types in left-to-right order.
@@ -77,15 +77,16 @@ public:
     for (auto arg : call.getOperands()) {
       Type argTy = arg.getType();
       if (argTy == refTy) {
-        newArgs.push_back(quake::UnwrapOp::create(rewriter, loc, wireTy, arg));
+        newArgs.push_back(
+            cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, arg));
         resultTys.push_back(wireTy);
         continue;
       }
-      if (isa<quake::VeqType>(argTy)) {
+      if (isa<cudaq::quake::VeqType>(argTy)) {
         // Cases we handle are concat or concat + relax_size.
-        if (auto relax = arg.getDefiningOp<quake::RelaxSizeOp>())
+        if (auto relax = arg.getDefiningOp<cudaq::quake::RelaxSizeOp>())
           arg = relax.getInputVec();
-        auto concat = arg.getDefiningOp<quake::ConcatOp>();
+        auto concat = arg.getDefiningOp<cudaq::quake::ConcatOp>();
         if (!concat) {
           LLVM_DEBUG(llvm::dbgs() << arg << " is not a concat.\n");
           return failure();
@@ -96,18 +97,18 @@ public:
             return failure();
           }
         const std::size_t cableSize = concat.getTargets().size();
-        auto cableTy = quake::CableType::get(ctx, cableSize);
+        auto cableTy = cudaq::quake::CableType::get(ctx, cableSize);
         SmallVector<Value> unwraps;
         for (auto carg : concat.getTargets())
           unwraps.push_back(
-              quake::UnwrapOp::create(rewriter, loc, wireTy, carg));
-        newArgs.push_back(
-            quake::BundleCableOp::create(rewriter, loc, cableTy, unwraps));
+              cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, carg));
+        newArgs.push_back(cudaq::quake::BundleCableOp::create(
+            rewriter, loc, cableTy, unwraps));
         resultTys.push_back(cableTy);
         continue;
       }
-      if (isa<quake::StruqType>(argTy)) {
-        auto mkStruq = arg.getDefiningOp<quake::MakeStruqOp>();
+      if (isa<cudaq::quake::StruqType>(argTy)) {
+        auto mkStruq = arg.getDefiningOp<cudaq::quake::MakeStruqOp>();
         if (!mkStruq) {
           LLVM_DEBUG(llvm::dbgs() << arg << " is not a make_struq.\n");
           return failure();
@@ -116,16 +117,16 @@ public:
         SmallVector<Value> unwraps;
         for (auto strArg : mkStruq.getVeqs()) {
           auto strArgTy = strArg.getType();
-          if (isa<quake::RefType>(strArgTy)) {
+          if (isa<cudaq::quake::RefType>(strArgTy)) {
             unwraps.push_back(
-                quake::UnwrapOp::create(rewriter, loc, wireTy, strArg));
+                cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, strArg));
             cableSize++;
             continue;
           }
-          if (auto veqTy = dyn_cast<quake::VeqType>(strArgTy)) {
-            if (auto relax = strArg.getDefiningOp<quake::RelaxSizeOp>())
+          if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(strArgTy)) {
+            if (auto relax = strArg.getDefiningOp<cudaq::quake::RelaxSizeOp>())
               strArg = relax.getInputVec();
-            auto concat = strArg.getDefiningOp<quake::ConcatOp>();
+            auto concat = strArg.getDefiningOp<cudaq::quake::ConcatOp>();
             if (!concat) {
               LLVM_DEBUG(llvm::dbgs() << arg << " is not a concat.\n");
               return failure();
@@ -139,15 +140,15 @@ public:
             cableSize += concat.getTargets().size();
             for (auto carg : concat.getTargets())
               unwraps.push_back(
-                  quake::UnwrapOp::create(rewriter, loc, wireTy, carg));
+                  cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, carg));
             continue;
           }
           LLVM_DEBUG(llvm::dbgs() << strArg << " is not supported.\n");
           return failure();
         }
-        auto cableTy = quake::CableType::get(ctx, cableSize);
-        newArgs.push_back(
-            quake::BundleCableOp::create(rewriter, loc, cableTy, unwraps));
+        auto cableTy = cudaq::quake::CableType::get(ctx, cableSize);
+        newArgs.push_back(cudaq::quake::BundleCableOp::create(
+            rewriter, loc, cableTy, unwraps));
         resultTys.push_back(cableTy);
         continue;
       }
@@ -156,7 +157,7 @@ public:
     }
 
     // Create a quake.call_by_ref operation.
-    auto callByRef = quake::CallByRefOp::create(
+    auto callByRef = cudaq::quake::CallByRefOp::create(
         rewriter, loc, call.getCalleeAttr(), resultTys, newArgs);
 
     // Wrap the wires and cables.
@@ -166,50 +167,51 @@ public:
     for (auto arg : call.getOperands()) {
       Type argTy = arg.getType();
       if (argTy == refTy) {
-        quake::WrapOp::create(rewriter, loc, results[i++], arg);
+        cudaq::quake::WrapOp::create(rewriter, loc, results[i++], arg);
         continue;
       }
-      if (isa<quake::VeqType>(argTy)) {
-        if (auto relax = arg.getDefiningOp<quake::RelaxSizeOp>())
+      if (isa<cudaq::quake::VeqType>(argTy)) {
+        if (auto relax = arg.getDefiningOp<cudaq::quake::RelaxSizeOp>())
           arg = relax.getInputVec();
-        auto concat = arg.getDefiningOp<quake::ConcatOp>();
+        auto concat = arg.getDefiningOp<cudaq::quake::ConcatOp>();
         const std::size_t cableSize =
-            cast<quake::CableType>(resultTys[i]).getSize();
+            cast<cudaq::quake::CableType>(resultTys[i]).getSize();
         SmallVector<Type> wireTys(cableSize);
         std::fill(wireTys.begin(), wireTys.end(), wireTy);
-        auto split =
-            quake::SplitCableOp::create(rewriter, loc, wireTys, results[i++]);
+        auto split = cudaq::quake::SplitCableOp::create(rewriter, loc, wireTys,
+                                                        results[i++]);
         SmallVector<Value> concatTargs{concat.getTargets().begin(),
                                        concat.getTargets().end()};
         for (auto [j, wire] : llvm::enumerate(split.getResults()))
-          quake::WrapOp::create(rewriter, loc, wire, concatTargs[j]);
+          cudaq::quake::WrapOp::create(rewriter, loc, wire, concatTargs[j]);
       }
-      if (isa<quake::StruqType>(argTy)) {
-        auto mkStruq = arg.getDefiningOp<quake::MakeStruqOp>();
+      if (isa<cudaq::quake::StruqType>(argTy)) {
+        auto mkStruq = arg.getDefiningOp<cudaq::quake::MakeStruqOp>();
         const std::size_t cableSize =
-            cast<quake::CableType>(resultTys[i]).getSize();
+            cast<cudaq::quake::CableType>(resultTys[i]).getSize();
         SmallVector<Type> wireTys(cableSize);
         std::fill(wireTys.begin(), wireTys.end(), wireTy);
-        auto split =
-            quake::SplitCableOp::create(rewriter, loc, wireTys, results[i++]);
+        auto split = cudaq::quake::SplitCableOp::create(rewriter, loc, wireTys,
+                                                        results[i++]);
         std::size_t j = 0;
         SmallVector<Value> splitResults{split.getResults().begin(),
                                         split.getResults().end()};
         for (auto strArg : mkStruq.getVeqs()) {
           auto strArgTy = strArg.getType();
-          if (isa<quake::RefType>(strArgTy)) {
-            quake::WrapOp::create(rewriter, loc, splitResults[j++], strArg);
+          if (isa<cudaq::quake::RefType>(strArgTy)) {
+            cudaq::quake::WrapOp::create(rewriter, loc, splitResults[j++],
+                                         strArg);
             continue;
           }
-          if (isa<quake::VeqType>(strArgTy)) {
-            if (auto relax = strArg.getDefiningOp<quake::RelaxSizeOp>())
+          if (isa<cudaq::quake::VeqType>(strArgTy)) {
+            if (auto relax = strArg.getDefiningOp<cudaq::quake::RelaxSizeOp>())
               strArg = relax.getInputVec();
-            auto concat = strArg.getDefiningOp<quake::ConcatOp>();
+            auto concat = strArg.getDefiningOp<cudaq::quake::ConcatOp>();
             SmallVector<Value> concatTargs{concat.getTargets().begin(),
                                            concat.getTargets().end()};
             for (std::size_t k = 0, K = concatTargs.size(); k < K; ++k)
-              quake::WrapOp::create(rewriter, loc, splitResults[j++],
-                                    concatTargs[k]);
+              cudaq::quake::WrapOp::create(rewriter, loc, splitResults[j++],
+                                           concatTargs[k]);
             continue;
           }
           LLVM_DEBUG(llvm::dbgs() << strArg << " is not supported.\n");
@@ -235,8 +237,8 @@ public:
     RewritePatternSet patterns(ctx);
 
     patterns.insert<CallPattern>(ctx);
-    quake::ExtractRefOp::getCanonicalizationPatterns(patterns, ctx);
-    quake::GetMemberOp::getCanonicalizationPatterns(patterns, ctx);
+    cudaq::quake::ExtractRefOp::getCanonicalizationPatterns(patterns, ctx);
+    cudaq::quake::GetMemberOp::getCanonicalizationPatterns(patterns, ctx);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns))))
       signalPassFailure();
   }

--- a/lib/Optimizer/Transforms/CombineMeasurements.cpp
+++ b/lib/Optimizer/Transforms/CombineMeasurements.cpp
@@ -45,22 +45,22 @@ struct Analysis {
 
   mlir::DenseMap<mlir::Value, std::size_t> measurements;
   OutputNamesType resultQubitVals;
-  quake::MzOp lastMeasurement;
+  cudaq::quake::MzOp lastMeasurement;
 
   bool empty() const { return measurements.empty(); }
 
   LogicalResult analyze(func::FuncOp func) {
-    quake::AllocaOp qalloc;
+    cudaq::quake::AllocaOp qalloc;
     std::size_t currentOffset = 0;
 
     for (auto &block : func.getRegion()) {
       for (auto &op : block) {
-        if (auto alloc = dyn_cast_or_null<quake::AllocaOp>(&op)) {
+        if (auto alloc = dyn_cast_or_null<cudaq::quake::AllocaOp>(&op)) {
           if (qalloc)
             return op.emitError("Multiple qalloc statements found");
 
           qalloc = alloc;
-        } else if (auto measure = dyn_cast_or_null<quake::MzOp>(&op)) {
+        } else if (auto measure = dyn_cast_or_null<cudaq::quake::MzOp>(&op)) {
           if (!measure.use_empty()) {
             measure.emitWarning("Measurements with uses are not supported");
             return success();
@@ -70,9 +70,9 @@ struct Analysis {
           auto ty = veqOp.getType();
 
           std::size_t size = 0;
-          if (auto veqTy = dyn_cast<quake::RefType>(ty))
+          if (auto veqTy = dyn_cast<cudaq::quake::RefType>(ty))
             size = 1;
-          else if (auto veqTy = dyn_cast<quake::VeqType>(ty)) {
+          else if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(ty)) {
             size = veqTy.getSize();
             if (size == 0)
               return op.emitError("Unknown measurement size");
@@ -89,7 +89,7 @@ struct Analysis {
   }
 };
 
-class ExtendQubitMeasurePattern : public OpRewritePattern<quake::MzOp> {
+class ExtendQubitMeasurePattern : public OpRewritePattern<cudaq::quake::MzOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
@@ -108,11 +108,11 @@ public:
   //   %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
   // ```
   // And collect output names information:  `"[[[0,[1,"q0"]],[1,[2,"q1"]]]]"`
-  LogicalResult matchAndRewrite(quake::MzOp measure,
+  LogicalResult matchAndRewrite(cudaq::quake::MzOp measure,
                                 PatternRewriter &rewriter) const override {
 
     auto veqOp = measure.getOperand(0);
-    if (auto extract = veqOp.getDefiningOp<quake::ExtractRefOp>()) {
+    if (auto extract = veqOp.getDefiningOp<cudaq::quake::ExtractRefOp>()) {
       auto veq = extract.getVeq();
       std::size_t idx;
 
@@ -130,9 +130,9 @@ public:
 
       auto resultType = cudaq::cc::StdvecType::get(measure.getType(0));
       if (measure == analysis.lastMeasurement) {
-        rewriter.replaceOpWithNewOp<quake::MzOp>(measure, TypeRange{resultType},
-                                                 ValueRange{veq},
-                                                 measure.getRegisterNameAttr());
+        rewriter.replaceOpWithNewOp<cudaq::quake::MzOp>(
+            measure, TypeRange{resultType}, ValueRange{veq},
+            measure.getRegisterNameAttr());
         return success();
       }
       if (measure.use_empty()) {
@@ -149,7 +149,7 @@ private:
   Analysis &analysis;
 };
 
-class ExtendVeqMeasurePattern : public OpRewritePattern<quake::MzOp> {
+class ExtendVeqMeasurePattern : public OpRewritePattern<cudaq::quake::MzOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
@@ -169,10 +169,10 @@ public:
   //   %measOut = quake.mz %1 : (!quake.veq<4>) -> !cc.stdvec<!quake.measure>
   // ```
   // And collect output names information:  `"[[[0,[1,"q0"]],[1,[2,"q1"]]]]"`
-  LogicalResult matchAndRewrite(quake::MzOp measure,
+  LogicalResult matchAndRewrite(cudaq::quake::MzOp measure,
                                 PatternRewriter &rewriter) const override {
     auto veqOp = measure.getOperand(0);
-    if (auto subveq = veqOp.getDefiningOp<quake::SubVeqOp>()) {
+    if (auto subveq = veqOp.getDefiningOp<cudaq::quake::SubVeqOp>()) {
       std::size_t low;
       if (subveq.hasConstantLowerBound())
         low = subveq.getConstantLowerBound();
@@ -200,7 +200,7 @@ public:
       }
 
       if (measure == analysis.lastMeasurement)
-        rewriter.replaceOpWithNewOp<quake::MzOp>(
+        rewriter.replaceOpWithNewOp<cudaq::quake::MzOp>(
             measure, measure.getResultTypes(), ValueRange{subveq.getVeq()},
             measure.getRegisterNameAttr());
       else if (measure.use_empty())

--- a/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -27,34 +27,34 @@ struct Analysis {
   Analysis(Analysis &&) = delete;
   Analysis &operator=(const Analysis &) = delete;
 
-  SmallVector<quake::AllocaOp> allocations;
+  SmallVector<cudaq::quake::AllocaOp> allocations;
   SmallVector<std::pair<std::size_t, std::size_t>> offsetSizes;
-  SmallVector<quake::DeallocOp> deallocs;
-  quake::AllocaOp newAlloc;
+  SmallVector<cudaq::quake::DeallocOp> deallocs;
+  cudaq::quake::AllocaOp newAlloc;
 
   bool empty() const { return allocations.empty(); }
 };
 
-class AllocaPat : public OpRewritePattern<quake::AllocaOp> {
+class AllocaPat : public OpRewritePattern<cudaq::quake::AllocaOp> {
 public:
   explicit AllocaPat(MLIRContext *ctx, Analysis &a)
       : OpRewritePattern(ctx), analysis(a) {}
 
-  LogicalResult matchAndRewrite(quake::AllocaOp alloc,
+  LogicalResult matchAndRewrite(cudaq::quake::AllocaOp alloc,
                                 PatternRewriter &rewriter) const override {
     for (auto p : llvm::enumerate(analysis.allocations)) {
       if (alloc == p.value()) {
         auto i = p.index();
         auto &os = analysis.offsetSizes[i];
-        if (isa<quake::RefType>(alloc.getType())) {
+        if (isa<cudaq::quake::RefType>(alloc.getType())) {
           [[maybe_unused]] Value ext =
-              rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(
+              rewriter.replaceOpWithNewOp<cudaq::quake::ExtractRefOp>(
                   alloc, analysis.newAlloc, os.first);
           LLVM_DEBUG(llvm::dbgs()
                      << "replace " << alloc << " with " << ext << '\n');
           return success();
         }
-        if (isa<quake::VeqType>(alloc.getType())) {
+        if (isa<cudaq::quake::VeqType>(alloc.getType())) {
           Value lo = arith::ConstantIntOp::create(
               rewriter, alloc.getLoc(), rewriter.getI64Type(), os.first);
           Value hi = arith::ConstantIntOp::create(rewriter, alloc.getLoc(),
@@ -63,33 +63,35 @@ public:
           // trying to print alloc after the replace gives a segfault
           LLVM_DEBUG(llvm::dbgs() << "replace " << alloc);
           [[maybe_unused]] Value subveq =
-              rewriter.replaceOpWithNewOp<quake::SubVeqOp>(
+              rewriter.replaceOpWithNewOp<cudaq::quake::SubVeqOp>(
                   alloc, alloc.getType(), analysis.newAlloc, lo, hi);
           LLVM_DEBUG(llvm::dbgs() << " with " << subveq << '\n');
           return success();
         }
-        if (auto sty = dyn_cast<quake::StruqType>(alloc.getType())) {
+        if (auto sty = dyn_cast<cudaq::quake::StruqType>(alloc.getType())) {
           SmallVector<Value> parts;
           std::size_t inner = os.first;
           auto loc = alloc.getLoc();
           for (auto m : sty.getMembers()) {
             auto v = [&]() -> Value {
-              if (isa<quake::RefType>(m)) {
-                auto result = quake::ExtractRefOp::create(
+              if (isa<cudaq::quake::RefType>(m)) {
+                auto result = cudaq::quake::ExtractRefOp::create(
                     rewriter, loc, analysis.newAlloc, inner);
                 inner++;
                 return result;
               }
-              assert(cast<quake::VeqType>(m).hasSpecifiedSize());
-              std::size_t dist = inner + cast<quake::VeqType>(m).getSize() - 1;
-              auto result = quake::SubVeqOp::create(
+              assert(cast<cudaq::quake::VeqType>(m).hasSpecifiedSize());
+              std::size_t dist =
+                  inner + cast<cudaq::quake::VeqType>(m).getSize() - 1;
+              auto result = cudaq::quake::SubVeqOp::create(
                   rewriter, loc, m, analysis.newAlloc, inner, dist);
               inner = dist + 1;
               return result;
             }();
             parts.push_back(v);
           }
-          rewriter.replaceOpWithNewOp<quake::MakeStruqOp>(alloc, sty, parts);
+          rewriter.replaceOpWithNewOp<cudaq::quake::MakeStruqOp>(alloc, sty,
+                                                                 parts);
           return success();
         }
         return alloc.emitOpError("has unexpected type");
@@ -118,10 +120,10 @@ public:
     std::size_t currentOffset = 0;
     for (auto &block : func.getRegion())
       for (auto &op : block) {
-        if (auto alloc = dyn_cast_or_null<quake::AllocaOp>(&op)) {
+        if (auto alloc = dyn_cast_or_null<cudaq::quake::AllocaOp>(&op)) {
           if (alloc.getSize() || alloc.hasInitializedState())
             return;
-          auto size = quake::getAllocationSize(alloc.getType());
+          auto size = cudaq::quake::getAllocationSize(alloc.getType());
           if (size == 0)
             // Skip zero-size allocas. Merging them would
             // produce subveq(lo, lo-1) which is invalid.
@@ -129,7 +131,8 @@ public:
           analysis.allocations.push_back(alloc);
           analysis.offsetSizes.emplace_back(currentOffset, size);
           currentOffset += size;
-        } else if (auto dealloc = dyn_cast_or_null<quake::DeallocOp>(&op)) {
+        } else if (auto dealloc =
+                       dyn_cast_or_null<cudaq::quake::DeallocOp>(&op)) {
           analysis.deallocs.push_back(dealloc);
         }
       }
@@ -143,8 +146,8 @@ public:
     auto loc = analysis.allocations.front().getLoc();
     OpBuilder rewriter(ctx);
     rewriter.setInsertionPointToStart(entryBlock);
-    auto veqTy = quake::VeqType::get(ctx, currentOffset);
-    analysis.newAlloc = quake::AllocaOp::create(rewriter, loc, veqTy);
+    auto veqTy = cudaq::quake::VeqType::get(ctx, currentOffset);
+    analysis.newAlloc = cudaq::quake::AllocaOp::create(rewriter, loc, veqTy);
 
     // 3. Greedily replace the uses of the original alloca ops with uses of
     // partitions of the new alloca op. Replace subveq of subveq with a single
@@ -153,10 +156,10 @@ public:
     {
       RewritePatternSet patterns(ctx);
       patterns.insert<AllocaPat>(ctx, analysis);
-      quake::ExtractRefOp::getCanonicalizationPatterns(patterns, ctx);
-      quake::GetMemberOp::getCanonicalizationPatterns(patterns, ctx);
-      quake::SubVeqOp::getCanonicalizationPatterns(patterns, ctx);
-      quake::ConcatOp::getCanonicalizationPatterns(patterns, ctx);
+      cudaq::quake::ExtractRefOp::getCanonicalizationPatterns(patterns, ctx);
+      cudaq::quake::GetMemberOp::getCanonicalizationPatterns(patterns, ctx);
+      cudaq::quake::SubVeqOp::getCanonicalizationPatterns(patterns, ctx);
+      cudaq::quake::ConcatOp::getCanonicalizationPatterns(patterns, ctx);
       if (failed(applyPatternsGreedily(func.getOperation(),
                                        std::move(patterns)))) {
         func.emitOpError("combining alloca, subveq, and extract ops failed");
@@ -171,8 +174,8 @@ public:
       for (auto &block : func.getRegion()) {
         if (block.hasNoSuccessors()) {
           rewriter.setInsertionPoint(block.getTerminator());
-          quake::DeallocOp::create(rewriter, analysis.newAlloc.getLoc(),
-                                   analysis.newAlloc);
+          cudaq::quake::DeallocOp::create(rewriter, analysis.newAlloc.getLoc(),
+                                          analysis.newAlloc);
         }
       }
     }

--- a/lib/Optimizer/Transforms/Decomposition.cpp
+++ b/lib/Optimizer/Transforms/Decomposition.cpp
@@ -76,7 +76,8 @@ struct Decomposition
           return WalkResult::advance();
         }
         for (auto arg : funcOp.getArguments())
-          if (isa<quake::RefType, quake::VeqType>(arg.getType())) {
+          if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(
+                  arg.getType())) {
             kernels.push_back(funcOp);
             return WalkResult::advance();
           }
@@ -84,7 +85,7 @@ struct Decomposition
         return WalkResult::skip();
       }
       // Check if it is controlled quake.apply
-      if (auto applyOp = dyn_cast<quake::ApplyOp>(op))
+      if (auto applyOp = dyn_cast<cudaq::quake::ApplyOp>(op))
         if (!applyOp.getControls().empty())
           return WalkResult::interrupt();
 

--- a/lib/Optimizer/Transforms/DecompositionPatternSelection.cpp
+++ b/lib/Optimizer/Transforms/DecompositionPatternSelection.cpp
@@ -82,8 +82,8 @@ struct BasisTarget : public ConversionTarget {
     addLegalDialect<arith::ArithDialect, cf::ControlFlowDialect,
                     cudaq::cc::CCDialect, func::FuncDialect,
                     math::MathDialect>();
-    addDynamicallyLegalDialect<quake::QuakeDialect>([&](Operation *op) {
-      if (auto optor = dyn_cast<quake::OperatorInterface>(op)) {
+    addDynamicallyLegalDialect<cudaq::quake::QuakeDialect>([&](Operation *op) {
+      if (auto optor = dyn_cast<cudaq::quake::OperatorInterface>(op)) {
         auto name = optor->getName().stripDialect();
         for (auto info : legalOperatorSet) {
           if (info.name != name)
@@ -96,7 +96,7 @@ struct BasisTarget : public ConversionTarget {
       }
 
       // Handle quake.exp_pauli.
-      if (isa<quake::ExpPauliOp>(op)) {
+      if (isa<cudaq::quake::ExpPauliOp>(op)) {
         // If the target defines it as a legal op, return true, else false.
         return std::find_if(legalOperatorSet.begin(), legalOperatorSet.end(),
                             [](auto &&el) { return el.name == "exp_pauli"; }) !=

--- a/lib/Optimizer/Transforms/DecompositionPatterns.cpp
+++ b/lib/Optimizer/Transforms/DecompositionPatterns.cpp
@@ -58,18 +58,19 @@ inline Value createDivF(Location loc, Value numerator, double denominator,
 }
 
 /// @brief Returns true if \p op contains any `ControlType` operands.
-inline bool containsControlTypes(quake::OperatorInterface op) {
+inline bool containsControlTypes(cudaq::quake::OperatorInterface op) {
   return llvm::any_of(op.getControls(), [](const Value &v) {
-    return isa<quake::ControlType>(v.getType());
+    return isa<cudaq::quake::ControlType>(v.getType());
   });
 }
 
 namespace {
 /// @brief This is a wrapper class for `PatternRewriter::create<>()` for
-/// `QuakeOperator`s. If the controls and targets are `quake::WireType`, then
-/// this wrapper class's methods update the controls and targets in the `create`
-/// calls to the corresponding wires in the output. If they are NOT `WireType`,
-/// then the creates behave the exact same as a regular `PatternRewriter`.
+/// `QuakeOperator`s. If the controls and targets are `cudaq::quake::WireType`,
+/// then this wrapper class's methods update the controls and targets in the
+/// `create` calls to the corresponding wires in the output. If they are NOT
+/// `WireType`, then the creates behave the exact same as a regular
+/// `PatternRewriter`.
 class QuakeOperatorCreator {
 public:
   QuakeOperatorCreator(PatternRewriter &rewriter) : rewriter(rewriter) {}
@@ -78,26 +79,27 @@ public:
   /// builder for cases when you have one input ValueRange.
   SmallVector<Type> getResultType(ValueRange operands) {
     std::size_t numOutputWires = llvm::count_if(operands, [](const Value &v) {
-      return isa<quake::WireType>(v.getType());
+      return isa<cudaq::quake::WireType>(v.getType());
     });
 
-    return SmallVector<Type>(numOutputWires,
-                             quake::WireType::get(rewriter.getContext()));
+    return SmallVector<Type>(
+        numOutputWires, cudaq::quake::WireType::get(rewriter.getContext()));
   }
 
   /// Construct a resultType (suitable to be pass into the `TypeRange wires`
   /// builder for cases when you have two input ValueRanges.
   SmallVector<Type> getResultType(ValueRange operands1, ValueRange operands2) {
     std::size_t numOutputWires =
-        llvm::count_if(
-            operands1,
-            [](const Value &v) { return isa<quake::WireType>(v.getType()); }) +
+        llvm::count_if(operands1,
+                       [](const Value &v) {
+                         return isa<cudaq::quake::WireType>(v.getType());
+                       }) +
         llvm::count_if(operands2, [](const Value &v) {
-          return isa<quake::WireType>(v.getType());
+          return isa<cudaq::quake::WireType>(v.getType());
         });
 
-    return SmallVector<Type>(numOutputWires,
-                             quake::WireType::get(rewriter.getContext()));
+    return SmallVector<Type>(
+        numOutputWires, cudaq::quake::WireType::get(rewriter.getContext()));
   }
 
   /// Pluck out the values from \p newValues whose type is `WireType` and
@@ -105,7 +107,7 @@ public:
   void selectWiresAndReplaceUses(Operation *op, ValueRange newValues) {
     SmallVector<Value, 4> newWireValues;
     for (const auto &v : newValues)
-      if (isa<quake::WireType>(v.getType()))
+      if (isa<cudaq::quake::WireType>(v.getType()))
         newWireValues.push_back(v);
     assert(op->getResults().size() == newWireValues.size() &&
            "incorrect number of output wires provided");
@@ -118,9 +120,9 @@ public:
                                  Value target) {
     SmallVector<Value, 4> newWireValues;
     for (const auto &v : controls)
-      if (isa<quake::WireType>(v.getType()))
+      if (isa<cudaq::quake::WireType>(v.getType()))
         newWireValues.push_back(v);
-    if (isa<quake::WireType>(target.getType()))
+    if (isa<cudaq::quake::WireType>(target.getType()))
       newWireValues.push_back(target);
     assert(op->getResults().size() == newWireValues.size() &&
            "incorrect number of output wires provided");
@@ -135,7 +137,8 @@ public:
     auto resultWires = op.getWires();
     auto resultIt = resultWires.begin();
     auto resultWiresEnd = resultWires.end();
-    if (isa<quake::WireType>(target.getType()) && resultIt != resultWiresEnd)
+    if (isa<cudaq::quake::WireType>(target.getType()) &&
+        resultIt != resultWiresEnd)
       target = *resultIt;
     return op;
   }
@@ -148,7 +151,8 @@ public:
     auto resultWires = op.getWires();
     auto resultIt = resultWires.begin();
     auto resultWiresEnd = resultWires.end();
-    if (isa<quake::WireType>(target.getType()) && resultIt != resultWiresEnd)
+    if (isa<cudaq::quake::WireType>(target.getType()) &&
+        resultIt != resultWiresEnd)
       target = *resultIt;
     return op;
   }
@@ -161,9 +165,11 @@ public:
     auto resultWires = op.getWires();
     auto resultIt = resultWires.begin();
     auto resultWiresEnd = resultWires.end();
-    if (isa<quake::WireType>(control.getType()) && resultIt != resultWiresEnd)
+    if (isa<cudaq::quake::WireType>(control.getType()) &&
+        resultIt != resultWiresEnd)
       control = *resultIt++;
-    if (isa<quake::WireType>(target.getType()) && resultIt != resultWiresEnd)
+    if (isa<cudaq::quake::WireType>(target.getType()) &&
+        resultIt != resultWiresEnd)
       target = *resultIt;
     return op;
   }
@@ -179,9 +185,11 @@ public:
     auto resultIt = resultWires.begin();
     auto resultWiresEnd = resultWires.end();
     for (auto &c : controls)
-      if (isa<quake::WireType>(c.getType()) && resultIt != resultWiresEnd)
+      if (isa<cudaq::quake::WireType>(c.getType()) &&
+          resultIt != resultWiresEnd)
         c = *resultIt++;
-    if (isa<quake::WireType>(target.getType()) && resultIt != resultWiresEnd)
+    if (isa<cudaq::quake::WireType>(target.getType()) &&
+        resultIt != resultWiresEnd)
       target = *resultIt;
     return op;
   }
@@ -197,9 +205,11 @@ public:
     auto resultIt = resultWires.begin();
     auto resultWiresEnd = resultWires.end();
     for (auto &c : controls)
-      if (isa<quake::WireType>(c.getType()) && resultIt != resultWiresEnd)
+      if (isa<cudaq::quake::WireType>(c.getType()) &&
+          resultIt != resultWiresEnd)
         c = *resultIt++;
-    if (isa<quake::WireType>(target.getType()) && resultIt != resultWiresEnd)
+    if (isa<cudaq::quake::WireType>(target.getType()) &&
+        resultIt != resultWiresEnd)
       target = *resultIt;
     return op;
   }
@@ -215,9 +225,11 @@ public:
     auto resultIt = resultWires.begin();
     auto resultWiresEnd = resultWires.end();
     for (auto &c : controls)
-      if (isa<quake::WireType>(c.getType()) && resultIt != resultWiresEnd)
+      if (isa<cudaq::quake::WireType>(c.getType()) &&
+          resultIt != resultWiresEnd)
         c = *resultIt++;
-    if (isa<quake::WireType>(target.getType()) && resultIt != resultWiresEnd)
+    if (isa<cudaq::quake::WireType>(target.getType()) &&
+        resultIt != resultWiresEnd)
       target = *resultIt;
     return op;
   }
@@ -232,7 +244,8 @@ public:
     auto resultIt = resultWires.begin();
     auto resultWiresEnd = resultWires.end();
     for (auto &t : targets)
-      if (isa<quake::WireType>(t.getType()) && resultIt != resultWiresEnd)
+      if (isa<cudaq::quake::WireType>(t.getType()) &&
+          resultIt != resultWiresEnd)
         t = *resultIt++;
     return op;
   }
@@ -246,7 +259,7 @@ private:
 ///
 /// Note: This function assumes that the operation has already been tested for
 /// reference semantics.
-static LogicalResult checkNumControls(quake::OperatorInterface op,
+static LogicalResult checkNumControls(cudaq::quake::OperatorInterface op,
                                       std::size_t requiredNumControls) {
   auto opControls = op.getControls();
   if (opControls.size() > requiredNumControls)
@@ -255,7 +268,7 @@ static LogicalResult checkNumControls(quake::OperatorInterface op,
   // Compute the number of controls
   std::size_t numControls = 0;
   for (auto control : opControls) {
-    if (auto veq = dyn_cast<quake::VeqType>(control.getType())) {
+    if (auto veq = dyn_cast<cudaq::quake::VeqType>(control.getType())) {
       if (!veq.hasSpecifiedSize())
         return failure();
       numControls += veq.getSize();
@@ -274,7 +287,7 @@ static LogicalResult checkNumControls(quake::OperatorInterface op,
 ///
 /// Note: This function assumes that the operation has already been tested for
 /// reference semantics.
-static LogicalResult checkAndExtractControls(quake::OperatorInterface op,
+static LogicalResult checkAndExtractControls(cudaq::quake::OperatorInterface op,
                                              MutableArrayRef<Value> controls,
                                              PatternRewriter &rewriter) {
   if (failed(checkNumControls(op, controls.size())))
@@ -282,11 +295,11 @@ static LogicalResult checkAndExtractControls(quake::OperatorInterface op,
 
   std::size_t controlIndex = 0;
   for (Value control : op.getControls()) {
-    if (auto veq = dyn_cast<quake::VeqType>(control.getType())) {
+    if (auto veq = dyn_cast<cudaq::quake::VeqType>(control.getType())) {
       for (std::size_t i = 0, end = veq.getSize(); i < end; ++i) {
         Value index = createConstant(op.getLoc(), i, rewriter);
-        Value qref =
-            quake::ExtractRefOp::create(rewriter, op.getLoc(), control, index);
+        Value qref = cudaq::quake::ExtractRefOp::create(rewriter, op.getLoc(),
+                                                        control, index);
         controls[controlIndex] = qref;
         controlIndex += 1;
       }
@@ -345,12 +358,12 @@ namespace {
 struct HToPhasedRxType; // forward declare the pattern type, defined in the
                         // macro below
 struct HToPhasedRx
-    : public cudaq::DecompositionPattern<HToPhasedRxType, quake::HOp> {
+    : public cudaq::DecompositionPattern<HToPhasedRxType, cudaq::quake::HOp> {
 
   using cudaq::DecompositionPattern<HToPhasedRxType,
-                                    quake::HOp>::DecompositionPattern;
+                                    cudaq::quake::HOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::HOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::HOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -367,10 +380,12 @@ struct HToPhasedRx
 
     std::array<Value, 2> parameters = {pi_2, pi_2};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = pi;
     parameters[1] = zero;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -386,11 +401,12 @@ struct ExpPauliDecompositionType; // forward declare the pattern type, defined
                                   // in the macro below
 struct ExpPauliDecomposition
     : public cudaq::DecompositionPattern<ExpPauliDecompositionType,
-                                         quake::ExpPauliOp> {
-  using cudaq::DecompositionPattern<ExpPauliDecompositionType,
-                                    quake::ExpPauliOp>::DecompositionPattern;
+                                         cudaq::quake::ExpPauliOp> {
+  using cudaq::DecompositionPattern<
+      ExpPauliDecompositionType,
+      cudaq::quake::ExpPauliOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::ExpPauliOp expPauliOp,
+  LogicalResult matchAndRewrite(cudaq::quake::ExpPauliOp expPauliOp,
                                 PatternRewriter &rewriter) const override {
     auto loc = expPauliOp.getLoc();
     auto module = expPauliOp->getParentOfType<ModuleOp>();
@@ -496,7 +512,8 @@ struct ExpPauliDecomposition
     SmallVector<Value> qubitSupport;
     for (std::size_t i = 0; i < size; i++) {
       Value index = arith::ConstantIntOp::create(rewriter, loc, i, 64);
-      Value qubitI = quake::ExtractRefOp::create(rewriter, loc, qubits, index);
+      Value qubitI =
+          cudaq::quake::ExtractRefOp::create(rewriter, loc, qubits, index);
       if (pauliWordStr[i] != 'I')
         qubitSupport.push_back(qubitI);
 
@@ -504,10 +521,10 @@ struct ExpPauliDecomposition
         APFloat d(M_PI_2);
         Value param = arith::ConstantFloatOp::create(rewriter, loc,
                                                      rewriter.getF64Type(), d);
-        quake::RxOp::create(rewriter, loc, ValueRange{param}, ValueRange{},
-                            ValueRange{qubitI});
+        cudaq::quake::RxOp::create(rewriter, loc, ValueRange{param},
+                                   ValueRange{}, ValueRange{qubitI});
       } else if (pauliWordStr[i] == 'X') {
-        quake::HOp::create(rewriter, loc, ValueRange{qubitI});
+        cudaq::quake::HOp::create(rewriter, loc, ValueRange{qubitI});
       }
     }
 
@@ -521,8 +538,8 @@ struct ExpPauliDecomposition
 
     std::vector<std::pair<Value, Value>> toReverse;
     for (std::size_t i = 0; i < qubitSupport.size() - 1; i++) {
-      quake::XOp::create(rewriter, loc, ValueRange{qubitSupport[i]},
-                         ValueRange{qubitSupport[i + 1]});
+      cudaq::quake::XOp::create(rewriter, loc, ValueRange{qubitSupport[i]},
+                                ValueRange{qubitSupport[i + 1]});
       toReverse.emplace_back(qubitSupport[i], qubitSupport[i + 1]);
     }
 
@@ -530,26 +547,27 @@ struct ExpPauliDecomposition
     Value negTwoTheta = arith::MulFOp::create(
         rewriter, loc,
         createConstant(loc, -2.0, rewriter.getF64Type(), rewriter), theta);
-    quake::RzOp::create(rewriter, loc, ValueRange{negTwoTheta}, ValueRange{},
-                        ValueRange{qubitSupport.back()});
+    cudaq::quake::RzOp::create(rewriter, loc, ValueRange{negTwoTheta},
+                               ValueRange{}, ValueRange{qubitSupport.back()});
 
     std::reverse(toReverse.begin(), toReverse.end());
     for (auto &[i, j] : toReverse)
-      quake::XOp::create(rewriter, loc, ValueRange{i}, ValueRange{j});
+      cudaq::quake::XOp::create(rewriter, loc, ValueRange{i}, ValueRange{j});
 
     for (std::size_t i = 0; i < pauliWordStr.size(); i++) {
       std::size_t k = pauliWordStr.size() - 1 - i;
       Value index = arith::ConstantIntOp::create(rewriter, loc, k, 64);
-      Value qubitK = quake::ExtractRefOp::create(rewriter, loc, qubits, index);
+      Value qubitK =
+          cudaq::quake::ExtractRefOp::create(rewriter, loc, qubits, index);
 
       if (pauliWordStr[k] == 'Y') {
         APFloat d(-M_PI_2);
         Value param = arith::ConstantFloatOp::create(rewriter, loc,
                                                      rewriter.getF64Type(), d);
-        quake::RxOp::create(rewriter, loc, ValueRange{param}, ValueRange{},
-                            ValueRange{qubitK});
+        cudaq::quake::RxOp::create(rewriter, loc, ValueRange{param},
+                                   ValueRange{}, ValueRange{qubitK});
       } else if (pauliWordStr[k] == 'X') {
-        quake::HOp::create(rewriter, loc, ValueRange{qubitK});
+        cudaq::quake::HOp::create(rewriter, loc, ValueRange{qubitK});
       }
     }
 
@@ -566,16 +584,17 @@ REGISTER_DECOMPOSITION_PATTERN(ExpPauliDecomposition, "exp_pauli", "rx", "h",
 // quake apply specialization.
 struct R1ToRzType; // forward declare the pattern type, defined in the macro
                    // below
-struct R1ToRz : public cudaq::DecompositionPattern<R1ToRzType, quake::R1Op> {
+struct R1ToRz
+    : public cudaq::DecompositionPattern<R1ToRzType, cudaq::quake::R1Op> {
   using cudaq::DecompositionPattern<R1ToRzType,
-                                    quake::R1Op>::DecompositionPattern;
+                                    cudaq::quake::R1Op>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::R1Op r1Op,
+  LogicalResult matchAndRewrite(cudaq::quake::R1Op r1Op,
                                 PatternRewriter &rewriter) const override {
     if (!r1Op.getControls().empty())
       return failure();
 
-    rewriter.replaceOpWithNewOp<quake::RzOp>(
+    rewriter.replaceOpWithNewOp<cudaq::quake::RzOp>(
         r1Op, r1Op.isAdj(), r1Op.getParameters(), r1Op.getControls(),
         r1Op.getTargets());
     return success();
@@ -589,16 +608,17 @@ REGISTER_DECOMPOSITION_PATTERN(R1ToRz, "r1", "rz");
 // quake.u3(0, 0, λ) [control] target
 struct R1ToU3Type; // forward declare the pattern type, defined in the macro
                    // below
-struct R1ToU3 : public cudaq::DecompositionPattern<R1ToU3Type, quake::R1Op> {
+struct R1ToU3
+    : public cudaq::DecompositionPattern<R1ToU3Type, cudaq::quake::R1Op> {
   using cudaq::DecompositionPattern<R1ToU3Type,
-                                    quake::R1Op>::DecompositionPattern;
+                                    cudaq::quake::R1Op>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::R1Op r1Op,
+  LogicalResult matchAndRewrite(cudaq::quake::R1Op r1Op,
                                 PatternRewriter &rewriter) const override {
     Location loc = r1Op->getLoc();
     Value zero = createConstant(loc, 0.0, rewriter.getF64Type(), rewriter);
     std::array<Value, 3> parameters = {zero, zero, r1Op.getParameters()[0]};
-    rewriter.replaceOpWithNewOp<quake::U3Op>(
+    rewriter.replaceOpWithNewOp<cudaq::quake::U3Op>(
         r1Op, r1Op.isAdj(), parameters, r1Op.getControls(), r1Op.getTargets());
     return success();
   }
@@ -611,11 +631,11 @@ REGISTER_DECOMPOSITION_PATTERN(R1ToU3, "r1(n)", "u3(n)");
 struct R1AdjToR1Type; // forward declare the pattern type, defined in the macro
                       // below
 struct R1AdjToR1
-    : public cudaq::DecompositionPattern<R1AdjToR1Type, quake::R1Op> {
+    : public cudaq::DecompositionPattern<R1AdjToR1Type, cudaq::quake::R1Op> {
   using cudaq::DecompositionPattern<R1AdjToR1Type,
-                                    quake::R1Op>::DecompositionPattern;
+                                    cudaq::quake::R1Op>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::R1Op op,
+  LogicalResult matchAndRewrite(cudaq::quake::R1Op op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -633,7 +653,7 @@ struct R1AdjToR1
     SmallVector<Value> parameters = {angle};
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::R1Op>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::R1Op>(loc, parameters, noControls, target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -650,11 +670,11 @@ REGISTER_DECOMPOSITION_PATTERN(R1AdjToR1, "r1<adj>", "r1");
 struct SwapToCXType; // forward declare the pattern type, defined in the macro
                      // below
 struct SwapToCX
-    : public cudaq::DecompositionPattern<SwapToCXType, quake::SwapOp> {
+    : public cudaq::DecompositionPattern<SwapToCXType, cudaq::quake::SwapOp> {
   using cudaq::DecompositionPattern<SwapToCXType,
-                                    quake::SwapOp>::DecompositionPattern;
+                                    cudaq::quake::SwapOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::SwapOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::SwapOp op,
                                 PatternRewriter &rewriter) const override {
     // Op info
     Location loc = op->getLoc();
@@ -662,9 +682,9 @@ struct SwapToCX
     Value b = op.getTarget(1);
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::XOp>(loc, b, a);
-    qRewriter.create<quake::XOp>(loc, a, b);
-    qRewriter.create<quake::XOp>(loc, b, a);
+    qRewriter.create<cudaq::quake::XOp>(loc, b, a);
+    qRewriter.create<cudaq::quake::XOp>(loc, a, b);
+    qRewriter.create<cudaq::quake::XOp>(loc, b, a);
 
     qRewriter.selectWiresAndReplaceUses(op, ValueRange{a, b});
     rewriter.eraseOp(op);
@@ -684,11 +704,12 @@ REGISTER_DECOMPOSITION_PATTERN(SwapToCX, "swap", "x(1)");
 // quake.s<adj> target;
 struct CHToCXType; // forward declare the pattern type, defined in the macro
                    // below
-struct CHToCX : public cudaq::DecompositionPattern<CHToCXType, quake::HOp> {
+struct CHToCX
+    : public cudaq::DecompositionPattern<CHToCXType, cudaq::quake::HOp> {
   using cudaq::DecompositionPattern<CHToCXType,
-                                    quake::HOp>::DecompositionPattern;
+                                    cudaq::quake::HOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::HOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::HOp op,
                                 PatternRewriter &rewriter) const override {
     if (failed(checkNumControls(op, 1)))
       return failure();
@@ -699,13 +720,13 @@ struct CHToCX : public cudaq::DecompositionPattern<CHToCXType, quake::HOp> {
     Value target = op.getTarget();
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::SOp>(loc, target);
-    qRewriter.create<quake::HOp>(loc, target);
-    qRewriter.create<quake::TOp>(loc, target);
-    qRewriter.create<quake::XOp>(loc, control, target);
-    qRewriter.create<quake::TOp>(loc, /*isAdj=*/true, target);
-    qRewriter.create<quake::HOp>(loc, target);
-    qRewriter.create<quake::SOp>(loc, /*isAdj=*/true, target);
+    qRewriter.create<cudaq::quake::SOp>(loc, target);
+    qRewriter.create<cudaq::quake::HOp>(loc, target);
+    qRewriter.create<cudaq::quake::TOp>(loc, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, control, target);
+    qRewriter.create<cudaq::quake::TOp>(loc, /*isAdj=*/true, target);
+    qRewriter.create<cudaq::quake::HOp>(loc, target);
+    qRewriter.create<cudaq::quake::SOp>(loc, /*isAdj=*/true, target);
 
     qRewriter.selectWiresAndReplaceUses(op, ValueRange{control, target});
     rewriter.eraseOp(op);
@@ -728,11 +749,11 @@ REGISTER_DECOMPOSITION_PATTERN(CHToCX, "h(1)", "s", "h", "t", "x(1)");
 struct SToPhasedRxType; // forward declare the pattern type, defined in the
                         // macro below
 struct SToPhasedRx
-    : public cudaq::DecompositionPattern<SToPhasedRxType, quake::SOp> {
+    : public cudaq::DecompositionPattern<SToPhasedRxType, cudaq::quake::SOp> {
   using cudaq::DecompositionPattern<SToPhasedRxType,
-                                    quake::SOp>::DecompositionPattern;
+                                    cudaq::quake::SOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::SOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::SOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -751,13 +772,16 @@ struct SToPhasedRx
 
     std::array<Value, 2> parameters = {pi_2, zero};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = angle;
     parameters[1] = pi_2;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = negPi_2;
     parameters[1] = zero;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -774,11 +798,12 @@ REGISTER_DECOMPOSITION_PATTERN(SToPhasedRx, "s", "phased_rx");
 // patterns such as controlled-r1 to cnot.
 struct SToR1Type; // forward declare the pattern type, defined in the macro
                   // below
-struct SToR1 : public cudaq::DecompositionPattern<SToR1Type, quake::SOp> {
+struct SToR1
+    : public cudaq::DecompositionPattern<SToR1Type, cudaq::quake::SOp> {
   using cudaq::DecompositionPattern<SToR1Type,
-                                    quake::SOp>::DecompositionPattern;
+                                    cudaq::quake::SOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::SOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::SOp op,
                                 PatternRewriter &rewriter) const override {
     // Op info
     auto loc = op->getLoc();
@@ -788,7 +813,7 @@ struct SToR1 : public cudaq::DecompositionPattern<SToR1Type, quake::SOp> {
     SmallVector<Value> controls(op.getControls());
     Value target = op.getTarget();
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::R1Op>(loc, angle, controls, target);
+    qRewriter.create<cudaq::quake::R1Op>(loc, angle, controls, target);
 
     qRewriter.selectWiresAndReplaceUses(op, controls, target);
     rewriter.eraseOp(op);
@@ -809,11 +834,11 @@ REGISTER_DECOMPOSITION_PATTERN(SToR1, "s(n)", "r1(n)");
 struct TToPhasedRxType; // forward declare the pattern type, defined in the
                         // macro below
 struct TToPhasedRx
-    : public cudaq::DecompositionPattern<TToPhasedRxType, quake::TOp> {
+    : public cudaq::DecompositionPattern<TToPhasedRxType, cudaq::quake::TOp> {
   using cudaq::DecompositionPattern<TToPhasedRxType,
-                                    quake::TOp>::DecompositionPattern;
+                                    cudaq::quake::TOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::TOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::TOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -833,13 +858,16 @@ struct TToPhasedRx
 
     std::array<Value, 2> parameters = {pi_2, zero};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = angle;
     parameters[1] = pi_2;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = negPi_2;
     parameters[1] = zero;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -856,11 +884,12 @@ REGISTER_DECOMPOSITION_PATTERN(TToPhasedRx, "t", "phased_rx");
 // patterns such as controlled-r1 to cnot.
 struct TToR1Type; // forward declare the pattern type, defined in the macro
                   // below
-struct TToR1 : public cudaq::DecompositionPattern<TToR1Type, quake::TOp> {
+struct TToR1
+    : public cudaq::DecompositionPattern<TToR1Type, cudaq::quake::TOp> {
   using cudaq::DecompositionPattern<TToR1Type,
-                                    quake::TOp>::DecompositionPattern;
+                                    cudaq::quake::TOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::TOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::TOp op,
                                 PatternRewriter &rewriter) const override {
     // Op info
     auto loc = op->getLoc();
@@ -869,7 +898,7 @@ struct TToR1 : public cudaq::DecompositionPattern<TToR1Type, quake::TOp> {
     SmallVector<Value> controls(op.getControls());
     Value target = op.getTarget();
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::R1Op>(loc, angle, controls, target);
+    qRewriter.create<cudaq::quake::R1Op>(loc, angle, controls, target);
 
     qRewriter.selectWiresAndReplaceUses(op, controls, target);
     rewriter.eraseOp(op);
@@ -889,11 +918,12 @@ REGISTER_DECOMPOSITION_PATTERN(TToR1, "t(n)", "r1(n)");
 // quake.h target
 struct CXToCZType; // forward declare the pattern type, defined in the macro
                    // below
-struct CXToCZ : public cudaq::DecompositionPattern<CXToCZType, quake::XOp> {
+struct CXToCZ
+    : public cudaq::DecompositionPattern<CXToCZType, cudaq::quake::XOp> {
   using cudaq::DecompositionPattern<CXToCZType,
-                                    quake::XOp>::DecompositionPattern;
+                                    cudaq::quake::XOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::XOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::XOp op,
                                 PatternRewriter &rewriter) const override {
     if (failed(checkNumControls(op, 1)))
       return failure();
@@ -912,13 +942,13 @@ struct CXToCZ : public cudaq::DecompositionPattern<CXToCZType, quake::XOp> {
       negControl = (*negatedControls)[0];
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::HOp>(loc, target);
+    qRewriter.create<cudaq::quake::HOp>(loc, target);
     if (negControl)
-      qRewriter.create<quake::XOp>(loc, controls);
-    qRewriter.create<quake::ZOp>(loc, controls, target);
+      qRewriter.create<cudaq::quake::XOp>(loc, controls);
+    qRewriter.create<cudaq::quake::ZOp>(loc, controls, target);
     if (negControl)
-      qRewriter.create<quake::XOp>(loc, controls);
-    qRewriter.create<quake::HOp>(loc, target);
+      qRewriter.create<cudaq::quake::XOp>(loc, controls);
+    qRewriter.create<cudaq::quake::HOp>(loc, target);
 
     qRewriter.selectWiresAndReplaceUses(op, controls, target);
     rewriter.eraseOp(op);
@@ -934,11 +964,12 @@ REGISTER_DECOMPOSITION_PATTERN(CXToCZ, "x(1)", "h", "z(1)");
 // quake.h target
 struct CCXToCCZType; // forward declare the pattern type, defined in the macro
                      // below
-struct CCXToCCZ : public cudaq::DecompositionPattern<CCXToCCZType, quake::XOp> {
+struct CCXToCCZ
+    : public cudaq::DecompositionPattern<CCXToCCZType, cudaq::quake::XOp> {
   using cudaq::DecompositionPattern<CCXToCCZType,
-                                    quake::XOp>::DecompositionPattern;
+                                    cudaq::quake::XOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::XOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::XOp op,
                                 PatternRewriter &rewriter) const override {
     SmallVector<Value, 2> controls(2);
     if (failed(checkAndExtractControls(op, controls, rewriter)))
@@ -949,10 +980,10 @@ struct CCXToCCZ : public cudaq::DecompositionPattern<CCXToCCZType, quake::XOp> {
     Value target = op.getTarget();
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::HOp>(loc, target);
-    auto zOp = qRewriter.create<quake::ZOp>(loc, controls, target);
+    qRewriter.create<cudaq::quake::HOp>(loc, target);
+    auto zOp = qRewriter.create<cudaq::quake::ZOp>(loc, controls, target);
     zOp.setNegatedQubitControls(op.getNegatedQubitControls());
-    qRewriter.create<quake::HOp>(loc, target);
+    qRewriter.create<cudaq::quake::HOp>(loc, target);
 
     qRewriter.selectWiresAndReplaceUses(op, controls, target);
     rewriter.eraseOp(op);
@@ -967,11 +998,11 @@ REGISTER_DECOMPOSITION_PATTERN(CCXToCCZ, "x(2)", "h", "z(2)");
 struct XToPhasedRxType; // forward declare the pattern type, defined in the
                         // macro below
 struct XToPhasedRx
-    : public cudaq::DecompositionPattern<XToPhasedRxType, quake::XOp> {
+    : public cudaq::DecompositionPattern<XToPhasedRxType, cudaq::quake::XOp> {
   using cudaq::DecompositionPattern<XToPhasedRxType,
-                                    quake::XOp>::DecompositionPattern;
+                                    cudaq::quake::XOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::XOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::XOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -987,7 +1018,8 @@ struct XToPhasedRx
 
     SmallVector<Value> parameters = {pi, zero};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1006,11 +1038,11 @@ REGISTER_DECOMPOSITION_PATTERN(XToPhasedRx, "x", "phased_rx");
 struct YToPhasedRxType; // forward declare the pattern type, defined in the
                         // macro below
 struct YToPhasedRx
-    : public cudaq::DecompositionPattern<YToPhasedRxType, quake::YOp> {
+    : public cudaq::DecompositionPattern<YToPhasedRxType, cudaq::quake::YOp> {
   using cudaq::DecompositionPattern<YToPhasedRxType,
-                                    quake::YOp>::DecompositionPattern;
+                                    cudaq::quake::YOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::YOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::YOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -1027,7 +1059,8 @@ struct YToPhasedRx
 
     SmallVector<Value> parameters = {pi, negPi_2};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1044,11 +1077,12 @@ REGISTER_DECOMPOSITION_PATTERN(YToPhasedRx, "y", "phased_rx");
 
 struct CYToCXType; // forward declare the pattern type, defined in the macro
                    // below
-struct CYToCX : public cudaq::DecompositionPattern<CYToCXType, quake::YOp> {
+struct CYToCX
+    : public cudaq::DecompositionPattern<CYToCXType, cudaq::quake::YOp> {
   using cudaq::DecompositionPattern<CYToCXType,
-                                    quake::YOp>::DecompositionPattern;
+                                    cudaq::quake::YOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::YOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::YOp op,
                                 PatternRewriter &rewriter) const override {
     if (failed(checkNumControls(op, 1)))
       return failure();
@@ -1063,9 +1097,9 @@ struct CYToCX : public cudaq::DecompositionPattern<CYToCXType, quake::YOp> {
     SmallVector<Value> controls = op.getControls();
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::SOp>(loc, /*isAdj=*/true, target);
-    qRewriter.create<quake::XOp>(loc, controls, target);
-    qRewriter.create<quake::SOp>(loc, target);
+    qRewriter.create<cudaq::quake::SOp>(loc, /*isAdj=*/true, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, controls, target);
+    qRewriter.create<cudaq::quake::SOp>(loc, target);
 
     qRewriter.selectWiresAndReplaceUses(op, controls, target);
     rewriter.eraseOp(op);
@@ -1093,11 +1127,12 @@ REGISTER_DECOMPOSITION_PATTERN(CYToCX, "y(1)", "s", "x(1)");
 // NOTE: `┴` denotes the adjoint of `T`.
 struct CCZToCXType; // forward declare the pattern type, defined in the macro
                     // below
-struct CCZToCX : public cudaq::DecompositionPattern<CCZToCXType, quake::ZOp> {
+struct CCZToCX
+    : public cudaq::DecompositionPattern<CCZToCXType, cudaq::quake::ZOp> {
   using cudaq::DecompositionPattern<CCZToCXType,
-                                    quake::ZOp>::DecompositionPattern;
+                                    cudaq::quake::ZOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::ZOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::ZOp op,
                                 PatternRewriter &rewriter) const override {
     // This decomposition does not support `quake.control` types because the
     // input controls are used as targets during this transformation.
@@ -1130,21 +1165,21 @@ struct CCZToCX : public cudaq::DecompositionPattern<CCZToCXType, quake::ZOp> {
     }
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::XOp>(loc, controls[1], target);
-    qRewriter.create<quake::TOp>(loc, /*isAdj=*/!negC0, target);
-    qRewriter.create<quake::XOp>(loc, controls[0], target);
-    qRewriter.create<quake::TOp>(loc, target);
-    qRewriter.create<quake::XOp>(loc, controls[1], target);
-    qRewriter.create<quake::TOp>(loc, /*isAdj=*/!negC1, target);
-    qRewriter.create<quake::XOp>(loc, controls[0], target);
-    qRewriter.create<quake::TOp>(loc, /*isAdj=*/negC0 && !negC1, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, controls[1], target);
+    qRewriter.create<cudaq::quake::TOp>(loc, /*isAdj=*/!negC0, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, controls[0], target);
+    qRewriter.create<cudaq::quake::TOp>(loc, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, controls[1], target);
+    qRewriter.create<cudaq::quake::TOp>(loc, /*isAdj=*/!negC1, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, controls[0], target);
+    qRewriter.create<cudaq::quake::TOp>(loc, /*isAdj=*/negC0 && !negC1, target);
 
-    qRewriter.create<quake::XOp>(loc, controls[0], controls[1]);
-    qRewriter.create<quake::TOp>(loc, /*isAdj=*/true, controls[1]);
-    qRewriter.create<quake::XOp>(loc, controls[0], controls[1]);
-    qRewriter.create<quake::TOp>(loc, /*isAdj=*/negC0, controls[1]);
+    qRewriter.create<cudaq::quake::XOp>(loc, controls[0], controls[1]);
+    qRewriter.create<cudaq::quake::TOp>(loc, /*isAdj=*/true, controls[1]);
+    qRewriter.create<cudaq::quake::XOp>(loc, controls[0], controls[1]);
+    qRewriter.create<cudaq::quake::TOp>(loc, /*isAdj=*/negC0, controls[1]);
 
-    qRewriter.create<quake::TOp>(loc, /*isAdj=*/negC1, controls[0]);
+    qRewriter.create<cudaq::quake::TOp>(loc, /*isAdj=*/negC1, controls[0]);
 
     qRewriter.selectWiresAndReplaceUses(op, controls, target);
     rewriter.eraseOp(op);
@@ -1163,11 +1198,12 @@ REGISTER_DECOMPOSITION_PATTERN(CCZToCX, "z(2)", "t", "x(1)");
 
 struct CZToCXType; // forward declare the pattern type, defined in the macro
                    // below
-struct CZToCX : public cudaq::DecompositionPattern<CZToCXType, quake::ZOp> {
+struct CZToCX
+    : public cudaq::DecompositionPattern<CZToCXType, cudaq::quake::ZOp> {
   using cudaq::DecompositionPattern<CZToCXType,
-                                    quake::ZOp>::DecompositionPattern;
+                                    cudaq::quake::ZOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::ZOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::ZOp op,
                                 PatternRewriter &rewriter) const override {
     // This decomposition does not support `quake.control` types because the
     // input controls are used as targets during this transformation.
@@ -1186,13 +1222,13 @@ struct CZToCX : public cudaq::DecompositionPattern<CZToCXType, quake::ZOp> {
       negControl = (*negatedControls)[0];
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::HOp>(loc, target);
+    qRewriter.create<cudaq::quake::HOp>(loc, target);
     if (negControl)
-      qRewriter.create<quake::XOp>(loc, controls);
-    qRewriter.create<quake::XOp>(loc, controls, target);
+      qRewriter.create<cudaq::quake::XOp>(loc, controls);
+    qRewriter.create<cudaq::quake::XOp>(loc, controls, target);
     if (negControl)
-      qRewriter.create<quake::XOp>(loc, controls);
-    qRewriter.create<quake::HOp>(loc, target);
+      qRewriter.create<cudaq::quake::XOp>(loc, controls);
+    qRewriter.create<cudaq::quake::HOp>(loc, target);
 
     qRewriter.selectWiresAndReplaceUses(op, controls, target);
     rewriter.eraseOp(op);
@@ -1209,11 +1245,11 @@ REGISTER_DECOMPOSITION_PATTERN(CZToCX, "z(1)", "h", "x(1)");
 struct ZToPhasedRxType; // forward declare the pattern type, defined in the
                         // macro below
 struct ZToPhasedRx
-    : public cudaq::DecompositionPattern<ZToPhasedRxType, quake::ZOp> {
+    : public cudaq::DecompositionPattern<ZToPhasedRxType, cudaq::quake::ZOp> {
   using cudaq::DecompositionPattern<ZToPhasedRxType,
-                                    quake::ZOp>::DecompositionPattern;
+                                    cudaq::quake::ZOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::ZOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::ZOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -1231,13 +1267,16 @@ struct ZToPhasedRx
 
     std::array<Value, 2> parameters = {pi_2, zero};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = negPi;
     parameters[1] = pi_2;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = negPi_2;
     parameters[1] = zero;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1259,11 +1298,12 @@ REGISTER_DECOMPOSITION_PATTERN(ZToPhasedRx, "z", "phased_rx");
 // quake.r1(λ/2) target
 struct CR1ToCXType; // forward declare the pattern type, defined in the macro
                     // below
-struct CR1ToCX : public cudaq::DecompositionPattern<CR1ToCXType, quake::R1Op> {
+struct CR1ToCX
+    : public cudaq::DecompositionPattern<CR1ToCXType, cudaq::quake::R1Op> {
   using cudaq::DecompositionPattern<CR1ToCXType,
-                                    quake::R1Op>::DecompositionPattern;
+                                    cudaq::quake::R1Op>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::R1Op op,
+  LogicalResult matchAndRewrite(cudaq::quake::R1Op op,
                                 PatternRewriter &rewriter) const override {
     if (containsControlTypes(op))
       return failure();
@@ -1290,13 +1330,13 @@ struct CR1ToCX : public cudaq::DecompositionPattern<CR1ToCXType, quake::R1Op> {
     Value negHalfAngle = arith::NegFOp::create(rewriter, loc, halfAngle);
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::R1Op>(loc, /*isAdj*/ negControl, halfAngle,
-                                  noControls, control);
-    qRewriter.create<quake::XOp>(loc, control, target);
-    qRewriter.create<quake::R1Op>(loc, /*isAdj*/ negControl, negHalfAngle,
-                                  noControls, target);
-    qRewriter.create<quake::XOp>(loc, control, target);
-    qRewriter.create<quake::R1Op>(loc, halfAngle, noControls, target);
+    qRewriter.create<cudaq::quake::R1Op>(loc, /*isAdj*/ negControl, halfAngle,
+                                         noControls, control);
+    qRewriter.create<cudaq::quake::XOp>(loc, control, target);
+    qRewriter.create<cudaq::quake::R1Op>(loc, /*isAdj*/ negControl,
+                                         negHalfAngle, noControls, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, control, target);
+    qRewriter.create<cudaq::quake::R1Op>(loc, halfAngle, noControls, target);
 
     qRewriter.selectWiresAndReplaceUses(op, ValueRange{control, target});
     rewriter.eraseOp(op);
@@ -1313,11 +1353,11 @@ REGISTER_DECOMPOSITION_PATTERN(CR1ToCX, "r1(1)", "r1", "x(1)");
 struct R1ToPhasedRxType; // forward declare the pattern type, defined in the
                          // macro below
 struct R1ToPhasedRx
-    : public cudaq::DecompositionPattern<R1ToPhasedRxType, quake::R1Op> {
+    : public cudaq::DecompositionPattern<R1ToPhasedRxType, cudaq::quake::R1Op> {
   using cudaq::DecompositionPattern<R1ToPhasedRxType,
-                                    quake::R1Op>::DecompositionPattern;
+                                    cudaq::quake::R1Op>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::R1Op op,
+  LogicalResult matchAndRewrite(cudaq::quake::R1Op op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -1339,13 +1379,16 @@ struct R1ToPhasedRx
 
     std::array<Value, 2> parameters = {pi_2, zero};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = negAngle;
     parameters[1] = pi_2;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = negPi_2;
     parameters[1] = zero;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1368,11 +1411,12 @@ REGISTER_DECOMPOSITION_PATTERN(R1ToPhasedRx, "r1", "phased_rx");
 // quake.rz(-π/2) target
 struct CRxToCXType; // forward declare the pattern type, defined in the macro
                     // below
-struct CRxToCX : public cudaq::DecompositionPattern<CRxToCXType, quake::RxOp> {
+struct CRxToCX
+    : public cudaq::DecompositionPattern<CRxToCXType, cudaq::quake::RxOp> {
   using cudaq::DecompositionPattern<CRxToCXType,
-                                    quake::RxOp>::DecompositionPattern;
+                                    cudaq::quake::RxOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::RxOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::RxOp op,
                                 PatternRewriter &rewriter) const override {
     Value control;
     if (failed(checkAndExtractControls(op, control, rewriter)))
@@ -1399,14 +1443,14 @@ struct CRxToCX : public cudaq::DecompositionPattern<CRxToCXType, quake::RxOp> {
     Value negPI_2 = createConstant(loc, -M_PI_2, angleType, rewriter);
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::SOp>(loc, /*isAdj*/ negControl, target);
-    qRewriter.create<quake::XOp>(loc, control, target);
-    qRewriter.create<quake::RyOp>(loc, negHalfAngle, noControls, target);
-    qRewriter.create<quake::XOp>(loc, control, target);
-    qRewriter.create<quake::RyOp>(loc, /*isAdj*/ negControl, halfAngle,
-                                  noControls, target);
-    qRewriter.create<quake::RzOp>(loc, /*isAdj*/ negControl, negPI_2,
-                                  noControls, target);
+    qRewriter.create<cudaq::quake::SOp>(loc, /*isAdj*/ negControl, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, control, target);
+    qRewriter.create<cudaq::quake::RyOp>(loc, negHalfAngle, noControls, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, control, target);
+    qRewriter.create<cudaq::quake::RyOp>(loc, /*isAdj*/ negControl, halfAngle,
+                                         noControls, target);
+    qRewriter.create<cudaq::quake::RzOp>(loc, /*isAdj*/ negControl, negPI_2,
+                                         noControls, target);
 
     qRewriter.selectWiresAndReplaceUses(op, ValueRange{control, target});
     rewriter.eraseOp(op);
@@ -1421,11 +1465,11 @@ REGISTER_DECOMPOSITION_PATTERN(CRxToCX, "rx(1)", "s", "x(1)", "ry", "rz");
 struct RxToPhasedRxType; // forward declare the pattern type, defined in the
                          // macro below
 struct RxToPhasedRx
-    : public cudaq::DecompositionPattern<RxToPhasedRxType, quake::RxOp> {
+    : public cudaq::DecompositionPattern<RxToPhasedRxType, cudaq::quake::RxOp> {
   using cudaq::DecompositionPattern<RxToPhasedRxType,
-                                    quake::RxOp>::DecompositionPattern;
+                                    cudaq::quake::RxOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::RxOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::RxOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -1444,7 +1488,8 @@ struct RxToPhasedRx
 
     SmallVector<Value> parameters = {angle, zero};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1459,11 +1504,11 @@ REGISTER_DECOMPOSITION_PATTERN(RxToPhasedRx, "rx", "phased_rx");
 struct RxAdjToRxType; // forward declare the pattern type, defined in the macro
                       // below
 struct RxAdjToRx
-    : public cudaq::DecompositionPattern<RxAdjToRxType, quake::RxOp> {
+    : public cudaq::DecompositionPattern<RxAdjToRxType, cudaq::quake::RxOp> {
   using cudaq::DecompositionPattern<RxAdjToRxType,
-                                    quake::RxOp>::DecompositionPattern;
+                                    cudaq::quake::RxOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::RxOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::RxOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -1482,7 +1527,7 @@ struct RxAdjToRx
     SmallVector<Value> parameters = {angle};
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::RxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::RxOp>(loc, parameters, noControls, target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1503,11 +1548,12 @@ REGISTER_DECOMPOSITION_PATTERN(RxAdjToRx, "rx<adj>", "rx");
 // quake.x [control] target
 struct CRyToCXType; // forward declare the pattern type, defined in the macro
                     // below
-struct CRyToCX : public cudaq::DecompositionPattern<CRyToCXType, quake::RyOp> {
+struct CRyToCX
+    : public cudaq::DecompositionPattern<CRyToCXType, cudaq::quake::RyOp> {
   using cudaq::DecompositionPattern<CRyToCXType,
-                                    quake::RyOp>::DecompositionPattern;
+                                    cudaq::quake::RyOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::RyOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::RyOp op,
                                 PatternRewriter &rewriter) const override {
     Value control;
     if (failed(checkAndExtractControls(op, control, rewriter)))
@@ -1531,11 +1577,11 @@ struct CRyToCX : public cudaq::DecompositionPattern<CRyToCXType, quake::RyOp> {
     Value negHalfAngle = arith::NegFOp::create(rewriter, loc, halfAngle);
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::RyOp>(loc, halfAngle, noControls, target);
-    qRewriter.create<quake::XOp>(loc, control, target);
-    qRewriter.create<quake::RyOp>(loc, /*isAdj*/ negControl, negHalfAngle,
-                                  noControls, target);
-    qRewriter.create<quake::XOp>(loc, control, target);
+    qRewriter.create<cudaq::quake::RyOp>(loc, halfAngle, noControls, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, control, target);
+    qRewriter.create<cudaq::quake::RyOp>(loc, /*isAdj*/ negControl,
+                                         negHalfAngle, noControls, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, control, target);
 
     qRewriter.selectWiresAndReplaceUses(op, ValueRange{control, target});
     rewriter.eraseOp(op);
@@ -1550,11 +1596,11 @@ REGISTER_DECOMPOSITION_PATTERN(CRyToCX, "ry(1)", "ry", "x(1)");
 struct RyToPhasedRxType; // forward declare the pattern type, defined in the
                          // macro below
 struct RyToPhasedRx
-    : public cudaq::DecompositionPattern<RyToPhasedRxType, quake::RyOp> {
+    : public cudaq::DecompositionPattern<RyToPhasedRxType, cudaq::quake::RyOp> {
   using cudaq::DecompositionPattern<RyToPhasedRxType,
-                                    quake::RyOp>::DecompositionPattern;
+                                    cudaq::quake::RyOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::RyOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::RyOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -1573,7 +1619,8 @@ struct RyToPhasedRx
 
     SmallVector<Value> parameters = {angle, pi_2};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1588,11 +1635,11 @@ REGISTER_DECOMPOSITION_PATTERN(RyToPhasedRx, "ry", "phased_rx");
 struct RyAdjToRyType; // forward declare the pattern type, defined in the macro
                       // below
 struct RyAdjToRy
-    : public cudaq::DecompositionPattern<RyAdjToRyType, quake::RyOp> {
+    : public cudaq::DecompositionPattern<RyAdjToRyType, cudaq::quake::RyOp> {
   using cudaq::DecompositionPattern<RyAdjToRyType,
-                                    quake::RyOp>::DecompositionPattern;
+                                    cudaq::quake::RyOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::RyOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::RyOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -1611,7 +1658,7 @@ struct RyAdjToRy
     SmallVector<Value> parameters = {angle};
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::RyOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::RyOp>(loc, parameters, noControls, target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1632,11 +1679,12 @@ REGISTER_DECOMPOSITION_PATTERN(RyAdjToRy, "ry<adj>", "ry");
 // quake.x [control] target
 struct CRzToCXType; // forward declare the pattern type, defined in the macro
                     // below
-struct CRzToCX : public cudaq::DecompositionPattern<CRzToCXType, quake::RzOp> {
+struct CRzToCX
+    : public cudaq::DecompositionPattern<CRzToCXType, cudaq::quake::RzOp> {
   using cudaq::DecompositionPattern<CRzToCXType,
-                                    quake::RzOp>::DecompositionPattern;
+                                    cudaq::quake::RzOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::RzOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::RzOp op,
                                 PatternRewriter &rewriter) const override {
     Value control;
     if (failed(checkAndExtractControls(op, control, rewriter)))
@@ -1660,11 +1708,11 @@ struct CRzToCX : public cudaq::DecompositionPattern<CRzToCXType, quake::RzOp> {
     Value negHalfAngle = arith::NegFOp::create(rewriter, loc, halfAngle);
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::RzOp>(loc, halfAngle, noControls, target);
-    qRewriter.create<quake::XOp>(loc, control, target);
-    qRewriter.create<quake::RzOp>(loc, /*isAdj*/ negControl, negHalfAngle,
-                                  noControls, target);
-    qRewriter.create<quake::XOp>(loc, control, target);
+    qRewriter.create<cudaq::quake::RzOp>(loc, halfAngle, noControls, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, control, target);
+    qRewriter.create<cudaq::quake::RzOp>(loc, /*isAdj*/ negControl,
+                                         negHalfAngle, noControls, target);
+    qRewriter.create<cudaq::quake::XOp>(loc, control, target);
 
     qRewriter.selectWiresAndReplaceUses(op, ValueRange{control, target});
     rewriter.eraseOp(op);
@@ -1681,11 +1729,11 @@ REGISTER_DECOMPOSITION_PATTERN(CRzToCX, "rz(1)", "rz", "x(1)");
 struct RzToPhasedRxType; // forward declare the pattern type, defined in the
                          // macro below
 struct RzToPhasedRx
-    : public cudaq::DecompositionPattern<RzToPhasedRxType, quake::RzOp> {
+    : public cudaq::DecompositionPattern<RzToPhasedRxType, cudaq::quake::RzOp> {
   using cudaq::DecompositionPattern<RzToPhasedRxType,
-                                    quake::RzOp>::DecompositionPattern;
+                                    cudaq::quake::RzOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::RzOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::RzOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -1707,13 +1755,16 @@ struct RzToPhasedRx
 
     std::array<Value, 2> parameters = {pi_2, zero};
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = negAngle;
     parameters[1] = pi_2;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
     parameters[0] = negPi_2;
     parameters[1] = zero;
-    qRewriter.create<quake::PhasedRxOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::PhasedRxOp>(loc, parameters, noControls,
+                                               target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1728,11 +1779,11 @@ REGISTER_DECOMPOSITION_PATTERN(RzToPhasedRx, "rz", "phased_rx");
 struct RzAdjToRzType; // forward declare the pattern type, defined in the macro
                       // below
 struct RzAdjToRz
-    : public cudaq::DecompositionPattern<RzAdjToRzType, quake::RzOp> {
+    : public cudaq::DecompositionPattern<RzAdjToRzType, cudaq::quake::RzOp> {
   using cudaq::DecompositionPattern<RzAdjToRzType,
-                                    quake::RzOp>::DecompositionPattern;
+                                    cudaq::quake::RzOp>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::RzOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::RzOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getControls().empty())
       return failure();
@@ -1751,7 +1802,7 @@ struct RzAdjToRz
     SmallVector<Value> parameters = {angle};
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::RzOp>(loc, parameters, noControls, target);
+    qRewriter.create<cudaq::quake::RzOp>(loc, parameters, noControls, target);
 
     qRewriter.selectWiresAndReplaceUses(op, target);
     rewriter.eraseOp(op);
@@ -1773,12 +1824,12 @@ REGISTER_DECOMPOSITION_PATTERN(RzAdjToRz, "rz<adj>", "rz");
 // quake.rz(ϕ) target
 struct U3ToRotationsType; // forward declare the pattern type, defined in the
                           // macro below
-struct U3ToRotations
-    : public cudaq::DecompositionPattern<U3ToRotationsType, quake::U3Op> {
+struct U3ToRotations : public cudaq::DecompositionPattern<U3ToRotationsType,
+                                                          cudaq::quake::U3Op> {
   using cudaq::DecompositionPattern<U3ToRotationsType,
-                                    quake::U3Op>::DecompositionPattern;
+                                    cudaq::quake::U3Op>::DecompositionPattern;
 
-  LogicalResult matchAndRewrite(quake::U3Op op,
+  LogicalResult matchAndRewrite(cudaq::quake::U3Op op,
                                 PatternRewriter &rewriter) const override {
     // Op info
     Location loc = op->getLoc();
@@ -1802,11 +1853,11 @@ struct U3ToRotations
     Value negPi_2 = arith::NegFOp::create(rewriter, loc, pi_2);
 
     QuakeOperatorCreator qRewriter(rewriter);
-    qRewriter.create<quake::RzOp>(loc, lam, controls, target);
-    qRewriter.create<quake::RxOp>(loc, pi_2, controls, target);
-    qRewriter.create<quake::RzOp>(loc, theta, controls, target);
-    qRewriter.create<quake::RxOp>(loc, negPi_2, controls, target);
-    qRewriter.create<quake::RzOp>(loc, phi, controls, target);
+    qRewriter.create<cudaq::quake::RzOp>(loc, lam, controls, target);
+    qRewriter.create<cudaq::quake::RxOp>(loc, pi_2, controls, target);
+    qRewriter.create<cudaq::quake::RzOp>(loc, theta, controls, target);
+    qRewriter.create<cudaq::quake::RxOp>(loc, negPi_2, controls, target);
+    qRewriter.create<cudaq::quake::RzOp>(loc, phi, controls, target);
 
     qRewriter.selectWiresAndReplaceUses(op, controls, target);
     rewriter.eraseOp(op);

--- a/lib/Optimizer/Transforms/DecompositionPatterns.h
+++ b/lib/Optimizer/Transforms/DecompositionPatterns.h
@@ -100,7 +100,7 @@ void populateWithAllDecompositionPatterns(mlir::RewritePatternSet &patterns);
 /// The returned conversion target will accept operations in the MLIR dialects
 /// arith::ArithDialect, cf::ControlFlowDialect, cudaq::cc::CCDialect,
 /// func::FuncDialect, and math::MathDialect, as well as operations in the
-/// quake::QuakeDialect that appear in `targetBasis`.
+/// cudaq::quake::QuakeDialect that appear in `targetBasis`.
 std::unique_ptr<mlir::ConversionTarget>
 createBasisTarget(mlir::MLIRContext &context,
                   mlir::ArrayRef<std::string> targetBasis);

--- a/lib/Optimizer/Transforms/DependencyAnalysis.cpp
+++ b/lib/Optimizer/Transforms/DependencyAnalysis.cpp
@@ -28,7 +28,7 @@ namespace cudaq::opt {
 
 using namespace mlir;
 
-#define RAW(X) quake::X
+#define RAW(X) cudaq::quake::X
 #define RAW_MEASURE_OPS MEASURE_OPS(RAW)
 #define RAW_GATE_OPS GATE_OPS(RAW)
 #define RAW_QUANTUM_OPS QUANTUM_OPS(RAW)
@@ -56,7 +56,7 @@ std::size_t getOperandIDXFromResultIDX(std::size_t resultidx, Operation *op) {
     return 0;
   // Currently, all classical operands precede all quantum operands
   for (auto type : op->getOperandTypes()) {
-    if (!quake::isQuantumType(type))
+    if (!cudaq::quake::isQuantumType(type))
       resultidx++;
     else
       break;
@@ -74,7 +74,7 @@ std::size_t getResultIDXFromOperandIDX(std::size_t operand_idx, Operation *op) {
     return 1;
   std::size_t numPrecedingClassical = 0;
   for (auto type : op->getOperandTypes()) {
-    if (!quake::isQuantumType(type))
+    if (!cudaq::quake::isQuantumType(type))
       numPrecedingClassical++;
     else
       break;
@@ -652,8 +652,8 @@ protected:
   void codeGen(OpBuilder &builder) override {
     assert(qubit.has_value() && "Trying to codeGen a virtual allocation "
                                 "without a physical qubit assigned!");
-    auto wirety = quake::WireType::get(builder.getContext());
-    auto alloc = quake::BorrowWireOp::create(
+    auto wirety = cudaq::quake::WireType::get(builder.getContext());
+    auto alloc = cudaq::quake::BorrowWireOp::create(
         builder, builder.getUnknownLoc(), wirety,
         cudaq::opt::topologyAgnosticWiresetName, qubit.value());
     wire = alloc.getResult();
@@ -661,7 +661,7 @@ protected:
   }
 
 public:
-  InitDependencyNode(quake::BorrowWireOp op) : wire(op.getResult()) {
+  InitDependencyNode(cudaq::quake::BorrowWireOp op) : wire(op.getResult()) {
     // Lookup qid from op
     auto qid = op.getIdentity();
     qids.insert(qid);
@@ -852,7 +852,7 @@ public:
     // TODO: quake.discriminate is currently the only operation in the quake
     // dialect that doesn't operate on wires. This will need to be updated if
     // that changes.
-    if (isa<quake::DiscriminateOp>(op))
+    if (isa<cudaq::quake::DiscriminateOp>(op))
       quantumOp = false;
 
     height = 0;
@@ -939,7 +939,7 @@ public:
       for (auto &edge : successor->dependencies) {
         if (edge.node == this) {
           // If the output isn't a linear type, then don't worry about it
-          if (quake::isQuantumType(edge.getValue().getType())) {
+          if (cudaq::quake::isQuantumType(edge.getValue().getType())) {
             auto idx = getDependencyForQID(edge.qid.value()).value();
             auto dependency = dependencies[idx];
             edge = dependency;
@@ -1709,15 +1709,15 @@ protected:
 
   void genOp(OpBuilder &builder) override {
     auto wire = dependencies[0].getValue();
-    auto newOp =
-        quake::ReturnWireOp::create(builder, builder.getUnknownLoc(), wire);
+    auto newOp = cudaq::quake::ReturnWireOp::create(
+        builder, builder.getUnknownLoc(), wire);
     newOp->setAttrs(associated->getAttrs());
     newOp->removeAttr("dnodeid");
     associated = newOp;
   }
 
 public:
-  RootDependencyNode(quake::ReturnWireOp op,
+  RootDependencyNode(cudaq::quake::ReturnWireOp op,
                      SmallVector<DependencyEdge> dependencies)
       : OpDependencyNode(op, dependencies) {
     // TODO: does this below comment still hold?
@@ -1799,7 +1799,9 @@ public:
   bool isRoot() override { return false; }
   bool isLeaf() override { return true; }
   // TODO: I'm pretty sure this is always true
-  bool isQuantumOp() override { return quake::isQuantumType(barg.getType()); }
+  bool isQuantumOp() override {
+    return cudaq::quake::isQuantumType(barg.getType());
+  }
   unsigned numTicks() override { return 0; }
 
   void eraseEdgeForQID(VirtualQID qid) override {
@@ -2598,7 +2600,7 @@ protected:
     // Remove operands from shadow dependencies
     // First operand must be conditional, skip it
     for (unsigned i = 1; i < operands.size(); i++) {
-      if (!quake::isQuantumType(operands[i].getType())) {
+      if (!cudaq::quake::isQuantumType(operands[i].getType())) {
         operands.erase(operands.begin() + i);
         i--;
       }
@@ -2924,8 +2926,8 @@ public:
 /// * control flow operations (except `if`s) are not allowed
 /// * memory stores may be rearranged (this is not a hard error)
 bool validateOp(Operation *op) {
-  if (isQuakeOperation(op) && !quake::isLinearValueForm(op) &&
-      !isa<quake::DiscriminateOp>(op)) {
+  if (isQuakeOperation(op) && !cudaq::quake::isLinearValueForm(op) &&
+      !isa<cudaq::quake::DiscriminateOp>(op)) {
     op->emitRemark("DependencyAnalysisPass: requires all quake operations to "
                    "be in value form. Function will be skipped");
     return false;
@@ -2954,7 +2956,7 @@ bool validateOp(Operation *op) {
                     "may be reordered");
   }
 
-  if (isa<quake::NullWireOp>(op)) {
+  if (isa<cudaq::quake::NullWireOp>(op)) {
     op->emitRemark(
         "DependencyAnalysisPass: `quake.borrow_wire` is only "
         "supported qubit allocation operation. Function will be skipped");
@@ -3026,7 +3028,7 @@ public:
       if (!node)
         return nullptr;
 
-      if (isa<quake::ReturnWireOp>(&op))
+      if (isa<cudaq::quake::ReturnWireOp>(&op))
         roots[node] = &op;
 
       if (isTerminator) {
@@ -3078,10 +3080,10 @@ public:
 
     DependencyNode *newNode;
 
-    if (auto init = dyn_cast<quake::BorrowWireOp>(op)) {
+    if (auto init = dyn_cast<cudaq::quake::BorrowWireOp>(op)) {
       newNode = new InitDependencyNode(init);
       vallocs++;
-    } else if (auto sink = dyn_cast<quake::ReturnWireOp>(op)) {
+    } else if (auto sink = dyn_cast<cudaq::quake::ReturnWireOp>(op)) {
       newNode = new RootDependencyNode(sink, dependencies);
     } else if (auto ifop = dyn_cast<cudaq::cc::IfOp>(op)) {
       freeClassicals[op] = SetVector<ShadowDependencyNode *>();

--- a/lib/Optimizer/Transforms/DesugarCableOps.cpp
+++ b/lib/Optimizer/Transforms/DesugarCableOps.cpp
@@ -29,26 +29,27 @@ using namespace mlir;
  */
 
 namespace {
-class AttachWirePattern : public OpRewritePattern<quake::AttachWireOp> {
+class AttachWirePattern : public OpRewritePattern<cudaq::quake::AttachWireOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::AttachWireOp attach,
+  LogicalResult matchAndRewrite(cudaq::quake::AttachWireOp attach,
                                 PatternRewriter &rewriter) const override {
     auto loc = attach.getLoc();
     auto *ctx = rewriter.getContext();
-    auto size = cast<quake::CableType>(attach.getCable().getType()).getSize();
+    auto size =
+        cast<cudaq::quake::CableType>(attach.getCable().getType()).getSize();
     LLVM_DEBUG(llvm::dbgs() << "attach: " << attach << '\n');
-    SmallVector<Type> wiresTy(size, quake::WireType::get(ctx));
-    auto split =
-        quake::SplitCableOp::create(rewriter, loc, wiresTy, attach.getCable());
+    SmallVector<Type> wiresTy(size, cudaq::quake::WireType::get(ctx));
+    auto split = cudaq::quake::SplitCableOp::create(rewriter, loc, wiresTy,
+                                                    attach.getCable());
     SmallVector<Value> args{split.getResults().begin(),
                             split.getResults().begin() + attach.getIndex()};
     args.push_back(attach.getWire());
     args.append(split.getResults().begin() + attach.getIndex(),
                 split.getResults().end());
     [[maybe_unused]] auto bundle =
-        rewriter.replaceOpWithNewOp<quake::BundleCableOp>(
+        rewriter.replaceOpWithNewOp<cudaq::quake::BundleCableOp>(
             attach, attach.getType(), ValueRange{args});
     LLVM_DEBUG(llvm::dbgs() << "split/bundle: " << split << '\n'
                             << bundle << '\n');
@@ -56,19 +57,20 @@ public:
   }
 };
 
-class DetachWirePattern : public OpRewritePattern<quake::DetachWireOp> {
+class DetachWirePattern : public OpRewritePattern<cudaq::quake::DetachWireOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::DetachWireOp detach,
+  LogicalResult matchAndRewrite(cudaq::quake::DetachWireOp detach,
                                 PatternRewriter &rewriter) const override {
     auto loc = detach.getLoc();
     auto *ctx = rewriter.getContext();
-    auto size = cast<quake::CableType>(detach.getCable().getType()).getSize();
+    auto size =
+        cast<cudaq::quake::CableType>(detach.getCable().getType()).getSize();
     LLVM_DEBUG(llvm::dbgs() << "detach: " << detach << '\n');
-    SmallVector<Type> wiresTy(size, quake::WireType::get(ctx));
-    auto split =
-        quake::SplitCableOp::create(rewriter, loc, wiresTy, detach.getCable());
+    SmallVector<Type> wiresTy(size, cudaq::quake::WireType::get(ctx));
+    auto split = cudaq::quake::SplitCableOp::create(rewriter, loc, wiresTy,
+                                                    detach.getCable());
     auto pos = detach.getIndex();
     SmallVector<Value> args;
     args.reserve(split.getResults().size() - 1);
@@ -76,7 +78,7 @@ public:
       if (i != pos)
         args.push_back(res);
     Value detachee = split.getResult(pos);
-    Value bundle = quake::BundleCableOp::create(
+    Value bundle = cudaq::quake::BundleCableOp::create(
         rewriter, loc, detach.getResult(1).getType(), ValueRange{args});
     rewriter.replaceOp(detach, ValueRange{detachee, bundle});
     LLVM_DEBUG(llvm::dbgs() << "split/bundle: " << split << '\n'

--- a/lib/Optimizer/Transforms/EraseNoise.cpp
+++ b/lib/Optimizer/Transforms/EraseNoise.cpp
@@ -26,11 +26,12 @@ using namespace mlir;
 /// This pass exists simply to remove all the quake.apply_noise Ops from the IR.
 
 namespace {
-class EraseApplyNoisePattern : public OpRewritePattern<quake::ApplyNoiseOp> {
+class EraseApplyNoisePattern
+    : public OpRewritePattern<cudaq::quake::ApplyNoiseOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ApplyNoiseOp noise,
+  LogicalResult matchAndRewrite(cudaq::quake::ApplyNoiseOp noise,
                                 PatternRewriter &rewriter) const override {
     rewriter.eraseOp(noise);
     return success();

--- a/lib/Optimizer/Transforms/ExpandControlVeqs.cpp
+++ b/lib/Optimizer/Transforms/ExpandControlVeqs.cpp
@@ -37,23 +37,24 @@ public:
 
     // Search through the controls for veqs with known sizes
     for (auto [index, control] : llvm::enumerate(op.getControls())) {
-      if (isa<quake::VeqType>(control.getType())) {
-        auto size = quake::getVeqSize(control);
+      if (isa<cudaq::quake::VeqType>(control.getType())) {
+        auto size = cudaq::quake::getVeqSize(control);
         if (!size)
           return failure();
 
         // Use the inner sized veq for extract_ref when looking through
         // RelaxSizeOp (extract_ref needs a sized veq operand).
         Value veqVal = control;
-        if (auto relaxOp = control.template getDefiningOp<quake::RelaxSizeOp>())
+        if (auto relaxOp =
+                control.template getDefiningOp<cudaq::quake::RelaxSizeOp>())
           veqVal = relaxOp.getInputVec();
 
         // For each of the qubits in the veq, create an extraction instruction
         // The result of the extraction will be a new control
         // The veq is not added the newControls, so it will be dropped
         for (size_t i = 0; i < *size; ++i) {
-          auto ext =
-              quake::ExtractRefOp::create(rewriter, op.getLoc(), veqVal, i);
+          auto ext = cudaq::quake::ExtractRefOp::create(rewriter, op.getLoc(),
+                                                        veqVal, i);
           newControls.push_back(ext);
           update = true;
         }
@@ -91,8 +92,8 @@ private:
     for (auto control : op.getControls()) {
       // Valid ops have no control veqs with a resolvable size (including
       // veq<?> whose size can be determined through RelaxSizeOp).
-      if (isa<quake::VeqType>(control.getType()))
-        if (quake::getVeqSize(control))
+      if (isa<cudaq::quake::VeqType>(control.getType()))
+        if (cudaq::quake::getVeqSize(control))
           return false;
     }
 
@@ -105,29 +106,43 @@ public:
     func::FuncOp func = getOperation();
     RewritePatternSet patterns(ctx);
     patterns.insert<
-        ExpandPat<quake::HOp>, ExpandPat<quake::PhasedRxOp>,
-        ExpandPat<quake::R1Op>, ExpandPat<quake::RxOp>, ExpandPat<quake::RyOp>,
-        ExpandPat<quake::RzOp>, ExpandPat<quake::SOp>, ExpandPat<quake::SwapOp>,
-        ExpandPat<quake::TOp>, ExpandPat<quake::U2Op>, ExpandPat<quake::U3Op>,
-        ExpandPat<quake::XOp>, ExpandPat<quake::YOp>, ExpandPat<quake::ZOp>>(
-        ctx);
+        ExpandPat<cudaq::quake::HOp>, ExpandPat<cudaq::quake::PhasedRxOp>,
+        ExpandPat<cudaq::quake::R1Op>, ExpandPat<cudaq::quake::RxOp>,
+        ExpandPat<cudaq::quake::RyOp>, ExpandPat<cudaq::quake::RzOp>,
+        ExpandPat<cudaq::quake::SOp>, ExpandPat<cudaq::quake::SwapOp>,
+        ExpandPat<cudaq::quake::TOp>, ExpandPat<cudaq::quake::U2Op>,
+        ExpandPat<cudaq::quake::U3Op>, ExpandPat<cudaq::quake::XOp>,
+        ExpandPat<cudaq::quake::YOp>, ExpandPat<cudaq::quake::ZOp>>(ctx);
     ConversionTarget target(*ctx);
-    target.addLegalDialect<quake::QuakeDialect>();
-    target.addDynamicallyLegalOp<quake::HOp>(checkLegal<quake::HOp>);
-    target.addDynamicallyLegalOp<quake::PhasedRxOp>(
-        checkLegal<quake::PhasedRxOp>);
-    target.addDynamicallyLegalOp<quake::R1Op>(checkLegal<quake::R1Op>);
-    target.addDynamicallyLegalOp<quake::RxOp>(checkLegal<quake::RxOp>);
-    target.addDynamicallyLegalOp<quake::RyOp>(checkLegal<quake::RyOp>);
-    target.addDynamicallyLegalOp<quake::RzOp>(checkLegal<quake::RzOp>);
-    target.addDynamicallyLegalOp<quake::SOp>(checkLegal<quake::SOp>);
-    target.addDynamicallyLegalOp<quake::SwapOp>(checkLegal<quake::SwapOp>);
-    target.addDynamicallyLegalOp<quake::TOp>(checkLegal<quake::TOp>);
-    target.addDynamicallyLegalOp<quake::U2Op>(checkLegal<quake::U2Op>);
-    target.addDynamicallyLegalOp<quake::U3Op>(checkLegal<quake::U3Op>);
-    target.addDynamicallyLegalOp<quake::XOp>(checkLegal<quake::XOp>);
-    target.addDynamicallyLegalOp<quake::YOp>(checkLegal<quake::YOp>);
-    target.addDynamicallyLegalOp<quake::ZOp>(checkLegal<quake::ZOp>);
+    target.addLegalDialect<cudaq::quake::QuakeDialect>();
+    target.addDynamicallyLegalOp<cudaq::quake::HOp>(
+        checkLegal<cudaq::quake::HOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::PhasedRxOp>(
+        checkLegal<cudaq::quake::PhasedRxOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::R1Op>(
+        checkLegal<cudaq::quake::R1Op>);
+    target.addDynamicallyLegalOp<cudaq::quake::RxOp>(
+        checkLegal<cudaq::quake::RxOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::RyOp>(
+        checkLegal<cudaq::quake::RyOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::RzOp>(
+        checkLegal<cudaq::quake::RzOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::SOp>(
+        checkLegal<cudaq::quake::SOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::SwapOp>(
+        checkLegal<cudaq::quake::SwapOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::TOp>(
+        checkLegal<cudaq::quake::TOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::U2Op>(
+        checkLegal<cudaq::quake::U2Op>);
+    target.addDynamicallyLegalOp<cudaq::quake::U3Op>(
+        checkLegal<cudaq::quake::U3Op>);
+    target.addDynamicallyLegalOp<cudaq::quake::XOp>(
+        checkLegal<cudaq::quake::XOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::YOp>(
+        checkLegal<cudaq::quake::YOp>);
+    target.addDynamicallyLegalOp<cudaq::quake::ZOp>(
+        checkLegal<cudaq::quake::ZOp>);
     if (failed(applyPartialConversion(func.getOperation(), target,
                                       std::move(patterns)))) {
       signalPassFailure();

--- a/lib/Optimizer/Transforms/ExpandMeasurements.cpp
+++ b/lib/Optimizer/Transforms/ExpandMeasurements.cpp
@@ -27,7 +27,8 @@ using namespace mlir;
 // per-qubit measurement results, so neither requires expansion to a register.
 template <typename A>
 bool usesIndividualQubit(A x) {
-  return isa<quake::MeasureType, cudaq::cc::MeasureHandleType>(x.getType());
+  return isa<cudaq::quake::MeasureType, cudaq::cc::MeasureHandleType>(
+      x.getType());
 }
 
 // Generalized pattern for expanding a multiple qubit measurement (whether it is
@@ -64,18 +65,18 @@ public:
     // Per-element scalar result type tracks the original stdvec element
     // type. For handle inputs we measure into `!cc.measure_handle` per
     // qubit.
-    Type perElemTy = isHandleResult
-                         ? static_cast<Type>(handleTy)
-                         : static_cast<Type>(quake::MeasureType::get(ctx));
+    Type perElemTy =
+        isHandleResult ? static_cast<Type>(handleTy)
+                       : static_cast<Type>(cudaq::quake::MeasureType::get(ctx));
 
     // Classify users so we only allocate the buffers we actually need, and
     // collect the discriminate users at the same time. The legacy
     // `!quake.measure` path has only `quake.discriminate` consumers by
     // construction; the handle path may have either, both, or none.
-    SmallVector<quake::DiscriminateOp> discUsers;
+    SmallVector<cudaq::quake::DiscriminateOp> discUsers;
     bool hasNonDiscUser = false;
     for (auto *u : measureOp.getMeasOut().getUsers()) {
-      if (auto d = dyn_cast<quake::DiscriminateOp>(u))
+      if (auto d = dyn_cast<cudaq::quake::DiscriminateOp>(u))
         discUsers.push_back(d);
       else
         hasNonDiscUser = true;
@@ -92,14 +93,14 @@ public:
     // in.
     unsigned numQubits = 0u;
     for (auto v : measureOp.getTargets())
-      if (isa<quake::RefType>(v.getType()))
+      if (isa<cudaq::quake::RefType>(v.getType()))
         ++numQubits;
     Value totalToRead =
         arith::ConstantIntOp::create(rewriter, loc, numQubits, 64);
     auto i64Ty = rewriter.getI64Type();
     for (auto v : measureOp.getTargets())
-      if (isa<quake::VeqType>(v.getType())) {
-        Value vecSz = quake::VeqSizeOp::create(rewriter, loc, i64Ty, v);
+      if (isa<cudaq::quake::VeqType>(v.getType())) {
+        Value vecSz = cudaq::quake::VeqSizeOp::create(rewriter, loc, i64Ty, v);
         totalToRead = arith::AddIOp::create(rewriter, loc, totalToRead, vecSz);
       }
 
@@ -121,7 +122,8 @@ public:
     auto storePerElement = [&](OpBuilder &builder, Location loc, Value meas,
                                Value offset) {
       if (needI1Buf) {
-        auto bit = quake::DiscriminateOp::create(builder, loc, i1Ty, meas);
+        auto bit =
+            cudaq::quake::DiscriminateOp::create(builder, loc, i1Ty, meas);
         auto addr = cudaq::cc::ComputePtrOp::create(
             builder, loc, cudaq::cc::PointerType::get(i8Ty), i1Buff, offset);
         auto bitByte = cudaq::cc::CastOp::create(
@@ -141,18 +143,19 @@ public:
     Value buffOff = arith::ConstantIntOp::create(rewriter, loc, 0, 64);
     Value one = arith::ConstantIntOp::create(rewriter, loc, 1, 64);
     for (auto v : measureOp.getTargets()) {
-      if (isa<quake::RefType>(v.getType())) {
+      if (isa<cudaq::quake::RefType>(v.getType())) {
         auto meas = A::create(rewriter, loc, perElemTy, v).getMeasOut();
         storePerElement(rewriter, loc, meas, buffOff);
         buffOff = arith::AddIOp::create(rewriter, loc, buffOff, one);
       } else {
-        assert(isa<quake::VeqType>(v.getType()));
-        Value vecSz = quake::VeqSizeOp::create(rewriter, loc, i64Ty, v);
+        assert(isa<cudaq::quake::VeqType>(v.getType()));
+        Value vecSz = cudaq::quake::VeqSizeOp::create(rewriter, loc, i64Ty, v);
         cudaq::opt::factory::createInvariantLoop(
             rewriter, loc, vecSz,
             [&](OpBuilder &builder, Location loc, Region &, Block &block) {
               Value iv = block.getArgument(0);
-              Value qv = quake::ExtractRefOp::create(builder, loc, v, iv);
+              Value qv =
+                  cudaq::quake::ExtractRefOp::create(builder, loc, v, iv);
               auto meas = A::create(builder, loc, perElemTy, qv);
               if (auto registerName = measureOp.getRegisterNameAttr())
                 meas.setRegisterName(registerName);
@@ -208,9 +211,9 @@ public:
 };
 
 namespace {
-using MxRewrite = ExpandRewritePattern<quake::MxOp>;
-using MyRewrite = ExpandRewritePattern<quake::MyOp>;
-using MzRewrite = ExpandRewritePattern<quake::MzOp>;
+using MxRewrite = ExpandRewritePattern<cudaq::quake::MxOp>;
+using MyRewrite = ExpandRewritePattern<cudaq::quake::MyOp>;
+using MzRewrite = ExpandRewritePattern<cudaq::quake::MzOp>;
 
 // Expand `quake.discriminate : !cc.stdvec<!cc.measure_handle> ->
 // !cc.stdvec<i1>` when the input handle vector is *not* the direct result
@@ -223,18 +226,18 @@ using MzRewrite = ExpandRewritePattern<quake::MzOp>;
 // case stays handled by `ExpandRewritePattern` to avoid an extra
 // per-element load.
 class ExpandStdvecHandleDiscriminate
-    : public OpRewritePattern<quake::DiscriminateOp> {
+    : public OpRewritePattern<cudaq::quake::DiscriminateOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::DiscriminateOp disc,
+  LogicalResult matchAndRewrite(cudaq::quake::DiscriminateOp disc,
                                 PatternRewriter &rewriter) const override {
     Value handleVec = disc.getMeasurement();
     auto stdvecTy = dyn_cast<cudaq::cc::StdvecType>(handleVec.getType());
     if (!stdvecTy ||
         !isa<cudaq::cc::MeasureHandleType>(stdvecTy.getElementType()))
       return failure();
-    if (handleVec.getDefiningOp<quake::MeasurementInterface>())
+    if (handleVec.getDefiningOp<cudaq::quake::MeasurementInterface>())
       return failure();
 
     auto loc = disc.getLoc();
@@ -264,8 +267,8 @@ public:
               builder, loc, cudaq::cc::PointerType::get(handleTy), handleData,
               iv);
           Value handleVal = cudaq::cc::LoadOp::create(builder, loc, handleAddr);
-          Value bit =
-              quake::DiscriminateOp::create(builder, loc, i1Ty, handleVal);
+          Value bit = cudaq::quake::DiscriminateOp::create(builder, loc, i1Ty,
+                                                           handleVal);
           Value byteAddr = cudaq::cc::ComputePtrOp::create(
               builder, loc, cudaq::cc::PointerType::get(i8Ty), i1Buff, iv);
           Value bitByte = cudaq::cc::CastOp::create(
@@ -286,22 +289,23 @@ public:
 
 /// Convert a `quake.reset` with a `veq` argument into a loop over the elements
 /// of the `veq` and `quake.reset` on each of them.
-class ResetRewrite : public OpRewritePattern<quake::ResetOp> {
+class ResetRewrite : public OpRewritePattern<cudaq::quake::ResetOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ResetOp resetOp,
+  LogicalResult matchAndRewrite(cudaq::quake::ResetOp resetOp,
                                 PatternRewriter &rewriter) const override {
     auto loc = resetOp.getLoc();
     auto veqArg = resetOp.getTargets();
     auto i64Ty = rewriter.getI64Type();
-    Value vecSz = quake::VeqSizeOp::create(rewriter, loc, i64Ty, veqArg);
+    Value vecSz = cudaq::quake::VeqSizeOp::create(rewriter, loc, i64Ty, veqArg);
     cudaq::opt::factory::createInvariantLoop(
         rewriter, loc, vecSz,
         [&](OpBuilder &builder, Location loc, Region &, Block &block) {
           Value iv = block.getArgument(0);
-          Value qv = quake::ExtractRefOp::create(builder, loc, veqArg, iv);
-          quake::ResetOp::create(builder, loc, TypeRange{}, qv);
+          Value qv =
+              cudaq::quake::ExtractRefOp::create(builder, loc, veqArg, iv);
+          cudaq::quake::ResetOp::create(builder, loc, TypeRange{}, qv);
         });
     rewriter.eraseOp(resetOp);
     return success();
@@ -319,19 +323,23 @@ public:
     patterns.insert<MxRewrite, MyRewrite, MzRewrite, ResetRewrite,
                     ExpandStdvecHandleDiscriminate>(ctx);
     ConversionTarget target(*ctx);
-    target.addLegalDialect<quake::QuakeDialect, cudaq::cc::CCDialect,
+    target.addLegalDialect<cudaq::quake::QuakeDialect, cudaq::cc::CCDialect,
                            arith::ArithDialect, LLVM::LLVMDialect>();
-    target.addDynamicallyLegalOp<quake::MxOp>(
-        [](quake::MxOp x) { return usesIndividualQubit(x.getMeasOut()); });
-    target.addDynamicallyLegalOp<quake::MyOp>(
-        [](quake::MyOp x) { return usesIndividualQubit(x.getMeasOut()); });
-    target.addDynamicallyLegalOp<quake::MzOp>(
-        [](quake::MzOp x) { return usesIndividualQubit(x.getMeasOut()); });
-    target.addDynamicallyLegalOp<quake::ResetOp>([](quake::ResetOp r) {
-      return !isa<quake::VeqType>(r.getTargets().getType());
+    target.addDynamicallyLegalOp<cudaq::quake::MxOp>([](cudaq::quake::MxOp x) {
+      return usesIndividualQubit(x.getMeasOut());
     });
-    target.addDynamicallyLegalOp<quake::DiscriminateOp>(
-        [](quake::DiscriminateOp d) {
+    target.addDynamicallyLegalOp<cudaq::quake::MyOp>([](cudaq::quake::MyOp x) {
+      return usesIndividualQubit(x.getMeasOut());
+    });
+    target.addDynamicallyLegalOp<cudaq::quake::MzOp>([](cudaq::quake::MzOp x) {
+      return usesIndividualQubit(x.getMeasOut());
+    });
+    target.addDynamicallyLegalOp<cudaq::quake::ResetOp>(
+        [](cudaq::quake::ResetOp r) {
+          return !isa<cudaq::quake::VeqType>(r.getTargets().getType());
+        });
+    target.addDynamicallyLegalOp<cudaq::quake::DiscriminateOp>(
+        [](cudaq::quake::DiscriminateOp d) {
           // Scalar discriminate is always legal.
           auto stdvecTy =
               dyn_cast<cudaq::cc::StdvecType>(d.getMeasurement().getType());
@@ -347,7 +355,8 @@ public:
           // a measurement op is similarly folded (step 4 again). Only
           // the indirect case needs `ExpandStdvecHandleDiscriminate`.
           return d.getMeasurement()
-                     .getDefiningOp<quake::MeasurementInterface>() != nullptr;
+                     .getDefiningOp<cudaq::quake::MeasurementInterface>() !=
+                 nullptr;
         });
     if (failed(applyPartialConversion(op, target, std::move(patterns)))) {
       op->emitOpError("could not expand measurements");

--- a/lib/Optimizer/Transforms/FactorQuantumAlloc.cpp
+++ b/lib/Optimizer/Transforms/FactorQuantumAlloc.cpp
@@ -21,27 +21,27 @@ namespace cudaq::opt {
 
 using namespace mlir;
 
-static bool allocaOfVeqStruq(quake::AllocaOp alloc) {
-  return isa<quake::VeqType, quake::StruqType>(alloc.getType());
+static bool allocaOfVeqStruq(cudaq::quake::AllocaOp alloc) {
+  return isa<cudaq::quake::VeqType, cudaq::quake::StruqType>(alloc.getType());
 }
 
-static bool allocaOfUnspecifiedSize(quake::AllocaOp alloc) {
-  if (auto veqTy = dyn_cast<quake::VeqType>(alloc.getType()))
+static bool allocaOfUnspecifiedSize(cudaq::quake::AllocaOp alloc) {
+  if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(alloc.getType()))
     return !veqTy.hasSpecifiedSize();
-  if (auto ty = dyn_cast<quake::StruqType>(alloc.getType()))
+  if (auto ty = dyn_cast<cudaq::quake::StruqType>(alloc.getType()))
     return !ty.hasSpecifiedSize();
   return false;
 }
 
 static bool isUseConvertible(Operation *op) {
-  if (isa<quake::DeallocOp, quake::GetMemberOp>(op))
+  if (isa<cudaq::quake::DeallocOp, cudaq::quake::GetMemberOp>(op))
     return true;
 
   // extract_ref is ok, iff it has a constant offset
-  if (auto ext = dyn_cast<quake::ExtractRefOp>(op))
+  if (auto ext = dyn_cast<cudaq::quake::ExtractRefOp>(op))
     return ext.hasConstantIndex();
 
-  auto sub = dyn_cast<quake::SubVeqOp>(op);
+  auto sub = dyn_cast<cudaq::quake::SubVeqOp>(op);
   if (!sub)
     return false;
 
@@ -64,7 +64,7 @@ static bool isUseConvertible(Operation *op) {
   return true;
 }
 
-static bool usesAreConvertible(quake::AllocaOp alloc) {
+static bool usesAreConvertible(cudaq::quake::AllocaOp alloc) {
   for (auto *users : alloc->getUsers())
     if (!isUseConvertible(users))
       return false;
@@ -72,14 +72,14 @@ static bool usesAreConvertible(quake::AllocaOp alloc) {
 }
 
 namespace {
-class AllocaPattern : public OpRewritePattern<quake::AllocaOp> {
+class AllocaPattern : public OpRewritePattern<cudaq::quake::AllocaOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
   /// If we are here, then all uses of \p allocOp are either an ExtractRefOp
   /// with a constant index or a DeallocOp. Any other user is assumed to block
   /// the factoring of the allocation.
-  LogicalResult matchAndRewrite(quake::AllocaOp allocOp,
+  LogicalResult matchAndRewrite(cudaq::quake::AllocaOp allocOp,
                                 PatternRewriter &rewriter) const override {
     auto loc = allocOp.getLoc();
 
@@ -88,20 +88,20 @@ public:
         allocOp.hasInitializedState())
       return failure();
 
-    if (auto stqTy = dyn_cast<quake::StruqType>(allocOp.getType())) {
+    if (auto stqTy = dyn_cast<cudaq::quake::StruqType>(allocOp.getType())) {
       // allocOp is a struq.
       // 1. Convert the allocation into a member by member allocation.
       SmallVector<Value> memAllocs;
       for (auto memTy : stqTy.getMembers())
         memAllocs.emplace_back(
-            quake::AllocaOp::create(rewriter, loc, memTy).getResult());
+            cudaq::quake::AllocaOp::create(rewriter, loc, memTy).getResult());
       // 2. Create a value of the original struq type using quake.make_struq.
       auto aggregate =
-          quake::MakeStruqOp::create(rewriter, loc, stqTy, memAllocs);
+          cudaq::quake::MakeStruqOp::create(rewriter, loc, stqTy, memAllocs);
       // 3. Walk all the uses. If they are quake.get_member operations, replace
       // them with direct uses.
       for (auto *user : llvm::make_early_inc_range(allocOp->getUsers()))
-        if (auto getMem = dyn_cast<quake::GetMemberOp>(user)) {
+        if (auto getMem = dyn_cast<cudaq::quake::GetMemberOp>(user)) {
           auto index = getMem.getIndex();
           rewriter.replaceOp(getMem, memAllocs[index]);
         }
@@ -110,15 +110,16 @@ public:
     }
 
     // allocOp must be a veq.
-    auto veqTy = cast<quake::VeqType>(allocOp.getType());
+    auto veqTy = cast<cudaq::quake::VeqType>(allocOp.getType());
     std::size_t size = veqTy.getSize();
-    SmallVector<quake::AllocaOp> newAllocs;
+    SmallVector<cudaq::quake::AllocaOp> newAllocs;
     auto *ctx = rewriter.getContext();
-    auto refTy = quake::RefType::get(ctx);
+    auto refTy = cudaq::quake::RefType::get(ctx);
 
     // Split the aggregate veq into a sequence of distinct alloca of ref.
     for (std::size_t i = 0; i < size; ++i)
-      newAllocs.emplace_back(quake::AllocaOp::create(rewriter, loc, refTy));
+      newAllocs.emplace_back(
+          cudaq::quake::AllocaOp::create(rewriter, loc, refTy));
 
     if (usesAreConvertible(allocOp)) {
       // Visit all users and replace them accordingly.
@@ -129,10 +130,11 @@ public:
     } else {
       // Uses are more complex so just concat the refs together.
       SmallVector<Value> theRefs;
-      std::for_each(newAllocs.begin(), newAllocs.end(), [&](quake::AllocaOp a) {
-        theRefs.push_back(a.getResult());
-      });
-      rewriter.replaceOpWithNewOp<quake::ConcatOp>(allocOp, veqTy, theRefs);
+      std::for_each(
+          newAllocs.begin(), newAllocs.end(),
+          [&](cudaq::quake::AllocaOp a) { theRefs.push_back(a.getResult()); });
+      rewriter.replaceOpWithNewOp<cudaq::quake::ConcatOp>(allocOp, veqTy,
+                                                          theRefs);
     }
     return success();
   }
@@ -140,21 +142,21 @@ public:
   static LogicalResult
   rewriteOpAndUsers(Operation *op, std::int64_t start,
                     PatternRewriter &rewriter, std::size_t size,
-                    SmallVector<quake::AllocaOp> &newAllocs) {
+                    SmallVector<cudaq::quake::AllocaOp> &newAllocs) {
     // First handle the users. Note that this can recurse.
     SmallVector<Operation *> users{op->getUsers().begin(),
                                    op->getUsers().end()};
     for (auto *user : users) {
-      if (auto dealloc = dyn_cast<quake::DeallocOp>(user)) {
+      if (auto dealloc = dyn_cast<cudaq::quake::DeallocOp>(user)) {
         rewriter.setInsertionPoint(dealloc);
         auto deloc = dealloc.getLoc();
         for (std::size_t i = 0; i < size - 1; ++i)
-          quake::DeallocOp::create(rewriter, deloc, newAllocs[i]);
-        rewriter.replaceOpWithNewOp<quake::DeallocOp>(dealloc,
-                                                      newAllocs[size - 1]);
+          cudaq::quake::DeallocOp::create(rewriter, deloc, newAllocs[i]);
+        rewriter.replaceOpWithNewOp<cudaq::quake::DeallocOp>(
+            dealloc, newAllocs[size - 1]);
         continue;
       }
-      if (auto subveq = dyn_cast<quake::SubVeqOp>(user)) {
+      if (auto subveq = dyn_cast<cudaq::quake::SubVeqOp>(user)) {
         auto lowInt = [&]() -> std::optional<std::int32_t> {
           if (subveq.hasConstantLowerBound())
             return {subveq.getConstantLowerBound()};
@@ -171,16 +173,16 @@ public:
         rewriter.eraseOp(subveq);
         continue;
       }
-      if (auto ext = dyn_cast<quake::ExtractRefOp>(user)) {
+      if (auto ext = dyn_cast<cudaq::quake::ExtractRefOp>(user)) {
         auto index = ext.getConstantIndex();
         rewriter.replaceOp(ext, newAllocs[start + index].getResult());
       }
     }
 
     // Now handle the base operation.
-    if (isa<quake::SubVeqOp>(op)) {
+    if (isa<cudaq::quake::SubVeqOp>(op)) {
       rewriter.eraseOp(op);
-    } else if (auto ext = dyn_cast<quake::ExtractRefOp>(op)) {
+    } else if (auto ext = dyn_cast<cudaq::quake::ExtractRefOp>(op)) {
       auto index = ext.getConstantIndex();
       rewriter.replaceOp(ext, newAllocs[start + index].getResult());
     }
@@ -188,11 +190,11 @@ public:
   }
 };
 
-class DeallocPattern : public OpRewritePattern<quake::DeallocOp> {
+class DeallocPattern : public OpRewritePattern<cudaq::quake::DeallocOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::DeallocOp dealloc,
+  LogicalResult matchAndRewrite(cudaq::quake::DeallocOp dealloc,
                                 PatternRewriter &rewriter) const override {
     // 0. Check necessary preconditions. Must be a Veq or Struq with a constant
     // size.
@@ -200,12 +202,12 @@ public:
     if (!alloc)
       return failure();
     auto allocTy = alloc.getType();
-    if (alloc.getDefiningOp<quake::InitializeStateOp>())
+    if (alloc.getDefiningOp<cudaq::quake::InitializeStateOp>())
       return failure();
-    if (auto ty = dyn_cast<quake::VeqType>(allocTy)) {
+    if (auto ty = dyn_cast<cudaq::quake::VeqType>(allocTy)) {
       if (!ty.hasSpecifiedSize())
         return failure();
-    } else if (auto ty = dyn_cast<quake::StruqType>(allocTy)) {
+    } else if (auto ty = dyn_cast<cudaq::quake::StruqType>(allocTy)) {
       if (!ty.hasSpecifiedSize())
         return failure();
     } else {
@@ -214,17 +216,17 @@ public:
     }
 
     auto loc = dealloc.getLoc();
-    if (auto veqTy = dyn_cast<quake::VeqType>(allocTy)) {
+    if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(allocTy)) {
       generateDeallocs(veqTy, rewriter, loc, alloc);
-    } else if (auto stqTy = dyn_cast<quake::StruqType>(allocTy)) {
+    } else if (auto stqTy = dyn_cast<cudaq::quake::StruqType>(allocTy)) {
       for (auto iter : llvm::enumerate(stqTy.getMembers())) {
         Type memTy = iter.value();
-        auto mem = quake::GetMemberOp::create(rewriter, loc, memTy, alloc,
-                                              iter.index());
-        if (auto veqTy = dyn_cast<quake::VeqType>(memTy))
+        auto mem = cudaq::quake::GetMemberOp::create(rewriter, loc, memTy,
+                                                     alloc, iter.index());
+        if (auto veqTy = dyn_cast<cudaq::quake::VeqType>(memTy))
           generateDeallocs(veqTy, rewriter, loc, mem);
         else
-          quake::DeallocOp::create(rewriter, loc, mem);
+          cudaq::quake::DeallocOp::create(rewriter, loc, mem);
       }
     }
 
@@ -233,14 +235,15 @@ public:
     return success();
   }
 
-  static void generateDeallocs(quake::VeqType veqTy, PatternRewriter &rewriter,
-                               Location loc, Value alloc) {
+  static void generateDeallocs(cudaq::quake::VeqType veqTy,
+                               PatternRewriter &rewriter, Location loc,
+                               Value alloc) {
     assert(veqTy.hasSpecifiedSize());
     std::size_t size = veqTy.getSize();
 
     for (std::size_t i = 0; i < size; ++i) {
-      Value r = quake::ExtractRefOp::create(rewriter, loc, alloc, i);
-      quake::DeallocOp::create(rewriter, loc, r);
+      Value r = cudaq::quake::ExtractRefOp::create(rewriter, loc, alloc, i);
+      cudaq::quake::DeallocOp::create(rewriter, loc, r);
     }
   };
 };

--- a/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
+++ b/lib/Optimizer/Transforms/GetConcreteMatrix.cpp
@@ -23,12 +23,12 @@ using namespace mlir;
 namespace {
 
 class CustomUnitaryPattern
-    : public OpRewritePattern<quake::CustomUnitarySymbolOp> {
+    : public OpRewritePattern<cudaq::quake::CustomUnitarySymbolOp> {
 
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::CustomUnitarySymbolOp customOp,
+  LogicalResult matchAndRewrite(cudaq::quake::CustomUnitarySymbolOp customOp,
                                 PatternRewriter &rewriter) const override {
 
     // Check if the generator associated with custom operation is a function. If
@@ -62,7 +62,7 @@ public:
         parentModule.lookupSymbol<cudaq::cc::GlobalOp>(concreteMatrix);
 
     if (ccGlobalOp) {
-      rewriter.replaceOpWithNewOp<quake::CustomUnitarySymbolOp>(
+      rewriter.replaceOpWithNewOp<cudaq::quake::CustomUnitarySymbolOp>(
           customOp,
           FlatSymbolRefAttr::get(parentModule.getContext(), concreteMatrix),
           customOp.getIsAdj(), customOp.getParameters(), customOp.getControls(),

--- a/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
+++ b/lib/Optimizer/Transforms/GlobalizeArrayValues.cpp
@@ -99,8 +99,8 @@ static bool useDataToInitState(cudaq::cc::ReifySpanOp reify) {
   for (auto *user : reify->getUsers())
     if (auto data = dyn_cast<cudaq::cc::StdvecDataOp>(user))
       if (std::distance(data->user_begin(), data->user_end()) == 1)
-        return isa<quake::InitializeStateOp, quake::CreateStateOp>(
-            *data->user_begin());
+        return isa<cudaq::quake::InitializeStateOp,
+                   cudaq::quake::CreateStateOp>(*data->user_begin());
   return false;
 }
 

--- a/lib/Optimizer/Transforms/LambdaLifting.cpp
+++ b/lib/Optimizer/Transforms/LambdaLifting.cpp
@@ -272,10 +272,10 @@ private:
 /// Convert a compute_action to a series of calls. A compute_action is
 /// semantically a special form of a call site.
 struct ComputeActionOpPattern
-    : public OpRewritePattern<quake::ComputeActionOp> {
+    : public OpRewritePattern<cudaq::quake::ComputeActionOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ComputeActionOp comAct,
+  LogicalResult matchAndRewrite(cudaq::quake::ComputeActionOp comAct,
                                 PatternRewriter &rewriter) const override {
     // In lambda lifting, we only deal with rewriting the quake.compute_action
     // Op if it has lambda arguments.
@@ -308,13 +308,13 @@ struct ComputeActionOpPattern
     if (!actionCallee)
       return failure();
     auto computeArgs = getArgs(comAct.getCompute());
-    quake::ApplyOp::create(rewriter, loc, TypeRange{}, computeCallee,
-                           /*isAdjoint=*/comAct.getIsDagger(), ValueRange{},
-                           computeArgs);
-    quake::ApplyOp::create(rewriter, loc, TypeRange{}, actionCallee,
-                           /*isAdjoint=*/false, ValueRange{},
-                           getArgs(comAct.getAction()));
-    rewriter.replaceOpWithNewOp<quake::ApplyOp>(
+    cudaq::quake::ApplyOp::create(rewriter, loc, TypeRange{}, computeCallee,
+                                  /*isAdjoint=*/comAct.getIsDagger(),
+                                  ValueRange{}, computeArgs);
+    cudaq::quake::ApplyOp::create(rewriter, loc, TypeRange{}, actionCallee,
+                                  /*isAdjoint=*/false, ValueRange{},
+                                  getArgs(comAct.getAction()));
+    rewriter.replaceOpWithNewOp<cudaq::quake::ApplyOp>(
         comAct, TypeRange{}, computeCallee,
         /*isAdjoint=*/!comAct.getIsDagger(), ValueRange{}, computeArgs);
     return success();

--- a/lib/Optimizer/Transforms/LiftArrayAllocPatterns.inc
+++ b/lib/Optimizer/Transforms/LiftArrayAllocPatterns.inc
@@ -85,8 +85,7 @@ public:
             //     ArrayRef<cudaq::cc::ExtractValueArg>{offset});
 
             auto extractValue = cudaq::cc::ExtractValueOp::create(
-                rewriter,
-                loc, eleTy, conArr,
+                rewriter, loc, eleTy, conArr,
                 ArrayRef<cudaq::cc::ExtractValueArg>{offset});
             rewriter.replaceAllUsesWith(load, extractValue);
             insertOpToErase(load);
@@ -166,7 +165,8 @@ public:
           }
           continue;
         }
-        if (isa<quake::InitializeStateOp, quake::CreateStateOp>(u)) {
+        if (isa<cudaq::quake::InitializeStateOp, cudaq::quake::CreateStateOp>(
+                u)) {
           toGlobalUses.push_back(u);
           continue;
         }
@@ -221,8 +221,8 @@ public:
           if (cast->hasOneUse()) {
             auto &use = *cast->getUses().begin();
             Operation *u = use.getOwner();
-            if (isa_and_present<quake::InitializeStateOp, quake::CreateStateOp>(
-                    u)) {
+            if (isa_and_present<cudaq::quake::InitializeStateOp,
+                                cudaq::quake::CreateStateOp>(u)) {
               toGlobalUses.push_back(u);
               continue;
             }
@@ -233,7 +233,8 @@ public:
         toGlobalUses.push_back(op);
         continue;
       }
-      if (isa<quake::InitializeStateOp, quake::CreateStateOp>(op)) {
+      if (isa<cudaq::quake::InitializeStateOp, cudaq::quake::CreateStateOp>(
+              op)) {
         toGlobalUses.push_back(op);
         continue;
       }

--- a/lib/Optimizer/Transforms/LinearCtrlRelations.cpp
+++ b/lib/Optimizer/Transforms/LinearCtrlRelations.cpp
@@ -23,12 +23,12 @@ namespace cudaq::opt {
 using namespace mlir;
 
 namespace {
-class ThreadControl : public OpRewritePattern<quake::ToControlOp> {
+class ThreadControl : public OpRewritePattern<cudaq::quake::ToControlOp> {
 public:
   explicit ThreadControl(MLIRContext *ctx, DominanceInfo &di)
       : OpRewritePattern(ctx), dom(di) {}
 
-  LogicalResult matchAndRewrite(quake::ToControlOp toCtrl,
+  LogicalResult matchAndRewrite(cudaq::quake::ToControlOp toCtrl,
                                 PatternRewriter &rewriter) const override {
     LLVM_DEBUG(llvm::dbgs() << "\n\n" << toCtrl << '\n');
     SmallVector<Operation *> users(toCtrl->getUsers().begin(),
@@ -41,7 +41,7 @@ public:
     if (numUsers == 1) {
       // User must be a FromControlOp. We can erase them both.
       if (auto fromCtrl =
-              dyn_cast_if_present<quake::FromControlOp>(users.front())) {
+              dyn_cast_if_present<cudaq::quake::FromControlOp>(users.front())) {
         fromCtrl.replaceAllUsesWith(toCtrl.getQubit());
         rewriter.eraseOp(fromCtrl);
         rewriter.eraseOp(toCtrl);
@@ -82,10 +82,10 @@ public:
     // 2. Thread the wire value to each successive user.
     Value wireDef = toCtrl.getQubit();
     auto *ctx = rewriter.getContext();
-    auto wireTy = quake::WireType::get(ctx);
+    auto wireTy = cudaq::quake::WireType::get(ctx);
     for (auto *user : orderedUsers) {
       assert(user);
-      if (isa<quake::FromControlOp>(user)) {
+      if (isa<cudaq::quake::FromControlOp>(user)) {
         assert(user == orderedUsers.back() &&
                "FromControlOp must post-dominate all the users");
         rewriter.replaceOp(user, wireDef);
@@ -97,11 +97,11 @@ public:
       std::size_t operandNumber = Uninitialized;
       for (auto iter : llvm::enumerate(user->getOperands())) {
         Value opnd = iter.value();
-        if (isa<quake::WireType>(opnd.getType())) {
+        if (isa<cudaq::quake::WireType>(opnd.getType())) {
           position++;
           continue;
         }
-        if (auto x = opnd.getDefiningOp<quake::ToControlOp>())
+        if (auto x = opnd.getDefiningOp<cudaq::quake::ToControlOp>())
           if (x.getOperation() == toCtrl.getOperation()) {
             operandNumber = iter.index();
             break;

--- a/lib/Optimizer/Transforms/LowerUnwind.cpp
+++ b/lib/Optimizer/Transforms/LowerUnwind.cpp
@@ -155,7 +155,7 @@ private:
         for (auto &region : pr.first->getRegions())
           for (auto &block : region)
             for (auto &o : block)
-              if (isa<quake::AllocaOp>(o))
+              if (isa<cudaq::quake::AllocaOp>(o))
                 allocas.push_back(&o);
         if (!allocas.empty())
           scopeAllocMap[pr.first] = allocas;
@@ -285,22 +285,22 @@ static SmallVector<Operation *> populateExitTerminators(Region &reg) {
   return results;
 }
 
-static SmallVector<quake::AllocaOp> populateQuakeAllocas(Region &reg) {
-  SmallVector<quake::AllocaOp> results;
+static SmallVector<cudaq::quake::AllocaOp> populateQuakeAllocas(Region &reg) {
+  SmallVector<cudaq::quake::AllocaOp> results;
   for (Block &b : reg)
     for (Operation &o : b)
-      if (auto q = dyn_cast<quake::AllocaOp>(o))
+      if (auto q = dyn_cast<cudaq::quake::AllocaOp>(o))
         results.push_back(q);
   return results;
 }
 
-static DenseMap<Operation *, SmallVector<quake::AllocaOp>>
+static DenseMap<Operation *, SmallVector<cudaq::quake::AllocaOp>>
 populateTerminatorAllocaMap(const SmallVector<Operation *> &terminators,
-                            const SmallVector<quake::AllocaOp> &qallocas,
+                            const SmallVector<cudaq::quake::AllocaOp> &qallocas,
                             DominanceInfo &dom) {
-  DenseMap<Operation *, SmallVector<quake::AllocaOp>> results;
+  DenseMap<Operation *, SmallVector<cudaq::quake::AllocaOp>> results;
   for (auto *t : terminators) {
-    SmallVector<quake::AllocaOp> domList;
+    SmallVector<cudaq::quake::AllocaOp> domList;
     for (auto a : qallocas)
       if (dom.dominates(a.getOperation(), t))
         domList.push_back(a);
@@ -323,14 +323,14 @@ static bool anyPrimitiveAncestor(
   return false;
 }
 
-static Value adjustedDeallocArg(quake::AllocaOp alloc) {
+static Value adjustedDeallocArg(cudaq::quake::AllocaOp alloc) {
   if (auto init = alloc.getInitializedState())
     return init.getResult();
   return alloc.getResult();
 }
 
 static Value adjustedDeallocArg(Operation *op) {
-  return adjustedDeallocArg(cast<quake::AllocaOp>(op));
+  return adjustedDeallocArg(cast<cudaq::quake::AllocaOp>(op));
 }
 
 namespace {
@@ -378,7 +378,8 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
       auto *contOp = pr.first;
       rewriter.setInsertionPoint(contOp);
       for (auto a : llvm::reverse(pr.second))
-        quake::DeallocOp::create(rewriter, a.getLoc(), adjustedDeallocArg(a));
+        cudaq::quake::DeallocOp::create(rewriter, a.getLoc(),
+                                        adjustedDeallocArg(a));
       rewriter.replaceOpWithNewOp<cf::BranchOp>(contOp, nextBlock,
                                                 contOp->getOperands());
     }
@@ -392,8 +393,8 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
       if (Block *blk = blockInfo.continueBlock) {
         rewriter.setInsertionPointToEnd(blk);
         for (auto a : llvm::reverse(qallocas))
-          quake::DeallocOp::create(rewriter, a->getLoc(),
-                                   adjustedDeallocArg(a));
+          cudaq::quake::DeallocOp::create(rewriter, a->getLoc(),
+                                          adjustedDeallocArg(a));
         if (asPrimitive) {
           Block *landingPad = getLandingPad(infoMap, scope).continueBlock;
           cf::BranchOp::create(rewriter, loc, landingPad, blk->getArguments());
@@ -406,8 +407,8 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
       if (Block *blk = blockInfo.breakBlock) {
         rewriter.setInsertionPointToEnd(blk);
         for (auto a : llvm::reverse(qallocas))
-          quake::DeallocOp::create(rewriter, a->getLoc(),
-                                   adjustedDeallocArg(a));
+          cudaq::quake::DeallocOp::create(rewriter, a->getLoc(),
+                                          adjustedDeallocArg(a));
         if (asPrimitive) {
           Block *landingPad = getLandingPad(infoMap, scope).breakBlock;
           cf::BranchOp::create(rewriter, loc, landingPad, blk->getArguments());
@@ -420,8 +421,8 @@ struct ScopeOpPattern : public OpRewritePattern<cudaq::cc::ScopeOp> {
       if (Block *blk = blockInfo.returnBlock) {
         rewriter.setInsertionPointToEnd(blk);
         for (auto a : llvm::reverse(qallocas))
-          quake::DeallocOp::create(rewriter, a->getLoc(),
-                                   adjustedDeallocArg(a));
+          cudaq::quake::DeallocOp::create(rewriter, a->getLoc(),
+                                          adjustedDeallocArg(a));
         assert(asPrimitive);
         Block *landingPad = getLandingPad(infoMap, scope).returnBlock;
         cf::BranchOp::create(rewriter, loc, landingPad, blk->getArguments());
@@ -472,7 +473,8 @@ struct FuncLikeOpPattern : public OpRewritePattern<OP> {
       auto *exitOp = pr.first;
       rewriter.setInsertionPoint(exitOp);
       for (auto a : llvm::reverse(pr.second))
-        quake::DeallocOp::create(rewriter, a.getLoc(), adjustedDeallocArg(a));
+        cudaq::quake::DeallocOp::create(rewriter, a.getLoc(),
+                                        adjustedDeallocArg(a));
     }
 
     // Here, we handle the unwind return jumps.
@@ -491,8 +493,8 @@ struct FuncLikeOpPattern : public OpRewritePattern<OP> {
       if (Block *exitBlock = blockInfo.returnBlock) {
         rewriter.setInsertionPointToEnd(exitBlock);
         for (auto a : llvm::reverse(qallocas))
-          quake::DeallocOp::create(rewriter, a->getLoc(),
-                                   adjustedDeallocArg(a));
+          cudaq::quake::DeallocOp::create(rewriter, a->getLoc(),
+                                          adjustedDeallocArg(a));
         TERM::create(rewriter, func.getLoc(), exitBlock->getArguments());
         func.getBody().push_back(exitBlock);
       }

--- a/lib/Optimizer/Transforms/Mapping.cpp
+++ b/lib/Optimizer/Transforms/Mapping.cpp
@@ -101,7 +101,7 @@ public:
         allowMeasurementMapping(false) {}
 
   /// Main entry point into SabreRouter routing algorithm
-  void route(Block &block, ArrayRef<quake::BorrowWireOp> sources);
+  void route(Block &block, ArrayRef<cudaq::quake::BorrowWireOp> sources);
 
   /// After routing, this contains the final values for all the qubits
   ArrayRef<Value> getPhyToWire() { return phyToWire; }
@@ -165,13 +165,13 @@ void SabreRouter::visitUsers(ResultRange::user_range users,
     if (incremented)
       incremented->push_back(user);
 
-    if (!quake::isSupportedMappingOperation(user)) {
+    if (!cudaq::quake::isSupportedMappingOperation(user)) {
       LLVM_DEBUG({
         auto *tmpOp = dyn_cast<mlir::Operation *>(user);
         logger.getOStream() << "WARNING: unsupported op: " << *tmpOp << '\n';
       });
     } else {
-      auto wires = quake::getQuantumOperands(user);
+      auto wires = cudaq::quake::getQuantumOperands(user);
       if (entry->second == wires.size()) {
         SmallVector<cudaq::Placement::VirtualQ, 2> qubits;
         for (auto wire : wires)
@@ -209,15 +209,15 @@ LogicalResult SabreRouter::mapOperation(VirtualOp &virtOp) {
   SmallVector<Value, 2> newOpWires;
   for (auto phy : deviceQubits)
     newOpWires.push_back(phyToWire[phy.index]);
-  if (failed(quake::setQuantumOperands(virtOp.op, newOpWires)))
+  if (failed(cudaq::quake::setQuantumOperands(virtOp.op, newOpWires)))
     return failure();
 
-  if (isa<quake::SinkOp, quake::ReturnWireOp>(virtOp.op))
+  if (isa<cudaq::quake::SinkOp, cudaq::quake::ReturnWireOp>(virtOp.op))
     return success();
 
   // Update the mapping between device qubits and wires.
-  for (auto &&[w, q] :
-       llvm::zip_equal(quake::getQuantumResults(virtOp.op), deviceQubits))
+  for (auto &&[w, q] : llvm::zip_equal(
+           cudaq::quake::getQuantumResults(virtOp.op), deviceQubits))
     phyToWire[q.index] = w;
 
   return success();
@@ -275,7 +275,7 @@ void SabreRouter::selectExtendedLayer() {
       // We only add operations that can influence placement to the extended
       // frontlayer, i.e., quantum operators that use two qubits.
       if (!virtOp.op->hasTrait<cudaq::QuantumMeasure>() &&
-          quake::getQuantumOperands(virtOp.op).size() == 2)
+          cudaq::quake::getQuantumOperands(virtOp.op).size() == 2)
         extendedLayer.emplace_back(virtOp);
     tmpLayer = std::move(newTmpLayer);
   }
@@ -349,7 +349,8 @@ SabreRouter::Swap SabreRouter::chooseSwap() {
   return candidates[minIdx];
 }
 
-void SabreRouter::route(Block &block, ArrayRef<quake::BorrowWireOp> sources) {
+void SabreRouter::route(Block &block,
+                        ArrayRef<cudaq::quake::BorrowWireOp> sources) {
 #ifndef NDEBUG
   constexpr char logLineComment[] =
       "//===-------------------------------------------===//\n";
@@ -375,11 +376,11 @@ void SabreRouter::route(Block &block, ArrayRef<quake::BorrowWireOp> sources) {
   }
 
   OpBuilder builder(&block, block.begin());
-  auto wireType = builder.getType<quake::WireType>();
+  auto wireType = builder.getType<cudaq::quake::WireType>();
   auto addSwap = [&](cudaq::Placement::DeviceQ q0,
                      cudaq::Placement::DeviceQ q1) {
     placement.swap(q0, q1);
-    auto swap = quake::SwapOp::create(
+    auto swap = cudaq::quake::SwapOp::create(
         builder, builder.getUnknownLoc(), TypeRange{wireType, wireType}, false,
         ValueRange{}, ValueRange{},
         ValueRange{phyToWire[q0.index], phyToWire[q1.index]},
@@ -568,15 +569,17 @@ struct MappingPrep : public cudaq::opt::impl::MappingPrepBase<MappingPrep> {
     return sparseInt;
   }
 
-  quake::WireSetOp insertWireSetOpForDevice(cudaq::Device &d, ModuleOp mod) {
-    if (auto wires = mod.lookupSymbol<quake::WireSetOp>(mappedWireSetName))
+  cudaq::quake::WireSetOp insertWireSetOpForDevice(cudaq::Device &d,
+                                                   ModuleOp mod) {
+    if (auto wires =
+            mod.lookupSymbol<cudaq::quake::WireSetOp>(mappedWireSetName))
       return wires;
 
     auto adjacency = getAdjacencyFromDevice(d, mod.getContext());
     OpBuilder builder(mod.getBodyRegion());
-    auto wireSetOp = quake::WireSetOp::create(builder, builder.getUnknownLoc(),
-                                              mappedWireSetName,
-                                              d.getNumQubits(), adjacency);
+    auto wireSetOp = cudaq::quake::WireSetOp::create(
+        builder, builder.getUnknownLoc(), mappedWireSetName, d.getNumQubits(),
+        adjacency);
     wireSetOp.setPrivate();
     return wireSetOp;
   }
@@ -630,7 +633,8 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
     //  * The kernel can only have one block
 
     auto mod = func->getParentOfType<ModuleOp>();
-    auto wireSetOp = mod.lookupSymbol<quake::WireSetOp>(mappedWireSetName);
+    auto wireSetOp =
+        mod.lookupSymbol<cudaq::quake::WireSetOp>(mappedWireSetName);
     if (!wireSetOp) {
       // Silently return without error if no mapped wire set is found in the
       // module.
@@ -652,7 +656,7 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
     // them.
     StringRef inputWireSet;
     std::optional<std::uint32_t> highestIdentity;
-    auto walkResult = func.walk([&](quake::BorrowWireOp borrowOp) {
+    auto walkResult = func.walk([&](cudaq::quake::BorrowWireOp borrowOp) {
       if (inputWireSet.empty()) {
         inputWireSet = borrowOp.getSetName();
       } else if (borrowOp.getSetName() != inputWireSet) {
@@ -701,21 +705,21 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
 
     const std::size_t deviceNumQubits = deviceInstance->getNumQubits();
 
-    SmallVector<quake::BorrowWireOp> sources(deviceNumQubits);
-    SmallVector<quake::ReturnWireOp> returnsToRemove;
+    SmallVector<cudaq::quake::BorrowWireOp> sources(deviceNumQubits);
+    SmallVector<cudaq::quake::ReturnWireOp> returnsToRemove;
     DenseMap<Value, cudaq::Placement::VirtualQ> wireToVirtualQ;
     SmallVector<std::size_t> userQubitsMeasured;
     DenseMap<std::size_t, Value> finalQubitWire;
     Operation *lastSource = nullptr;
     for (Operation &op : block.getOperations()) {
-      if (auto qop = dyn_cast<quake::BorrowWireOp>(op)) {
+      if (auto qop = dyn_cast<cudaq::quake::BorrowWireOp>(op)) {
         // Assign a new virtual qubit to the resulting wire.
         auto id = qop.getIdentity();
         wireToVirtualQ[qop.getResult()] = cudaq::Placement::VirtualQ(id);
         finalQubitWire[id] = qop.getResult();
         sources[id] = qop;
         lastSource = &op;
-      } else if (dyn_cast<quake::NullWireOp>(op)) {
+      } else if (dyn_cast<cudaq::quake::NullWireOp>(op)) {
         if (nonComposable) {
           op.emitOpError(
               "the mapper requires borrow operations and prohibits null wires");
@@ -723,7 +727,7 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
         }
         LLVM_DEBUG(llvm::dbgs() << "null_wire ops are not expected");
         return;
-      } else if (dyn_cast<quake::AllocaOp>(op)) {
+      } else if (dyn_cast<cudaq::quake::AllocaOp>(op)) {
         if (nonComposable) {
           op.emitOpError("the mapper requires borrow operations and prohibits "
                          "reference semantics");
@@ -731,16 +735,17 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
         }
         LLVM_DEBUG(llvm::dbgs() << "quantum reference semantics not expected");
         return;
-      } else if (quake::isSupportedMappingOperation(&op)) {
+      } else if (cudaq::quake::isSupportedMappingOperation(&op)) {
         // Make sure the operation is using value semantics.
-        if (!quake::isLinearValueForm(&op)) {
+        if (!cudaq::quake::isLinearValueForm(&op)) {
           if (nonComposable) {
             llvm::errs() << "This is not SSA form: " << op << '\n';
-            llvm::errs() << "isa<quake::NullWireOp>() = "
-                         << isa<quake::NullWireOp>(&op) << '\n';
+            llvm::errs() << "isa<cudaq::quake::NullWireOp>() = "
+                         << isa<cudaq::quake::NullWireOp>(&op) << '\n';
             llvm::errs() << "isAllReferences() = "
-                         << quake::isAllReferences(&op) << '\n';
-            llvm::errs() << "isWrapped() = " << quake::isWrapped(&op) << '\n';
+                         << cudaq::quake::isAllReferences(&op) << '\n';
+            llvm::errs() << "isWrapped() = " << cudaq::quake::isWrapped(&op)
+                         << '\n';
             func.emitError("The mapper requires value semantics.");
             signalPassFailure();
           }
@@ -750,14 +755,14 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
 
         // Since `quake.return_wire` operations do not generate new wires, we
         // don't need to further analyze.
-        if (auto rop = dyn_cast<quake::ReturnWireOp>(op)) {
+        if (auto rop = dyn_cast<cudaq::quake::ReturnWireOp>(op)) {
           returnsToRemove.push_back(rop);
           continue;
         }
 
         // Get the wire operands and check if the operators uses at most two
         // qubits. N.B: Measurements do not have this restriction.
-        auto wireOperands = quake::getQuantumOperands(&op);
+        auto wireOperands = cudaq::quake::getQuantumOperands(&op);
         if (!op.hasTrait<cudaq::QuantumMeasure>() && wireOperands.size() > 2) {
           if (nonComposable) {
             func.emitError("Cannot map a kernel with operators that use more "
@@ -769,13 +774,13 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
         }
 
         // Save which qubits are measured
-        if (isa<quake::MeasurementInterface>(op))
+        if (isa<cudaq::quake::MeasurementInterface>(op))
           for (const auto &wire : wireOperands)
             userQubitsMeasured.push_back(wireToVirtualQ[wire].index);
 
         // Map the result wires to the appropriate virtual qubits.
-        for (auto &&[wire, newWire] :
-             llvm::zip_equal(wireOperands, quake::getQuantumResults(&op))) {
+        for (auto &&[wire, newWire] : llvm::zip_equal(
+                 wireOperands, cudaq::quake::getQuantumResults(&op))) {
           // Don't use wireToVirtualQ[a] = wireToVirtualQ[b]. It will work
           // *most* of the time but cause memory corruption other times because
           // DenseMap references can be invalidated upon insertion of new pairs.
@@ -797,7 +802,7 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
     }
 
     // Make all existing borrow_wire ops use the mapped wire set.
-    func.walk([&](quake::BorrowWireOp borrowOp) {
+    func.walk([&](cudaq::quake::BorrowWireOp borrowOp) {
       borrowOp.setSetName(mappedWireSetName);
     });
 
@@ -808,21 +813,22 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
     returnsToRemove.clear();
 
     OpBuilder builder(&block, block.begin());
-    auto wireTy = builder.getType<quake::WireType>();
+    auto wireTy = builder.getType<cudaq::quake::WireType>();
     auto unknownLoc = builder.getUnknownLoc();
 
     // Add implicit measurements if necessary
     if (userQubitsMeasured.empty()) {
       builder.setInsertionPoint(block.getTerminator());
-      auto measTy = quake::MeasureType::get(builder.getContext());
+      auto measTy = cudaq::quake::MeasureType::get(builder.getContext());
       Type resTy = builder.getI1Type();
       for (unsigned i = 0; i < sources.size(); i++) {
         if (sources[i] != nullptr) {
-          auto measureOp =
-              quake::MzOp::create(builder, finalQubitWire[i].getLoc(),
-                                  TypeRange{measTy, wireTy}, finalQubitWire[i]);
-          quake::DiscriminateOp::create(builder, finalQubitWire[i].getLoc(),
-                                        resTy, measureOp.getMeasOut());
+          auto measureOp = cudaq::quake::MzOp::create(
+              builder, finalQubitWire[i].getLoc(), TypeRange{measTy, wireTy},
+              finalQubitWire[i]);
+          cudaq::quake::DiscriminateOp::create(builder,
+                                               finalQubitWire[i].getLoc(),
+                                               resTy, measureOp.getMeasOut());
 
           wireToVirtualQ.insert(
               {measureOp.getWires()[0], wireToVirtualQ[finalQubitWire[i]]});
@@ -834,7 +840,7 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
 
     // Save the order of the measurements. They are not allowed to change.
     SmallVector<mlir::Operation *> measureOrder;
-    func.walk([&](quake::MeasurementInterface measure) {
+    func.walk([&](cudaq::quake::MeasurementInterface measure) {
       measureOrder.push_back(measure);
       for (auto user : measure->getUsers())
         measureOrder.push_back(user);
@@ -846,8 +852,8 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
     builder.setInsertionPointAfter(lastSource);
     for (unsigned i = 0; i < deviceInstance->getNumQubits(); i++) {
       if (!sources[i]) {
-        auto borrowOp = quake::BorrowWireOp::create(builder, unknownLoc, wireTy,
-                                                    mappedWireSetName, i);
+        auto borrowOp = cudaq::quake::BorrowWireOp::create(
+            builder, unknownLoc, wireTy, mappedWireSetName, i);
         wireToVirtualQ[borrowOp.getResult()] = cudaq::Placement::VirtualQ(i);
         sources[i] = borrowOp;
       }
@@ -884,8 +890,8 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
         s->erase();
       } else {
         // highestMappedQubit = i;
-        quake::ReturnWireOp::create(builder, phyToWire[i].getLoc(),
-                                    phyToWire[i]);
+        cudaq::quake::ReturnWireOp::create(builder, phyToWire[i].getLoc(),
+                                           phyToWire[i]);
       }
     }
 

--- a/lib/Optimizer/Transforms/MemToReg.cpp
+++ b/lib/Optimizer/Transforms/MemToReg.cpp
@@ -76,7 +76,9 @@ static bool onlyTakesLinearTypeArguments(Operation *op) {
   return op->hasTrait<cudaq::cc::LinearTypeArgsTrait>();
 }
 
-static bool isLinearType(Value v) { return quake::isLinearType(v.getType()); }
+static bool isLinearType(Value v) {
+  return cudaq::quake::isLinearType(v.getType());
+}
 
 template <typename T>
 void appendToWorklist(std::deque<Block *> &d, T collection) {
@@ -117,11 +119,11 @@ private:
 
   void determineAllocSet(func::FuncOp func) {
     SmallVector<Operation *> allocations;
-    auto qrefTy = quake::RefType::get(func.getContext());
+    auto qrefTy = cudaq::quake::RefType::get(func.getContext());
     func->walk([&](Operation *op) {
       if (isMemoryAlloc(op)) {
         // Make sure this is stack here. Can we make use of an Interface?
-        if (auto alloc = dyn_cast<quake::AllocaOp>(op)) {
+        if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(op)) {
           if (!alloc.hasInitializedState() && alloc.getType() == qrefTy)
             allocations.push_back(op);
         } else if (auto alloc = dyn_cast<cudaq::cc::AllocaOp>(op)) {
@@ -139,7 +141,7 @@ private:
         v = alloc.getResult();
       for (auto *u : a->getUsers()) {
         // Don't convert quake.custom_op as it has ambiguous semantics.
-        if (isa<quake::CustomUnitarySymbolOp>(u) ||
+        if (isa<cudaq::quake::CustomUnitarySymbolOp>(u) ||
             (!isMemoryUse(u) && !nonEscapingDef(u, v))) {
           add = nullptr;
           break;
@@ -176,8 +178,8 @@ static bool isDescendantOf(Operation *op, Value defVal) {
 
 /// Return the type after \p ty is dereferenced.
 static Type dereferencedType(Type ty) {
-  if (isa<quake::RefType>(ty))
-    return quake::WireType::get(ty.getContext());
+  if (isa<cudaq::quake::RefType>(ty))
+    return cudaq::quake::WireType::get(ty.getContext());
   return cast<cudaq::cc::PointerType>(ty).getElementType();
 }
 
@@ -317,9 +319,9 @@ public:
   /// Create a re-load of a memory reference. This can be used to place a
   /// dominating load operation immediately prior to an op with regions.
   SSAReg reloadMemoryReference(OpBuilder &builder, MemRef mr) {
-    if (isa<quake::RefType>(mr.getType())) {
-      auto wireTy = quake::WireType::get(builder.getContext());
-      return quake::UnwrapOp::create(builder, mr.getLoc(), wireTy, mr);
+    if (isa<cudaq::quake::RefType>(mr.getType())) {
+      auto wireTy = cudaq::quake::WireType::get(builder.getContext());
+      return cudaq::quake::UnwrapOp::create(builder, mr.getLoc(), wireTy, mr);
     }
     return cudaq::cc::LoadOp::create(builder, mr.getLoc(), mr);
   }
@@ -544,36 +546,37 @@ private:
 namespace {
 /// The reset operation is a bit of an oddball and doesn't support the
 /// QuakeOperator interface. Handle it special for now.
-class ResetOpPattern : public OpRewritePattern<quake::ResetOp> {
+class ResetOpPattern : public OpRewritePattern<cudaq::quake::ResetOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ResetOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::ResetOp op,
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto wireTy = quake::WireType::get(rewriter.getContext());
+    auto wireTy = cudaq::quake::WireType::get(rewriter.getContext());
     auto opnd = op.getTargets();
-    assert(opnd.getType() == quake::RefType::get(rewriter.getContext()));
-    Value target = quake::UnwrapOp::create(rewriter, loc, wireTy, opnd);
+    assert(opnd.getType() == cudaq::quake::RefType::get(rewriter.getContext()));
+    Value target = cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, opnd);
     auto newOp =
-        quake::ResetOp::create(rewriter, loc, TypeRange{wireTy}, target);
-    rewriter.replaceOpWithNewOp<quake::WrapOp>(op, newOp.getResult(0), opnd);
+        cudaq::quake::ResetOp::create(rewriter, loc, TypeRange{wireTy}, target);
+    rewriter.replaceOpWithNewOp<cudaq::quake::WrapOp>(op, newOp.getResult(0),
+                                                      opnd);
     return success();
   }
 };
 
-class DeallocOpPattern : public OpRewritePattern<quake::DeallocOp> {
+class DeallocOpPattern : public OpRewritePattern<cudaq::quake::DeallocOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::DeallocOp op,
+  LogicalResult matchAndRewrite(cudaq::quake::DeallocOp op,
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto wireTy = quake::WireType::get(rewriter.getContext());
+    auto wireTy = cudaq::quake::WireType::get(rewriter.getContext());
     auto opnd = op.getReference();
-    assert(isa<quake::RefType>(opnd.getType()));
-    Value target = quake::UnwrapOp::create(rewriter, loc, wireTy, opnd);
-    rewriter.replaceOpWithNewOp<quake::SinkOp>(op, target);
+    assert(isa<cudaq::quake::RefType>(opnd.getType()));
+    Value target = cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, opnd);
+    rewriter.replaceOpWithNewOp<cudaq::quake::SinkOp>(op, target);
     return success();
   }
 };
@@ -589,16 +592,17 @@ public:
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     SmallVector<Value> unwrapCtrls;
-    auto wireTy = quake::WireType::get(rewriter.getContext());
-    auto qrefTy = quake::RefType::get(rewriter.getContext());
+    auto wireTy = cudaq::quake::WireType::get(rewriter.getContext());
+    auto qrefTy = cudaq::quake::RefType::get(rewriter.getContext());
     // Scan the control and target positions. Any that were not Wires will be
     // promoted to Wires via an unwrap operation. These unwrap ops become the
     // arguments to the quantum value form of the new quantum operation.
-    if constexpr (!quake::isMeasure<OP>) {
+    if constexpr (!cudaq::quake::isMeasure<OP>) {
       for (auto opnd : op.getControls()) {
         auto opndTy = opnd.getType();
         if (opndTy == qrefTy) {
-          auto unwrap = quake::UnwrapOp::create(rewriter, loc, wireTy, opnd);
+          auto unwrap =
+              cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, opnd);
           unwrapCtrls.push_back(unwrap);
         } else {
           unwrapCtrls.push_back(opnd);
@@ -609,7 +613,8 @@ public:
     for (auto opnd : op.getTargets()) {
       auto opndTy = opnd.getType();
       if (opndTy == qrefTy) {
-        auto unwrap = quake::UnwrapOp::create(rewriter, loc, wireTy, opnd);
+        auto unwrap =
+            cudaq::quake::UnwrapOp::create(rewriter, loc, wireTy, opnd);
         unwrapTargs.push_back(unwrap);
       } else {
         unwrapTargs.push_back(opnd);
@@ -623,8 +628,8 @@ public:
         auto opndTy = i.value().getType();
         auto offset = i.index() + addend;
         if (opndTy == qrefTy) {
-          quake::WrapOp::create(rewriter, loc, newOp.getResult(offset),
-                                i.value());
+          cudaq::quake::WrapOp::create(rewriter, loc, newOp.getResult(offset),
+                                       i.value());
         } else if (opndTy == wireTy) {
           op.getResult(count++).replaceAllUsesWith(newOp.getResult(offset));
         }
@@ -632,7 +637,7 @@ public:
       rewriter.eraseOp(op);
     };
 
-    if constexpr (quake::isMeasure<OP>) {
+    if constexpr (cudaq::quake::isMeasure<OP>) {
       // The result type of the bits is the same. Add the wire types.
       SmallVector<Type> newTy = {op.getMeasOut().getType()};
       SmallVector<Type> wireTys(unwrapTargs.size(), wireTy);
@@ -673,18 +678,18 @@ public:
   static std::size_t wireCount(ArrayRef<Value> ctls, ArrayRef<Value> trgs) {
     std::size_t result = 0;
     for (Value v : ctls)
-      if (quake::isQuantumValueType(v.getType()))
+      if (cudaq::quake::isQuantumValueType(v.getType()))
         result++;
     for (Value v : trgs)
-      if (quake::isQuantumValueType(v.getType()))
+      if (cudaq::quake::isQuantumValueType(v.getType()))
         result++;
     return result;
   }
 };
 
-#define WRAPPER(OpClass) Wrapper<quake::OpClass>
+#define WRAPPER(OpClass) Wrapper<cudaq::quake::OpClass>
 #define WRAPPER_QUANTUM_OPS QUANTUM_OPS(WRAPPER)
-#define RAW(OpClass) quake::OpClass
+#define RAW(OpClass) cudaq::quake::OpClass
 #define RAW_QUANTUM_OPS QUANTUM_OPS(RAW)
 
 namespace {
@@ -719,9 +724,9 @@ public:
 
     // 3) Cleanup the dead ops. Make sure to delay erasing wrap ops since they
     // may still have uses.
-    SmallVector<quake::WrapOp> wrapOps;
+    SmallVector<cudaq::quake::WrapOp> wrapOps;
     for (auto *op : cleanUps) {
-      if (auto wrap = dyn_cast<quake::WrapOp>(op)) {
+      if (auto wrap = dyn_cast<cudaq::quake::WrapOp>(op)) {
         wrapOps.push_back(wrap);
         continue;
       }
@@ -768,8 +773,8 @@ public:
                             const MemoryAnalysis &memAnalysis,
                             SmallPtrSetImpl<Operation *> &cleanUps) {
     auto *ctx = &getContext();
-    auto wireTy = quake::WireType::get(ctx);
-    auto qrefTy = quake::RefType::get(ctx);
+    auto wireTy = cudaq::quake::WireType::get(ctx);
+    auto qrefTy = cudaq::quake::RefType::get(ctx);
 
     if (auto ifOp = dyn_cast<cudaq::cc::IfOp>(parent)) {
       // Special case: add an else region if it is absent from parent.
@@ -806,8 +811,8 @@ public:
             if (arg.getType() == qrefTy) {
               OpBuilder builder(ctx);
               builder.setInsertionPointToStart(block);
-              Value v =
-                  quake::UnwrapOp::create(builder, arg.getLoc(), wireTy, arg);
+              Value v = cudaq::quake::UnwrapOp::create(builder, arg.getLoc(),
+                                                       wireTy, arg);
               dataFlow.addBinding(block, arg, v);
             }
           }
@@ -824,18 +829,18 @@ public:
             if (!quantumValues)
               continue;
             // If this op defines a quantum reference, record it in the maps.
-            if (auto alloc = dyn_cast<quake::AllocaOp>(op);
+            if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(op);
                 alloc && memAnalysis.isMember(alloc)) {
               // If it is a known non-escaping alloca, then replace it with a
               // null wire and record it for removal.
               if (!dataFlow.hasBinding(block, alloc)) {
                 OpBuilder builder(alloc);
-                Value v =
-                    quake::NullWireOp::create(builder, alloc.getLoc(), wireTy);
+                Value v = cudaq::quake::NullWireOp::create(
+                    builder, alloc.getLoc(), wireTy);
                 cleanUps.insert(alloc);
                 dataFlow.addBinding(block, alloc, v);
               }
-            } else if (auto alloc = dyn_cast<quake::AllocaOp>(op);
+            } else if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(op);
                        alloc && alloc.hasInitializedState()) {
               // If this is an quake.alloca followed by a quake.init_state, just
               // skip this op. It has to remain in reference form and there
@@ -846,14 +851,15 @@ public:
               for (auto v : op->getOperands())
                 if (v.getType() == qrefTy && dataFlow.hasBinding(block, v))
                   if (auto vBinding = dataFlow.getBinding(block, v)) {
-                    quake::WrapOp::create(builder, op->getLoc(), vBinding, v);
+                    cudaq::quake::WrapOp::create(builder, op->getLoc(),
+                                                 vBinding, v);
                     dataFlow.cancelBinding(block, v);
                   }
               builder.setInsertionPointAfter(op);
               for (auto r : op->getResults())
                 if (r.getType() == qrefTy) {
-                  Value v =
-                      quake::UnwrapOp::create(builder, op->getLoc(), wireTy, r);
+                  Value v = cudaq::quake::UnwrapOp::create(
+                      builder, op->getLoc(), wireTy, r);
                   dataFlow.addBinding(block, r, v);
                 }
             }
@@ -876,7 +882,7 @@ public:
 
           // If this is a new value being created, add it to the map of values
           // for this block so it can be tracked and forwarded.
-          if (auto nullWire = dyn_cast<quake::NullWireOp>(op)) {
+          if (auto nullWire = dyn_cast<cudaq::quake::NullWireOp>(op)) {
             if (quantumValues)
               dataFlow.addBinding(block, nullWire, nullWire.getResult());
             continue;
@@ -935,7 +941,7 @@ public:
             useop.replaceAllUsesWith(newDef);
             cleanUps.insert(useop);
           };
-          if (auto unwrap = dyn_cast<quake::UnwrapOp>(op)) {
+          if (auto unwrap = dyn_cast<cudaq::quake::UnwrapOp>(op)) {
             if (quantumValues)
               handleUse(unwrap, unwrap.getRefValue());
             continue;
@@ -966,7 +972,7 @@ public:
             }
             cleanUps.insert(defop);
           };
-          if (auto wrap = dyn_cast<quake::WrapOp>(op)) {
+          if (auto wrap = dyn_cast<cudaq::quake::WrapOp>(op)) {
             if (quantumValues)
               handleDefinition(wrap, wrap.getWireValue(), wrap.getRefValue());
             continue;
@@ -989,7 +995,8 @@ public:
             if ((v.getType() == qrefTy) && dataFlow.hasBinding(block, v))
               if (auto vBinding = dataFlow.getBinding(block, v)) {
                 OpBuilder builder(op);
-                quake::WrapOp::create(builder, op->getLoc(), vBinding, v);
+                cudaq::quake::WrapOp::create(builder, op->getLoc(), vBinding,
+                                             v);
                 dataFlow.cancelBinding(block, v);
               }
 
@@ -1059,13 +1066,13 @@ public:
           auto oldVal = dataFlow.getBinding(block, liveOut);
           if (!oldVal) {
             OpBuilder builder(term);
-            oldVal = quake::UnwrapOp::create(
+            oldVal = cudaq::quake::UnwrapOp::create(
                 builder, term->getLoc(),
-                quake::WireType::get(builder.getContext()), liveOut);
+                cudaq::quake::WireType::get(builder.getContext()), liveOut);
           }
           addTerminatorArgument(term, target, oldVal);
-        } else if ((usePromo ||
-                    (onlyLinear && !isa<quake::RefType>(liveOut.getType()))) &&
+        } else if ((usePromo || (onlyLinear && !isa<cudaq::quake::RefType>(
+                                                   liveOut.getType()))) &&
                    dataFlow.isEntryBlock(block)) {
           auto newVal = dataFlow.getPromotedValue(liveOut);
           dataFlow.addBinding(block, liveOut, newVal);
@@ -1133,8 +1140,8 @@ public:
       for (auto iter : llvm::enumerate(allDefs)) {
         auto i = iter.index() + parent->getNumResults();
         if (np->getResult(i).getType() == wireTy)
-          quake::WrapOp::create(builder, np->getLoc(), np->getResult(i),
-                                iter.value());
+          cudaq::quake::WrapOp::create(builder, np->getLoc(), np->getResult(i),
+                                       iter.value());
         else
           cudaq::cc::StoreOp::create(builder, np->getLoc(), np->getResult(i),
                                      iter.value());
@@ -1170,11 +1177,11 @@ public:
     RewritePatternSet patterns(ctx);
     patterns.insert<WRAPPER_QUANTUM_OPS, ResetOpPattern, DeallocOpPattern>(ctx);
     ConversionTarget target(*ctx);
-    target.addDynamicallyLegalOp<RAW_QUANTUM_OPS, quake::ResetOp,
-                                 quake::DeallocOp>(
-        [](Operation *op) { return !quake::hasNonVectorReference(op); });
-    target.addLegalOp<quake::UnwrapOp, quake::WrapOp, quake::NullWireOp,
-                      quake::SinkOp>();
+    target.addDynamicallyLegalOp<RAW_QUANTUM_OPS, cudaq::quake::ResetOp,
+                                 cudaq::quake::DeallocOp>(
+        [](Operation *op) { return !cudaq::quake::hasNonVectorReference(op); });
+    target.addLegalOp<cudaq::quake::UnwrapOp, cudaq::quake::WrapOp,
+                      cudaq::quake::NullWireOp, cudaq::quake::SinkOp>();
     if (failed(applyPartialConversion(func, target, std::move(patterns)))) {
       emitError(func.getLoc(), "error converting to QLS form\n");
       signalPassFailure();

--- a/lib/Optimizer/Transforms/MultiControlDecomposition.cpp
+++ b/lib/Optimizer/Transforms/MultiControlDecomposition.cpp
@@ -50,10 +50,10 @@ public:
     entryBlock = &(*func.getBody().begin());
   }
 
-  LogicalResult v_decomposition(quake::OperatorInterface op);
+  LogicalResult v_decomposition(cudaq::quake::OperatorInterface op);
 
 private:
-  LogicalResult extractControls(quake::OperatorInterface op,
+  LogicalResult extractControls(cudaq::quake::OperatorInterface op,
                                 SmallVectorImpl<Value> &newControls,
                                 SmallVectorImpl<bool> &negatedControls);
 
@@ -67,21 +67,21 @@ private:
 } // namespace
 
 LogicalResult
-Decomposer::extractControls(quake::OperatorInterface op,
+Decomposer::extractControls(cudaq::quake::OperatorInterface op,
                             SmallVectorImpl<Value> &newControls,
                             SmallVectorImpl<bool> &negatedControls) {
   auto negControls = op.getNegatedControls();
   for (auto [index, control] : llvm::enumerate(op.getControls())) {
     size_t size = 1;
-    if (isa<quake::RefType>(control.getType())) {
+    if (isa<cudaq::quake::RefType>(control.getType())) {
       newControls.push_back(control);
-    } else if (auto veq = dyn_cast<quake::VeqType>(control.getType())) {
+    } else if (auto veq = dyn_cast<cudaq::quake::VeqType>(control.getType())) {
       if (!veq.hasSpecifiedSize())
         return failure();
       size = veq.getSize();
       for (size_t i = 0; i < size; ++i)
-        newControls.push_back(
-            quake::ExtractRefOp::create(builder, op.getLoc(), control, i));
+        newControls.push_back(cudaq::quake::ExtractRefOp::create(
+            builder, op.getLoc(), control, i));
     }
     if (negControls)
       negatedControls.append(size, (*negControls)[index]);
@@ -94,11 +94,11 @@ ArrayRef<Value> Decomposer::getAncillas(Location loc, std::size_t numAncillas) {
   builder.setInsertionPointToStart(entryBlock);
   // If we don't have enough ancillas, allocate some more.
   for (size_t i = allocatedAncillas.size(); i < numAncillas; ++i)
-    allocatedAncillas.push_back(quake::AllocaOp::create(builder, loc));
+    allocatedAncillas.push_back(cudaq::quake::AllocaOp::create(builder, loc));
   return {allocatedAncillas.begin(), allocatedAncillas.begin() + numAncillas};
 }
 
-LogicalResult Decomposer::v_decomposition(quake::OperatorInterface op) {
+LogicalResult Decomposer::v_decomposition(cudaq::quake::OperatorInterface op) {
   builder.setInsertionPoint(op);
   // First, we need to extract controls from any `veq` that might been used as
   // a control for this operation.
@@ -112,7 +112,7 @@ LogicalResult Decomposer::v_decomposition(quake::OperatorInterface op) {
     return failure();
 
   // We don't decompose CCX and CCZ as they are handle by another pass.
-  if (controls.size() == 2 && isa<quake::XOp, quake::ZOp>(op))
+  if (controls.size() == 2 && isa<cudaq::quake::XOp, cudaq::quake::ZOp>(op))
     return failure();
 
   // Operator info
@@ -123,7 +123,7 @@ LogicalResult Decomposer::v_decomposition(quake::OperatorInterface op) {
 
   // Compute the required number of ancillas to decompose this operation.
   // Allocate new qubits if necessary.
-  size_t requiredAncillas = isa<quake::XOp, quake::ZOp>(op)
+  size_t requiredAncillas = isa<cudaq::quake::XOp, cudaq::quake::ZOp>(op)
                                 ? controls.size() - 2
                                 : controls.size() - 1;
   auto ancillas = getAncillas(loc, requiredAncillas);
@@ -131,21 +131,22 @@ LogicalResult Decomposer::v_decomposition(quake::OperatorInterface op) {
   // Compute intermediate results
   SmallVector<Operation *> toCleanup;
   std::array<Value, 2> cs = {controls[0], controls[1]};
-  toCleanup.push_back(quake::XOp::create(builder, loc, cs, ancillas[0]));
+  toCleanup.push_back(cudaq::quake::XOp::create(builder, loc, cs, ancillas[0]));
   if (!negatedControls.empty() && (negatedControls[0] || negatedControls[1]))
     toCleanup.back()->setAttr("negated_qubit_controls",
                               builder.getDenseBoolArrayAttr(
                                   {negatedControls[0], negatedControls[1]}));
   for (std::size_t c = 2, a = 0, n = requiredAncillas + 1; c < n; ++c, ++a) {
     cs = {controls[c], ancillas[a]};
-    toCleanup.push_back(quake::XOp::create(builder, loc, cs, ancillas[a + 1]));
+    toCleanup.push_back(
+        cudaq::quake::XOp::create(builder, loc, cs, ancillas[a + 1]));
     if (!negatedControls.empty() && negatedControls[c])
       toCleanup.back()->setAttr("negated_qubit_controls",
                                 builder.getDenseBoolArrayAttr({true, false}));
   }
 
   // Compute output
-  if (!isa<quake::XOp, quake::ZOp>(op)) {
+  if (!isa<cudaq::quake::XOp, cudaq::quake::ZOp>(op)) {
     createOperator(loc, name, parameters, ancillas.back(), targets, builder);
   } else {
     cs = {controls.back(), ancillas.back()};
@@ -178,9 +179,9 @@ struct Decomposition
       return;
 
     Decomposer decomposer(func);
-    func.walk([&](quake::OperatorInterface op) {
+    func.walk([&](cudaq::quake::OperatorInterface op) {
       // This pass does not handle Quake's value semantics form.
-      if (!quake::isAllReferences(op))
+      if (!cudaq::quake::isAllReferences(op))
         return;
       if (failed(decomposer.v_decomposition(op)))
         return;

--- a/lib/Optimizer/Transforms/ObserveAnsatz.cpp
+++ b/lib/Optimizer/Transforms/ObserveAnsatz.cpp
@@ -25,11 +25,11 @@ enum class MeasureBasis { I, X, Y, Z };
 void appendMeasurement(MeasureBasis &basis, OpBuilder &builder, Location &loc,
                        Value &qubit) {
   SmallVector<Value> targets{qubit};
-  if (quake::isLinearType(qubit.getType())) {
+  if (cudaq::quake::isLinearType(qubit.getType())) {
     // Value semantics
-    auto wireTy = quake::WireType::get(builder.getContext());
+    auto wireTy = cudaq::quake::WireType::get(builder.getContext());
     if (basis == MeasureBasis::X) {
-      auto newOp = quake::HOp::create(
+      auto newOp = cudaq::quake::HOp::create(
           builder, loc, TypeRange{wireTy}, /*is_adj=*/false, ValueRange{},
           ValueRange{}, targets, DenseBoolArrayAttr{});
       qubit.replaceAllUsesExcept(newOp.getResult(0), newOp);
@@ -38,23 +38,23 @@ void appendMeasurement(MeasureBasis &basis, OpBuilder &builder, Location &loc,
       llvm::APFloat d(M_PI_2);
       Value rotation =
           arith::ConstantFloatOp::create(builder, loc, builder.getF64Type(), d);
-      auto newOp =
-          quake::RxOp::create(builder, loc, TypeRange{wireTy}, /*is_adj=*/false,
-                              ValueRange{rotation}, ValueRange{},
-                              ValueRange{qubit}, DenseBoolArrayAttr{});
+      auto newOp = cudaq::quake::RxOp::create(
+          builder, loc, TypeRange{wireTy}, /*is_adj=*/false,
+          ValueRange{rotation}, ValueRange{}, ValueRange{qubit},
+          DenseBoolArrayAttr{});
       qubit.replaceAllUsesExcept(newOp.getResult(0), newOp);
       qubit = newOp.getResult(0);
     }
   } else {
     // Reference semantics
     if (basis == MeasureBasis::X) {
-      quake::HOp::create(builder, loc, ValueRange{}, targets);
+      cudaq::quake::HOp::create(builder, loc, ValueRange{}, targets);
     } else if (basis == MeasureBasis::Y) {
       llvm::APFloat d(M_PI_2);
       Value rotation =
           arith::ConstantFloatOp::create(builder, loc, builder.getF64Type(), d);
       SmallVector<Value> params{rotation};
-      quake::RxOp::create(builder, loc, params, ValueRange{}, targets);
+      cudaq::quake::RxOp::create(builder, loc, params, ValueRange{}, targets);
     }
   }
 }
@@ -105,15 +105,15 @@ private:
 
     AnsatzMetadata data;
 
-    funcOp->walk([&](quake::BorrowWireOp op) {
+    funcOp->walk([&](cudaq::quake::BorrowWireOp op) {
       Value wire = op.getResult();
       // Wires are linear types that must be used exactly once, so traverse
       // those uses until the end of the linear operators.
       // NOTE - if this is ever moved to other passes that have different use
       // cases than this one, then it needs to be updated to support ResetOp,
       // which is not an operator interface (I don't think).
-      while (auto gate =
-                 dyn_cast<quake::OperatorInterface>(*wire.getUsers().begin())) {
+      while (auto gate = dyn_cast<cudaq::quake::OperatorInterface>(
+                 *wire.getUsers().begin())) {
         std::size_t qopNum = 0;
         auto controls = gate.getControls();
         for (auto w : controls) {
@@ -139,9 +139,9 @@ private:
     });
 
     // walk and find all quantum allocations
-    auto walkResult = funcOp->walk([&](quake::AllocaOp op) {
+    auto walkResult = funcOp->walk([&](cudaq::quake::AllocaOp op) {
       Value result = op.getResult();
-      if (auto veq = dyn_cast<quake::VeqType>(result.getType())) {
+      if (auto veq = dyn_cast<cudaq::quake::VeqType>(result.getType())) {
         // Update data.nQubits here and store qubit info as indexes into
         // the veq, in case we don't encounter any ExtractRefOps for
         // them later.
@@ -164,7 +164,7 @@ private:
     }
 
     // NOTE: assumes canonicalization and cse have run.
-    funcOp->walk([&](quake::ExtractRefOp op) {
+    funcOp->walk([&](cudaq::quake::ExtractRefOp op) {
       if (op.hasConstantIndex())
         data.qubitValues.insert({op.getConstantIndex(), op.getResult()});
     });
@@ -191,7 +191,8 @@ private:
     }
 
     // Count all measures
-    funcOp->walk([&](quake::MzOp op) { data.measurements.push_back(op); });
+    funcOp->walk(
+        [&](cudaq::quake::MzOp op) { data.measurements.push_back(op); });
 
     infoMap.insert({operation, data});
   }
@@ -238,7 +239,7 @@ public:
     for (auto *op : iter->second.measurements) {
       bool safeToRemove = [&]() {
         for (auto user : op->getUsers())
-          if (!isa<quake::SinkOp, quake::ReturnWireOp>(user))
+          if (!isa<cudaq::quake::SinkOp, cudaq::quake::ReturnWireOp>(user))
             return false;
         return true;
       }();
@@ -247,7 +248,7 @@ public:
             "Cannot observe kernel with non dangling measurements.");
 
       for (auto result : op->getResults())
-        if (quake::isLinearType(result.getType()))
+        if (cudaq::quake::isLinearType(result.getType()))
           result.replaceAllUsesWith(op->getOperand(0));
 
       op->dropAllReferences();
@@ -273,8 +274,8 @@ public:
     auto loc = funcOp.getBody().back().getTerminator()->getLoc();
     Operation *last = &funcOp.getBody().back().front();
     funcOp.walk([&](Operation *op) {
-      if (dyn_cast<quake::OperatorInterface>(op) ||
-          dyn_cast<quake::AllocaOp>(op))
+      if (dyn_cast<cudaq::quake::OperatorInterface>(op) ||
+          dyn_cast<cudaq::quake::AllocaOp>(op))
         last = op;
     });
     builder.setInsertionPointAfter(last);
@@ -305,7 +306,7 @@ public:
         auto veqOp = seekIndexed->second.first;
         auto index = seekIndexed->second.second;
         auto extractRef =
-            quake::ExtractRefOp::create(builder, loc, veqOp, index);
+            cudaq::quake::ExtractRefOp::create(builder, loc, veqOp, index);
         qubitVal = extractRef.getResult();
       } else {
         qubitVal = seek->second;
@@ -320,21 +321,21 @@ public:
         qubitsToMeasure.push_back(qubitVal);
     }
 
-    auto measTy = quake::MeasureType::get(builder.getContext());
-    auto wireTy = quake::WireType::get(builder.getContext());
+    auto measTy = cudaq::quake::MeasureType::get(builder.getContext());
+    auto wireTy = cudaq::quake::WireType::get(builder.getContext());
     for (const auto &[measureNum, qubitToMeasure] :
          llvm::enumerate(qubitsToMeasure)) {
       // add the measure
       char regName[16];
       std::snprintf(regName, sizeof(regName), "r%05lu", measureNum);
-      if (quake::isLinearType(qubitToMeasure.getType())) {
-        auto newOp = quake::MzOp::create(
+      if (cudaq::quake::isLinearType(qubitToMeasure.getType())) {
+        auto newOp = cudaq::quake::MzOp::create(
             builder, loc, TypeRange{measTy, wireTy}, ValueRange{qubitToMeasure},
             builder.getStringAttr(regName));
         qubitToMeasure.replaceAllUsesExcept(newOp.getResult(1), newOp);
       } else {
-        quake::MzOp::create(builder, loc, measTy, qubitToMeasure,
-                            builder.getStringAttr(regName));
+        cudaq::quake::MzOp::create(builder, loc, measTy, qubitToMeasure,
+                                   builder.getStringAttr(regName));
       }
     }
 

--- a/lib/Optimizer/Transforms/PhaseFolding.cpp
+++ b/lib/Optimizer/Transforms/PhaseFolding.cpp
@@ -21,7 +21,7 @@ namespace cudaq::opt {
 
 using namespace mlir;
 
-#define RAW(X) quake::X
+#define RAW(X) cudaq::quake::X
 // AXIS-SPECIFIC: Defines which operations break a circuit into subcircuits
 #define CIRCUIT_BREAKERS(MACRO)                                                \
   MACRO(YOp), MACRO(ZOp), MACRO(HOp), MACRO(R1Op), MACRO(RxOp),                \
@@ -30,7 +30,7 @@ using namespace mlir;
 
 // AXIS-SPECIFIC: could allow controlled y and z here
 static bool isCNOT(Operation *op) {
-  if (auto xop = dyn_cast<quake::XOp>(op))
+  if (auto xop = dyn_cast<cudaq::quake::XOp>(op))
     return xop.getControls().size() == 1;
   return false;
 }
@@ -43,13 +43,13 @@ static bool isCNOT(Operation *op) {
 /// restrict the possible optimizations, so future work to recognize
 /// these possible side effects could be beneficial.
 static bool isSupportedValue(Value ref) {
-  if (!isa<quake::RefType>(ref.getType()))
+  if (!isa<cudaq::quake::RefType>(ref.getType()))
     return false;
 
   if (!ref.getDefiningOp())
     return false;
 
-  if (!ref.getDefiningOp<quake::AllocaOp>())
+  if (!ref.getDefiningOp<cudaq::quake::AllocaOp>())
     return false;
 
   // TODO: Concat op allows the pointer to be loaded again in a separate
@@ -62,7 +62,7 @@ static bool isSupportedValue(Value ref) {
   // aliases to resume reasoning after the alias is definitely no longer
   // used if it is relatively isolated.
   for (auto user : ref.getUsers())
-    if (isa<quake::ConcatOp>(user))
+    if (isa<cudaq::quake::ConcatOp>(user))
       return false;
 
   return true;
@@ -77,10 +77,10 @@ static bool isCircuitBreaker(Operation *op) {
   if (!isQuakeOperation(op))
     return true;
 
-  if (isa<RAW_CIRCUIT_BREAKERS, quake::NullWireOp>(op))
+  if (isa<RAW_CIRCUIT_BREAKERS, cudaq::quake::NullWireOp>(op))
     return true;
 
-  auto opi = dyn_cast<quake::OperatorInterface>(op);
+  auto opi = dyn_cast<cudaq::quake::OperatorInterface>(op);
 
   if (!opi)
     return true;
@@ -90,7 +90,7 @@ static bool isCircuitBreaker(Operation *op) {
     return true;
 
   // If any values are unsupported, the operation is also unsupported
-  for (auto operand : quake::getQuantumOperands(op))
+  for (auto operand : cudaq::quake::getQuantumOperands(op))
     if (!isSupportedValue(operand))
       return true;
 
@@ -98,7 +98,7 @@ static bool isCircuitBreaker(Operation *op) {
 }
 
 inline bool isTwoQubitOp(Operation *op) {
-  return quake::getQuantumOperands(op).size() == 2;
+  return cudaq::quake::getQuantumOperands(op).size() == 2;
 }
 
 namespace {
@@ -114,13 +114,13 @@ class Netlist {
 public:
   Netlist(mlir::func::FuncOp func) {
     func.walk([&](Operation *op) {
-      if (auto allocaop = dyn_cast<quake::AllocaOp>(op)) {
-        if (isa<quake::RefType>(allocaop.getType()))
+      if (auto allocaop = dyn_cast<cudaq::quake::AllocaOp>(op)) {
+        if (isa<cudaq::quake::RefType>(allocaop.getType()))
           allocNetlist(allocaop);
         return;
       }
 
-      for (auto operand : quake::getQuantumOperands(op))
+      for (auto operand : cudaq::quake::getQuantumOperands(op))
         if (isSupportedValue(operand))
           netlists[getIndexOf(operand)].push_back(op);
     });
@@ -205,7 +205,7 @@ protected:
           subcircuit->addAnchorPoint(op->getOperand(1), op);
         else
           subcircuit->addAnchorPoint(op->getOperand(0), op);
-      } else if (!isa<quake::XOp>(op)) {
+      } else if (!isa<cudaq::quake::XOp>(op)) {
         // AXIS-SPECIFIC
         subcircuit->num_rot_gates++;
       }
@@ -244,7 +244,8 @@ protected:
 
           if (otherWrapper)
             otherWrapper->pruneFrom(op);
-        } else if (isa<quake::RzOp>(op) && subcircuit->ops.contains(op)) {
+        } else if (isa<cudaq::quake::RzOp>(op) &&
+                   subcircuit->ops.contains(op)) {
           // AXIS-SPECIFIC
           subcircuit->num_rot_gates--;
         }
@@ -511,7 +512,7 @@ public:
 
 class PhaseStorage {
   SmallVector<Phase> phases;
-  SmallVector<quake::RzOp> rotations;
+  SmallVector<cudaq::quake::RzOp> rotations;
   size_t numCombined = 0;
 
   /// @brief Merges the rotation at prev_idx with rzop by adding their
@@ -520,7 +521,7 @@ class PhaseStorage {
   /// to ensure that dynamic rotation angles (e.g., dependent on
   /// measurement results) are indeed available, as earlier angles
   /// will always be available later, but not vice-versa.
-  void combineRotations(size_t prev_idx, quake::RzOp rzop) {
+  void combineRotations(size_t prev_idx, cudaq::quake::RzOp rzop) {
     auto old_rzop = rotations[prev_idx];
     auto rot_arg1 = old_rzop.getOperand(0);
     auto rot_arg2 = rzop.getOperand(0);
@@ -536,7 +537,7 @@ class PhaseStorage {
 public:
   /// @brief registers a new rotation op for the given phase
   /// @returns true if the rotation was combined, false otherwise
-  bool addOrCombineRotationForPhase(quake::RzOp op, Phase phase) {
+  bool addOrCombineRotationForPhase(cudaq::quake::RzOp op, Phase phase) {
     for (size_t i = 0; i < phases.size(); i++)
       if (phases[i] == phase) {
         combineRotations(i, op);
@@ -602,19 +603,19 @@ class PhaseFoldingPass
         auto target_phase = getPhase(target);
         auto new_target_phase = Phase::sum(target_phase, control_phase);
         setPhase(target, new_target_phase);
-      } else if (isa<quake::XOp>(op)) {
+      } else if (isa<cudaq::quake::XOp>(op)) {
         // Simple not, invert target phase
         // AXIS-SPECIFIC: Would want to handle y and z gates here too
         auto target = op->getOperand(0);
         auto target_phase = getPhase(target);
         auto new_target_phase = Phase::invert(target_phase);
         setPhase(target, new_target_phase);
-      } else if (auto rzop = dyn_cast<quake::RzOp>(op)) {
+      } else if (auto rzop = dyn_cast<cudaq::quake::RzOp>(op)) {
         // Rotation, try to merge by looking up in store
         auto target = op->getOperand(1);
         auto target_phase = getPhase(target);
         store.addOrCombineRotationForPhase(rzop, target_phase);
-      } else if (auto swap = dyn_cast<quake::SwapOp>(op)) {
+      } else if (auto swap = dyn_cast<cudaq::quake::SwapOp>(op)) {
         // Swap phases
         auto target1 = op->getOperand(0);
         auto target2 = op->getOperand(1);
@@ -646,7 +647,7 @@ public:
 
     auto subcircuitBuild = root.nest("Building subcircuits");
     subcircuitBuild.start();
-    func.walk([&](quake::XOp op) {
+    func.walk([&](cudaq::quake::XOp op) {
       // AXIS-SPECIFIC: controlled not only
       if (!::isCNOT(op) || nl.wasProcessed(op))
         return;

--- a/lib/Optimizer/Transforms/PruneCtrlRelations.cpp
+++ b/lib/Optimizer/Transforms/PruneCtrlRelations.cpp
@@ -35,7 +35,7 @@ public:
     auto *ctx = rewriter.getContext();
     if (op.getControls().empty())
       return failure();
-    auto wireTy = quake::WireType::get(ctx);
+    auto wireTy = cudaq::quake::WireType::get(ctx);
     bool nothingToDo = [&]() {
       for (auto cv : op.getControls())
         if (cv.getType() == wireTy)
@@ -49,7 +49,7 @@ public:
     // this op to remove the artificial constraints.
     auto coarity = op.getWires().size();
     auto loc = op.getLoc();
-    auto ctrlTy = quake::ControlType::get(ctx);
+    auto ctrlTy = cudaq::quake::ControlType::get(ctx);
     SmallVector<Value> newCtrls;
 
     // For each wire control, convert the wire to a control with a ToControlOp.
@@ -57,10 +57,11 @@ public:
     for (auto cv : op.getControls()) {
       if (cv.getType() == wireTy) {
         Value input;
-        if (auto fromCtrl = cv.template getDefiningOp<quake::FromControlOp>()) {
+        if (auto fromCtrl =
+                cv.template getDefiningOp<cudaq::quake::FromControlOp>()) {
           input = fromCtrl.getCtrlbit();
         } else {
-          input = quake::ToControlOp::create(rewriter, loc, ctrlTy, cv);
+          input = cudaq::quake::ToControlOp::create(rewriter, loc, ctrlTy, cv);
         }
         newCtrls.push_back(input);
         coarity--;
@@ -82,8 +83,8 @@ public:
     for (auto i : llvm::enumerate(op.getControls())) {
       auto cv = i.value();
       if (cv.getType() == wireTy) {
-        Value fromCtrl = quake::FromControlOp::create(rewriter, loc, wireTy,
-                                                      newCtrls[i.index()]);
+        Value fromCtrl = cudaq::quake::FromControlOp::create(
+            rewriter, loc, wireTy, newCtrls[i.index()]);
         op.getResult(i.index()).replaceAllUsesWith(fromCtrl);
       } else {
         op.getResult(i.index()).replaceAllUsesWith(newOp.getResult(newIdx++));
@@ -104,14 +105,14 @@ public:
 /// both operations can be bypassed and the input to the `quake.from_ctrl` can
 /// be forwarded directly to the users of the `quake.to_ctrl`. There are no
 /// intervening ops on the wire by definition.
-class ForwardControl : public OpRewritePattern<quake::ToControlOp> {
+class ForwardControl : public OpRewritePattern<cudaq::quake::ToControlOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::ToControlOp toCtrl,
+  LogicalResult matchAndRewrite(cudaq::quake::ToControlOp toCtrl,
                                 PatternRewriter &rewriter) const override {
     if (auto fromCtrl =
-            toCtrl.getQubit().getDefiningOp<quake::FromControlOp>()) {
+            toCtrl.getQubit().getDefiningOp<cudaq::quake::FromControlOp>()) {
       rewriter.replaceOp(toCtrl, fromCtrl.getCtrlbit());
       return success();
     }
@@ -120,7 +121,7 @@ public:
 };
 } // namespace
 
-#define WRAPPER(OpClass) MakeControl<quake::OpClass>
+#define WRAPPER(OpClass) MakeControl<cudaq::quake::OpClass>
 #define WRAPPER_GATE_OPS GATE_OPS(WRAPPER)
 
 namespace {

--- a/lib/Optimizer/Transforms/PySynthCallableBlockArgs.cpp
+++ b/lib/Optimizer/Transforms/PySynthCallableBlockArgs.cpp
@@ -94,18 +94,18 @@ public:
   }
 };
 
-class UpdateQuakeApplyOp : public OpConversionPattern<quake::ApplyOp> {
+class UpdateQuakeApplyOp : public OpConversionPattern<cudaq::quake::ApplyOp> {
 public:
   const SmallVector<StringRef> &names;
   llvm::DenseMap<std::size_t, std::size_t> &blockArgToNameMap;
   UpdateQuakeApplyOp(MLIRContext *ctx,
                      const SmallVector<StringRef> &functionNames,
                      llvm::DenseMap<std::size_t, std::size_t> &map)
-      : OpConversionPattern<quake::ApplyOp>(ctx), names(functionNames),
+      : OpConversionPattern<cudaq::quake::ApplyOp>(ctx), names(functionNames),
         blockArgToNameMap(map) {}
 
   LogicalResult
-  matchAndRewrite(quake::ApplyOp op, OpAdaptor adaptor,
+  matchAndRewrite(cudaq::quake::ApplyOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto callableOperand = adaptor.getOperands().front();
     auto module = op->getParentOp()->getParentOfType<ModuleOp>();
@@ -118,7 +118,7 @@ public:
       if (!replacement)
         return failure();
 
-      rewriter.replaceOpWithNewOp<quake::ApplyOp>(
+      rewriter.replaceOpWithNewOp<cudaq::quake::ApplyOp>(
           op, TypeRange{}, FlatSymbolRefAttr::get(ctx, replacement.getName()),
           adaptor.getIsAdj(), adaptor.getControls(), adaptor.getActuals());
       return success();
@@ -172,8 +172,8 @@ public:
     ConversionTarget target(*ctx);
     // We should remove these operations
     target.addIllegalOp<func::CallIndirectOp>();
-    target.addDynamicallyLegalOp<quake::ApplyOp>([](Operation *op) {
-      if (auto apply = dyn_cast<quake::ApplyOp>(op)) {
+    target.addDynamicallyLegalOp<cudaq::quake::ApplyOp>([](Operation *op) {
+      if (auto apply = dyn_cast<cudaq::quake::ApplyOp>(op)) {
         if (isa<BlockArgument>(apply.getOperand(0))) {
           return false;
         }

--- a/lib/Optimizer/Transforms/QuakePropagateMetadata.cpp
+++ b/lib/Optimizer/Transforms/QuakePropagateMetadata.cpp
@@ -39,7 +39,10 @@ public:
     ModuleOp moduleOp = getOperation();
     /// NOTE: If the module has an occurrence of `quake.apply` then the step to
     /// build call graph fails. Hence, we skip the pass in such cases.
-    if (moduleOp.walk([](quake::ApplyOp op) { return WalkResult::interrupt(); })
+    if (moduleOp
+            .walk([](cudaq::quake::ApplyOp op) {
+              return WalkResult::interrupt();
+            })
             .wasInterrupted()) {
       LLVM_DEBUG(
           llvm::dbgs()

--- a/lib/Optimizer/Transforms/QuakeSimplify.cpp
+++ b/lib/Optimizer/Transforms/QuakeSimplify.cpp
@@ -37,7 +37,7 @@ public:
 
     auto targets = qop.getTargets();
     if (targets.size() != 1 ||
-        !quake::isQuantumValueType(targets[0].getType())) {
+        !cudaq::quake::isQuantumValueType(targets[0].getType())) {
       LLVM_DEBUG(llvm::dbgs() << "operation must have 1 target\n");
       return failure();
     }
@@ -60,8 +60,8 @@ public:
     }
     Value prevTrgt = prevTrgs[0];
     auto last = prev.getNumResults() - 1;
-    if (!isa<quake::WireType>(trgt.getType()) ||
-        !isa<quake::WireType>(prevTrgt.getType()) ||
+    if (!isa<cudaq::quake::WireType>(trgt.getType()) ||
+        !isa<cudaq::quake::WireType>(prevTrgt.getType()) ||
         trgt != prev.getResult(last)) {
       LLVM_DEBUG(llvm::dbgs() << "target wire must thread\n");
       return failure();
@@ -77,13 +77,14 @@ public:
     for (auto iter : llvm::enumerate(llvm::zip(controls, prevCtls))) {
       auto n = iter.index();
       auto [c, pc] = iter.value();
-      if (isa<quake::ControlType>(c.getType()))
-        if (!isa<quake::ControlType>(pc.getType()) || c != pc) {
+      if (isa<cudaq::quake::ControlType>(c.getType()))
+        if (!isa<cudaq::quake::ControlType>(pc.getType()) || c != pc) {
           LLVM_DEBUG(llvm::dbgs() << "control must be the same\n");
           return failure();
         }
-      if (!isa<quake::WireType>(c.getType()) ||
-          !isa<quake::WireType>(pc.getType()) || c != prev.getResult(n)) {
+      if (!isa<cudaq::quake::WireType>(c.getType()) ||
+          !isa<cudaq::quake::WireType>(pc.getType()) ||
+          c != prev.getResult(n)) {
         LLVM_DEBUG(llvm::dbgs() << "control wire must be threaded\n");
         return failure();
       }
@@ -101,32 +102,32 @@ public:
 };
 
 template <>
-class HermitianElimination<quake::SwapOp>
-    : public OpRewritePattern<quake::SwapOp> {
+class HermitianElimination<cudaq::quake::SwapOp>
+    : public OpRewritePattern<cudaq::quake::SwapOp> {
 public:
-  using Base = OpRewritePattern<quake::SwapOp>;
+  using Base = OpRewritePattern<cudaq::quake::SwapOp>;
   using Base::Base;
 
-  LogicalResult matchAndRewrite(quake::SwapOp qop,
+  LogicalResult matchAndRewrite(cudaq::quake::SwapOp qop,
                                 PatternRewriter &rewriter) const override {
     if (qop.getNegatedQubitControls())
       return failure();
 
     auto targets = qop.getTargets();
     if (targets.size() != 2 ||
-        !quake::isQuantumValueType(targets[0].getType()) ||
-        !quake::isQuantumValueType(targets[1].getType())) {
+        !cudaq::quake::isQuantumValueType(targets[0].getType()) ||
+        !cudaq::quake::isQuantumValueType(targets[1].getType())) {
       LLVM_DEBUG(llvm::dbgs() << "operation must have 2 targets\n");
       return failure();
     }
 
     // Check that these are the same swap op back-to-back.
-    auto prev0 = targets[0].template getDefiningOp<quake::SwapOp>();
+    auto prev0 = targets[0].template getDefiningOp<cudaq::quake::SwapOp>();
     if (!prev0) {
       LLVM_DEBUG(llvm::dbgs() << "previous operation 0 must be the same\n");
       return failure();
     }
-    auto prev1 = targets[1].template getDefiningOp<quake::SwapOp>();
+    auto prev1 = targets[1].template getDefiningOp<cudaq::quake::SwapOp>();
     if (!prev1) {
       LLVM_DEBUG(llvm::dbgs() << "previous operation 1 must be the same\n");
       return failure();
@@ -148,10 +149,10 @@ public:
     auto matches = [](Value u0, Value u1, Value d0, Value d1) -> bool {
       return (u0 == d0 && u1 == d1) || (u0 == d1 && u1 == d0);
     };
-    if (!isa<quake::WireType>(targets[0].getType()) ||
-        !isa<quake::WireType>(prevTrgs[0].getType()) ||
-        !isa<quake::WireType>(targets[1].getType()) ||
-        !isa<quake::WireType>(prevTrgs[1].getType()) ||
+    if (!isa<cudaq::quake::WireType>(targets[0].getType()) ||
+        !isa<cudaq::quake::WireType>(prevTrgs[0].getType()) ||
+        !isa<cudaq::quake::WireType>(targets[1].getType()) ||
+        !isa<cudaq::quake::WireType>(prevTrgs[1].getType()) ||
         !matches(targets[0], targets[1], prev0.getResult(last - 1),
                  prev0.getResult(last))) {
       LLVM_DEBUG(llvm::dbgs() << "target wires must thread\n");
@@ -168,13 +169,14 @@ public:
     for (auto iter : llvm::enumerate(llvm::zip(controls, prevCtls))) {
       auto n = iter.index();
       auto [c, pc] = iter.value();
-      if (isa<quake::ControlType>(c.getType()))
-        if (!isa<quake::ControlType>(pc.getType()) || c != pc) {
+      if (isa<cudaq::quake::ControlType>(c.getType()))
+        if (!isa<cudaq::quake::ControlType>(pc.getType()) || c != pc) {
           LLVM_DEBUG(llvm::dbgs() << "control must be the same\n");
           return failure();
         }
-      if (!isa<quake::WireType>(c.getType()) ||
-          !isa<quake::WireType>(pc.getType()) || c != prev0.getResult(n)) {
+      if (!isa<cudaq::quake::WireType>(c.getType()) ||
+          !isa<cudaq::quake::WireType>(pc.getType()) ||
+          c != prev0.getResult(n)) {
         LLVM_DEBUG(llvm::dbgs() << "control wire must be threaded\n");
         return failure();
       }
@@ -204,7 +206,7 @@ public:
 
     auto targets = qop.getTargets();
     if (targets.size() != 1 ||
-        !quake::isQuantumValueType(targets[0].getType())) {
+        !cudaq::quake::isQuantumValueType(targets[0].getType())) {
       LLVM_DEBUG(llvm::dbgs() << "must have 1 target\n");
       return failure();
     }
@@ -228,8 +230,8 @@ public:
     }
     Value prevTrgt = prevTrgs[0];
     auto last = prev.getNumResults() - 1;
-    if (!isa<quake::WireType>(trgt.getType()) ||
-        !isa<quake::WireType>(prevTrgt.getType()) ||
+    if (!isa<cudaq::quake::WireType>(trgt.getType()) ||
+        !isa<cudaq::quake::WireType>(prevTrgt.getType()) ||
         trgt != prev.getResult(last)) {
       LLVM_DEBUG(llvm::dbgs() << "target wire must thread\n" << qop << '\n');
       return failure();
@@ -245,13 +247,14 @@ public:
     for (auto iter : llvm::enumerate(llvm::zip(controls, prevCtls))) {
       auto n = iter.index();
       auto [c, pc] = iter.value();
-      if (isa<quake::ControlType>(c.getType()))
-        if (!isa<quake::ControlType>(pc.getType()) || c != pc) {
+      if (isa<cudaq::quake::ControlType>(c.getType()))
+        if (!isa<cudaq::quake::ControlType>(pc.getType()) || c != pc) {
           LLVM_DEBUG(llvm::dbgs() << "control must be the same\n");
           return failure();
         }
-      if (!isa<quake::WireType>(c.getType()) ||
-          !isa<quake::WireType>(pc.getType()) || c != prev.getResult(n)) {
+      if (!isa<cudaq::quake::WireType>(c.getType()) ||
+          !isa<cudaq::quake::WireType>(pc.getType()) ||
+          c != prev.getResult(n)) {
         LLVM_DEBUG(llvm::dbgs() << "control must be threaded\n");
         return failure();
       }
@@ -295,25 +298,25 @@ public:
 };
 
 // Z = SS
-class DoubleSOp : public OpRewritePattern<quake::SOp> {
+class DoubleSOp : public OpRewritePattern<cudaq::quake::SOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::SOp qop,
+  LogicalResult matchAndRewrite(cudaq::quake::SOp qop,
                                 PatternRewriter &rewriter) const override {
     if (qop.getNegatedQubitControls())
       return failure();
 
     auto targets = qop.getTargets();
     if (targets.size() != 1 ||
-        !quake::isQuantumValueType(targets[0].getType())) {
+        !cudaq::quake::isQuantumValueType(targets[0].getType())) {
       LLVM_DEBUG(llvm::dbgs() << "operation must have 1 target\n");
       return failure();
     }
     Value trgt = targets[0];
 
     // Check that these are the same Hermitian op back-to-back.
-    auto prev = targets[0].template getDefiningOp<quake::SOp>();
+    auto prev = targets[0].template getDefiningOp<cudaq::quake::SOp>();
     if (!prev) {
       LLVM_DEBUG(llvm::dbgs() << "previous operation must be the same\n");
       return failure();
@@ -329,8 +332,8 @@ public:
     }
     Value prevTrgt = prevTrgs[0];
     auto last = prev.getNumResults() - 1;
-    if (!isa<quake::WireType>(trgt.getType()) ||
-        !isa<quake::WireType>(prevTrgt.getType()) ||
+    if (!isa<cudaq::quake::WireType>(trgt.getType()) ||
+        !isa<cudaq::quake::WireType>(prevTrgt.getType()) ||
         trgt != prev.getResult(last)) {
       LLVM_DEBUG(llvm::dbgs() << "target wire must thread\n");
       return failure();
@@ -346,13 +349,14 @@ public:
     for (auto iter : llvm::enumerate(llvm::zip(controls, prevCtls))) {
       auto n = iter.index();
       auto [c, pc] = iter.value();
-      if (isa<quake::ControlType>(c.getType()))
-        if (!isa<quake::ControlType>(pc.getType()) || c != pc) {
+      if (isa<cudaq::quake::ControlType>(c.getType()))
+        if (!isa<cudaq::quake::ControlType>(pc.getType()) || c != pc) {
           LLVM_DEBUG(llvm::dbgs() << "control must be the same\n");
           return failure();
         }
-      if (!isa<quake::WireType>(c.getType()) ||
-          !isa<quake::WireType>(pc.getType()) || c != prev.getResult(n)) {
+      if (!isa<cudaq::quake::WireType>(c.getType()) ||
+          !isa<cudaq::quake::WireType>(pc.getType()) ||
+          c != prev.getResult(n)) {
         LLVM_DEBUG(llvm::dbgs() << "control wire must be threaded\n");
         return failure();
       }
@@ -360,34 +364,34 @@ public:
 
     // Rewrite the back-to-back S gates.
     LLVM_DEBUG(llvm::dbgs() << "replaced: " << qop << '\n' << prev << '\n');
-    rewriter.replaceOpWithNewOp<quake::ZOp>(qop, qop.getResultTypes(),
-                                            UnitAttr{}, ValueRange{}, prevCtls,
-                                            prevTrgs, DenseBoolArrayAttr{});
+    rewriter.replaceOpWithNewOp<cudaq::quake::ZOp>(
+        qop, qop.getResultTypes(), UnitAttr{}, ValueRange{}, prevCtls, prevTrgs,
+        DenseBoolArrayAttr{});
     rewriter.eraseOp(prev);
     return success();
   }
 };
 
 // S = TT
-class DoubleTOp : public OpRewritePattern<quake::TOp> {
+class DoubleTOp : public OpRewritePattern<cudaq::quake::TOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::TOp qop,
+  LogicalResult matchAndRewrite(cudaq::quake::TOp qop,
                                 PatternRewriter &rewriter) const override {
     if (qop.getNegatedQubitControls())
       return failure();
 
     auto targets = qop.getTargets();
     if (targets.size() != 1 ||
-        !quake::isQuantumValueType(targets[0].getType())) {
+        !cudaq::quake::isQuantumValueType(targets[0].getType())) {
       LLVM_DEBUG(llvm::dbgs() << "operation must have 1 target\n");
       return failure();
     }
     Value trgt = targets[0];
 
     // Check that these are the same Hermitian op back-to-back.
-    auto prev = targets[0].template getDefiningOp<quake::TOp>();
+    auto prev = targets[0].template getDefiningOp<cudaq::quake::TOp>();
     if (!prev) {
       LLVM_DEBUG(llvm::dbgs() << "previous operation must be T\n");
       return failure();
@@ -403,8 +407,8 @@ public:
     }
     Value prevTrgt = prevTrgs[0];
     auto last = prev.getNumResults() - 1;
-    if (!isa<quake::WireType>(trgt.getType()) ||
-        !isa<quake::WireType>(prevTrgt.getType()) ||
+    if (!isa<cudaq::quake::WireType>(trgt.getType()) ||
+        !isa<cudaq::quake::WireType>(prevTrgt.getType()) ||
         trgt != prev.getResult(last)) {
       LLVM_DEBUG(llvm::dbgs() << "target wire must thread\n");
       return failure();
@@ -420,13 +424,14 @@ public:
     for (auto iter : llvm::enumerate(llvm::zip(controls, prevCtls))) {
       auto n = iter.index();
       auto [c, pc] = iter.value();
-      if (isa<quake::ControlType>(c.getType()))
-        if (!isa<quake::ControlType>(pc.getType()) || c != pc) {
+      if (isa<cudaq::quake::ControlType>(c.getType()))
+        if (!isa<cudaq::quake::ControlType>(pc.getType()) || c != pc) {
           LLVM_DEBUG(llvm::dbgs() << "control must be the same\n");
           return failure();
         }
-      if (!isa<quake::WireType>(c.getType()) ||
-          !isa<quake::WireType>(pc.getType()) || c != prev.getResult(n)) {
+      if (!isa<cudaq::quake::WireType>(c.getType()) ||
+          !isa<cudaq::quake::WireType>(pc.getType()) ||
+          c != prev.getResult(n)) {
         LLVM_DEBUG(llvm::dbgs() << "control wire must be threaded\n");
         return failure();
       }
@@ -434,39 +439,40 @@ public:
 
     // Rewrite the back-to-back S gates.
     LLVM_DEBUG(llvm::dbgs() << "replaced: " << qop << '\n' << prev << '\n');
-    rewriter.replaceOpWithNewOp<quake::SOp>(qop, qop.getResultTypes(),
-                                            UnitAttr{}, ValueRange{}, prevCtls,
-                                            prevTrgs, DenseBoolArrayAttr{});
+    rewriter.replaceOpWithNewOp<cudaq::quake::SOp>(
+        qop, qop.getResultTypes(), UnitAttr{}, ValueRange{}, prevCtls, prevTrgs,
+        DenseBoolArrayAttr{});
     rewriter.eraseOp(prev);
     return success();
   }
 };
 
 // S = YSX
-class ReduceYSX : public OpRewritePattern<quake::XOp> {
+class ReduceYSX : public OpRewritePattern<cudaq::quake::XOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::XOp qop,
+  LogicalResult matchAndRewrite(cudaq::quake::XOp qop,
                                 PatternRewriter &rewriter) const override {
     if (qop.getNegatedQubitControls())
       return failure();
 
     auto targets = qop.getTargets();
     if (targets.size() != 1 ||
-        !quake::isQuantumValueType(targets[0].getType())) {
+        !cudaq::quake::isQuantumValueType(targets[0].getType())) {
       LLVM_DEBUG(llvm::dbgs() << "operation must have 1 target\n");
       return failure();
     }
     Value trgt = targets[0];
 
     // Check that these are the same Hermitian op back-to-back.
-    auto prev0 = targets[0].template getDefiningOp<quake::SOp>();
+    auto prev0 = targets[0].template getDefiningOp<cudaq::quake::SOp>();
     if (!prev0) {
       LLVM_DEBUG(llvm::dbgs() << "previous operation must be S\n");
       return failure();
     }
-    auto prev = prev0.getTargets()[0].template getDefiningOp<quake::YOp>();
+    auto prev =
+        prev0.getTargets()[0].template getDefiningOp<cudaq::quake::YOp>();
     if (!prev) {
       LLVM_DEBUG(llvm::dbgs() << "previous previous operation must be Y\n");
       return failure();
@@ -485,9 +491,9 @@ public:
     Value prevTrgt = prevTrgs[0];
     auto last0 = prev0.getNumResults() - 1;
     auto last = prev.getNumResults() - 1;
-    if (!isa<quake::WireType>(trgt.getType()) ||
-        !isa<quake::WireType>(prev0Trgt.getType()) ||
-        !isa<quake::WireType>(prevTrgt.getType()) ||
+    if (!isa<cudaq::quake::WireType>(trgt.getType()) ||
+        !isa<cudaq::quake::WireType>(prev0Trgt.getType()) ||
+        !isa<cudaq::quake::WireType>(prevTrgt.getType()) ||
         trgt != prev0.getResult(last0) || prev0Trgt != prev.getResult(last)) {
       LLVM_DEBUG(llvm::dbgs() << "target wire must thread\n");
       return failure();
@@ -506,15 +512,16 @@ public:
          llvm::enumerate(llvm::zip(controls, prev0Ctls, prevCtls))) {
       auto n = iter.index();
       auto [c, p0c, pc] = iter.value();
-      if (isa<quake::ControlType>(c.getType()))
-        if (!isa<quake::ControlType>(pc.getType()) || c != pc || p0c != pc) {
+      if (isa<cudaq::quake::ControlType>(c.getType()))
+        if (!isa<cudaq::quake::ControlType>(pc.getType()) || c != pc ||
+            p0c != pc) {
           LLVM_DEBUG(llvm::dbgs() << "control must be the same\n");
           return failure();
         }
-      if (!isa<quake::WireType>(c.getType()) ||
-          !isa<quake::WireType>(pc.getType()) ||
-          !isa<quake::WireType>(pc.getType()) || c != prev0.getResult(n) ||
-          p0c != prev.getResult(n)) {
+      if (!isa<cudaq::quake::WireType>(c.getType()) ||
+          !isa<cudaq::quake::WireType>(pc.getType()) ||
+          !isa<cudaq::quake::WireType>(pc.getType()) ||
+          c != prev0.getResult(n) || p0c != prev.getResult(n)) {
         LLVM_DEBUG(llvm::dbgs() << "control wire must be threaded\n");
         return failure();
       }
@@ -524,9 +531,9 @@ public:
     LLVM_DEBUG(llvm::dbgs() << "replaced: " << qop << '\n'
                             << prev0 << '\n'
                             << prev << '\n');
-    rewriter.replaceOpWithNewOp<quake::SOp>(qop, qop.getResultTypes(),
-                                            UnitAttr{}, ValueRange{}, prevCtls,
-                                            prevTrgs, DenseBoolArrayAttr{});
+    rewriter.replaceOpWithNewOp<cudaq::quake::SOp>(
+        qop, qop.getResultTypes(), UnitAttr{}, ValueRange{}, prevCtls, prevTrgs,
+        DenseBoolArrayAttr{});
     rewriter.eraseOp(prev0);
     rewriter.eraseOp(prev);
     return success();
@@ -543,13 +550,17 @@ public:
     auto *ctx = &getContext();
     auto *op = getOperation();
     RewritePatternSet patterns(ctx);
-    patterns.insert<
-        DoubleSOp, DoubleTOp, ReduceYSX, HermitianElimination<quake::HOp>,
-        HermitianElimination<quake::SwapOp>, HermitianElimination<quake::XOp>,
-        HermitianElimination<quake::YOp>, HermitianElimination<quake::ZOp>,
-        RotationCombine<quake::R1Op>, RotationCombine<quake::RxOp>,
-        RotationCombine<quake::RyOp>, RotationCombine<quake::RzOp>,
-        RotationCombine<quake::PhasedRxOp>>(ctx);
+    patterns.insert<DoubleSOp, DoubleTOp, ReduceYSX,
+                    HermitianElimination<cudaq::quake::HOp>,
+                    HermitianElimination<cudaq::quake::SwapOp>,
+                    HermitianElimination<cudaq::quake::XOp>,
+                    HermitianElimination<cudaq::quake::YOp>,
+                    HermitianElimination<cudaq::quake::ZOp>,
+                    RotationCombine<cudaq::quake::R1Op>,
+                    RotationCombine<cudaq::quake::RxOp>,
+                    RotationCombine<cudaq::quake::RyOp>,
+                    RotationCombine<cudaq::quake::RzOp>,
+                    RotationCombine<cudaq::quake::PhasedRxOp>>(ctx);
     if (failed(applyPatternsGreedily(op, std::move(patterns))))
       signalPassFailure();
   }

--- a/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
+++ b/lib/Optimizer/Transforms/QuakeSynthesizer.cpp
@@ -111,7 +111,7 @@ static bool hasInitStateUse(BlockArgument argument) {
   for (auto *argUser : argument.getUsers())
     if (auto stdvecDataOp = dyn_cast<cudaq::cc::StdvecDataOp>(argUser))
       for (auto *dataUser : stdvecDataOp->getUsers())
-        if (isa<quake::InitializeStateOp>(dataUser))
+        if (isa<cudaq::quake::InitializeStateOp>(dataUser))
           return true;
   return false;
 }
@@ -543,7 +543,7 @@ public:
       }
 
       if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(type)) {
-        if (isa<quake::StateType>(ptrTy.getElementType())) {
+        if (isa<cudaq::quake::StateType>(ptrTy.getElementType())) {
           // Special case of a `cudaq::state*` which must be in the same address
           // space. This references a container to a set of simulation
           // amplitudes.
@@ -554,7 +554,8 @@ public:
                   Value rawPtr = arith::ConstantIntOp::create(
                       builder, loc, reinterpret_cast<std::intptr_t>(*concrete),
                       sizeof(void *) * 8);
-                  auto stateTy = quake::StateType::get(builder.getContext());
+                  auto stateTy =
+                      cudaq::quake::StateType::get(builder.getContext());
                   return cudaq::cc::CastOp::create(
                       builder, loc, cudaq::cc::PointerType::get(stateTy),
                       rawPtr);

--- a/lib/Optimizer/Transforms/RefToVeqAlloc.cpp
+++ b/lib/Optimizer/Transforms/RefToVeqAlloc.cpp
@@ -19,7 +19,7 @@ namespace cudaq::opt {
 using namespace mlir;
 
 namespace {
-struct AllocaPat : public OpRewritePattern<quake::AllocaOp> {
+struct AllocaPat : public OpRewritePattern<cudaq::quake::AllocaOp> {
   using OpRewritePattern::OpRewritePattern;
 
   // Replace:
@@ -27,12 +27,14 @@ struct AllocaPat : public OpRewritePattern<quake::AllocaOp> {
   // with:
   //   %0 = quake.alloca !quake.veq<1>
   //   %1 = quake.extract_ref %0[0] : (!quake.veq<1>) -> !quake.ref
-  LogicalResult matchAndRewrite(quake::AllocaOp alloc,
+  LogicalResult matchAndRewrite(cudaq::quake::AllocaOp alloc,
                                 PatternRewriter &rewriter) const override {
-    if (isa<quake::VeqType>(alloc.getType()))
+    if (isa<cudaq::quake::VeqType>(alloc.getType()))
       return failure();
-    Value newAlloc = quake::AllocaOp::create(rewriter, alloc.getLoc(), 1u);
-    rewriter.replaceOpWithNewOp<quake::ExtractRefOp>(alloc, newAlloc, 0u);
+    Value newAlloc =
+        cudaq::quake::AllocaOp::create(rewriter, alloc.getLoc(), 1u);
+    rewriter.replaceOpWithNewOp<cudaq::quake::ExtractRefOp>(alloc, newAlloc,
+                                                            0u);
     return success();
   }
 };

--- a/lib/Optimizer/Transforms/RegToMem.cpp
+++ b/lib/Optimizer/Transforms/RegToMem.cpp
@@ -26,7 +26,7 @@ namespace cudaq::opt {
 
 using namespace mlir;
 
-#define RAW(X) quake::X
+#define RAW(X) cudaq::quake::X
 #define RAW_MEASURE_OPS MEASURE_OPS(RAW)
 #define RAW_GATE_OPS GATE_OPS(RAW)
 #define RAW_QUANTUM_OPS QUANTUM_OPS(RAW)
@@ -73,7 +73,9 @@ struct RegToMemAnalysis {
 
   ArrayRef<Operation *> getWires() const { return theWires; }
 
-  ArrayRef<quake::UnwrapOp> getUnwrapReferences() const { return unwrapRefs; }
+  ArrayRef<cudaq::quake::UnwrapOp> getUnwrapReferences() const {
+    return unwrapRefs;
+  }
 
 private:
   void *toOpaque(Value v) const { return v.getAsOpaquePointer(); }
@@ -95,14 +97,14 @@ private:
   }
 
   void insertToEqClass(Value v) {
-    if (quake::isLinearValueForm(v))
+    if (cudaq::quake::isLinearValueForm(v))
       eqClasses.insert(toOpaque(v));
     insertBlockArgumentToEqClass(v);
   }
 
   /// Is this a quake.unwrap that is in our definitions set?
   bool isUnwrapRef(Value v) {
-    if (auto unwrap = v.getDefiningOp<quake::UnwrapOp>())
+    if (auto unwrap = v.getDefiningOp<cudaq::quake::UnwrapOp>())
       return std::find(unwrapRefs.begin(), unwrapRefs.end(), unwrap) !=
              unwrapRefs.end();
     return false;
@@ -110,7 +112,7 @@ private:
 
   void insertToEqClass(Value v, Value u) {
     LLVM_DEBUG(llvm::dbgs() << "add eqv of " << v << " and " << u << "\n");
-    if (quake::isLinearValueForm(v) || isUnwrapRef(v))
+    if (cudaq::quake::isLinearValueForm(v) || isUnwrapRef(v))
       eqClasses.unionSets(toOpaque(v), toOpaque(u));
     insertBlockArgumentToEqClass(v);
   }
@@ -119,7 +121,7 @@ private:
   // that we count them correctly.
   void collectBorrowWires(func::FuncOp func) {
     DenseMap<StringRef, DenseMap<std::int32_t, Value>> uniqBorrows;
-    func.walk([&](quake::BorrowWireOp borrow) {
+    func.walk([&](cudaq::quake::BorrowWireOp borrow) {
       LLVM_DEBUG(llvm::dbgs() << "adding borrow : " << borrow << '\n');
       theWires.push_back(borrow.getOperation());
       auto iter = uniqBorrows.find(borrow.getSetName());
@@ -146,19 +148,19 @@ private:
   SmallVector<Value> collectLinearValues(A &&vals) {
     SmallVector<Value> result;
     for (Value v : vals)
-      if (quake::isLinearType(v.getType()))
+      if (cudaq::quake::isLinearType(v.getType()))
         result.push_back(v);
     return result;
   }
   void performAnalysis(func::FuncOp func) {
     collectBorrowWires(func);
     func.walk([&](Operation *op) {
-      if (auto nwire = dyn_cast<quake::NullWireOp>(op)) {
+      if (auto nwire = dyn_cast<cudaq::quake::NullWireOp>(op)) {
         LLVM_DEBUG(llvm::dbgs() << "adding |0> : " << nwire << '\n');
         theWires.push_back(nwire.getOperation());
         eqClasses.insert(toOpaque(nwire));
         ++cardinality;
-      } else if (auto unwrap = dyn_cast<quake::UnwrapOp>(op)) {
+      } else if (auto unwrap = dyn_cast<cudaq::quake::UnwrapOp>(op)) {
         LLVM_DEBUG(llvm::dbgs() << "adding unwrap: " << unwrap << '\n');
         unwrapRefs.push_back(unwrap);
         eqClasses.insert(toOpaque(unwrap));
@@ -171,10 +173,10 @@ private:
         for (auto [t, r] : llvm::zip(wireOpnds, op->getResults().drop_front()))
           insertToEqClass(t, r);
       } else if (isa<RAW_GATE_OPS>(op)) {
-        auto gate = cast<quake::OperatorInterface>(op);
+        auto gate = cast<cudaq::quake::OperatorInterface>(op);
         // Check that the IR is not in the pruned control form.
         if (llvm::any_of(gate.getControls(), [](Value v) {
-              return isa<quake::ControlType>(v.getType());
+              return isa<cudaq::quake::ControlType>(v.getType());
             })) {
           op->emitError("must use linear-ctrl-form before regtomem");
           analysisFailed = true;
@@ -187,14 +189,14 @@ private:
         for (auto [t, r] : llvm::zip(
                  wireTargs, op->getResults().drop_front(wireCtrls.size())))
           insertToEqClass(t, r);
-      } else if (auto reset = dyn_cast<quake::ResetOp>(op)) {
+      } else if (auto reset = dyn_cast<cudaq::quake::ResetOp>(op)) {
         auto wireTargs =
             collectLinearValues(ArrayRef<Value>{reset.getTargets()});
         for (auto [t, r] : llvm::zip(wireTargs, reset.getResults()))
           insertToEqClass(t, r);
-      } else if (auto sink = dyn_cast<quake::SinkOp>(op)) {
+      } else if (auto sink = dyn_cast<cudaq::quake::SinkOp>(op)) {
         insertToEqClass(sink.getTarget());
-      } else if (auto ret = dyn_cast<quake::ReturnWireOp>(op)) {
+      } else if (auto ret = dyn_cast<cudaq::quake::ReturnWireOp>(op)) {
         insertToEqClass(ret.getTarget());
       } else if (auto ccif = dyn_cast<cudaq::cc::IfOp>(op)) {
         if (!ccif.getLinearArgs().empty()) {
@@ -213,11 +215,11 @@ private:
         auto *parent = cont->getParentOp();
         if (auto ccif = dyn_cast<cudaq::cc::IfOp>(parent)) {
           for (auto iter : llvm::enumerate(cont.getOperands()))
-            if (quake::isLinearType(iter.value().getType()))
+            if (cudaq::quake::isLinearType(iter.value().getType()))
               insertToEqClass(ccif.getResult(iter.index()), iter.value());
         } else if (isa<cudaq::cc::ScopeOp>(parent)) {
           if (llvm::any_of(cont.getOperands(), [](Value v) {
-                return quake::isQuantumValueType(v.getType());
+                return cudaq::quake::isQuantumValueType(v.getType());
               })) {
             analysisFailed = true;
             return;
@@ -234,7 +236,7 @@ private:
           for (auto [so, fo] :
                llvm::zip(branch->getSuccessor(i)->getArguments(),
                          succOperands.getForwardedOperands()))
-            if (quake::isLinearType(so.getType()))
+            if (cudaq::quake::isLinearType(so.getType()))
               insertToEqClass(so, fo);
         }
       }
@@ -268,7 +270,7 @@ private:
   }
 
   SmallVector<Operation *> theWires;
-  SmallVector<quake::UnwrapOp> unwrapRefs;
+  SmallVector<cudaq::quake::UnwrapOp> unwrapRefs;
   llvm::EquivalenceClasses<void *> eqClasses;
   DenseMap<void *, unsigned> setIds;
   unsigned cardinality = 0;
@@ -289,7 +291,7 @@ public:
     auto findLookupValue = [&](Value v) -> Value {
       if (auto id = analysis.idFromValue(v))
         return allocas[*id];
-      if (auto u = v.template getDefiningOp<quake::UnwrapOp>())
+      if (auto u = v.template getDefiningOp<cudaq::quake::UnwrapOp>())
         return u.getRefValue();
       return v;
     };
@@ -301,11 +303,11 @@ public:
     };
     auto eraseWrapUsers = [&](auto op) {
       for (auto *usr : op->getUsers())
-        if (isa<quake::WrapOp>(usr))
+        if (isa<cudaq::quake::WrapOp>(usr))
           rewriter.eraseOp(usr);
     };
 
-    if constexpr (quake::isMeasure<OP>) {
+    if constexpr (cudaq::quake::isMeasure<OP>) {
       auto args = collect(op.getOperands());
       auto nameAttr = op.getRegisterNameAttr();
       eraseWrapUsers(op);
@@ -314,16 +316,16 @@ public:
                      args, nameAttr);
       op.getResult(0).replaceAllUsesWith(newOp.getResult(0));
       rewriter.eraseOp(op);
-    } else if constexpr (std::is_same_v<OP, quake::ResetOp>) {
+    } else if constexpr (std::is_same_v<OP, cudaq::quake::ResetOp>) {
       // Reset is a special case.
       auto targ = findLookupValue(op.getTargets());
       eraseWrapUsers(op);
-      quake::ResetOp::create(rewriter, loc, TypeRange{}, targ);
+      cudaq::quake::ResetOp::create(rewriter, loc, TypeRange{}, targ);
       rewriter.eraseOp(op);
-    } else if constexpr (std::is_same_v<OP, quake::SinkOp>) {
+    } else if constexpr (std::is_same_v<OP, cudaq::quake::SinkOp>) {
       auto targ = findLookupValue(op.getTarget());
-      rewriter.replaceOpWithNewOp<quake::DeallocOp>(op, targ);
-    } else if constexpr (std::is_same_v<OP, quake::ReturnWireOp>) {
+      rewriter.replaceOpWithNewOp<cudaq::quake::DeallocOp>(op, targ);
+    } else if constexpr (std::is_same_v<OP, cudaq::quake::ReturnWireOp>) {
       rewriter.eraseOp(op);
     } else {
       auto ctrls = collect(op.getControls());
@@ -348,7 +350,7 @@ struct EraseWiresBranch : public OpRewritePattern<cf::BranchOp> {
                                 PatternRewriter &rewriter) const override {
     SmallVector<Value> newOperands;
     for (auto v : branch.getDestOperands()) {
-      if (quake::isLinearType(v.getType()))
+      if (cudaq::quake::isLinearType(v.getType()))
         blocks.insert(branch.getDest());
       else
         newOperands.push_back(v);
@@ -369,14 +371,14 @@ struct EraseWiresCondBranch : public OpRewritePattern<cf::CondBranchOp> {
                                 PatternRewriter &rewriter) const override {
     SmallVector<Value> newTrueOperands;
     for (auto v : branch.getTrueDestOperands()) {
-      if (quake::isLinearType(v.getType()))
+      if (cudaq::quake::isLinearType(v.getType()))
         blocks.insert(branch.getTrueDest());
       else
         newTrueOperands.push_back(v);
     }
     SmallVector<Value> newFalseOperands;
     for (auto v : branch.getFalseDestOperands()) {
-      if (quake::isLinearType(v.getType()))
+      if (cudaq::quake::isLinearType(v.getType()))
         blocks.insert(branch.getFalseDest());
       else
         newFalseOperands.push_back(v);
@@ -402,13 +404,13 @@ struct EraseWiresIf : public OpRewritePattern<cudaq::cc::IfOp> {
   LogicalResult matchAndRewrite(cudaq::cc::IfOp ifOp,
                                 PatternRewriter &rewriter) const override {
     auto *ctx = rewriter.getContext();
-    auto wireTy = quake::WireType::get(ctx);
+    auto wireTy = cudaq::quake::WireType::get(ctx);
 
     // Create a new if operation, pruning the result type and discarding the
     // operands of the original if operation.
     SmallVector<Type> newIfTy;
     for (auto ty : ifOp.getResultTypes())
-      if (!quake::isLinearType(ty))
+      if (!cudaq::quake::isLinearType(ty))
         newIfTy.push_back(ty);
     auto origThenArgs = ifOp.getThenRegion().front().getArguments();
     auto origElseArgs = ifOp.getElseRegion().front().getArguments();
@@ -434,8 +436,8 @@ struct EraseWiresIf : public OpRewritePattern<cudaq::cc::IfOp> {
         for (auto [arg, from] : llvm::zip(entry.getArguments(), origArgs)) {
           auto id = analysis.idFromValue(from);
           assert(id);
-          auto unwrap = quake::UnwrapOp::create(builder, ifOp.getLoc(), wireTy,
-                                                allocas[*id]);
+          auto unwrap = cudaq::quake::UnwrapOp::create(builder, ifOp.getLoc(),
+                                                       wireTy, allocas[*id]);
           arg.replaceAllUsesWith(unwrap);
         }
       }
@@ -446,7 +448,7 @@ struct EraseWiresIf : public OpRewritePattern<cudaq::cc::IfOp> {
             SmallVector<Value> newOpnds;
             OpBuilder builder(cont);
             for (auto v : cont.getOperands())
-              if (!quake::isLinearType(v.getType()))
+              if (!cudaq::quake::isLinearType(v.getType()))
                 newOpnds.push_back(v);
             cudaq::cc::ContinueOp::create(builder, cont.getLoc(), newOpnds);
             rewriter.eraseOp(cont);
@@ -460,11 +462,11 @@ struct EraseWiresIf : public OpRewritePattern<cudaq::cc::IfOp> {
     SmallVector<Value> unwraps;
     unsigned i = 0;
     for (auto v : ifOp.getResults()) {
-      if (quake::isLinearType(v.getType())) {
+      if (cudaq::quake::isLinearType(v.getType())) {
         auto id = analysis.idFromValue(v);
         assert(id);
-        auto unwrap = quake::UnwrapOp::create(rewriter, ifOp.getLoc(), wireTy,
-                                              allocas[*id]);
+        auto unwrap = cudaq::quake::UnwrapOp::create(rewriter, ifOp.getLoc(),
+                                                     wireTy, allocas[*id]);
         unwraps.push_back(unwrap);
       } else {
         unwraps.push_back(newIf.getResult(i++));
@@ -478,7 +480,7 @@ struct EraseWiresIf : public OpRewritePattern<cudaq::cc::IfOp> {
   ArrayRef<Value> allocas;
 };
 
-#define NOWRAP(OP) CollapseWrappers<quake::OP>
+#define NOWRAP(OP) CollapseWrappers<cudaq::quake::OP>
 #define NOWRAP_QUANTUM_OPS QUANTUM_OPS(NOWRAP)
 
 class RegToMemPass : public cudaq::opt::impl::RegToMemBase<RegToMemPass> {
@@ -505,14 +507,14 @@ public:
     SmallVector<Value> borrowAllocas;
     for (auto *nwire : llvm::reverse(analysis.getWires())) {
       OpBuilder builder(ctx);
-      const bool fromWire = isa<quake::BorrowWireOp>(nwire);
+      const bool fromWire = isa<cudaq::quake::BorrowWireOp>(nwire);
       if (fromWire)
         builder.setInsertionPointToStart(&func.getBody().front());
       else
         builder.setInsertionPoint(nwire);
-      auto qrefTy = quake::RefType::get(ctx);
-      Value a =
-          quake::AllocaOp::create(builder, nwire->getLoc(), qrefTy, Value{});
+      auto qrefTy = cudaq::quake::RefType::get(ctx);
+      Value a = cudaq::quake::AllocaOp::create(builder, nwire->getLoc(), qrefTy,
+                                               Value{});
       if (fromWire)
         borrowAllocas.push_back(a);
       if (auto opt = analysis.idFromValue(nwire->getResult(0))) {
@@ -540,22 +542,23 @@ public:
     auto hasNoWires = [](Operation *op) {
       return op->getOperands().empty() ||
              !llvm::any_of(op->getOperands(), [](Value v) {
-               return v && quake::isLinearType(v.getType());
+               return v && cudaq::quake::isLinearType(v.getType());
              });
     };
     BlockSet fixupBlocks;
     RewritePatternSet patterns(ctx);
-    patterns.insert<NOWRAP_QUANTUM_OPS, CollapseWrappers<quake::ResetOp>,
-                    CollapseWrappers<quake::ReturnWireOp>,
-                    CollapseWrappers<quake::SinkOp>, EraseWiresIf>(
+    patterns.insert<NOWRAP_QUANTUM_OPS, CollapseWrappers<cudaq::quake::ResetOp>,
+                    CollapseWrappers<cudaq::quake::ReturnWireOp>,
+                    CollapseWrappers<cudaq::quake::SinkOp>, EraseWiresIf>(
         ctx, analysis, allocas);
     patterns.insert<EraseWiresBranch, EraseWiresCondBranch>(ctx, fixupBlocks);
     ConversionTarget target(*ctx);
-    target.addDynamicallyLegalOp<RAW_QUANTUM_OPS, quake::ResetOp, cf::BranchOp,
-                                 cf::CondBranchOp, cudaq::cc::IfOp>(
-        [&](Operation *op) { return hasNoWires(op); });
-    target.addIllegalOp<quake::SinkOp, quake::ReturnWireOp>();
-    target.addLegalOp<quake::UnwrapOp, quake::DeallocOp>();
+    target
+        .addDynamicallyLegalOp<RAW_QUANTUM_OPS, cudaq::quake::ResetOp,
+                               cf::BranchOp, cf::CondBranchOp, cudaq::cc::IfOp>(
+            [&](Operation *op) { return hasNoWires(op); });
+    target.addIllegalOp<cudaq::quake::SinkOp, cudaq::quake::ReturnWireOp>();
+    target.addLegalOp<cudaq::quake::UnwrapOp, cudaq::quake::DeallocOp>();
     target.addLegalDialect<cudaq::cc::CCDialect>();
     if (failed(applyPartialConversion(func, target, std::move(patterns)))) {
       func.emitError("error converting to memory form\n");
@@ -568,7 +571,8 @@ public:
     // 4) Cleanup all the block arguments, NullWireOp, or UnwrapOp.
     cleanupBlocks(fixupBlocks);
     func.walk([&](Operation *op) -> WalkResult {
-      if (isa<quake::NullWireOp, quake::BorrowWireOp, quake::UnwrapOp>(op) &&
+      if (isa<cudaq::quake::NullWireOp, cudaq::quake::BorrowWireOp,
+              cudaq::quake::UnwrapOp>(op) &&
           op->getUses().empty()) {
         op->erase();
         return WalkResult::skip();
@@ -576,7 +580,7 @@ public:
       if (isa<func::ReturnOp>(op) && !borrowAllocas.empty()) {
         OpBuilder builder(op);
         for (auto v : borrowAllocas)
-          quake::DeallocOp::create(builder, func.getLoc(), v);
+          cudaq::quake::DeallocOp::create(builder, func.getLoc(), v);
       }
       return WalkResult::advance();
     });
@@ -587,7 +591,7 @@ public:
     for (auto *b : blocks) {
       unsigned i = 0;
       for (auto arg : b->getArguments()) {
-        if (quake::isLinearType(arg.getType()))
+        if (cudaq::quake::isLinearType(arg.getType()))
           b->eraseArgument(i);
         else
           ++i;

--- a/lib/Optimizer/Transforms/ReplaceStateWithKernel.cpp
+++ b/lib/Optimizer/Transforms/ReplaceStateWithKernel.cpp
@@ -36,15 +36,16 @@ namespace {
 /// ```
 // clang-format on
 class ReplaceGetNumQubitsPattern
-    : public OpRewritePattern<quake::GetNumberOfQubitsOp> {
+    : public OpRewritePattern<cudaq::quake::GetNumberOfQubitsOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::GetNumberOfQubitsOp numQubits,
+  LogicalResult matchAndRewrite(cudaq::quake::GetNumberOfQubitsOp numQubits,
                                 PatternRewriter &rewriter) const override {
 
     auto stateOp = numQubits.getState();
-    auto materializeState = stateOp.getDefiningOp<quake::MaterializeStateOp>();
+    auto materializeState =
+        stateOp.getDefiningOp<cudaq::quake::MaterializeStateOp>();
     if (!materializeState) {
       LLVM_DEBUG(llvm::dbgs() << "ReplaceStateWithKernel: failed to replace "
                                  "`quake.get_num_qubits`: "
@@ -72,19 +73,19 @@ public:
 /// ```
 // clang-format on
 class ReplaceInitStatePattern
-    : public OpRewritePattern<quake::InitializeStateOp> {
+    : public OpRewritePattern<cudaq::quake::InitializeStateOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::InitializeStateOp initState,
+  LogicalResult matchAndRewrite(cudaq::quake::InitializeStateOp initState,
                                 PatternRewriter &rewriter) const override {
     auto allocaOp = initState.getTargets();
     auto stateOp = initState.getState();
 
     if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(stateOp.getType())) {
-      if (isa<quake::StateType>(ptrTy.getElementType())) {
+      if (isa<cudaq::quake::StateType>(ptrTy.getElementType())) {
         auto materializeState =
-            stateOp.getDefiningOp<quake::MaterializeStateOp>();
+            stateOp.getDefiningOp<cudaq::quake::MaterializeStateOp>();
         if (!materializeState) {
           LLVM_DEBUG(llvm::dbgs() << "ReplaceStateWithKernel: failed to "
                                      "replace `quake.init_state`: "

--- a/lib/Optimizer/Transforms/ResetBeforeReuse.cpp
+++ b/lib/Optimizer/Transforms/ResetBeforeReuse.cpp
@@ -58,7 +58,7 @@ class RegUseTracker {
 
 public:
   RegUseTracker(func::FuncOp func) : domInfo(func) {
-    func->walk([&](quake::AllocaOp qalloc) {
+    func->walk([&](cudaq::quake::AllocaOp qalloc) {
       regToOrderedUsers[qalloc.getResult()] =
           sortUsers(qalloc.getResult().getUsers(), domInfo);
     });
@@ -68,9 +68,10 @@ public:
   // list (regToOrderedUsers) and filtering out any operations that have been
   // erased during rewriting to avoid use-after-free bugs.
   SmallVector<Operation *, 8> getUsers(mlir::Value qreg) const {
-    if (!isa<quake::VeqType>(qreg.getType()))
-      mlir::emitError(qreg.getLoc(),
-                      "Unexpected type used: expected a quake::VeqType.");
+    if (!isa<cudaq::quake::VeqType>(qreg.getType()))
+      mlir::emitError(
+          qreg.getLoc(),
+          "Unexpected type used: expected a cudaq::quake::VeqType.");
 
     auto iter = regToOrderedUsers.find(qreg);
     if (iter == regToOrderedUsers.end())
@@ -92,14 +93,14 @@ public:
   RegUseTracker &operator=(const RegUseTracker &) = delete;
 };
 
-class ResetAfterMeasurePattern : public OpRewritePattern<quake::MzOp> {
+class ResetAfterMeasurePattern : public OpRewritePattern<cudaq::quake::MzOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
   explicit ResetAfterMeasurePattern(MLIRContext *ctx, RegUseTracker &tracker)
       : OpRewritePattern(ctx), tracker(tracker) {}
 
-  LogicalResult matchAndRewrite(quake::MzOp mz,
+  LogicalResult matchAndRewrite(cudaq::quake::MzOp mz,
                                 PatternRewriter &rewriter) const override {
     SmallVector<Operation *> useOps;
     bool modified = false;
@@ -107,31 +108,34 @@ public:
       auto *nextOp = getNextUse(measuredQubit, mz);
       if (nextOp) {
         // If the user is a reset/measure op, nothing to do.
-        if (isa<quake::ResetOp>(nextOp) || isa<quake::MzOp>(nextOp)) {
+        if (isa<cudaq::quake::ResetOp>(nextOp) ||
+            isa<cudaq::quake::MzOp>(nextOp)) {
           continue;
         }
 
         // If this is a dealloc op, nothing to do.
-        if (isa<quake::DeallocOp>(nextOp)) {
+        if (isa<cudaq::quake::DeallocOp>(nextOp)) {
           continue;
         }
 
         // Insert reset
         Location loc = mz->getLoc();
         rewriter.setInsertionPointAfter(mz);
-        quake::ResetOp::create(rewriter, loc, TypeRange{}, measuredQubit);
+        cudaq::quake::ResetOp::create(rewriter, loc, TypeRange{},
+                                      measuredQubit);
         // Insert a conditional X to initialize qubit after reset.
         auto measOut = mz.getMeasOut();
         mlir::Value measBit = [&]() {
           for (auto *out : measOut.getUsers()) {
             // A mz may be accompanied by a store op, find that op.
-            if (auto disc = dyn_cast_if_present<quake::DiscriminateOp>(out)) {
+            if (auto disc =
+                    dyn_cast_if_present<cudaq::quake::DiscriminateOp>(out)) {
               rewriter.setInsertionPointAfter(disc);
               return disc.getResult();
             }
           }
           // No discriminate exists - create the discriminate Op
-          auto discOp = quake::DiscriminateOp::create(
+          auto discOp = cudaq::quake::DiscriminateOp::create(
               rewriter, loc, rewriter.getI1Type(), measOut);
           return discOp.getResult();
         }();
@@ -142,7 +146,7 @@ public:
               auto &bodyBlock = region.front();
               OpBuilder::InsertionGuard guad(opBuilder);
               opBuilder.setInsertionPointToStart(&bodyBlock);
-              quake::XOp::create(opBuilder, location, measuredQubit);
+              cudaq::quake::XOp::create(opBuilder, location, measuredQubit);
               cudaq::cc::ContinueOp::create(opBuilder, location);
             });
         modified = true;
@@ -167,9 +171,9 @@ private:
     }
 
     // No next use is found, check if this is an extracted qubit.
-    if (isa<quake::RefType>(qubit.getType())) {
-      if (auto extractOp =
-              dyn_cast_if_present<quake::ExtractRefOp>(qubit.getDefiningOp())) {
+    if (isa<cudaq::quake::RefType>(qubit.getType())) {
+      if (auto extractOp = dyn_cast_if_present<cudaq::quake::ExtractRefOp>(
+              qubit.getDefiningOp())) {
         LLVM_DEBUG(llvm::dbgs() << "Defining op: " << *extractOp << "\n");
         auto reg = extractOp.getVeq();
         std::optional<int64_t> index =
@@ -178,13 +182,13 @@ private:
                 : cudaq::getIndexValueAsInt(extractOp.getIndex());
         LLVM_DEBUG(llvm::dbgs() << "Reg: " << reg
                                 << "; index = " << index.value_or(-1) << "\n");
-        if (isa<quake::AllocaOp>(reg.getDefiningOp())) {
+        if (isa<cudaq::quake::AllocaOp>(reg.getDefiningOp())) {
           const auto orderedUsers = tracker.getUsers(reg);
           for (auto v : llvm::enumerate(orderedUsers)) {
             if (v.value() != extractOp) {
               // This is another extract.
               auto nextExtractOp =
-                  dyn_cast_if_present<quake::ExtractRefOp>(v.value());
+                  dyn_cast_if_present<cudaq::quake::ExtractRefOp>(v.value());
               if (nextExtractOp) {
                 std::optional<int64_t> nextIndex =
                     nextExtractOp.hasConstantIndex()

--- a/lib/Optimizer/Transforms/ResourceCount.cpp
+++ b/lib/Optimizer/Transforms/ResourceCount.cpp
@@ -20,10 +20,10 @@ cudaq::opt::countResourcesFromIR(ModuleOp module) {
   // out before running the gate-erasing pass manager.
   std::size_t allocated = 0;
   bool unresolvedVeq = false;
-  module.walk([&](quake::AllocaOp alloc) {
-    if (isa<quake::RefType>(alloc.getType())) {
+  module.walk([&](cudaq::quake::AllocaOp alloc) {
+    if (isa<cudaq::quake::RefType>(alloc.getType())) {
       allocated++;
-    } else if (auto size = quake::getVeqSize(alloc.getResult())) {
+    } else if (auto size = cudaq::quake::getVeqSize(alloc.getResult())) {
       allocated += *size;
     } else {
       unresolvedVeq = true;

--- a/lib/Optimizer/Transforms/ResourceCountPreprocess.cpp
+++ b/lib/Optimizer/Transforms/ResourceCountPreprocess.cpp
@@ -42,7 +42,7 @@ struct ResourceCountPreprocessPass
     if (it != qubitIndexMap.end())
       return it->second;
     auto base = nextQubitIndex;
-    if (auto size = quake::getVeqSize(veq))
+    if (auto size = cudaq::quake::getVeqSize(veq))
       nextQubitIndex += *size;
     qubitIndexMap[veq] = base;
     return base;
@@ -51,15 +51,15 @@ struct ResourceCountPreprocessPass
   /// Resolve a quake value to a globally unique qubit index.
   std::optional<std::size_t> resolveQubitIndex(Value v) {
     // extract_ref from a qvector: base offset + local index.
-    if (auto extractRef = v.getDefiningOp<quake::ExtractRefOp>())
+    if (auto extractRef = v.getDefiningOp<cudaq::quake::ExtractRefOp>())
       if (extractRef.hasConstantIndex())
         return getVeqBase(extractRef.getVeq()) + extractRef.getConstantIndex();
     // Wire semantics: concrete physical index from routing.
-    if (auto borrow = v.getDefiningOp<quake::BorrowWireOp>())
+    if (auto borrow = v.getDefiningOp<cudaq::quake::BorrowWireOp>())
       return static_cast<std::size_t>(borrow.getIdentity());
     // Single-qubit alloca: assign a unique index by declaration order.
-    if (v.getDefiningOp<quake::AllocaOp>() &&
-        isa<quake::RefType>(v.getType())) {
+    if (v.getDefiningOp<cudaq::quake::AllocaOp>() &&
+        isa<cudaq::quake::RefType>(v.getType())) {
       auto it = qubitIndexMap.find(v);
       if (it != qubitIndexMap.end())
         return it->second;
@@ -74,13 +74,13 @@ struct ResourceCountPreprocessPass
     if (!isQuakeOperation(op))
       return false;
 
-    auto opi = dyn_cast<quake::OperatorInterface>(op);
+    auto opi = dyn_cast<cudaq::quake::OperatorInterface>(op);
 
     if (!opi)
       return false;
 
     // Measures may affect control flow, don't remove for now
-    if (isa<quake::MeasurementInterface>(op))
+    if (isa<cudaq::quake::MeasurementInterface>(op))
       return false;
 
     auto name = op->getName().stripDialect();
@@ -92,7 +92,8 @@ struct ResourceCountPreprocessPass
     // (e.g. from ConcatOp when Python passes a list of controls).
     auto resolveOperands = [&](auto operands, std::vector<std::size_t> &out) {
       for (auto val : operands) {
-        if (auto concat = val.template getDefiningOp<quake::ConcatOp>()) {
+        if (auto concat =
+                val.template getDefiningOp<cudaq::quake::ConcatOp>()) {
           for (auto operand : concat.getTargets()) {
             if (auto idx = resolveQubitIndex(operand))
               out.push_back(*idx);

--- a/lib/Optimizer/Transforms/SROA.cpp
+++ b/lib/Optimizer/Transforms/SROA.cpp
@@ -143,7 +143,7 @@ public:
       auto *op = worklist.back();
       worklist.pop_back();
       visited.push_back(op);
-      if (isa<quake::InitializeStateOp>(op))
+      if (isa<cudaq::quake::InitializeStateOp>(op))
         return true;
       if (auto cast = dyn_cast<cudaq::cc::CastOp>(op)) {
         if (isa<cudaq::cc::PointerType>(cast.getType())) {

--- a/lib/Optimizer/Transforms/StatePreparation.cpp
+++ b/lib/Optimizer/Transforms/StatePreparation.cpp
@@ -165,7 +165,7 @@ public:
   void applyX(std::size_t control, std::size_t target) {
     auto qubitC = createQubitRef(control);
     auto qubitT = createQubitRef(target);
-    quake::XOp::create(rewriter, loc, qubitC, qubitT);
+    cudaq::quake::XOp::create(rewriter, loc, qubitC, qubitT);
   };
 
 private:
@@ -173,7 +173,7 @@ private:
     if (qubitRefs.contains(index))
       return qubitRefs[index];
 
-    auto ref = quake::ExtractRefOp::create(rewriter, loc, qubits, index);
+    auto ref = cudaq::quake::ExtractRefOp::create(rewriter, loc, qubits, index);
     qubitRefs[index] = ref;
     return ref;
   }
@@ -199,8 +199,8 @@ public:
         phaseThreshold(t) {}
 
   template <typename Op,
-            std::enable_if_t<std::is_same<Op, quake::RyOp>::value ||
-                                 std::is_same<Op, quake::RzOp>::value,
+            std::enable_if_t<std::is_same<Op, cudaq::quake::RyOp>::value ||
+                                 std::is_same<Op, cudaq::quake::RzOp>::value,
                              int> = 0>
   void applyUniformlyControlledRotation(size_t numQubits,
                                         const std::span<double> angles) {
@@ -209,7 +209,7 @@ public:
       auto k = numQubits - j + 1;
       auto numControls = j - 1;
       auto target = j - 1;
-      auto alphaK = std::same_as<Op, quake::RyOp>
+      auto alphaK = std::same_as<Op, cudaq::quake::RyOp>
                         ? cudaq::details::getAlphaY(angles, numQubits, k)
                         : cudaq::details::getAlphaZ(angles, numQubits, k);
       applyRotation<Op>(alphaK, numControls, target);
@@ -240,14 +240,14 @@ public:
 
     // Apply uniformly controlled y-rotations (for magnitudes), the construction
     // in Eq. (4).
-    applyUniformlyControlledRotation<quake::RyOp>(numQubits, magnitudes);
+    applyUniformlyControlledRotation<cudaq::quake::RyOp>(numQubits, magnitudes);
 
     if (!needsPhaseEqualization)
       return;
 
     // Apply uniformly controlled z-rotations (for phases), the construction in
     // Eq. (4).
-    applyUniformlyControlledRotation<quake::RzOp>(numQubits, phases);
+    applyUniformlyControlledRotation<cudaq::quake::RzOp>(numQubits, phases);
   }
 
 private:
@@ -324,18 +324,19 @@ namespace {
 ///   }
 /// }
 /// ```
-class StatePrepPattern : public OpRewritePattern<quake::InitializeStateOp> {
+class StatePrepPattern
+    : public OpRewritePattern<cudaq::quake::InitializeStateOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
   explicit StatePrepPattern(MLIRContext *ctx, double phaseThreshold)
       : OpRewritePattern(ctx), phaseThreshold(phaseThreshold) {}
 
-  LogicalResult matchAndRewrite(quake::InitializeStateOp init,
+  LogicalResult matchAndRewrite(cudaq::quake::InitializeStateOp init,
                                 PatternRewriter &rewriter) const override {
     auto loc = init.getLoc();
     auto qubits = init.getTargets();
-    auto alloc = qubits.getDefiningOp<quake::AllocaOp>();
+    auto alloc = qubits.getDefiningOp<cudaq::quake::AllocaOp>();
     if (!alloc)
       return init.emitOpError("failed to replace op (alloca expected)");
 
@@ -343,7 +344,7 @@ public:
     Value data = init.getState();
 
     // Check that this is a state pointer coming from an argument.
-    auto createState = data.getDefiningOp<quake::CreateStateOp>();
+    auto createState = data.getDefiningOp<cudaq::quake::CreateStateOp>();
     if (!createState)
       return init.emitOpError("cannot perform state preparation synthesis on "
                               "arguments to the kernel");
@@ -392,13 +393,15 @@ private:
   double phaseThreshold;
 };
 
-class FoldQubitsPattern : public OpRewritePattern<quake::GetNumberOfQubitsOp> {
+class FoldQubitsPattern
+    : public OpRewritePattern<cudaq::quake::GetNumberOfQubitsOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::GetNumberOfQubitsOp getnum,
+  LogicalResult matchAndRewrite(cudaq::quake::GetNumberOfQubitsOp getnum,
                                 PatternRewriter &rewriter) const override {
-    auto create = getnum.getState().getDefiningOp<quake::CreateStateOp>();
+    auto create =
+        getnum.getState().getDefiningOp<cudaq::quake::CreateStateOp>();
     if (!create)
       return failure();
     auto len = cudaq::opt::factory::maybeValueOfIntConstant(create.getLength());
@@ -414,13 +417,15 @@ public:
   }
 };
 
-class KillDeleteStatePattern : public OpRewritePattern<quake::DeleteStateOp> {
+class KillDeleteStatePattern
+    : public OpRewritePattern<cudaq::quake::DeleteStateOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::DeleteStateOp delstate,
+  LogicalResult matchAndRewrite(cudaq::quake::DeleteStateOp delstate,
                                 PatternRewriter &rewriter) const override {
-    auto create = delstate.getState().getDefiningOp<quake::CreateStateOp>();
+    auto create =
+        delstate.getState().getDefiningOp<cudaq::quake::CreateStateOp>();
     if (!create)
       return failure();
     if (!create->hasOneUse())

--- a/lib/Optimizer/Transforms/UnitarySynthesis.cpp
+++ b/lib/Optimizer/Transforms/UnitarySynthesis.cpp
@@ -52,9 +52,9 @@ public:
   /// calls the new replacement function with the same operands as the original
   /// operation. The 'control' and 'adjoint' variations are handled by
   /// `ApplySpecialization` pass.
-  virtual void emitDecomposedFuncOp(quake::CustomUnitarySymbolOp customOp,
-                                    PatternRewriter &rewriter,
-                                    std::string funcName) = 0;
+  virtual void
+  emitDecomposedFuncOp(cudaq::quake::CustomUnitarySymbolOp customOp,
+                       PatternRewriter &rewriter, std::string funcName) = 0;
   bool isAboveThreshold(double value) { return std::abs(value) > TOL; };
   virtual ~Decomposer() = default;
 };
@@ -97,7 +97,7 @@ struct OneQubitOpZYZ : public Decomposer {
     angles.gamma = sum - diff;
   }
 
-  void emitDecomposedFuncOp(quake::CustomUnitarySymbolOp customOp,
+  void emitDecomposedFuncOp(cudaq::quake::CustomUnitarySymbolOp customOp,
                             PatternRewriter &rewriter,
                             std::string funcName) override {
     auto parentModule = customOp->getParentOfType<ModuleOp>();
@@ -120,17 +120,17 @@ struct OneQubitOpZYZ : public Decomposer {
     if (isAboveThreshold(angles.gamma)) {
       auto gamma = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, angles.gamma, floatTy);
-      quake::RzOp::create(rewriter, loc, gamma, ValueRange{}, arguments);
+      cudaq::quake::RzOp::create(rewriter, loc, gamma, ValueRange{}, arguments);
     }
     if (isAboveThreshold(angles.beta)) {
       auto beta = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, angles.beta, floatTy);
-      quake::RyOp::create(rewriter, loc, beta, ValueRange{}, arguments);
+      cudaq::quake::RyOp::create(rewriter, loc, beta, ValueRange{}, arguments);
     }
     if (isAboveThreshold(angles.alpha)) {
       auto alpha = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, angles.alpha, floatTy);
-      quake::RzOp::create(rewriter, loc, alpha, ValueRange{}, arguments);
+      cudaq::quake::RzOp::create(rewriter, loc, alpha, ValueRange{}, arguments);
     }
     /// NOTE: Typically global phase can be ignored but, if this decomposition
     /// is applied in a kernel that is called with `cudaq::control`, the global
@@ -143,8 +143,10 @@ struct OneQubitOpZYZ : public Decomposer {
       auto phase = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, globalPhase, floatTy);
       Value negPhase = arith::NegFOp::create(rewriter, loc, phase);
-      quake::R1Op::create(rewriter, loc, phase, ValueRange{}, arguments[0]);
-      quake::RzOp::create(rewriter, loc, negPhase, ValueRange{}, arguments[0]);
+      cudaq::quake::R1Op::create(rewriter, loc, phase, ValueRange{},
+                                 arguments[0]);
+      cudaq::quake::RzOp::create(rewriter, loc, negPhase, ValueRange{},
+                                 arguments[0]);
     }
     func::ReturnOp::create(rewriter, loc);
     rewriter.restoreInsertionPoint(insPt);
@@ -337,7 +339,7 @@ struct TwoQubitOpKAK : public Decomposer {
                                  TOL));
   }
 
-  void emitDecomposedFuncOp(quake::CustomUnitarySymbolOp customOp,
+  void emitDecomposedFuncOp(cudaq::quake::CustomUnitarySymbolOp customOp,
                             PatternRewriter &rewriter,
                             std::string funcName) override {
     auto a0 = OneQubitOpZYZ(components.a0);
@@ -364,55 +366,62 @@ struct TwoQubitOpKAK : public Decomposer {
     FloatType floatTy = rewriter.getF64Type();
     /// NOTE: Operator notation is right-to-left, whereas circuit notation is
     /// left-to-right. Hence, operations are applied in reverse order.
-    quake::ApplyOp::create(
+    cudaq::quake::ApplyOp::create(
         rewriter, loc, TypeRange{},
         SymbolRefAttr::get(rewriter.getContext(), funcName + "b0"), false,
         ValueRange{}, ValueRange{arguments[1]});
-    quake::ApplyOp::create(
+    cudaq::quake::ApplyOp::create(
         rewriter, loc, TypeRange{},
         SymbolRefAttr::get(rewriter.getContext(), funcName + "b1"), false,
         ValueRange{}, ValueRange{arguments[0]});
     /// TODO: Refactor to use a transformation pass for `quake.exp_pauli`
     /// XX
     if (isAboveThreshold(components.x)) {
-      quake::HOp::create(rewriter, loc, arguments[0]);
-      quake::HOp::create(rewriter, loc, arguments[1]);
-      quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
+      cudaq::quake::HOp::create(rewriter, loc, arguments[0]);
+      cudaq::quake::HOp::create(rewriter, loc, arguments[1]);
+      cudaq::quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
       auto xAngle = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, -2.0 * components.x, floatTy);
-      quake::RzOp::create(rewriter, loc, xAngle, ValueRange{}, arguments[0]);
-      quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
-      quake::HOp::create(rewriter, loc, arguments[1]);
-      quake::HOp::create(rewriter, loc, arguments[0]);
+      cudaq::quake::RzOp::create(rewriter, loc, xAngle, ValueRange{},
+                                 arguments[0]);
+      cudaq::quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
+      cudaq::quake::HOp::create(rewriter, loc, arguments[1]);
+      cudaq::quake::HOp::create(rewriter, loc, arguments[0]);
     }
     /// YY
     if (isAboveThreshold(components.y)) {
       auto piBy2 = cudaq::opt::factory::createFloatConstant(loc, rewriter,
                                                             M_PI_2, floatTy);
-      quake::RxOp::create(rewriter, loc, piBy2, ValueRange{}, arguments[0]);
-      quake::RxOp::create(rewriter, loc, piBy2, ValueRange{}, arguments[1]);
-      quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
+      cudaq::quake::RxOp::create(rewriter, loc, piBy2, ValueRange{},
+                                 arguments[0]);
+      cudaq::quake::RxOp::create(rewriter, loc, piBy2, ValueRange{},
+                                 arguments[1]);
+      cudaq::quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
       auto yAngle = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, -2.0 * components.y, floatTy);
-      quake::RzOp::create(rewriter, loc, yAngle, ValueRange{}, arguments[0]);
-      quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
+      cudaq::quake::RzOp::create(rewriter, loc, yAngle, ValueRange{},
+                                 arguments[0]);
+      cudaq::quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
       Value negPiBy2 = arith::NegFOp::create(rewriter, loc, piBy2);
-      quake::RxOp::create(rewriter, loc, negPiBy2, ValueRange{}, arguments[1]);
-      quake::RxOp::create(rewriter, loc, negPiBy2, ValueRange{}, arguments[0]);
+      cudaq::quake::RxOp::create(rewriter, loc, negPiBy2, ValueRange{},
+                                 arguments[1]);
+      cudaq::quake::RxOp::create(rewriter, loc, negPiBy2, ValueRange{},
+                                 arguments[0]);
     }
     /// ZZ
     if (isAboveThreshold(components.z)) {
-      quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
+      cudaq::quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
       auto zAngle = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, -2.0 * components.z, floatTy);
-      quake::RzOp::create(rewriter, loc, zAngle, ValueRange{}, arguments[0]);
-      quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
+      cudaq::quake::RzOp::create(rewriter, loc, zAngle, ValueRange{},
+                                 arguments[0]);
+      cudaq::quake::XOp::create(rewriter, loc, arguments[1], arguments[0]);
     }
-    quake::ApplyOp::create(
+    cudaq::quake::ApplyOp::create(
         rewriter, loc, TypeRange{},
         SymbolRefAttr::get(rewriter.getContext(), funcName + "a0"), false,
         ValueRange{}, ValueRange{arguments[1]});
-    quake::ApplyOp::create(
+    cudaq::quake::ApplyOp::create(
         rewriter, loc, TypeRange{},
         SymbolRefAttr::get(rewriter.getContext(), funcName + "a1"), false,
         ValueRange{}, ValueRange{arguments[0]});
@@ -421,8 +430,10 @@ struct TwoQubitOpKAK : public Decomposer {
       auto phase = cudaq::opt::factory::createFloatConstant(
           loc, rewriter, globalPhase, floatTy);
       Value negPhase = arith::NegFOp::create(rewriter, loc, phase);
-      quake::R1Op::create(rewriter, loc, phase, ValueRange{}, arguments[0]);
-      quake::RzOp::create(rewriter, loc, negPhase, ValueRange{}, arguments[0]);
+      cudaq::quake::R1Op::create(rewriter, loc, phase, ValueRange{},
+                                 arguments[0]);
+      cudaq::quake::RzOp::create(rewriter, loc, negPhase, ValueRange{},
+                                 arguments[0]);
     }
     func::ReturnOp::create(rewriter, loc);
     rewriter.restoreInsertionPoint(insPt);
@@ -435,11 +446,11 @@ struct TwoQubitOpKAK : public Decomposer {
 };
 
 class CustomUnitaryPattern
-    : public OpRewritePattern<quake::CustomUnitarySymbolOp> {
+    : public OpRewritePattern<cudaq::quake::CustomUnitarySymbolOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(quake::CustomUnitarySymbolOp customOp,
+  LogicalResult matchAndRewrite(cudaq::quake::CustomUnitarySymbolOp customOp,
                                 PatternRewriter &rewriter) const override {
     auto parentModule = customOp->getParentOfType<ModuleOp>();
     /// Get the global constant holding the concrete matrix corresponding to
@@ -476,7 +487,7 @@ public:
         return failure();
       }
     }
-    rewriter.replaceOpWithNewOp<quake::ApplyOp>(
+    rewriter.replaceOpWithNewOp<cudaq::quake::ApplyOp>(
         customOp, TypeRange{},
         SymbolRefAttr::get(rewriter.getContext(), funcName), customOp.isAdj(),
         customOp.getControls(), customOp.getTargets());

--- a/lib/Optimizer/Transforms/WiresToWiresets.cpp
+++ b/lib/Optimizer/Transforms/WiresToWiresets.cpp
@@ -25,35 +25,35 @@ namespace cudaq::opt {
 using namespace mlir;
 
 namespace {
-class NullWirePat : public OpRewritePattern<quake::NullWireOp> {
+class NullWirePat : public OpRewritePattern<cudaq::quake::NullWireOp> {
 public:
   unsigned *counter;
   StringRef setName;
 
   NullWirePat(MLIRContext *context, unsigned *c, StringRef name)
-      : OpRewritePattern<quake::NullWireOp>(context), counter(c),
+      : OpRewritePattern<cudaq::quake::NullWireOp>(context), counter(c),
         setName(name) {}
 
-  LogicalResult matchAndRewrite(quake::NullWireOp alloc,
+  LogicalResult matchAndRewrite(cudaq::quake::NullWireOp alloc,
                                 PatternRewriter &rewriter) const override {
 
     auto index = (*counter)++;
-    auto wirety = quake::WireType::get(rewriter.getContext());
-    rewriter.replaceOpWithNewOp<quake::BorrowWireOp>(alloc, wirety, setName,
-                                                     index);
+    auto wirety = cudaq::quake::WireType::get(rewriter.getContext());
+    rewriter.replaceOpWithNewOp<cudaq::quake::BorrowWireOp>(alloc, wirety,
+                                                            setName, index);
 
     return success();
   }
 };
 
-class SinkOpPat : public OpRewritePattern<quake::SinkOp> {
+class SinkOpPat : public OpRewritePattern<cudaq::quake::SinkOp> {
   using OpRewritePattern::OpRewritePattern;
 
 public:
-  LogicalResult matchAndRewrite(quake::SinkOp release,
+  LogicalResult matchAndRewrite(cudaq::quake::SinkOp release,
                                 PatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<quake::ReturnWireOp>(release,
-                                                     release.getOperand());
+    rewriter.replaceOpWithNewOp<cudaq::quake::ReturnWireOp>(
+        release, release.getOperand());
 
     return success();
   }
@@ -89,9 +89,9 @@ struct AssignWireIndicesPass
                                  cudaq::opt::topologyAgnosticWiresetName);
     patterns.insert<SinkOpPat>(ctx);
     ConversionTarget target(*ctx);
-    target.addLegalDialect<quake::QuakeDialect>();
-    target.addIllegalOp<quake::NullWireOp>();
-    target.addIllegalOp<quake::SinkOp>();
+    target.addLegalDialect<cudaq::quake::QuakeDialect>();
+    target.addIllegalOp<cudaq::quake::NullWireOp>();
+    target.addIllegalOp<cudaq::quake::SinkOp>();
     if (failed(applyPartialConversion(func, target, std::move(patterns)))) {
       func->emitOpError("Converting individual wires to wireset wires failed");
       signalPassFailure();
@@ -106,7 +106,7 @@ struct AddWiresetPass
   void runOnOperation() override {
     ModuleOp mod = getOperation();
     OpBuilder builder(mod.getBodyRegion());
-    auto wireSetOp = quake::WireSetOp::create(
+    auto wireSetOp = cudaq::quake::WireSetOp::create(
         builder, builder.getUnknownLoc(),
         cudaq::opt::topologyAgnosticWiresetName, INT_MAX, ElementsAttr{});
     wireSetOp.setPrivate();

--- a/python/runtime/cudaq/algorithms/py_observe_async.cpp
+++ b/python/runtime/cudaq/algorithms/py_observe_async.cpp
@@ -48,7 +48,7 @@ isValidObserveKernel_impl(const std::string &kernelName, MlirModule kernelMod) {
 
   // Are measurements specified?
   if (kernelFunc
-          .walk([&](quake::MeasurementInterface measure) {
+          .walk([&](cudaq::quake::MeasurementInterface measure) {
             // FIXME!! This is incorrect. If the kernel has calls, they are
             // completely ignored.
             return mlir::WalkResult::interrupt();

--- a/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
+++ b/python/runtime/cudaq/platform/py_alt_launch_kernel.cpp
@@ -426,7 +426,7 @@ void cudaq::packArgs(
           addArgument(argData, nanobind::cast<pauli_word>(arg).str());
         })
         .Case([&](cc::PointerType ty) {
-          if (isa<quake::StateType>(ty.getElementType())) {
+          if (isa<cudaq::quake::StateType>(ty.getElementType())) {
             auto *stateArg = nanobind::cast<state *>(arg);
 
             if (stateArg == nullptr)

--- a/python/runtime/mlir/py_register_dialects.cpp
+++ b/python/runtime/mlir/py_register_dialects.cpp
@@ -56,33 +56,38 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
       nanobind::arg("load") = true,
       nanobind::arg("context") = nanobind::none());
 
-  mlir_type_subclass(
-      quakeMod, "RefType",
-      [](MlirType type) { return mlir::isa<quake::RefType>(unwrap(type)); })
+  mlir_type_subclass(quakeMod, "RefType",
+                     [](MlirType type) {
+                       return mlir::isa<cudaq::quake::RefType>(unwrap(type));
+                     })
       .def_classmethod(
           "get",
           [](nanobind::object cls, MlirContext context) {
-            return wrap(quake::RefType::get(unwrap(context)));
+            return wrap(cudaq::quake::RefType::get(unwrap(context)));
           },
           nanobind::arg("cls"), nanobind::arg("context") = nanobind::none());
 
-  mlir_type_subclass(
-      quakeMod, "MeasureType",
-      [](MlirType type) { return mlir::isa<quake::MeasureType>(unwrap(type)); })
+  mlir_type_subclass(quakeMod, "MeasureType",
+                     [](MlirType type) {
+                       return mlir::isa<cudaq::quake::MeasureType>(
+                           unwrap(type));
+                     })
       .def_classmethod(
           "get",
           [](nanobind::object cls, MlirContext context) {
-            return wrap(quake::MeasureType::get(unwrap(context)));
+            return wrap(cudaq::quake::MeasureType::get(unwrap(context)));
           },
           nanobind::arg("cls"), nanobind::arg("context") = nanobind::none());
 
   mlir::python::nanobind_adaptors::mlir_type_subclass(
       quakeMod, "VeqType",
-      [](MlirType type) { return mlir::isa<quake::VeqType>(unwrap(type)); })
+      [](MlirType type) {
+        return mlir::isa<cudaq::quake::VeqType>(unwrap(type));
+      })
       .def_classmethod(
           "get",
           [](nanobind::object cls, std::size_t size, MlirContext context) {
-            return wrap(quake::VeqType::get(unwrap(context), size));
+            return wrap(cudaq::quake::VeqType::get(unwrap(context), size));
           },
           nanobind::arg("cls"),
           nanobind::arg("size") = std::numeric_limits<std::size_t>::max(),
@@ -90,7 +95,7 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
       .def_staticmethod(
           "hasSpecifiedSize",
           [](MlirType type) {
-            auto veqTy = dyn_cast<quake::VeqType>(unwrap(type));
+            auto veqTy = dyn_cast<cudaq::quake::VeqType>(unwrap(type));
             if (!veqTy)
               throw std::runtime_error(
                   "Invalid type passed to VeqType.getSize()");
@@ -101,7 +106,7 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
       .def_staticmethod(
           "getSize",
           [](MlirType type) {
-            auto veqTy = dyn_cast<quake::VeqType>(unwrap(type));
+            auto veqTy = dyn_cast<cudaq::quake::VeqType>(unwrap(type));
             if (!veqTy)
               throw std::runtime_error(
                   "Invalid type passed to VeqType.getSize()");
@@ -113,18 +118,21 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
   quakeMod.def(
       "isConstantQuantumRefType",
       [](MlirType type) {
-        return quake::isConstantQuantumRefType(unwrap(type));
+        return cudaq::quake::isConstantQuantumRefType(unwrap(type));
       },
       nanobind::arg("type"));
 
   quakeMod.def(
       "getAllocationSize",
-      [](MlirType type) { return quake::getAllocationSize(unwrap(type)); },
+      [](MlirType type) {
+        return cudaq::quake::getAllocationSize(unwrap(type));
+      },
       nanobind::arg("type"));
 
-  mlir_type_subclass(
-      quakeMod, "StruqType",
-      [](MlirType type) { return mlir::isa<quake::StruqType>(unwrap(type)); })
+  mlir_type_subclass(quakeMod, "StruqType",
+                     [](MlirType type) {
+                       return mlir::isa<cudaq::quake::StruqType>(unwrap(type));
+                     })
       .def_classmethod(
           "get",
           [](nanobind::object cls, nanobind::list aggregateTypes,
@@ -133,7 +141,7 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
             for (nanobind::handle t : aggregateTypes)
               inTys.push_back(unwrap(nanobind::cast<MlirType>(t)));
 
-            return wrap(quake::StruqType::get(unwrap(context), inTys));
+            return wrap(cudaq::quake::StruqType::get(unwrap(context), inTys));
           },
           nanobind::arg("cls"), nanobind::arg("aggregateTypes"),
           nanobind::arg("context") = nanobind::none())
@@ -145,7 +153,8 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
             for (nanobind::handle t : aggregateTypes)
               inTys.push_back(unwrap(nanobind::cast<MlirType>(t)));
 
-            return wrap(quake::StruqType::get(unwrap(context), name, inTys));
+            return wrap(
+                cudaq::quake::StruqType::get(unwrap(context), name, inTys));
           },
           nanobind::arg("cls"), nanobind::arg("name"),
           nanobind::arg("aggregateTypes"),
@@ -153,7 +162,7 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
       .def_classmethod(
           "getTypes",
           [](nanobind::object cls, MlirType structTy) {
-            auto ty = dyn_cast<quake::StruqType>(unwrap(structTy));
+            auto ty = dyn_cast<cudaq::quake::StruqType>(unwrap(structTy));
             if (!ty)
               throw std::runtime_error(
                   "invalid type passed to StruqType.getTypes(), must be a "
@@ -164,7 +173,7 @@ static void registerQuakeDialectAndTypes(nanobind::module_ &m) {
             return ret;
           })
       .def_classmethod("getName", [](nanobind::object cls, MlirType structTy) {
-        auto ty = dyn_cast<quake::StruqType>(unwrap(structTy));
+        auto ty = dyn_cast<cudaq::quake::StruqType>(unwrap(structTy));
         if (!ty)
           throw std::runtime_error(
               "invalid type passed to StruqType.getName(), must be a "
@@ -200,13 +209,14 @@ static void registerCCDialectAndTypes(nanobind::module_ &m) {
           },
           nanobind::arg("cls"), nanobind::arg("context") = nanobind::none());
 
-  mlir_type_subclass(
-      ccMod, "StateType",
-      [](MlirType type) { return mlir::isa<quake::StateType>(unwrap(type)); })
+  mlir_type_subclass(ccMod, "StateType",
+                     [](MlirType type) {
+                       return mlir::isa<cudaq::quake::StateType>(unwrap(type));
+                     })
       .def_classmethod(
           "get",
           [](nanobind::object cls, MlirContext context) {
-            return wrap(quake::StateType::get(unwrap(context)));
+            return wrap(cudaq::quake::StateType::get(unwrap(context)));
           },
           nanobind::arg("cls"), nanobind::arg("context") = nanobind::none());
 

--- a/runtime/common/DeviceCodeRegistry.cpp
+++ b/runtime/common/DeviceCodeRegistry.cpp
@@ -9,10 +9,10 @@
 #include "DeviceCodeRegistry.h"
 #include "cudaq/qis/qkernel.h"
 #include "cudaq/runtime/logger/logger.h"
+#include <algorithm>
 #include <map>
 #include <mutex>
 #include <shared_mutex>
-#include <string>
 #include <vector>
 
 // Shared mutex to guard concurrent access to global kernel data (e.g.,

--- a/runtime/cudaq/builder/QuakeValue.cpp
+++ b/runtime/cudaq/builder/QuakeValue.cpp
@@ -102,7 +102,7 @@ std::size_t QuakeValue::getRequiredElements() {
 QuakeValue QuakeValue::operator[](const std::size_t idx) {
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
-  if (!isa<cc::StdvecType, quake::VeqType>(type)) {
+  if (!isa<cc::StdvecType, cudaq::quake::VeqType>(type)) {
     std::string typeName;
     {
       llvm::raw_string_ostream os(typeName);
@@ -115,9 +115,9 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
 
   Value indexVar = arith::ConstantIntOp::create(opBuilder, idx, 32);
 
-  if (isa<quake::VeqType>(type)) {
+  if (isa<cudaq::quake::VeqType>(type)) {
     Value extractedQubit =
-        quake::ExtractRefOp::create(opBuilder, vectorValue, indexVar);
+        cudaq::quake::ExtractRefOp::create(opBuilder, vectorValue, indexVar);
     return QuakeValue(opBuilder, extractedQubit);
   }
 
@@ -140,7 +140,7 @@ QuakeValue QuakeValue::operator[](const std::size_t idx) {
 QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
-  if (!isa<cc::StdvecType, quake::VeqType>(type)) {
+  if (!isa<cc::StdvecType, cudaq::quake::VeqType>(type)) {
     std::string typeName;
     {
       llvm::raw_string_ostream os(typeName);
@@ -153,9 +153,9 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
 
   Value indexVar = idx.getValue();
 
-  if (isa<quake::VeqType>(type)) {
+  if (isa<cudaq::quake::VeqType>(type)) {
     Value extractedQubit =
-        quake::ExtractRefOp::create(opBuilder, vectorValue, indexVar);
+        cudaq::quake::ExtractRefOp::create(opBuilder, vectorValue, indexVar);
     return QuakeValue(opBuilder, extractedQubit);
   }
 
@@ -177,7 +177,7 @@ QuakeValue QuakeValue::operator[](const QuakeValue &idx) {
 QuakeValue QuakeValue::size() {
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
-  if (!isa<cc::StdvecType, quake::VeqType>(type))
+  if (!isa<cc::StdvecType, cudaq::quake::VeqType>(type))
     throw std::runtime_error("This QuakeValue does not expose .size().");
 
   Type i64Ty = opBuilder.getI64Type();
@@ -185,13 +185,13 @@ QuakeValue QuakeValue::size() {
   if (isa<cc::StdvecType>(type))
     ret = cc::StdvecSizeOp::create(opBuilder, i64Ty, vectorValue);
   else
-    ret = quake::VeqSizeOp::create(opBuilder, i64Ty, vectorValue);
+    ret = cudaq::quake::VeqSizeOp::create(opBuilder, i64Ty, vectorValue);
 
   return QuakeValue(opBuilder, ret);
 }
 
 std::optional<std::size_t> QuakeValue::constantSize() {
-  if (auto qvecTy = dyn_cast<quake::VeqType>(getValue().getType()))
+  if (auto qvecTy = dyn_cast<cudaq::quake::VeqType>(getValue().getType()))
     if (qvecTy.hasSpecifiedSize())
       return qvecTy.getSize();
 
@@ -202,7 +202,7 @@ QuakeValue QuakeValue::slice(const std::size_t startIdx,
                              const std::size_t count) {
   Value vectorValue = value->asMLIR();
   Type type = vectorValue.getType();
-  if (!isa<cc::StdvecType, quake::VeqType>(type))
+  if (!isa<cc::StdvecType, cudaq::quake::VeqType>(type))
     throw std::runtime_error("This QuakeValue is not sliceable.");
 
   if (count == 0)
@@ -210,7 +210,7 @@ QuakeValue QuakeValue::slice(const std::size_t startIdx,
 
   Value startIdxValue = arith::ConstantIntOp::create(opBuilder, startIdx, 64);
   Value countValue = arith::ConstantIntOp::create(opBuilder, count, 64);
-  if (auto veqType = mlir::dyn_cast_if_present<quake::VeqType>(type)) {
+  if (auto veqType = mlir::dyn_cast_if_present<cudaq::quake::VeqType>(type)) {
     auto veqSize = veqType.getSize();
     if (startIdx + count > veqSize)
       throw std::runtime_error("Invalid number of elements requested in slice, "
@@ -220,9 +220,9 @@ QuakeValue QuakeValue::slice(const std::size_t startIdx,
     auto one = arith::ConstantIntOp::create(opBuilder, 1, 64);
     Value offset = arith::AddIOp::create(opBuilder, startIdxValue, countValue);
     offset = arith::SubIOp::create(opBuilder, offset, one);
-    auto sizedVecTy = quake::VeqType::get(opBuilder.getContext(), count);
-    Value subVeq = quake::SubVeqOp::create(opBuilder, sizedVecTy, vectorValue,
-                                           startIdxValue, offset);
+    auto sizedVecTy = cudaq::quake::VeqType::get(opBuilder.getContext(), count);
+    Value subVeq = cudaq::quake::SubVeqOp::create(
+        opBuilder, sizedVecTy, vectorValue, startIdxValue, offset);
     return QuakeValue(opBuilder, subVeq);
   }
 

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -111,12 +111,12 @@ convertArgumentTypeToMLIR(std::vector<std::complex<float>> &e) {
 
 KernelBuilderType convertArgumentTypeToMLIR(cudaq::qubit &e) {
   return KernelBuilderType(
-      [](MLIRContext *ctx) { return quake::RefType::get(ctx); });
+      [](MLIRContext *ctx) { return cudaq::quake::RefType::get(ctx); });
 }
 
 KernelBuilderType convertArgumentTypeToMLIR(cudaq::qvector<> &e) {
   return KernelBuilderType(
-      [](MLIRContext *ctx) { return quake::VeqType::getUnsized(ctx); });
+      [](MLIRContext *ctx) { return cudaq::quake::VeqType::getUnsized(ctx); });
 }
 
 KernelBuilderType convertArgumentTypeToMLIR(std::vector<cudaq::pauli_word> &) {
@@ -127,7 +127,7 @@ KernelBuilderType convertArgumentTypeToMLIR(std::vector<cudaq::pauli_word> &) {
 
 KernelBuilderType convertArgumentTypeToMLIR(cudaq::state *&) {
   return KernelBuilderType([](MLIRContext *ctx) {
-    return cudaq::cc::PointerType::get(quake::StateType::get(ctx));
+    return cudaq::cc::PointerType::get(cudaq::quake::StateType::get(ctx));
   });
 }
 
@@ -200,13 +200,14 @@ void exp_pauli(ImplicitLocOpBuilder &builder, const QuakeValue &theta,
     for (auto &v : qubits)
       values.push_back(v.getValue());
 
-    qubitsVal = quake::ConcatOp::create(
-        builder, quake::VeqType::get(builder.getContext(), qubits.size()),
+    qubitsVal = cudaq::quake::ConcatOp::create(
+        builder,
+        cudaq::quake::VeqType::get(builder.getContext(), qubits.size()),
         values);
   }
 
   auto thetaVal = theta.getValue();
-  if (!isa<quake::VeqType>(qubitsVal.getType()))
+  if (!isa<cudaq::quake::VeqType>(qubitsVal.getType()))
     throw std::runtime_error(
         "exp_pauli must take a QuakeValue of veq type as second argument.");
   if (!thetaVal.getType().isIntOrFloat())
@@ -214,8 +215,8 @@ void exp_pauli(ImplicitLocOpBuilder &builder, const QuakeValue &theta,
                              "type as first argument.");
   CUDAQ_INFO("kernel_builder apply exp_pauli {}", pauliWord);
 
-  quake::ExpPauliOp::create(builder, ValueRange{thetaVal}, ValueRange{},
-                            ValueRange{qubitsVal}, pauliWord);
+  cudaq::quake::ExpPauliOp::create(builder, ValueRange{thetaVal}, ValueRange{},
+                                   ValueRange{qubitsVal}, pauliWord);
 }
 
 /// @brief Search the given `FuncOp` for all `CallOps` recursively.
@@ -233,7 +234,7 @@ void addAllCalledFunctionRecursively(
       StringRef calleeName;
       if (auto callOp = dyn_cast<func::CallOp>(op))
         calleeName = callOp.getCallee();
-      else if (auto applyOp = dyn_cast<quake::ApplyOp>(op))
+      else if (auto applyOp = dyn_cast<cudaq::quake::ApplyOp>(op))
         calleeName = applyOp.getCalleeAttrNameStr();
 
       // We don't have a CallOp or an ApplyOp, drop out
@@ -321,14 +322,14 @@ void call(ImplicitLocOpBuilder &builder, std::string &name,
     Type argType = otherFuncCloned.getArgumentTypes()[i++];
     Value value = v.getValue();
     Type inType = value.getType();
-    auto inAsVeqTy = dyn_cast_or_null<quake::VeqType>(inType);
-    auto argAsVeqTy = dyn_cast_or_null<quake::VeqType>(argType);
+    auto inAsVeqTy = dyn_cast_or_null<cudaq::quake::VeqType>(inType);
+    auto argAsVeqTy = dyn_cast_or_null<cudaq::quake::VeqType>(argType);
 
     // If both are veqs, make sure we don't have veq<N> -> veq<?>
     if (inAsVeqTy && argAsVeqTy) {
       // make sure they are both the same veq<...> type
       if (inAsVeqTy.hasSpecifiedSize() && !argAsVeqTy.hasSpecifiedSize())
-        value = quake::RelaxSizeOp::create(builder, argAsVeqTy, value);
+        value = cudaq::quake::RelaxSizeOp::create(builder, argAsVeqTy, value);
     } else if (inType != argType) {
       std::string inS, argS;
       {
@@ -374,14 +375,14 @@ void applyControlOrAdjoint(ImplicitLocOpBuilder &builder, std::string &name,
     Type argType = otherFuncCloned.getArgumentTypes()[i];
     Value value = v.getValue();
     Type inType = value.getType();
-    auto inAsVeqTy = dyn_cast_or_null<quake::VeqType>(inType);
-    auto argAsVeqTy = dyn_cast_or_null<quake::VeqType>(argType);
+    auto inAsVeqTy = dyn_cast_or_null<cudaq::quake::VeqType>(inType);
+    auto argAsVeqTy = dyn_cast_or_null<cudaq::quake::VeqType>(argType);
 
     // If both are veqs, make sure we don't have veq<N> -> veq<?>
     if (inAsVeqTy && argAsVeqTy) {
       // make sure they are both the same veq<...> type
       if (inAsVeqTy.hasSpecifiedSize() && !argAsVeqTy.hasSpecifiedSize())
-        value = quake::RelaxSizeOp::create(builder, argAsVeqTy, value);
+        value = cudaq::quake::RelaxSizeOp::create(builder, argAsVeqTy, value);
     } else if (inType != argType) {
       std::string inS, argS;
       {
@@ -397,9 +398,9 @@ void applyControlOrAdjoint(ImplicitLocOpBuilder &builder, std::string &name,
   }
 
   auto realName = std::string(cudaq::runtime::cudaqGenPrefixName) + name;
-  quake::ApplyOp::create(builder, TypeRange{},
-                         SymbolRefAttr::get(builder.getContext(), realName),
-                         isAdjoint, controls, mlirValues);
+  cudaq::quake::ApplyOp::create(
+      builder, TypeRange{}, SymbolRefAttr::get(builder.getContext(), realName),
+      isAdjoint, controls, mlirValues);
 }
 
 void control(ImplicitLocOpBuilder &builder, std::string &name,
@@ -483,7 +484,7 @@ Type KernelBuilderType::create(MLIRContext *ctx) { return creator(ctx); }
 
 QuakeValue qalloc(ImplicitLocOpBuilder &builder) {
   CUDAQ_INFO("kernel_builder allocating a single qubit");
-  Value qubit = quake::AllocaOp::create(builder);
+  Value qubit = cudaq::quake::AllocaOp::create(builder);
   return QuakeValue(builder, qubit);
 }
 
@@ -491,8 +492,8 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder, const std::size_t nQubits) {
   CUDAQ_INFO("kernel_builder allocating {} qubits", nQubits);
 
   auto context = builder.getContext();
-  Value qubits =
-      quake::AllocaOp::create(builder, quake::VeqType::get(context, nQubits));
+  Value qubits = cudaq::quake::AllocaOp::create(
+      builder, cudaq::quake::VeqType::get(context, nQubits));
 
   return QuakeValue(builder, qubits);
 }
@@ -509,30 +510,33 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder, QuakeValue &sizeOrVec) {
     Value initials = cc::StdvecDataOp::create(builder, ptrTy, value);
     auto i64Ty = builder.getI64Type();
     Value size = cc::StdvecSizeOp::create(builder, i64Ty, value);
-    auto stateTy = cc::PointerType::get(quake::StateType::get(context));
-    auto state = quake::CreateStateOp::create(builder, stateTy, initials, size);
-    Value numQubits = quake::GetNumberOfQubitsOp::create(builder, i64Ty, state);
+    auto stateTy = cc::PointerType::get(cudaq::quake::StateType::get(context));
+    auto state =
+        cudaq::quake::CreateStateOp::create(builder, stateTy, initials, size);
+    Value numQubits =
+        cudaq::quake::GetNumberOfQubitsOp::create(builder, i64Ty, state);
     // allocate the number of qubits we need
-    auto veqTy = quake::VeqType::getUnsized(context);
-    Value qubits = quake::AllocaOp::create(builder, veqTy, numQubits);
+    auto veqTy = cudaq::quake::VeqType::getUnsized(context);
+    Value qubits = cudaq::quake::AllocaOp::create(builder, veqTy, numQubits);
 
-    qubits = quake::InitializeStateOp::create(builder, veqTy, qubits, state);
-    quake::DeleteStateOp::create(builder, state);
+    qubits =
+        cudaq::quake::InitializeStateOp::create(builder, veqTy, qubits, state);
+    cudaq::quake::DeleteStateOp::create(builder, state);
     return QuakeValue(builder, qubits);
   }
 
   if (auto statePtrTy = dyn_cast<cc::PointerType>(type)) {
     auto eleTy = statePtrTy.getElementType();
-    if (auto stateTy = dyn_cast<quake::StateType>(eleTy)) {
+    if (auto stateTy = dyn_cast<cudaq::quake::StateType>(eleTy)) {
       // get the number of qubits
-      auto numQubits = quake::GetNumberOfQubitsOp::create(
+      auto numQubits = cudaq::quake::GetNumberOfQubitsOp::create(
           builder, builder.getI64Type(), value);
       // allocate the number of qubits we need
-      auto veqTy = quake::VeqType::getUnsized(context);
-      Value qubits = quake::AllocaOp::create(builder, veqTy, numQubits);
+      auto veqTy = cudaq::quake::VeqType::getUnsized(context);
+      Value qubits = cudaq::quake::AllocaOp::create(builder, veqTy, numQubits);
       // Add the initialize state op
-      qubits = quake::InitializeStateOp::create(builder, qubits.getType(),
-                                                qubits, value);
+      qubits = cudaq::quake::InitializeStateOp::create(
+          builder, qubits.getType(), qubits, value);
       return QuakeValue(builder, qubits);
     }
   }
@@ -541,8 +545,8 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder, QuakeValue &sizeOrVec) {
     throw std::runtime_error(
         "Invalid parameter passed to qalloc (must be integer type).");
 
-  Value qubits = quake::AllocaOp::create(
-      builder, quake::VeqType::getUnsized(context), value);
+  Value qubits = cudaq::quake::AllocaOp::create(
+      builder, cudaq::quake::VeqType::getUnsized(context), value);
 
   return QuakeValue(builder, qubits);
 }
@@ -642,8 +646,8 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder,
                                    ValueRange{vecPtr, idxOp});
 
   // Allocate the qubits
-  Value qubits = quake::AllocaOp::create(
-      builder, quake::VeqType::getUnsized(context), size.getResult(0));
+  Value qubits = cudaq::quake::AllocaOp::create(
+      builder, cudaq::quake::VeqType::getUnsized(context), size.getResult(0));
 
   // Use callback to retrieve the data pointer of the captured vector `state` at
   // runtime.
@@ -653,24 +657,25 @@ QuakeValue qalloc(ImplicitLocOpBuilder &builder,
                                       ValueRange{vecPtr, idxOp});
 
   // Add the initialize state op
-  qubits = quake::InitializeStateOp::create(builder, qubits.getType(), qubits,
-                                            dataPtr.getResult(0));
+  qubits = cudaq::quake::InitializeStateOp::create(
+      builder, qubits.getType(), qubits, dataPtr.getResult(0));
   return QuakeValue(builder, qubits);
 }
 
 QuakeValue qalloc(mlir::ImplicitLocOpBuilder &builder, cudaq::state *state,
                   StateVectorStorage &stateVectorStorage) {
   auto *context = builder.getContext();
-  auto statePtrTy = cudaq::cc::PointerType::get(quake::StateType::get(context));
+  auto statePtrTy =
+      cudaq::cc::PointerType::get(cudaq::quake::StateType::get(context));
   auto statePtr = cc::CastOp::create(
       builder, builder.getLoc(), statePtrTy,
       arith::ConstantIntOp::create(builder,
                                    reinterpret_cast<std::intptr_t>(state), 64));
   // Add the initialize state op
-  Value qubits = quake::AllocaOp::create(
-      builder, quake::VeqType::get(context, state->get_num_qubits()));
-  qubits = quake::InitializeStateOp::create(builder, qubits.getType(), qubits,
-                                            statePtr);
+  Value qubits = cudaq::quake::AllocaOp::create(
+      builder, cudaq::quake::VeqType::get(context, state->get_num_qubits()));
+  qubits = cudaq::quake::InitializeStateOp::create(builder, qubits.getType(),
+                                                   qubits, statePtr);
   return QuakeValue(builder, qubits);
 }
 
@@ -687,11 +692,12 @@ void handleOneQubitBroadcast(ImplicitLocOpBuilder &builder, auto param,
   CUDAQ_INFO("kernel_builder handling operation broadcast on qvector.");
 
   auto loc = builder.getLoc();
-  Value rank = quake::VeqSizeOp::create(builder, builder.getI64Type(), veq);
+  Value rank =
+      cudaq::quake::VeqSizeOp::create(builder, builder.getI64Type(), veq);
   auto bodyBuilder = [&](OpBuilder &builder, Location loc, Region &,
                          Block &block) {
-    Value ref =
-        quake::ExtractRefOp::create(builder, loc, veq, block.getArgument(0));
+    Value ref = cudaq::quake::ExtractRefOp::create(builder, loc, veq,
+                                                   block.getArgument(0));
 
     QuakeOp::create(builder, loc, adjoint, param, ValueRange(), ref);
   };
@@ -710,19 +716,19 @@ void applyOneQubitOp(ImplicitLocOpBuilder &builder, auto &&params, auto &&ctrls,
     CUDAQ_INFO("kernel_builder apply {}", std::string(#NAME));                 \
     auto value = target.getValue();                                            \
     auto type = value.getType();                                               \
-    if (isa<quake::VeqType>(type)) {                                           \
+    if (isa<cudaq::quake::VeqType>(type)) {                                    \
       if (!ctrls.empty())                                                      \
         throw std::runtime_error(                                              \
             "Cannot specify controls for a veq broadcast.");                   \
-      handleOneQubitBroadcast<quake::QUAKENAME>(builder, ValueRange(),         \
-                                                target.getValue());            \
+      handleOneQubitBroadcast<cudaq::quake::QUAKENAME>(builder, ValueRange(),  \
+                                                       target.getValue());     \
       return;                                                                  \
     }                                                                          \
     std::vector<Value> ctrlValues;                                             \
     std::transform(ctrls.begin(), ctrls.end(), std::back_inserter(ctrlValues), \
                    [](auto &el) { return el.getValue(); });                    \
-    applyOneQubitOp<quake::QUAKENAME>(builder, ValueRange(), ctrlValues,       \
-                                      value, adjoint);                         \
+    applyOneQubitOp<cudaq::quake::QUAKENAME>(builder, ValueRange(),            \
+                                             ctrlValues, value, adjoint);      \
   }
 
 CUDAQ_ONE_QUBIT_IMPL(h, HOp)
@@ -738,19 +744,19 @@ CUDAQ_ONE_QUBIT_IMPL(z, ZOp)
     CUDAQ_INFO("kernel_builder apply {}", std::string(#NAME));                 \
     Value value = target.getValue();                                           \
     auto type = value.getType();                                               \
-    if (isa<quake::VeqType>(type)) {                                           \
+    if (isa<cudaq::quake::VeqType>(type)) {                                    \
       if (!ctrls.empty())                                                      \
         throw std::runtime_error(                                              \
             "Cannot specify controls for a veq broadcast.");                   \
-      handleOneQubitBroadcast<quake::QUAKENAME>(builder, parameter.getValue(), \
-                                                target.getValue());            \
+      handleOneQubitBroadcast<cudaq::quake::QUAKENAME>(                        \
+          builder, parameter.getValue(), target.getValue());                   \
       return;                                                                  \
     }                                                                          \
     std::vector<Value> ctrlValues;                                             \
     std::transform(ctrls.begin(), ctrls.end(), std::back_inserter(ctrlValues), \
                    [](auto &el) { return el.getValue(); });                    \
-    applyOneQubitOp<quake::QUAKENAME>(builder, parameter.getValue(),           \
-                                      ctrlValues, value, false);               \
+    applyOneQubitOp<cudaq::quake::QUAKENAME>(builder, parameter.getValue(),    \
+                                             ctrlValues, value, false);        \
   }
 
 CUDAQ_ONE_QUBIT_PARAM_IMPL(rx, RxOp)
@@ -769,15 +775,15 @@ void u3(ImplicitLocOpBuilder &builder, std::vector<QuakeValue> &parameters,
   std::transform(ctrls.begin(), ctrls.end(), std::back_inserter(ctrlValues),
                  [](auto &el) { return el.getValue(); });
   std::vector<Value> qubitValues{target.getValue()};
-  quake::U3Op::create(builder, adjoint, parameterValues, ctrlValues,
-                      qubitValues);
+  cudaq::quake::U3Op::create(builder, adjoint, parameterValues, ctrlValues,
+                             qubitValues);
 }
 
 template <typename QuakeMeasureOp>
 QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,
                         const std::string &regName) {
   auto type = value.getType();
-  if (!isa<quake::RefType, quake::VeqType>(type))
+  if (!isa<cudaq::quake::RefType, cudaq::quake::VeqType>(type))
     throw std::runtime_error("Invalid parameter passed to mz.");
 
   CUDAQ_INFO("kernel_builder apply measurement");
@@ -790,8 +796,8 @@ QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,
     strAttr = builder.getStringAttr(regName);
 
   Type resTy = builder.getI1Type();
-  Type measTy = quake::MeasureType::get(builder.getContext());
-  if (!isa<quake::RefType>(type)) {
+  Type measTy = cudaq::quake::MeasureType::get(builder.getContext());
+  if (!isa<cudaq::quake::RefType>(type)) {
     resTy = cc::StdvecType::get(resTy);
     measTy = cc::StdvecType::get(measTy);
   }
@@ -802,27 +808,31 @@ QuakeValue applyMeasure(ImplicitLocOpBuilder &builder, Value value,
   else
     measureResult = QuakeMeasureOp::create(builder, measTy, value).getMeasOut();
 
-  Value bits = quake::DiscriminateOp::create(builder, resTy, measureResult);
+  Value bits =
+      cudaq::quake::DiscriminateOp::create(builder, resTy, measureResult);
   return QuakeValue(builder, bits);
 }
 
 QuakeValue mx(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQvec,
               const std::string &regName) {
-  return applyMeasure<quake::MxOp>(builder, qubitOrQvec.getValue(), regName);
+  return applyMeasure<cudaq::quake::MxOp>(builder, qubitOrQvec.getValue(),
+                                          regName);
 }
 
 QuakeValue my(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQvec,
               const std::string &regName) {
-  return applyMeasure<quake::MyOp>(builder, qubitOrQvec.getValue(), regName);
+  return applyMeasure<cudaq::quake::MyOp>(builder, qubitOrQvec.getValue(),
+                                          regName);
 }
 
 QuakeValue mz(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQvec,
               const std::string &regName) {
-  return applyMeasure<quake::MzOp>(builder, qubitOrQvec.getValue(), regName);
+  return applyMeasure<cudaq::quake::MzOp>(builder, qubitOrQvec.getValue(),
+                                          regName);
 }
 
 void reset(ImplicitLocOpBuilder &builder, const QuakeValue &qubitOrQvec) {
-  quake::ResetOp::create(builder, TypeRange{}, qubitOrQvec.getValue());
+  cudaq::quake::ResetOp::create(builder, TypeRange{}, qubitOrQvec.getValue());
 }
 
 void swap(ImplicitLocOpBuilder &builder, const std::vector<QuakeValue> &ctrls,
@@ -834,11 +844,11 @@ void swap(ImplicitLocOpBuilder &builder, const std::vector<QuakeValue> &ctrls,
                  [](auto &el) { return el.getValue(); });
   std::transform(qubits.begin(), qubits.end(), std::back_inserter(qubitValues),
                  [](auto &el) { return el.getValue(); });
-  quake::SwapOp::create(builder, adjoint, ValueRange(), ctrlValues,
-                        qubitValues);
+  cudaq::quake::SwapOp::create(builder, adjoint, ValueRange(), ctrlValues,
+                               qubitValues);
 }
 
-void checkAndUpdateRegName(quake::MeasurementInterface &measure) {
+void checkAndUpdateRegName(cudaq::quake::MeasurementInterface &measure) {
   auto regName = measure.getOptionalRegisterName();
   if (!regName.has_value() || regName.value().empty()) {
     auto regNameUpdate = "auto_register_" + std::to_string(regCounter++);
@@ -864,7 +874,7 @@ std::string name(std::string_view kernelName) {
 }
 
 bool isQubitType(Type ty) {
-  if (isa<quake::RefType, quake::VeqType>(ty))
+  if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(ty))
     return true;
   if (auto vecTy = dyn_cast<cudaq::cc::StdvecType>(ty))
     return isQubitType(vecTy.getElementType());

--- a/runtime/cudaq/platform/default/python/QPU.cpp
+++ b/runtime/cudaq/platform/default/python/QPU.cpp
@@ -245,7 +245,7 @@ static void updateExecutionContext(mlir::ModuleOp module) {
     return;
 
   for (auto &artifact : module) {
-    quake::detail::QuakeFunctionAnalysis analysis{&artifact};
+    cudaq::quake::detail::QuakeFunctionAnalysis analysis{&artifact};
     auto info = analysis.getAnalysisInfo();
     if (info.empty())
       continue;

--- a/runtime/internal/compiler/ArgumentConversion.cpp
+++ b/runtime/internal/compiler/ArgumentConversion.cpp
@@ -138,7 +138,7 @@ static Value genConstant(OpBuilder &, cudaq::cc::CallableType, void *, ModuleOp,
   auto loc = initFunc.getLoc();
 
   auto argTypes = calleeFunc.getArgumentTypes();
-  auto retTy = quake::VeqType::getUnsized(ctx);
+  auto retTy = cudaq::quake::VeqType::getUnsized(ctx);
   auto funcTy = FunctionType::get(ctx, argTypes, TypeRange{retTy});
 
   initFunc.setName(initKernelName);
@@ -184,7 +184,7 @@ static Value genConstant(OpBuilder &, cudaq::cc::CallableType, void *, ModuleOp,
     Value blockBegin = begin;
     Value blockAllocSize = zero;
     for (auto &op : block) {
-      if (auto alloc = dyn_cast<quake::AllocaOp>(&op)) {
+      if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(&op)) {
         newBuilder.setInsertionPointAfter(alloc);
 
         if (!arg) {
@@ -196,11 +196,11 @@ static Value genConstant(OpBuilder &, cudaq::cc::CallableType, void *, ModuleOp,
         if (!allocSize)
           allocSize = arith::ConstantIntOp::create(
               newBuilder, loc, newBuilder.getI64Type(),
-              quake::getAllocationSize(alloc.getType()));
+              cudaq::quake::getAllocationSize(alloc.getType()));
 
         auto offset = arith::SubIOp::create(newBuilder, loc, allocSize, one);
-        subArg =
-            quake::SubVeqOp::create(newBuilder, loc, retTy, arg, begin, offset);
+        subArg = cudaq::quake::SubVeqOp::create(newBuilder, loc, retTy, arg,
+                                                begin, offset);
         alloc.replaceAllUsesWith(subArg);
         cleanUps.push_back(alloc);
         begin = arith::AddIOp::create(newBuilder, loc, begin, allocSize);
@@ -214,8 +214,8 @@ static Value genConstant(OpBuilder &, cudaq::cc::CallableType, void *, ModuleOp,
 
           auto offset =
               arith::SubIOp::create(newBuilder, loc, blockAllocSize, one);
-          Value ret = quake::SubVeqOp::create(newBuilder, loc, retTy, arg,
-                                              blockBegin, offset);
+          Value ret = cudaq::quake::SubVeqOp::create(newBuilder, loc, retTy,
+                                                     arg, blockBegin, offset);
 
           assert(arg && "No veq allocations found");
           replacedReturn = func::ReturnOp::create(newBuilder, loc, ret);
@@ -285,12 +285,12 @@ createNumQubitsFunc(OpBuilder &builder, ModuleOp moduleOp,
 
     for (auto &op : block) {
       // Calculate allocation size (existing allocation size plus new one)
-      if (auto alloc = dyn_cast<quake::AllocaOp>(&op)) {
+      if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(&op)) {
         Value allocSize = alloc.getSize();
         if (!allocSize)
           allocSize = arith::ConstantIntOp::create(
               newBuilder, loc, newBuilder.getI64Type(),
-              quake::getAllocationSize(alloc.getType()));
+              cudaq::quake::getAllocationSize(alloc.getType()));
         newBuilder.setInsertionPointAfter(alloc);
         size = arith::AddIOp::create(newBuilder, loc, size, allocSize);
       }
@@ -363,7 +363,8 @@ genConstant(OpBuilder &builder, const cudaq::state *v, llvm::DataLayout &layout,
     Value ptrInt =
         genIntegerConstant(builder, reinterpret_cast<std::int64_t>(v), 64);
     // Cast int value to state ptr
-    auto statePtrTy = cudaq::cc::PointerType::get(quake::StateType::get(ctx));
+    auto statePtrTy =
+        cudaq::cc::PointerType::get(cudaq::quake::StateType::get(ctx));
     Value statePtrVal =
         cudaq::cc::CastOp::create(builder, loc, statePtrTy, ptrInt);
     return statePtrVal;
@@ -503,8 +504,9 @@ genConstant(OpBuilder &builder, const cudaq::state *v, llvm::DataLayout &layout,
     }
 
     // Create a substitution for the state pointer.
-    auto statePtrTy = cudaq::cc::PointerType::get(quake::StateType::get(ctx));
-    return quake::MaterializeStateOp::create(
+    auto statePtrTy =
+        cudaq::cc::PointerType::get(cudaq::quake::StateType::get(ctx));
+    return cudaq::quake::MaterializeStateOp::create(
         builder, loc, statePtrTy, builder.getStringAttr(numQubitsKernelName),
         builder.getStringAttr(initKernelName));
   }
@@ -946,7 +948,7 @@ void cudaq_internal::compiler::ArgumentConverter::gen(
             })
             .Case([&](cudaq::cc::PointerType ptrTy)
                       -> cudaq::cc::ArgumentSubstitutionOp {
-              if (ptrTy.getElementType() == quake::StateType::get(ctx))
+              if (ptrTy.getElementType() == cudaq::quake::StateType::get(ctx))
                 return buildSubst(static_cast<const cudaq::state *>(argPtr),
                                   dataLayout, kernelName, substModule, *this);
               return {};

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -431,7 +431,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
   // Populate conditional measurement flag in the context.
   if (emulate && executionContext && executionContext->name == "sample") {
     for (auto &artifact : moduleOp) {
-      quake::detail::QuakeFunctionAnalysis analysis{&artifact};
+      cudaq::quake::detail::QuakeFunctionAnalysis analysis{&artifact};
       auto info = analysis.getAnalysisInfo();
       if (info.empty())
         continue;
@@ -474,7 +474,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
             std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
         if (funcOp) {
           bool hasNamedMeasurements = false;
-          funcOp.walk([&](quake::MeasurementInterface meas) {
+          funcOp.walk([&](cudaq::quake::MeasurementInterface meas) {
             if (meas.getOptionalRegisterName().has_value()) {
               hasNamedMeasurements = true;
               return mlir::WalkResult::interrupt();

--- a/runtime/internal/compiler/JIT.cpp
+++ b/runtime/internal/compiler/JIT.cpp
@@ -271,7 +271,7 @@ cudaq_internal::compiler::createJITEngine(ModuleOp &moduleOp,
 
     bool containsWireSet =
         module
-            ->walk<WalkOrder::PreOrder>([](quake::WireSetOp wireSetOp) {
+            ->walk<WalkOrder::PreOrder>([](cudaq::quake::WireSetOp wireSetOp) {
               return WalkResult::interrupt();
             })
             .wasInterrupted();

--- a/runtime/internal/compiler/RuntimeMLIR.cpp
+++ b/runtime/internal/compiler/RuntimeMLIR.cpp
@@ -444,7 +444,7 @@ qirProfileTranslationFunction(const std::string &qirProfile, Operation *op,
   std::string errMsg;
   llvm::raw_string_ostream errOs(errMsg);
   bool containsWireSet =
-      op->walk<WalkOrder::PreOrder>([](quake::WireSetOp wireSetOp) {
+      op->walk<WalkOrder::PreOrder>([](cudaq::quake::WireSetOp wireSetOp) {
           return WalkResult::interrupt();
         }).wasInterrupted();
 

--- a/test/plugin/CustomPassPlugin.cpp
+++ b/test/plugin/CustomPassPlugin.cpp
@@ -20,11 +20,11 @@ using namespace mlir;
 
 namespace {
 
-struct ReplaceH : public OpRewritePattern<quake::HOp> {
+struct ReplaceH : public OpRewritePattern<cudaq::quake::HOp> {
   using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(quake::HOp hOp,
+  LogicalResult matchAndRewrite(cudaq::quake::HOp hOp,
                                 PatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<quake::SOp>(
+    rewriter.replaceOpWithNewOp<cudaq::quake::SOp>(
         hOp, hOp.isAdj(), hOp.getParameters(), hOp.getControls(),
         hOp.getTargets());
     return success();
@@ -45,8 +45,8 @@ public:
     RewritePatternSet patterns(ctx);
     patterns.insert<ReplaceH>(ctx);
     ConversionTarget target(*ctx);
-    target.addLegalDialect<quake::QuakeDialect>();
-    target.addIllegalOp<quake::HOp>();
+    target.addLegalDialect<cudaq::quake::QuakeDialect>();
+    target.addIllegalOp<cudaq::quake::HOp>();
     if (failed(applyPartialConversion(circuit, target, std::move(patterns)))) {
       circuit.emitOpError("simple pass failed");
       signalPassFailure();

--- a/tools/cudaq-translate/cudaq-translate.cpp
+++ b/tools/cudaq-translate/cudaq-translate.cpp
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
                                     "quake mlir to llvm ir compiler\n");
 
   DialectRegistry registry;
-  registry.insert<cudaq::cc::CCDialect, quake::QuakeDialect>();
+  registry.insert<cudaq::cc::CCDialect, cudaq::quake::QuakeDialect>();
   cudaq::registerAllDialects(registry);
   mlir::func::registerInlinerExtension(registry);
   mlir::LLVM::registerInlinerInterface(registry);

--- a/unittests/Optimizer/DecompositionPatternSelectionTest.cpp
+++ b/unittests/Optimizer/DecompositionPatternSelectionTest.cpp
@@ -137,7 +137,7 @@ protected:
   void SetUp() override {
     context = std::make_unique<MLIRContext>();
     context->loadDialect<arith::ArithDialect, cudaq::cc::CCDialect,
-                         func::FuncDialect, quake::QuakeDialect>();
+                         func::FuncDialect, cudaq::quake::QuakeDialect>();
     // set up graph in children classes
   }
 
@@ -159,12 +159,12 @@ protected:
 
     // Create n_qubits qubit wires
     SmallVector<Value> controls;
-    auto wireType = quake::WireType::get(context.get());
+    auto wireType = cudaq::quake::WireType::get(context.get());
     for (unsigned i = 0; i < nCtrls; ++i) {
-      auto qubit = quake::AllocaOp::create(builder, loc, wireType);
+      auto qubit = cudaq::quake::AllocaOp::create(builder, loc, wireType);
       controls.push_back(qubit.getResult());
     }
-    auto targetQubit = quake::AllocaOp::create(builder, loc, wireType);
+    auto targetQubit = cudaq::quake::AllocaOp::create(builder, loc, wireType);
     SmallVector<Value> targets{targetQubit};
 
     // Create the operation of type Op with the qubits
@@ -232,28 +232,28 @@ protected:
 TEST_F(BaseDecompositionPatternSelectionTest, BasisTargetParsesSimpleGates) {
   std::vector<std::string> basis{"h", "t", "x"};
   auto target = cudaq::createBasisTarget(*context, basis);
-  EXPECT_TRUE(isLegal<quake::HOp>(target));
-  EXPECT_TRUE(isLegal<quake::TOp>(target));
-  EXPECT_TRUE(isLegal<quake::XOp>(target));
+  EXPECT_TRUE(isLegal<cudaq::quake::HOp>(target));
+  EXPECT_TRUE(isLegal<cudaq::quake::TOp>(target));
+  EXPECT_TRUE(isLegal<cudaq::quake::XOp>(target));
 
-  EXPECT_FALSE(isLegal<quake::HOp>(target, 1));
-  EXPECT_FALSE(isLegal<quake::TOp>(target, 1));
-  EXPECT_FALSE(isLegal<quake::XOp>(target, 1));
-  EXPECT_FALSE(isLegal<quake::ZOp>(target));
+  EXPECT_FALSE(isLegal<cudaq::quake::HOp>(target, 1));
+  EXPECT_FALSE(isLegal<cudaq::quake::TOp>(target, 1));
+  EXPECT_FALSE(isLegal<cudaq::quake::XOp>(target, 1));
+  EXPECT_FALSE(isLegal<cudaq::quake::ZOp>(target));
 }
 
 TEST_F(BaseDecompositionPatternSelectionTest,
        BasisTargetParsesControlledGates) {
   std::vector<std::string> basis{"x(1)", "z(2)"};
   auto target = cudaq::createBasisTarget(*context, basis);
-  EXPECT_TRUE(isLegal<quake::XOp>(target, 1));
-  EXPECT_TRUE(isLegal<quake::ZOp>(target, 2));
+  EXPECT_TRUE(isLegal<cudaq::quake::XOp>(target, 1));
+  EXPECT_TRUE(isLegal<cudaq::quake::ZOp>(target, 2));
 
-  EXPECT_FALSE(isLegal<quake::XOp>(target));
-  EXPECT_FALSE(isLegal<quake::XOp>(target, 2));
-  EXPECT_FALSE(isLegal<quake::ZOp>(target));
-  EXPECT_FALSE(isLegal<quake::ZOp>(target, 1));
-  EXPECT_FALSE(isLegal<quake::ZOp>(target, 3));
+  EXPECT_FALSE(isLegal<cudaq::quake::XOp>(target));
+  EXPECT_FALSE(isLegal<cudaq::quake::XOp>(target, 2));
+  EXPECT_FALSE(isLegal<cudaq::quake::ZOp>(target));
+  EXPECT_FALSE(isLegal<cudaq::quake::ZOp>(target, 1));
+  EXPECT_FALSE(isLegal<cudaq::quake::ZOp>(target, 3));
 }
 
 TEST_F(BaseDecompositionPatternSelectionTest,
@@ -261,10 +261,10 @@ TEST_F(BaseDecompositionPatternSelectionTest,
   std::vector<std::string> basis{"x(n)"};
   auto target = cudaq::createBasisTarget(*context, basis);
 
-  EXPECT_TRUE(isLegal<quake::XOp>(target, 0));
-  EXPECT_TRUE(isLegal<quake::XOp>(target, 1));
-  EXPECT_TRUE(isLegal<quake::XOp>(target, 2));
-  EXPECT_TRUE(isLegal<quake::XOp>(target, 10));
+  EXPECT_TRUE(isLegal<cudaq::quake::XOp>(target, 0));
+  EXPECT_TRUE(isLegal<cudaq::quake::XOp>(target, 1));
+  EXPECT_TRUE(isLegal<cudaq::quake::XOp>(target, 2));
+  EXPECT_TRUE(isLegal<cudaq::quake::XOp>(target, 10));
 }
 
 //===----------------------------------------------------------------------===//

--- a/unittests/Optimizer/DecompositionPatternsTest.cpp
+++ b/unittests/Optimizer/DecompositionPatternsTest.cpp
@@ -36,7 +36,7 @@ protected:
   void SetUp() override {
     context = std::make_unique<MLIRContext>();
     context->loadDialect<arith::ArithDialect, cudaq::cc::CCDialect,
-                         func::FuncDialect, quake::QuakeDialect>();
+                         func::FuncDialect, cudaq::quake::QuakeDialect>();
   }
 
   std::unique_ptr<MLIRContext> context;
@@ -98,7 +98,7 @@ ModuleOp createTestModule(MLIRContext *context, StringRef gateSpecStr) {
 
   // Create function type: (qubits...) -> ()
   SmallVector<Type> inputTypes;
-  auto refType = quake::RefType::get(context);
+  auto refType = cudaq::quake::RefType::get(context);
   for (size_t i = 0; i < numQubits; ++i) {
     inputTypes.push_back(refType);
   }
@@ -124,54 +124,54 @@ ModuleOp createTestModule(MLIRContext *context, StringRef gateSpecStr) {
                                                         builder.getF64Type());
 
   if (gateName == "h") {
-    quake::HOp::create(builder, loc, isAdj, controls, target);
+    cudaq::quake::HOp::create(builder, loc, isAdj, controls, target);
   } else if (gateName == "s") {
-    quake::SOp::create(builder, loc, isAdj, controls, target);
+    cudaq::quake::SOp::create(builder, loc, isAdj, controls, target);
   } else if (gateName == "t") {
-    quake::TOp::create(builder, loc, isAdj, controls, target);
+    cudaq::quake::TOp::create(builder, loc, isAdj, controls, target);
   } else if (gateName == "x") {
-    quake::XOp::create(builder, loc, isAdj, controls, target);
+    cudaq::quake::XOp::create(builder, loc, isAdj, controls, target);
   } else if (gateName == "y") {
-    quake::YOp::create(builder, loc, isAdj, controls, target);
+    cudaq::quake::YOp::create(builder, loc, isAdj, controls, target);
   } else if (gateName == "z") {
-    quake::ZOp::create(builder, loc, isAdj, controls, target);
+    cudaq::quake::ZOp::create(builder, loc, isAdj, controls, target);
   } else if (gateName == "rx") {
-    quake::RxOp::create(builder, loc, isAdj, ValueRange{pi_2}, controls,
-                        target);
+    cudaq::quake::RxOp::create(builder, loc, isAdj, ValueRange{pi_2}, controls,
+                               target);
   } else if (gateName == "ry") {
-    quake::RyOp::create(builder, loc, isAdj, ValueRange{pi_2}, controls,
-                        target);
+    cudaq::quake::RyOp::create(builder, loc, isAdj, ValueRange{pi_2}, controls,
+                               target);
   } else if (gateName == "rz") {
-    quake::RzOp::create(builder, loc, isAdj, ValueRange{pi_2}, controls,
-                        target);
+    cudaq::quake::RzOp::create(builder, loc, isAdj, ValueRange{pi_2}, controls,
+                               target);
   } else if (gateName == "r1") {
-    quake::R1Op::create(builder, loc, isAdj, ValueRange{pi_2}, controls,
-                        target);
+    cudaq::quake::R1Op::create(builder, loc, isAdj, ValueRange{pi_2}, controls,
+                               target);
   } else if (gateName == "u3") {
-    quake::U3Op::create(builder, loc, isAdj, ValueRange{pi_2, pi_2, pi_2},
-                        controls, target);
+    cudaq::quake::U3Op::create(builder, loc, isAdj,
+                               ValueRange{pi_2, pi_2, pi_2}, controls, target);
   } else if (gateName == "phased_rx") {
-    quake::PhasedRxOp::create(builder, loc, isAdj, ValueRange{{pi_2, pi_2}},
-                              controls, target);
+    cudaq::quake::PhasedRxOp::create(
+        builder, loc, isAdj, ValueRange{{pi_2, pi_2}}, controls, target);
   } else if (gateName == "swap") {
     // Swap needs 2 targets
     Value target = entry->getArgument(0);
     Value target2 = entry->getArgument(1);
-    quake::SwapOp::create(builder, loc, ValueRange{target, target2});
+    cudaq::quake::SwapOp::create(builder, loc, ValueRange{target, target2});
   } else if (gateName == "exp_pauli") {
     Value target = entry->getArgument(0);
     Value target2 = entry->getArgument(1);
     // Create a veq from the two target qubits using ConcatOp
     SmallVector<Value> targetValues = {target, target2};
-    Value qubitsVal = quake::ConcatOp::create(
-        builder, loc, quake::VeqType::get(builder.getContext(), 2),
+    Value qubitsVal = cudaq::quake::ConcatOp::create(
+        builder, loc, cudaq::quake::VeqType::get(builder.getContext(), 2),
         targetValues);
 
-    quake::ExpPauliOp::create(builder, loc,
-                              /* parameters = */ ValueRange{pi_2},
-                              /* controls = */ ValueRange{},
-                              /* targets = */ qubitsVal,
-                              /* pauliLiteral = */ "XX");
+    cudaq::quake::ExpPauliOp::create(builder, loc,
+                                     /* parameters = */ ValueRange{pi_2},
+                                     /* controls = */ ValueRange{},
+                                     /* targets = */ qubitsVal,
+                                     /* pauliLiteral = */ "XX");
   } else {
     // Unsupported gate for this test
     ADD_FAILURE() << "unknown gate: " << gateName;
@@ -186,7 +186,7 @@ llvm::StringSet<> collectGateTypesInModule(ModuleOp module) {
   llvm::StringSet<> gates;
 
   module.walk([&](Operation *op) {
-    if (auto optor = dyn_cast<quake::OperatorInterface>(op)) {
+    if (auto optor = dyn_cast<cudaq::quake::OperatorInterface>(op)) {
       std::string gateName = optor->getName().stripDialect().str();
       auto numControls = optor.getControls().size();
 

--- a/unittests/Optimizer/HermitianTrait.cpp
+++ b/unittests/Optimizer/HermitianTrait.cpp
@@ -15,22 +15,24 @@ using namespace mlir;
 
 TEST(Quake, HermitianTrait) {
   MLIRContext context;
-  context.loadDialect<quake::QuakeDialect>();
+  context.loadDialect<cudaq::quake::QuakeDialect>();
   OpBuilder builder(&context);
 
-  Value qubit = quake::AllocaOp::create(builder, builder.getUnknownLoc());
-  Operation *op = quake::HOp::create(builder, builder.getUnknownLoc(), qubit);
+  Value qubit =
+      cudaq::quake::AllocaOp::create(builder, builder.getUnknownLoc());
+  Operation *op =
+      cudaq::quake::HOp::create(builder, builder.getUnknownLoc(), qubit);
   ASSERT_TRUE(op->hasTrait<cudaq::Hermitian>());
 
-  auto optor = dyn_cast<quake::OperatorInterface>(op);
+  auto optor = dyn_cast<cudaq::quake::OperatorInterface>(op);
   ASSERT_TRUE(optor->hasTrait<cudaq::Hermitian>());
   // The following does not work because of an MLIR bug
   // ASSERT_TRUE(optor.hasTrait<cudaq::Hermitian>());
 
-  op = quake::TOp::create(builder, builder.getUnknownLoc(), qubit);
+  op = cudaq::quake::TOp::create(builder, builder.getUnknownLoc(), qubit);
   ASSERT_FALSE(op->hasTrait<cudaq::Hermitian>());
 
-  optor = dyn_cast<quake::OperatorInterface>(op);
+  optor = dyn_cast<cudaq::quake::OperatorInterface>(op);
   ASSERT_FALSE(optor->hasTrait<cudaq::Hermitian>());
   // The following does not work because of an MLIR bug
   // ASSERT_TRUE(optor.hasTrait<cudaq::Hermitian>());

--- a/utils/CircuitCheck/CircuitCheck.cpp
+++ b/utils/CircuitCheck/CircuitCheck.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv);
 
   MLIRContext context;
-  context.loadDialect<cudaq::cc::CCDialect, quake::QuakeDialect,
+  context.loadDialect<cudaq::cc::CCDialect, cudaq::quake::QuakeDialect,
                       arith::ArithDialect, func::FuncDialect>();
 
   ParserConfig config(&context);

--- a/utils/CircuitCheck/UnitaryBuilder.cpp
+++ b/utils/CircuitCheck/UnitaryBuilder.cpp
@@ -16,7 +16,7 @@ using namespace mlir;
 LogicalResult UnitaryBuilder::build(func::FuncOp func) {
   for (auto arg : func.getArguments()) {
     auto type = arg.getType();
-    if (isa<quake::RefType, quake::VeqType>(type))
+    if (isa<cudaq::quake::RefType, cudaq::quake::VeqType>(type))
       if (allocateQubits(arg) == WalkResult::interrupt())
         return failure();
   }
@@ -27,24 +27,24 @@ LogicalResult UnitaryBuilder::build(func::FuncOp func) {
   SmallVector<Complex, 16> matrix;
   SmallVector<Qubit, 16> qubits;
   auto result = func.walk([&](Operation *op) {
-    if (auto nullWireOp = dyn_cast<quake::NullWireOp>(op))
+    if (auto nullWireOp = dyn_cast<cudaq::quake::NullWireOp>(op))
       return allocateQubits(nullWireOp.getResult());
-    if (auto borrowOp = dyn_cast<quake::BorrowWireOp>(op))
+    if (auto borrowOp = dyn_cast<cudaq::quake::BorrowWireOp>(op))
       return allocateQubits(borrowOp.getResult());
-    if (auto allocOp = dyn_cast<quake::AllocaOp>(op))
+    if (auto allocOp = dyn_cast<cudaq::quake::AllocaOp>(op))
       return allocateQubits(allocOp.getResult());
-    if (auto extractOp = dyn_cast<quake::ExtractRefOp>(op))
+    if (auto extractOp = dyn_cast<cudaq::quake::ExtractRefOp>(op))
       return visitExtractOp(extractOp);
-    if (auto unwrapOp = dyn_cast<quake::UnwrapOp>(op))
+    if (auto unwrapOp = dyn_cast<cudaq::quake::UnwrapOp>(op))
       return visitUnwrapOp(unwrapOp);
-    if (auto optor = dyn_cast<quake::OperatorInterface>(op)) {
+    if (auto optor = dyn_cast<cudaq::quake::OperatorInterface>(op)) {
       optor.getOperatorMatrix(matrix);
       // If the operator couldn't produce a matrix, stop the walk.
       if (matrix.empty()) {
         optor.emitOpError("Couldn't produce matrix.");
         return WalkResult::interrupt();
       }
-      auto quantumOperands = quake::getQuantumOperands(op);
+      auto quantumOperands = cudaq::quake::getQuantumOperands(op);
       if (quantumOperands.empty()) {
         optor.emitOpError("Couldn't get quantum operands");
         return WalkResult::interrupt();
@@ -55,13 +55,14 @@ LogicalResult UnitaryBuilder::build(func::FuncOp func) {
         return WalkResult::interrupt();
       }
 
-      for (auto &&[newQuantumOp, quantumOp] : llvm::zip(
-               quake::getQuantumResults(op), quake::getQuantumOperands(op)))
+      for (auto &&[newQuantumOp, quantumOp] :
+           llvm::zip(cudaq::quake::getQuantumResults(op),
+                     cudaq::quake::getQuantumOperands(op)))
         qubitMap.insert({newQuantumOp, qubitMap[quantumOp]});
 
       // When checking mapped circuits, we do a software swap, i.e., just change
       // the qubit mapping instead of applying the swap operation.
-      if (upToMapping && isa<quake::SwapOp>(op)) {
+      if (upToMapping && isa<cudaq::quake::SwapOp>(op)) {
         std::swap(qubitMap[op->getResult(0)], qubitMap[op->getResult(1)]);
       } else {
         if (optor.getNegatedControls())
@@ -87,7 +88,7 @@ LogicalResult UnitaryBuilder::build(func::FuncOp func) {
 // Visitors
 //===----------------------------------------------------------------------===//
 
-WalkResult UnitaryBuilder::visitExtractOp(quake::ExtractRefOp op) {
+WalkResult UnitaryBuilder::visitExtractOp(cudaq::quake::ExtractRefOp op) {
   Value veq = op.getVeq();
   ArrayRef<unsigned> qubits = qubitMap[veq];
   std::size_t index = 0;
@@ -103,7 +104,7 @@ WalkResult UnitaryBuilder::visitExtractOp(quake::ExtractRefOp op) {
   return WalkResult::advance();
 }
 
-WalkResult UnitaryBuilder::visitUnwrapOp(quake::UnwrapOp op) {
+WalkResult UnitaryBuilder::visitUnwrapOp(cudaq::quake::UnwrapOp op) {
   ArrayRef<unsigned> qubits = qubitMap[op.getOperand()];
   auto [entry, _] = qubitMap.try_emplace(op.getResult());
   entry->second.push_back(qubits.front());
@@ -117,7 +118,7 @@ WalkResult UnitaryBuilder::allocateQubits(Value value) {
     return WalkResult::interrupt();
   }
   auto &qubits = entry->second;
-  if (auto veq = dyn_cast<quake::VeqType>(value.getType())) {
+  if (auto veq = dyn_cast<cudaq::quake::VeqType>(value.getType())) {
     if (!veq.hasSpecifiedSize()) {
       value.getDefiningOp()->emitError("Veq doesn't have a specified size.");
       return WalkResult::interrupt();
@@ -148,7 +149,7 @@ LogicalResult UnitaryBuilder::getValueAsInt(Value value, std::size_t &result) {
 LogicalResult UnitaryBuilder::getQubits(ValueRange values,
                                         SmallVectorImpl<Qubit> &qubits) {
   for (Value value : values) {
-    if (auto veq = dyn_cast<quake::VeqType>(value.getType())) {
+    if (auto veq = dyn_cast<cudaq::quake::VeqType>(value.getType())) {
       if (!veq.hasSpecifiedSize())
         return failure();
       llvm::copy(qubitMap[value], std::back_inserter(qubits));

--- a/utils/CircuitCheck/UnitaryBuilder.h
+++ b/utils/CircuitCheck/UnitaryBuilder.h
@@ -34,9 +34,9 @@ private:
   // Visitors
   //===--------------------------------------------------------------------===//
 
-  mlir::WalkResult visitExtractOp(quake::ExtractRefOp op);
+  mlir::WalkResult visitExtractOp(cudaq::quake::ExtractRefOp op);
 
-  mlir::WalkResult visitUnwrapOp(quake::UnwrapOp op);
+  mlir::WalkResult visitUnwrapOp(cudaq::quake::UnwrapOp op);
 
   mlir::WalkResult allocateQubits(mlir::Value value);
 


### PR DESCRIPTION
This moves the quake namespace to cudaq::quake in preparation for adding formal subprojects to the CUDA-Q monorepo.