### PR TITLE
[nvqpp] Copy a returned measure_handle vector to the heap

### DIFF
--- a/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertStmt.cpp
@@ -335,6 +335,16 @@ bool QuakeBridgeVisitor::VisitReturnStmt(clang::ReturnStmt *x) {
       // necessarily an explicit cast or promotion node in the AST.)
       auto load = cc::LoadOp::create(builder, loc, result);
       result = load.getResult();
+      // A `std::vector<measure_handle>` local is a descriptor slot, so it
+      // arrives here in pointer form. After promoting it to a value, refresh
+      // `resTy` to the loaded vector type so the `SpanLikeType` branch below
+      // copies the vector contents to the heap before returning. Without the
+      // refresh that branch tests the stale pointer type and is skipped,
+      // returning a descriptor that aliases a buffer freed when the callee
+      // returns.
+      if (auto sv = dyn_cast<cc::StdvecType>(result.getType());
+          sv && isa<cc::MeasureHandleType>(sv.getElementType()))
+        resTy = result.getType();
       if (load.getType() == builder.getI8Type()) {
         auto fnTy = load->getParentOfType<func::FuncOp>().getFunctionType();
         auto i1Ty = builder.getI1Type();

--- a/targettests/execution/measure_handle_vec_assign.cpp
+++ b/targettests/execution/measure_handle_vec_assign.cpp
@@ -57,6 +57,24 @@ __qpu__ std::vector<bool> loop_carry_last() {
   return cudaq::to_bools(prev);
 }
 
+// Returning a `std::vector<measure_handle>` local by value must copy the buffer
+// to the heap on return; otherwise the caller's binding aliases the callee's
+// buffer, which is freed when the callee returns.  The callee measures and
+// returns the handle vector, and the caller copy-initializes a local from that
+// by-value return.
+__qpu__ std::vector<cudaq::measure_result>
+measure_and_return(cudaq::qview<> qv) {
+  auto r = mz(qv);
+  return r;
+}
+
+__qpu__ std::vector<bool> return_by_value() {
+  cudaq::qvector qv(2);
+  x(qv[0]);                        // |10>
+  auto s = measure_and_return(qv); // copy-init from a by-value return
+  return cudaq::to_bools(s);
+}
+
 int main() {
   {
     auto bits = outer_outlives_inner();
@@ -72,7 +90,15 @@ int main() {
       std::cout << b;
     std::cout << "\n";
   }
+  {
+    auto bits = return_by_value();
+    std::cout << "ret:";
+    for (bool b : bits)
+      std::cout << b;
+    std::cout << "\n";
+  }
 }
 
 // CHECK: outer:01
 // CHECK: carry:10
+// CHECK: ret:10


### PR DESCRIPTION
Follow-up to #4603 to fix regression found by CUDA-Q Libraries

A `std::vector<measure_handle>` local is lowered to a descriptor stack slot, so it reaches the return statement in pointer form. The return path promotes it to a value with a load but did not update the type it then inspects, so the branch that copies vector contents to the heap on return was skipped. The function returned a descriptor aliasing a buffer that is freed when the callee returns, double-freed by the caller's binding.

Refresh the inspected type after the load for the measure_handle-vector case so the heap copy is emitted. Other pointer-form returns are unchanged.

Adds an execution test covering return-by-value of a measured handle vector.