### PR TITLE
[runtime][nvqir] Wire `qec` runtime calls to `stim`

### DIFF
--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -23,6 +23,7 @@
 #include <concepts>
 #include <cstdarg>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <queue>
 #include <sstream>
@@ -432,6 +433,24 @@ public:
   virtual cudaq::ExecutionResult
   sample(const std::vector<std::size_t> &qubitIdxs, const int shots,
          bool includeSequentialData = true) = 0;
+
+  /// @brief Declare a `qec.detector` over one or more prior measurements,
+  /// addressed by measurement indices or identifiers assigned by this
+  /// simulator. Default no-op; QEC-capable backends override.
+  virtual void detector(const std::int64_t *indices, std::size_t count) {}
+
+  /// @brief Declare a `qec.logical_observable` over one or more prior
+  /// measurements, tagged with @p observable_index. Default no-op; QEC-capable
+  /// backends override.
+  virtual void logical_observable(const std::int64_t *indices,
+                                  std::size_t count,
+                                  std::size_t observable_index = 0) {}
+
+  /// @brief Declare N detectors element-wise over two parallel index arrays
+  /// (cross-round / pair detectors) of the same size. Default no-op;
+  /// QEC-capable backends override.
+  virtual void pair_detectors(const std::int64_t *prev,
+                              const std::int64_t *curr, std::size_t count) {}
 
   /// @brief Return the name of this CircuitSimulator
   virtual std::string name() const = 0;

--- a/runtime/nvqir/NVQIR.cpp
+++ b/runtime/nvqir/NVQIR.cpp
@@ -783,6 +783,65 @@ static std::vector<std::size_t> safeArrayToVectorSizeT(Array *arr) {
   return arrayToVectorSizeT(arr);
 }
 
+// Each `Result*` in the incoming buffer is the bit pattern of an `i64`
+// chronological measurement index (the runtime representation of
+// `!cc.measure_handle` post-conversion); it is NOT a heap `Result` object and
+// must not be dereferenced.
+static inline std::int64_t resultPtrToMeasureIndex(Result *r) {
+  return static_cast<std::int64_t>(reinterpret_cast<std::intptr_t>(r));
+}
+
+// Validate the `(results, count)` pair from the QIR side and return the
+// indices as `std::vector<int64_t>`.
+static std::vector<std::int64_t> resultArrayToIndices(Result **results,
+                                                      std::int64_t count) {
+  if (count < 0)
+    throw std::invalid_argument("QEC: count must be non-negative, got " +
+                                std::to_string(count));
+  if (count > 0 && !results)
+    throw std::invalid_argument("QEC: results pointer is null with count=" +
+                                std::to_string(count));
+  std::vector<std::int64_t> indices;
+  indices.reserve(static_cast<std::size_t>(count));
+  for (std::int64_t i = 0; i < count; i++)
+    indices.push_back(resultPtrToMeasureIndex(results[i]));
+  return indices;
+}
+
+void __quantum__qis__detector(Result **results, std::int64_t count) {
+  auto indices = resultArrayToIndices(results, count);
+  nvqir::getCircuitSimulatorInternal()->detector(indices.data(),
+                                                 indices.size());
+}
+
+void __quantum__qis__logical_observable(Result **results, std::int64_t count,
+                                        std::int64_t observable_index) {
+  if (observable_index < 0)
+    throw std::invalid_argument(
+        std::string("QEC: `observable_index` must be non-negative, got ") +
+        std::to_string(observable_index));
+  auto indices = resultArrayToIndices(results, count);
+  nvqir::getCircuitSimulatorInternal()->logical_observable(
+      indices.data(), indices.size(),
+      static_cast<std::size_t>(observable_index));
+}
+
+void __quantum__qis__pair_detectors(Result **prev_results,
+                                    std::int64_t prev_count,
+                                    Result **curr_results,
+                                    std::int64_t curr_count) {
+  if (prev_count != curr_count)
+    throw std::invalid_argument(
+        std::string("QEC: `pair_detectors` requires equal-length `prev` and "
+                    "`curr` measurement arrays, got `prev_count`=") +
+        std::to_string(prev_count) +
+        " `curr_count`=" + std::to_string(curr_count));
+  auto prev = resultArrayToIndices(prev_results, prev_count);
+  auto curr = resultArrayToIndices(curr_results, curr_count);
+  nvqir::getCircuitSimulatorInternal()->pair_detectors(prev.data(), curr.data(),
+                                                       prev.size());
+}
+
 // It may not always be possible for the compiler to reduce a program fully to
 // QIR. In such cases, code generation may elect to produce a trap in the
 // kernel, which calls this function. The trap should explain the issue to the

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -648,23 +648,13 @@ public:
     return result;
   }
 
-  /// @brief Commit any pending `sampleQubits` as `M` ops in `recordedCircuit`
-  /// so subsequent `DETECTOR rec[-N]` / `OBSERVABLE_INCLUDE rec[-N]`
-  /// instructions can reference them. Required because in `cudaq::sample` +
-  /// `explicitMeasurements` mode `mz()` defers the `M` op to flush time, so
-  /// a `qec.detector(handle)` immediately following an `mz` would otherwise
-  /// emit a `rec[-N]` referencing an `M` that has not yet been laid down.
-  void flushPendingSampleMeasurements() {
-    if (!sampleQubits.empty())
-      flushAnySamplingTasks(/*force=*/false);
-  }
-
   /// @brief Translate chronological measurement indices into Stim record-
   /// reference targets (`lookback | TARGET_RECORD_BIT`). Throws
-  /// `std::out_of_range` if any index lies outside `[0, num_measurements)`.
+  /// `std::out_of_range` if any index lies outside `[0, num_measurements)`
+  /// so a broken upstream lowering surfaces at the first bad call instead
+  /// of producing a malformed DEM downstream.
   std::vector<std::uint32_t>
-  measurementIndicesToRecordTargets(const char *op_name,
-                                    const std::int64_t *indices,
+  measurementIndicesToRecordTargets(const std::int64_t *indices,
                                     std::size_t count) const {
     std::vector<std::uint32_t> targets;
     targets.reserve(count);
@@ -672,10 +662,10 @@ public:
       const auto idx = indices[i];
       if (idx < 0 || static_cast<std::size_t>(idx) >= num_measurements)
         throw std::out_of_range(
-            fmt::format("{}: measurement index {} is out of range [0, {}); the "
-                        "lowering must produce chronological indices into the "
-                        "current kernel's measurement record",
-                        op_name, idx, num_measurements));
+            "QEC: measurement index " + std::to_string(idx) +
+            " is out of range [0, " + std::to_string(num_measurements) +
+            "); the lowering must produce chronological indices into the "
+            "current kernel's measurement record");
       auto lookback = static_cast<std::uint32_t>(num_measurements -
                                                  static_cast<std::size_t>(idx));
       targets.push_back(lookback | stim::TARGET_RECORD_BIT);
@@ -684,18 +674,24 @@ public:
   }
 
   void detector(const std::int64_t *indices, std::size_t count) override {
-    flushPendingSampleMeasurements();
-    auto targets =
-        measurementIndicesToRecordTargets("detector", indices, count);
+    // Commit any deferred sample `M` ops so subsequent `DETECTOR rec[-N]`
+    // references resolve. In `cudaq::sample` + `explicitMeasurements` mode
+    // `mz()` defers the `M` op to flush time; without this nudge a
+    // `qec.detector(handle)` immediately following an `mz` would emit a
+    // `rec[-N]` pointing at an `M` not yet laid down, which
+    // `stim::ErrorAnalyzer::circuit_to_detector_error_model` rejects.
+    if (!sampleQubits.empty())
+      flushAnySamplingTasks(/*force=*/false);
+    auto targets = measurementIndicesToRecordTargets(indices, count);
     if (!targets.empty())
       recordedCircuit.safe_append_u("DETECTOR", targets);
   }
 
   void logical_observable(const std::int64_t *indices, std::size_t count,
                           std::size_t observable_index) override {
-    flushPendingSampleMeasurements();
-    auto targets =
-        measurementIndicesToRecordTargets("logical_observable", indices, count);
+    if (!sampleQubits.empty())
+      flushAnySamplingTasks(/*force=*/false);
+    auto targets = measurementIndicesToRecordTargets(indices, count);
     if (!targets.empty())
       recordedCircuit.safe_append_ua("OBSERVABLE_INCLUDE", targets,
                                      static_cast<double>(observable_index));
@@ -703,13 +699,13 @@ public:
 
   void pair_detectors(const std::int64_t *prev, const std::int64_t *curr,
                       std::size_t count) override {
-    flushPendingSampleMeasurements();
+    if (!sampleQubits.empty())
+      flushAnySamplingTasks(/*force=*/false);
     std::vector<std::vector<std::uint32_t>> all_targets;
     all_targets.reserve(count);
     for (std::size_t i = 0; i < count; i++) {
       const std::int64_t pair[2] = {prev[i], curr[i]};
-      all_targets.push_back(
-          measurementIndicesToRecordTargets("pair_detectors", pair, 2));
+      all_targets.push_back(measurementIndicesToRecordTargets(pair, 2));
     }
     for (const auto &targets : all_targets)
       if (!targets.empty())

--- a/runtime/nvqir/stim/StimCircuitSimulator.cpp
+++ b/runtime/nvqir/stim/StimCircuitSimulator.cpp
@@ -63,6 +63,13 @@ protected:
   /// for speed)
   bool is_msm_mode = false;
 
+  /// @brief Accumulated Stim circuit covering gates, measurements, noise,
+  /// detectors, and observables. Reset alongside `num_measurements` in
+  /// `deallocateStateImpl` and `setToZeroState` so successive kernel
+  /// executions on a reused simulator start from a clean slate. Stim-side
+  /// internal only; not part of any public CUDA-Q API.
+  stim::Circuit recordedCircuit;
+
   std::optional<StimNoiseType>
   isValidStimNoiseChannel(const kraus_channel &channel) const {
 
@@ -271,9 +278,11 @@ protected:
     msm_err_count = 0;
     msm_id_counter = 0;
     is_msm_mode = false;
+    recordedCircuit.clear();
   }
 
-  /// @brief Apply operation to all Stim simulators.
+  /// @brief Apply operation to all Stim simulators and append it to the
+  /// persistent `recordedCircuit` log.
   void applyOpToSims(const std::string &gate_name,
                      const std::vector<uint32_t> &targets) {
     if (targets.empty())
@@ -283,6 +292,7 @@ protected:
     tempCircuit.safe_append_u(gate_name, targets);
     tableau->safe_do_circuit(tempCircuit);
     sampleSim->safe_do_circuit(tempCircuit);
+    recordedCircuit.safe_append_u(gate_name, targets);
   }
 
   /// @brief Apply the noise channel on \p qubits
@@ -385,6 +395,8 @@ protected:
         // Only apply the noise operations to the sample simulator (not the
         // Tableau simulator).
         sampleSim->safe_do_circuit(noiseOps);
+        recordedCircuit.safe_append_u(res.value().stim_name, qubits,
+                                      channel.parameters);
 
         // Increment the error count by the number of mechanisms
         msm_err_count += res->params.size();
@@ -490,6 +502,10 @@ protected:
     // Reset all qubits to |0> and clear measurement records, preserving
     // the allocated simulators for reuse (required by the PTSBE
     // per-trajectory loop which calls setToZeroState between trajectories).
+    // `recordedCircuit` is cleared before the reset `R` ops so the next
+    // trajectory's circuit starts with its own resets, not stacked on top
+    // of the previous trajectory's gates and detectors.
+    recordedCircuit.clear();
     auto nq = sampleSim->num_qubits;
     if (nq > 0) {
       std::vector<std::uint32_t> allQubits(nq);
@@ -630,6 +646,74 @@ public:
     if (includeSequentialData)
       result.sequentialData = std::move(sequentialData);
     return result;
+  }
+
+  /// @brief Commit any pending `sampleQubits` as `M` ops in `recordedCircuit`
+  /// so subsequent `DETECTOR rec[-N]` / `OBSERVABLE_INCLUDE rec[-N]`
+  /// instructions can reference them. Required because in `cudaq::sample` +
+  /// `explicitMeasurements` mode `mz()` defers the `M` op to flush time, so
+  /// a `qec.detector(handle)` immediately following an `mz` would otherwise
+  /// emit a `rec[-N]` referencing an `M` that has not yet been laid down.
+  void flushPendingSampleMeasurements() {
+    if (!sampleQubits.empty())
+      flushAnySamplingTasks(/*force=*/false);
+  }
+
+  /// @brief Translate chronological measurement indices into Stim record-
+  /// reference targets (`lookback | TARGET_RECORD_BIT`). Throws
+  /// `std::out_of_range` if any index lies outside `[0, num_measurements)`.
+  std::vector<std::uint32_t>
+  measurementIndicesToRecordTargets(const char *op_name,
+                                    const std::int64_t *indices,
+                                    std::size_t count) const {
+    std::vector<std::uint32_t> targets;
+    targets.reserve(count);
+    for (std::size_t i = 0; i < count; i++) {
+      const auto idx = indices[i];
+      if (idx < 0 || static_cast<std::size_t>(idx) >= num_measurements)
+        throw std::out_of_range(
+            fmt::format("{}: measurement index {} is out of range [0, {}); the "
+                        "lowering must produce chronological indices into the "
+                        "current kernel's measurement record",
+                        op_name, idx, num_measurements));
+      auto lookback = static_cast<std::uint32_t>(num_measurements -
+                                                 static_cast<std::size_t>(idx));
+      targets.push_back(lookback | stim::TARGET_RECORD_BIT);
+    }
+    return targets;
+  }
+
+  void detector(const std::int64_t *indices, std::size_t count) override {
+    flushPendingSampleMeasurements();
+    auto targets =
+        measurementIndicesToRecordTargets("detector", indices, count);
+    if (!targets.empty())
+      recordedCircuit.safe_append_u("DETECTOR", targets);
+  }
+
+  void logical_observable(const std::int64_t *indices, std::size_t count,
+                          std::size_t observable_index) override {
+    flushPendingSampleMeasurements();
+    auto targets =
+        measurementIndicesToRecordTargets("logical_observable", indices, count);
+    if (!targets.empty())
+      recordedCircuit.safe_append_ua("OBSERVABLE_INCLUDE", targets,
+                                     static_cast<double>(observable_index));
+  }
+
+  void pair_detectors(const std::int64_t *prev, const std::int64_t *curr,
+                      std::size_t count) override {
+    flushPendingSampleMeasurements();
+    std::vector<std::vector<std::uint32_t>> all_targets;
+    all_targets.reserve(count);
+    for (std::size_t i = 0; i < count; i++) {
+      const std::int64_t pair[2] = {prev[i], curr[i]};
+      all_targets.push_back(
+          measurementIndicesToRecordTargets("pair_detectors", pair, 2));
+    }
+    for (const auto &targets : all_targets)
+      if (!targets.empty())
+        recordedCircuit.safe_append_u("DETECTOR", targets);
   }
 
   bool isStateVectorSimulator() const override { return false; }

--- a/unittests/backends/StimTester.cpp
+++ b/unittests/backends/StimTester.cpp
@@ -170,7 +170,6 @@ CUDAQ_TEST(StimQECTester, DetectorThrowsOnOutOfRangeIndex) {
     FAIL() << "expected std::out_of_range";
   } catch (const std::out_of_range &e) {
     const std::string what(e.what());
-    EXPECT_NE(what.find("detector"), std::string::npos) << what;
     EXPECT_NE(what.find("9"), std::string::npos) << what;
     EXPECT_NE(what.find("[0, 2)"), std::string::npos) << what;
   }

--- a/unittests/backends/StimTester.cpp
+++ b/unittests/backends/StimTester.cpp
@@ -6,11 +6,15 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "StimCircuitSimulator.cpp"
-
-#include <gtest/gtest.h>
-
 #include "CUDAQTestUtils.h"
+#include "StimCircuitSimulator.cpp"
+#include "common/ExecutionContext.h"
+#include "nvqir/AnalysisScope.h"
+#include "nvqir/QIRTypes.h"
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
 
 /// Wrapper to expose protected methods for testing.
 class StimCircuitSimulatorTester : public nvqir::StimCircuitSimulator {
@@ -27,7 +31,36 @@ public:
   }
 
   void resetToZero() { setToZeroState(); }
+
+  /// @brief Render `recordedCircuit` as a Stim-format string for inspection
+  /// from the test body.
+  std::string recordedCircuitText() const {
+    std::stringstream ss;
+    ss << recordedCircuit;
+    return ss.str();
+  }
 };
+
+// QEC declaration ops are wired into the Stim NVQIR backend by the runtime
+// adapters in `runtime/nvqir/NVQIR.cpp`. Declared here so the test runner
+// picks up the definitions from libnvqir; tests then exercise the full path
+// from `extern "C"` symbol → `Result**`-to-`int64_t`-vector conversion →
+// dispatch to the active simulator's QEC virtuals.
+extern "C" void __quantum__qis__detector(Result **results, std::int64_t count);
+extern "C" void __quantum__qis__logical_observable(Result **results,
+                                                   std::int64_t count,
+                                                   std::int64_t obs_index);
+extern "C" void __quantum__qis__pair_detectors(Result **prev_results,
+                                               std::int64_t prev_count,
+                                               Result **curr_results,
+                                               std::int64_t curr_count);
+
+/// @brief Encode an `int64_t` chronological measurement index as the
+/// `Result*` bit pattern the QIR ABI delivers to the QEC runtime adapter.
+/// Mirrors the lowering pattern in `cudaq/test/Transforms/qir_api_qec.qke`.
+static Result *measureIndexAsResultPtr(std::int64_t i) {
+  return reinterpret_cast<Result *>(static_cast<std::intptr_t>(i));
+}
 
 CUDAQ_TEST(StimTester, TwoQubitPauliProducts) {
   StimCircuitSimulatorTester sim;
@@ -60,4 +93,192 @@ CUDAQ_TEST(StimTester, SetToZeroStatePreservesSimulators) {
     sim.resetToZero();
   }
   EXPECT_EQ(false, sim.mz(q0));
+}
+
+CUDAQ_TEST(StimQECTester, DetectorEmitsRecordReferences) {
+  StimCircuitSimulatorTester sim;
+  sim.setRandomSeed(42);
+  auto q0 = sim.allocateQubit();
+  auto q1 = sim.allocateQubit();
+  sim.mz(q0);
+  sim.mz(q1);
+
+  const std::int64_t indices[] = {0, 1};
+  sim.detector(indices, 2);
+
+  const auto text = sim.recordedCircuitText();
+  EXPECT_NE(text.find("DETECTOR rec[-2] rec[-1]"), std::string::npos)
+      << "recordedCircuit was:\n"
+      << text;
+}
+
+CUDAQ_TEST(StimQECTester, LogicalObservableAccumulates) {
+  StimCircuitSimulatorTester sim;
+  sim.setRandomSeed(42);
+  auto q0 = sim.allocateQubit();
+  auto q1 = sim.allocateQubit();
+  auto q2 = sim.allocateQubit();
+  sim.mz(q0);
+  sim.mz(q1);
+  sim.mz(q2);
+
+  const std::int64_t idsA[] = {0, 1};
+  sim.logical_observable(idsA, 2, /*observable_index=*/0);
+  const std::int64_t idsB[] = {2};
+  sim.logical_observable(idsB, 1, /*observable_index=*/0);
+
+  const auto text = sim.recordedCircuitText();
+  EXPECT_NE(text.find("OBSERVABLE_INCLUDE(0) rec[-3] rec[-2]"),
+            std::string::npos)
+      << text;
+  EXPECT_NE(text.find("OBSERVABLE_INCLUDE(0) rec[-1]"), std::string::npos)
+      << text;
+}
+
+CUDAQ_TEST(StimQECTester, PairDetectorsEmitsOnePerPair) {
+  StimCircuitSimulatorTester sim;
+  sim.setRandomSeed(42);
+  auto q0 = sim.allocateQubit();
+  auto q1 = sim.allocateQubit();
+  auto q2 = sim.allocateQubit();
+  auto q3 = sim.allocateQubit();
+  sim.mz(q0); // index 0
+  sim.mz(q1); // index 1
+  sim.mz(q2); // index 2
+  sim.mz(q3); // index 3
+
+  const std::int64_t prev[] = {0, 1};
+  const std::int64_t curr[] = {2, 3};
+  sim.pair_detectors(prev, curr, 2);
+
+  const auto text = sim.recordedCircuitText();
+  EXPECT_NE(text.find("DETECTOR rec[-4] rec[-2]"), std::string::npos) << text;
+  EXPECT_NE(text.find("DETECTOR rec[-3] rec[-1]"), std::string::npos) << text;
+}
+
+CUDAQ_TEST(StimQECTester, DetectorThrowsOnOutOfRangeIndex) {
+  StimCircuitSimulatorTester sim;
+  sim.setRandomSeed(42);
+  auto q0 = sim.allocateQubit();
+  auto q1 = sim.allocateQubit();
+  sim.mz(q0);
+  sim.mz(q1); // num_measurements = 2
+
+  const std::int64_t mixed[] = {0, 9};
+  try {
+    sim.detector(mixed, 2);
+    FAIL() << "expected std::out_of_range";
+  } catch (const std::out_of_range &e) {
+    const std::string what(e.what());
+    EXPECT_NE(what.find("detector"), std::string::npos) << what;
+    EXPECT_NE(what.find("9"), std::string::npos) << what;
+    EXPECT_NE(what.find("[0, 2)"), std::string::npos) << what;
+  }
+
+  EXPECT_EQ(sim.recordedCircuitText().find("DETECTOR"), std::string::npos)
+      << sim.recordedCircuitText();
+}
+
+CUDAQ_TEST(StimQECTester, PairDetectorsAllOrNothingOnOutOfRange) {
+  StimCircuitSimulatorTester sim;
+  sim.setRandomSeed(42);
+  auto q0 = sim.allocateQubit();
+  auto q1 = sim.allocateQubit();
+  auto q2 = sim.allocateQubit();
+  auto q3 = sim.allocateQubit();
+  sim.mz(q0);
+  sim.mz(q1);
+  sim.mz(q2);
+  sim.mz(q3); // num_measurements = 4
+
+  const std::int64_t prev[] = {0, 1};
+  const std::int64_t curr[] = {2, 99};
+  EXPECT_ANY_THROW(sim.pair_detectors(prev, curr, 2));
+  EXPECT_EQ(sim.recordedCircuitText().find("DETECTOR"), std::string::npos)
+      << sim.recordedCircuitText();
+}
+
+CUDAQ_TEST(StimQECTester, PairDetectorsAdapterRejectsSizeMismatch) {
+  Result *prev[1] = {measureIndexAsResultPtr(0)};
+  Result *curr[2] = {measureIndexAsResultPtr(1), measureIndexAsResultPtr(2)};
+  EXPECT_ANY_THROW(__quantum__qis__pair_detectors(prev, 1, curr, 2));
+}
+
+CUDAQ_TEST(StimQECTester, AdapterRejectsNegativeCount) {
+  Result *results[1] = {measureIndexAsResultPtr(0)};
+  EXPECT_ANY_THROW(__quantum__qis__detector(results, /*count=*/-1));
+  EXPECT_ANY_THROW(__quantum__qis__logical_observable(results, /*count=*/-1,
+                                                      /*obs_index=*/0));
+}
+
+CUDAQ_TEST(StimQECTester, AdapterRejectsNullBufferWithPositiveCount) {
+  EXPECT_ANY_THROW(__quantum__qis__detector(nullptr, /*count=*/2));
+}
+
+CUDAQ_TEST(StimQECTester, AdapterRejectsNegativeObservableIndex) {
+  Result *results[1] = {measureIndexAsResultPtr(0)};
+  EXPECT_ANY_THROW(__quantum__qis__logical_observable(results, /*count=*/1,
+                                                      /*obs_index=*/-1));
+}
+
+// End-to-end coverage of the NVQIR adapter
+CUDAQ_TEST(StimQECTester, AdapterDispatchesToActiveSimulator) {
+  StimCircuitSimulatorTester sim;
+  sim.setRandomSeed(42);
+  nvqir::AnalysisScope scope{"stim_qec_adapter_test", sim, {}};
+
+  auto q0 = sim.allocateQubit();
+  auto q1 = sim.allocateQubit();
+  sim.mz(q0);
+  sim.mz(q1);
+
+  Result *indices[] = {measureIndexAsResultPtr(0), measureIndexAsResultPtr(1)};
+  __quantum__qis__detector(indices, 2);
+
+  const auto text = sim.recordedCircuitText();
+  EXPECT_NE(text.find("DETECTOR rec[-2] rec[-1]"), std::string::npos) << text;
+}
+
+/// @brief RAII guard for the thread-local execution-context pointer used by
+/// the simulator. Without this, an `ASSERT_*` failure inside the test would
+/// abort before `resetExecutionContext`, leaving the global pointer dangling
+/// to a destructed `ExecutionContext` and corrupting downstream tests.
+class ScopedExecutionContext {
+public:
+  explicit ScopedExecutionContext(cudaq::ExecutionContext &ctx) {
+    cudaq::detail::setExecutionContext(&ctx);
+  }
+  ~ScopedExecutionContext() { cudaq::detail::resetExecutionContext(); }
+  ScopedExecutionContext(const ScopedExecutionContext &) = delete;
+  ScopedExecutionContext &operator=(const ScopedExecutionContext &) = delete;
+};
+
+CUDAQ_TEST(StimQECTester, DetectorFlushesPendingSampleMeasurements) {
+  StimCircuitSimulatorTester sim;
+  sim.setRandomSeed(42);
+
+  cudaq::ExecutionContext ctx("sample", /*shots=*/1);
+  ctx.explicitMeasurements = true;
+  sim.configureExecutionContext(ctx);
+  ScopedExecutionContext ctxGuard{ctx};
+
+  auto q0 = sim.allocateQubit();
+  auto q1 = sim.allocateQubit();
+  sim.mz(q0, "h0");
+  sim.mz(q1, "h1");
+
+  // Before the QEC call, the deferred `M` op is not yet in the recorded
+  // circuit.
+  EXPECT_EQ(sim.recordedCircuitText().find("M "), std::string::npos);
+
+  const std::int64_t indices[] = {0, 1};
+  sim.detector(indices, 2);
+
+  const auto text = sim.recordedCircuitText();
+  const auto mPos = text.find("M ");
+  const auto dPos = text.find("DETECTOR");
+  ASSERT_NE(mPos, std::string::npos) << text;
+  ASSERT_NE(dPos, std::string::npos) << text;
+  EXPECT_LT(mPos, dPos) << "M must land before DETECTOR:\n" << text;
+  EXPECT_NE(text.find("DETECTOR rec[-2] rec[-1]"), std::string::npos) << text;
 }


### PR DESCRIPTION
### Summary

- Wire the three QIR runtime symbols PR #4561 declared (`__quantum__qis__detector`, `__quantum__qis__logical_observable`, `__quantum__qis__pair_detectors`) into the Stim NVQIR backend so kernels containing `qec.*` ops do something at runtime instead of resolving to unresolved externals.

### What changed

- NVQIR adapters (`runtime/nvqir/NVQIR.cpp`): three `extern "C"` functions. Each `Result*` entry in the ABI buffer is the bit pattern of an `i64` chronological measurement index; the adapter reinterprets it through `intptr_t` and dispatches the resulting `std::vector<int64_t>` to the active simulator's QEC virtual. 

- Simulator base virtual functions (`runtime/nvqir/CircuitSimulator.h`): Non-QEC-capable backends silently drop QEC declarations; no per-target erase pass needed.

- Stim override (`runtime/nvqir/stim/StimCircuitSimulator.cpp`): new `stim::Circuit recordedCircuit` member accumulating gates, measurements, and noise (`applyOpToSims` and the noise-channel branch each append). The three overrides:

- Lifecycle: `recordedCircuit` is cleared alongside `num_measurements` in `deallocateStateImpl` and in `setToZeroState`'s preserve-simulators branch. Successive `cudaq::sample` invocations on the reused thread-local simulator would otherwise stack new gates on top of the previous kernel's record while `rec[-N]` restarts from zero, producing a malformed DEM. Consumers that need the recorded circuit must read it before `endExecution` runs.


