### PR TITLE
[docs] Document `measure_handle` and `dem_from_kernel`

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -15,9 +15,15 @@
 #   TARGET_OPTION <Option>: extra option for the target
 #   SOURCE_DIR <DIR>: the directory that SOURCE_LOCATION is relative to (if not the default)
 #   LAUNCH_COMMAND <COMMAND>: the command to launch the test (e.g., mpirun)
+#   LIBRARY_MODE: compile in library mode instead of the default MLIR mode
 function(add_nvqpp_test TEST_NAME SOURCE_LOCATION)
-  cmake_parse_arguments(PARSED_ARGS "" "TARGET;LABELS;SOURCE_DIR;LAUNCH_COMMAND;APPLICATION_ARGS;TARGET_OPTION;EXTRA_COMPILE_ARGS;MIN_GPUS" "" ${ARGN})
-  set(NVQPP_COMPILE_ARGS "--library-mode -I${CMAKE_SOURCE_DIR}/runtime/include")
+  cmake_parse_arguments(PARSED_ARGS "LIBRARY_MODE" "TARGET;LABELS;SOURCE_DIR;LAUNCH_COMMAND;APPLICATION_ARGS;TARGET_OPTION;EXTRA_COMPILE_ARGS;MIN_GPUS" "" ${ARGN})
+  # Snippets compile in MLIR mode by default.
+  if(PARSED_ARGS_LIBRARY_MODE)
+    set(NVQPP_COMPILE_ARGS "--library-mode -I${CMAKE_SOURCE_DIR}/runtime/include")
+  else()
+    set(NVQPP_COMPILE_ARGS "--enable-mlir -I${CMAKE_SOURCE_DIR}/runtime/include")
+  endif()
   if(PARSED_ARGS_TARGET)
     set(NVQPP_COMPILE_ARGS "${NVQPP_COMPILE_ARGS} --target ${PARSED_ARGS_TARGET}")
     if (PARSED_ARGS_TARGET_OPTION)
@@ -52,8 +58,9 @@ endfunction()
 add_nvqpp_test(GHZ examples/cpp/basics/static_kernel.cpp)
 add_nvqpp_test(ExpVals examples/cpp/basics/expectation_values.cpp)
 add_nvqpp_test(MidCircuitMeasurements examples/cpp/basics/mid_circuit_measurement.cpp)
+add_nvqpp_test(MeasuringKernels examples/cpp/measuring_kernels.cpp)
 add_nvqpp_test(PhaseEstimation applications/cpp/phase_estimation.cpp)
-add_nvqpp_test(Grover applications/cpp/grover.cpp)
+add_nvqpp_test(Grover applications/cpp/grover.cpp LIBRARY_MODE)
 add_nvqpp_test(QAOA applications/cpp/qaoa_maxcut.cpp)
 add_nvqpp_test(VQEH2 applications/cpp/vqe_h2.cpp)
 add_nvqpp_test(AmplitudeEstimation applications/cpp/amplitude_estimation.cpp)
@@ -81,6 +88,9 @@ add_nvqpp_test(PTSBE_BellDepol bell_circuit_under_depol_noise.cpp SOURCE_DIR ${P
 add_nvqpp_test(PTSBE_InspectData inspect_execution_data.cpp SOURCE_DIR ${PTSBE_CPP_SNIPPET_DIR})
 add_nvqpp_test(PTSBE_SamplingStrategies sampling_strategies.cpp SOURCE_DIR ${PTSBE_CPP_SNIPPET_DIR})
 add_nvqpp_test(PTSBE_ShotAllocation shot_allocation.cpp SOURCE_DIR ${PTSBE_CPP_SNIPPET_DIR})
+
+set(DEM_CPP_SNIPPET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sphinx/snippets/cpp/using/examples/dem)
+add_nvqpp_test(DEM_FromKernel dem_from_kernel.cpp SOURCE_DIR ${DEM_CPP_SNIPPET_DIR})
 
 if (cuDensityMat_FOUND)
   add_nvqpp_test(Dynamics_Snippets using/backends/dynamics.cpp SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sphinx/snippets/cpp/ TARGET dynamics LABELS gpu_required)  
@@ -160,7 +170,7 @@ if (MPI_CXX_FOUND AND cuTensorNet_FOUND)
     LABELS "gpu_required;mgpus_required")
 endif()
 
-add_nvqpp_test(photonics_sim targets/cpp/photonics.cpp TARGET orca-photonics)
+add_nvqpp_test(photonics_sim targets/cpp/photonics.cpp TARGET orca-photonics LIBRARY_MODE)
 
 # Only add the python tests if we built the python API
 if (CUDAQ_ENABLE_PYTHON)
@@ -198,6 +208,9 @@ if (CUDAQ_ENABLE_PYTHON)
   add_pycudaq_test(PTSBE_InspectData inspect_execution_data.py SOURCE_DIR ${PTSBE_PY_SNIPPET_DIR})
   add_pycudaq_test(PTSBE_SamplingStrategies sampling_strategies.py SOURCE_DIR ${PTSBE_PY_SNIPPET_DIR})
   add_pycudaq_test(PTSBE_ShotAllocation shot_allocation.py SOURCE_DIR ${PTSBE_PY_SNIPPET_DIR})
+
+  set(DEM_PY_SNIPPET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sphinx/snippets/python/using/examples/dem)
+  add_pycudaq_test(DEM_FromKernel dem_from_kernel.py SOURCE_DIR ${DEM_PY_SNIPPET_DIR})
 
   if (CUDA_FOUND)
     add_pycudaq_test(EvolveDynamics using/backends/dynamics.py LABELS gpu_required SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sphinx/snippets/python)

--- a/docs/sphinx/api/default_ops.rst
+++ b/docs/sphinx/api/default_ops.rst
@@ -500,6 +500,13 @@ Negating the polarity of control qubits is similarly supported when using :code:
 Measurements on Qubits
 =============================
 
+The measurement operations :code:`mz`, :code:`mx`, and :code:`my` return a
+measurement handle rather than a bare classical value:
+:code:`cudaq::measure_handle` in C++ (also available as the alias
+:code:`cudaq::measure_result`), and the :code:`measure_handle` type in
+Python. See :doc:`../using/examples/measuring_kernels` for how to discriminate
+handles and the host-device boundary rule.
+
 :code:`mz`
 ---------------------
 

--- a/docs/sphinx/api/languages/cpp_api.rst
+++ b/docs/sphinx/api/languages/cpp_api.rst
@@ -132,6 +132,31 @@ Common
 .. doxygenfunction:: cudaq::run_async(std::size_t qpu_id, std::size_t shots, QuantumKernel &&kernel, ARGS &&...args)
 .. doxygenfunction:: cudaq::run_async(std::size_t qpu_id, std::size_t shots, cudaq::noise_model &noise_model, QuantumKernel &&kernel, ARGS &&...args)
 
+.. doxygenclass:: cudaq::measure_handle
+
+.. doxygentypedef:: cudaq::measure_result
+
+The measurement operations ``mz`` / ``mx`` / ``my`` return a
+``cudaq::measure_handle`` (also available under the alias
+``cudaq::measure_result``) rather than a bare classical value. Inside a kernel the
+handle converts to a classical value implicitly (the compiler intercepts the
+coercion), which defers discrimination. The helpers below discriminate a
+vector of handles.
+
+.. cpp:function:: std::vector<bool> cudaq::to_bools(const std::vector<measure_result> &results)
+
+    Discriminate a vector of measurement handles into their boolean outcomes.
+    Used inside a kernel (where the compiler intercepts the call); at host
+    scope the handles must already have been discriminated.
+
+.. cpp:function:: std::int64_t cudaq::to_integer(const std::vector<measure_result> &bits)
+.. cpp:function:: std::int64_t cudaq::to_integer(const std::vector<bool> &bits)
+.. cpp:function:: std::int64_t cudaq::to_integer(const std::string &bitstring)
+
+    Interpret a sequence of measurement outcomes as a little-endian unsigned
+    integer (bit ``i`` has weight ``2^i``). Overloads accept a vector of
+    handles, a vector of ``bool``, or a bitstring such as ``"011"``.
+
 .. doxygenclass:: cudaq::SimulationState
 
 .. doxygenstruct:: cudaq::SimulationState::Tensor
@@ -313,6 +338,39 @@ Algorithms
 
 .. doxygenclass:: cudaq::gradients::forward_difference
     :members:
+
+.. doxygenfunction:: cudaq::dem_from_kernel(QuantumKernel &&kernel, const cudaq::noise_model *noise, Args &&...args)
+.. doxygenfunction:: cudaq::dem_from_kernel(QuantumKernel &&kernel, Args &&...args)
+
+Quantum Error Correction
+========================
+
+These kernel-side declarations annotate a circuit with detectors and logical
+observables so a detector error model (DEM) can be extracted with
+``cudaq::dem_from_kernel``. They are intercepted by the compiler
+inside ``__qpu__`` kernels and lower to the ``qec`` dialect; for
+backends that do not consume them they are erased before execution.
+
+.. cpp:function:: template <typename... MeasArgs> void cudaq::detector(MeasArgs &&...ms)
+
+    Declare one detector as the parity of the referenced measurements. Each
+    argument is a ``cudaq::measure_result`` or a
+    ``std::vector<cudaq::measure_result>``. A detector is a parity constraint
+    that is deterministic under noise-free execution.
+
+.. cpp:function:: void cudaq::detectors(const std::vector<measure_result> &prev, const std::vector<measure_result> &curr)
+
+    Declare N detectors at once by pairing two equal-length handle vectors
+    element-wise (``detector(prev[i], curr[i])`` for each ``i``); the standard
+    form for cross-round detectors. Length agreement is enforced at runtime.
+
+.. cpp:function:: template <typename... MeasArgs> void cudaq::logical_observable(MeasArgs &&...ms)
+.. cpp:function:: void cudaq::logical_observable(const std::vector<measure_result> &ms, std::size_t observable_index)
+
+    Declare one logical observable as the parity of the referenced
+    measurements. The variadic form uses observable index ``0``; codes with
+    ``k`` logical qubits use the ``(vector, observable_index)`` overload to
+    declare observables ``0..k-1``.
 
 Platform
 =========

--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -72,6 +72,22 @@ Kernel Execution
 .. autofunction:: cudaq::draw
 .. autofunction:: cudaq::translate
 .. autofunction:: cudaq::estimate_resources
+.. autofunction:: cudaq::dem_from_kernel
+
+Quantum Error Correction
+=============================
+
+These functions are called inside an ``@cudaq.kernel`` body to declare
+detectors and logical observables for detector-error-model generation with
+``cudaq.dem_from_kernel``, and to discriminate measurement handles. They are
+intercepted by the compiler; calling them at host scope raises
+``RuntimeError``. (``cudaq.to_integer`` is likewise available inside kernels
+to pack discriminated bits into an integer.)
+
+.. autofunction:: cudaq::detector
+.. autofunction:: cudaq::detectors
+.. autofunction:: cudaq::logical_observable
+.. autofunction:: cudaq::to_bools
 
 Backend Configuration
 =============================
@@ -258,6 +274,8 @@ Data Types
 .. autoclass:: cudaq::qubit
 .. autoclass:: cudaq::qreg
 .. autoclass:: cudaq::qvector
+
+.. autoclass:: cudaq::measure_handle
 
 .. autoclass:: cudaq::ComplexMatrix
     :members:

--- a/docs/sphinx/snippets/cpp/using/examples/dem/dem_from_kernel.cpp
+++ b/docs/sphinx/snippets/cpp/using/examples/dem/dem_from_kernel.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// nvq++ dem_from_kernel.cpp -o dem && ./dem
+
+// [Begin Docs]
+#include <cstdio>
+#include <cudaq.h>
+#include <cudaq/algorithms/dem.h>
+// [End Docs]
+
+// [Begin Kernel]
+// A 3-qubit bit-flip memory experiment. Each round measures the data qubits;
+// cross-round detectors pair each measurement with its value in the previous
+// round, and a final logical observable reads out the register. In-kernel
+// `apply_noise` seeds the error mechanisms the detector error model reports.
+__qpu__ void memory_experiment(int rounds) {
+  cudaq::qvector data(3);
+  auto prev = mz(data);
+
+  for (int r = 0; r < rounds; ++r) {
+    cudaq::apply_noise<cudaq::x_error>(0.01, data[0]);
+    cudaq::apply_noise<cudaq::x_error>(0.01, data[1]);
+    cudaq::apply_noise<cudaq::x_error>(0.01, data[2]);
+
+    auto curr = mz(data);
+    // One detector per qubit, pairing this round with the previous one.
+    cudaq::detectors(prev, curr);
+    prev = curr;
+  }
+  cudaq::logical_observable(prev[0], prev[1], prev[2]);
+}
+// [End Kernel]
+
+int main() {
+  // [Begin Generate]
+  // Generate the detector error model as Stim `.dem` text. A noise model must
+  // be supplied for the in-kernel `apply_noise` mechanisms to take effect.
+  // Parse the text with Stim (`stim::DetectorErrorModel{dem}`) to drive a
+  // decoder.
+  cudaq::noise_model noise;
+  std::string dem =
+      cudaq::dem_from_kernel(memory_experiment, &noise, /*rounds=*/2);
+  std::printf("%s\n", dem.c_str());
+  // [End Generate]
+  return 0;
+}

--- a/docs/sphinx/snippets/python/using/examples/dem/dem_from_kernel.py
+++ b/docs/sphinx/snippets/python/using/examples/dem/dem_from_kernel.py
@@ -1,0 +1,46 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# [Begin Docs]
+import cudaq
+# [End Docs]
+
+
+# [Begin Kernel]
+# A 3-qubit bit-flip memory experiment. Each round measures the data qubits;
+# cross-round detectors pair each measurement with its value in the previous
+# round, and a final logical observable reads out the register. In-kernel
+# `apply_noise` seeds the error mechanisms the detector error model reports.
+@cudaq.kernel
+def memory_experiment(rounds: int):
+    data = cudaq.qvector(3)
+    prev = mz(data)
+
+    for r in range(rounds):
+        cudaq.apply_noise(cudaq.XError, 0.01, data[0])
+        cudaq.apply_noise(cudaq.XError, 0.01, data[1])
+        cudaq.apply_noise(cudaq.XError, 0.01, data[2])
+
+        curr = mz(data)
+        # One detector per qubit, pairing this round with the previous one.
+        cudaq.detectors(prev, curr)
+        prev = curr
+
+    cudaq.logical_observable(prev[0], prev[1], prev[2])
+
+
+# [End Kernel]
+
+# [Begin Generate]
+# Generate the detector error model as Stim `.dem` text. A noise model must be
+# supplied for the in-kernel `apply_noise` mechanisms to take effect. Parse the
+# text with `stim.DetectorErrorModel(dem)` to drive a decoder.
+noise = cudaq.NoiseModel()
+dem = cudaq.dem_from_kernel(memory_experiment, 2, noise_model=noise)
+print(dem)
+# [End Generate]

--- a/docs/sphinx/using/examples/dem_from_kernel.rst
+++ b/docs/sphinx/using/examples/dem_from_kernel.rst
@@ -27,7 +27,13 @@ standard form for cross-round detectors); and
 The example below is a three-qubit bit-flip memory experiment: each round
 measures the data qubits and pairs them with the previous round via
 ``detectors``, with a final ``logical_observable`` reading out the register.
-In-kernel ``apply_noise`` seeds the error mechanisms.
+In-kernel ``apply_noise`` seeds the error mechanisms. Each call applies a
+single-qubit bit-flip channel (``cudaq::x_error`` in C++, ``cudaq.XError`` in
+Python) that applies a Pauli ``X`` with the given probability, so a flipped
+data qubit shows up as a parity change in the next ``detectors`` pair. 
+See the :doc:`C++ </api/languages/cpp_api>` and 
+:doc:`Python </api/languages/python_api>` API references for ``apply_noise``
+and the other predefined noise channels.
 
 .. tab:: Python
 
@@ -63,6 +69,20 @@ The ``.dem`` text is a list of independent error mechanisms. Each
 ``error(p) D... L...`` line gives one mechanism: its probability ``p``, the
 detectors it flips (its *symptoms*, ``D``), and the logical observables it
 flips (its *frame changes*, ``L``).
+
+Output DEM: With two rounds and three data qubits, there are six independent
+``error`` mechanisms: one bit-flip per qubit per round at the in-kernel
+probability ``0.01`` (printed at full floating-point precision). Each error
+flips one detector together with the logical observable ``L0``:
+
+.. code-block:: text
+
+    error(0.01000000000000000021) D0 L0
+    error(0.01000000000000000021) D1 L0
+    error(0.01000000000000000021) D2 L0
+    error(0.01000000000000000021) D3 L0
+    error(0.01000000000000000021) D4 L0
+    error(0.01000000000000000021) D5 L0
 
 Limitations
 ------------

--- a/docs/sphinx/using/examples/dem_from_kernel.rst
+++ b/docs/sphinx/using/examples/dem_from_kernel.rst
@@ -1,0 +1,78 @@
+Detector Error Models
+=====================
+
+.. _dem_from_kernel:
+
+A *detector error model* (DEM) is a detector error matrix (capturing which
+detectors each error mechanism flips) together with a noise model that
+assigns a likelihood to each error mechanism. It is the input a decoder needs
+to infer which errors occurred from a circuit's measurement record. 
+
+In CUDA-Q you declare the parity checks (*detectors*) and *logical observables* 
+directly inside a kernel, then extract the DEM with
+:code:`cudaq::dem_from_kernel` (C++) or :code:`cudaq.dem_from_kernel` (Python)
+as text in Stim's standard
+`.dem file format <https://github.com/quantumlib/Stim/blob/main/doc/file_format_dem_detector_error_model.md>`__,
+which ``stim.DetectorErrorModel`` parses back into a decoder-ready model. The
+measurements that feed the declarations are *measurement handles*
+(:doc:`measuring_kernels`).
+
+Three kernel-side declarations are available in both C++ and Python : 
+``detector(m0, m1, ...)`` declares one detector as a parity
+constraint over the given measurements; ``detectors(prev, curr)`` declares ``N``
+detectors by pairing two equal-length handle vectors element-wise (the
+standard form for cross-round detectors); and
+``logical_observable(m0, m1, ...)`` declares a logical observable.
+
+The example below is a three-qubit bit-flip memory experiment: each round
+measures the data qubits and pairs them with the previous round via
+``detectors``, with a final ``logical_observable`` reading out the register.
+In-kernel ``apply_noise`` seeds the error mechanisms.
+
+.. tab:: Python
+
+   .. literalinclude:: ../../snippets/python/using/examples/dem/dem_from_kernel.py
+        :language: python
+        :start-after: [Begin Kernel]
+        :end-before: [End Kernel]
+
+.. tab:: C++
+
+   .. literalinclude:: ../../snippets/cpp/using/examples/dem/dem_from_kernel.cpp
+        :language: cpp
+        :start-after: [Begin Kernel]
+        :end-before: [End Kernel]
+
+Pass the kernel (and a noise model) to ``dem_from_kernel`` to extract the DEM.
+
+.. tab:: Python
+
+   .. literalinclude:: ../../snippets/python/using/examples/dem/dem_from_kernel.py
+        :language: python
+        :start-after: [Begin Generate]
+        :end-before: [End Generate]
+
+.. tab:: C++
+
+   .. literalinclude:: ../../snippets/cpp/using/examples/dem/dem_from_kernel.cpp
+        :language: cpp
+        :start-after: [Begin Generate]
+        :end-before: [End Generate]
+
+The ``.dem`` text is a list of independent error mechanisms. Each
+``error(p) D... L...`` line gives one mechanism: its probability ``p``, the
+detectors it flips (its *symptoms*, ``D``), and the logical observables it
+flips (its *frame changes*, ``L``).
+
+Limitations
+------------
+
+* **Stabilizer (Clifford) circuits only.** The DEM formalism requires detectors
+  to be deterministic under noise-free execution, which is only well defined for
+  Clifford circuits; a non-Clifford gate raises a diagnostic.
+* **No measurement-conditional control flow.** Branching on a measurement result
+  changes the measurement count shot-to-shot and breaks the detector matrix
+  model; such kernels are rejected.
+* **Independent Pauli noise.** Each error mechanism is assumed independent..
+* **Pre-decomposition.** The DEM reflects the abstract kernel circuit, not the
+  hardware-decomposed circuit.

--- a/docs/sphinx/using/examples/examples.rst
+++ b/docs/sphinx/using/examples/examples.rst
@@ -20,6 +20,7 @@ Examples that illustrate how to use CUDA-Q for application development are avail
       Optimizers & Gradients  <../../examples/python/optimizers_gradients.ipynb>
       Noisy Simulations <../../examples/python/noisy_simulations.ipynb>
       Pre-Trajectory Sampling with Batch Execution <ptsbe.rst>
+      Detector Error Models <dem_from_kernel.rst>
       Constructing Operators <operators.rst>
       Performance Optimizations <../../examples/python/performance_optimizations.ipynb>
       Using Quantum Hardware Providers <hardware_providers.rst>

--- a/docs/sphinx/using/examples/measuring_kernels.rst
+++ b/docs/sphinx/using/examples/measuring_kernels.rst
@@ -47,6 +47,31 @@ Specific qubits or registers can be measured rather than the entire kernel.
         :start-after: [Begin Sample2]
         :end-before: [End Sample2]
 
+Measurement Handles
+----------------------------------------------
+
+In CUDA-Q, :code:`mz`, :code:`mx`, and :code:`my` return a *measurement
+handle* — :code:`cudaq::measure_handle` in C++ (with the alias
+:code:`cudaq::measure_result`), and the :code:`measure_handle` type in
+Python — rather than a classical value. Measuring a single qubit returns one
+handle; measuring a :code:`qvector` returns a vector of handles. A handle
+records a measurement event and defers reading its classical value, so the
+same measurement can drive mid-circuit conditional logic and
+quantum-error-correction declarations (see :doc:`dem_from_kernel`).
+
+A handle is *discriminated* into its classical bit by using it in a boolean
+context inside the kernel — for example the :code:`if (b0)` test in the
+mid-circuit example below. To read a whole vector of handles at once,
+discriminate it in bulk with :code:`to_bools` (yielding a
+:code:`list[bool]` / :code:`std::vector<bool>`) or :code:`to_integer`
+(packing the bits little-endian into an integer). The C++ mid-circuit example
+below returns :code:`to_bools(mz(q))`; a Python kernel typed to return
+:code:`list[bool]` discriminates a returned handle vector automatically.
+
+A handle cannot cross the host-device boundary without being discriminated:
+convert it to a boolean, :code:`list[bool]` / :code:`std::vector<bool>`, or
+integer inside the kernel before returning it.
+
 Mid-circuit Measurement and Conditional Logic
 ----------------------------------------------
 


### PR DESCRIPTION
User-facing docs for `cudaq::measure_handle` (the new `mz`/`mx`/`my` return type) and `cudaq::dem_from_kernel` + the `detector`/`detectors`/`logical_observable` QEC ops.