### PR TITLE
[Python] measure_handle frontend cleanups

### DIFF
--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -1781,17 +1781,11 @@ class PyASTBridge(ast.NodeVisitor):
             # function name
             fullName = nvqppPrefix + self.name
 
-            # Create the FuncOp
-            f = func.FuncOp(fullName,
-                            self.signature.get_lifted_type(),
-                            loc=self.loc)
-            self.kernelFuncOp = f
-
-            # Set this kernel as an entry point if the argument types are
-            # classical only
+            # Determine whether this kernel will be an entry point (no quantum
+            # types in the signature). Run this check before creating the
+            # `FuncOp` so a rejection does not leave an orphaned op in the module.
             anyQuantumType = any(
                 self.isQuantumType(ty) for ty in self.signature.arg_types)
-            f.attributes.__setitem__('cudaq-kernel', UnitAttr.get())
             if not anyQuantumType:
                 # `cudaq::measure_handle` is device-only and must not appear
                 # either directly or transitively in the parameter or return
@@ -1802,6 +1796,16 @@ class PyASTBridge(ast.NodeVisitor):
                 if (self.signature.return_type and
                         containsMeasureHandle(self.signature.return_type)):
                     self.emitFatalError(boundaryDiagnostic, node)
+
+            # Create the FuncOp
+            f = func.FuncOp(fullName,
+                            self.signature.get_lifted_type(),
+                            loc=self.loc)
+            self.kernelFuncOp = f
+            f.attributes.__setitem__('cudaq-kernel', UnitAttr.get())
+            # Set this kernel as an entry point if the argument types are
+            # classical only
+            if not anyQuantumType:
                 f.attributes.__setitem__('cudaq-entrypoint', UnitAttr.get())
 
             # Create the entry block
@@ -5177,7 +5181,40 @@ class PyASTBridge(ast.NodeVisitor):
             return
 
         self.walkingReturnNode = True
-        self.visit(node.value)
+        # If we are returning a tuple expression with a struct return type,
+        # coerce each element to its expected member type *before* assembling
+        # the struct. Without this, an intermediate struct whose element
+        # types include `!cc.measure_handle` is constructed; that intermediate
+        # type survives to QIR lowering and fails to legalize even though the
+        # outer struct is later coerced to the expected type.
+        expectedRet = self.signature.return_type
+        if (isinstance(node.value, ast.Tuple) and expectedRet is not None and
+                cc.StructType.isinstance(expectedRet) and
+                len(cc.StructType.getTypes(expectedRet)) == len(
+                    node.value.elts)):
+            expectedEleTys = cc.StructType.getTypes(expectedRet)
+            # Mirror the frame discipline that `self.visit(tuple_node)` would
+            # have performed via `visit_Tuple`: push a child frame so
+            # `pushValue` from each element visit lands on this scratch frame
+            # rather than on `visit_Return`'s frame.
+            self.valueStack.pushFrame()
+            for eleNode in node.value.elts:
+                self.visit(eleNode)
+            elementValues = self.popAllValues(len(node.value.elts))
+            elementValues.reverse()
+            # Replicate `visit_Tuple`'s container-entry validation (e.g. the
+            # "only dataclass literals" check) that we would otherwise bypass
+            # by taking this branch instead of going through `visit_Tuple`.
+            for idx, value in enumerate(elementValues):
+                self.__validate_container_entry(value, node.value.elts[idx])
+            coerced = [
+                self.changeOperandToType(eleTy, val, allowDemotion=True)
+                for eleTy, val in zip(expectedEleTys, elementValues)
+            ]
+            self.pushValue(self.__createStructWithKnownValues(coerced))
+            self.valueStack.popFrame()
+        else:
+            self.visit(node.value)
         self.walkingReturnNode = False
 
         if self.valueStack.currentNumValues == 0:

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -5182,39 +5182,22 @@ class PyASTBridge(ast.NodeVisitor):
 
         self.walkingReturnNode = True
         # If we are returning a tuple expression with a struct return type,
-        # coerce each element to its expected member type *before* assembling
-        # the struct. Without this, an intermediate struct whose element
-        # types include `!cc.measure_handle` is constructed; that intermediate
-        # type survives to QIR lowering and fails to legalize even though the
-        # outer struct is later coerced to the expected type.
+        # signal `visit_Tuple` to coerce each element to its expected member
+        # type before assembling the struct. Without this, an intermediate
+        # struct whose element types include `!cc.measure_handle` is built
+        # and survives to QIR lowering, where it fails to legalize even
+        # though the outer struct is later coerced to the expected type.
         expectedRet = self.signature.return_type
         if (isinstance(node.value, ast.Tuple) and expectedRet is not None and
                 cc.StructType.isinstance(expectedRet) and
                 len(cc.StructType.getTypes(expectedRet)) == len(
                     node.value.elts)):
-            expectedEleTys = cc.StructType.getTypes(expectedRet)
-            # Mirror the frame discipline that `self.visit(tuple_node)` would
-            # have performed via `visit_Tuple`: push a child frame so
-            # `pushValue` from each element visit lands on this scratch frame
-            # rather than on `visit_Return`'s frame.
-            self.valueStack.pushFrame()
-            for eleNode in node.value.elts:
-                self.visit(eleNode)
-            elementValues = self.popAllValues(len(node.value.elts))
-            elementValues.reverse()
-            # Replicate `visit_Tuple`'s container-entry validation (e.g. the
-            # "only dataclass literals" check) that we would otherwise bypass
-            # by taking this branch instead of going through `visit_Tuple`.
-            for idx, value in enumerate(elementValues):
-                self.__validate_container_entry(value, node.value.elts[idx])
-            coerced = [
-                self.changeOperandToType(eleTy, val, allowDemotion=True)
-                for eleTy, val in zip(expectedEleTys, elementValues)
-            ]
-            self.pushValue(self.__createStructWithKnownValues(coerced))
-            self.valueStack.popFrame()
-        else:
+            self._tupleReturnExpectedEleTys = cc.StructType.getTypes(
+                expectedRet)
+        try:
             self.visit(node.value)
+        finally:
+            self._tupleReturnExpectedEleTys = None
         self.walkingReturnNode = False
 
         if self.valueStack.currentNumValues == 0:
@@ -5294,11 +5277,25 @@ class PyASTBridge(ast.NodeVisitor):
     def visit_Tuple(self, node):
         """Map tuples in the Python AST to equivalents in MLIR."""
 
+        # Consume any expected element types set by an outer caller (e.g.
+        # `visit_Return` for a tuple-returning kernel) so per-element type
+        # coercion happens before the struct is assembled. Reset to `None`
+        # immediately so nested tuples in the element visits below do not
+        # inherit this caller's expectations.
+        expectedEleTys = getattr(self, '_tupleReturnExpectedEleTys', None)
+        self._tupleReturnExpectedEleTys = None
+
         [self.visit(el) for el in node.elts]
         elementValues = self.popAllValues(len(node.elts))
         elementValues.reverse()
         for idx, value in enumerate(elementValues):
             self.__validate_container_entry(value, node.elts[idx])
+        if expectedEleTys is not None and len(expectedEleTys) == len(
+                elementValues):
+            elementValues = [
+                self.changeOperandToType(eleTy, val, allowDemotion=True)
+                for eleTy, val in zip(expectedEleTys, elementValues)
+            ]
         struct = self.__createStructWithKnownValues(elementValues)
         self.pushValue(struct)
 

--- a/python/cudaq/kernel/utils.py
+++ b/python/cudaq/kernel/utils.py
@@ -457,7 +457,13 @@ def mlirTypeFromAnnotation(annotation,
                     f"Unable to get list elements when inferring type from annotation ("
                     f"{ast.unparse(annotation) if hasattr(ast, 'unparse') else annotation})."
                 )
-            argTypes = [mlirTypeFromAnnotation(a, ctx) for a in args.elts]
+            argTypes = [
+                mlirTypeFromAnnotation(a,
+                                       ctx,
+                                       raiseError=raiseError,
+                                       cudaqAliases=cudaqAliases)
+                for a in args.elts
+            ]
             if not isinstance(ret, ast.Constant) or ret.value:
                 localEmitFatalError("passing kernels as arguments that return"
                                     " a value is not currently supported")
@@ -474,7 +480,10 @@ def mlirTypeFromAnnotation(annotation,
 
             eleTypeNode = annotation.slice
             # expected that slice is a Name node
-            listEleTy = mlirTypeFromAnnotation(eleTypeNode, ctx)
+            listEleTy = mlirTypeFromAnnotation(eleTypeNode,
+                                               ctx,
+                                               raiseError=raiseError,
+                                               cudaqAliases=cudaqAliases)
             return cc.StdvecType.get(listEleTy)
 
         if isinstance(annotation,
@@ -497,7 +506,13 @@ def mlirTypeFromAnnotation(annotation,
                     f"annotation ({ast.unparse(annotation) if hasattr(ast, 'unparse') else annotation})."
                 )
 
-            eleTypes = [mlirTypeFromAnnotation(v, ctx) for v in elements]
+            eleTypes = [
+                mlirTypeFromAnnotation(v,
+                                       ctx,
+                                       raiseError=raiseError,
+                                       cudaqAliases=cudaqAliases)
+                for v in elements
+            ]
             tupleTy = mlirTryCreateStructType(eleTypes)
             if tupleTy is None:
                 localEmitFatalError("Hybrid quantum-classical data types and "

--- a/python/tests/kernel/test_assignments.py
+++ b/python/tests/kernel/test_assignments.py
@@ -1391,8 +1391,7 @@ def test_inner_functions():
                 x(q)
 
         fct()
-        # FIXME: aggregate-element typing does not currently auto-discriminate, so coerce explicitly.
-        return i, bool(mz(q))
+        return i, mz(q)
 
     out = cudaq.run(test1, True, False, shots_count=10)
     assert all(res == (True, False) for res in out)

--- a/python/tests/kernel/test_measure_handle.py
+++ b/python/tests/kernel/test_measure_handle.py
@@ -278,6 +278,17 @@ def test_boundary_handle_in_callable_parameter_is_admissible():
     k.compile()
 
 
+def test_boundary_handle_vector_via_alias_is_rejected():
+    import cudaq as cq
+
+    @cq.kernel
+    def k(hs: list[cq.measure_handle]):
+        pass
+
+    with pytest.raises(RuntimeError, match=re.escape(_BOUNDARY_DIAG)):
+        k.compile()
+
+
 def test_boundary_make_kernel_handle_arg_is_rejected():
     # `cudaq.make_kernel(...)` constructs an entry-point FuncOp directly
     # without going through the AST-bridge boundary check. The boundary rule
@@ -328,6 +339,24 @@ def test_int_handle_in_arithmetic_promotes_through_bool():
     results = cudaq.run(k, shots_count=1)
     assert len(results) == 1
     assert results[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# Aggregate-element auto-discriminate
+# ---------------------------------------------------------------------------
+
+
+def test_tuple_return_with_handle_element_discriminates():
+
+    @cudaq.kernel
+    def k(first: bool) -> tuple[bool, bool]:
+        q = cudaq.qubit()
+        x(q)
+        return first, mz(q)
+
+    results = cudaq.run(k, True, shots_count=1)
+    assert len(results) == 1
+    assert results[0] == (True, True)
 
 
 # leave for gdb debugging

--- a/python/tests/kernel/test_measure_handle.py
+++ b/python/tests/kernel/test_measure_handle.py
@@ -341,24 +341,6 @@ def test_int_handle_in_arithmetic_promotes_through_bool():
     assert results[0] == 2
 
 
-# ---------------------------------------------------------------------------
-# Aggregate-element auto-discriminate
-# ---------------------------------------------------------------------------
-
-
-def test_tuple_return_with_handle_element_discriminates():
-
-    @cudaq.kernel
-    def k(first: bool) -> tuple[bool, bool]:
-        q = cudaq.qubit()
-        x(q)
-        return first, mz(q)
-
-    results = cudaq.run(k, True, shots_count=1)
-    assert len(results) == 1
-    assert results[0] == (True, True)
-
-
 # leave for gdb debugging
 if __name__ == "__main__":
     import os


### PR DESCRIPTION
- Thread `raiseError` and `cudaqAliases` through `mlirTypeFromAnnotation`'s recursive calls (`Callable` / `list` / `tuple`) so type aliases like `import cudaq as cq` resolve `list[cq.measure_handle]` to the boundary diagnostic instead of falling through to the generic "not yet a supported type" error.

- Run the host-device `measure_handle` boundary check before creating the `FuncOp` so a rejection does not leave an orphaned op in the module.

- Discriminate per-element when returning a tuple expression whose type is a struct, so an intermediate struct with `!cc.measure_handle` in its element types is never constructed. Without this, the intermediate type survives to QIR lowering and fails to legalize on `cudaq.run` even though the outer struct is later coerced to the expected type.