### PR TITLE
End-to-end sample_policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ __pycache__/
 .vscode/*
 .theia/*
 *.code-workspace
+.env
 
 # Container files
 **/.docker/*

--- a/python/cudaq/runtime/sample.py
+++ b/python/cudaq/runtime/sample.py
@@ -74,8 +74,8 @@ def __broadcastSample(kernel,
         ctx.totalIterations = N
         ctx.batchIteration = i
         ctx.explicitMeasurements = explicit_measurements
-        policy = cudaq_runtime.sample_policy(ctx, kernel_name,
-                                             explicit_measurements)
+        policy = cudaq_runtime.SamplePolicy(ctx, kernel_name,
+                                            explicit_measurements)
         res = cudaq_runtime.launch_sample(policy, ctx, lambda: kernel(*a))
         results.append(res)
 
@@ -178,8 +178,7 @@ def sample(kernel,
     ctx.kernelName = kernel_name
     ctx.explicitMeasurements = explicit_measurements
     ctx.allowJitEngineCaching = True
-    policy = cudaq_runtime.sample_policy(ctx, kernel_name,
-                                         explicit_measurements)
+    policy = cudaq_runtime.SamplePolicy(ctx, kernel_name, explicit_measurements)
 
     counts = cudaq_runtime.SampleResult()
     while counts.get_total_shots() < shots_count:

--- a/python/cudaq/runtime/sample.py
+++ b/python/cudaq/runtime/sample.py
@@ -68,13 +68,15 @@ def __broadcastSample(kernel,
     N = len(argSet)
     results = []
     for i, a in enumerate(argSet):
+        kernel_name = kernel.name if hasattr(kernel, 'name') else ''
         ctx = cudaq_runtime.ExecutionContext('sample', shots_count)
+        ctx.kernelName = kernel_name
         ctx.totalIterations = N
         ctx.batchIteration = i
         ctx.explicitMeasurements = explicit_measurements
-        with ctx:
-            kernel(*a)
-        res = ctx.result
+        policy = cudaq_runtime.sample_policy(ctx, kernel_name,
+                                             explicit_measurements)
+        res = cudaq_runtime.launch_sample(policy, ctx, lambda: kernel(*a))
         results.append(res)
 
     return results
@@ -171,25 +173,27 @@ def sample(kernel,
         cudaq_runtime.unset_noise()
         return res
 
+    kernel_name = kernel.name if hasattr(kernel, 'name') else ''
     ctx = cudaq_runtime.ExecutionContext("sample", shots_count)
-    ctx.kernelName = kernel.name if hasattr(kernel, 'name') else ''
+    ctx.kernelName = kernel_name
     ctx.explicitMeasurements = explicit_measurements
     ctx.allowJitEngineCaching = True
+    policy = cudaq_runtime.sample_policy(ctx, kernel_name,
+                                         explicit_measurements)
 
     counts = cudaq_runtime.SampleResult()
     while counts.get_total_shots() < shots_count:
-        with ctx:
-            kernel(*args)
+        result = cudaq_runtime.launch_sample(policy, ctx, lambda: kernel(*args))
         # If the platform is a hardware QPU, launch only once
         countsTotalIsZero = counts.get_total_shots() == 0
-        resultTotalWasReached = ctx.result.get_total_shots() == shots_count
+        resultTotalWasReached = result.get_total_shots() == shots_count
         if (countsTotalIsZero and
                 resultTotalWasReached) or cudaq_runtime.isQuantumDevice():
             # Early return for case where all shots were gathered the first time
             # through this loop.This avoids an additional copy.
             cudaq_runtime.unset_noise()
-            return ctx.result
-        counts += ctx.result
+            return result
+        counts += result
         if counts.get_total_shots() == 0:
             if explicit_measurements:
                 raise RuntimeError(
@@ -199,7 +203,6 @@ def sample(kernel,
                   "results when executed. Exiting shot loop to avoid infinite "
                   "loop.")
             break
-        ctx.result.clear()
     cudaq_runtime.unset_noise()
     ctx.unset_jit_engine()
     return counts

--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -104,6 +104,7 @@ declare_mlir_python_extension(CUDAQuantumPythonSources.Extension
     ../runtime/cudaq/algorithms/py_evolve.cpp
     ../runtime/cudaq/algorithms/py_observe_async.cpp
     ../runtime/cudaq/algorithms/py_optimizer.cpp
+    ../runtime/cudaq/algorithms/py_sample.cpp
     ../runtime/cudaq/algorithms/py_sample_async.cpp
     ../runtime/cudaq/algorithms/py_sample_ptsbe.cpp
     ../runtime/cudaq/algorithms/py_resource_count.cpp

--- a/python/extension/CUDAQuantumExtension.cpp
+++ b/python/extension/CUDAQuantumExtension.cpp
@@ -22,6 +22,7 @@
 #include "runtime/cudaq/algorithms/py_optimizer.h"
 #include "runtime/cudaq/algorithms/py_resource_count.h"
 #include "runtime/cudaq/algorithms/py_run.h"
+#include "runtime/cudaq/algorithms/py_sample.h"
 #include "runtime/cudaq/algorithms/py_sample_async.h"
 #include "runtime/cudaq/algorithms/py_sample_ptsbe.h"
 #include "runtime/cudaq/algorithms/py_state.h"
@@ -134,6 +135,7 @@ NB_MODULE(_quakeDialects, m) {
   bindPyRunAsync(cudaqRuntime);
   bindPyTranslate(cudaqRuntime);
   bindCountResources(cudaqRuntime);
+  bindPySample(cudaqRuntime);
   bindSampleAsync(cudaqRuntime);
   bindSamplePTSBE(cudaqRuntime);
   bindObserveAsync(cudaqRuntime);

--- a/python/runtime/cudaq/algorithms/py_sample.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "py_sample.h"
+#include "cudaq/algorithms/launch.h"
+#include "cudaq/algorithms/sample.h"
+#include <nanobind/stl/string.h>
+
+using namespace cudaq;
+
+static void construct_sample_policy(sample_policy *self, ExecutionContext &ctx,
+                                    const std::string &kernelName,
+                                    bool explicitMeasurements) {
+  new (self) sample_policy();
+  self->kernelName = kernelName;
+  self->options.shots = ctx.shots;
+  self->options.explicit_measurements = explicitMeasurements;
+  self->noiseModel = get_platform().get_noise(ctx.qpuId);
+}
+
+static sample_result launch_sample(sample_policy &policy, ExecutionContext &ctx,
+                                   nanobind::callable callable) {
+  return detail::launch(policy, ctx.qpuId, ctx, get_platform(),
+                        [&]() { callable(); });
+}
+
+void cudaq::bindPySample(nanobind::module_ &mod) {
+  nanobind::class_<sample_policy>(mod, "sample_policy")
+      .def("__init__", construct_sample_policy, nanobind::arg("ctx"),
+           nanobind::arg("kernel_name"),
+           nanobind::arg("explicit_measurements"));
+
+  mod.def("launch_sample", launch_sample, "FIXME: document",
+          nanobind::arg("policy"), nanobind::arg("ctx"),
+          nanobind::arg("callable"));
+}

--- a/python/runtime/cudaq/algorithms/py_sample.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample.cpp
@@ -21,10 +21,22 @@ static void construct_sample_policy(sample_policy *self, ExecutionContext &ctx,
   self->options.shots = ctx.shots;
   self->options.explicit_measurements = explicitMeasurements;
   self->noiseModel = get_platform().get_noise(ctx.qpuId);
+  // For now the noise model has to be duplicated on the policy unfortunately.
+  // get_noise() still expects it on the execution context.
+  // TODO: Store the noise on the platform or QPU instead.
+  ctx.noiseModel = self->noiseModel;
 }
 
 static sample_result launch_sample(sample_policy &policy, ExecutionContext &ctx,
                                    nanobind::callable callable) {
+  auto &platform = get_platform();
+  if (platform.is_remote()) {
+    async_sample_policy async_policy;
+    async_policy.inner = policy;
+    auto res = detail::launch(async_policy, ctx.qpuId, ctx, platform,
+                              [&]() { callable(); });
+    return res.get();
+  }
   return detail::launch(policy, ctx.qpuId, ctx, get_platform(),
                         [&]() { callable(); });
 }

--- a/python/runtime/cudaq/algorithms/py_sample.cpp
+++ b/python/runtime/cudaq/algorithms/py_sample.cpp
@@ -9,6 +9,7 @@
 #include "py_sample.h"
 #include "cudaq/algorithms/launch.h"
 #include "cudaq/algorithms/sample.h"
+#include "cudaq/algorithms/sample/policy.h"
 #include <nanobind/stl/string.h>
 
 using namespace cudaq;
@@ -42,12 +43,29 @@ static sample_result launch_sample(sample_policy &policy, ExecutionContext &ctx,
 }
 
 void cudaq::bindPySample(nanobind::module_ &mod) {
-  nanobind::class_<sample_policy>(mod, "sample_policy")
+  nanobind::class_<sample_policy>(mod, "SamplePolicy")
       .def("__init__", construct_sample_policy, nanobind::arg("ctx"),
-           nanobind::arg("kernel_name"),
-           nanobind::arg("explicit_measurements"));
+           nanobind::arg("kernel_name"), nanobind::arg("explicit_measurements"))
+      .def_prop_ro(
+          "kernel_name",
+          [](const sample_policy &policy) { return policy.kernelName; },
+          "The kernel name.")
+      .def_prop_ro(
+          "shots",
+          [](const sample_policy &policy) { return policy.options.shots; },
+          "The number of shots.")
+      .def_prop_ro("explicit_measurements",
+                   [](const sample_policy &policy) {
+                     return policy.options.explicit_measurements;
+                   })
+      .def("__repr__", [](const sample_policy &p) {
+        return cudaq_fmt::format("SamplePolicy(kernel_name='{}', shots={}, "
+                                 "explicit_measurements={})",
+                                 p.kernelName, p.options.shots,
+                                 p.options.explicit_measurements);
+      });
 
-  mod.def("launch_sample", launch_sample, "FIXME: document",
+  mod.def("launch_sample", launch_sample, "Policy based sample launch.",
           nanobind::arg("policy"), nanobind::arg("ctx"),
           nanobind::arg("callable"));
 }

--- a/python/runtime/cudaq/algorithms/py_sample.h
+++ b/python/runtime/cudaq/algorithms/py_sample.h
@@ -8,21 +8,8 @@
 
 #pragma once
 
-#include "common/ObserveResult.h"
-#include "cudaq/algorithms/observe/options.h"
+#include <nanobind/nanobind.h>
 
 namespace cudaq {
-
-/// @brief Tag and options for computing expectation values.
-struct observe_policy {
-  /// @brief The name of the policy.
-  static constexpr char name[] = "observe";
-
-  /// Associated result type for synchronous APIs keyed off this policy.
-  using result_type = observe_result;
-
-  /// Observe options.
-  observe_options options;
-};
-
+void bindPySample(nanobind::module_ &mod);
 } // namespace cudaq

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -93,9 +93,12 @@ protected:
     auto modulePtr = compileModulePreamble(src);
     CUDAQ_INFO("specializing remote rest kernel via module ({}) with {} policy",
                kernelName, policy.name);
+    // Temporary hack until we have a proper way of configuring the compiler
+    // based on the policy.
+    auto ctx = cudaq::getExecutionContext();
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
-    return compiler.runPassPipeline(policy, kernelName, modulePtr, args);
+    return compiler.runPassPipeline(ctx, kernelName, modulePtr, args);
   }
 
 public:
@@ -274,6 +277,9 @@ public:
                       noiseModel, emulate);
     std::vector<cudaq::KernelExecution> codes;
 
+    // Temporary hack until we have a proper way of configuring the compiler
+    // based on the policy.
+    auto ctx = cudaq::getExecutionContext();
     if (std::holds_alternative<SourceModule>(module)) {
       const auto &src = std::get<SourceModule>(module);
       kernelName = src.getName();
@@ -281,7 +287,7 @@ public:
 
       auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
 
-      codes = compiler.lowerQuakeCode(policy, kernelName, moduleOp, args);
+      codes = compiler.lowerQuakeCode(ctx, kernelName, moduleOp, args);
     } else {
       const auto &compiled = std::get<CompiledModule>(module);
       kernelName = compiled.getName();

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -270,13 +270,13 @@ public:
   /// configured pass pipeline; pre-compiled modules are emitted directly.
   /// The resolved kernel name is returned via @p kernelName.
   template <typename Policy>
-  std::vector<cudaq::KernelExecution>
+  std::pair<std::string, std::vector<cudaq::KernelExecution>>
   compileKernelExecutions(Policy &policy, const AnyModule &module,
-                          KernelArgs args, std::string &kernelName) {
+                          KernelArgs args) {
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
     std::vector<cudaq::KernelExecution> codes;
-
+    std::string kernelName;
     // Temporary hack until we have a proper way of configuring the compiler
     // based on the policy.
     auto ctx = cudaq::getExecutionContext();
@@ -295,7 +295,7 @@ public:
       codes = compiler.emitKernelExecutions(compiled);
     }
 
-    return codes;
+    return {kernelName, codes};
   }
 
   void completeLaunchKernel(const std::string &kernelName,

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -19,6 +19,7 @@
 #include "nvqir/AnalysisScope.h"
 #include "nvqir/resourcecounter/ResourceCounterScope.h"
 #include "cudaq/Support/TargetConfig.h"
+#include "cudaq/algorithms/sample/policy.h"
 #include "cudaq/platform/platform_iface.h"
 #include "cudaq/platform/qpu.h"
 #include "cudaq/platform/qpu_utils.h"
@@ -72,6 +73,30 @@ protected:
 
   /// @brief The target configuration
   cudaq::config::TargetConfig targetConfig;
+
+  const void *compileModulePreamble(const SourceModule &src) const {
+    const auto &kernelName = src.getName();
+    auto mlirArt = src.getMlir();
+    if (!mlirArt)
+      throw std::runtime_error(
+          "compileModulePreamble requires an MLIR artifact on "
+          "the SourceModule for kernel '" +
+          kernelName + "'.");
+    auto modulePtr = mlirArt->getOpaqueModulePtr();
+    return modulePtr;
+  }
+
+  template <typename Policy>
+  CompiledModule compileModuleImpl(Policy &policy, const SourceModule &src,
+                                   KernelArgs args, bool isEntryPoint) {
+    const auto &kernelName = src.getName();
+    auto modulePtr = compileModulePreamble(src);
+    CUDAQ_INFO("specializing remote rest kernel via module ({}) with {} policy",
+               kernelName, policy.name);
+    Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
+                      noiseModel, emulate);
+    return compiler.runPassPipeline(policy, kernelName, modulePtr, args);
+  }
 
 public:
   /// @brief The constructor
@@ -216,13 +241,7 @@ public:
   CompiledModule compileModule(const SourceModule &src, KernelArgs args,
                                bool isEntryPoint) override {
     const auto &kernelName = src.getName();
-    auto mlirArt = src.getMlir();
-    if (!mlirArt)
-      throw std::runtime_error(
-          "BaseRemoteRESTQPU::compileModule requires an MLIR artifact on "
-          "the SourceModule for kernel '" +
-          kernelName + "'.");
-    auto modulePtr = mlirArt->getOpaqueModulePtr();
+    auto modulePtr = compileModulePreamble(src);
     CUDAQ_INFO("specializing remote rest kernel via module ({})", kernelName);
     auto executionContext = cudaq::getExecutionContext();
 
@@ -236,6 +255,41 @@ public:
                       noiseModel, emulate);
     return compiler.runPassPipeline(executionContext, kernelName, modulePtr,
                                     args);
+  }
+
+  CompiledModule compileModule(sample_policy &policy, const SourceModule &src,
+                               KernelArgs args, bool isEntryPoint) override {
+    return compileModuleImpl(policy, src, args, isEntryPoint);
+  }
+
+  /// @brief Build the list of kernel executions for the given module under
+  /// a specific sampling policy. Source modules are lowered through the
+  /// configured pass pipeline; pre-compiled modules are emitted directly.
+  /// The resolved kernel name is returned via @p kernelName.
+  template <typename Policy>
+  std::vector<cudaq::KernelExecution>
+  compileKernelExecutions(Policy &policy, const AnyModule &module,
+                          KernelArgs args, std::string &kernelName) {
+    Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
+                      noiseModel, emulate);
+    std::vector<cudaq::KernelExecution> codes;
+
+    if (std::holds_alternative<SourceModule>(module)) {
+      const auto &src = std::get<SourceModule>(module);
+      kernelName = src.getName();
+      CUDAQ_INFO("launching remote rest kernel ({})", kernelName);
+
+      auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
+
+      codes = compiler.lowerQuakeCode(policy, kernelName, moduleOp, args);
+    } else {
+      const auto &compiled = std::get<CompiledModule>(module);
+      kernelName = compiled.getName();
+      CUDAQ_INFO("launching remote rest kernel via module ({})", kernelName);
+      codes = compiler.emitKernelExecutions(compiled);
+    }
+
+    return codes;
   }
 
   void completeLaunchKernel(const std::string &kernelName,
@@ -386,6 +440,83 @@ public:
 
     // Otherwise make this synchronous
     executionContext->result = future.get();
+  }
+
+  async_sample_result
+  completeLaunchKernel(async_sample_policy &policy,
+                       const std::string &kernelName,
+                       std::vector<cudaq::KernelExecution> &&codes) {
+    // Get the current execution context and number of shots
+    std::size_t localShots = 1000;
+    if (policy.inner.options.shots != std::numeric_limits<std::size_t>::max() &&
+        policy.inner.options.shots != 0)
+      localShots = policy.inner.options.shots;
+
+    executor->setShots(localShots);
+
+    auto executionContext = cudaq::getExecutionContext();
+    // Execute the codes produced in quake lowering
+    // Allow developer to disable remote sending (useful for debugging IR)
+    assert(!emulate);
+    if (getEnvBool("DISABLE_REMOTE_SEND", false))
+      return {};
+    // Cannot be observe and run at the same time
+    const cudaq::details::ExecutionContextType execType =
+        cudaq::details::ExecutionContextType::sample;
+
+    auto future = executor->execute(codes, execType,
+                                    &executionContext->invocationResultBuffer);
+    return async_sample_result(std::move(future));
+  }
+
+  sample_result
+  completeLaunchKernel(sample_policy &policy, const std::string &kernelName,
+                       std::vector<cudaq::KernelExecution> &&codes) {
+
+    // Get the current execution context and number of shots
+    std::size_t localShots = 1000;
+    if (policy.options.shots != std::numeric_limits<std::size_t>::max() &&
+        policy.options.shots != 0)
+      localShots = policy.options.shots;
+
+    executor->setShots(localShots);
+
+    // If emulation requested, then just grab the function and invoke it with
+    // the simulator
+    assert(emulate);
+
+    // Fetch the thread-specific seed outside and then pass it inside.
+    std::size_t seed = cudaq::get_random_seed();
+
+    // Launch the execution of the simulated jobs asynchronously
+    std::vector<cudaq::ExecutionResult> results;
+
+    // If seed is 0, then it has not been set.
+    if (seed > 0)
+      cudaq::set_random_seed(seed);
+
+    // Otherwise, this is a non-adaptive sampling or observe.
+    // We run the kernel(s) (multiple kernels if this is a multi-term
+    // observe) one time each.
+    for (std::size_t i = 0; i < codes.size(); i++) {
+      cudaq::ExecutionContext context("sample", localShots);
+      sample_policy localPolicy;
+      localPolicy.options.shots = localShots;
+      localPolicy.reorderIdx = std::move(codes[i].mapping_reorder_idx);
+      localPolicy.kernelName = kernelName;
+      assert(codes[i].jit);
+      auto result = detail::with_policy_and_ctx(localPolicy, context, [&]() {
+        return cudaq::ExecutionManager::with_default_em(
+            localPolicy, [&]() { codes[i].jit->run(kernelName); });
+      });
+
+      // For each register, add the context results into result.
+      for (auto &regName : result.register_names()) {
+        results.emplace_back(result.to_map(regName), regName);
+        results.back().sequentialData = result.sequential_data(regName);
+      }
+    }
+    return cudaq::sample_result(results);
   }
 };
 

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -22,6 +22,7 @@ namespace cudaq {
 
 class SimulationState;
 class ExecutionManager;
+class KernelArgs;
 
 /// The ExecutionContext is an abstraction to indicate how a CUDA-Q kernel
 /// should be executed.
@@ -155,6 +156,9 @@ public:
   /// use it for multiple discrete calls.
   std::optional<cudaq::JitEngine> jitEng = std::nullopt;
 
+  /// @brief Dispatcher towards the policy specific launch.
+  std::function<void(const AnyModule &module, const KernelArgs &args)>
+      executeKernelApi;
   /// @endcond
 };
 
@@ -217,4 +221,33 @@ void saveArtifact(const std::string kernelName, const cudaq::JitEngine jit);
 /// Returns std::nullopt if no artifact has been saved yet.
 std::optional<JitEngine> getArtifactJit(const std::string &kernelName);
 }; // namespace compiler_artifact
+
+namespace detail {
+/// @brief Execute the given function within the given policy andexecution
+/// context.
+template <typename Policy, typename Callable, typename... Args>
+auto with_policy_and_ctx(Policy &policy, ExecutionContext &ctx, Callable &&f,
+                         Args &&...args)
+    -> std::invoke_result_t<Callable, Args...> {
+
+  // Save the outer execution context (if any) so we can restore it after.
+  auto *outerContext = getExecutionContext();
+  detail::setExecutionContext(&ctx);
+
+  // Cleanup runs after the kernel returns or throws.
+  auto cleanup = [&outerContext]() {
+    detail::resetExecutionContext();
+    if (outerContext)
+      detail::setExecutionContext(outerContext);
+  };
+
+  if constexpr (std::is_void_v<std::invoke_result_t<Callable, Args...>>) {
+    try_finally([&] { f(std::forward<Args>(args)...); }, cleanup);
+    return;
+  }
+
+  return try_finally([&] { return f(std::forward<Args>(args)...); }, cleanup);
+}
+
+} // namespace detail
 } // namespace cudaq

--- a/runtime/common/ExecutionContext.h
+++ b/runtime/common/ExecutionContext.h
@@ -223,7 +223,7 @@ std::optional<JitEngine> getArtifactJit(const std::string &kernelName);
 }; // namespace compiler_artifact
 
 namespace detail {
-/// @brief Execute the given function within the given policy andexecution
+/// @brief Execute the given function within the given policy and execution
 /// context.
 template <typename Policy, typename Callable, typename... Args>
 auto with_policy_and_ctx(Policy &policy, ExecutionContext &ctx, Callable &&f,

--- a/runtime/common/Future.h
+++ b/runtime/common/Future.h
@@ -204,4 +204,11 @@ using async_observe_result = async_result<observe_result>;
 /// @brief Return type for asynchronous sampling.
 using async_sample_result = async_result<sample_result>;
 
+/// @brief Wrapper for a policy to return an async_result.
+template <typename InnerPolicy>
+struct policy_wrapper {
+  InnerPolicy inner;
+  using result_type = async_result<typename InnerPolicy::result_type>;
+};
+
 } // namespace cudaq

--- a/runtime/common/Future.h
+++ b/runtime/common/Future.h
@@ -206,7 +206,7 @@ using async_sample_result = async_result<sample_result>;
 
 /// @brief Wrapper for a policy to return an async_result.
 template <typename InnerPolicy>
-struct policy_wrapper {
+struct async_policy_wrapper {
   InnerPolicy inner;
   using result_type = async_result<typename InnerPolicy::result_type>;
 };

--- a/runtime/cudaq/algorithms/launch.h
+++ b/runtime/cudaq/algorithms/launch.h
@@ -1,0 +1,71 @@
+
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "common/ExecutionContext.h"
+#include "common/KernelArgs.h"
+#include "cudaq/platform.h"
+#include "cudaq/platform/qpu.h"
+#include "cudaq/qis/execution_manager.h"
+#include "cudaq/utils/cudaq_utils.h"
+#include <stdexcept>
+
+namespace cudaq {
+namespace detail {
+
+/// @brief Execute the given function within the given execution context.
+template <typename Policy, typename Callable, typename... Args>
+auto launch(Policy &policy, std::size_t qpu_id, ExecutionContext &ctx,
+            quantum_platform &platform, Callable &&f, Args &&...args)
+    -> Policy::result_type {
+
+  // Python builds without CUDAQ_LIBRARY_MODE defined, so we need to check for
+  // it at runtime
+  bool library_mode = platform.is_library_mode();
+#ifdef CUDAQ_LIBRARY_MODE
+  library_mode = true;
+#endif
+  if (library_mode) {
+    // async_policy (policy_wrapper) + library mode is unreachable:
+    if constexpr (requires { policy.inner; })
+      throw std::logic_error("async policy must not reach library-mode path");
+    else {
+      CUDAQ_INFO("Launching kernel in library mode with policy {}",
+                 policy.name);
+      return detail::with_policy_and_ctx(policy, ctx, [&]() {
+        return cudaq::ExecutionManager::with_default_em(
+            policy, [&]() { f(std::forward<Args>(args)...); });
+      });
+    }
+  }
+
+  typename Policy::result_type result;
+  auto &qpu = platform.getQPU(qpu_id);
+  ctx.executeKernelApi = [&qpu, &result, &policy, &ctx](
+                             const AnyModule &module, const KernelArgs &args) {
+    result = qpu.launchKernel(policy, module, args);
+  };
+
+  if constexpr (requires { policy.inner; })
+    CUDAQ_INFO("Launching kernel in async mode with policy {}",
+               policy.inner.name);
+  else
+    CUDAQ_INFO("Launching kernel in sync mode with policy {}", policy.name);
+
+  detail::try_finally(
+      [&] {
+        detail::with_policy_and_ctx(policy, ctx, std::forward<Callable>(f),
+                                    std::forward<Args>(args)...);
+      },
+      [&] { ctx.executeKernelApi = nullptr; });
+  return result;
+}
+} // namespace detail
+} // namespace cudaq

--- a/runtime/cudaq/algorithms/launch.h
+++ b/runtime/cudaq/algorithms/launch.h
@@ -33,7 +33,7 @@ auto launch(Policy &policy, std::size_t qpu_id, ExecutionContext &ctx,
   library_mode = true;
 #endif
   if (library_mode) {
-    // async_policy (policy_wrapper) + library mode is unreachable:
+    // async_policy (async_policy_wrapper) + library mode is unreachable:
     if constexpr (requires { policy.inner; })
       throw std::logic_error("async policy must not reach library-mode path");
     else {

--- a/runtime/cudaq/algorithms/launch.h
+++ b/runtime/cudaq/algorithms/launch.h
@@ -48,8 +48,8 @@ auto launch(Policy &policy, std::size_t qpu_id, ExecutionContext &ctx,
 
   typename Policy::result_type result;
   auto &qpu = platform.getQPU(qpu_id);
-  ctx.executeKernelApi = [&qpu, &result, &policy, &ctx](
-                             const AnyModule &module, const KernelArgs &args) {
+  ctx.executeKernelApi = [&qpu, &result, &policy](const AnyModule &module,
+                                                  const KernelArgs &args) {
     result = qpu.launchKernel(policy, module, args);
   };
 

--- a/runtime/cudaq/algorithms/policy_cpos.h
+++ b/runtime/cudaq/algorithms/policy_cpos.h
@@ -79,9 +79,8 @@ namespace detail {
 ///        @c finalize_simulation_circuit_impl overload exists for type @p T.
 template <class T>
 concept has_sim_custom_finalize =
-    requires(nvqir::CircuitSimulator &sim, const T &policy,
-             cudaq::ExecutionContext &ctx) {
-      finalize_simulation_circuit_impl(sim, policy, ctx);
+    requires(nvqir::CircuitSimulator &sim, const T &policy) {
+      finalize_simulation_circuit_impl(sim, policy);
     };
 
 /// @brief CPO function object for CircuitSimulator finalization.
@@ -93,7 +92,7 @@ struct finalize_simulation_circuit_fn {
   decltype(auto) operator()(nvqir::CircuitSimulator &sim, const Policy &policy,
                             cudaq::ExecutionContext &ctx) const {
     if constexpr (has_sim_custom_finalize<Policy>) {
-      return finalize_simulation_circuit_impl(sim, policy, ctx);
+      return finalize_simulation_circuit_impl(sim, policy);
     } else {
       return finalize_simulation_circuit_impl(sim, ctx);
     }

--- a/runtime/cudaq/algorithms/sample.h
+++ b/runtime/cudaq/algorithms/sample.h
@@ -137,9 +137,9 @@ runSampling(KernelFunctor &&wrappedKernel, quantum_platform &platform,
     auto noise = platform.get_noise(qpu_id);
     std::optional<noise_model> noise_opt =
         noise ? std::make_optional(*noise) : std::nullopt;
-    auto restult = runSamplingAsync(wrappedKernel, platform, kernelName, shots,
-                                    explicitMeasurements, qpu_id, noise_opt);
-    return restult.get();
+    auto result = runSamplingAsync(wrappedKernel, platform, kernelName, shots,
+                                   explicitMeasurements, qpu_id, noise_opt);
+    return result.get();
   }
 
   // Create the execution context.

--- a/runtime/cudaq/algorithms/sample.h
+++ b/runtime/cudaq/algorithms/sample.h
@@ -172,8 +172,7 @@ runSampling(KernelFunctor &&wrappedKernel, quantum_platform &platform,
       if (explicitMeasurements)
         throw std::runtime_error(
             "The sampling option `explicit_measurements` is not supported on "
-            "a "
-            "kernel without any measurement operation.");
+            "a kernel without any measurement operation.");
       printf("WARNING: this kernel invocation produced 0 shots worth "
              "of results when executed. Exiting shot loop to avoid "
              "infinite loop.");

--- a/runtime/cudaq/algorithms/sample.h
+++ b/runtime/cudaq/algorithms/sample.h
@@ -11,6 +11,7 @@
 #include "common/ExecutionContext.h"
 #include "common/SampleResult.h"
 #include "cudaq/algorithms/broadcast.h"
+#include "cudaq/algorithms/launch.h"
 #include "cudaq/algorithms/sample/options.h"
 #include "cudaq/algorithms/sample/policy.h"
 #include "cudaq/concepts.h"
@@ -49,15 +50,19 @@ concept SampleCallValid =
 
 namespace details {
 
-/// @brief Take the input KernelFunctor (a lambda that captures runtime
-/// arguments and invokes the quantum kernel) and invoke the sampling process.
+/// @brief Validate sampling arguments, populate the given execution context
+/// and sample policy, and (in library mode) trace the kernel to detect any
+/// mid-circuit conditional feedback.
+/// @param ctx The execution context to populate (must already be constructed
+/// with name "sample").
+/// @param policy The sample policy to populate.
 template <typename KernelFunctor>
-std::optional<sample_result>
-runSampling(KernelFunctor &&wrappedKernel, quantum_platform &platform,
-            const std::string &kernelName, int shots, bool explicitMeasurements,
-            std::size_t qpu_id = 0, details::future *futureResult = nullptr,
-            std::size_t batchIteration = 0, std::size_t totalBatchIters = 0) {
-
+void samplePreamble(ExecutionContext &ctx, sample_policy &policy,
+                    KernelFunctor &&wrappedKernel, quantum_platform &platform,
+                    const std::string &kernelName, int shots,
+                    bool explicitMeasurements, std::size_t qpu_id,
+                    std::size_t batchIteration = 0,
+                    std::size_t totalBatchIters = 0) {
   if (cudaq::detail::hasConditionalFeedback(kernelName))
     throw std::runtime_error(
         "`cudaq::sample` and `cudaq::sample_async` no longer support kernels "
@@ -70,12 +75,20 @@ runSampling(KernelFunctor &&wrappedKernel, quantum_platform &platform,
     throw std::runtime_error("The sampling option `explicit_measurements` is "
                              "not supported on this target.");
 
-  // Create the execution context.
-  ExecutionContext ctx("sample", shots, qpu_id);
   ctx.kernelName = kernelName;
   ctx.batchIteration = batchIteration;
   ctx.totalIterations = totalBatchIters;
   ctx.explicitMeasurements = explicitMeasurements;
+
+  policy.kernelName = kernelName;
+  policy.options.shots = shots;
+  policy.options.explicit_measurements = explicitMeasurements;
+  policy.noiseModel = platform.get_noise(qpu_id);
+
+  // For now the noise model has to be duplicated on the policy unfortunately.
+  // get_noise() still expects it on the execution context.
+  // TODO: Store the noise on the platform or QPU instead.
+  ctx.noiseModel = policy.noiseModel;
 
 #ifdef CUDAQ_LIBRARY_MODE
   // If we have a kernel that has its quake code registered, we
@@ -103,36 +116,63 @@ runSampling(KernelFunctor &&wrappedKernel, quantum_platform &platform,
     }
   }
 #endif
+}
 
-  // Indicate that this is an asynchronous execution.
-  ctx.asyncExec = futureResult != nullptr;
+template <typename KernelFunctor>
+auto runSamplingAsync(KernelFunctor &&wrappedKernel, quantum_platform &platform,
+                      const std::string &kernelName, int shots,
+                      bool explicitMeasurements = false, std::size_t qpu_id = 0,
+                      std::optional<noise_model> noise = std::nullopt);
 
-  auto isQuantumDevice = (platform.is_remote() || platform.is_emulated());
+/// @brief Take the input KernelFunctor (a lambda that captures runtime
+/// arguments and invokes the quantum kernel) and invoke the sampling process.
+template <typename KernelFunctor>
+sample_result
+runSampling(KernelFunctor &&wrappedKernel, quantum_platform &platform,
+            const std::string &kernelName, int shots, bool explicitMeasurements,
+            std::size_t qpu_id = 0, std::size_t batchIteration = 0,
+            std::size_t totalBatchIters = 0) {
+
+  if (platform.is_remote(qpu_id)) {
+    auto noise = platform.get_noise(qpu_id);
+    std::optional<noise_model> noise_opt =
+        noise ? std::make_optional(*noise) : std::nullopt;
+    auto restult = runSamplingAsync(wrappedKernel, platform, kernelName, shots,
+                                    explicitMeasurements, qpu_id, noise_opt);
+    return restult.get();
+  }
+
+  // Create the execution context.
+  ExecutionContext ctx("sample", shots, qpu_id);
+  sample_policy policy;
+  samplePreamble(ctx, policy, std::forward<KernelFunctor>(wrappedKernel),
+                 platform, kernelName, shots, explicitMeasurements, qpu_id,
+                 batchIteration, totalBatchIters);
+
+  auto isQuantumDevice = platform.is_emulated(qpu_id);
 
   // Loop until all shots are returned.
   cudaq::sample_result counts;
-  while (counts.get_total_shots() < static_cast<std::size_t>(shots)) {
-    platform.with_execution_context(ctx,
-                                    std::forward<KernelFunctor>(wrappedKernel));
-    if (futureResult) {
-      *futureResult = ctx.futureResult;
-      return std::nullopt;
-    }
 
-    // If target is hardware backend, need to launch only once, hence exit early
+  while (counts.get_total_shots() < static_cast<std::size_t>(shots)) {
+    auto result = detail::launch(policy, qpu_id, ctx, platform,
+                                 std::forward<KernelFunctor>(wrappedKernel));
+
+    // If target is hardware backend, need to launch only once, hence exit
+    // early
     if (isQuantumDevice)
-      return ctx.result;
+      return result;
 
     if (counts.get_total_shots() == 0)
-      counts = std::move(ctx.result); // optimize for first iteration
+      counts = std::move(result); // optimize for first iteration
     else
-      counts += ctx.result;
+      counts += result;
 
-    ctx.result.clear();
     if (counts.get_total_shots() == 0) {
       if (explicitMeasurements)
         throw std::runtime_error(
-            "The sampling option `explicit_measurements` is not supported on a "
+            "The sampling option `explicit_measurements` is not supported on "
+            "a "
             "kernel without any measurement operation.");
       printf("WARNING: this kernel invocation produced 0 shots worth "
              "of results when executed. Exiting shot loop to avoid "
@@ -160,8 +200,8 @@ runSampling(KernelFunctor &&wrappedKernel, quantum_platform &platform,
 template <typename KernelFunctor>
 auto runSamplingAsync(KernelFunctor &&wrappedKernel, quantum_platform &platform,
                       const std::string &kernelName, int shots,
-                      bool explicitMeasurements = false, std::size_t qpu_id = 0,
-                      std::optional<noise_model> noise = std::nullopt) {
+                      bool explicitMeasurements, std::size_t qpu_id,
+                      std::optional<noise_model> noise) {
   if (qpu_id >= platform.num_qpus()) {
     throw std::invalid_argument("Provided qpu_id " + std::to_string(qpu_id) +
                                 " is invalid (must be < " +
@@ -169,29 +209,27 @@ auto runSamplingAsync(KernelFunctor &&wrappedKernel, quantum_platform &platform,
                                 " i.e. platform.num_qpus())");
   }
 
+#ifndef CUDAQ_LIBRARY_MODE
   // Treat an empty noise model as "no noise".
   const bool hasNoise = noise.has_value() && !noise->empty();
-
   // If we are remote, then create the sampling executor with `cudaq::future`
   // provided. Note: noise model is not supported on remote platforms.
   if (platform.is_remote(qpu_id)) {
     if (hasNoise)
       throw std::runtime_error(
           "Noise model is not supported on remote platforms.");
-    details::future futureResult;
-    details::runSampling(std::forward<KernelFunctor>(wrappedKernel), platform,
-                         kernelName, shots, explicitMeasurements, qpu_id,
-                         &futureResult);
-    return async_sample_result(std::move(futureResult));
-  }
 
-  // For local platforms, create an asynchronous task that properly handles the
-  // noise model lifecycle:
-  // 1. Capture noise model BY VALUE in the task (extends lifetime)
-  // 2. Set noise model at the START of the task (before
-  // configureExecutionContext)
-  // 3. Reset noise model at the END of the task (including on exception)
-  // This avoids dangling pointers and global state pollution.
+    // Create the execution context.
+    ExecutionContext ctx("sample", shots, qpu_id);
+    async_sample_policy async_policy;
+    samplePreamble(ctx, async_policy.inner,
+                   std::forward<KernelFunctor>(wrappedKernel), platform,
+                   kernelName, shots, explicitMeasurements, qpu_id);
+    return detail::launch(async_policy, qpu_id, ctx, platform,
+                          std::forward<KernelFunctor>(wrappedKernel));
+  }
+#endif
+
   KernelExecutionTask task(
       [qpu_id, explicitMeasurements, shots, kernelName, &platform,
        noise = std::move(noise),
@@ -202,7 +240,7 @@ auto runSamplingAsync(KernelFunctor &&wrappedKernel, quantum_platform &platform,
         if (hasNoise)
           platform.set_noise(&noise.value(), qpu_id);
 
-        std::optional<sample_result> result;
+        sample_result result;
         try {
           result = details::runSampling(kernel, platform, kernelName, shots,
                                         explicitMeasurements, qpu_id);
@@ -217,7 +255,7 @@ auto runSamplingAsync(KernelFunctor &&wrappedKernel, quantum_platform &platform,
         if (hasNoise)
           platform.reset_noise(qpu_id);
 
-        return result.value();
+        return result;
       });
 
   return async_sample_result(
@@ -251,10 +289,9 @@ sample_result sample(QuantumKernel &&kernel, Args &&...args) {
   auto &platform = cudaq::get_platform();
   auto kernelName = cudaq::getKernelName(kernel);
   return details::runSampling(
-             [&]() mutable { kernel(std::forward<Args>(args)...); }, platform,
-             kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
-             /*explicitMeasurements=*/false)
-      .value();
+      [&]() mutable { kernel(std::forward<Args>(args)...); }, platform,
+      kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
+      /*explicitMeasurements=*/false);
 }
 
 /// @overload
@@ -284,9 +321,8 @@ auto sample(std::size_t shots, QuantumKernel &&kernel, Args &&...args) {
   auto &platform = cudaq::get_platform();
   auto kernelName = cudaq::getKernelName(kernel);
   return details::runSampling(
-             [&]() mutable { kernel(std::forward<Args>(args)...); }, platform,
-             kernelName, shots, /*explicitMeasurements=*/false)
-      .value();
+      [&]() mutable { kernel(std::forward<Args>(args)...); }, platform,
+      kernelName, shots, /*explicitMeasurements=*/false);
 }
 
 /// @brief Sample the given quantum kernel expression and return the
@@ -316,12 +352,16 @@ sample_result sample(const sample_options &options, QuantumKernel &&kernel,
   auto &platform = cudaq::get_platform();
   auto shots = options.shots;
   auto kernelName = cudaq::getKernelName(kernel);
-  if (!options.noise.empty())
+  if (!options.noise.empty()) {
     platform.set_noise(&options.noise);
+    CUDAQ_INFO("Setting noise model onto the platform");
+  }
   auto ret = details::runSampling(
-                 [&]() mutable { kernel(std::forward<Args>(args)...); },
-                 platform, kernelName, shots, options.explicit_measurements)
-                 .value();
+      [&]() mutable { kernel(std::forward<Args>(args)...); }, platform,
+      kernelName, shots, options.explicit_measurements);
+  if (!options.noise.empty()) {
+    CUDAQ_INFO("Resetting noise model from the platform");
+  }
   platform.reset_noise();
   return ret;
 }
@@ -478,12 +518,11 @@ std::vector<sample_result> sample(QuantumKernel &&kernel,
           Args &...singleIterParameters) -> sample_result {
     auto kernelName = cudaq::getKernelName(kernel);
     auto ret = details::runSampling(
-                   [&kernel, &singleIterParameters...]() mutable {
-                     kernel(std::forward<Args>(singleIterParameters)...);
-                   },
-                   platform, kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
-                   /*explicitMeasurements=*/false, qpuId, nullptr, counter, N)
-                   .value();
+        [&kernel, &singleIterParameters...]() mutable {
+          kernel(std::forward<Args>(singleIterParameters)...);
+        },
+        platform, kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
+        /*explicitMeasurements=*/false, qpuId, counter, N);
     return ret;
   };
 
@@ -515,12 +554,11 @@ std::vector<sample_result> sample(std::size_t shots, QuantumKernel &&kernel,
           Args &...singleIterParameters) -> sample_result {
     auto kernelName = cudaq::getKernelName(kernel);
     auto ret = details::runSampling(
-                   [&kernel, &singleIterParameters...]() mutable {
-                     kernel(std::forward<Args>(singleIterParameters)...);
-                   },
-                   platform, kernelName, shots, /*explicitMeasurements=*/false,
-                   qpuId, nullptr, counter, N)
-                   .value();
+        [&kernel, &singleIterParameters...]() mutable {
+          kernel(std::forward<Args>(singleIterParameters)...);
+        },
+        platform, kernelName, shots, /*explicitMeasurements=*/false, qpuId,
+        counter, N);
     return ret;
   };
 
@@ -558,12 +596,10 @@ std::vector<sample_result> sample(const sample_options &options,
           Args &...singleIterParameters) -> sample_result {
     auto kernelName = cudaq::getKernelName(kernel);
     auto ret = details::runSampling(
-                   [&kernel, &singleIterParameters...]() mutable {
-                     kernel(std::forward<Args>(singleIterParameters)...);
-                   },
-                   platform, kernelName, shots, explicit_mz, qpuId, nullptr,
-                   counter, N)
-                   .value();
+        [&kernel, &singleIterParameters...]() mutable {
+          kernel(std::forward<Args>(singleIterParameters)...);
+        },
+        platform, kernelName, shots, explicit_mz, qpuId, counter, N);
     return ret;
   };
 
@@ -597,12 +633,11 @@ sample_n(QuantumKernel &&kernel, ArgumentSet<Args...> &&params) {
           Args &...singleIterParameters) -> sample_result {
     auto kernelName = cudaq::getKernelName(kernel);
     auto ret = details::runSampling(
-                   [&kernel, &singleIterParameters...]() mutable {
-                     kernel(std::forward<Args>(singleIterParameters)...);
-                   },
-                   platform, kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
-                   /*explicitMeasurements=*/false, qpuId, nullptr, counter, N)
-                   .value();
+        [&kernel, &singleIterParameters...]() mutable {
+          kernel(std::forward<Args>(singleIterParameters)...);
+        },
+        platform, kernelName, /*shots=*/DEFAULT_NUM_SHOTS,
+        /*explicitMeasurements=*/false, qpuId, counter, N);
     return ret;
   };
 
@@ -635,12 +670,11 @@ sample_n(std::size_t shots, QuantumKernel &&kernel,
           Args &...singleIterParameters) -> sample_result {
     auto kernelName = cudaq::getKernelName(kernel);
     auto ret = details::runSampling(
-                   [&kernel, &singleIterParameters...]() mutable {
-                     kernel(std::forward<Args>(singleIterParameters)...);
-                   },
-                   platform, kernelName, shots, /*explicitMeasurements=*/false,
-                   qpuId, nullptr, counter, N)
-                   .value();
+        [&kernel, &singleIterParameters...]() mutable {
+          kernel(std::forward<Args>(singleIterParameters)...);
+        },
+        platform, kernelName, shots, /*explicitMeasurements=*/false, qpuId,
+        counter, N);
     return ret;
   };
 

--- a/runtime/cudaq/algorithms/sample/policy.h
+++ b/runtime/cudaq/algorithms/sample/policy.h
@@ -35,8 +35,8 @@ struct sample_policy {
   /// @brief The name of the kernel being executed.
   std::string kernelName;
 
-  /// @brief Whether or not to simply concatenate measurements in execution
-  /// order.
+  /// @brief Flag to indicate that a warning about named measurement registers
+  /// in sampling context has already been emitted.
   bool warnedNamedMeasurements = false;
 
   /// @brief A vector containing information about how to reorder the global
@@ -53,6 +53,6 @@ struct sample_policy {
                                    const sample_policy &policy);
 };
 
-using async_sample_policy = policy_wrapper<sample_policy>;
+using async_sample_policy = async_policy_wrapper<sample_policy>;
 
 } // namespace cudaq

--- a/runtime/cudaq/algorithms/sample/policy.h
+++ b/runtime/cudaq/algorithms/sample/policy.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "common/Future.h"
 #include "common/SampleResult.h"
 #include "cudaq/algorithms/sample/options.h"
 
@@ -22,20 +23,36 @@ class ExecutionContext;
 
 /// @brief Tag and options for sampling quantum circuit measurements.
 struct sample_policy {
+  /// @brief The name of the policy.
+  static constexpr char name[] = "sample";
+
   /// Associated result type for synchronous APIs keyed off this policy.
   using result_type = sample_result;
 
   /// Sampling  options.
   sample_options options;
 
+  /// @brief The name of the kernel being executed.
+  std::string kernelName;
+
+  /// @brief Whether or not to simply concatenate measurements in execution
+  /// order.
+  bool warnedNamedMeasurements = false;
+
+  /// @brief A vector containing information about how to reorder the global
+  /// register after execution. Empty means no reordering.
+  mutable std::vector<std::size_t> reorderIdx;
+
+  mutable const noise_model *noiseModel = nullptr;
+
   friend sample_result
   finalize_execution_manager_impl(ExecutionManager &mgr,
-                                  const sample_policy &policy,
-                                  ExecutionContext &ctx);
+                                  const sample_policy &policy);
   friend sample_result
   finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
-                                   const sample_policy &policy,
-                                   ExecutionContext &ctx);
+                                   const sample_policy &policy);
 };
+
+using async_sample_policy = policy_wrapper<sample_policy>;
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -36,6 +36,25 @@ cudaq::DefaultQPU::unifiedLaunchModule(const cudaq::AnyModule &module,
   return rawFn->getFn()(argData, /*isRemote=*/false);
 }
 
+cudaq::sample_result
+cudaq::DefaultQPU::launchKernel(cudaq::sample_policy &policy,
+                                const cudaq::AnyModule &module,
+                                cudaq::KernelArgs args) {
+  CUDAQ_INFO("DefaultQPU::launchKernel {}", policy.name);
+  return cudaq::ExecutionManager::with_default_em(
+      policy,
+      [this, &module, &args]() { this->unifiedLaunchModule(module, args); });
+}
+
+cudaq::async_sample_result
+cudaq::DefaultQPU::launchKernel(async_sample_policy &policy,
+                                const cudaq::AnyModule &module,
+                                cudaq::KernelArgs args) {
+  throw std::runtime_error(
+      "DefaultQPU does not support launching the async_sample_policy.");
+  return async_sample_result{};
+}
+
 void cudaq::DefaultQPU::configureExecutionContext(
     ExecutionContext &context) const {
   ScopedTraceWithContext("DefaultPlatform::prepareExecutionContext",

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -52,7 +52,6 @@ cudaq::DefaultQPU::launchKernel(async_sample_policy &policy,
                                 cudaq::KernelArgs args) {
   throw std::runtime_error(
       "DefaultQPU does not support launching the async_sample_policy.");
-  return async_sample_result{};
 }
 
 void cudaq::DefaultQPU::configureExecutionContext(

--- a/runtime/cudaq/platform/default/DefaultQPU.h
+++ b/runtime/cudaq/platform/default/DefaultQPU.h
@@ -24,6 +24,13 @@ public:
   KernelThunkResultType unifiedLaunchModule(const cudaq::AnyModule &module,
                                             cudaq::KernelArgs args) override;
 
+  sample_result launchKernel(sample_policy &policy, const AnyModule &module,
+                             KernelArgs args) override;
+
+  async_sample_result launchKernel(async_sample_policy &policy,
+                                   const AnyModule &module,
+                                   KernelArgs args) override;
+
   void configureExecutionContext(ExecutionContext &context) const override;
   void beginExecution() override;
   void endExecution() override;

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -11,6 +11,24 @@
 using namespace cudaq;
 cudaq::RemoteRESTQPU::~RemoteRESTQPU() = default;
 
+sample_result RemoteRESTQPU::launchKernel(sample_policy &policy,
+                                          const AnyModule &module,
+                                          KernelArgs args) {
+  CUDAQ_INFO("RemoteRESTQPU::launchKernel {}", policy.name);
+  std::string kernelName;
+  auto codes = compileKernelExecutions(policy, module, args, kernelName);
+  return completeLaunchKernel(policy, kernelName, std::move(codes));
+}
+
+async_sample_result RemoteRESTQPU::launchKernel(async_sample_policy &policy,
+                                                const AnyModule &module,
+                                                KernelArgs args) {
+  CUDAQ_INFO("RemoteRESTQPU::launchKernel async {}", policy.inner.name);
+  std::string kernelName;
+  auto codes = compileKernelExecutions(policy.inner, module, args, kernelName);
+  return completeLaunchKernel(policy, kernelName, std::move(codes));
+}
+
 KernelThunkResultType
 RemoteRESTQPU::unifiedLaunchModule(const AnyModule &module, KernelArgs args) {
   Compiler compiler(serverHelper.get(), backendConfig, targetConfig, noiseModel,

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -15,8 +15,7 @@ sample_result RemoteRESTQPU::launchKernel(sample_policy &policy,
                                           const AnyModule &module,
                                           KernelArgs args) {
   CUDAQ_INFO("RemoteRESTQPU::launchKernel {}", policy.name);
-  std::string kernelName;
-  auto codes = compileKernelExecutions(policy, module, args, kernelName);
+  auto [kernelName, codes] = compileKernelExecutions(policy, module, args);
   return completeLaunchKernel(policy, kernelName, std::move(codes));
 }
 
@@ -24,8 +23,8 @@ async_sample_result RemoteRESTQPU::launchKernel(async_sample_policy &policy,
                                                 const AnyModule &module,
                                                 KernelArgs args) {
   CUDAQ_INFO("RemoteRESTQPU::launchKernel async {}", policy.inner.name);
-  std::string kernelName;
-  auto codes = compileKernelExecutions(policy.inner, module, args, kernelName);
+  auto [kernelName, codes] =
+      compileKernelExecutions(policy.inner, module, args);
   return completeLaunchKernel(policy, kernelName, std::move(codes));
 }
 

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.h
@@ -27,6 +27,13 @@ public:
   /// synchronous invocation.
   KernelThunkResultType unifiedLaunchModule(const AnyModule &module,
                                             KernelArgs args) override;
+
+  sample_result launchKernel(sample_policy &policy, const AnyModule &module,
+                             KernelArgs args) override;
+
+  async_sample_result launchKernel(async_sample_policy &policy,
+                                   const AnyModule &module,
+                                   KernelArgs args) override;
 };
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
@@ -78,8 +78,7 @@ void cudaq::FermioniqQPU::launchImpl(const cudaq::CompiledModule &compiled) {
 cudaq::sample_result
 cudaq::FermioniqQPU::launchKernel(cudaq::sample_policy &policy,
                                   const AnyModule &module, KernelArgs args) {
-  std::string kernelName;
-  auto codes = compileKernelExecutions(policy, module, args, kernelName);
+  auto [kernelName, codes] = compileKernelExecutions(policy, module, args);
   CUDAQ_INFO("FermioniqBaseQPU launching kernel ({}) with policy {}",
              kernelName, policy.name);
   if (codes.size() != 1)
@@ -91,8 +90,8 @@ cudaq::FermioniqQPU::launchKernel(cudaq::sample_policy &policy,
 cudaq::async_sample_result
 cudaq::FermioniqQPU::launchKernel(cudaq::async_sample_policy &policy,
                                   const AnyModule &module, KernelArgs args) {
-  std::string kernelName;
-  auto codes = compileKernelExecutions(policy.inner, module, args, kernelName);
+  auto [kernelName, codes] =
+      compileKernelExecutions(policy.inner, module, args);
   CUDAQ_INFO("FermioniqBaseQPU launching kernel ({}) with policy {}",
              kernelName, policy.inner.name);
   if (codes.size() != 1)

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
@@ -75,4 +75,30 @@ void cudaq::FermioniqQPU::launchImpl(const cudaq::CompiledModule &compiled) {
   completeLaunchKernel(compiled.getName(), std::move(codes));
 }
 
+cudaq::sample_result
+cudaq::FermioniqQPU::launchKernel(cudaq::sample_policy &policy,
+                                  const AnyModule &module, KernelArgs args) {
+  std::string kernelName;
+  auto codes = compileKernelExecutions(policy, module, args, kernelName);
+  CUDAQ_INFO("FermioniqBaseQPU launching kernel ({}) with policy {}",
+             kernelName, policy.name);
+  if (codes.size() != 1)
+    throw std::runtime_error("Provider only allows 1 circuit at a time.");
+
+  return completeLaunchKernel(policy, kernelName, std::move(codes));
+}
+
+cudaq::async_sample_result
+cudaq::FermioniqQPU::launchKernel(cudaq::async_sample_policy &policy,
+                                  const AnyModule &module, KernelArgs args) {
+  std::string kernelName;
+  auto codes = compileKernelExecutions(policy.inner, module, args, kernelName);
+  CUDAQ_INFO("FermioniqBaseQPU launching kernel ({}) with policy {}",
+             kernelName, policy.inner.name);
+  if (codes.size() != 1)
+    throw std::runtime_error("Provider only allows 1 circuit at a time.");
+
+  return completeLaunchKernel(policy, kernelName, std::move(codes));
+}
+
 CUDAQ_REGISTER_TYPE(cudaq::QPU, cudaq::FermioniqQPU, fermioniq)

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
@@ -66,18 +66,24 @@ public:
   CompiledModule compileModule(const SourceModule &src, KernelArgs args,
                                bool isEntryPoint) override {
     const auto &kernelName = src.getName();
-    auto mlirArt = src.getMlir();
-    if (!mlirArt)
-      throw std::runtime_error(
-          "FermioniqBaseQPU::compileModule requires an MLIR artifact on the "
-          "SourceModule for kernel '" +
-          kernelName + "'.");
-    auto modulePtr = mlirArt->getOpaqueModulePtr();
+    auto modulePtr = compileModulePreamble(src);
     CUDAQ_INFO("FermioniqBaseQPU compiling kernel via module ({})", kernelName);
     return compileImpl(
         kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
           return compiler.runPassPipeline(ctx, kernelName, modulePtr, args);
         });
+  }
+
+  sample_result launchKernel(sample_policy &policy, const AnyModule &module,
+                             KernelArgs args) override;
+
+  async_sample_result launchKernel(async_sample_policy &policy,
+                                   const AnyModule &module,
+                                   KernelArgs args) override;
+
+  CompiledModule compileModule(sample_policy &policy, const SourceModule &src,
+                               KernelArgs args, bool isEntryPoint) override {
+    return compileModuleImpl(policy, src, args, isEntryPoint);
   }
 
 private:
@@ -86,6 +92,17 @@ private:
               std::function<CompiledModule(Compiler &, ExecutionContext *)>
                   runPassPipeline);
 
+  template <typename Policy>
+  CompiledModule compileImpl(Policy &policy, const SourceModule &src,
+                             KernelArgs args, bool isEntryPoint) {
+    const auto &kernelName = src.getName();
+    auto modulePtr = compileModulePreamble(src);
+    CUDAQ_INFO("FermioniqBaseQPU compiling kernel via module ({})", kernelName);
+    return compileImpl(
+        kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
+          return compiler.runPassPipeline(policy, kernelName, modulePtr, args);
+        });
+  }
   void launchImpl(const CompiledModule &compiled);
 };
 

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "qpu.h"
+#include "algorithms/sample/policy.h"
 #include "common/CompiledModule.h"
 #include "common/ExecutionContext.h"
 #include "common/KernelArgs.h"
@@ -45,6 +46,20 @@ cudaq::QPU::unifiedLaunchModule(const AnyModule &module, KernelArgs args) {
   return runJITCompiledModule(compiled, args);
 }
 
+sample_result cudaq::QPU::launchKernel(sample_policy &policy,
+                                       const AnyModule &module,
+                                       KernelArgs args) {
+  throw std::runtime_error(
+      "This QPU does not support launching the sample_policy.");
+}
+
+async_sample_result cudaq::QPU::launchKernel(async_sample_policy &policy,
+                                             const AnyModule &module,
+                                             KernelArgs args) {
+  throw std::runtime_error(
+      "This QPU does not support launching the async_sample_policy.");
+}
+
 cudaq::KernelThunkResultType
 cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
                                  KernelArgs args) {
@@ -80,6 +95,13 @@ cudaq::QPU::runJITCompiledModule(const CompiledModule &compiled,
   // Fully specialized, no result.
   funcPtr();
   return {nullptr, 0};
+}
+
+cudaq::CompiledModule cudaq::QPU::compileModule(sample_policy &,
+                                                const SourceModule &src,
+                                                KernelArgs args,
+                                                bool isEntryPoint) {
+  return compileModule(src, args, isEntryPoint);
 }
 
 cudaq::CompiledModule cudaq::QPU::compileModule(const SourceModule &src,

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -13,6 +13,8 @@
 #include "common/KernelArgs.h"
 #include "common/Registry.h"
 #include "common/ThunkInterface.h"
+#include "cudaq/algorithms/policies.h"
+#include "cudaq/algorithms/sample/policy.h"
 #include "cudaq/remote_capabilities.h"
 
 namespace mlir {
@@ -141,11 +143,23 @@ public:
                          cudaq::optimizer &optimizer, const int n_params,
                          const std::size_t shots) {}
 
+  virtual sample_result launchKernel(sample_policy &policy,
+                                     const AnyModule &module, KernelArgs args);
+
+  virtual async_sample_result launchKernel(async_sample_policy &policy,
+                                           const AnyModule &module,
+                                           KernelArgs args);
+
   [[nodiscard]] virtual KernelThunkResultType
   unifiedLaunchModule(const AnyModule &module, KernelArgs args);
 
   [[nodiscard]] virtual CompiledModule
   compileModule(const SourceModule &src, KernelArgs args, bool isEntryPoint);
+
+  [[nodiscard]] virtual CompiledModule compileModule(sample_policy &,
+                                                     const SourceModule &src,
+                                                     KernelArgs args,
+                                                     bool isEntryPoint);
 
   /// @brief Notify the QPU that a new random seed value is set.
   /// By default do nothing, let subclasses override.

--- a/runtime/cudaq/platform/quantum_platform.cpp
+++ b/runtime/cudaq/platform/quantum_platform.cpp
@@ -7,10 +7,12 @@
  ******************************************************************************/
 
 #include "cudaq/platform/quantum_platform.h"
+#include "algorithms/sample/policy.h"
 #include "common/CompiledModule.h"
 #include "common/ExecutionContext.h"
 #include "common/PluginUtils.h"
 #include "common/RuntimeTarget.h"
+#include "cudaq/Support/TargetConfig.h"
 #include "cudaq/platform/qpu.h"
 #include "cudaq/runtime/logger/logger.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -235,6 +237,11 @@ CompiledModule quantum_platform::compileModule(const SourceModule &src,
                                                bool isEntryPoint) {
   validateQpuId(qpu_id);
   auto &qpu = platformQPUs[qpu_id];
+  auto ctx = cudaq::getExecutionContext();
+  if (ctx && ctx->name == "sample") {
+    sample_policy policy;
+    return qpu->compileModule(policy, src, args, isEntryPoint);
+  }
   return qpu->compileModule(src, args, isEntryPoint);
 }
 
@@ -274,6 +281,14 @@ cudaq::CodeGenConfig quantum_platform::get_codegen_config() {
 const RuntimeTarget *quantum_platform::get_runtime_target() const {
   return runtimeTarget.get();
 }
+
+bool quantum_platform::is_library_mode() const {
+  const auto *rt = get_runtime_target();
+  if (!rt || !rt->config.BackendConfig)
+    return false;
+  auto &bc = rt->config.BackendConfig.value();
+  return !bc.LibraryModeExecutionManager.empty();
+}
 } // namespace cudaq
 
 cudaq::KernelThunkResultType
@@ -283,9 +298,14 @@ cudaq::altLaunchKernel(const char *kernelName,
   ScopedTraceWithContext("altLaunchKernel", kernelName, argsSize);
   auto &platform = *getQuantumPlatformInternal();
   std::string kernName = kernelName;
-  std::size_t qpu_id = cudaq::getCurrentQpuId();
   KernelArgs args{KernelArgs::PackedArgs{kernelArgs, argsSize, resultOffset}};
   SourceModule src{kernName, kernelFunc};
+  auto ctx = cudaq::getExecutionContext();
+  if (ctx && ctx->executeKernelApi) {
+    ctx->executeKernelApi(src, args);
+    return {};
+  }
+  std::size_t qpu_id = cudaq::getCurrentQpuId();
   return platform.unifiedLaunchModule(src, args, qpu_id);
 }
 
@@ -294,11 +314,16 @@ cudaq::streamlinedLaunchKernel(const char *kernelName,
                                const std::vector<void *> &rawArgs) {
   std::size_t argsSize = rawArgs.size();
   ScopedTraceWithContext("streamlinedLaunchKernel", kernelName, argsSize);
-  auto &platform = *getQuantumPlatformInternal();
   std::string kernName = kernelName;
-  std::size_t qpu_id = cudaq::getCurrentQpuId();
   KernelArgs args{rawArgs};
   SourceModule src{kernName};
+  auto ctx = cudaq::getExecutionContext();
+  if (ctx && ctx->executeKernelApi) {
+    ctx->executeKernelApi(src, args);
+    return {};
+  }
+  auto &platform = *getQuantumPlatformInternal();
+  std::size_t qpu_id = cudaq::getCurrentQpuId();
   [[maybe_unused]] auto r = platform.unifiedLaunchModule(src, args, qpu_id);
   // NB: The streamlined launch will never return results. Use alt or hybrid if
   // the kernel returns results.
@@ -311,6 +336,11 @@ cudaq::streamlinedLaunchModule(const CompiledModule &compiled,
   ScopedTraceWithContext("streamlinedLaunchModule", compiled.getName(),
                          rawArgs.size());
 
+  auto ctx = cudaq::getExecutionContext();
+  if (ctx && ctx->executeKernelApi) {
+    ctx->executeKernelApi(compiled, {rawArgs});
+    return {};
+  }
   auto &platform = *getQuantumPlatformInternal();
   std::size_t qpu_id = getCurrentQpuId();
   return platform.unifiedLaunchModule(compiled, {rawArgs}, qpu_id);
@@ -321,7 +351,6 @@ cudaq::CompiledModule cudaq::streamlinedCompileModule(
     const std::vector<void *> &rawArgs, bool isEntryPoint) {
   ScopedTraceWithContext("streamlinedCompileModule", kernelName,
                          rawArgs.size());
-
   auto &platform = *getQuantumPlatformInternal();
   std::size_t qpu_id = getCurrentQpuId();
   SourceModule src{kernelName, moduleOp.getAsOpaquePointer()};
@@ -338,12 +367,21 @@ cudaq::hybridLaunchKernel(const char *kernelName, cudaq::KernelThunkType kernel,
   const std::string kernName = kernelName;
   std::size_t qpu_id = cudaq::getCurrentQpuId();
   SourceModule src{kernName, kernel};
-  if (platform.is_remote(qpu_id)) {
-    // This path should never call a kernel that returns results.
-    [[maybe_unused]] auto r =
-        platform.unifiedLaunchModule(src, {rawArgs}, qpu_id);
+
+  KernelArgs kargs = platform.is_remote(qpu_id)
+                         ? KernelArgs{rawArgs}
+                         : KernelArgs{{args, argsSize, resultOffset}, rawArgs};
+
+  auto ctx = cudaq::getExecutionContext();
+  if (ctx && ctx->executeKernelApi) {
+    ctx->executeKernelApi(src, kargs);
     return {};
   }
-  KernelArgs hybrid{{args, argsSize, resultOffset}, rawArgs};
-  return platform.unifiedLaunchModule(src, hybrid, qpu_id);
+
+  if (platform.is_remote(qpu_id)) {
+    // This path should never call a kernel that returns results.
+    [[maybe_unused]] auto r = platform.unifiedLaunchModule(src, kargs, qpu_id);
+    return {};
+  }
+  return platform.unifiedLaunchModule(src, kargs, qpu_id);
 }

--- a/runtime/cudaq/platform/quantum_platform.h
+++ b/runtime/cudaq/platform/quantum_platform.h
@@ -129,6 +129,11 @@ public:
   ///  Get the number of QPUs available with this platform.
   std::size_t num_qpus() const { return platformQPUs.size(); }
 
+  QPU &getQPU(std::size_t qpu_id = 0) const {
+    validateQpuId(qpu_id);
+    return *(platformQPUs[qpu_id].get());
+  }
+
   /// Return whether this platform is a simulator.
   bool is_simulator(std::size_t qpu_id = 0) const;
 
@@ -162,6 +167,9 @@ public:
   // any other user-defined settings (nvq++ target option compile flags or
   // `set_target` arguments).
   const RuntimeTarget *get_runtime_target() const;
+
+  /// True if the active target runs without the MLIR/QIR kernel launch path.
+  bool is_library_mode() const;
 
   /// @brief Turn off any noise models.
   void reset_noise(std::size_t qpu_id = 0);

--- a/runtime/cudaq/qis/execution_manager.cpp
+++ b/runtime/cudaq/qis/execution_manager.cpp
@@ -46,6 +46,10 @@ void ExecutionManager::configureExecutionContext(ExecutionContext &ctx) {
   nvqir::getCircuitSimulatorInternal()->configureExecutionContext(ctx);
 }
 
+void ExecutionManager::configureExecutionContext(const sample_policy &policy) {
+  nvqir::getCircuitSimulatorInternal()->configureExecutionContext(policy);
+}
+
 void ExecutionManager::finalizeExecutionContext(ExecutionContext &ctx) {
   policies::withPolicy(ctx.name, [&](auto policy) {
     policies::visitResult(

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -16,7 +16,9 @@
 #include "cudaq/host_config.h"
 #include "cudaq/operators.h"
 #include "cudaq/qis/measure_handle.h"
+#include "cudaq/utils/cudaq_utils.h"
 #include <deque>
+#include <iostream>
 #include <string_view>
 #include <vector>
 
@@ -76,6 +78,9 @@ public:
 using measure_result = measure_handle;
 #endif
 
+class ExecutionManager;
+inline ExecutionManager *getDefaultExecutionManager();
+
 /// The ExecutionManager provides a base class describing a concrete sub-system
 /// for allocating qudits and executing quantum instructions on those qudits.
 /// This type is templated on the concrete qudit type (`qubit`, `qmode`, etc).
@@ -114,8 +119,7 @@ public:
   bool memoryLeaked() { return !tracker.allDeallocated(); }
 
   /// Configure the execution context before an execution.
-  void configureExecutionContext(const sample_policy &policy,
-                                 ExecutionContext &ctx);
+  void configureExecutionContext(const sample_policy &policy);
   void configureExecutionContext(ExecutionContext &ctx);
 
   /// Finalize the execution context after an execution.
@@ -123,8 +127,8 @@ public:
 
   virtual void finalizeExecutionContext(const other_policies &policy,
                                         ExecutionContext &ctx) {}
-  virtual sample_result finalizeExecutionContext(const sample_policy &policy,
-                                                 ExecutionContext &ctx) = 0;
+  virtual sample_result
+  finalizeExecutionContext(const sample_policy &policy) = 0;
 
   /// Set up the execution manager for a new execution.
   virtual void beginExecution() {}
@@ -207,11 +211,27 @@ public:
   }
 
   virtual ~ExecutionManager() = default;
+
+  /// @brief Execute the given function within the given execution context.
+  template <typename Policy>
+  static auto with_default_em(Policy &policy, std::function<void()> f)
+      -> Policy::result_type {
+    auto em = getDefaultExecutionManager();
+    em->configureExecutionContext(policy);
+    em->beginExecution();
+    typename Policy::result_type result;
+    detail::try_finally([&] { f(); },
+                        [&] {
+                          result = em->finalizeExecutionContext(policy);
+                          em->endExecution();
+                        });
+    return result;
+  }
 };
 
 inline sample_result finalize_execution_manager_impl(
     ExecutionManager &mgr, const sample_policy &policy, ExecutionContext &ctx) {
-  return mgr.finalizeExecutionContext(policy, ctx);
+  return mgr.finalizeExecutionContext(policy);
 }
 
 inline void finalize_execution_manager_impl(ExecutionManager &mgr,

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -18,7 +18,6 @@
 #include "cudaq/qis/measure_handle.h"
 #include "cudaq/utils/cudaq_utils.h"
 #include <deque>
-#include <iostream>
 #include <string_view>
 #include <vector>
 

--- a/runtime/cudaq/qis/managers/BasicExecutionManager.h
+++ b/runtime/cudaq/qis/managers/BasicExecutionManager.h
@@ -81,9 +81,7 @@ protected:
   /// @brief Subtype-specific method for performing qudit reset.
   virtual void resetQudit(const QuditInfo &q) = 0;
 
-  void finalizeExecutionContextImpl(ExecutionContext &ctx) {
-    assert(&ctx == cudaq::getExecutionContext() &&
-           "cannot finalize non-current execution context");
+  void finalizeExecutionContextImpl() {
     ScopedTraceWithContext("BasicExecutionManager::finalizeExecutionContext");
     synchronize();
   }

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -147,8 +147,8 @@ protected:
     requestedAllocations.clear();
   }
 
-  void finalizeExecutionContextImpl(ExecutionContext &ctx) {
-    BasicExecutionManager::finalizeExecutionContextImpl(ctx);
+  void finalizeExecutionContextImpl() {
+    BasicExecutionManager::finalizeExecutionContextImpl();
 
     if (!requestedAllocations.empty()) {
       CUDAQ_INFO("[DefaultExecutionManager] Flushing remaining {} allocations "
@@ -162,15 +162,14 @@ protected:
     }
   }
 
-  sample_result finalizeExecutionContext(const sample_policy &policy,
-                                         ExecutionContext &ctx) override {
-    finalizeExecutionContextImpl(ctx);
-    return simulator()->finalizeExecutionContext(policy, ctx);
+  sample_result finalizeExecutionContext(const sample_policy &policy) override {
+    finalizeExecutionContextImpl();
+    return simulator()->finalizeExecutionContext(policy);
   }
 
   void finalizeExecutionContext(const other_policies &policy,
                                 ExecutionContext &ctx) override {
-    finalizeExecutionContextImpl(ctx);
+    finalizeExecutionContextImpl();
     simulator()->finalizeExecutionContext(ctx);
   }
 

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -159,18 +159,16 @@ protected:
   void deallocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {}
 
   /// @brief Process results into the execution context
-  void finalizeExecutionContextImpl(std::vector<std::size_t> &ids,
-                                    ExecutionContext &ctx) {
-    BasicExecutionManager::finalizeExecutionContextImpl(ctx);
+  void finalizeExecutionContextImpl(std::vector<std::size_t> &ids) {
+    BasicExecutionManager::finalizeExecutionContextImpl();
     for (auto &s : sampleQudits) {
       ids.push_back(s.id);
     }
   }
 
-  sample_result finalizeExecutionContext(const sample_policy &policy,
-                                         ExecutionContext &ctx) override {
+  sample_result finalizeExecutionContext(const sample_policy &policy) override {
     std::vector<std::size_t> ids;
-    finalizeExecutionContextImpl(ids, ctx);
+    finalizeExecutionContextImpl(ids);
     // Photonics kernels measure explicitly via `mz()`; `sampleQudits` is
     // populated by `measureQudit`. An empty list means no measurement was
     // recorded - either the kernel completed without an `mz()` or it threw
@@ -182,7 +180,7 @@ protected:
     if (sampleQudits.empty())
       return sample_result{};
     CUDAQ_INFO("Sampling");
-    auto shots = ctx.shots;
+    auto shots = policy.options.shots;
     auto sampleResult =
         qpp::sample(shots, state, ids, sampleQudits.front().levels);
     cudaq::ExecutionResult counts;
@@ -206,7 +204,7 @@ protected:
   void finalizeExecutionContext(const other_policies &policy,
                                 ExecutionContext &ctx) override {
     std::vector<std::size_t> ids;
-    finalizeExecutionContextImpl(ids, ctx);
+    finalizeExecutionContextImpl(ids);
 
     if (ctx.name == "extract-state") {
       CUDAQ_INFO("Extracting state");

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -386,7 +386,7 @@ cudaq_internal::compiler::Compiler::assembleCompiledModule(
 }
 
 cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
-    cudaq::ExecutionContext *executionContext, const std::string &kernelName,
+    cudaq::sample_policy &policy, const std::string &kernelName,
     const void *modulePtr, cudaq::KernelArgs args,
     std::shared_ptr<mlir::MLIRContext> context) {
   mlir::ModuleOp m_module = mlir::ModuleOp::getFromOpaquePointer(modulePtr);
@@ -394,7 +394,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
   auto [moduleOp, epFunc] = prepareModule(kernelName, m_module, args);
 
   // Populate conditional measurement flag in the context.
-  if (emulate && executionContext && executionContext->name == "sample") {
+  if (emulate) {
     for (auto &artifact : moduleOp) {
       cudaq::quake::detail::QuakeFunctionAnalysis analysis{&artifact};
       auto info = analysis.getAnalysisInfo();
@@ -416,6 +416,56 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
 
   bool combineMeasurements = executeMainPipeline(moduleOp, kernelName);
 
+  auto mapping_reorder_idx = extractMappingReorderIdx(moduleOp, epFunc);
+
+  // Warn if kernel has named measurement registers (sub-registers).
+  if (!policy.warnedNamedMeasurements) {
+    auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
+        std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
+    if (funcOp) {
+      bool hasNamedMeasurements = false;
+      funcOp.walk([&](cudaq::quake::MeasurementInterface meas) {
+        if (meas.getOptionalRegisterName().has_value()) {
+          hasNamedMeasurements = true;
+          return mlir::WalkResult::interrupt();
+        }
+        return mlir::WalkResult::advance();
+      });
+      if (hasNamedMeasurements) {
+        policy.warnedNamedMeasurements = true;
+        std::cerr << "WARNING: Kernel \"" << kernelName
+                  << "\" uses named measurement results "
+                  << "but is invoked in sampling mode. Support for "
+                  << "sub-registers in `sample_result` is deprecated and will "
+                  << "be removed in a future release. Use `run` to retrieve "
+                  << "individual measurement results." << std::endl;
+      }
+    }
+  }
+  // No need to add measurements only to remove them eventually
+  if (postCodeGenPasses.find("remove-measurements") == std::string::npos)
+    applyPipeline("func.func(add-measurements)", moduleOp, kernelName);
+
+  // Apply observations if necessary
+  std::vector<std::pair<std::string, mlir::ModuleOp>> modules;
+  modules.emplace_back(kernelName, moduleOp);
+
+  bool needJit = emulate;
+  return assembleCompiledModule(kernelName, modules, needJit,
+                                emulate && combineMeasurements, std::nullopt,
+                                mapping_reorder_idx, context);
+}
+
+cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
+    cudaq::ExecutionContext *executionContext, const std::string &kernelName,
+    const void *modulePtr, cudaq::KernelArgs args,
+    std::shared_ptr<mlir::MLIRContext> context) {
+  mlir::ModuleOp m_module = mlir::ModuleOp::getFromOpaquePointer(modulePtr);
+  assert(!context || context.get() == m_module.getContext());
+  auto [moduleOp, epFunc] = prepareModule(kernelName, m_module, args);
+
+  bool combineMeasurements = executeMainPipeline(moduleOp, kernelName);
+
   // We need to run resource counting preprocessing after the pass pipeline as
   // the pre-processing might change the IR structure (may interfere with
   // other passes).
@@ -429,42 +479,6 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
   }
 
   auto mapping_reorder_idx = extractMappingReorderIdx(moduleOp, epFunc);
-
-  if (executionContext) {
-    if (executionContext->name == "sample") {
-      executionContext->reorderIdx = mapping_reorder_idx;
-      // Warn if kernel has named measurement registers (sub-registers).
-      if (!executionContext->warnedNamedMeasurements) {
-        auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
-            std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
-        if (funcOp) {
-          bool hasNamedMeasurements = false;
-          funcOp.walk([&](cudaq::quake::MeasurementInterface meas) {
-            if (meas.getOptionalRegisterName().has_value()) {
-              hasNamedMeasurements = true;
-              return mlir::WalkResult::interrupt();
-            }
-            return mlir::WalkResult::advance();
-          });
-          if (hasNamedMeasurements) {
-            executionContext->warnedNamedMeasurements = true;
-            std::cerr
-                << "WARNING: Kernel \"" << kernelName
-                << "\" uses named measurement results "
-                << "but is invoked in sampling mode. Support for "
-                << "sub-registers in `sample_result` is deprecated and will "
-                << "be removed in a future release. Use `run` to retrieve "
-                << "individual measurement results." << std::endl;
-          }
-        }
-      }
-      // No need to add measurements only to remove them eventually
-      if (postCodeGenPasses.find("remove-measurements") == std::string::npos)
-        applyPipeline("func.func(add-measurements)", moduleOp, kernelName);
-    } else {
-      executionContext->reorderIdx.clear();
-    }
-  }
 
   // Apply observations if necessary
   std::vector<std::pair<std::string, mlir::ModuleOp>> modules;
@@ -572,6 +586,14 @@ cudaq_internal::compiler::Compiler::emitKernelExecutions(
   }
 
   return codes;
+}
+
+std::vector<cudaq::KernelExecution>
+cudaq_internal::compiler::Compiler::lowerQuakeCode(
+    cudaq::sample_policy &policy, const std::string &kernelName,
+    const void *modulePtr, cudaq::KernelArgs args) {
+  auto compiled = runPassPipeline(policy, kernelName, modulePtr, args, nullptr);
+  return emitKernelExecutions(compiled);
 }
 
 /// @brief Extract the Quake representation for the given kernel name and

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -386,7 +386,7 @@ cudaq_internal::compiler::Compiler::assembleCompiledModule(
 }
 
 cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
-    cudaq::sample_policy &policy, const std::string &kernelName,
+    cudaq::ExecutionContext *executionContext, const std::string &kernelName,
     const void *modulePtr, cudaq::KernelArgs args,
     std::shared_ptr<mlir::MLIRContext> context) {
   mlir::ModuleOp m_module = mlir::ModuleOp::getFromOpaquePointer(modulePtr);
@@ -394,7 +394,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
   auto [moduleOp, epFunc] = prepareModule(kernelName, m_module, args);
 
   // Populate conditional measurement flag in the context.
-  if (emulate) {
+  if (emulate && executionContext && executionContext->name == "sample") {
     for (auto &artifact : moduleOp) {
       cudaq::quake::detail::QuakeFunctionAnalysis analysis{&artifact};
       auto info = analysis.getAnalysisInfo();
@@ -416,56 +416,6 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
 
   bool combineMeasurements = executeMainPipeline(moduleOp, kernelName);
 
-  auto mapping_reorder_idx = extractMappingReorderIdx(moduleOp, epFunc);
-
-  // Warn if kernel has named measurement registers (sub-registers).
-  if (!policy.warnedNamedMeasurements) {
-    auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
-        std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
-    if (funcOp) {
-      bool hasNamedMeasurements = false;
-      funcOp.walk([&](cudaq::quake::MeasurementInterface meas) {
-        if (meas.getOptionalRegisterName().has_value()) {
-          hasNamedMeasurements = true;
-          return mlir::WalkResult::interrupt();
-        }
-        return mlir::WalkResult::advance();
-      });
-      if (hasNamedMeasurements) {
-        policy.warnedNamedMeasurements = true;
-        std::cerr << "WARNING: Kernel \"" << kernelName
-                  << "\" uses named measurement results "
-                  << "but is invoked in sampling mode. Support for "
-                  << "sub-registers in `sample_result` is deprecated and will "
-                  << "be removed in a future release. Use `run` to retrieve "
-                  << "individual measurement results." << std::endl;
-      }
-    }
-  }
-  // No need to add measurements only to remove them eventually
-  if (postCodeGenPasses.find("remove-measurements") == std::string::npos)
-    applyPipeline("func.func(add-measurements)", moduleOp, kernelName);
-
-  // Apply observations if necessary
-  std::vector<std::pair<std::string, mlir::ModuleOp>> modules;
-  modules.emplace_back(kernelName, moduleOp);
-
-  bool needJit = emulate;
-  return assembleCompiledModule(kernelName, modules, needJit,
-                                emulate && combineMeasurements, std::nullopt,
-                                mapping_reorder_idx, context);
-}
-
-cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
-    cudaq::ExecutionContext *executionContext, const std::string &kernelName,
-    const void *modulePtr, cudaq::KernelArgs args,
-    std::shared_ptr<mlir::MLIRContext> context) {
-  mlir::ModuleOp m_module = mlir::ModuleOp::getFromOpaquePointer(modulePtr);
-  assert(!context || context.get() == m_module.getContext());
-  auto [moduleOp, epFunc] = prepareModule(kernelName, m_module, args);
-
-  bool combineMeasurements = executeMainPipeline(moduleOp, kernelName);
-
   // We need to run resource counting preprocessing after the pass pipeline as
   // the pre-processing might change the IR structure (may interfere with
   // other passes).
@@ -479,6 +429,42 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
   }
 
   auto mapping_reorder_idx = extractMappingReorderIdx(moduleOp, epFunc);
+
+  if (executionContext) {
+    if (executionContext->name == "sample") {
+      executionContext->reorderIdx = mapping_reorder_idx;
+      // Warn if kernel has named measurement registers (sub-registers).
+      if (!executionContext->warnedNamedMeasurements) {
+        auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
+            std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
+        if (funcOp) {
+          bool hasNamedMeasurements = false;
+          funcOp.walk([&](cudaq::quake::MeasurementInterface meas) {
+            if (meas.getOptionalRegisterName().has_value()) {
+              hasNamedMeasurements = true;
+              return mlir::WalkResult::interrupt();
+            }
+            return mlir::WalkResult::advance();
+          });
+          if (hasNamedMeasurements) {
+            executionContext->warnedNamedMeasurements = true;
+            std::cerr
+                << "WARNING: Kernel \"" << kernelName
+                << "\" uses named measurement results "
+                << "but is invoked in sampling mode. Support for "
+                << "sub-registers in `sample_result` is deprecated and will "
+                << "be removed in a future release. Use `run` to retrieve "
+                << "individual measurement results." << std::endl;
+          }
+        }
+      }
+      // No need to add measurements only to remove them eventually
+      if (postCodeGenPasses.find("remove-measurements") == std::string::npos)
+        applyPipeline("func.func(add-measurements)", moduleOp, kernelName);
+    } else {
+      executionContext->reorderIdx.clear();
+    }
+  }
 
   // Apply observations if necessary
   std::vector<std::pair<std::string, mlir::ModuleOp>> modules;
@@ -586,14 +572,6 @@ cudaq_internal::compiler::Compiler::emitKernelExecutions(
   }
 
   return codes;
-}
-
-std::vector<cudaq::KernelExecution>
-cudaq_internal::compiler::Compiler::lowerQuakeCode(
-    cudaq::sample_policy &policy, const std::string &kernelName,
-    const void *modulePtr, cudaq::KernelArgs args) {
-  auto compiled = runPassPipeline(policy, kernelName, modulePtr, args, nullptr);
-  return emitKernelExecutions(compiled);
 }
 
 /// @brief Extract the Quake representation for the given kernel name and

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -9,7 +9,9 @@
 
 #include "common/CompiledModule.h"
 #include "common/KernelArgs.h"
+#include "common/SampleResult.h"
 #include "cudaq_internal/compiler/CompiledModuleHelper.h"
+#include "cudaq/algorithms/sample/policy.h"
 #include <map>
 #include <memory>
 #include <string>
@@ -120,6 +122,11 @@ public:
   /// the context, guaranteeing it outlives the artifacts. Otherwise the
   /// context lifetime must be managed by the caller.
   cudaq::CompiledModule
+  runPassPipeline(cudaq::sample_policy &policy, const std::string &kernelName,
+                  const void *modulePtr, cudaq::KernelArgs args,
+                  std::shared_ptr<mlir::MLIRContext> context = nullptr);
+
+  cudaq::CompiledModule
   runPassPipeline(cudaq::ExecutionContext *executionContext,
                   const std::string &kernelName, const void *modulePtr,
                   cudaq::KernelArgs args,
@@ -139,6 +146,9 @@ public:
   /// Unchecked assumption: there are no other references to \p module (within
   /// the scope of this launch instance). It can be disposed and/or modified by
   /// this call in any way necessary without breaking some other kernel launch.
+  std::vector<cudaq::KernelExecution>
+  lowerQuakeCode(cudaq::sample_policy &policy, const std::string &kernelName,
+                 const void *modulePtr, cudaq::KernelArgs args);
   std::vector<cudaq::KernelExecution>
   lowerQuakeCode(cudaq::ExecutionContext *executionContext,
                  const std::string &kernelName, const void *modulePtr,

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -9,9 +9,7 @@
 
 #include "common/CompiledModule.h"
 #include "common/KernelArgs.h"
-#include "common/SampleResult.h"
 #include "cudaq_internal/compiler/CompiledModuleHelper.h"
-#include "cudaq/algorithms/sample/policy.h"
 #include <map>
 #include <memory>
 #include <string>
@@ -122,11 +120,6 @@ public:
   /// the context, guaranteeing it outlives the artifacts. Otherwise the
   /// context lifetime must be managed by the caller.
   cudaq::CompiledModule
-  runPassPipeline(cudaq::sample_policy &policy, const std::string &kernelName,
-                  const void *modulePtr, cudaq::KernelArgs args,
-                  std::shared_ptr<mlir::MLIRContext> context = nullptr);
-
-  cudaq::CompiledModule
   runPassPipeline(cudaq::ExecutionContext *executionContext,
                   const std::string &kernelName, const void *modulePtr,
                   cudaq::KernelArgs args,
@@ -146,9 +139,6 @@ public:
   /// Unchecked assumption: there are no other references to \p module (within
   /// the scope of this launch instance). It can be disposed and/or modified by
   /// this call in any way necessary without breaking some other kernel launch.
-  std::vector<cudaq::KernelExecution>
-  lowerQuakeCode(cudaq::sample_policy &policy, const std::string &kernelName,
-                 const void *modulePtr, cudaq::KernelArgs args);
   std::vector<cudaq::KernelExecution>
   lowerQuakeCode(cudaq::ExecutionContext *executionContext,
                  const std::string &kernelName, const void *modulePtr,

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -274,8 +274,7 @@ public:
   virtual void finalizeExecutionContext(const cudaq::other_policies &policy,
                                         cudaq::ExecutionContext &ctx) {}
   virtual cudaq::sample_result
-  finalizeExecutionContext(const cudaq::sample_policy &policy,
-                           cudaq::ExecutionContext &ctx) = 0;
+  finalizeExecutionContext(const cudaq::sample_policy &policy) = 0;
 
   /// @brief Clean up after execution ends.
   virtual void endExecution() {}
@@ -284,6 +283,13 @@ public:
   /// handle <psi | H | psi> instead of NVQIR applying measure
   /// basis quantum gates to change to the Z basis and sample.
   virtual bool canHandleObserve() { return false; }
+
+  /// @brief Set the execution context
+  void configureExecutionContext(const cudaq::sample_policy &policy) {
+    noiseModel = policy.noiseModel;
+    currentCircuitName = policy.kernelName;
+    CUDAQ_INFO("Setting current circuit name to {}", currentCircuitName);
+  }
 
   /// @brief Set the execution context
   void configureExecutionContext(cudaq::ExecutionContext &context) {
@@ -1006,21 +1012,17 @@ public:
 
 protected:
   /// @brief Reset the current execution context.
-  void finalizeExecutionContextImpl(cudaq::ExecutionContext &context) {
-    // Get the ExecutionContext name
-    auto execContextName = context.name;
-
+  void finalizeExecutionContextImpl() {
     // Flush the queue if there are any gates to apply
     flushGateQueue();
   }
 
   cudaq::sample_result
-  finalizeExecutionContext(const cudaq::sample_policy &policy,
-                           cudaq::ExecutionContext &context) override {
-    finalizeExecutionContextImpl(context);
+  finalizeExecutionContext(const cudaq::sample_policy &policy) override {
+    finalizeExecutionContextImpl();
 
     // Sample the state over the specified number of shots
-    if (sampleQubits.empty() && !context.explicitMeasurements) {
+    if (sampleQubits.empty() && !policy.options.explicit_measurements) {
       sampleQubits.resize(getNumQubits());
       if (sampleQubits.empty())
         throw std::runtime_error(
@@ -1060,9 +1062,9 @@ protected:
     // Reorder the global register (if necessary). This might be necessary if
     // the mapping pass had run and we want to undo the shuffle that occurred
     // during mapping.
-    if (!context.reorderIdx.empty()) {
-      internalResult.reorder(context.reorderIdx);
-      context.reorderIdx.clear();
+    if (!policy.reorderIdx.empty()) {
+      internalResult.reorder(policy.reorderIdx);
+      policy.reorderIdx.clear();
     }
 
     // Clear the sample bits for the next run
@@ -1078,7 +1080,7 @@ protected:
                                 cudaq::ExecutionContext &context) override {
     if (nQubitsAllocated == 0)
       return;
-    finalizeExecutionContextImpl(context);
+    finalizeExecutionContextImpl();
 
     // Set the state data if requested.
     if (context.name == "extract-state") {
@@ -1468,9 +1470,8 @@ namespace cudaq {
 
 inline sample_result
 finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
-                                 const sample_policy &policy,
-                                 ExecutionContext &ctx) {
-  return sim.finalizeExecutionContext(policy, ctx);
+                                 const sample_policy &policy) {
+  return sim.finalizeExecutionContext(policy);
 }
 
 } // namespace cudaq

--- a/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
@@ -151,9 +151,7 @@ protected:
   }
 
   cudaq::sample_result
-  finalizeExecutionContext(const cudaq::sample_policy &policy,
-                           cudaq::ExecutionContext &ctx) override {
-    finalizeExecutionContextImpl(ctx);
+  finalizeExecutionContext(const cudaq::sample_policy &policy) override {
     return cudaq::sample_result();
   }
 

--- a/unittests/Optimizer/QuakeSynthTester.cpp
+++ b/unittests/Optimizer/QuakeSynthTester.cpp
@@ -93,13 +93,12 @@ cudaq::sample_result sampleJitCode(ExecutionEngine *jit,
                                    const std::string &kernelName) {
   auto &p = cudaq::get_platform();
   return cudaq::details::runSampling(
-             [&]() {
-               auto err = jit->invokePacked(cudaq::runtime::cudaqGenPrefixName +
-                                            kernelName);
-               ASSERT_TRUE(!err);
-             },
-             p, kernelName, 1000, /*explicitMeasurements=*/false)
-      .value();
+      [&]() {
+        auto err =
+            jit->invokePacked(cudaq::runtime::cudaqGenPrefixName + kernelName);
+        ASSERT_TRUE(!err);
+      },
+      p, kernelName, 1000, /*explicitMeasurements=*/false);
 }
 
 /// @brief Run observation on the JIT compiled kernel function

--- a/unittests/backends/CMakeLists.txt
+++ b/unittests/backends/CMakeLists.txt
@@ -6,6 +6,12 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
+# Undoing the setting of CUDAQ_LIBRARY_MODE for the backends directory.
+get_directory_property(defs COMPILE_DEFINITIONS)
+list(REMOVE_ITEM defs CUDAQ_LIBRARY_MODE)
+set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "${defs}")
+
+
 # List of libraries to link with by default to create a test executable
 set(default_backend_unittest_libs
   fmt::fmt-header-only

--- a/unittests/backends/QPPTester.h
+++ b/unittests/backends/QPPTester.h
@@ -21,8 +21,7 @@ public:
     // a quick set-reset to trigger sampling
     this->configureExecutionContext(ctx);
     cudaq::detail::setExecutionContext(&ctx);
-    auto sampleResults =
-        this->finalizeExecutionContext(cudaq::sample_policy{}, ctx);
+    auto sampleResults = this->finalizeExecutionContext(cudaq::sample_policy{});
     cudaq::detail::resetExecutionContext();
 
     return sampleResults.begin()->first;

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -58,16 +58,15 @@ protected:
   void deallocateQudit(const cudaq::QuditInfo &q) override {}
   void deallocateQudits(const std::vector<cudaq::QuditInfo> &qudits) override {}
 
-  sample_result finalizeExecutionContext(const sample_policy &policy,
-                                         ExecutionContext &ctx) override {
-    BasicExecutionManager::finalizeExecutionContextImpl(ctx);
+  sample_result finalizeExecutionContext(const sample_policy &policy) override {
+    BasicExecutionManager::finalizeExecutionContextImpl();
 
     std::vector<std::size_t> ids;
     for (auto &s : sampleQudits) {
       ids.push_back(s.id);
     }
-    auto sampleResult =
-        qpp::sample(ctx.shots, state, ids, sampleQudits.begin()->levels);
+    auto sampleResult = qpp::sample(policy.options.shots, state, ids,
+                                    sampleQudits.begin()->levels);
 
     ExecutionResult execResult;
     for (auto [result, count] : sampleResult) {


### PR DESCRIPTION
## Summary

This change continues the runtime refactor from a single global `ExecutionContext` (control + inputs + results via `ctx.name` and `ctx.result`) toward **typed policies** that carry launch inputs and return results by value.

For **`sample`**, the policy path is wired end-to-end in C++ and Python:

## The key changes in this PR are
1. We are no longer calling `with_execution_context`. 
    1. We want to get away from the virtual family of calls: configure, begin, end, finalize
    2. `with_execution_context` is calling `ExecutionManager::finalizeContext` too late. We need to result sooner.
    3. The RAII pattern of `with_execution_context` is still helpful so it has been broken up into 
        - `with_policy_and_ctx`: only installs the ExecutionContext. Does not do any of the configure, begin, end, finalize calls
        - `with_default_em`: takes care of returning the result based on the policy from the ExecutionManager
    1. `with_default_em` is helpful for emulation and library mode where no QPU is called but a result is still needed.

2. The ExecutionContext is no longer passed through the policy overloads. For instance, it has been removed from the hidden friends of the policy:
```
  friend sample_result
  finalize_execution_manager_impl(ExecutionManager &mgr,
                                  const sample_policy &policy);
  friend sample_result
  finalize_simulation_circuit_impl(nvqir::CircuitSimulator &sim,
                                   const sample_policy &policy);
```

3. We are a lot more explicit about the use of the async versus the sync policy is used. We only use the async policy for remote backends and we use the synchronous policy for all other backends (running in a separate thread to emulate asynchronous behavior). This is not a change of behavior since this is exactly what was done before but it is now a lot more apparent. Example:
```
async_sample_result
  completeLaunchKernel(async_sample_policy &policy,
                       const std::string &kernelName,
                       std::vector<cudaq::KernelExecution> &&codes) {
...
    auto executionContext = cudaq::getExecutionContext();
    // Execute the codes produced in quake lowering
    // Allow developer to disable remote sending (useful for debugging IR)
    assert(!emulate);
    if (getEnvBool("DISABLE_REMOTE_SEND", false))
      return {};
    // Cannot be observe and run at the same time
    const cudaq::details::ExecutionContextType execType =
        cudaq::details::ExecutionContextType::sample;

    auto future = executor->execute(codes, execType,
                                    &executionContext->invocationResultBuffer);
    return async_sample_result(std::move(future));
  }
```

4.  Because the same code might be called from the different policy overloads, the biggest part of these diffs is about moving code into common function. They are called:
    - samplePreamble
    - compileModulePreamble
    - compileKernelExecutions
    - compileModuleImpl
Some of which are templatized to work with any policy type.

5. Of course, a new API is added to the QPU:
```
  virtual sample_result launchKernel(sample_policy &policy,
                                     const AnyModule &module, KernelArgs args);

  virtual async_sample_result launchKernel(async_sample_policy &policy,
                                           const AnyModule &module,
                                           KernelArgs args);
```

6. Which are called by installing a dispatcher (`executeKernelApi) on the ExcutionContext (the technique used by the architecture team)
```
template <typename Policy, typename Callable, typename... Args>
auto launch(Policy &policy, std::size_t qpu_id, ExecutionContext &ctx,
            quantum_platform &platform, Callable &&f, Args &&...args)
    -> Policy::result_type {
...
  typename Policy::result_type result;
  auto &qpu = platform.getQPU(qpu_id);
  ctx.executeKernelApi = [&qpu, &result, &policy, &ctx](
                             const AnyModule &module, const KernelArgs &args) {
    result = qpu.launchKernel(policy, module, args);
  };

  detail::try_finally(
      [&] {
        detail::with_policy_and_ctx(policy, ctx, std::forward<Callable>(f),
                                    std::forward<Args>(args)...);
      },
      [&] { ctx.executeKernelApi = nullptr; });
  return result;
}
```

7. In the callbacks, the `executeKernelApi` is called if it is installed, which is going to call the policy overload instead of the `unifiedLaunchModule` API.
```
cudaq::KernelThunkResultType
cudaq::altLaunchKernel(const char *kernelName,
                       cudaq::KernelThunkType kernelFunc, void *kernelArgs,
                       std::uint64_t argsSize, std::uint64_t resultOffset) {
  ScopedTraceWithContext("altLaunchKernel", kernelName, argsSize);
  auto &platform = *getQuantumPlatformInternal();
  std::string kernName = kernelName;
  KernelArgs args{KernelArgs::PackedArgs{kernelArgs, argsSize, resultOffset}};
  SourceModule src{kernName, kernelFunc};
  auto ctx = cudaq::getExecutionContext();
  if (ctx && ctx->executeKernelApi) {
    ctx->executeKernelApi(src, args);
    return {};
  }
  std::size_t qpu_id = cudaq::getCurrentQpuId();
  return platform.unifiedLaunchModule(src, args, qpu_id);
}
```

8. In the python case, we are able to call the C++ `detail::launch` API, by simply passing a sample_policy object. `py_sample.h` and `py_sample.cpp` were introduced for this mechanism. The asynchronous flow was already calling the C++ runAsyncSampling API, so nothing had to be done. 

9. The compiler has overloads as well. Example:
```
  cudaq::CompiledModule
  runPassPipeline(cudaq::sample_policy &policy, const std::string &kernelName,
                  const void *modulePtr, cudaq::KernelArgs args,
                  std::shared_ptr<mlir::MLIRContext> context = nullptr);
```
When an overload has been added, the code relying on the execution context has been removed. Forcing all paths to use the overloads. In particular the `compileModule` member of the QPUs now calls a common template based implementation that passes a policy:
```
  CompiledModule compileModule(sample_policy &policy, const SourceModule &src,
                               KernelArgs args, bool isEntryPoint) override {
    return compileModuleImpl(policy, src, args, isEntryPoint);
  }
```

Since this is only called from python, the policy dispatch happens based on the policy name.
```
CompiledModule quantum_platform::compileModule(const SourceModule &src,
                                               const KernelArgs &args,
                                               std::size_t qpu_id,
                                               bool isEntryPoint) {
  validateQpuId(qpu_id);
  auto &qpu = platformQPUs[qpu_id];
  auto ctx = cudaq::getExecutionContext();
  if (ctx && ctx->name == "sample") {
    sample_policy policy;
    return qpu->compileModule(policy, src, args, isEntryPoint);
  }
  return qpu->compileModule(src, args, isEntryPoint);
}
```
This is then only part of the flow that is not end-to-end yet and for which more refactoring might be needed.