### PR TITLE
bump LONG_RUNNING_NOTEBOOKS timeout, cap pytest jobs

### DIFF
--- a/docs/notebook_validation.py
+++ b/docs/notebook_validation.py
@@ -126,7 +126,7 @@ def execute(notebook_filename, jupyter_kernel=None, timeout_seconds=300):
                                                       '.nbconvert.ipynb')
     notebook_basename = os.path.basename(notebook_filename)
     if notebook_basename in LONG_RUNNING_NOTEBOOKS:
-        timeout_seconds = 2100
+        timeout_seconds = 3600
 
     try:
         start_time = time.perf_counter()

--- a/scripts/validate_pycudaq.sh
+++ b/scripts/validate_pycudaq.sh
@@ -107,6 +107,8 @@ echo "Environment sanitized (unset: $SANITIZE_VARS)"
 # so each worker only needs 1 OMP thread for small test simulations.
 export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
 
+pytest_workers="${PYTEST_WORKERS:-4}"
+
 # Parallel job count for snippet/example execution (xargs -P)
 if [ "$(uname)" = "Darwin" ]; then
     parallel_jobs=$(sysctl -n hw.ncpu)
@@ -333,7 +335,7 @@ fi
 
 # Run core tests
 echo "Running core tests."
-python3 -m pytest -v -n auto "$root_folder/tests" \
+python3 -m pytest -v -n "$pytest_workers" "$root_folder/tests" \
     --ignore "$root_folder/tests/backends" \
     --ignore "$root_folder/tests/dynamics/integrators" \
     --ignore "$root_folder/tests/parallel" \
@@ -353,7 +355,7 @@ fi
 
 # Run backend tests (single invocation with xdist; --rootdir matches upstream import layout)
 echo "Running backend tests."
-python3 -m pytest -v -n auto --rootdir "$root_folder/tests" "$root_folder/tests/backends"
+python3 -m pytest -v -n "$pytest_workers" --rootdir "$root_folder/tests" "$root_folder/tests/backends"
 status=$?
 # Exit code 5 indicates that no tests were collected.
 if [ ! $status -eq 0 ] && [ ! $status -eq 5 ]; then


### PR DESCRIPTION
Multiple recent failures seen in publishing:

- [25960499951](https://github.com/NVIDIA/cuda-quantum/actions/runs/25960499951):
    - test_kernel_parameters.py::test_nested_list3_bool --> MemoryError: std::bad_alloc
    - test_kernel_parameters.py::test_nested_list3_int  --> MemoryError: std::bad_alloc
    - test_kernel_parameters.py::test_nested_list4_int --> MemoryError: std::bad_alloc
    - divisive_clustering_coresets.ipynb --> timeout
- [25953369669](https://github.com/NVIDIA/cuda-quantum/actions/runs/25953369669):
    - same 3 nested-list tests above (same errors)
    - ptsbe/test_async_broadcast.py::test_ptsbe_broadcast_single_argument --> RuntimeError: cudaq.ptsbe.sample() failed: std::bad_alloc
    - ptsbe/test_async_broadcast.py::test_ptsbe_broadcast_three_angles --> std::bad_alloc
    - ptsbe/test_execution_data.py::test_no_execution_data_by_default  --> std::bad_alloc
    - 5× ERROR (fixture/setup failures) under test_execution_data.py --> all std::bad_alloc
- [25950788265](https://github.com/NVIDIA/cuda-quantum/actions/runs/25950788265):
    - test_run_kernel.py::test_return_dynamics_measure_results --> MemoryError: std::bad_alloc
    
This is likely due to memory starvation from the pytest workers.

Also it seems the timeout needs to be bumped again for the long running notebooks.