### PR TITLE
Parametrise compiler based on CompileTarget options 

### DIFF
--- a/cudaq/include/cudaq/Target/CompileTarget.h
+++ b/cudaq/include/cudaq/Target/CompileTarget.h
@@ -57,6 +57,10 @@ public:
   /// Whether branching on measurement results is supported.
   bool supportConditionalsOnMeasureResults = true;
 
+  /// Whether to retrieve mapping reorder indices from MLIR and store it as
+  /// compiled metadata.
+  bool storeReorderIdx = false;
+
   /// Whether to generate resource counts.
   ///
   /// When true, the compiler will generate resource counts during compilation

--- a/cudaq/include/cudaq/Target/CompileTarget.h
+++ b/cudaq/include/cudaq/Target/CompileTarget.h
@@ -43,6 +43,9 @@ public:
     bool runsStandardFinalize = false;
     /// Whether to disable qubit mapping.
     bool disableQubitMapping = false;
+
+    /// Whether to run the add-measurements pass.
+    bool addMeasurements = false;
   };
 
   /// Pipeline configuration, populated by the constructor.

--- a/cudaq/include/cudaq/Target/CompileTarget.h
+++ b/cudaq/include/cudaq/Target/CompileTarget.h
@@ -57,6 +57,13 @@ public:
   /// Whether branching on measurement results is supported.
   bool supportConditionalsOnMeasureResults = true;
 
+  /// Whether to generate resource counts.
+  ///
+  /// When true, the compiler will generate resource counts during compilation
+  /// and simplify the IR to remove all quantum operations already accounted
+  /// for in the counts.
+  bool generateResourceCounts = false;
+
   /// When set, emit one lowered module per non-identity Pauli term of this
   /// observable. The resulting `CompiledModule` will contain a compilation
   /// artifact for each term.

--- a/cudaq/include/cudaq/Target/CompileTarget.h
+++ b/cudaq/include/cudaq/Target/CompileTarget.h
@@ -8,7 +8,9 @@
 #pragma once
 
 #include "cudaq/Target/TargetConfig.h"
+#include "cudaq/operators.h"
 #include <map>
+#include <optional>
 #include <string>
 
 namespace cudaq {
@@ -54,6 +56,11 @@ public:
 
   /// Whether branching on measurement results is supported.
   bool supportConditionalsOnMeasureResults = true;
+
+  /// When set, emit one lowered module per non-identity Pauli term of this
+  /// observable. The resulting `CompiledModule` will contain a compilation
+  /// artifact for each term.
+  std::optional<cudaq::spin_op> pauliTermSplitObservable;
 
   /// Construct a CompileTarget from static and runtime backend configurations.
   CompileTarget(config::TargetConfig targetConfig,

--- a/cudaq/include/cudaq/Target/CompileTarget.h
+++ b/cudaq/include/cudaq/Target/CompileTarget.h
@@ -49,6 +49,12 @@ public:
   /// Whether to emulate execution locally.
   bool emulate = false;
 
+  /// Issue a warning if named measurements are contained in the kernel.
+  bool warnNamedMeasurements = false;
+
+  /// Whether branching on measurement results is supported.
+  bool supportConditionalsOnMeasureResults = true;
+
   /// Construct a CompileTarget from static and runtime backend configurations.
   CompileTarget(config::TargetConfig targetConfig,
                 std::map<std::string, std::string> runtimeConfig, bool emulate);

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -269,12 +269,19 @@ public:
   };
 
   using QPU::getCompileTarget;
-  std::unique_ptr<CompileTarget> getCompileTarget(ExecutionContext *) override {
+  std::unique_ptr<CompileTarget>
+  getCompileTarget(ExecutionContext *ctx) override {
     std::filesystem::path cudaqLibPath{cudaq::getCUDAQLibraryPath()};
     auto platformPath = cudaqLibPath.parent_path().parent_path() / "targets";
 
-    return std::make_unique<BaseRemoteRESTQPUCompileTarget>(
+    auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
         serverHelper.get(), platformPath, targetConfig, backendConfig, emulate);
+    if (ctx && ctx->name == "observe") {
+      if (!ctx->spin.has_value())
+        throw std::runtime_error("observe execution requires a spin_op");
+      target->pauliTermSplitObservable = ctx->spin;
+    }
+    return target;
   }
 
   std::unique_ptr<CompileTarget>

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -295,6 +295,7 @@ public:
         serverHelper.get(), platformPath, targetConfig, backendConfig, emulate);
     target->warnNamedMeasurements = !policy.warnedNamedMeasurements;
     target->supportConditionalsOnMeasureResults = !emulate;
+    target->pipelineConfig.addMeasurements = true;
     target->storeReorderIdx = true;
     return target;
   }

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -280,6 +280,8 @@ public:
       if (!ctx->spin.has_value())
         throw std::runtime_error("observe execution requires a spin_op");
       target->pauliTermSplitObservable = ctx->spin;
+    } else if (ctx && ctx->name == "resource-count") {
+      target->generateResourceCounts = true;
     }
     return target;
   }

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -295,6 +295,7 @@ public:
         serverHelper.get(), platformPath, targetConfig, backendConfig, emulate);
     target->warnNamedMeasurements = !policy.warnedNamedMeasurements;
     target->supportConditionalsOnMeasureResults = !emulate;
+    target->storeReorderIdx = true;
     return target;
   }
 
@@ -414,9 +415,8 @@ public:
       // Launch the execution of the simulated jobs asynchronously
       future = cudaq::details::future(std::async(
           std::launch::async,
-          [&, codes, localShots, kernelName, seed, isObserve, isRun,
-           reorderIdx =
-               executionContext->reorderIdx]() mutable -> cudaq::sample_result {
+          [&, codes, localShots, kernelName, seed, isObserve,
+           isRun]() mutable -> cudaq::sample_result {
             std::vector<cudaq::ExecutionResult> results;
 
             // If seed is 0, then it has not been set.
@@ -453,7 +453,7 @@ public:
               // observe) one time each.
               for (std::size_t i = 0; i < codes.size(); i++) {
                 cudaq::ExecutionContext context("sample", localShots);
-                context.reorderIdx = reorderIdx;
+                context.reorderIdx = codes[i].mapping_reorder_idx;
                 context.executionManager = cudaq::getDefaultExecutionManager();
                 context.kernelName = kernelName;
                 context.warnedNamedMeasurements =

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -97,6 +97,23 @@ protected:
     Compiler compiler(getCompileTarget(policy));
     return compiler.runPassPipeline(ctx, kernelName, modulePtr, args);
   }
+  // Overload for sample policy
+  CompiledModule compileModuleImpl(sample_policy &policy,
+                                   const SourceModule &src, KernelArgs args,
+                                   bool isEntryPoint) {
+    const auto &kernelName = src.getName();
+    auto modulePtr = compileModulePreamble(src);
+    CUDAQ_INFO("specializing remote rest kernel via module ({}) with {} policy",
+               kernelName, policy.name);
+    // Temporary hack until we have a proper way of configuring the compiler
+    // based on the policy.
+    auto ctx = cudaq::getExecutionContext();
+    Compiler compiler(getCompileTarget(policy));
+    auto compiled = compiler.runPassPipeline(ctx, kernelName, modulePtr, args);
+    if (compiler.hasWarnedNamedMeasurements())
+      policy.warnedNamedMeasurements = true;
+    return compiled;
+  }
 
 public:
   /// @brief The constructor
@@ -260,6 +277,18 @@ public:
         serverHelper.get(), platformPath, targetConfig, backendConfig, emulate);
   }
 
+  std::unique_ptr<CompileTarget>
+  getCompileTarget(sample_policy &policy) override {
+    std::filesystem::path cudaqLibPath{cudaq::getCUDAQLibraryPath()};
+    auto platformPath = cudaqLibPath.parent_path().parent_path() / "targets";
+
+    auto target = std::make_unique<BaseRemoteRESTQPUCompileTarget>(
+        serverHelper.get(), platformPath, targetConfig, backendConfig, emulate);
+    target->warnNamedMeasurements = !policy.warnedNamedMeasurements;
+    target->supportConditionalsOnMeasureResults = !emulate;
+    return target;
+  }
+
   CompiledModule compileModule(const SourceModule &src, KernelArgs args,
                                bool isEntryPoint) override {
     const auto &kernelName = src.getName();
@@ -273,9 +302,12 @@ public:
           "Remote rest execution can only be performed via cudaq::sample(), "
           "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
 
-    Compiler compiler(getCompileTarget());
-    return compiler.runPassPipeline(executionContext, kernelName, modulePtr,
-                                    args);
+    Compiler compiler(getCompileTarget(executionContext));
+    auto compiled =
+        compiler.runPassPipeline(executionContext, kernelName, modulePtr, args);
+    if (compiler.hasWarnedNamedMeasurements())
+      executionContext->warnedNamedMeasurements = true;
+    return compiled;
   }
 
   CompiledModule compileModule(sample_policy &policy, const SourceModule &src,
@@ -305,6 +337,8 @@ public:
       auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
 
       codes = compiler.lowerQuakeCode(ctx, kernelName, moduleOp, args);
+      if (ctx && compiler.hasWarnedNamedMeasurements())
+        ctx->warnedNamedMeasurements = true;
     } else {
       const auto &compiled = std::get<CompiledModule>(module);
       kernelName = compiled.getName();

--- a/runtime/common/BaseRemoteRESTQPU.h
+++ b/runtime/common/BaseRemoteRESTQPU.h
@@ -91,27 +91,12 @@ protected:
     auto modulePtr = compileModulePreamble(src);
     CUDAQ_INFO("specializing remote rest kernel via module ({}) with {} policy",
                kernelName, policy.name);
-    // Temporary hack until we have a proper way of configuring the compiler
-    // based on the policy.
-    auto ctx = cudaq::getExecutionContext();
     Compiler compiler(getCompileTarget(policy));
-    return compiler.runPassPipeline(ctx, kernelName, modulePtr, args);
-  }
-  // Overload for sample policy
-  CompiledModule compileModuleImpl(sample_policy &policy,
-                                   const SourceModule &src, KernelArgs args,
-                                   bool isEntryPoint) {
-    const auto &kernelName = src.getName();
-    auto modulePtr = compileModulePreamble(src);
-    CUDAQ_INFO("specializing remote rest kernel via module ({}) with {} policy",
-               kernelName, policy.name);
-    // Temporary hack until we have a proper way of configuring the compiler
-    // based on the policy.
-    auto ctx = cudaq::getExecutionContext();
-    Compiler compiler(getCompileTarget(policy));
-    auto compiled = compiler.runPassPipeline(ctx, kernelName, modulePtr, args);
-    if (compiler.hasWarnedNamedMeasurements())
-      policy.warnedNamedMeasurements = true;
+    auto compiled = compiler.runPassPipeline(kernelName, modulePtr, args);
+    if constexpr (std::is_same_v<Policy, sample_policy>) {
+      if (compiler.hasWarnedNamedMeasurements())
+        policy.warnedNamedMeasurements = true;
+    }
     return compiled;
   }
 
@@ -271,6 +256,11 @@ public:
   using QPU::getCompileTarget;
   std::unique_ptr<CompileTarget>
   getCompileTarget(ExecutionContext *ctx) override {
+    if (!ctx)
+      throw std::runtime_error(
+          "Remote rest execution can only be performed via cudaq::sample(), "
+          "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
+
     std::filesystem::path cudaqLibPath{cudaq::getCUDAQLibraryPath()};
     auto platformPath = cudaqLibPath.parent_path().parent_path() / "targets";
 
@@ -305,19 +295,9 @@ public:
     const auto &kernelName = src.getName();
     auto modulePtr = compileModulePreamble(src);
     CUDAQ_INFO("specializing remote rest kernel via module ({})", kernelName);
-    auto executionContext = cudaq::getExecutionContext();
 
-    // TODO future iterations of this should support non-void return types.
-    if (!executionContext)
-      throw std::runtime_error(
-          "Remote rest execution can only be performed via cudaq::sample(), "
-          "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
-
-    Compiler compiler(getCompileTarget(executionContext));
-    auto compiled =
-        compiler.runPassPipeline(executionContext, kernelName, modulePtr, args);
-    if (compiler.hasWarnedNamedMeasurements())
-      executionContext->warnedNamedMeasurements = true;
+    Compiler compiler(getCompileTarget(getExecutionContext()));
+    auto compiled = compiler.runPassPipeline(kernelName, modulePtr, args);
     return compiled;
   }
 
@@ -337,9 +317,6 @@ public:
     Compiler compiler(getCompileTarget(policy));
     std::vector<cudaq::KernelExecution> codes;
     std::string kernelName;
-    // Temporary hack until we have a proper way of configuring the compiler
-    // based on the policy.
-    auto ctx = cudaq::getExecutionContext();
     if (std::holds_alternative<SourceModule>(module)) {
       const auto &src = std::get<SourceModule>(module);
       kernelName = src.getName();
@@ -347,9 +324,11 @@ public:
 
       auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
 
-      codes = compiler.lowerQuakeCode(ctx, kernelName, moduleOp, args);
-      if (ctx && compiler.hasWarnedNamedMeasurements())
-        ctx->warnedNamedMeasurements = true;
+      codes = compiler.lowerQuakeCode(kernelName, moduleOp, args);
+      if constexpr (std::is_same_v<Policy, sample_policy>) {
+        if (compiler.hasWarnedNamedMeasurements())
+          policy.warnedNamedMeasurements = true;
+      }
     } else {
       const auto &compiled = std::get<CompiledModule>(module);
       kernelName = compiled.getName();
@@ -457,9 +436,6 @@ public:
                 context.reorderIdx = codes[i].mapping_reorder_idx;
                 context.executionManager = cudaq::getDefaultExecutionManager();
                 context.kernelName = kernelName;
-                context.warnedNamedMeasurements =
-                    executionContext ? executionContext->warnedNamedMeasurements
-                                     : false;
                 assert(codes[i].jit);
                 cudaq::platform::with_execution_context(
                     context, [&]() { codes[i].jit->run(kernelName); });
@@ -567,6 +543,8 @@ public:
     // observe) one time each.
     for (std::size_t i = 0; i < codes.size(); i++) {
       cudaq::ExecutionContext context("sample", localShots);
+      // Avoid emitting the warning again during execution
+      context.warnedNamedMeasurements = policy.warnedNamedMeasurements;
       sample_policy localPolicy;
       localPolicy.options.shots = localShots;
       localPolicy.reorderIdx = std::move(codes[i].mapping_reorder_idx);

--- a/runtime/common/CompiledModule.h
+++ b/runtime/common/CompiledModule.h
@@ -270,6 +270,9 @@ protected:
 /// pointers. Build instances with
 /// `cudaq_internal::compiler::CompiledModuleHelper`.
 class CompiledModule : public FatQuakeModule {
+public:
+  using CompilationMetadata = FatQuakeModule::CompilationMetadata;
+
 private:
   friend class cudaq_internal::compiler::CompiledModuleHelper;
 

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -52,6 +52,8 @@ RemoteRESTQPU::unifiedLaunchModule(const AnyModule &module, KernelArgs args) {
     // Get the Quake code, lowered according to config file.
     codes =
         compiler.lowerQuakeCode(executionContext, kernelName, moduleOp, args);
+    if (executionContext && compiler.hasWarnedNamedMeasurements())
+      executionContext->warnedNamedMeasurements = true;
   } else {
     const auto &compiled = std::get<CompiledModule>(module);
     kernelName = compiled.getName();

--- a/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
+++ b/runtime/cudaq/platform/default/rest/RemoteRESTQPU.cpp
@@ -30,8 +30,7 @@ async_sample_result RemoteRESTQPU::launchKernel(async_sample_policy &policy,
 
 KernelThunkResultType
 RemoteRESTQPU::unifiedLaunchModule(const AnyModule &module, KernelArgs args) {
-  auto executionContext = cudaq::getExecutionContext();
-  Compiler compiler(getCompileTarget());
+  Compiler compiler(getCompileTarget(getExecutionContext()));
 
   std::string kernelName;
   std::vector<cudaq::KernelExecution> codes;
@@ -41,19 +40,10 @@ RemoteRESTQPU::unifiedLaunchModule(const AnyModule &module, KernelArgs args) {
     kernelName = src.getName();
     CUDAQ_INFO("launching remote rest kernel ({})", kernelName);
 
-    // TODO future iterations of this should support non-void return types.
-    if (!executionContext)
-      throw std::runtime_error(
-          "Remote rest execution can only be performed via cudaq::sample(), "
-          "cudaq::observe(), cudaq::run(), or cudaq::contrib::draw().");
-
     auto [moduleOp, context] = Compiler::loadQuakeCodeByName(kernelName);
 
     // Get the Quake code, lowered according to config file.
-    codes =
-        compiler.lowerQuakeCode(executionContext, kernelName, moduleOp, args);
-    if (executionContext && compiler.hasWarnedNamedMeasurements())
-      executionContext->warnedNamedMeasurements = true;
+    codes = compiler.lowerQuakeCode(kernelName, moduleOp, args);
   } else {
     const auto &compiled = std::get<CompiledModule>(module);
     kernelName = compiled.getName();

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
@@ -25,17 +25,8 @@ cudaq::CompiledModule cudaq::FermioniqQPU::compileImpl(
         "Remote rest execution can only be performed via cudaq::sample(), "
         "cudaq::observe(), or cudaq::contrib::draw().");
 
-  // When the user issues an observe call, we don't want to use the default
-  // CUDA-Q behaviour that splits up the circuit into several ansatz
-  // sub circuit. Instead, we pass a "sample" context to the compiler to
-  // prevent circuit splitting. This target handles observable evaluation
-  // server-side.
-  cudaq::ExecutionContext sampleContext("sample", 1);
-  ExecutionContext *compileCtx =
-      (executionContext->name == "observe") ? &sampleContext : executionContext;
-
-  Compiler compiler(getCompileTarget(compileCtx));
-  auto compiled = runPassPipeline(compiler, compileCtx);
+  Compiler compiler(getCompileTarget(executionContext));
+  auto compiled = runPassPipeline(compiler, executionContext);
   if (compiler.hasWarnedNamedMeasurements())
     executionContext->warnedNamedMeasurements = true;
   return compiled;

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
@@ -10,23 +10,31 @@
 #include "nlohmann/json.hpp"
 #include "cudaq/runtime/logger/cudaq_fmt.h"
 #include <memory>
+#include <optional>
 
 cudaq::FermioniqQPU::~FermioniqQPU() = default;
 
-cudaq::CompiledModule cudaq::FermioniqQPU::compileImpl(
-    const std::string &kernelName,
-    std::function<cudaq::CompiledModule(cudaq_internal::compiler::Compiler &)>
-        runPassPipeline) {
-  Compiler compiler(getCompileTarget(getExecutionContext()));
-  auto compiled = runPassPipeline(compiler);
-  return compiled;
-}
-
-void cudaq::FermioniqQPU::launchImpl(const cudaq::CompiledModule &compiled) {
+cudaq::KernelThunkResultType
+cudaq::FermioniqQPU::unifiedLaunchModule(const AnyModule &module,
+                                         KernelArgs args) {
   auto *executionContext = getExecutionContext();
-
   Compiler compiler(getCompileTarget(executionContext));
-  auto codes = compiler.emitKernelExecutions(compiled);
+  std::optional<CompiledModule> compiled;
+
+  if (std::holds_alternative<SourceModule>(module)) {
+    const auto &src = std::get<SourceModule>(module);
+    const auto &kernelName = src.getName();
+    CUDAQ_INFO("FermioniqBaseQPU launching kernel ({})", kernelName);
+    auto [quakeModule, context] = Compiler::loadQuakeCodeByName(kernelName);
+    compiled = compiler.runPassPipeline(kernelName, quakeModule, args,
+                                        std::move(context));
+  } else {
+    compiled = std::get<CompiledModule>(module);
+    CUDAQ_INFO("FermioniqBaseQPU launching kernel via module ({})",
+               compiled->getName());
+  }
+
+  auto codes = compiler.emitKernelExecutions(*compiled);
 
   if (codes.size() != 1)
     throw std::runtime_error("Provider only allows 1 circuit at a time.");
@@ -49,7 +57,8 @@ void cudaq::FermioniqQPU::launchImpl(const cudaq::CompiledModule &compiled) {
     codes[0].user_data = user_data;
   }
 
-  completeLaunchKernel(compiled.getName(), std::move(codes));
+  completeLaunchKernel(compiled->getName(), std::move(codes));
+  return {};
 }
 
 cudaq::sample_result

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
@@ -35,7 +35,10 @@ cudaq::CompiledModule cudaq::FermioniqQPU::compileImpl(
       (executionContext->name == "observe") ? &sampleContext : executionContext;
 
   Compiler compiler(getCompileTarget(compileCtx));
-  return runPassPipeline(compiler, compileCtx);
+  auto compiled = runPassPipeline(compiler, compileCtx);
+  if (compiler.hasWarnedNamedMeasurements())
+    executionContext->warnedNamedMeasurements = true;
+  return compiled;
 }
 
 void cudaq::FermioniqQPU::launchImpl(const cudaq::CompiledModule &compiled) {

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.cpp
@@ -15,30 +15,15 @@ cudaq::FermioniqQPU::~FermioniqQPU() = default;
 
 cudaq::CompiledModule cudaq::FermioniqQPU::compileImpl(
     const std::string &kernelName,
-    std::function<cudaq::CompiledModule(cudaq_internal::compiler::Compiler &,
-                                        cudaq::ExecutionContext *)>
+    std::function<cudaq::CompiledModule(cudaq_internal::compiler::Compiler &)>
         runPassPipeline) {
-  auto *executionContext = getExecutionContext();
-  // TODO future iterations of this should support non-void return types.
-  if (!executionContext)
-    throw std::runtime_error(
-        "Remote rest execution can only be performed via cudaq::sample(), "
-        "cudaq::observe(), or cudaq::contrib::draw().");
-
-  Compiler compiler(getCompileTarget(executionContext));
-  auto compiled = runPassPipeline(compiler, executionContext);
-  if (compiler.hasWarnedNamedMeasurements())
-    executionContext->warnedNamedMeasurements = true;
+  Compiler compiler(getCompileTarget(getExecutionContext()));
+  auto compiled = runPassPipeline(compiler);
   return compiled;
 }
 
 void cudaq::FermioniqQPU::launchImpl(const cudaq::CompiledModule &compiled) {
   auto *executionContext = getExecutionContext();
-  // TODO future iterations of this should support non-void return types.
-  if (!executionContext)
-    throw std::runtime_error(
-        "Remote rest execution can only be performed via cudaq::sample(), "
-        "cudaq::observe(), or cudaq::contrib::draw().");
 
   Compiler compiler(getCompileTarget(executionContext));
   auto codes = compiler.emitKernelExecutions(compiled);

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
@@ -43,25 +43,7 @@ public:
   }
 
   KernelThunkResultType unifiedLaunchModule(const AnyModule &module,
-                                            KernelArgs args) override {
-    if (std::holds_alternative<SourceModule>(module)) {
-      const auto &src = std::get<SourceModule>(module);
-      const auto &kernelName = src.getName();
-      CUDAQ_INFO("FermioniqBaseQPU launching kernel ({})", kernelName);
-      auto [quakeModule, context] = Compiler::loadQuakeCodeByName(kernelName);
-      auto compiled = compileImpl(kernelName, [&](Compiler &compiler) {
-        return compiler.runPassPipeline(kernelName, quakeModule, args,
-                                        std::move(context));
-      });
-      launchImpl(compiled);
-    } else {
-      const auto &compiled = std::get<CompiledModule>(module);
-      CUDAQ_INFO("FermioniqBaseQPU launching kernel via module ({})",
-                 compiled.getName());
-      launchImpl(compiled);
-    }
-    return {};
-  }
+                                            KernelArgs args) override;
 
   using BaseRemoteRESTQPU::getCompileTarget;
   std::unique_ptr<CompileTarget>
@@ -76,49 +58,12 @@ public:
     return target;
   }
 
-  CompiledModule compileModule(const SourceModule &src, KernelArgs args,
-                               bool isEntryPoint) override {
-    const auto &kernelName = src.getName();
-    auto modulePtr = compileModulePreamble(src);
-    CUDAQ_INFO("FermioniqBaseQPU compiling kernel via module ({})", kernelName);
-    return compileImpl(kernelName, [&](Compiler &compiler) {
-      return compiler.runPassPipeline(kernelName, modulePtr, args);
-    });
-  }
-
   sample_result launchKernel(sample_policy &policy, const AnyModule &module,
                              KernelArgs args) override;
 
   async_sample_result launchKernel(async_sample_policy &policy,
                                    const AnyModule &module,
                                    KernelArgs args) override;
-
-  CompiledModule compileModule(sample_policy &policy, const SourceModule &src,
-                               KernelArgs args, bool isEntryPoint) override {
-    return compileModuleImpl(policy, src, args, isEntryPoint);
-  }
-
-private:
-  CompiledModule
-  compileImpl(const std::string &kernelName,
-              std::function<CompiledModule(Compiler &)> runPassPipeline);
-
-  template <typename Policy>
-  CompiledModule compileImpl(Policy &policy, const SourceModule &src,
-                             KernelArgs args, bool isEntryPoint) {
-    const auto &kernelName = src.getName();
-    auto modulePtr = compileModulePreamble(src);
-    CUDAQ_INFO("FermioniqBaseQPU compiling kernel via module ({})", kernelName);
-    return compileImpl(kernelName, [&](Compiler &compiler) {
-      auto res = compiler.runPassPipeline(kernelName, modulePtr, args);
-      if constexpr (std::is_same_v<Policy, sample_policy>) {
-        if (compiler.hasWarnedNamedMeasurements())
-          policy.warnedNamedMeasurements = true;
-      }
-      return res;
-    });
-  }
-  void launchImpl(const CompiledModule &compiled);
 };
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "common/BaseRemoteRESTQPU.h"
+#include <optional>
 
 namespace cudaq {
 
@@ -61,6 +62,19 @@ public:
       launchImpl(compiled);
     }
     return {};
+  }
+
+  using BaseRemoteRESTQPU::getCompileTarget;
+  std::unique_ptr<CompileTarget>
+  getCompileTarget(ExecutionContext *ctx) override {
+    auto target = BaseRemoteRESTQPU::getCompileTarget(ctx);
+    // This target handles observable evaluation server-side.
+    // We don't want to split up the circuit into several ansatz
+    // sub circuit.
+    if (ctx && ctx->name == "observe") {
+      target->pauliTermSplitObservable = std::nullopt;
+    }
+    return target;
   }
 
   CompiledModule compileModule(const SourceModule &src, KernelArgs args,

--- a/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
+++ b/runtime/cudaq/platform/fermioniq/FermioniqQPU.h
@@ -49,11 +49,10 @@ public:
       const auto &kernelName = src.getName();
       CUDAQ_INFO("FermioniqBaseQPU launching kernel ({})", kernelName);
       auto [quakeModule, context] = Compiler::loadQuakeCodeByName(kernelName);
-      auto compiled = compileImpl(
-          kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
-            return compiler.runPassPipeline(ctx, kernelName, quakeModule, args,
-                                            std::move(context));
-          });
+      auto compiled = compileImpl(kernelName, [&](Compiler &compiler) {
+        return compiler.runPassPipeline(kernelName, quakeModule, args,
+                                        std::move(context));
+      });
       launchImpl(compiled);
     } else {
       const auto &compiled = std::get<CompiledModule>(module);
@@ -71,7 +70,7 @@ public:
     // This target handles observable evaluation server-side.
     // We don't want to split up the circuit into several ansatz
     // sub circuit.
-    if (ctx && ctx->name == "observe") {
+    if (ctx->name == "observe") {
       target->pauliTermSplitObservable = std::nullopt;
     }
     return target;
@@ -82,10 +81,9 @@ public:
     const auto &kernelName = src.getName();
     auto modulePtr = compileModulePreamble(src);
     CUDAQ_INFO("FermioniqBaseQPU compiling kernel via module ({})", kernelName);
-    return compileImpl(
-        kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
-          return compiler.runPassPipeline(ctx, kernelName, modulePtr, args);
-        });
+    return compileImpl(kernelName, [&](Compiler &compiler) {
+      return compiler.runPassPipeline(kernelName, modulePtr, args);
+    });
   }
 
   sample_result launchKernel(sample_policy &policy, const AnyModule &module,
@@ -103,8 +101,7 @@ public:
 private:
   CompiledModule
   compileImpl(const std::string &kernelName,
-              std::function<CompiledModule(Compiler &, ExecutionContext *)>
-                  runPassPipeline);
+              std::function<CompiledModule(Compiler &)> runPassPipeline);
 
   template <typename Policy>
   CompiledModule compileImpl(Policy &policy, const SourceModule &src,
@@ -112,10 +109,14 @@ private:
     const auto &kernelName = src.getName();
     auto modulePtr = compileModulePreamble(src);
     CUDAQ_INFO("FermioniqBaseQPU compiling kernel via module ({})", kernelName);
-    return compileImpl(
-        kernelName, [&](Compiler &compiler, ExecutionContext *ctx) {
-          return compiler.runPassPipeline(policy, kernelName, modulePtr, args);
-        });
+    return compileImpl(kernelName, [&](Compiler &compiler) {
+      auto res = compiler.runPassPipeline(kernelName, modulePtr, args);
+      if constexpr (std::is_same_v<Policy, sample_policy>) {
+        if (compiler.hasWarnedNamedMeasurements())
+          policy.warnedNamedMeasurements = true;
+      }
+      return res;
+    });
   }
   void launchImpl(const CompiledModule &compiled);
 };

--- a/runtime/cudaq/platform/qpu.cpp
+++ b/runtime/cudaq/platform/qpu.cpp
@@ -103,16 +103,14 @@ cudaq::CompiledModule cudaq::QPU::compileModule(sample_policy &,
   return compileModule(src, args, isEntryPoint);
 }
 
-std::unique_ptr<cudaq::CompileTarget> cudaq::QPU::getCompileTarget() {
-  return getCompileTarget(getExecutionContext());
-}
 std::unique_ptr<cudaq::CompileTarget>
 cudaq::QPU::getCompileTarget(ExecutionContext *context) {
   throw std::runtime_error("no CompileTarget defined for this QPU");
 }
 std::unique_ptr<cudaq::CompileTarget>
 cudaq::QPU::getCompileTarget(sample_policy &) {
-  return getCompileTarget();
+  throw std::runtime_error(
+      "no CompileTarget defined for sample_policy this QPU");
 }
 
 cudaq::CompiledModule cudaq::QPU::compileModule(const SourceModule &src,

--- a/runtime/cudaq/platform/qpu.h
+++ b/runtime/cudaq/platform/qpu.h
@@ -158,8 +158,7 @@ public:
   // Overload for sample policy
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>
   getCompileTarget(sample_policy &policy);
-  // Overloads for currently unsupported policies (to be removed).
-  [[nodiscard]] virtual std::unique_ptr<CompileTarget> getCompileTarget();
+  // Overload for currently unsupported policies (to be removed).
   [[nodiscard]] virtual std::unique_ptr<CompileTarget>
   getCompileTarget(ExecutionContext *context);
 

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -288,7 +288,7 @@ cudaq_internal::compiler::Compiler::assembleCompiledModule(
     const std::string &kernelName,
     std::vector<std::pair<std::string, mlir::ModuleOp>> &modules, bool needJit,
     bool runCombineMeasurements, std::optional<cudaq::Resources> resourceCounts,
-    const std::vector<std::size_t> &mappingReorderIdx,
+    cudaq::CompiledModule::CompilationMetadata metadata,
     std::shared_ptr<mlir::MLIRContext> context) {
   std::vector<
       cudaq_internal::compiler::CompiledModuleHelper::NamedCompiledArtifact>
@@ -324,7 +324,7 @@ cudaq_internal::compiler::Compiler::assembleCompiledModule(
   }
 
   return cudaq_internal::compiler::CompiledModuleHelper::createCompiledModule(
-      kernelName, {}, std::move(artifacts), {.reorderIdx = mappingReorderIdx});
+      kernelName, {}, std::move(artifacts), std::move(metadata));
 }
 
 cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
@@ -336,7 +336,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
   auto [moduleOp, epFunc] = prepareModule(kernelName, m_module, args);
 
   // Populate conditional measurement flag in the context.
-  if (emulate && executionContext && executionContext->name == "sample") {
+  if (!target->supportConditionalsOnMeasureResults) {
     for (auto &artifact : moduleOp) {
       cudaq::quake::detail::QuakeFunctionAnalysis analysis{&artifact};
       auto info = analysis.getAnalysisInfo();
@@ -373,34 +373,34 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
 
   auto mapping_reorder_idx = extractMappingReorderIdx(moduleOp, epFunc);
 
+  // Warn if kernel has named measurement registers (sub-registers).
+  if (target->warnNamedMeasurements) {
+    auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
+        std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
+    if (funcOp) {
+      bool hasNamedMeasurements = false;
+      funcOp.walk([&](cudaq::quake::MeasurementInterface meas) {
+        if (meas.getOptionalRegisterName().has_value()) {
+          hasNamedMeasurements = true;
+          return mlir::WalkResult::interrupt();
+        }
+        return mlir::WalkResult::advance();
+      });
+      if (hasNamedMeasurements) {
+        warnedNamedMeasurements = true;
+        std::cerr << "WARNING: Kernel \"" << kernelName
+                  << "\" uses named measurement results "
+                  << "but is invoked in sampling mode. Support for "
+                  << "sub-registers in `sample_result` is deprecated and will "
+                  << "be removed in a future release. Use `run` to retrieve "
+                  << "individual measurement results." << std::endl;
+      }
+    }
+  }
+
   if (executionContext) {
     if (executionContext->name == "sample") {
       executionContext->reorderIdx = mapping_reorder_idx;
-      // Warn if kernel has named measurement registers (sub-registers).
-      if (!executionContext->warnedNamedMeasurements) {
-        auto funcOp = moduleOp.template lookupSymbol<mlir::func::FuncOp>(
-            std::string(cudaq::runtime::cudaqGenPrefixName) + kernelName);
-        if (funcOp) {
-          bool hasNamedMeasurements = false;
-          funcOp.walk([&](cudaq::quake::MeasurementInterface meas) {
-            if (meas.getOptionalRegisterName().has_value()) {
-              hasNamedMeasurements = true;
-              return mlir::WalkResult::interrupt();
-            }
-            return mlir::WalkResult::advance();
-          });
-          if (hasNamedMeasurements) {
-            executionContext->warnedNamedMeasurements = true;
-            std::cerr
-                << "WARNING: Kernel \"" << kernelName
-                << "\" uses named measurement results "
-                << "but is invoked in sampling mode. Support for "
-                << "sub-registers in `sample_result` is deprecated and will "
-                << "be removed in a future release. Use `run` to retrieve "
-                << "individual measurement results." << std::endl;
-          }
-        }
-      }
       // No need to add measurements only to remove them eventually
       if (target->pipelineConfig.postCodeGenPasses.find(
               "remove-measurements") == std::string::npos)
@@ -463,7 +463,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
                              executionContext->name == "resource-count");
   return assembleCompiledModule(
       kernelName, modules, needJit, emulate && combineMeasurements,
-      std::move(resourceCounts), mapping_reorder_idx, context);
+      std::move(resourceCounts), {.reorderIdx = mapping_reorder_idx}, context);
 }
 
 std::vector<cudaq::KernelExecution>

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -363,7 +363,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
   // the pre-processing might change the IR structure (may interfere with
   // other passes).
   std::optional<cudaq::Resources> resourceCounts;
-  if (executionContext && executionContext->name == "resource-count") {
+  if (target->generateResourceCounts) {
     auto result = cudaq::opt::countResourcesFromIR(moduleOp);
     if (failed(result))
       throw std::runtime_error(
@@ -458,8 +458,7 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
     modules.emplace_back(kernelName, moduleOp);
   }
 
-  bool needJit = emulate || (executionContext &&
-                             executionContext->name == "resource-count");
+  bool needJit = emulate || target->generateResourceCounts;
   return assembleCompiledModule(
       kernelName, modules, needJit, emulate && combineMeasurements,
       std::move(resourceCounts), {.reorderIdx = mapping_reorder_idx}, context);

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -412,11 +412,10 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
 
   // Apply observations if necessary
   std::vector<std::pair<std::string, mlir::ModuleOp>> modules;
-  if (executionContext && executionContext->name == "observe") {
+  if (target->pauliTermSplitObservable) {
     mapping_reorder_idx.clear();
     applyPipeline("canonicalize,cse", moduleOp, kernelName);
-    cudaq::spin_op &spin = executionContext->spin.value();
-    for (const auto &term : spin) {
+    for (const auto &term : *target->pauliTermSplitObservable) {
       if (term.is_identity())
         continue;
 

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -400,13 +400,11 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
     }
   }
 
-  if (executionContext) {
-    if (executionContext->name == "sample") {
-      // No need to add measurements only to remove them eventually
-      if (target->pipelineConfig.postCodeGenPasses.find(
-              "remove-measurements") == std::string::npos)
-        applyPipeline("func.func(add-measurements)", moduleOp, kernelName);
-    }
+  if (target->pipelineConfig.addMeasurements) {
+    // No need to add measurements only to remove them eventually
+    if (target->pipelineConfig.postCodeGenPasses.find("remove-measurements") ==
+        std::string::npos)
+      applyPipeline("func.func(add-measurements)", moduleOp, kernelName);
   }
 
   // Apply observations if necessary

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -371,7 +371,9 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
     resourceCounts = std::move(*result);
   }
 
-  auto mapping_reorder_idx = extractMappingReorderIdx(moduleOp, epFunc);
+  std::vector<std::size_t> mapping_reorder_idx;
+  if (target->storeReorderIdx)
+    mapping_reorder_idx = extractMappingReorderIdx(moduleOp, epFunc);
 
   // Warn if kernel has named measurement registers (sub-registers).
   if (target->warnNamedMeasurements) {
@@ -400,20 +402,16 @@ cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
 
   if (executionContext) {
     if (executionContext->name == "sample") {
-      executionContext->reorderIdx = mapping_reorder_idx;
       // No need to add measurements only to remove them eventually
       if (target->pipelineConfig.postCodeGenPasses.find(
               "remove-measurements") == std::string::npos)
         applyPipeline("func.func(add-measurements)", moduleOp, kernelName);
-    } else {
-      executionContext->reorderIdx.clear();
     }
   }
 
   // Apply observations if necessary
   std::vector<std::pair<std::string, mlir::ModuleOp>> modules;
   if (target->pauliTermSplitObservable) {
-    mapping_reorder_idx.clear();
     applyPipeline("canonicalize,cse", moduleOp, kernelName);
     for (const auto &term : *target->pauliTermSplitObservable) {
       if (term.is_identity())

--- a/runtime/internal/compiler/Compiler.cpp
+++ b/runtime/internal/compiler/Compiler.cpp
@@ -328,9 +328,8 @@ cudaq_internal::compiler::Compiler::assembleCompiledModule(
 }
 
 cudaq::CompiledModule cudaq_internal::compiler::Compiler::runPassPipeline(
-    cudaq::ExecutionContext *executionContext, const std::string &kernelName,
-    const void *modulePtr, cudaq::KernelArgs args,
-    std::shared_ptr<mlir::MLIRContext> context) {
+    const std::string &kernelName, const void *modulePtr,
+    cudaq::KernelArgs args, std::shared_ptr<mlir::MLIRContext> context) {
   mlir::ModuleOp m_module = mlir::ModuleOp::getFromOpaquePointer(modulePtr);
   assert(!context || context.get() == m_module.getContext());
   auto [moduleOp, epFunc] = prepareModule(kernelName, m_module, args);
@@ -520,10 +519,9 @@ cudaq_internal::compiler::Compiler::emitKernelExecutions(
 /// platform directory for the targeted backend.
 std::vector<cudaq::KernelExecution>
 cudaq_internal::compiler::Compiler::lowerQuakeCode(
-    cudaq::ExecutionContext *executionContext, const std::string &kernelName,
-    const void *modulePtr, cudaq::KernelArgs args) {
-  auto compiled =
-      runPassPipeline(executionContext, kernelName, modulePtr, args);
+    const std::string &kernelName, const void *modulePtr,
+    cudaq::KernelArgs args) {
+  auto compiled = runPassPipeline(kernelName, modulePtr, args);
   return emitKernelExecutions(compiled);
 }
 

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -56,6 +56,9 @@ class Compiler {
   /// @brief Flag indicating whether we should print the IR.
   bool printIR = false;
 
+  /// Whether compilation emitted a named measurement warning.
+  bool warnedNamedMeasurements = false;
+
   mlir::ModuleOp lowerQuakeCodeBuildModule(const std::string &,
                                            mlir::ModuleOp module,
                                            mlir::MLIRContext *,
@@ -85,10 +88,14 @@ class Compiler {
       std::vector<std::pair<std::string, mlir::ModuleOp>> &modules,
       bool needJit, bool runCombineMeasurements,
       std::optional<cudaq::Resources> resourceCounts,
-      const std::vector<std::size_t> &mappingReorderIdx,
+      cudaq::CompiledModule::CompilationMetadata metadata,
       std::shared_ptr<mlir::MLIRContext> context);
 
 public:
+  /// Whether compilation emitted a warning about the presence of named
+  /// measurements.
+  bool hasWarnedNamedMeasurements() const { return warnedNamedMeasurements; }
+
   static std::pair<const void *, std::shared_ptr<mlir::MLIRContext>>
   loadQuakeCodeByName(const std::string &kernelName);
 

--- a/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
+++ b/runtime/internal/compiler/include/cudaq_internal/compiler/Compiler.h
@@ -112,8 +112,7 @@ public:
   /// the context, guaranteeing it outlives the artifacts. Otherwise the
   /// context lifetime must be managed by the caller.
   cudaq::CompiledModule
-  runPassPipeline(cudaq::ExecutionContext *executionContext,
-                  const std::string &kernelName, const void *modulePtr,
+  runPassPipeline(const std::string &kernelName, const void *modulePtr,
                   cudaq::KernelArgs args,
                   std::shared_ptr<mlir::MLIRContext> context = nullptr);
 
@@ -132,8 +131,7 @@ public:
   /// the scope of this launch instance). It can be disposed and/or modified by
   /// this call in any way necessary without breaking some other kernel launch.
   std::vector<cudaq::KernelExecution>
-  lowerQuakeCode(cudaq::ExecutionContext *executionContext,
-                 const std::string &kernelName, const void *modulePtr,
+  lowerQuakeCode(const std::string &kernelName, const void *modulePtr,
                  cudaq::KernelArgs args);
 };
 


### PR DESCRIPTION
~This needs to be merged after #4599. Until I rebase, you should ignore the first commit when reviewing.~ Done.

In this PR I introduce compiler options within the `CompileTarget` type. This allows us to finally remove any dependency of the compilation on the execution context!