### PR TITLE
Get the noise model from the simulator instead of the executionContext.

### DIFF
--- a/runtime/cudaq/algorithms/optimizers/nlopt/nlopt-src/src/algs/stogo/global.h
+++ b/runtime/cudaq/algorithms/optimizers/nlopt/nlopt-src/src/algs/stogo/global.h
@@ -51,7 +51,7 @@ public:
 
   Global(RTBox, Pobj, Pgrad, GlobalParams);
 
-  virtual ~Global(){};
+  virtual ~Global() {};
 
   //  Global& operator=(const Global &);
 

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -78,10 +78,6 @@ void quantum_platform::set_noise(const noise_model *model, std::size_t qpu_id) {
 }
 
 const noise_model *quantum_platform::get_noise(std::size_t qpu_id) {
-  ExecutionContext *executionContext;
-  if ((executionContext = getExecutionContext()) != nullptr)
-    return executionContext->noiseModel;
-
   validateQpuId(qpu_id);
   auto &platformQPU = platformQPUs[qpu_id];
   return platformQPU->getNoiseModel();

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -138,10 +138,6 @@ public:
   virtual std::unique_ptr<cudaq::SimulationState>
   createStateFromData(const cudaq::state_data &) = 0;
 
-  /// @brief Set the current noise model to consider when
-  /// simulating the state.
-  void setNoiseModel(const cudaq::noise_model *noise) { noiseModel = noise; }
-
   /// @brief Get the current noise model.
   const cudaq::noise_model *getNoiseModel() const { return noiseModel; }
 
@@ -826,7 +822,6 @@ protected:
   /// @brief Flush the gate queue, run all queued gate
   /// application tasks.
   void flushGateQueueImpl() override {
-    auto executionContext = cudaq::getExecutionContext();
 
     while (!gateQueue.empty()) {
       auto &next = gateQueue.front();
@@ -1294,7 +1289,6 @@ public:
   /// context, just measure, collapse, and return the bit.
   bool mz(const std::size_t qubitIdx,
           const std::string &registerName) override {
-    auto executionContext = cudaq::getExecutionContext();
 
     // Flush the Gate Queue
     flushGateQueue();

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -109,6 +109,9 @@ protected:
   /// @brief Internal result
   cudaq::sample_result internalResult = {};
 
+  /// @brief Noise model to apply to the current execution.
+  const cudaq::noise_model *noiseModel = nullptr;
+
 public:
   /// @brief The constructor
   CircuitSimulator() = default;
@@ -136,9 +139,11 @@ public:
   createStateFromData(const cudaq::state_data &) = 0;
 
   /// @brief Set the current noise model to consider when
-  /// simulating the state. This should be overridden by
-  /// simulation strategies that support noise modeling.
-  virtual void setNoiseModel(cudaq::noise_model &noise) = 0;
+  /// simulating the state.
+  void setNoiseModel(const cudaq::noise_model *noise) { noiseModel = noise; }
+
+  /// @brief Get the current noise model.
+  const cudaq::noise_model *getNoiseModel() const { return noiseModel; }
 
   virtual void setRandomSeed(std::size_t seed) {
     // do nothing
@@ -841,8 +846,7 @@ protected:
           gateQueue.pop();
         throw std::runtime_error("Unknown exception in applyGate");
       }
-      if (executionContext && executionContext->noiseModel &&
-          !executionContext->noiseModel->empty()) {
+      if (getNoiseModel() && !getNoiseModel()->empty()) {
         std::vector<double> params(next.parameters.begin(),
                                    next.parameters.end());
         applyNoiseChannel(next.operationName, next.controls, next.targets,
@@ -877,15 +881,6 @@ public:
   CircuitSimulatorBase() = default;
   /// @brief The destructor
   virtual ~CircuitSimulatorBase() = default;
-
-  /// @brief Set the current noise model to consider when
-  /// simulating the state. This should be overridden by
-  /// simulation strategies that support noise modeling.
-  void setNoiseModel(cudaq::noise_model &noise) override {
-    // Fixme consider this as a warning instead of a hard error
-    throw std::runtime_error(
-        "The current backend does not support noise modeling.");
-  }
 
   /// @brief Compute the expected value of the given spin op
   /// with respect to the current state, <psi | H | psi>.
@@ -1113,6 +1108,8 @@ public:
   /// @brief Set the execution context
   void configureExecutionContext(cudaq::ExecutionContext &context) override {
     context.canHandleObserve = canHandleObserve();
+    noiseModel = context.noiseModel;
+    context.noiseModel = nullptr;
     currentCircuitName = context.kernelName;
     CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
   }
@@ -1315,8 +1312,7 @@ public:
 
     // Apply measurement noise (if any)
     // Note: gate noises are applied during flushGateQueue
-    if (executionContext && executionContext->noiseModel &&
-        !executionContext->noiseModel->empty())
+    if (getNoiseModel() && !getNoiseModel()->empty())
       applyNoiseChannel(/*gateName=*/"mz", /*controls=*/{},
                         /*targets=*/{qubitIdx}, /*params=*/{});
 

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -808,7 +808,7 @@ void __quantum__qis__apply_kraus_channel_double(std::int64_t krausChannelKey,
   if (!ctx)
     return;
 
-  auto *noise = ctx->noiseModel;
+  auto *noise = nvqir::getCircuitSimulatorInternal()->getNoiseModel();
   if (cudaq::isInTracerMode()) {
     std::vector<double> paramVec(params, params + numParams);
     std::vector<cudaq::QuditInfo> targets;
@@ -846,7 +846,7 @@ __quantum__qis__apply_kraus_channel_float(std::int64_t krausChannelKey,
   if (!ctx)
     return;
 
-  auto *noise = ctx->noiseModel;
+  auto *noise = nvqir::getCircuitSimulatorInternal()->getNoiseModel();
   if (cudaq::isInTracerMode()) {
     std::vector<double> paramVec;
     paramVec.reserve(numParams);

--- a/runtime/nvqir/cutensornet/simulator_cutensornet.inc
+++ b/runtime/nvqir/cutensornet/simulator_cutensornet.inc
@@ -296,7 +296,7 @@ void SimulatorTensorNetBase<ScalarType>::applyNoiseChannel(
     return;
 
   // Do nothing if no noise model
-  if (!executionContext->noiseModel)
+  if (!this->getNoiseModel())
     return;
 
   // Get the name as a string
@@ -305,7 +305,7 @@ void SimulatorTensorNetBase<ScalarType>::applyNoiseChannel(
   qubits.insert(qubits.end(), targets.begin(), targets.end());
 
   // Get the Kraus channels specified for this gate and qubits
-  auto krausChannels = executionContext->noiseModel->get_channels(
+  auto krausChannels = this->getNoiseModel()->get_channels(
       gName, targets, controls, params);
 
   // If none, do nothing

--- a/runtime/nvqir/cutensornet/simulator_mps.h
+++ b/runtime/nvqir/cutensornet/simulator_mps.h
@@ -240,7 +240,7 @@ public:
                                 bool includeSequentialData = true) override {
     auto executionContext = cudaq::getExecutionContext();
 
-    const bool hasNoise = executionContext && executionContext->noiseModel;
+    const bool hasNoise = this->getNoiseModel() != nullptr;
     if (!hasNoise || shots < 1)
       return SimulatorTensorNetBase<ScalarType>::sample(measuredBits, shots,
                                                         includeSequentialData);
@@ -317,7 +317,7 @@ public:
     auto executionContext = cudaq::getExecutionContext();
 
     LOG_API_TIME();
-    const bool hasNoise = executionContext && executionContext->noiseModel;
+    const bool hasNoise = this->getNoiseModel() != nullptr;
     // If no noise, just use base class implementation.
     if (!hasNoise)
       return SimulatorTensorNetBase<ScalarType>::observe(ham);

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -180,7 +180,7 @@ protected:
       return;
 
     // Do nothing if no noise model
-    if (!executionContext->noiseModel)
+    if (!getNoiseModel())
       return;
 
     // Get the name as a string
@@ -193,8 +193,8 @@ protected:
     }
 
     // Get the Kraus channels specified for this gate and qubits
-    auto krausChannels = executionContext->noiseModel->get_channels(
-        gName, targets, controls, params);
+    auto krausChannels =
+        getNoiseModel()->get_channels(gName, targets, controls, params);
 
     // If none, do nothing
     if (krausChannels.empty())

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -297,7 +297,7 @@ protected:
       return;
 
     // Do nothing if no noise model
-    if (!executionContext->noiseModel)
+    if (!getNoiseModel())
       return;
 
     // Get the name as a string
@@ -312,8 +312,8 @@ protected:
       stimTargets.push_back(static_cast<std::uint32_t>(q));
 
     // Get the Kraus channels specified for this gate and qubits
-    auto krausChannels = executionContext->noiseModel->get_channels(
-        gName, targets, controls, params);
+    auto krausChannels =
+        getNoiseModel()->get_channels(gName, targets, controls, params);
 
     // If none, do nothing
     if (krausChannels.empty())


### PR DESCRIPTION
In preparation for the policy work, I am removing occurrences where simulation gets the noise model from the a global execution context. Instead the noise is saved in the simulator itself and accessed by a new `getNoiseModel()` method on the simulators. 

The context is only used to pass the information. In the future the noise model will come from the policy which is not global and will require this local storage.