### PR TITLE
Introduce CompileOptions and plumb through Compiler API

### DIFF
--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -234,8 +234,11 @@ public:
 
     Compiler compiler(serverHelper.get(), backendConfig, targetConfig,
                       noiseModel, emulate);
+    cudaq_internal::compiler::CompileOptions options =
+        cudaq_internal::compiler::CompileOptions::fromExecutionContext(
+            executionContext, emulate);
     return compiler.runPassPipeline(executionContext, kernelName, modulePtr,
-                                    args);
+                                    args, options);
   }
 
   void completeLaunchKernel(const std::string &kernelName,

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -34,8 +34,11 @@ RemoteRESTQPU::unifiedLaunchModule(const AnyModule &module, KernelArgs args) {
     auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
 
     // Get the Quake code, lowered according to config file.
-    codes =
-        compiler.lowerQuakeCode(executionContext, kernelName, moduleOp, args);
+    cudaq_internal::compiler::CompileOptions options =
+        cudaq_internal::compiler::CompileOptions::fromExecutionContext(
+            executionContext, emulate);
+    codes = compiler.lowerQuakeCode(executionContext, kernelName, moduleOp,
+                                    args, options);
   } else {
     const auto &compiled = std::get<CompiledModule>(module);
     kernelName = compiled.getName();

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
@@ -50,8 +50,11 @@ public:
       auto [quakeModule, context] = Compiler::loadQuakeCodeByName(kernelName);
       auto compiled = compileImpl(
           kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
+            cudaq_internal::compiler::CompileOptions options =
+                cudaq_internal::compiler::CompileOptions::fromExecutionContext(
+                    ctx, emulate);
             return compiler.runPassPipeline(ctx, kernelName, quakeModule, args,
-                                            std::move(context));
+                                            options, std::move(context));
           });
       launchImpl(compiled);
     } else {
@@ -76,7 +79,11 @@ public:
     CUDAQ_INFO("FermioniqBaseQPU compiling kernel via module ({})", kernelName);
     return compileImpl(
         kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
-          return compiler.runPassPipeline(ctx, kernelName, modulePtr, args);
+          cudaq_internal::compiler::CompileOptions options =
+              cudaq_internal::compiler::CompileOptions::fromExecutionContext(
+                  ctx, emulate);
+          return compiler.runPassPipeline(ctx, kernelName, modulePtr, args,
+                                          options);
         });
   }
 

--- a/runtime/internal/compiler/CMakeLists.txt
+++ b/runtime/internal/compiler/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(cudaq-mlir-runtime
   SHARED
     ArgumentConversion.cpp
     Compiler.cpp
+    CompileOptions.cpp
     CompiledModuleHelper.cpp
     JITTargetPipeline.cpp
     JIT.cpp

--- a/runtime/internal/compiler/CompileOptions.cpp
+++ b/runtime/internal/compiler/CompileOptions.cpp
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#include "cudaq_internal/compiler/CompileOptions.h"
+
+cudaq_internal::compiler::CompileOptions
+cudaq_internal::compiler::CompileOptions::fromExecutionContext(
+    const cudaq::ExecutionContext *ctx, bool emulate) {
+  (void)ctx;
+  (void)emulate;
+  return {};
+}

--- a/runtime/internal/compiler/CompileOptions.cpp
+++ b/runtime/internal/compiler/CompileOptions.cpp
@@ -10,7 +10,9 @@
 cudaq_internal::compiler::CompileOptions
 cudaq_internal::compiler::CompileOptions::fromExecutionContext(
     const cudaq::ExecutionContext *ctx, bool emulate) {
-  (void)ctx;
   (void)emulate;
+  if (ctx && ctx->name == "resource-count") {
+    return {.generateResourceCounts = true};
+  }
   return {};
 }

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -388,7 +388,8 @@ cudaq_internal::compiler::Compiler::assembleCompiledModule(
 cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
     cudaq::ExecutionContext *executionContext, const std::string &kernelName,
     const void *modulePtr, cudaq::KernelArgs args,
-    std::shared_ptr<mlir::MLIRContext> context) {
+    std::shared_ptr<mlir::MLIRContext> context,
+    const CompileOptions &options) {
   mlir::ModuleOp m_module = mlir::ModuleOp::getFromOpaquePointer(modulePtr);
   assert(!context || context.get() == m_module.getContext());
   auto [moduleOp, epFunc] = prepareModule(kernelName, m_module, args);
@@ -581,9 +582,9 @@ cudaq_internal::compiler::Compiler::emitKernelExecutions(
 std::vector<cudaq::KernelExecution>
 cudaq_internal::compiler::Compiler::lowerQuakeCode(
     cudaq::ExecutionContext *executionContext, const std::string &kernelName,
-    const void *modulePtr, cudaq::KernelArgs args) {
+    const void *modulePtr, cudaq::KernelArgs args, const CompileOptions &options) {
   auto compiled =
-      runPassPipeline(executionContext, kernelName, modulePtr, args, nullptr);
+      runPassPipeline(executionContext, kernelName, modulePtr, args, nullptr, options);
   return emitKernelExecutions(compiled);
 }
 

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -388,8 +388,7 @@ cudaq_internal::compiler::Compiler::assembleCompiledModule(
 cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
     cudaq::ExecutionContext *executionContext, const std::string &kernelName,
     const void *modulePtr, cudaq::KernelArgs args,
-    std::shared_ptr<mlir::MLIRContext> context,
-    const CompileOptions &options) {
+    const CompileOptions &options, std::shared_ptr<mlir::MLIRContext> context) {
   mlir::ModuleOp m_module = mlir::ModuleOp::getFromOpaquePointer(modulePtr);
   assert(!context || context.get() == m_module.getContext());
   auto [moduleOp, epFunc] = prepareModule(kernelName, m_module, args);
@@ -421,7 +420,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
   // the pre-processing might change the IR structure (may interfere with
   // other passes).
   std::optional<cudaq::Resources> resourceCounts;
-  if (executionContext && executionContext->name == "resource-count") {
+  if (options.generateResourceCounts) {
     auto result = cudaq::opt::countResourcesFromIR(moduleOp);
     if (failed(result))
       throw std::runtime_error(
@@ -582,9 +581,10 @@ cudaq_internal::compiler::Compiler::emitKernelExecutions(
 std::vector<cudaq::KernelExecution>
 cudaq_internal::compiler::Compiler::lowerQuakeCode(
     cudaq::ExecutionContext *executionContext, const std::string &kernelName,
-    const void *modulePtr, cudaq::KernelArgs args, const CompileOptions &options) {
+    const void *modulePtr, cudaq::KernelArgs args,
+    const CompileOptions &options) {
   auto compiled =
-      runPassPipeline(executionContext, kernelName, modulePtr, args, nullptr, options);
+      runPassPipeline(executionContext, kernelName, modulePtr, args, options);
   return emitKernelExecutions(compiled);
 }
 

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/CompileOptions.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/CompileOptions.h
@@ -1,0 +1,21 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+#include "common/ExecutionContext.h"
+
+namespace cudaq_internal::compiler {
+
+/// Options for `Compiler::runPassPipeline` and `Compiler::lowerQuakeCode`.
+struct CompileOptions {
+  /// Build options from an execution context.
+  static CompileOptions fromExecutionContext(const cudaq::ExecutionContext *ctx,
+                                             bool emulate = false);
+};
+
+} // namespace cudaq_internal::compiler

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/CompileOptions.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/CompileOptions.h
@@ -13,7 +13,14 @@ namespace cudaq_internal::compiler {
 
 /// Options for `Compiler::runPassPipeline` and `Compiler::lowerQuakeCode`.
 struct CompileOptions {
-  /// Build options from an execution context.
+  /// Whether to generate resource counts.
+  ///
+  /// When true, the compiler will generate resource counts during compilation
+  /// and simplify the IR to remove all quantum operations already accounted
+  /// for in the counts.
+  bool generateResourceCounts = false;
+
+  /// Configure compilation options from an execution context.
   static CompileOptions fromExecutionContext(const cudaq::ExecutionContext *ctx,
                                              bool emulate = false);
 };

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -9,6 +9,7 @@
 
 #include "common/CompiledModule.h"
 #include "common/KernelArgs.h"
+#include "cudaq_internal/compiler/CompileOptions.h"
 #include "cudaq_internal/compiler/CompiledModuleHelper.h"
 #include <map>
 #include <memory>
@@ -123,7 +124,8 @@ public:
   runPassPipeline(cudaq::ExecutionContext *executionContext,
                   const std::string &kernelName, const void *modulePtr,
                   cudaq::KernelArgs args,
-                  std::shared_ptr<mlir::MLIRContext> context = nullptr);
+                  std::shared_ptr<mlir::MLIRContext> context = nullptr,
+                  const CompileOptions &options = {});
 
   /// @brief Emit target-specific code for each `MlirArtifact` in the
   /// `CompiledModule` and produce `KernelExecution` objects.
@@ -142,6 +144,7 @@ public:
   std::vector<cudaq::KernelExecution>
   lowerQuakeCode(cudaq::ExecutionContext *executionContext,
                  const std::string &kernelName, const void *modulePtr,
-                 cudaq::KernelArgs args);
+                 cudaq::KernelArgs args,
+                 const CompileOptions &options = {});
 };
 } // namespace cudaq_internal::compiler

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -123,9 +123,8 @@ public:
   cudaq::CompiledModule
   runPassPipeline(cudaq::ExecutionContext *executionContext,
                   const std::string &kernelName, const void *modulePtr,
-                  cudaq::KernelArgs args,
-                  std::shared_ptr<mlir::MLIRContext> context = nullptr,
-                  const CompileOptions &options = {});
+                  cudaq::KernelArgs args, const CompileOptions &options = {},
+                  std::shared_ptr<mlir::MLIRContext> context = nullptr);
 
   /// @brief Emit target-specific code for each `MlirArtifact` in the
   /// `CompiledModule` and produce `KernelExecution` objects.
@@ -144,7 +143,6 @@ public:
   std::vector<cudaq::KernelExecution>
   lowerQuakeCode(cudaq::ExecutionContext *executionContext,
                  const std::string &kernelName, const void *modulePtr,
-                 cudaq::KernelArgs args,
-                 const CompileOptions &options = {});
+                 cudaq::KernelArgs args, const CompileOptions &options = {});
 };
 } // namespace cudaq_internal::compiler


### PR DESCRIPTION
This PR sets up the plumbing to define compilation options in a new `CompileOptions` struct. Such an options struct can get constructed from an execution context using `CompileOptions::fromExecutionContext`. The first goal is to remove any dependency on the execution context within `Compiler::runPassPipeline` (and hence also from `Compiler::lowerQuakeCode`).

I wanted to get this first PR out today. I'll open a follow up PR tomorrow with more config options.