### PR TITLE
[qec] Add `detector`, `logical_observable`, `detectors` source-language support

### DIFF
--- a/cudaq/lib/Frontend/nvqpp/CMakeLists.txt
+++ b/cudaq/lib/Frontend/nvqpp/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_library(${LIBRARY_NAME}
 
   LINK_LIBS PUBLIC
     CCDialect
+    QECDialect
     QuakeDialect
     OptimBuilder
 

--- a/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -11,6 +11,7 @@
 #include "cudaq/Optimizer/Builder/Factory.h"
 #include "cudaq/Optimizer/Builder/Intrinsics.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Dialect/QEC/QECOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
@@ -53,6 +54,24 @@ Value loadHandleVectorIfPointer(OpBuilder &builder, Location loc, Value v) {
         sv && isa<cudaq::cc::MeasureHandleType>(sv.getElementType()))
       return cudaq::cc::LoadOp::create(builder, loc, v);
   return v;
+}
+
+// Same intent as `isInNamespace`, but only matches when the immediate
+// enclosing namespace is `nsName`. `isInNamespace` drills through nested
+// namespaces, so it would silently hijack a user-defined
+// `cudaq::qec::detector` or `cudaq::foo::detector` that happens to
+// share a name with a bridge-intercepted call.
+bool isInDirectNamespace(const clang::Decl *x, mlir::StringRef nsName) {
+  assert(x && "decl is null");
+  auto *ctx = x->getDeclContext();
+  // Walk past transparent contexts (linkage specs, etc.) but not through
+  // regular namespaces.
+  while (ctx && ctx->isTransparentContext())
+    ctx = ctx->getParent();
+  if (auto *ns = llvm::dyn_cast_or_null<clang::NamespaceDecl>(ctx))
+    if (const auto *ident = ns->getIdentifier())
+      return ident->getName() == nsName;
+  return false;
 }
 } // namespace
 
@@ -2505,6 +2524,68 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
       if (devFuncTy.getResults().empty())
         return true;
       return pushValue(devCall.getResult(0));
+    }
+
+    const bool inCudaqDirect = isInDirectNamespace(func, "cudaq");
+
+    // QEC operations
+    if (funcName == "detector" && inCudaqDirect) {
+      SmallVector<Value> measurements;
+      measurements.reserve(args.size());
+      for (auto arg : args) {
+        Value v = loadHandleIfPointer(builder, loc, arg);
+        measurements.push_back(loadHandleVectorIfPointer(builder, loc, v));
+      }
+      qec::DetectorOp::create(builder, loc, measurements);
+      return true;
+    }
+
+    if (funcName == "logical_observable" && inCudaqDirect) {
+      std::int64_t obsIndex = 0;
+      const bool hasIndexParam =
+          func->getNumParams() == 2 &&
+          func->getParamDecl(1)->getType()->isIntegerType();
+      if (hasIndexParam) {
+        const clang::Expr *idxExpr = x->getArg(1);
+        auto evaluated = idxExpr->getIntegerConstantExpr(*astContext);
+        if (!evaluated) {
+          reportClangError(
+              x, mangler,
+              "`cudaq::logical_observable` requires a compile-time constant "
+              "`observable_index`");
+          return false;
+        }
+        if ((evaluated->isSigned() && evaluated->isNegative()) ||
+            evaluated->getActiveBits() > 63) {
+          reportClangError(x, mangler,
+                           "`cudaq::logical_observable` `observable_index` "
+                           "must be in the range [0, 2^63 - 1]");
+          return false;
+        }
+        obsIndex = evaluated->getSExtValue();
+        args.pop_back();
+      }
+
+      SmallVector<Value> measurements;
+      measurements.reserve(args.size());
+      for (auto arg : args) {
+        Value v = loadHandleIfPointer(builder, loc, arg);
+        measurements.push_back(loadHandleVectorIfPointer(builder, loc, v));
+      }
+
+      // Skip the `observableIndex` attribute for the default 0 so the
+      // printed IR matches the spec shape (no `index 0` literal).
+      auto idxAttr =
+          (obsIndex == 0) ? IntegerAttr{} : builder.getI64IntegerAttr(obsIndex);
+      qec::ObservableOp::create(builder, loc, measurements, idxAttr);
+      return true;
+    }
+
+    if (funcName == "detectors" && inCudaqDirect) {
+      Value prev = loadHandleVectorIfPointer(builder, loc, args[0]);
+      Value curr = loadHandleVectorIfPointer(builder, loc, args[1]);
+      qec::DetectorsOp::create(builder, loc, prev, curr);
+      return true;
     }
 
     // Finally, flag the call as an error except anything in cudaq::solvers or

--- a/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -58,7 +58,7 @@ Value loadHandleVectorIfPointer(OpBuilder &builder, Location loc, Value v) {
 
 // Same intent as `isInNamespace`, but only matches when the immediate
 // enclosing namespace is `nsName`. `isInNamespace` drills through nested
-// namespaces, so it would silently hijack a user-defined
+// namespaces, so it would silently "hijack" a user-defined
 // `cudaq::qec::detector` or `cudaq::foo::detector` that happens to
 // share a name with a bridge-intercepted call.
 bool isInDirectNamespace(const clang::Decl *x, mlir::StringRef nsName) {

--- a/cudaq/test/AST-Quake/qec_ops.cpp
+++ b/cudaq/test/AST-Quake/qec_ops.cpp
@@ -1,0 +1,389 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | cudaq-opt | FileCheck %s
+
+#include <cudaq.h>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// `cudaq::detector(h)` — single scalar handle.
+// ---------------------------------------------------------------------------
+
+struct DetectorScalar {
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    auto h = mz(q);
+    cudaq::detector(h);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__DetectorScalar()
+// CHECK:           %[[VAL_Q:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[VAL_M:.*]] = quake.mz %[[VAL_Q]] name "h" : (!quake.ref) -> !cc.measure_handle
+// CHECK:           %[[VAL_HA:.*]] = cc.alloca !cc.measure_handle
+// CHECK:           cc.store %[[VAL_M]], %[[VAL_HA]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[VAL_HL:.*]] = cc.load %[[VAL_HA]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           qec.detector %[[VAL_HL]] : !cc.measure_handle
+// CHECK-NOT:       quake.discriminate
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// `cudaq::detector(h0, h1, h2)` — variadic scalar handles.
+// ---------------------------------------------------------------------------
+
+struct DetectorVariadic {
+  void operator()() __qpu__ {
+    cudaq::qubit q0, q1, q2;
+    auto h0 = mz(q0);
+    auto h1 = mz(q1);
+    auto h2 = mz(q2);
+    cudaq::detector(h0, h1, h2);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__DetectorVariadic()
+// CHECK:           %[[VAL_H0:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[VAL_H1:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[VAL_H2:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           qec.detector %[[VAL_H0]], %[[VAL_H1]], %[[VAL_H2]] : !cc.measure_handle, !cc.measure_handle, !cc.measure_handle
+// CHECK-NOT:       quake.discriminate
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// `cudaq::detector(vec)` — single stdvec of handles.
+// ---------------------------------------------------------------------------
+
+struct DetectorVector {
+  void operator()() __qpu__ {
+    cudaq::qvector qs(4);
+    auto handles = mz(qs);
+    cudaq::detector(handles);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__DetectorVector()
+// CHECK:           %[[VAL_QS:.*]] = quake.alloca !quake.veq<4>
+// CHECK:           %[[VAL_HS:.*]] = quake.mz %[[VAL_QS]] name "handles" : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           qec.detector %[[VAL_HS]] : !cc.stdvec<!cc.measure_handle>
+// CHECK-NOT:       quake.discriminate
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// `cudaq::detector(hs, h)` — mixed scalar + list operands.
+// ---------------------------------------------------------------------------
+
+struct DetectorMixed {
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    cudaq::qvector qs(2);
+    auto h = mz(q);
+    auto hs = mz(qs);
+    cudaq::detector(hs, h);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__DetectorMixed()
+// CHECK:           %[[VAL_M:.*]] = quake.mz %{{.*}} name "h" : (!quake.ref) -> !cc.measure_handle
+// CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "hs" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           qec.detector %[[VAL_HS]], %{{.*}} : !cc.stdvec<!cc.measure_handle>, !cc.measure_handle
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// `cudaq::logical_observable(...)` — variadic default index.
+// ---------------------------------------------------------------------------
+
+struct ObservableVariadic {
+  void operator()() __qpu__ {
+    cudaq::qubit q0, q1;
+    auto h0 = mz(q0);
+    auto h1 = mz(q1);
+    cudaq::logical_observable(h0, h1);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableVariadic()
+// CHECK:           %[[VAL_H0:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[VAL_H1:.*]] = cc.load %{{.*}} : !cc.ptr<!cc.measure_handle>
+// CHECK:           qec.observable %[[VAL_H0]], %[[VAL_H1]] : !cc.measure_handle, !cc.measure_handle
+// CHECK-NOT:       index
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// `cudaq::logical_observable(vec)` — vector form, default index 0.
+// ---------------------------------------------------------------------------
+
+struct ObservableVectorDefault {
+  void operator()() __qpu__ {
+    cudaq::qvector qs(3);
+    auto handles = mz(qs);
+    cudaq::logical_observable(handles);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableVectorDefault()
+// CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "handles"
+// CHECK:           qec.observable %[[VAL_HS]] : !cc.stdvec<!cc.measure_handle>
+// CHECK-NOT:       index
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// `cudaq::logical_observable(vec, 2)` — vector form, explicit index.
+// ---------------------------------------------------------------------------
+
+struct ObservableVectorIndexed {
+  void operator()() __qpu__ {
+    cudaq::qvector qs(3);
+    auto handles = mz(qs);
+    cudaq::logical_observable(handles, 2);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableVectorIndexed()
+// CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "handles"
+// CHECK:           qec.observable %[[VAL_HS]] index 2 : !cc.stdvec<!cc.measure_handle>
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// `cudaq::logical_observable(vec, constexpr_var)` — index is any C++
+// compile-time constant, evaluated via Clang's AST constant evaluator.
+// Covers `constexpr` named values, simple expressions like `2 + 1`, and
+// templated non-type parameters.
+// ---------------------------------------------------------------------------
+
+struct ObservableConstexprIndex {
+  void operator()() __qpu__ {
+    cudaq::qvector qs(3);
+    auto handles = mz(qs);
+    constexpr std::size_t kIdx = 5;
+    cudaq::logical_observable(handles, kIdx);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableConstexprIndex()
+// CHECK:           qec.observable %{{.*}} index 5 : !cc.stdvec<!cc.measure_handle>
+// CHECK:           return
+// CHECK:         }
+
+struct ObservableExpressionIndex {
+  void operator()() __qpu__ {
+    cudaq::qvector qs(3);
+    auto handles = mz(qs);
+    cudaq::logical_observable(handles, 2 + 1);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableExpressionIndex()
+// CHECK:           qec.observable %{{.*}} index 3 : !cc.stdvec<!cc.measure_handle>
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// `cudaq::logical_observable(hs, h)` — mixed list + scalar operands via
+// the variadic overload (default `observable_index = 0`).
+// ---------------------------------------------------------------------------
+
+struct ObservableMixed {
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    cudaq::qvector qs(2);
+    auto h = mz(q);
+    auto hs = mz(qs);
+    cudaq::logical_observable(hs, h);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableMixed()
+// CHECK:           %[[VAL_M:.*]] = quake.mz %{{.*}} name "h" : (!quake.ref) -> !cc.measure_handle
+// CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "hs" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           qec.observable %[[VAL_HS]], %{{.*}} : !cc.stdvec<!cc.measure_handle>, !cc.measure_handle
+// CHECK-NOT:       index
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// Rvalue measurement handles
+// ---------------------------------------------------------------------------
+
+struct DetectorRvalueScalar {
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    cudaq::detector(mz(q));
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__DetectorRvalueScalar()
+// CHECK:           %[[VAL_M:.*]] = quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
+// CHECK:           qec.detector %{{.*}} : !cc.measure_handle
+// CHECK:           return
+// CHECK:         }
+
+struct ObservableRvalueVariadic {
+  void operator()() __qpu__ {
+    cudaq::qubit q0, q1;
+    cudaq::logical_observable(mz(q0), mz(q1));
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ObservableRvalueVariadic()
+// CHECK:           qec.observable %{{.*}}, %{{.*}} : !cc.measure_handle, !cc.measure_handle
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// `cudaq::detectors(prev, curr)` — paired stdvecs.
+// ---------------------------------------------------------------------------
+
+struct PairDetectors {
+  void operator()() __qpu__ {
+    cudaq::qvector ancA(3), ancB(3);
+    auto prev = mz(ancA);
+    auto curr = mz(ancB);
+    cudaq::detectors(prev, curr);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__PairDetectors()
+// CHECK:           %[[VAL_P:.*]] = quake.mz %{{.*}} name "prev" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[VAL_C:.*]] = quake.mz %{{.*}} name "curr" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           qec.pair_detectors %[[VAL_P]], %[[VAL_C]] : <!cc.measure_handle>, <!cc.measure_handle>
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// End-to-end: distance-3 bit-flip repetition code with cross-round detectors
+// and a final logical observable.
+// ---------------------------------------------------------------------------
+
+struct RepCodeD3 {
+  void operator()(int nRounds) __qpu__ {
+    cudaq::qvector data(3);
+    cudaq::qubit anc0, anc1;
+    cudaq::measure_handle prev_s0, prev_s1;
+
+    for (int r = 0; r < nRounds; r++) {
+      cx(data[0], anc0);
+      cx(data[1], anc0);
+      cx(data[1], anc1);
+      cx(data[2], anc1);
+
+      auto s0 = mz(anc0);
+      auto s1 = mz(anc1);
+      reset(anc0);
+      reset(anc1);
+
+      if (r > 0) {
+        cudaq::detector(prev_s0, s0);
+        cudaq::detector(prev_s1, s1);
+      }
+      prev_s0 = s0;
+      prev_s1 = s1;
+    }
+    auto readout = mz(data);
+    cudaq::logical_observable(readout);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__RepCodeD3(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK-DAG:       %[[CONSTANT_0:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[CONSTANT_1:.*]] = arith.constant 0 : i32
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[ARG0]], %[[ALLOCA_0]] : !cc.ptr<i32>
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.veq<3>
+// CHECK:           %[[ALLOCA_2:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[ALLOCA_3:.*]] = quake.alloca !quake.ref
+// CHECK:           %[[ALLOCA_4:.*]] = cc.alloca !cc.measure_handle
+// CHECK:           %[[ALLOCA_5:.*]] = cc.alloca !cc.measure_handle
+// CHECK:           cc.scope {
+// CHECK:             %[[ALLOCA_6:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[CONSTANT_1]], %[[ALLOCA_6]] : !cc.ptr<i32>
+// CHECK:             cc.loop while {
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_6]] : !cc.ptr<i32>
+// CHECK:               %[[LOAD_1:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i32>
+// CHECK:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[LOAD_0]], %[[LOAD_1]] : i32
+// CHECK:               cc.condition %[[CMPI_0]]
+// CHECK:             } do {
+// CHECK:               cc.scope {
+// CHECK:                 %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_1]][0] : (!quake.veq<3>) -> !quake.ref
+// CHECK:                 quake.x {{\[}}%[[EXTRACT_REF_0]]] %[[ALLOCA_2]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:                 %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_1]][1] : (!quake.veq<3>) -> !quake.ref
+// CHECK:                 quake.x {{\[}}%[[EXTRACT_REF_1]]] %[[ALLOCA_2]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:                 %[[EXTRACT_REF_2:.*]] = quake.extract_ref %[[ALLOCA_1]][1] : (!quake.veq<3>) -> !quake.ref
+// CHECK:                 quake.x {{\[}}%[[EXTRACT_REF_2]]] %[[ALLOCA_3]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:                 %[[EXTRACT_REF_3:.*]] = quake.extract_ref %[[ALLOCA_1]][2] : (!quake.veq<3>) -> !quake.ref
+// CHECK:                 quake.x {{\[}}%[[EXTRACT_REF_3]]] %[[ALLOCA_3]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:                 %[[MZ_0:.*]] = quake.mz %[[ALLOCA_2]] name "s0" : (!quake.ref) -> !cc.measure_handle
+// CHECK:                 %[[ALLOCA_7:.*]] = cc.alloca !cc.measure_handle
+// CHECK:                 cc.store %[[MZ_0]], %[[ALLOCA_7]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[MZ_1:.*]] = quake.mz %[[ALLOCA_3]] name "s1" : (!quake.ref) -> !cc.measure_handle
+// CHECK:                 %[[ALLOCA_8:.*]] = cc.alloca !cc.measure_handle
+// CHECK:                 cc.store %[[MZ_1]], %[[ALLOCA_8]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 quake.reset %[[ALLOCA_2]] : (!quake.ref) -> ()
+// CHECK:                 quake.reset %[[ALLOCA_3]] : (!quake.ref) -> ()
+// CHECK:                 %[[LOAD_2:.*]] = cc.load %[[ALLOCA_6]] : !cc.ptr<i32>
+// CHECK:                 %[[CMPI_1:.*]] = arith.cmpi sgt, %[[LOAD_2]], %[[CONSTANT_1]] : i32
+// CHECK:                 cc.if(%[[CMPI_1]]) {
+// CHECK:                   %[[LOAD_3:.*]] = cc.load %[[ALLOCA_4]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                   %[[LOAD_4:.*]] = cc.load %[[ALLOCA_7]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                   qec.detector %[[LOAD_3]], %[[LOAD_4]] : !cc.measure_handle, !cc.measure_handle
+// CHECK:                   %[[LOAD_5:.*]] = cc.load %[[ALLOCA_5]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                   %[[LOAD_6:.*]] = cc.load %[[ALLOCA_8]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                   qec.detector %[[LOAD_5]], %[[LOAD_6]] : !cc.measure_handle, !cc.measure_handle
+// CHECK:                 }
+// CHECK:                 %[[LOAD_7:.*]] = cc.load %[[ALLOCA_7]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 cc.store %[[LOAD_7]], %[[ALLOCA_4]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[LOAD_8:.*]] = cc.load %[[ALLOCA_8]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 cc.store %[[LOAD_8]], %[[ALLOCA_5]] : !cc.ptr<!cc.measure_handle>
+// CHECK:               }
+// CHECK:               cc.continue
+// CHECK:             } step {
+// CHECK:               %[[LOAD_9:.*]] = cc.load %[[ALLOCA_6]] : !cc.ptr<i32>
+// CHECK:               %[[ADDI_0:.*]] = arith.addi %[[LOAD_9]], %[[CONSTANT_0]] : i32
+// CHECK:               cc.store %[[ADDI_0]], %[[ALLOCA_6]] : !cc.ptr<i32>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[MZ_2:.*]] = quake.mz %[[ALLOCA_1]] name "readout" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           qec.observable %[[MZ_2]] : !cc.stdvec<!cc.measure_handle>
+// CHECK:           return
+// CHECK:         }
+
+// ---------------------------------------------------------------------------
+// A user-defined `cudaq::qec::detector` must NOT be hijacked by the bridge:
+// the QEC handlers gate on the IMMEDIATE enclosing namespace being `cudaq`
+// (`isInDirectNamespace`), so sub-namespace symbols with the same name
+// dispatch through the regular function-call path. The bridge would
+// otherwise silently shadow QEC-side helpers a user might add.
+// ---------------------------------------------------------------------------
+
+namespace cudaq::qec {
+inline void detector(cudaq::measure_handle h) {
+  (void)h;
+}
+} // namespace cudaq::qec
+
+struct NamespacedDetectorIsNotHijacked {
+  void operator()() __qpu__ {
+    cudaq::qubit q;
+    auto h = mz(q);
+    cudaq::qec::detector(h);
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__NamespacedDetectorIsNotHijacked()
+// CHECK:           call @_ZN5cudaq3qec8detectorENS_14measure_handleE(%{{.*}})
+// CHECK-NOT:       qec.detector
+// CHECK:           return
+// CHECK:         }

--- a/cudaq/test/AST-Quake/qec_ops.cpp
+++ b/cudaq/test/AST-Quake/qec_ops.cpp
@@ -361,11 +361,7 @@ struct RepCodeD3 {
 // CHECK:         }
 
 // ---------------------------------------------------------------------------
-// A user-defined `cudaq::qec::detector` must NOT be hijacked by the bridge:
-// the QEC handlers gate on the IMMEDIATE enclosing namespace being `cudaq`
-// (`isInDirectNamespace`), so sub-namespace symbols with the same name
-// dispatch through the regular function-call path. The bridge would
-// otherwise silently shadow QEC-side helpers a user might add.
+// A user-defined `cudaq::qec::detector` function
 // ---------------------------------------------------------------------------
 
 namespace cudaq::qec {
@@ -374,7 +370,7 @@ inline void detector(cudaq::measure_handle h) {
 }
 } // namespace cudaq::qec
 
-struct NamespacedDetectorIsNotHijacked {
+struct NamespacedDetectorIsAllowed {
   void operator()() __qpu__ {
     cudaq::qubit q;
     auto h = mz(q);
@@ -382,7 +378,7 @@ struct NamespacedDetectorIsNotHijacked {
   }
 };
 
-// CHECK-LABEL:   func.func @__nvqpp__mlirgen__NamespacedDetectorIsNotHijacked()
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__NamespacedDetectorIsAllowed()
 // CHECK:           call @_ZN5cudaq3qec8detectorENS_14measure_handleE(%{{.*}})
 // CHECK-NOT:       qec.detector
 // CHECK:           return

--- a/cudaq/test/AST-error/qec_ops.cpp
+++ b/cudaq/test/AST-error/qec_ops.cpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake -verify %s
+
+#include <cudaq.h>
+#include <vector>
+
+// expected-note@* 0+ {{}}
+
+struct NonConstantObservableIndex {
+  void operator()(int idx) __qpu__ {
+    cudaq::qvector qs(3);
+    auto h = mz(qs);
+    // expected-error@+2{{`cudaq::logical_observable` requires a compile-time constant `observable_index`}}
+    // expected-error@+1{{statement not supported in qpu kernel}}
+    cudaq::logical_observable(h, static_cast<std::size_t>(idx));
+  }
+};
+
+struct NonConstantObservableIndexFromArg {
+  void operator()(std::size_t idx) __qpu__ {
+    cudaq::qvector qs(3);
+    auto h = mz(qs);
+    // expected-error@+2{{`cudaq::logical_observable` requires a compile-time constant `observable_index`}}
+    // expected-error@+1{{statement not supported in qpu kernel}}
+    cudaq::logical_observable(h, idx);
+  }
+};
+
+struct NegativeObservableIndex {
+  void operator()() __qpu__ {
+    cudaq::qvector qs(3);
+    auto h = mz(qs);
+    // expected-error@+2{{`cudaq::logical_observable` `observable_index` must be in the range [0, 2^63 - 1]}}
+    // expected-error@+1{{statement not supported in qpu kernel}}
+    cudaq::logical_observable(h, static_cast<std::size_t>(-1));
+  }
+};
+
+struct OverflowObservableIndex {
+  void operator()() __qpu__ {
+    cudaq::qvector qs(3);
+    auto h = mz(qs);
+    // expected-error@+2{{`cudaq::logical_observable` `observable_index` must be in the range [0, 2^63 - 1]}}
+    // expected-error@+1{{statement not supported in qpu kernel}}
+    cudaq::logical_observable(h, 9223372036854775808ULL);
+  }
+};

--- a/python/cudaq/__init__.py
+++ b/python/cudaq/__init__.py
@@ -204,7 +204,8 @@ else:
 parallel = cudaq_runtime.parallel
 
 # Primitive Types (stubs; used only in kernels, parsed to MLIR)
-from .kernel_types import measure_handle, qubit, qvector, qview
+from .kernel_types import (_KERNEL_ONLY_ERROR_MESSAGE, measure_handle, qubit,
+                           qvector, qview)
 
 Pauli = cudaq_runtime.Pauli
 Kernel = PyKernel
@@ -327,7 +328,39 @@ def to_bools(handles):
     ``!cc.stdvec<!cc.measure_handle>``. Host-side invocation raises a
     ``RuntimeError``.
     """
-    raise RuntimeError("device-only; usable only inside @cudaq.kernel")
+    raise RuntimeError(_KERNEL_ONLY_ERROR_MESSAGE.format("cudaq.to_bools"))
+
+
+def detector(*measurements):
+    """Define a detector over one or more measurement results.
+
+    A detector is a parity constraint: under noise-free execution the XOR of
+    the referenced measurements is deterministic. Each call defines one
+    detector. Arguments are individual ``cudaq.measure_handle`` values or a
+    single ``list[cudaq.measure_handle]``.
+    """
+    raise RuntimeError(_KERNEL_ONLY_ERROR_MESSAGE.format("cudaq.detector"))
+
+
+def logical_observable(*measurements, observable_index=0):
+    """Define a logical observable over one or more measurement results.
+
+    The variadic form uses ``observable_index = 0``. Codes with ``k``
+    logical qubits should pass a single ``list[cudaq.measure_handle]`` and
+    an explicit ``observable_index`` for each observable ``0..k-1``.
+    """
+    raise RuntimeError(
+        _KERNEL_ONLY_ERROR_MESSAGE.format("cudaq.logical_observable"))
+
+
+def detectors(prev, curr):
+    """Define N detectors by pairing two measurement vectors element-wise.
+
+    Standard form for cross-round detectors: each detector ``i`` is the
+    parity of ``prev[i]`` and ``curr[i]``. Size agreement between ``prev``
+    and ``curr`` is checked at runtime.
+    """
+    raise RuntimeError(_KERNEL_ONLY_ERROR_MESSAGE.format("cudaq.detectors"))
 
 
 def __clearKernelRegistries():

--- a/python/cudaq/kernel/ast_bridge.py
+++ b/python/cudaq/kernel/ast_bridge.py
@@ -20,7 +20,7 @@ from cudaq.mlir._mlir_libs._quakeDialects import (cudaq_runtime, load_intrinsic,
                                                   gen_vector_of_complex_constant
                                                  )
 from cudaq.kernel_types import qview
-from cudaq.mlir.dialects import arith, cc, complex, func, math, quake
+from cudaq.mlir.dialects import arith, cc, complex, func, math, qec, quake
 from cudaq.mlir.ir import (BoolAttr, Block, BlockArgument, Context, ComplexType,
                            DenseBoolArrayAttr, DenseI32ArrayAttr,
                            DenseI64ArrayAttr, DictAttr, F32Type, F64Type,
@@ -1609,6 +1609,59 @@ class PyASTBridge(ast.NodeVisitor):
                     self.emitFatalError("too many values", self.currentNode)
             groupedVals = *frontVals, values, *backVals
         return groupedVals[0] if len(groupedVals) == 1 else groupedVals
+
+    def _lowerQECOp(self, node):
+        """Lower ``cudaq.detector(...)``, ``cudaq.logical_observable(...)``,
+        and ``cudaq.detectors(prev, curr)`` to the matching ``qec.*`` MLIR op.
+        """
+        name = node.func.attr
+        isPair = (name == "detectors")
+
+        if isPair:
+            if len(node.args) != 2:
+                self.emitFatalError(
+                    "cudaq.detectors takes exactly two "
+                    "list[cudaq.measure_handle] arguments", node)
+        elif not node.args:
+            self.emitFatalError(
+                f"cudaq.{name} requires at least one "
+                f"cudaq.measure_handle argument", node)
+
+        obsIndex = 0
+        if name == "logical_observable":
+            for kw in node.keywords:
+                if kw.arg != "observable_index":
+                    continue
+                try:
+                    val = ast.literal_eval(kw.value)
+                except (ValueError, SyntaxError):
+                    val = None
+                if not isinstance(val, int) or isinstance(val, bool):
+                    self.emitFatalError(
+                        "cudaq.logical_observable requires "
+                        "observable_index to be an integer literal", node)
+                if val < 0 or val > (1 << 63) - 1:
+                    self.emitFatalError(
+                        "cudaq.logical_observable observable_index must "
+                        "be in the range [0, 2^63 - 1]", node)
+                obsIndex = val
+
+        n = len(node.args)
+        if n == 1:
+            values = [self.__groupValues(node.args, [1])]
+        else:
+            values = list(self.__groupValues(node.args, [n]))
+
+        if isPair:
+            prev, curr = values
+            qec.DetectorsOp(prev, curr)
+        elif name == "logical_observable":
+            # Skip the attribute at the default 0 so the printed IR omits
+            # the optional `index N` literal at the spec shape.
+            idxAttr = None if obsIndex == 0 else obsIndex
+            qec.ObservableOp(values, observableIndex=idxAttr)
+        else:
+            qec.DetectorOp(values)
 
     def __get_root_value(self, pyVal):
         """Strips any attribute and subscript expressions from the node to get
@@ -3635,6 +3688,10 @@ class PyASTBridge(ast.NodeVisitor):
                         self.pushValue(
                             quake.DiscriminateOp(resTy, handle).result)
                         return
+
+                    if node.func.attr in ("detector", "logical_observable",
+                                          "detectors"):
+                        return self._lowerQECOp(node)
 
                     if node.func.attr == 'adjoint' or node.func.attr == 'control':
 

--- a/python/cudaq/kernel/kernel_builder.py
+++ b/python/cudaq/kernel/kernel_builder.py
@@ -24,7 +24,7 @@ from cudaq.mlir.ir import (BoolAttr, Block, Context, Module, TypeAttr, UnitAttr,
                            FlatSymbolRefAttr)
 from cudaq.mlir.passmanager import PassManager
 from cudaq.mlir.dialects import (complex as complexDialect, arith, quake, cc,
-                                 func, math)
+                                 func, math, qec)
 from cudaq.mlir._mlir_libs._quakeDialects import (
     cudaq_runtime, gen_vector_of_complex_constant, load_intrinsic)
 from cudaq.kernel_types import qubit, qvector
@@ -1241,6 +1241,88 @@ class PyKernel(object):
         ```
         """
         return self.__measure(quake.MyOp, target, regName)
+
+    def __qecOperandValue(self, qv, opName):
+        """Normalize a builder-side QEC operand: must be a
+        ``QuakeValue`` whose MLIR type is ``!cc.measure_handle`` or
+        ``!cc.stdvec<!cc.measure_handle>`` (the value forms produced by
+        ``mz`` / ``mx`` / ``my`` for scalar and ``qvector`` targets)."""
+        if not isinstance(qv, QuakeValue):
+            emitFatalError(
+                f"kernel.{opName} arguments must be QuakeValue "
+                f"measurement handles (returned by kernel.mz / mx / my)")
+        ty = qv.mlirValue.type
+        ok = (cc.MeasureHandleType.isinstance(ty) or
+              (cc.StdvecType.isinstance(ty) and cc.MeasureHandleType.isinstance(
+                  cc.StdvecType.getElementType(ty))))
+        if not ok:
+            emitFatalError(
+                f"kernel.{opName} arguments must each be a "
+                f"cudaq.measure_handle or list[cudaq.measure_handle]")
+        return qv.mlirValue
+
+    def detector(self, *measurements):
+        """Define a detector over one or more measurement results.
+
+        A detector is a parity constraint: under noise-free execution the
+        XOR of the referenced measurements is deterministic. Each call
+        defines one detector. Arguments are :class:`QuakeValue` handles
+        returned by ``kernel.mz`` / ``mx`` / ``my`` (scalar handles or
+        handle vectors).
+        """
+        if not measurements:
+            emitFatalError("kernel.detector requires at least one "
+                           "cudaq.measure_handle argument")
+        with self.ctx, self.insertPoint, self.loc:
+            values = [
+                self.__qecOperandValue(m, "detector") for m in measurements
+            ]
+            qec.DetectorOp(values)
+
+    def logical_observable(self, *measurements, observable_index=0):
+        """Define a logical observable over one or more measurement results.
+
+        ``observable_index`` selects which logical qubit observable this
+        call defines; codes with a single logical qubit can omit it. Any
+        combination of scalar handles and handle vectors is accepted.
+        """
+        if not measurements:
+            emitFatalError("kernel.logical_observable requires at least one "
+                           "cudaq.measure_handle argument")
+        if not isinstance(observable_index, int) or isinstance(
+                observable_index, bool):
+            emitFatalError(
+                "kernel.logical_observable requires observable_index "
+                "to be an integer literal")
+        if observable_index < 0 or observable_index > (1 << 63) - 1:
+            emitFatalError(
+                "kernel.logical_observable observable_index must be in "
+                "the range [0, 2^63 - 1]")
+        with self.ctx, self.insertPoint, self.loc:
+            values = [
+                self.__qecOperandValue(m, "logical_observable")
+                for m in measurements
+            ]
+            # Skip the attribute at the default 0 so the printed IR omits
+            # the optional `index 0` literal at the spec shape.
+            idxAttr = None if observable_index == 0 else observable_index
+            qec.ObservableOp(values, observableIndex=idxAttr)
+
+    def detectors(self, prev, curr):
+        """Define N detectors by pairing two measurement vectors
+        element-wise. Standard form for cross-round detectors: each
+        detector ``i`` is the parity of ``prev[i]`` and ``curr[i]``.
+        Both arguments must be ``list[cudaq.measure_handle]`` handles
+        (returned by ``kernel.mz`` on a ``qvector``).
+        """
+        with self.ctx, self.insertPoint, self.loc:
+            prevV = self.__qecOperandValue(prev, "detectors")
+            currV = self.__qecOperandValue(curr, "detectors")
+            for v in (prevV, currV):
+                if not cc.StdvecType.isinstance(v.type):
+                    emitFatalError("kernel.detectors arguments must each be a "
+                                   "list[cudaq.measure_handle]")
+            qec.DetectorsOp(prevV, currV)
 
     def adjoint(self, otherKernel, *target_arguments):
         """

--- a/python/cudaq/kernel_types.py
+++ b/python/cudaq/kernel_types.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Iterator, overload
 
-_KERNEL_ONLY_ERROR_MESSAGE = "Type '{}' can only be used within a CUDA-Q kernel."
+_KERNEL_ONLY_ERROR_MESSAGE = "'{}' can be used only in CUDA-Q kernels"
 
 
 class KernelTypeError(RuntimeError):
@@ -48,11 +48,9 @@ class measure_handle(KernelType):
     ``list[measure_handle]``.
 
     Instantiating ``cudaq.measure_handle()`` at host scope raises
-    ``RuntimeError`` (it is device-only).
+    ``KernelTypeError`` (a ``RuntimeError`` subclass) since it is
+    device-only.
     """
-
-    def __new__(cls, *args, **kwargs):
-        raise RuntimeError("device-only; usable only inside @cudaq.kernel")
 
     def __init__(self) -> None:
         ...

--- a/python/cudaq/mlir/dialects/QECOps.td
+++ b/python/cudaq/mlir/dialects/QECOps.td
@@ -1,0 +1,14 @@
+/***********************************************************-*- tablegen -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifndef PYTHON_BINDINGS_QEC_OPS
+#define PYTHON_BINDINGS_QEC_OPS
+
+include "cudaq/Optimizer/Dialect/QEC/QECOps.td"
+
+#endif

--- a/python/cudaq/mlir/dialects/qec.py
+++ b/python/cudaq/mlir/dialects/qec.py
@@ -1,0 +1,9 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+from ._qec_ops_gen import *

--- a/python/extension/CMakeLists.txt
+++ b/python/extension/CMakeLists.txt
@@ -46,6 +46,14 @@ declare_mlir_dialect_python_bindings(
     dialects/cc.py
   DIALECT_NAME cc)
 
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT CUDAQuantumPythonSources
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../cudaq/mlir"
+  TD_FILE dialects/QECOps.td
+  SOURCES
+    dialects/qec.py
+  DIALECT_NAME qec)
+
 if(APPLE)
   set(_quakeDialects_mlir_runtime_sources "")
   set(_quakeDialects_extra_link_libs

--- a/python/tests/kernel/test_measure_handle.py
+++ b/python/tests/kernel/test_measure_handle.py
@@ -26,16 +26,14 @@ def reset_run_clear():
 
 
 def test_host_construction_raises_runtime_error():
-    with pytest.raises(
-            RuntimeError,
-            match=r"^device-only; usable only inside @cudaq\.kernel$"):
+    with pytest.raises(RuntimeError,
+                       match="can be used only in CUDA-Q kernels"):
         cudaq.measure_handle()
 
 
 def test_host_to_bools_raises_runtime_error():
-    with pytest.raises(
-            RuntimeError,
-            match=r"^device-only; usable only inside @cudaq\.kernel$"):
+    with pytest.raises(RuntimeError,
+                       match="can be used only in CUDA-Q kernels"):
         cudaq.to_bools([])
 
 

--- a/python/tests/kernel/test_qec_ops.py
+++ b/python/tests/kernel/test_qec_ops.py
@@ -150,14 +150,6 @@ def test_observable_overflow_idx_rejected():
 # ===========================================================================
 
 
-@pytest.fixture
-def builder_kernel_and_handles():
-    kernel = cudaq.make_kernel()
-    qs = kernel.qalloc(2)
-    hs = kernel.mz(qs)
-    return kernel, hs
-
-
 def test_builder_detector_no_args_rejected():
     kernel = cudaq.make_kernel()
     with pytest.raises(RuntimeError) as e:
@@ -190,6 +182,14 @@ def test_builder_detectors_scalar_arg_rejected():
         kernel.detectors(h0, h1)
     assert ("kernel.detectors arguments must each be a "
             "list[cudaq.measure_handle]") in str(e.value)
+
+
+@pytest.fixture
+def builder_kernel_and_handles():
+    kernel = cudaq.make_kernel()
+    qs = kernel.qalloc(2)
+    hs = kernel.mz(qs)
+    return kernel, hs
 
 
 def test_builder_observable_non_int_idx_rejected(builder_kernel_and_handles):

--- a/python/tests/kernel/test_qec_ops.py
+++ b/python/tests/kernel/test_qec_ops.py
@@ -1,0 +1,214 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+import pytest
+import cudaq
+
+_DETECTOR_EMPTY = ("detector requires at least one "
+                   "cudaq.measure_handle argument")
+_OBSERVABLE_EMPTY = ("logical_observable requires at least one "
+                     "cudaq.measure_handle argument")
+_OBS_IDX_NOT_INT = ("logical_observable requires observable_index "
+                    "to be an integer literal")
+_OBS_IDX_RANGE = ("logical_observable observable_index must be in "
+                  "the range [0, 2^63 - 1]")
+
+
+@pytest.fixture(autouse=True)
+def reset_run_clear():
+    cudaq.reset_target()
+    yield
+    cudaq.__clearKernelRegistries()
+    cudaq.reset_target()
+
+
+# ---------------------------------------------------------------------------
+# Host-scope invocation fails loudly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op,args", [
+    (cudaq.detector, ()),
+    (cudaq.logical_observable, ()),
+    (cudaq.detectors, ([], [])),
+])
+def test_host_raises(op, args):
+    with pytest.raises(RuntimeError) as e:
+        op(*args)
+    assert "can be used only in CUDA-Q kernels" in str(e.value)
+
+
+# ---------------------------------------------------------------------------
+# Bridge-level rejections: empty operand lists and wrong arity for the
+# binary op.
+# ---------------------------------------------------------------------------
+
+
+def test_detector_no_args_rejected():
+
+    @cudaq.kernel
+    def k():
+        cudaq.detector()
+
+    with pytest.raises(RuntimeError) as e:
+        k.compile()
+    assert _DETECTOR_EMPTY in str(e.value)
+
+
+def test_observable_no_args_rejected():
+
+    @cudaq.kernel
+    def k():
+        cudaq.logical_observable()
+
+    with pytest.raises(RuntimeError) as e:
+        k.compile()
+    assert _OBSERVABLE_EMPTY in str(e.value)
+
+
+def test_detectors_one_arg_rejected():
+
+    @cudaq.kernel
+    def k():
+        qs = cudaq.qvector(3)
+        handles = mz(qs)
+        cudaq.detectors(handles)
+
+    with pytest.raises(RuntimeError) as e:
+        k.compile()
+    assert ("cudaq.detectors takes exactly two "
+            "list[cudaq.measure_handle] arguments") in str(e.value)
+
+
+# ---------------------------------------------------------------------------
+# `observable_index` must be a Python integer literal in `[0, 2^63 - 1]`.
+# ---------------------------------------------------------------------------
+
+
+def test_observable_runtime_idx_rejected():
+
+    @cudaq.kernel
+    def k(idx: int):
+        qs = cudaq.qvector(2)
+        handles = mz(qs)
+        cudaq.logical_observable(handles, observable_index=idx)
+
+    with pytest.raises(RuntimeError) as e:
+        k.compile()
+    assert _OBS_IDX_NOT_INT in str(e.value)
+
+
+_MODULE_OBS_IDX = 5
+
+
+def test_observable_module_var_rejected():
+
+    @cudaq.kernel
+    def k():
+        qs = cudaq.qvector(3)
+        handles = mz(qs)
+        cudaq.logical_observable(handles, observable_index=_MODULE_OBS_IDX)
+
+    with pytest.raises(RuntimeError) as e:
+        k.compile()
+    assert _OBS_IDX_NOT_INT in str(e.value)
+
+
+def test_observable_negative_idx_rejected():
+
+    @cudaq.kernel
+    def k():
+        qs = cudaq.qvector(2)
+        handles = mz(qs)
+        cudaq.logical_observable(handles, observable_index=-1)
+
+    with pytest.raises(RuntimeError) as e:
+        k.compile()
+    assert _OBS_IDX_RANGE in str(e.value)
+
+
+def test_observable_overflow_idx_rejected():
+
+    @cudaq.kernel
+    def k():
+        qs = cudaq.qvector(2)
+        handles = mz(qs)
+        cudaq.logical_observable(handles, observable_index=9223372036854775808)
+
+    with pytest.raises(RuntimeError) as e:
+        k.compile()
+    assert _OBS_IDX_RANGE in str(e.value)
+
+
+# ===========================================================================
+# `cudaq.make_kernel()` programmatic builder surface.
+# ===========================================================================
+
+
+@pytest.fixture
+def builder_kernel_and_handles():
+    kernel = cudaq.make_kernel()
+    qs = kernel.qalloc(2)
+    hs = kernel.mz(qs)
+    return kernel, hs
+
+
+def test_builder_detector_no_args_rejected():
+    kernel = cudaq.make_kernel()
+    with pytest.raises(RuntimeError) as e:
+        kernel.detector()
+    assert _DETECTOR_EMPTY in str(e.value)
+
+
+def test_builder_observable_no_args_rejected():
+    kernel = cudaq.make_kernel()
+    with pytest.raises(RuntimeError) as e:
+        kernel.logical_observable()
+    assert _OBSERVABLE_EMPTY in str(e.value)
+
+
+def test_builder_detector_non_handle_rejected():
+    kernel = cudaq.make_kernel()
+    with pytest.raises(RuntimeError) as e:
+        kernel.detector(42)
+    assert ("kernel.detector arguments must be QuakeValue "
+            "measurement handles") in str(e.value)
+
+
+def test_builder_detectors_scalar_arg_rejected():
+    kernel = cudaq.make_kernel()
+    q0 = kernel.qalloc()
+    q1 = kernel.qalloc()
+    h0 = kernel.mz(q0)
+    h1 = kernel.mz(q1)
+    with pytest.raises(RuntimeError) as e:
+        kernel.detectors(h0, h1)
+    assert ("kernel.detectors arguments must each be a "
+            "list[cudaq.measure_handle]") in str(e.value)
+
+
+def test_builder_observable_non_int_idx_rejected(builder_kernel_and_handles):
+    kernel, hs = builder_kernel_and_handles
+    with pytest.raises(RuntimeError) as e:
+        kernel.logical_observable(hs, observable_index="not-an-int")
+    assert _OBS_IDX_NOT_INT in str(e.value)
+
+
+@pytest.mark.parametrize("idx", [-1, 9223372036854775808])
+def test_builder_observable_idx_out_of_range(builder_kernel_and_handles, idx):
+    kernel, hs = builder_kernel_and_handles
+    with pytest.raises(RuntimeError) as e:
+        kernel.logical_observable(hs, observable_index=idx)
+    assert _OBS_IDX_RANGE in str(e.value)
+
+
+# leave for gdb debugging
+if __name__ == "__main__":
+    import os
+    loc = os.path.abspath(__file__)
+    pytest.main([loc, "-rP"])

--- a/python/tests/mlir/qec_ops.py
+++ b/python/tests/mlir/qec_ops.py
@@ -1,0 +1,435 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# RUN: PYTHONPATH=../../ pytest -rP  %s | FileCheck %s
+
+import os
+import pytest
+import cudaq
+
+# ---------------------------------------------------------------------------
+# `cudaq.detector(h)` — single scalar handle.
+# ---------------------------------------------------------------------------
+
+
+def test_detector_scalar():
+
+    @cudaq.kernel
+    def kernel_detector_scalar():
+        q = cudaq.qubit()
+        h = mz(q)
+        cudaq.detector(h)
+
+    print(kernel_detector_scalar)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_detector_scalar
+# CHECK-SAME:      attributes {"cudaq-entrypoint"
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           %[[VAL_1:.*]] = quake.mz %[[VAL_0]] name "h" : (!quake.ref) -> !cc.measure_handle
+# CHECK:           qec.detector %[[VAL_1]] : !cc.measure_handle
+# CHECK-NOT:       quake.discriminate
+# CHECK:           return
+# CHECK:         }
+
+# ---------------------------------------------------------------------------
+# `cudaq.detector(h0, h1, h2)` — variadic scalar handles.
+# ---------------------------------------------------------------------------
+
+
+def test_detector_variadic():
+
+    @cudaq.kernel
+    def kernel_detector_variadic():
+        q0 = cudaq.qubit()
+        q1 = cudaq.qubit()
+        q2 = cudaq.qubit()
+        h0 = mz(q0)
+        h1 = mz(q1)
+        h2 = mz(q2)
+        cudaq.detector(h0, h1, h2)
+
+    print(kernel_detector_variadic)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_detector_variadic
+# CHECK:           %[[H0:.*]] = quake.mz %{{.*}} name "h0" : (!quake.ref) -> !cc.measure_handle
+# CHECK:           %[[H1:.*]] = quake.mz %{{.*}} name "h1" : (!quake.ref) -> !cc.measure_handle
+# CHECK:           %[[H2:.*]] = quake.mz %{{.*}} name "h2" : (!quake.ref) -> !cc.measure_handle
+# CHECK:           qec.detector %[[H0]], %[[H1]], %[[H2]] : !cc.measure_handle, !cc.measure_handle, !cc.measure_handle
+# CHECK-NOT:       quake.discriminate
+# CHECK:           return
+# CHECK:         }
+
+# ---------------------------------------------------------------------------
+# `cudaq.detector(vec)` — single stdvec of handles.
+# ---------------------------------------------------------------------------
+
+
+def test_detector_vector():
+
+    @cudaq.kernel
+    def kernel_detector_vector():
+        qs = cudaq.qvector(4)
+        handles = mz(qs)
+        cudaq.detector(handles)
+
+    print(kernel_detector_vector)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_detector_vector
+# CHECK:           %[[VS:.*]] = quake.mz %{{.*}} name "handles" : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.detector %[[VS]] : !cc.stdvec<!cc.measure_handle>
+# CHECK-NOT:       quake.discriminate
+# CHECK:           return
+# CHECK:         }
+
+# ---------------------------------------------------------------------------
+# `cudaq.logical_observable(...)` — variadic, default index 0 omitted.
+# ---------------------------------------------------------------------------
+
+
+def test_observable_variadic():
+
+    @cudaq.kernel
+    def kernel_observable_variadic():
+        q0 = cudaq.qubit()
+        q1 = cudaq.qubit()
+        h0 = mz(q0)
+        h1 = mz(q1)
+        cudaq.logical_observable(h0, h1)
+
+    print(kernel_observable_variadic)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_observable_variadic
+# CHECK:           %[[H0:.*]] = quake.mz %{{.*}} name "h0"
+# CHECK:           %[[H1:.*]] = quake.mz %{{.*}} name "h1"
+# CHECK:           qec.observable %[[H0]], %[[H1]] : !cc.measure_handle, !cc.measure_handle
+# CHECK-NOT:       index
+# CHECK-NOT:       quake.discriminate
+# CHECK:           return
+# CHECK:         }
+
+# ---------------------------------------------------------------------------
+# `cudaq.logical_observable(vec)` — vector form, default index 0 omitted.
+# ---------------------------------------------------------------------------
+
+
+def test_observable_vector():
+
+    @cudaq.kernel
+    def kernel_observable_vector_default():
+        qs = cudaq.qvector(3)
+        handles = mz(qs)
+        cudaq.logical_observable(handles)
+
+    print(kernel_observable_vector_default)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_observable_vector_default
+# CHECK:           %[[VS:.*]] = quake.mz %{{.*}} name "handles" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.observable %[[VS]] : !cc.stdvec<!cc.measure_handle>
+# CHECK-NOT:       index
+# CHECK:           return
+# CHECK:         }
+
+# ---------------------------------------------------------------------------
+# `cudaq.logical_observable(vec, observable_index=2)` — explicit index.
+# ---------------------------------------------------------------------------
+
+
+def test_observable_indexed():
+
+    @cudaq.kernel
+    def kernel_observable_explicit_idx():
+        qs = cudaq.qvector(3)
+        handles = mz(qs)
+        cudaq.logical_observable(handles, observable_index=2)
+
+    print(kernel_observable_explicit_idx)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_observable_explicit_idx
+# CHECK:           %[[VS:.*]] = quake.mz %{{.*}} name "handles" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.observable %[[VS]] index 2 : !cc.stdvec<!cc.measure_handle>
+# CHECK:           return
+# CHECK:         }
+
+# ---------------------------------------------------------------------------
+# `cudaq.detector(mz(q))` — nested call (no intermediate handle binding).
+# ---------------------------------------------------------------------------
+
+
+def test_detector_nested_mz():
+
+    @cudaq.kernel
+    def kernel_detector_nested_mz():
+        q = cudaq.qubit()
+        cudaq.detector(mz(q))
+
+    print(kernel_detector_nested_mz)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_detector_nested_mz
+# CHECK:           %[[VAL_0:.*]] = quake.alloca !quake.ref
+# CHECK:           %[[H:.*]] = quake.mz %[[VAL_0]] : (!quake.ref) -> !cc.measure_handle
+# CHECK:           qec.detector %[[H]] : !cc.measure_handle
+# CHECK:           return
+# CHECK:         }
+
+# ---------------------------------------------------------------------------
+# Mixed shape: scalar handles + handle lists in the same call. The dialect
+# op accepts any combination (`Variadic<AnyTypeOf<[scalar, list]>>`) and
+# Q3's QIR conversion (`packMeasurementHandles` mixed-or-multi-stdvec
+# branch) flattens the mix into a single `Result**` array, so a natural
+# QEC-source-code call like "combine these stabilizers (list) with the
+# boundary readout (scalar)" lowers cleanly.
+# ---------------------------------------------------------------------------
+
+
+def test_detector_mixed():
+
+    @cudaq.kernel
+    def kernel_detector_mixed():
+        q = cudaq.qubit()
+        qs = cudaq.qvector(2)
+        h = mz(q)
+        hs = mz(qs)
+        cudaq.detector(hs, h)
+
+    print(kernel_detector_mixed)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_detector_mixed
+# CHECK:           %[[VAL_M:.*]] = quake.mz %{{.*}} name "h" : (!quake.ref) -> !cc.measure_handle
+# CHECK:           %[[VAL_HS:.*]] = quake.mz %{{.*}} name "hs" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.detector %[[VAL_HS]], %[[VAL_M]] : !cc.stdvec<!cc.measure_handle>, !cc.measure_handle
+# CHECK-NOT:       quake.discriminate
+# CHECK:           return
+# CHECK:         }
+
+# ---------------------------------------------------------------------------
+# `cudaq.detectors(prev, curr)` — paired stdvecs.
+# ---------------------------------------------------------------------------
+
+
+def test_pair_detectors():
+
+    @cudaq.kernel
+    def kernel_pair_detectors():
+        ancA = cudaq.qvector(3)
+        ancB = cudaq.qvector(3)
+        prev = mz(ancA)
+        curr = mz(ancB)
+        cudaq.detectors(prev, curr)
+
+    print(kernel_pair_detectors)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_pair_detectors
+# CHECK:           %[[P:.*]] = quake.mz %{{.*}} name "prev" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[C:.*]] = quake.mz %{{.*}} name "curr" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.pair_detectors %[[P]], %[[C]] : <!cc.measure_handle>, <!cc.measure_handle>
+# CHECK:           return
+# CHECK:         }
+
+# ---------------------------------------------------------------------------
+# End-to-end distance-3 repetition code
+# ---------------------------------------------------------------------------
+
+
+def test_rep_code_d3():
+
+    @cudaq.kernel
+    def kernel_rep_code_d3(n_rounds: int):
+        data = cudaq.qvector(3)
+        anc0 = cudaq.qubit()
+        anc1 = cudaq.qubit()
+        prev_s0 = cudaq.measure_handle()
+        prev_s1 = cudaq.measure_handle()
+
+        for r in range(n_rounds):
+            x.ctrl(data[0], anc0)
+            x.ctrl(data[1], anc0)
+            x.ctrl(data[1], anc1)
+            x.ctrl(data[2], anc1)
+            s0 = mz(anc0)
+            s1 = mz(anc1)
+            reset(anc0)
+            reset(anc1)
+            if r > 0:
+                cudaq.detector(prev_s0, s0)
+                cudaq.detector(prev_s1, s1)
+            prev_s0 = s0
+            prev_s1 = s1
+        readout = mz(data)
+        cudaq.logical_observable(readout)
+
+    print(kernel_rep_code_d3)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__kernel_rep_code_d3
+# CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+# CHECK-DAG:       %[[CONSTANT_0:.*]] = arith.constant 1 : i64
+# CHECK-DAG:       %[[CONSTANT_1:.*]] = arith.constant 0 : i64
+# CHECK:           %[[UNDEF_0:.*]] = cc.undef !cc.measure_handle
+# CHECK:           %[[UNDEF_1:.*]] = cc.undef !cc.measure_handle
+# CHECK:           %[[UNDEF_2:.*]] = cc.undef i64
+# CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<3>
+# CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.ref
+# CHECK:           %[[ALLOCA_2:.*]] = quake.alloca !quake.ref
+# CHECK:           %[[UNDEF_3:.*]] = cc.undef !cc.measure_handle
+# CHECK:           %[[UNDEF_4:.*]] = cc.undef !cc.measure_handle
+# CHECK:           %[[LOOP_0:.*]]:6 = cc.loop while ((%[[VAL_0:.*]] = %[[CONSTANT_1]], %[[VAL_1:.*]] = %[[UNDEF_2]], %[[VAL_2:.*]] = %[[UNDEF_1]], %[[VAL_3:.*]] = %[[UNDEF_0]], %[[VAL_4:.*]] = %[[UNDEF_3]], %[[VAL_5:.*]] = %[[UNDEF_4]]) -> (i64, i64, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle)) {
+# CHECK:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_0]], %[[ARG0]] : i64
+# CHECK:             cc.condition %[[CMPI_0]](%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : i64, i64, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle)
+# CHECK:           } do {
+# CHECK:           ^bb0(%[[VAL_6:.*]]: i64, %[[VAL_7:.*]]: i64, %[[VAL_8:.*]]: !cc.measure_handle, %[[VAL_9:.*]]: !cc.measure_handle, %[[VAL_10:.*]]: !cc.measure_handle, %[[VAL_11:.*]]: !cc.measure_handle):
+# CHECK:             %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_0]][0] : (!quake.veq<3>) -> !quake.ref
+# CHECK:             quake.x {{\[}}%[[EXTRACT_REF_0]]] %[[ALLOCA_1]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:             %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_0]][1] : (!quake.veq<3>) -> !quake.ref
+# CHECK:             quake.x {{\[}}%[[EXTRACT_REF_1]]] %[[ALLOCA_1]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:             %[[EXTRACT_REF_2:.*]] = quake.extract_ref %[[ALLOCA_0]][1] : (!quake.veq<3>) -> !quake.ref
+# CHECK:             quake.x {{\[}}%[[EXTRACT_REF_2]]] %[[ALLOCA_2]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:             %[[EXTRACT_REF_3:.*]] = quake.extract_ref %[[ALLOCA_0]][2] : (!quake.veq<3>) -> !quake.ref
+# CHECK:             quake.x {{\[}}%[[EXTRACT_REF_3]]] %[[ALLOCA_2]] : (!quake.ref, !quake.ref) -> ()
+# CHECK:             %[[MZ_0:.*]] = quake.mz %[[ALLOCA_1]] name "s0" : (!quake.ref) -> !cc.measure_handle
+# CHECK:             %[[MZ_1:.*]] = quake.mz %[[ALLOCA_2]] name "s1" : (!quake.ref) -> !cc.measure_handle
+# CHECK:             quake.reset %[[ALLOCA_1]] : (!quake.ref) -> ()
+# CHECK:             quake.reset %[[ALLOCA_2]] : (!quake.ref) -> ()
+# CHECK:             %[[CMPI_1:.*]] = arith.cmpi sgt, %[[VAL_6]], %[[CONSTANT_1]] : i64
+# CHECK:             cc.if(%[[CMPI_1]]) {
+# CHECK:               qec.detector %[[VAL_10]], %[[MZ_0]] : !cc.measure_handle, !cc.measure_handle
+# CHECK:               qec.detector %[[VAL_11]], %[[MZ_1]] : !cc.measure_handle, !cc.measure_handle
+# CHECK:             } else {
+# CHECK:             }
+# CHECK:             cc.continue %[[VAL_6]], %[[VAL_6]], %[[MZ_0]], %[[MZ_1]], %[[MZ_0]], %[[MZ_1]] : i64, i64, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle
+# CHECK:           } step {
+# CHECK:           ^bb0(%[[VAL_12:.*]]: i64, %[[VAL_13:.*]]: i64, %[[VAL_14:.*]]: !cc.measure_handle, %[[VAL_15:.*]]: !cc.measure_handle, %[[VAL_16:.*]]: !cc.measure_handle, %[[VAL_17:.*]]: !cc.measure_handle):
+# CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_12]], %[[CONSTANT_0]] : i64
+# CHECK:             cc.continue %[[ADDI_0]], %[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_16]], %[[VAL_17]] : i64, i64, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle, !cc.measure_handle
+# CHECK:           }
+# CHECK:           %[[MZ_2:.*]] = quake.mz %[[ALLOCA_0]] name "readout" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.observable %[[MZ_2]] : !cc.stdvec<!cc.measure_handle>
+# CHECK-NOT:       quake.discriminate
+# CHECK:           return
+# CHECK:         }
+
+# ===========================================================================
+# `cudaq.make_kernel()` programmatic builder surface.
+# ===========================================================================
+
+
+def test_b_detector_scalar():
+    kernel = cudaq.make_kernel()
+    q = kernel.qalloc()
+    h = kernel.mz(q)
+    kernel.detector(h)
+    print(kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
+# CHECK:           %[[H:.*]] = quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
+# CHECK:           qec.detector %[[H]] : !cc.measure_handle
+# CHECK:           return
+
+
+def test_b_detector_vector():
+    kernel = cudaq.make_kernel()
+    qs = kernel.qalloc(4)
+    hs = kernel.mz(qs)
+    kernel.detector(hs)
+    print(kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
+# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<4>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.detector %[[HS]] : !cc.stdvec<!cc.measure_handle>
+# CHECK:           return
+
+
+def test_b_detector_mixed():
+    kernel = cudaq.make_kernel()
+    q = kernel.qalloc()
+    qs = kernel.qalloc(2)
+    h = kernel.mz(q)
+    hs = kernel.mz(qs)
+    kernel.detector(hs, h)
+    print(kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
+# CHECK:           %[[H:.*]] = quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
+# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.detector %[[HS]], %[[H]] : !cc.stdvec<!cc.measure_handle>, !cc.measure_handle
+# CHECK:           return
+
+
+def test_b_observable_variadic():
+    kernel = cudaq.make_kernel()
+    q0 = kernel.qalloc()
+    q1 = kernel.qalloc()
+    h0 = kernel.mz(q0)
+    h1 = kernel.mz(q1)
+    kernel.logical_observable(h0, h1)
+    print(kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
+# CHECK:           %[[H0:.*]] = quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
+# CHECK:           %[[H1:.*]] = quake.mz %{{.*}} : (!quake.ref) -> !cc.measure_handle
+# CHECK:           qec.observable %[[H0]], %[[H1]] : !cc.measure_handle, !cc.measure_handle
+# CHECK-NOT:       index
+# CHECK:           return
+
+
+def test_b_observable_vector():
+    kernel = cudaq.make_kernel()
+    qs = kernel.qalloc(3)
+    hs = kernel.mz(qs)
+    kernel.logical_observable(hs)
+    print(kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
+# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.observable %[[HS]] : !cc.stdvec<!cc.measure_handle>
+# CHECK-NOT:       index
+# CHECK:           return
+
+
+def test_b_observable_indexed():
+    kernel = cudaq.make_kernel()
+    qs = kernel.qalloc(3)
+    hs = kernel.mz(qs)
+    kernel.logical_observable(hs, observable_index=2)
+    print(kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
+# CHECK:           %[[HS:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.observable %[[HS]] index 2 : !cc.stdvec<!cc.measure_handle>
+# CHECK:           return
+
+
+def test_b_pair_detectors():
+    kernel = cudaq.make_kernel()
+    qsA = kernel.qalloc(3)
+    qsB = kernel.qalloc(3)
+    prev = kernel.mz(qsA)
+    curr = kernel.mz(qsB)
+    kernel.detectors(prev, curr)
+    print(kernel)
+
+
+# CHECK-LABEL:   func.func @__nvqpp__mlirgen__PythonKernelBuilderInstance
+# CHECK:           %[[P:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           %[[C:.*]] = quake.mz %{{.*}} : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+# CHECK:           qec.pair_detectors %[[P]], %[[C]] : <!cc.measure_handle>, <!cc.measure_handle>
+# CHECK:           return

--- a/runtime/cudaq/builder/kernel_builder.cpp
+++ b/runtime/cudaq/builder/kernel_builder.cpp
@@ -16,6 +16,7 @@
 #include "cudaq/Optimizer/CodeGen/Passes.h"
 #include "cudaq/Optimizer/Dialect/CC/CCDialect.h"
 #include "cudaq/Optimizer/Dialect/CC/CCOps.h"
+#include "cudaq/Optimizer/Dialect/QEC/QECOps.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeDialect.h"
 #include "cudaq/Optimizer/Dialect/Quake/QuakeOps.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
@@ -828,6 +829,43 @@ QuakeValue mz(ImplicitLocOpBuilder &builder, QuakeValue &qubitOrQvec,
               const std::string &regName) {
   return applyMeasure<cudaq::quake::MzOp>(builder, qubitOrQvec.getValue(),
                                           regName);
+}
+
+static std::vector<Value>
+qecOperandValues(const std::vector<QuakeValue> &operands) {
+  std::vector<Value> values;
+  values.reserve(operands.size());
+  std::transform(operands.begin(), operands.end(), std::back_inserter(values),
+                 [](const QuakeValue &qv) { return qv.getValue(); });
+  return values;
+}
+
+void detector(ImplicitLocOpBuilder &builder,
+              const std::vector<QuakeValue> &measurements) {
+  cudaq::qec::DetectorOp::create(builder, qecOperandValues(measurements));
+}
+
+void logical_observable(ImplicitLocOpBuilder &builder,
+                        const std::vector<QuakeValue> &measurements,
+                        std::size_t observableIndex) {
+  if (observableIndex >
+      static_cast<std::size_t>(std::numeric_limits<std::int64_t>::max()))
+    throw std::runtime_error("kernel_builder logical_observable "
+                             "observable_index must be in the range "
+                             "[0, 2^63 - 1]");
+  // Skip the attribute at the default 0 so the printed IR omits the optional
+  // `index 0` literal at the spec shape.
+  auto idxAttr = (observableIndex == 0)
+                     ? IntegerAttr{}
+                     : builder.getI64IntegerAttr(
+                           static_cast<std::int64_t>(observableIndex));
+  cudaq::qec::ObservableOp::create(builder, qecOperandValues(measurements),
+                                   idxAttr);
+}
+
+void detectors(ImplicitLocOpBuilder &builder, QuakeValue &prev,
+               QuakeValue &curr) {
+  cudaq::qec::DetectorsOp::create(builder, prev.getValue(), curr.getValue());
 }
 
 void reset(ImplicitLocOpBuilder &builder, const QuakeValue &qubitOrQvec) {

--- a/runtime/cudaq/builder/kernel_builder.h
+++ b/runtime/cudaq/builder/kernel_builder.h
@@ -224,6 +224,20 @@ CUDAQ_DETAILS_MEASURE_DECLARATION(mx)
 CUDAQ_DETAILS_MEASURE_DECLARATION(my)
 CUDAQ_DETAILS_MEASURE_DECLARATION(mz)
 
+/// @brief Declare a detector over one or more measurement results.
+void detector(mlir::ImplicitLocOpBuilder &builder,
+              const std::vector<QuakeValue> &measurements);
+
+/// @brief Declare a logical observable over one or more measurement results.
+void logical_observable(mlir::ImplicitLocOpBuilder &builder,
+                        const std::vector<QuakeValue> &measurements,
+                        std::size_t observableIndex);
+
+/// @brief Declare N detectors by pairing two measurement vectors
+/// element-wise.
+void detectors(mlir::ImplicitLocOpBuilder &builder, QuakeValue &prev,
+               QuakeValue &curr);
+
 void exp_pauli(mlir::ImplicitLocOpBuilder &builder, const QuakeValue &theta,
                const std::vector<QuakeValue> &qubits,
                const std::string &pauliWord);
@@ -385,6 +399,12 @@ concept AllAreQuakeValues =
      std::is_same_v<
          std::remove_reference_t<std::tuple_element<0, std::tuple<Ts...>>>,
          QuakeValue>);
+
+// Sibling of `AllAreQuakeValues` that actually rejects mixed packs of two or
+// more arguments.
+template <class... Ts>
+concept AllDecayToQuakeValue =
+    (std::is_same_v<std::decay_t<Ts>, QuakeValue> && ...);
 
 template <typename... Args>
 class kernel_builder : public details::kernel_builder_base {
@@ -659,6 +679,52 @@ public:
   CUDAQ_BUILDER_ADD_MEASURE(mx)
   CUDAQ_BUILDER_ADD_MEASURE(my)
   CUDAQ_BUILDER_ADD_MEASURE(mz)
+
+  /// @brief Define a detector over one or more measurement results.
+  ///
+  /// Arguments are `QuakeValue` handles returned by `mz`/`mx`/`my`
+  /// (scalar handles or handle vectors); any mix is supported, mirroring
+  /// the `qec.detector` dialect op's `Variadic<AnyTypeOf<[scalar, list]>>`
+  /// operand surface. The `AllDecayToQuakeValue` concept keeps this
+  /// variadic from competing with non-`QuakeValue` argument shapes (e.g.
+  /// the integer-taking `logical_observable` overload below).
+  template <typename... MeasArgs>
+    requires(sizeof...(MeasArgs) >= 1) && AllDecayToQuakeValue<MeasArgs...>
+  void detector(MeasArgs &&...measurements) {
+    std::vector<QuakeValue> values{std::forward<MeasArgs>(measurements)...};
+    details::detector(*opBuilder, values);
+  }
+
+  /// @brief Define a logical observable over one or more measurement
+  /// results.
+  ///
+  /// The variadic-handle form uses `observable_index = 0`. To declare a
+  /// non-default index, use the `(QuakeValue, std::size_t)` overload
+  /// below. `observable_index` must be in `[0, 2^63 - 1]`.
+  template <typename... MeasArgs>
+    requires(sizeof...(MeasArgs) >= 1) && AllDecayToQuakeValue<MeasArgs...>
+  void logical_observable(MeasArgs &&...measurements) {
+    std::vector<QuakeValue> values{std::forward<MeasArgs>(measurements)...};
+    details::logical_observable(*opBuilder, values, /*observableIndex=*/0);
+  }
+
+  /// @brief `logical_observable` with an explicit `observable_index`.
+  /// Takes a single `QuakeValue` handle (typically a
+  /// `!cc.stdvec<!cc.measure_handle>` from `mz` on a `qvector`, but a
+  /// scalar handle is also accepted by the dialect).
+  void logical_observable(QuakeValue measurements,
+                          std::size_t observable_index) {
+    std::vector<QuakeValue> values{measurements};
+    details::logical_observable(*opBuilder, values, observable_index);
+  }
+
+  /// @brief Define N detectors by pairing two measurement vectors
+  /// element-wise. Standard form for cross-round detectors: each
+  /// detector `i` is the parity of `prev[i]` and `curr[i]`. Both
+  /// arguments must be handle-list `QuakeValue`s.
+  void detectors(QuakeValue prev, QuakeValue curr) {
+    details::detectors(*opBuilder, prev, curr);
+  }
 
   /// @brief SWAP operation for swapping the quantum states of two qubits.
   void swap(const QuakeValue &first, const QuakeValue &second) {

--- a/runtime/cudaq/qis/qubit_qis.h
+++ b/runtime/cudaq/qis/qubit_qis.h
@@ -574,6 +574,77 @@ inline std::vector<bool> to_bools(const std::vector<measure_result> &results) {
 #endif
 }
 
+// QEC kernel-side operations: `cudaq::detector`, `cudaq::logical_observable`,
+// and `cudaq::detectors` - they consume `measure_handle`, which is itself
+// MLIR-mode only. The AST bridge intercepts every call inside `__qpu__`
+// kernels and lowers it to the corresponding `qec.*` MLIR op. The inline bodies
+// below are never reached in a built kernel; reaching one means the bridge
+// missed an interception path, so they throw to fail loudly instead of
+// producing wrong results.
+#ifndef CUDAQ_LIBRARY_MODE
+
+namespace details {
+template <typename T>
+concept any_measure_result_or_vec =
+    std::is_same_v<std::remove_cvref_t<T>, measure_result> ||
+    std::is_same_v<std::remove_cvref_t<T>, std::vector<measure_result>>;
+} // namespace details
+
+/// @brief Define a detector over one or more measurement results.
+///
+/// A detector is a parity constraint: under noise-free execution the XOR of
+/// the referenced measurements is deterministic. Each argument is either an
+/// individual `cudaq::measure_result` or a
+/// `std::vector<cudaq::measure_result>`, or any combination.
+template <typename... MeasArgs>
+  requires(sizeof...(MeasArgs) >= 1) &&
+          (details::any_measure_result_or_vec<MeasArgs> && ...)
+void detector(MeasArgs &&...ms) {
+  ((void)ms, ...);
+  throw std::runtime_error(details::kQpuOnlyHostScopeError);
+}
+
+/// @brief Define a logical observable over one or more measurement results.
+///
+/// A logical observable is a binary sum of measurement results that equals
+/// the outcome of measuring a logical operator. Each argument is either an
+/// individual `cudaq::measure_result` or a
+/// `std::vector<cudaq::measure_result>`, or any combination. Codes
+/// with `k` logical qubits should pair a single
+/// `std::vector<cudaq::measure_result>` with an explicit `observable_index`
+/// for each observable `0..k-1` (see the `(vector, std::size_t)` overload).
+template <typename... MeasArgs>
+  requires(sizeof...(MeasArgs) >= 1) &&
+          (details::any_measure_result_or_vec<MeasArgs> && ...)
+void logical_observable(MeasArgs &&...ms) {
+  ((void)ms, ...);
+  throw std::runtime_error(details::kQpuOnlyHostScopeError);
+}
+
+// Disambiguate from the variadic when an explicit `observable_index` is
+// passed (the variadic rejects integer arguments via its concept). The
+// `observable_index` parameter is non-defaulted to keep
+// `logical_observable(vec)` unambiguously routed through the variadic.
+inline void logical_observable(const std::vector<measure_result> &ms,
+                               std::size_t observable_index) {
+  (void)ms;
+  (void)observable_index;
+  throw std::runtime_error(details::kQpuOnlyHostScopeError);
+}
+
+/// @brief Define N detectors by pairing two measurement vectors element-wise.
+///
+/// Standard form for cross-round detectors: each detector `i` is the parity
+/// of `prev[i]` and `curr[i]`.
+inline void detectors(const std::vector<measure_result> &prev,
+                      const std::vector<measure_result> &curr) {
+  (void)prev;
+  (void)curr;
+  throw std::runtime_error(details::kQpuOnlyHostScopeError);
+}
+
+#endif // !CUDAQ_LIBRARY_MODE
+
 // This concept tests if `Kernel` is a `Callable` that takes the arguments,
 // `Args`, and returns `void`.
 template <typename Kernel, typename... Args>

--- a/unittests/integration/builder_tester.cpp
+++ b/unittests/integration/builder_tester.cpp
@@ -1646,3 +1646,71 @@ CUDAQ_TEST(BuilderTester, checkExplicitMeasurements) {
     }
   }
 }
+
+// ----------------------------------------------------------------------------
+// QEC kernel-side operations on the programmatic builder surface.
+// ----------------------------------------------------------------------------
+
+CUDAQ_TEST(BuilderTester, checkQecDetectorScalar) {
+  auto kernel = cudaq::make_kernel();
+  auto q = kernel.qalloc();
+  auto h = kernel.mz(q);
+  kernel.detector(h);
+  EXPECT_NO_THROW(kernel.to_quake());
+}
+
+CUDAQ_TEST(BuilderTester, checkQecDetectorVector) {
+  auto kernel = cudaq::make_kernel();
+  auto qs = kernel.qalloc(4);
+  auto hs = kernel.mz(qs);
+  kernel.detector(hs);
+  EXPECT_NO_THROW(kernel.to_quake());
+}
+
+CUDAQ_TEST(BuilderTester, checkQecDetectorMixed) {
+  auto kernel = cudaq::make_kernel();
+  auto q = kernel.qalloc();
+  auto qs = kernel.qalloc(2);
+  auto h = kernel.mz(q);
+  auto hs = kernel.mz(qs);
+  kernel.detector(hs, h);
+  EXPECT_NO_THROW(kernel.to_quake());
+}
+
+CUDAQ_TEST(BuilderTester, checkQecObservableVariadic) {
+  auto kernel = cudaq::make_kernel();
+  auto q0 = kernel.qalloc();
+  auto q1 = kernel.qalloc();
+  auto h0 = kernel.mz(q0);
+  auto h1 = kernel.mz(q1);
+  kernel.logical_observable(h0, h1);
+  EXPECT_NO_THROW(kernel.to_quake());
+}
+
+CUDAQ_TEST(BuilderTester, checkQecObservableIndexed) {
+  auto kernel = cudaq::make_kernel();
+  auto qs = kernel.qalloc(3);
+  auto hs = kernel.mz(qs);
+  kernel.logical_observable(hs, /*observable_index=*/2);
+  EXPECT_NO_THROW(kernel.to_quake());
+}
+
+CUDAQ_TEST(BuilderTester, checkQecPairDetectors) {
+  auto kernel = cudaq::make_kernel();
+  auto qsA = kernel.qalloc(3);
+  auto qsB = kernel.qalloc(3);
+  auto prev = kernel.mz(qsA);
+  auto curr = kernel.mz(qsB);
+  kernel.detectors(prev, curr);
+  EXPECT_NO_THROW(kernel.to_quake());
+}
+
+CUDAQ_TEST(BuilderTester, checkQecDetectorsScalarRejected) {
+  auto kernel = cudaq::make_kernel();
+  auto q0 = kernel.qalloc();
+  auto q1 = kernel.qalloc();
+  auto h0 = kernel.mz(q0);
+  auto h1 = kernel.mz(q1);
+  kernel.detectors(h0, h1);
+  EXPECT_ANY_THROW({ kernel.to_quake(); });
+}


### PR DESCRIPTION
### Summary

Adds the QEC source-language surfaces for detector, logical-observable, and paired-detector declarations in both C++ and Python.

Kernel source and builder calls now emit the `qec.detector`, `qec.observable`, and `qec.pair_detectors` ops added by earlier PRs. 

_Note: `cudaq::dem_from_kernel` remains follow-up scope._

### Motivation

Prior PRs added the QEC dialect, QIR lowering, and Stim runtime wiring. This PR makes that path reachable from user kernels and programmatic builders, while keeping the DEM analysis API isolated to the next PR.

_Note: https://github.com/NVIDIA/cuda-quantum/pull/4539 required for hardware targets._

### What Changed

- Adds C++ `cudaq::detector`, `cudaq::logical_observable`, and `cudaq::detectors` kernel-side declarations.
- Lowers those declarations through the C++ AST bridge and C++ `make_kernel` builder.
- Adds Python AST-bridge and `cudaq.make_kernel` support for the same operations.
- Adds Python QEC dialect bindings.
- Supports scalar/list/mixed measurement-handle operands for detector and logical-observable declarations where the dialect accepts them.

### Risks and Downstream Impact

The new source surfaces emit QEC declaration ops, but this PR does not add the user-facing DEM-generation API. End-to-end `.dem` generation lands in the follow-up PR. No CUDA-QX API change.