### PR TITLE
[core opt] Fixes broken add measurements pass.

### DIFF
--- a/cudaq/lib/Optimizer/Transforms/AddMeasurements.cpp
+++ b/cudaq/lib/Optimizer/Transforms/AddMeasurements.cpp
@@ -24,7 +24,7 @@ namespace {
 
 /// Analysis class that examines a function to determine whether it contains
 /// measurement operations and collects all qubit allocations. Also, gather all
-/// the returns for redirection
+/// the returns for redirection.
 struct Analysis {
   Analysis() = default;
 
@@ -35,13 +35,20 @@ struct Analysis {
         return WalkResult::interrupt();
       }
       if (auto alloc = dyn_cast<cudaq::quake::AllocaOp>(op)) {
+        // Adjust the op if there is an InitState.
         if (alloc->hasOneUse()) {
           Operation *user = *alloc->getUsers().begin();
           if (isa<cudaq::quake::InitializeStateOp>(user))
             op = user;
         }
         allocations.emplace_back(op);
+      } else if (isa<cudaq::quake::NullWireOp, cudaq::quake::NullCableOp>(op)) {
+        allocations.emplace_back(op);
+      } else if (isa<cudaq::quake::SinkOp, cudaq::quake::DeallocOp>(op)) {
+        // Record deallocations. These supercede return ops in precedence.
+        deallocations.emplace_back(op);
       } else if (isa<func::ReturnOp>(op)) {
+        // Use returns if the deallocations are not present.
         returns.emplace_back(op);
       }
       return WalkResult::advance();
@@ -50,10 +57,49 @@ struct Analysis {
 
   bool hasMeasurement = false;
   SmallVector<Operation *> allocations;
+  SmallVector<Operation *> deallocations;
   SmallVector<func::ReturnOp> returns;
 
+  bool hasQubitDeallocs() const { return !deallocations.empty(); }
   bool hasQubitAlloca() const { return !allocations.empty(); }
 };
+
+/// Add measurement operations before the deallocations. This transformation is
+/// written to work in either reference or value semantics. There is no
+/// control-flow rewrite. We expect that an analysis will be provided to
+/// determine terminal measurement operations.
+LogicalResult addDeallocMeasurements(func::FuncOp funcOp,
+                                     SmallVector<Operation *> &deallocations) {
+  auto ctx = funcOp.getContext();
+  OpBuilder builder(ctx);
+
+  auto measTy = cudaq::quake::MeasureType::get(builder.getContext());
+  auto stdvecTy = cudaq::cc::StdvecType::get(measTy);
+  for (auto *op : deallocations) {
+    if (auto dealloc = dyn_cast<cudaq::quake::DeallocOp>(op)) {
+      auto loc = dealloc.getLoc();
+      builder.setInsertionPoint(dealloc);
+      auto resTy = [&]() -> Type {
+        if (isa<cudaq::quake::RefType>(dealloc.getReference().getType()))
+          return measTy;
+        return stdvecTy;
+      }();
+      cudaq::quake::MzOp::create(builder, loc, resTy, dealloc.getReference());
+    } else {
+      auto sink = cast<cudaq::quake::SinkOp>(op);
+      auto loc = sink.getLoc();
+      builder.setInsertionPoint(sink);
+      auto meas = cudaq::quake::MzOp::create(
+          builder, loc, TypeRange{measTy, sink.getTarget().getType()},
+          sink.getTarget());
+      cudaq::quake::SinkOp::create(builder, loc, TypeRange{},
+                                   meas.getResult(1));
+      sink->dropAllReferences();
+      sink.erase();
+    }
+  }
+  return success();
+}
 
 /// Add measurement operations for all allocated qubits in a function.
 /// This transformation creates a new block at the end of the function,
@@ -62,9 +108,9 @@ struct Analysis {
 /// For vector allocations, the measurements are collected into a vector of
 /// measurement results.
 LogicalResult
-addMeasurements(func::FuncOp funcOp, SmallVector<Operation *> &allocations,
-                const SmallVector<func::ReturnOp> &returnsToReplace) {
-  auto loc = funcOp.getLoc();
+addReturnMeasurements(func::FuncOp funcOp,
+                      SmallVector<Operation *> &allocations,
+                      const SmallVector<func::ReturnOp> &returnsToReplace) {
   auto ctx = funcOp.getContext();
   OpBuilder builder(ctx);
 
@@ -74,6 +120,7 @@ addMeasurements(func::FuncOp funcOp, SmallVector<Operation *> &allocations,
   // Add block arguments for return values if the function returns anything
   ArrayRef<Type> returnTypes = funcOp.getFunctionType().getResults();
   if (!returnTypes.empty()) {
+    auto loc = funcOp.getLoc();
     SmallVector<Location> argLocs(returnTypes.size(), loc);
     newBlock->addArguments(returnTypes, argLocs);
   }
@@ -90,18 +137,23 @@ addMeasurements(func::FuncOp funcOp, SmallVector<Operation *> &allocations,
   builder.setInsertionPointToEnd(newBlock);
   auto measTy = cudaq::quake::MeasureType::get(builder.getContext());
   for (auto [index, alloca] : llvm::enumerate(allocations)) {
-    if (isa<cudaq::quake::VeqType>(alloca->getResult(0).getType())) {
+    Type allocTy = alloca->getResult(0).getType();
+    auto loc = alloca->getLoc();
+    if (isa<cudaq::quake::VeqType>(allocTy)) {
       auto stdvecTy = cudaq::cc::StdvecType::get(measTy);
       cudaq::quake::MzOp::create(builder, loc, stdvecTy,
                                  ValueRange{alloca->getResult(0)});
+    } else if (isa<cudaq::quake::RefType>(allocTy)) {
+      auto val = alloca->getResult(0);
+      cudaq::quake::MzOp::create(builder, loc, measTy, val);
     } else {
-      cudaq::quake::MzOp::create(builder, loc, measTy, alloca->getResult(0));
+      return failure();
     }
   }
 
   // Add the final return using block arguments
+  auto loc = funcOp.getLoc();
   func::ReturnOp::create(builder, loc, newBlock->getArguments());
-
   return success();
 }
 
@@ -136,8 +188,14 @@ struct AddMeasurementsPass
       return;
 
     LLVM_DEBUG(llvm::dbgs() << "Before adding measurements:\n" << *func);
-    if (failed(addMeasurements(func, analysis.allocations, analysis.returns)))
-      signalPassFailure();
+    if (analysis.hasQubitDeallocs()) {
+      if (failed(addDeallocMeasurements(func, analysis.deallocations)))
+        signalPassFailure();
+    } else {
+      if (failed(addReturnMeasurements(func, analysis.allocations,
+                                       analysis.returns)))
+        signalPassFailure();
+    }
     LLVM_DEBUG(llvm::dbgs() << "After adding measurements:\n" << *func);
   }
 };

--- a/cudaq/test/Transforms/add_measurements-0.qke
+++ b/cudaq/test/Transforms/add_measurements-0.qke
@@ -106,20 +106,19 @@ func.func @__nvqpp__mlirgen__function_kernel._Z6kernelb(%arg0: i1) -> i32 attrib
 }
 
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__function_kernel._Z6kernelb(
-// CHECK-SAME:                                                            %[[VAL_0:.*]]: i1) -> i32 attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
-// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_2:.*]] = arith.constant 255 : i32
-// CHECK:           %[[VAL_3:.*]] = quake.alloca !quake.ref
-// CHECK:           quake.h %[[VAL_3]] : (!quake.ref) -> ()
-// CHECK:           cf.cond_br %[[VAL_0]], ^bb1, ^bb2
+// CHECK-SAME:      %[[ARG0:.*]]: i1) -> i32 attributes {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 255 : i32
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
+// CHECK:           quake.h %[[ALLOCA_0]] : (!quake.ref) -> ()
+// CHECK:           cf.cond_br %[[ARG0]], ^bb1, ^bb2
 // CHECK:         ^bb1:
-// CHECK:           quake.x %[[VAL_3]] : (!quake.ref) -> ()
-// CHECK:           quake.dealloc %[[VAL_3]] : !quake.ref
-// CHECK:           cf.br ^bb3(%[[VAL_2]] : i32)
+// CHECK:           quake.x %[[ALLOCA_0]] : (!quake.ref) -> ()
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[ALLOCA_0]] : (!quake.ref) -> !quake.measure
+// CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.ref
+// CHECK:           return %[[CONSTANT_1]] : i32
 // CHECK:         ^bb2:
-// CHECK:           quake.dealloc %[[VAL_3]] : !quake.ref
-// CHECK:           cf.br ^bb3(%[[VAL_1]] : i32)
-// CHECK:         ^bb3(%[[VAL_4:.*]]: i32):
-// CHECK:           %[[VAL_5:.*]] = quake.mz %[[VAL_3]] : (!quake.ref) -> !quake.measure
-// CHECK:           return %[[VAL_4]] : i32
+// CHECK:           %[[MZ_1:.*]] = quake.mz %[[ALLOCA_0]] : (!quake.ref) -> !quake.measure
+// CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.ref
+// CHECK:           return %[[CONSTANT_0]] : i32
 // CHECK:         }

--- a/cudaq/test/Transforms/add_measurements-2.qke
+++ b/cudaq/test/Transforms/add_measurements-2.qke
@@ -31,6 +31,27 @@ module attributes {cc.sizeof_string = 32 : i64, llvm.data_layout = "e-m:e-p270:3
     quake.sink %3#1 : !quake.wire
     return
   }
+
+  // mixed modes with scopes
+  func.func @mixed() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+    cc.scope {
+      %0 = quake.null_wire
+      %1 = quake.null_wire
+      %2 = quake.h %0 : (!quake.wire) -> !quake.wire
+      %3:2 = quake.x [%2] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+      quake.sink %3#0 : !quake.wire
+      quake.sink %3#1 : !quake.wire
+    }
+    cc.scope {
+      %0 = quake.alloca !quake.ref
+      %1 = quake.null_wire
+      quake.h %0 : (!quake.ref) -> ()
+      %3 = quake.x [%0] %1 : (!quake.ref, !quake.wire) -> !quake.wire
+      quake.sink %3#0 : !quake.wire
+      quake.dealloc %0 : !quake.ref
+    }
+    return
+  }  
 }
 
 // CHECK-LABEL:   func.func @foo.bar()
@@ -52,3 +73,26 @@ module attributes {cc.sizeof_string = 32 : i64, llvm.data_layout = "e-m:e-p270:3
 // CHECK-DAG:       quake.sink %[[MZ_1]] : !quake.wire
 // CHECK:           return
 
+// CHECK-LABEL:   func.func @mixed()
+// CHECK:           cc.scope {
+// CHECK-DAG:         %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK-DAG:         %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:             %[[H_0:.*]] = quake.h %[[NULL_WIRE_0]] : (!quake.wire) -> !quake.wire
+// CHECK:             %[[X_0:.*]]:2 = quake.x {{\[}}%[[H_0]]] %[[NULL_WIRE_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK:             %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[X_0]]#0 : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:             quake.sink %[[MZ_0]] : !quake.wire
+// CHECK:             %[[VAL_1:.*]], %[[MZ_1:.*]] = quake.mz %[[X_0]]#1 : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:             quake.sink %[[MZ_1]] : !quake.wire
+// CHECK:           }
+// CHECK:           cc.scope {
+// CHECK-DAG:         %[[ALLOCA_0:.*]] = quake.alloca !quake.ref
+// CHECK-DAG:         %[[NULL_WIRE_2:.*]] = quake.null_wire
+// CHECK:             quake.h %[[ALLOCA_0]] : (!quake.ref) -> ()
+// CHECK:             %[[X_1:.*]] = quake.x {{\[}}%[[ALLOCA_0]]] %[[NULL_WIRE_2]] : (!quake.ref, !quake.wire) -> !quake.wire
+// CHECK:             %[[VAL_2:.*]], %[[MZ_2:.*]] = quake.mz %[[X_1]] : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK:             quake.sink %[[MZ_2]] : !quake.wire
+// CHECK:             %[[MZ_3:.*]] = quake.mz %[[ALLOCA_0]] : (!quake.ref) -> !quake.measure
+// CHECK:             quake.dealloc %[[ALLOCA_0]] : !quake.ref
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/cudaq/test/Transforms/add_measurements-2.qke
+++ b/cudaq/test/Transforms/add_measurements-2.qke
@@ -47,7 +47,7 @@ module attributes {cc.sizeof_string = 32 : i64, llvm.data_layout = "e-m:e-p270:3
       %1 = quake.null_wire
       quake.h %0 : (!quake.ref) -> ()
       %3 = quake.x [%0] %1 : (!quake.ref, !quake.wire) -> !quake.wire
-      quake.sink %3#0 : !quake.wire
+      quake.sink %3 : !quake.wire
       quake.dealloc %0 : !quake.ref
     }
     return

--- a/cudaq/test/Transforms/add_measurements-2.qke
+++ b/cudaq/test/Transforms/add_measurements-2.qke
@@ -1,0 +1,54 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt -add-measurements %s | FileCheck %s
+
+module attributes {cc.sizeof_string = 32 : i64, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", llvm.triple = "x86_64-unknown-linux-gnu", quake.mangled_name_map = {__nvqpp__mlirgen__function_bell_no_return._Z14bell_no_returnv = "_Z14bell_no_returnv"}} {
+
+  // reference test
+  func.func @foo.bar() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+    %0 = quake.alloca !quake.veq<2>
+    %1 = quake.extract_ref %0[0] : (!quake.veq<2>) -> !quake.ref
+    quake.h %1 : (!quake.ref) -> ()
+    %2 = quake.extract_ref %0[1] : (!quake.veq<2>) -> !quake.ref
+    quake.x [%1] %2 : (!quake.ref, !quake.ref) -> ()
+    quake.dealloc %0 : !quake.veq<2>
+    return
+  }
+
+  // value test
+  func.func @test() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this} {
+    %0 = quake.null_wire
+    %1 = quake.null_wire
+    %2 = quake.h %0 : (!quake.wire) -> !quake.wire
+    %3:2 = quake.x [%2] %1 : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+    quake.sink %3#0 : !quake.wire
+    quake.sink %3#1 : !quake.wire
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @foo.bar()
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           quake.h
+// CHECK:           quake.x
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[ALLOCA_0]] : (!quake.veq<2>) -> !cc.stdvec<!quake.measure>
+// CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.veq<2>
+// CHECK:           return
+
+// CHECK-LABEL:   func.func @test()
+// CHECK-DAG:       %[[NULL_WIRE_0:.*]] = quake.null_wire
+// CHECK-DAG:       %[[NULL_WIRE_1:.*]] = quake.null_wire
+// CHECK:           %[[H_0:.*]] = quake.h %[[NULL_WIRE_0]] : (!quake.wire) -> !quake.wire
+// CHECK:           %[[X_0:.*]]:2 = quake.x {{\[}}%[[H_0]]] %[[NULL_WIRE_1]] : (!quake.wire, !quake.wire) -> (!quake.wire, !quake.wire)
+// CHECK-DAG:       %[[VAL_0:.*]], %[[MZ_0:.*]] = quake.mz %[[X_0]]#0 : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK-DAG:       quake.sink %[[MZ_0]] : !quake.wire
+// CHECK-DAG:       %[[VAL_1:.*]], %[[MZ_1:.*]] = quake.mz %[[X_0]]#1 : (!quake.wire) -> (!quake.measure, !quake.wire)
+// CHECK-DAG:       quake.sink %[[MZ_1]] : !quake.wire
+// CHECK:           return
+


### PR DESCRIPTION
Fix #3492.

This updates the add-measurements pass to correctly handle the presence of deallocations. Furthermore, it updates the pass to deal with both value semantics and reference semantics forms of kernels.

Kernels that have not had deallocations placed will continue to use the old algorithm, which assumes reference semantics.

Add new regression tests.