### PR TITLE
Updated sample semantics (simple fix)

### DIFF
--- a/lib/Optimizer/Transforms/Mapping.cpp
+++ b/lib/Optimizer/Transforms/Mapping.cpp
@@ -768,10 +768,14 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
           return;
         }
 
-        // Save which qubits are measured
+        // Save which qubits are measured, preserving measurement encounter
+        // order and ignoring duplicate measurements for the global register.
         if (isa<quake::MeasurementInterface>(op))
-          for (const auto &wire : wireOperands)
-            userQubitsMeasured.push_back(wireToVirtualQ[wire].index);
+          for (const auto &wire : wireOperands) {
+            auto virtualQubit = wireToVirtualQ[wire].index;
+            if (!llvm::is_contained(userQubitsMeasured, virtualQubit))
+              userQubitsMeasured.push_back(virtualQubit);
+          }
 
         // Map the result wires to the appropriate virtual qubits.
         for (auto &&[wire, newWire] :
@@ -906,10 +910,11 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
 
     // Now populate mapping_reorder_idx attribute. This attribute will be used
     // by downstream processing to reconstruct a global register as if mapping
-    // had not occurred. This is important because the global register is
-    // required to be sorted by qubit allocation order, and mapping can change
-    // that apparent order AND introduce ancilla qubits that we don't want to
-    // appear in the final global register.
+    // had not occurred. This is important because the global register follows
+    // measurement order, and mapping can change that apparent order AND
+    // introduce ancilla qubits that we don't want to appear in the final global
+    // register. Explicit measurements use their encounter order; implicit
+    // measurements inserted by this pass use allocation order.
 
     // pair is <first=virtual, second=physical>
     using VirtPhyPairType = std::pair<std::size_t, std::size_t>;
@@ -924,14 +929,18 @@ struct MappingFunc : public cudaq::opt::impl::MappingFuncBase<MappingFunc> {
                [&](const VirtPhyPairType &a, const VirtPhyPairType &b) {
                  return a.second < b.second;
                });
-    // Now find out how to reorder `measuredQubits` such that the elements are
-    // ordered based on the *virtual* qubits (i.e. measuredQubits[].first).
-    llvm::SmallVector<std::size_t> reorder_idx(measuredQubits.size());
-    for (std::size_t ix = 0; auto &element : reorder_idx)
-      element = ix++;
-    llvm::sort(reorder_idx, [&](const std::size_t &i1, const std::size_t &i2) {
-      return measuredQubits[i1].first < measuredQubits[i2].first;
-    });
+    // Now find out how to reorder `measuredQubits` such that the elements
+    // follow the original measurement encounter order.
+    llvm::SmallVector<std::size_t> reorder_idx;
+    reorder_idx.reserve(userQubitsMeasured.size());
+    for (auto measuredVirtualQubit : userQubitsMeasured) {
+      auto iter = llvm::find_if(measuredQubits, [&](const auto &element) {
+        return element.first == measuredVirtualQubit;
+      });
+      assert(iter != measuredQubits.end() &&
+             "measured qubit must be present in physical-sorted list");
+      reorder_idx.push_back(std::distance(measuredQubits.begin(), iter));
+    }
     // After kernel execution is complete, you can pass reorder_idx[] into
     // sample_result::reorder() in order to undo the ordering change to the
     // global register that the mapping pass induced.

--- a/python/tests/kernel/test_explicit_measurements.py
+++ b/python/tests/kernel/test_explicit_measurements.py
@@ -131,9 +131,8 @@ def test_named_measurement():
 
 
 def test_measurement_order():
-    """ Test for if the "explicit measurements" option is enabled, the global 
-        register contains the concatenated measurements in the order they were
-        executed in the kernel. """
+    """ Test that the global register contains the concatenated measurements
+        in the order they were executed in the kernel. """
 
     @cudaq.kernel
     def kernel():
@@ -144,7 +143,7 @@ def test_measurement_order():
         mz(q[2])
 
     counts = cudaq.sample(kernel)
-    assert counts["100"] == 1000
+    assert counts["010"] == 1000
 
     counts = cudaq.sample(kernel, explicit_measurements=True)
     assert counts["010"] == 1000
@@ -196,6 +195,21 @@ def test_no_measurements():
     assert "not supported on a kernel without any measurement" in repr(e)
 
 
+def test_default_measurement_order_issue_4153():
+
+    @cudaq.kernel
+    def kernel():
+        q = cudaq.qvector(4)
+        x(q[2])
+        mz(q[2])
+        mz(q[0])
+        mz(q[1])
+        mz(q[3])
+
+    counts = cudaq.sample(kernel)
+    assert counts["1000"] == 1000
+
+
 def test_mixed_basis_measurement_order_and_preservation():
 
     @cudaq.kernel
@@ -203,8 +217,8 @@ def test_mixed_basis_measurement_order_and_preservation():
         q = cudaq.qvector(9)
 
         # Prepare a non-palindromic deterministic pattern over measured bits.
-        # q0=0 (mz), q1=1 (mz), q2=1 (mx), q3=? (my), q4=0 (mz), q5=0 (mx),
-        # q6=1 (mz) -> 011?001 in allocation order.
+        # q4=0 (mz), q2=1 (mx), q3=? (my), q0=0 (mz), q5=0 (mx),
+        # q6=1 (mz), q1=1 (mz) -> 01?0011 in measurement order.
         x(q[1])
         x(q[2])
         h(q[2])
@@ -227,9 +241,9 @@ def test_mixed_basis_measurement_order_and_preservation():
         assert len(bits) == 7
         assert bits[0] == '0'
         assert bits[1] == '1'
-        assert bits[2] == '1'
+        assert bits[3] == '0'
         assert bits[4] == '0'
-        assert bits[5] == '0'
+        assert bits[5] == '1'
         assert bits[6] == '1'
         total_counts += counts[bits]
 

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -184,7 +184,7 @@ public:
 
   /// Metadata on the compilation artifacts.
   struct CompilationMetadata {
-    /// Qubit reorder indices emitted by the qubit-mapping pass.
+    /// Global-register reorder indices emitted by the qubit-mapping pass.
     std::vector<std::size_t> reorderIdx;
   };
 

--- a/runtime/common/KernelExecution.h
+++ b/runtime/common/KernelExecution.h
@@ -26,6 +26,8 @@ struct KernelExecution {
   std::optional<cudaq::JitEngine> jit;
   std::optional<Resources> resourceCounts;
   cudaq::cudaq_json output_names;
+  /// Reorder indices that map backend bitstrings into the expected global
+  /// register order.
   std::vector<std::size_t> mapping_reorder_idx;
   cudaq::cudaq_json user_data;
   KernelExecution(const std::string &n, const std::string &c,

--- a/runtime/common/ServerHelper.h
+++ b/runtime/common/ServerHelper.h
@@ -70,7 +70,7 @@ protected:
   /// @brief Output names indexed by jobID/taskID
   std::map<std::string, OutputNamesType> outputNames;
 
-  /// @brief Reordering indices indexed by jobID/taskID (used by mapping pass)
+  /// @brief Global-register reordering indices indexed by jobID/taskID.
   std::map<std::string, std::vector<std::size_t>> reorderIdx;
 
   /// @brief  Information about the runtime target managing this server helper.

--- a/runtime/cudaq/platform/default/rest/helpers/anyon/AnyonServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/anyon/AnyonServerHelper.cpp
@@ -284,7 +284,7 @@ AnyonServerHelper::processResults(ServerMessage &postJobResponse,
   sample_result sampleResult(srs);
 
   // Now reorder according to reorderIdx[]. This sorts the global bitstring in
-  // original user qubit allocation order.
+  // the expected global register order.
   auto thisJobReorderIdxIt = reorderIdx.find(jobId);
   if (thisJobReorderIdxIt != reorderIdx.end()) {
     auto &thisJobReorderIdx = thisJobReorderIdxIt->second;

--- a/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/iqm/IQMServerHelper.cpp
@@ -295,7 +295,7 @@ IQMServerHelper::processResults(ServerMessage &postJobResponse,
 
   // The original sampleResult is ordered by qubit number (FIXME: VERIFY THIS)
   // Now reorder according to reorderIdx[]. This sorts the global bitstring in
-  // original user qubit allocation order.
+  // the expected global register order.
   auto thisJobReorderIdxIt = reorderIdx.find(jobID);
   if (thisJobReorderIdxIt != reorderIdx.end()) {
     auto &thisJobReorderIdx = thisJobReorderIdxIt->second;

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -426,7 +426,7 @@ OQCServerHelper::processResults(ServerMessage &postJobResponse,
   sampleResult.reorder(idx);
 
   // Now reorder according to reorderIdx[]. This sorts the global bitstring in
-  // original user qubit allocation order.
+  // the expected global register order.
   auto thisJobReorderIdxIt = reorderIdx.find(jobId);
   if (thisJobReorderIdxIt != reorderIdx.end()) {
     auto &thisJobReorderIdx = thisJobReorderIdxIt->second;

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -700,9 +700,19 @@ protected:
     if (executionContext->hasConditionalsOnMeasureResults && !force)
       return;
 
+    std::vector<std::size_t> qubitsInMeasurementOrder;
+
     // Sort the qubit indices (unless we're in the optimized sampling mode that
-    // simply concatenates sequential measurements)
+    // simply concatenates sequential measurements). Keep a de-duplicated copy
+    // of the original order so the global register can reflect the user's
+    // measurement order.
     if (!executionContext->explicitMeasurements) {
+      for (auto q : sampleQubits)
+        if (std::find(qubitsInMeasurementOrder.begin(),
+                      qubitsInMeasurementOrder.end(),
+                      q) == qubitsInMeasurementOrder.end())
+          qubitsInMeasurementOrder.push_back(q);
+
       std::sort(sampleQubits.begin(), sampleQubits.end());
       auto last = std::unique(sampleQubits.begin(), sampleQubits.end());
       sampleQubits.erase(last, sampleQubits.end());
@@ -727,36 +737,67 @@ protected:
           << std::endl;
     }
 
+    auto appendRegisterResult = [&](const std::string &regName,
+                                    const std::vector<std::size_t> &qubits) {
+      // Find the position of the qubits we have in the result bit string
+      // Create a map of qubit to bit string location
+      std::unordered_map<std::size_t, std::size_t> qubitLocMap;
+      for (std::size_t i = 0; i < qubits.size(); i++) {
+        auto iter =
+            std::find(sampleQubits.begin(), sampleQubits.end(), qubits[i]);
+        auto idx = std::distance(sampleQubits.begin(), iter);
+        qubitLocMap.insert({qubits[i], idx});
+      }
+
+      cudaq::ExecutionResult tmp(regName);
+      for (auto &[bits, count] : execResult.counts) {
+        std::string b = "";
+        b.reserve(qubits.size());
+        for (auto &qb : qubits)
+          b += bits[qubitLocMap[qb]];
+        tmp.appendResult(b, count);
+      }
+
+      internalResult.append(tmp);
+    };
+
+    auto sortUniqueQubits = [](std::vector<std::size_t> &qubits) {
+      std::sort(qubits.begin(), qubits.end());
+      auto last = std::unique(qubits.begin(), qubits.end());
+      qubits.erase(last, qubits.end());
+    };
+
+    // If the compiler/mapping pipeline provided a reorder index, it already
+    // describes the final global-register order, including source measurement
+    // order. Keep sampled bits in backend order and let finalize apply it.
+    // Without a reorder index, preserve measurement order here for local /
+    // unmapped simulator execution.
+    const bool preserveMeasurementOrder = executionContext->reorderIdx.empty();
+
     if (registerNameToMeasuredQubit.empty()) {
-      internalResult.append(execResult, executionContext->explicitMeasurements);
+      if (preserveMeasurementOrder && !executionContext->explicitMeasurements &&
+          qubitsInMeasurementOrder != sampleQubits) {
+        appendRegisterResult(cudaq::GlobalRegisterName,
+                             qubitsInMeasurementOrder);
+      } else {
+        internalResult.append(execResult,
+                              executionContext->explicitMeasurements);
+      }
     } else {
-
       for (auto &[regName, qubits] : registerNameToMeasuredQubit) {
-        // Measurements are sorted according to qubit allocation order
-        std::sort(qubits.begin(), qubits.end());
-        auto last = std::unique(qubits.begin(), qubits.end());
-        qubits.erase(last, qubits.end());
-
-        // Find the position of the qubits we have in the result bit string
-        // Create a map of qubit to bit string location
-        std::unordered_map<std::size_t, std::size_t> qubitLocMap;
-        for (std::size_t i = 0; i < qubits.size(); i++) {
-          auto iter =
-              std::find(sampleQubits.begin(), sampleQubits.end(), qubits[i]);
-          auto idx = std::distance(sampleQubits.begin(), iter);
-          qubitLocMap.insert({qubits[i], idx});
+        // Unless the mapping pass already provided a reorder, the global
+        // register follows user measurement order. Other named registers keep
+        // the legacy qubit-index ordering.
+        if (regName == cudaq::GlobalRegisterName) {
+          if (preserveMeasurementOrder)
+            qubits = qubitsInMeasurementOrder;
+          else
+            sortUniqueQubits(qubits);
+        } else {
+          sortUniqueQubits(qubits);
         }
 
-        cudaq::ExecutionResult tmp(regName);
-        for (auto &[bits, count] : execResult.counts) {
-          std::string b = "";
-          b.reserve(qubits.size());
-          for (auto &qb : qubits)
-            b += bits[qubitLocMap[qb]];
-          tmp.appendResult(b, count);
-        }
-
-        internalResult.append(tmp);
+        appendRegisterResult(regName, qubits);
       }
     }
 

--- a/targettests/execution/global_reg_sample.cpp
+++ b/targettests/execution/global_reg_sample.cpp
@@ -31,8 +31,8 @@ int main() {
   auto test1 = []() __qpu__ {
     cudaq::qubit a, b;
     x(a);
-    mz(b);
     mz(a);
+    mz(b);
   };
   SAMPLE_AND_PRINT_GLOBAL_REG(test1);
   // CHECK: test1:
@@ -42,8 +42,8 @@ int main() {
   auto test2 = []() __qpu__ {
     cudaq::qubit a, b;
     x(a);
-    auto ret_b = mz(b);
     auto ret_a = mz(a);
+    auto ret_b = mz(b);
   };
   SAMPLE_AND_PRINT_GLOBAL_REG(test2);
   // CHECK: test2:

--- a/targettests/execution/mapping_test-2.cpp
+++ b/targettests/execution/mapping_test-2.cpp
@@ -22,6 +22,17 @@ __qpu__ void foo() {
   auto result = mz(q);
 }
 
+__qpu__ void out_of_order() {
+  cudaq::qvector q(3);
+  x(q[0]);
+  x(q[1]);
+  x<cudaq::ctrl>(q[0], q[1]);
+  x<cudaq::ctrl>(q[0], q[2]); // requires a swap(q0,q1)
+  mz(q[2]);
+  mz(q[0]);
+  mz(q[1]);
+}
+
 int main() {
   auto result = cudaq::sample(1000, foo);
   result.dump();
@@ -29,6 +40,11 @@ int main() {
   // If the swap is working correctly, this will show "101". If it is working
   // incorrectly, it may show something like "011".
   std::cout << "most_probable \"" << result.most_probable() << "\"\n";
+
+  auto orderedResult = cudaq::sample(1000, out_of_order);
+  orderedResult.dump();
+  std::cout << "out_of_order most_probable \""
+            << orderedResult.most_probable() << "\"\n";
 
   return 0;
 }
@@ -51,3 +67,5 @@ int main() {
 // STDOUT-DAG: result%1 : { 0:1000 }
 // STDOUT-DAG: result%2 : { 1:1000 }
 // STDOUT-DAG: most_probable "101"
+// STDOUT-DAG: { 110:1000 }
+// STDOUT-DAG: out_of_order most_probable "110"

--- a/targettests/execution/mixed_basis_sample.cpp
+++ b/targettests/execution/mixed_basis_sample.cpp
@@ -49,18 +49,16 @@ int main() {
     // Every bitstring must be 7 bits (7 measured qubits).
     assert(bits.size() == 7);
 
-    // Deterministic z-basis results.
-    assert(bits[0] == '0'); // q0 mz -> 0
-    assert(bits[1] == '1'); // q1 mz -> 1
-    assert(bits[4] == '0'); // q4 mz -> 0
-    assert(bits[5] == '1'); // q5 mx(|->) -> 1
-    assert(bits[6] == '1'); // q6 mz -> 1
-
-    // q2: mx(|+>) -> 0
-    assert(bits[2] == '0');
+    // Measurement execution order: q4, q2, q3, q0, q5, q6, q1.
+    assert(bits[0] == '0'); // q4 mz -> 0
+    assert(bits[1] == '0'); // q2 mx(|+>) -> 0
+    assert(bits[3] == '0'); // q0 mz -> 0
+    assert(bits[4] == '1'); // q5 mx(|->) -> 1
+    assert(bits[5] == '1'); // q6 mz -> 1
+    assert(bits[6] == '1'); // q1 mz -> 1
 
     // q3: my(|0>) is non-deterministic, just check valid bit.
-    assert(bits[3] == '0' || bits[3] == '1');
+    assert(bits[2] == '0' || bits[2] == '1');
   }
 
   printf("passed\n");

--- a/unittests/integration/measure_reset_tester.cpp
+++ b/unittests/integration/measure_reset_tester.cpp
@@ -74,13 +74,28 @@ TEST(MeasureResetTester, checkLibModeOrdering) {
     }
   };
 
-  // Bit string ordered according to qubit allocation order.
+  // Bit string ordered according to measurement order.
   auto counts = cudaq::sample(kernel, true);
   counts.dump();
-  EXPECT_EQ("10", counts.begin()->first);
+  EXPECT_EQ("01", counts.begin()->first);
   counts = cudaq::sample(kernel, false);
   counts.dump();
   EXPECT_EQ("10", counts.begin()->first);
+}
+
+TEST(MeasureResetTester, checkDefaultMeasurementOrderIssue4153) {
+  auto kernel = []() __qpu__ {
+    cudaq::qvector q(4);
+    x(q[2]);
+    mz(q[2]);
+    mz(q[0]);
+    mz(q[1]);
+    mz(q[3]);
+  };
+
+  auto counts = cudaq::sample(kernel);
+  counts.dump();
+  EXPECT_EQ(counts.count("1000"), 1000);
 }
 
 TEST(MeasureResetTester, checkMixedBasisOrderingAndPreservation) {
@@ -90,8 +105,8 @@ TEST(MeasureResetTester, checkMixedBasisOrderingAndPreservation) {
     cudaq::qvector q(7);
 
     // Prepare a non-palindromic deterministic pattern over measured bits.
-    // q0=0 (mz), q1=1 (mz), q2=1 (mx), q3=? (my), q4=0 (mz), q5=0 (mx),
-    // q6=1 (mz) -> 011?001 in allocation order.
+    // q4=0 (mz), q2=1 (mx), q3=? (my), q0=0 (mz), q5=0 (mx),
+    // q6=1 (mz), q1=1 (mz) -> 01?0011 in measurement order.
     x(q[1]);
     x(q[2]);
     h(q[2]);
@@ -99,13 +114,13 @@ TEST(MeasureResetTester, checkMixedBasisOrderingAndPreservation) {
     x(q[6]);
 
     // Mix measurement bases and execution order.
-    mz(q[4]);
-    mx(q[2]);
-    my(q[3]);
-    mz(q[0]);
-    mx(q[5]);
-    mz(q[6]);
-    mz(q[1]);
+    mz(q[4]); // q4=0
+    mx(q[2]); // q2=1
+    my(q[3]); // q3=?
+    mz(q[0]); // q0=0
+    mx(q[5]); // q5=0
+    mz(q[6]); // q6=1
+    mz(q[1]); // q1=1
   };
 
   auto counts = cudaq::sample(shots, kernel);
@@ -118,9 +133,9 @@ TEST(MeasureResetTester, checkMixedBasisOrderingAndPreservation) {
     }
     EXPECT_EQ(bits[0], '0');
     EXPECT_EQ(bits[1], '1');
-    EXPECT_EQ(bits[2], '1');
+    EXPECT_EQ(bits[3], '0');
     EXPECT_EQ(bits[4], '0');
-    EXPECT_EQ(bits[5], '0');
+    EXPECT_EQ(bits[5], '1');
     EXPECT_EQ(bits[6], '1');
     totalCounts += count;
   }


### PR DESCRIPTION
## Summary

Fixes #4153 by making default `sample()` global-register bitstrings follow the order of explicit terminal `mz` measurements, without enabling the broader `explicit_measurements=True` behavior.

For example, a kernel that ends with:

```cpp
mz(q[2]);
mz(q[0]);
mz(q[1]);
mz(q[3]);
```

now reports the `__global__` bitstring in that same order.

## Details

`sample()` already tracks which qubits are measured through `sampleQubits`, but the simulator path sorted those qubits before building the `__global__` result. That made the bitstring follow qubit allocation order instead of the order in which the user wrote the measurements.

This PR preserves the original measurement encounter order before sorting for backend execution. For local simulator execution, `__global__` is rebuilt from the backend result using that preserved order.

Some execution paths run the qubit-mapping compiler pass before sampling. That pass can change which physical backend qubit represents each source-level qubit. The compiler already uses `mapping_reorder_idx` to translate result bit positions after that transformation. This PR also updates `mapping_reorder_idx` so that translation reconstructs the user-facing `__global__` register in measurement encounter order instead of source qubit allocation order.

Implicit measurements inserted by the mapping pass still use allocation order, because there is no explicit user-written measurement order to preserve in that case.
