### PR TITLE
[core] Teach compiler when to combine quantum allocations

### DIFF
--- a/cudaq/include/cudaq/Optimizer/Builder/Factory.h
+++ b/cudaq/include/cudaq/Optimizer/Builder/Factory.h
@@ -43,6 +43,8 @@ T convertBitsToBytes(T bits) {
   return (bits + 7) / 8;
 }
 
+constexpr const char disableQubitCombineAttrName[] = "cc.no_qubit_combine";
+
 namespace factory {
 
 constexpr const char targetTripleAttrName[] = "llvm.triple";

--- a/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.td
+++ b/cudaq/include/cudaq/Optimizer/Dialect/CC/CCOps.td
@@ -96,7 +96,14 @@ def cc_ScopeOp : CCOp<"scope",
     using BodyBuilderFn =
         llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)>;
 
-    bool hasAllocation(bool quantumAllocs = true);
+    // Determine if the scope has any allocation.
+    bool hasAllocation();
+
+    // Determine if the scope has a classical allocation, ignoring quantum.
+    bool hasClassicalAllocation();
+    
+    // Determine if the scope has a quantum allocation, ignoring classical.
+    bool hasQuantumAllocation();
   }];
 }
 

--- a/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
+++ b/cudaq/lib/Frontend/nvqpp/ConvertExpr.cpp
@@ -2472,8 +2472,9 @@ bool QuakeBridgeVisitor::VisitCallExpr(clang::CallExpr *x) {
         vecPtr = cc::StdvecDataOp::create(builder, loc, ptrTy, args[0]);
         auto bits = svecTy.getElementType().getIntOrFloatBitWidth();
         assert(bits > 0);
-        auto scale = arith::ConstantIntOp::create(
-            builder, loc, args[1].getType(), (bits + 7) / 8);
+        auto scale =
+            arith::ConstantIntOp::create(builder, loc, args[1].getType(),
+                                         cudaq::opt::convertBitsToBytes(bits));
         offset = arith::MulIOp::create(builder, loc, scale, args[1]);
       } else {
         ptrTy = cc::PointerType::get(eleTy);

--- a/cudaq/lib/Optimizer/CodeGen/ReturnToOutputLog.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/ReturnToOutputLog.cpp
@@ -203,7 +203,8 @@ public:
                                    cudaq::opt::QIRBoolSpanRecordOutput,
                                    ArrayRef<Value>{rawData, size});
             } else {
-              std::int32_t byteSize = (intTy.getWidth() + 7) / 8;
+              std::int32_t byteSize =
+                  cudaq::opt::convertBitsToBytes(intTy.getWidth());
               Value elemSize =
                   arith::ConstantIntOp::create(rewriter, loc, byteSize, 32);
               func::CallOp::create(rewriter, loc, TypeRange{},

--- a/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
+++ b/cudaq/lib/Optimizer/Dialect/CC/CCOps.cpp
@@ -57,7 +57,7 @@ Value cudaq::cc::getByteSizeOfType(OpBuilder &builder, Location loc, Type ty,
 
   // Handle primitive types with constant sizes.
   auto primSize = [](auto ty) -> unsigned {
-    return (ty.getIntOrFloatBitWidth() + 7) / 8;
+    return cudaq::opt::convertBitsToBytes(ty.getIntOrFloatBitWidth());
   };
   auto rawSize =
       TypeSwitch<Type, std::optional<std::int32_t>>(ty)
@@ -2018,26 +2018,38 @@ void cudaq::cc::ScopeOp::getSuccessorRegions(
 
 // If quantumAllocs, then just look for any allocate memory effect. Otherwise,
 // look for any allocate memory other than from the quake dialect.
-template <bool quantumAllocs>
+template <bool quantumAllocs, bool classicalAllocs>
 bool hasAllocation(Region &region) {
   for (auto &block : region)
     for (auto &op : block) {
       if (auto mem = dyn_cast<MemoryEffectOpInterface>(op))
-        if (mem.hasEffect<MemoryEffects::Allocate>())
-          if (quantumAllocs || !isa<cudaq::quake::AllocaOp>(op))
+        if (mem.hasEffect<MemoryEffects::Allocate>()) {
+          if (quantumAllocs && isa<cudaq::quake::AllocaOp>(op))
             return true;
+          if (classicalAllocs && !isa<cudaq::quake::AllocaOp>(op))
+            return true;
+        }
       if (!isa<cudaq::cc::ScopeOp>(op))
         for (auto &opReg : op.getRegions())
-          if (hasAllocation<quantumAllocs>(opReg))
+          if (hasAllocation<quantumAllocs, classicalAllocs>(opReg))
             return true;
     }
   return false;
 }
 
-bool cudaq::cc::ScopeOp::hasAllocation(bool quantumAllocs) {
-  if (quantumAllocs)
-    return ::hasAllocation</*quantumAllocs=*/true>(getRegion());
-  return ::hasAllocation</*quantumAllocs=*/false>(getRegion());
+bool cudaq::cc::ScopeOp::hasAllocation() {
+  return ::hasAllocation</*quantumAllocs=*/true, /*classicalAllocs=*/true>(
+      getRegion());
+}
+
+bool cudaq::cc::ScopeOp::hasClassicalAllocation() {
+  return ::hasAllocation</*quantumAllocs=*/false, /*classicalAllocs=*/true>(
+      getRegion());
+}
+
+bool cudaq::cc::ScopeOp::hasQuantumAllocation() {
+  return ::hasAllocation</*quantumAllocs=*/true, /*classicalAllocs=*/false>(
+      getRegion());
 }
 
 namespace {

--- a/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
+++ b/cudaq/lib/Optimizer/Transforms/CombineQuantumAlloc.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "PassDetails.h"
+#include "cudaq/Optimizer/Builder/Factory.h"
 #include "cudaq/Optimizer/Transforms/Passes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -113,6 +114,13 @@ public:
     func::FuncOp func = getOperation();
     LLVM_DEBUG(llvm::dbgs() << "Function before combining quake alloca:\n"
                             << func << "\n\n");
+
+    if (func->hasAttr(cudaq::opt::disableQubitCombineAttrName)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Combining quake alloca is disabled for " << func.getName()
+                 << " as it contains scoped qubits.\n");
+      return;
+    }
 
     // 1. Scan the top-level of the function for all alloca operations. Exit if
     // any of them are parametric.

--- a/cudaq/lib/Optimizer/Transforms/LowerToCFG.cpp
+++ b/cudaq/lib/Optimizer/Transforms/LowerToCFG.cpp
@@ -56,7 +56,12 @@ public:
     auto *initBlock = rewriter.getInsertionBlock();
     Value stackSave;
     auto ptrTy = cudaq::cc::PointerType::get(rewriter.getI8Type());
-    if (scopeOp.hasAllocation(/*quantumAllocs=*/false)) {
+    if (scopeOp.hasQuantumAllocation())
+      if (auto fn = scopeOp->getParentOfType<func::FuncOp>())
+        fn->setAttr(cudaq::opt::disableQubitCombineAttrName,
+                    UnitAttr::get(scopeOp.getContext()));
+
+    if (scopeOp.hasClassicalAllocation()) {
       auto call = func::CallOp::create(rewriter, loc, ptrTy,
                                        cudaq::llvmStackSave, ArrayRef<Value>{});
       stackSave = call.getResult(0);

--- a/cudaq/test/Transforms/scoped_qalloc.qke
+++ b/cudaq/test/Transforms/scoped_qalloc.qke
@@ -1,0 +1,63 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --lower-to-cfg --combine-quantum-alloc --canonicalize --symbol-dce %s | FileCheck %s
+
+module {
+  func.func @__nvqpp__mlirgen__main_kernel..0x71bec5c78650.run(%arg0: !cc.callable<() -> i64>) attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, quake.cudaq_run = [i64]} {
+    %0 = cc.scope -> (i64) {
+      %5 = quake.alloca !quake.veq<10>
+      %6 = quake.extract_ref %5[0] : (!quake.veq<10>) -> !quake.ref
+      quake.h %6 : (!quake.ref) -> ()
+      %7 = quake.extract_ref %5[0] : (!quake.veq<10>) -> !quake.ref
+      %measOut = quake.mz %7 : (!quake.ref) -> !cc.measure_handle
+      %8 = quake.discriminate %measOut : (!cc.measure_handle) -> i1
+      %9 = cc.cast unsigned %8 : (i1) -> i64
+      quake.dealloc %5 : !quake.veq<10>
+      cc.continue %9 : i64
+    }
+    %1 = cc.scope -> (i64) {
+      %5 = quake.alloca !quake.veq<10>
+      %6 = quake.extract_ref %5[0] : (!quake.veq<10>) -> !quake.ref
+      quake.h %6 : (!quake.ref) -> ()
+      %7 = quake.extract_ref %5[0] : (!quake.veq<10>) -> !quake.ref
+      %measOut = quake.mz %7 : (!quake.ref) -> !cc.measure_handle
+      %8 = quake.discriminate %measOut : (!cc.measure_handle) -> i1
+      %9 = cc.cast unsigned %8 : (i1) -> i64
+      quake.dealloc %5 : !quake.veq<10>
+      cc.continue %9 : i64
+    }
+    %2 = cc.scope -> (i64) {
+      %5 = quake.alloca !quake.veq<10>
+      %6 = quake.extract_ref %5[0] : (!quake.veq<10>) -> !quake.ref
+      quake.h %6 : (!quake.ref) -> ()
+      %7 = quake.extract_ref %5[0] : (!quake.veq<10>) -> !quake.ref
+      %measOut = quake.mz %7 : (!quake.ref) -> !cc.measure_handle
+      %8 = quake.discriminate %measOut : (!cc.measure_handle) -> i1
+      %9 = cc.cast unsigned %8 : (i1) -> i64
+      quake.dealloc %5 : !quake.veq<10>
+      cc.continue %9 : i64
+    }
+    %3 = arith.addi %0, %1 : i64
+    %4 = arith.addi %3, %2 : i64
+    cc.log_output %4 : i64
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @__nvqpp__mlirgen__main_kernel..0x71bec5c78650.run(
+// CHECK-SAME:      cc.no_qubit_combine
+// CHECK:           %[[ALLOCA_0:.*]] = quake.alloca !quake.veq<10>
+// CHECK:           quake.dealloc %[[ALLOCA_0]] : !quake.veq<10>
+// CHECK:           %[[ALLOCA_1:.*]] = quake.alloca !quake.veq<10>
+// CHECK:           quake.dealloc %[[ALLOCA_1]] : !quake.veq<10>
+// CHECK:           %[[ALLOCA_2:.*]] = quake.alloca !quake.veq<10>
+// CHECK:           quake.dealloc %[[ALLOCA_2]] : !quake.veq<10>
+// CHECK-NOT:       quake.alloca
+// CHECK:           return
+

--- a/runtime/internal/compiler/ArgumentConversion.cpp
+++ b/runtime/internal/compiler/ArgumentConversion.cpp
@@ -621,7 +621,7 @@ ArrayAttr genRecursiveConstantArray(OpBuilder &builder,
     };
   } else if (auto intTy = dyn_cast<IntegerType>(eleTy)) {
     unsigned width = intTy.getWidth();
-    stepBy = (width + 7) / 8;
+    stepBy = cudaq::opt::convertBitsToBytes(width);
     genAttr = [=](char *p) -> Attribute {
       std::uint64_t val = 0;
       switch (width) {


### PR DESCRIPTION
When quantum allocations come from entirely different scopes, we track those allocations independently right up until the high-level control flow is erased and we lower to a CFG. Subsequently, if there were quake allocations in those scopes that were erased, we do not want to combine them into a single allocation as that may be an oversubscription to resources. Instead, we want to allocation and deallocate qubits as per the user's algorithm. This is now the default.

The former approach, to combine all qubits into a single allocation, is entirely valid semantically. That approach may still be desirable for certain scenarios, which could be rather simply supported by adding a pass option to LowerToCFG.

Fix #4407.