### PR TITLE
Add `qec` dialect skeleton

### DIFF
--- a/include/cudaq/Optimizer/CAPI/Dialects.h
+++ b/include/cudaq/Optimizer/CAPI/Dialects.h
@@ -16,6 +16,7 @@ extern "C" {
 #endif
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Quake, quake);
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(QEC, qec);
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(CC, cc);
 
 // Register Quake, CC, and all upstream MLIR dialects into `context`.

--- a/include/cudaq/Optimizer/Dialect/CMakeLists.txt
+++ b/include/cudaq/Optimizer/Dialect/CMakeLists.txt
@@ -7,4 +7,5 @@
 # ============================================================================ #
 
 add_subdirectory(CC)
+add_subdirectory(QEC)
 add_subdirectory(Quake)

--- a/include/cudaq/Optimizer/Dialect/QEC/CMakeLists.txt
+++ b/include/cudaq/Optimizer/Dialect/QEC/CMakeLists.txt
@@ -1,11 +1,9 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-add_subdirectory(CC)
-add_subdirectory(QEC)
-add_subdirectory(Quake)
+add_cudaq_dialect(QEC qec)

--- a/include/cudaq/Optimizer/Dialect/QEC/QECDialect.h
+++ b/include/cudaq/Optimizer/Dialect/QEC/QECDialect.h
@@ -1,0 +1,13 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "mlir/IR/Dialect.h"
+
+#include "cudaq/Optimizer/Dialect/QEC/QECDialect.h.inc"

--- a/include/cudaq/Optimizer/Dialect/QEC/QECDialect.td
+++ b/include/cudaq/Optimizer/Dialect/QEC/QECDialect.td
@@ -1,0 +1,26 @@
+/********************************************************** -*- tablegen -*- ***
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifndef CUDAQ_OPTIMIZER_DIALECT_QEC_IR_QEC
+#define CUDAQ_OPTIMIZER_DIALECT_QEC_IR_QEC
+
+include "mlir/IR/OpBase.td"
+
+def QECDialect : Dialect {
+  let name = "qec";
+  let summary = "QEC operations for CUDA-Q (detectors, logical observables).";
+  let description = [{
+    The QEC dialect houses quantum error correction operations such as detector
+    declarations and logical observable declarations. These are separate from
+    the Quake dialect to keep Quake focused on circuit semantics while giving
+    QEC annotations a dedicated namespace.
+  }];
+  let cppNamespace = "cudaq::qec";
+}
+
+#endif // CUDAQ_OPTIMIZER_DIALECT_QEC_IR_QEC

--- a/include/cudaq/Optimizer/Dialect/QEC/QECOps.h
+++ b/include/cudaq/Optimizer/Dialect/QEC/QECOps.h
@@ -1,0 +1,18 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
+#include "cudaq/Optimizer/Dialect/QEC/QECDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OpDefinition.h"
+
+#define GET_OP_CLASSES
+#include "cudaq/Optimizer/Dialect/QEC/QECOps.h.inc"

--- a/include/cudaq/Optimizer/Dialect/QEC/QECOps.td
+++ b/include/cudaq/Optimizer/Dialect/QEC/QECOps.td
@@ -1,0 +1,75 @@
+/********************************************************** -*- tablegen -*- ***
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifndef CUDAQ_OPTIMIZER_DIALECT_QEC_OPS
+#define CUDAQ_OPTIMIZER_DIALECT_QEC_OPS
+
+include "cudaq/Optimizer/Dialect/CC/CCTypes.td"
+include "cudaq/Optimizer/Dialect/QEC/QECDialect.td"
+include "mlir/IR/OpBase.td"
+
+class QECOp<string mnemonic, list<Trait> traits = []>
+    : Op<QECDialect, mnemonic, traits>;
+
+def QEC_DetectorOp : QECOp<"detector"> {
+  let summary = "Declare a detector over measurement results.";
+  let description = [{
+    Declares a parity constraint over one or more measurement results.
+    Under noise-free execution the XOR of the referenced measurements
+    is deterministic. Operands may be individual `!cc.measure_handle`
+    values or a `!cc.stdvec<!cc.measure_handle>` collection. This is a
+    side-effecting declaration that informs the backend.
+  }];
+  let arguments = (ins
+    Variadic<AnyTypeOf<[cc_MeasureHandleType,
+                        StdvecOf<[cc_MeasureHandleType]>]>>:$measurements
+  );
+  let results = (outs);
+  let assemblyFormat = [{
+    `(` $measurements `)` attr-dict `:` `(` type($measurements) `)`
+  }];
+}
+
+def QEC_DetectorsOp : QECOp<"detectors"> {
+  let summary = "Declare N detectors by pairing previous and current measurement vectors.";
+  let description = [{
+    Given two `!cc.stdvec<!cc.measure_handle>` collections of measurement
+    results, declares N detectors where detector `i` is the parity of
+    `prev[i]` and `curr[i]`. `!cc.stdvec` carries no static size, so size
+    agreement between `prev` and `curr` is checked at runtime.
+  }];
+  let arguments = (ins
+    StdvecOf<[cc_MeasureHandleType]>:$prev,
+    StdvecOf<[cc_MeasureHandleType]>:$curr
+  );
+  let results = (outs);
+  let assemblyFormat = [{
+    `(` $prev `,` $curr `)` attr-dict `:`
+    `(` qualified(type($prev)) `,` qualified(type($curr)) `)`
+  }];
+}
+
+def QEC_ObservableOp : QECOp<"observable"> {
+  let summary = "Declare a logical observable over measurement results.";
+  let description = [{
+    Declares a logical observable as a binary sum of measurement results.
+    Operands may be individual `!cc.measure_handle` values or a
+    `!cc.stdvec<!cc.measure_handle>` collection.
+  }];
+  let arguments = (ins
+    Variadic<AnyTypeOf<[cc_MeasureHandleType,
+                        StdvecOf<[cc_MeasureHandleType]>]>>:$measurements,
+    DefaultValuedOptionalAttr<I64Attr, "0">:$observableIndex
+  );
+  let results = (outs);
+  let assemblyFormat = [{
+    `(` $measurements `)` (`index` $observableIndex^)? attr-dict `:` `(` type($measurements) `)`
+  }];
+}
+
+#endif // CUDAQ_OPTIMIZER_DIALECT_QEC_OPS

--- a/include/cudaq/Optimizer/Dialect/QEC/QECTypes.td
+++ b/include/cudaq/Optimizer/Dialect/QEC/QECTypes.td
@@ -1,0 +1,15 @@
+/********************************************************** -*- tablegen -*- ***
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifndef CUDAQ_OPTIMIZER_DIALECT_QEC_TYPES
+#define CUDAQ_OPTIMIZER_DIALECT_QEC_TYPES
+
+include "cudaq/Optimizer/Dialect/QEC/QECDialect.td"
+include "mlir/IR/OpBase.td"
+
+#endif // CUDAQ_OPTIMIZER_DIALECT_QEC_TYPES

--- a/include/cudaq/Optimizer/InitAllDialects.h
+++ b/include/cudaq/Optimizer/InitAllDialects.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
+#include "cudaq/Optimizer/Dialect/QEC/QECDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
@@ -33,6 +34,7 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
 
     // CUDA-Q dialects
     cudaq::cc::CCDialect,
+    cudaq::qec::QECDialect,
     cudaq::quake::QuakeDialect
   >();
   // clang-format on

--- a/lib/Optimizer/CAPI/CMakeLists.txt
+++ b/lib/Optimizer/CAPI/CMakeLists.txt
@@ -11,9 +11,11 @@ add_mlir_public_c_api_library(CUDAQuantumMLIRCAPI
 
   DEPENDS
   QuakeDialectIncGen
+  QECOpsIncGen
 
   LINK_LIBS PRIVATE
   QuakeDialect
   CCDialect
+  QECDialect
   MLIRRegisterAllDialects
 )

--- a/lib/Optimizer/CAPI/Dialects.cpp
+++ b/lib/Optimizer/CAPI/Dialects.cpp
@@ -8,15 +8,18 @@
 
 #include "cudaq/Optimizer/CAPI/Dialects.h"
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
+#include "cudaq/Optimizer/Dialect/QEC/QECDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "mlir/InitAllDialects.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Quake, quake, cudaq::quake::QuakeDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(QEC, qec, cudaq::qec::QECDialect)
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(CC, cc, cudaq::cc::CCDialect)
 
 extern "C" void cudaqRegisterAllDialects(MlirContext context) {
   mlir::DialectRegistry registry;
-  registry.insert<cudaq::quake::QuakeDialect, cudaq::cc::CCDialect>();
+  registry.insert<cudaq::quake::QuakeDialect, cudaq::qec::QECDialect,
+                  cudaq::cc::CCDialect>();
   mlir::registerAllDialects(registry);
   auto *mlirContext = unwrap(context);
   mlirContext->appendDialectRegistry(registry);

--- a/lib/Optimizer/Dialect/QEC/CMakeLists.txt
+++ b/lib/Optimizer/Dialect/QEC/CMakeLists.txt
@@ -1,11 +1,22 @@
 # ============================================================================ #
-# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-add_subdirectory(CC)
-add_subdirectory(QEC)
-add_subdirectory(Quake)
+add_cudaq_dialect_library(QECDialect
+  QECDialect.cpp
+  QECOps.cpp
+
+  DEPENDS
+  QECDialectIncGen
+  QECOpsIncGen
+  QECTypesIncGen
+
+  LINK_LIBS
+  CCDialect
+  QuakeDialect
+  MLIRIR
+)

--- a/lib/Optimizer/Dialect/QEC/QECDialect.cpp
+++ b/lib/Optimizer/Dialect/QEC/QECDialect.cpp
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/Optimizer/Dialect/QEC/QECDialect.h"
+#include "cudaq/Optimizer/Dialect/QEC/QECOps.h"
+
+using namespace mlir;
+
+#include "cudaq/Optimizer/Dialect/QEC/QECDialect.cpp.inc"
+
+void cudaq::qec::QECDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "cudaq/Optimizer/Dialect/QEC/QECOps.cpp.inc"
+      >();
+}

--- a/lib/Optimizer/Dialect/QEC/QECOps.cpp
+++ b/lib/Optimizer/Dialect/QEC/QECOps.cpp
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/Optimizer/Dialect/QEC/QECOps.h"
+#include "cudaq/Optimizer/Dialect/CC/CCTypes.h"
+
+using namespace mlir;
+
+#define GET_OP_CLASSES
+#include "cudaq/Optimizer/Dialect/QEC/QECOps.cpp.inc"

--- a/runtime/internal/compiler/CMakeLists.txt
+++ b/runtime/internal/compiler/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
   target_link_libraries(cudaq-mlir-runtime
     PRIVATE
       CCDialect
+      QECDialect
       QuakeDialect
       OptCodeGen
       OptTransforms

--- a/test/Transforms/qec-errors.qke
+++ b/test/Transforms/qec-errors.qke
@@ -1,0 +1,32 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt %s -split-input-file -verify-diagnostics
+
+func.func @bad_detectors_elem(%bad : !cc.stdvec<i32>,
+                               %good : !cc.stdvec<!cc.measure_handle>) {
+  // expected-error @+1 {{must be stdvec of}}
+  qec.detectors(%bad, %good) : (!cc.stdvec<i32>, !cc.stdvec<!cc.measure_handle>)
+  return
+}
+
+// -----
+
+func.func @bad_detector_elem(%bad : i32) {
+  // expected-error @+1 {{must be variadic of}}
+  qec.detector(%bad) : (i32)
+  return
+}
+
+// -----
+
+func.func @bad_observable_elem(%bad : !cc.stdvec<i32>) {
+  // expected-error @+1 {{must be variadic of}}
+  qec.observable(%bad) : (!cc.stdvec<i32>)
+  return
+}

--- a/test/Transforms/qec-roundtrip-ops.qke
+++ b/test/Transforms/qec-roundtrip-ops.qke
@@ -1,0 +1,40 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt %s | cudaq-opt | FileCheck %s
+
+func.func @det_obs_roundtrip(%h0 : !cc.measure_handle,
+                              %h1 : !cc.measure_handle,
+                              %v : !cc.stdvec<!cc.measure_handle>) {
+  qec.detector(%h0) : (!cc.measure_handle)
+  qec.detector(%h0, %h1) : (!cc.measure_handle, !cc.measure_handle)
+  qec.detector(%v) : (!cc.stdvec<!cc.measure_handle>)
+  qec.detector(%h0, %v) : (!cc.measure_handle, !cc.stdvec<!cc.measure_handle>)
+  qec.observable(%h0) : (!cc.measure_handle)
+  qec.observable(%h0) index 0 : (!cc.measure_handle)
+  qec.observable(%h0) index 1 : (!cc.measure_handle)
+  qec.observable(%v) index 2 : (!cc.stdvec<!cc.measure_handle>)
+  qec.detectors(%v, %v) : (!cc.stdvec<!cc.measure_handle>, !cc.stdvec<!cc.measure_handle>)
+  return
+}
+
+// CHECK-LABEL:   func.func @det_obs_roundtrip(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<!cc.measure_handle>) {
+// CHECK:           qec.detector(%[[ARG0]]) : (!cc.measure_handle)
+// CHECK:           qec.detector(%[[ARG0]], %[[ARG1]]) : (!cc.measure_handle, !cc.measure_handle)
+// CHECK:           qec.detector(%[[ARG2]]) : (!cc.stdvec<!cc.measure_handle>)
+// CHECK:           qec.detector(%[[ARG0]], %[[ARG2]]) : (!cc.measure_handle, !cc.stdvec<!cc.measure_handle>)
+// CHECK:           qec.observable(%[[ARG0]]) : (!cc.measure_handle)
+// CHECK:           qec.observable(%[[ARG0]]) : (!cc.measure_handle)
+// CHECK:           qec.observable(%[[ARG0]]) index 1 : (!cc.measure_handle)
+// CHECK:           qec.observable(%[[ARG2]]) index 2 : (!cc.stdvec<!cc.measure_handle>)
+// CHECK:           qec.detectors(%[[ARG2]], %[[ARG2]]) : (!cc.stdvec<!cc.measure_handle>, !cc.stdvec<!cc.measure_handle>)
+// CHECK:           return
+// CHECK:         }

--- a/tools/cudaq-opt/CMakeLists.txt
+++ b/tools/cudaq-opt/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(cudaq-opt
   MLIRArithDialect
 
   CCDialect
+  QECDialect
   QuakeDialect
   OptCodeGen
   OptTransforms

--- a/tools/cudaq-quake/CMakeLists.txt
+++ b/tools/cudaq-quake/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(cudaq-quake
   clangFrontend
 
   CCDialect
+  QECDialect
   QuakeDialect
   cudaq-mlirgen
 )

--- a/tools/cudaq-translate/CMakeLists.txt
+++ b/tools/cudaq-translate/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(${TOOL_NAME}
     CCDialect
     OptCodeGen
     OptTransforms
+    QECDialect
     QuakeDialect
     cudaq-qir-verifier
 )


### PR DESCRIPTION
### Summary

* First PR of the QEC detectors and observables task. 
* Adds the `qec` MLIR dialect with three ops:
```
  qec.detector(measurements...) : (...)
  qec.detectors(prev, curr) : (!cc.stdvec<!cc.measure_handle>, ...)
  qec.observable(measurements...) [index N] : (...)
```
* Operands are `!cc.measure_handle` or `!cc.stdvec<!cc.measure_handle>`. The dialect ships with parse/print support, registry hooks, explicit links from `cudaq-opt`, `cudaq-quake`, `cudaq-translate`, and the runtime MLIR layer.

* No transforms, lowerings, runtime, or AST bridge yet; those land in follow-up PRs.

Made-with: Cursor