### PR TITLE
[C++] Allow `std::vector<measure_handle>::operator=` in kernels

### DIFF
--- a/cudaq/lib/Frontend/nvqpp/ConvertDecl.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertDecl.cpp
@@ -743,11 +743,40 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
     if (x->getInit()) {
       // At the very least, its a vector var = vec_init;
       auto initVec = popValue();
-      symbolTable.insert(x->getName(), initVec);
+      auto elementType = vecType.getElementType();
+
+      // For `std::vector<measure_handle>` locals only, allocate stack
+      // storage for the descriptor so reassignment (`v = w;`) and
+      // cross-scope mutation (`if (cond) { v = w; }`) lower to `cc.store`
+      // into a stable per-name address.
+      //
+      // Mirrors the scalar `measure_handle` allocation in the basic-type
+      // path and the `measure_handle::operator=` arm. Within a kernel scope
+      // `std::vector<measure_handle>` has `std::span<measure_handle>`-
+      // like value semantics: the `(data_ptr, size)` descriptor is what
+      // gets copied; element mutations land in the underlying storage
+      // shared between descriptors that alias the same data.
+      //
+      // For handle vectors, if the initializer is itself a pointer (from
+      // another stack-allocated handle vector), load the descriptor first
+      // so the value form (not the pointer) goes into the new alloca.
+      Value initSpan = initVec;
+      if (isa<cc::MeasureHandleType>(elementType)) {
+        if (isa<cc::PointerType>(initSpan.getType()))
+          initSpan = cc::LoadOp::create(builder, loc, initSpan);
+        Value alloca = cc::AllocaOp::create(builder, loc, vecType);
+        cc::StoreOp::create(builder, loc, initSpan, alloca);
+        symbolTable.insert(x->getName(), alloca);
+      } else {
+        symbolTable.insert(x->getName(), initVec);
+      }
 
       // Let's try to see if this was a auto var = mz(qreg)
-      // and if so, find the mz and tag it with the variable name
-      auto elementType = vecType.getElementType();
+      // and if so, find the mz and tag it with the variable name.
+      // Walk from `initSpan`: for non-handle vectors `initSpan == initVec`
+      // (no load was inserted); for handle vectors, walking the post-load
+      // value avoids the cc.load masking the underlying mz / discriminate
+      // / stdvec_init op when the initializer was a fresh measurement.
 
       // Accept both the `bool`-valued (`std::vector<bool>` form, lowered as
       // discriminate-of-measure-interface) and the handle-valued
@@ -763,19 +792,19 @@ bool QuakeBridgeVisitor::VisitVarDecl(clang::VarDecl *x) {
       auto attachName = [&](cudaq::quake::MeasurementInterface meas) {
         meas.setRegisterName(builder.getStringAttr(x->getName()));
       };
-      if (auto descr = initVec.getDefiningOp<cudaq::quake::DiscriminateOp>()) {
+      if (auto descr = initSpan.getDefiningOp<cudaq::quake::DiscriminateOp>()) {
         if (auto meas =
                 descr.getMeasurement()
                     .getDefiningOp<cudaq::quake::MeasurementInterface>())
           attachName(meas);
       } else if (auto meas =
-                     initVec
+                     initSpan
                          .getDefiningOp<cudaq::quake::MeasurementInterface>()) {
         attachName(meas);
       }
 
       // Did this come from a stdvec init op? If not drop out
-      auto stdVecInit = initVec.getDefiningOp<cc::StdvecInitOp>();
+      auto stdVecInit = initSpan.getDefiningOp<cc::StdvecInitOp>();
       if (!stdVecInit)
         return true;
 

--- a/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -45,8 +45,10 @@ Value loadHandleIfPointer(OpBuilder &builder, Location loc, Value v) {
   return v;
 }
 
-// Same intent as `loadHandleIfPointer`, but for the bulk-discriminate /
-// `to_integer` paths where the lvalue carries a `std::vector<measure_handle>`.
+// Same intent as `loadHandleIfPointer`, but for an
+// `std::vector<measure_handle>` lvalue. Handle-vector locals get stack storage
+// allocated by stdvec decl-init path; downstream consumers expecting the
+// `!cc.stdvec<!cc.measure_handle>` descriptor use this helper to normalize.
 Value loadHandleVectorIfPointer(OpBuilder &builder, Location loc, Value v) {
   if (auto ptrTy = dyn_cast<cudaq::cc::PointerType>(v.getType()))
     if (auto sv = dyn_cast<cudaq::cc::StdvecType>(ptrTy.getElementType());
@@ -1457,6 +1459,26 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
   // is called, we need to convert that to loading the size field of the pair.
   // For θ.empty(), the size is loaded and compared to zero.
   if (isInClassInNamespace(func, "vector", "std")) {
+    // `std::vector<measure_handle>::operator=` is intercepted here. Mirrors the
+    // scalar `measure_handle::operator=` arm.
+    if (auto *md = dyn_cast<clang::CXXMethodDecl>(func);
+        md && md->getOverloadedOperator() == clang::OO_Equal) {
+      // Peek the lhs type before popping; only intercept when it is the
+      // handle-vector slot pointer.
+      Value thisPeek = valueStack[valueStack.size() - 2];
+      bool isHandleVecPtr = false;
+      if (auto ptrTy = dyn_cast<cc::PointerType>(thisPeek.getType()))
+        if (auto sv = dyn_cast<cc::StdvecType>(ptrTy.getElementType()))
+          isHandleVecPtr = isa<cc::MeasureHandleType>(sv.getElementType());
+      if (isHandleVecPtr) {
+        Value rhs = loadHandleVectorIfPointer(builder, loc, popValue());
+        Value thisVal = popValue();
+        // Drop the callee value the visitor pushed for the call.
+        [[maybe_unused]] auto calleeOp = popValue();
+        cc::StoreOp::create(builder, loc, rhs, thisVal);
+        return pushValue(thisVal);
+      }
+    }
     // Get the size of the std::vector.
     auto svec = popValue();
     if (isa<cc::PointerType>(svec.getType()))

--- a/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -137,6 +137,14 @@ bool QuakeBridgeVisitor::TraverseCXXForRangeStmt(clang::CXXForRangeStmt *x,
   if (!TraverseStmt(x->getRangeInit()))
     return false;
   Value buffer = popValue();
+  // `std::vector<measure_handle>` locals are stack-allocated by
+  // `ConvertDecl.cpp`'s stdvec decl-init path and arrive here as
+  // `!cc.ptr<!cc.stdvec<!cc.measure_handle>>`. The `SpanLikeType` dispatch
+  // below needs the descriptor value, not the pointer, so normalize. The
+  // `quake::VeqType` arm is unaffected.
+  if (auto ptrTy = dyn_cast<cc::PointerType>(buffer.getType()))
+    if (isa<cc::SpanLikeType>(ptrTy.getElementType()))
+      buffer = cc::LoadOp::create(builder, loc, buffer);
   bool result = true;
   auto *body = x->getBody();
   auto *loopVar = x->getLoopVariable();
@@ -336,6 +344,9 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *x) {
         if (fnTy.getNumResults() == 1 && fnTy.getResult(0) == i1Ty)
           result = cc::CastOp::create(builder, loc, i1Ty, result);
       }
+      // Refresh `resTy` after the load so the `SpanLikeType` dispatch below
+      // sees the loaded value's type, not the original pointer type.
+      resTy = result.getType();
     }
     if (auto vecTy = dyn_cast<cc::SpanLikeType>(resTy)) {
       // Returning vector data that was allocated on the stack is not valid.

--- a/cudaq/test/AST-Quake/measure_bell.cpp
+++ b/cudaq/test/AST-Quake/measure_bell.cpp
@@ -31,49 +31,56 @@ struct bell {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__bell(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_3:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_5:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_2]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK-SAME:      %[[ARG0:.*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : i32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i32
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[ARG0]], %[[ALLOCA_0]] : !cc.ptr<i32>
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[ALLOCA_2:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[CONSTANT_1]], %[[ALLOCA_2]] : !cc.ptr<i32>
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_6:.*]] = cc.alloca i32
-// CHECK:             cc.store %[[VAL_2]], %[[VAL_6]] : !cc.ptr<i32>
+// CHECK:             %[[ALLOCA_3:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[CONSTANT_1]], %[[ALLOCA_3]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// CHECK:               %[[VAL_8:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
-// CHECK:               %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:               cc.condition %[[VAL_9]]
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_3]] : !cc.ptr<i32>
+// CHECK:               %[[LOAD_1:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i32>
+// CHECK:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[LOAD_0]], %[[LOAD_1]] : i32
+// CHECK:               cc.condition %[[CMPI_0]]
 // CHECK:             } do {
-// CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
-// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_112]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
-// CHECK:               %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_35:.*]] = quake.discriminate %[[VAL_15]] : (!cc.measure_handle) -> i1
-// CHECK:               %[[VAL_16:.*]] = cc.alloca i1
-// CHECK:               cc.store %[[VAL_35]], %[[VAL_16]] : !cc.ptr<i1>
-// CHECK:               %[[VAL_17:.*]] = cc.load %[[VAL_16]] : !cc.ptr<i1>
-// CHECK:               %[[VAL_18:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_19:.*]] = cc.load %[[VAL_18]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_39:.*]] = quake.discriminate %[[VAL_19]] : (!cc.measure_handle) -> i1
-// CHECK:               %[[VAL_20:.*]] = arith.cmpi eq, %[[VAL_17]], %[[VAL_39]] : i1
-// CHECK:               cc.if(%[[VAL_20]]) {
-// CHECK:                 %[[VAL_21:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
-// CHECK:                 %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_1]] : i32
-// CHECK:                 cc.store %[[VAL_22]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:               cc.scope {
+// CHECK:                 %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_1]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:                 quake.h %[[EXTRACT_REF_0]] : (!quake.ref) -> ()
+// CHECK:                 %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_1]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:                 quake.x {{\[}}%[[EXTRACT_REF_0]]] %[[EXTRACT_REF_1]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:                 %[[MZ_0:.*]] = quake.mz %[[ALLOCA_1]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:                 %[[ALLOCA_4:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:                 cc.store %[[MZ_0]], %[[ALLOCA_4]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 %[[LOAD_2:.*]] = cc.load %[[ALLOCA_4]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[LOAD_2]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:                 %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[LOAD_3:.*]] = cc.load %[[CAST_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[LOAD_3]] : (!cc.measure_handle) -> i1
+// CHECK:                 %[[ALLOCA_5:.*]] = cc.alloca i1
+// CHECK:                 cc.store %[[DISCRIMINATE_0]], %[[ALLOCA_5]] : !cc.ptr<i1>
+// CHECK:                 %[[LOAD_4:.*]] = cc.load %[[ALLOCA_5]] : !cc.ptr<i1>
+// CHECK:                 %[[LOAD_5:.*]] = cc.load %[[ALLOCA_4]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 %[[STDVEC_DATA_1:.*]] = cc.stdvec_data %[[LOAD_5]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:                 %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[STDVEC_DATA_1]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[LOAD_6:.*]] = cc.load %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[LOAD_6]] : (!cc.measure_handle) -> i1
+// CHECK:                 %[[CMPI_1:.*]] = arith.cmpi eq, %[[LOAD_4]], %[[DISCRIMINATE_1]] : i1
+// CHECK:                 cc.if(%[[CMPI_1]]) {
+// CHECK:                   %[[LOAD_7:.*]] = cc.load %[[ALLOCA_2]] : !cc.ptr<i32>
+// CHECK:                   %[[ADDI_0:.*]] = arith.addi %[[LOAD_7]], %[[CONSTANT_0]] : i32
+// CHECK:                   cc.store %[[ADDI_0]], %[[ALLOCA_2]] : !cc.ptr<i32>
+// CHECK:                 }
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_23:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// CHECK:               %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_1]] : i32
-// CHECK:               cc.store %[[VAL_24]], %[[VAL_6]] : !cc.ptr<i32>
+// CHECK:               %[[LOAD_8:.*]] = cc.load %[[ALLOCA_3]] : !cc.ptr<i32>
+// CHECK:               %[[ADDI_1:.*]] = arith.addi %[[LOAD_8]], %[[CONSTANT_0]] : i32
+// CHECK:               cc.store %[[ADDI_1]], %[[ALLOCA_3]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return
@@ -97,46 +104,51 @@ struct libertybell {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__libertybell(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_3:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_5:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_2]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK-SAME:      %[[ARG0:.*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : i32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i32
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[ARG0]], %[[ALLOCA_0]] : !cc.ptr<i32>
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[ALLOCA_2:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[CONSTANT_1]], %[[ALLOCA_2]] : !cc.ptr<i32>
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_6:.*]] = cc.alloca i32
-// CHECK:             cc.store %[[VAL_2]], %[[VAL_6]] : !cc.ptr<i32>
+// CHECK:             %[[ALLOCA_3:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[CONSTANT_1]], %[[ALLOCA_3]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// CHECK:               %[[VAL_8:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
-// CHECK:               %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:               cc.condition %[[VAL_9]]
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_3]] : !cc.ptr<i32>
+// CHECK:               %[[LOAD_1:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i32>
+// CHECK:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[LOAD_0]], %[[LOAD_1]] : i32
+// CHECK:               cc.condition %[[CMPI_0]]
 // CHECK:             } do {
-// CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
-// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_112]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
-// CHECK:               %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_35:.*]] = quake.discriminate %[[VAL_15]] : (!cc.measure_handle) -> i1
-// CHECK:               %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_17:.*]] = cc.load %[[VAL_16]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_39:.*]] = quake.discriminate %[[VAL_17]] : (!cc.measure_handle) -> i1
-// CHECK:               %[[VAL_18:.*]] = arith.cmpi eq, %[[VAL_35]], %[[VAL_39]] : i1
-// CHECK:               cc.if(%[[VAL_18]]) {
-// CHECK:                 %[[VAL_19:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
-// CHECK:                 %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_1]] : i32
-// CHECK:                 cc.store %[[VAL_20]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:               cc.scope {
+// CHECK:                 %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_1]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:                 quake.h %[[EXTRACT_REF_0]] : (!quake.ref) -> ()
+// CHECK:                 %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_1]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:                 quake.x {{\[}}%[[EXTRACT_REF_0]]] %[[EXTRACT_REF_1]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:                 %[[MZ_0:.*]] = quake.mz %[[ALLOCA_1]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:                 %[[ALLOCA_4:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:                 cc.store %[[MZ_0]], %[[ALLOCA_4]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 %[[LOAD_2:.*]] = cc.load %[[ALLOCA_4]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[LOAD_2]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:                 %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[LOAD_3:.*]] = cc.load %[[CAST_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[LOAD_3]] : (!cc.measure_handle) -> i1
+// CHECK:                 %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[STDVEC_DATA_0]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[LOAD_4:.*]] = cc.load %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[LOAD_4]] : (!cc.measure_handle) -> i1
+// CHECK:                 %[[CMPI_1:.*]] = arith.cmpi eq, %[[DISCRIMINATE_0]], %[[DISCRIMINATE_1]] : i1
+// CHECK:                 cc.if(%[[CMPI_1]]) {
+// CHECK:                   %[[LOAD_5:.*]] = cc.load %[[ALLOCA_2]] : !cc.ptr<i32>
+// CHECK:                   %[[ADDI_0:.*]] = arith.addi %[[LOAD_5]], %[[CONSTANT_0]] : i32
+// CHECK:                   cc.store %[[ADDI_0]], %[[ALLOCA_2]] : !cc.ptr<i32>
+// CHECK:                 }
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_21:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// CHECK:               %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_1]] : i32
-// CHECK:               cc.store %[[VAL_22]], %[[VAL_6]] : !cc.ptr<i32>
+// CHECK:               %[[LOAD_6:.*]] = cc.load %[[ALLOCA_3]] : !cc.ptr<i32>
+// CHECK:               %[[ADDI_1:.*]] = arith.addi %[[LOAD_6]], %[[CONSTANT_0]] : i32
+// CHECK:               cc.store %[[ADDI_1]], %[[ALLOCA_3]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return
@@ -162,52 +174,59 @@ struct tinkerbell {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__tinkerbell(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
-// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_3:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_0]], %[[VAL_3]] : !cc.ptr<i32>
-// CHECK:           %[[VAL_4:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_5:.*]] = cc.alloca i32
-// CHECK:           cc.store %[[VAL_2]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK-SAME:      %[[ARG0:.*]]: i32) attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : i32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0 : i32
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[ARG0]], %[[ALLOCA_0]] : !cc.ptr<i32>
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[ALLOCA_2:.*]] = cc.alloca i32
+// CHECK:           cc.store %[[CONSTANT_1]], %[[ALLOCA_2]] : !cc.ptr<i32>
 // CHECK:           cc.scope {
-// CHECK:             %[[VAL_6:.*]] = cc.alloca i32
-// CHECK:             cc.store %[[VAL_2]], %[[VAL_6]] : !cc.ptr<i32>
+// CHECK:             %[[ALLOCA_3:.*]] = cc.alloca i32
+// CHECK:             cc.store %[[CONSTANT_1]], %[[ALLOCA_3]] : !cc.ptr<i32>
 // CHECK:             cc.loop while {
-// CHECK:               %[[VAL_7:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// CHECK:               %[[VAL_8:.*]] = cc.load %[[VAL_3]] : !cc.ptr<i32>
-// CHECK:               %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_7]], %[[VAL_8]] : i32
-// CHECK:               cc.condition %[[VAL_9]]
+// CHECK:               %[[LOAD_0:.*]] = cc.load %[[ALLOCA_3]] : !cc.ptr<i32>
+// CHECK:               %[[LOAD_1:.*]] = cc.load %[[ALLOCA_0]] : !cc.ptr<i32>
+// CHECK:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[LOAD_0]], %[[LOAD_1]] : i32
+// CHECK:               cc.condition %[[CMPI_0]]
 // CHECK:             } do {
-// CHECK:               %[[VAL_10:.*]] = quake.extract_ref %[[VAL_4]][0] : (!quake.veq<2>) -> !quake.ref
-// CHECK:               quake.h %[[VAL_10]] : (!quake.ref) -> ()
-// CHECK:               %[[VAL_11:.*]] = quake.extract_ref %[[VAL_4]][1] : (!quake.veq<2>) -> !quake.ref
-// CHECK:               quake.x {{\[}}%[[VAL_10]]] %[[VAL_11]] : (!quake.ref, !quake.ref) -> ()
-// CHECK:               %[[VAL_112:.*]] = quake.mz %[[VAL_4]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:               %[[VAL_13:.*]] = cc.stdvec_data %[[VAL_112]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
-// CHECK:               %[[VAL_14:.*]] = cc.cast %[[VAL_13]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_15:.*]] = cc.load %[[VAL_14]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[H0A:.*]] = cc.alloca !cc.measure_handle
-// CHECK:               cc.store %[[VAL_15]], %[[H0A]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_16:.*]] = cc.compute_ptr %[[VAL_13]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[VAL_17:.*]] = cc.load %[[VAL_16]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[H1A:.*]] = cc.alloca !cc.measure_handle
-// CHECK:               cc.store %[[VAL_17]], %[[H1A]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[H0L:.*]] = cc.load %[[H0A]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[H0D:.*]] = quake.discriminate %[[H0L]] : (!cc.measure_handle) -> i1
-// CHECK:               %[[H1L:.*]] = cc.load %[[H1A]] : !cc.ptr<!cc.measure_handle>
-// CHECK:               %[[H1D:.*]] = quake.discriminate %[[H1L]] : (!cc.measure_handle) -> i1
-// CHECK:               %[[VAL_18:.*]] = arith.cmpi eq, %[[H0D]], %[[H1D]] : i1
-// CHECK:               cc.if(%[[VAL_18]]) {
-// CHECK:                 %[[VAL_19:.*]] = cc.load %[[VAL_5]] : !cc.ptr<i32>
-// CHECK:                 %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_1]] : i32
-// CHECK:                 cc.store %[[VAL_20]], %[[VAL_5]] : !cc.ptr<i32>
+// CHECK:               cc.scope {
+// CHECK:                 %[[EXTRACT_REF_0:.*]] = quake.extract_ref %[[ALLOCA_1]][0] : (!quake.veq<2>) -> !quake.ref
+// CHECK:                 quake.h %[[EXTRACT_REF_0]] : (!quake.ref) -> ()
+// CHECK:                 %[[EXTRACT_REF_1:.*]] = quake.extract_ref %[[ALLOCA_1]][1] : (!quake.veq<2>) -> !quake.ref
+// CHECK:                 quake.x {{\[}}%[[EXTRACT_REF_0]]] %[[EXTRACT_REF_1]] : (!quake.ref, !quake.ref) -> ()
+// CHECK:                 %[[MZ_0:.*]] = quake.mz %[[ALLOCA_1]] name "results" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:                 %[[ALLOCA_4:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:                 cc.store %[[MZ_0]], %[[ALLOCA_4]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 %[[LOAD_2:.*]] = cc.load %[[ALLOCA_4]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[LOAD_2]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:                 %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[LOAD_3:.*]] = cc.load %[[CAST_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[ALLOCA_5:.*]] = cc.alloca !cc.measure_handle
+// CHECK:                 cc.store %[[LOAD_3]], %[[ALLOCA_5]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[LOAD_4:.*]] = cc.load %[[ALLOCA_4]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 %[[STDVEC_DATA_1:.*]] = cc.stdvec_data %[[LOAD_4]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:                 %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[STDVEC_DATA_1]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[LOAD_5:.*]] = cc.load %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[ALLOCA_6:.*]] = cc.alloca !cc.measure_handle
+// CHECK:                 cc.store %[[LOAD_5]], %[[ALLOCA_6]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[LOAD_6:.*]] = cc.load %[[ALLOCA_5]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[LOAD_6]] : (!cc.measure_handle) -> i1
+// CHECK:                 %[[LOAD_7:.*]] = cc.load %[[ALLOCA_6]] : !cc.ptr<!cc.measure_handle>
+// CHECK:                 %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[LOAD_7]] : (!cc.measure_handle) -> i1
+// CHECK:                 %[[CMPI_1:.*]] = arith.cmpi eq, %[[DISCRIMINATE_0]], %[[DISCRIMINATE_1]] : i1
+// CHECK:                 cc.if(%[[CMPI_1]]) {
+// CHECK:                   %[[LOAD_8:.*]] = cc.load %[[ALLOCA_2]] : !cc.ptr<i32>
+// CHECK:                   %[[ADDI_0:.*]] = arith.addi %[[LOAD_8]], %[[CONSTANT_0]] : i32
+// CHECK:                   cc.store %[[ADDI_0]], %[[ALLOCA_2]] : !cc.ptr<i32>
+// CHECK:                 }
 // CHECK:               }
 // CHECK:               cc.continue
 // CHECK:             } step {
-// CHECK:               %[[VAL_21:.*]] = cc.load %[[VAL_6]] : !cc.ptr<i32>
-// CHECK:               %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_1]] : i32
-// CHECK:               cc.store %[[VAL_22]], %[[VAL_6]] : !cc.ptr<i32>
+// CHECK:               %[[LOAD_9:.*]] = cc.load %[[ALLOCA_3]] : !cc.ptr<i32>
+// CHECK:               %[[ADDI_1:.*]] = arith.addi %[[LOAD_9]], %[[CONSTANT_0]] : i32
+// CHECK:               cc.store %[[ADDI_1]], %[[ALLOCA_3]] : !cc.ptr<i32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return

--- a/cudaq/test/AST-Quake/std_vector_assignment.cpp
+++ b/cudaq/test/AST-Quake/std_vector_assignment.cpp
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// RUN: cudaq-quake %s | FileCheck %s
+
+#include <cudaq.h>
+#include <vector>
+
+struct VectorHandleAssign {
+  void operator()() __qpu__ {
+    cudaq::qvector qv(2);
+    auto m = mz(qv);
+    auto m_new = mz(qv);
+    m = m_new;
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__VectorHandleAssign() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[QV:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[M:.*]] = quake.mz %[[QV]] name "m" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[M_ADDR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %[[M]], %[[M_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[M_NEW:.*]] = quake.mz %[[QV]] name "m_new" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[M_NEW_ADDR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %[[M_NEW]], %[[M_NEW_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[M_NEW_VAL:.*]] = cc.load %[[M_NEW_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           cc.store %[[M_NEW_VAL]], %[[M_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           return
+// CHECK:         }
+
+
+struct LoopCarriedReassign {
+  void operator()(int nRounds) __qpu__ {
+    cudaq::qvector qvec(3);
+    auto m = mz(qvec);
+    for (int round = 0; round < nRounds; round++) {
+      auto m_new = mz(qvec);
+      m = m_new;
+    }
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__LoopCarriedReassign(
+// CHECK:           %[[QVEC:.*]] = quake.alloca !quake.veq<3>
+// CHECK:           %[[M_OUTER:.*]] = quake.mz %[[QVEC]] name "m" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[M_ADDR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %[[M_OUTER]], %[[M_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           cc.scope {
+// CHECK:             cc.loop while {
+// CHECK:               cc.condition
+// CHECK:             } do {
+// CHECK:               cc.scope {
+// CHECK:                 %[[M_NEW:.*]] = quake.mz %[[QVEC]] name "m_new" : (!quake.veq<3>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:                 %[[M_NEW_ADDR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:                 cc.store %[[M_NEW]], %[[M_NEW_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 %[[M_NEW_VAL:.*]] = cc.load %[[M_NEW_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:                 cc.store %[[M_NEW_VAL]], %[[M_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:               }
+
+
+struct ConditionalReassign {
+  bool operator()(bool cond) __qpu__ {
+    cudaq::qvector qv(2);
+    auto m = mz(qv);
+    if (cond) {
+      cudaq::qvector qv2(2);
+      auto m_new = mz(qv2);
+      m = m_new;
+    }
+    return m[0];
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ConditionalReassign(
+// CHECK:           %[[QV:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[M:.*]] = quake.mz %[[QV]] name "m" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[M_ADDR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %[[M]], %[[M_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           cc.if(%{{.*}}) {
+// CHECK:             %[[QV2:.*]] = quake.alloca !quake.veq<2>
+// CHECK:             %[[M_NEW:.*]] = quake.mz %[[QV2]] name "m_new" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:             %[[M_NEW_ADDR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:             cc.store %[[M_NEW]], %[[M_NEW_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:             %[[M_NEW_VAL:.*]] = cc.load %[[M_NEW_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:             cc.store %[[M_NEW_VAL]], %[[M_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           }
+// CHECK:           %[[POST:.*]] = cc.load %[[M_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %{{.*}} = cc.stdvec_data %[[POST]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:           return %{{.*}} : i1
+
+
+struct ChainedAssign {
+  void operator()() __qpu__ {
+    cudaq::qvector qv(2);
+    auto a = mz(qv);
+    auto b = mz(qv);
+    auto c = mz(qv);
+    a = b = c;
+  }
+};
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__ChainedAssign() attributes {"cudaq-entrypoint", "cudaq-kernel"} {
+// CHECK:           %[[A:.*]] = quake.mz %{{.*}} name "a" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[A_ADDR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %[[A]], %[[A_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[B:.*]] = quake.mz %{{.*}} name "b" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[B_ADDR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %[[B]], %[[B_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[C:.*]] = quake.mz %{{.*}} name "c" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[C_ADDR:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %[[C]], %[[C_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[C_VAL:.*]] = cc.load %[[C_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           cc.store %[[C_VAL]], %[[B_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[B_VAL:.*]] = cc.load %[[B_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           cc.store %[[B_VAL]], %[[A_ADDR]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           return

--- a/cudaq/test/AST-Quake/vector_bool.cpp
+++ b/cudaq/test/AST-Quake/vector_bool.cpp
@@ -22,14 +22,17 @@ struct t1 {
 
 // clang-format off
 // CHECK-LABEL:   func.func @__nvqpp__mlirgen__t1(
-// CHECK-SAME:        %[[VAL_0:.*]]: !cc.stdvec<f64>{{.*}}) -> i1 attributes
-// CHECK:           %[[VAL_1:.*]] = quake.alloca !quake.veq<2>
-// CHECK:           %[[VAL_12:.*]] = quake.mz %[[VAL_1]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
-// CHECK:           %[[VAL_3:.*]] = cc.stdvec_data %[[VAL_12]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
-// CHECK:           %[[VAL_4:.*]] = cc.cast %[[VAL_3]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
-// CHECK:           %[[VAL_5:.*]] = cc.load %[[VAL_4]] : !cc.ptr<!cc.measure_handle>
-// CHECK:           %[[VAL_6:.*]] = quake.discriminate %[[VAL_5]] : (!cc.measure_handle) -> i1
-// CHECK:           return %[[VAL_6]] : i1
+// CHECK-SAME:      %[[ARG0:.*]]: !cc.stdvec<f64>{{.*}}) -> i1 attributes
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<2>
+// CHECK:           %[[MZ_0:.*]] = quake.mz %[[ALLOCA_0]] name "vec" : (!quake.veq<2>) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[ALLOCA_1:.*]] = cc.alloca !cc.stdvec<!cc.measure_handle>
+// CHECK:           cc.store %[[MZ_0]], %[[ALLOCA_1]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[LOAD_0:.*]] = cc.load %[[ALLOCA_1]] : !cc.ptr<!cc.stdvec<!cc.measure_handle>>
+// CHECK:           %[[STDVEC_DATA_0:.*]] = cc.stdvec_data %[[LOAD_0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[STDVEC_DATA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[LOAD_1:.*]] = cc.load %[[CAST_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[LOAD_1]] : (!cc.measure_handle) -> i1
+// CHECK:           return %[[DISCRIMINATE_0]] : i1
 // CHECK:         }
 // CHECK-NOT:     func.func private @_ZNKSt14_Bit_referencecvbEv() -> i1
 // clang-format on

--- a/cudaq/test/AST-error/vector.cpp
+++ b/cudaq/test/AST-error/vector.cpp
@@ -22,6 +22,8 @@ struct VectorVectorReturner {
       for (std::size_t j = 0, M = v.size(); j < M; ++j)
         r[j] = v[j];
     }
+    // expected-error@+2 {{unhandled vector element type is not yet supported}}
+    // expected-error@+1 {{statement not supported in qpu kernel}}
     return result;
   }
 };


### PR DESCRIPTION
Unblocks the QEC cross-round detector pattern `(auto m = mz(qv); for (...) { auto m_new = mz(qv); ...; m = m_new; })` by enabling `std::vector<measure_handle>::operator=` in `__qpu__` kernels. Handle-vector locals now get stack storage when they're declared, and assignment lowers to `cc.store` through the LHS address. Mirrors the scalar `measure_handle` precedent; non-handle stdvec types stay on the legacy SSA-binding path.