### PR TITLE
Retry transient apt fetch failures in devcontainer build

### DIFF
--- a/docker/build/devcontainer.Dockerfile
+++ b/docker/build/devcontainer.Dockerfile
@@ -42,9 +42,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Tolerate transient apt mirror failures.
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
     && echo 'Acquire::Retries::Delay::Maximum "30";' >> /etc/apt/apt.conf.d/80-retries
-RUN apt update && apt-get install -y --no-install-recommends ca-certificates wget build-essential \
-    && apt-get upgrade -y libc-bin libcap2 \
-    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+# Retry-wrap so a stale index (e.g. mirror 404 on a freshly-rotated .deb) is
+# refreshed by the next `apt update` rather than failing the build.
+RUN for i in 1 2 3; do \
+        apt update \
+        && apt-get install -y --no-install-recommends ca-certificates wget build-essential \
+        && apt-get upgrade -y libc-bin libcap2 \
+        && break \
+        || { echo "apt attempt $i failed, retrying"; sleep $((10*i)); }; \
+    done \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # We need to remove the preinstalled cuda keyring as this will conflict when installing even non-cuda packages.
 # When cuda packages are installed below, the keyring will be reinstalled.
@@ -52,15 +59,19 @@ RUN rm -f /etc/apt/sources.list.d/cuda.list
 
 # Install Mellanox OFED runtime dependencies.
 
-RUN apt-get update && apt-get install -y --no-install-recommends gnupg \
-    && wget -qO - "https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox" | apt-key add - \
-    && mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d "https://linux.mellanox.com/public/repo/mlnx_ofed/5.3-1.0.0.1/ubuntu20.04/mellanox_mlnx_ofed.list" \
-    && apt-get update -y && apt-get install -y --no-install-recommends \
-        ibverbs-providers ibverbs-utils \
-        libibmad5 libibumad3 libibverbs1 librdmacm1 \
+RUN for i in 1 2 3; do \
+        apt-get update && apt-get install -y --no-install-recommends gnupg \
+        && wget -qO - "https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox" | apt-key add - \
+        && mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d "https://linux.mellanox.com/public/repo/mlnx_ofed/5.3-1.0.0.1/ubuntu20.04/mellanox_mlnx_ofed.list" \
+        && apt-get update -y && apt-get install -y --no-install-recommends \
+            ibverbs-providers ibverbs-utils \
+            libibmad5 libibumad3 libibverbs1 librdmacm1 \
+        && break \
+        || { echo "apt attempt $i failed, retrying"; sleep $((10*i)); }; \
+    done \
     && rm /etc/apt/trusted.gpg && rm /etc/apt/sources.list.d/mellanox_mlnx_ofed.list \
     && apt-get remove -y gnupg \
-    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy over SLURM PMI2.
 
@@ -78,9 +89,13 @@ ENV LIBRARY_PATH="$GDRCOPY_INSTALL_PREFIX/lib64:$LIBRARY_PATH"
 COPY --from=ompibuild "$GDRCOPY_INSTALL_PREFIX" "$GDRCOPY_INSTALL_PREFIX"
 
 RUN echo "$GDRCOPY_INSTALL_PREFIX/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
-    && apt-get update -y && apt-get install -y --no-install-recommends \
-        libgcrypt20 libnuma1 \
-    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+    && for i in 1 2 3; do \
+        apt-get update -y && apt-get install -y --no-install-recommends \
+            libgcrypt20 libnuma1 \
+        && break \
+        || { echo "apt attempt $i failed, retrying"; sleep $((10*i)); }; \
+    done \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy over UCX.
 
@@ -104,9 +119,13 @@ ENV CPATH="$PMIX_INSTALL_PREFIX/include:$CPATH"
 ENV LD_LIBRARY_PATH="$PMIX_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
 COPY --from=ompibuild "$PMIX_INSTALL_PREFIX" "$PMIX_INSTALL_PREFIX"
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        hwloc libevent-dev \
-    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+RUN for i in 1 2 3; do \
+        apt-get update -y && apt-get install -y --no-install-recommends \
+            hwloc libevent-dev \
+        && break \
+        || { echo "apt attempt $i failed, retrying"; sleep $((10*i)); }; \
+    done \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy over OpenMPI and install runtime dependencies.
 
@@ -122,9 +141,13 @@ ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENMPI_INSTALL_PREFIX/lib"
 COPY --from=ompibuild "$OPENMPI_INSTALL_PREFIX" "$OPENMPI_INSTALL_PREFIX"
 
 RUN echo "$OPENMPI_INSTALL_PREFIX/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig \
-    && apt-get update -y && apt-get install -y --no-install-recommends \
-        flex openssh-client \
-    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
+    && for i in 1 2 3; do \
+        apt-get update -y && apt-get install -y --no-install-recommends \
+            flex openssh-client \
+        && break \
+        || { echo "apt attempt $i failed, retrying"; sleep $((10*i)); }; \
+    done \
+    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set some configurations in the form of environment variables.
 
@@ -147,7 +170,11 @@ RUN if [ -n "$cuda_packages" ]; then \
         && cuda_packages=$(echo "$cuda_packages" | tr ' ' '\n' | xargs -I {} echo {}-$(echo ${CUDA_VERSION} | cut -d. -f1-2 | tr . -)) \
         && wget -q "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/$arch_folder/cuda-keyring_1.1-1_all.deb" \
         && dpkg -i cuda-keyring_1.1-1_all.deb \
-        && apt-get update && apt-get install -y --no-install-recommends --allow-change-held-packages $cuda_packages \
+        && for i in 1 2 3; do \
+            apt-get update && apt-get install -y --no-install-recommends --allow-change-held-packages $cuda_packages \
+            && break \
+            || { echo "apt attempt $i failed, retrying"; sleep $((10*i)); }; \
+        done \
         && rm cuda-keyring_1.1-1_all.deb \
         && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*; \
     fi
@@ -178,8 +205,12 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 # Note: for docker images, we fixed the cuquantum version (with `==`) to avoid unintentional upgrades.
 # e.g., API marked as deprecated in a minor version upgrade may break build.
 # For Python pip installations, we allow minor version upgrades with `~=`, assuming the API is stable.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 python3-pip && \
+RUN for i in 1 2 3; do \
+        apt-get update && apt-get install -y --no-install-recommends \
+            python3 python3-pip \
+        && break \
+        || { echo "apt attempt $i failed, retrying"; sleep $((10*i)); }; \
+    done && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* && \
     if [ "$(echo $CUDA_VERSION | cut -d . -f1)" = "13" ]; then \
         cupy_version=13.6.0; \


### PR DESCRIPTION
This is to fix issues such as:

https://github.com/NVIDIA/cuda-quantum/actions/runs/26180606186/job/77037150869

I am not sure if this is the best method to help with these issues, but it is the most reasonable one I can think of right now. An entire job retry mechanism feels potentially very wasteful in-case there is an actual error in the code, we do not want to try rebuilding the devcontainer 3 times indiscriminately.

This is not an issue in only the devcontainer build, of course. The assets build suffers from this issue as well.


## Cause

Ubuntu mirrors occasionally serve a stale Packages index pointing at a .deb version that's already been rotated out of the pool, causing apt to fail with a 404 on the actual download. The Dockerfile already has
  `Acquire::Retries "5"`, but apt treats 404s as terminal and won't retry them — only a fresh apt update against an updated index recovers.

  Wraps each apt-get update && apt-get install block in docker/build/devcontainer.Dockerfile (7 total) with a 3-attempt shell loop and exponential backoff. On retry, apt update re-fetches the index, so the
  second/third attempt sees the rotated filenames and proceeds. Idempotent cleanup steps (autoremove, clean, rm of one-shot files) stay outside the loop.

  Triggered by an arm64 OpenMPI image build that failed on libgnutls30t64_3.8.3-1.1ubuntu3.6_arm64.deb returning 404 mid-install.





Full error log:
```
#10 34.49 Err:37 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 libgnutls30t64 arm64 3.8.3-1.1ubuntu3.6
#10 34.49   404  Not Found [IP: 91.189.92.19 80]
#10 35.91 Get:74 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libcufile-12-6 1.11.1.6-1 [734 kB]
#10 36.06 Get:75 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libcurand-12-6 10.3.7.77-1 [41.3 MB]
#10 36.73 Get:76 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libcusolver-12-6 11.7.1.2-1 [97.1 MB]
#10 37.64 Get:77 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libcusparse-12-6 12.5.4.2-1 [121 MB]
#10 39.06 Get:78 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libnpp-12-6 12.3.1.54-1 [93.8 MB]
#10 40.14 Get:79 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libnvfatbin-12-6 12.6.77-1 [646 kB]
#10 40.31 Get:80 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libnvjitlink-12-6 12.6.85-1 [13.5 MB]
#10 40.69 Get:81 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libnvjpeg-12-6 12.3.3.54-1 [2195 kB]
#10 40.72 Fetched 595 MB in 9s (67.4 MB/s)
#10 40.72 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gnutls28/libgnutls30t64_3.8.3-1.1ubuntu3.6_arm64.deb  404  Not Found [IP: 91.189.92.19 80]
#10 40.72 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
#10 ERROR: process "/bin/bash -c apt update && apt-get install -y --no-install-recommends ca-certificates wget build-essential     && apt-get upgrade -y libc-bin libcap2     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
------
 > [stage-1  3/17] RUN apt update && apt-get install -y --no-install-recommends ca-certificates wget build-essential     && apt-get upgrade -y libc-bin libcap2     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*:
36.06 Get:75 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libcurand-12-6 10.3.7.77-1 [41.3 MB]
36.73 Get:76 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libcusolver-12-6 11.7.1.2-1 [97.1 MB]
37.64 Get:77 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libcusparse-12-6 12.5.4.2-1 [121 MB]
39.06 Get:78 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libnpp-12-6 12.3.1.54-1 [93.8 MB]
40.14 Get:79 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libnvfatbin-12-6 12.6.77-1 [646 kB]
40.31 Get:80 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libnvjitlink-12-6 12.6.85-1 [13.5 MB]
40.69 Get:81 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa  libnvjpeg-12-6 12.3.3.54-1 [2195 kB]
40.72 Fetched 595 MB in 9s (67.4 MB/s)
40.72 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gnutls28/libgnutls30t64_3.8.3-1.1ubuntu3.6_arm64.deb  404  Not Found [IP: 91.189.92.19 80]
40.72 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
------
devcontainer.Dockerfile:45
--------------------
  44 |         && echo 'Acquire::Retries::Delay::Maximum "30";' >> /etc/apt/apt.conf.d/80-retries
  45 | >>> RUN apt update && apt-get install -y --no-install-recommends ca-certificates wget build-essential \
  46 | >>>     && apt-get upgrade -y libc-bin libcap2 \
  47 | >>>     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/* 
  48 |     
--------------------
ERROR: failed to solve: process "/bin/bash -c apt update && apt-get install -y --no-install-recommends ca-certificates wget build-essential     && apt-get upgrade -y libc-bin libcap2     && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```