### PR TITLE
Moving code up and down class hierarchies in preparation for policies

### DIFF
--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -213,46 +213,6 @@ public:
                                         serverHelper, executor);
   }
 
-  /// @brief Launch the kernel. Extract the Quake code and lower to the
-  /// representation required by the targeted backend. Handle all pertinent
-  /// modifications for the execution context as well as asynchronous or
-  /// synchronous invocation.
-  KernelThunkResultType unifiedLaunchModule(const AnyModule &module,
-                                            KernelArgs args) override {
-    Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
-                      noiseModel, emulate);
-    std::string kernelName;
-    std::vector<cudaq::KernelExecution> codes;
-
-    if (std::holds_alternative<SourceModule>(module)) {
-      const auto &src = std::get<SourceModule>(module);
-      kernelName = src.getName();
-      CUDAQ_INFO("launching remote rest kernel ({})", kernelName);
-
-      auto executionContext = cudaq::getExecutionContext();
-
-      // TODO future iterations of this should support non-void return types.
-      if (!executionContext)
-        throw std::runtime_error(
-            "Remote rest execution can only be performed via cudaq::sample(), "
-            "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
-
-      auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
-
-      // Get the Quake code, lowered according to config file.
-      codes =
-          compiler.lowerQuakeCode(executionContext, kernelName, moduleOp, args);
-    } else {
-      const auto &compiled = std::get<CompiledModule>(module);
-      kernelName = compiled.getName();
-      CUDAQ_INFO("launching remote rest kernel via module ({})", kernelName);
-      codes = compiler.emitKernelExecutions(compiled);
-    }
-
-    completeLaunchKernel(kernelName, std::move(codes));
-    return {};
-  }
-
   CompiledModule compileModule(const SourceModule &src, KernelArgs args,
                                bool isEntryPoint) override {
     const auto &kernelName = src.getName();

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -8,6 +8,43 @@
 
 #include "RemoteRESTQPU.h"
 
+using namespace cudaq;
 cudaq::RemoteRESTQPU::~RemoteRESTQPU() = default;
+
+KernelThunkResultType
+RemoteRESTQPU::unifiedLaunchModule(const AnyModule &module, KernelArgs args) {
+  Compiler compiler(serverHelper.get(), backendConfig, targetConfig, noiseModel,
+                    emulate);
+  std::string kernelName;
+  std::vector<cudaq::KernelExecution> codes;
+
+  if (std::holds_alternative<SourceModule>(module)) {
+    const auto &src = std::get<SourceModule>(module);
+    kernelName = src.getName();
+    CUDAQ_INFO("launching remote rest kernel ({})", kernelName);
+
+    auto executionContext = cudaq::getExecutionContext();
+
+    // TODO future iterations of this should support non-void return types.
+    if (!executionContext)
+      throw std::runtime_error(
+          "Remote rest execution can only be performed via cudaq::sample(), "
+          "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
+
+    auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
+
+    // Get the Quake code, lowered according to config file.
+    codes =
+        compiler.lowerQuakeCode(executionContext, kernelName, moduleOp, args);
+  } else {
+    const auto &compiled = std::get<CompiledModule>(module);
+    kernelName = compiled.getName();
+    CUDAQ_INFO("launching remote rest kernel via module ({})", kernelName);
+    codes = compiler.emitKernelExecutions(compiled);
+  }
+
+  completeLaunchKernel(kernelName, std::move(codes));
+  return {};
+}
 
 CUDAQ_REGISTER_TYPE(cudaq::QPU, cudaq::RemoteRESTQPU, remote_rest)

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
@@ -20,6 +20,13 @@ public:
   RemoteRESTQPU() : BaseRemoteRESTQPU() {}
   RemoteRESTQPU(RemoteRESTQPU &&) = delete;
   ~RemoteRESTQPU() override;
+
+  /// @brief Launch the kernel. Extract the Quake code and lower to the
+  /// representation required by the targeted backend. Handle all pertinent
+  /// modifications for the execution context as well as asynchronous or
+  /// synchronous invocation.
+  KernelThunkResultType unifiedLaunchModule(const AnyModule &module,
+                                            KernelArgs args) override;
 };
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.cpp
@@ -80,6 +80,10 @@ KernelThunkResultType cudaq::OrcaRemoteRESTQPU::launchKernelCommon(
 
   ctx->shots = shots;
 
+  if (!(ctx->name == "sample" || ctx->name == "extract-state" ||
+        ctx->name == "tracer"))
+    throw std::runtime_error(ctx->name + " is not supported on this target");
+
   details::future future;
   future = executor->execute(params, kernelName);
 
@@ -99,11 +103,6 @@ KernelThunkResultType cudaq::OrcaRemoteRESTQPU::launchKernelCommon(
 void cudaq::OrcaRemoteRESTQPU::enqueue(cudaq::QuantumTask &task) {
   CUDAQ_INFO("OrcaRemoteRESTQPU: Enqueue Task on QPU {}", qpu_id);
   execution_queue->enqueue(task);
-}
-
-void cudaq::OrcaRemoteRESTQPU::launchKernel(const std::string &,
-                                            const std::vector<void *> &) {
-  throw std::runtime_error("launch kernel on raw args not implemented");
 }
 
 CUDAQ_REGISTER_TYPE(QPU, OrcaRemoteRESTQPU, orca)

--- a/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
+++ b/runtime/cudaq/platform/orca/OrcaRemoteRESTQPU.h
@@ -109,8 +109,5 @@ public:
     void *argData = packed ? packed->data.data() : nullptr;
     return launchKernelCommon(src.getName(), kernelFunc, argData);
   }
-
-  void launchKernel(const std::string &kernelName,
-                    const std::vector<void *> &rawArgs);
 };
 } // namespace cudaq

--- a/runtime/cudaq/qis/execution_manager.cpp
+++ b/runtime/cudaq/qis/execution_manager.cpp
@@ -11,10 +11,15 @@
 #include "common/PluginUtils.h"
 #include "cudaq/algorithms/policy_cpos.h"
 #include "cudaq/algorithms/policy_dispatch.h"
+#include "nvqir/CircuitSimulator.h"
 
 using namespace cudaq;
 
 static ExecutionManager *execution_manager;
+
+namespace nvqir {
+CircuitSimulator *getCircuitSimulatorInternal();
+}
 
 void cudaq::setExecutionManagerInternal(ExecutionManager *em) {
   CUDAQ_INFO("external caller setting the execution manager.");
@@ -35,6 +40,10 @@ ExecutionManager *cudaq::detail::getExecutionManagerFromContext() {
   if (ctx)
     return ctx->executionManager;
   return nullptr;
+}
+
+void ExecutionManager::configureExecutionContext(ExecutionContext &ctx) {
+  nvqir::getCircuitSimulatorInternal()->configureExecutionContext(ctx);
 }
 
 void ExecutionManager::finalizeExecutionContext(ExecutionContext &ctx) {

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -114,7 +114,9 @@ public:
   bool memoryLeaked() { return !tracker.allDeallocated(); }
 
   /// Configure the execution context before an execution.
-  virtual void configureExecutionContext(ExecutionContext &ctx) {}
+  void configureExecutionContext(const sample_policy &policy,
+                                 ExecutionContext &ctx);
+  void configureExecutionContext(ExecutionContext &ctx);
 
   /// Finalize the execution context after an execution.
   void finalizeExecutionContext(ExecutionContext &ctx);

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -147,11 +147,6 @@ protected:
     requestedAllocations.clear();
   }
 
-  void configureExecutionContext(ExecutionContext &ctx) override {
-    BasicExecutionManager::configureExecutionContext(ctx);
-    simulator()->configureExecutionContext(ctx);
-  }
-
   void finalizeExecutionContextImpl(ExecutionContext &ctx) {
     BasicExecutionManager::finalizeExecutionContextImpl(ctx);
 

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -158,15 +158,6 @@ protected:
   /// @brief Deallocate a set of `qudits` (`qumodes`) with a single call.
   void deallocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {}
 
-  /// @brief Configure and validate the execution context
-  void configureExecutionContext(ExecutionContext &ctx) override {
-    BasicExecutionManager::configureExecutionContext(ctx);
-
-    if (!(ctx.name == "sample" || ctx.name == "extract-state" ||
-          ctx.name == "tracer"))
-      throw std::runtime_error(ctx.name + " is not supported on this target");
-  }
-
   /// @brief Process results into the execution context
   void finalizeExecutionContextImpl(std::vector<std::size_t> &ids,
                                     ExecutionContext &ctx) {

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -109,6 +109,12 @@ protected:
   /// @brief Internal result
   cudaq::sample_result internalResult = {};
 
+  /// @brief Reference to the current circuit name.
+  std::string currentCircuitName = "";
+
+  /// @brief Get the name of the current circuit being executed.
+  std::string getCircuitName() const { return currentCircuitName; }
+
   /// @brief Noise model to apply to the current execution.
   const cudaq::noise_model *noiseModel = nullptr;
 
@@ -273,8 +279,21 @@ public:
   /// @brief Clean up after execution ends.
   virtual void endExecution() {}
 
-  /// @brief Configure the execution context for this simulator.
-  virtual void configureExecutionContext(cudaq::ExecutionContext &context) = 0;
+  /// @brief Return true if this CircuitSimulator can
+  /// handle <psi | H | psi> instead of NVQIR applying measure
+  /// basis quantum gates to change to the Z basis and sample.
+  virtual bool canHandleObserve() { return false; }
+
+  /// @brief Set the execution context
+  void configureExecutionContext(cudaq::ExecutionContext &context) {
+    context.canHandleObserve = canHandleObserve();
+    noiseModel = context.noiseModel;
+    // Stress testing the fact that the context is just used topass the noise
+    // and no one is supposed to use it after that.
+    context.noiseModel = nullptr;
+    currentCircuitName = context.kernelName;
+    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
+  }
 
   /// @brief Whether or not this is a state vector simulator
   virtual bool isStateVectorSimulator() const { return false; }
@@ -457,10 +476,6 @@ public:
           parameters(params) {}
   };
 
-private:
-  /// @brief Reference to the current circuit name.
-  std::string currentCircuitName = "";
-
 protected:
   /// @brief A tracker for qubit allocation
   cudaq::QuditIdTracker tracker;
@@ -503,9 +518,6 @@ protected:
 
   /// @brief The current queue of operations to execute
   std::queue<GateApplicationTask> gateQueue;
-
-  /// @brief Get the name of the current circuit being executed.
-  std::string getCircuitName() const { return currentCircuitName; }
 
   /// @brief Get the number of shots to execute (only valid if executionContext
   /// is set)
@@ -552,11 +564,6 @@ protected:
   /// @brief Perform the actual mechanics of measuring a qubit,
   /// left as a task for concrete subtypes.
   virtual bool measureQubit(const std::size_t qubitIdx) = 0;
-
-  /// @brief Return true if this CircuitSimulator can
-  /// handle <psi | H | psi> instead of NVQIR applying measure
-  /// basis quantum gates to change to the Z basis and sample.
-  virtual bool canHandleObserve() { return false; }
 
   /// @brief Return the internal state representation. This
   /// is meant for subtypes to override
@@ -1098,15 +1105,6 @@ public:
 
     tracker = {};
     internalResult = {};
-  }
-
-  /// @brief Set the execution context
-  void configureExecutionContext(cudaq::ExecutionContext &context) override {
-    context.canHandleObserve = canHandleObserve();
-    noiseModel = context.noiseModel;
-    context.noiseModel = nullptr;
-    currentCircuitName = context.kernelName;
-    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
   }
 
   /// @brief Apply a pre-constructed gate task to the simulator state.

--- a/runtime/nvqir/resourcecounter/ResourceCounter.h
+++ b/runtime/nvqir/resourcecounter/ResourceCounter.h
@@ -87,14 +87,6 @@ public:
     prepopulated = false;
   }
 
-  void configureExecutionContext(cudaq::ExecutionContext &context) override {
-    if (context.name != "resource-count")
-      throw std::runtime_error(
-          "Illegal use of resource counter simulator! (Did you attempt to run "
-          "a kernel inside of a choice function?)");
-    this->CircuitSimulatorBase::configureExecutionContext(context);
-  }
-
   cudaq::Resources *getResourceCounts() { return &this->resourceCounts; }
   void setResourceCounts(cudaq::Resources &&rc) {
     this->resourceCounts = std::move(rc);


### PR DESCRIPTION
This is another PR in preparation for using policies. 
1. `configureExecutionContext` is made non-virtual in `ExecutionManager` and `CircuitSimulator`. 
    Under the existing code, it does not really needed to be virtual. This will greatly simplify using policies, since each policy could introduce and overloaded version. Code is moved up the hierarchy so the base class can do all the work. When policies are intorduced, there will only be one place to check and specialize. 
1. The `BaseRemoteRESTQPU` kernel launch is moved into the concrete `RemoteRESTQPU` class because every other subclass of `BaseRemoteRESTQPU` overwrites the launch.
1.  Clean-ups in the `OrcaRemoteRESTQPU.h`