### PR TITLE
Fix qpp density matrix overlap calculation

### DIFF
--- a/python/tests/builder/test_state.py
+++ b/python/tests/builder/test_state.py
@@ -160,6 +160,18 @@ def test_state_density_matrix_simple():
     cudaq.reset_target()
 
 
+def test_state_density_matrix_mixed_overlap():
+    cudaq.set_target('density-matrix-cpu')
+
+    rho = np.diag([0.4, 0.3, 0.2, 0.1]).astype(np.complex128)
+    state = cudaq.State.from_data(rho)
+
+    # Density matrix overlap is the Hilbert-Schmidt inner product.
+    assert np.isclose(state.overlap(state), np.trace(rho.conj().T @ rho))
+
+    cudaq.reset_target()
+
+
 def test_state_density_matrix_integration():
     """
     An integration test on the state density matrix class. Uses a CUDA-Q

--- a/python/tests/builder/test_state.py
+++ b/python/tests/builder/test_state.py
@@ -160,7 +160,7 @@ def test_state_density_matrix_simple():
     cudaq.reset_target()
 
 
-def test_state_density_matrix_mixed_overlap():
+def test_state_density_matrix_self_overlap():
     cudaq.set_target('density-matrix-cpu')
 
     rho = np.diag([0.4, 0.3, 0.2, 0.1]).astype(np.complex128)
@@ -168,6 +168,21 @@ def test_state_density_matrix_mixed_overlap():
 
     # Density matrix overlap is the Hilbert-Schmidt inner product.
     assert np.isclose(state.overlap(state), np.trace(rho.conj().T @ rho))
+
+    cudaq.reset_target()
+
+
+def test_state_density_matrix_cross_overlap():
+    cudaq.set_target('density-matrix-cpu')
+
+    rho = np.diag([0.4, 0.3, 0.2, 0.1]).astype(np.complex128)
+    sigma = np.diag([0.1, 0.2, 0.3, 0.4]).astype(np.complex128)
+    state = cudaq.State.from_data(rho)
+    other_state = cudaq.State.from_data(sigma)
+
+    # Density matrix overlap is the Hilbert-Schmidt inner product.
+    assert np.isclose(state.overlap(other_state),
+                      np.trace(rho.conj().T @ sigma))
 
     cudaq.reset_target()
 

--- a/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
+++ b/runtime/nvqir/qpp/QppDMCircuitSimulator.cpp
@@ -44,10 +44,7 @@ struct QppDmState : public cudaq::SimulationState {
         reinterpret_cast<std::complex<double> *>(other.getTensor().data),
         other.getTensor().extents[0], other.getTensor().extents[1]);
 
-    // For qubit systems, F(rho,sigma) = tr(rho*sigma) + 2 *
-    // sqrt(det(rho)*det(sigma))
-    auto detprod = rho.determinant() * sigma.determinant();
-    return (rho * sigma).trace().real() + 2 * std::sqrt(detprod.real());
+    return (rho.adjoint() * sigma).trace();
   }
 
   std::complex<double>


### PR DESCRIPTION
## Summary

This removes the determinant-based overlap formula from the qpp density-matrix backend and aligns it with the existing density-matrix behavior used by the dynamics backend.

The previous implementation used:

```cpp
Tr(rho * sigma) + 2 * sqrt(det(rho) * det(sigma))
```
That expression is only valid as a 2x2 density-matrix closed form, but the backend applies it to arbitrary 2^n x 2^n density matrices. For full-rank multi-qubit mixed states this returns a value that is neither the Hilbert-Schmidt inner product nor the density-matrix fidelity.

This patch does not attempt to redefine the public overlap contract for density matrices. It only removes the invalid 2x2-only formula and makes density-matrix-cpu consistent with the existing dynamics density-matrix implementation, which computes Tr(rho† sigma).

**Reproducer**
For a normalized 2-qubit density matrix:
```
import cudaq, numpy as np

rho = np.diag([0.4, 0.3, 0.2, 0.1]).astype(np.complex128)

for target in ["density-matrix-cpu", "dynamics"]:
    cudaq.reset_target()
    cudaq.set_target(target)
    state = cudaq.State.from_data(rho)
    print(target, state.overlap(state))

print("expected HS:", np.trace(rho.conj().T @ rho))
```
Before:
```
density-matrix-cpu: 0.3048
dynamics:           0.3
expected HS:        0.3
```
After:
```
density-matrix-cpu: 0.3
dynamics:           0.3
expected HS:        0.3
```

**Note**: If maintainers feel density-matrix `overlap` should remain unspecified, or that the intended fix should instead define a fidelity-based API, feel free to modify/close this PR.