### PR TITLE
Backtracking some of the changes of #4519

### DIFF
--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -78,6 +78,10 @@ void quantum_platform::set_noise(const noise_model *model, std::size_t qpu_id) {
 }
 
 const noise_model *quantum_platform::get_noise(std::size_t qpu_id) {
+  ExecutionContext *executionContext = getExecutionContext();
+  if (executionContext != nullptr)
+    return executionContext->noiseModel;
+
   validateQpuId(qpu_id);
   auto &platformQPU = platformQPUs[qpu_id];
   return platformQPU->getNoiseModel();

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -288,9 +288,6 @@ public:
   void configureExecutionContext(cudaq::ExecutionContext &context) {
     context.canHandleObserve = canHandleObserve();
     noiseModel = context.noiseModel;
-    // Stress testing the fact that the context is just used topass the noise
-    // and no one is supposed to use it after that.
-    context.noiseModel = nullptr;
     currentCircuitName = context.kernelName;
     CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
   }


### PR DESCRIPTION
#4519 went a bit too far in enforcing that the noise is not extracted from the execution context. CUDAQ-X has scenarios when this is still needed. We need move further along the policy work to be able to fully remove noise from the execution context.