### PR TITLE
Lower `qec` ops to QIR runtime

### DIFF
--- a/cudaq/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
+++ b/cudaq/include/cudaq/Optimizer/CodeGen/QIRFunctionNames.h
@@ -40,6 +40,12 @@ static constexpr const char QIRCustomAdjOp[] =
     "__quantum__qis__custom_unitary__adj";
 static constexpr const char QIRExpPauli[] = "__quantum__qis__exp_pauli";
 
+static constexpr const char QIRDetector[] = "__quantum__qis__detector";
+static constexpr const char QIRLogicalObservable[] =
+    "__quantum__qis__logical_observable";
+static constexpr const char QIRPairDetectors[] =
+    "__quantum__qis__pair_detectors";
+
 static constexpr const char NVQIRInvokeWithControlBits[] =
     "invokeWithControlQubits";
 static constexpr const char NVQIRInvokeRotationWithControlBits[] =

--- a/cudaq/include/cudaq/Optimizer/Dialect/QEC/QECDialect.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/QEC/QECDialect.td
@@ -18,7 +18,7 @@ def QECDialect : Dialect {
     The QEC dialect houses quantum error correction operations such as detector
     declarations and logical observable declarations. These are separate from
     the Quake dialect to keep Quake focused on circuit semantics while giving
-    QEC annotations a dedicated namespace.
+    QEC operations a dedicated namespace.
   }];
   let cppNamespace = "cudaq::qec";
 }

--- a/cudaq/lib/Optimizer/Builder/Intrinsics.cpp
+++ b/cudaq/lib/Optimizer/Builder/Intrinsics.cpp
@@ -578,6 +578,10 @@ static constexpr IntrinsicCode intrinsicTable[] = {
   func.func private @__quantum__qis__convert_array_to_stdvector(!qir_array) -> !qir_array
   func.func private @__quantum__qis__free_converted_stdvector(!qir_array)
 
+  func.func private @__quantum__qis__detector(!cc.ptr<!qir_result>, i64)
+  func.func private @__quantum__qis__logical_observable(!cc.ptr<!qir_result>, i64, i64)
+  func.func private @__quantum__qis__pair_detectors(!cc.ptr<!qir_result>, i64, !cc.ptr<!qir_result>, i64)
+
   llvm.func @generalizedInvokeWithRotationsControlsTargets(i64, i64, i64, i64, !qir_llvmptr, ...) attributes {sym_visibility = "private"}
   llvm.func @__quantum__qis__apply_kraus_channel_generalized(i64, i64, i64, i64, i64, ...) attributes {sym_visibility = "private"}
 )#"},

--- a/cudaq/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/cudaq/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -41,12 +41,14 @@ add_cudaq_library(OptCodeGen
     CodeGenTypesIncGen
     OptCodeGenPassIncGen
     OptTransformsPassIncGen
+    QECDialect
     QuakeDialect
     cudaq-qir-verifier
     
   LINK_LIBS PUBLIC
     CCDialect
     OptimBuilder
+    QECDialect
     QuakeDialect
 
     MLIRArithTransforms

--- a/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ConvertToQIRAPI.cpp
@@ -9,6 +9,7 @@
 #include "CodeGenOps.h"
 #include "PassDetails.h"
 #include "nlohmann/json.hpp"
+#include "cudaq/Optimizer/Builder/Factory.h"
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/Builder/Runtime.h"
 #include "cudaq/Optimizer/CodeGen/Passes.h"
@@ -16,6 +17,7 @@
 #include "cudaq/Optimizer/CodeGen/QIRFunctionNames.h"
 #include "cudaq/Optimizer/CodeGen/QIROpaqueStructTypes.h"
 #include "cudaq/Optimizer/CodeGen/QuakeToExecMgr.h"
+#include "cudaq/Optimizer/Dialect/QEC/QECOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h" // for GlobalizeArrayValues
 #include "llvm/Support/Debug.h"
 #include "mlir/Pass/PassManager.h"
@@ -194,13 +196,13 @@ struct QIRAPITypeConverter : public TypeConverter {
     return cudaq::cc::StructType::get(ty.getContext(), mems);
   }
 
-  Type getQubitType(MLIRContext *ctx) {
+  Type getQubitType(MLIRContext *ctx) const {
     return cudaq::cg::getQubitType(ctx, useOpaque);
   }
-  Type getArrayType(MLIRContext *ctx) {
+  Type getArrayType(MLIRContext *ctx) const {
     return cudaq::cg::getArrayType(ctx, useOpaque);
   }
-  Type getResultType(MLIRContext *ctx) {
+  Type getResultType(MLIRContext *ctx) const {
     return cudaq::cg::getResultType(ctx, useOpaque);
   }
 
@@ -2201,6 +2203,210 @@ static void commonQuakeHandlingPatterns(RewritePatternSet &patterns,
 }
 
 //===----------------------------------------------------------------------===//
+// QEC declaration-op lowering patterns.
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// Materialize the `Result*` post-conversion type expected by the QIR
+// runtime ABI.
+static Type getQIRResultPtrType(const TypeConverter *converter,
+                                MLIRContext *ctx) {
+  return static_cast<const QIRAPITypeConverter *>(converter)->getResultType(
+      ctx);
+}
+
+// Compute a `(Result**, i64 size)` pair for a variadic measurement-handle
+// operand list. Three shapes are handled:
+//
+//   1. Single `!cc.stdvec<i64>` operand — pass through `(data, size)`
+//      with no copy.
+//   2. All `i64` (scalar) operands — allocate a `Result*[N]` buffer and
+//      store each operand cast to `Result*`. Count is statically known.
+//   3. Mixed scalar + stdvec, or multiple vectors — allocate a dynamic-
+//      size `Result*[total]` buffer and copy each stdvec via a counted
+//      `cc.loop` while storing each scalar at the running offset.
+static std::pair<Value, Value>
+packMeasurementHandles(Location loc, ConversionPatternRewriter &rewriter,
+                       Type resultPtrTy, ValueRange operands) {
+  auto i64Ty = rewriter.getI64Type();
+  auto ptrToPtrTy = cudaq::cc::PointerType::get(resultPtrTy);
+
+  // Single-stdvec fast path: zero-copy pass-through.
+  if (operands.size() == 1 &&
+      isa<cudaq::cc::StdvecType>(operands.front().getType())) {
+    Value vec = operands.front();
+    auto stdvecTy = cast<cudaq::cc::StdvecType>(vec.getType());
+    auto dataPtrTy = cudaq::cc::PointerType::get(
+        cudaq::cc::ArrayType::get(stdvecTy.getElementType()));
+    Value data = cudaq::cc::StdvecDataOp::create(rewriter, loc, dataPtrTy, vec);
+    Value size = cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, vec);
+    Value asPtrPtr = cudaq::cc::CastOp::create(rewriter, loc, ptrToPtrTy, data);
+    return {asPtrPtr, size};
+  }
+
+  // All-scalar fast path: static count, no loops.
+  if (llvm::all_of(operands,
+                   [](Value v) { return isa<IntegerType>(v.getType()); })) {
+    auto count = static_cast<std::int64_t>(operands.size());
+    Value countVal = arith::ConstantIntOp::create(rewriter, loc, count, 64);
+    Value buf =
+        cudaq::cc::AllocaOp::create(rewriter, loc, resultPtrTy, countVal);
+    for (auto pair : llvm::enumerate(operands)) {
+      auto idx = static_cast<std::int32_t>(pair.index());
+      Value resultPtr =
+          cudaq::cc::CastOp::create(rewriter, loc, resultPtrTy, pair.value());
+      Value eltPtr = cudaq::cc::ComputePtrOp::create(
+          rewriter, loc, ptrToPtrTy, buf,
+          ArrayRef<cudaq::cc::ComputePtrArg>{idx});
+      cudaq::cc::StoreOp::create(rewriter, loc, resultPtr, eltPtr);
+    }
+    Value bufAsPtrPtr =
+        cudaq::cc::CastOp::create(rewriter, loc, ptrToPtrTy, buf);
+    return {bufAsPtrPtr, countVal};
+  }
+
+  // General path: dynamic total size, mixed scalars + vectors (or multiple
+  // vectors). Compute total size first so the alloca dominates every store.
+  Value totalSize = arith::ConstantIntOp::create(rewriter, loc, 0, 64);
+  Value one = arith::ConstantIntOp::create(rewriter, loc, 1, 64);
+  for (Value v : operands) {
+    Value contribution =
+        isa<IntegerType>(v.getType())
+            ? one
+            : cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, v)
+                  .getResult();
+    totalSize = arith::AddIOp::create(rewriter, loc, totalSize, contribution);
+  }
+  Value buf =
+      cudaq::cc::AllocaOp::create(rewriter, loc, resultPtrTy, totalSize);
+  Value offset = arith::ConstantIntOp::create(rewriter, loc, 0, 64);
+  for (Value v : operands) {
+    if (isa<IntegerType>(v.getType())) {
+      Value resultPtr =
+          cudaq::cc::CastOp::create(rewriter, loc, resultPtrTy, v);
+      Value dest = cudaq::cc::ComputePtrOp::create(
+          rewriter, loc, ptrToPtrTy, buf,
+          ArrayRef<cudaq::cc::ComputePtrArg>{offset});
+      cudaq::cc::StoreOp::create(rewriter, loc, resultPtr, dest);
+      offset = arith::AddIOp::create(rewriter, loc, offset, one);
+    } else {
+      auto stdvecTy = cast<cudaq::cc::StdvecType>(v.getType());
+      auto eltTy = stdvecTy.getElementType();
+      auto dataPtrTy =
+          cudaq::cc::PointerType::get(cudaq::cc::ArrayType::get(eltTy));
+      Value srcData =
+          cudaq::cc::StdvecDataOp::create(rewriter, loc, dataPtrTy, v);
+      Value srcSize = cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, v);
+      Value baseOffset = offset;
+      cudaq::opt::factory::createInvariantLoop(
+          rewriter, loc, srcSize,
+          [&](OpBuilder &builder, Location loc, Region &, Block &block) {
+            Value iv = block.getArgument(0);
+            Value srcEltPtr = cudaq::cc::ComputePtrOp::create(
+                builder, loc, cudaq::cc::PointerType::get(eltTy), srcData,
+                ArrayRef<cudaq::cc::ComputePtrArg>{iv});
+            Value srcVal = cudaq::cc::LoadOp::create(builder, loc, srcEltPtr);
+            Value resultPtr =
+                cudaq::cc::CastOp::create(builder, loc, resultPtrTy, srcVal);
+            Value destIdx = arith::AddIOp::create(builder, loc, baseOffset, iv);
+            Value destPtr = cudaq::cc::ComputePtrOp::create(
+                builder, loc, ptrToPtrTy, buf,
+                ArrayRef<cudaq::cc::ComputePtrArg>{destIdx});
+            cudaq::cc::StoreOp::create(builder, loc, resultPtr, destPtr);
+          });
+      offset = arith::AddIOp::create(rewriter, loc, offset, srcSize);
+    }
+  }
+  Value bufAsPtrPtr = cudaq::cc::CastOp::create(rewriter, loc, ptrToPtrTy, buf);
+  return {bufAsPtrPtr, totalSize};
+}
+
+// Helper to extract `(Result**, size)` from a single stdvec operand.
+static std::pair<Value, Value> unpackStdvec(Location loc,
+                                            ConversionPatternRewriter &rewriter,
+                                            Type resultPtrTy, Value vec) {
+  auto i64Ty = rewriter.getI64Type();
+  auto ptrToPtrTy = cudaq::cc::PointerType::get(resultPtrTy);
+  auto stdvecTy = cast<cudaq::cc::StdvecType>(vec.getType());
+  auto dataPtrTy = cudaq::cc::PointerType::get(
+      cudaq::cc::ArrayType::get(stdvecTy.getElementType()));
+  Value data = cudaq::cc::StdvecDataOp::create(rewriter, loc, dataPtrTy, vec);
+  Value size = cudaq::cc::StdvecSizeOp::create(rewriter, loc, i64Ty, vec);
+  Value asPtrPtr = cudaq::cc::CastOp::create(rewriter, loc, ptrToPtrTy, data);
+  return {asPtrPtr, size};
+}
+
+struct DetectorOpConversion
+    : public OpConversionPattern<cudaq::qec::DetectorOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(cudaq::qec::DetectorOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto resultPtrTy =
+        getQIRResultPtrType(getTypeConverter(), rewriter.getContext());
+    auto [buf, count] = packMeasurementHandles(loc, rewriter, resultPtrTy,
+                                               adaptor.getMeasurements());
+    rewriter.replaceOpWithNewOp<func::CallOp>(
+        op, TypeRange{}, cudaq::opt::QIRDetector, ValueRange{buf, count});
+    return success();
+  }
+};
+
+struct ObservableOpConversion
+    : public OpConversionPattern<cudaq::qec::ObservableOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(cudaq::qec::ObservableOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto resultPtrTy =
+        getQIRResultPtrType(getTypeConverter(), rewriter.getContext());
+    auto [buf, count] = packMeasurementHandles(loc, rewriter, resultPtrTy,
+                                               adaptor.getMeasurements());
+    Value obsIdx = arith::ConstantIntOp::create(rewriter, loc,
+                                                op.getObservableIndex(), 64);
+    rewriter.replaceOpWithNewOp<func::CallOp>(op, TypeRange{},
+                                              cudaq::opt::QIRLogicalObservable,
+                                              ValueRange{buf, count, obsIdx});
+    return success();
+  }
+};
+
+struct PairDetectorsOpConversion
+    : public OpConversionPattern<cudaq::qec::DetectorsOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(cudaq::qec::DetectorsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto resultPtrTy =
+        getQIRResultPtrType(getTypeConverter(), rewriter.getContext());
+    auto [prevBuf, prevSize] =
+        unpackStdvec(loc, rewriter, resultPtrTy, adaptor.getPrev());
+    auto [currBuf, currSize] =
+        unpackStdvec(loc, rewriter, resultPtrTy, adaptor.getCurr());
+    rewriter.replaceOpWithNewOp<func::CallOp>(
+        op, TypeRange{}, cudaq::opt::QIRPairDetectors,
+        ValueRange{prevBuf, prevSize, currBuf, currSize});
+    return success();
+  }
+};
+
+} // namespace
+
+static void commonQECHandlingPatterns(RewritePatternSet &patterns,
+                                      TypeConverter &typeConverter,
+                                      MLIRContext *ctx) {
+  patterns.insert<DetectorOpConversion, ObservableOpConversion,
+                  PairDetectorsOpConversion>(typeConverter, ctx);
+}
+
+//===----------------------------------------------------------------------===//
 // Modifier classes
 //===----------------------------------------------------------------------===//
 
@@ -2252,6 +2458,7 @@ struct FullQIR {
         QuantumGatePattern<Self, cudaq::quake::YOp>,
         QuantumGatePattern<Self, cudaq::quake::ZOp>>(typeConverter, ctx);
     commonQuakeHandlingPatterns(patterns, typeConverter, ctx);
+    commonQECHandlingPatterns(patterns, typeConverter, ctx);
     commonClassicalHandlingPatterns(patterns, typeConverter, ctx);
   }
 
@@ -2321,6 +2528,7 @@ struct AnyProfileQIR {
         QuantumGatePattern<Self, cudaq::quake::YOp>,
         QuantumGatePattern<Self, cudaq::quake::ZOp>>(typeConverter, ctx);
     commonQuakeHandlingPatterns(patterns, typeConverter, ctx);
+    commonQECHandlingPatterns(patterns, typeConverter, ctx);
     commonClassicalHandlingPatterns(patterns, typeConverter, ctx);
   }
 
@@ -2407,7 +2615,8 @@ struct QuakeToQIRAPIPass
                            cf::ControlFlowDialect, func::FuncDialect,
                            LLVM::LLVMDialect>();
     target.addIllegalDialect<cudaq::quake::QuakeDialect,
-                             cudaq::codegen::CodeGenDialect>();
+                             cudaq::codegen::CodeGenDialect,
+                             cudaq::qec::QECDialect>();
     target.addLegalOp<cudaq::codegen::MaterializeConstantArrayOp>();
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp fn) {
       return !needsTypeConversion(fn.getFunctionType()) &&

--- a/cudaq/test/Transforms/qir_api_qec.qke
+++ b/cudaq/test/Transforms/qir_api_qec.qke
@@ -1,0 +1,337 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --convert-to-qir-api %s | FileCheck --implicit-check-not="qec." %s
+// RUN: cudaq-opt --convert-to-qir-api --convert-to-cfg --cc-to-llvm %s \
+// RUN:   | FileCheck --check-prefix=LLVM --implicit-check-not="qec." %s
+
+// -----
+// Single scalar handle, end-to-end
+
+func.func @detector_scalar() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+  %q = quake.alloca !quake.ref
+  %m = quake.mz %q name "h" : (!quake.ref) -> !cc.measure_handle
+  qec.detector %m : !cc.measure_handle
+  return
+}
+
+// CHECK-LABEL:   func.func @detector_scalar() attributes {"cudaq-entrypoint", "cudaq-kernel", "qir-api"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_0:.*]] = call @__quantum__rt__qubit_allocate() : () -> !cc.ptr<!llvm.struct<"Qubit", opaque>>
+// CHECK:           %[[ADDRESS_OF_0:.*]] = cc.address_of @cstr.6800 : !cc.ptr<!llvm.array<2 x i8>>
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[ADDRESS_OF_0]] : (!cc.ptr<!llvm.array<2 x i8>>) -> !cc.ptr<i8>
+// CHECK:           %[[VAL_1:.*]] = call @__quantum__qis__mz__to__register(%[[VAL_0]], %[[CAST_0]]) {registerName = "h"} : (!cc.ptr<!llvm.struct<"Qubit", opaque>>, !cc.ptr<i8>) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[CAST_1:.*]] = cc.cast %[[VAL_1]] : (!cc.ptr<!llvm.struct<"Result", opaque>>) -> i64
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 1>
+// CHECK:           %[[CAST_2:.*]] = cc.cast %[[CAST_1]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[CAST_3:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 1>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           cc.store %[[CAST_2]], %[[CAST_3]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[CAST_4:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 1>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__detector(%[[CAST_4]], %[[CONSTANT_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----
+// Multi-handle variadic: alloca Result*[N] with static count, store each.
+
+func.func @detector_multi(%h0: !cc.measure_handle,
+                          %h1: !cc.measure_handle,
+                          %h2: !cc.measure_handle) attributes {"cudaq-kernel"} {
+  qec.detector %h0, %h1, %h2 : !cc.measure_handle, !cc.measure_handle, !cc.measure_handle
+  return
+}
+
+// CHECK-LABEL:   func.func @detector_multi(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 3 : i64
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 3>
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[ARG0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 3>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           cc.store %[[CAST_0]], %[[CAST_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[CAST_2:.*]] = cc.cast %[[ARG1]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[ALLOCA_0]][1] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 3>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           cc.store %[[CAST_2]], %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[CAST_3:.*]] = cc.cast %[[ARG2]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[COMPUTE_PTR_1:.*]] = cc.compute_ptr %[[ALLOCA_0]][2] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 3>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           cc.store %[[CAST_3]], %[[COMPUTE_PTR_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[CAST_4:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 3>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__detector(%[[CAST_4]], %[[CONSTANT_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----
+// Single stdvec: pass-through via `cc.stdvec_data` + `cc.stdvec_size`.
+
+func.func @detector_stdvec(%v: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.detector %v : !cc.stdvec<!cc.measure_handle>
+  return
+}
+
+// CHECK-LABEL:   func.func @detector_stdvec(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__detector(%[[CAST_0]], %[[STDVEC_SIZE_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----
+// Mixed scalar + stdvec: dynamic total size, scalar stored at running
+// offset, stdvec contents copied via an invariant `cc.loop`.
+
+func.func @detector_mixed(%h: !cc.measure_handle,
+                          %v: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.detector %h, %v : !cc.measure_handle, !cc.stdvec<!cc.measure_handle>
+  return
+}
+
+// CHECK-LABEL:   func.func @detector_mixed(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_1]] : i64
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.ptr<!llvm.struct<"Result", opaque>>{{\[}}%[[ADDI_0]] : i64]
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[ARG0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           cc.store %[[CAST_0]], %[[CAST_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG1]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_0]]) -> (i64)) {
+// CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[STDVEC_SIZE_1]] : i64
+// CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]] : i64)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_1:.*]]: i64):
+// CHECK:             %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[STDVEC_DATA_0]]{{\[}}%[[VAL_1]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
+// CHECK:             %[[LOAD_0:.*]] = cc.load %[[COMPUTE_PTR_0]] : !cc.ptr<i64>
+// CHECK:             %[[CAST_2:.*]] = cc.cast %[[LOAD_0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:             %[[ADDI_1:.*]] = arith.addi %[[VAL_1]], %[[CONSTANT_1]] : i64
+// CHECK:             %[[COMPUTE_PTR_1:.*]] = cc.compute_ptr %[[ALLOCA_0]]{{\[}}%[[ADDI_1]]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:             cc.store %[[CAST_2]], %[[COMPUTE_PTR_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:             cc.continue %[[VAL_1]] : i64
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_2:.*]]: i64):
+// CHECK:             %[[ADDI_2:.*]] = arith.addi %[[VAL_2]], %[[CONSTANT_1]] : i64
+// CHECK:             cc.continue %[[ADDI_2]] : i64
+// CHECK:           } {invariant}
+// CHECK:           %[[CAST_3:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__detector(%[[CAST_3]], %[[ADDI_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----
+// Two stdvecs (no scalars): general path also fires here because the
+// fast path requires exactly one operand. Each stdvec is copied via
+// its own `cc.loop`; the size is the runtime sum.
+
+func.func @detector_two_stdvec(%a: !cc.stdvec<!cc.measure_handle>,
+                               %b: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.detector %a, %b : !cc.stdvec<!cc.measure_handle>, !cc.stdvec<!cc.measure_handle>
+  return
+}
+
+// CHECK-LABEL:   func.func @detector_two_stdvec(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[STDVEC_SIZE_1]] : i64
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.ptr<!llvm.struct<"Result", opaque>>{{\[}}%[[ADDI_0]] : i64]
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_2:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_0]]) -> (i64)) {
+// CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[STDVEC_SIZE_2]] : i64
+// CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]] : i64)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_1:.*]]: i64):
+// CHECK:             %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[STDVEC_DATA_0]]{{\[}}%[[VAL_1]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
+// CHECK:             %[[LOAD_0:.*]] = cc.load %[[COMPUTE_PTR_0]] : !cc.ptr<i64>
+// CHECK:             %[[CAST_0:.*]] = cc.cast %[[LOAD_0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:             %[[COMPUTE_PTR_1:.*]] = cc.compute_ptr %[[ALLOCA_0]]{{\[}}%[[VAL_1]]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:             cc.store %[[CAST_0]], %[[COMPUTE_PTR_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:             cc.continue %[[VAL_1]] : i64
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_2:.*]]: i64):
+// CHECK:             %[[ADDI_1:.*]] = arith.addi %[[VAL_2]], %[[CONSTANT_1]] : i64
+// CHECK:             cc.continue %[[ADDI_1]] : i64
+// CHECK:           } {invariant}
+// CHECK:           %[[STDVEC_DATA_1:.*]] = cc.stdvec_data %[[ARG1]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_3:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[LOOP_1:.*]] = cc.loop while ((%[[VAL_3:.*]] = %[[CONSTANT_0]]) -> (i64)) {
+// CHECK:             %[[CMPI_1:.*]] = arith.cmpi slt, %[[VAL_3]], %[[STDVEC_SIZE_3]] : i64
+// CHECK:             cc.condition %[[CMPI_1]](%[[VAL_3]] : i64)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_4:.*]]: i64):
+// CHECK:             %[[COMPUTE_PTR_2:.*]] = cc.compute_ptr %[[STDVEC_DATA_1]]{{\[}}%[[VAL_4]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
+// CHECK:             %[[LOAD_1:.*]] = cc.load %[[COMPUTE_PTR_2]] : !cc.ptr<i64>
+// CHECK:             %[[CAST_1:.*]] = cc.cast %[[LOAD_1]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:             %[[ADDI_2:.*]] = arith.addi %[[STDVEC_SIZE_2]], %[[VAL_4]] : i64
+// CHECK:             %[[COMPUTE_PTR_3:.*]] = cc.compute_ptr %[[ALLOCA_0]]{{\[}}%[[ADDI_2]]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:             cc.store %[[CAST_1]], %[[COMPUTE_PTR_3]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:             cc.continue %[[VAL_4]] : i64
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_5:.*]]: i64):
+// CHECK:             %[[ADDI_3:.*]] = arith.addi %[[VAL_5]], %[[CONSTANT_1]] : i64
+// CHECK:             cc.continue %[[ADDI_3]] : i64
+// CHECK:           } {invariant}
+// CHECK:           %[[CAST_2:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__detector(%[[CAST_2]], %[[ADDI_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----
+// Observable, scalar handle, default `index 0`.
+
+func.func @observable_scalar_default(%h: !cc.measure_handle) attributes {"cudaq-kernel"} {
+  qec.observable %h : !cc.measure_handle
+  return
+}
+
+// CHECK-LABEL:   func.func @observable_scalar_default(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : i64
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 1>
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[ARG0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 1>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           cc.store %[[CAST_0]], %[[CAST_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[CAST_2:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 1>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__logical_observable(%[[CAST_2]], %[[CONSTANT_1]], %[[CONSTANT_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----
+// Observable, multi-handle, explicit `index 1`.
+
+func.func @observable_multi_indexed(%h0: !cc.measure_handle,
+                                    %h1: !cc.measure_handle) attributes {"cudaq-kernel"} {
+  qec.observable %h0, %h1 index 1 : !cc.measure_handle, !cc.measure_handle
+  return
+}
+
+// CHECK-LABEL:   func.func @observable_multi_indexed(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : i64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 2 : i64
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 2>
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[ARG0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 2>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           cc.store %[[CAST_0]], %[[CAST_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[CAST_2:.*]] = cc.cast %[[ARG1]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[ALLOCA_0]][1] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 2>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           cc.store %[[CAST_2]], %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[CAST_3:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x 2>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__logical_observable(%[[CAST_3]], %[[CONSTANT_1]], %[[CONSTANT_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----
+// Observable, single stdvec, explicit `index 2`.
+
+func.func @observable_stdvec_indexed(%v: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.observable %v index 2 : !cc.stdvec<!cc.measure_handle>
+  return
+}
+
+// CHECK-LABEL:   func.func @observable_stdvec_indexed(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 2 : i64
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__logical_observable(%[[CAST_0]], %[[STDVEC_SIZE_0]], %[[CONSTANT_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----
+// Observable with mixed scalar + stdvec operand and explicit index:
+// general path produces a single buffer + size, then the call appends
+// the observable index.
+
+func.func @observable_mixed_indexed(%h: !cc.measure_handle,
+                                    %v: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.observable %h, %v index 3 : !cc.measure_handle, !cc.stdvec<!cc.measure_handle>
+  return
+}
+
+// CHECK-LABEL:   func.func @observable_mixed_indexed(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 3 : i64
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 1 : i64
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[ADDI_0:.*]] = arith.addi %[[STDVEC_SIZE_0]], %[[CONSTANT_2]] : i64
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.ptr<!llvm.struct<"Result", opaque>>{{\[}}%[[ADDI_0]] : i64]
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[ARG0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           cc.store %[[CAST_0]], %[[CAST_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG1]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[LOOP_0:.*]] = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_1]]) -> (i64)) {
+// CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[STDVEC_SIZE_1]] : i64
+// CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]] : i64)
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_1:.*]]: i64):
+// CHECK:             %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[STDVEC_DATA_0]]{{\[}}%[[VAL_1]]] : (!cc.ptr<!cc.array<i64 x ?>>, i64) -> !cc.ptr<i64>
+// CHECK:             %[[LOAD_0:.*]] = cc.load %[[COMPUTE_PTR_0]] : !cc.ptr<i64>
+// CHECK:             %[[CAST_2:.*]] = cc.cast %[[LOAD_0]] : (i64) -> !cc.ptr<!llvm.struct<"Result", opaque>>
+// CHECK:             %[[ADDI_1:.*]] = arith.addi %[[VAL_1]], %[[CONSTANT_2]] : i64
+// CHECK:             %[[COMPUTE_PTR_1:.*]] = cc.compute_ptr %[[ALLOCA_0]]{{\[}}%[[ADDI_1]]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>, i64) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:             cc.store %[[CAST_2]], %[[COMPUTE_PTR_1]] : !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:             cc.continue %[[VAL_1]] : i64
+// CHECK:           } step {
+// CHECK:           ^bb0(%[[VAL_2:.*]]: i64):
+// CHECK:             %[[ADDI_2:.*]] = arith.addi %[[VAL_2]], %[[CONSTANT_2]] : i64
+// CHECK:             cc.continue %[[ADDI_2]] : i64
+// CHECK:           } {invariant}
+// CHECK:           %[[CAST_3:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.ptr<!llvm.struct<"Result", opaque>> x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__logical_observable(%[[CAST_3]], %[[ADDI_0]], %[[CONSTANT_0]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----
+// `pair_detectors`: two stdvecs as `(data, size)` pairs.
+
+func.func @pair_detectors(%prev: !cc.stdvec<!cc.measure_handle>,
+                          %curr: !cc.stdvec<!cc.measure_handle>) attributes {"cudaq-kernel"} {
+  qec.pair_detectors %prev, %curr
+    : !cc.stdvec<!cc.measure_handle>, !cc.stdvec<!cc.measure_handle>
+  return
+}
+
+// CHECK-LABEL:   func.func @pair_detectors(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !cc.stdvec<i64>) attributes {"cudaq-kernel", "qir-api"} {
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[ARG0]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_0:.*]] = cc.stdvec_size %[[ARG0]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           %[[STDVEC_DATA_1:.*]] = cc.stdvec_data %[[ARG1]] : (!cc.stdvec<i64>) -> !cc.ptr<!cc.array<i64 x ?>>
+// CHECK:           %[[STDVEC_SIZE_1:.*]] = cc.stdvec_size %[[ARG1]] : (!cc.stdvec<i64>) -> i64
+// CHECK:           %[[CAST_1:.*]] = cc.cast %[[STDVEC_DATA_1]] : (!cc.ptr<!cc.array<i64 x ?>>) -> !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>
+// CHECK:           call @__quantum__qis__pair_detectors(%[[CAST_0]], %[[STDVEC_SIZE_0]], %[[CAST_1]], %[[STDVEC_SIZE_1]]) : (!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64, !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64) -> ()
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-DAG: func.func private @__quantum__qis__detector(!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64)
+// CHECK-DAG: func.func private @__quantum__qis__logical_observable(!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64, i64)
+// CHECK-DAG: func.func private @__quantum__qis__pair_detectors(!cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64, !cc.ptr<!cc.ptr<!llvm.struct<"Result", opaque>>>, i64)
+
+// LLVM-DAG: llvm.func @__quantum__qis__detector(!llvm.ptr, i64) attributes {sym_visibility = "private"}
+// LLVM-DAG: llvm.func @__quantum__qis__logical_observable(!llvm.ptr, i64, i64) attributes {sym_visibility = "private"}
+// LLVM-DAG: llvm.func @__quantum__qis__pair_detectors(!llvm.ptr, i64, !llvm.ptr, i64) attributes {sym_visibility = "private"}
+// LLVM-DAG: llvm.call @__quantum__qis__detector({{.*}}) : (!llvm.ptr, i64) -> ()
+// LLVM-DAG: llvm.call @__quantum__qis__logical_observable({{.*}}) : (!llvm.ptr, i64, i64) -> ()
+// LLVM-DAG: llvm.call @__quantum__qis__pair_detectors({{.*}}) : (!llvm.ptr, i64, !llvm.ptr, i64) -> ()


### PR DESCRIPTION
### Summary

Lower `qec.detector` / `qec.observable` / `qec.pair_detectors` to QIR runtime calls inside the existing `--convert-to-qir-api` patterns. 

### What Changed

- Three `OpConversionPattern`s in `ConvertToQIRAPI.cpp` plus a `packMeasurementHandles` helper that handles the all-scalar / single-stdvec / mixed-or-multi-stdvec shapes in one place.
- Single-stdvec form: variadic ops dispatch one `(Result**, count)` call regardless of operand mix. `pair_detectors` keeps `(prev, prev_size,  curr, curr_size)` so the runtime can enforce length agreement.
- Runtime symbols: `__quantum__qis__detector`, `__quantum__qis__logical_observable`, `__quantum__qis__pair_detectors`.
