### PR TITLE
Remove redundant cudaDeviceSynchronize after H2D param copy

### DIFF
--- a/runtime/nvqir/cudensitymat/CuDensityMatTimeStepper.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatTimeStepper.cpp
@@ -85,7 +85,6 @@ void CuDensityMatTimeStepper::computeImpl(
   }
   double *param_d =
       static_cast<double *>(cudaq::dynamics::createArrayGpu(paramValues));
-  HANDLE_CUDA_ERROR(cudaDeviceSynchronize());
   {
     cudaq::dynamics::PerfMetricScopeTimer metricTimer(
         "cudensitymatOperatorComputeAction");


### PR DESCRIPTION
## Summary
Removes a redundant `cudaDeviceSynchronize()` in `CuDensityMatTimeStepper::computeImpl` between the host→device copy of  operator parameters and `cudensitymatOperatorComputeAction`.

The sync is functionally unnecessary, inconsistent with the rest of the cudensitymat module, and a measurable hot-path overhead in long time-evolution schedules.

**Why**
createArrayGpu uses synchronous cudaMemcpy(HostToDevice), so the following cudaDeviceSynchronize() is unnecessary. The subsequent cudensitymatOperatorComputeAction runs on the default stream and is naturally ordered after the copy.

**Perf**
Removing this sync saves ~10–15 µs on A100, A `computeImpl` hot-path microbench (dim=4, 10000 iters) shows 7% on A100. for E2E, shows 2%~3% on A100.

