### PR TITLE
[core] Fix cudaq-quake segfault on _Complex-typed std::complex ctor

### DIFF
--- a/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -3442,6 +3442,16 @@ bool QuakeBridgeVisitor::VisitCXXConstructExpr(clang::CXXConstructExpr *x) {
     if (isVectorOfQubitRefs)
       return true;
     if (ctorName == "complex") {
+      // `_Complex T` is not modeled; only handle `complex<T>(re, im)`.
+      if (x->getNumArgs() != 2 || valueStack.size() < 2) {
+        reportClangError(
+            x, mangler,
+            "unsupported std::complex constructor; for imaginary literals "
+            "such as `1.0i`, add `using namespace std::complex_literals;` so "
+            "the literal has type std::complex<double>");
+        raisedError = true;
+        return false;
+      }
       Value imag = popValue();
       Value real = popValue();
       return pushValue(mlir::complex::CreateOp::create(


### PR DESCRIPTION
When complex literals like `0.5i` are used without `using namespace std::complex_literals;`, the AST contains a single-argument converting constructor `std::complex<T>(_Complex T)`. The visitor doesn't model `_Complex T` values, so the surrounding `BinaryOperator` falls through to `arith::AddFOp` (because `clang::Type::isFloatingType()` returns true for `_Complex`) and pushes only one value. The complex-ctor branch in `VisitCXXConstructExpr` then `popValue()`s twice, reading past the empty value stack and segfaulting.

Guard the branch on `getNumArgs() == 2` and `valueStack.size() >= 2`; otherwise emit a clear clang diagnostic pointing the user at `std::complex_literals` and set `raisedError` so the type-stack rebalance assertion in `TraverseCXXConstructExpr` does not fire.

Fixes #4600.

# Example
```
  #include <cudaq.h>
  #include <complex>
  #include <vector>

  CUDAQ_REGISTER_OPERATION(
      unitary_3, 1, 0,
      (std::vector<std::complex<double>>{
           0.311740+0.286260i, -0.905661+0.025514i,
           0.903697+0.064850i,  0.323887-0.272442i}));

  struct main_circuit { uint64_t operator()() __qpu__ {
      cudaq::qubit q; unitary_3(q); return mz(q);
  }};
  int main() { return 0; }
```

## Before
```
  $ cudaq-quake test.cpp
  cudaq-quake: SmallVector.h:315: ... Assertion `!empty()' failed.
  PLEASE submit a bug report to https://github.com/NVIDIA/cuda-quantum and include the crash backtrace.
  Stack dump:
  0.  Program arguments: cudaq-quake test.cpp
  1.  <eof> parser at end of file
   #0 llvm::sys::PrintStackTrace(...)
   #1 llvm::sys::RunSignalHandlers()
   #2 SignalHandler(...)
   #4 cudaq::details::QuakeBridgeVisitor::VisitCXXConstructExpr(...)
   ...
  Segmentation fault (core dumped)
```
  ## After

  Same source, same command:
```
  $ cudaq-quake test.cpp
  test.cpp:8:10: error: unsupported std::complex constructor; for imaginary
  literals such as `1.0i`, add `using namespace std::complex_literals;` so the
  literal has type std::complex<double>
      8 |          0.311740+0.286260i, -0.905661+0.025514i,
        |          ^
  1 error generated.
  $ echo $?
  1
```
  Adding using namespace std::complex_literals; (or switching to {re, im} initializers) then lowers cleanly.