### PR TITLE
Fix for adaptive QIR

### DIFF
--- a/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -114,6 +114,7 @@ void createTargetCodegenPipeline(PassManager &pm,
   auto tgt = StringRef(options.target).split(':').first;
   opts.allowDynamicResult = tgt == "qir" || tgt == "qir-full";
   pm.addPass(cudaq::opt::createReturnToOutputLog(opts));
+  pm.addNestedPass<func::FuncOp>(cudaq::opt::createEraseVectorCopyCtor());
   pm.addPass(createConvertMathToFuncs());
   pm.addPass(createSymbolDCEPass());
   pm.addPass(cudaq::opt::createCCToLLVM());

--- a/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
+++ b/cudaq/lib/Optimizer/CodeGen/Pipelines.cpp
@@ -114,7 +114,8 @@ void createTargetCodegenPipeline(PassManager &pm,
   auto tgt = StringRef(options.target).split(':').first;
   opts.allowDynamicResult = tgt == "qir" || tgt == "qir-full";
   pm.addPass(cudaq::opt::createReturnToOutputLog(opts));
-  pm.addNestedPass<func::FuncOp>(cudaq::opt::createEraseVectorCopyCtor());
+  if (!opts.allowDynamicResult)
+    pm.addNestedPass<func::FuncOp>(cudaq::opt::createEraseVectorCopyCtor());
   pm.addPass(createConvertMathToFuncs());
   pm.addPass(createSymbolDCEPass());
   pm.addPass(cudaq::opt::createCCToLLVM());

--- a/cudaq/test/Transforms/erase_vcc_adaptive_vector_bool.qke
+++ b/cudaq/test/Transforms/erase_vcc_adaptive_vector_bool.qke
@@ -1,0 +1,118 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-opt --return-to-output-log --erase-vector-copy-ctor %s | FileCheck %s
+
+module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__function_repro._Z5reprov.run = "__nvqpp__mlirgen__function_repro._Z5reprov.run.entry"}} {
+  func.func @__nvqpp__mlirgen__function_repro._Z5reprov.run() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, "qir-api", quake.cudaq_run = [i32]} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i64 = arith.constant 8 : i64
+    %false = arith.constant false
+    %c2_i64 = arith.constant 2 : i64
+    %c3_i64 = arith.constant 3 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c5_i64 = arith.constant 5 : i64
+    %c6_i64 = arith.constant 6 : i64
+    %c7_i64 = arith.constant 7 : i64
+    %0 = call @__quantum__rt__qubit_allocate_array(%c8_i64) : (i64) -> !cc.ptr<none>
+    %1 = cc.alloca !cc.array<i8 x 8>
+    %18 = call @_Z13packed_sourcem(%c0_i64) : (i64) -> i64
+    %19 = cc.cast %1 : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+    %20 = arith.andi %18, %c1_i64 : i64
+    %21 = arith.cmpi ne, %20, %c0_i64 : i64
+    %22 = cc.cast unsigned %21 : (i1) -> i8
+    cc.store %22, %19 : !cc.ptr<i8>
+    %23 = cc.compute_ptr %1[1] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+    %24 = arith.shrui %18, %c1_i64 : i64
+    %25 = arith.andi %24, %c1_i64 : i64
+    %26 = arith.cmpi ne, %25, %c0_i64 : i64
+    %27 = cc.cast unsigned %26 : (i1) -> i8
+    cc.store %27, %23 : !cc.ptr<i8>
+    %28 = cc.compute_ptr %1[2] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+    %29 = arith.shrui %18, %c2_i64 : i64
+    %30 = arith.andi %29, %c1_i64 : i64
+    %31 = arith.cmpi ne, %30, %c0_i64 : i64
+    %32 = cc.cast unsigned %31 : (i1) -> i8
+    cc.store %32, %28 : !cc.ptr<i8>
+    %33 = cc.compute_ptr %1[3] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+    %34 = arith.shrui %18, %c3_i64 : i64
+    %35 = arith.andi %34, %c1_i64 : i64
+    %36 = arith.cmpi ne, %35, %c0_i64 : i64
+    %37 = cc.cast unsigned %36 : (i1) -> i8
+    cc.store %37, %33 : !cc.ptr<i8>
+    %38 = cc.compute_ptr %1[4] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+    %39 = arith.shrui %18, %c4_i64 : i64
+    %40 = arith.andi %39, %c1_i64 : i64
+    %41 = arith.cmpi ne, %40, %c0_i64 : i64
+    %42 = cc.cast unsigned %41 : (i1) -> i8
+    cc.store %42, %38 : !cc.ptr<i8>
+    %43 = cc.compute_ptr %1[5] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+    %44 = arith.shrui %18, %c5_i64 : i64
+    %45 = arith.andi %44, %c1_i64 : i64
+    %46 = arith.cmpi ne, %45, %c0_i64 : i64
+    %47 = cc.cast unsigned %46 : (i1) -> i8
+    cc.store %47, %43 : !cc.ptr<i8>
+    %48 = cc.compute_ptr %1[6] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+    %49 = arith.shrui %18, %c6_i64 : i64
+    %50 = arith.andi %49, %c1_i64 : i64
+    %51 = arith.cmpi ne, %50, %c0_i64 : i64
+    %52 = cc.cast unsigned %51 : (i1) -> i8
+    cc.store %52, %48 : !cc.ptr<i8>
+    %53 = cc.compute_ptr %1[7] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+    %54 = arith.shrui %18, %c7_i64 : i64
+    %55 = arith.andi %54, %c1_i64 : i64
+    %56 = arith.cmpi ne, %55, %c0_i64 : i64
+    %57 = cc.cast unsigned %56 : (i1) -> i8
+    cc.store %57, %53 : !cc.ptr<i8>
+    %58 = call @malloc(%c8_i64) : (i64) -> !cc.ptr<i8>
+    call @llvm.memcpy.p0.p0.i64(%58, %19, %c8_i64, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+    %59 = cc.alloca !cc.array<i8 x 8>
+    %60 = cc.cast %59 : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+    call @llvm.memcpy.p0.p0.i64(%60, %58, %c8_i64, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+    call @free(%58) : (!cc.ptr<i8>) -> ()
+    cf.br ^bb1(%c0_i32, %c0_i64 : i32, i64)
+  ^bb1(%61: i32, %62: i64):
+    %63 = arith.cmpi ult, %62, %c8_i64 : i64
+    cf.cond_br %63, ^bb2, ^bb5
+  ^bb2:
+    %64 = cc.compute_ptr %59[%62] : (!cc.ptr<!cc.array<i8 x 8>>, i64) -> !cc.ptr<i8>
+    %65 = cc.load %64 : !cc.ptr<i8>
+    %66 = cc.cast %65 : (i8) -> i1
+    cf.cond_br %66, ^bb3, ^bb4(%61 : i32)
+  ^bb3:
+    %67 = call @__quantum__rt__array_get_element_ptr_1d(%0, %62) : (!cc.ptr<none>, i64) -> !cc.ptr<!cc.ptr<none>>
+    %68 = cc.load %67 : !cc.ptr<!cc.ptr<none>>
+    call @__quantum__qis__x(%68) : (!cc.ptr<none>) -> ()
+    %69 = arith.addi %61, %c1_i32 : i32
+    cf.br ^bb4(%69 : i32)
+  ^bb4(%70: i32):
+    %71 = arith.addi %62, %c1_i64 : i64
+    cf.br ^bb1(%70, %71 : i32, i64)
+  ^bb5:
+    cc.log_output %61 : i32
+    call @__quantum__rt__qubit_release_array(%0) : (!cc.ptr<none>) -> ()
+    return
+  }
+  func.func private @_Z13packed_sourcem(i64) -> i64 attributes {"cudaq-devicecall", passthrough = [["cudaq-fnid", "1669714268"]]}
+  func.func private @llvm.memcpy.p0.p0.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
+  func.func private @malloc(i64) -> !cc.ptr<i8>
+  func.func private @free(!cc.ptr<i8>)
+  func.func private @__quantum__rt__qubit_allocate_array(i64) -> !cc.ptr<none>
+  func.func private @__quantum__rt__qubit_release_array(!cc.ptr<none>)
+  func.func private @__quantum__rt__array_get_element_ptr_1d(!cc.ptr<none>, i64) -> !cc.ptr<!cc.ptr<none>>
+  func.func private @__quantum__qis__x(!cc.ptr<none>)
+}
+
+// CHECK-LABEL: func.func @__nvqpp__mlirgen__function_repro._Z5reprov.run()
+// CHECK-NOT:     call @malloc
+// CHECK-NOT:     call @free
+// CHECK-NOT:     call @llvm.memcpy
+// CHECK:         return

--- a/cudaq/test/Translate/vector_bool_adaptive_heap_copy.qke
+++ b/cudaq/test/Translate/vector_bool_adaptive_heap_copy.qke
@@ -1,0 +1,142 @@
+// ========================================================================== //
+// Copyright (c) 2026 NVIDIA Corporation & Affiliates.                        //
+// All rights reserved.                                                       //
+//                                                                            //
+// This source code and the accompanying materials are made available under   //
+// the terms of the Apache License 2.0 which accompanies this distribution.   //
+// ========================================================================== //
+
+// RUN: cudaq-translate --convert-to=qir-adaptive %s | FileCheck --implicit-check-not="@malloc" --implicit-check-not="@free" --implicit-check-not="store i8" %s
+module attributes {quake.mangled_name_map = {__nvqpp__mlirgen__function_repro._Z5reprov.run = "__nvqpp__mlirgen__function_repro._Z5reprov.run.entry"}} {
+  func.func @__nvqpp__mlirgen__function_repro._Z5reprov.run() attributes {"cudaq-entrypoint", "cudaq-kernel", no_this, quake.cudaq_run = [i32]} {
+    %c7_i64 = arith.constant 7 : i64
+    %c6_i64 = arith.constant 6 : i64
+    %c5_i64 = arith.constant 5 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c3_i64 = arith.constant 3 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %false = arith.constant false
+    %c8_i64 = arith.constant 8 : i64
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %0 = cc.scope -> (i32) {
+      %1 = quake.alloca !quake.veq<8>
+      %2 = quake.extract_ref %1[0] : (!quake.veq<8>) -> !quake.ref
+      quake.h %2 : (!quake.ref) -> ()
+      %3 = quake.extract_ref %1[1] : (!quake.veq<8>) -> !quake.ref
+      quake.h %3 : (!quake.ref) -> ()
+      %4 = quake.extract_ref %1[2] : (!quake.veq<8>) -> !quake.ref
+      quake.h %4 : (!quake.ref) -> ()
+      %5 = quake.extract_ref %1[3] : (!quake.veq<8>) -> !quake.ref
+      quake.h %5 : (!quake.ref) -> ()
+      %6 = quake.extract_ref %1[4] : (!quake.veq<8>) -> !quake.ref
+      quake.h %6 : (!quake.ref) -> ()
+      %7 = quake.extract_ref %1[5] : (!quake.veq<8>) -> !quake.ref
+      quake.h %7 : (!quake.ref) -> ()
+      %8 = quake.extract_ref %1[6] : (!quake.veq<8>) -> !quake.ref
+      quake.h %8 : (!quake.ref) -> ()
+      %9 = quake.extract_ref %1[7] : (!quake.veq<8>) -> !quake.ref
+      quake.h %9 : (!quake.ref) -> ()
+      %10 = cc.scope -> (!cc.stdvec<i1>) {
+        %16 = cc.alloca !cc.array<i8 x 8>
+        %17 = func.call @opaque_source(%c0_i64) : (i64) -> i64
+        %18 = cc.cast %16 : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+        %19 = arith.andi %17, %c1_i64 : i64
+        %20 = arith.cmpi ne, %19, %c0_i64 : i64
+        %21 = cc.cast unsigned %20 : (i1) -> i8
+        cc.store %21, %18 : !cc.ptr<i8>
+        %22 = cc.compute_ptr %16[1] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+        %23 = arith.shrui %17, %c1_i64 : i64
+        %24 = arith.andi %23, %c1_i64 : i64
+        %25 = arith.cmpi ne, %24, %c0_i64 : i64
+        %26 = cc.cast unsigned %25 : (i1) -> i8
+        cc.store %26, %22 : !cc.ptr<i8>
+        %27 = cc.compute_ptr %16[2] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+        %28 = arith.shrui %17, %c2_i64 : i64
+        %29 = arith.andi %28, %c1_i64 : i64
+        %30 = arith.cmpi ne, %29, %c0_i64 : i64
+        %31 = cc.cast unsigned %30 : (i1) -> i8
+        cc.store %31, %27 : !cc.ptr<i8>
+        %32 = cc.compute_ptr %16[3] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+        %33 = arith.shrui %17, %c3_i64 : i64
+        %34 = arith.andi %33, %c1_i64 : i64
+        %35 = arith.cmpi ne, %34, %c0_i64 : i64
+        %36 = cc.cast unsigned %35 : (i1) -> i8
+        cc.store %36, %32 : !cc.ptr<i8>
+        %37 = cc.compute_ptr %16[4] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+        %38 = arith.shrui %17, %c4_i64 : i64
+        %39 = arith.andi %38, %c1_i64 : i64
+        %40 = arith.cmpi ne, %39, %c0_i64 : i64
+        %41 = cc.cast unsigned %40 : (i1) -> i8
+        cc.store %41, %37 : !cc.ptr<i8>
+        %42 = cc.compute_ptr %16[5] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+        %43 = arith.shrui %17, %c5_i64 : i64
+        %44 = arith.andi %43, %c1_i64 : i64
+        %45 = arith.cmpi ne, %44, %c0_i64 : i64
+        %46 = cc.cast unsigned %45 : (i1) -> i8
+        cc.store %46, %42 : !cc.ptr<i8>
+        %47 = cc.compute_ptr %16[6] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+        %48 = arith.shrui %17, %c6_i64 : i64
+        %49 = arith.andi %48, %c1_i64 : i64
+        %50 = arith.cmpi ne, %49, %c0_i64 : i64
+        %51 = cc.cast unsigned %50 : (i1) -> i8
+        cc.store %51, %47 : !cc.ptr<i8>
+        %52 = cc.compute_ptr %16[7] : (!cc.ptr<!cc.array<i8 x 8>>) -> !cc.ptr<i8>
+        %53 = arith.shrui %17, %c7_i64 : i64
+        %54 = arith.andi %53, %c1_i64 : i64
+        %55 = arith.cmpi ne, %54, %c0_i64 : i64
+        %56 = cc.cast unsigned %55 : (i1) -> i8
+        cc.store %56, %52 : !cc.ptr<i8>
+        %57 = func.call @malloc(%c8_i64) : (i64) -> !cc.ptr<i8>
+        func.call @llvm.memcpy.p0.p0.i64(%57, %18, %c8_i64, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+        %58 = cc.stdvec_init %57, %c8_i64 : (!cc.ptr<i8>, i64) -> !cc.stdvec<i1>
+        cc.continue %58 : !cc.stdvec<i1>
+      }
+      %11 = cc.stdvec_data %10 : (!cc.stdvec<i1>) -> !cc.ptr<i8>
+      %12 = cc.stdvec_size %10 : (!cc.stdvec<i1>) -> i64
+      %13 = cc.alloca i8[%12 : i64]
+      %14 = cc.cast %13 : (!cc.ptr<!cc.array<i8 x ?>>) -> !cc.ptr<i8>
+      func.call @llvm.memcpy.p0.p0.i64(%14, %11, %12, %false) : (!cc.ptr<i8>, !cc.ptr<i8>, i64, i1) -> ()
+      func.call @free(%11) : (!cc.ptr<i8>) -> ()
+      %15:2 = cc.loop while ((%arg0 = %c0_i32, %arg1 = %c0_i64) -> (i32, i64)) {
+        %16 = arith.cmpi ult, %arg1, %12 : i64
+        cc.condition %16(%arg0, %arg1 : i32, i64)
+      } do {
+      ^bb0(%arg0: i32, %arg1: i64):
+        %16 = cc.compute_ptr %13[%arg1] : (!cc.ptr<!cc.array<i8 x ?>>, i64) -> !cc.ptr<i8>
+        %17 = cc.load %16 : !cc.ptr<i8>
+        %18 = cc.cast %17 : (i8) -> i1
+        %19 = cc.if(%18) -> i32 {
+          %20 = quake.extract_ref %1[%arg1] : (!quake.veq<8>, i64) -> !quake.ref
+          quake.x %20 : (!quake.ref) -> ()
+          %21 = arith.addi %arg0, %c1_i32 : i32
+          cc.continue %21 : i32
+        } else {
+          cc.continue %arg0 : i32
+        }
+        cc.continue %19, %arg1 : i32, i64
+      } step {
+      ^bb0(%arg0: i32, %arg1: i64):
+        %16 = arith.addi %arg1, %c1_i64 : i64
+        cc.continue %arg0, %16 : i32, i64
+      }
+      quake.dealloc %1 : !quake.veq<8>
+      cc.continue %15#0 : i32
+    }
+    cc.log_output %0 : i32
+    return
+  }
+  func.func private @opaque_source(i64) -> i64
+  func.func private @llvm.memcpy.p0.p0.i64(!cc.ptr<i8>, !cc.ptr<i8>, i64, i1)
+  func.func private @malloc(i64) -> !cc.ptr<i8>
+  func.func private @free(!cc.ptr<i8>)
+}
+
+// CHECK-LABEL: define void @__nvqpp__mlirgen__function_repro._Z5reprov.run()
+// CHECK:         call void @__quantum__qis__h__body
+// CHECK:         call i64 @opaque_source
+// CHECK:         call void @__quantum__qis__x__body
+// CHECK:         call void @__quantum__rt__int_record_output
+// CHECK:         ret void


### PR DESCRIPTION
Before this change, a `__qpu__` function that returned a `std::vector<bool>` of size > 1 broke adaptive QIR. The vector was built element-by-element (a store loop) and, after inlining, the frontend's vector copy-ctor idiom was left in the IR. PR #4455 emptied the inliner's per-step canonicalizer to preserve inlined scopes, so this dead heap buffer was no longer folded on the codegen path. Its `store`s survived into adaptive QIR, which bans heap stores, aborting JIT translation.

```
QIR verification error - invalid instruction found:
    store i8 %X, ptr %Y, align 1 (adaptive profile)
```

The fix is to run the existing `erase-vector-copy-ctor` pass right after `return-to-output-log` in `createTargetCodegenPipeline`. The copy-ctor idiom only reaches matchable form after QIR conversion and lower-to-cfg, which run after the inliner's own run of the pass, so the earlier invocation can't catch it.

@bmhowe23 for viz.