### PR TITLE
[opt][qec] Add `EraseQEC` pass for hardware-prep pipeline

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
+++ b/cudaq/include/cudaq/Optimizer/Transforms/Passes.td
@@ -449,6 +449,17 @@ def EraseNopCalls : Pass<"erase-nop-calls"> {
   }];
 }
 
+def EraseQEC : Pass<"erase-qec"> {
+  let summary = "Erase QEC detector and observable operations.";
+  let description = [{
+    Removes `qec.detector`, `qec.observable`, and `qec.pair_detectors` operations
+    from the IR. These are side-effecting declaration ops: they record a
+    parity-check or logical-observable relationship over prior measurement
+    results so a detector error model can be built from the kernel. This pass
+    strips them.
+  }];
+}
+
 def EraseVectorCopyCtor : Pass<"erase-vector-copy-ctor"> {
   let summary = "Erase unneeded vector copy ctor idiom after inlining.";
   let description = [{

--- a/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ add_cudaq_library(OptTransforms
   DistributedDeviceCall.cpp
   EraseNoise.cpp
   EraseNopCalls.cpp
+  EraseQEC.cpp
   EraseVectorCopyCtor.cpp
   ExpandControlVeqs.cpp
   ExpandMeasurements.cpp
@@ -80,12 +81,14 @@ add_cudaq_library(OptTransforms
   DEPENDS
     OptTransformsPassIncGen
     CCDialect
+    QECDialect
     QuakeDialect
     
   LINK_LIBS PUBLIC
     CCDialect
     MLIRIR
     OptimBuilder
+    QECDialect
     QuakeDialect
 )
 

--- a/cudaq/lib/Optimizer/Transforms/EraseQEC.cpp
+++ b/cudaq/lib/Optimizer/Transforms/EraseQEC.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "PassDetails.h"
+#include "cudaq/Optimizer/Dialect/QEC/QECOps.h"
+#include "cudaq/Optimizer/Transforms/Passes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace cudaq::opt {
+#define GEN_PASS_DEF_ERASEQEC
+#include "cudaq/Optimizer/Transforms/Passes.h.inc"
+} // namespace cudaq::opt
+
+#define DEBUG_TYPE "erase-qec"
+
+using namespace mlir;
+
+/// \file
+/// Strip QEC declaration ops (`qec.detector`, `qec.observable`,
+/// `qec.pair_detectors`) from the IR.
+
+namespace {
+
+template <typename Op>
+class EraseQECOpPattern : public OpRewritePattern<Op> {
+public:
+  using OpRewritePattern<Op>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(Op op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+class EraseQECPass : public cudaq::opt::impl::EraseQECBase<EraseQECPass> {
+public:
+  using EraseQECBase::EraseQECBase;
+
+  void runOnOperation() override {
+    auto *op = getOperation();
+    LLVM_DEBUG(llvm::dbgs() << "Before QEC erasure:\n" << *op << "\n\n");
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.insert<EraseQECOpPattern<cudaq::qec::DetectorOp>,
+                    EraseQECOpPattern<cudaq::qec::ObservableOp>,
+                    EraseQECOpPattern<cudaq::qec::DetectorsOp>>(ctx);
+    if (failed(applyPatternsGreedily(op, std::move(patterns))))
+      signalPassFailure();
+    LLVM_DEBUG(llvm::dbgs() << "After QEC erasure:\n" << *op << "\n\n");
+  }
+};
+
+} // namespace

--- a/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/Transforms/Pipelines.cpp
@@ -83,6 +83,7 @@ static void
 createHardwareTargetPrepPipeline(OpPassManager &pm,
                                  const TargetPrepPipelineOptions &options) {
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createEraseNoise());
+  pm.addNestedPass<func::FuncOp>(cudaq::opt::createEraseQEC());
   createTargetPrepPipeline(pm, options);
   pm.addNestedPass<func::FuncOp>(cudaq::opt::createStatePreparation());
 }

--- a/cudaq/test/Transforms/erase-qec.qke
+++ b/cudaq/test/Transforms/erase-qec.qke
@@ -1,0 +1,55 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --erase-qec --split-input-file %s | \
+// RUN:   FileCheck --implicit-check-not="qec." %s
+
+func.func @qec_kernel(%h0 : !cc.measure_handle,
+                      %h1 : !cc.measure_handle,
+                      %v : !cc.stdvec<!cc.measure_handle>) -> i1 {
+  %q = quake.alloca !quake.ref
+  quake.h %q : (!quake.ref) -> ()
+  %m = quake.mz %q : (!quake.ref) -> !quake.measure
+  qec.detector %h0 : !cc.measure_handle
+  qec.detector %h0, %h1 : !cc.measure_handle, !cc.measure_handle
+  qec.detector %v : !cc.stdvec<!cc.measure_handle>
+  qec.observable %h0 : !cc.measure_handle
+  qec.observable %v index 1 : !cc.stdvec<!cc.measure_handle>
+  qec.pair_detectors %v, %v : !cc.stdvec<!cc.measure_handle>, !cc.stdvec<!cc.measure_handle>
+  %r = quake.discriminate %m : (!quake.measure) -> i1
+  return %r : i1
+}
+
+// CHECK-LABEL:   func.func @qec_kernel(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.measure_handle,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<!cc.measure_handle>) -> i1 {
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.h %[[ALLOCA_0]] : (!quake.ref) -> ()
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[ALLOCA_0]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[MZ_0]] : (!quake.measure) -> i1
+// CHECK:           return %[[DISCRIMINATE_0]] : i1
+// CHECK:         }
+
+// -----
+
+func.func @no_qec_kernel() -> i1 {
+  %q = quake.alloca !quake.ref
+  quake.h %q : (!quake.ref) -> ()
+  %m = quake.mz %q : (!quake.ref) -> !quake.measure
+  %r = quake.discriminate %m : (!quake.measure) -> i1
+  return %r : i1
+}
+
+// CHECK-LABEL:   func.func @no_qec_kernel() -> i1 {
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.h %[[ALLOCA_0]] : (!quake.ref) -> ()
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[ALLOCA_0]] : (!quake.ref) -> !quake.measure
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[MZ_0]] : (!quake.measure) -> i1
+// CHECK:           return %[[DISCRIMINATE_0]] : i1
+// CHECK:         }


### PR DESCRIPTION
### Summary

Adds the `--erase-qec` MLIR pass that strips `qec.detector`, `qec.observable`, and `qec.detectors` ops from the IR,
and slots it into the hardware-prep pipeline. The emulation pipeline is deliberately untouched so the analysis-engine path can observe those ops as needed

Made-with: Cursor