### PR TITLE
[CI] markdown-link-check: ignore cppreference, set UA for mpich

### DIFF
--- a/.github/pre-commit/md_link_check_config.json
+++ b/.github/pre-commit/md_link_check_config.json
@@ -16,6 +16,12 @@
           "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
           "Accept-Language": "en-US,en;q=0.9"
         }
+      },
+      {
+        "urls": ["https://www.mpich.org/"],
+        "headers": {
+          "User-Agent": "curl/8.0"
+        }
       }
     ],
     "ignorePatterns": [
@@ -24,6 +30,10 @@
       },
       {
         "pattern": "^https://gcc.gnu.org/"
+      },
+      {
+        "_comment": "Cloudflare blocks programmatic clients (TLS fingerprint, not UA); no header workaround possible. Verified with curl + lychee + markdown-link-check across multiple UAs.",
+        "pattern": "^https://en\\.cppreference\\.com/"
       },
       {
         "pattern": "^https://epubs.siam.org/doi/10.1137/S0097539796300921"


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cuda-quantum/issues/4571

  7 cppreference URLs across the CUDA-Q specification docs were returning 403.
  This is Cloudflare TLS-fingerprint blocking — confirmed by reproducing 403
  from `curl` and `lychee` with **every** UA combination I tried (Chrome desktop,
  Firefox, Safari, Googlebot, default-curl, `Mozilla/5.0`, empty UA, even full
  browser header sets with `Sec-Fetch-*` and `Accept-Language`). No HTTP header
  tweak gets past it; the block is at the TLS layer.