### PR TITLE
[Python] Clear `_resolving_arguments` on exception in `ensure_not_recursive`

### DIFF
--- a/python/cudaq/kernel/kernel_decorator.py
+++ b/python/cudaq/kernel/kernel_decorator.py
@@ -67,9 +67,14 @@ def ensure_not_recursive(method):
             )
 
         self._resolving_arguments = True
-        ret = method(self, *args, **kwargs)
-        self._resolving_arguments = False
-        return ret
+        try:
+            return method(self, *args, **kwargs)
+        finally:
+            # Clear the flag on every exit path. Without `finally`, an
+            # exception raised by `method` leaks `_resolving_arguments=True`
+            # to the next invocation, which then misreports the real error
+            # as a recursive-call diagnostic.
+            self._resolving_arguments = False
 
     return wrapper
 


### PR DESCRIPTION
### Summary

`PyKernelDecorator.ensure_not_recursive` left `_resolving_arguments=True` when the wrapped `resolve_captured_arguments` method raised. Every subsequent invocation on the same instance then misreported the real error as `"recursive kernel call detected in <name>"`. Wrap the body in `try/finally` so the flag is cleared on every exit path.