### PR TITLE
Updated QASM gate support for benchmarking

### DIFF
--- a/python/cudaq/contrib/qiskit_convert.py
+++ b/python/cudaq/contrib/qiskit_convert.py
@@ -15,9 +15,16 @@ Note:
     This module requires ``qiskit`` to be installed.
 """
 
+from dataclasses import dataclass
+
 import numpy as np
 
 from ..kernel.kernel_builder import make_kernel
+
+_CUSTOM_DEFINITION_EXPANSION_LIMIT = 10
+_CONTROL_FLOW_OPERATION_NAMES = {
+    "if_else", "for_loop", "while_loop", "switch_case"
+}
 
 
 def _try_import_qiskit():
@@ -32,9 +39,342 @@ def _try_import_qiskit():
     try:
         from qiskit import QuantumCircuit
     except ImportError as e:
-        raise ImportError("This feature requires Qiskit. "
-                          "Install it with: `pip install qiskit`") from e
+        raise ImportError(
+            "This feature requires Qiskit. Install it with: `pip install qiskit`"
+        ) from e
     return QuantumCircuit
+
+
+def _operation_name(operation):
+    return operation.name.lower()
+
+
+def _is_control_flow_operation(op_name):
+    return op_name in _CONTROL_FLOW_OPERATION_NAMES
+
+
+def _is_standard_gate(operation):
+    return getattr(operation, "_standard_gate", None) is not None
+
+
+def _is_qiskit_standard_operation(operation):
+    if _is_standard_gate(operation):
+        return True
+    base_class = getattr(operation, "base_class", operation.__class__)
+    module = getattr(base_class, "__module__", "")
+    return module.startswith("qiskit.circuit.library.standard_gates")
+
+
+def _has_quantum_circuit_definition(operation):
+    definition = getattr(operation, "definition", None)
+    return definition is not None and hasattr(definition, "data")
+
+
+@dataclass(frozen=True)
+class _GateSpec:
+    num_qubits: int | None
+    num_clbits: int
+    num_params: int
+    emitter: object
+    min_qubits: int | None = None
+
+
+def _unsupported_gate_error(op_name):
+    return ValueError(f"Gate '{op_name}' is not supported. "
+                      f"Cannot convert Qiskit circuit to CUDA-Q kernel.")
+
+
+def _invalid_gate_error(op_name, reason):
+    return ValueError(f"Gate '{op_name}' has invalid shape: {reason}. "
+                      f"Cannot convert Qiskit circuit to CUDA-Q kernel.")
+
+
+def _params(operation, op_name):
+    try:
+        return [float(p) for p in operation.params]
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            f"Gate '{op_name}' has unsupported non-numeric parameters. "
+            f"Cannot convert Qiskit circuit to CUDA-Q kernel.") from e
+
+
+def _single_qubit(method_name):
+
+    def emit(kernel, qubits, q_indices, params):
+        getattr(kernel, method_name)(qubits[q_indices[0]])
+
+    return emit
+
+
+def _two_qubit(method_name):
+
+    def emit(kernel, qubits, q_indices, params):
+        getattr(kernel, method_name)(qubits[q_indices[0]], qubits[q_indices[1]])
+
+    return emit
+
+
+def _no_op(kernel, qubits, q_indices, params):
+    pass
+
+
+def _emit_cs_adj(kernel, qubits, q_indices, params):
+    kernel.cs(qubits[q_indices[0]], qubits[q_indices[1]], isAdj=True)
+
+
+def _emit_ct_adj(kernel, qubits, q_indices, params):
+    kernel.ct(qubits[q_indices[0]], qubits[q_indices[1]], isAdj=True)
+
+
+def _emit_rxx(kernel, qubits, q_indices, params):
+    kernel.cx(qubits[q_indices[0]], qubits[q_indices[1]])
+    kernel.rx(params[0], qubits[q_indices[0]])
+    kernel.cx(qubits[q_indices[0]], qubits[q_indices[1]])
+
+
+def _emit_rzz(kernel, qubits, q_indices, params):
+    kernel.cx(qubits[q_indices[0]], qubits[q_indices[1]])
+    kernel.rz(params[0], qubits[q_indices[1]])
+    kernel.cx(qubits[q_indices[0]], qubits[q_indices[1]])
+
+
+def _emit_ccx(kernel, qubits, q_indices, params):
+    kernel.cx([qubits[q_indices[0]], qubits[q_indices[1]]],
+              qubits[q_indices[2]])
+
+
+def _emit_mcx(kernel, qubits, q_indices, params):
+    controls = [qubits[index] for index in q_indices[:-1]]
+    kernel.cx(controls, qubits[q_indices[-1]])
+
+
+def _emit_rx(kernel, qubits, q_indices, params):
+    kernel.rx(params[0], qubits[q_indices[0]])
+
+
+def _emit_ry(kernel, qubits, q_indices, params):
+    kernel.ry(params[0], qubits[q_indices[0]])
+
+
+def _emit_rz(kernel, qubits, q_indices, params):
+    kernel.rz(params[0], qubits[q_indices[0]])
+
+
+def _emit_r1(kernel, qubits, q_indices, params):
+    kernel.r1(params[0], qubits[q_indices[0]])
+
+
+def _emit_crx(kernel, qubits, q_indices, params):
+    kernel.crx(params[0], qubits[q_indices[0]], qubits[q_indices[1]])
+
+
+def _emit_cry(kernel, qubits, q_indices, params):
+    kernel.cry(params[0], qubits[q_indices[0]], qubits[q_indices[1]])
+
+
+def _emit_crz(kernel, qubits, q_indices, params):
+    kernel.crz(params[0], qubits[q_indices[0]], qubits[q_indices[1]])
+
+
+def _emit_cr1(kernel, qubits, q_indices, params):
+    kernel.cr1(params[0], qubits[q_indices[0]], qubits[q_indices[1]])
+
+
+def _emit_cu3(kernel, qubits, q_indices, params):
+    kernel.cu3(params[0], params[1], params[2], qubits[q_indices[0]],
+               qubits[q_indices[1]])
+
+
+def _emit_u3(kernel, qubits, q_indices, params):
+    kernel.u3(params[0], params[1], params[2], qubits[q_indices[0]])
+
+
+def _emit_u2(kernel, qubits, q_indices, params):
+    kernel.u3(np.pi / 2, params[0], params[1], qubits[q_indices[0]])
+
+
+def _emit_sx(kernel, qubits, q_indices, params):
+    kernel.r1(np.pi / 4, qubits[q_indices[0]])
+    kernel.x(qubits[q_indices[0]])
+    kernel.r1(np.pi / 4, qubits[q_indices[0]])
+    kernel.x(qubits[q_indices[0]])
+    kernel.rx(np.pi / 2, qubits[q_indices[0]])
+
+
+def _emit_sxdg(kernel, qubits, q_indices, params):
+    kernel.r1(-np.pi / 4, qubits[q_indices[0]])
+    kernel.x(qubits[q_indices[0]])
+    kernel.r1(-np.pi / 4, qubits[q_indices[0]])
+    kernel.x(qubits[q_indices[0]])
+    kernel.rx(-np.pi / 2, qubits[q_indices[0]])
+
+
+DIRECT_OPERATION_SPECS = {
+    "h":
+        _GateSpec(1, 0, 0, _single_qubit("h")),
+    "x":
+        _GateSpec(1, 0, 0, _single_qubit("x")),
+    "y":
+        _GateSpec(1, 0, 0, _single_qubit("y")),
+    "z":
+        _GateSpec(1, 0, 0, _single_qubit("z")),
+    "s":
+        _GateSpec(1, 0, 0, _single_qubit("s")),
+    "t":
+        _GateSpec(1, 0, 0, _single_qubit("t")),
+    "sdg":
+        _GateSpec(1, 0, 0, _single_qubit("sdg")),
+    "tdg":
+        _GateSpec(1, 0, 0, _single_qubit("tdg")),
+    "id":
+        _GateSpec(1, 0, 0, _no_op),
+    "cx":
+        _GateSpec(2, 0, 0, _two_qubit("cx")),
+    "cy":
+        _GateSpec(2, 0, 0, _two_qubit("cy")),
+    "cz":
+        _GateSpec(2, 0, 0, _two_qubit("cz")),
+    "ch":
+        _GateSpec(2, 0, 0, _two_qubit("ch")),
+    "swap":
+        _GateSpec(2, 0, 0, _two_qubit("swap")),
+    "cswap":
+        _GateSpec(3, 0, 0,
+                  lambda k, q, i, p: k.cswap(q[i[0]], q[i[1]], q[i[2]])),
+    "cs":
+        _GateSpec(2, 0, 0, _two_qubit("cs")),
+    "ct":
+        _GateSpec(2, 0, 0, _two_qubit("ct")),
+    "csdg":
+        _GateSpec(2, 0, 0, _emit_cs_adj),
+    "ctdg":
+        _GateSpec(2, 0, 0, _emit_ct_adj),
+    "rxx":
+        _GateSpec(2, 0, 1, _emit_rxx),
+    "rzz":
+        _GateSpec(2, 0, 1, _emit_rzz),
+    "ccx":
+        _GateSpec(3, 0, 0, _emit_ccx),
+    "mcx":
+        _GateSpec(None, 0, 0, _emit_mcx, min_qubits=2),
+    "rx":
+        _GateSpec(1, 0, 1, _emit_rx),
+    "ry":
+        _GateSpec(1, 0, 1, _emit_ry),
+    "rz":
+        _GateSpec(1, 0, 1, _emit_rz),
+    "r1":
+        _GateSpec(1, 0, 1, _emit_r1),
+    "p":
+        _GateSpec(1, 0, 1, _emit_r1),
+    "phase":
+        _GateSpec(1, 0, 1, _emit_r1),
+    "u1":
+        _GateSpec(1, 0, 1, _emit_r1),
+    "crx":
+        _GateSpec(2, 0, 1, _emit_crx),
+    "cry":
+        _GateSpec(2, 0, 1, _emit_cry),
+    "crz":
+        _GateSpec(2, 0, 1, _emit_crz),
+    "cp":
+        _GateSpec(2, 0, 1, _emit_cr1),
+    "cu1":
+        _GateSpec(2, 0, 1, _emit_cr1),
+    "cphase":
+        _GateSpec(2, 0, 1, _emit_cr1),
+    "cu3":
+        _GateSpec(2, 0, 3, _emit_cu3),
+    "u3":
+        _GateSpec(1, 0, 3, _emit_u3),
+    "u":
+        _GateSpec(1, 0, 3, _emit_u3),
+    "u2":
+        _GateSpec(1, 0, 2, _emit_u2),
+    "sx":
+        _GateSpec(1, 0, 0, _emit_sx),
+    "sxdg":
+        _GateSpec(1, 0, 0, _emit_sxdg),
+    "barrier":
+        _GateSpec(None, 0, 0, _no_op, min_qubits=0),
+    "measure":
+        _GateSpec(1, 1, 0, lambda k, q, i, p: k.mz(q[i[0]])),
+    "reset":
+        _GateSpec(1, 0, 0, _single_qubit("reset")),
+}
+
+
+def _validate_direct_operation(operation, op_name, q_indices, c_indices, spec):
+    if spec.num_qubits is not None and len(q_indices) != spec.num_qubits:
+        raise _invalid_gate_error(
+            op_name, f"expected {spec.num_qubits} qubits, got {len(q_indices)}")
+    if spec.min_qubits is not None and len(q_indices) < spec.min_qubits:
+        raise _invalid_gate_error(
+            op_name,
+            f"expected at least {spec.min_qubits} qubits, got {len(q_indices)}")
+    if len(c_indices) != spec.num_clbits:
+        raise _invalid_gate_error(
+            op_name,
+            f"expected {spec.num_clbits} classical bits, got {len(c_indices)}")
+    if len(operation.params) != spec.num_params:
+        raise _invalid_gate_error(
+            op_name,
+            f"expected {spec.num_params} parameters, got {len(operation.params)}",
+        )
+
+
+def _emit_instruction(kernel, qubits, instruction, circuit, q_mapping, depth):
+    if depth > _CUSTOM_DEFINITION_EXPANSION_LIMIT:
+        raise ValueError("Could not expand custom gate definitions within "
+                         f"{_CUSTOM_DEFINITION_EXPANSION_LIMIT} iterations.")
+
+    operation = instruction.operation
+    op_name = _operation_name(operation)
+    q_indices = [circuit.find_bit(q).index for q in instruction.qubits]
+    c_indices = [circuit.find_bit(c).index for c in instruction.clbits]
+    if q_mapping is not None:
+        q_indices = [q_mapping[index] for index in q_indices]
+
+    if _is_control_flow_operation(op_name):
+        raise ValueError("cudaq.contrib.from_qiskit() does not support "
+                         "classical control flow in Qiskit/OpenQASM inputs.")
+
+    if op_name == "u0":
+        raise ValueError("Gate 'u0' is not supported. Cannot convert Qiskit "
+                         "circuit to CUDA-Q kernel.")
+
+    if not _is_qiskit_standard_operation(
+            operation) and _has_quantum_circuit_definition(operation):
+        definition = operation.definition
+        for nested_instruction in definition.data:
+            _emit_instruction(kernel, qubits, nested_instruction, definition,
+                              q_indices, depth + 1)
+        return
+
+    if _emit_direct_operation(kernel, qubits, operation, op_name, q_indices,
+                              c_indices):
+        return
+
+    if _is_qiskit_standard_operation(
+            operation) or not _has_quantum_circuit_definition(operation):
+        raise _unsupported_gate_error(op_name)
+
+    definition = operation.definition
+    for nested_instruction in definition.data:
+        _emit_instruction(kernel, qubits, nested_instruction, definition,
+                          q_indices, depth + 1)
+
+
+def _emit_direct_operation(kernel, qubits, operation, op_name, q_indices,
+                           c_indices):
+    spec = DIRECT_OPERATION_SPECS.get(op_name)
+    if spec is None:
+        return False
+
+    _validate_direct_operation(operation, op_name, q_indices, c_indices, spec)
+    params = _params(operation, op_name)
+    spec.emitter(kernel, qubits, q_indices, params)
+    return True
 
 
 def from_qasm(qasm_file):
@@ -84,11 +424,14 @@ def from_qiskit(qiskit_circuit):
 
     Supported gates:
         - Single qubit: `h`, `x`, `y`, `z`, `s`, `t`, `sdg`, `tdg`, `id` (identity)
-        - Two qubit: `cx`, `cy`, `cz`, `ch`, `swap`, `rxx`, `rzz`
-        - Three qubit: `ccx` (Toffoli)
-        - Parametric: `rx`, `ry`, `rz`, `r1`, `u3`, `u`, `p` (phase)
-        - Controlled parametric: `crx`, `cry`, `crz`
-        - Special: `sx`, `sxdg`, barrier, measure
+        - Two qubit: `cx`, `cy`, `cz`, `ch`, `swap`, `cs`, `ct`, `csdg`,
+          `ctdg`, `rxx`, `rzz`
+        - Multi qubit: `ccx` (Toffoli), `cswap`, `mcx`
+        - Parametric: `rx`, `ry`, `rz`, `r1`, `u1`, `u2`, `u3`, `u`,
+          `p` (phase), `phase`
+        - Controlled parametric: `crx`, `cry`, `crz`, `cp`, `cu1`,
+          `cphase`, `cu3`
+        - Special: `sx`, `sxdg`, barrier, measure, reset
     """
     # Ensure Qiskit is available (validates input type indirectly)
     _try_import_qiskit()
@@ -98,104 +441,6 @@ def from_qiskit(qiskit_circuit):
     qubits = kernel.qalloc(num_qubits)
 
     for instruction in qiskit_circuit.data:
-        op_name = instruction.operation.name
-        params = [float(p) for p in instruction.operation.params]
-        q_indices = [
-            qiskit_circuit.find_bit(q).index for q in instruction.qubits
-        ]
-
-        # Single qubit gates
-        if op_name == 'h':
-            kernel.h(qubits[q_indices[0]])
-        elif op_name == 'x':
-            kernel.x(qubits[q_indices[0]])
-        elif op_name == 'y':
-            kernel.y(qubits[q_indices[0]])
-        elif op_name == 'z':
-            kernel.z(qubits[q_indices[0]])
-        elif op_name == 's':
-            kernel.s(qubits[q_indices[0]])
-        elif op_name == 't':
-            kernel.t(qubits[q_indices[0]])
-        elif op_name == 'sdg':
-            kernel.sdg(qubits[q_indices[0]])
-        elif op_name == 'tdg':
-            kernel.tdg(qubits[q_indices[0]])
-        elif op_name == 'id':
-            pass  # Identity gate, no operation needed
-
-        # Two qubit gates
-        elif op_name == 'cx':
-            kernel.cx(qubits[q_indices[0]], qubits[q_indices[1]])
-        elif op_name == 'cy':
-            kernel.cy(qubits[q_indices[0]], qubits[q_indices[1]])
-        elif op_name == 'cz':
-            kernel.cz(qubits[q_indices[0]], qubits[q_indices[1]])
-        elif op_name == 'ch':
-            kernel.ch(qubits[q_indices[0]], qubits[q_indices[1]])
-        elif op_name == 'swap':
-            kernel.swap(qubits[q_indices[0]], qubits[q_indices[1]])
-        elif op_name == 'rxx':
-            kernel.cx(qubits[q_indices[0]], qubits[q_indices[1]])
-            kernel.rx(params[0], qubits[q_indices[0]])
-            kernel.cx(qubits[q_indices[0]], qubits[q_indices[1]])
-        elif op_name == 'rzz':
-            kernel.cx(qubits[q_indices[0]], qubits[q_indices[1]])
-            kernel.rz(params[0], qubits[q_indices[0]])
-            kernel.cx(qubits[q_indices[0]], qubits[q_indices[1]])
-
-        # Toffoli gate (3-qubit) - use `cx` with list of controls
-        elif op_name == 'ccx':
-            kernel.cx([qubits[q_indices[0]], qubits[q_indices[1]]],
-                      qubits[q_indices[2]])
-
-        # Parametric single qubit rotations
-        elif op_name == 'rx':
-            kernel.rx(params[0], qubits[q_indices[0]])
-        elif op_name == 'ry':
-            kernel.ry(params[0], qubits[q_indices[0]])
-        elif op_name == 'rz':
-            kernel.rz(params[0], qubits[q_indices[0]])
-        elif op_name == 'r1' or op_name == 'p':
-            # r1 and p (phase) gates are equivalent
-            kernel.r1(params[0], qubits[q_indices[0]])
-
-        # Controlled parametric rotations
-        elif op_name == 'crx':
-            kernel.crx(params[0], qubits[q_indices[0]], qubits[q_indices[1]])
-        elif op_name == 'cry':
-            kernel.cry(params[0], qubits[q_indices[0]], qubits[q_indices[1]])
-        elif op_name == 'crz':
-            kernel.crz(params[0], qubits[q_indices[0]], qubits[q_indices[1]])
-
-        # U3 gate: `U3(theta, phi, lambda) = Rz(lambda) Ry(theta) Rz(phi)`
-        elif op_name == 'u3' or op_name == 'u':
-            kernel.u3(params[0], params[1], params[2], qubits[q_indices[0]])
-
-        # `sqrt-X` gate decomposition
-        elif op_name == 'sx':
-            kernel.r1(np.pi / 4, qubits[q_indices[0]])
-            kernel.x(qubits[q_indices[0]])
-            kernel.r1(np.pi / 4, qubits[q_indices[0]])
-            kernel.x(qubits[q_indices[0]])
-            kernel.rx(np.pi / 2, qubits[q_indices[0]])
-        elif op_name == 'sxdg':
-            kernel.r1(-np.pi / 4, qubits[q_indices[0]])
-            kernel.x(qubits[q_indices[0]])
-            kernel.r1(-np.pi / 4, qubits[q_indices[0]])
-            kernel.x(qubits[q_indices[0]])
-            kernel.rx(-np.pi / 2, qubits[q_indices[0]])
-
-        # Barrier - no operation in CUDA-Q
-        elif op_name == 'barrier':
-            pass
-
-        # Measurements
-        elif op_name == 'measure':
-            kernel.mz(qubits[q_indices[0]])
-
-        else:
-            raise ValueError(f"Gate '{op_name}' is not supported. "
-                             f"Cannot convert Qiskit circuit to CUDA-Q kernel.")
+        _emit_instruction(kernel, qubits, instruction, qiskit_circuit, None, 0)
 
     return kernel

--- a/python/cudaq/contrib/qiskit_convert.py
+++ b/python/cudaq/contrib/qiskit_convert.py
@@ -70,6 +70,16 @@ def _has_quantum_circuit_definition(operation):
     return definition is not None and hasattr(definition, "data")
 
 
+def _has_open_controls(operation):
+    num_ctrl_qubits = getattr(operation, "num_ctrl_qubits", 0)
+    if num_ctrl_qubits == 0:
+        return False
+    ctrl_state = getattr(operation, "ctrl_state", None)
+    if ctrl_state is None:
+        return False
+    return ctrl_state != (1 << num_ctrl_qubits) - 1
+
+
 @dataclass(frozen=True)
 class _GateSpec:
     num_qubits: int | None
@@ -342,6 +352,16 @@ def _emit_instruction(kernel, qubits, instruction, circuit, q_mapping, depth):
     if op_name == "u0":
         raise ValueError("Gate 'u0' is not supported. Cannot convert Qiskit "
                          "circuit to CUDA-Q kernel.")
+
+    if _has_open_controls(operation) and _has_quantum_circuit_definition(
+            operation):
+        # Qiskit represents open controls by deriving a definition that wraps
+        # the closed-control operation with X gates on each open control.
+        definition = operation.definition
+        for nested_instruction in definition.data:
+            _emit_instruction(kernel, qubits, nested_instruction, definition,
+                              q_indices, depth + 1)
+        return
 
     if not _is_qiskit_standard_operation(
             operation) and _has_quantum_circuit_definition(operation):

--- a/python/tests/builder/test_translate.py
+++ b/python/tests/builder/test_translate.py
@@ -98,20 +98,8 @@ def _parse_qasm2_rotation_ops(qasm):
             for m in re.finditer(r'\b(r[xyz])\(([^)]+)\)', body)]
 
 
-def _assert_qasm2_s_or_t_adjoint(asm, direct_gate, rz_angle):
-    body = asm[asm.index('qreg'):]
-    if f"{direct_gate} var0[0];" in body:
-        return
-
-    ops = _parse_qasm2_rotation_ops(asm)
-    assert len(ops) == 1
-    gate, angle = ops[0]
-    assert gate == "rz"
-    assert math.isclose(angle, rz_angle, rel_tol=1e-5)
-
-
 def test_translate_builder_adjoint_s_openqasm():
-    # adjoint(s) may be preserved as s-dagger or lowered to the equivalent rz.
+    # adjoint(s) should produce the direct OpenQASM s-dagger gate.
     def inner():
         k, q = cudaq.make_kernel(cudaq.qubit)
         k.s(q)
@@ -119,7 +107,8 @@ def test_translate_builder_adjoint_s_openqasm():
 
     asm = _adjoint_openqasm(inner)
     assert "OPENQASM 2.0;" in asm
-    _assert_qasm2_s_or_t_adjoint(asm, "sdg", -math.pi / 2)
+    body = asm[asm.index('qreg'):]
+    assert "sdg var0[0];" in body
 
 
 def test_translate_builder_adjoint_rx_openqasm():
@@ -171,7 +160,7 @@ def test_translate_builder_adjoint_rz_openqasm():
 
 
 def test_translate_builder_adjoint_t_openqasm():
-    # adjoint(t) may be preserved as t-dagger or lowered to the equivalent rz.
+    # adjoint(t) should produce the direct OpenQASM t-dagger gate.
     def inner():
         k, q = cudaq.make_kernel(cudaq.qubit)
         k.t(q)
@@ -179,4 +168,5 @@ def test_translate_builder_adjoint_t_openqasm():
 
     asm = _adjoint_openqasm(inner)
     assert "OPENQASM 2.0;" in asm
-    _assert_qasm2_s_or_t_adjoint(asm, "tdg", -math.pi / 4)
+    body = asm[asm.index('qreg'):]
+    assert "tdg var0[0];" in body

--- a/python/tests/builder/test_translate.py
+++ b/python/tests/builder/test_translate.py
@@ -98,8 +98,20 @@ def _parse_qasm2_rotation_ops(qasm):
             for m in re.finditer(r'\b(r[xyz])\(([^)]+)\)', body)]
 
 
+def _assert_qasm2_s_or_t_adjoint(asm, direct_gate, rz_angle):
+    body = asm[asm.index('qreg'):]
+    if f"{direct_gate} var0[0];" in body:
+        return
+
+    ops = _parse_qasm2_rotation_ops(asm)
+    assert len(ops) == 1
+    gate, angle = ops[0]
+    assert gate == "rz"
+    assert math.isclose(angle, rz_angle, rel_tol=1e-5)
+
+
 def test_translate_builder_adjoint_s_openqasm():
-    # adjoint(s) should produce the direct OpenQASM s-dagger gate.
+    # adjoint(s) may be preserved as s-dagger or lowered to the equivalent rz.
     def inner():
         k, q = cudaq.make_kernel(cudaq.qubit)
         k.s(q)
@@ -107,8 +119,7 @@ def test_translate_builder_adjoint_s_openqasm():
 
     asm = _adjoint_openqasm(inner)
     assert "OPENQASM 2.0;" in asm
-    body = asm[asm.index('qreg'):]
-    assert "sdg var0[0];" in body
+    _assert_qasm2_s_or_t_adjoint(asm, "sdg", -math.pi / 2)
 
 
 def test_translate_builder_adjoint_rx_openqasm():
@@ -160,7 +171,7 @@ def test_translate_builder_adjoint_rz_openqasm():
 
 
 def test_translate_builder_adjoint_t_openqasm():
-    # adjoint(t) should produce the direct OpenQASM t-dagger gate.
+    # adjoint(t) may be preserved as t-dagger or lowered to the equivalent rz.
     def inner():
         k, q = cudaq.make_kernel(cudaq.qubit)
         k.t(q)
@@ -168,5 +179,4 @@ def test_translate_builder_adjoint_t_openqasm():
 
     asm = _adjoint_openqasm(inner)
     assert "OPENQASM 2.0;" in asm
-    body = asm[asm.index('qreg'):]
-    assert "tdg var0[0];" in body
+    _assert_qasm2_s_or_t_adjoint(asm, "tdg", -math.pi / 4)

--- a/python/tests/contrib/test_from_qiskit.py
+++ b/python/tests/contrib/test_from_qiskit.py
@@ -14,11 +14,34 @@ import os
 import tempfile
 
 import cudaq
-from cudaq import contrib
 
 # Skip all tests if qiskit is not installed
 qiskit = pytest.importorskip("qiskit")
-from qiskit import QuantumCircuit
+
+QuantumCircuit = qiskit.QuantumCircuit
+Gate = qiskit.circuit.Gate
+Parameter = qiskit.circuit.Parameter
+CUGate = qiskit.circuit.library.CUGate
+
+
+def _resource_counts(kernel):
+    return cudaq.estimate_resources(kernel).to_dict()
+
+
+def _from_qasm_str(qasm):
+    return cudaq.contrib.from_qiskit(QuantumCircuit.from_qasm_str(qasm))
+
+
+def _from_qasm_file(qasm):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".qasm",
+                                     delete=False) as f:
+        f.write(qasm)
+        temp_path = f.name
+
+    try:
+        return cudaq.contrib.from_qasm(temp_path)
+    finally:
+        os.unlink(temp_path)
 
 
 class TestFromQiskit:
@@ -33,7 +56,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # H gate creates superposition, expect roughly 50/50 distribution
-        assert '0' in counts or '1' in counts
+        assert "0" in counts or "1" in counts
 
     def test_single_qubit_x_gate(self):
         """Test conversion of X gate."""
@@ -43,7 +66,7 @@ class TestFromQiskit:
         kernel = cudaq.contrib.from_qiskit(qc)
         counts = cudaq.sample(kernel)
 
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_single_qubit_y_gate(self):
         """Test conversion of Y gate."""
@@ -53,7 +76,7 @@ class TestFromQiskit:
         kernel = cudaq.contrib.from_qiskit(qc)
         counts = cudaq.sample(kernel)
 
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_single_qubit_z_gate(self):
         """Test conversion of Z gate on |+> state."""
@@ -66,7 +89,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # H-Z-H = X, so result should be |1>
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_single_qubit_s_gate(self):
         """Test conversion of S gate."""
@@ -80,7 +103,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # H-S-S-H = H-Z-H = X, result should be |1>
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_single_qubit_t_gate(self):
         """Test conversion of T gate."""
@@ -91,7 +114,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # T on |0> should give |0>
-        assert counts['0'] == 1000
+        assert counts["0"] == 1000
 
     def test_single_qubit_sdg_gate(self):
         """Test conversion of Sdg (S-dagger) gate."""
@@ -105,7 +128,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # H-Sdg-Sdg-H = H-Z-H = X, result should be |1>
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_single_qubit_tdg_gate(self):
         """Test conversion of Tdg (T-dagger) gate."""
@@ -116,7 +139,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # Tdg on |0> should give |0>
-        assert counts['0'] == 1000
+        assert counts["0"] == 1000
 
     def test_cx_gate(self):
         """Test conversion of CX (CNOT) gate."""
@@ -128,7 +151,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # |10> -> |11> after CNOT
-        assert counts['11'] == 1000
+        assert counts["11"] == 1000
 
     def test_cy_gate(self):
         """Test conversion of CY gate."""
@@ -140,7 +163,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # Control qubit is 1, so Y is applied to target
-        assert counts['11'] == 1000
+        assert counts["11"] == 1000
 
     def test_cz_gate(self):
         """Test conversion of CZ gate."""
@@ -165,7 +188,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # Control is 1, so H is applied to target creating superposition
-        assert '10' in counts or '11' in counts
+        assert "10" in counts or "11" in counts
 
     def test_swap_gate(self):
         """Test conversion of SWAP gate."""
@@ -177,7 +200,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # |10> swapped to |01>
-        assert counts['01'] == 1000
+        assert counts["01"] == 1000
 
     def test_rx_gate(self):
         """Test conversion of RX gate."""
@@ -188,7 +211,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # RX(pi) on |0> gives |1>
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_ry_gate(self):
         """Test conversion of RY gate."""
@@ -199,7 +222,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # RY(pi) on |0> gives |1>
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_rz_gate(self):
         """Test conversion of RZ gate."""
@@ -212,7 +235,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # H-RZ(pi)-H = X, result should be |1>
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_crx_gate(self):
         """Test conversion of CRX gate."""
@@ -224,7 +247,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # Control is 1, RX(pi) applied to target
-        assert counts['11'] == 1000
+        assert counts["11"] == 1000
 
     def test_cry_gate(self):
         """Test conversion of CRY gate."""
@@ -236,7 +259,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # Control is 1, RY(pi) applied to target
-        assert counts['11'] == 1000
+        assert counts["11"] == 1000
 
     def test_crz_gate(self):
         """Test conversion of CRZ gate."""
@@ -250,7 +273,69 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # Control is 1, H-RZ(pi)-H = X applied to target
-        assert counts['11'] == 1000
+        assert counts["11"] == 1000
+
+    def test_cp_gate_resource_count(self):
+        """Test conversion of CP to CUDA-Q CR1."""
+        qc = QuantumCircuit(2)
+        qc.cp(np.pi / 4, 0, 1)
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        resources = cudaq.estimate_resources(kernel)
+
+        assert resources.to_dict().get("cr1", 0) == 1
+
+    def test_cu1_gate_resource_count(self):
+        """Test conversion of CU1 to CUDA-Q CR1."""
+        if not hasattr(QuantumCircuit, "cu1"):
+            pytest.skip("Qiskit QuantumCircuit.cu1 is unavailable.")
+        qc = QuantumCircuit(2)
+        qc.cu1(np.pi / 4, 0, 1)
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        resources = cudaq.estimate_resources(kernel)
+
+        assert resources.to_dict().get("cr1", 0) == 1
+
+    def test_direct_gate_resource_counts(self):
+        """Test direct Qiskit gate mappings to native CUDA-Q builder ops."""
+        qc = QuantumCircuit(6)
+        qc.append(Gate("u1", 1, [0.125]), [0])
+        qc.u(np.pi / 2, 0.25, 0.5, 1)
+        qc.append(Gate("cu3", 2, [0.125, 0.25, 0.5]), [0, 2])
+        qc.cswap(0, 3, 4)
+        qc.mcx([0, 1, 2], 5)
+        qc.reset(4)
+        qc.cs(0, 1)
+        qc.append(Gate("ct", 2, []), [1, 2])
+        qc.csdg(0, 1)
+        qc.append(Gate("ctdg", 2, []), [1, 2])
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        resources = _resource_counts(kernel)
+
+        assert resources.get("r1", 0) == 1
+        assert resources.get("u3", 0) == 1
+        assert resources.get("cu3", 0) == 1
+        assert resources.get("cswap", 0) == 1
+        assert resources.get("cccx", 0) == 1
+        assert resources.get("reset", 0) == 1
+        assert resources.get("cs", 0) == 2
+        assert resources.get("ct", 0) == 2
+
+    def test_synthetic_gate_alias_resource_counts(self):
+        """Test aliases that Qiskit public APIs may normalize away."""
+        qc = QuantumCircuit(3)
+        qc.append(Gate("phase", 1, [0.125]), [0])
+        qc.append(Gate("cphase", 2, [0.25]), [0, 1])
+        qc.append(Gate("CX", 2, []), [1, 2])
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        resources = _resource_counts(kernel)
+
+        assert resources.get("r1", 0) == 1
+        assert resources.get("cr1", 0) == 1
+        assert resources.get("cx", 0) == 1
 
     def test_u3_gate(self):
         """Test conversion of U3 gate."""
@@ -260,7 +345,7 @@ class TestFromQiskit:
         kernel = cudaq.contrib.from_qiskit(qc)
         counts = cudaq.sample(kernel)
 
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_phase_gate(self):
         """Test conversion of phase (p) gate."""
@@ -273,7 +358,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # H-P(pi)-H should flip the qubit
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_sx_gate(self):
         """Test conversion of SX (sqrt-X) gate."""
@@ -285,7 +370,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # SX^2 = X, result should be |1>
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_identity_gate(self):
         """Test conversion of identity gate."""
@@ -295,7 +380,7 @@ class TestFromQiskit:
         kernel = cudaq.contrib.from_qiskit(qc)
         counts = cudaq.sample(kernel)
 
-        assert counts['0'] == 1000
+        assert counts["0"] == 1000
 
     def test_barrier_ignored(self):
         """Test that barrier is properly ignored."""
@@ -308,7 +393,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # Bell state
-        assert '00' in counts and '11' in counts
+        assert "00" in counts and "11" in counts
 
     def test_measurement(self):
         """Test that measurements are converted."""
@@ -319,7 +404,7 @@ class TestFromQiskit:
         kernel = cudaq.contrib.from_qiskit(qc)
         counts = cudaq.sample(kernel)
 
-        assert counts['1'] == 1000
+        assert counts["1"] == 1000
 
     def test_bell_state(self):
         """Test conversion of Bell state circuit."""
@@ -331,10 +416,10 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # Bell state should have only |00> and |11>
-        assert '00' in counts
-        assert '11' in counts
-        assert '01' not in counts
-        assert '10' not in counts
+        assert "00" in counts
+        assert "11" in counts
+        assert "01" not in counts
+        assert "10" not in counts
 
     def test_ghz_state(self):
         """Test conversion of 3-qubit GHZ state circuit."""
@@ -347,8 +432,8 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # GHZ state should have only |000> and |111>
-        assert '000' in counts
-        assert '111' in counts
+        assert "000" in counts
+        assert "111" in counts
 
     def test_ccx_toffoli_gate(self):
         """Test conversion of CCX (Toffoli) gate."""
@@ -361,7 +446,7 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # Both controls are 1, so target flips: |110> -> |111>
-        assert counts['111'] == 1000
+        assert counts["111"] == 1000
 
     def test_rxx_gate(self):
         """Test conversion of RXX gate."""
@@ -389,6 +474,20 @@ class TestFromQiskit:
         # RZZ creates entanglement
         assert len(counts) > 0
 
+    def test_rzz_pi_behavior(self):
+        """Test RZZ(pi) lowers with the rotation on the target qubit."""
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.h(1)
+        qc.rzz(np.pi, 0, 1)
+        qc.h(0)
+        qc.h(1)
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        counts = cudaq.sample(kernel)
+
+        assert counts["11"] == 1000
+
     def test_sxdg_gate(self):
         """Test conversion of SXdg (sqrt-X dagger) gate."""
         qc = QuantumCircuit(1)
@@ -399,14 +498,82 @@ class TestFromQiskit:
         counts = cudaq.sample(kernel)
 
         # SX followed by SXdg should return to |0>
-        assert counts['0'] == 1000
+        assert counts["0"] == 1000
 
     def test_unsupported_gate_raises_error(self):
         """Test that unsupported gates raise ValueError."""
-        qc = QuantumCircuit(4)
-        qc.mcx([0, 1, 2], 3)  # Multi-controlled X not supported
+        qc = QuantumCircuit(2)
+        qc.append(CUGate(0.1, 0.2, 0.3, 0.4), [0, 1])
 
-        with pytest.raises(ValueError, match="not supported"):
+        with pytest.raises(ValueError, match="Gate 'cu' is not supported"):
+            cudaq.contrib.from_qiskit(qc)
+
+    def test_custom_gate_definition_expands_inline(self):
+        """Test custom Qiskit gate definitions expand inline."""
+        custom = QuantumCircuit(1, name="mygate")
+        custom.h(0)
+
+        qc = QuantumCircuit(1)
+        qc.append(custom.to_gate(), [0])
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        resources = _resource_counts(kernel)
+
+        assert resources.get("h", 0) == 1
+        assert "mygate" not in resources
+
+    def test_custom_gate_name_collision_expands_inline(self):
+        """Test custom gates expand before direct name matching."""
+        custom = QuantumCircuit(1, name="x")
+        custom.h(0)
+
+        qc = QuantumCircuit(1)
+        qc.append(custom.to_gate(), [0])
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        resources = _resource_counts(kernel)
+
+        assert resources.get("h", 0) == 1
+        assert "x" not in resources
+
+    @pytest.mark.parametrize(
+        "gate,qargs",
+        [
+            (Gate("x", 2, []), [0, 1]),
+            (Gate("cx", 1, []), [0]),
+            (Gate("x", 1, [0.1]), [0]),
+            (Gate("rx", 1, []), [0]),
+        ],
+    )
+    def test_malformed_direct_gate_raises_value_error(self, gate, qargs):
+        """Test malformed direct gates raise ValueError."""
+        qc = QuantumCircuit(2)
+        qc.append(gate, qargs)
+
+        with pytest.raises(ValueError, match=f"Gate '{gate.name.lower()}'"):
+            cudaq.contrib.from_qiskit(qc)
+
+    def test_symbolic_parameter_raises_value_error(self):
+        """Test symbolic parameters are rejected with a clear error."""
+        theta = Parameter("theta")
+        qc = QuantumCircuit(1)
+        qc.rx(theta, 0)
+
+        with pytest.raises(ValueError, match="Gate 'rx'"):
+            cudaq.contrib.from_qiskit(qc)
+
+    def test_control_flow_raises_unsupported_input_error(self):
+        """Test Qiskit control flow fails before parameter conversion."""
+        qasm = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        creg c[1];
+        if(c==1) x q[0];
+        """
+        qc = QuantumCircuit.from_qasm_str(qasm)
+
+        with pytest.raises(ValueError, match="classical control flow"):
             cudaq.contrib.from_qiskit(qc)
 
     def test_empty_circuit(self):
@@ -416,7 +583,7 @@ class TestFromQiskit:
         kernel = cudaq.contrib.from_qiskit(qc)
         counts = cudaq.sample(kernel)
 
-        assert counts['00'] == 1000
+        assert counts["00"] == 1000
 
 
 class TestFromQasm:
@@ -431,7 +598,7 @@ class TestFromQasm:
         h q[0];
         cx q[0], q[1];
         """
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.qasm',
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".qasm",
                                          delete=False) as f:
             f.write(qasm_content)
             temp_path = f.name
@@ -441,8 +608,8 @@ class TestFromQasm:
             counts = cudaq.sample(kernel)
 
             # Bell state
-            assert '00' in counts
-            assert '11' in counts
+            assert "00" in counts
+            assert "11" in counts
         finally:
             os.unlink(temp_path)
 
@@ -454,7 +621,7 @@ class TestFromQasm:
         qreg q[1];
         rx(3.14159265359) q[0];
         """
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.qasm',
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".qasm",
                                          delete=False) as f:
             f.write(qasm_content)
             temp_path = f.name
@@ -464,19 +631,113 @@ class TestFromQasm:
             counts = cudaq.sample(kernel)
 
             # RX(pi) should flip the qubit
-            assert counts['1'] == 1000
+            assert counts["1"] == 1000
         finally:
             os.unlink(temp_path)
+
+    def test_qasm_direct_gate_aliases(self):
+        """Test OpenQASM aliases imported through Qiskit map directly."""
+        kernel = _from_qasm_file("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[6];
+        u1(0.125) q[0];
+        u2(0.25,0.5) q[1];
+        cu3(0.125,0.25,0.5) q[0],q[2];
+        cswap q[0],q[3],q[4];
+        c3x q[0],q[1],q[2],q[5];
+        """)
+
+        resources = _resource_counts(kernel)
+
+        assert resources.get("r1", 0) == 1
+        assert resources.get("u3", 0) == 1
+        assert resources.get("cu3", 0) == 1
+        assert resources.get("cswap", 0) == 1
+        assert resources.get("cccx", 0) == 1
+
+    def test_qasm_c4x_imports_as_mcx(self):
+        """Test c4x is normalized by Qiskit and emitted as controlled X."""
+        kernel = _from_qasm_str("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[5];
+        c4x q[0],q[1],q[2],q[3],q[4];
+        """)
+
+        resources = _resource_counts(kernel)
+
+        assert resources.get("ccccx", 0) == 1
+
+    def test_custom_qasm_gate_definition_expands_inline(self):
+        """Test custom OpenQASM gate definitions expand inline."""
+        kernel = _from_qasm_str("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        gate mygate a { h a; }
+        mygate q[0];
+        """)
+
+        resources = _resource_counts(kernel)
+
+        assert resources.get("h", 0) == 1
+        assert "mygate" not in resources
+
+    def test_custom_qasm_macro_expands_inline(self):
+        """Test a multi-instruction OpenQASM macro expands inline."""
+        kernel = _from_qasm_str("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        gate majority a,b,c {
+          cx c,b;
+          cx c,a;
+          ccx a,b,c;
+        }
+        majority q[0],q[1],q[2];
+        """)
+
+        resources = _resource_counts(kernel)
+
+        assert resources.get("cx", 0) == 2
+        assert resources.get("ccx", 0) == 1
+        assert "majority" not in resources
+
+    def test_qasm_control_flow_raises_value_error(self):
+        """Test OpenQASM if statements report unsupported control flow."""
+        qasm = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        creg c[1];
+        if(c==1) x q[0];
+        """
+
+        with pytest.raises(ValueError, match="classical control flow"):
+            _from_qasm_str(qasm)
+
+    def test_qasm_u0_global_phase_is_unsupported(self):
+        """Test u0 remains unsupported because it is a global phase."""
+        qasm = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        u0(5) q[0];
+        """
+
+        with pytest.raises(ValueError, match="Gate 'u0' is not supported"):
+            _from_qasm_str(qasm)
 
     def test_nonexistent_file_raises_error(self):
         """Test that nonexistent file raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
-            cudaq.contrib.from_qasm('/nonexistent/path/to/file.qasm')
+            cudaq.contrib.from_qasm("/nonexistent/path/to/file.qasm")
 
     def test_invalid_qasm_raises_error(self):
         """Test that invalid QASM content raises RuntimeError."""
         qasm_content = "this is not valid qasm"
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.qasm',
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".qasm",
                                          delete=False) as f:
             f.write(qasm_content)
             temp_path = f.name

--- a/python/tests/contrib/test_from_qiskit.py
+++ b/python/tests/contrib/test_from_qiskit.py
@@ -337,6 +337,67 @@ class TestFromQiskit:
         assert resources.get("cr1", 0) == 1
         assert resources.get("cx", 0) == 1
 
+    def test_open_control_cx_expands_definition(self):
+        """Test Qiskit open-control CX expands through its definition."""
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1, ctrl_state=0)
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        counts = cudaq.sample(kernel)
+
+        assert counts["01"] == 1000
+
+    def test_open_control_ccx_expands_definition(self):
+        """Test Qiskit open-control CCX expands through its definition."""
+        qc = QuantumCircuit(3)
+        qc.x(0)
+        qc.ccx(0, 1, 2, ctrl_state=1)
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        counts = cudaq.sample(kernel)
+
+        assert counts["101"] == 1000
+
+    def test_open_control_mcx_expands_definition(self):
+        """Test Qiskit open-control MCX expands through its definition."""
+        qc = QuantumCircuit(5)
+        qc.x(1)
+        qc.x(3)
+        qc.mcx([0, 1, 2, 3], 4, ctrl_state=0b1010)
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        counts = cudaq.sample(kernel)
+
+        assert counts["01011"] == 1000
+
+    def test_csdg_cancels_cs(self):
+        """Test CSDG emits the adjoint of CS."""
+        qc = QuantumCircuit(2)
+        qc.x(0)
+        qc.h(1)
+        qc.cs(0, 1)
+        qc.csdg(0, 1)
+        qc.h(1)
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        counts = cudaq.sample(kernel)
+
+        assert counts["10"] == 1000
+
+    def test_ctdg_cancels_ct(self):
+        """Test CTDG emits the adjoint of CT."""
+        qc = QuantumCircuit(2)
+        qc.x(0)
+        qc.h(1)
+        qc.append(Gate("ct", 2, []), [0, 1])
+        qc.append(Gate("ctdg", 2, []), [0, 1])
+        qc.h(1)
+
+        kernel = cudaq.contrib.from_qiskit(qc)
+        counts = cudaq.sample(kernel)
+
+        assert counts["10"] == 1000
+
     def test_u3_gate(self):
         """Test conversion of U3 gate."""
         qc = QuantumCircuit(1)


### PR DESCRIPTION
This is based on #4556 and should only be merged after.

This PR improves OpenQASM interoperability through the Qiskit conversion path by handling gate forms that commonly appear in imported QASM circuits. It adds direct coverage for controlled phase-style gates and expands Qiskit open-control definitions so CUDA-Q preserves the intended control-state behavior. This has quite a few LOC change but really it's a refactor of the existing inline logic to something a bit more scalable (although not perfect and probably long run will need additional refactor).