### PR TITLE
[CI] macOS: exclude Xcode release candidates from latest-stable selector

### DIFF
--- a/.github/actions/setup-xcode-stable/action.yml
+++ b/.github/actions/setup-xcode-stable/action.yml
@@ -1,5 +1,8 @@
 name: Set up latest stable Xcode
-description: Select the newest non-beta Xcode installed on the macOS runner.
+description: >-
+  Select the newest stable Xcode installed on the macOS runner. Excludes
+  betas and release candidates (matches the "latest-stable" semantics of
+  maxim-lobanov/setup-xcode).
 
 outputs:
   version:
@@ -23,9 +26,21 @@ runs:
       run: |
         set -euo pipefail
 
-        # Mirrors the selection strategy from maxim-lobanov/setup-xcode
-        # (scan installed Xcode apps, ignore beta releases, choose newest
-        # stable), but keeps it local to avoid external-action allowlist issues.
+        # Implements the "latest-stable" selection strategy from
+        # maxim-lobanov/setup-xcode (scan installed Xcode apps, exclude
+        # both betas and release candidates, choose the newest stable),
+        # kept local to avoid external-action allowlist issues.
+        #
+        # Note: LicenseInfo.plist's licenseType is not a reliable signal
+        # for release candidates (Apple commonly sets it to "GM" or
+        # "Release" on RCs, not "Beta"). GitHub-hosted runners do, however,
+        # name pre-release bundles consistently, e.g.
+        #   /Applications/Xcode_<v>_beta_<n>.app
+        #   /Applications/Xcode_<v>_Release_Candidate.app
+        # so we filter on the .app bundle name in addition to the license
+        # type. Without this, an RC's SDK can be selected and its absolute
+        # path baked into cached LLVM CMake imported targets, only to vanish
+        # from the runner image once Apple ships the GA build.
         selection_file=$(mktemp)
         python3 > "$selection_file" <<'PY'
         from pathlib import Path
@@ -33,14 +48,29 @@ runs:
         import re
         import sys
 
+        # The "rc" token must be delimited by non-letters on both sides so
+        # it matches "_RC.", "_RC1.", "-rc.", etc. but not substrings of
+        # real words. \b alone is insufficient because "_" is a word char
+        # in Python regex, so "_RC" has no boundary between "_" and "R".
+        PRERELEASE_NAME = re.compile(
+            r"(beta"
+            r"|release[\s_.\-]?candidate"
+            r"|(?<![A-Za-z])rc\d*(?![A-Za-z]))",
+            re.IGNORECASE)
+
         def semver_key(version):
             return tuple(int(part) for part in re.findall(r"\d+", version))
 
         versions = []
-        for app in Path("/Applications").iterdir():
+        for app in sorted(Path("/Applications").iterdir()):
             if not app.is_dir() or app.is_symlink():
                 continue
             if not re.match(r"^Xcode.*\.app$", app.name):
+                continue
+
+            if PRERELEASE_NAME.search(app.name):
+                print(f"Skipping pre-release Xcode (bundle name): {app.name}",
+                      file=sys.stderr)
                 continue
 
             version_plist = app / "Contents" / "version.plist"
@@ -56,7 +86,11 @@ runs:
             version = str(version_info.get("CFBundleShortVersionString", ""))
             build = str(version_info.get("ProductBuildVersion", ""))
             license_type = str(license_info.get("licenseType", "")).lower()
-            if not version or not license_type or "beta" in license_type:
+            if not version or not license_type:
+                continue
+            if "beta" in license_type:
+                print(f"Skipping pre-release Xcode (license type): {app.name}",
+                      file=sys.stderr)
                 continue
 
             versions.append((semver_key(version), version, build, str(app)))

--- a/.github/workflows/dev_environment_macos.yml
+++ b/.github/workflows/dev_environment_macos.yml
@@ -90,12 +90,16 @@ jobs:
           # when the copied files change), macOS uses ORAS artifact caching with no
           # content-based invalidation. This hash ensures cache is rebuilt when
           # build scripts or the devdeps workflow itself change (e.g. LLVM_PROJECTS).
+          # The Xcode selector is included because the selected SDK's absolute
+          # path is baked into cached LLVM CMake imported targets — changing
+          # the selection strategy must force a clean rebuild.
           scripts_hash=$(cat \
             scripts/install_prerequisites.sh \
             scripts/build_llvm.sh \
             scripts/set_env_defaults.sh \
             cmake/caches/LLVM.cmake \
             .github/workflows/dev_environment_macos.yml \
+            .github/actions/setup-xcode-stable/action.yml \
             tpls/customizations/llvm/*.diff \
             | sha256sum | cut -c1-8)
           echo "scripts_hash=$scripts_hash" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Summary

Tighten the macOS Xcode selector to exclude release candidates (in addition to betas), and invalidate the macOS LLVM devdeps cache so the existing tarball — built against a now-deleted RC SDK — is replaced on the next CI run.

### Motivation

macOS CI has been failing in Build & Test and the py3.11 / py3.13 wheel jobs with:
```
CMake Error in lib/LineEditor/CMakeLists.txt:
  Imported target "LibEdit::LibEdit" includes non-existent path
    "/Applications/Xcode_26.5_Release_Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/usr/include"
  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:
  * The path was deleted, renamed, or moved to another location.
  * An install or uninstall procedure did not complete successfully.
  * The installation package was faulty and references files it does
    not provide.
CMake Generate step failed.  Build files cannot be regenerated correctly.
ninja: error: rebuilding 'build.ninja': subcommand failed
Failed to build compiler components.
```
py3.12 wheel passed on the same run — the classic runner-roulette signature when a cached absolute path resolves on some `macos-26` VMs but not others.

Root cause in two parts, both in our CI plumbing:

1. `.github/actions/setup-xcode-stable/action.yml` only filtered by `LicenseInfo.plist`'s `licenseType == "beta"`. Apple ships release candidates with `licenseType` set to `"GM"` or `"Release"`, so `Xcode_26.5_Release_Candidate.app` was selected as "newest stable" when the LLVM devdeps cache was built. Its SDK's absolute path got baked into LLVM's `LibEdit::LibEdit` imported target inside the cached `~/.llvm-project/build` tree. Once GA Xcode 26.5 rolled out, the RC was removed from some `macos-26` images, and the baked-in path stopped resolving.

2. The Xcode selector file was not part of `dev_environment_macos.yml`'s `scripts_hash`. Fixing the selector alone would have no effect — consumer jobs would keep pulling the same RC-poisoned ORAS tarball.
