### PR TITLE
remove codecov from deployments

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -376,23 +376,6 @@ jobs:
         run: |
           echo '${{ steps.read_json.outputs.result }}'
 
-  coverage:
-    name: Update code coverage
-    if: ${{ ! inputs.devcontainer_only }}
-    needs: [metadata, config]
-    strategy:
-      matrix:
-        platform: [amd64]
-        toolchain: [llvm]
-      fail-fast: false
-    uses: ./.github/workflows/generate_cc.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    with:
-      platform: linux/${{ matrix.platform }}
-      devdeps_image: ${{ fromJson(needs.config.outputs.json).image_hash[format('{0}-{1}', matrix.platform, matrix.toolchain)] }}
-      export_environment: false
-
   extdevdeps:
     name: Create dev environment
     needs: [metadata, config, openmpi]


### PR DESCRIPTION
code coverage is failing in deployments. Let's just remove it. It doesn't make a ton of sense there, as code coverage will be done in CI anyways.

It is currently disabled in CI while I work on getting the performance better, but once it is enabled in CI, then deployments is redundant and wasting runner time.