### PR TITLE
Build observe_result during finalization.

### DIFF
--- a/runtime/cudaq/algorithms/observe/policy.h
+++ b/runtime/cudaq/algorithms/observe/policy.h
@@ -13,6 +13,9 @@
 
 namespace cudaq {
 
+class ExecutionManager;
+class ExecutionContext;
+
 /// @brief Tag and options for computing expectation values.
 struct observe_policy {
   /// @brief The name of the policy.
@@ -23,6 +26,11 @@ struct observe_policy {
 
   /// Observe options.
   observe_options options;
+
+  friend observe_result
+  finalize_execution_manager_impl(ExecutionManager &mgr,
+                                  const observe_policy &policy,
+                                  ExecutionContext &ctx);
 };
 
 } // namespace cudaq

--- a/runtime/cudaq/platform/default/DefaultQPU.cpp
+++ b/runtime/cudaq/platform/default/DefaultQPU.cpp
@@ -78,7 +78,5 @@ void cudaq::DefaultQPU::finalizeExecutionContext(
   ScopedTraceWithContext(context.name == "observe" ? TIMING_OBSERVE : 0,
                          "DefaultPlatform::finalizeExecutionContext",
                          context.name);
-  handleObservation(context);
-
   getExecutionContext()->executionManager->finalizeExecutionContext(context);
 }

--- a/runtime/cudaq/qis/execution_manager.cpp
+++ b/runtime/cudaq/qis/execution_manager.cpp
@@ -12,6 +12,7 @@
 #include "nvqir/CircuitSimulator.h"
 #include "cudaq/algorithms/policy_cpos.h"
 #include "cudaq/algorithms/policy_dispatch.h"
+#include <stdexcept>
 
 using namespace cudaq;
 
@@ -55,6 +56,10 @@ void ExecutionManager::finalizeExecutionContext(ExecutionContext &ctx) {
     policies::visitResult(
         [&]() { return cudaq::finalize_execution_manager(*this, policy, ctx); },
         [&](sample_result &&r) { ctx.result = std::move(r); },
+        [&](observe_result &&r) {
+          ctx.result = r.raw_data();
+          ctx.expectationValue = r.expectation();
+        },
         [&](policies::void_result &&r) {});
   });
 }

--- a/runtime/cudaq/qis/execution_manager.cpp
+++ b/runtime/cudaq/qis/execution_manager.cpp
@@ -12,7 +12,6 @@
 #include "nvqir/CircuitSimulator.h"
 #include "cudaq/algorithms/policy_cpos.h"
 #include "cudaq/algorithms/policy_dispatch.h"
-#include <stdexcept>
 
 using namespace cudaq;
 

--- a/runtime/cudaq/qis/execution_manager.h
+++ b/runtime/cudaq/qis/execution_manager.h
@@ -126,6 +126,8 @@ public:
 
   virtual void finalizeExecutionContext(const other_policies &policy,
                                         ExecutionContext &ctx) {}
+  virtual observe_result finalizeExecutionContext(const observe_policy &policy,
+                                                  ExecutionContext &ctx) = 0;
   virtual sample_result
   finalizeExecutionContext(const sample_policy &policy) = 0;
 
@@ -231,6 +233,13 @@ public:
 inline sample_result finalize_execution_manager_impl(
     ExecutionManager &mgr, const sample_policy &policy, ExecutionContext &ctx) {
   return mgr.finalizeExecutionContext(policy);
+}
+
+inline observe_result
+finalize_execution_manager_impl(ExecutionManager &mgr,
+                                const observe_policy &policy,
+                                ExecutionContext &ctx) {
+  return mgr.finalizeExecutionContext(policy, ctx);
 }
 
 inline void finalize_execution_manager_impl(ExecutionManager &mgr,

--- a/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/default/DefaultExecutionManager.cpp
@@ -167,6 +167,12 @@ protected:
     return simulator()->finalizeExecutionContext(policy);
   }
 
+  observe_result finalizeExecutionContext(const observe_policy &policy,
+                                          ExecutionContext &ctx) override {
+    finalizeExecutionContextImpl();
+    return simulator()->finalizeExecutionContext(policy, ctx);
+  }
+
   void finalizeExecutionContext(const other_policies &policy,
                                 ExecutionContext &ctx) override {
     finalizeExecutionContextImpl();

--- a/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
+++ b/runtime/cudaq/qis/managers/photonics/PhotonicsExecutionManager.cpp
@@ -201,6 +201,12 @@ protected:
     return result;
   }
 
+  observe_result finalizeExecutionContext(const observe_policy &,
+                                          ExecutionContext &ctx) override {
+    throw std::runtime_error(
+        "observe policy not supported for this photonics simulator.");
+  }
+
   void finalizeExecutionContext(const other_policies &policy,
                                 ExecutionContext &ctx) override {
     std::vector<std::size_t> ids;

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -267,12 +267,19 @@ public:
       cudaq::policies::visitResult(
           [&]() { return finalize_simulation_circuit(*this, policy, ctx); },
           [&](cudaq::sample_result &&r) { ctx.result = std::move(r); },
+          [&](cudaq::observe_result &&r) {
+            ctx.result = r.raw_data();
+            ctx.expectationValue = r.expectation();
+          },
           [&](cudaq::policies::void_result &&r) {});
     });
   }
 
   virtual void finalizeExecutionContext(const cudaq::other_policies &policy,
                                         cudaq::ExecutionContext &ctx) {}
+  virtual cudaq::observe_result
+  finalizeExecutionContext(const cudaq::observe_policy &policy,
+                           cudaq::ExecutionContext &ctx) = 0;
   virtual cudaq::sample_result
   finalizeExecutionContext(const cudaq::sample_policy &policy) = 0;
 
@@ -1015,6 +1022,38 @@ protected:
   void finalizeExecutionContextImpl() {
     // Flush the queue if there are any gates to apply
     flushGateQueue();
+  }
+
+  cudaq::observe_result
+  finalizeExecutionContext(const cudaq::observe_policy &,
+                           cudaq::ExecutionContext &ctx) override {
+    finalizeExecutionContextImpl();
+    if (!ctx.spin.has_value())
+      throw std::runtime_error("[observe] ExecutionContext specified without a "
+                               "cudaq::spin_op.");
+
+    std::vector<cudaq::ExecutionResult> results;
+    cudaq::spin_op &H = ctx.spin.value();
+    assert(cudaq::spin_op::canonicalize(H) == H);
+
+    if (ctx.canHandleObserve) {
+      auto [exp, data] = measureSpinOp(H);
+      return cudaq::observe_result(exp, H, data);
+    } else {
+      double sum = 0.0;
+      for (const auto &term : H) {
+        if (term.is_identity())
+          sum += term.evaluate_coefficient().real();
+        else {
+          auto [exp, data] = measureSpinOp(term);
+          results.emplace_back(data.to_map(), term.get_term_id(), exp);
+          sum += term.evaluate_coefficient().real() * exp;
+        }
+      };
+
+      auto data = cudaq::sample_result(sum, results);
+      return cudaq::observe_result(sum, H, data);
+    }
   }
 
   cudaq::sample_result

--- a/runtime/nvqir/CircuitSimulator.h
+++ b/runtime/nvqir/CircuitSimulator.h
@@ -1049,7 +1049,7 @@ protected:
           results.emplace_back(data.to_map(), term.get_term_id(), exp);
           sum += term.evaluate_coefficient().real() * exp;
         }
-      };
+      }
 
       auto data = cudaq::sample_result(sum, results);
       return cudaq::observe_result(sum, H, data);

--- a/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
@@ -10,6 +10,7 @@
 #include "CuDensityMatContext.h"
 #include "CuDensityMatErrorHandling.h"
 #include "CuDensityMatState.h"
+#include "ObserveResult.h"
 #include "common/FmtCore.h"
 #include "cudaq/cudaq_mpi.h"
 #include "cudaq/distributed/mpi_plugin.h"
@@ -153,6 +154,13 @@ protected:
   cudaq::sample_result
   finalizeExecutionContext(const cudaq::sample_policy &policy) override {
     return cudaq::sample_result();
+  }
+
+  cudaq::observe_result
+  finalizeExecutionContext(const cudaq::observe_policy &,
+                           cudaq::ExecutionContext &ctx) override {
+    finalizeExecutionContextImpl(ctx);
+    return cudaq::observe_result();
   }
 
   void finalizeExecutionContext(const cudaq::other_policies &policy,

--- a/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
+++ b/runtime/nvqir/cudensitymat/CuDensityMatSim.cpp
@@ -153,14 +153,15 @@ protected:
 
   cudaq::sample_result
   finalizeExecutionContext(const cudaq::sample_policy &policy) override {
-    return cudaq::sample_result();
+    throw std::runtime_error(fmt::format(
+        "[dynamics target] {} policy is not supported.", policy.name));
   }
 
   cudaq::observe_result
-  finalizeExecutionContext(const cudaq::observe_policy &,
+  finalizeExecutionContext(const cudaq::observe_policy &policy,
                            cudaq::ExecutionContext &ctx) override {
-    finalizeExecutionContextImpl(ctx);
-    return cudaq::observe_result();
+    throw std::runtime_error(fmt::format(
+        "[dynamics target] {} policy is not supported.", policy.name));
   }
 
   void finalizeExecutionContext(const cudaq::other_policies &policy,

--- a/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
+++ b/unittests/qudit/simple_qudit/SimpleQuditExecutionManager.cpp
@@ -84,6 +84,11 @@ protected:
     return result;
   }
 
+  observe_result finalizeExecutionContext(const observe_policy &,
+                                          ExecutionContext &) override {
+    throw std::runtime_error("observe is not implemented for SimpleQudit.");
+  }
+
   void endExecution() override {
     sampleQudits.clear();
     BasicExecutionManager::endExecution();


### PR DESCRIPTION
This PR is moving the production of the observe_result in the simulator finalization phase, using the observe_policy. This is in order to bring symmetry with how the sample_result is produced. It builds on the changes of #4339 and adds a new observe_policy overload. 

This does not bring end-to-end support for the observe_policy, but like #4339, is a first step in this direction and a change worth testing on its own. 