### PR TITLE
[ci] Auto-delete stale bot/* branches on the daily cleanup schedule

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -23,25 +23,48 @@ name: Clean up
 jobs:
   bot_branches:
     name: Delete temporary bot/* branches
-    if: github.event_name == 'workflow_dispatch' && inputs.delete_temp_branches
+    # Manual dispatch deletes all bot/* branches; the daily schedule deletes only stale ones.
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.delete_temp_branches) ||
+      github.event.schedule == '0 0 * * *'
     runs-on: ubuntu-latest
 
     steps:
       - run: |
           retry() { for n in 1 2 3; do "$@" && return 0; [ $n -lt 3 ] && sleep $((15*n*n)); done; return 1; }
-          branches_to_delete=`retry gh api --paginate \
+
+          # On the schedule, only delete branches older than the cutoff so an active publish is not disrupted.
+          cutoff=""
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+            cutoff=$(date -u -d '1 day ago' +%s)
+          fi
+
+          branches=`retry gh api --paginate \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/branches \
-            --jq '.[] | select(.name | test("^bot/[0-9]+")).name'`
+            --jq '.[] | select(.name | test("^bot/[0-9]+")) | "\(.name) \(.commit.sha)"'`
 
-          for branch in $branches_to_delete; do
+          echo "$branches" | while read -r branch sha; do
+            [ -n "$branch" ] || continue
+            if [ -n "$cutoff" ]; then
+              commit_date=`retry gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /repos/${{ github.repository }}/commits/$sha \
+                --jq '.commit.committer.date'`
+              commit_ts=$(date -u -d "$commit_date" +%s)
+              if [ "$commit_ts" -ge "$cutoff" ]; then
+                echo "Skipping $branch (tip commit updated within the last day)."
+                continue
+              fi
+            fi
             echo "Deleting $branch."
             retry gh api \
               --method DELETE \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/nvidia/cuda-quantum/git/refs/heads/$branch
+              /repos/${{ github.repository }}/git/refs/heads/$branch
           done
         env:
           GH_TOKEN: ${{ secrets.REPO_BOT_ACCESS_TOKEN || github.token }}


### PR DESCRIPTION
The "Delete temporary bot/* branches" job was gated on `github.event_name == 'workflow_dispatch' && inputs.delete_temp_branches`, so it only ran on a manual dispatch and was always skipped on the scheduled cleanup runs. Publishing creates bot/<run_id>/<name> staging branches and deletes them when it finishes, but a failed or cancelled publish leaks the branch, so they accumulated indefinitely.

Let the job also run on the daily (0 0 * * *) schedule, but on scheduled runs only delete branches whose tip commit is older than one day. That clears leaked branches automatically while never touching a branch an in-flight publishing run may still be using. A manual dispatch keeps its existing "delete all bot/* branches" behavior.

Also use ${{ github.repository }} for the ref-delete call instead of the hardcoded nvidia/cuda-quantum, matching the branch-listing call.