### PR TITLE
[opt] Fix #4527: vector `quake.discriminate` is not `Pure`

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/Quake/QuakeOps.td
@@ -1176,7 +1176,9 @@ def MzOp : Measurement<"mz"> {
   let extraClassDeclaration = OpBaseDeclaration;
 }
 
-def quake_DiscriminateOp : QuakeOp<"discriminate", [Pure]> {
+def quake_DiscriminateOp : QuakeOp<"discriminate",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     DeclareOpInterfaceMethods<ConditionallySpeculatable>]> {
   let summary = "Converts a measurement to a classical integral value.";
   let description = [{
     Quake's measurement operators return a value of type `!quake.measure` or,
@@ -1187,8 +1189,17 @@ def quake_DiscriminateOp : QuakeOp<"discriminate", [Pure]> {
 
     While a measurement of a wire changes/corrupts the state of the wire, the
     model maintains that the classical measurement value is non-volatile.
-    Multiple applications of discriminate on the same value will yield the
-    same result for a given result type.
+    Multiple applications of discriminate on the same scalar measurement
+    handle yield the same result, so the scalar form is treated as pure.
+
+    The vector form (`!cc.stdvec<!cc.measure_handle>` or
+    `!cc.stdvec<!quake.measure>`) operates on a `(data_ptr, size)`
+    descriptor that aliases mutable backing storage; storing a new handle
+    into a slot through that storage changes the result of a subsequent
+    discriminate of the same descriptor. The vector form therefore
+    declares a `MemoryEffects::Read` effect and is not speculatable, so
+    CSE/LICM cannot fold or hoist it across writes to the backing
+    storage.
   }];
 
   let arguments = (ins

--- a/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/Quake/QuakeOps.cpp
@@ -901,6 +901,21 @@ LogicalResult cudaq::quake::DiscriminateOp::verify() {
   return success();
 }
 
+void cudaq::quake::DiscriminateOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  if (isa<cudaq::cc::StdvecType>(getMeasurement().getType()))
+    effects.emplace_back(MemoryEffects::Read::get(),
+                         SideEffects::DefaultResource::get());
+}
+
+mlir::Speculation::Speculatability
+cudaq::quake::DiscriminateOp::getSpeculatability() {
+  return isa<cudaq::cc::StdvecType>(getMeasurement().getType())
+             ? Speculation::NotSpeculatable
+             : Speculation::Speculatable;
+}
+
 LogicalResult cudaq::quake::BundleCableOp::verify() {
   auto ty = cast<cudaq::quake::CableType>(getResult().getType());
   if (getWires().size() != ty.getSize())

--- a/cudaq/test/Transforms/discriminate_issue_4527.qke
+++ b/cudaq/test/Transforms/discriminate_issue_4527.qke
@@ -1,0 +1,83 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --cse %s | FileCheck %s
+
+func.func @vector_handle_discriminate_with_store(%h0: !cc.measure_handle, %h1: !cc.measure_handle) -> (!cc.stdvec<i1>, !cc.stdvec<i1>) {
+  %c2 = arith.constant 2 : i64
+  %data = cc.alloca !cc.array<!cc.measure_handle x 2>
+  %slot0 = cc.cast %data : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+  %slot1 = cc.compute_ptr %data[1] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+  cc.store %h0, %slot0 : !cc.ptr<!cc.measure_handle>
+  cc.store %h0, %slot1 : !cc.ptr<!cc.measure_handle>
+  %dataPtr = cc.cast %data : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+  %vec = cc.stdvec_init %dataPtr, %c2 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+  %bits0 = quake.discriminate %vec : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+  cc.store %h1, %slot1 : !cc.ptr<!cc.measure_handle>
+  %bits1 = quake.discriminate %vec : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+  return %bits0, %bits1 : !cc.stdvec<i1>, !cc.stdvec<i1>
+}
+
+// CHECK-LABEL:   func.func @vector_handle_discriminate_with_store(
+// CHECK-SAME:      %[[ARG0:.*]]: !cc.measure_handle,
+// CHECK-SAME:      %[[ARG1:.*]]: !cc.measure_handle) -> (!cc.stdvec<i1>, !cc.stdvec<i1>) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 2 : i64
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.array<!cc.measure_handle x 2>
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[ALLOCA_0]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:           cc.store %[[ARG0]], %[[CAST_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           cc.store %[[ARG0]], %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:           %[[STDVEC_INIT_0:.*]] = cc.stdvec_init %[[CAST_1]], %[[CONSTANT_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[STDVEC_INIT_0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+// CHECK:           cc.store %[[ARG1]], %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[DISCRIMINATE_1:.*]] = quake.discriminate %[[STDVEC_INIT_0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+// CHECK:           return %[[DISCRIMINATE_0]], %[[DISCRIMINATE_1]] : !cc.stdvec<i1>, !cc.stdvec<i1>
+// CHECK:         }
+
+
+func.func @scalar_handle_discriminate_folds(%h: !cc.measure_handle)-> (i1, i1) {
+  %a = quake.discriminate %h : (!cc.measure_handle) -> i1
+  %b = quake.discriminate %h : (!cc.measure_handle) -> i1
+  return %a, %b : i1, i1
+}
+
+// CHECK-LABEL:   func.func @scalar_handle_discriminate_folds(
+// CHECK-SAME:      %[[ARG0:.*]]: !cc.measure_handle) -> (i1, i1) {
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[ARG0]] : (!cc.measure_handle) -> i1
+// CHECK:           return %[[DISCRIMINATE_0]], %[[DISCRIMINATE_0]] : i1, i1
+// CHECK:         }
+
+
+func.func @vector_handle_discriminate_no_store_folds(%h: !cc.measure_handle) -> (!cc.stdvec<i1>, !cc.stdvec<i1>) {
+  %c2 = arith.constant 2 : i64
+  %data = cc.alloca !cc.array<!cc.measure_handle x 2>
+  %slot0 = cc.cast %data : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+  %slot1 = cc.compute_ptr %data[1] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+  cc.store %h, %slot0 : !cc.ptr<!cc.measure_handle>
+  cc.store %h, %slot1 : !cc.ptr<!cc.measure_handle>
+  %dataPtr = cc.cast %data : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+  %vec = cc.stdvec_init %dataPtr, %c2 : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+  %bits0 = quake.discriminate %vec : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+  %bits1 = quake.discriminate %vec : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+  return %bits0, %bits1 : !cc.stdvec<i1>, !cc.stdvec<i1>
+}
+
+// CHECK-LABEL:   func.func @vector_handle_discriminate_no_store_folds(
+// CHECK-SAME:      %[[ARG0:.*]]: !cc.measure_handle) -> (!cc.stdvec<i1>, !cc.stdvec<i1>) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 2 : i64
+// CHECK:           %[[ALLOCA_0:.*]] = cc.alloca !cc.array<!cc.measure_handle x 2>
+// CHECK:           %[[CAST_0:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[COMPUTE_PTR_0:.*]] = cc.compute_ptr %[[ALLOCA_0]][1] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.measure_handle>
+// CHECK:           cc.store %[[ARG0]], %[[CAST_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           cc.store %[[ARG0]], %[[COMPUTE_PTR_0]] : !cc.ptr<!cc.measure_handle>
+// CHECK:           %[[CAST_1:.*]] = cc.cast %[[ALLOCA_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x 2>>) -> !cc.ptr<!cc.array<!cc.measure_handle x ?>>
+// CHECK:           %[[STDVEC_INIT_0:.*]] = cc.stdvec_init %[[CAST_1]], %[[CONSTANT_0]] : (!cc.ptr<!cc.array<!cc.measure_handle x ?>>, i64) -> !cc.stdvec<!cc.measure_handle>
+// CHECK:           %[[DISCRIMINATE_0:.*]] = quake.discriminate %[[STDVEC_INIT_0]] : (!cc.stdvec<!cc.measure_handle>) -> !cc.stdvec<i1>
+// CHECK:           return %[[DISCRIMINATE_0]], %[[DISCRIMINATE_0]] : !cc.stdvec<i1>, !cc.stdvec<i1>
+// CHECK:         }

--- a/python/tests/kernel/test_measure_handle.py
+++ b/python/tests/kernel/test_measure_handle.py
@@ -341,6 +341,31 @@ def test_int_handle_in_arithmetic_promotes_through_bool():
     assert results[0] == 2
 
 
+def test_handle_vector_issue_4527():
+
+    @cudaq.kernel
+    def k() -> int:
+        qv = cudaq.qvector(2)
+        combined = [cudaq.measure_handle() for _ in range(2)]
+        x(qv[0])
+        h0 = mz(qv[0])
+        h1 = mz(qv[1])
+        combined[0] = h0
+        combined[1] = h1
+        first = cudaq.to_integer(cudaq.to_bools(combined))
+        x(qv[0])
+        h2 = mz(qv[0])
+        h3 = mz(qv[1])
+        combined[0] = h2
+        combined[1] = h3
+        second = cudaq.to_integer(cudaq.to_bools(combined))
+        return first * 16 + second
+
+    results = cudaq.run(k, shots_count=1)
+    assert len(results) == 1
+    assert results[0] == 16
+
+
 # leave for gdb debugging
 if __name__ == "__main__":
     import os


### PR DESCRIPTION
### Summary

- Fixes https://github.com/NVIDIA/cuda-quantum/issues/4527
-  `quake.discriminate` over `!cc.stdvec<!cc.measure_handle>` was marked `[Pure]`, but the operand is a `stdvec` descriptor over mutable backing storage. MLIR's CSE folded two such ops with the same SSA descriptor across an intervening `cc.store` to the buffer, silently mis-compiling kernels that pre-allocate a `measure_handle` slot buffer and rebuild it per round.

### Affects both Python and C++

The asymmetry between Python and C++ in the issue title is a pipeline-ordering accident, not an IR-shape difference:
- `nvq++` AOT is saved by `cudaq-opt` running `expand-measurements` before `cse`.
- `cudaq.translate(..., format="qir")` and any direct `cudaq-translate --convert-to=qir` invocation hit the bug because they run `createTargetFinalizePipeline` (canonicalize, cse, symbol-dce) before `addAOTPipelineConvertToQIR`.
- The runtime JIT path for hardware and emulator targets (e.g. Quantinuum) runs CSE inside `emul-jit-prep-pipeline`'s `createClassicalOptimizationPipeline` before the backend's `JITHighLevelPipeline = "expand-measurements"`.

### Alternatives Considered

- Factor `ExpandStdvecHandleDiscriminate` into a narrow early pass scheduled before every CSE entry point (in `createTargetPrepPipeline`, `createTargetFinalizePipeline`, and the top of `addAOTPipelineConvertToQIR`). Rejected: soundness depends on pipeline-scheduling discipline. Every future target / tool / lit-test invocation that runs CSE on bridge IR would have to remember the ordering. 
- Remove `[Pure]` entirely. Rejected: pessimizes scalar discriminate, regresses.
- Split into `quake.discriminate_scalar` and `quake.discriminate_vector`. Rejected: doubles the maintenance surface — every consumer dispatching on op type, two verifiers, two lowering paths.